### PR TITLE
ensuring that create_license has the latest data from db

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -1432,6 +1432,9 @@ class Purchase < ApplicationRecord
   end
 
   def create_license!
+    if persisted? && (purchase_state_previously_changed? || purchase_state == 'successful')
+      reload
+    end
     return if is_gift_sender_purchase
     return unless link.is_licensed
     return if license.present?


### PR DESCRIPTION
fix(Only issue one license key for gifted purchases (to the giftee) #193): 

the create_license issue appears to be a race condition.

current flow
1. when callback runs create_artifacts_and_send_receipt!
2. create_license is called and stale data means that is_gift_sender_purchase may be falsey
3. two licenses get created

new flow
1. when callback runs create_artifacts_and_send_receipt!
2. create_license is called and reloads the latest data
3. is_gift_sender_purchase is accurate
