### PR TITLE
Fix: Multiple Bug Fixes on Help Pages

### DIFF
--- a/public/help/article/101-designing-your-product-page.html
+++ b/public/help/article/101-designing-your-product-page.html
@@ -212,7 +212,7 @@
                         <p><img src="https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/64248bcc4cd1ab01bbe8b082/file-qFRruuIBdB.png"
                                 style="width: 100%; max-width: 100%; "></p>
                         <p>The custom field info will be accessible in the <a
-                                href="https://www.gumroad.com/customers">Audience tab</a> and the <a
+                                href="https://www.gumroad.com/customers">Sales tab</a> and the <a
                                 href="74-the-analytics-dashboard.html#sales-csv">sales CSV</a>.</p>
                         <h2 id="More-like-this-recommendations-5J9b1">More like this recommendations</h2>
                         <p>Our <a href="334-more-like-this.html">More like this</a> feature allows you to recommend

--- a/public/help/article/155-things-you-cant-sell-on-gumroad.html
+++ b/public/help/article/155-things-you-cant-sell-on-gumroad.html
@@ -241,7 +241,7 @@
                         <p>If you share, promote, or sell content that violates the guidelines listed above, it is a
                             violation of our Terms of Service.&nbsp;</p>
                         <p>Depending on the situation, we may be forced to suspend your account and refund your sales.
-                            This is our prerogative as detailed in section 8 of <a href="https://gumroad.com/terms"
+                            This is our prerogative as detailed in section 11.3 of <a href="https://gumroad.com/terms"
                                 target="_blank">our Terms</a>.</p>
                         <p>But if that is not the case, and we are able to pay you:</p>
                         <ul>

--- a/public/help/article/196-contact-gumroad.html
+++ b/public/help/article/196-contact-gumroad.html
@@ -187,7 +187,7 @@
   </tr>
  </tbody>
 </table>
-<p>We hope that our <a href="/help/../help.gumroad.com/index.html">Help Center</a> can address the majority of your issues, but if not, we will be pleased to assist you.</p>
+<p>We hope that our <a href="https://gumroad.com/help">Help Center</a> can address the majority of your issues, but if not, we will be pleased to assist you.</p>
 <p>To contact us, email <a href="mailto:support@gumroad.com">support@gumroad.com</a></p>
 <h2>Phone support</h2>
 <p>Unfortunately, we don't have the capacity at this time to offer phone support.</p>

--- a/public/help/article/266-why-are-my-customers-purchases-failing.html
+++ b/public/help/article/266-why-are-my-customers-purchases-failing.html
@@ -196,7 +196,7 @@
  <li>Use a different email address to make the purchase.&nbsp;</li>
  <li>Use a different card or PayPal account</li>
 </ol>
-<p>Purchase errors are rare on Gumroad, but they <span>do </span>happen, and more likely than not you will be contacted by a desperate customer at some point, pleading for you to take their money. If that's the case, simply direct them to <a href="https://customers.gumroad.com/before-you-buy/why-did-my-payment-fail">this page</a> or contact us!</p>
+<p>Purchase errors are rare on Gumroad, but they <span>do </span>happen, and more likely than not you will be contacted by a desperate customer at some point, pleading for you to take their money. If that's the case, simply direct them to <a href="https://gumroad.com/help/article/266-why-are-my-customers-purchases-failing.html">this page</a> or contact us!</p>
     </article>
 
         <section class="articleFoot">

--- a/public/help/article/64-is-gumroad-for-me.html
+++ b/public/help/article/64-is-gumroad-for-me.html
@@ -258,16 +258,23 @@
                         <h2>Need help getting from $0 to $1?</h2>
                         <p>Check out any of our following free resources:</p>
                         <ul>
-                            <li><a href="https://gumroad.com/university">Gumroad University</a>, a place to learn the
+                            <li><a href="https://gumroad.com/university" target="_blank">How to use Gumroad</a> - learn
+                                the
                                 ropes of selling online</li>
-                            <li>The <a href="http://www.gumroad.com/gumroad/posts">Gumroad Blog</a> and Gumroad's
-                                creator <a href="https://gumroad.com/gumroad">challenges</a></li>
-                            <li>Our page of <a href="https://gumroad.com/gumroadhelp">free product examples</a> - see
+                            <li>The <a href="https://gumroad.gumroad.com/?section=o4PMUt5fxAqrAJY-iUaBCQ%3D%3D"
+                                    target="_blank">Gumroad Blog</a> and Gumroad's
+                                High Converting <a href="https://gumroad.com/gumroad" target="_blank">Sales Page
+                                    Course</a></li>
+                            <li>Inspiring Stories from the <a href="https://www.youtube.com/@GumroadUniversity/videos"
+                                    target="_blank">Gumroad Podcast</a>
+                            </li>
+                            <li>Our page of <a href="https://gumroad.com/gumroadhelp" target="_blank">free product
+                                    examples</a> - see
                                 how products work from a customer's perspective</li>
-                            <li><a href="155-things-you-cant-sell-on-gumroad.html">Thing that are not allowed on
+                            <li><a href="155-things-you-cant-sell-on-gumroad.html" target="_blank">Things that are not
+                                    allowed on
                                     Gumroad</a></li>
                         </ul>
-                        <p> <a href="https://gumroad.com/university"></a></p>
                     </article>
 
                     <section class="articleFoot">

--- a/public/help/article/67-the-settings-menu.html
+++ b/public/help/article/67-the-settings-menu.html
@@ -203,7 +203,7 @@
                         <h2 id="Settings-qq1SF">Settings</h2>
                         <p>To make sure any changes you make to your <a
                                 href="http://www.gumroad.com/settings">settings</a> are permanent, always remember to
-                            click the <b>"Update Settings"</b> button at the bottom of the screen.</p>
+                            click the <b>"Update Settings"</b> button at the top of the screen.</p>
                         <h3 id="User-details-1a67i">User details</h3>
                         <p><img alt="The image shows a simplified user interface titled" placeholder="" is="" in=""
                                 src="https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/63f4a18dfd897d5b05cdadef/file-zqFmweIbsb.png"

--- a/public/help/category/319-start-selling.html
+++ b/public/help/category/319-start-selling.html
@@ -197,8 +197,6 @@
 
                 <li><a href="/help/article/335-custom-refund-policy.html"><i class="icon-article-doc"></i><span>Set a custom refund policy</span></a></li>
 
-                <li><a href="/help/article/339-product-bundles.html"><i class="icon-article-doc"></i><span>Product bundles</span></a></li>
-
         </ul><!--/articleList-->
 
 

--- a/public/help/category/328-market-your-work.html
+++ b/public/help/category/328-market-your-work.html
@@ -171,8 +171,6 @@
 
                 <li><a href="/help/article/333-affiliates-on-gumroad.html"><i class="icon-article-doc"></i><span>Affiliates on Gumroad</span></a></li>
 
-                <li><a href="/help/article/339-product-bundles.html"><i class="icon-article-doc"></i><span>Product bundles</span></a></li>
-
         </ul><!--/articleList-->
 
 


### PR DESCRIPTION
This PR fixes bugs on multiple help pages:
1. [Designing Your Product Page](https://gumroad.com/help/article/101-designing-your-product-page.html): Changed 'Audience' tab to 'Sales' tab to keep the terminology constant throughout the Help pages
2. [Things you cannot sell on Gumroad](https://gumroad.com/help/article/155-things-you-cant-sell-on-gumroad.html): Updated the section to 11.3 as per the current terms
3. [Contact Gumroad](https://gumroad.com/help/article/196-contact-gumroad.html): Updated the Help center url to the correct one
4. [Why customer payments fail](https://gumroad.com/help/article/266-why-are-my-customers-purchases-failing.html): Updated the link at the bottom to the correct page url
5. [Why choose Gumroad](https://gumroad.com/help/article/64-is-gumroad-for-me.html): Fixed the link to the blog and updated other links 
6. [Account settings](https://gumroad.com/help/article/67-the-settings-menu.html): Updated text for the 'Update Settings' button
7. [Start Selling](https://gumroad.com/help/category/319-start-selling.html) and [Market your Work](https://gumroad.com/help/category/328-market-your-work.html): Removed 'Product Bundles' which is already present in 'Add a product' category