### PR TITLE
Ensure 1099-MISC eligibility test uses sufficient basis points

### DIFF
--- a/spec/models/concerns/user/taxation_spec.rb
+++ b/spec/models/concerns/user/taxation_spec.rb
@@ -133,7 +133,11 @@ describe User::Taxation do
     before do
       create(:merchant_account_stripe, user: @user)
       create(:tos_agreement, user: @user)
-      @affiliate = create(:direct_affiliate, affiliate_user: @user, affiliate_basis_points: [10_00, 15_00, 20_00].sample)
+      @affiliate = create(
+        :direct_affiliate,
+        affiliate_user: @user,
+        affiliate_basis_points: [15_00, 20_00].sample
+      )
 
       10.times do
         create(:purchase, price_cents: 100_00,


### PR DESCRIPTION
```
Failures:

  1) User::Taxation#eligible_for_1099_misc? when user is compliant returns true
     Failure/Error: expect(@user.eligible_for_1099_misc?(year)).to eq(true)
       Expected false to eq true.
     # ./spec/models/concerns/user/taxation_spec.rb:193:in `block (4 levels) in <main>'
```

The test for `eligible_for_1099_misc?` was flaky because when `affiliate_basis_points` was randomly selected as `10_00,` the total affiliate credits would be exactly at the threshold (`100_00`). This edge case would then cause the test to fail.

By removing `10_00` from the possible random values and only using `15_00` or `20_00`, we ensure the affiliate credits will always be safely above the minimum threshold, making the test more reliable.