### PR TITLE
feat: Implement initial membership pausing functionality

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -5,7 +5,7 @@ class SubscriptionsController < ApplicationController
   before_action :authenticate_user!, except: PUBLIC_ACTIONS
   after_action :verify_authorized, except: PUBLIC_ACTIONS
 
-  before_action :fetch_subscription, only: %i[unsubscribe_by_seller unsubscribe_by_user magic_link send_magic_link]
+  before_action :fetch_subscription, only: %i[unsubscribe_by_seller unsubscribe_by_user magic_link send_magic_link pause resume]
   before_action :hide_layouts, only: [:manage, :magic_link, :send_magic_link]
   before_action :set_noindex_header, only: [:manage]
   before_action :check_can_manage, only: [:manage, :unsubscribe_by_user]
@@ -55,6 +55,26 @@ class SubscriptionsController < ApplicationController
     CustomerMailer.subscription_magic_link(@subscription.id, email).deliver_later(queue: "critical")
 
     head :no_content
+  end
+
+  def pause
+    authorize @subscription
+    @subscription.pause!(paused_by_user: true)
+    render json: { success: true }
+  rescue ActiveRecord::RecordInvalid => e
+    render json: { success: false, error: e.message }
+  rescue StandardError => e # Catching generic StandardError for other potential issues from the model
+    render json: { success: false, error: e.message }, status: :unprocessable_entity
+  end
+
+  def resume
+    authorize @subscription
+    @subscription.resume!
+    render json: { success: true }
+  rescue ActiveRecord::RecordInvalid => e
+    render json: { success: false, error: e.message }
+  rescue StandardError => e # Catching generic StandardError for other potential issues from the model
+    render json: { success: false, error: e.message }, status: :unprocessable_entity
   end
 
   private

--- a/app/javascript/components/server-components/SubscriptionManager.tsx
+++ b/app/javascript/components/server-components/SubscriptionManager.tsx
@@ -77,6 +77,8 @@ type Props = {
     is_overdue_for_charge: boolean;
     is_gift: boolean;
     is_installment_plan: boolean;
+    status: string; // Added: 'alive', 'paused', 'cancelled', etc.
+    paused_at: string | null; // Added
   };
   contact_info: {
     email: string;
@@ -107,6 +109,16 @@ const SubscriptionManager = ({
   used_card,
 }: Props) => {
   const url = new URL(useOriginalLocation());
+
+  // Determine initial paused state from props
+  const initialIsPaused = subscription.status === "paused";
+  const [isPaused, setIsPaused] = React.useState(initialIsPaused);
+  // Update isPaused if subscription.status changes (e.g. after successful API call and prop refresh)
+  React.useEffect(() => {
+    setIsPaused(subscription.status === "paused");
+  }, [subscription.status]);
+
+  const [isLoadingPauseResume, setIsLoadingPauseResume] = React.useState(false);
 
   const subscriptionEntity = subscription.is_installment_plan ? "installment plan" : "membership";
   const restartable = !subscription.alive || subscription.pending_cancellation;
@@ -310,6 +322,61 @@ const SubscriptionManager = ({
     }
   });
 
+  const handlePauseSubscription = async () => {
+    setIsLoadingPauseResume(true);
+    try {
+      const response = await fetch(`/subscriptions/${subscription.id}/pause`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': document.querySelector<HTMLMetaElement>('[name=csrf-token]')?.content || '',
+        },
+      });
+      const data = await response.json();
+      if (data.success) {
+        setIsPaused(true); // Update local state immediately
+        // Ideally, the parent component would refresh the subscription prop,
+        // which would then flow down and update via useEffect.
+        // For now, we'll update local state and show a message.
+        // Consider passing a function from parent to trigger data refresh if needed.
+        showAlert(`Your ${subscriptionEntity} has been paused.`, "success");
+        // TODO: Potentially update subscription.status and subscription.paused_at locally
+        // or rely on a full prop refresh if this component re-fetches data.
+      } else {
+        showAlert(data.error || `Failed to pause ${subscriptionEntity}.`, "error");
+      }
+    } catch (error) {
+      showAlert(`An error occurred while pausing the ${subscriptionEntity}.`, "error");
+      console.error("Pause subscription error:", error);
+    }
+    setIsLoadingPauseResume(false);
+  };
+
+  const handleResumeSubscription = async () => {
+    setIsLoadingPauseResume(true);
+    try {
+      const response = await fetch(`/subscriptions/${subscription.id}/resume`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': document.querySelector<HTMLMetaElement>('[name=csrf-token]')?.content || '',
+        },
+      });
+      const data = await response.json();
+      if (data.success) {
+        setIsPaused(false); // Update local state immediately
+        showAlert(`Your ${subscriptionEntity} has been resumed.`, "success");
+        // TODO: Potentially update subscription.status and subscription.paused_at locally
+      } else {
+        showAlert(data.error || `Failed to resume ${subscriptionEntity}.`, "error");
+      }
+    } catch (error) {
+      showAlert(`An error occurred while resuming the ${subscriptionEntity}.`, "error");
+      console.error("Resume subscription error:", error);
+    }
+    setIsLoadingPauseResume(false);
+  };
+
   const hasSavedCard = state.savedCreditCard != null;
   const isPendingFirstGifteePayment = subscription.is_gift && subscription.successful_purchases_count === 1;
   const formattedSubscriptionEndDate = parseISO(subscription.end_time_of_subscription).toLocaleDateString(undefined, {
@@ -367,6 +434,51 @@ const SubscriptionManager = ({
           ) : null}
         </div>
       </StateContext.Provider>
+
+      {/* Pause and Resume Section */}
+      {!subscription.is_installment_plan && ( // Assuming pause/resume is not for installment plans for now
+        <div style={{ marginTop: '1rem', marginBottom: '1rem', padding: '1rem', border: '1px solid #eee', borderRadius: '4px' }}>
+          <h4>Subscription Status</h4>
+          {isPaused ? (
+            <>
+              <p>
+                Status: Paused
+                {subscription.paused_at && (
+                  <>
+                    {' since '}
+                    {new Date(subscription.paused_at).toLocaleDateString(undefined, {
+                      day: 'numeric',
+                      month: 'short',
+                      year: 'numeric',
+                    })}
+                  </>
+                )}
+              </p>
+              <p>Your {subscriptionEntity} is currently paused. You will not be billed, and access to content may be limited. Resume to restore access and billing.</p>
+              <Button
+                color="primary"
+                onClick={handleResumeSubscription}
+                disabled={isLoadingPauseResume}
+              >
+                {isLoadingPauseResume ? "Resuming..." : `Resume ${subscriptionEntity}`}
+              </Button>
+            </>
+          ) : (
+            <>
+              <p>Status: Active</p>
+              {/* Could add 'Resumed on [date]' if subscription.resumed_at is available */}
+              <p>You can pause your {subscriptionEntity}. While paused, you will not be billed, and your access may be limited until you resume.</p>
+              <Button
+                color="secondary"
+                onClick={handlePauseSubscription}
+                disabled={isLoadingPauseResume || cancelled /* Do not allow pause if already cancelled or request to cancel is made */}
+              >
+                {isLoadingPauseResume ? "Pausing..." : `Pause ${subscriptionEntity}`}
+              </Button>
+            </>
+          )}
+        </div>
+      )}
 
       {!restartable && !subscription.is_installment_plan ? (
         <div>

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -16,6 +16,8 @@ class Subscription < ApplicationRecord
   include Purchase::Searchable::SubscriptionCallbacks
   include AfterCommitEverywhere
 
+  attr_accessor :paused_at, :resumed_at, :next_charge_at
+
   # time allowed after card declined for buyer to have a successful charge before ending the subscription
   ALLOWED_TIME_BEFORE_FAIL_AND_UNSUBSCRIBE = 5.days
   # time before subscription fails to send reminder about card declined
@@ -36,6 +38,8 @@ class Subscription < ApplicationRecord
             5 => :is_resubscription_pending_confirmation,
             6 => :mor_fee_applicable,
             7 => :is_installment_plan,
+            8 => :paused,
+            9 => :user_requested_pause,
             :column => "flags",
             :flag_query_mode => :bit_operator,
             check_for_column: false
@@ -65,6 +69,7 @@ class Subscription < ApplicationRecord
 
   before_create :enable_flat_fee
   before_create :enable_mor_fee
+  before_create :set_initial_next_charge_at
   after_create :update_last_payment_option
   after_save :create_interruption_event, if: -> { deactivated_at_previously_changed? }
   after_create :create_interruption_event, if: -> { deactivated_at.present? } # needed in addition to the `after_save`. See https://github.com/gumroad/web/pull/26305#discussion_r1336425626
@@ -119,6 +124,7 @@ class Subscription < ApplicationRecord
   # ended), there are few instances where we want pending cancellation subscriptions to not be considered alive and in those instances, the caller
   # sets include_pending_cancellation as false and those subscriptions will not be considered alive. This is named different from active to avoid confusion.
   def alive?(include_pending_cancellation: true)
+    return false if paused?
     return false if failed_at.present? || ended_at.present?
     return true if cancelled_at.nil?
 
@@ -313,6 +319,7 @@ class Subscription < ApplicationRecord
     purchase.update_balance_and_mark_successful!
     original_purchase.update!(should_exclude_product_review: false) if original_purchase.should_exclude_product_review?
     self.credit_card_id = purchase.credit_card_id
+    self.next_charge_at = end_time_of_subscription
     save!
     create_purchase_event(purchase)
     if purchase.was_product_recommended
@@ -827,7 +834,9 @@ class Subscription < ApplicationRecord
   end
 
   def status
-    if deactivated_at.present?
+    if paused? && deactivated_at.present?
+      "paused"
+    elsif deactivated_at.present?
       termination_reason
     elsif pending_failure?
       "pending_failure"
@@ -868,7 +877,54 @@ class Subscription < ApplicationRecord
     true_original_purchase.is_gift_sender_purchase?
   end
 
+  def pause!(paused_by_user: true)
+    self.paused_at = Time.current
+    self.paused = true
+    self.user_requested_pause = paused_by_user
+    self.deactivated_at = Time.current # stop current access and billing
+    save!
+
+    subscription_events.create!(event_type: :paused, occurred_at: self.paused_at)
+    send_subscription_paused_webhook
+  end
+
+  def resume!
+    self.resumed_at = Time.current
+    self.paused = false
+    paused_duration = self.resumed_at - self.paused_at
+
+    if self.next_charge_at.present?
+      self.next_charge_at += paused_duration
+    elsif self.last_successful_charge_at.present? # Calculate based on last charge + period + paused_duration
+      self.next_charge_at = self.last_successful_charge_at + period + paused_duration
+    end
+
+    self.deactivated_at = nil # resume access and billing
+    save!
+
+    subscription_events.create!(event_type: :resumed, occurred_at: self.resumed_at)
+    send_subscription_resumed_webhook
+  end
+
+  def send_subscription_paused_webhook
+    # TODO: Define parameters for paused webhook
+    # params = { paused_at: self.paused_at.as_json }
+    # send_notification_webhook(resource_name: "subscription.paused", params: params)
+    send_notification_webhook(resource_name: "subscription.paused") # Placeholder
+  end
+
+  def send_subscription_resumed_webhook
+    # TODO: Define parameters for resumed webhook
+    # params = { resumed_at: self.resumed_at.as_json, next_charge_at: self.next_charge_at.as_json }
+    # send_notification_webhook(resource_name: "subscription.resumed", params: params)
+    send_notification_webhook(resource_name: "subscription.resumed") # Placeholder
+  end
+
   private
+    def set_initial_next_charge_at
+      self.next_charge_at = end_time_of_subscription
+    end
+
     def send_notification_webhook(resource_name:, params: nil)
       args = [5.seconds, nil, nil, resource_name, id]
       args << params.deep_stringify_keys if params.present?

--- a/app/presenters/checkout_presenter.rb
+++ b/app/presenters/checkout_presenter.rb
@@ -216,6 +216,10 @@ class CheckoutPresenter
         is_overdue_for_charge: subscription.overdue_for_charge?,
         is_gift: subscription.gift?,
         is_installment_plan: subscription.is_installment_plan,
+        status: subscription.status,
+        paused_at: subscription.paused_at&.iso8601,
+        next_charge_at: subscription.next_charge_at&.iso8601,
+        resumed_at: subscription.resumed_at&.iso8601,
       }
     }
   end

--- a/app/services/subscription/updater_service.rb
+++ b/app/services/subscription/updater_service.rb
@@ -30,6 +30,10 @@ class Subscription::UpdaterService
   end
 
   def perform
+    if subscription.paused?
+      return { success: false, error_message: "Cannot update a paused #{subscription_entity}. Please resume it first." }
+    end
+
     error_message = validate_params
     return { success: false, error_message: } if error_message.present?
 

--- a/app/sidekiq/recurring_charge_worker.rb
+++ b/app/sidekiq/recurring_charge_worker.rb
@@ -9,6 +9,7 @@ class RecurringChargeWorker
     SuoSemaphore.recurring_charge(subscription_id).lock do
       Rails.logger.info("Processing RecurringChargeWorker#perform(#{subscription_id})")
       subscription = Subscription.find(subscription_id)
+      return if subscription.paused?
       return if subscription.link.user.suspended?
       return unless subscription.alive?(include_pending_cancellation: false)
       return if subscription.is_test_subscription || subscription.current_subscription_price_cents == 0

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -781,6 +781,8 @@ Rails.application.routes.draw do
         post :unsubscribe_by_user
         post :unsubscribe_by_seller
         put :update, to: "purchases#update_subscription"
+        post :pause
+        post :resume
       end
     end
 

--- a/db/migrate/20231027120000_add_pause_fields_to_subscriptions.rb
+++ b/db/migrate/20231027120000_add_pause_fields_to_subscriptions.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# TODO: Replace 6.1 with the actual Rails version being used if different.
+# The migration version might need adjustment based on the project's Rails version.
+# For example, if using Rails 7.0, it would be ActiveRecord::Migration[7.0].
+# Assuming 6.1 for now as it's a common version.
+class AddPauseFieldsToSubscriptions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :subscriptions, :paused_at, :datetime, null: true
+    add_column :subscriptions, :resumed_at, :datetime, null: true
+    add_column :subscriptions, :next_charge_at, :datetime, null: true
+  end
+end


### PR DESCRIPTION
This commit introduces the core backend and frontend changes to allow you to pause and resume your subscriptions.

Key changes include:

-   **Subscription Model:**
    -   Added `paused_at`, `resumed_at`, `next_charge_at` attributes.
    -   Added `paused` and `user_requested_pause` flags.
    -   Implemented `pause!` and `resume!` methods with associated logic for state changes, event creation, and webhook calls.
    -   Updated `status` and `alive?` methods to account for the paused state.

-   **Subscriptions Controller & Routes:**
    -   Added `pause` and `resume` actions to manage subscription pausing via API calls.
    -   Defined `POST` routes for these actions.

-   **Subscription::UpdaterService:**
    -   Prevents updates to subscriptions that are currently paused.

-   **RecurringChargeWorker:**
    -   Skips processing charges for paused subscriptions.

-   **User Interface (SubscriptionManager.tsx):**
    -   Added UI elements (status display, Pause/Resume buttons).
    -   Implemented API calls to the new backend endpoints.

-   **CheckoutPresenter:**
    -   Updated to provide pause-related status and timestamps to the frontend.

-   **Database Migration:**
    -   Added a migration to create `paused_at`, `resumed_at`, and `next_charge_at` columns in the `subscriptions` table.

Further work will involve running migrations, adding comprehensive tests, and ensuring the build is stable. 