### PR TITLE
Update bson gem to avoid GCC15 compilation errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,7 +216,7 @@ GEM
     braintree (4.21.0)
       builder (>= 3.2.4)
       rexml (>= 3.1.9)
-    bson (5.0.1)
+    bson (5.1.1)
     buftok (0.3.0)
     bugsnag (6.27.1)
       concurrent-ruby (~> 1.0)


### PR DESCRIPTION
I'm having compilation errors for current version of BSON gem (due to GCC 15 as I assume). Updating this gem fixes this issue for me.

Output:

```
/home/sk/.local/share/mise/installs/ruby/3.4.3/include/ruby-3.4.0/ruby/internal/scan_args.h:259:16:
note: ‘true’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding
‘#include <stdbool.h>’
/home/sk/.local/share/mise/installs/ruby/3.4.3/include/ruby-3.4.0/ruby/internal/scan_args.h:263:16:
error: ‘false’ undeclared (first use in this function)
  263 |         return false;
      |                ^~~~~
/home/sk/.local/share/mise/installs/ruby/3.4.3/include/ruby-3.4.0/ruby/internal/scan_args.h:263:16:
note: ‘false’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding
‘#include <stdbool.h>’
/home/sk/.local/share/mise/installs/ruby/3.4.3/include/ruby-3.4.0/ruby/internal/scan_args.h:
At top level:
/home/sk/.local/share/mise/installs/ruby/3.4.3/include/ruby-3.4.0/ruby/internal/scan_args.h:268:8:
error: unknown type name ‘bool’
  268 | static bool
      |        ^~~~
/home/sk/.local/share/mise/installs/ruby/3.4.3/include/ruby-3.4.0/ruby/internal/scan_args.h:268:8:
note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding
‘#include <stdbool.h>’
/home/sk/.local/share/mise/installs/ruby/3.4.3/include/ruby-3.4.0/ruby/internal/scan_args.h:282:8:
error: unknown type name ‘bool’
  282 | static bool
      |        ^~~~
/home/sk/.local/share/mise/installs/ruby/3.4.3/include/ruby-3.4.0/ruby/internal/scan_args.h:282:8:
note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding
‘#include <stdbool.h>’
/home/sk/.local/share/mise/installs/ruby/3.4.3/include/ruby-3.4.0/ruby/internal/scan_args.h:303:8:
error: unknown type name ‘bool’
  303 | static bool
      |        ^~~~
/home/sk/.local/share/mise/installs/ruby/3.4.3/include/ruby-3.4.0/ruby/internal/scan_args.h:303:8:
note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding
‘#include <stdbool.h>’
/home/sk/.local/share/mise/installs/ruby/3.4.3/include/ruby-3.4.0/ruby/internal/scan_args.h:334:8:
error: unknown type name ‘bool’
  334 | static bool
      |        ^~~~
/home/sk/.local/share/mise/installs/ruby/3.4.3/include/ruby-3.4.0/ruby/internal/scan_args.h:334:8:
note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding
‘#include <stdbool.h>’
/home/sk/.local/share/mise/installs/ruby/3.4.3/include/ruby-3.4.0/ruby/internal/scan_args.h:349:8:
error: unknown type name ‘bool’
  349 | static bool
      |        ^~~~
/home/sk/.local/share/mise/installs/ruby/3.4.3/include/ruby-3.4.0/ruby/internal/scan_args.h:349:8:
note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding
‘#include <stdbool.h>’
/home/sk/.local/share/mise/installs/ruby/3.4.3/include/ruby-3.4.0/ruby/internal/scan_args.h:390:18:
error: unknown type name ‘bool’
  390 |                  bool f_var, bool f_hash, bool f_block,
      |                  ^~~~
/home/sk/.local/share/mise/installs/ruby/3.4.3/include/ruby-3.4.0/ruby/internal/scan_args.h:390:18:
note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding
‘#include <stdbool.h>’
/home/sk/.local/share/mise/installs/ruby/3.4.3/include/ruby-3.4.0/ruby/internal/scan_args.h:390:30:
error: unknown type name ‘bool’
  390 |                  bool f_var, bool f_hash, bool f_block,
      |                              ^~~~
/home/sk/.local/share/mise/installs/ruby/3.4.3/include/ruby-3.4.0/ruby/internal/scan_args.h:390:30:
note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding
‘#include <stdbool.h>’
/home/sk/.local/share/mise/installs/ruby/3.4.3/include/ruby-3.4.0/ruby/internal/scan_args.h:390:43:
error: unknown type name ‘bool’
  390 |                  bool f_var, bool f_hash, bool f_block,
      |                                           ^~~~
/home/sk/.local/share/mise/installs/ruby/3.4.3/include/ruby-3.4.0/ruby/internal/scan_args.h:390:43:
note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding
‘#include <stdbool.h>’
In file included from
/home/sk/.local/share/mise/installs/ruby/3.4.3/include/ruby-3.4.0/ruby/intern.h:41,
from
/home/sk/.local/share/mise/installs/ruby/3.4.3/include/ruby-3.4.0/ruby/ruby.h:194:
/home/sk/.local/share/mise/installs/ruby/3.4.3/include/ruby-3.4.0/ruby/internal/intern/load.h:234:25:
error: unknown type name ‘bool’
  234 | void rb_ext_ractor_safe(bool flag);
      |                         ^~~~
/home/sk/.local/share/mise/installs/ruby/3.4.3/include/ruby-3.4.0/ruby/internal/intern/load.h:1:1:
note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding
‘#include <stdbool.h>’
  +++ |+#include <stdbool.h>
    1 | #ifndef  RBIMPL_INTERN_LOAD_H                        /*-*-C++-*-vi:se ft=cpp:*/
bytebuf.c: In function ‘rb_bson_byte_buffer_initialize’:
/home/sk/.local/share/mise/installs/ruby/3.4.3/include/ruby-3.4.0/ruby/internal/scan_args.h:368:5:
error: implicit declaration of function ‘rb_scan_args_set’; did you mean
‘rb_scan_args_kw’? [-Wimplicit-function-declaration]
  368 |     rb_scan_args_set(RB_SCAN_ARGS_PASS_CALLED_KEYWORDS, argc, argv, 
      |     ^~~~~~~~~~~~~~~~
/home/sk/.local/share/mise/installs/ruby/3.4.3/include/ruby-3.4.0/ruby/internal/scan_args.h:498:9:
note: in expansion of macro ‘rb_scan_args0’
  498 |         rb_scan_args0(                                        
      |         ^~~~~~~~~~~~~
bytebuf.c:37:3: note: in expansion of macro ‘rb_scan_args’
   37 |   rb_scan_args(argc, argv, "01", &bytes);
      |   ^~~~~~~~~~~~
At top level:
cc1: note: unrecognized command-line option ‘-Wno-self-assign’ may have been intended to
silence earlier diagnostics
cc1: note: unrecognized command-line option ‘-Wno-parentheses-equality’ may have been
intended to silence earlier diagnostics
cc1: note: unrecognized command-line option ‘-Wno-constant-logical-operand’ may have been
intended to silence earlier diagnostics
make: *** [Makefile:251: bytebuf.o] Error 1

make failed, exit code 2

Gem files will remain installed in
/home/sk/.local/share/mise/installs/ruby/3.4.3/lib/ruby/gems/3.4.0/gems/bson-5.0.1 for
inspection.
Results logged to
/home/sk/.local/share/mise/installs/ruby/3.4.3/lib/ruby/gems/3.4.0/extensions/x86_64-linux/3.4.0/bson-5.0.1/gem_make.out

/home/sk/.local/share/mise/installs/ruby/3.4.3/lib/ruby/site_ruby/3.4.0/rubygems/ext/builder.rb:125:in
'Gem::Ext::Builder.run'
/home/sk/.local/share/mise/installs/ruby/3.4.3/lib/ruby/site_ruby/3.4.0/rubygems/ext/builder.rb:51:in
'block in Gem::Ext::Builder.make'
/home/sk/.local/share/mise/installs/ruby/3.4.3/lib/ruby/site_ruby/3.4.0/rubygems/ext/builder.rb:43:in
'Array#each'
/home/sk/.local/share/mise/installs/ruby/3.4.3/lib/ruby/site_ruby/3.4.0/rubygems/ext/builder.rb:43:in
'Gem::Ext::Builder.make'
/home/sk/.local/share/mise/installs/ruby/3.4.3/lib/ruby/site_ruby/3.4.0/rubygems/ext/ext_conf_builder.rb:44:in
'Gem::Ext::ExtConfBuilder.build'
/home/sk/.local/share/mise/installs/ruby/3.4.3/lib/ruby/site_ruby/3.4.0/rubygems/ext/builder.rb:206:in
'Gem::Ext::Builder#build_extension'
/home/sk/.local/share/mise/installs/ruby/3.4.3/lib/ruby/site_ruby/3.4.0/rubygems/ext/builder.rb:240:in
'block in Gem::Ext::Builder#build_extensions'
/home/sk/.local/share/mise/installs/ruby/3.4.3/lib/ruby/site_ruby/3.4.0/rubygems/ext/builder.rb:237:in
'Array#each'
/home/sk/.local/share/mise/installs/ruby/3.4.3/lib/ruby/site_ruby/3.4.0/rubygems/ext/builder.rb:237:in
'Gem::Ext::Builder#build_extensions'
/home/sk/.local/share/mise/installs/ruby/3.4.3/lib/ruby/site_ruby/3.4.0/rubygems/installer.rb:844:in
'Gem::Installer#build_extensions'
/home/sk/.local/share/mise/installs/ruby/3.4.3/lib/ruby/gems/3.4.0/gems/bundler-2.5.10/lib/bundler/rubygems_gem_installer.rb:76:in
'Bundler::RubyGemsGemInstaller#build_extensions'
/home/sk/.local/share/mise/installs/ruby/3.4.3/lib/ruby/gems/3.4.0/gems/bundler-2.5.10/lib/bundler/rubygems_gem_installer.rb:28:in
'Bundler::RubyGemsGemInstaller#install'
/home/sk/.local/share/mise/installs/ruby/3.4.3/lib/ruby/gems/3.4.0/gems/bundler-2.5.10/lib/bundler/source/rubygems.rb:205:in
'Bundler::Source::Rubygems#install'
/home/sk/.local/share/mise/installs/ruby/3.4.3/lib/ruby/gems/3.4.0/gems/bundler-2.5.10/lib/bundler/installer/gem_installer.rb:54:in
'Bundler::GemInstaller#install'
/home/sk/.local/share/mise/installs/ruby/3.4.3/lib/ruby/gems/3.4.0/gems/bundler-2.5.10/lib/bundler/installer/gem_installer.rb:16:in
'Bundler::GemInstaller#install_from_spec'
/home/sk/.local/share/mise/installs/ruby/3.4.3/lib/ruby/gems/3.4.0/gems/bundler-2.5.10/lib/bundler/installer/parallel_installer.rb:132:in
'Bundler::ParallelInstaller#do_install'
/home/sk/.local/share/mise/installs/ruby/3.4.3/lib/ruby/gems/3.4.0/gems/bundler-2.5.10/lib/bundler/installer/parallel_installer.rb:123:in
'block in Bundler::ParallelInstaller#worker_pool'
/home/sk/.local/share/mise/installs/ruby/3.4.3/lib/ruby/gems/3.4.0/gems/bundler-2.5.10/lib/bundler/worker.rb:62:in
'Bundler::Worker#apply_func'
/home/sk/.local/share/mise/installs/ruby/3.4.3/lib/ruby/gems/3.4.0/gems/bundler-2.5.10/lib/bundler/worker.rb:57:in
'block in Bundler::Worker#process_queue'
  <internal:kernel>:168:in 'Kernel#loop'
/home/sk/.local/share/mise/installs/ruby/3.4.3/lib/ruby/gems/3.4.0/gems/bundler-2.5.10/lib/bundler/worker.rb:54:in
'Bundler::Worker#process_queue'
/home/sk/.local/share/mise/installs/ruby/3.4.3/lib/ruby/gems/3.4.0/gems/bundler-2.5.10/lib/bundler/worker.rb:90:in
'block (2 levels) in Bundler::Worker#create_threads'

An error occurred while installing bson (5.0.1), and Bundler cannot
continue.

In Gemfile:
  database_cleaner-mongoid was resolved to 2.0.1, which depends on
    mongoid was resolved to 9.0.1, which depends on
      mongo was resolved to 2.20.1, which depends on
        bson
```