### PR TITLE
Avoid raising error when PayPal API does not return connected account details

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -997,7 +997,7 @@ class User < ApplicationRecord
 
     return nil unless has_paypal_account_connected?
 
-    paypal_connect_account.paypal_account_details["primary_email"]
+    paypal_connect_account.paypal_account_details&.dig("primary_email")
   end
 
   protected

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -677,6 +677,14 @@ describe User, :vcr do
       user.update!(payment_address: "")
       expect(user.paypal_payout_email).to eq nil
     end
+
+    it "returns nil if payment_address is blank and connected PayPal account details are not available" do
+      user.update!(payment_address: "")
+      create(:merchant_account_paypal, user:, charge_processor_merchant_id: "B66YJBBNCRW6L")
+      allow_any_instance_of(MerchantAccount).to receive(:paypal_account_details).and_return(nil)
+
+      expect(user.paypal_payout_email).to eq nil
+    end
   end
 
   describe "#build_user_compliance_info" do


### PR DESCRIPTION
**Why**

In some cases, PayPal API does not return details of the connected account e.g. if the account details are locked. We need to handle such cases to not raise an error.