### PR TITLE
Reduced interval between `UpdateUserBalanceStatsCacheWorker` jobs

### DIFF
--- a/app/sidekiq/large_sellers_update_user_balance_stats_cache_worker.rb
+++ b/app/sidekiq/large_sellers_update_user_balance_stats_cache_worker.rb
@@ -4,7 +4,7 @@ class LargeSellersUpdateUserBalanceStatsCacheWorker
   include Sidekiq::Job
   sidekiq_options retry: 1, queue: :low
 
-  MINUTES_BETWEEN_JOBS = 5
+  MINUTES_BETWEEN_JOBS = 1
 
   def perform
     minutes_between_jobs = ($redis.get(RedisKey.balance_stats_scheduler_minutes_between_jobs) || MINUTES_BETWEEN_JOBS).to_i


### PR DESCRIPTION
- because of the number of large sellers we have, some of the jobs are being scheduled for the next day and that causes issues because there is a lock on the execution
- this reduces the interval so we can keep the data fresher

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Reduced the default interval between scheduled balance stats update jobs, resulting in more frequent updates for user balance statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->