### PR TITLE
Fix: Update subscription checks in SendMembershipsPriceUpdateEmailsJob

### DIFF
--- a/app/sidekiq/send_memberships_price_update_emails_job.rb
+++ b/app/sidekiq/send_memberships_price_update_emails_job.rb
@@ -14,7 +14,7 @@ class SendMembershipsPriceUpdateEmailsJob
 
         subscription_plan_change.update!(notified_subscriber_at: Time.current)
         CustomerLowPriorityMailer.subscription_price_change_notification(
-          subscription_id: subscription_plan_change.subscription_id,
+          subscription_id: subscription.id,
           new_price: subscription_plan_change.perceived_price_cents,
         ).deliver_later(queue: "low")
       end

--- a/app/sidekiq/send_memberships_price_update_emails_job.rb
+++ b/app/sidekiq/send_memberships_price_update_emails_job.rb
@@ -9,7 +9,8 @@ class SendMembershipsPriceUpdateEmailsJob
       .applicable_for_product_price_change_as_of(7.days.from_now.to_date)
       .where(notified_subscriber_at: nil)
       .find_each do |subscription_plan_change|
-        next if subscription_plan_change.subscription.pending_cancellation?
+        subscription = subscription_plan_change.subscription
+        next if !subscription.alive? || subscription.pending_cancellation?
 
         subscription_plan_change.update!(notified_subscriber_at: Time.current)
         CustomerLowPriorityMailer.subscription_price_change_notification(

--- a/spec/sidekiq/send_memberships_price_update_emails_job_spec.rb
+++ b/spec/sidekiq/send_memberships_price_update_emails_job_spec.rb
@@ -35,6 +35,36 @@ describe SendMembershipsPriceUpdateEmailsJob do
 
         expect(CustomerLowPriorityMailer).not_to have_received(:subscription_price_change_notification)
       end
+
+      it "does not send notification emails for subscriptions that are fully cancelled" do
+        subscription.update!(cancelled_at: 1.day.ago, deactivated_at: 1.day.ago)
+
+        expect do
+          subject.perform
+        end.not_to change { applicable_plan_change.reload.notified_subscriber_at }
+
+        expect(CustomerLowPriorityMailer).not_to have_received(:subscription_price_change_notification)
+      end
+
+      it "does not send notification emails for subscriptions that have ended" do
+        subscription.update!(ended_at: 1.day.ago, deactivated_at: 1.day.ago)
+
+        expect do
+          subject.perform
+        end.not_to change { applicable_plan_change.reload.notified_subscriber_at }
+
+        expect(CustomerLowPriorityMailer).not_to have_received(:subscription_price_change_notification)
+      end
+
+      it "does not send notification emails for subscriptions that have failed" do
+        subscription.update!(failed_at: 1.day.ago, deactivated_at: 1.day.ago)
+
+        expect do
+          subject.perform
+        end.not_to change { applicable_plan_change.reload.notified_subscriber_at }
+
+        expect(CustomerLowPriorityMailer).not_to have_received(:subscription_price_change_notification)
+      end
     end
 
     context "when there are non-applicable subscription plan changes" do


### PR DESCRIPTION
It now checks if subscriptions are alive and not pending cancellation before sending price change notifications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced safeguards to prevent sending price update notification emails to subscriptions that are inactive, including cancelled, ended, or failed statuses.

- **Tests**
  - Added tests to confirm no notification emails are sent and timestamps remain unchanged for inactive subscriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->