### PR TITLE
Fix validation issue that prevented uploading covers on new Calls

### DIFF
--- a/app/models/asset_preview.rb
+++ b/app/models/asset_preview.rb
@@ -264,7 +264,7 @@ class AssetPreview < ApplicationRecord
     end
 
     def reset_moderated_by_iffy_flag
-      link&.update!(moderated_by_iffy: false)
+      link&.update_flag!(:moderated_by_iffy, false)
     end
 
     def safe_url?(url)

--- a/app/models/asset_preview.rb
+++ b/app/models/asset_preview.rb
@@ -264,7 +264,7 @@ class AssetPreview < ApplicationRecord
     end
 
     def reset_moderated_by_iffy_flag
-      link&.update_flag!(:moderated_by_iffy, false)
+      link&.update_attribute(:moderated_by_iffy, false)
     end
 
     def safe_url?(url)

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1540,7 +1540,7 @@ class Link < ApplicationRecord
     end
 
     def reset_moderated_by_iffy_flag
-      update!(moderated_by_iffy: false)
+      update_flag!(:moderated_by_iffy, false)
     end
 
     def queue_iffy_ingest_job_if_unpublished_by_admin

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1540,7 +1540,7 @@ class Link < ApplicationRecord
     end
 
     def reset_moderated_by_iffy_flag
-      update_flag!(:moderated_by_iffy, false)
+      update_attribute(:moderated_by_iffy, false)
     end
 
     def queue_iffy_ingest_job_if_unpublished_by_admin

--- a/app/models/product_file.rb
+++ b/app/models/product_file.rb
@@ -359,7 +359,7 @@ class ProductFile < ApplicationRecord
 
     def reset_moderated_by_iffy_flag
       return unless filegroup == "image"
-      link&.update!(moderated_by_iffy: false)
+      link&.update_flag!(:moderated_by_iffy, false)
     end
 
     def stamp_existing_pdfs_if_needed

--- a/app/models/product_file.rb
+++ b/app/models/product_file.rb
@@ -359,7 +359,7 @@ class ProductFile < ApplicationRecord
 
     def reset_moderated_by_iffy_flag
       return unless filegroup == "image"
-      link&.update_flag!(:moderated_by_iffy, false)
+      link&.update_attribute(:moderated_by_iffy, false)
     end
 
     def stamp_existing_pdfs_if_needed

--- a/app/models/rich_content.rb
+++ b/app/models/rich_content.rb
@@ -108,6 +108,6 @@ class RichContent < ApplicationRecord
 
     def reset_moderated_by_iffy_flag
       return unless entity.is_a?(Link)
-      entity.update_flag!(:moderated_by_iffy, false)
+      entity.update_attribute(:moderated_by_iffy, false)
     end
 end

--- a/app/models/rich_content.rb
+++ b/app/models/rich_content.rb
@@ -108,6 +108,6 @@ class RichContent < ApplicationRecord
 
     def reset_moderated_by_iffy_flag
       return unless entity.is_a?(Link)
-      entity.update!(moderated_by_iffy: false)
+      entity.update_flag!(:moderated_by_iffy, false)
     end
 end

--- a/spec/requests/products/edit/calls_spec.rb
+++ b/spec/requests/products/edit/calls_spec.rb
@@ -36,6 +36,7 @@ describe "Calls Edit", type: :feature, js: true do
   end
 
   it "allows editing durations" do
+    call = create(:call_product, user: seller, durations: [])
     visit edit_link_path(call.unique_permalink)
 
     click_on "Add duration"

--- a/spec/requests/products/edit/calls_spec.rb
+++ b/spec/requests/products/edit/calls_spec.rb
@@ -4,6 +4,14 @@ require "spec_helper"
 require "shared_examples/authorize_called"
 
 describe "Calls Edit", type: :feature, js: true do
+
+  def upload_image(filenames)
+    click_on "Upload images or videos"
+    page.attach_file(filenames.map { |filename| file_fixture(filename) }) do
+      select_tab "Computer files"
+    end
+  end
+
   let(:seller) { create(:user, :eligible_for_service_products) }
   let(:call) { create(:call_product, user: seller) }
 
@@ -11,9 +19,24 @@ describe "Calls Edit", type: :feature, js: true do
 
   before { Feature.activate_user(:product_edit_react, seller) }
 
-  it "allows editing durations" do
+  it "supports attaching covers on calls without durations" do
     call = create(:call_product, user: seller, durations: [])
+    visit edit_link_path(call.unique_permalink)
+    upload_image(["test.png"])
+    wait_for_ajax
+    sleep 1
 
+    select_disclosure "Add cover" do
+      upload_image(["test-small.jpg"])
+    end
+    wait_for_ajax
+
+    within_section "Cover", section_element: :section do
+      expect(page).to have_selector("button[role='tab']", count: 2)
+    end
+  end
+
+  it "allows editing durations" do
     visit edit_link_path(call.unique_permalink)
 
     click_on "Add duration"

--- a/spec/requests/products/edit/calls_spec.rb
+++ b/spec/requests/products/edit/calls_spec.rb
@@ -4,7 +4,6 @@ require "spec_helper"
 require "shared_examples/authorize_called"
 
 describe "Calls Edit", type: :feature, js: true do
-
   def upload_image(filenames)
     click_on "Upload images or videos"
     page.attach_file(filenames.map { |filename| file_fixture(filename) }) do


### PR DESCRIPTION
### What

Fixes a validation issue that prevented covers from being uploaded to new Call products.

Steps to reproduce:
- Create a new Call product
- Attempt to upload a cover image
- Fails with  "Could not process your preview, please try again."

### Why

Uploading a cover created a new asset preview, which in turn triggered the `reset_moderated_by_iffy_flag` action on the product. Updating the `moderated_by_iffy` flag on the product required it to pass validation. In the case of a new Call, validation failed because the user had not yet added a duration (`calls_must_have_at_least_one_duration`).

The fix is to update the `moderated_by_iffy` flag on the product without triggering validations and callbacks. This better reflect the intent of the action and preserves the expectation that products are not validated until the first time the user saves them.