### PR TITLE
Enabled `stackprof` in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gem "rake", "13.2.1"
 
 group :development do
   gem "derailed_benchmarks", "~> 2.1"
-  gem "stackprof", "~> 0.2"
 end
 
 group :staging, :production do
@@ -180,6 +179,7 @@ gem "sitemap_generator", "~> 6.3"
 gem "slack-notifier", "~> 2.4"
 gem "sprockets-rails", "~> 3.4", require: "sprockets/railtie"
 gem "ssrf_filter", "~> 1.2.0"
+gem "stackprof", "~> 0.2"
 gem "state_machines-activerecord", "~> 0.8"
 gem "streamio-ffmpeg", "~> 3.0"
 gem "stripe", "~> 12.0"


### PR DESCRIPTION
ref https://github.com/antiwork/gumroad/issues/234

- this allows us to generate flamegraphs within `rack-mini-profiler` on production, to aid with debugging performance issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency configuration to make "stackprof" available in all environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->