### PR TITLE
copy_to_clipboard helper in Admin

### DIFF
--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -77,7 +77,11 @@ module AdminHelper
       concat block_given? ? capture(&block) : tag.span(text)
       concat(
         with_tooltip(tip: "Copy to clipboard") do
-          tag.button(data: { clipboard_text: text }) do
+          tag.button(
+            type: "button",
+            aria: { label: "Copy to clipboard" },
+            data: { clipboard_text: text },
+          ) do
             icon("outline-duplicate")
           end
         end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -46,16 +46,11 @@ module AdminHelper
     return capture(&block) if tip.blank?
 
     uuid = SecureRandom.uuid
-    css_classes = ["has-tooltip", position]
-    tag.span(
-      safe_join(
-        [
-          tag.span(aria: { describedby: uuid }, &block),
-          tag.span(tip, role: "tooltip", id: uuid)
-        ]
-      ),
-      class: css_classes.compact.join(" ")
-    )
+
+    tag.span(class: ["has-tooltip", position]) do
+      concat tag.span(aria: { describedby: uuid }, &block)
+      concat tag.span(tip, role: "tooltip", id: uuid)
+    end
   end
 
   def blocked_email_tooltip(email)
@@ -75,5 +70,18 @@ module AdminHelper
 
   def admin_action(props)
     react_component("AdminActionButton", props:, prerender: true)
+  end
+
+  def copy_to_clipboard(text, &block)
+    tag.div(class: "inline-flex items-center gap-1") do
+      concat block_given? ? capture(&block) : tag.span(text)
+      concat(
+        with_tooltip(tip: "Copy to clipboard") do
+          tag.button(data: { clipboard_text: text }) do
+            icon("outline-duplicate")
+          end
+        end
+      )
+    end
   end
 end

--- a/app/javascript/packs/admin.ts
+++ b/app/javascript/packs/admin.ts
@@ -1,3 +1,4 @@
+import Clipboard from "clipboard";
 import ReactOnRails from "react-on-rails";
 
 import BasePage from "$app/utils/base_page";
@@ -7,3 +8,28 @@ import AdminSearchPopover from "$app/components/server-components/Admin/SearchPo
 
 BasePage.initialize();
 ReactOnRails.register({ AdminNav, AdminSearchPopover });
+
+let clipboard: Clipboard | null = null;
+
+// Supplements AdminHelper#copy_to_clipboard.
+function registerClipboardHandlers() {
+  if (clipboard) {
+    clipboard.destroy();
+  }
+
+  clipboard = new Clipboard("[data-clipboard-text]");
+
+  clipboard.on("success", (e: Clipboard.Event) => {
+    const tooltip = e.trigger.closest(".has-tooltip")?.querySelector<HTMLElement>("[role='tooltip']");
+
+    if (tooltip) {
+      const original = tooltip.textContent || "";
+      tooltip.textContent = "Copied!";
+      setTimeout(() => (tooltip.textContent = original), 2000);
+    }
+
+    e.clearSelection();
+  });
+}
+
+document.addEventListener("DOMContentLoaded", registerClipboardHandlers);

--- a/app/views/admin/purchases/_purchase.html.erb
+++ b/app/views/admin/purchases/_purchase.html.erb
@@ -22,11 +22,11 @@
     <dl>
       <% if purchase.seller.support_email.present? %>
         <dt>Seller support email</dt>
-        <dd><%= mail_to purchase.seller.support_email %></dd>
+        <dd><%= copy_to_clipboard purchase.seller.support_email %></dd>
       <% end %>
 
       <dt>Seller email</dt>
-      <dd><%= mail_to purchase.seller.email %></dd>
+      <dd><%= copy_to_clipboard purchase.seller.email %></dd>
 
       <% if purchase.merchant_account %>
         <dt>Merchant account</dt>

--- a/app/views/admin/users/_user.html.erb
+++ b/app/views/admin/users/_user.html.erb
@@ -18,14 +18,14 @@
           <% if user.form_email.present? %>
             <li>
               Email:
-              <%= mail_to(user.form_email) %>
+              <%= copy_to_clipboard(user.form_email) %>
               <%= blocked_email_tooltip(user.form_email) %>
             </li>
           <% end %>
           <% if user.support_email.present? %>
             <li>
               Support email:
-              <%= mail_to(user.support_email) %>
+              <%= copy_to_clipboard(user.support_email) %>
             </li>
           <% end %>
           <% if user.payments.any? %>


### PR DESCRIPTION
Original requested via https://github.com/antiwork/gumroad/pull/316.

This adds a new `copy_to_clipboard` helper.

<img width="339" alt="image" src="https://github.com/user-attachments/assets/42ca9fb7-b152-4b2b-a575-aea7410b847b" />

I have only updated the places that the original PR touched, this also supports wrapping arbitrary elements like:

```ruby
copy_to_clipboard "Text to be copied" do
  link_to user.name, admin_user_path(user)
end
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a copy-to-clipboard button for email addresses in admin user and purchase views, allowing quick copying of emails instead of using mailto links.

- **Improvements**
  - Tooltips now provide feedback when an email address is copied, displaying a "Copied!" message for a short time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->