### PR TITLE
Content upsells do not have UpsellPurchase#selected_product

### DIFF
--- a/app/models/upsell_purchase.rb
+++ b/app/models/upsell_purchase.rb
@@ -17,7 +17,7 @@ class UpsellPurchase < ApplicationRecord
     {
       name: upsell.name,
       discount: purchase.original_offer_code&.displayed_amount_off(purchase.link.price_currency_type, with_symbol: true),
-      selected_product: selected_product.name,
+      selected_product: selected_product&.name,
       selected_version: upsell_variant&.selected_variant&.name,
     }
   end

--- a/spec/models/upsell_purchase_spec.rb
+++ b/spec/models/upsell_purchase_spec.rb
@@ -82,6 +82,38 @@ describe UpsellPurchase do
           }
         )
       end
+
+      context "when the upsell is a content upsell" do
+        let(:seller) { create(:named_seller) }
+        let(:purchase) { create(:purchase, link: product1) }
+        let(:content_upsell) do
+          create(
+            :upsell,
+            name: "Content Upsell",
+            product: product1,
+            seller: seller,
+            is_content_upsell: true,
+            cross_sell: true
+          )
+        end
+        let(:upsell_purchase) do
+          create(
+            :upsell_purchase,
+            upsell: content_upsell,
+            purchase: purchase,
+            selected_product: nil
+          )
+        end
+
+        it "returns nil for selected_product" do
+          expect(upsell_purchase.as_json).to match(
+            name: "Content Upsell",
+            discount: "$1",
+            selected_product: nil,
+            selected_version: nil,
+          )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This fixes a few issues related to purchasing content upsells (e.g. verifying license key via the API).

`UpsellPurchase#selected_product_id` was made optional when [introducing content upsells](https://github.com/antiwork/gumroad-old/pull/29092), i.e. upsells embedded in a blog post or email.

What what I can see, this makes sense because:

- `#select_product_id` actually refers to "the product the user already has in cart that triggered the upsell".
- Content upsells are not triggered by an existing item in cart, but rather the user action of clicking that upsell in the content.
