### PR TITLE
Improve "Best selling" for larger numbers

### DIFF
--- a/app/javascript/components/server-components/DashboardPage.tsx
+++ b/app/javascript/components/server-components/DashboardPage.tsx
@@ -257,16 +257,28 @@ const ProductsTable = ({ sales }: TableProps) => {
               </a>
             </td>
             <td data-label="Products">
-              <a href={Routes.edit_link_url({ id }, { host: appDomain })} style={{ wordWrap: "break-word" }}>
+              <a href={Routes.edit_link_url({ id }, { host: appDomain })} className="line-clamp-2" title={name}>
                 {name}
               </a>
             </td>
-            <td data-label="Sales">{sales.toLocaleString(locale)}</td>
-            <td data-label="Revenue">{formatPrice(revenue)}</td>
-            <td data-label="Visits">{visits.toLocaleString(locale)}</td>
-            <td data-label="Today">{formatPrice(today)}</td>
-            <td data-label="Last 7 days">{formatPrice(last_7)}</td>
-            <td data-label="Last 30 days">{formatPrice(last_30)}</td>
+            <td data-label="Sales" title={sales.toLocaleString(locale)} className="text-nowrap">
+              {sales.toLocaleString(locale, { notation: "compact" })}
+            </td>
+            <td data-label="Revenue" title={formatPrice(revenue)} className="text-nowrap">
+              {formatPrice(revenue)}
+            </td>
+            <td data-label="Visits" title={visits.toLocaleString(locale)} className="text-nowrap">
+              {visits.toLocaleString(locale, { notation: "compact" })}
+            </td>
+            <td data-label="Today" className="text-nowrap">
+              {formatPrice(today)}
+            </td>
+            <td data-label="Last 7 days" className="text-nowrap">
+              {formatPrice(last_7)}
+            </td>
+            <td data-label="Last 30 days" className="text-nowrap">
+              {formatPrice(last_30)}
+            </td>
           </tr>
         ))}
       </tbody>


### PR DESCRIPTION
## Before

<img src="https://github.com/user-attachments/assets/09e9140a-8100-4dcf-a862-accb577a2b5b" width=550px />

## After

<img src="https://github.com/user-attachments/assets/f33dd674-d2a1-4077-b11a-ed8ef838171a" width=550px />

(All clamped text/numbers has hover state to see the full name / exact numeric value)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved product sales table with more compact and readable formatting for numbers (e.g., "1.2K").
  - Long product names are now truncated for a cleaner look, with full names shown on hover.
  - Added tooltips to display full values for sales, visits, and revenue.
  - Enhanced table styling for better consistency and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->