### PR TITLE
Show approved review videos on product page

### DIFF
--- a/app/controllers/product_review_videos/streaming_urls_controller.rb
+++ b/app/controllers/product_review_videos/streaming_urls_controller.rb
@@ -29,7 +29,7 @@ class ProductReviewVideos::StreamingUrlsController < ApplicationController
         skip_authorization
         true
       else
-        authorize @product_review_video, :streaming_urls?
+        authorize @product_review_video, :stream?
       end
     end
 

--- a/app/controllers/product_review_videos/streaming_urls_controller.rb
+++ b/app/controllers/product_review_videos/streaming_urls_controller.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class ProductReviewVideos::StreamingUrlsController < ApplicationController
+  before_action :set_product_review_video
+  after_action :verify_authorized
+
+  def index
+    return head :unauthorized unless authorized?
+
+    render json: {
+      media_urls: [
+        product_review_video_stream_path(
+          @product_review_video.external_id,
+          format: :smil
+        ),
+        @product_review_video.video_file.signed_download_url
+      ]
+    }
+  end
+
+  private
+    def set_product_review_video
+      @product_review_video = ProductReviewVideo.alive
+        .find_by_external_id!(params[:product_review_video_id])
+    end
+
+    def authorized?
+      if authorize_anonymous_user_access?
+        skip_authorization
+        true
+      else
+        authorize @product_review_video, :streaming_urls?
+      end
+    end
+
+    def authorize_anonymous_user_access?
+      @product_review_video.approved? || authorized_by_purchase_email_digest?
+    end
+
+    def authorized_by_purchase_email_digest?
+      ActiveSupport::SecurityUtils.secure_compare(
+        @product_review_video.product_review.purchase.email_digest,
+        params[:purchase_email_digest].to_s
+      )
+    end
+end

--- a/app/controllers/product_review_videos/streaming_urls_controller.rb
+++ b/app/controllers/product_review_videos/streaming_urls_controller.rb
@@ -8,7 +8,7 @@ class ProductReviewVideos::StreamingUrlsController < ApplicationController
     return head :unauthorized unless authorized?
 
     render json: {
-      media_urls: [
+      streaming_urls: [
         product_review_video_stream_path(
           @product_review_video.external_id,
           format: :smil

--- a/app/controllers/product_review_videos/streams_controller.rb
+++ b/app/controllers/product_review_videos/streams_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class ProductReviewVideos::StreamsController < ApplicationController
+  before_action :set_product_review_video
+
+  def show
+    respond_to do |format|
+      format.smil { render plain: @product_review_video.video_file.smil_xml }
+    end
+  end
+
+  private
+    def set_product_review_video
+      @product_review_video = ProductReviewVideo.alive.find_by_external_id!(params[:product_review_video_id])
+    end
+end

--- a/app/controllers/product_reviews_controller.rb
+++ b/app/controllers/product_reviews_controller.rb
@@ -15,7 +15,7 @@ class ProductReviewsController < ApplicationController
     pagination, reviews = pagy(
       product.product_reviews
         .alive
-        .includes(:response, purchase: :purchaser)
+        .includes(:response, approved_video: :video_file, purchase: :purchaser)
         .where(has_message: true)
         .order(rating: :desc, created_at: :desc, id: :desc),
       page: [permitted_params[:page].to_i, 1].max,

--- a/app/controllers/product_reviews_controller.rb
+++ b/app/controllers/product_reviews_controller.rb
@@ -15,8 +15,8 @@ class ProductReviewsController < ApplicationController
     pagination, reviews = pagy(
       product.product_reviews
         .alive
+        .visible_on_product_page
         .includes(:response, approved_video: :video_file, purchase: :purchaser)
-        .where(has_message: true)
         .order(rating: :desc, created_at: :desc, id: :desc),
       page: [permitted_params[:page].to_i, 1].max,
       limit: PER_PAGE

--- a/app/javascript/components/Review.tsx
+++ b/app/javascript/components/Review.tsx
@@ -5,6 +5,7 @@ import { Review as ReviewType } from "$app/data/product_reviews";
 import { Icon } from "$app/components/Icons";
 import { RatingStars } from "$app/components/RatingStars";
 import { ReviewResponseForm } from "$app/components/ReviewResponseForm";
+import { ReviewVideoPlayer } from "$app/components/ReviewVideoPlayer";
 import { useUserAgentInfo } from "$app/components/UserAgent";
 import { WithTooltip } from "$app/components/WithTooltip";
 
@@ -74,7 +75,8 @@ export const Review = ({
           <RatingStars rating={review.rating} />
           {review.is_new ? <span className="pill small primary">New</span> : null}
         </span>
-        <p style={{ margin: 0 }}>{review.message}</p>
+        {review.message ? <p style={{ margin: 0 }}>{review.message}</p> : null}
+        {review.video ? <ReviewVideoPlayer id={review.video.id} thumbnail={review.video.thumbnail_url} /> : null}
         <section style={{ display: "flex", gap: "var(--spacer-1)", alignItems: "center", flexWrap: "wrap" }}>
           <ReviewUserAttribution avatarUrl={review.rater.avatar_url} name={review.rater.name} isBuyer />
         </section>

--- a/app/javascript/components/Review.tsx
+++ b/app/javascript/components/Review.tsx
@@ -76,7 +76,7 @@ export const Review = ({
           {review.is_new ? <span className="pill small primary">New</span> : null}
         </span>
         {review.message ? <p style={{ margin: 0 }}>{review.message}</p> : null}
-        {review.video ? <ReviewVideoPlayer id={review.video.id} thumbnail={review.video.thumbnail_url} /> : null}
+        {review.video ? <ReviewVideoPlayer videoId={review.video.id} thumbnail={review.video.thumbnail_url} /> : null}
         <section style={{ display: "flex", gap: "var(--spacer-1)", alignItems: "center", flexWrap: "wrap" }}>
           <ReviewUserAttribution avatarUrl={review.rater.avatar_url} name={review.rater.name} isBuyer />
         </section>

--- a/app/javascript/components/ReviewVideoPlayer.tsx
+++ b/app/javascript/components/ReviewVideoPlayer.tsx
@@ -1,52 +1,65 @@
-import React from "react";
+import cx from "classnames";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 
+import { getStreamingUrls } from "$app/data/product_reviews";
 import { createJWPlayer } from "$app/utils/jwPlayer";
 
+import { LoadingSpinner } from "$app/components/LoadingSpinner";
 import { PlayVideoIcon } from "$app/components/PlayVideoIcon";
 
-export const ReviewVideoPlayer = ({ sources, thumbnail }: { sources: string[]; thumbnail?: string }) => {
-  const uid = React.useId();
+function usePlayer(videoId: string, uid: string) {
+  const [loading, setLoading] = useState(false);
+  const [showPlayer, setShowPlayer] = useState(false);
+  const playerRef = useRef<jwplayer.JWPlayer | null>(null);
 
-  const player = React.useRef<jwplayer.JWPlayer | null>(null);
-  const [showPlayer, setShowPlayer] = React.useState(false);
+  const onPlay = useCallback(async () => {
+    setLoading(true);
 
-  React.useEffect(() => {
-    if (!showPlayer) return;
+    const { streaming_urls } = await getStreamingUrls(videoId);
 
-    void createJWPlayer(`${uid}-video`, {
-      playlist: [
-        {
-          sources: sources.map((source) => ({ file: source })),
-        },
-      ],
-    }).then((jwPlayer) => {
-      player.current = jwPlayer;
-      jwPlayer
-        .on("ready", () => {
-          if (player.current?.getState() === "playing") {
-            player.current.play();
-          }
-        })
-        .on("complete", () => {
-          setShowPlayer(false);
-          player.current = null;
-        });
+    playerRef.current = await createJWPlayer(`${uid}-video`, {
+      playlist: [{ sources: streaming_urls.map((file) => ({ file })) }],
     });
-  }, [showPlayer]);
+    playerRef.current.on("ready", () => {
+      setShowPlayer(true);
+      playerRef.current?.play();
+    });
+  }, [videoId, uid]);
 
-  const playerElement = () => <div id={`${uid}-video`}></div>;
-  const thumbnailElement = () => (
-    <figure className="relative aspect-video w-full">
-      <img src={thumbnail} className="absolute h-full w-full rounded-t bg-black object-cover" />
-      <button
-        className="link absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
-        onClick={() => setShowPlayer(true)}
-        aria-label="Watch"
-      >
-        <PlayVideoIcon />
-      </button>
-    </figure>
+  useEffect(
+    () => () => {
+      if (playerRef.current) {
+        playerRef.current.remove();
+        playerRef.current = null;
+      }
+    },
+    [],
   );
 
-  return <div className="w-full overflow-hidden rounded">{showPlayer ? playerElement() : thumbnailElement()}</div>;
+  return { loading, showPlayer, onPlay, playerId: `${uid}-video` };
+}
+
+export const ReviewVideoPlayer = ({ id, thumbnail }: { id: string; thumbnail?: string | null }) => {
+  const uid = React.useId();
+
+  const { loading, showPlayer, onPlay, playerId } = usePlayer(id, uid);
+
+  return (
+    <div className="relative aspect-video w-full overflow-hidden rounded bg-black">
+      <div id={playerId} className={cx({ hidden: !showPlayer })}></div>
+      <figure className={cx("relative aspect-video w-full", { hidden: showPlayer })}>
+        {thumbnail ? (
+          <img src={thumbnail} loading="lazy" className="absolute h-full w-full rounded-t bg-black object-cover" />
+        ) : null}
+        <button
+          className="link absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
+          onClick={() => void onPlay()}
+          aria-label="Watch"
+          disabled={loading}
+        >
+          {loading ? <LoadingSpinner width="3em" /> : <PlayVideoIcon />}
+        </button>
+      </figure>
+    </div>
+  );
 };

--- a/app/javascript/components/ReviewVideoPlayer.tsx
+++ b/app/javascript/components/ReviewVideoPlayer.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+
+import { createJWPlayer } from "$app/utils/jwPlayer";
+
+import { PlayVideoIcon } from "$app/components/PlayVideoIcon";
+
+export const ReviewVideoPlayer = ({ sources, thumbnail }: { sources: string[]; thumbnail?: string }) => {
+  const uid = React.useId();
+
+  const player = React.useRef<jwplayer.JWPlayer | null>(null);
+  const [showPlayer, setShowPlayer] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!showPlayer) return;
+
+    void createJWPlayer(`${uid}-video`, {
+      playlist: [
+        {
+          sources: sources.map((source) => ({ file: source })),
+        },
+      ],
+    }).then((jwPlayer) => {
+      player.current = jwPlayer;
+      jwPlayer
+        .on("ready", () => {
+          if (player.current?.getState() === "playing") {
+            player.current.play();
+          }
+        })
+        .on("complete", () => {
+          setShowPlayer(false);
+          player.current = null;
+        });
+    });
+  }, [showPlayer]);
+
+  const playerElement = () => <div id={`${uid}-video`}></div>;
+  const thumbnailElement = () => (
+    <figure className="relative aspect-video w-full">
+      <img src={thumbnail} className="absolute h-full w-full rounded-t bg-black object-cover" />
+      <button
+        className="link absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
+        onClick={() => setShowPlayer(true)}
+        aria-label="Watch"
+      >
+        <PlayVideoIcon />
+      </button>
+    </figure>
+  );
+
+  return <div className="w-full overflow-hidden rounded">{showPlayer ? playerElement() : thumbnailElement()}</div>;
+};

--- a/app/javascript/components/ReviewVideoPlayer.tsx
+++ b/app/javascript/components/ReviewVideoPlayer.tsx
@@ -39,10 +39,10 @@ function usePlayer(videoId: string, uid: string) {
   return { loading, showPlayer, onPlay, playerId: `${uid}-video` };
 }
 
-export const ReviewVideoPlayer = ({ id, thumbnail }: { id: string; thumbnail?: string | null }) => {
+export const ReviewVideoPlayer = ({ videoId, thumbnail }: { videoId: string; thumbnail?: string | null }) => {
   const uid = React.useId();
 
-  const { loading, showPlayer, onPlay, playerId } = usePlayer(id, uid);
+  const { loading, showPlayer, onPlay, playerId } = usePlayer(videoId, uid);
 
   return (
     <div className="relative aspect-video w-full overflow-hidden rounded bg-black">

--- a/app/javascript/data/product_reviews.ts
+++ b/app/javascript/data/product_reviews.ts
@@ -31,7 +31,7 @@ export const setProductRating = async ({
 export type Review = {
   id: string;
   rating: number;
-  message: string;
+  message: string | null;
   rater: { name: string; avatar_url: string };
   purchase_id: string;
   is_new: boolean;
@@ -41,6 +41,10 @@ export type Review = {
       date: string;
       humanized: string;
     };
+  } | null;
+  video: {
+    id: string;
+    thumbnail_url: string | null;
   } | null;
 };
 

--- a/app/javascript/data/product_reviews.ts
+++ b/app/javascript/data/product_reviews.ts
@@ -67,3 +67,15 @@ export const getReview = async (reviewId: string): Promise<{ review: Review }> =
 
   return cast<{ review: Review }>(await response.json());
 };
+
+export const getStreamingUrls = async (id: string) => {
+  const response = await request({
+    method: "GET",
+    url: Routes.product_review_video_streaming_urls_path(id),
+    accept: "json",
+  });
+
+  if (!response.ok) throw new ResponseError();
+
+  return cast<{ streaming_urls: string[] }>(await response.json());
+};

--- a/app/models/concerns/video_file/has_thumbnail.rb
+++ b/app/models/concerns/video_file/has_thumbnail.rb
@@ -8,7 +8,7 @@ module VideoFile::HasThumbnail
 
   included do
     has_one_attached :thumbnail do |attachable|
-      attachable.variant :poster, resize_to_limit: [1280, 720], preprocessed: true
+      attachable.variant :preview, resize_to_limit: [1280, 720], preprocessed: true
     end
 
     validate :validate_thumbnail
@@ -30,7 +30,7 @@ module VideoFile::HasThumbnail
   def thumbnail_url
     return nil unless thumbnail.attached?
 
-    url = thumbnail.variant(:poster).url || thumbnail.url
+    url = thumbnail.variant(:preview).url || thumbnail.url
     url.present? ? cdn_url_for(url) : nil
   end
 end

--- a/app/models/concerns/video_file/has_thumbnail.rb
+++ b/app/models/concerns/video_file/has_thumbnail.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module VideoFile::HasThumbnail
+  extend ActiveSupport::Concern
+
+  THUMBNAIL_SUPPORTED_CONTENT_TYPES = /jpeg|gif|png|jpg/i
+  THUMBNAIL_MAXIMUM_SIZE = 5.megabytes
+
+  included do
+    has_one_attached :thumbnail do |attachable|
+      attachable.variant :poster, resize_to_limit: [1280, 720], preprocessed: true
+    end
+
+    validate :validate_thumbnail
+  end
+
+  def validate_thumbnail
+    return unless thumbnail.attached?
+
+    if !thumbnail.image? || !thumbnail.content_type.match?(THUMBNAIL_SUPPORTED_CONTENT_TYPES)
+      errors.add(:thumbnail, "must be a JPG, PNG, or GIF image.")
+      return
+    end
+
+    if thumbnail.byte_size > THUMBNAIL_MAXIMUM_SIZE
+      errors.add(:thumbnail, "must be smaller than 5 MB.")
+    end
+  end
+
+  def thumbnail_url
+    return nil unless thumbnail.attached?
+
+    url = thumbnail.variant(:poster).url || thumbnail.url
+    url.present? ? cdn_url_for(url) : nil
+  end
+end

--- a/app/models/product_review.rb
+++ b/app/models/product_review.rb
@@ -14,6 +14,12 @@ class ProductReview < ApplicationRecord
   has_many :videos, dependent: :destroy, class_name: "ProductReviewVideo"
   has_one :approved_video, -> { approved }, class_name: "ProductReviewVideo"
 
+  scope :visible_on_product_page,
+        -> {
+          left_joins(:approved_video)
+            .where("product_reviews.has_message = true OR product_review_videos.id IS NOT NULL")
+        }
+
   validates_presence_of :purchase
   validates_presence_of :link
   validates_uniqueness_of :purchase_id

--- a/app/models/product_review.rb
+++ b/app/models/product_review.rb
@@ -12,7 +12,7 @@ class ProductReview < ApplicationRecord
   belongs_to :purchase, optional: true
   has_one :response, class_name: "ProductReviewResponse"
   has_many :videos, dependent: :destroy, class_name: "ProductReviewVideo"
-  has_one :approved_video, -> { approved }, class_name: "ProductReviewVideo"
+  has_one :approved_video, -> { alive.approved }, class_name: "ProductReviewVideo"
 
   scope :visible_on_product_page,
         -> {

--- a/app/models/product_review.rb
+++ b/app/models/product_review.rb
@@ -12,6 +12,7 @@ class ProductReview < ApplicationRecord
   belongs_to :purchase, optional: true
   has_one :response, class_name: "ProductReviewResponse"
   has_many :videos, dependent: :destroy, class_name: "ProductReviewVideo"
+  has_one :approved_video, -> { approved }, class_name: "ProductReviewVideo"
 
   validates_presence_of :purchase
   validates_presence_of :link

--- a/app/models/video_file.rb
+++ b/app/models/video_file.rb
@@ -11,6 +11,7 @@ class VideoFile < ApplicationRecord
   has_s3_fields :url
 
   belongs_to :record, polymorphic: true
+  belongs_to :user
 
   has_flags 1 => :is_transcoded_for_hls,
             2 => :analyze_completed,

--- a/app/models/video_file.rb
+++ b/app/models/video_file.rb
@@ -8,6 +8,8 @@ class VideoFile < ApplicationRecord
   include SignedUrlHelper
   include FlagShihTzu
 
+  include VideoFile::HasThumbnail
+
   has_s3_fields :url
 
   belongs_to :record, polymorphic: true

--- a/app/models/video_file.rb
+++ b/app/models/video_file.rb
@@ -5,6 +5,7 @@ class VideoFile < ApplicationRecord
   include Deletable
   include S3Retrievable
   include CdnDeletable, CdnUrlHelper
+  include SignedUrlHelper
   include FlagShihTzu
 
   has_s3_fields :url
@@ -19,6 +20,18 @@ class VideoFile < ApplicationRecord
   validate :url_is_s3
 
   after_create_commit :schedule_file_analysis
+
+  def smil_xml
+    smil_xml = ::Builder::XmlMarkup.new
+
+    smil_xml.smil do |smil|
+      smil.body do |body|
+        body.switch do |switch|
+          switch.video(src: signed_cloudfront_url(s3_key, is_video: true))
+        end
+      end
+    end
+  end
 
   private
     def schedule_file_analysis

--- a/app/models/video_file.rb
+++ b/app/models/video_file.rb
@@ -36,6 +36,10 @@ class VideoFile < ApplicationRecord
     end
   end
 
+  def signed_download_url
+    signed_download_url_for_s3_key_and_filename(s3_key, s3_filename, is_video: true)
+  end
+
   private
     def schedule_file_analysis
       AnalyzeFileWorker.perform_async(id, self.class.name)

--- a/app/policies/product_review_video_policy.rb
+++ b/app/policies/product_review_video_policy.rb
@@ -9,7 +9,7 @@ class ProductReviewVideoPolicy < ApplicationPolicy
     approve?
   end
 
-  def streaming_urls?
+  def stream?
     return true if record.approved?
     purchased_by_user?(record) || owned_by_seller?(record)
   end

--- a/app/policies/product_review_video_policy.rb
+++ b/app/policies/product_review_video_policy.rb
@@ -9,6 +9,11 @@ class ProductReviewVideoPolicy < ApplicationPolicy
     approve?
   end
 
+  def streaming_urls?
+    return true if record.approved?
+    purchased_by_user?(record) || owned_by_seller?(record)
+  end
+
   private
     def role_permitted?
       user.role_owner_for?(seller) ||
@@ -18,5 +23,9 @@ class ProductReviewVideoPolicy < ApplicationPolicy
 
     def owned_by_seller?(record)
       record.product_review.purchase.seller_id == seller.id
+    end
+
+    def purchased_by_user?(record)
+      record.product_review.purchase.purchaser_id == user.id
     end
 end

--- a/app/presenters/product_review_presenter.rb
+++ b/app/presenters/product_review_presenter.rb
@@ -36,6 +36,17 @@ class ProductReviewPresenter
           },
         } :
         nil,
+      video: video_props,
     }
   end
+
+  private
+    def video_props
+      return nil unless product_review.approved_video.present?
+
+      {
+        id: product_review.approved_video.external_id,
+        thumbnail_url: product_review.approved_video.video_file.thumbnail_url,
+      }
+    end
 end

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -6,5 +6,8 @@
 # Mime::Type.register "text/richtext", :rtf
 # Mime::Type.register_alias "text/html", :iphone
 Mime::Type.register "image/svg+xml", :svg
+Mime::Type.register "application/smil+xml", :smil
+Mime::Type.register "application/x-mpegurl", :m3u8
+
 # TODO remove this when rack is updated to v3
 Rack::Mime::MIME_TYPES[".mjs"] = "text/javascript"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -625,6 +625,7 @@ Rails.application.routes.draw do
     resources :product_review_videos, only: [] do
       scope module: :product_review_videos do
         resource :stream, only: [:show]
+        resources :streaming_urls, only: [:index]
       end
     end
 
@@ -1113,6 +1114,7 @@ Rails.application.routes.draw do
   resources :product_review_videos, only: [] do
     scope module: :product_review_videos do
       resource :stream, only: [:show]
+      resources :media_urls, only: [:index]
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -622,6 +622,12 @@ Rails.application.routes.draw do
     put "/product_reviews/set", to: "product_reviews#set", format: :json
     resources :product_reviews, only: [:index, :show]
     resource :product_review_response, only: [:update], format: :json
+    resources :product_review_videos, only: [] do
+      scope module: :product_review_videos do
+        resource :stream, only: [:show]
+      end
+    end
+
     resources :calls, only: [:update]
 
     resources :purchase_custom_fields, only: [:create]
@@ -1104,6 +1110,11 @@ Rails.application.routes.draw do
 
   resources :product_reviews, only: [:index, :show]
   resource :product_review_response, only: [:update], format: :json
+  resources :product_review_videos, only: [] do
+    scope module: :product_review_videos do
+      resource :stream, only: [:show]
+    end
+  end
 
   namespace :checkout do
     namespace :upsells do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1114,7 +1114,7 @@ Rails.application.routes.draw do
   resources :product_review_videos, only: [] do
     scope module: :product_review_videos do
       resource :stream, only: [:show]
-      resources :media_urls, only: [:index]
+      resources :streaming_urls, only: [:index]
     end
   end
 

--- a/db/migrate/20250416203854_add_user_to_video_files.rb
+++ b/db/migrate/20250416203854_add_user_to_video_files.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddUserToVideoFiles < ActiveRecord::Migration[7.1]
   def change
     add_reference :video_files, :user, null: false, foreign_key: false

--- a/db/migrate/20250416203854_add_user_to_video_files.rb
+++ b/db/migrate/20250416203854_add_user_to_video_files.rb
@@ -1,0 +1,5 @@
+class AddUserToVideoFiles < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :video_files, :user, null: false, foreign_key: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_04_06_055017) do
+ActiveRecord::Schema[7.1].define(version: 2025_04_16_203854) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -2612,7 +2612,9 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_06_055017) do
     t.datetime "deleted_from_cdn_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
     t.index ["record_type", "record_id"], name: "index_video_files_on_record"
+    t.index ["user_id"], name: "index_video_files_on_user_id"
   end
 
   create_table "wishlist_followers", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|

--- a/spec/controllers/product_review_videos/streaming_urls_controller_spec.rb
+++ b/spec/controllers/product_review_videos/streaming_urls_controller_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe ProductReviewVideos::StreamingUrlsController, type: :controller do
+  let(:seller) { create(:user) }
+  let(:purchaser) { create(:user) }
+
+  let(:link) { create(:product, user: seller) }
+  let(:purchase) { create(:purchase, seller:, purchaser:, link:) }
+
+  let(:product_review) { create(:product_review, purchase:) }
+  let(:product_review_video) { create(:product_review_video, product_review:) }
+
+  describe "GET #index" do
+    context "when the product review video is approved" do
+      before { product_review_video.approved! }
+
+      it "returns the correct media URLs" do
+        get :index, params: {
+          product_review_video_id: product_review_video.external_id
+        }, format: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body[:media_urls]).to eq(
+          [
+            product_review_video_stream_path(
+              product_review_video.external_id,
+              format: :smil
+            ),
+            product_review_video.video_file.signed_download_url
+          ]
+        )
+      end
+    end
+
+    context "when the product review video is not approved" do
+      before { product_review_video.pending_review! }
+
+      context "when the user is not logged in" do
+        it "returns unauthorized status" do
+          get :index, params: {
+            product_review_video_id: product_review_video.external_id
+          }, format: :json
+
+          expect(response).to have_http_status(:unauthorized)
+        end
+      end
+
+      context "when a valid purchase email digest is provided" do
+        it "returns a successful response" do
+          get :index, params: {
+            product_review_video_id: product_review_video.external_id,
+            purchase_email_digest: purchase.email_digest
+          }, format: :json
+
+          expect(response).to have_http_status(:ok)
+        end
+      end
+
+      context "when the user is the seller" do
+        before { sign_in(seller) }
+
+        it "returns a successful response" do
+          get :index, params: {
+            product_review_video_id: product_review_video.external_id,
+          }, format: :json
+
+          expect(response).to have_http_status(:ok)
+        end
+      end
+
+      context "when the user is the purchaser" do
+        before { sign_in(purchaser) }
+
+        it "returns a successful response" do
+          get :index, params: {
+            product_review_video_id: product_review_video.external_id,
+          }, format: :json
+
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+
+    context "when the product review video is not found" do
+      it "raises a RecordNotFound error" do
+        expect do
+          get :index, params: {
+            product_review_video_id: "nonexistent_id"
+          }, format: :json
+        end.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end

--- a/spec/controllers/product_review_videos/streaming_urls_controller_spec.rb
+++ b/spec/controllers/product_review_videos/streaming_urls_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ProductReviewVideos::StreamingUrlsController, type: :controller d
         }, format: :json
 
         expect(response).to have_http_status(:ok)
-        expect(response.parsed_body[:media_urls]).to eq(
+        expect(response.parsed_body[:streaming_urls]).to eq(
           [
             product_review_video_stream_path(
               product_review_video.external_id,

--- a/spec/controllers/product_review_videos/streams_controller_spec.rb
+++ b/spec/controllers/product_review_videos/streams_controller_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe ProductReviewVideos::StreamsController do
+  describe "GET show" do
+    let(:smil_xml) { '<smil><body><switch><video src="sample.mp4" /></switch></body></smil>' }
+    let!(:product_review_video) { create(:product_review_video) }
+
+    context "when the video exists" do
+      it "returns smil content when format is smil" do
+        allow_any_instance_of(VideoFile).to receive(:smil_xml).and_return(smil_xml)
+
+        get :show, params: { product_review_video_id: product_review_video.external_id, format: :smil }
+
+        expect(response).to have_http_status(:success)
+        expect(response.content_type).to include("application/smil+xml")
+        expect(response.body).to eq(smil_xml)
+      end
+
+      it "returns 406 for non-smil formats" do
+        expect do
+          get :show, params: { product_review_video_id: product_review_video.external_id, format: :html }
+        end.to raise_error(ActionController::UnknownFormat)
+      end
+
+      it "returns 406 when no format is specified" do
+        expect do
+          get :show, params: { product_review_video_id: product_review_video.external_id }
+        end.to raise_error(ActionController::UnknownFormat)
+      end
+    end
+
+    context "when the video does not exist" do
+      it "returns 404 for non-existent video" do
+        expect do
+          get :show, params: { product_review_video_id: "non-existent-id", format: :smil }
+        end.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "when the video is soft deleted" do
+      before do
+        product_review_video.mark_deleted!
+      end
+
+      it "returns 404 for soft deleted video" do
+        expect do
+          get :show, params: { product_review_video_id: product_review_video.external_id, format: :smil }
+        end.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end

--- a/spec/models/concerns/video_file/has_thumbnail_spec.rb
+++ b/spec/models/concerns/video_file/has_thumbnail_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe VideoFile::HasThumbnail do
+  subject(:video_file) { build(:video_file) }
+
+  let(:jpg_image) { fixture_file_upload("test.jpg") }
+  let(:png_image) { fixture_file_upload("test.png") }
+  let(:gif_image) { fixture_file_upload("test.gif") }
+
+  describe "validations" do
+    context "when no thumbnail is attached" do
+      it "is valid" do
+        expect(video_file.valid?).to eq(true)
+      end
+    end
+
+    context "when a valid thumbnail is attached" do
+      it "is valid with a JPG image" do
+        video_file.thumbnail.attach(jpg_image)
+        expect(video_file.valid?).to eq(true)
+      end
+
+      it "is valid with a PNG image" do
+        video_file.thumbnail.attach(png_image)
+        expect(video_file.valid?).to eq(true)
+      end
+
+      it "is valid with a GIF image" do
+        video_file.thumbnail.attach(gif_image)
+        expect(video_file.valid?).to eq(true)
+      end
+    end
+
+    context "when the thumbnail has an invalid content type" do
+      let(:txt_file) { fixture_file_upload("blah.txt") }
+      let(:mp4_file) { fixture_file_upload("test.mp4") }
+
+      it "is invalid with a text file" do
+        video_file.thumbnail.attach(txt_file)
+        expect(video_file.valid?).to eq(false)
+        expect(video_file.errors[:thumbnail]).to include("must be a JPG, PNG, or GIF image.")
+      end
+
+      it "is invalid with a video file" do
+        video_file.thumbnail.attach(mp4_file)
+        expect(video_file.valid?).to eq(false)
+        expect(video_file.errors[:thumbnail]).to include("must be a JPG, PNG, or GIF image.")
+      end
+    end
+
+    context "when the thumbnail is too large" do
+      let(:large_image_over_5mb) { fixture_file_upload("P1110259.JPG") }
+
+      it "is invalid with a file over 5MB" do
+        video_file.thumbnail.attach(large_image_over_5mb)
+        expect(video_file.valid?).to eq(false)
+        expect(video_file.errors[:thumbnail]).to include("must be smaller than 5 MB.")
+      end
+    end
+  end
+
+  describe "#preview_thumbnail_url" do
+    context "when a thumbnail is attached" do
+      it "returns a valid representation URL" do
+        video_file.thumbnail.attach(jpg_image)
+        video_file.save!
+
+        expect(video_file.thumbnail_url).to eq("https://gumroad-specs.s3.amazonaws.com/#{video_file.thumbnail.key}")
+
+        video_file.thumbnail.variant(:poster).processed
+        expect(video_file.thumbnail_url).to eq("https://gumroad-specs.s3.amazonaws.com/#{video_file.thumbnail.variant(:poster).key}")
+      end
+    end
+
+    context "when no thumbnail is attached" do
+      it "returns nil" do
+        expect(video_file.thumbnail_url).to be_nil
+      end
+    end
+  end
+end

--- a/spec/models/concerns/video_file/has_thumbnail_spec.rb
+++ b/spec/models/concerns/video_file/has_thumbnail_spec.rb
@@ -69,8 +69,8 @@ RSpec.describe VideoFile::HasThumbnail do
 
         expect(video_file.thumbnail_url).to eq("https://gumroad-specs.s3.amazonaws.com/#{video_file.thumbnail.key}")
 
-        video_file.thumbnail.variant(:poster).processed
-        expect(video_file.thumbnail_url).to eq("https://gumroad-specs.s3.amazonaws.com/#{video_file.thumbnail.variant(:poster).key}")
+        video_file.thumbnail.variant(:preview).processed
+        expect(video_file.thumbnail_url).to eq("https://gumroad-specs.s3.amazonaws.com/#{video_file.thumbnail.variant(:preview).key}")
       end
     end
 

--- a/spec/models/product_review_spec.rb
+++ b/spec/models/product_review_spec.rb
@@ -97,13 +97,33 @@ describe ProductReview do
   end
 
   describe ".visible_on_product_page" do
-    let!(:has_message) { create(:product_review, message: "has_message") }
-    let!(:has_video) { create(:product_review, videos: [build(:product_review_video, :approved)]) }
+    let!(:only_has_message) { create(:product_review, message: "has_message") }
+    let!(:only_has_approved_video) do
+      create(
+        :product_review,
+        message: nil,
+        videos: [build(:product_review_video, :approved)]
+      )
+    end
+    let!(:only_has_pending_video) do
+      create(
+        :product_review,
+        message: nil,
+        videos: [build(:product_review_video, :pending_review)]
+      )
+    end
+    let!(:only_has_deleted_approved_video) do
+      create(
+        :product_review,
+        message: nil,
+        videos: [build(:product_review_video, :approved, deleted_at: Time.current)]
+      )
+    end
     let!(:no_message_or_video) { create(:product_review, message: nil, videos: []) }
 
     it "includes reviews with has_message: true" do
       expect(ProductReview.visible_on_product_page.pluck(:id))
-        .to contain_exactly(has_message.id, has_video.id)
+        .to contain_exactly(only_has_message.id, only_has_approved_video.id)
     end
   end
 end

--- a/spec/models/product_review_spec.rb
+++ b/spec/models/product_review_spec.rb
@@ -95,4 +95,15 @@ describe ProductReview do
     expect(product_review).to_not be_valid
     expect(product_review.errors.full_messages).to eq(["Adult keywords are not allowed"])
   end
+
+  describe ".visible_on_product_page" do
+    let!(:has_message) { create(:product_review, message: "has_message") }
+    let!(:has_video) { create(:product_review, videos: [build(:product_review_video, :approved)]) }
+    let!(:no_message_or_video) { create(:product_review, message: nil, videos: []) }
+
+    it "includes reviews with has_message: true" do
+      expect(ProductReview.visible_on_product_page.pluck(:id))
+        .to contain_exactly(has_message.id, has_video.id)
+    end
+  end
 end

--- a/spec/models/video_file_spec.rb
+++ b/spec/models/video_file_spec.rb
@@ -22,4 +22,21 @@ RSpec.describe VideoFile, type: :model do
       expect(video_file.errors[:url]).to include("must be an S3 URL")
     end
   end
+
+  describe "#smil_xml" do
+    it "returns properly formatted SMIL XML with signed cloudfront URL" do
+      s3_key = "attachments/1234567890abcdef1234567890abcdef/original/myvideo.mp4"
+      s3_url = "#{S3_BASE_URL}attachments/1234567890abcdef1234567890abcdef/original/myvideo.mp4"
+      signed_url = "https://cdn.example.com/signed-url-for-video.mp4"
+
+      video_file = create(:video_file, url: s3_url)
+
+      allow(video_file).to receive(:signed_cloudfront_url).with(s3_key, is_video: true).and_return(signed_url)
+
+      expected_xml = <<~XML.strip
+        <smil><body><switch><video src="#{signed_url}"/></switch></body></smil>
+      XML
+      expect(video_file.smil_xml).to eq(expected_xml)
+    end
+  end
 end

--- a/spec/policies/product_review_video_policy_spec.rb
+++ b/spec/policies/product_review_video_policy_spec.rb
@@ -40,14 +40,17 @@ describe ProductReviewVideoPolicy do
     ).user
   end
 
+  let(:purchaser) { create(:user) }
+  let(:another_user) { create(:user) }
+
   let(:product) { create(:product, user: seller) }
-  let(:purchase) { create(:purchase, link: product, seller: seller) }
-  let(:product_review) { create(:product_review, purchase: purchase) }
+  let(:purchase) { create(:purchase, link: product, seller:, purchaser:) }
+  let(:product_review) { create(:product_review, purchase:) }
   let(:product_review_video_for_seller) do
     create(
       :product_review_video,
-      product_review: product_review,
-      approval_status: :pending_review
+      :pending_review,
+      product_review: product_review
     )
   end
 
@@ -91,6 +94,53 @@ describe ProductReviewVideoPolicy do
         :support_for_seller,
         :accountant_for_seller,
         :marketing_for_seller,
+      ]
+    end
+  end
+
+  permissions :streaming_urls? do
+    context "when the video has been approved" do
+      let(:record) { product_review_video_for_another_seller }
+
+      before { record.approved! }
+
+      it_behaves_like "an access-granting policy for roles", [:seller]
+    end
+
+    context "when the video has not been approved" do
+      let(:record) { product_review_video_for_another_seller }
+
+      before { record.pending_review! }
+
+      it_behaves_like "an access-denying policy for roles", [:seller]
+    end
+
+    context "when the video is for the seller's product review" do
+      let(:record) { product_review_video_for_seller }
+
+      before { record.pending_review! }
+
+      it_behaves_like "an access-granting policy for roles", [
+        :seller,
+        :admin_for_seller,
+        :support_for_seller,
+        :accountant_for_seller,
+        :marketing_for_seller,
+      ]
+    end
+
+    context "when the video is for the purchaser's product review" do
+      let(:context_seller) { purchaser }
+      let(:record) { product_review_video_for_seller }
+
+      before { record.pending_review! }
+
+      it_behaves_like "an access-granting policy for roles", [
+        :purchaser,
+      ]
+
+      it_behaves_like "an access-denying policy for roles", [
+        :seller,
       ]
     end
   end

--- a/spec/policies/product_review_video_policy_spec.rb
+++ b/spec/policies/product_review_video_policy_spec.rb
@@ -98,7 +98,7 @@ describe ProductReviewVideoPolicy do
     end
   end
 
-  permissions :streaming_urls? do
+  permissions :stream? do
     context "when the video has been approved" do
       let(:record) { product_review_video_for_another_seller }
 

--- a/spec/presenters/product_review_presenter_spec.rb
+++ b/spec/presenters/product_review_presenter_spec.rb
@@ -18,7 +18,8 @@ describe ProductReviewPresenter do
           rating: product_review.rating,
           purchase_id: product_review.purchase.external_id,
           is_new: true,
-          response: nil
+          response: nil,
+          video: nil
         }
       )
     end
@@ -89,6 +90,25 @@ describe ProductReviewPresenter do
             expect(described_class.new(product_review).product_review_props[:rater][:name]).to eq("Purchaser")
           end
         end
+      end
+    end
+
+    context "product review has videos" do
+      let(:video) { create(:product_review_video, product_review:) }
+
+      it "only includes the approved video" do
+        video.pending_review!
+        product_review.reload
+        expect(described_class.new(product_review).product_review_props[:video]).to be nil
+
+        video.approved!
+        product_review.reload
+        expect(described_class.new(product_review).product_review_props[:video]).to eq(
+          {
+            id: video.external_id,
+            thumbnail_url: video.video_file.thumbnail_url,
+          }
+        )
       end
     end
   end

--- a/spec/support/factories/video_files.rb
+++ b/spec/support/factories/video_files.rb
@@ -2,8 +2,9 @@
 
 FactoryBot.define do
   factory :video_file do
-    record { create(:user) }
     url { "https://s3.amazonaws.com/gumroad-specs/specs/ScreenRecording.mov" }
     filetype { "mov" }
+    user { create(:user) }
+    record { user }
   end
 end


### PR DESCRIPTION
Part of https://github.com/antiwork/gumroad/issues/20.

<img width="1162" alt="image" src="https://github.com/user-attachments/assets/441b7899-2b65-45a0-a88d-67e31446ceaa" />


---

On a high level:

**Rails**

- **MIME Types**: Registers `.smil` and `.m3u8` formats.
  - I've tested this in a branch app to make sure it doesn't interfere with existing routes
- **Streaming Endpoints**:
  - `GET /product_review_videos/:id/stream.smil`: returns SMIL playlist.
  - `GET /product_review_videos/:id/streaming_urls.json`: returns SMIL and signed download URLs.
- **Authorization**: Only approved videos or users related to the purchase can access streaming URLs (`ProductReviewVideoPolicy#stream?`).
- **Thumbnails**:
  - Adds `VideoFile::HasThumbnail` concern with validations and `:preview` variant (1280x720).
  - Adds `#thumbnail_url` helper.
  - This mostly follows existing pattern in `ProductFile`. With consolidate these two.
- **Model Changes**:
  - Adds `user_id` to `video_files`.
  - Adds `ProductReview#approved_video` and `.visible_on_product_page` scope.

**React**

- **`ReviewVideoPlayer`**:
  - Fetches streaming URLs on-demand.
  - Lazily loads and initializes JW Player.
  - Displays a thumbnail with a play button and loading state.
