### PR TITLE
Removed scheduling gap between user balance stats workers

### DIFF
--- a/app/sidekiq/large_sellers_update_user_balance_stats_cache_worker.rb
+++ b/app/sidekiq/large_sellers_update_user_balance_stats_cache_worker.rb
@@ -4,13 +4,10 @@ class LargeSellersUpdateUserBalanceStatsCacheWorker
   include Sidekiq::Job
   sidekiq_options retry: 1, queue: :low
 
-  MINUTES_BETWEEN_JOBS = 1
-
   def perform
-    minutes_between_jobs = ($redis.get(RedisKey.balance_stats_scheduler_minutes_between_jobs) || MINUTES_BETWEEN_JOBS).to_i
     user_ids = UserBalanceStatsService.cacheable_users.pluck(:id)
-    user_ids.each.with_index do |user_id, i|
-      UpdateUserBalanceStatsCacheWorker.perform_in(i * minutes_between_jobs.minutes, user_id)
+    user_ids.each do |user_id|
+      UpdateUserBalanceStatsCacheWorker.perform_async(user_id)
     end
   end
 end


### PR DESCRIPTION
- UpdateUserBalanceStatsCacheWorker has a lock on it, which prevent multiple jobs from being scheduled at the same time
- there is a bug where we don't update the user balance status for up to 6 hours because the cron'd update jobs prevent us from re-scheduling newer cache update
- we can workaround that by just adding all jobs to the update queue and allowing Sidekiq to process them as fast as it wants

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the scheduling of balance stats update jobs for large sellers by enqueuing all jobs immediately, resulting in faster processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->