### PR TITLE
Fix for input field when creating a new product

### DIFF
--- a/app/javascript/components/server-components/NewProductPage.tsx
+++ b/app/javascript/components/server-components/NewProductPage.tsx
@@ -193,12 +193,40 @@ const NewProductPage = ({
                   placeholder="Price your product"
                   value={price}
                   onChange={(e) => {
-                    setPrice(e.target.value);
+                    const inputValue = e.target.value;
+                    if (currencyCode === "jpy") {
+                      const numericOnly = inputValue.replace(/[^0-9]/gu, "");
+                      setPrice(numericOnly);
+                      errors.delete("price");
+                      return;
+                    }
+                    const hasPeriod = inputValue.includes(".");
+                    if (hasPeriod) {
+                      const parts = inputValue.split(".");
+                      const wholePart = parts[0].replace(/[^0-9,]/gu, "");
+                      const decimalPart = parts
+                        .slice(1)
+                        .join("")
+                        .replace(/[^0-9]/gu, "");
+                      setPrice(`${wholePart}.${decimalPart}`);
+                    } else {
+                      const filteredValue = inputValue.replace(/[^0-9,]/gu, "");
+                      setPrice(filteredValue);
+                    }
                     errors.delete("price");
+                  }}
+                  onKeyDown={(e) => {
+                    if (!/[0-9.,]|Backspace|Delete|ArrowLeft|ArrowRight|Tab|Home|End/u.test(e.key)) {
+                      e.preventDefault();
+                    }
+                    if (currencyCode === "jpy" && /[.,]/u.test(e.key)) {
+                      e.preventDefault();
+                    }
                   }}
                   autoComplete="off"
                   aria-invalid={errors.has("price")}
                 />
+
 
                 {isRecurringBilling ? (
                   <label className="pill select" style={{ border: "unset" }}>


### PR DESCRIPTION
# UI Update: Update text field of price when creating a new product.

## Old Version
The old version of the text field supports inputting text in the text field, which is not correct.

## Updated Version:
The newer version of the text field would allow the user to only input numbers, decimals and comma seperaors hyphen. We also handle the edge cases for JPY, and also not having , after a . is presented. 

## Changes
| Old Version | New Version |
|-------------|-------------|
| <img width="214" alt="Screenshot 2025-04-07 at 5 12 08 AM" src="https://github.com/user-attachments/assets/bba4c27d-6773-4c4b-a6cb-64dfef058e80" /> | <img width="214" alt="Screenshot 2025-04-07 at 5 11 31 AM" src="https://github.com/user-attachments/assets/49f51496-6bbc-4878-a230-557040fa9beb" />|




## Supported Numbers
- 1,222.11
- 12000
- 1,00,000
- 100,000.22

**Important Note:** I found this issue and raised a quick PR when working on this [issue](https://github.com/antiwork/gumroad/issues/11), I am currently in the middle of closing the github issue, but there are a few problems
. after clicking "Next: Customise" button, Even adding my own AWS credentials didn't solve the issue. 
. Please add the AI icon to assets or provide figma access to srineesh.salur@gmail.com

If anyone from the gumroad team could solve these issues or add a set of instructions in Readme, it would be very helpful. Feel free to reach out to me at srineesh.salur@gmail.com

<img width="825" alt="Screenshot 2025-04-07 at 5 20 24 AM" src="https://github.com/user-attachments/assets/2b353be3-c665-482c-b18d-79f430a1731d" />