### PR TITLE
Fix balance page spec failure

### DIFF
--- a/app/javascript/components/server-components/BalancePage.tsx
+++ b/app/javascript/components/server-components/BalancePage.tsx
@@ -15,6 +15,7 @@ import { Modal } from "$app/components/Modal";
 import { PaginationProps } from "$app/components/Pagination";
 import { showAlert } from "$app/components/server-components/Alert";
 import { ExportPayoutsPopover } from "$app/components/server-components/BalancePage/ExportPayoutsPopover";
+import { useUserAgentInfo } from "$app/components/UserAgent";
 import { WithTooltip } from "$app/components/WithTooltip";
 
 import placeholder from "$assets/images/placeholders/payouts.png";
@@ -630,6 +631,7 @@ const BalancePage = ({
   pagination: PaginationProps;
 }) => {
   const loggedInUser = useLoggedInUser();
+  const userAgentInfo = useUserAgentInfo();
 
   const [pastPayoutPeriodData, setPastPayoutPeriodData] = React.useState(past_payout_period_data);
   const [pagination, setPagination] = React.useState(initialPagination);
@@ -781,7 +783,11 @@ const BalancePage = ({
                   >
                     {instant_payout.payable_balances.map((balance) => (
                       <option key={balance.id} value={balance.id}>
-                        {new Date(balance.date).toLocaleDateString()}
+                        {new Date(balance.date).toLocaleDateString(userAgentInfo.locale, {
+                          month: "long",
+                          day: "numeric",
+                          year: "numeric",
+                        })}
                       </option>
                     ))}
                   </select>


### PR DESCRIPTION
- Fix the spec failing on `main` due to an unknown `api_error` thrown by Stripe on sandbox, when trying to create an instant payout on a newly created test custom connect account e.g. [here](https://dashboard.stripe.com/acct_1REX6kS9d4JZw3hp/test/logs/req_8vKTp1h2zc1VuJ). Updated the spec to use an existing custom connect account on sandbox to test instant payouts. 
- Also changed the displayed dates, when initiating an instant payout from Payouts page, to a more readable format i.e. April 16, 2025 instead of 4/16/2025. This also fixes the same spec failing on local due to mismatch in localized date format.