### PR TITLE
Throttle community chat message requests

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -249,11 +249,11 @@ class Rack::Attack
                  period: 60.seconds
 
   # Throttle community chat messages
-  # Initial: 20rpm, Max: 100 requests/9 hours (per community, per IP)
-  throttle_by_ip path: /\A\/internal\/communities\/.*\/chat_messages\z/,
-                 method: :post,
-                 requests: 20,
-                 period: 60.seconds
+  # 60 requests per 60 seconds (per community, per IP)
+  throttle_by_ip_for_period path: /\A\/internal\/communities\/.*\/chat_messages\z/,
+                           method: :post,
+                           requests: 60,
+                           period: 60.seconds
 
   # Do not throttle for health check requests
   safelist("allow from localhost", &:localhost?)

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -251,9 +251,9 @@ class Rack::Attack
   # Throttle community chat messages
   # 60 requests per 60 seconds (per community, per IP)
   throttle_by_ip_for_period path: /\A\/internal\/communities\/.*\/chat_messages\z/,
-                           method: :post,
-                           requests: 60,
-                           period: 60.seconds
+                            method: :post,
+                            requests: 60,
+                            period: 60.seconds
 
   # Do not throttle for health check requests
   safelist("allow from localhost", &:localhost?)

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -248,6 +248,13 @@ class Rack::Attack
                  requests: 2,
                  period: 60.seconds
 
+  # Throttle community chat messages
+  # Initial: 20rpm, Max: 100 requests/9 hours (per community, per IP)
+  throttle_by_ip path: /\A\/internal\/communities\/.*\/chat_messages\z/,
+                 method: :post,
+                 requests: 20,
+                 period: 60.seconds
+
   # Do not throttle for health check requests
   safelist("allow from localhost", &:localhost?)
 end


### PR DESCRIPTION
Allows sending maximum 60 community chat messages per minute.