### PR TITLE
Add `/discover` path

### DIFF
--- a/app/javascript/components/server-components/Discover/index.tsx
+++ b/app/javascript/components/server-components/Discover/index.tsx
@@ -98,7 +98,7 @@ const Discover = (props: Props) => {
   const parseUrlParams = (href: string) => {
     const url = new URL(href);
     const parsedParams: SearchRequest = {
-      taxonomy: url.pathname === "/" ? undefined : url.pathname.replace("/", ""),
+      taxonomy: url.pathname === "/" || url.pathname === "/discover" ? undefined : url.pathname.replace("/", ""),
       curated_product_ids: props.curated_product_ids.slice(url.pathname === "/" ? recommendedProductsCount : 0),
     };
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -148,6 +148,7 @@ Rails.application.routes.draw do
   constraints DiscoverDomainConstraint do
     get "/", to: "discover#index", as: :discover
 
+    get "/discover", to: "discover#index"
     get "/discover/recommended_products", to: "discover#recommended_products", as: :discover_recommended_products
     namespace :discover do
       resources :recommended_wishlists, only: [:index]
@@ -943,6 +944,7 @@ Rails.application.routes.draw do
     get "/CHARGE" => redirect("/charge")
 
     # discover
+    get "/discover", to: "discover#index"
     get "/discover/categories",          to: "discover#categories"
     get "/discover_search_autocomplete", to: "discover/search_autocomplete#search"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -146,7 +146,7 @@ Rails.application.routes.draw do
   end
 
   constraints DiscoverDomainConstraint do
-    get "/", to: "discover#index", as: :discover
+    get "/", to: "discover#index"
 
     get "/discover", to: "discover#index"
     get "/discover/recommended_products", to: "discover#recommended_products", as: :discover_recommended_products

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -146,7 +146,7 @@ Rails.application.routes.draw do
   end
 
   constraints DiscoverDomainConstraint do
-    get "/", to: "discover#index"
+    get "/", to: "discover#index", as: :discover
 
     get "/discover", to: "discover#index"
     get "/discover/recommended_products", to: "discover#recommended_products", as: :discover_recommended_products


### PR DESCRIPTION
Pre-requisite for https://github.com/antiwork/gumroad/pull/159.

Currently `gumroad.com/discover` redirects to `gumroad.com` via a Cloudfare rule. We will need the app to serve `/discover` in order to remove the rule.

This change is quite safe on its own because re-enabling the Cloudfare rule effectively makes this a no-op. But 
this has to be rolled out separately to avoid breaking discovery.

Nonetheless I'll merge this tomorrow when I can monitor the roll out.