### PR TITLE
Enable Rack::MiniProfiler in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gem "rake", "13.2.1"
 
 group :development do
   gem "derailed_benchmarks", "~> 2.1"
-  gem "rack-mini-profiler", "~> 3.0", require: false
   gem "stackprof", "~> 0.2"
 end
 
@@ -146,6 +145,7 @@ gem "pundit", "~> 2.3"
 gem "public_suffix", "~> 5.0"
 gem "rack-attack", "~> 6.6"
 gem "rack-cors", "~> 2.0"
+gem "rack-mini-profiler", "~> 3.0", require: false
 gem "rack-ssl", "~> 1.4"
 gem "rack-timeout", "~> 0.6", require: "rack/timeout/base"
 gem "rack-utf8_sanitizer", "~> 1.8"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,6 +16,7 @@ class ApplicationController < ActionController::Base
   include CurrentSeller
   include HelperWidget
   include UtmLinkTracking
+  include RackMiniProfilerAuthorization
 
   before_action :save_us_from_ddos
   before_action :debug_headers

--- a/app/controllers/concerns/rack_mini_profiler_authorization.rb
+++ b/app/controllers/concerns/rack_mini_profiler_authorization.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module RackMiniProfilerAuthorization
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :authorize_rack_mini_profiler
+  end
+
+  private
+    def authorize_rack_mini_profiler
+      Rack::MiniProfiler.authorize_request if authorize_rack_mini_profiler?
+    end
+
+    def authorize_rack_mini_profiler?
+      return true if Rails.env.development?
+
+      current_user&.is_team_member?
+    end
+end

--- a/app/javascript/stylesheets/_global.scss
+++ b/app/javascript/stylesheets/_global.scss
@@ -302,3 +302,9 @@ meter {
     @include value;
   }
 }
+
+// Unset max-width for Rack::MiniProfiler results to (expectedly) expand beyond
+// the narrow parent container.
+.profiler-results * {
+  max-width: unset;
+}

--- a/config/initializers/rack_profiler.rb
+++ b/config/initializers/rack_profiler.rb
@@ -1,8 +1,51 @@
 # frozen_string_literal: true
 
-if ENV["RACK_MINI_PROFILER_ENABLED"] == "1"
-  require "rack-mini-profiler"
+require "rack-mini-profiler"
 
-  # initialization is skipped so trigger it
-  Rack::MiniProfilerRails.initialize!(Rails.application)
+Rack::MiniProfilerRails.initialize!(Rails.application)
+
+Rack::MiniProfiler.config.authorization_mode = :allow_authorized
+
+Rack::MiniProfiler.config.skip_paths = [
+  /#{ASSET_DOMAIN}/o,
+]
+
+Rack::MiniProfiler.config.start_hidden = true
+
+Rack::MiniProfiler.config.storage_instance = Rack::MiniProfiler::RedisStore.new(
+  connection: $redis,
+  expires_in: 1.hour.in_seconds,
+)
+
+Rack::MiniProfiler.config.user_provider = ->(env) do
+  request = ActionDispatch::Request.new(env)
+  id = request.cookies["_gumroad_guid"] || request.remote_ip || "unknown"
+
+  Digest::SHA256.hexdigest(id.to_s)
 end
+
+# Rack::Headers makes accessing the headers case-insensitive, so
+# headers["Content-Type"] is the same as headers["content-type"]. MiniProfiler
+# specifically looks for "Content-Type" and would skip injecting the profiler
+# if the header is actually "content-type".
+class EnsureHeadersIsRackHeadersObject
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    status, headers, body = @app.call(env)
+    response = Rack::Response[status, headers, body]
+
+    # Debug why the original headers object is sometimes a Hash and sometimes a
+    # Rack::Headers object.
+    response.add_header("X-Original-Headers-Class", headers.class.name)
+
+    response.finish
+  end
+end
+
+Rails.application.config.middleware.insert_after(
+  Rack::MiniProfiler,
+  EnsureHeadersIsRackHeadersObject
+)


### PR DESCRIPTION
Having `Rack::MiniProfiler` in production makes identifying and addressing performance-related issues much much easier.
 
Most of our routes are rendered by Rails with some going through `react-router`. This minimal setup should work for all of the Rails-rendered ones and we can address the `react-router` ones later when needed.

