### PR TITLE
Always treat folder names as Strings

### DIFF
--- a/app/javascript/components/TiptapExtensions/FileEmbedGroup.tsx
+++ b/app/javascript/components/TiptapExtensions/FileEmbedGroup.tsx
@@ -236,7 +236,16 @@ export const FileEmbedGroup = TiptapNode.create<{ getConfig: () => FileGroupConf
   selectable: true,
   draggable: true,
   atom: true,
-  addAttributes: () => ({ uid: { isRequired: true }, name: { default: null } }),
+  addAttributes: () => ({
+    uid: { isRequired: true },
+    name: {
+      default: null,
+      // Explicitly parse to keep the value as String. Tiptap by default tries
+      // to coerce the value automatically and converts `1.0` or `1` to a
+      // number.
+      parseHTML: (element) => element.getAttribute("name"),
+    },
+  }),
   parseHTML: () => [{ tag: "file-embed-group" }],
   renderHTML: ({ HTMLAttributes }) => ["file-embed-group", HTMLAttributes, 0],
   addStorage: () => ({ lastCreatedUid: null }),

--- a/app/models/concerns/rich_contents.rb
+++ b/app/models/concerns/rich_contents.rb
@@ -11,12 +11,15 @@ module RichContents
   def rich_content_folder_name(folder_id)
     return if folder_id.blank?
 
-    alive_rich_contents.each do |page|
-      folder = page.description.find { |node| node["type"] == RichContent::FILE_EMBED_GROUP_NODE_TYPE && node.dig("attrs", "uid") == folder_id }
-      return folder.dig("attrs", "name") if folder.present?
-    end
+    folder = alive_rich_contents
+      .lazy
+      .flat_map(&:description)
+      .find do |node|
+        node["type"] == RichContent::FILE_EMBED_GROUP_NODE_TYPE &&
+          node.dig("attrs", "uid") == folder_id
+      end
 
-    nil
+    folder ? folder.dig("attrs", "name").to_s : nil
   end
 
   def rich_content_json

--- a/spec/models/concerns/rich_contents_spec.rb
+++ b/spec/models/concerns/rich_contents_spec.rb
@@ -66,17 +66,24 @@ describe RichContents do
           ] },
           { "type" => "paragraph", "content" => [{ "type" => "text", "text" => "Ignore me" }] }]
 
-        page3_description = [{ "type" => "fileEmbedGroup", "attrs" => { "name" => "folder 2", "uid" => folder2_id }, "content" => [
-          { "type" => "fileEmbed", "attrs" => { "id" => file3.external_id, "uid" => SecureRandom.uuid } },
-          { "type" => "fileEmbed", "attrs" => { "id" => file4.external_id, "uid" => SecureRandom.uuid } },
-          { "type" => "fileEmbed", "attrs" => { "id" => file5.external_id, "uid" => SecureRandom.uuid } },
-        ] }]
+        page3_description = [
+          {
+            "type" => "fileEmbedGroup",
+            # Ensure folders with numeric names are handled as strings
+            "attrs" => { "name" => 100, "uid" => folder2_id },
+            "content" => [
+              { "type" => "fileEmbed", "attrs" => { "id" => file3.external_id, "uid" => SecureRandom.uuid } },
+              { "type" => "fileEmbed", "attrs" => { "id" => file4.external_id, "uid" => SecureRandom.uuid } },
+              { "type" => "fileEmbed", "attrs" => { "id" => file5.external_id, "uid" => SecureRandom.uuid } },
+            ]
+          }
+        ]
 
         create(:rich_content, entity: product, title: "Page 2", description: page2_description, position: 1)
         create(:rich_content, entity: product, title: "Page 3", description: page3_description, position: 2)
 
         expect(product.reload.rich_content_folder_name(folder1_id)).to eq ("folder 1")
-        expect(product.reload.rich_content_folder_name(folder2_id)).to eq ("folder 2")
+        expect(product.reload.rich_content_folder_name(folder2_id)).to eq ("100")
       end
     end
   end

--- a/spec/requests/products/edit/rich_text_editor_spec.rb
+++ b/spec/requests/products/edit/rich_text_editor_spec.rb
@@ -1176,9 +1176,10 @@ describe("Product Edit Rich Text Editor", type: :feature, js: true) do
         end
       end
 
-      fill_in "Folder name", with: "My folder"
+      # Ensure folders with numeric names are saved as strings.
+      fill_in "Folder name", with: "100"
       send_keys(:enter)
-      within_file_group("My folder") do
+      within_file_group("100") do
         expect(page).to have_embed(name: "Second file")
       end
 
@@ -1190,7 +1191,7 @@ describe("Product Edit Rich Text Editor", type: :feature, js: true) do
       sleep 0.5 # Wait for the editor to update
       save_change
 
-      new_folder_uid = @product.reload.rich_contents.first.description.find { |node| node["type"] == RichContent::FILE_EMBED_GROUP_NODE_TYPE && node["attrs"]["name"] == "My folder" }["attrs"]["uid"]
+      new_folder_uid = @product.reload.rich_contents.first.description.find { |node| node["type"] == RichContent::FILE_EMBED_GROUP_NODE_TYPE && node["attrs"]["name"] == "100" }["attrs"]["uid"]
       expect(@product.reload.rich_contents.first.description).to eq(
         [
           {
@@ -1214,7 +1215,7 @@ describe("Product Edit Rich Text Editor", type: :feature, js: true) do
           {
             "type" => RichContent::FILE_EMBED_GROUP_NODE_TYPE,
             "attrs" => {
-              "name" => "My folder",
+              "name" => "100",
               "uid" => new_folder_uid
             },
             "content" => [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured that folder names containing numeric values are consistently treated and displayed as strings, preventing unintended type conversion issues.

- **Tests**
  - Updated tests to verify correct handling and display of numeric folder names as strings in file embed folders and related rich content features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->