### PR TITLE
Fix readme logo in darkmode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 <p align="center">
-  <img src="https://public-files.gumroad.com/logo/gumroad.svg" height="100" alt="Gumroad logo">
+  <picture>
+    <source srcset="https://public-files.gumroad.com/logo/gumroad-dark.svg" media="(prefers-color-scheme: dark)">
+    <source srcset="https://public-files.gumroad.com/logo/gumroad.svg" media="(prefers-color-scheme: light)">
+    <img src="https://public-files.gumroad.com/logo/gumroad.svg" height="100" alt="Gumroad logo">
+  </picture>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 <p align="center">
   <a href="./LICENSE.md">License</a> •
   <a href="./CODE_OF_CONDUCT.md">Code of Conduct</a> •
-  <a href="./CONTRIBUTING.md">Contributing</a> •
+  <a href="./CONTRIBUTING.md">Contributing</a>
 </p>
 
 ## Table of Contents


### PR DESCRIPTION
Dark mode:

<img width="818" alt="image" src="https://github.com/user-attachments/assets/c1fbb767-3290-4634-93fa-92f5892f9181" />


Light mode:

<img width="794" alt="image" src="https://github.com/user-attachments/assets/ea4bffc7-a138-4842-9379-b26205228500" />
