### PR TITLE
Update repo url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/gumroad/web.git"
+    "url": "git+https://github.com/antiwork/gumroad.git"
   },
   "type": "module",
   "author": "Gumroad Developers",


### PR DESCRIPTION
Minor change in package.json because the old url (https://github.com/gumroad/web.git) is 404.

There are other links that may need to be updated separately.

## Links in documentations

`rg -C 1 github.com/gumroad docs/`

<img width="700" alt="Cursor 2025-04-04 3 10 53 PM" src="https://github.com/user-attachments/assets/2143ee4c-ec88-40ec-afd3-731c2cea9369" />

<details><summary>Snippet</summary>

```
docs/setup_without_docker/mac.md
109-
110:Now follow the rest of the [README.md](https://github.com/gumroad/web/blob/main/README.md) for the installation process. Once done open https://gumroad.dev after running the `foreman` command and it should point to your Gumroad server!

docs/sidekiq.md
66-
67:Situation: we need to run the [`AnnualPayoutExportWorker` job](https://github.com/gumroad/web/blob/develop/app/workers/annual_payout_export_worker.rb) for all creators that have received at least one payout last year, so we can send them out the year in review email afterward.
68-
--
75-
76:[](https://github.com/gumroad/web/pull/24939#issuecomment-1404714940)

docs/alerts.md
4-
5:Recycle the unhealthy instances by [terminating them](https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#Instances:sort=tag:Name) (50% first, then the other 50% after five minutes). Note: **Make sure not to terminate steward instances**. Please follow [these steps](https://github.com/gumroad/infrastructure/blob/master/docs/upgrading_stewards.md) to recycle steward instances.
6-
--
29-
30:1. There is a replica lag. Go into the [AWS Console](https://<AWS_ACCOUNT_ID>.signin.aws.amazon.com/console) --> RDS --> Instances and show monitoring on the Production Replica. If the lag is very high, follow this [commit](https://github.com/gumroad/web/commit/14a50ecde5ee557be12fc14906d6b443cce9d352) to remove the replica and use master directly. Make sure to revert/undo this once the lag is gone and push the commits to master --> deploy --> staging.
31-2. This is usually a sign that [mLab](https://status.mlab.com/) is having some issue and you can check the status of it [here](https://status.compose.io/).
--
65-
66:This will tell you all files larger than 20MB. Likely it will be a log directory that is exploding. If not, make sure to examine what you are removing before you actually remove it. If it is safe to remove, remove the files and/or directories. Check [New Relic](https://rpm.newrelic.com/accounts/85918/servers) to ensure the disk usage went down. If not, try starting the stopping the instance. HOWEVER, follow the directions [here](https://github.com/gumroad/web/wiki/Upgrading-AWS-instances#how-to-run-the-rolling-upgrade-on-production) to ensure the site does not go down.
67-

docs/testing.md
86-
87:<https://github.com/gumroad/web/issues/8410#issuecomment-318496067>
88-
--
110-
111:_If you are sure the failing specs are unrelated to your PR:_ It could be a flaky spec. Confirm the spec passes multiple times locally but not on CI. Let the reviewer know when you assign it for review ([example](https://github.com/gumroad/web/pull/26680#issuecomment-1747253174)).
112-
--
161-
162:3. Remove `Rails.env.development? ||` part from this [line](https://github.com/gumroad/web/blob/3a63b5bd586f38761cc395a3318f34a8216c64b4/lib/gumroad_domain_constraint.rb#L5)
163-
--
242-
243:There is a simple web app in our repository called [web-overlay-test](https://github.com/gumroad/web-overlay-test). Once you check it out, follow these instructions to test the overlay and/or embed.
244-

docs/deploying.md
89-
90:Find the git tag for that commit from the [tags page on GitHub](https://github.com/gumroad/web/tags). Let's say the tag name is `production-d6b4605/2018-05-02-13-16-03`.
91-Execute the following command to create a new branch from the tag:
```

</details>

## Links in code comments

` rg -C 1 github.com/gumroad --glob '!docs/'`

<img width="700" alt="image" src="https://github.com/user-attachments/assets/a5568f14-20cf-4932-8d95-c0d5369f6875" />

<details><summary>Snippet</summary>

```
app/services/order/create_service.rb
133-      # Meanwhile, we can set the url_parameters from referrer when it's missing in the request.
134:      # Related GH issue: https://github.com/gumroad/web/issues/18190
135-      # TODO (ershad): Remove parsing url_parameters from referrer after fixing the root issue.

config/initializers/003_stripe.rb
3-Stripe.api_version = "2023-10-16; risk_in_requirements_beta=v1"
4:# Ref: https://github.com/gumroad/web/issues/17770, https://stripe.com/docs/rate-limits#object-lock-timeouts
5-Stripe.max_network_retries = 3

config/initializers/mail_encodings.rb
7-# as per https://github.com/mikel/mail/pull/1210.
8:# See https://github.com/gumroad/web/pull/24988 for more information.
9-module Mail

config/initializers/rpush.rb
150-# The rpush daemon needs all rpush apps to be present in Redis at start up.
151:# (See https://github.com/gumroad/web/pull/11372#discussion_r329752185)
152-if ENV["INITIALIZE_RPUSH_APPS"]

config/database.yml
13-  # wondering).
14:  # See https://github.com/gumroad/infrastructure/issues/479 for more details.
15-  pool: <%= ENV["DB_POOL_SIZE"].presence || ENV["RAILS_MAX_THREADS"].presence || 5 %>

db/migrate/20200830200804_add_base_tier_price_to_prices.rb
4-  # TODO(helen): remove this column when confident that tiered pricing data
5:  # migration was successful (see https://github.com/gumroad/web/pull/13830)
6-  def up

public/help/article/280-create-application-api.html
201-<h3 id="Sign-in-with-Gumroad-RE3bQ">Sign in with Gumroad</h3>
202:<p>If your website is built on Ruby on Rails, you can use the <a href="https://github.com/gumroad/omniauth-gumroad">Gumroad Omniauth gem</a> to enable "Sign in with Gumroad" in your software. Otherwise, use whatever OAuth/OmniAuth library your framework of choice supports. You will be provided with an Application ID (aka client_id ) and Application Secret (aka&nbsp; client_secret ) to use in the authentication process.</p>
203-<br>

db/migrate/20201214172042_add_stripe_sca_columns_to_purchase.rb
4-  def up
5:    # Using raw SQL due to a bug in departure gem: https://github.com/gumroad/web/pull/17299#issuecomment-786054996
6-    execute <<~SQL

db/migrate/20210219002017_migrate_es_indices_document_type.rb
3-class MigrateEsIndicesDocumentType < ActiveRecord::Migration[6.1]
4:  # Original migration: https://github.com/gumroad/web/blob/cf862531f1308deabe5753f80a069a19495adfbe/db/migrate/20210219002017_migrate_es_indices_document_type.rb
5-

db/migrate/20210303113039_add_last_active_sessions_invalidated_at_to_users.rb
4-  def up
5:    # Using raw SQL due to a bug in departure gem: https://github.com/gumroad/web/pull/17299#issuecomment-786054996
6-    execute <<~SQL

db/migrate/20200721210221_record_tiered_pricing_migration.rb
4-  # TODO(helen): remove these columns when confident that tiered pricing data
5:  # migration was successful (see https://github.com/gumroad/web/pull/13830)
6-  # Also see note in `Price` model re. `.alive` and `#alive?` methods

db/migrate/20210101171009_add_processor_payment_intent_id_to_service_charges.rb
4-  def up
5:    # Using raw SQL due to a bug in departure gem: https://github.com/gumroad/web/pull/17299#issuecomment-786054996
6-    execute <<~SQL

app/javascript/stylesheets/_legacy.scss
214-// "form > section" styles on the files view which is now wrapped in "form > main".
215:// See https://github.com/gumroad/web/pull/26111#discussion_r1232782397 for more
216-// details.

app/models/user.rb
757-  # Useful to resolve inconsistencies between Rails, Elasticsearch and MySQL which may all have
758:  # different TZ databases: https://github.com/gumroad/web/pull/25208
759-  # Note that it doesn't acknowledge DST by nature: it is just the difference between the timezone's

app/models/credit.rb
143-  # from their PayPal/Stripe Connect balance (since there's no way to specify that the refund should be taken out entirely
144:  # from the Gumroad's portion of the purchase, see https://github.com/gumroad/web/issues/20820#issuecomment-1021042784).
145-  #

app/models/subscription.rb
69-  after_save :create_interruption_event, if: -> { deactivated_at_previously_changed? }
70:  after_create :create_interruption_event, if: -> { deactivated_at.present? } # needed in addition to the `after_save`. See https://github.com/gumroad/web/pull/26305#discussion_r1336425626
71-  after_commit :send_ended_notification_webhook, if: Proc.new { |subscription|

app/models/seller_profile_products_section.rb
4-  def product_names
5:    # Prevents a full table scan (see https://github.com/gumroad/web/pull/26855)
6-    Link.where(user_id: seller_id, id: shown_products).pluck(:name)

app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
293-      if stripe_payout["amount"] >= 0
294:        # Ignore events about automatic on-schedule payouts (not triggered by Gumroad). Ref: https://github.com/gumroad/web/issues/16938
295-        Rails.logger.info("Ignoring automatic payout event #{stripe_event_id} for stripe account #{stripe_connect_account_id}")
--
323-        # days aren't final: https://stripe.com/docs/api/payouts/object#payout_object-status
324:        # https://github.com/gumroad/web/pull/23719
325-        HandlePayoutReversedWorker.perform_in(7.days, payment.id, reversing_payout_id, stripe_connect_account_id)

app/business/payments/payouts/processor/paypal/paypal_payout_processor.rb
285-      # status using another API call to Paypal.
286:      # Ref: https://github.com/gumroad/web/issues/9474
287-      if new_payment_state == "pending"
--
327-      # status using another API call to Paypal.
328:      # Ref: https://github.com/gumroad/web/issues/9474
329-      UpdatePayoutStatusWorker.perform_in(5.minutes, payment.id) if split_payment_info["state"] == "pending"

spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
8721-        # We need to set the company name to first and last name to make sure this is what is used for payouts
8722:        # Ref: https://github.com/gumroad/web/issues/19882
8723-        it "does not include company details in params and sets the company name to first and last name" do

app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
177-
178:    # Request 3DS manually when preparing future charges for all Indian cards. Ref: https://github.com/gumroad/web/issues/20783
179-    chargeable.prepare! # loads the payment method's info, including card country
--
237-
238:    # Request 3DS manually when preparing future charges for all Indian cards. Ref: https://github.com/gumroad/web/issues/20783
239-    params.deep_merge!(REQUEST_MANUAL_3DS_PARAMS) if should_setup_future_usage && chargeable.country == Compliance::Countries::IND.alpha2

app/javascript/components/server-components/Developer/WidgetsPage.tsx
219-            >
220:              {/* Without <span> React overwrites overlay script changes  - https://github.com/gumroad/web/pull/27983 */}
221-              <span>{buttonText || "Buy on"}</span>

app/models/purchase.rb
55-  # to be able to return preorders from the time they were created instead of when they were concluded.
56:  # https://github.com/gumroad/web/pull/17699
57-  CHARGED_SALES_SEARCH_OPTIONS = {

app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
169-      # Set the company's name to the individual's first and last name so that this is used as the Stripe account name and during payouts
170:      # Ref: https://github.com/gumroad/web/issues/19882
171-      diff_attributes[:company] = { name: user_compliance_info.first_and_last_name }

app/javascript/components/RichTextEditor.tsx
346-    // This manually re-renders the component in these cases.
347:    // See also https://github.com/gumroad/web/pull/26370/files#r1273868758
348-    const handleTransaction = () => setRenderedAt(Date.now());

app/javascript/components/TiptapExtensions/Image.tsx
147-  draggable: true,
148:  // fixes bug, see: https://github.com/gumroad/web/pull/24134#issuecomment-1247356616
149-  isolating: true,

app/controllers/concerns/process_refund.rb
6-      # We don't support commas in refund amount
7:      # Reference: https://github.com/gumroad/web/pull/17747
8-      return render json: { success: false, message: "Commas not supported in refund amount." } if amount&.include?(",")

spec/models/link_spec.rb
3944-  describe "currencies" do
3945:    # to prevent issues like https://github.com/gumroad/web/issues/15021
3946-    # when ours and Money's subunit treatment are diverging

app/javascript/utils/with_social_connect.js
26-  // Make sure this works when Megaphone is re-enabled as we've added a no-tracking feature.
27:  // See https://github.com/gumroad/web/pull/16941/files#r556685303
28-  /* Connects current user to Facebook and persists user info

app/controllers/application_controller.rb
394-    # Since Safari doesn't allow setting third-party cookies by default
395:    # (reference: https://github.com/gumroad/web/pull/17775#issuecomment-815047658),
396-    # the 'affiliate_id' cookie doesn't persist in the user's browser for

app/presenters/library_presenter.rb
27-      )
28:      .find_each(batch_size: 3000, order: :desc) # required to avoid full table scans. See https://github.com/gumroad/web/pull/25970
29-      .to_a

app/modules/user/stats.rb
597-    # Note: This logic was imported from the deprecated User#customers method.
598:    # https://github.com/gumroad/web/blob/06bbac3499e82a198b7bd17b26e0ccbcf2939cf8/app/modules/user/customers.rb#L20-L55
599-    matching_sales = sales.all_success_states.not_is_gift_receiver_purchase
```
</details>