### PR TITLE
fix: README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 <p align="center">
-  [Gumroad](https://gumroad.com) is an e-commerce platform that enables creators to sell products directly to consumers. This repository contains the source code for the Gumroad web application.
+  <a href="https://gumroad.com">Gumroad</a> is an e-commerce platform that enables creators to sell products directly to consumers. This repository contains the source code for the Gumroad web application.
 </p>
 
 ## Table of Contents


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/6d2e04a7-79ff-4738-8709-9c355b30620a)

After:

![image](https://github.com/user-attachments/assets/53f78ae8-765b-4b79-bb85-66005296febd)

**Reason of this behaviour:**

Markdown syntax is not parsed inside raw HTML tags in most Markdown renderers. Markdown was written inside &lt;p> tag


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README to use an HTML anchor tag instead of a Markdown link for the Gumroad reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->