### PR TITLE
Removed unnecessary API requests to fetch balances

### DIFF
--- a/app/javascript/components/Stats.tsx
+++ b/app/javascript/components/Stats.tsx
@@ -52,9 +52,7 @@ export const Stats = ({
         ) : null}
       </h2>
       <div ref={containerRef} style={{ overflow: "hidden", overflowWrap: "initial" }}>
-        <span style={adjustedFontSize ? { fontSize: adjustedFontSize } : undefined}>
-          {value ?? "-"}
-        </span>
+        <span style={adjustedFontSize ? { fontSize: adjustedFontSize } : undefined}>{value ?? "-"}</span>
       </div>
     </section>
   );

--- a/app/javascript/components/Stats.tsx
+++ b/app/javascript/components/Stats.tsx
@@ -1,67 +1,24 @@
 import cx from "classnames";
 import * as React from "react";
-import { cast } from "ts-safe-cast";
 
 import { assertDefined } from "$app/utils/assert";
-import { assertResponseError, request, ResponseError } from "$app/utils/request";
 
 import { Icon } from "$app/components/Icons";
-import { Progress } from "$app/components/Progress";
-import { showAlert } from "$app/components/server-components/Alert";
-import { useRunOnce } from "$app/components/useRunOnce";
 import { WithTooltip } from "$app/components/WithTooltip";
-
-const useFetchStat = () => {
-  const fetchStat = async ({ url }: { url: string }): Promise<string> => {
-    try {
-      const response = await request({
-        method: "GET",
-        url,
-        accept: "json",
-      });
-      if (response.ok) {
-        const responseData = cast<{ success: true; value: string } | { success: false; error?: string }>(
-          await response.json(),
-        );
-        if (responseData.success) return responseData.value;
-        throw new ResponseError(responseData.error);
-      }
-      throw new ResponseError();
-    } catch (e) {
-      assertResponseError(e);
-      showAlert(e.message, "error");
-      return "-";
-    }
-  };
-
-  return fetchStat;
-};
 
 export const Stats = ({
   title,
   description,
   value,
   className,
-  url,
 }: {
   title: React.ReactNode;
   description?: string;
   value?: string;
   className?: string;
-  url?: string;
 }) => {
   const [adjustedFontSize, setAdjustedFontSize] = React.useState<number | null>(null);
   const containerRef = React.useRef<HTMLDivElement | null>(null);
-  const [valueText, setValueText] = React.useState(value ?? "");
-  const fetchStat = useFetchStat();
-
-  useRunOnce(() => {
-    if (url) {
-      fetchStat({ url })
-        .then((newValue) => setValueText(newValue))
-        .catch(() => setValueText("-"));
-    }
-  });
 
   React.useEffect(() => {
     const calculateFontSize = () => {
@@ -73,7 +30,7 @@ export const Stats = ({
           const canvas = document.createElement("canvas");
           const context = assertDefined(canvas.getContext("2d"), "Canvas 2d context missing");
           context.font = `${style.fontSize} ${style.fontFamily}`;
-          const valueWidth = context.measureText(valueText).width;
+          const valueWidth = context.measureText(value ?? "").width;
           const fontSize = parseFloat(style.fontSize);
           setAdjustedFontSize(valueWidth > containerWidth ? (containerWidth * fontSize) / valueWidth : fontSize);
         })
@@ -96,7 +53,7 @@ export const Stats = ({
       </h2>
       <div ref={containerRef} style={{ overflow: "hidden", overflowWrap: "initial" }}>
         <span style={adjustedFontSize ? { fontSize: adjustedFontSize } : undefined}>
-          {value ? value : valueText === "" ? <Progress width="1.2em" /> : valueText}
+          {value ?? "-"}
         </span>
       </div>
     </section>

--- a/app/javascript/components/server-components/DashboardPage.tsx
+++ b/app/javascript/components/server-components/DashboardPage.tsx
@@ -386,25 +386,21 @@ export const DashboardPage = ({
               title="Balance"
               description="Your current balance available for payout"
               value={balances.balance}
-              url={Routes.balance_path()}
             />
             <Stats
               title="Last 7 days"
               description="Your total sales in the last 7 days"
               value={balances.last_seven_days_sales_total}
-              url={Routes.sales_dashboard_path()}
             />
             <Stats
               title="Last 28 days"
               description="Your total sales in the last 28 days"
               value={balances.last_28_days_sales_total}
-              url={Routes.sales_dashboard_path()}
             />
             <Stats
               title="Total earnings"
               description="Your all-time net earnings from all products, excluding refunds and chargebacks"
               value={balances.total}
-              url={Routes.dashboard_total_revenue_path()}
             />
           </div>
 

--- a/app/javascript/components/server-components/DashboardPage.tsx
+++ b/app/javascript/components/server-components/DashboardPage.tsx
@@ -382,11 +382,7 @@ export const DashboardPage = ({
           <h2>Activity</h2>
 
           <div className="stats-grid">
-            <Stats
-              title="Balance"
-              description="Your current balance available for payout"
-              value={balances.balance}
-            />
+            <Stats title="Balance" description="Your current balance available for payout" value={balances.balance} />
             <Stats
               title="Last 7 days"
               description="Your total sales in the last 7 days"


### PR DESCRIPTION
refs https://github.com/antiwork/gumroad-old/pull/28712/files

- since the PR above, we've been including the balance/stats directly into the page instead of relying on loading them via secondary API requests
- as a result, we're currently loading 4 different pages and not even using the result
- some of these requests are even just returning HTML because they don't have JSON equivalents
- we can do away with that and simplify the code in the process

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified the statistics display by removing asynchronous fetching and progress indicators. The statistic value is now displayed directly from the provided value.
  - Removed clickable links and URL-based navigation from the statistics components on the dashboard.
  - Updated font sizing and tooltip support for improved readability and usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->