### PR TITLE
Basic models for ProductReviewVideo & VideoFile

### DIFF
--- a/app/models/product_review.rb
+++ b/app/models/product_review.rb
@@ -11,6 +11,7 @@ class ProductReview < ApplicationRecord
   belongs_to :link, optional: true
   belongs_to :purchase, optional: true
   has_one :response, class_name: "ProductReviewResponse"
+  has_many :videos, dependent: :destroy, class_name: "ProductReviewVideo"
 
   validates_presence_of :purchase
   validates_presence_of :link

--- a/app/models/product_review_video.rb
+++ b/app/models/product_review_video.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class ProductReviewVideo < ApplicationRecord
+  include Deletable
+
+  belongs_to :product_review
+
+  has_one :video_file, as: :record, dependent: :destroy
+  validates :video_file, presence: true
+
+  enum :approval_status,
+       %w[pending_review approved rejected].index_by(&:itself),
+       default: :pending_review
+end

--- a/app/models/video_file.rb
+++ b/app/models/video_file.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class VideoFile < ApplicationRecord
+  include WithFileProperties
+  include Deletable
+  include S3Retrievable
+  include CdnDeletable, CdnUrlHelper
+  include FlagShihTzu
+
+  has_s3_fields :url
+
+  belongs_to :record, polymorphic: true
+
+  has_flags 1 => :is_transcoded_for_hls,
+            2 => :analyze_completed,
+            :flag_query_mode => :bit_operator
+
+  validates :url, presence: true
+  validate :url_is_s3
+
+  after_create_commit :schedule_file_analysis
+
+  private
+    def schedule_file_analysis
+      AnalyzeFileWorker.perform_async(id, self.class.name)
+    end
+
+    def url_is_s3
+      errors.add(:url, "must be an S3 URL") unless s3?
+    end
+end

--- a/spec/models/product_review_video_spec.rb
+++ b/spec/models/product_review_video_spec.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe ProductReviewVideo, type: :model do
+end

--- a/spec/models/video_file_spec.rb
+++ b/spec/models/video_file_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe VideoFile, type: :model do
+  it "schedules a job to analyze the file after creation" do
+    video_file = create(:video_file)
+
+    expect(AnalyzeFileWorker).to have_enqueued_sidekiq_job(video_file.id, VideoFile.name)
+  end
+
+  describe "#url" do
+    it "must startwith S3_BASE_URL" do
+      video_file = build(:video_file)
+
+      video_file.url = "#{S3_BASE_URL}/video.mp4"
+      video_file.validate
+      expect(video_file.errors[:url]).to be_empty
+
+      video_file.url = "https://example.com/video.mp4"
+      video_file.validate
+      expect(video_file.errors[:url]).to include("must be an S3 URL")
+    end
+  end
+end

--- a/spec/sidekiq/analyze_file_worker_spec.rb
+++ b/spec/sidekiq/analyze_file_worker_spec.rb
@@ -11,5 +11,11 @@ describe AnalyzeFileWorker do
       expect_any_instance_of(ProductFile).to receive(:analyze)
       AnalyzeFileWorker.new.perform(product_file.id)
     end
+
+    it "calls analyze for video files" do
+      video_file = create(:video_file)
+      expect_any_instance_of(VideoFile).to receive(:analyze)
+      AnalyzeFileWorker.new.perform(video_file.id, VideoFile.name)
+    end
   end
 end

--- a/spec/support/factories/product_review_videos.rb
+++ b/spec/support/factories/product_review_videos.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :product_review_video do
+    association :product_review
+
+    approval_status { :pending_review }
+
+    after(:build) do |video|
+      video.video_file ||= build(:video_file, record: video)
+    end
+  end
+end

--- a/spec/support/factories/video_files.rb
+++ b/spec/support/factories/video_files.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :video_file do
+    record { create(:user) }
+    url { "https://s3.amazonaws.com/gumroad-specs/specs/ScreenRecording.mov" }
+    filetype { "mov" }
+  end
+end


### PR DESCRIPTION
This PR adds the basic boilerplate models for `ProductReviewVideo` & `VideoFile`. 

This has not added transcoding capabilities to `VideoFile` yet.