### PR TITLE
Removed check for last signed-in value at during caching

### DIFF
--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -6,7 +6,6 @@ class RedisKey
     def number_of_creators = "company_page:number_of_creators"
     def prev_week_payout_usd = "homepage:prev_week_payout_usd"
     def balance_stats_sales_caching_threshold = "balance_stats:sales_caching_threshold"
-    def balance_stats_days_since_sign_in_caching_threshold = "balance_stats:days_since_sign_in_caching_threshold"
     def balance_stats_users_excluded_from_caching = "balance_stats:users_excluded_from_caching"
     def balance_stats_scheduler_minutes_between_jobs = "balance_stats_scheduler:minutes_between_jobs"
     def elasticsearch_indexer_worker_ignore_404_errors_on_indices = "elasticsearch_indexer_worker:ignore_404_errors_on_indices"

--- a/spec/services/user_balance_stats_service_spec.rb
+++ b/spec/services/user_balance_stats_service_spec.rb
@@ -213,10 +213,10 @@ describe UserBalanceStatsService do
       user_4 = create(:large_seller, sales_count: 50, user: build(:user, current_sign_in_at: 3.days.ago)).user
       # With default values
       stub_const("#{described_class}::DEFAULT_SALES_CACHING_THRESHOLD", 100)
-      expect(described_class.cacheable_users).to match_array([user_2])
+      expect(described_class.cacheable_users).to match_array([user_1, user_2])
       # With custom redis set values
       $redis.set(RedisKey.balance_stats_sales_caching_threshold, 40)
-      expect(described_class.cacheable_users).to match_array([user_2, user_4])
+      expect(described_class.cacheable_users).to match_array([user_1, user_2, user_3, user_4])
       $redis.sadd(RedisKey.balance_stats_users_excluded_from_caching, [user_1.id, user_3.id])
       expect(described_class.cacheable_users).to match_array([user_2, user_4])
     end

--- a/spec/services/user_balance_stats_service_spec.rb
+++ b/spec/services/user_balance_stats_service_spec.rb
@@ -160,7 +160,6 @@ describe UserBalanceStatsService do
     context "when user is large seller" do
       before do
         stub_const("#{described_class}::DEFAULT_SALES_CACHING_THRESHOLD", 100)
-        stub_const("#{described_class}::DEFAULT_DAYS_SINCE_SIGN_IN_CACHING_THRESHOLD", 7)
         user.current_sign_in_at = 1.day.ago
         user.save!
         expect(described_class).to receive(:cacheable_users).and_call_original
@@ -214,13 +213,10 @@ describe UserBalanceStatsService do
       user_4 = create(:large_seller, sales_count: 50, user: build(:user, current_sign_in_at: 3.days.ago)).user
       # With default values
       stub_const("#{described_class}::DEFAULT_SALES_CACHING_THRESHOLD", 100)
-      stub_const("#{described_class}::DEFAULT_DAYS_SINCE_SIGN_IN_CACHING_THRESHOLD", 7)
       expect(described_class.cacheable_users).to match_array([user_2])
       # With custom redis set values
       $redis.set(RedisKey.balance_stats_sales_caching_threshold, 40)
       expect(described_class.cacheable_users).to match_array([user_2, user_4])
-      $redis.set(RedisKey.balance_stats_days_since_sign_in_caching_threshold, 15)
-      expect(described_class.cacheable_users).to match_array([user_1, user_2, user_3, user_4])
       $redis.sadd(RedisKey.balance_stats_users_excluded_from_caching, [user_1.id, user_3.id])
       expect(described_class.cacheable_users).to match_array([user_2, user_4])
     end


### PR DESCRIPTION
refs https://github.com/antiwork/gumroad/issues/234

- if the user has been signed in for a while, this value won't update and it'll mean the cache won't be used, which doesn't really make a lot of sense because the cache should be tied to the size of the user and not when they last logged in

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated user eligibility criteria by removing the recent sign-in date filter; caching now relies only on sales count and exclusion rules. No changes visible to end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->