### PR TITLE
Fix checkout “Future installments” amount (show per-installment, not total)

### DIFF
--- a/app/javascript/components/Checkout/index.tsx
+++ b/app/javascript/components/Checkout/index.tsx
@@ -192,11 +192,10 @@ export const Checkout = ({
     if (!item.product.installment_plan || !item.pay_in_installments) return sum;
 
     const price = getDiscountedPrice(cart, item).price;
-    const firstInstallmentPrice = calculateFirstInstallmentPaymentPriceCents(
-      price,
-      item.product.installment_plan.number_of_installments,
-    );
-    return sum + (price - firstInstallmentPrice);
+    const n = item.product.installment_plan.number_of_installments;
+    if (n <= 1) return sum; // no future installments
+    const baseInstallment = Math.floor(price / n);
+    return sum + baseInstallment;
   }, 0);
 
   const isDesktop = useIsAboveBreakpoint("lg");


### PR DESCRIPTION
Bug-
At checkout the installment breakdown showed:
Payment today        $678
Future installments  $1 356   ← sum of remaining installments
The “Future installments” line displayed the sum of all upcoming payments (price – firstInstallment) instead of the amount charged per installment.

Fix-
- const firstInstallmentPrice = calculateFirstInstallmentPaymentPriceCents(price, n);
- return sum + (price - firstInstallmentPrice);          // total remainder
+ const baseInstallment = Math.floor(price / n);         // one installment
+ return sum + baseInstallment;

![image](https://github.com/user-attachments/assets/1eec2534-606e-47f7-8133-1f7ec7adcc8e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the calculation of future installment amounts in the checkout process, resulting in clearer and more predictable installment totals for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->