### PR TITLE
Set noindex header for OAuth authorization flows in logins and signup controllers

### DIFF
--- a/app/controllers/logins_controller.rb
+++ b/app/controllers/logins_controller.rb
@@ -7,6 +7,7 @@ class LoginsController < Devise::SessionsController
   before_action :block_json_request, only: :new
   after_action :clear_dashboard_preference, only: :destroy
   before_action :reset_impersonated_user, only: :destroy
+  before_action :set_noindex_header, only: :new, if: -> { params[:next]&.start_with?("/oauth/authorize") }
 
   def new
     @hide_layouts = true

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -4,6 +4,7 @@ class SignupController < Devise::RegistrationsController
   include OauthApplicationConfig, ValidateRecaptcha
 
   before_action :verify_captcha_and_handle_existing_users, only: :create
+  before_action :set_noindex_header, only: :new, if: -> { params[:next]&.start_with?("/oauth/authorize") }
 
   def new
     @hide_layouts = true

--- a/spec/controllers/logins_controller_spec.rb
+++ b/spec/controllers/logins_controller_spec.rb
@@ -52,6 +52,16 @@ describe LoginsController do
         expect(assigns[:application]).to eq @oauth_application
         expect(assigns[:auth_presenter].application).to eq @oauth_application
       end
+
+      it "sets noindex header when next param starts with /oauth/authorize" do
+        get :new, params: { next: "/oauth/authorize?client_id=123" }
+        expect(response.headers["X-Robots-Tag"]).to eq "noindex"
+      end
+
+      it "does not set noindex header for regular login" do
+        get :new
+        expect(response.headers["X-Robots-Tag"]).to be_nil
+      end
     end
   end
 

--- a/spec/controllers/signup_controller_spec.rb
+++ b/spec/controllers/signup_controller_spec.rb
@@ -26,6 +26,16 @@ describe SignupController do
 
         expect(assigns[:application]).to eq @oauth_application
       end
+
+      it "sets noindex header when next param starts with /oauth/authorize" do
+        get :new, params: { next: "/oauth/authorize?client_id=123" }
+        expect(response.headers["X-Robots-Tag"]).to eq "noindex"
+      end
+
+      it "does not set noindex header for regular signup" do
+        get :new
+        expect(response.headers["X-Robots-Tag"]).to be_nil
+      end
     end
   end
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a mechanism to prevent search engines from indexing the login and signup pages when accessed with certain OAuth parameters.

- **Tests**
  - Introduced tests to verify that the noindex header is correctly set or omitted based on the presence and value of specific parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->