### PR TITLE
Gracefully load sidekiq-pro in all environments

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,5 +1,14 @@
 # frozen_string_literal: true
 
+# `sidekiq-pro` is now only autoloaded in staging/production due to the Gemfile
+# group. This ensures `sidekiq-pro` is correctly loaded in all environments
+# when available.
+begin
+  require "sidekiq-pro"
+rescue LoadError
+  warn "sidekiq-pro is not installed"
+end
+
 require Rails.root.join("lib", "extras", "sidekiq_makara_reset_context_middleware")
 
 Sidekiq.configure_server do |config|


### PR DESCRIPTION
`sidekiq-pro` was [recently](https://github.com/antiwork/gumroad/pull/155) scoped to the staging and production Gemfile groups, preventing it from being autoloaded in other environments.

Causing the following failure for non-staging, non-prod environments when `sidekiq-pro` is installed.

```
# undefined method 'super_fetch!' for an instance of Sidekiq::Config
Sidekiq::Client.reliable_push! if defined?(Sidekiq::Pro) && !Rails.env.test?
```

Because:

- `Sidekiq::Pro` is defined since the gem is installed
- `Sidekiq::Client.reliable_push!` is NOT available because `sidekiq-pro` is not autoloaded