### PR TITLE
Specify node version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Before you begin, ensure you have the following installed:
 #### Node.js
 
 - https://nodejs.org/en/download
+- Install the version listed in [the .node-version file](./.node-version)
 
 #### Docker
 


### PR DESCRIPTION
Even after running `corepack enable`, running `node -v` does not output the right node version in `node-version`. We should update the README to explicitly say what version to install. 

Advisor: @s3ththompson 