### PR TITLE
Fallback to product cover for wishlist thumbnails

### DIFF
--- a/app/presenters/wishlist_presenter.rb
+++ b/app/presenters/wishlist_presenter.rb
@@ -65,7 +65,15 @@ class WishlistPresenter
     }
   end
 
-  ASSOCIATIONS_FOR_CARD = [:user, alive_wishlist_products: :product].freeze
+  ASSOCIATIONS_FOR_CARD = [
+    :user,
+    {
+      alive_wishlist_products: {
+        product: [:thumbnail_alive, :display_asset_previews]
+      }
+    }
+  ].freeze
+
   def card_props(pundit_user:, following:, layout: nil, recommended_by: nil)
     thumbnails = wishlist.alive_wishlist_products.last(4).map { product_thumbnail(_1.product) }
     thumbnails = [thumbnails.last].compact if thumbnails.size < 4
@@ -85,7 +93,7 @@ class WishlistPresenter
 
   private
     def product_thumbnail(product)
-      { url: product.thumbnail_alive&.url, native_type: product.native_type }
+      { url: product.thumbnail_or_cover_url, native_type: product.native_type }
     end
 
     def selections_in_wishlist_props(product:)

--- a/spec/presenters/wishlist_presenter_spec.rb
+++ b/spec/presenters/wishlist_presenter_spec.rb
@@ -341,6 +341,40 @@ describe WishlistPresenter do
       end
     end
 
+    context "thumbnails" do
+      let!(:product_with_only_thumbnail) { create(:product) }
+      let!(:product_with_only_cover) { create(:product) }
+      let!(:product_with_neither_1) { create(:product) }
+      let!(:product_with_neither_2) { create(:product) }
+
+      let!(:thumbnail) { create(:thumbnail, product: product_with_only_thumbnail) }
+      let!(:cover_image) { create(:asset_preview_jpg, link: product_with_only_cover) }
+
+      let!(:wishlist_for_thumbnails) do
+        create(
+          :wishlist,
+          wishlist_products: [
+            build(:wishlist_product, product: product_with_only_thumbnail),
+            build(:wishlist_product, product: product_with_only_cover),
+            build(:wishlist_product, product: product_with_neither_1),
+            build(:wishlist_product, product: product_with_neither_2),
+          ],
+        )
+      end
+
+      it "falls back to cover image url" do
+        result = described_class.new(wishlist: wishlist_for_thumbnails)
+          .card_props(pundit_user:, following: false)
+
+        expect(result[:thumbnails]).to contain_exactly(
+          { url: thumbnail.url, native_type: "digital" },
+          { url: cover_image.url, native_type: "digital" },
+          { url: nil, native_type: "digital" },
+          { url: nil, native_type: "digital" },
+        )
+      end
+    end
+
     context "for the user's own wishlist" do
       let(:pundit_user) { SellerContext.new(user: wishlist.user, seller: wishlist.user) }
 


### PR DESCRIPTION
Before

![image](https://github.com/user-attachments/assets/cbddd652-36ab-4c67-adcb-32e37abe3508)

After 

![image](https://github.com/user-attachments/assets/102ab653-0b51-41f3-9b2a-f9c6b01ba784)
