### PR TITLE
Refactor linked_license method to always return sender's license

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -2489,11 +2489,7 @@ class Purchase < ApplicationRecord
   end
 
   def linked_license
-    if license_key.present?
-      license
-    elsif is_gift_sender_purchase && gift.giftee_purchase.present? && gift.giftee_purchase.license_key.present?
-      gift.giftee_purchase.license
-    end
+    license
   end
 
   def load_and_prepare_chargeable(credit_card)

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -5360,8 +5360,8 @@ describe Purchase, :vcr do
       let(:giftee_purchase) { create(:purchase, is_gift_receiver_purchase: true, license: create(:license), link: create(:product, is_licensed: true)) }
       let!(:gift) { create(:gift, gifter_purchase:, giftee_purchase:) }
 
-      it "returns the giftee's license" do
-        expect(gifter_purchase.reload.linked_license).to eq(giftee_purchase.license)
+      it "doesn't return the giftee's license" do
+        expect(gifter_purchase.reload.linked_license).to be_nil
       end
     end
 


### PR DESCRIPTION
Resolves: https://github.com/antiwork/gumroad/issues/193
This pull request modifies the behavior of the `linked_license` method in the `Purchase` model and updates the associated test to reflect the change. The most important changes include removing logic that previously returned the giftee's license and adjusting the test to verify the updated behavior.

### Changes to `linked_license` logic:
* [`app/models/purchase.rb`](diffhunk://#diff-9908a4393f2c931886fc757f7c0a023bf908a1efd1cf26c99306c523079c76fcL2492-L2496): Removed the conditional logic that returned the giftee's license if the purchase was a gift sender purchase and the giftee purchase had a license (`linked_license` method).

### Updates to tests:
* [`spec/models/purchase_spec.rb`](diffhunk://#diff-c468b2c2854ba83c8f1bcb20ce1fff6d08657883e822de293b97d207eb9aab43L5363-R5364): Updated the test for `linked_license` to verify that it no longer returns the giftee's license, ensuring the new behavior is validated.