### PR TITLE
Send kindle emails via SendGrid

### DIFF
--- a/app/mailers/customer_mailer.rb
+++ b/app/mailers/customer_mailer.rb
@@ -121,7 +121,7 @@ class CustomerMailer < ApplicationMailer
       to: kindle_email,
       from: "noreply@#{CUSTOMERS_MAIL_DOMAIN}",
       subject: "convert",
-      delivery_method_options: MailerInfo.random_delivery_method_options(domain: :customers, seller: creator)
+      delivery_method_options: MailerInfo.default_delivery_method_options(domain: :customers)
     )
   end
 


### PR DESCRIPTION
Fix for the following error when sending through Resend:

```
Net::ReadTimeout: Net::ReadTimeout with #<TCPSocket:(closed)>
```