### PR TITLE
Add tax type field to CSV export and corresponding tests

### DIFF
--- a/app/services/exports/purchase_export_service.rb
+++ b/app/services/exports/purchase_export_service.rb
@@ -3,7 +3,7 @@
 class Exports::PurchaseExportService
   PURCHASE_FIELDS = [
     "Purchase ID", "Item Name", "Buyer Name", "Purchase Email", "Buyer Email", "Do not contact?",
-    "Purchase Date", "Purchase Time (UTC timezone)", "Subtotal ($)", "Taxes ($)", "Shipping ($)",
+    "Purchase Date", "Purchase Time (UTC timezone)", "Subtotal ($)", "Taxes ($)", "Tax Type", "Shipping ($)",
     "Sale Price ($)", "Fees ($)", "Net Total ($)", "Tip ($)", "Tax Included in Price?",
     "Street Address", "City", "Zip Code", "State", "Country", "Referrer", "Refunded?",
     "Partial Refund ($)", "Fully Refunded?", "Disputed?", "Dispute Won?", "Variants",
@@ -137,6 +137,7 @@ class Exports::PurchaseExportService
         "Purchase Time (UTC timezone)" => purchase.created_at.to_time.to_s,
         "Subtotal ($)" => purchase.sub_total,
         "Taxes ($)" => purchase.tax_dollars,
+        "Tax Type" => purchase.tax_label,
         "Shipping ($)" => purchase.shipping_dollars,
         "Sale Price ($)" => purchase.price_dollars,
         "Fees ($)" => purchase.fee_dollars,

--- a/spec/services/exports/purchase_export_service_spec.rb
+++ b/spec/services/exports/purchase_export_service_spec.rb
@@ -530,6 +530,22 @@ describe Exports::PurchaseExportService do
         end
       end
     end
+
+    describe "tax type field" do
+      it "includes the tax type (VAT, GST, or sales tax) in the CSV export" do
+        @purchase.update!(was_purchase_taxable: true, was_tax_excluded_from_price: true, tax_cents: 110, country: "Italy")
+        allow(@purchase).to receive(:tax_label).and_return("Sales tax")
+        row = last_data_row
+        expect(field_value(row, "Tax Type")).to eq("Sales tax")
+      end
+
+      it "is blank if the purchase is not taxable" do
+        @purchase.update!(was_purchase_taxable: false)
+        allow(@purchase).to receive(:tax_label).and_return(nil)
+        row = last_data_row
+        expect(field_value(row, "Tax Type")).to be_nil
+      end
+    end
   end
 
   def field_index(name)


### PR DESCRIPTION
resolves https://github.com/antiwork/gumroad/issues/278

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a "Tax Type" column to purchase export CSVs, displaying tax label information for each purchase.

- **Tests**
  - Introduced tests to verify correct inclusion of the "Tax Type" field in purchase export CSVs for both taxable and non-taxable purchases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->