### PR TITLE
feat(ci): added vet for general OSS security best practice

### DIFF
--- a/.github/vet/policy.yml
+++ b/.github/vet/policy.yml
@@ -1,0 +1,23 @@
+name: General Purpose OSS Best Practices
+description: |
+  This filter suite contains rules for implementing minimum
+  security guardrails against risky OSS components.
+tags:
+  - general
+  - gumroad
+filters:
+  - name: critical-or-high-vulns
+    check_type: CheckTypeVulnerability
+    summary: Critical or high risk vulnerabilities were found
+    value: |
+      vulns.critical.exists(p, true) || vulns.high.exists(p, true)
+  - name: low-popularity
+    check_type: CheckTypePopularity
+    summary: Component popularity is low by Github stars count
+    value: |
+      projects.exists(p, (p.type == "GITHUB") && (p.stars < 10))
+  - name: osv-malware
+    check_type: CheckTypeMalware
+    summary: Malicious (malware) component detected
+    value: |
+      vulns.all.exists(v, v.id.startsWith("MAL-"))

--- a/.github/workflows/vet-ci.yml
+++ b/.github/workflows/vet-ci.yml
@@ -1,0 +1,35 @@
+name: vet OSS Components
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  # Required for actions/checkout@v4
+  contents: read
+
+  # Required for writing pull request comment
+  issues: write
+  pull-requests: write
+
+jobs:
+  vet:
+    name: vet
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@v4
+
+      - name: Run vet
+        id: vet
+        uses: safedep/vet-action@v1
+        with:
+          policy: .github/vet/policy.yml
+        env:
+          # Required for writing pull request comment
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/vet-ci.yml
+++ b/.github/workflows/vet-ci.yml
@@ -29,6 +29,7 @@ jobs:
         uses: safedep/vet-action@v1
         with:
           policy: .github/vet/policy.yml
+          enable-comments-proxy: true # Enable Comments Proxy Server to create comments on GitHub PRs
         env:
           # Required for writing pull request comment
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR, help gumroad become a safer project, by consuming Secure OSS. 

Integrate [vet](https://github.com/safedep/vet) to automate vetting of OSS packages for security vulnerabilities and other risks. The policy is configured to be minimal, checking only for critical & high risk vulnerabilities, malicious libraries. The policy can be fine tuned / improved based on usage.

Vet Docs: https://docs.safedep.io/about

Vet-Action Docs: https://github.com/safedep/vet-action

Vet will only run when new packages are added.

Screenshorts

![image](https://github.com/user-attachments/assets/92e5ef4a-8031-4d1f-b0a6-69a9cd4b810b)

![Screenshot from 2025-04-04 20-01-19](https://github.com/user-attachments/assets/4c6540e2-d496-45af-b1c9-9612f4f8c190)

![Screenshot from 2025-04-04 20-01-06](https://github.com/user-attachments/assets/08392e85-7c0d-40ad-9629-a6851c4cca30)
