### PR TITLE
Feat DAILY payout option for creators

### DIFF
--- a/app/javascript/components/InstantPayoutStatus.tsx
+++ b/app/javascript/components/InstantPayoutStatus.tsx
@@ -1,0 +1,29 @@
+import * as React from "react";
+
+export const InstantPayoutStatus = () => {
+  return (
+    <div className="flex items-center rounded-md border border-blue-200 bg-blue-50 p-4">
+      <div className="mr-2 flex h-6 w-6 items-center justify-center rounded-full bg-blue-400 text-white">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+          <path d="M12 9h.01" />
+          <path d="M11 12h1v4h1" />
+        </svg>
+      </div>
+      <p className="text-gray-700 text-sm text-black">
+        Every day, your balance from the previous day will be sent to you via instant payouts, subject to a{" "}
+        <span className="font-semibold">3% fee</span>.
+      </p>
+    </div>
+  );
+};

--- a/app/javascript/components/server-components/Settings/PaymentsPage.tsx
+++ b/app/javascript/components/server-components/Settings/PaymentsPage.tsx
@@ -37,6 +37,7 @@ import { useUserAgentInfo } from "$app/components/UserAgent";
 import { WithTooltip } from "$app/components/WithTooltip";
 
 import logo from "$assets/images/logo-g.svg";
+import { InstantPayoutStatus } from "$app/components/InstantPayoutStatus";
 
 export type PayoutDebitCardData = { type: "saved" } | { type: "new"; element: StripeCardElement } | undefined;
 
@@ -56,7 +57,7 @@ export type User = {
   joined_at: string;
 };
 
-const PAYOUT_FREQUENCIES = ["weekly", "monthly", "quarterly"] as const;
+const PAYOUT_FREQUENCIES = ["weekly", "monthly", "quarterly", "daily"] as const;
 type PayoutFrequency = (typeof PAYOUT_FREQUENCIES)[number];
 
 export type ComplianceInfo = {
@@ -890,6 +891,7 @@ const PaymentsPage = (props: Props) => {
                   label: frequency.charAt(0).toUpperCase() + frequency.slice(1),
                 }))}
               />
+              {payoutFrequency === "daily" && <InstantPayoutStatus />}
             </fieldset>
             <fieldset className={cx({ danger: payoutThresholdCents.error })}>
               <label htmlFor="payout_threshold_cents">Minimum payout threshold</label>

--- a/app/modules/user/payout_schedule.rb
+++ b/app/modules/user/payout_schedule.rb
@@ -8,6 +8,7 @@ module User::PayoutSchedule
   WEEKLY = "weekly"
   MONTHLY = "monthly"
   QUARTERLY = "quarterly"
+  DAILY = "daily"
 
   include CurrencyHelper
 

--- a/app/services/payout_users_service.rb
+++ b/app/services/payout_users_service.rb
@@ -27,7 +27,13 @@ class PayoutUsersService
 
     user_ids.each do |user_id|
       user = User.find(user_id)
-      payment, payment_errors = Payouts.create_payment(date, processor_type, user, payout_type:)
+
+      effective_payout_type = payout_type
+      if user.payout_schedule == User::PayoutSchedule::DAILY
+        effective_payout_type = Payouts::PAYOUT_TYPE_INSTANT
+      end
+
+      payment, payment_errors = Payouts.create_payment(date, processor_type, user, payout_type: effective_payout_type)
 
       if payment_errors.blank? && payment.present?
         # Money transferred to a cross-border-payouts Stripe Connect a/c becomes payable after 24 hours,


### PR DESCRIPTION
Closes #12 

## Support daily payouts through instant payouts

- [x] Add DAILY option to User::PayoutSchedule
- [x] Update frontend to have "Daily" option with instant payout status
- [x] Update PayoutUsersService to pass Payouts::PAYOUT_TYPE_INSTANT for payout_type for users with payout_schedule set to "daily"


Video and Screenshots
https://sumanbiswas-website.s3.ap-south-1.amazonaws.com/daily-payout.mkv
<img width="912" alt="image" src="https://github.com/user-attachments/assets/3b1ef573-2cda-4cab-8f37-458197f56b29" />