### PR TITLE
Make community chat feature opt-in by default

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -124,7 +124,6 @@ class LinksController < ApplicationController
 
     begin
       @product.save!
-      toggle_community_chat!(true)
     rescue ActiveRecord::RecordNotSaved, ActiveRecord::RecordInvalid, Link::LinkInvalid
       @error_message = if @product&.errors&.any?
         @product.errors.full_messages.first

--- a/app/javascript/components/ProductEdit/ProductTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/index.tsx
@@ -195,6 +195,10 @@ export const ProductTab = () => {
                       label="Invite your customers to your Gumroad community chat"
                       value={product.community_chat_enabled}
                       onChange={(newValue) => updateProduct({ community_chat_enabled: newValue })}
+                      help={{
+                        label: "Learn more",
+                        dataHelperPrompt: "What is a community chat?",
+                      }}
                     />
                   )}
                   <CircleIntegrationEditor

--- a/app/javascript/components/ProductEdit/ProductTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/index.tsx
@@ -197,7 +197,7 @@ export const ProductTab = () => {
                       onChange={(newValue) => updateProduct({ community_chat_enabled: newValue })}
                       help={{
                         label: "Learn more",
-                        dataHelperPrompt: "What is a community chat?",
+                        dataHelperPrompt: "What is Gumroad community chat?",
                       }}
                     />
                   )}

--- a/app/javascript/components/SettingRow.tsx
+++ b/app/javascript/components/SettingRow.tsx
@@ -7,7 +7,7 @@ import { WithTooltip } from "$app/components/WithTooltip";
 type ToggleProps = {
   label: string;
   value: boolean;
-  help?: { url: string; label: string | React.ReactNode; tooltip?: string };
+  help?: { url?: string; dataHelperPrompt?: string; label: string | React.ReactNode; tooltip?: string };
   onChange?: (newValue: boolean) => void;
   dropdown?: React.ReactNode;
   disabled?: boolean;
@@ -16,12 +16,26 @@ export const ToggleSettingRow = ({ label, value, help, onChange, dropdown, disab
   const toggle = (
     <Toggle value={value} onChange={onChange} disabled={Boolean(disabled)}>
       {label}
-      {help ? (
-        <WithTooltip tip={help.tooltip || null} position="top">
-          <a href={help.url} target="_blank" rel="noopener noreferrer" className="learn-more" style={{ flexShrink: 0 }}>
-            {help.label}
-          </a>
-        </WithTooltip>
+      {help?.url || help?.dataHelperPrompt ? (
+        <span className="ml-2">
+          <WithTooltip tip={help.tooltip || null} position="top">
+            {help.url ? (
+              <a
+                href={help.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="learn-more"
+                style={{ flexShrink: 0 }}
+              >
+                {help.label}
+              </a>
+            ) : (
+              <a data-helper-prompt={help.dataHelperPrompt} className="learn-more" style={{ flexShrink: 0 }}>
+                {help.label}
+              </a>
+            )}
+          </WithTooltip>
+        </span>
       ) : null}
     </Toggle>
   );

--- a/app/policies/community_policy.rb
+++ b/app/policies/community_policy.rb
@@ -2,7 +2,7 @@
 
 class CommunityPolicy < ApplicationPolicy
   def index?
-    user.accessible_communities_ids.any? || (Feature.active?(:communities, user) && !user.is_buyer?)
+    user.accessible_communities_ids.any?
   end
 
   def show?

--- a/public/help/article/347-gumroad-community.html
+++ b/public/help/article/347-gumroad-community.html
@@ -182,16 +182,11 @@
                             <li>Find the "Invite your customers to your Gumroad community chat" toggle in the product settings</li>
                             <li>Switch the toggle ON and save the changes</li>
                         </ol>
-                        <p>Once enabled, a new "Communities" link will appear in the main sidebar, and customers who purchase this product will gain access to its community.</p>
+                        <p>Once enabled, a new "Community" link will appear in the main sidebar, and customers who purchase this product will gain access to its community.</p>
 
                         <h2 id="managing-your-community">Managing your Community</h2>
                         <h3>Accessing your Communities</h3>
-                        <p>As a seller, you can access all your product communities from the main navigation:</p>
-                        <ol>
-                            <li>Click on "Communities" in the main sidebar</li>
-                            <li>If this is your first time, you'll see an empty state prompt to enable Community for a product</li>
-                            <li>Once enabled for at least one product, you'll see a list of your product communities</li>
-                        </ol>
+                        <p>As a seller, you can access all your product communities from the main navigation once you have enabled Community for at least one product. You'll see a list of your product communities by accessing the "Community" link in the main sidebar.</p>
 
                         <h3>Product-specific chat spaces</h3>
                         <p>Each product with Community enabled has its own dedicated chat space:</p>
@@ -252,25 +247,28 @@
                         <h2 id="community-best-practices">Community best practices</h2>
                         <p>To build an engaging and valuable community:</p>
                         <ul>
-                            <li><strong>Welcome new members</strong>: Create a pinned welcome post with community guidelines (coming soon!)</li>
                             <li><strong>Regular engagement</strong>: Check in daily to answer questions and acknowledge comments</li>
                             <li><strong>Value-added content</strong>: Share exclusive tips, updates, and behind-the-scenes information</li>
                             <li><strong>Encourage participation</strong>: Ask questions and create discussion topics</li>
                             <li><strong>Celebrate successes</strong>: Highlight customer achievements and use cases</li>
                             <li><strong>Address concerns promptly</strong>: Respond to issues quickly to show responsiveness</li>
+                            <li><strong>Welcome new members</strong>: Create a pinned welcome post with community guidelines (coming soon!)</li>
                         </ul>
 
                         <h2 id="restrictions-and-limitations">Restrictions and limitations</h2>
                         <ul>
                             <li>Communities are product-specific and cannot be merged</li>
                             <li>Access is limited to customers who have purchased the product</li>
-                            <li>Basic text formatting is supported, but attachments are limited to images</li>
+                            <li>Only plain text messages are supported</li>
                             <li>Communities cannot be transferred between Gumroad accounts</li>
+                            <li>Community messages are not searchable</li>
+                            <li>Once a message is marked as read automatically, it cannot be marked as unread</li>
+                            <li>No instant message notifications (daily and weekly recaps can be enabled though)</li>
                         </ul>
                     </article>
 
                     <section class="articleFoot">
-                        <time class="lu" datetime=2025-04-07>Last updated on April 7, 2025</time>
+                        <time class="lu" datetime=2025-04-07>Last updated on April 8, 2025</time>
                     </section>
 
                 </div><!--/contentWrapper-->

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -3118,31 +3118,8 @@ describe LinksController, :vcr do
             Feature.activate_user(:communities, seller)
           end
 
-          it "enables community chat by default for regular products" do
+          it "does not enable community chat by default" do
             params = { price_cents: 100, name: "test link" }
-
-            post :create, params: { format: :json, link: params }
-
-            expect(response.parsed_body["success"]).to be(true)
-            product = seller.links.last
-            expect(product.community_chat_enabled?).to be(true)
-            expect(product.active_community).to be_present
-          end
-
-          it "does not enable community chat for coffee products" do
-            seller.update!(created_at: (User::MIN_AGE_FOR_SERVICE_PRODUCTS + 1.day).ago)
-            params = { price_cents: 100, name: "test link", native_type: Link::NATIVE_TYPE_COFFEE }
-
-            post :create, params: { format: :json, link: params }
-
-            expect(response.parsed_body["success"]).to be(true)
-            product = seller.links.last
-            expect(product.community_chat_enabled?).to be(false)
-            expect(product.active_community).to be_nil
-          end
-
-          it "does not enable community chat for bundle products" do
-            params = { price_cents: 100, name: "test link", native_type: Link::NATIVE_TYPE_BUNDLE }
 
             post :create, params: { format: :json, link: params }
 

--- a/spec/policies/community_policy_spec.rb
+++ b/spec/policies/community_policy_spec.rb
@@ -61,13 +61,13 @@ describe CommunityPolicy do
         expect(subject).to permit(seller_context, Community)
       end
 
-      it "grants access to seller who has at least one product but no active communities" do
+      it "denies access to seller who has at least one product but no active communities" do
         another_seller = create(:user)
         create(:product, user: another_seller)
         Feature.activate_user(:communities, another_seller)
         seller_context = SellerContext.new(user: another_seller, seller:)
 
-        expect(subject).to permit(seller_context, Community)
+        expect(subject).not_to permit(seller_context, Community)
       end
     end
 

--- a/spec/requests/communities_spec.rb
+++ b/spec/requests/communities_spec.rb
@@ -18,20 +18,6 @@ describe "Communities", :js, type: :feature do
     have_selector("[aria-label='Message content']", text: content, match: :first)
   end
 
-  it "shows empty state if there are no communities to a seller" do
-    create(:product, user: seller)
-
-    login_as(seller)
-
-    visit community_path
-
-    expect(page).to have_text("Build your community, one product at a time!")
-    expect(page).to have_text("When you publish a product, we automatically create a dedicated community chat—your own space to connect with customers, answer questions, and build relationships.")
-    expect(page).to have_link("Enable community chat for your products", href: products_path)
-    expect(find("a", text: "learn more about community chats")["data-helper-prompt"]).to eq("How do I enable community chat for my product?")
-    expect(page).to have_button("Go back")
-  end
-
   context "when the logged in seller has an active community" do
     let(:product) { create(:product, name: "Mastering Rails", user: seller, community_chat_enabled: true) }
     let!(:community) { create(:community, resource: product, seller:) }

--- a/spec/requests/main_navigation_spec.rb
+++ b/spec/requests/main_navigation_spec.rb
@@ -76,7 +76,7 @@ describe "Main Navigation", type: :feature, js: true do
         visit library_path
 
         within "nav[aria-label='Main']" do
-          expect(page).to have_link("Community", href: community_path)
+          expect(page).not_to have_link("Community", href: community_path)
         end
       end
     end

--- a/spec/requests/products/creation_spec.rb
+++ b/spec/requests/products/creation_spec.rb
@@ -308,16 +308,17 @@ describe "Product creation", type: :feature, js: true do
     end
   end
 
-  it "automatically enables the community chat on creating a product" do
+  it "does not automatically enable the community chat on creating a product" do
     Feature.activate_user(:communities, seller)
     visit new_product_path
     choose "Digital product"
     fill_in "Name", with: "My product"
     fill_in "Price", with: 1
     click_on "Next: Customize"
-    expect(page).to have_checked_field("Invite your customers to your Gumroad community chat")
+    wait_for_ajax
+    expect(page).not_to have_checked_field("Invite your customers to your Gumroad community chat")
     product = seller.products.last
-    expect(product.community_chat_enabled?).to be(true)
-    expect(product.active_community).to be_present
+    expect(product.community_chat_enabled?).to be(false)
+    expect(product.active_community).to be_nil
   end
 end


### PR DESCRIPTION
Makes a few changes re: the community chat feature:

1. Keeps the "Invite your customers to your Gumroad community chat" toggle OFF by default for newly added products (earlier it was ON by default)
2. Hides the "Community" link in the main nav if the logged in user either does not have a product with the community enabled or if they don't have a purchased product that has the community enabled (earlier, a creator having products but no active community would see this link)

Part of https://github.com/antiwork/gumroad/issues/14.
