### PR TITLE
Check database risk state in Helper suspension info

### DIFF
--- a/app/controllers/api/internal/helper/users_controller.rb
+++ b/app/controllers/api/internal/helper/users_controller.rb
@@ -107,6 +107,13 @@ class Api::Internal::Helper::UsersController < Api::Internal::Helper::BaseContro
           updated_at: user_data["actionStatusCreatedAt"],
           appeal_url: user_data["appealUrl"]
         }
+      elsif user.suspended?
+        render json: {
+          success: true,
+          status: "Suspended",
+          updated_at: user.comments.where(comment_type: [Comment::COMMENT_TYPE_SUSPENSION_NOTE, Comment::COMMENT_TYPE_SUSPENDED]).order(created_at: :desc).first&.created_at,
+          appeal_url: nil
+        }
       else
         render json: {
           success: true,

--- a/app/controllers/api/internal/helper/users_controller.rb
+++ b/app/controllers/api/internal/helper/users_controller.rb
@@ -118,7 +118,7 @@ class Api::Internal::Helper::UsersController < Api::Internal::Helper::BaseContro
         render json: {
           success: true,
           status: "Compliant",
-          suspended_at: nil,
+          updated_at: nil,
           appeal_url: nil
         }
       end


### PR DESCRIPTION
Many users are now suspended by updating user_risk_state rather than creating a record on Iffy. This makes sure Helper doesn't wrongly consider them compliant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved suspension status reporting to correctly show users as "Suspended" when locally suspended, even if external data is missing.
- **Tests**
  - Added test coverage for scenarios where a user is locally suspended but not reported as suspended by the external system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->