### PR TITLE
Published bundles must always have at least one product

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -449,7 +449,7 @@ class LinksController < ApplicationController
 
     begin
       @product.publish!
-    rescue Link::LinkInvalid
+    rescue Link::LinkInvalid, ActiveRecord::RecordInvalid
       return render json: { success: false, error_message: @product.errors.full_messages[0] }
     rescue => e
       Bugsnag.notify(e)

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -189,6 +189,7 @@ class Link < ApplicationRecord
   validates_presence_of :filetype
   validates_presence_of :filegroup
   validate :bundle_is_not_in_bundle, if: :is_bundle_changed?
+  validate :published_bundle_must_have_at_least_one_product, on: :update
   validate :user_is_eligible_for_service_products, on: :create, if: :is_service?
   validate :commission_price_is_valid, if: -> { native_type == Link::NATIVE_TYPE_COMMISSION }
   validate :one_coffee_per_user, on: :create, if: -> { native_type == Link::NATIVE_TYPE_COFFEE }
@@ -388,7 +389,6 @@ class Link < ApplicationRecord
     enforce_shipping_destinations_presence!
     enforce_user_email_confirmation!
     enforce_merchant_account_exits_for_new_users!
-    enforce_bundle_must_have_at_least_one_product!
 
     if auto_transcode_videos?
       transcode_videos!
@@ -1326,14 +1326,6 @@ class Link < ApplicationRecord
 
       errors.add(:base, "You must connect connect at least one payment method before you can publish this product for sale.")
       raise LinkInvalid, "You must connect connect at least one payment method before you can publish this product for sale."
-    end
-
-    def enforce_bundle_must_have_at_least_one_product!
-      return if not_is_bundle?
-      return if bundle_products.alive.exists?
-
-      errors.add(:base, "Bundles must have at least one product.")
-      raise LinkInvalid, "Bundles must have at least one product."
     end
 
     def free_trial_only_enabled_if_recurring_billing

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -146,7 +146,7 @@ class Link < ApplicationRecord
   has_one :product_refund_policy, foreign_key: "product_id"
   has_one :staff_picked_product, foreign_key: "product_id"
   has_one :custom_domain, -> { alive }, foreign_key: "product_id"
-  has_many :bundle_products, foreign_key: "bundle_id"
+  has_many :bundle_products, foreign_key: "bundle_id", inverse_of: :bundle
   has_many :wishlist_products, foreign_key: "product_id"
   has_many :call_availabilities, foreign_key: "call_id"
   has_one :call_limitation_info, foreign_key: "call_id"

--- a/app/modules/product/validations.rb
+++ b/app/modules/product/validations.rb
@@ -58,6 +58,14 @@ module Product::Validations
       errors.add(:base, "This product cannot be converted to a bundle because it is already part of a bundle.")
     end
 
+    def published_bundle_must_have_at_least_one_product
+      return unless published?
+      return if not_is_bundle?
+      return if bundle_products.alive.exists?
+
+      errors.add(:base, "Bundles must have at least one product.")
+    end
+
     def user_is_eligible_for_service_products
       return if user.eligible_for_service_products?
 

--- a/spec/controllers/bundles_controller_spec.rb
+++ b/spec/controllers/bundles_controller_spec.rb
@@ -456,7 +456,16 @@ describe BundlesController do
 
       it "converts it to a bundle" do
         expect do
-          put :update, params: { id: product.external_id }
+          put :update, params: {
+            id: product.external_id,
+            products: [
+              {
+                product_id: versioned_product.external_id,
+                variant_id: versioned_product.alive_variants.first.external_id,
+                quantity: 1,
+              },
+            ]
+          }
           product.reload
         end.to change { product.is_bundle }.from(false).to(true)
            .and change { product.native_type }.from(Link::NATIVE_TYPE_DIGITAL).to(Link::NATIVE_TYPE_BUNDLE)

--- a/spec/controllers/bundles_controller_spec.rb
+++ b/spec/controllers/bundles_controller_spec.rb
@@ -469,6 +469,11 @@ describe BundlesController do
           product.reload
         end.to change { product.is_bundle }.from(false).to(true)
            .and change { product.native_type }.from(Link::NATIVE_TYPE_DIGITAL).to(Link::NATIVE_TYPE_BUNDLE)
+
+        expect(product.bundle_products.count).to eq(1)
+        expect(product.bundle_products.first.product).to eq(versioned_product)
+        expect(product.bundle_products.first.variant).to eq(versioned_product.alive_variants.first)
+        expect(product.bundle_products.first.quantity).to eq(1)
       end
     end
 

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -1287,17 +1287,40 @@ describe OrdersController, :vcr do
           let(:bundle_text_field) { create(:custom_field, name: "Text field") }
           let(:bundle_checkbox_field) { create(:custom_field, name: "Checkbox field", type: CustomField::TYPE_CHECKBOX) }
           let(:bundle_terms_field) { create(:custom_field, name: "https://example.com", type: CustomField::TYPE_TERMS) }
-          let(:bundle_product) { create(:bundle_product, bundle: product_2, product: create(:product, user: product_2.user, custom_fields: [bundle_text_field, bundle_checkbox_field, bundle_terms_field])) }
 
-          before { product_2.update!(is_bundle: true) }
+          let(:product_in_bundle) do
+            create(
+              :product,
+              user: seller_1,
+              custom_fields: [bundle_text_field, bundle_checkbox_field, bundle_terms_field]
+            )
+          end
+
+          let(:product_2) do
+            create(
+             :product,
+             :bundle,
+             user: seller_1,
+             bundle_products: [
+               build(:bundle_product, product: product_in_bundle)
+             ]
+           )
+          end
+          let(:bundle_product) { product_2.bundle_products.first }
 
           it "sets the bundle custom fields" do
-            multiple_purchase_params[:line_items][1][:custom_fields] = [{ id: country_field.external_id, value: "UK" }]
+            multiple_purchase_params[:line_items][1][:custom_fields] = [
+              { id: country_field.external_id, value: "UK" }
+            ]
             multiple_purchase_params[:line_items][1][:bundle_products] = [
               {
                 product_id: bundle_product.product.external_id,
                 quantity: 1,
-                custom_fields: [{ id: bundle_text_field.external_id, value: "Hi" }, { id: bundle_checkbox_field.external_id, value: true }, { id: bundle_terms_field.external_id, value: true }]
+                custom_fields: [
+                  { id: bundle_text_field.external_id, value: "Hi" },
+                  { id: bundle_checkbox_field.external_id, value: true },
+                  { id: bundle_terms_field.external_id, value: true }
+                ]
               }
             ]
             post :create, params: multiple_purchase_params

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -1770,7 +1770,7 @@ describe Link, :vcr do
   end
 
   describe "#bundle_is_not_in_bundle" do
-    let!(:product) { create(:product) }
+    let!(:product) { create(:product, :unpublished) }
 
     context "product is not in bundle" do
       it "does not add an error to the product" do

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -767,7 +767,7 @@ describe Link, :vcr do
         it "raises a Link::LinkInvalid error" do
           expect do
             @product.publish!
-          end.to raise_error(Link::LinkInvalid)
+          end.to raise_error(ActiveRecord::RecordInvalid)
           expect(@product.reload.purchase_disabled_at).to_not be(nil)
           expect(@product.errors.full_messages.to_sentence).to eq("Bundles must have at least one product.")
         end

--- a/spec/requests/bundles/edit_spec.rb
+++ b/spec/requests/bundles/edit_spec.rb
@@ -501,7 +501,7 @@ describe("Bundle edit page", type: :feature, js: true) do
       within(:fieldset, "Has not yet bought") do
         expect(page).to_not have_button("Bundle Product 1")
         expect(page).to_not have_button("Bundle Product 2")
-        expect(page).to have_combo_box "Has not yet bought", options: ["Bundle", "Bundle Product 1", "Bundle Product 2"]
+        expect(page).to have_combo_box "Has not yet bought", options: ["Bundle Product 1", "Bundle Product 2", "Bundle"]
       end
     end
 
@@ -516,7 +516,7 @@ describe("Bundle edit page", type: :feature, js: true) do
       within(:fieldset, "Bought") do
         expect(page).to_not have_button("Bundle Product 1")
         expect(page).to_not have_button("Bundle Product 2")
-        expect(page).to have_combo_box "Bought", options: ["Bundle", "Bundle Product 1", "Bundle Product 2"]
+        expect(page).to have_combo_box "Bought", options: ["Bundle Product 1", "Bundle Product 2", "Bundle"]
       end
       send_keys :escape
       find(:combo_box, "Has not yet bought").click
@@ -524,7 +524,7 @@ describe("Bundle edit page", type: :feature, js: true) do
       within(:fieldset, "Has not yet bought") do
         expect(page).to_not have_button("Bundle Product 1")
         expect(page).to_not have_button("Bundle Product 2")
-        expect(page).to have_combo_box "Has not yet bought", options: ["Bundle", "Bundle Product 1", "Bundle Product 2"]
+        expect(page).to have_combo_box "Has not yet bought", options: ["Bundle Product 1", "Bundle Product 2", "Bundle"]
       end
     end
   end

--- a/spec/requests/bundles/edit_spec.rb
+++ b/spec/requests/bundles/edit_spec.rb
@@ -290,10 +290,13 @@ describe("Bundle edit page", type: :feature, js: true) do
       end
       uncheck "All products", checked: true
       expect(page).to_not have_selector("[aria-label='Bundle products']")
+
+      click_on "Save changes"
+      expect(page).to have_alert(text: "Bundles must have at least one product.")
     end
 
     context "when the bundle has no products" do
-      let(:empty_bundle) { create(:product, user: seller, is_bundle: true) }
+      let(:empty_bundle) { create(:product, :unpublished, user: seller, is_bundle: true) }
 
       it "displays a placeholder" do
         visit "#{bundle_path(empty_bundle.external_id)}/content"
@@ -305,6 +308,9 @@ describe("Bundle edit page", type: :feature, js: true) do
 
         expect(page).to_not have_section("Select products")
         expect(page).to have_selector("[aria-label='Product selector']")
+
+        click_on "Publish and continue"
+        expect(page).to have_alert(text: "Bundles must have at least one product.")
       end
     end
   end

--- a/spec/requests/products/edit/preview_spec.rb
+++ b/spec/requests/products/edit/preview_spec.rb
@@ -211,10 +211,7 @@ describe("Product Edit Previews", type: :feature, js: true) do
     it_behaves_like "displaying collaborator"
 
     context "that is a bundle" do
-      before do
-        product.update!(is_bundle: true)
-        create_list(:bundle_product, 2, bundle: product)
-      end
+      let(:product) { create(:product, :bundle, user: seller) }
 
       it_behaves_like "displaying collaborator"
     end

--- a/spec/support/factories/links.rb
+++ b/spec/support/factories/links.rb
@@ -136,11 +136,16 @@ My email is test@gmail.com <i>Reach out and say hi!</i>
       description { "This is a bundle of products" }
       is_bundle { true }
 
-      after(:create) do |product|
-        product.bundle_products = build_list(:bundle_product, 2, bundle: product) do |bundle_product, i|
-          bundle_product.product.update(name: "Bundle Product #{i + 1}")
+      bundle_products do
+        bundle_products = build_list(:bundle_product, 2, bundle: instance) do |bundle_product, i|
+          bundle_product.product.update!(name: "Bundle Product #{i + 1}")
         end
       end
+    end
+
+    trait :unpublished do
+      draft { true }
+      purchase_disabled_at { Time.current }
     end
 
     factory :product_with_files do

--- a/spec/support/factories/links.rb
+++ b/spec/support/factories/links.rb
@@ -137,7 +137,7 @@ My email is test@gmail.com <i>Reach out and say hi!</i>
       is_bundle { true }
 
       bundle_products do
-        bundle_products = build_list(:bundle_product, 2, bundle: instance) do |bundle_product, i|
+        build_list(:bundle_product, 2, bundle: instance) do |bundle_product, i|
           bundle_product.product.update!(name: "Bundle Product #{i + 1}")
         end
       end


### PR DESCRIPTION
Previously we only check that a bundle must have at least one product at publish-time, this could lead to empty bundles when:

- Converting a published product to a bundle
- Removing content from an already published bundle
- etc

This PR enforces that published bundles must always have at least one product. 