### PR TITLE
Fixed duplicate context lookups across app

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,9 +6,10 @@
   <% bclass.push(@body_class) if @body_class %>
   <% show_nav = !@hide_layouts && user_signed_in? %>
   <% bclass.push("sidebar-nav") if show_nav %>
+  <% custom_context = RenderingExtension.custom_context(self) %>
   <body id="<%= @body_id %>" class="<%= bclass.join(" ") %>" style="<%= params[:as_embed] && "background: transparent" %>">
-    <div id="design-settings" data-settings="<%= RenderingExtension.custom_context(self)[:design_settings].to_json %>" style="display: none;"></div>
-    <div id="user-agent-info" data-settings="<%= RenderingExtension.custom_context(self)[:user_agent_info].to_json %>" style="display: none;"></div>
+    <div id="design-settings" data-settings="<%= custom_context[:design_settings].to_json %>" style="display: none;"></div>
+    <div id="user-agent-info" data-settings="<%= custom_context[:user_agent_info].to_json %>" style="display: none;"></div>
     <%= render("layouts/shared/flash") %>
     <% if show_nav %>
       <%= react_component "Nav", props: { title: @title }, prerender: true %>


### PR DESCRIPTION
refs https://github.com/antiwork/gumroad/issues/234

- because we were calling the custom_context function twice, we were doing all the DB queries twice
- this saves ~4 DB queries per page load when logged in, resulting in a ~2% win

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved performance and maintainability by optimizing how custom context data is accessed when embedding design settings and user agent information in the layout. No visible changes to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->