### PR TITLE
fix: incorrect UI display of discount in installments on product page

### DIFF
--- a/app/javascript/components/Product/CtaButton.tsx
+++ b/app/javascript/components/Product/CtaButton.tsx
@@ -84,7 +84,7 @@ export const CtaButton = React.forwardRef<HTMLAnchorElement, Props>(
     const [referrer, setReferrer] = React.useState("");
     useRunOnce(() => setReferrer(document.referrer));
 
-    const { selectedOption, pppDiscounted } = applySelection(
+    const { selectedOption, pppDiscounted, discountedPriceCents } = applySelection(
       product,
       discountCode?.valid ? discountCode.discount : null,
       selection,
@@ -165,7 +165,7 @@ export const CtaButton = React.forwardRef<HTMLAnchorElement, Props>(
             {showInstallmentPlanNotes ? (
               <small className="text-center">
                 {formatInstallmentPaymentSchedule(
-                  price,
+                  discountedPriceCents,
                   product.currency_code,
                   product.installment_plan.number_of_installments,
                 )}

--- a/spec/requests/purchases/product/installment_plan_spec.rb
+++ b/spec/requests/purchases/product/installment_plan_spec.rb
@@ -9,6 +9,7 @@ describe "Product with installment plan", type: :feature, js: true do
 
   it "allows paying in installments" do
     visit product.long_url
+    expect(page).to have_text("First installment of US$3.34, followed by 2 monthly installments of US$3.33", normalize_ws: true)
 
     click_on "Pay in 3 installments"
 
@@ -168,6 +169,7 @@ describe "Product with installment plan", type: :feature, js: true do
 
     it "applies the discount to all charges even if it's only for one memebership cycle" do
       visit product.long_url + "/" + offer_code_valid_for_one_billing_cycle.code
+      expect(page).to have_text("First installment of US$3.34, followed by 2 monthly installments of US$3.33", normalize_ws: true)
 
       click_on "Pay in 3 installments"
 

--- a/spec/requests/purchases/product/installment_plan_spec.rb
+++ b/spec/requests/purchases/product/installment_plan_spec.rb
@@ -9,7 +9,7 @@ describe "Product with installment plan", type: :feature, js: true do
 
   it "allows paying in installments" do
     visit product.long_url
-    expect(page).to have_text("First installment of US$3.34, followed by 2 monthly installments of US$3.33", normalize_ws: true)
+    expect(page).to have_text("First installment of $3.34, followed by 2 monthly installments of $3.33", normalize_ws: true)
 
     click_on "Pay in 3 installments"
 
@@ -169,7 +169,7 @@ describe "Product with installment plan", type: :feature, js: true do
 
     it "applies the discount to all charges even if it's only for one memebership cycle" do
       visit product.long_url + "/" + offer_code_valid_for_one_billing_cycle.code
-      expect(page).to have_text("First installment of US$3.34, followed by 2 monthly installments of US$3.33", normalize_ws: true)
+      expect(page).to have_text("First installment of $3.34, followed by 2 monthly installments of $3.33", normalize_ws: true)
 
       click_on "Pay in 3 installments"
 


### PR DESCRIPTION
Closes https://github.com/antiwork/gumroad/issues/3

This PR fixes an issue where product discounts weren't being properly shown in the UI in case of multiple installment payments in the `pre-checkout page`.

Now, the installment payment schedule correctly shows the discounted price divided into installments, giving customers accurate information about what they'll pay.

## Changes
- Use the already calculated `discountedPriceCents` value when showing installment payment schedules

## Testing
Verified installment payment calculations display correctly with:
- Regular discount codes for both types in percentage and cents
- Product variants with price differences

Tested locally as attached in the screenshot below for the cases as mentioned:

1. Discount is in percentage
![image](https://github.com/user-attachments/assets/00d2718b-2167-4080-a7a2-b93629b0531d)

2. Discount is in cents
![image](https://github.com/user-attachments/assets/70778ddd-30cb-4b56-97b6-20250234aff7)

3. Product variants with price differences

Testing video: 

Before and after the changes are highlighted here -

https://github.com/user-attachments/assets/2e1e62d1-fe2a-4854-b92d-51b6d9f7df5c
