### PR TITLE
Add RevertToProductLevelRefundPolicies one-time script

### DIFF
--- a/app/services/onetime/revert_to_product_level_refund_policies.rb
+++ b/app/services/onetime/revert_to_product_level_refund_policies.rb
@@ -31,8 +31,8 @@ class Onetime::RevertToProductLevelRefundPolicies < Onetime::Base
 
       message_prefix = "Seller: #{seller_id} (#{index + 1}/#{seller_ids.size})"
       seller = User.find(seller_id)
-      if seller.deleted?
-        Rails.logger.info "#{message_prefix}: skipped (deleted)"
+      if !seller.account_active?
+        Rails.logger.info "#{message_prefix}: skipped (not active)"
         next
       end
 

--- a/app/services/onetime/revert_to_product_level_refund_policies.rb
+++ b/app/services/onetime/revert_to_product_level_refund_policies.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# Used to process select sellers manually
+# For the rest, we'll use `seller_refund_policy_disabled_for_all` feature flag to override User#refund_policy_enabled flag
+#
+
+class Onetime::RevertToProductLevelRefundPolicies < Onetime::Base
+  LAST_PROCESSED_ID_KEY = :last_processed_seller_for_revert_to_product_level_refund_policy_id
+
+  attr_reader :seller_ids, :invalid_seller_ids
+
+  def self.reset_last_processed_id
+    $redis.del(LAST_PROCESSED_ID_KEY)
+  end
+
+  def initialize(seller_ids: [])
+    raise ArgumentError, "Seller ids not found" if seller_ids.blank?
+
+    @seller_ids = seller_ids
+    @invalid_seller_ids = []
+    @last_processed_index = ($redis.get(LAST_PROCESSED_ID_KEY) || -1).to_i
+  end
+
+  def process
+    ReplicaLagWatcher.watch()
+    seller_ids.each_with_index do |seller_id, index|
+      if index <= @last_processed_index
+        Rails.logger.info "Seller: #{seller_id} (#{index + 1}/#{seller_ids.size}): skipped (already processed in previous run)"
+        next
+      end
+
+      message_prefix = "Seller: #{seller_id} (#{index + 1}/#{seller_ids.size})"
+      seller = User.find(seller_id)
+      if seller.deleted?
+        Rails.logger.info "#{message_prefix}: skipped (deleted)"
+        next
+      end
+
+      if seller.refund_policy_enabled?
+        seller.with_lock do
+          seller.update!(refund_policy_enabled: false)
+          ContactingCreatorMailer.product_level_refund_policies_reverted(seller.id).deliver_later
+          Rails.logger.info "#{message_prefix}: processed and email sent"
+        end
+      else
+        Rails.logger.info "#{message_prefix}: skipped (already processed)"
+        next
+      end
+
+      $redis.set(LAST_PROCESSED_ID_KEY, index, ex: 1.month)
+    rescue => e
+      Rails.logger.info "#{message_prefix}: error: #{e.message}"
+      invalid_seller_ids << { seller_id => e.message }
+    end
+  end
+end

--- a/spec/services/onetime/revert_to_product_level_refund_policies_spec.rb
+++ b/spec/services/onetime/revert_to_product_level_refund_policies_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe Onetime::RevertToProductLevelRefundPolicies do
 
   describe "#process" do
     let!(:seller_with_refund) { create(:user) }
-    let!(:deleted_seller) { create(:user, deleted_at: 1.day.ago) }
 
     before do
       described_class.reset_last_processed_id
@@ -55,14 +54,15 @@ RSpec.describe Onetime::RevertToProductLevelRefundPolicies do
       expect(Rails.logger).to have_received(:info).with(/Seller: #{seller_with_refund.id}.*skipped \(already processed in previous run\)/)
     end
 
-    it "skips deleted sellers" do
-      service = described_class.new(seller_ids: [deleted_seller.id])
+    it "skips inactive sellers" do
+      allow_any_instance_of(User).to receive(:account_active?).and_return(false)
+      service = described_class.new(seller_ids: [seller_with_refund.id])
 
       expect do
         service.process
       end.not_to have_enqueued_mail(ContactingCreatorMailer, :product_level_refund_policies_reverted)
 
-      expect(Rails.logger).to have_received(:info).with(/Seller: #{deleted_seller.id}.*skipped \(deleted\)/)
+      expect(Rails.logger).to have_received(:info).with(/Seller: #{seller_with_refund.id}.*skipped \(not active\)/)
     end
 
     it "processes active sellers with refund_policy_enabled=true" do

--- a/spec/services/onetime/revert_to_product_level_refund_policies_spec.rb
+++ b/spec/services/onetime/revert_to_product_level_refund_policies_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Onetime::RevertToProductLevelRefundPolicies do
+  describe ".reset_last_processed_id" do
+    before do
+      $redis.set(described_class::LAST_PROCESSED_ID_KEY, 123)
+    end
+
+    it "clears the last processed ID" do
+      expect { described_class.reset_last_processed_id }.to change {
+        $redis.get(described_class::LAST_PROCESSED_ID_KEY)
+      }.from("123").to(nil)
+    end
+  end
+
+  describe "#initialize" do
+    let!(:seller) { create(:user, refund_policy_enabled: true) }
+    let(:seller_ids) { [seller.id] }
+
+    it "accepts seller IDs directly" do
+      service = described_class.new(seller_ids: seller_ids)
+      expect(service.seller_ids).to eq(seller_ids)
+    end
+
+    it "raises error when seller_ids is empty" do
+      expect { described_class.new(seller_ids: []) }.to raise_error(ArgumentError, /Seller ids not found/)
+    end
+  end
+
+  describe "#process" do
+    let!(:seller_with_refund) { create(:user) }
+    let!(:deleted_seller) { create(:user, deleted_at: 1.day.ago) }
+
+    before do
+      described_class.reset_last_processed_id
+      allow(Rails.logger).to receive(:info)
+      allow(ReplicaLagWatcher).to receive(:watch)
+      seller_with_refund.update!(refund_policy_enabled: true)
+    end
+
+    it "watches for replica lag" do
+      service = described_class.new(seller_ids: [seller_with_refund.id])
+      service.process
+      expect(ReplicaLagWatcher).to have_received(:watch)
+    end
+
+    it "skips sellers that were already processed in previous runs" do
+      $redis.set(described_class::LAST_PROCESSED_ID_KEY, 0)
+
+      service = described_class.new(seller_ids: [seller_with_refund.id])
+      service.process
+
+      expect(Rails.logger).to have_received(:info).with(/Seller: #{seller_with_refund.id}.*skipped \(already processed in previous run\)/)
+    end
+
+    it "skips deleted sellers" do
+      service = described_class.new(seller_ids: [deleted_seller.id])
+
+      expect do
+        service.process
+      end.not_to have_enqueued_mail(ContactingCreatorMailer, :product_level_refund_policies_reverted)
+
+      expect(Rails.logger).to have_received(:info).with(/Seller: #{deleted_seller.id}.*skipped \(deleted\)/)
+    end
+
+    it "processes active sellers with refund_policy_enabled=true" do
+      service = described_class.new(seller_ids: [seller_with_refund.id])
+
+      expect do
+        service.process
+      end.to have_enqueued_mail(ContactingCreatorMailer, :product_level_refund_policies_reverted).with(seller_with_refund.id)
+
+      expect(Rails.logger).to have_received(:info).with(/Seller: #{seller_with_refund.id}.*processed and email sent/)
+
+      expect(seller_with_refund.reload.refund_policy_enabled?).to be false
+    end
+
+    it "does not send emails to sellers with refund_policy_enabled=false" do
+      seller_without_refund = create(:user)
+      seller_without_refund.update!(refund_policy_enabled: false)
+
+      service = described_class.new(seller_ids: [seller_without_refund.id])
+
+      expect do
+        service.process
+      end.not_to have_enqueued_mail(ContactingCreatorMailer, :product_level_refund_policies_reverted)
+
+      expect(Rails.logger).to have_received(:info).with(/Seller: #{seller_without_refund.id}.*skipped \(already processed\)/)
+    end
+
+    it "updates Redis with the last processed index" do
+      service = described_class.new(seller_ids: [seller_with_refund.id])
+      allow($redis).to receive(:set).and_call_original
+
+      service.process
+
+      expect($redis).to have_received(:set).with(
+        described_class::LAST_PROCESSED_ID_KEY,
+        kind_of(Integer),
+        ex: 1.month
+      ).once
+    end
+
+    it "handles errors during processing and tracks invalid seller IDs" do
+      error_seller = create(:user)
+      error_seller.update_column(:flags, error_seller.flags | (1 << 46))
+      expect(error_seller.refund_policy_enabled?).to be true
+
+      service = described_class.new(seller_ids: [seller_with_refund.id, error_seller.id])
+
+      allow(User).to receive(:find).and_call_original
+      allow(User).to receive(:find).with(error_seller.id).and_raise(StandardError.new("Test error"))
+
+      expect do
+        service.process
+      end.to have_enqueued_mail(ContactingCreatorMailer, :product_level_refund_policies_reverted).with(seller_with_refund.id)
+          .and not_have_enqueued_mail(ContactingCreatorMailer, :product_level_refund_policies_reverted).with(error_seller.id)
+
+      expect(service.invalid_seller_ids).to include(a_hash_including(error_seller.id => "Test error"))
+    end
+  end
+end


### PR DESCRIPTION
Part of https://github.com/antiwork/gumroad/issues/74

Adds a one-time script to process select sellers:
* send `ContactingCreatorMailer.product_level_refund_policies_reverted`
* update `refund_policy_enabled` to `false` (account-level refund policy)