### PR TITLE
Add receipt URL to Canada monthly sales report job

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -756,6 +756,10 @@ class Purchase < ApplicationRecord
     json
   end
 
+  def receipt_url
+    Rails.application.routes.url_helpers.receipt_purchase_url(external_id, email: email, host: "#{PROTOCOL}://#{DOMAIN}")
+  end
+
   def as_json_for_license
     json = as_json
     json[:product_name] = json.delete :link_name

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -739,7 +739,7 @@ class Purchase < ApplicationRecord
       json[:discover_fee_percentage] = discover_fee_per_thousand / 10
     end
 
-    json[:receipt_url] = Rails.application.routes.url_helpers.receipt_purchase_url(external_id, email: email, host: "#{PROTOCOL}://#{DOMAIN}") if options[:include_receipt_url]
+    json[:receipt_url] = receipt_url if options[:include_receipt_url]
 
     if options[:include_ping]
       cached_value = options[:include_ping][:value] if options[:include_ping].is_a? Hash

--- a/app/services/dispute_evidence/create_from_dispute_service.rb
+++ b/app/services/dispute_evidence/create_from_dispute_service.rb
@@ -66,7 +66,7 @@ class DisputeEvidence::CreateFromDisputeService
       rows << "Product type: #{product.is_physical? ? "physical product" : type}"
       rows << "Product variant: #{variant_names_displayable(purchase.variant_names)}" if purchase.variant_names.present?
       rows << "Quantity purchased: #{purchase.quantity}" if purchase.quantity > 1
-      rows << "Receipt: #{Rails.application.routes.url_helpers.receipt_purchase_url(purchase.external_id, email: purchase.email, host: DOMAIN, protocol: PROTOCOL)}"
+      rows << "Receipt: #{purchase.receipt_url}"
       rows << "Live product: #{purchase.link.long_url}"
       rows.join("\n")
     end

--- a/app/sidekiq/create_canada_monthly_sales_report_job.rb
+++ b/app/sidekiq/create_canada_monthly_sales_report_job.rb
@@ -49,6 +49,7 @@ class CreateCanadaMonthlySalesReportJob
             Money.new(fee_cents).format(no_cents_if_whole: false, symbol: false),
             Money.new(purchase.shipping_cents).format(no_cents_if_whole: false, symbol: false),
             Money.new(total_cents).format(no_cents_if_whole: false, symbol: false),
+            purchase.receipt_url
           ]
 
           temp_file.write(row.to_csv)
@@ -88,6 +89,7 @@ class CreateCanadaMonthlySalesReportJob
         "Gumroad Fee",
         "Shipping",
         "Total",
+        "Receipt URL",
       ]
     end
 end

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -3741,7 +3741,7 @@ describe Purchase, :vcr do
     let(:purchase) { create(:purchase) }
 
     it "returns the correct receipt URL" do
-      expected_url = "http://#{PROTOCOL}:#{DOMAIN}/purchases/#{purchase.external_id}/receipt?email=#{CGI.escape(purchase.email)}"
+      expected_url = "#{PROTOCOL}://#{DOMAIN}/purchases/#{purchase.external_id}/receipt?email=#{CGI.escape(purchase.email)}"
       expect(purchase.receipt_url).to eq(expected_url)
     end
   end

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -3737,6 +3737,15 @@ describe Purchase, :vcr do
     end
   end
 
+  describe "#receipt_url" do
+    let(:purchase) { create(:purchase) }
+
+    it "returns the correct receipt URL" do
+      expected_url = "http://#{PROTOCOL}:#{DOMAIN}/purchases/#{purchase.external_id}/receipt?email=#{CGI.escape(purchase.email)}"
+      expect(purchase.receipt_url).to eq(expected_url)
+    end
+  end
+
   describe "email" do
     describe "on create" do
       describe "valid email" do

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -777,7 +777,7 @@ describe Purchase, :vcr do
     end
 
     it "contains receipt_url only when include_receipt_url is set" do
-      receipt_url = Rails.application.routes.url_helpers.receipt_purchase_url(@purchase.external_id, email: @purchase.email, host: "#{PROTOCOL}://#{DOMAIN}")
+      receipt_url = @purchase.receipt_url
       expect(@purchase.as_json[:receipt_url]).to be nil
       expect(@purchase.as_json(include_receipt_url: true)[:receipt_url]).to eq receipt_url
     end

--- a/spec/requests/purchases/product/taxes_spec.rb
+++ b/spec/requests/purchases/product/taxes_spec.rb
@@ -325,7 +325,7 @@ describe("Product Page - Tax Scenarios", type: :feature, js: true) do
 
       # Check VAT ID is present on the invoice as well
 
-      visit Rails.application.routes.url_helpers.receipt_purchase_url(purchase.external_id, email: purchase.email, host: "#{PROTOCOL}://#{DOMAIN}")
+      visit purchase.receipt_url
       click_on("Generate")
       expect(page).to(have_text("NL860999063B01"))
     end
@@ -364,7 +364,7 @@ describe("Product Page - Tax Scenarios", type: :feature, js: true) do
 
         # Check VAT ID is present on the invoice as well
 
-        visit Rails.application.routes.url_helpers.receipt_purchase_url(purchase.external_id, email: purchase.email, host: "#{PROTOCOL}://#{DOMAIN}")
+        visit purchase.receipt_url
         click_on("Generate")
         expect(page).to(have_text("NL860999063B01"))
       end
@@ -473,7 +473,7 @@ describe("Product Page - Tax Scenarios", type: :feature, js: true) do
 
       # Check ABN ID is present on the invoice as well
 
-      visit Rails.application.routes.url_helpers.receipt_purchase_url(purchase.external_id, email: purchase.email, host: "#{PROTOCOL}://#{DOMAIN}")
+      visit purchase.receipt_url
       click_on("Generate")
       expect(page).to(have_text("51824753556"))
     end
@@ -592,7 +592,7 @@ describe("Product Page - Tax Scenarios", type: :feature, js: true) do
 
         # Check GST ID is present on the invoice as well
 
-        visit Rails.application.routes.url_helpers.receipt_purchase_url(purchase.external_id, email: purchase.email, host: "#{PROTOCOL}://#{DOMAIN}")
+        visit purchase.receipt_url
         click_on("Generate")
         expect(page).to(have_text("T9100001B"))
       end
@@ -728,7 +728,7 @@ describe("Product Page - Tax Scenarios", type: :feature, js: true) do
 
       # Check MVA ID is present on the invoice as well
 
-      visit Rails.application.routes.url_helpers.receipt_purchase_url(purchase.external_id, email: purchase.email, host: "#{PROTOCOL}://#{DOMAIN}")
+      visit purchase.receipt_url
       click_on("Generate")
       expect(page).to(have_text("Norway VAT Registration"))
       expect(page).to(have_text("977074010MVA"))
@@ -831,7 +831,7 @@ describe("Product Page - Tax Scenarios", type: :feature, js: true) do
 
         # Check Tax ID is present on the invoice as well
 
-        visit Rails.application.routes.url_helpers.receipt_purchase_url(purchase.external_id, email: purchase.email, host: "#{PROTOCOL}://#{DOMAIN}")
+        visit purchase.receipt_url
         click_on("Generate")
         expect(page).to(have_text("528491"))
       end
@@ -913,7 +913,7 @@ describe("Product Page - Tax Scenarios", type: :feature, js: true) do
 
         # Check Tax ID is present on the invoice as well
 
-        visit Rails.application.routes.url_helpers.receipt_purchase_url(purchase.external_id, email: purchase.email, host: "#{PROTOCOL}://#{DOMAIN}")
+        visit purchase.receipt_url
         click_on("Generate")
         expect(page).to(have_text("5-8356-7825-6246"))
       end
@@ -995,7 +995,7 @@ describe("Product Page - Tax Scenarios", type: :feature, js: true) do
 
         # Check Tax ID is present on the invoice as well
 
-        visit Rails.application.routes.url_helpers.receipt_purchase_url(purchase.external_id, email: purchase.email, host: "#{PROTOCOL}://#{DOMAIN}")
+        visit purchase.receipt_url
         click_on("Generate")
         expect(page).to(have_text("NZ62-332-956"))
       end
@@ -1077,7 +1077,7 @@ describe("Product Page - Tax Scenarios", type: :feature, js: true) do
 
         # Check Tax ID is present on the invoice as well
 
-        visit Rails.application.routes.url_helpers.receipt_purchase_url(purchase.external_id, email: purchase.email, host: "#{PROTOCOL}://#{DOMAIN}")
+        visit purchase.receipt_url
         click_on("Generate")
         expect(page).to(have_text("4734567892"))
       end
@@ -1180,7 +1180,7 @@ describe("Product Page - Tax Scenarios", type: :feature, js: true) do
 
         # Check Tax ID is present on the invoice as well
 
-        visit Rails.application.routes.url_helpers.receipt_purchase_url(purchase.external_id, email: purchase.email, host: "#{PROTOCOL}://#{DOMAIN}")
+        visit purchase.receipt_url
         click_on("Generate")
         expect(page).to(have_text("CHE-123.456.788"))
       end
@@ -1262,7 +1262,7 @@ describe("Product Page - Tax Scenarios", type: :feature, js: true) do
 
         # Check Tax ID is present on the invoice as well
 
-        visit Rails.application.routes.url_helpers.receipt_purchase_url(purchase.external_id, email: purchase.email, host: "#{PROTOCOL}://#{DOMAIN}")
+        visit purchase.receipt_url
         click_on("Generate")
         expect(page).to(have_text("923456789012345"))
       end
@@ -1344,7 +1344,7 @@ describe("Product Page - Tax Scenarios", type: :feature, js: true) do
 
         # Check Tax ID is present on the invoice as well
 
-        visit Rails.application.routes.url_helpers.receipt_purchase_url(purchase.external_id, email: purchase.email, host: "#{PROTOCOL}://#{DOMAIN}")
+        visit purchase.receipt_url
         click_on("Generate")
         expect(page).to(have_text("27AAPFU0939F1ZV"))
       end
@@ -1443,7 +1443,7 @@ describe("Product Page - Tax Scenarios", type: :feature, js: true) do
         expect(purchase.gumroad_tax_cents).to eq(0)
         expect(purchase.was_purchase_taxable).to be(false)
 
-        visit Rails.application.routes.url_helpers.receipt_purchase_url(purchase.external_id, email: purchase.email, host: "#{PROTOCOL}://#{DOMAIN}")
+        visit purchase.receipt_url
         click_on("Generate")
         expect(page).to(have_text("123456789012345"))
       end
@@ -1543,7 +1543,7 @@ describe("Product Page - Tax Scenarios", type: :feature, js: true) do
 
         # Check Tax ID is present on the invoice as well
 
-        visit Rails.application.routes.url_helpers.receipt_purchase_url(purchase.external_id, email: purchase.email, host: "#{PROTOCOL}://#{DOMAIN}")
+        visit purchase.receipt_url
         click_on("Generate")
         expect(page).to(have_text("623456785"))
       end
@@ -1643,7 +1643,7 @@ describe("Product Page - Tax Scenarios", type: :feature, js: true) do
 
         # Check Tax ID is present on the invoice as well
 
-        visit Rails.application.routes.url_helpers.receipt_purchase_url(purchase.external_id, email: purchase.email, host: "#{PROTOCOL}://#{DOMAIN}")
+        visit purchase.receipt_url
         click_on("Generate")
         expect(page).to(have_text("72345678-9"))
       end
@@ -1743,7 +1743,7 @@ describe("Product Page - Tax Scenarios", type: :feature, js: true) do
 
         # Check Tax ID is present on the invoice as well
 
-        visit Rails.application.routes.url_helpers.receipt_purchase_url(purchase.external_id, email: purchase.email, host: "#{PROTOCOL}://#{DOMAIN}")
+        visit purchase.receipt_url
         click_on("Generate")
         expect(page).to(have_text("623.456.789-1"))
       end
@@ -1843,7 +1843,7 @@ describe("Product Page - Tax Scenarios", type: :feature, js: true) do
 
         # Check Tax ID is present on the invoice as well
 
-        visit Rails.application.routes.url_helpers.receipt_purchase_url(purchase.external_id, email: purchase.email, host: "#{PROTOCOL}://#{DOMAIN}")
+        visit purchase.receipt_url
         click_on("Generate")
         expect(page).to(have_text("123456789"))
       end
@@ -1943,7 +1943,7 @@ describe("Product Page - Tax Scenarios", type: :feature, js: true) do
 
         # Check Tax ID is present on the invoice as well
 
-        visit Rails.application.routes.url_helpers.receipt_purchase_url(purchase.external_id, email: purchase.email, host: "#{PROTOCOL}://#{DOMAIN}")
+        visit purchase.receipt_url
         click_on("Generate")
         expect(page).to(have_text("1790027740001"))
       end
@@ -2043,7 +2043,7 @@ describe("Product Page - Tax Scenarios", type: :feature, js: true) do
 
         # Check Tax ID is present on the invoice as well
 
-        visit Rails.application.routes.url_helpers.receipt_purchase_url(purchase.external_id, email: purchase.email, host: "#{PROTOCOL}://#{DOMAIN}")
+        visit purchase.receipt_url
         click_on("Generate")
         expect(page).to(have_text("623-456-782"))
       end
@@ -2143,7 +2143,7 @@ describe("Product Page - Tax Scenarios", type: :feature, js: true) do
 
         # Check Tax ID is present on the invoice as well
 
-        visit Rails.application.routes.url_helpers.receipt_purchase_url(purchase.external_id, email: purchase.email, host: "#{PROTOCOL}://#{DOMAIN}")
+        visit purchase.receipt_url
         click_on("Generate")
         expect(page).to(have_text("123456789"))
       end
@@ -2243,7 +2243,7 @@ describe("Product Page - Tax Scenarios", type: :feature, js: true) do
 
         # Check Tax ID is present on the invoice as well
 
-        visit Rails.application.routes.url_helpers.receipt_purchase_url(purchase.external_id, email: purchase.email, host: "#{PROTOCOL}://#{DOMAIN}")
+        visit purchase.receipt_url
         click_on("Generate")
         expect(page).to(have_text("830302300054"))
       end
@@ -2341,7 +2341,7 @@ describe("Product Page - Tax Scenarios", type: :feature, js: true) do
         expect(purchase.gumroad_tax_cents).to eq(0)
         expect(purchase.was_purchase_taxable).to be(false)
 
-        visit Rails.application.routes.url_helpers.receipt_purchase_url(purchase.external_id, email: purchase.email, host: "#{PROTOCOL}://#{DOMAIN}")
+        visit purchase.receipt_url
         click_on("Generate")
         expect(page).to(have_text("A123456789P"))
       end
@@ -2441,7 +2441,7 @@ describe("Product Page - Tax Scenarios", type: :feature, js: true) do
 
         # Check Tax ID is present on the invoice as well
 
-        visit Rails.application.routes.url_helpers.receipt_purchase_url(purchase.external_id, email: purchase.email, host: "#{PROTOCOL}://#{DOMAIN}")
+        visit purchase.receipt_url
         click_on("Generate")
         expect(page).to(have_text("X89-2104-12345678"))
       end
@@ -2561,7 +2561,7 @@ describe("Product Page - Tax Scenarios", type: :feature, js: true) do
 
         # Check Tax ID is present on the invoice as well
 
-        visit Rails.application.routes.url_helpers.receipt_purchase_url(purchase.external_id, email: purchase.email, host: "#{PROTOCOL}://#{DOMAIN}")
+        visit purchase.receipt_url
         click_on("Generate")
         expect(page).to(have_text("RTL-630713-7M9"))
       end
@@ -2661,7 +2661,7 @@ describe("Product Page - Tax Scenarios", type: :feature, js: true) do
 
         # Check Tax ID is present on the invoice as well
 
-        visit Rails.application.routes.url_helpers.receipt_purchase_url(purchase.external_id, email: purchase.email, host: "#{PROTOCOL}://#{DOMAIN}")
+        visit purchase.receipt_url
         click_on("Generate")
         expect(page).to(have_text("MD9234564"))
       end
@@ -2761,7 +2761,7 @@ describe("Product Page - Tax Scenarios", type: :feature, js: true) do
 
         # Check Tax ID is present on the invoice as well
 
-        visit Rails.application.routes.url_helpers.receipt_purchase_url(purchase.external_id, email: purchase.email, host: "#{PROTOCOL}://#{DOMAIN}")
+        visit purchase.receipt_url
         click_on("Generate")
         expect(page).to(have_text("1234567"))
       end
@@ -2859,7 +2859,7 @@ describe("Product Page - Tax Scenarios", type: :feature, js: true) do
         expect(purchase.gumroad_tax_cents).to eq(0)
         expect(purchase.was_purchase_taxable).to be(false)
 
-        visit Rails.application.routes.url_helpers.receipt_purchase_url(purchase.external_id, email: purchase.email, host: "#{PROTOCOL}://#{DOMAIN}")
+        visit purchase.receipt_url
         click_on("Generate")
         expect(page).to(have_text("12345678-1234"))
       end
@@ -3056,7 +3056,7 @@ describe("Product Page - Tax Scenarios", type: :feature, js: true) do
 
         # Check Tax ID is present on the invoice as well
 
-        visit Rails.application.routes.url_helpers.receipt_purchase_url(purchase.external_id, email: purchase.email, host: "#{PROTOCOL}://#{DOMAIN}")
+        visit purchase.receipt_url
         click_on("Generate")
         expect(page).to(have_text("1234567894"))
       end
@@ -3156,7 +3156,7 @@ describe("Product Page - Tax Scenarios", type: :feature, js: true) do
 
         # Check Tax ID is present on the invoice as well
 
-        visit Rails.application.routes.url_helpers.receipt_purchase_url(purchase.external_id, email: purchase.email, host: "#{PROTOCOL}://#{DOMAIN}")
+        visit purchase.receipt_url
         click_on("Generate")
         expect(page).to(have_text("300710482300003"))
       end
@@ -3256,7 +3256,7 @@ describe("Product Page - Tax Scenarios", type: :feature, js: true) do
 
         # Check Tax ID is present on the invoice as well
 
-        visit Rails.application.routes.url_helpers.receipt_purchase_url(purchase.external_id, email: purchase.email, host: "#{PROTOCOL}://#{DOMAIN}")
+        visit purchase.receipt_url
         click_on("Generate")
         expect(page).to(have_text("101134702"))
       end
@@ -3356,7 +3356,7 @@ describe("Product Page - Tax Scenarios", type: :feature, js: true) do
 
         # Check Tax ID is present on the invoice as well
 
-        visit Rails.application.routes.url_helpers.receipt_purchase_url(purchase.external_id, email: purchase.email, host: "#{PROTOCOL}://#{DOMAIN}")
+        visit purchase.receipt_url
         click_on("Generate")
         expect(page).to(have_text("116-82-00276"))
       end
@@ -3454,7 +3454,7 @@ describe("Product Page - Tax Scenarios", type: :feature, js: true) do
         expect(purchase.gumroad_tax_cents).to eq(0)
         expect(purchase.was_purchase_taxable).to be(false)
 
-        visit Rails.application.routes.url_helpers.receipt_purchase_url(purchase.external_id, email: purchase.email, host: "#{PROTOCOL}://#{DOMAIN}")
+        visit purchase.receipt_url
         click_on("Generate")
         expect(page).to(have_text("12-345678-A"))
       end
@@ -3554,7 +3554,7 @@ describe("Product Page - Tax Scenarios", type: :feature, js: true) do
 
         # Check Tax ID is present on the invoice as well
 
-        visit Rails.application.routes.url_helpers.receipt_purchase_url(purchase.external_id, email: purchase.email, host: "#{PROTOCOL}://#{DOMAIN}")
+        visit purchase.receipt_url
         click_on("Generate")
         expect(page).to(have_text("0105536112014"))
       end
@@ -3654,7 +3654,7 @@ describe("Product Page - Tax Scenarios", type: :feature, js: true) do
 
         # Check Tax ID is present on the invoice as well
 
-        visit Rails.application.routes.url_helpers.receipt_purchase_url(purchase.external_id, email: purchase.email, host: "#{PROTOCOL}://#{DOMAIN}")
+        visit purchase.receipt_url
         click_on("Generate")
         expect(page).to(have_text("1729171602"))
       end
@@ -3754,7 +3754,7 @@ describe("Product Page - Tax Scenarios", type: :feature, js: true) do
 
         # Check Tax ID is present on the invoice as well
 
-        visit Rails.application.routes.url_helpers.receipt_purchase_url(purchase.external_id, email: purchase.email, host: "#{PROTOCOL}://#{DOMAIN}")
+        visit purchase.receipt_url
         click_on("Generate")
         expect(page).to(have_text("4928621938"))
       end
@@ -3854,7 +3854,7 @@ describe("Product Page - Tax Scenarios", type: :feature, js: true) do
 
         # Check Tax ID is present on the invoice as well
 
-        visit Rails.application.routes.url_helpers.receipt_purchase_url(purchase.external_id, email: purchase.email, host: "#{PROTOCOL}://#{DOMAIN}")
+        visit purchase.receipt_url
         click_on("Generate")
         expect(page).to(have_text("123456789"))
       end
@@ -3954,7 +3954,7 @@ describe("Product Page - Tax Scenarios", type: :feature, js: true) do
 
         # Check Tax ID is present on the invoice as well
 
-        visit Rails.application.routes.url_helpers.receipt_purchase_url(purchase.external_id, email: purchase.email, host: "#{PROTOCOL}://#{DOMAIN}")
+        visit purchase.receipt_url
         click_on("Generate")
         expect(page).to(have_text("0193456780-001"))
       end
@@ -4152,7 +4152,7 @@ describe("Product Page - Tax Scenarios", type: :feature, js: true) do
 
         # Check QST ID is present on the invoice as well
 
-        visit Rails.application.routes.url_helpers.receipt_purchase_url(purchase.external_id, email: purchase.email, host: "#{PROTOCOL}://#{DOMAIN}")
+        visit purchase.receipt_url
         click_on("Generate")
         expect(page).to(have_text("1002092821TQ0001"))
       end

--- a/spec/sidekiq/create_canada_monthly_sales_report_job_spec.rb
+++ b/spec/sidekiq/create_canada_monthly_sales_report_job_spec.rb
@@ -82,6 +82,7 @@ describe CreateCanadaMonthlySalesReportJob do
                                         "Gumroad Fee",
                                         "Shipping",
                                         "Total",
+                                        "Receipt URL",
                                       ])
 
       expect(@purchase1.purchase_taxjar_info).to be_present
@@ -101,6 +102,7 @@ describe CreateCanadaMonthlySalesReportJob do
                                         "30.00",
                                         "0.00",
                                         "113.00",
+                                        @purchase1.receipt_url,
                                       ])
 
       expect(@purchase2.purchase_taxjar_info).to be_present
@@ -120,6 +122,7 @@ describe CreateCanadaMonthlySalesReportJob do
                                         "30.00",
                                         "0.00",
                                         "114.98",
+                                        @purchase2.receipt_url,
                                       ])
     end
   end


### PR DESCRIPTION
## Summary by CodeRabbit

- **New Features**
  - Added a "Receipt URL" column to the Canada monthly sales report CSV export.

- **Refactor**
  - Simplified receipt URL generation throughout the app for consistency and maintainability.

- **Tests**
  - Updated and added tests to verify the new receipt URL method and its usage in reports and receipts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a "Receipt URL" column to the Canada Monthly Sales Report CSV export.

- **Refactor**
	- Simplified receipt URL generation throughout the app for improved consistency.

- **Tests**
	- Updated and expanded tests to verify correct receipt URL generation and inclusion in reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->