### PR TITLE
Posting a video-less review should not show thumbnails

### DIFF
--- a/app/javascript/components/ReviewForm.tsx
+++ b/app/javascript/components/ReviewForm.tsx
@@ -238,6 +238,8 @@ export const ReviewForm = React.forwardRef<
             ? { kind: "existing", id: review.video.id, thumbnailUrl: review.video.thumbnail_url }
             : { kind: "none" },
         );
+        setMessage(review.message ?? "");
+        setReviewMode(review.video ? "video" : "text");
 
         showAlert("Review submitted successfully!", "success");
       } catch (error) {


### PR DESCRIPTION
Repro steps:

- Choose video review when editing a review
- Do not record any video
- Submit the review

| Before | After |
|--------|--------|
|  <img width="230" alt="image" src="https://github.com/user-attachments/assets/e8bbade0-6bfc-458d-a2a5-91dbd3fdb572" />  |  <img width="223" alt="image" src="https://github.com/user-attachments/assets/5d60af53-86c6-43d0-9772-d5db2adf2bc8" /> | 