### PR TITLE
`exec` AnyCable for correct signal handling

### DIFF
--- a/bin/anycable-go
+++ b/bin/anycable-go
@@ -19,4 +19,4 @@ if [[ "$version" != "latest" ]]; then
   fi
 fi
 
-./bin/dist/anycable-go $@
+exec ./bin/dist/anycable-go $@


### PR DESCRIPTION
When using Foreman, our processes need to handle termination signals correctly. Without `exec`, the shell remains as the parent process, and signals sent by Foreman may not reach the AnyCable server process directly.

This can leave the process running and hogging its port even after shutdown, causing conflicts on restart:

```
anycable_ws.1  | broadcasting HTTP server at http://gumroad.dev:8080 stopped: listen tcp 127.0.0.1:8080: bind: address already in use
```