### PR TITLE
docker-compose: add “:Z” SELinux label to data bind-mounts

### DIFF
--- a/docker/docker-compose-local-linux.yml
+++ b/docker/docker-compose-local-linux.yml
@@ -4,7 +4,7 @@ services:
   db:
     image: mysql:8.0.32
     volumes:
-      - ./tmp/mysql:/var/lib/mysql
+      - ./tmp/mysql:/var/lib/mysql:Z
     ports:
       - "3306:3306"
     environment:
@@ -21,14 +21,14 @@ services:
     ports:
       - "6379:6379"
     volumes:
-      - ./tmp/redis:/data
+      - ./tmp/redis:/data:Z
 
   mongo:
     image: mongo:3.6.16
     ports:
       - "27017:27017"
     volumes:
-      - ./tmp/mongo:/data/db
+      - ./tmp/mongo:/data/db:Z
     command: "mongod --smallfiles"
 
   elasticsearch:
@@ -45,8 +45,8 @@ services:
     image: nginx:1.23.3
     network_mode: host
     volumes:
-      - ./local-nginx/gumroad_dev.conf:/etc/nginx/conf.d/default.conf
-      - ./local-nginx/certs:/etc/ssl/certs/
+      - ./local-nginx/gumroad_dev.conf:/etc/nginx/conf.d/default.conf:Z
+      - ./local-nginx/certs:/etc/ssl/certs/:Z
     extra_hosts:
       - "host.docker.internal:127.0.0.1"
 


### PR DESCRIPTION
I'm running Fedora and have issue running mongo/mysql/redis through docker-compose because they have only read-only permissions to folders they create.

### What changed  
• In `docker/docker-compose-local-linux.yml` each bind mount that maps a
  host directory into a container’s data directory now ends with `:Z`  
  ```
  - ./tmp/mysql:/var/lib/mysql        →  - ./tmp/mysql:/var/lib/mysql:Z
  - ./tmp/redis:/data                 →  - ./tmp/redis:/data:Z
  - ./tmp/mongo:/data/db              →  - ./tmp/mongo:/data/db:Z
  ```
  (no change needed for the named volume `elasticsearch7data`).

### Why  
On Fedora / RHEL and other SELinux-enabled distros the containers start
as an unprivileged user.  
When a plain bind mount is used, SELinux labels on the host files
(`user_home_t`) block write access and MySQL/Redis/Mongo fail with

```
find: '/var/lib/mysql/': Permission denied
chown: changing ownership of … : Permission denied
```

The `:Z` suffix tells Docker to relabel the mounted directory with the
container-friendly `svirt_sandbox_file_t` type, allowing the databases to
start normally.

### Compatibility  
• The flag is ignored on systems without SELinux (Ubuntu, Debian,
  macOS/Windows Docker Desktop, WSL2), so behaviour there is unchanged.  
• No image or runtime versions are affected; Compose v1.25+ / Compose-V2
  already understand the option.

### Result  
Developers on Fedora/RHEL (or anyone with SELinux in enforcing mode) can
run `make local` / `docker compose up` without extra manual steps, while
other platforms continue to work as before.

If you already experienced this issue, then you need to run `make stop_local && make local` to reinitialize these folders properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated Docker Compose configuration to improve compatibility with SELinux on Linux systems for MySQL, Redis, MongoDB, and Nginx services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->