### PR TITLE
Index `followers` to better support our query patterns

### DIFF
--- a/db/migrate/20250406055017_add_index_to_followers_table.rb
+++ b/db/migrate/20250406055017_add_index_to_followers_table.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddIndexToFollowersTable < ActiveRecord::Migration[7.1]
+  def change
+    change_table :followers, bulk: true do |t|
+      t.index [:followed_id, :confirmed_at]
+      t.remove_index [:followed_id, :follower_user_id]
+      t.remove_index [:follower_user_id, :followed_id]
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_04_02_175205) do
+ActiveRecord::Schema[7.1].define(version: 2025_04_06_055017) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -875,9 +875,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_02_175205) do
     t.datetime "confirmed_at", precision: nil
     t.datetime "deleted_at", precision: nil
     t.index ["email", "followed_id"], name: "index_followers_on_email_and_followed_id", unique: true
-    t.index ["followed_id", "email"], name: "index_follows_on_followed_id_and_email"
-    t.index ["followed_id", "follower_user_id"], name: "index_followers_on_followed_id_and_follower_user_id"
-    t.index ["follower_user_id", "followed_id"], name: "index_followers_on_follower_user_id_and_followed_id"
+    t.index ["followed_id", "confirmed_at"], name: "index_followers_on_followed_id_and_confirmed_at"
+    t.index ["followed_id", "email"], name: "index_followers_on_followed_id_and_email"
   end
 
   create_table "friendly_id_slugs", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
We frequently query followers filtered by followed_id and ordered by
confirmed_at. (e.g. on the /followers page)

This could take 80+ seconds for sellers with a large amount of
following.

I am hoping that this composite index on (followed_id, confirmed_at) can
help more efficiently perform range scans without a filesort, improving
query performances.

I left these out of the composite index:

- `deleted_at`: vast majority of the records should have `deleted_at is
  NULL`
- `id`: I think this is only going to help if we switch to cursor-based
  pagination (unlikely to be prioritized)

I had tested this with a local table of 1M records. Will further
bench this once it's rolled out and make adjustments if needed.