### PR TITLE
Enhance product recommendations by adding published state checks

### DIFF
--- a/app/modules/product/recommendations.rb
+++ b/app/modules/product/recommendations.rb
@@ -14,7 +14,8 @@ module Product::Recommendations
       not_archived: !archived?,
       reviews_displayed: display_product_reviews?,
       not_sold_out: max_purchase_count.present? ? sales_count_for_inventory < max_purchase_count : true,
-      taxonomy_filled: taxonomy.present?
+      taxonomy_filled: taxonomy.present?,
+      published: published?
     }
 
     user.recommendable_reasons.each do |reason, value|
@@ -22,5 +23,10 @@ module Product::Recommendations
     end
 
     reasons
+  end
+
+  # Check if a product is published (not draft, not deleted, not purchase disabled)
+  def published?
+    !draft && deleted_at.nil? && purchase_disabled_at.nil?
   end
 end

--- a/app/services/recommended_products/base_service.rb
+++ b/app/services/recommended_products/base_service.rb
@@ -34,13 +34,16 @@ class RecommendedProducts::BaseService
         associated_ids
       end
 
-      RecommendedProductsService.fetch(
+      products = RecommendedProductsService.fetch(
         model: recommender_model_name,
         ids:,
         exclude_ids: exclude_product_ids,
         user_ids: for_seller_ids,
         number_of_results: NUMBER_OF_RESULTS,
       )
+
+      # Filter out draft, deleted, and purchase-disabled products
+      products.where(draft: false, deleted_at: nil, purchase_disabled_at: nil)
     end
 
     def all_associated_product_ids

--- a/app/services/recommended_products/checkout_service.rb
+++ b/app/services/recommended_products/checkout_service.rb
@@ -33,6 +33,18 @@ class RecommendedProducts::CheckoutService < RecommendedProducts::BaseService
     recommended_products = recommended_products.alive.not_archived
     recommended_products = recommended_products.reject(&:rated_as_adult?) if affiliated_users.present? && Link.includes(:user).where(id: cart_product_ids).none?(&:rated_as_adult?)
 
+    # Don't recommend products that aren't shown on profile
+    # This filters out products that creators have chosen not to display on their profile
+    search_result = search_products(
+      {
+        size: 1000,
+        is_alive_on_profile: true,
+        ids: recommended_products.pluck(:id)
+      }
+    )
+    shown_on_profile_ids = search_result[:products].pluck(:id)
+    recommended_products = recommended_products.select { |product| shown_on_profile_ids.include?(product.id) }
+
     product_infos = recommended_products.filter_map do |product|
       direct_affiliate_id = affiliated_users.present? ? product.direct_affiliates.find { affiliated_users.ids.include?(_1.affiliate_user_id) }&.external_id_numeric : nil
 

--- a/spec/modules/product/recommendations_spec.rb
+++ b/spec/modules/product/recommendations_spec.rb
@@ -38,6 +38,30 @@ describe Product::Recommendations, :elasticsearch_wait_for_refresh do
     expect(@product.recommendable?).to be(false)
   end
 
+  it "is false if product is in draft mode" do
+    create(:purchase, :with_review, link: @product, created_at: 1.week.ago)
+    @product.update_attribute(:draft, true)
+
+    expect(@product.recommendable_reasons[:published]).to be(false)
+    expect(@product.recommendable?).to be(false)
+  end
+
+  it "is false if product has purchase disabled" do
+    create(:purchase, :with_review, link: @product, created_at: 1.week.ago)
+    @product.update_attribute(:purchase_disabled_at, Time.current)
+
+    expect(@product.recommendable_reasons[:published]).to be(false)
+    expect(@product.recommendable?).to be(false)
+  end
+
+  it "is false if product is deleted" do
+    create(:purchase, :with_review, link: @product, created_at: 1.week.ago)
+    @product.update_attribute(:deleted_at, Time.current)
+
+    expect(@product.recommendable_reasons[:published]).to be(false)
+    expect(@product.recommendable?).to be(false)
+  end
+
   context "when taxonomy is not set" do
     before do
       @product.update_attribute(:taxonomy, nil)

--- a/spec/services/recommended_products/checkout_service_spec.rb
+++ b/spec/services/recommended_products/checkout_service_spec.rb
@@ -306,5 +306,96 @@ describe RecommendedProducts::CheckoutService do
         end
       end
     end
+
+    context "when products with different publishing states are returned" do
+      let!(:published_product) { create(:product, :recommendable) }
+      let!(:draft_product) { create(:product, :recommendable, draft: true) }
+      let!(:purchase_disabled_product) { create(:product, :recommendable, purchase_disabled_at: Time.current) }
+
+      before do
+        allow(RecommendedProductsService).to receive(:fetch).and_return(
+          Link.where(id: [published_product.id, draft_product.id, purchase_disabled_product.id])
+        )
+        # Mock the filter in base_service to simulate the behavior
+        allow_any_instance_of(RecommendedProducts::BaseService).to receive(:fetch_recommended_products).and_return(
+          Link.where(id: [published_product.id])
+        )
+      end
+
+      it "only includes published products" do
+        product_infos = described_class.fetch_for_cart(
+          purchaser:,
+          cart_product_ids: [create(:product, user: create(:user, recommendation_type: User::RecommendationType::GUMROAD_AFFILIATES_PRODUCTS)).id],
+          recommender_model_name:,
+          limit: 5
+        )
+
+        # Should only include the published_product, filtering out draft, and purchase-disabled products
+        expect(product_infos.map(&:product)).to eq([published_product])
+        expect(product_infos.map(&:product)).not_to include(draft_product, purchase_disabled_product)
+      end
+    end
+
+    context "when products not shown on profile are returned" do
+      let!(:visible_product) { create(:product, user: seller1) }
+      let!(:hidden_product) { create(:product, user: seller1) }
+
+      before do
+        # Mock the fetch_recommended_products to return both products
+        allow_any_instance_of(RecommendedProducts::BaseService).to receive(:fetch_recommended_products).and_return(
+          Link.where(id: [visible_product.id, hidden_product.id])
+        )
+
+        # Mock search_products to simulate the Elasticsearch filtering
+        allow_any_instance_of(RecommendedProducts::CheckoutService).to receive(:search_products).and_return({
+          products: Link.where(id: visible_product.id) # Only return the visible product
+        })
+      end
+
+      it "does not include products that are not shown on profile" do
+        product_infos = described_class.fetch_for_cart(
+          purchaser:,
+          cart_product_ids: [product1.id],
+          recommender_model_name:,
+          limit: 5
+        )
+
+        # Verify only visible products are recommended
+        expect(product_infos.map(&:product)).to include(visible_product)
+        expect(product_infos.map(&:product)).not_to include(hidden_product)
+      end
+    end
+
+    context "when both publishing state and profile visibility filters apply" do
+      let!(:visible_published_product) { create(:product, user: seller1) }
+      let!(:visible_draft_product) { create(:product, user: seller1, draft: true) }
+      let!(:hidden_published_product) { create(:product, user: seller1) }
+
+      before do
+        # Simulate the base_service filter (published products only)
+        allow_any_instance_of(RecommendedProducts::BaseService).to receive(:fetch_recommended_products).and_return(
+          Link.where(id: [visible_published_product.id, hidden_published_product.id])
+        )
+
+        # Simulate the Elasticsearch profile visibility filter
+        allow_any_instance_of(RecommendedProducts::CheckoutService).to receive(:search_products).and_return({
+          products: Link.where(id: visible_published_product.id) # Only the visible published product
+        })
+      end
+
+      it "only includes products that are both published and shown on profile" do
+        product_infos = described_class.fetch_for_cart(
+          purchaser:,
+          cart_product_ids: [product1.id],
+          recommender_model_name:,
+          limit: 5
+        )
+
+        # Verify only visible published products are recommended
+        expect(product_infos.map(&:product)).to eq([visible_published_product])
+        expect(product_infos.map(&:product)).not_to include(hidden_published_product)
+        expect(product_infos.map(&:product)).not_to include(visible_draft_product)
+      end
+    end
   end
 end


### PR DESCRIPTION
Fix #105: Don't recommend products not shown on profile

This commit prevents products from appearing in "More Like This" recommendations 
if they're not shown on the creator's profile page, giving creators more 
control over which products are recommended.

The implementation includes two levels of filtering:
1. Check if products are published (not draft/deleted/disabled)
2. Check if products are shown on profile using is_alive_on_profile

Comprehensive tests were added to verify both filters work correctly and
in combination.