### PR TITLE
fix: navigation on store subdomains

### DIFF
--- a/app/javascript/components/Discover/Layout.tsx
+++ b/app/javascript/components/Discover/Layout.tsx
@@ -29,8 +29,7 @@ export const Layout: React.FC<{
   const rootTaxonomy = getRootTaxonomy(taxonomyPath);
 
   setQuery ??= (query) => (window.location.href = Routes.discover_url({ host: discoverDomain, query }));
-  onTaxonomyChange ??= (newTaxonomyPath) =>
-    (window.location.href = Routes.discover_url({ host: discoverDomain, taxonomy: newTaxonomyPath }));
+  onTaxonomyChange ??= (newTaxonomyPath) => (window.location.href = newTaxonomyPath ? newTaxonomyPath : "/");
 
   const headerCta = currentSeller && (
     <a href={Routes.library_url()} className="button">
@@ -69,17 +68,15 @@ export const Layout: React.FC<{
           <Search query={query} setQuery={setQuery} />
           {isDesktop ? headerCta : nav}
           {isDesktop ? (
-            <div
-              style={{ display: "flex", justifyContent: "space-between", flexGrow: 1, alignItems: "center", order: 1 }}
-            >
+            <div className="order-1 flex flex-grow items-center justify-between">
               {nav}
               {avatar}
             </div>
           ) : null}
         </div>
         {showTaxonomy && taxonomyPath ? (
-          <div style={{ display: "grid", gridColumn: "1" }}>
-            <div style={{ gridColumn: "1" }}>
+          <div className="col-start-1 grid">
+            <div className="col-start-1">
               <TaxonomyCategoryBreadcrumbs
                 taxonomyPath={taxonomyPath}
                 taxonomies={taxonomiesForNav}

--- a/app/javascript/components/Discover/Layout.tsx
+++ b/app/javascript/components/Discover/Layout.tsx
@@ -21,7 +21,18 @@ export const Layout: React.FC<{
   setQuery?: (query: string) => void;
   className?: string;
   children: React.ReactNode;
-}> = ({ taxonomiesForNav, taxonomyPath, showTaxonomy, onTaxonomyChange, query, setQuery, className, children }) => {
+  forceDomain?: boolean;
+}> = ({
+  taxonomiesForNav,
+  taxonomyPath,
+  showTaxonomy,
+  onTaxonomyChange,
+  query,
+  setQuery,
+  className,
+  children,
+  forceDomain = false,
+}) => {
   const { discoverDomain } = useDomains();
   const isDesktop = useIsAboveBreakpoint("lg");
   const currentSeller = useCurrentSeller();
@@ -30,6 +41,12 @@ export const Layout: React.FC<{
 
   setQuery ??= (query) => (window.location.href = Routes.discover_url({ host: discoverDomain, query }));
   onTaxonomyChange ??= (newTaxonomyPath) => (window.location.href = newTaxonomyPath ? newTaxonomyPath : "/");
+
+  onTaxonomyChange ??= (newTaxonomyPath) => {
+    window.location.href = forceDomain
+      ? newTaxonomyPath || "/"
+      : Routes.discover_url({ host: discoverDomain, taxonomy: newTaxonomyPath });
+  };
 
   const headerCta = currentSeller && (
     <a href={Routes.library_url()} className="button">
@@ -48,6 +65,7 @@ export const Layout: React.FC<{
       wholeTaxonomy={taxonomiesForNav}
       currentTaxonomyPath={taxonomyPath}
       onClickTaxonomy={onTaxonomyChange}
+      forceDomain={forceDomain}
       footer={<footer>{headerCta}</footer>}
     />
   );

--- a/app/javascript/components/Discover/Layout.tsx
+++ b/app/javascript/components/Discover/Layout.tsx
@@ -40,7 +40,6 @@ export const Layout: React.FC<{
   const rootTaxonomy = getRootTaxonomy(taxonomyPath);
 
   setQuery ??= (query) => (window.location.href = Routes.discover_url({ host: discoverDomain, query }));
-  onTaxonomyChange ??= (newTaxonomyPath) => (window.location.href = newTaxonomyPath ? newTaxonomyPath : "/");
 
   onTaxonomyChange ??= (newTaxonomyPath) => {
     window.location.href = forceDomain

--- a/app/javascript/components/Discover/Nav.tsx
+++ b/app/javascript/components/Discover/Nav.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 
 import { getRootTaxonomy, getRootTaxonomyCss, getRootTaxonomyImage, Taxonomy } from "$app/utils/discover";
 
+import { useDomains } from "$app/components/DomainSettings";
 import { MenuItem, NestedMenu } from "$app/components/NestedMenu";
 import { useIsAboveBreakpoint } from "$app/components/useIsAboveBreakpoint";
 
@@ -16,7 +17,13 @@ export const Nav = ({
   onClickTaxonomy: (taxonomySlugPath?: string) => void;
   footer?: React.ReactNode;
 }) => {
-  const menuItems = React.useMemo(() => generateTaxonomyItemsForMenu(wholeTaxonomy), [wholeTaxonomy]);
+  const { discoverDomain } = useDomains();
+  const discoverUrl = Routes.discover_url({ host: discoverDomain });
+
+  const menuItems = React.useMemo(
+    () => generateTaxonomyItemsForMenu(wholeTaxonomy, discoverUrl),
+    [wholeTaxonomy, discoverUrl],
+  );
   const selectedCategory = menuItems.find((menuItem) => menuItem.href === `/${currentTaxonomyPath ?? ""}`)?.key;
 
   const isDesktop = useIsAboveBreakpoint("lg");
@@ -39,7 +46,7 @@ export const Nav = ({
   );
 };
 
-const generateTaxonomyItemsForMenu = (wholeTaxonomy: Taxonomy[]) => {
+const generateTaxonomyItemsForMenu = (wholeTaxonomy: Taxonomy[], discoverUrl: string) => {
   const taxonomyMap = new Map(wholeTaxonomy.map((tc) => [tc.key, tc]));
   const generateHref = (taxonomyCategory: Taxonomy): string => {
     const slugs = [];
@@ -48,7 +55,7 @@ const generateTaxonomyItemsForMenu = (wholeTaxonomy: Taxonomy[]) => {
       slugs.unshift(curr.slug);
       curr = curr.parent_key ? taxonomyMap.get(curr.parent_key) : undefined;
     }
-    return `/${slugs.join("/")}`;
+    return `${discoverUrl}${slugs.join("/")}`;
   };
 
   return [

--- a/app/javascript/components/Discover/Nav.tsx
+++ b/app/javascript/components/Discover/Nav.tsx
@@ -26,7 +26,8 @@ export const Nav = ({
     () => generateTaxonomyItemsForMenu(wholeTaxonomy, forceDomain ? discoverUrl : ""),
     [wholeTaxonomy, discoverUrl],
   );
-  const selectedCategory = menuItems.find((menuItem) => menuItem.href === `/${currentTaxonomyPath ?? ""}`)?.key;
+
+  const selectedCategory = menuItems.find((menuItem) => menuItem.href === (currentTaxonomyPath ?? ""))?.key;
 
   const isDesktop = useIsAboveBreakpoint("lg");
 

--- a/app/javascript/components/Discover/Nav.tsx
+++ b/app/javascript/components/Discover/Nav.tsx
@@ -11,17 +11,19 @@ export const Nav = ({
   currentTaxonomyPath,
   onClickTaxonomy,
   footer,
+  forceDomain = false,
 }: {
   wholeTaxonomy: Taxonomy[];
   currentTaxonomyPath?: string | undefined;
   onClickTaxonomy: (taxonomySlugPath?: string) => void;
   footer?: React.ReactNode;
+  forceDomain?: boolean;
 }) => {
   const { discoverDomain } = useDomains();
   const discoverUrl = Routes.discover_url({ host: discoverDomain });
 
   const menuItems = React.useMemo(
-    () => generateTaxonomyItemsForMenu(wholeTaxonomy, discoverUrl),
+    () => generateTaxonomyItemsForMenu(wholeTaxonomy, forceDomain ? discoverUrl : ""),
     [wholeTaxonomy, discoverUrl],
   );
   const selectedCategory = menuItems.find((menuItem) => menuItem.href === `/${currentTaxonomyPath ?? ""}`)?.key;

--- a/app/javascript/components/Home/Nav.tsx
+++ b/app/javascript/components/Home/Nav.tsx
@@ -63,11 +63,11 @@ export const Nav = () => {
 
   const navLinks = (
     <>
-      <NavLink text="Home" href={Routes.root_path()} />
-      <NavLink text="About" href={Routes.about_path()} />
-      <NavLink text="Features" href={Routes.features_path()} />
-      <NavLink text="Pricing" href={Routes.pricing_path()} />
-      <NavLink text="Taxes" href={Routes.taxes_path()} />
+      <NavLink text="Home" href={Routes.root_url()} />
+      <NavLink text="About" href={Routes.about_url()} />
+      <NavLink text="Features" href={Routes.features_url()} />
+      <NavLink text="Pricing" href={Routes.pricing_url()} />
+      <NavLink text="Taxes" href={Routes.taxes_url()} />
     </>
   );
 
@@ -83,7 +83,7 @@ export const Nav = () => {
   return (
     <section role="navigation">
       <div className="sticky left-0 right-0 top-0 z-50 flex h-20 justify-between border-b border-black bg-white pl-4 pr-4 lg:pl-8 lg:pr-0 dark:border-b-white/[.35] dark:bg-black">
-        <a href={Routes.root_path()} className="flex items-center">
+        <a href={Routes.root_url()} className="flex items-center">
           <img src={logo} alt="Gumroad" className="h-8 dark:invert" />
         </a>
         <div className="override hidden lg:flex lg:flex-1 lg:items-center lg:justify-center lg:gap-4">

--- a/app/javascript/components/server-components/Discover/ProductPage.tsx
+++ b/app/javascript/components/server-components/Discover/ProductPage.tsx
@@ -12,6 +12,7 @@ const ProductPage = (props: Props & { taxonomy_path: string | null; taxonomies_f
     taxonomyPath={props.taxonomy_path ?? undefined}
     taxonomiesForNav={props.taxonomies_for_nav}
     className="custom-sections"
+    forceDomain
   >
     <Layout cart hasHero {...props} />
     {/* render an empty div for the add section button */}


### PR DESCRIPTION
Closes https://github.com/antiwork/gumroad/issues/29

This PR fix the navigation issue when the user is accessing the store subdomain.
For the main navigation, and the categories, it should redirect to the main domain (gumroad.com)