### PR TITLE
Cached repetitive data lookups for creator analytics

### DIFF
--- a/app/services/creator_analytics/caching_proxy.rb
+++ b/app/services/creator_analytics/caching_proxy.rb
@@ -31,7 +31,7 @@ class CreatorAnalytics::CachingProxy
   # Generates cached data for all possible dates for a seller
   def generate_cache
     return if @user.suspended?
-    first_sale_created_at = @user.first_sale_created_at_for_analytics
+    first_sale_created_at = self.first_sale_created_at
     return if first_sale_created_at.nil?
 
     first_sale_date = first_sale_created_at.in_time_zone(@user.timezone).to_date
@@ -101,7 +101,12 @@ class CreatorAnalytics::CachingProxy
 
     # Direct proxy for CreatorAnalytics::Web
     def analytics_data(start_date, end_date, by: :date)
-      CreatorAnalytics::Web.new(user: @user, dates: (start_date .. end_date).to_a).public_send("by_#{by}")
+      CreatorAnalytics::Web.new(
+        user: @user,
+        dates: (start_date .. end_date).to_a,
+        first_sale_created_at: first_sale_created_at,
+        products: products
+      ).public_send("by_#{by}")
     end
 
     # Fetches and caches the analytics data for one specific date
@@ -154,5 +159,13 @@ class CreatorAnalytics::CachingProxy
         hash[ hash.key(date - 1) || date ] = date
       end
       hash_result.map { |array| Range.new(*array) }
+    end
+
+    def first_sale_created_at
+      @_first_sale_created_at ||= @user.first_sale_created_at_for_analytics
+    end
+
+    def products
+      @_products ||= @user.products_for_creator_analytics.load
     end
 end

--- a/app/services/creator_analytics/web.rb
+++ b/app/services/creator_analytics/web.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 class CreatorAnalytics::Web
-  def initialize(user:, dates:)
+  def initialize(user:, dates:, first_sale_created_at: nil, products: nil)
     @user = user
     @dates = dates
+    @first_sale_created_at = first_sale_created_at
+    @products = products
   end
 
   def by_date
@@ -104,7 +106,7 @@ class CreatorAnalytics::Web
         start_date: D3.formatted_date(@dates.first),
         end_date: D3.formatted_date(@dates.last),
       }
-      first_sale_created_at = @user.first_sale_created_at_for_analytics
+      first_sale_created_at = self.first_sale_created_at
       metadata[:first_sale_date] = D3.formatted_date_with_timezone(first_sale_created_at, @user.timezone) if first_sale_created_at
       metadata
     end
@@ -117,8 +119,12 @@ class CreatorAnalytics::Web
       CreatorAnalytics::Sales.new(user: @user, products:, dates: @dates)
     end
 
+    def first_sale_created_at
+      @_first_sale_created_at ||= @first_sale_created_at || @user.first_sale_created_at_for_analytics
+    end
+
     def products
-      @_products ||= @user.products_for_creator_analytics.load
+      @_products ||= @products || @user.products_for_creator_analytics.load
     end
 
     def product_permalinks


### PR DESCRIPTION
- because of how the code is structured, we create a separate CreatorAnalytics::Web instance for every missing date range
- this then calls the `products_for_creator_analytics` method on a user, which returns a different relation each time, so query caching doesn't work
- instead, we can just calculate this once in the caching proxy and then pass it to the web instance
- I'll refactor this properly in the future once the fix is confirmed good