### PR TITLE
Allow creators to approve review videos

### DIFF
--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -160,7 +160,13 @@ class CustomersController < Sellers::BaseController
     end
 
     def load_sales(sales)
-      sales.records.includes(:tip, product_review: [:response], utm_link: [target_resource: [:seller, :user]]).load
+      sales.records
+        .includes(
+          :tip,
+          product_review: [:response, { alive_videos: [:video_file] }],
+          utm_link: [target_resource: [:seller, :user]]
+        )
+        .load
     end
 
     def set_title

--- a/app/javascript/components/server-components/Audience/CustomersPage.tsx
+++ b/app/javascript/components/server-components/Audience/CustomersPage.tsx
@@ -1624,9 +1624,11 @@ const ReviewVideosSubsections = ({ review, onChange }: { review: Review; onChang
       <div className="flex flex-col gap-4">
         <h5>Pending video</h5>
         <ReviewVideoPlayer videoId={pendingVideo.id} thumbnail={pendingVideo.thumbnail_url} />
-        <Button color="primary" className="flex-1" onClick={() => void approveVideo(pendingVideo)} disabled={loading}>
-          Show on product page
-        </Button>
+        {pendingVideo.can_approve ? (
+          <Button color="primary" className="flex-1" onClick={() => void approveVideo(pendingVideo)} disabled={loading}>
+            Show on product page
+          </Button>
+        ) : null}
       </div>
     </section>
   ) : null;

--- a/app/javascript/components/server-components/Audience/CustomersPage.tsx
+++ b/app/javascript/components/server-components/Audience/CustomersPage.tsx
@@ -1602,6 +1602,7 @@ const ReviewVideosSubsections = ({ review, onChange }: { review: Review; onChang
     try {
       await approveReviewVideo(video.id);
       onChange({ ...review, videos: [{ ...video, approval_status: "approved" }] });
+      showAlert("This video review is now live!", "success");
     } catch (e) {
       assertResponseError(e);
       showAlert("Something went wrong", "error");

--- a/app/javascript/components/server-components/Audience/CustomersPage.tsx
+++ b/app/javascript/components/server-components/Audience/CustomersPage.tsx
@@ -42,6 +42,8 @@ import {
   completeCommission,
   getCharges,
   File,
+  ReviewVideo,
+  approveReviewVideo,
 } from "$app/data/customers";
 import {
   CurrencyCode,
@@ -80,6 +82,7 @@ import { useSortingTableDriver } from "$app/components/useSortingTableDriver";
 import { WithTooltip } from "$app/components/WithTooltip";
 
 import placeholder from "$assets/images/placeholders/customers.png";
+import { ReviewVideoPlayer } from "$app/components/ReviewVideoPlayer";
 
 type Product = { id: string; name: string; variants: { id: string; name: string }[] };
 
@@ -1587,6 +1590,55 @@ const EmailSection = ({
   );
 };
 
+const ReviewVideosSubsections = ({ review, onChange }: { review: Review; onChange: (review: Review) => void }) => {
+  const [loading, setLoading] = React.useState(false);
+
+  const approvedVideo = review.videos.find((video) => video.approval_status === "approved");
+  const pendingVideo = review.videos.find((video) => video.approval_status === "pending_review");
+
+  const approveVideo = async (video: ReviewVideo) => {
+    setLoading(true);
+
+    try {
+      await approveReviewVideo(video.id);
+      onChange({ ...review, videos: [{ ...video, approval_status: "approved" }] });
+    } catch (e) {
+      assertResponseError(e);
+      showAlert("Something went wrong", "error");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const approvedVideoSubsection = approvedVideo ? (
+    <section>
+      <div className="flex flex-col gap-4">
+        <h5>Approved video</h5>
+        <ReviewVideoPlayer videoId={approvedVideo.id} thumbnail={approvedVideo.thumbnail_url} />
+      </div>
+    </section>
+  ) : null;
+
+  const pendingVideoSubsection = pendingVideo ? (
+    <section>
+      <div className="flex flex-col gap-4">
+        <h5>Pending video</h5>
+        <ReviewVideoPlayer videoId={pendingVideo.id} thumbnail={pendingVideo.thumbnail_url} />
+        <Button color="primary" className="flex-1" onClick={() => void approveVideo(pendingVideo)} disabled={loading}>
+          Show on product page
+        </Button>
+      </div>
+    </section>
+  ) : null;
+
+  return approvedVideoSubsection || pendingVideoSubsection ? (
+    <>
+      {approvedVideoSubsection}
+      {pendingVideoSubsection}
+    </>
+  ) : null;
+};
+
 const ReviewSection = ({
   review,
   purchaseId,
@@ -1610,6 +1662,7 @@ const ReviewSection = ({
         {review.message}
       </section>
     ) : null}
+    <ReviewVideosSubsections review={review} onChange={onChange} />
     {review.response ? (
       <section>
         <h5>Response</h5>

--- a/app/javascript/components/server-components/Audience/CustomersPage.tsx
+++ b/app/javascript/components/server-components/Audience/CustomersPage.tsx
@@ -71,6 +71,7 @@ import { PriceInput } from "$app/components/PriceInput";
 import { Progress } from "$app/components/Progress";
 import { RatingStars } from "$app/components/RatingStars";
 import { ReviewResponseForm } from "$app/components/ReviewResponseForm";
+import { ReviewVideoPlayer } from "$app/components/ReviewVideoPlayer";
 import { Select } from "$app/components/Select";
 import { showAlert } from "$app/components/server-components/Alert";
 import { Toggle } from "$app/components/Toggle";
@@ -82,7 +83,6 @@ import { useSortingTableDriver } from "$app/components/useSortingTableDriver";
 import { WithTooltip } from "$app/components/WithTooltip";
 
 import placeholder from "$assets/images/placeholders/customers.png";
-import { ReviewVideoPlayer } from "$app/components/ReviewVideoPlayer";
 
 type Product = { id: string; name: string; variants: { id: string; name: string }[] };
 

--- a/app/javascript/data/customers.ts
+++ b/app/javascript/data/customers.ts
@@ -36,6 +36,7 @@ export type ReviewVideo = {
   id: string;
   approval_status: "pending_review" | "approved" | "rejected";
   thumbnail_url: string | null;
+  can_approve: boolean;
 };
 export type Call = { id: string; call_url: string | null; start_time: string; end_time: string };
 export type File = {

--- a/app/javascript/data/customers.ts
+++ b/app/javascript/data/customers.ts
@@ -26,7 +26,17 @@ export type Address = {
 export type Tracking = { shipped: false } | { shipped: true; url: string | null };
 export type Option = { id: string; name: string };
 export type ReviewResponse = { message: string };
-export type Review = { rating: number; message: string | null; response: ReviewResponse | null };
+export type Review = {
+  rating: number;
+  message: string | null;
+  response: ReviewResponse | null;
+  videos: ReviewVideo[];
+};
+export type ReviewVideo = {
+  id: string;
+  approval_status: "pending_review" | "approved" | "rejected";
+  thumbnail_url: string | null;
+};
 export type Call = { id: string; call_url: string | null; start_time: string; end_time: string };
 export type File = {
   id: string;
@@ -411,5 +421,17 @@ export const completeCommission = async (commissionId: string) => {
 
   if (!response.ok) {
     throw new ResponseError(cast<{ errors: string[] }>(await response.json()).errors[0]);
+  }
+};
+
+export const approveReviewVideo = async (videoId: string) => {
+  const response = await request({
+    method: "POST",
+    accept: "json",
+    url: Routes.internal_product_review_video_approvals_url(videoId),
+  });
+
+  if (!response.ok) {
+    throw new ResponseError();
   }
 };

--- a/app/models/product_review.rb
+++ b/app/models/product_review.rb
@@ -15,6 +15,7 @@ class ProductReview < ApplicationRecord
   has_many :videos, dependent: :destroy, class_name: "ProductReviewVideo"
   has_many :alive_videos, -> { alive }, class_name: "ProductReviewVideo"
   has_one :approved_video, -> { alive.approved }, class_name: "ProductReviewVideo"
+  has_one :pending_video, -> { alive.pending_review }, class_name: "ProductReviewVideo"
 
   scope :visible_on_product_page,
         -> {

--- a/app/models/product_review.rb
+++ b/app/models/product_review.rb
@@ -11,7 +11,9 @@ class ProductReview < ApplicationRecord
   belongs_to :link, optional: true
   belongs_to :purchase, optional: true
   has_one :response, class_name: "ProductReviewResponse"
+
   has_many :videos, dependent: :destroy, class_name: "ProductReviewVideo"
+  has_many :alive_videos, -> { alive }, class_name: "ProductReviewVideo"
   has_one :approved_video, -> { alive.approved }, class_name: "ProductReviewVideo"
 
   scope :visible_on_product_page,

--- a/app/presenters/customer_presenter.rb
+++ b/app/presenters/customer_presenter.rb
@@ -103,6 +103,7 @@ class CustomerPresenter
           response: review.response ? {
             message: review.response.message,
           } : nil,
+          videos: review_videos_props(review.alive_videos),
         } : nil,
       call: call.present? ?
         {
@@ -171,5 +172,17 @@ class CustomerPresenter
         extension: File.extname(file.filename.to_s).delete(".").upcase,
         key: file.key
       }
+    end
+
+    def review_videos_props(alive_videos)
+      # alive_videos of different states are pre-loaded together to simplify
+      # the query, and there is guaranteed to be at-most one pending and
+      # at-most one approved video.
+      pending = alive_videos.find(&:pending_review?)
+      approved = alive_videos.find(&:approved?)
+
+      [pending, approved]
+        .compact
+        .map { |video| ProductReviewVideoPresenter.new(video).props }
     end
 end

--- a/app/presenters/customer_presenter.rb
+++ b/app/presenters/customer_presenter.rb
@@ -174,7 +174,7 @@ class CustomerPresenter
       }
     end
 
-    def review_videos_props(alive_videos, pundit_user:)
+    def review_videos_props(alive_videos:, pundit_user:)
       # alive_videos of different states are pre-loaded together to simplify
       # the query, and there is guaranteed to be at-most one pending and
       # at-most one approved video.

--- a/app/presenters/customer_presenter.rb
+++ b/app/presenters/customer_presenter.rb
@@ -103,7 +103,7 @@ class CustomerPresenter
           response: review.response ? {
             message: review.response.message,
           } : nil,
-          videos: review_videos_props(review.alive_videos),
+          videos: review_videos_props(alive_videos: review.alive_videos, pundit_user:),
         } : nil,
       call: call.present? ?
         {
@@ -174,7 +174,7 @@ class CustomerPresenter
       }
     end
 
-    def review_videos_props(alive_videos)
+    def review_videos_props(alive_videos, pundit_user:)
       # alive_videos of different states are pre-loaded together to simplify
       # the query, and there is guaranteed to be at-most one pending and
       # at-most one approved video.
@@ -183,6 +183,6 @@ class CustomerPresenter
 
       [pending, approved]
         .compact
-        .map { |video| ProductReviewVideoPresenter.new(video).props }
+        .map { |video| ProductReviewVideoPresenter.new(video).props(pundit_user:) }
     end
 end

--- a/app/presenters/product_review_video_presenter.rb
+++ b/app/presenters/product_review_video_presenter.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class ProductReviewVideoPresenter
+  attr_reader :video
+
+  def initialize(video)
+    @video = video
+  end
+
+  def props
+    {
+      id: video.external_id,
+      approval_status: video.approval_status,
+      thumbnail_url: video.video_file.thumbnail_url,
+    }
+  end
+end

--- a/app/presenters/product_review_video_presenter.rb
+++ b/app/presenters/product_review_video_presenter.rb
@@ -7,11 +7,12 @@ class ProductReviewVideoPresenter
     @video = video
   end
 
-  def props
+  def props(pundit_user:)
     {
       id: video.external_id,
       approval_status: video.approval_status,
       thumbnail_url: video.video_file.thumbnail_url,
+      can_approve: Pundit.policy!(pundit_user, video).approve?,
     }
   end
 end

--- a/app/views/contacting_creator_mailer/review_submitted.html.erb
+++ b/app/views/contacting_creator_mailer/review_submitted.html.erb
@@ -1,11 +1,23 @@
 <%= header_section("New review") %>
 <div>
   <div><%= @buyer %> reviewed <%= link_to @product.name, @product.long_url %></div>
+
   <%= render("shared/mailers/review_rating", rating: @review.rating) %>
+
   <% if @review.message.present? %>
     <div>
       <i><%= "\"#{@review.message}\"" %></i>
     </div>
   <% end %>
+
+  <% if @review.pending_video.present? %>
+    <div>
+      <%= link_to customers_url(query: @review.purchase.email) do %>
+        <%= render("shared/mailers/video_file_thumbnail", video_file: @review.pending_video.video_file) %>
+      <% end %>
+    </div>
+    <%= link_to "Review & approve video", customers_url(query: @review.purchase.email), class: "button" %>
+  <% end %>
+
   <%= link_to "View all reviews", @product.long_url, class: "button primary" %>
 </div>

--- a/app/views/shared/mailers/_video_file_thumbnail.html.erb
+++ b/app/views/shared/mailers/_video_file_thumbnail.html.erb
@@ -1,0 +1,14 @@
+<figure style="width: 100%; position: relative;">
+  <% if video_file.thumbnail_url.present? %>
+    <%= image_tag(
+      video_file.thumbnail_url,
+      width: 1280,
+      height: 720,
+      style: "width: 100%; height: auto;"
+    ) %>
+  <% else %>
+    <!-- 16:9 aspect ratio via padding -->
+    <div style="background-color: black; display:block; width:100%; height:0; padding-top:56.25%;">
+    </div>
+  <% end %>
+</figure>

--- a/lib/mailer_previews/contacting_creator_mailer_preview.rb
+++ b/lib/mailer_previews/contacting_creator_mailer_preview.rb
@@ -185,7 +185,7 @@ class ContactingCreatorMailerPreview < ActionMailer::Preview
   end
 
   def review_submitted
-    ContactingCreatorMailer.review_submitted(ProductReview.where.not(message: nil).last&.id)
+    ContactingCreatorMailer.review_submitted(ProductReview.last&.id)
   end
 
   def upcoming_call_reminder

--- a/spec/mailers/contacting_creator_mailer_spec.rb
+++ b/spec/mailers/contacting_creator_mailer_spec.rb
@@ -1751,6 +1751,23 @@ describe ContactingCreatorMailer do
         expect(mail.body.encoded).to_not have_text('""')
       end
     end
+
+    context "when the review has a pending video" do
+      let!(:pending_video) do
+        create(
+          :product_review_video,
+          :pending_review,
+          product_review: review,
+          video_file: create(:video_file, :with_thumbnail)
+        )
+      end
+
+      it "includes the video thumbnail" do
+        mail = ContactingCreatorMailer.review_submitted(review.id)
+        expect(mail.body.encoded).to have_selector("img[src='#{pending_video.video_file.thumbnail_url}']")
+        expect(mail.body.encoded).to have_link("Review & approve video", href: customers_url(query: review.purchase.email))
+      end
+    end
   end
 
   describe "#upcoming_call_reminder" do

--- a/spec/presenters/customer_presenter_spec.rb
+++ b/spec/presenters/customer_presenter_spec.rb
@@ -110,6 +110,7 @@ describe CustomerPresenter do
             response: {
               message: "Thank you!",
             },
+            videos: [],
           },
           call: nil,
           commission: nil,
@@ -309,6 +310,23 @@ describe CustomerPresenter do
             term: utm_link.utm_term,
             content: utm_link.utm_content,
           }
+        )
+      end
+    end
+
+    context "purchase has review videos" do
+      let(:purchase) { create(:purchase) }
+      let(:product_review) { create(:product_review, purchase:) }
+
+      let!(:alive_approved_video) { create(:product_review_video, :approved, product_review:) }
+      let!(:alive_pending_video) { create(:product_review_video, :pending_review, product_review:) }
+      let!(:soft_deleted_video) { create(:product_review_video, :approved, product_review:, deleted_at: Time.current) }
+
+      it "includes the review videos" do
+        props = described_class.new(purchase: purchase.reload).customer(pundit_user:)
+        expect(props[:review][:videos]).to contain_exactly(
+          ProductReviewVideoPresenter.new(alive_approved_video).props,
+          ProductReviewVideoPresenter.new(alive_pending_video).props,
         )
       end
     end

--- a/spec/presenters/customer_presenter_spec.rb
+++ b/spec/presenters/customer_presenter_spec.rb
@@ -325,8 +325,8 @@ describe CustomerPresenter do
       it "includes the review videos" do
         props = described_class.new(purchase: purchase.reload).customer(pundit_user:)
         expect(props[:review][:videos]).to contain_exactly(
-          ProductReviewVideoPresenter.new(alive_approved_video).props,
-          ProductReviewVideoPresenter.new(alive_pending_video).props,
+          ProductReviewVideoPresenter.new(alive_approved_video).props(pundit_user:),
+          ProductReviewVideoPresenter.new(alive_pending_video).props(pundit_user:),
         )
       end
     end

--- a/spec/presenters/product_review_video_presenter_spec.rb
+++ b/spec/presenters/product_review_video_presenter_spec.rb
@@ -3,17 +3,47 @@
 require "spec_helper"
 
 RSpec.describe ProductReviewVideoPresenter do
-  let(:video) { create(:product_review_video, :approved) }
+  let(:seller) { create(:user) }
+  let(:another_seller) { create(:user) }
+
+  let(:link) { create(:product, user: seller) }
+  let(:purchase) { create(:purchase, seller:, link:) }
+  let(:product_review) { create(:product_review, purchase:) }
+
+  let(:video) { create(:product_review_video, :approved, product_review:) }
+
+  let(:pundit_user) { SellerContext.new(user: seller, seller:) }
 
   describe "#props" do
     it "returns the correct props" do
       presenter = described_class.new(video)
 
-      expect(presenter.props).to eq(
+      expect(presenter.props(pundit_user:)).to match(
         id: video.external_id,
         approval_status: video.approval_status,
-        thumbnail_url: video.video_file.thumbnail_url
+        thumbnail_url: video.video_file.thumbnail_url,
+        can_approve: true
       )
+    end
+
+    describe "can_approve" do
+      context "when the user has approval permission" do
+        let(:pundit_user) { SellerContext.new(user: seller, seller:) }
+
+        it "returns true" do
+          presenter = described_class.new(video)
+          expect(presenter.props(pundit_user:)[:can_approve]).to eq(true)
+        end
+      end
+
+      context "when the user does not have approval permission" do
+        let(:pundit_user) { SellerContext.new(user: another_seller, seller: another_seller) }
+
+        it "returns false" do
+          presenter = described_class.new(video)
+          expect(presenter.props(pundit_user:)[:can_approve]).to eq(false)
+        end
+      end
     end
   end
 end

--- a/spec/presenters/product_review_video_presenter_spec.rb
+++ b/spec/presenters/product_review_video_presenter_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe ProductReviewVideoPresenter do
+  let(:video) { create(:product_review_video, :approved) }
+
+  describe "#props" do
+    it "returns the correct props" do
+      presenter = described_class.new(video)
+
+      expect(presenter.props).to eq(
+        id: video.external_id,
+        approval_status: video.approval_status,
+        thumbnail_url: video.video_file.thumbnail_url
+      )
+    end
+  end
+end

--- a/spec/support/factories/video_files.rb
+++ b/spec/support/factories/video_files.rb
@@ -6,5 +6,15 @@ FactoryBot.define do
     filetype { "mov" }
     user { create(:user) }
     record { user }
+
+    trait :with_thumbnail do
+      after(:build) do |video_file|
+        video_file.thumbnail.attach(
+          io: File.open(Rails.root.join("spec/support/fixtures/test-small.png")),
+          filename: "thumbnail.png",
+          content_type: "image/png"
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
Part of #20.

---

**Sales drawer**

<img width="1088" alt="image" src="https://github.com/user-attachments/assets/a953fc8e-4589-4ac0-985b-279ed34db322" />

---

**Email to the creator**

<img width="380" alt="Screenshot 2025-04-17 at 12 37 28 PM" src="https://github.com/user-attachments/assets/198f838f-bc05-451b-aadd-b83a4d6b36a6" />

(I haven't added the "play button icon" to the thumbnail due to CSS support in emails 🤦 will come back to this as a post-launch improvement.)
