### PR TITLE
Clean up policy logic for ProductReviewResponses

### DIFF
--- a/app/controllers/product_review_responses_controller.rb
+++ b/app/controllers/product_review_responses_controller.rb
@@ -3,30 +3,30 @@
 class ProductReviewResponsesController < ApplicationController
   before_action :authenticate_user!
   before_action :set_purchase
-  before_action :set_product_review
+  before_action :set_product_review!
+  before_action :set_or_build_review_response
 
   after_action :verify_authorized
 
   def update
-    seller = @product_review.link.user
-    user = logged_in_user
-    authorize ProductReviewResponse
-    return head :unauthorized unless user.role_owner_for?(seller) || user.role_admin_for?(seller) || user.role_support_for?(seller)
+    authorize @review_response
 
-    review_response = @product_review.response || @product_review.build_response
-
-    if review_response.update(update_params.merge(user: logged_in_user))
+    if @review_response.update(update_params.merge(user: logged_in_user))
       head :no_content
     else
-      render json: { error: review_response.errors.full_messages.to_sentence },
+      render json: { error: @review_response.errors.full_messages.to_sentence },
              status: :unprocessable_entity
     end
   end
 
   private
-    def set_product_review
+    def set_product_review!
       @product_review = @purchase.original_product_review
       e404_json if @product_review.blank?
+    end
+
+    def set_or_build_review_response
+      @review_response = @product_review.response || @product_review.build_response
     end
 
     def update_params

--- a/app/policies/product_review_response_policy.rb
+++ b/app/policies/product_review_response_policy.rb
@@ -2,8 +2,17 @@
 
 class ProductReviewResponsePolicy < ApplicationPolicy
   def update?
-    user.role_owner_for?(seller) ||
-      user.role_admin_for?(seller) ||
-      user.role_support_for?(seller)
+    role_permitted? && owned_by_seller?(record)
   end
+
+  private
+    def role_permitted?
+      user.role_owner_for?(seller) ||
+        user.role_admin_for?(seller) ||
+        user.role_support_for?(seller)
+    end
+
+    def owned_by_seller?(record)
+      record.product_review.link.user_id == seller.id
+    end
 end

--- a/spec/controllers/product_review_responses_controller_spec.rb
+++ b/spec/controllers/product_review_responses_controller_spec.rb
@@ -11,6 +11,8 @@ describe ProductReviewResponsesController do
     let!(:purchase) { create(:purchase, link: product, purchaser: purchaser) }
     let!(:product_review) { create(:product_review, purchase: purchase) }
 
+    let(:product_review_for_another_seller) { create(:product_review) }
+
     before do
       sign_in seller
     end
@@ -77,6 +79,15 @@ describe ProductReviewResponsesController do
       put :update, params: { purchase_id: purchase.external_id, message: "Updated" }, as: :json
 
       expect(response).to have_http_status(:not_found)
+    end
+
+    it "401s when the product review is for another seller" do
+      put :update, params: {
+        purchase_id: product_review_for_another_seller.purchase.external_id,
+        message: "Updated",
+      }, as: :json
+
+      expect(response).to have_http_status(:unauthorized)
     end
   end
 end


### PR DESCRIPTION
I think this will allow Devin to one-shot adding a delete feature to product review responses.