### PR TITLE
fix(security): Sanitize product description to prevent XSS

### DIFF
--- a/app/services/save_public_files_service.rb
+++ b/app/services/save_public_files_service.rb
@@ -13,6 +13,9 @@ class SavePublicFilesService
     ActiveRecord::Base.transaction do
       persisted_files = resource.alive_public_files
       doc = Nokogiri::HTML.fragment(content)
+      sanitizer = Rails::Html::SafeListSanitizer.new
+      sanitized_content = sanitizer.sanitize(doc.to_html)
+      doc = Nokogiri::HTML.fragment(sanitized_content)
       file_ids_in_content = extract_file_ids_from_content(doc)
 
       update_existing_files(persisted_files, file_ids_in_content)


### PR DESCRIPTION
This PR fixes a Stored XSS vulnerability in the product description field by sanitizing the HTML content on the backend using Rails::Html::SafeListSanitizer.

Files modified:

- /app/gumroad/app/services/save_public_files_service.rb

The patch addresses the issue by preventing malicious HTML/JavaScript from being stored and subsequently rendered. This approach was chosen over frontend sanitization or avoiding dangerouslySetInnerHTML because backend sanitization is the most effective way to prevent Stored XSS.

There are no known assumptions or potential side effects.