### PR TITLE
Community: Minor fixes re: user experience

### DIFF
--- a/app/controllers/api/internal/communities/chat_messages_controller.rb
+++ b/app/controllers/api/internal/communities/chat_messages_controller.rb
@@ -60,14 +60,12 @@ class Api::Internal::Communities::ChatMessagesController < Api::Internal::BaseCo
     end
 
     def broadcast_message(message_props, type)
-      begin
-        CommunityChannel.broadcast_to(
-          "community_#{@community.external_id}",
-          { type:, message: message_props },
-        )
-      rescue => e
-        Rails.logger.error("Error broadcasting message to community channel: #{e.message}")
-        Bugsnag.notify(e)
-      end
+      CommunityChannel.broadcast_to(
+        "community_#{@community.external_id}",
+        { type:, message: message_props },
+      )
+    rescue => e
+      Rails.logger.error("Error broadcasting message to community channel: #{e.message}")
+      Bugsnag.notify(e)
     end
 end

--- a/app/controllers/api/internal/communities/chat_messages_controller.rb
+++ b/app/controllers/api/internal/communities/chat_messages_controller.rb
@@ -16,10 +16,7 @@ class Api::Internal::Communities::ChatMessagesController < Api::Internal::BaseCo
 
     if message.save
       message_props = CommunityChatMessagePresenter.new(message:).props
-      CommunityChannel.broadcast_to(
-        "community_#{@community.external_id}",
-        { type: CommunityChannel::CREATE_CHAT_MESSAGE_TYPE, message: message_props },
-      )
+      broadcast_message(message_props, CommunityChannel::CREATE_CHAT_MESSAGE_TYPE)
       render json: { message: message_props }
     else
       render json: { error: message.errors.full_messages.first }, status: :unprocessable_entity
@@ -29,10 +26,7 @@ class Api::Internal::Communities::ChatMessagesController < Api::Internal::BaseCo
   def update
     if @message.update(permitted_params)
       message_props = CommunityChatMessagePresenter.new(message: @message).props
-      CommunityChannel.broadcast_to(
-        "community_#{@community.external_id}",
-        { type: CommunityChannel::UPDATE_CHAT_MESSAGE_TYPE, message: message_props },
-      )
+      broadcast_message(message_props, CommunityChannel::UPDATE_CHAT_MESSAGE_TYPE)
       render json: { message: message_props }
     else
       render json: { error: @message.errors.full_messages.first }, status: :unprocessable_entity
@@ -42,10 +36,7 @@ class Api::Internal::Communities::ChatMessagesController < Api::Internal::BaseCo
   def destroy
     @message.mark_deleted!
     message_props = CommunityChatMessagePresenter.new(message: @message).props
-    CommunityChannel.broadcast_to(
-      "community_#{@community.external_id}",
-      { type: CommunityChannel::DELETE_CHAT_MESSAGE_TYPE, message: message_props },
-    )
+    broadcast_message(message_props, CommunityChannel::DELETE_CHAT_MESSAGE_TYPE)
     head :ok
   end
 
@@ -66,5 +57,17 @@ class Api::Internal::Communities::ChatMessagesController < Api::Internal::BaseCo
 
     def permitted_params
       params.require(:community_chat_message).permit(:content)
+    end
+
+    def broadcast_message(message_props, type)
+      begin
+        CommunityChannel.broadcast_to(
+          "community_#{@community.external_id}",
+          { type:, message: message_props },
+        )
+      rescue => e
+        Rails.logger.error("Error broadcasting message to community channel: #{e.message}")
+        Bugsnag.notify(e)
+      end
     end
 end

--- a/app/javascript/components/server-components/CommunitiesPage/CommunityView.tsx
+++ b/app/javascript/components/server-components/CommunitiesPage/CommunityView.tsx
@@ -116,6 +116,7 @@ export const CommunityView = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const {
+    hasProducts,
     communities,
     notificationSettings,
     selectedCommunity,
@@ -590,7 +591,7 @@ export const CommunityView = () => {
         <GoBackHeader />
 
         {communities.length === 0 ? (
-          <EmptyCommunitiesPlaceholder />
+          <EmptyCommunitiesPlaceholder hasProducts={hasProducts} />
         ) : selectedCommunity ? (
           <div className="flex flex-1 overflow-hidden">
             <div
@@ -861,7 +862,7 @@ const GoBackHeader = () => {
   );
 };
 
-const EmptyCommunitiesPlaceholder = () => (
+const EmptyCommunitiesPlaceholder = ({ hasProducts }: { hasProducts: boolean }) => (
   <main>
     <section>
       <div className="placeholder">
@@ -873,11 +874,11 @@ const EmptyCommunitiesPlaceholder = () => (
           When you publish a product, we automatically create a dedicated community chat—your own space to connect with
           customers, answer questions, and build relationships.
         </p>
-        <NavigationButton href={Routes.new_product_path()} color="accent">
-          Create your first product
+        <NavigationButton href={hasProducts ? Routes.products_path() : Routes.new_product_path()} color="accent">
+          {hasProducts ? "Enable community chat for your product" : "Create a product with community"}
         </NavigationButton>
         <p>
-          or <a data-helper-prompt="How do I create a community chat?">learn more about community chats</a>
+          or <a data-helper-prompt="How do I enable community chat for my product?">learn more about community chats</a>
         </p>
       </div>
     </section>

--- a/app/javascript/components/server-components/CommunitiesPage/CommunityView.tsx
+++ b/app/javascript/components/server-components/CommunitiesPage/CommunityView.tsx
@@ -875,7 +875,7 @@ const EmptyCommunitiesPlaceholder = ({ hasProducts }: { hasProducts: boolean }) 
           customers, answer questions, and build relationships.
         </p>
         <NavigationButton href={hasProducts ? Routes.products_path() : Routes.new_product_path()} color="accent">
-          {hasProducts ? "Enable community chat for your product" : "Create a product with community"}
+          {hasProducts ? "Enable community chat for your products" : "Create a product with community"}
         </NavigationButton>
         <p>
           or <a data-helper-prompt="How do I enable community chat for my product?">learn more about community chats</a>

--- a/app/javascript/components/server-components/CommunitiesPage/useCommunities.ts
+++ b/app/javascript/components/server-components/CommunitiesPage/useCommunities.ts
@@ -25,6 +25,7 @@ const sortByName = <T extends { name: string }>(items: readonly T[]) =>
 
 export const useCommunities = () => {
   const data = cast<{
+    has_products: boolean;
     communities: Community[];
     notification_settings: CommunityNotificationSettings;
     selectedCommunityId?: string;
@@ -135,6 +136,7 @@ export const useCommunities = () => {
   );
 
   return {
+    hasProducts: data.has_products,
     communities,
     notificationSettings,
     selectedCommunity,

--- a/app/javascript/data/communities.ts
+++ b/app/javascript/data/communities.ts
@@ -46,6 +46,7 @@ export async function getCommunities({ abortSignal }: { abortSignal: AbortSignal
   });
   if (!response.ok) throw new ResponseError();
   return cast<{
+    has_products: boolean;
     communities: Community[];
     notification_settings: CommunityNotificationSettings;
   }>(await response.json());

--- a/app/presenters/communities_presenter.rb
+++ b/app/presenters/communities_presenter.rb
@@ -54,6 +54,7 @@ class CommunitiesPresenter
     end
 
     {
+      has_products: current_user.products.visible_and_not_archived.exists?,
       communities: communities_props,
       notification_settings: notification_settings.each_with_object({}) do |(seller_id, settings), hash|
         seller_external_id = seller_id_to_external_id_map[seller_id]

--- a/spec/presenters/communities_presenter_spec.rb
+++ b/spec/presenters/communities_presenter_spec.rb
@@ -16,8 +16,9 @@ RSpec.describe CommunitiesPresenter do
     context "when user has no accessible communities" do
       it "returns appropriate props" do
         expect(props).to eq(
+          has_products: false,
           communities: [],
-          notification_settings: {}
+          notification_settings: {},
         )
       end
     end
@@ -34,6 +35,7 @@ RSpec.describe CommunitiesPresenter do
 
       it "returns appropriate props" do
         expect(props).to eq(
+          has_products: false,
           communities: [
             CommunityPresenter.new(community:, current_user:).props
           ],

--- a/spec/requests/communities_spec.rb
+++ b/spec/requests/communities_spec.rb
@@ -27,8 +27,8 @@ describe "Communities", :js, type: :feature do
 
     expect(page).to have_text("Build your community, one product at a time!")
     expect(page).to have_text("When you publish a product, we automatically create a dedicated community chat—your own space to connect with customers, answer questions, and build relationships.")
-    expect(page).to have_link("Create your first product", href: new_product_path)
-    expect(find("a", text: "learn more about community chats")["data-helper-prompt"]).to eq("How do I create a community chat?")
+    expect(page).to have_link("Enable community chat for your products", href: products_path)
+    expect(find("a", text: "learn more about community chats")["data-helper-prompt"]).to eq("How do I enable community chat for my product?")
     expect(page).to have_button("Go back")
   end
 


### PR DESCRIPTION
Addresses some minor fixes re: community feature:

1. Responds with a success instead of raising an exception for chat message operations despite encountering an error while broadcasting it back to the community channel
2. When seller has no communities but has products, shows a link to the products page instead of the new product page in the empty communities placeholder