### PR TITLE
Show Community link on the community-enabled product's download page for unregistered buyers

### DIFF
--- a/app/presenters/url_redirect_presenter.rb
+++ b/app/presenters/url_redirect_presenter.rb
@@ -136,7 +136,7 @@ class UrlRedirectPresenter
         discord: purchase.present? && DiscordIntegration.is_enabled_for(purchase) ? {
           connected: DiscordIntegration.discord_user_id_for(purchase).present?
         } : nil,
-        community_chat_url: purchase.present? && purchase.purchaser_id.present? && Feature.active?(:communities, purchase.seller) && product.community_chat_enabled? && product.active_community.present? ? community_path(purchase.seller.external_id, product.active_community.external_id) : nil,
+        community_chat_url:,
         ios_app_url: IOS_APP_STORE_URL,
         android_app_url: ANDROID_APP_STORE_URL,
         download_all_button: product_files.any? && url_redirect.with_product_files&.is_a?(Installment) && url_redirect.with_product_files&.is_downloadable? && url_redirect.entity_archive ? {
@@ -279,5 +279,15 @@ class UrlRedirectPresenter
         processing: false,
         thumbnail_url: nil,
       }
+    end
+
+    def community_chat_url
+      return unless purchase.present? && Feature.active?(:communities, purchase.seller) && product.community_chat_enabled? && product.active_community.present?
+
+      path = community_path(purchase.seller.external_id, product.active_community.external_id)
+
+      return signup_path(email: purchase.email, next: path) if purchase.purchaser_id.blank?
+
+      logged_in_user.present? ? path : login_path(email: purchase.email, next: path)
     end
 end

--- a/spec/presenters/url_redirect_presenter_spec.rb
+++ b/spec/presenters/url_redirect_presenter_spec.rb
@@ -522,6 +522,28 @@ describe UrlRedirectPresenter do
             community = create(:community, seller: product.user, resource: product)
             expect(presenter.download_page_with_content_props[:content][:community_chat_url]).to eq(community_path(product.user.external_id, community.external_id))
           end
+
+          context "when user is not logged in" do
+            let(:presenter) { described_class.new(url_redirect:, logged_in_user: nil) }
+
+            it "returns login path with next parameter when user is not logged in" do
+              community = create(:community, seller: product.user, resource: product)
+              expected_path = login_path(email: purchase.email, next: community_path(product.user.external_id, community.external_id))
+              expect(presenter.download_page_with_content_props[:content][:community_chat_url]).to eq(expected_path)
+            end
+          end
+
+          context "when purchase has no purchaser_id" do
+            before do
+              purchase.update!(purchaser_id: nil)
+            end
+
+            it "returns signup path with next parameter" do
+              community = create(:community, seller: product.user, resource: product)
+              expected_path = signup_path(email: purchase.email, next: community_path(product.user.external_id, community.external_id))
+              expect(presenter.download_page_with_content_props[:content][:community_chat_url]).to eq(expected_path)
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Part of https://github.com/antiwork/gumroad/issues/14.

### What

Shows the "Community" button on the download page for the unregistered buyers of a product for which community chat is enabled by the seller.

### Why

Uregistered users should be allowed to access the communities of the products they purchased after signing up. Currently the "Community" button is not shown to such users.