### PR TITLE
Allow anonymous access to Helper on marketing pages & Discover

### DIFF
--- a/app/controllers/concerns/helper_widget.rb
+++ b/app/controllers/concerns/helper_widget.rb
@@ -12,7 +12,7 @@ module HelperWidget
   end
 
   def show_helper_widget?
-    !Rails.env.test? && request.host == DOMAIN && current_seller && Feature.active?(:helper_widget, current_seller)
+    !Rails.env.test? && request.host == DOMAIN && current_seller
   end
 
   def enable_helper_guide?

--- a/app/controllers/concerns/helper_widget.rb
+++ b/app/controllers/concerns/helper_widget.rb
@@ -4,7 +4,13 @@ module HelperWidget
   extend ActiveSupport::Concern
 
   included do
-    helper_method :show_helper_widget?, :helper_widget_host, :helper_widget_email_hmac, :helper_customer_metadata, :enable_helper_guide?
+    helper_method :show_helper_widget?, :helper_widget_host, :helper_widget_init_data
+  end
+
+  class_methods do
+    def allow_anonymous_access_to_helper_widget(options = {})
+      before_action :allow_anonymous_access_to_helper_widget, options
+    end
   end
 
   def helper_widget_host
@@ -12,11 +18,22 @@ module HelperWidget
   end
 
   def show_helper_widget?
-    !Rails.env.test? && request.host == DOMAIN && current_seller
+    return false if Rails.env.test?
+    return false if request.host != DOMAIN
+
+    current_seller.present? || allow_anonymous_access_to_helper_widget?
   end
 
-  def enable_helper_guide?
-    Feature.active?(:helper_guide)
+  def allow_anonymous_access_to_helper_widget
+    @allow_anonymous_access_to_helper_widget = true
+  end
+
+  def allow_anonymous_access_to_helper_widget?
+    anonymous_helper_widget_access_enabled? && !!@allow_anonymous_access_to_helper_widget
+  end
+
+  def anonymous_helper_widget_access_enabled?
+    Feature.active?(:anonymous_helper_widget_access) || params[:anonymous_helper_widget_access].present?
   end
 
   def helper_customer_metadata
@@ -33,5 +50,25 @@ module HelperWidget
       GlobalConfig.get("HELPER_WIDGET_SECRET"),
       message
     )
+  end
+
+  def helper_widget_init_data
+    timestamp = (Time.current.to_f * 1000).to_i
+
+    data = {
+      title: "Support",
+      mailbox_slug: "gumroad",
+      icon_color: "#FF90E8",
+      enable_guide: true,
+      timestamp: timestamp,
+    }
+
+    if current_seller.present?
+      data[:email] = current_seller.email
+      data[:email_hash] = helper_widget_email_hmac(timestamp)
+      data[:customer_metadata] = helper_customer_metadata
+    end
+
+    data
   end
 end

--- a/app/controllers/discover_controller.rb
+++ b/app/controllers/discover_controller.rb
@@ -7,6 +7,8 @@ class DiscoverController < ApplicationController
   include ActionView::Helpers::NumberHelper, RecommendationType, CreateDiscoverSearch,
           DiscoverCuratedProducts, SearchProducts, AffiliateCookie
 
+  allow_anonymous_access_to_helper_widget only: [:index]
+
   before_action :set_affiliate_cookie, only: [:index]
 
   def index

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,6 +3,8 @@
 class HomeController < ApplicationController
   layout "home"
 
+  allow_anonymous_access_to_helper_widget
+
   before_action :set_meta_data
   before_action :set_layout_and_title
 

--- a/app/views/layouts/shared/_helper_widget.html.erb
+++ b/app/views/layouts/shared/_helper_widget.html.erb
@@ -1,21 +1,15 @@
 <% if show_helper_widget? %>
-  <% timestamp = (Time.now.to_f * 1000).to_i %>
-
-  <%= javascript_tag nonce: SecureHeaders.content_security_policy_script_nonce(request), data: { cfasync: "false" } do %>
+  <%= javascript_tag nonce: SecureHeaders.content_security_policy_script_nonce(request),
+    data: {
+      cfasync: "false",
+      helper_widget_init_data: helper_widget_init_data,
+    } do %>
     (function(d) {
+      var initData=JSON.parse(d.currentScript.dataset.helperWidgetInitData);
       var g=d.createElement("script");
       g.src="<%= helper_widget_host %>"+"/widget/sdk.js";
       g.onload=function(){
-        window.HelperWidget.init({
-          title: "Support",
-          email: "<%= current_seller.email %>",
-          email_hash: "<%= helper_widget_email_hmac(timestamp) %>",
-          mailbox_slug: "gumroad",
-          timestamp: <%= timestamp %>,
-          icon_color: "#FF90E8",
-          customer_metadata: <%= helper_customer_metadata.to_json.html_safe %>,
-          enable_guide: <%= enable_helper_guide? %>
-        });
+        window.HelperWidget.init(initData);
       }
       d.body.appendChild(g);
     })(document);

--- a/spec/controllers/concerns/helper_widget_spec.rb
+++ b/spec/controllers/concerns/helper_widget_spec.rb
@@ -6,7 +6,13 @@ describe HelperWidget, type: :controller do
   controller(ApplicationController) do
     include HelperWidget
 
+    allow_anonymous_access_to_helper_widget only: :anonymous_access_allowed
+
     def action
+      head :ok
+    end
+
+    def anonymous_access_allowed
       head :ok
     end
   end
@@ -15,7 +21,8 @@ describe HelperWidget, type: :controller do
   let(:user) { create(:user) }
 
   before do
-    routes.draw { get :action, to: "anonymous#action" }
+    routes.draw { get ":action", controller: "anonymous" }
+
     allow(GlobalConfig).to receive(:get).with("HELPER_WIDGET_SECRET").and_return("test_secret")
   end
 
@@ -69,6 +76,44 @@ describe HelperWidget, type: :controller do
         expect(controller.show_helper_widget?).to be false
       end
     end
+
+    describe "anonymous access" do
+      before do
+        allow(Rails.env).to receive(:test?).and_return(false)
+        stub_const("DOMAIN", "gumroad.com")
+        request.host = "gumroad.com"
+      end
+
+      context "feature is globally enabled" do
+        before do
+          Feature.activate(:anonymous_helper_widget_access)
+        end
+
+        it "returns true if anonymous access is allowed" do
+          get :anonymous_access_allowed
+          expect(controller.show_helper_widget?).to be true
+
+          get :action
+          expect(controller.show_helper_widget?).to be false
+        end
+      end
+
+      context "feature is enabled via query param" do
+        it "returns true" do
+          get :action, params: { anonymous_helper_widget_access: true }
+          expect(controller.show_helper_widget?).to be false
+
+          get :action
+          expect(controller.show_helper_widget?).to be false
+
+          get :anonymous_access_allowed, params: { anonymous_helper_widget_access: true }
+          expect(controller.show_helper_widget?).to be true
+
+          get :anonymous_access_allowed
+          expect(controller.show_helper_widget?).to be false
+        end
+      end
+    end
   end
 
   describe "#helper_widget_email_hmac" do
@@ -80,6 +125,41 @@ describe HelperWidget, type: :controller do
       timestamp = "1234567890"
       expected_hmac = OpenSSL::HMAC.hexdigest("sha256", "test_secret", "#{seller.email}:#{timestamp}")
       expect(controller.helper_widget_email_hmac(timestamp)).to eq(expected_hmac)
+    end
+  end
+
+  describe "#helper_widget_init_data", :freeze_time do
+    context "for signed-in users" do
+      before { sign_in(seller) }
+
+      it "includes user metadata" do
+        timestamp = (Time.current.to_f * 1000).to_i
+
+        expect(controller.helper_widget_init_data).to eq(
+          title: "Support",
+          mailbox_slug: "gumroad",
+          icon_color: "#FF90E8",
+          enable_guide: true,
+          timestamp: timestamp,
+          email: seller.email,
+          email_hash: controller.helper_widget_email_hmac(timestamp),
+          customer_metadata: HelperUserInfoService.new(email: seller.email).metadata
+        )
+      end
+    end
+
+    context "for anonymous users" do
+      it "does not include user metadata" do
+        timestamp = (Time.current.to_f * 1000).to_i
+
+        expect(controller.helper_widget_init_data).to eq(
+          title: "Support",
+          mailbox_slug: "gumroad",
+          icon_color: "#FF90E8",
+          enable_guide: true,
+          timestamp: timestamp,
+        )
+      end
     end
   end
 end

--- a/spec/controllers/concerns/helper_widget_spec.rb
+++ b/spec/controllers/concerns/helper_widget_spec.rb
@@ -35,7 +35,6 @@ describe HelperWidget, type: :controller do
     context "when conditions are met" do
       before do
         allow(Rails.env).to receive(:test?).and_return(false)
-        allow(Feature).to receive(:active?).with(:helper_widget, user).and_return(true)
         stub_const("DOMAIN", "gumroad.com")
         sign_in(user)
         request.host = "gumroad.com"
@@ -61,23 +60,8 @@ describe HelperWidget, type: :controller do
     context "when domain is not gumroad.com" do
       before do
         allow(Rails.env).to receive(:test?).and_return(false)
-        allow(Feature).to receive(:active?).with(:helper_widget, user).and_return(true)
         sign_in(user)
         request.host = "seller.gumroad.com"
-      end
-
-      it "returns false" do
-        get :action
-        expect(controller.show_helper_widget?).to be false
-      end
-    end
-
-    context "when feature is not active" do
-      before do
-        allow(Rails.env).to receive(:test?).and_return(false)
-        allow(Feature).to receive(:active?).with(:helper_widget, user).and_return(false)
-        sign_in(user)
-        request.host = "gumroad.com"
       end
 
       it "returns false" do


### PR DESCRIPTION
https://github.com/antiwork/gumroad/issues/177.

- `anonymous_helper_widget_access` feature flag controls the global roll out.
- query param `?anonymous_helper_widget_access=true` controls individual access

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enabled anonymous access to the helper widget on select pages, allowing users without accounts to interact with the widget where permitted.
- **Refactor**
	- Simplified and unified the helper widget’s initialization data, improving maintainability and client-side integration.
- **Bug Fixes**
	- Improved access control logic for displaying the helper widget, ensuring it appears only when appropriate.
- **Tests**
	- Expanded test coverage for anonymous access scenarios and widget initialization data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->