### PR TITLE
Set `max_refund_period_in_days` for product-level refund policy records

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,25 @@
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
-  "eslint.format.enable": true
+  "eslint.format.enable": true,
+  "workbench.colorCustomizations": {
+    "activityBar.activeBackground": "#ffc3f3",
+    "activityBar.background": "#ffc3f3",
+    "activityBar.foreground": "#15202b",
+    "activityBar.inactiveForeground": "#15202b99",
+    "activityBarBadge.background": "#7f9f00",
+    "activityBarBadge.foreground": "#15202b",
+    "commandCenter.border": "#15202b99",
+    "sash.hoverBorder": "#ffc3f3",
+    "statusBar.background": "#ff90e8",
+    "statusBar.foreground": "#15202b",
+    "statusBarItem.hoverBackground": "#ff5ddd",
+    "statusBarItem.remoteBackground": "#ff90e8",
+    "statusBarItem.remoteForeground": "#15202b",
+    "titleBar.activeBackground": "#ff90e8",
+    "titleBar.activeForeground": "#15202b",
+    "titleBar.inactiveBackground": "#ff90e899",
+    "titleBar.inactiveForeground": "#15202b99"
+  },
+  "peacock.color": "#rgb(255 144 232)"
 }

--- a/app/models/product_refund_policy.rb
+++ b/app/models/product_refund_policy.rb
@@ -35,7 +35,7 @@ class ProductRefundPolicy < RefundPolicy
   end
 
   def determine_max_refund_period_in_days
-    return RefundPolicy::ALLOWED_REFUND_PERIODS_IN_DAYS[0] if title.match?(/no refunds|final|no returns/i)
+    return 0 if title.match?(/no refunds|final|no returns/i)
 
     begin
       response = ask_ai(max_refund_period_in_days_prompt)

--- a/app/models/product_refund_policy.rb
+++ b/app/models/product_refund_policy.rb
@@ -34,6 +34,60 @@ class ProductRefundPolicy < RefundPolicy
     false
   end
 
+  def determine_max_refund_period_in_days
+    return RefundPolicy::ALLOWED_REFUND_PERIODS_IN_DAYS[0] if title.match?(/no refunds|final|no returns/i)
+
+    begin
+      response = ask_ai(max_refund_period_in_days_prompt)
+      days = Integer(response.dig("choices", 0, "message", "content")) rescue response.dig("choices", 0, "message", "content")
+
+      # Return only values from ALLOWED_REFUND_PERIODS_IN_DAYS or default to 30
+      if RefundPolicy::ALLOWED_REFUND_PERIODS_IN_DAYS.key?(days)
+        days
+      else
+        Rails.logger.debug("Unknown refund period for policy #{id}: #{days}")
+        RefundPolicy::DEFAULT_REFUND_PERIOD_IN_DAYS
+      end
+    rescue => e
+      Rails.logger.debug("Error determining max refund period for policy #{id}: #{e.message}")
+      RefundPolicy::DEFAULT_REFUND_PERIOD_IN_DAYS
+    end
+  end
+
+  def max_refund_period_in_days_prompt
+    prompt = <<~PROMPT
+      You are an expert content reviewer that responds in numbers only.
+      Your role is to determine the maximum number of days allowed for a refund policy based on the refund policy title.
+      If the refund policy or fine print has words like "no refunds", "refunds not allowed", "no returns", "returns not allowed", "final" etc.), it's a no-refunds policy
+
+      The allowed number of days are 0 (no refunds allowed), 7, 14, 30, or 183 (6 months). Use the number that most closely matches, but not above the maximum allowed.
+
+      Example 1: If the title is "30-day money back guarantee", return 30.
+      Example 2: If from the fine print it clearly states that there are no refunds, return 0.
+      Example 3: If from the analysis is is determined that is a a 3-day refund policy, return 3.
+      Example 4: If from the analysis is is determined that is a a 2-month refund policy, return 30.
+      Example 5: If from the analysis is is determined that is a a 1-year refund policy, return 183.
+
+      Return one of the allowed numbers only if you are 100% confident. If you are not 100% confident, return -1.
+
+      The response MUST be just a number. The only allowed numbers are: -1, 0, 7, 14, 30, 183.
+
+      Product name: #{product.name}
+      Product type: #{product.native_type}
+      Refund policy title: #{title}
+    PROMPT
+
+    if fine_print.present?
+      prompt += <<~FINE_PRINT
+        <refund policy fine print>
+          #{fine_print.truncate(300)}
+        </refund policy fine print>
+      FINE_PRINT
+    end
+
+    prompt
+  end
+
   private
     def no_refunds_prompt
       prompt = <<~PROMPT

--- a/app/models/product_refund_policy.rb
+++ b/app/models/product_refund_policy.rb
@@ -64,10 +64,9 @@ class ProductRefundPolicy < RefundPolicy
 
       Example 1: If the title is "30-day money back guarantee", return 30.
       Example 2: If from the fine print it clearly states that there are no refunds, return 0.
-      Example 3: If from the analysis is is determined that is a a 3-day refund policy, return 3.
-      Example 4: If from the analysis is is determined that is a a 2-month refund policy, return 30.
-      Example 5: If from the analysis is is determined that is a a 1-year refund policy, return 183.
-
+      Example 3: If the analysis determines that it is a 3-day refund policy, return 3.
+      Example 4: If the analysis determines that it is a 2-month refund policy, return 30.
+      Example 5: If the analysis determines that it is a 1-year refund policy, return 183.
       Return one of the allowed numbers only if you are 100% confident. If you are not 100% confident, return -1.
 
       The response MUST be just a number. The only allowed numbers are: -1, 0, 7, 14, 30, 183.

--- a/app/models/refund_policy.rb
+++ b/app/models/refund_policy.rb
@@ -20,9 +20,8 @@ class RefundPolicy < ApplicationRecord
 
   validates_presence_of :seller
   validates :fine_print, length: { maximum: 3_000 }
-  attribute :max_refund_period_in_days, :integer, default: DEFAULT_REFUND_PERIOD_IN_DAYS
 
-  validates :max_refund_period_in_days, inclusion: { in: ALLOWED_REFUND_PERIODS_IN_DAYS }
+  validates :max_refund_period_in_days, inclusion: { in: ALLOWED_REFUND_PERIODS_IN_DAYS }, allow_nil: true
 
   def as_json(*)
     {

--- a/app/models/refund_policy.rb
+++ b/app/models/refund_policy.rb
@@ -14,6 +14,8 @@ class RefundPolicy < ApplicationRecord
   }.freeze
   DEFAULT_REFUND_PERIOD_IN_DAYS = 30
 
+  attribute :max_refund_period_in_days, :integer, default: RefundPolicy::DEFAULT_REFUND_PERIOD_IN_DAYS
+
   belongs_to :seller, class_name: "User"
 
   stripped_fields :title, :fine_print, transform: -> { ActionController::Base.helpers.strip_tags(_1) }

--- a/app/models/refund_policy.rb
+++ b/app/models/refund_policy.rb
@@ -5,12 +5,24 @@ class RefundPolicy < ApplicationRecord
 
   has_paper_trail
 
+  ALLOWED_REFUND_PERIODS_IN_DAYS = {
+    0 => "No refunds allowed",
+    7 => "7-day money back guarantee",
+    14 => "14-day money back guarantee",
+    30 => "30-day money back guarantee",
+    183 => "6-month money back guarantee",
+  }.freeze
+  DEFAULT_REFUND_PERIOD_IN_DAYS = 30
+
   belongs_to :seller, class_name: "User"
 
   stripped_fields :title, :fine_print, transform: -> { ActionController::Base.helpers.strip_tags(_1) }
 
   validates_presence_of :seller
   validates :fine_print, length: { maximum: 3_000 }
+  attribute :max_refund_period_in_days, :integer, default: DEFAULT_REFUND_PERIOD_IN_DAYS
+
+  validates :max_refund_period_in_days, inclusion: { in: ALLOWED_REFUND_PERIODS_IN_DAYS }
 
   def as_json(*)
     {

--- a/app/models/seller_refund_policy.rb
+++ b/app/models/seller_refund_policy.rb
@@ -2,6 +2,9 @@
 
 class SellerRefundPolicy < RefundPolicy
   validates :seller, presence: true, uniqueness: { conditions: -> { where(product_id: nil) } }
+  validates :max_refund_period_in_days, presence: true
+
+  attribute :max_refund_period_in_days, :integer, default: RefundPolicy::DEFAULT_REFUND_PERIOD_IN_DAYS
 
   def title
     RefundPolicy::ALLOWED_REFUND_PERIODS_IN_DAYS[max_refund_period_in_days]

--- a/app/models/seller_refund_policy.rb
+++ b/app/models/seller_refund_policy.rb
@@ -1,21 +1,9 @@
 # frozen_string_literal: true
 
 class SellerRefundPolicy < RefundPolicy
-  ALLOWED_REFUND_PERIODS_IN_DAYS = {
-    0 => "No refunds allowed",
-    7 => "7-day money back guarantee",
-    14 => "14-day money back guarantee",
-    30 => "30-day money back guarantee",
-    183 => "6-month money back guarantee",
-  }.freeze
-  DEFAULT_REFUND_PERIOD_IN_DAYS = 30
-
-  attribute :max_refund_period_in_days, :integer, default: DEFAULT_REFUND_PERIOD_IN_DAYS
-
-  validates :max_refund_period_in_days, inclusion: { in: ALLOWED_REFUND_PERIODS_IN_DAYS }
   validates :seller, presence: true, uniqueness: { conditions: -> { where(product_id: nil) } }
 
   def title
-    ALLOWED_REFUND_PERIODS_IN_DAYS[max_refund_period_in_days]
+    RefundPolicy::ALLOWED_REFUND_PERIODS_IN_DAYS[max_refund_period_in_days]
   end
 end

--- a/app/presenters/settings_presenter.rb
+++ b/app/presenters/settings_presenter.rb
@@ -230,10 +230,10 @@ class SettingsPresenter
   def seller_refund_policy
     {
       enabled: seller.account_level_refund_policy_enabled?,
-      allowed_refund_periods_in_days: SellerRefundPolicy::ALLOWED_REFUND_PERIODS_IN_DAYS.keys.map do
+      allowed_refund_periods_in_days: RefundPolicy::ALLOWED_REFUND_PERIODS_IN_DAYS.keys.map do
         {
           key: _1,
-          value: SellerRefundPolicy::ALLOWED_REFUND_PERIODS_IN_DAYS[_1]
+          value: RefundPolicy::ALLOWED_REFUND_PERIODS_IN_DAYS[_1]
         }
       end,
       max_refund_period_in_days: seller.refund_policy.max_refund_period_in_days,

--- a/app/services/onetime/set_max_allowed_refund_period_for_product_refund_policies.rb
+++ b/app/services/onetime/set_max_allowed_refund_period_for_product_refund_policies.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class Onetime::SetMaxAllowedRefundPeriodForProductRefundPolicies < Onetime::Base
+  LAST_PROCESSED_ID_KEY = :last_processed_id
+
+  def self.reset_last_processed_id
+    $redis.del(LAST_PROCESSED_ID_KEY)
+  end
+
+  def initialize(max_id: ProductRefundPolicy.last!.id)
+    @max_id = max_id
+  end
+
+  def process
+    invalid_policy_ids = []
+    eligible_product_refund_policies.find_in_batches do |batch|
+      ReplicaLagWatcher.watch
+      Rails.logger.info "Processing product refund policies #{batch.first.id} to #{batch.last.id}"
+
+      batch.each do |product_refund_policy|
+        next if product_refund_policy.max_refund_period_in_days.present?
+
+        max_refund_period_in_days = product_refund_policy.determine_max_refund_period_in_days
+
+        product_refund_policy.with_lock do
+          product_refund_policy.update!(max_refund_period_in_days:)
+          Rails.logger.info "ProductRefundPolicy: #{product_refund_policy.id}: updated with max allowed refund period of #{max_refund_period_in_days} days"
+        end
+      rescue => e
+        invalid_policy_ids << { product_refund_policy.id => e.message }
+      end
+
+      $redis.set(LAST_PROCESSED_ID_KEY, batch.last.id, ex: 1.month)
+    end
+
+    Rails.logger.info "Invalid product refund policy ids: #{invalid_policy_ids}" if invalid_policy_ids.any?
+  end
+
+  private
+    attr_reader :max_id
+
+    def eligible_product_refund_policies
+      first_product_refund_policy_id = [first_eligible_product_refund_policy_id, $redis.get(LAST_PROCESSED_ID_KEY).to_i + 1].max
+      ProductRefundPolicy.where.not(product_id: nil).where(id: first_product_refund_policy_id..max_id)
+    end
+
+    def first_eligible_product_refund_policy_id
+      ProductRefundPolicy.where.not(product_id: nil).first!.id
+    end
+end

--- a/app/services/onetime/set_max_allowed_refund_period_for_product_refund_policies.rb
+++ b/app/services/onetime/set_max_allowed_refund_period_for_product_refund_policies.rb
@@ -22,12 +22,14 @@ class Onetime::SetMaxAllowedRefundPeriodForProductRefundPolicies < Onetime::Base
 
         max_refund_period_in_days = product_refund_policy.determine_max_refund_period_in_days
 
-        product_refund_policy.with_lock do
-          product_refund_policy.update!(max_refund_period_in_days:)
-          Rails.logger.info "ProductRefundPolicy: #{product_refund_policy.id}: updated with max allowed refund period of #{max_refund_period_in_days} days"
+        begin
+          product_refund_policy.with_lock do
+            product_refund_policy.update!(max_refund_period_in_days:)
+            Rails.logger.info "ProductRefundPolicy: #{product_refund_policy.id}: updated with max allowed refund period of #{max_refund_period_in_days} days"
+          end
+        rescue => e
+          invalid_policy_ids << { product_refund_policy.id => e.message }
         end
-      rescue => e
-        invalid_policy_ids << { product_refund_policy.id => e.message }
       end
 
       $redis.set(LAST_PROCESSED_ID_KEY, batch.last.id, ex: 1.month)

--- a/spec/models/product_refund_policy_spec.rb
+++ b/spec/models/product_refund_policy_spec.rb
@@ -57,7 +57,7 @@ describe ProductRefundPolicy do
       it "is valid with allowed refund period values" do
         RefundPolicy::ALLOWED_REFUND_PERIODS_IN_DAYS.keys.each do |days|
           refund_policy.max_refund_period_in_days = days
-          expect(refund_policy.valid?).to be true, "Expected #{days} to be a valid refund period"
+          expect(refund_policy.valid?).to be true
         end
       end
 
@@ -69,7 +69,7 @@ describe ProductRefundPolicy do
       it "is invalid with a refund period not in the allowed list" do
         [1, 15, 60, 200].each do |days|
           refund_policy.max_refund_period_in_days = days
-          expect(refund_policy.valid?).to be false, "Expected #{days} to be an invalid refund period"
+          expect(refund_policy.valid?).to be false
           expect(refund_policy.errors.details[:max_refund_period_in_days].first[:error]).to eq :inclusion
         end
       end

--- a/spec/models/product_refund_policy_spec.rb
+++ b/spec/models/product_refund_policy_spec.rb
@@ -52,6 +52,28 @@ describe ProductRefundPolicy do
       expect(refund_policy.valid?).to be false
       expect(refund_policy.errors.details[:product].first[:error]).to eq :invalid
     end
+
+    context "max_refund_period_in_days validation" do
+      it "is valid with allowed refund period values" do
+        RefundPolicy::ALLOWED_REFUND_PERIODS_IN_DAYS.keys.each do |days|
+          refund_policy.max_refund_period_in_days = days
+          expect(refund_policy.valid?).to be true, "Expected #{days} to be a valid refund period"
+        end
+      end
+
+      it "is valid with nil value" do
+        refund_policy.max_refund_period_in_days = nil
+        expect(refund_policy.valid?).to be true
+      end
+
+      it "is invalid with a refund period not in the allowed list" do
+        [1, 15, 60, 200].each do |days|
+          refund_policy.max_refund_period_in_days = days
+          expect(refund_policy.valid?).to be false, "Expected #{days} to be an invalid refund period"
+          expect(refund_policy.errors.details[:max_refund_period_in_days].first[:error]).to eq :inclusion
+        end
+      end
+    end
   end
 
   describe "stripped_fields" do
@@ -145,6 +167,63 @@ describe ProductRefundPolicy do
       allow(refund_policy.product).to receive(:published?).and_return(true)
       allow(refund_policy).to receive(:no_refunds?).and_return(false)
       expect(refund_policy.published_and_no_refunds?).to be false
+    end
+  end
+
+  describe "#determine_max_refund_period_in_days" do
+    let(:refund_policy) { create(:product_refund_policy) }
+
+    it "returns 0 when title contains 'no refunds'" do
+      refund_policy.title = "No refunds allowed"
+      expect(refund_policy.determine_max_refund_period_in_days).to eq 0
+    end
+
+    it "returns 0 when title contains 'final'" do
+      refund_policy.title = "All sales final"
+      expect(refund_policy.determine_max_refund_period_in_days).to eq 0
+    end
+
+    it "returns 0 when title contains 'no returns'" do
+      refund_policy.title = "No returns accepted"
+      expect(refund_policy.determine_max_refund_period_in_days).to eq 0
+    end
+
+    it "asks AI when title doesn't contain obvious no-refunds keywords", :vcr do
+      refund_policy.title = "14-day money back guarantee"
+      allow_any_instance_of(OpenAI::Client).to receive(:chat).and_return(
+        {
+          "choices" => [
+            {
+              "message" => {
+                "content" => "14"
+              }
+            }
+          ]
+        }
+      )
+      expect(refund_policy.determine_max_refund_period_in_days).to eq 14
+    end
+
+    it "returns default period when AI returns unrecognized value", :vcr do
+      refund_policy.title = "Custom policy"
+      allow_any_instance_of(OpenAI::Client).to receive(:chat).and_return(
+        {
+          "choices" => [
+            {
+              "message" => {
+                "content" => "42"
+              }
+            }
+          ]
+        }
+      )
+      expect(refund_policy.determine_max_refund_period_in_days).to eq RefundPolicy::DEFAULT_REFUND_PERIOD_IN_DAYS
+    end
+
+    it "returns default period when AI call fails" do
+      refund_policy.title = "Custom policy"
+      expect_any_instance_of(OpenAI::Client).to receive(:chat).and_raise(StandardError)
+      expect(refund_policy.determine_max_refund_period_in_days).to eq RefundPolicy::DEFAULT_REFUND_PERIOD_IN_DAYS
     end
   end
 end

--- a/spec/services/onetime/set_max_allowed_refund_period_for_product_refund_policies_spec.rb
+++ b/spec/services/onetime/set_max_allowed_refund_period_for_product_refund_policies_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Onetime::SetMaxAllowedRefundPeriodForProductRefundPolicies do
+  let(:product_one) { create(:product) }
+  let(:product_two) { create(:product) }
+  let!(:policy_one) { create(:product_refund_policy, product: product_one, max_refund_period_in_days: nil) }
+  let!(:policy_two) { create(:product_refund_policy, product: product_two, max_refund_period_in_days: nil) }
+  let!(:policy_with_value) { create(:product_refund_policy, max_refund_period_in_days: 30) }
+
+  describe ".reset_last_processed_id" do
+    it "deletes the redis key" do
+      $redis.set(described_class::LAST_PROCESSED_ID_KEY, 123)
+      described_class.reset_last_processed_id
+      expect($redis.get(described_class::LAST_PROCESSED_ID_KEY)).to be_nil
+    end
+  end
+
+  describe "#process" do
+    subject(:process) { described_class.new(max_id: policy_two.id).process }
+
+    before do
+      allow(ReplicaLagWatcher).to receive(:watch)
+      allow_any_instance_of(ProductRefundPolicy).to receive(:determine_max_refund_period_in_days).and_return(14)
+    end
+
+    it "updates eligible policies with max_refund_period_in_days" do
+      expect do
+        process
+      end.to change { policy_one.reload.max_refund_period_in_days }.from(nil).to(14)
+        .and change { policy_two.reload.max_refund_period_in_days }.from(nil).to(14)
+    end
+
+    it "skips policies that already have max_refund_period_in_days set" do
+      expect do
+        process
+      end.to not_change { policy_with_value.reload.max_refund_period_in_days }
+    end
+
+    it "updates the last processed id in redis" do
+      process
+      expect($redis.get(described_class::LAST_PROCESSED_ID_KEY).to_i).to eq(policy_two.id)
+    end
+
+    context "when there's a last processed id in redis" do
+      before do
+        $redis.set(described_class::LAST_PROCESSED_ID_KEY, policy_one.id)
+      end
+
+      it "only processes records after the last processed id" do
+        expect do
+          process
+        end.to not_change { policy_one.reload.max_refund_period_in_days }
+          .and change { policy_two.reload.max_refund_period_in_days }.from(nil).to(14)
+      end
+    end
+
+    context "when an error occurs while processing a policy" do
+      before do
+        # Create a class-level stub for with_lock that raises an error only for policy_one
+        allow_any_instance_of(ProductRefundPolicy).to receive(:with_lock) do |policy, &block|
+          if policy.id == policy_one.id
+            raise StandardError.new("Test error")
+          else
+            block.call
+          end
+        end
+        puts "policy_one ID: #{policy_one.id}"
+        puts "policy_two ID: #{policy_two.id}"
+      end
+
+      it "continues processing other policies" do
+        expect do
+          process
+        end.to not_change { policy_one.reload.max_refund_period_in_days }
+          .and change { policy_two.reload.max_refund_period_in_days }.from(nil).to(14)
+      end
+
+      it "logs invalid policy ids" do
+        expect(Rails.logger).to receive(:info).with(/Processing product refund policies/).at_least(:once)
+        expect(Rails.logger).to receive(:info).with(/updated with max allowed refund period/).at_least(:once)
+        expect(Rails.logger).to receive(:info).with(/Invalid product refund policy ids: /).at_least(:once)
+
+        process
+      end
+    end
+  end
+end


### PR DESCRIPTION
Part of https://github.com/antiwork/gumroad/issues/74

New one-time script to populate `max_refund_period_in_days` for `ProductRefundPolicy` records.

### Post-deploy

Run the script in production

* [ ] `output = Onetime::SetMaxAllowedRefundPeriodForProductRefundPolicies.new.process_with_logging`