### PR TITLE
Sales through PayPal Connect should fulfill payout criteria

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3089,51 +3089,6 @@ describe User, :vcr do
     end
   end
 
-  describe "#made_a_successful_sale_with_a_paypal_connect_account?" do
-    let(:user) { create(:user) }
-    let!(:paypal_connect_account) { create(:merchant_account_paypal, user:) }
-
-    context "when the user has made a successful sale with a PayPal Connect account" do
-      before do
-        create(:purchase, seller: user, link: create(:product, user:), merchant_account: paypal_connect_account)
-      end
-
-      context "when the PayPal Connect account is alive" do
-        it "returns true" do
-          expect(user.made_a_successful_sale_with_a_paypal_connect_account?).to eq(true)
-        end
-      end
-
-      context "when the PayPal Connect account has been deleted" do
-        before do
-          paypal_connect_account.mark_deleted!
-        end
-
-        it "returns true" do
-          expect(user.made_a_successful_sale_with_a_paypal_connect_account?).to eq(true)
-        end
-      end
-    end
-
-    context "when the user has not made a successful sale with a PayPal Connect account" do
-      before do
-        create(:failed_purchase, seller: user, link: create(:product, user:), merchant_account: paypal_connect_account)
-      end
-
-      it "returns false" do
-        expect(user.made_a_successful_sale_with_a_paypal_connect_account?).to eq(false)
-      end
-    end
-
-    context "when the user has no PayPal Connect account" do
-      it "returns false" do
-        paypal_connect_account.destroy!
-
-        expect(user.made_a_successful_sale_with_a_paypal_connect_account?).to eq(false)
-      end
-    end
-  end
-
   describe "#eligible_for_abandoned_cart_workflows?" do
     let(:user) { create(:user) }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2998,7 +2998,7 @@ describe User, :vcr do
     end
   end
 
-  describe "#made_a_successful_sale_with_a_stripe_connect_account?" do
+  describe "#made_a_successful_sale_with_a_stripe_connect_or_paypal_connect_account?" do
     let(:user) { create(:user) }
     let!(:stripe_connect_account) { create(:merchant_account_stripe_connect, user:) }
 
@@ -3009,7 +3009,7 @@ describe User, :vcr do
 
       context "when the Stripe Connect account is alive" do
         it "returns true" do
-          expect(user.made_a_successful_sale_with_a_stripe_connect_account?).to eq(true)
+          expect(user.made_a_successful_sale_with_a_stripe_connect_or_paypal_connect_account?).to eq(true)
         end
       end
 
@@ -3019,7 +3019,7 @@ describe User, :vcr do
         end
 
         it "returns true" do
-          expect(user.made_a_successful_sale_with_a_stripe_connect_account?).to eq(true)
+          expect(user.made_a_successful_sale_with_a_stripe_connect_or_paypal_connect_account?).to eq(true)
         end
       end
     end
@@ -3030,7 +3030,7 @@ describe User, :vcr do
       end
 
       it "returns false" do
-        expect(user.made_a_successful_sale_with_a_stripe_connect_account?).to eq(false)
+        expect(user.made_a_successful_sale_with_a_stripe_connect_or_paypal_connect_account?).to eq(false)
       end
     end
 
@@ -3038,7 +3038,98 @@ describe User, :vcr do
       it "returns false" do
         stripe_connect_account.destroy!
 
-        expect(user.made_a_successful_sale_with_a_stripe_connect_account?).to eq(false)
+        expect(user.made_a_successful_sale_with_a_stripe_connect_or_paypal_connect_account?).to eq(false)
+      end
+    end
+
+    context "when the user has made a successful sale with a PayPal Connect account" do
+      let!(:paypal_connect_account) { create(:merchant_account_paypal, user:) }
+
+      before do
+        create(:purchase, seller: user, link: create(:product, user:), merchant_account: paypal_connect_account)
+      end
+
+      context "when the PayPal Connect account is alive" do
+        it "returns true" do
+          expect(user.made_a_successful_sale_with_a_stripe_connect_or_paypal_connect_account?).to eq(true)
+        end
+      end
+
+      context "when the PayPal Connect account has been deleted" do
+        before do
+          paypal_connect_account.mark_deleted!
+        end
+
+        it "returns true" do
+          expect(user.made_a_successful_sale_with_a_stripe_connect_or_paypal_connect_account?).to eq(true)
+        end
+      end
+    end
+
+    context "when the user has not made a successful sale with a PayPal Connect account" do
+      let!(:paypal_connect_account) { create(:merchant_account_paypal, user:) }
+
+      before do
+        create(:failed_purchase, seller: user, link: create(:product, user:), merchant_account: paypal_connect_account)
+      end
+
+      it "returns false" do
+        expect(user.made_a_successful_sale_with_a_stripe_connect_or_paypal_connect_account?).to eq(false)
+      end
+    end
+
+    context "when the user has no PayPal Connect account" do
+      let!(:paypal_connect_account) { create(:merchant_account_paypal, user:) }
+
+      it "returns false" do
+        paypal_connect_account.destroy!
+
+        expect(user.made_a_successful_sale_with_a_stripe_connect_or_paypal_connect_account?).to eq(false)
+      end
+    end
+  end
+
+  describe "#made_a_successful_sale_with_a_paypal_connect_account?" do
+    let(:user) { create(:user) }
+    let!(:paypal_connect_account) { create(:merchant_account_paypal, user:) }
+
+    context "when the user has made a successful sale with a PayPal Connect account" do
+      before do
+        create(:purchase, seller: user, link: create(:product, user:), merchant_account: paypal_connect_account)
+      end
+
+      context "when the PayPal Connect account is alive" do
+        it "returns true" do
+          expect(user.made_a_successful_sale_with_a_paypal_connect_account?).to eq(true)
+        end
+      end
+
+      context "when the PayPal Connect account has been deleted" do
+        before do
+          paypal_connect_account.mark_deleted!
+        end
+
+        it "returns true" do
+          expect(user.made_a_successful_sale_with_a_paypal_connect_account?).to eq(true)
+        end
+      end
+    end
+
+    context "when the user has not made a successful sale with a PayPal Connect account" do
+      before do
+        create(:failed_purchase, seller: user, link: create(:product, user:), merchant_account: paypal_connect_account)
+      end
+
+      it "returns false" do
+        expect(user.made_a_successful_sale_with_a_paypal_connect_account?).to eq(false)
+      end
+    end
+
+    context "when the user has no PayPal Connect account" do
+      it "returns false" do
+        paypal_connect_account.destroy!
+
+        expect(user.made_a_successful_sale_with_a_paypal_connect_account?).to eq(false)
       end
     end
   end
@@ -3049,10 +3140,6 @@ describe User, :vcr do
     context "when user has a Stripe Connect account" do
       let!(:stripe_connect_account) { create(:merchant_account_stripe_connect, user:) }
 
-      it "returns true if the Stripe Connect account is alive" do
-        expect(user.eligible_for_abandoned_cart_workflows?).to eq(true)
-      end
-
       it "returns false if the Stripe Connect account has been deleted and there were no linked successful sales" do
         stripe_connect_account.mark_deleted!
 
@@ -3062,6 +3149,23 @@ describe User, :vcr do
       it "returns true if the Stripe Connect account has been deleted and there was at least one successful sale with that Stripe Connect account" do
         create(:purchase, seller: user, link: create(:product, user:), merchant_account: stripe_connect_account)
         stripe_connect_account.mark_deleted!
+
+        expect(user.eligible_for_abandoned_cart_workflows?).to eq(true)
+      end
+    end
+
+    context "when user has a PayPal Connect account" do
+      let!(:paypal_connect_account) { create(:merchant_account_paypal, user:) }
+
+      it "returns false if the PayPal Connect account has been deleted and there were no linked successful sales" do
+        paypal_connect_account.mark_deleted!
+
+        expect(user.eligible_for_abandoned_cart_workflows?).to eq(false)
+      end
+
+      it "returns true if the PayPal Connect account has been deleted and there was at least one successful sale with that PayPal Connect account" do
+        create(:purchase, seller: user, link: create(:product, user:), merchant_account: paypal_connect_account)
+        paypal_connect_account.mark_deleted!
 
         expect(user.eligible_for_abandoned_cart_workflows?).to eq(true)
       end
@@ -3101,10 +3205,6 @@ describe User, :vcr do
           allow(user).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE)
         end
 
-        it "returns true if the Stripe Connect account is alive" do
-          expect(user.eligible_to_send_emails?).to eq(true)
-        end
-
         it "returns false if the Stripe Connect account has been deleted and there were no linked successful sales" do
           stripe_connect_account.mark_deleted!
 
@@ -3114,6 +3214,27 @@ describe User, :vcr do
         it "returns true if the Stripe Connect account has been deleted and there was at least one successful sale with that Stripe Connect account" do
           create(:purchase, seller: user, link: create(:product, user:), merchant_account: stripe_connect_account)
           stripe_connect_account.mark_deleted!
+
+          expect(user.eligible_to_send_emails?).to eq(true)
+        end
+      end
+
+      context "when user has a PayPal Connect account" do
+        let!(:paypal_connect_account) { create(:merchant_account_paypal, user:) }
+
+        before do
+          allow(user).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE)
+        end
+
+        it "returns false if the PayPal Connect account has been deleted and there were no linked successful sales" do
+          paypal_connect_account.mark_deleted!
+
+          expect(user.eligible_to_send_emails?).to eq(false)
+        end
+
+        it "returns true if the PayPal Connect account has been deleted and there was at least one successful sale with that PayPal Connect account" do
+          create(:purchase, seller: user, link: create(:product, user:), merchant_account: paypal_connect_account)
+          paypal_connect_account.mark_deleted!
 
           expect(user.eligible_to_send_emails?).to eq(true)
         end

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -240,7 +240,8 @@ describe Workflow do
   describe "#publish!" do
     before do
       allow_any_instance_of(User).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE)
-      create(:merchant_account_stripe_connect, user: @workflow.seller)
+      stripe_connect_account = create(:merchant_account_stripe_connect, user: @workflow.seller)
+      create(:purchase, seller: @workflow.seller, link: @workflow.link, merchant_account: stripe_connect_account)
     end
 
     it "does nothing if the workflow is already published" do

--- a/spec/requests/customers/customers_spec.rb
+++ b/spec/requests/customers/customers_spec.rb
@@ -391,7 +391,8 @@ describe "Sales page", type: :feature, js: true do
 
       it "displays the missed posts and allows re-sending them" do
         allow_any_instance_of(User).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE)
-        create(:merchant_account_stripe_connect, user: seller)
+        stripe_connect_account = create(:merchant_account_stripe_connect, user: seller)
+        create(:purchase, seller:, link: product1, merchant_account: stripe_connect_account)
 
         post = posts.last
         visit customers_path

--- a/spec/requests/emails/create_spec.rb
+++ b/spec/requests/emails/create_spec.rb
@@ -10,7 +10,8 @@ describe("Email Creation Flow", :js, type: :feature) do
 
   before do
     allow_any_instance_of(User).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE)
-    create(:merchant_account_stripe_connect, user: seller)
+    stripe_connect_account = create(:merchant_account_stripe_connect, user: seller)
+    create(:purchase, seller:, link: product, merchant_account: stripe_connect_account)
   end
 
   include_context "with switching account to user as admin for seller"

--- a/spec/requests/workflows_spec.rb
+++ b/spec/requests/workflows_spec.rb
@@ -25,10 +25,12 @@ describe("Workflows", js: true, type: :feature) do
     @product = create(:product, name: "product name", user: seller, created_at: 2.hours.ago)
     @product2 = create(:product, name: "product 2 name", user: seller, created_at: 1.hour.ago)
     create(:purchase, link: @product)
-    index_model_records(Purchase)
 
     allow_any_instance_of(User).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE)
-    create(:merchant_account_stripe_connect, user: seller)
+    stripe_connect_account = create(:merchant_account_stripe_connect, user: seller)
+    create(:purchase, seller:, link: @product2, merchant_account: stripe_connect_account)
+
+    index_model_records(Purchase)
   end
 
   include_context "with switching account to user as admin for seller"

--- a/spec/services/workflow/manage_service_spec.rb
+++ b/spec/services/workflow/manage_service_spec.rb
@@ -389,7 +389,8 @@ describe Workflow::ManageService do
       end
 
       it "updates the workflow and unpublishes it if the save action is 'save_and_unpublish'" do
-        create(:merchant_account_stripe_connect, user: seller)
+        stripe_connect_account = create(:merchant_account_stripe_connect, user: seller)
+        create(:purchase, seller:, link: product, merchant_account: stripe_connect_account)
         workflow.publish!
 
         params[:save_action_name] = Workflow::SAVE_AND_UNPUBLISH_ACTION
@@ -417,9 +418,12 @@ describe Workflow::ManageService do
       end
 
       it "does not save changes while publishing the workflow if the seller's email is not confirmed" do
-        create(:merchant_account_stripe_connect, user: seller)
+        stripe_connect_account = create(:merchant_account_stripe_connect, user: seller)
+        create(:purchase, seller:, link: product, merchant_account: stripe_connect_account)
         seller.update!(confirmed_at: nil)
+
         params[:save_action_name] = Workflow::SAVE_AND_PUBLISH_ACTION
+
         expect do
           service = described_class.new(seller:, params:, product:, workflow:)
           expect(service.process).to eq([false, "You have to confirm your email address before you can do that."])

--- a/spec/services/workflow/save_installments_service_spec.rb
+++ b/spec/services/workflow/save_installments_service_spec.rb
@@ -5,7 +5,8 @@ require "spec_helper"
 describe Workflow::SaveInstallmentsService do
   before do
     allow_any_instance_of(User).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE)
-    create(:merchant_account_stripe_connect, user: seller)
+    stripe_connect_account = create(:merchant_account_stripe_connect, user: seller)
+    create(:purchase, seller:, link: product, merchant_account: stripe_connect_account)
   end
 
   describe "#process" do


### PR DESCRIPTION
As Stripe Connect account already does.

This also tightens the check slightly that it requires at least one successful sale. Previously, having a Stripe Connect account alone (without any sales) would fulfill the payout criteria for emails.