### PR TITLE
feat(auth): implement RESTful logout with DELETE method

### DIFF
--- a/app/javascript/components/Nav.tsx
+++ b/app/javascript/components/Nav.tsx
@@ -91,24 +91,30 @@ export const Nav = ({ title, children, footer, compact }: Props) => {
   );
 };
 
-export const LogoutDropdownItem = () => {
+export const LogoutDropdownItem = ({
+  routeParams,
+}: {
+  routeParams?: {
+    host?: string;
+  };
+}) => {
   const makeRequest = asyncVoid(async (ev: React.MouseEvent<HTMLAnchorElement>) => {
     ev.preventDefault();
 
     try {
-      await request({ method: "DELETE", accept: "html", url: Routes.logout_url() });
+      await request({ method: "DELETE", accept: "html", url: Routes.logout_url(routeParams) });
     } catch (e) {
       // Even if there's an error, continue with logout since the session might be invalid
     }
 
-    window.location.href = Routes.login_url();
+    window.location.href = Routes.login_url(routeParams);
   });
 
   return (
     <NavLinkDropdownItem
       text="Logout"
       icon="box-arrow-in-right-fill"
-      href={Routes.logout_url()}
+      href={Routes.logout_url(routeParams)}
       onClick={makeRequest}
       method="DELETE"
     />

--- a/app/javascript/components/Nav.tsx
+++ b/app/javascript/components/Nav.tsx
@@ -45,14 +45,17 @@ export const NavLinkDropdownItem = ({
   text,
   icon,
   href,
+  method = "GET",
   onClick,
+  ...props
 }: {
   text: string;
   icon: IconName;
   href: string;
+  method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
   onClick?: (ev: React.MouseEvent<HTMLAnchorElement>) => void;
-}) => (
-  <a role="menuitem" href={href} onClick={onClick}>
+} & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+  <a role="menuitem" href={href} data-method={method.toLowerCase()} onClick={onClick} {...props}>
     <Icon name={icon} />
     {text}
   </a>
@@ -85,6 +88,30 @@ export const Nav = ({ title, children, footer, compact }: Props) => {
       {children}
       <footer>{footer}</footer>
     </nav>
+  );
+};
+
+export const LogoutDropdownItem = () => {
+  const makeRequest = asyncVoid(async (ev: React.MouseEvent<HTMLAnchorElement>) => {
+    ev.preventDefault();
+
+    try {
+      await request({ method: "DELETE", accept: "html", url: Routes.logout_url() });
+    } catch (e) {
+      // Even if there's an error, continue with logout since the session might be invalid
+    }
+
+    window.location.href = Routes.login_url();
+  });
+
+  return (
+    <NavLinkDropdownItem
+      text="Logout"
+      icon="box-arrow-in-right-fill"
+      href={Routes.logout_url()}
+      onClick={makeRequest}
+      method="DELETE"
+    />
   );
 };
 

--- a/app/javascript/components/server-components/Admin/Nav.tsx
+++ b/app/javascript/components/server-components/Admin/Nav.tsx
@@ -5,7 +5,7 @@ import { register } from "$app/utils/serverComponentUtil";
 
 import { useAppDomain } from "$app/components/DomainSettings";
 import { useLoggedInUser } from "$app/components/LoggedInUser";
-import { Nav as NavFramework, NavLink, NavLinkDropdownItem, UnbecomeDropdownItem } from "$app/components/Nav";
+import { Nav as NavFramework, NavLink, UnbecomeDropdownItem, LogoutDropdownItem } from "$app/components/Nav";
 import { Popover } from "$app/components/Popover";
 
 type ImpersonatedUser = {
@@ -48,7 +48,7 @@ export const Nav = ({ title, current_user }: Props) => {
                 <hr />
               </>
             ) : null}
-            <NavLinkDropdownItem text="Logout" icon="box-arrow-in-right-fill" href={Routes.logout_url()} />
+            <LogoutDropdownItem />
             {loggedInUser?.isImpersonating ? <UnbecomeDropdownItem /> : null}
           </div>
         </Popover>

--- a/app/javascript/components/server-components/Admin/Nav.tsx
+++ b/app/javascript/components/server-components/Admin/Nav.tsx
@@ -48,7 +48,7 @@ export const Nav = ({ title, current_user }: Props) => {
                 <hr />
               </>
             ) : null}
-            <LogoutDropdownItem />
+            <LogoutDropdownItem routeParams={routeParams} />
             {loggedInUser?.isImpersonating ? <UnbecomeDropdownItem /> : null}
           </div>
         </Popover>

--- a/app/javascript/components/server-components/Nav.tsx
+++ b/app/javascript/components/server-components/Nav.tsx
@@ -120,7 +120,7 @@ export const Nav = (props: Props) => {
                 href={Routes.root_url({ ...routeParams, host: currentSeller?.subdomain ?? routeParams.host })}
               />
               <NavLinkDropdownItem text="Affiliates" icon="gift-fill" href={Routes.affiliates_url(routeParams)} />
-              <LogoutDropdownItem />
+              <LogoutDropdownItem routeParams={routeParams} />
               {loggedInUser?.isImpersonating ? <UnbecomeDropdownItem /> : null}
             </div>
           </Popover>

--- a/app/javascript/components/server-components/Nav.tsx
+++ b/app/javascript/components/server-components/Nav.tsx
@@ -8,7 +8,13 @@ import { initTeamMemberReadOnlyAccess } from "$app/utils/team_member_read_only";
 import { useCurrentSeller } from "$app/components/CurrentSeller";
 import { useAppDomain, useDiscoverUrl } from "$app/components/DomainSettings";
 import { useLoggedInUser, TeamMembership } from "$app/components/LoggedInUser";
-import { Nav as NavFramework, NavLink, NavLinkDropdownItem, UnbecomeDropdownItem } from "$app/components/Nav";
+import {
+  Nav as NavFramework,
+  NavLink,
+  NavLinkDropdownItem,
+  UnbecomeDropdownItem,
+  LogoutDropdownItem,
+} from "$app/components/Nav";
 import { Popover } from "$app/components/Popover";
 import { showAlert } from "$app/components/server-components/Alert";
 import { useRunOnce } from "$app/components/useRunOnce";
@@ -114,7 +120,7 @@ export const Nav = (props: Props) => {
                 href={Routes.root_url({ ...routeParams, host: currentSeller?.subdomain ?? routeParams.host })}
               />
               <NavLinkDropdownItem text="Affiliates" icon="gift-fill" href={Routes.affiliates_url(routeParams)} />
-              <NavLinkDropdownItem text="Logout" icon="box-arrow-in-right-fill" href={Routes.logout_url(routeParams)} />
+              <LogoutDropdownItem />
               {loggedInUser?.isImpersonating ? <UnbecomeDropdownItem /> : null}
             </div>
           </Popover>

--- a/app/views/doorkeeper/authorizations/_footer.html.erb
+++ b/app/views/doorkeeper/authorizations/_footer.html.erb
@@ -1,3 +1,3 @@
 <%= image_tag(logged_in_user.avatar_url, class: "user-avatar", size: "32", alt: logged_in_user.display_name) %>
 <span><%= logged_in_user.email %></span>
-<%= link_to "Logout", logout_path %>
+<%= link_to "Logout", logout_path, data: { method: :delete } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -334,7 +334,8 @@ Rails.application.routes.draw do
       get "/oauth/login" => "logins#new"
 
       post "login", to: "logins#create"
-      get "logout", to: "logins#destroy" # TODO: change the method to DELETE to conform to REST
+      delete "logout", to: "logins#destroy"
+      get "logout", to: "logins#destroy" # Fallback for legacy links
       post "forgot_password", to: "user/passwords#create"
       scope "/users" do
         get "/check_twitter_link", to: "users/oauth#check_twitter_link"


### PR DESCRIPTION
This pull request refactors the user logout functionality to be more RESTful by using the DELETE HTTP method instead of GET. This change improves the semantic correctness of the application's routing and aligns with modern web standards for handling destructive actions.

**Key Changes**
- Routes: The primary logout route in `config/routes.rb` has been changed to use `delete "/logout"`, directing to `logins#destroy`. The previous `get "/logout"` route is retained as a fallback to ensure that any legacy links, such as those in user emails, continue to function correctly.
- Frontend Components:
    - A new `LogoutDropdownItem` component has been created in `app/javascript/components/Nav.tsx`. This component now handles the logout action by sending a DELETE request to the server. It gracefully handles the response, redirecting the user to the login page even if the request fails, ensuring a consistent user experience.
    - The `NavLinkDropdownItem` component was enhanced to accept a method prop, allowing it to generate links with the appropriate data-method attribute for non-GET requests.
- Views: The logout link in the Doorkeeper authorization footer (`app/views/doorkeeper/authorizations/_footer.html.erb`) has been updated to use `method: :delete`.
- Testing: New tests have been added to `spec/controllers/logins_controller_spec.rb` to specifically cover the `DELETE #destroy` action. These tests verify that user session data and relevant cookies are cleared correctly upon logout and that user impersonation sessions are properly terminated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a dedicated logout option in navigation menus that securely signs users out using a DELETE request.
- **Bug Fixes**
  - Updated the logout link in the footer to use the correct HTTP method for improved security and consistency.
- **Chores**
  - Added tests to ensure the logout process via DELETE request clears relevant cookies and resets impersonation states.
- **Documentation**
  - Improved RESTful routing conventions for logout actions, with legacy support maintained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Seller Logout:

https://github.com/user-attachments/assets/ffeccd81-5f12-4dd4-9551-8aed8cb570c3


Admin Logout:

https://github.com/user-attachments/assets/d2dbe616-5f56-4ddf-943c-8b3d73439ffa

