### PR TITLE
Fix payout privilege check and update payout status fields

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -93,4 +93,8 @@ class Admin::BaseController < ApplicationController
     def xhr_or_json_request?
       request.xhr? || request.format.json?
     end
+
+    def require_user_has_payout_privileges!
+      render json: { success: false, message: "Failed! You don't have payout privileges." } unless current_user.has_payout_privilege
+    end
 end

--- a/app/controllers/admin/users/payouts_controller.rb
+++ b/app/controllers/admin/users/payouts_controller.rb
@@ -81,13 +81,13 @@ class Admin::Users::PayoutsController < Admin::BaseController
   end
 
   def pause
-    @user.update!(payouts_paused: true)
+    @user.update!(payouts_paused_internally: true)
 
     render json: { success: true, message: "User's payouts paused" }
   end
 
   def resume
-    @user.update!(payouts_paused: false)
+    @user.update!(payouts_paused_internally: false)
 
     render json: { success: true, message: "User's payouts resumed" }
   end


### PR DESCRIPTION
- Added `require_user_has_payout_privileges!` method in `Admin::BaseController` to enforce payout privilege checks for users.
- Updated `payouts_controller.rb` to change the field name from `payouts_paused` to `payouts_paused_internally` for clarity in the pause and resume actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of payout privileges for admin users, ensuring appropriate access control.
  - Updated internal logic for pausing and resuming user payouts to enhance accuracy of payout status management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->