### PR TITLE
Cached products for creator analytics

### DIFF
--- a/app/modules/user/stats.rb
+++ b/app/modules/user/stats.rb
@@ -565,6 +565,11 @@ module User::Stats
          .order(id: :desc)
   end
 
+  # Memoized version of products_for_creator_analytics to avoid re-running the query
+  def cached_products_for_creator_analytics
+    @_cached_products_for_creator_analytics ||= products_for_creator_analytics.load
+  end
+
   def first_sale_created_at_for_analytics
     union_sql = [:successful, :preorder_authorization_successful, :preorder_concluded_successfully].map do |state|
       "(" + sales.order(:created_at).select(:created_at).limit(1).where(purchase_state: state).to_sql + ")"

--- a/app/services/creator_analytics/web.rb
+++ b/app/services/creator_analytics/web.rb
@@ -118,7 +118,7 @@ class CreatorAnalytics::Web
     end
 
     def products
-      @_products ||= @user.products_for_creator_analytics.load
+      @user.cached_products_for_creator_analytics
     end
 
     def product_permalinks


### PR DESCRIPTION
refs https://github.com/antiwork/gumroad/issues/234

- this helps to prevent 4 of the heaviest remaining SQL queries on the dashboard by caching the data in the user model
- there's probably a slightly cleaner way of doing this but this prevents a huge refactor until we can measure the impact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance Improvements**
  - Enhanced analytics performance by introducing caching for product data, reducing redundant data loading during analytics operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->