### PR TITLE
feat: enable helper guide for gumroad admins

### DIFF
--- a/app/controllers/concerns/helper_widget.rb
+++ b/app/controllers/concerns/helper_widget.rb
@@ -4,7 +4,7 @@ module HelperWidget
   extend ActiveSupport::Concern
 
   included do
-    helper_method :show_helper_widget?, :helper_widget_host, :helper_widget_email_hmac, :helper_customer_metadata
+    helper_method :show_helper_widget?, :helper_widget_host, :helper_widget_email_hmac, :helper_customer_metadata, :enable_helper_guide?
   end
 
   def helper_widget_host
@@ -13,6 +13,10 @@ module HelperWidget
 
   def show_helper_widget?
     !Rails.env.test? && request.host == DOMAIN && current_seller && Feature.active?(:helper_widget, current_seller)
+  end
+
+  def enable_helper_guide?
+    !!current_user&.is_team_member?
   end
 
   def helper_customer_metadata

--- a/app/views/layouts/shared/_helper_widget.html.erb
+++ b/app/views/layouts/shared/_helper_widget.html.erb
@@ -14,6 +14,7 @@
           timestamp: <%= timestamp %>,
           icon_color: "#FF90E8",
           customer_metadata: <%= helper_customer_metadata.to_json.html_safe %>,
+          enable_guide: <%= enable_helper_guide?%>
         });
       }
       d.body.appendChild(g);

--- a/app/views/layouts/shared/_helper_widget.html.erb
+++ b/app/views/layouts/shared/_helper_widget.html.erb
@@ -14,7 +14,7 @@
           timestamp: <%= timestamp %>,
           icon_color: "#FF90E8",
           customer_metadata: <%= helper_customer_metadata.to_json.html_safe %>,
-          enable_guide: <%= enable_helper_guide?%>
+          enable_guide: <%= enable_helper_guide? %>
         });
       }
       d.body.appendChild(g);


### PR DESCRIPTION
Enable the Helper alpha feature to guide users and perform actions on the platform, limited to alpha testing with Gumroad team members only.

- Part of https://github.com/antiwork/helper/issues/158