### PR TITLE
Pause payouts for sellers on high failure rate

### DIFF
--- a/app/models/concerns/purchase/blockable.rb
+++ b/app/models/concerns/purchase/blockable.rb
@@ -177,6 +177,13 @@ module Purchase::Blockable
       failed_price_cents = failed_seller_purchases.sum(:price_cents)
       if failed_price_cents > max_seller_failed_purchases_price_cents
         seller.update!(payouts_paused_internally: true)
+
+        failed_price_amount = MoneyFormatter.format(failed_price_cents, :usd, no_cents_if_whole: true, symbol: true)
+        seller.comments.create(
+          content: "Payouts paused due to high volume of failed purchases (#{failed_price_amount} USD in #{failed_seller_purchases_watch_minutes} minutes).",
+          comment_type: Comment::COMMENT_TYPE_ON_PROBATION,
+          author_name: "pause_payouts_for_seller_based_on_recent_failures"
+        )
       end
     end
 

--- a/app/models/concerns/purchase/blockable.rb
+++ b/app/models/concerns/purchase/blockable.rb
@@ -158,6 +158,33 @@ module Purchase::Blockable
       block_buyer!
     end
 
+    def probate_seller_based_on_recent_failures!
+      return if Feature.inactive?(:block_seller_based_on_recent_failures)
+      return if IGNORED_ERROR_CODES.include?(error_code)
+
+      failed_seller_purchases_watch_minutes,
+      max_seller_failed_purchases_price_cents = $redis.mget(
+        RedisKey.failed_seller_purchases_watch_minutes,
+        RedisKey.max_seller_failed_purchases_price_cents
+      )
+
+      failed_seller_purchases_watch_minutes = failed_seller_purchases_watch_minutes.try(:to_i) || 60 # 1 hour
+      max_seller_failed_purchases_price_cents = max_seller_failed_purchases_price_cents.try(:to_i) || 200_000 # $2000
+
+      failed_seller_purchases = seller.sales.failed.with_stripe_fingerprint
+                                       .where(created_at: failed_seller_purchases_watch_minutes.minutes.ago..)
+
+      failed_price_cents = failed_seller_purchases.sum(:price_cents)
+      if failed_price_cents > max_seller_failed_purchases_price_cents
+        amount_in_dollars = MoneyFormatter.format(failed_price_cents, :usd, no_cents_if_whole: true, symbol: true)
+        content = <<~TEXT
+          Probated (payouts suspended) automatically on #{Time.current.to_fs(:formatted_date_full_month)} because of failed sales of #{amount_in_dollars} in #{failed_seller_purchases_watch_minutes} minutes
+        TEXT
+
+        seller.put_on_probation(author_name: "fraudulent_purchases_blocker", content:)
+      end
+    end
+
     def block_ip_address_based_on_recent_failures!
       return if BlockedObject.ip_address.find_active_object(ip_address).present?
 

--- a/app/models/concerns/purchase/blockable.rb
+++ b/app/models/concerns/purchase/blockable.rb
@@ -158,7 +158,7 @@ module Purchase::Blockable
       block_buyer!
     end
 
-    def probate_seller_based_on_recent_failures!
+    def pause_payouts_for_seller_based_on_recent_failures!
       return if Feature.inactive?(:block_seller_based_on_recent_failures)
       return if IGNORED_ERROR_CODES.include?(error_code)
 
@@ -177,11 +177,6 @@ module Purchase::Blockable
       failed_price_cents = failed_seller_purchases.sum(:price_cents)
       if failed_price_cents > max_seller_failed_purchases_price_cents
         seller.update!(payouts_paused_internally: true)
-        content = <<~TEXT
-          Probated (payouts suspended) automatically on #{Time.current.to_fs(:formatted_date_full_month)} because of failed sales of #{amount_in_dollars} in #{failed_seller_purchases_watch_minutes} minutes
-        TEXT
-
-        seller.put_on_probation(author_name: "fraudulent_purchases_blocker", content:)
       end
     end
 

--- a/app/models/concerns/purchase/blockable.rb
+++ b/app/models/concerns/purchase/blockable.rb
@@ -176,7 +176,7 @@ module Purchase::Blockable
 
       failed_price_cents = failed_seller_purchases.sum(:price_cents)
       if failed_price_cents > max_seller_failed_purchases_price_cents
-        amount_in_dollars = MoneyFormatter.format(failed_price_cents, :usd, no_cents_if_whole: true, symbol: true)
+        seller.update!(payouts_paused_internally: true)
         content = <<~TEXT
           Probated (payouts suspended) automatically on #{Time.current.to_fs(:formatted_date_full_month)} because of failed sales of #{amount_in_dollars} in #{failed_seller_purchases_watch_minutes} minutes
         TEXT

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -218,6 +218,7 @@ class Purchase < ApplicationRecord
     after_transition any => :failed, :do => :ban_fraudulent_buyer_browser_guid!
     after_transition any => :failed, :do => :ban_card_testers!
     after_transition any => :failed, :do => :block_purchases_on_product!, if: lambda { |purchase| purchase.price_cents.nonzero? && !purchase.is_recurring_subscription_charge }
+    after_transition any => :failed, :do => :probate_seller_based_on_recent_failures!, if: lambda { |purchase| purchase.price_cents.nonzero? }
     after_transition any => :failed, :do => :ban_buyer_on_fraud_related_error_code!
     after_transition any => :failed, :do => :suspend_buyer_on_fraudulent_card_decline!
     after_transition any => :failed, :do => :send_failure_email

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -218,7 +218,7 @@ class Purchase < ApplicationRecord
     after_transition any => :failed, :do => :ban_fraudulent_buyer_browser_guid!
     after_transition any => :failed, :do => :ban_card_testers!
     after_transition any => :failed, :do => :block_purchases_on_product!, if: lambda { |purchase| purchase.price_cents.nonzero? && !purchase.is_recurring_subscription_charge }
-    after_transition any => :failed, :do => :probate_seller_based_on_recent_failures!, if: lambda { |purchase| purchase.price_cents.nonzero? }
+    after_transition any => :failed, :do => :pause_payouts_for_seller_based_on_recent_failures!, if: lambda { |purchase| purchase.price_cents.nonzero? }
     after_transition any => :failed, :do => :ban_buyer_on_fraud_related_error_code!
     after_transition any => :failed, :do => :suspend_buyer_on_fraudulent_card_decline!
     after_transition any => :failed, :do => :send_failure_email

--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -40,5 +40,7 @@ class RedisKey
     def transcoded_videos_recentness_limit_in_months = "transcoded_videos_recentness_limit_in_months"
     def generate_fees_by_creator_location_job_max_execution_time_seconds = "generate_fees_by_creator_location_job:max_execution_time_seconds"
     def ytd_sales_report_emails = "reports:ytd_sales_report_emails"
+    def failed_seller_purchases_watch_minutes = "failed_seller_purchases_watch_minutes"
+    def max_seller_failed_purchases_price_cents = "max_seller_failed_purchases_price_cents"
   end
 end

--- a/spec/models/concerns/purchase/blockable_spec.rb
+++ b/spec/models/concerns/purchase/blockable_spec.rb
@@ -559,6 +559,107 @@ describe Purchase::Blockable do
         end
       end
     end
+
+    describe "probate seller based on recent failures" do
+      let(:seller) { create(:user) }
+      let(:product) { create(:product, user: seller) }
+      let!(:purchase) { create(:purchase, link: product, purchase_state: "in_progress") }
+
+      before do
+        Feature.activate(:block_seller_based_on_recent_failures)
+        $redis.set(RedisKey.failed_seller_purchases_watch_minutes, 60)
+        $redis.set(RedisKey.max_seller_failed_purchases_price_cents, 1000) # $10
+      end
+
+      context "when feature is inactive" do
+        before { Feature.deactivate(:block_seller_based_on_recent_failures) }
+
+        it "does not probate the seller" do
+          create_list(:failed_purchase, 5, link: product, price_cents: 250)
+          purchase.mark_failed!
+          expect(seller.reload.on_probation?).to be(false)
+        end
+      end
+
+      context "when error code is ignored" do
+        it "does not probate the seller" do
+          create_list(:failed_purchase, 5, link: product, price_cents: 250)
+          purchase.update!(error_code: PurchaseErrorCode::PERCEIVED_PRICE_CENTS_NOT_MATCHING)
+          purchase.mark_failed!
+          expect(seller.reload.on_probation?).to be(false)
+        end
+      end
+
+      context "when total failed amount is below threshold" do
+        it "does not probate the seller" do
+          create_list(:failed_purchase, 3, link: product, price_cents: 250)
+          purchase.mark_failed!
+          expect(seller.reload.on_probation?).to be(false)
+        end
+      end
+
+      context "when total failed amount is above threshold" do
+        it "probates the seller" do
+          create_list(:failed_purchase, 5, link: product, price_cents: 250)
+          purchase.mark_failed!
+          expect(seller.reload.on_probation?).to be(true)
+        end
+
+        it "adds a comment with the correct probation reason" do
+          travel_to Time.current do
+            create_list(:failed_purchase, 5, link: product, price_cents: 250)
+            purchase.mark_failed!
+
+            expect(seller.comments.last.content).to eq("Probated (payouts suspended) automatically on #{Time.current.to_fs(:formatted_date_full_month)} because of failed sales of $13.50 in 60 minutes")
+          end
+        end
+
+        context "when some purchases are outside the watch window" do
+          it "does not probate the seller" do
+            travel_to Time.current do
+              create_list(:failed_purchase, 2, link: product, price_cents: 250)
+              create_list(:failed_purchase, 3, link: product, price_cents: 250, created_at: 61.minutes.ago)
+              purchase.mark_failed!
+              expect(seller.reload.on_probation?).to be(false)
+            end
+          end
+        end
+      end
+
+      context "when redis keys are not set" do
+        before do
+          $redis.del(RedisKey.failed_seller_purchases_watch_minutes)
+          $redis.del(RedisKey.max_seller_failed_purchases_price_cents)
+        end
+
+        context "when total failed amount is below default threshold" do
+          it "does not probate the seller" do
+            # default max amount is $2000
+            create_list(:failed_purchase, 5, link: product, price_cents: 200_00)
+            purchase.mark_failed!
+            expect(seller.reload.on_probation?).to be(false)
+          end
+        end
+
+        context "when total failed amount is above default threshold" do
+          it "probates the seller" do
+            # default max amount is $2000
+            create_list(:failed_purchase, 11, link: product, price_cents: 200_00)
+            purchase.mark_failed!
+            expect(seller.reload.on_probation?).to be(true)
+          end
+
+          it "adds a comment with the correct probation reason using default values" do
+            travel_to Time.current do
+              create_list(:failed_purchase, 11, link: product, price_cents: 200_00)
+              purchase.mark_failed!
+
+              expect(seller.comments.last.content).to eq("Probated (payouts suspended) automatically on #{Time.current.to_fs(:formatted_date_full_month)} because of failed sales of $2,201 in 60 minutes")
+            end
+          end
+        end
+      end
+    end
   end
 
   describe "#charge_processor_fingerprint" do

--- a/spec/models/concerns/purchase/blockable_spec.rb
+++ b/spec/models/concerns/purchase/blockable_spec.rb
@@ -599,28 +599,25 @@ describe Purchase::Blockable do
       end
 
       context "when total failed amount is above threshold" do
-        it "probates the seller" do
+        it "pauses payouts internally" do
           create_list(:failed_purchase, 5, link: product, price_cents: 250)
           purchase.mark_failed!
-          expect(seller.reload.on_probation?).to be(true)
+          expect(seller.reload.payouts_paused_internally).to be(true)
         end
 
-        it "adds a comment with the correct probation reason" do
-          travel_to Time.current do
-            create_list(:failed_purchase, 5, link: product, price_cents: 250)
-            purchase.mark_failed!
-
-            expect(seller.comments.last.content).to eq("Probated (payouts suspended) automatically on #{Time.current.to_fs(:formatted_date_full_month)} because of failed sales of $13.50 in 60 minutes")
-          end
+        it "does not put seller on probation" do
+          create_list(:failed_purchase, 5, link: product, price_cents: 250)
+          purchase.mark_failed!
+          expect(seller.reload.on_probation?).to be(false)
         end
 
         context "when some purchases are outside the watch window" do
-          it "does not probate the seller" do
+          it "does not pause payouts internally" do
             travel_to Time.current do
               create_list(:failed_purchase, 2, link: product, price_cents: 250)
               create_list(:failed_purchase, 3, link: product, price_cents: 250, created_at: 61.minutes.ago)
               purchase.mark_failed!
-              expect(seller.reload.on_probation?).to be(false)
+              expect(seller.reload.payouts_paused_internally).to be(false)
             end
           end
         end
@@ -633,29 +630,20 @@ describe Purchase::Blockable do
         end
 
         context "when total failed amount is below default threshold" do
-          it "does not probate the seller" do
+          it "does not pause payouts internally" do
             # default max amount is $2000
             create_list(:failed_purchase, 5, link: product, price_cents: 200_00)
             purchase.mark_failed!
-            expect(seller.reload.on_probation?).to be(false)
+            expect(seller.reload.payouts_paused_internally).to be(false)
           end
         end
 
         context "when total failed amount is above default threshold" do
-          it "probates the seller" do
+          it "pauses payouts internally" do
             # default max amount is $2000
             create_list(:failed_purchase, 11, link: product, price_cents: 200_00)
             purchase.mark_failed!
-            expect(seller.reload.on_probation?).to be(true)
-          end
-
-          it "adds a comment with the correct probation reason using default values" do
-            travel_to Time.current do
-              create_list(:failed_purchase, 11, link: product, price_cents: 200_00)
-              purchase.mark_failed!
-
-              expect(seller.comments.last.content).to eq("Probated (payouts suspended) automatically on #{Time.current.to_fs(:formatted_date_full_month)} because of failed sales of $2,201 in 60 minutes")
-            end
+            expect(seller.reload.payouts_paused_internally).to be(true)
           end
         end
       end

--- a/spec/models/concerns/purchase/blockable_spec.rb
+++ b/spec/models/concerns/purchase/blockable_spec.rb
@@ -560,7 +560,7 @@ describe Purchase::Blockable do
       end
     end
 
-    describe "probate seller based on recent failures" do
+    describe "pause payouts for seller internally based on recent failures" do
       let(:seller) { create(:user) }
       let(:product) { create(:product, user: seller) }
       let!(:purchase) { create(:purchase, link: product, purchase_state: "in_progress") }
@@ -574,27 +574,30 @@ describe Purchase::Blockable do
       context "when feature is inactive" do
         before { Feature.deactivate(:block_seller_based_on_recent_failures) }
 
-        it "does not probate the seller" do
+        it "does not pause payouts for the seller" do
           create_list(:failed_purchase, 5, link: product, price_cents: 250)
           purchase.mark_failed!
-          expect(seller.reload.on_probation?).to be(false)
+
+          expect(seller.reload.payouts_paused_internally).to be(false)
         end
       end
 
       context "when error code is ignored" do
-        it "does not probate the seller" do
+        it "does not pause payouts for the seller" do
           create_list(:failed_purchase, 5, link: product, price_cents: 250)
           purchase.update!(error_code: PurchaseErrorCode::PERCEIVED_PRICE_CENTS_NOT_MATCHING)
           purchase.mark_failed!
-          expect(seller.reload.on_probation?).to be(false)
+
+          expect(seller.reload.payouts_paused_internally).to be(false)
         end
       end
 
       context "when total failed amount is below threshold" do
-        it "does not probate the seller" do
+        it "does not pause payouts for the seller" do
           create_list(:failed_purchase, 3, link: product, price_cents: 250)
           purchase.mark_failed!
-          expect(seller.reload.on_probation?).to be(false)
+
+          expect(seller.reload.payouts_paused_internally).to be(false)
         end
       end
 
@@ -602,13 +605,8 @@ describe Purchase::Blockable do
         it "pauses payouts internally" do
           create_list(:failed_purchase, 5, link: product, price_cents: 250)
           purchase.mark_failed!
-          expect(seller.reload.payouts_paused_internally).to be(true)
-        end
 
-        it "does not put seller on probation" do
-          create_list(:failed_purchase, 5, link: product, price_cents: 250)
-          purchase.mark_failed!
-          expect(seller.reload.on_probation?).to be(false)
+          expect(seller.reload.payouts_paused_internally).to be(true)
         end
 
         context "when some purchases are outside the watch window" do
@@ -634,6 +632,7 @@ describe Purchase::Blockable do
             # default max amount is $2000
             create_list(:failed_purchase, 5, link: product, price_cents: 200_00)
             purchase.mark_failed!
+
             expect(seller.reload.payouts_paused_internally).to be(false)
           end
         end
@@ -643,6 +642,7 @@ describe Purchase::Blockable do
             # default max amount is $2000
             create_list(:failed_purchase, 11, link: product, price_cents: 200_00)
             purchase.mark_failed!
+
             expect(seller.reload.payouts_paused_internally).to be(true)
           end
         end

--- a/spec/models/concerns/purchase/blockable_spec.rb
+++ b/spec/models/concerns/purchase/blockable_spec.rb
@@ -609,6 +609,16 @@ describe Purchase::Blockable do
           expect(seller.reload.payouts_paused_internally).to be(true)
         end
 
+        it "creates a comment with the failed amount" do
+          create_list(:failed_purchase, 5, link: product, price_cents: 250)
+          purchase.mark_failed!
+
+          comment = seller.comments.last
+          expect(comment.content).to eq("Payouts paused due to high volume of failed purchases ($13.50 USD in 60 minutes).")
+          expect(comment.comment_type).to eq(Comment::COMMENT_TYPE_ON_PROBATION)
+          expect(comment.author_name).to eq("pause_payouts_for_seller_based_on_recent_failures")
+        end
+
         context "when some purchases are outside the watch window" do
           it "does not pause payouts internally" do
             travel_to Time.current do


### PR DESCRIPTION
cc: @gumroadsteve2 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Seller payouts are now automatically paused if recent failed purchases exceed a configurable threshold within a set time window.

- **Tests**
  - Added comprehensive tests to verify the new seller payout pausing behavior under various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->