### PR TITLE
Fix the issue with highlighting selected Discover menu item

### DIFF
--- a/app/javascript/components/Discover/Nav.tsx
+++ b/app/javascript/components/Discover/Nav.tsx
@@ -27,7 +27,9 @@ export const Nav = ({
     [wholeTaxonomy, discoverUrl],
   );
 
-  const selectedCategory = menuItems.find((menuItem) => menuItem.href === (currentTaxonomyPath ?? ""))?.key;
+  const selectedCategory = menuItems.find(
+    (menuItem) => menuItem.href?.replace(discoverUrl, "").replace(/^\//u, "") === (currentTaxonomyPath ?? ""),
+  )?.key;
 
   const isDesktop = useIsAboveBreakpoint("lg");
 
@@ -62,7 +64,7 @@ const generateTaxonomyItemsForMenu = (wholeTaxonomy: Taxonomy[], discoverUrl: st
   };
 
   return [
-    { key: "all#key", label: "All", href: "/" },
+    { key: "all#key", label: "All", href: discoverUrl || "/" },
     ...wholeTaxonomy.map((taxonomy): MenuItem => {
       const root = getRootTaxonomy(taxonomy.slug);
       return {

--- a/app/javascript/components/Discover/Nav.tsx
+++ b/app/javascript/components/Discover/Nav.tsx
@@ -28,7 +28,7 @@ export const Nav = ({
   );
 
   const selectedCategory = menuItems.find(
-    (menuItem) => menuItem.href?.replace(discoverUrl, "").replace(/^\//u, "") === (currentTaxonomyPath ?? ""),
+    (menuItem) => menuItem.href?.replace(discoverUrl, "/") === (currentTaxonomyPath ? `/${currentTaxonomyPath}` : "/"),
   )?.key;
 
   const isDesktop = useIsAboveBreakpoint("lg");
@@ -60,7 +60,7 @@ const generateTaxonomyItemsForMenu = (wholeTaxonomy: Taxonomy[], discoverUrl: st
       slugs.unshift(curr.slug);
       curr = curr.parent_key ? taxonomyMap.get(curr.parent_key) : undefined;
     }
-    return `${discoverUrl}${slugs.join("/")}`;
+    return `${discoverUrl.replace(/\/$/u, "")}/${slugs.join("/")}`;
   };
 
   return [


### PR DESCRIPTION
Related to: #44

- Fix the issue with highlighting selected Discover menu item
- When on Discover page, use relative paths in links with leading `/`.