### PR TITLE
Email-marketing-improvements

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,12 +33,6 @@ GIT
       web-push
 
 GEM
-  remote: https://gems.contribsys.com/
-  specs:
-    sidekiq-pro (7.3.0)
-      sidekiq (>= 7.3.0, < 8)
-
-GEM
   remote: https://rubygems.org/
   specs:
     Ascii85 (1.1.1)
@@ -1239,8 +1233,8 @@ DEPENDENCIES
   sendgrid-ruby (~> 6.6)
   shakapacker (~> 8.0)
   shoulda-matchers (~> 6.0)
+  sidekiq (~> 7.2)
   sidekiq-cron (~> 1.9)
-  sidekiq-pro (~> 7.2)!
   sidekiq-unique-jobs (~> 8.0)
   sitemap_generator (~> 6.3)
   slack-notifier (~> 2.4)

--- a/app/javascript/components/server-components/EmailsPage/SegmentsTab.tsx
+++ b/app/javascript/components/server-components/EmailsPage/SegmentsTab.tsx
@@ -1,0 +1,152 @@
+import React from "react";
+
+import { Button } from "$app/components/Button";
+import { Icon } from "$app/components/Icons";
+import { Popover } from "$app/components/Popover";
+import { Layout } from "$app/components/server-components/EmailsPage";
+
+export const SegmentsTab = () => {
+  const [selectedSegmentId, setSelectedSegmentId] = React.useState<string | null>(null);
+  const [openPopoverId, setOpenPopoverId] = React.useState<string | null>(null);
+
+  const segments = [
+    {
+      external_id: "1",
+      name: "Active subscribers",
+      created_at: new Date("2025-02-13T00:00:00Z"),
+      last_used_at: new Date("2025-02-14T00:00:00Z"),
+      subscriber_count: 1302,
+      opens_rate: 0,
+      clicks_rate: 0,
+    },
+    {
+      external_id: "2",
+      name: "Casual subscribers",
+      created_at: new Date("2025-05-01T00:00:00Z"),
+      last_used_at: new Date("2025-05-01T00:00:00Z"),
+      subscriber_count: 830,
+      opens_rate: 0,
+      clicks_rate: 0,
+    },
+    {
+      external_id: "3",
+      name: "Cold subscribers",
+      created_at: new Date("2025-04-27T00:00:00Z"),
+      last_used_at: new Date("2025-04-27T00:00:00Z"),
+      subscriber_count: 567,
+      opens_rate: 0,
+      clicks_rate: 0,
+    },
+  ];
+
+  return (
+    <Layout selectedTab="segments">
+      <div>
+        <table aria-label="Segments" style={{ marginBottom: "var(--spacer-4)", width: "100%" }} aria-live="polite">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Created</th>
+              <th>Last used</th>
+              <th>Audience</th>
+              <th>Opens</th>
+              <th>Clicks</th>
+              <th aria-label="Actions"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {segments.map((segment) => (
+              <tr
+                key={segment.external_id}
+                aria-selected={segment.external_id === selectedSegmentId}
+                onClick={() => setSelectedSegmentId(segment.external_id)}
+                style={{ cursor: "pointer" }}
+              >
+                <td data-label="Name">{segment.name}</td>
+                <td data-label="Created" style={{ whiteSpace: "nowrap" }}>
+                  {segment.created_at.toLocaleDateString()}
+                </td>
+                <td data-label="Last used" style={{ whiteSpace: "nowrap" }}>
+                  {segment.last_used_at.toLocaleDateString()}
+                </td>
+                <td data-label="Audience" style={{ whiteSpace: "nowrap" }}>
+                  {segment.subscriber_count.toLocaleString()}
+                </td>
+                <td data-label="Opens">{segment.opens_rate}%</td>
+                <td data-label="Clicks">{segment.clicks_rate}%</td>
+                <td>
+                  <div style={{ display: "flex", gap: "var(--spacer-2)" }}>
+                    <Button className="icon-button" aria-label="Edit segment">
+                      <Icon name="pencil" />
+                    </Button>
+                    <Popover
+                      open={openPopoverId === segment.external_id}
+                      onToggle={(open) => setOpenPopoverId(open ? segment.external_id : null)}
+                      trigger={
+                        <Button
+                          className="icon-button"
+                          aria-label="More actions"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setOpenPopoverId(openPopoverId === segment.external_id ? null : segment.external_id);
+                          }}
+                        >
+                          <Icon name="three-dots" />
+                        </Button>
+                      }
+                      position="bottom"
+                    >
+                      {(close) => (
+                        <div style={{ minWidth: 120, display: "flex", flexDirection: "column" }}>
+                          <button
+                            style={{
+                              display: "flex",
+                              alignItems: "center",
+                              gap: 8,
+                              padding: "8px 16px",
+                              background: "none",
+                              border: "none",
+                              width: "100%",
+                              cursor: "pointer",
+                              font: "inherit",
+                            }}
+                            onClick={() => {
+                              close();
+                            }}
+                          >
+                            <Icon name="outline-duplicate" />
+                            Duplicate
+                          </button>
+                          <button
+                            style={{
+                              display: "flex",
+                              alignItems: "center",
+                              gap: 8,
+                              padding: "8px 16px",
+                              background: "none",
+                              border: "none",
+                              width: "100%",
+                              color: "var(--danger)",
+                              cursor: "pointer",
+                              font: "inherit",
+                            }}
+                            onClick={() => {
+                              close();
+                            }}
+                          >
+                            <Icon name="trash2" />
+                            Delete
+                          </button>
+                        </div>
+                      )}
+                    </Popover>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </Layout>
+  );
+};

--- a/app/javascript/components/server-components/EmailsPage/index.tsx
+++ b/app/javascript/components/server-components/EmailsPage/index.tsx
@@ -26,9 +26,10 @@ import { DraftsTab } from "$app/components/server-components/EmailsPage/DraftsTa
 import { EmailForm } from "$app/components/server-components/EmailsPage/EmailForm";
 import { PublishedTab } from "$app/components/server-components/EmailsPage/PublishedTab";
 import { ScheduledTab } from "$app/components/server-components/EmailsPage/ScheduledTab";
+import { SegmentsTab } from "$app/components/server-components/EmailsPage/SegmentsTab";
 import { WithTooltip } from "$app/components/WithTooltip";
 
-const TABS = ["published", "scheduled", "drafts", "subscribers"] as const;
+const TABS = ["published", "scheduled", "drafts", "subscribers", "segments"] as const;
 
 export const emailTabPath = (tab: (typeof TABS)[number]) => `/emails/${tab}`;
 export const newEmailPath = "/emails/new";
@@ -89,7 +90,15 @@ export const Layout = ({
               </a>
             ) : (
               <Link to={emailTabPath(tab)} role="tab" aria-selected={selectedTab === tab} key={tab}>
-                {tab === "published" ? "Published" : tab === "scheduled" ? "Scheduled" : "Drafts"}
+                {tab === "published"
+                  ? "Published"
+                  : tab === "scheduled"
+                    ? "Scheduled"
+                    : tab === "drafts"
+                      ? "Drafts"
+                      : tab === "segments"
+                        ? "Segments"
+                        : tab}
               </Link>
             ),
           )}
@@ -194,6 +203,10 @@ const routes: RouteObject[] = [
     path: emailTabPath("drafts"),
     element: <DraftsTab />,
     loader: async () => json(await getDraftInstallments({ page: 1, query: "" }).response, { status: 200 }),
+  },
+  {
+    path: emailTabPath("segments"),
+    element: <SegmentsTab />,
   },
   {
     path: newEmailPath,

--- a/app/javascript/components/server-components/FollowersPage.tsx
+++ b/app/javascript/components/server-components/FollowersPage.tsx
@@ -52,6 +52,9 @@ const Layout = ({
           <a href={Routes.followers_path()} role="tab" aria-selected="true">
             Subscribers
           </a>
+          <a href={`${Routes.emails_path()}/segments`} role="tab">
+            Segments
+          </a>
         </div>
       </header>
       {children}


### PR DESCRIPTION
Resolves #19
Todos -
Frontend -
1 - Add "Segments" tab to "Emails" page  Done
2 - Add segments table Done
3 - Add segment create/edit pages 
4 - Add component for building filter groups 
5 - Use cheapest viable model with Structured Outputs for AI filter generation 
6 - Update email create/edit page 
7 - Use filter group builder 
8 - Allow selecting a segment 
9 - Add preview in right aside -> Email -> Post 
10 - Add email drawer 
11 - Update workflow create/edit page 
12 - Use filter group builder 
13 - Allow selecting a segment

Backend -
1 - Add AudienceMemberFilter model
2 - Store filter configuration in a JSON column 
3 - Add JSON schemas for filter types 
    -> Date 
    -> Product 
    -> Payment 
    -> Location 
    -> Recipient 
4 - Add .filter that takes in a user ID and returns a ActiveRecord::Relation that returns all of the user's AudienceMembers that pass the filter. 
5 - Add AudienceMemberFilterGroup 
6 - Add one to many relationship with AudienceMemberFilter 
7 - Add .filter that takes in a user ID and returns a ActiveRecord::Relation that returns all of the user's AudienceMembers that pass the filter group (constituent filters are joined with logical ANDs) 
8 - Update [WithFiltering] to filter with AudienceMemberFilterGroups by default and then fall back to the existing JSON attributes 
9 -Backfill Installments and Workflows with AudienceMemberFilterGroups constructed from the existing [WithFiltering] JSON columns 
10 - Add Segment model 
11 - Add one to many relationship with AudienceMemberFilterGroup via WithFiltering 
12 - Update Installment and Workflow to have many to many relationship with Segment 
13 - All of an Installment/Workflow's AudienceMemberFilterGroups should be OR'd with all of its Segments' AudienceMemberFilterGroup 
14- Add preheaders to Installments 
15- Display them in a hidden div at the top of the email 
16- Add internal tags to Installments