### PR TITLE
fix(front-end): Fix Nav mobile hamburger menu on large screen

### DIFF
--- a/app/views/home/shared/_scripts.html.erb
+++ b/app/views/home/shared/_scripts.html.erb
@@ -20,6 +20,15 @@
       }
     });
 
+    // Close mobile menu when resizing to desktop size
+    window.addEventListener('resize', function() {
+      if (window.innerWidth >= 1024) {
+        mobileMenu.classList.add('hidden');
+        line1.classList.remove('translate-y-[5px]', '-rotate-45', 'transform-gpu');
+        line2.classList.remove('-translate-y-[5px]', 'rotate-45', 'transform-gpu');
+      }
+    });
+
     // Accordion functionality
     const accordionItems = document.querySelectorAll('.accordion-item')
     accordionItems.forEach(item => {


### PR DESCRIPTION
## Background

When resizing the `Nav` to medium-small size, the `Nav` converts the existing links into inside a hamburger menu. However, when resizing an open hamburger menu back to large (desktop) size, the open hamburger menu still exists while the default nav appearance also reappears, causing the users to see multiple redundant links (and poor styling) as seen in the screen recording attached below.

https://github.com/user-attachments/assets/45d63eb7-eac7-4893-9c29-422fdd6ea756

## Proposed Fix

- Close an open hamburger menu if window size enters large breakpoint.
- Add `hidden` styling attribute on large breakpoint to guarantee hamburger menu doesn't appear on large/desktop screen size.

Behavior on proposed fix:

https://github.com/user-attachments/assets/346f808b-9342-4c51-92bd-579db23beca0



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved mobile menu behavior to automatically close and reset when resizing the window to desktop size, ensuring consistent navigation experience across devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->