### PR TITLE
Cached Stripe API request to check eligibility for instant payouts

### DIFF
--- a/app/models/bank_account.rb
+++ b/app/models/bank_account.rb
@@ -77,7 +77,7 @@ class BankAccount < ApplicationRecord
   def supports_instant_payouts?
     return false unless stripe_connect_account_id.present? && stripe_external_account_id.present?
 
-    begin
+    @supports_instant_payouts ||= begin
       external_account = Stripe::Account.retrieve_external_account(
         stripe_connect_account_id,
         stripe_external_account_id


### PR DESCRIPTION
- through 2 different codepaths, we call `supports_instant_payouts`, but we don't need to call the Stripe API twice, so we can just cache the result here

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance Improvements**
  - Improved the efficiency of checking if instant payouts are supported, resulting in faster response times for repeated checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->