### PR TITLE
Reduced caching threshold for user balance stats service

### DIFF
--- a/app/services/user_balance_stats_service.rb
+++ b/app/services/user_balance_stats_service.rb
@@ -4,7 +4,7 @@ class UserBalanceStatsService
   include ActionView::Helpers::TranslationHelper
   include PayoutsHelper
   attr_reader :user
-  DEFAULT_SALES_CACHING_THRESHOLD = 100_000
+  DEFAULT_SALES_CACHING_THRESHOLD = 50_000
 
   def initialize(user:)
     @user = user


### PR DESCRIPTION
refs https://github.com/antiwork/gumroad/issues/234

- sites even as small as 50k can still have slow dashboards, so we should enable caching for them too

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the default sales threshold for user caching from 100,000 to 50,000.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->