### PR TITLE
feat: Pause memberships

### DIFF
--- a/app/javascript/components/server-components/Audience/CustomersPage.tsx
+++ b/app/javascript/components/server-components/Audience/CustomersPage.tsx
@@ -2059,10 +2059,6 @@ const SubscriptionPauseOrResumeSection = ({
   isPaused: boolean;
 }) => {
   const [open, setOpen] = React.useState(false);
-  const constructor = isInstallmentPlan ? "installment plan" : "subscription";
-  const actionLabel = isPaused ? "Resume" : "Pause";
-  const actionText = isPaused ? "resume" : "pause";
-  
   const handleAction = () => {
     if (isPaused) {
       onResume();
@@ -2079,22 +2075,22 @@ const SubscriptionPauseOrResumeSection = ({
           color="warning"
           onClick={() => setOpen(true)}
         >
-          {actionLabel} {constructor}
+          {isPaused ? "Resume" : "Pause"} {isInstallmentPlan ? "installment plan" : "subscription"}
         </Button>
         <Modal
           open={open}
-          title={`${actionLabel} ${constructor}`}
+          title={`${isPaused ? "Resume" : "Pause"} ${isInstallmentPlan ? "installment plan" : "subscription"}`}
           onClose={() => setOpen(false)}
           footer={
             <>
               <Button onClick={() => setOpen(false)}>Cancel</Button>
               <Button color="accent" onClick={handleAction}>
-                {actionLabel} {constructor}
+                {isPaused ? "Resume" : "Pause"} {isInstallmentPlan ? "installment plan" : "subscription"}
               </Button>
             </>
           }
         >
-          Would you like to {actionText} this {constructor}?
+          Would you like to {isPaused ? "resume" : "pause"} this {isInstallmentPlan ? "installment plan" : "subscription"}?
         </Modal>
       </div>
     </section>

--- a/app/javascript/components/server-components/SubscriptionManager.tsx
+++ b/app/javascript/components/server-components/SubscriptionManager.tsx
@@ -336,7 +336,7 @@ const SubscriptionManager = ({
     try {
       await resumeSubscriptionByUser(subscription.id);
       setResumeStatus("done");
-      setPaused(true)
+      setPaused(false)
       showAlert(`Your ${subscriptionEntity} has been resumed.`, "success");
     } catch (e) {
       assertResponseError(e);

--- a/app/javascript/components/server-components/SubscriptionManager.tsx
+++ b/app/javascript/components/server-components/SubscriptionManager.tsx
@@ -112,7 +112,7 @@ const SubscriptionManager = ({
   const subscriptionEntity = subscription.is_installment_plan ? "installment plan" : "membership";
   const restartable = !subscription.alive || subscription.pending_cancellation;
   const [cancelled, setCancelled] = React.useState(restartable);
-  const isPaused = subscription.paused != null;
+  const isPaused = subscription.paused;
   const [paused, setPaused] = React.useState(isPaused)
   const initialSelection = {
     recurrence: subscription.recurrence,

--- a/app/javascript/data/customers.ts
+++ b/app/javascript/data/customers.ts
@@ -88,6 +88,7 @@ export type Customer = {
       | "failed_payment"
       | "fixed_subscription_period_ended"
       | "cancelled"
+      | "paused"
       | null;
     is_installment_plan: boolean;
     remaining_charges: number | null;
@@ -292,6 +293,24 @@ export const cancelSubscription = (subscriptionId: string) =>
     method: "POST",
     accept: "json",
     url: Routes.unsubscribe_by_seller_subscription_path(subscriptionId),
+  }).then((response) => {
+    if (!response.ok) throw new ResponseError();
+  });
+
+export const pauseSubscription = (subscriptionId: string) =>
+  request({
+    method: "POST",
+    accept: "json",
+    url: Routes.pause_by_seller_subscription_path(subscriptionId),
+  }).then((response) => {
+    if (!response.ok) throw new ResponseError();
+  });
+
+export const resumeSubscription = (subscriptionId: string) => 
+  request({
+    method: "POST",
+    accept: "json",
+    url: Routes.resume_by_seller_subscription_path(subscriptionId),
   }).then((response) => {
     if (!response.ok) throw new ResponseError();
   });

--- a/app/javascript/data/subscription.ts
+++ b/app/javascript/data/subscription.ts
@@ -26,6 +26,40 @@ export const cancelSubscriptionByUser = async (subscriptionId: string): Promise<
   throw new ResponseError();
 };
 
+export const pauseSubscriptionByUser = async (subscriptionId: string): Promise<void> => {
+  const response = await request({
+    url: Routes.pause_by_user_subscription_path(subscriptionId),
+    method: "POST",
+    accept: "json",
+  });
+  if (response.ok) {
+    const responseData = cast<{ success: boolean; error?: string }>(await response.json());
+    if (responseData.success) {
+      return;
+    } else {
+      throw new ResponseError(responseData.error || "Failed to pause subscription");
+    }
+  }
+  throw new ResponseError();
+};
+
+export const resumeSubscriptionByUser = async (subscriptionId: string): Promise<void> => {
+  const response = await request({
+    url: Routes.resume_by_user_subscription_path(subscriptionId),
+    method: "POST", 
+    accept: "json",
+  });
+  if (response.ok) {
+    const responseData = cast<{ success: boolean; error?: string }>(await response.json());
+    if (responseData.success) {
+      return;
+    } else {
+      throw new ResponseError(responseData.error || "Failed to resume subscription");
+    }
+  }
+  throw new ResponseError();
+};
+
 export type UpdateSubscriptionPayload = {
   cardParams: AnyPaymentMethodParams | StripeErrorParams | null;
   recaptchaResponse: string | null;

--- a/app/mailers/contacting_creator_mailer.rb
+++ b/app/mailers/contacting_creator_mailer.rb
@@ -218,6 +218,40 @@ class ContactingCreatorMailer < ApplicationMailer
     @last_failed_purchase = @subscription.purchases.failed.last
   end
 
+  def subscription_paused(subscription_id)
+    @subscription = Subscription.find(subscription_id)
+    @seller = @subscription.seller
+    @subject = 
+      if @subscription.is_installment_plan?
+        "An installment plan has been paused."
+      else
+        "A subscription has been paused."
+      end
+  end
+  
+  def subscription_paused_by_customer(subscription_id)
+    @subscription = Subscription.find(subscription_id)
+    @seller = @subscription.seller
+    @subject = "A subscription has been paused."
+  end
+  
+  def subscription_resumed(subscription_id)
+    @subscription = Subscription.find(subscription_id)
+    @seller = @subscription.seller
+    @subject = 
+      if @subscription.is_installment_plan?
+        "An installment plan has been resumed."
+      else
+        "A subscription has been resumed."
+      end
+  end
+  
+  def subscription_resumed_by_customer(subscription_id)
+    @subscription = Subscription.find(subscription_id)
+    @seller = @subscription.seller
+    @subject = "A subscription has been resumed."
+  end
+
   def subscription_ended(subscription_id)
     @subscription = Subscription.find(subscription_id)
     @seller = @subscription.seller

--- a/app/mailers/customer_low_priority_mailer.rb
+++ b/app/mailers/customer_low_priority_mailer.rb
@@ -12,7 +12,8 @@ class CustomerLowPriorityMailer < ApplicationMailer
                                                      subscription_charge_failed subscription_product_deleted subscription_renewal_reminder
                                                      subscription_price_change_notification subscription_ended free_trial_expiring_soon
                                                      credit_card_expiring_membership subscription_early_fraud_warning_notification
-                                                     subscription_giftee_added_card]
+                                                     subscription_giftee_added_card subscription_paused subscription_paused_by_seller
+                                                     subscription_resumed subscription_resumed_by_seller]
 
   layout "layouts/email"
 
@@ -89,6 +90,50 @@ class CustomerLowPriorityMailer < ApplicationMailer
       else
         "Your subscription has been canceled."
       end
+  end
+
+  def subscription_paused(subscription_id)
+    @subscription = Subscription.find(subscription_id)
+    @subject =
+      if @subscription.is_installment_plan?
+        "Your installment plan has been paused."
+      else
+        "Your subscription has been paused."
+      end
+  end
+
+  def subscription_paused_by_seller(subscription_id)
+    @subscription = Subscription.find(subscription_id)
+    @subject =
+      if @subscription.is_installment_plan?
+        "Your installment plan has been paused."
+      else
+        "Your subscription has been paused."
+      end
+  end
+
+  def subscription_resumed(subscription_id)
+    @subscription = Subscription.find(subscription_id)
+    @subject =
+      if @subscription.is_installment_plan?
+        "Your installment plan has been resumed."
+      else
+        "Your subscription has been resumed."
+      end
+    @next_charge_date = @subscription.end_time_of_subscription.strftime("%B %e, %Y")
+    @price = @subscription.original_purchase.formatted_total_price
+  end
+
+  def subscription_resumed_by_seller(subscription_id)
+    @subscription = Subscription.find(subscription_id)
+    @subject =
+      if @subscription.is_installment_plan?
+        "Your installment plan has been resumed."
+      else
+        "Your subscription has been resumed."
+      end
+    @next_charge_date = @subscription.end_time_of_subscription.strftime("%B %e, %Y")
+    @price = @subscription.original_purchase.formatted_total_price
   end
 
   def subscription_card_declined(subscription_id)

--- a/app/models/resource_subscription.rb
+++ b/app/models/resource_subscription.rb
@@ -12,7 +12,7 @@ class ResourceSubscription < ApplicationRecord
   REFUNDED_RESOURCE_NAME = "refund"
   DISPUTE_RESOURCE_NAME = "dispute"
   DISPUTE_WON_RESOURCE_NAME = "dispute_won"
-  PAUSED_RESOURCE_NAME="subscription_paused"
+  PAUSED_RESOURCE_NAME = "subscription_paused"
   RESUMED_RESOURCE_NAME="subscription_resumed"
 
   VALID_RESOURCE_NAMES = [SALE_RESOURCE_NAME,

--- a/app/models/resource_subscription.rb
+++ b/app/models/resource_subscription.rb
@@ -13,7 +13,7 @@ class ResourceSubscription < ApplicationRecord
   DISPUTE_RESOURCE_NAME = "dispute"
   DISPUTE_WON_RESOURCE_NAME = "dispute_won"
   PAUSED_RESOURCE_NAME = "subscription_paused"
-  RESUMED_RESOURCE_NAME="subscription_resumed"
+  RESUMED_RESOURCE_NAME = "subscription_resumed"
 
   VALID_RESOURCE_NAMES = [SALE_RESOURCE_NAME,
                           CANCELLED_RESOURCE_NAME,

--- a/app/models/resource_subscription.rb
+++ b/app/models/resource_subscription.rb
@@ -12,6 +12,8 @@ class ResourceSubscription < ApplicationRecord
   REFUNDED_RESOURCE_NAME = "refund"
   DISPUTE_RESOURCE_NAME = "dispute"
   DISPUTE_WON_RESOURCE_NAME = "dispute_won"
+  PAUSED_RESOURCE_NAME="subscription_paused"
+  RESUMED_RESOURCE_NAME="subscription_resumed"
 
   VALID_RESOURCE_NAMES = [SALE_RESOURCE_NAME,
                           CANCELLED_RESOURCE_NAME,
@@ -20,7 +22,9 @@ class ResourceSubscription < ApplicationRecord
                           SUBSCRIPTION_UPDATED_RESOURCE_NAME,
                           REFUNDED_RESOURCE_NAME,
                           DISPUTE_RESOURCE_NAME,
-                          DISPUTE_WON_RESOURCE_NAME].freeze
+                          DISPUTE_WON_RESOURCE_NAME,
+                          PAUSED_RESOURCE_NAME,
+                          RESUMED_RESOURCE_NAME].freeze
 
   INVALID_POST_URL_HOSTS = %w(127.0.0.1 localhost 0.0.0.0)
 

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -899,7 +899,7 @@ class Subscription < ApplicationRecord
   end
 
   def last_paused_at
-    subscription_events.paused.order(occurred_at: :desc).first&.occured_at || paused_at
+    subscription_events.paused.order(occurred_at: :desc).first&.occurred_at || paused_at
   end
 
   def tier

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -391,7 +391,7 @@ class Subscription < ApplicationRecord
       self.paused_by_admin = by_admin
 
       save!
-      self.deactivate! # stops access and billing right away (also calls save!)
+      deactivate! # stops access and billing right away (also calls save!)
 
       if paused_by_buyer?
         CustomerLowPriorityMailer.subscription_paused(id).deliver_later(queue: "low")

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -853,7 +853,7 @@ class Subscription < ApplicationRecord
   def create_interruption_event
     event_type = if paused_at.present?
       :paused
-    elsif deactivated_at.present? 
+    elsif deactivated_at.present?
       :deactivated
     else 
       paused_at_previously_was.present? ? :resumed : :restarted

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -135,7 +135,7 @@ class Subscription < ApplicationRecord
 
   def alive_at?(time)
     start_time = true_original_purchase.created_at
-    end_time = next_event_at(:deactivated, start_time) || next_event_at(:paused, start_time) || deactivated_at || paused_at
+    end_time = next_event_at(:deactivated, start_time) || next_event_at(:paused, start_time)
 
     while start_time do
       return true if end_time.nil? && time > start_time

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -37,7 +37,7 @@ class Subscription < ApplicationRecord
             6 => :mor_fee_applicable,
             7 => :is_installment_plan,
             8 => :paused_by_buyer,
-            9 => :paused_by_admin,
+            9 => :paused_by_seller,
             :column => "flags",
             :flag_query_mode => :bit_operator,
             check_for_column: false
@@ -388,7 +388,7 @@ class Subscription < ApplicationRecord
       self.user_requested_pause_at = Time.current
       self.paused_at = Time.current
       self.paused_by_buyer = !by_seller
-      self.paused_by_admin = by_admin
+      self.paused_by_seller = by_admin
 
       save!
       deactivate! # stops access and billing right away (also calls save!)
@@ -412,7 +412,7 @@ class Subscription < ApplicationRecord
       original_paused_at = paused_at
       self.paused_at = nil
       self.paused_by_buyer = false
-      self.paused_by_admin = false
+      self.paused_by_seller = false
 
       self.deactivated_at = nil
       save!

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -433,7 +433,7 @@ class Subscription < ApplicationRecord
         ContactingCreatorMailer.subscription_resumed_by_customer(id).deliver_later(queue: "critical") if seller.enable_payment_email?
       end
 
-      send_resumed_notification_webhook
+      send_resumed_notification_webhook(pause_duration)
 
       #  schedule next charge if needed
       schedule_charge(end_time_of_subscription) if overdue_for_charge?
@@ -891,10 +891,10 @@ class Subscription < ApplicationRecord
     send_notification_webhook(resource_name: ResourceSubscription::PAUSED_RESOURCE_NAME)
   end
 
-  def send_resumed_notification_webhook
+  def send_resumed_notification_webhook(pause_duration)
     params = {
       resumed_at: Time.current.as_json,
-      paused_duration: (Time.current - last_paused_at).to_i
+      paused_duration: pause_duration
     }
     send_notification_webhook(resource_name: ResourceSubscription::RESUMED_RESOURCE_NAME, params:)
   end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -419,7 +419,7 @@ class Subscription < ApplicationRecord
       original_purchase&.add_to_audience_member_details
 
       pause_duration = (Time.current - (subscription_events.paused.order(occurred_at: :desc).first&.occurred_at || original_paused_at)).to_i
-      original_purchase.reschedule_workflow_installments(send_delay: pause_duration)
+      original_purchase&.reschedule_workflow_installments(send_delay: pause_duration)
       
       after_commit do
         ActivateIntegrationsWorker.perform_async(original_purchase.id)

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -398,7 +398,7 @@ class Subscription < ApplicationRecord
         ContactingCreatorMailer.subscription_paused_by_customer(id).deliver_later(queue: "critical") if seller.enable_payment_email?
       else
         CustomerLowPriorityMailer.subscription_paused_by_seller(id).deliver_later(queue: "low")
-      ContactingCreatorMailer.subscription_paused(id).deliver_later(queue: "critical") if seller.enable_payment_email?
+        ContactingCreatorMailer.subscription_paused(id).deliver_later(queue: "critical") if seller.enable_payment_email?
       end
 
       send_paused_notification_webhook

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -425,7 +425,7 @@ class Subscription < ApplicationRecord
         ActivateIntegrationsWorker.perform_async(original_purchase.id)
       end
 
-      if by_seller && !by_admin
+      if by_seller
         CustomerLowPriorityMailer.subscription_resumed_by_seller(id).deliver_later(queue: "low")
         ContactingCreatorMailer.subscription_resumed(id).deliver_later(queue: "critical") if seller.enable_payment_email?
       else

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -899,7 +899,7 @@ class Subscription < ApplicationRecord
   end
 
   def last_paused_at
-    subscription_events.paused.order(occured_at: :desc).first&.occured_at || paused_at
+    subscription_events.paused.order(occurred_at: :desc).first&.occured_at || paused_at
   end
 
   def tier

--- a/app/models/subscription_event.rb
+++ b/app/models/subscription_event.rb
@@ -9,7 +9,7 @@ class SubscriptionEvent < ApplicationRecord
   validates :event_type, :occurred_at, presence: true
   validate :consecutive_event_type_not_duplicated
 
-  enum event_type: %i[deactivated restarted]
+  enum event_type: %i[deactivated restarted paused resumed]
 
   private
     def assign_seller

--- a/app/policies/subscription_policy.rb
+++ b/app/policies/subscription_policy.rb
@@ -10,4 +10,19 @@ class SubscriptionPolicy < ApplicationPolicy
     user.role_admin_for?(seller) ||
     user.role_support_for?(seller)
   end
+
+  def pause_by_seller?
+    return false if record.link.user != seller
+  
+    user.role_admin_for?(seller) ||
+    user.role_support_for?(seller)
+  end
+
+  def resume_by_seller?
+    return false if record.link.user != seller
+  
+    user.role_admin_for?(seller) ||
+    user.role_support_for?(seller)
+  end
+
 end

--- a/app/presenters/checkout_presenter.rb
+++ b/app/presenters/checkout_presenter.rb
@@ -208,6 +208,7 @@ class CheckoutPresenter
         quantity: subscription.original_purchase.quantity,
         alive: subscription.alive?(include_pending_cancellation: false),
         pending_cancellation: subscription.pending_cancellation?,
+        paused: subscription.paused?,
         discount: offer_code&.discount,
         end_time_of_subscription: subscription.end_time_of_subscription.iso8601,
         successful_purchases_count: subscription.purchases.successful.count,

--- a/app/sidekiq/recurring_charge_worker.rb
+++ b/app/sidekiq/recurring_charge_worker.rb
@@ -13,6 +13,7 @@ class RecurringChargeWorker
       return unless subscription.alive?(include_pending_cancellation: false)
       return if subscription.is_test_subscription || subscription.current_subscription_price_cents == 0
       return if subscription.charges_completed?
+      return if subscription.paused_at.present? # explicitly checking if paused - does not charge if subscription is paused
       return if subscription.in_free_trial?
       last_successful_purchase = subscription.purchases.successful.last
       return if last_successful_purchase && (last_successful_purchase.created_at + subscription.period) > Time.current

--- a/app/views/contacting_creator_mailer/subscription_paused.html.erb
+++ b/app/views/contacting_creator_mailer/subscription_paused.html.erb
@@ -1,0 +1,14 @@
+<% if @subscription.is_installment_plan %>
+  <%= header_section("An installment plan has been paused.") %>
+<% else %>
+  <%= header_section("A subscription has been paused.") %>
+<% end %>
+<div>
+  <% if @subscription.is_installment_plan %>
+    <p>You have paused the installment plan for <%= link_to @subscription.email, customers_url(query: @subscription.email) %> for <%= @subscription.link.name %>.</p>
+    <p>They will no longer be charged and will lose access to the product immediately.</p>
+  <% else %>
+    <p>You have paused the subscription for <%= link_to @subscription.email, customers_url(query: @subscription.email) %> to <%= @subscription.link.name %>.</p>
+    <p>They will no longer be charged and will lose access to updates immediately.</p>
+  <% end %>
+</div>

--- a/app/views/contacting_creator_mailer/subscription_paused_by_customer.html.erb
+++ b/app/views/contacting_creator_mailer/subscription_paused_by_customer.html.erb
@@ -1,0 +1,5 @@
+<%= header_section("A subscription has been paused.") %>
+<div>
+  <p>Your customer (<%= link_to @subscription.email, customers_url(query: @subscription.email) %>) has paused their subscription to <%= @subscription.link.name %>.</p>
+  <p>They will no longer be charged and will lose access to updates immediately. They may resume their subscription at any time.</p>
+</div>

--- a/app/views/contacting_creator_mailer/subscription_resumed.html.erb
+++ b/app/views/contacting_creator_mailer/subscription_resumed.html.erb
@@ -1,0 +1,14 @@
+<% if @subscription.is_installment_plan %>
+  <%= header_section("An installment plan has been resumed.") %>
+<% else %>
+  <%= header_section("A subscription has been resumed.") %>
+<% end %>
+<div>
+  <% if @subscription.is_installment_plan %>
+    <p>You have resumed the installment plan for <%= link_to @subscription.email, customers_url(query: @subscription.email) %> for <%= @subscription.link.name %>.</p>
+    <p>They now have access to the product again and will be charged on their next billing date.</p>
+  <% else %>
+    <p>You have resumed the subscription for <%= link_to @subscription.email, customers_url(query: @subscription.email) %> to <%= @subscription.link.name %>.</p>
+    <p>They now have access to updates again and will be charged on their next billing date.</p>
+  <% end %>
+</div>

--- a/app/views/contacting_creator_mailer/subscription_resumed_by_customer.html.erb
+++ b/app/views/contacting_creator_mailer/subscription_resumed_by_customer.html.erb
@@ -1,0 +1,5 @@
+<%= header_section("A subscription has been resumed.") %>
+<div>
+  <p>Your customer (<%= link_to @subscription.email, customers_url(query: @subscription.email) %>) has resumed their subscription to <%= @subscription.link.name %>.</p>
+  <p>They now have access to updates again and will be charged on their next billing date.</p>
+</div>

--- a/app/views/customer_low_priority_mailer/subscription_paused.html.erb
+++ b/app/views/customer_low_priority_mailer/subscription_paused.html.erb
@@ -1,0 +1,8 @@
+<%= header_section("Your subscription has been paused.") %>
+<div>
+  <p>You have paused your subscription to <%= @subscription.link.name %>. You will no longer be charged and will lose access to updates immediately.</p>
+  <p>You can resume your subscription at any time.</p>
+</div>
+<div>
+  <%= link_to "Manage subscription", @edit_card_url, class: "button primary" %>
+</div>

--- a/app/views/customer_low_priority_mailer/subscription_paused_by_seller.html.erb
+++ b/app/views/customer_low_priority_mailer/subscription_paused_by_seller.html.erb
@@ -1,0 +1,13 @@
+<% if @subscription.is_installment_plan %>
+  <%= header_section("Your installment plan has been paused.") %>
+<% else %>
+  <%= header_section("Your subscription has been paused.") %>
+<% end %>
+<div>
+  <% if @subscription.is_installment_plan %>
+    <p>Your installment plan for <%= @subscription.link.name %> has been paused by the creator. You will no longer be charged and will lose access to the product immediately.</p>
+  <% else %>
+    <p>Your subscription to <%= @subscription.link.name %> has been paused by the creator. You will no longer be charged and will lose access to updates immediately.</p>
+  <% end %>
+  <p>The creator may resume your subscription at a later time.</p>
+</div>

--- a/app/views/customer_low_priority_mailer/subscription_resumed.html.erb
+++ b/app/views/customer_low_priority_mailer/subscription_resumed.html.erb
@@ -1,0 +1,8 @@
+<%= header_section("Your subscription has been resumed.") %>
+<div>
+  <p>You have resumed your subscription to <%= @subscription.link.name %>. You now have access to all updates again.</p>
+  <p>Your next payment of <%= @price %> will be charged on <%= @next_charge_date %>.</p>
+</div>
+<div>
+  <%= link_to "Manage subscription", @edit_card_url, class: "button primary" %>
+</div>

--- a/app/views/customer_low_priority_mailer/subscription_resumed_by_seller.html.erb
+++ b/app/views/customer_low_priority_mailer/subscription_resumed_by_seller.html.erb
@@ -1,0 +1,17 @@
+<% if @subscription.is_installment_plan %>
+  <%= header_section("Your installment plan has been resumed.") %>
+<% else %>
+  <%= header_section("Your subscription has been resumed.") %>
+<% end %>
+<div>
+  <% if @subscription.is_installment_plan %>
+    <p>Your installment plan for <%= @subscription.link.name %> has been resumed by the creator. You now have access to the product again.</p>
+    <p>Your next payment of <%= @price %> will be charged on <%= @next_charge_date %>.</p>
+  <% else %>
+    <p>Your subscription to <%= @subscription.link.name %> has been resumed by the creator. You now have access to all updates again.</p>
+    <p>Your next payment of <%= @price %> will be charged on <%= @next_charge_date %>.</p>
+  <% end %>
+</div>
+<div>
+  <%= link_to "Manage subscription", @edit_card_url, class: "button primary" %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -781,6 +781,10 @@ Rails.application.routes.draw do
         post :send_magic_link
         post :unsubscribe_by_user
         post :unsubscribe_by_seller
+        post :pause_by_user
+        post :pause_by_seller
+        post :resume_by_user
+        post :resume_by_seller
         put :update, to: "purchases#update_subscription"
       end
     end

--- a/db/migrate/20250624220949_add_paused_columns_to_subscriptions.rb
+++ b/db/migrate/20250624220949_add_paused_columns_to_subscriptions.rb
@@ -1,0 +1,6 @@
+class AddPausedColumnsToSubscriptions < ActiveRecord::Migration[7.1]
+  def change
+    add_column :subscriptions, :paused_at, :datetime
+    add_column :subscriptions, :user_requested_pause_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2141,10 +2141,12 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_25_212934) do
     t.bigint "user_id"
     t.datetime "cancelled_at"
     t.datetime "failed_at"
+    t.datetime "paused_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "flags", default: 0, null: false
     t.datetime "user_requested_cancellation_at"
+    t.datetime "user_requested_pause_at"
     t.integer "charge_occurrence_count"
     t.datetime "ended_at"
     t.bigint "last_payment_option_id"

--- a/lib/mailer_previews/contacting_creator_mailer_preview.rb
+++ b/lib/mailer_previews/contacting_creator_mailer_preview.rb
@@ -50,6 +50,26 @@ class ContactingCreatorMailerPreview < ActionMailer::Preview
     ContactingCreatorMailer.subscription_cancelled(Subscription.last&.id)
   end
 
+  def subscription_autocancelled
+    ContactingCreatorMailer.subscription_autocancelled(Subscription.where.not(failed_at: nil).last&.id)
+  end
+
+  def subscription_paused
+    ContactingCreatorMailer.subscription_paused(Subscription.last&.id)
+  end
+
+  def subscription_paused_by_customer
+    ContactingCreatorMailer.subscription_paused_by_customer(Subscription.last&.id)
+  end
+
+  def subscription_resumed
+    ContactingCreatorMailer.subscription_resumed(Subscription.last&.id)
+  end
+
+  def subscription_resumed_by_customer
+    ContactingCreatorMailer.subscription_resumed_by_customer(Subscription.last&.id)
+  end
+
   def subscription_ended
     ContactingCreatorMailer.subscription_ended(Subscription.last&.id)
   end

--- a/lib/mailer_previews/contacting_creator_mailer_preview.rb
+++ b/lib/mailer_previews/contacting_creator_mailer_preview.rb
@@ -167,10 +167,6 @@ class ContactingCreatorMailerPreview < ActionMailer::Preview
     ContactingCreatorMailer.video_transcode_failed(ProductFile.last&.id)
   end
 
-  def subscription_autocancelled
-    ContactingCreatorMailer.subscription_autocancelled(Subscription.where.not(failed_at: nil).last&.id)
-  end
-
   def annual_payout_summary
     user = User.last
     if user&.financial_annual_report_url_for(year: 2022).nil?

--- a/lib/mailer_previews/customer_low_priority_mailer_preview.rb
+++ b/lib/mailer_previews/customer_low_priority_mailer_preview.rb
@@ -30,6 +30,22 @@ class CustomerLowPriorityMailerPreview < ActionMailer::Preview
     CustomerLowPriorityMailer.subscription_cancelled_by_seller(Subscription.last&.id)
   end
 
+  def subscription_paused
+    CustomerLowPriorityMailer.subscription_paused(Subscription.last&.id)
+  end
+  
+  def subscription_paused_by_seller
+    CustomerLowPriorityMailer.subscription_paused_by_seller(Subscription.last&.id)
+  end
+  
+  def subscription_resumed
+    CustomerLowPriorityMailer.subscription_resumed(Subscription.last&.id)
+  end
+  
+  def subscription_resumed_by_seller
+    CustomerLowPriorityMailer.subscription_resumed_by_seller(Subscription.last&.id)
+  end
+
   def subscription_ended
     CustomerLowPriorityMailer.subscription_ended(Subscription.last&.id)
   end

--- a/spec/models/resource_subscription_spec.rb
+++ b/spec/models/resource_subscription_spec.rb
@@ -18,4 +18,14 @@ describe ResourceSubscription do
       expect(resource_subscription.content_type).to eq "application/x-www-form-urlencoded"
     end
   end
+
+  describe ".valid_resource_name?" do
+    it "returns true for paused resource name" do
+      expect(ResourceSubscription.valid_resource_name?(ResourceSubscription::PAUSED_RESOURCE_NAME)).to be true
+    end
+
+    it "returns true for resumed resource name" do
+      expect(ResourceSubscription.valid_resource_name?(ResourceSubscription::RESUMED_RESOURCE_NAME)).to be true
+    end
+  end
 end

--- a/spec/models/subscription_event_spec.rb
+++ b/spec/models/subscription_event_spec.rb
@@ -17,6 +17,10 @@ describe SubscriptionEvent do
       expect { create(:subscription_event, subscription: subscription, event_type: :restarted) }.to raise_error(ActiveRecord::RecordInvalid)
       create(:subscription_event, subscription:, event_type: :deactivated, occurred_at: 3.days.ago)
       expect { create(:subscription_event, subscription: subscription, event_type: :deactivated) }.to raise_error(ActiveRecord::RecordInvalid)
+      create(:subscription_event, subscription:, event_type: :paused, occurred_at: 2.days.ago)
+      expect { create(:subscription_event, subscription: subscription, event_type: :paused) }.to raise_error(ActiveRecord::RecordInvalid)
+      create(:subscription_event, subscription:, event_type: :resumed, occurred_at: 1.day.ago)
+      expect { create(:subscription_event, subscription: subscription, event_type: :resumed) }.to raise_error(ActiveRecord::RecordInvalid)
     end
   end
 end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -77,13 +77,10 @@ describe Subscription, :vcr do
         end.not_to change { @subscription.reload.subscription_events.paused.count }
       end
 
-      it "records a resumed event if paused_at is cleared and paused_at_previously_was is present" do
+      it "records a resumed event if paused_at is cleared and was previously present" do
         @subscription.update!(paused_at: 1.day.ago)
-        @subscription.reload
-    
+
         expect do
-          # Simulate the behavior where paused_at_previously_was is set during update
-          allow(@subscription).to receive(:paused_at_previously_was).and_return(1.day.ago)
           @subscription.update!(paused_at: nil)
           expect(@subscription.reload.subscription_events.resumed.last.occurred_at).to eq Time.current
         end.to change { @subscription.reload.subscription_events.resumed.count }.from(0).to(1)

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -185,8 +185,8 @@ describe Subscription, :vcr do
           resumed_at: Time.current.as_json,
           paused_duration: pause_duration.to_i
         }
-  
-        @subscription.send_resumed_notification_webhook
+    
+        @subscription.send_resumed_notification_webhook(pause_duration.to_i)
         expect(PostToPingEndpointsWorker).to have_enqueued_sidekiq_job(
           nil, nil, ResourceSubscription::RESUMED_RESOURCE_NAME, @subscription.id, expected_params
         )

--- a/spec/policies/subscription_policy_spec.rb
+++ b/spec/policies/subscription_policy_spec.rb
@@ -48,12 +48,80 @@ describe SubscriptionPolicy do
         expect(subject).to permit(seller_context, subscription)
       end
     end
+
+    permissions :pause_by_seller? do
+      it "grants access to owner" do
+        seller_context = SellerContext.new(user: seller, seller:)
+        expect(subject).to permit(seller_context, subscription)
+      end
+
+      it "denies access to accountant" do
+        seller_context = SellerContext.new(user: accountant_for_seller, seller:)
+        expect(subject).not_to permit(seller_context, subscription)
+      end
+
+      it "grants access to admin" do
+        seller_context = SellerContext.new(user: admin_for_seller, seller:)
+        expect(subject).to permit(seller_context, subscription)
+      end
+
+      it "denies access to marketing" do
+        seller_context = SellerContext.new(user: marketing_for_seller, seller:)
+        expect(subject).not_to permit(seller_context, subscription)
+      end
+
+      it "grants access to support" do
+        seller_context = SellerContext.new(user: support_for_seller, seller:)
+        expect(subject).to permit(seller_context, subscription)
+      end
+    end
+
+    permissions :resume_by_seller? do
+      it "grants access to owner" do
+        seller_context = SellerContext.new(user: seller, seller:)
+        expect(subject).to permit(seller_context, subscription)
+      end
+
+      it "denies access to accountant" do
+        seller_context = SellerContext.new(user: accountant_for_seller, seller:)
+        expect(subject).not_to permit(seller_context, subscription)
+      end
+
+      it "grants access to admin" do
+        seller_context = SellerContext.new(user: admin_for_seller, seller:)
+        expect(subject).to permit(seller_context, subscription)
+      end
+
+      it "denies access to marketing" do
+        seller_context = SellerContext.new(user: marketing_for_seller, seller:)
+        expect(subject).not_to permit(seller_context, subscription)
+      end
+
+      it "grants access to support" do
+        seller_context = SellerContext.new(user: support_for_seller, seller:)
+        expect(subject).to permit(seller_context, subscription)
+      end
+    end
   end
 
   context "with subscription belongs to other seller's product" do
     let(:subscription) { create(:subscription) }
 
     permissions :unsubscribe_by_seller? do
+      it "denies access" do
+        seller_context = SellerContext.new(user: seller, seller:)
+        expect(subject).to_not permit(seller_context, subscription)
+      end
+    end
+
+    permissions :pause_by_seller? do
+      it "denies access" do
+        seller_context = SellerContext.new(user: seller, seller:)
+        expect(subject).to_not permit(seller_context, subscription)
+      end
+    end
+
+    permissions :resume_by_seller? do
       it "denies access" do
         seller_context = SellerContext.new(user: seller, seller:)
         expect(subject).to_not permit(seller_context, subscription)

--- a/spec/presenters/checkout_presenter_spec.rb
+++ b/spec/presenters/checkout_presenter_spec.rb
@@ -566,6 +566,7 @@ describe CheckoutPresenter do
                                  prorated_discount_price_cents: @subscription.prorated_discount_price_cents,
                                  alive: false,
                                  pending_cancellation: true,
+                                 paused: false,
                                  discount: {
                                    type: "fixed",
                                    cents: 100,

--- a/spec/requests/subscription/pause_and_resume_spec.rb
+++ b/spec/requests/subscription/pause_and_resume_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Membership pause and resume functionality", type: :feature, js: true do
+  include ManageSubscriptionHelpers
+
+  before do
+    setup_subscription
+    setup_subscription_token
+    
+    # Ensure email notifications are enabled for consistent test behavior
+    @subscription.seller.update!(enable_payment_email: true)
+  end
+
+  context "as a buyer" do
+    before do
+      visit "/subscriptions/#{@subscription.external_id}/manage?token=#{@subscription.token}"
+    end
+
+    it "can pause a subscription" do
+      expect(page).to have_button("Pause membership")
+
+      # Mock mailers
+      allow(CustomerLowPriorityMailer).to receive_message_chain(:subscription_paused, :deliver_later)
+      allow(ContactingCreatorMailer).to receive_message_chain(:subscription_paused_by_customer, :deliver_later)
+
+      click_on "Pause membership"
+      wait_for_ajax
+
+      expect(page).to have_alert(text: "Membership paused")
+      expect(page).to have_button("Resume membership")
+      expect(@subscription.reload.paused_at).not_to be_nil
+
+      # Assert that emails were sent
+      expect(CustomerLowPriorityMailer).to have_received(:subscription_paused).with(@subscription.id)
+      expect(ContactingCreatorMailer).to have_received(:subscription_paused_by_customer).with(@subscription.id)
+    end
+
+    it "can resume a subscription" do
+      @subscription.pause!(by_seller: false)
+      visit "/subscriptions/#{@subscription.external_id}/manage?token=#{@subscription.token}"
+
+      expect(page).to have_button("Resume membership")
+
+      # Mock mailers
+      allow(CustomerLowPriorityMailer).to receive_message_chain(:subscription_resumed, :deliver_later)
+      allow(ContactingCreatorMailer).to receive_message_chain(:subscription_resumed_by_customer, :deliver_later)
+
+      click_on "Resume membership"
+      wait_for_ajax
+
+      expect(page).to have_alert(text: "Membership resumed")
+      expect(page).to have_button("Pause membership")
+      expect(@subscription.reload.paused_at).to be_nil
+
+      # Assert that emails were sent
+      expect(CustomerLowPriorityMailer).to have_received(:subscription_resumed).with(@subscription.id)
+      expect(ContactingCreatorMailer).to have_received(:subscription_resumed_by_customer).with(@subscription.id)
+    end
+  end
+
+  context "as a seller" do
+    before do
+      sign_in @subscription.seller
+      visit "/audience/customers"
+      find("td", text: @subscription.user.email).click
+    end
+
+    it "can pause a subscription" do
+      expect(page).to have_button("Pause")
+
+      # Mock mailers
+      allow(CustomerLowPriorityMailer).to receive_message_chain(:subscription_paused_by_seller, :deliver_later)
+      allow(ContactingCreatorMailer).to receive_message_chain(:subscription_paused, :deliver_later)
+
+      click_on "Pause"
+      wait_for_ajax
+
+      expect(page).to have_alert(text: "Membership paused")
+      expect(page).to have_button("Resume")
+      expect(@subscription.reload.paused_at).not_to be_nil
+
+      # Assert that emails were sent
+      expect(CustomerLowPriorityMailer).to have_received(:subscription_paused_by_seller).with(@subscription.id)
+      expect(ContactingCreatorMailer).to have_received(:subscription_paused).with(@subscription.id)
+    end
+
+    it "can resume a subscription" do
+      @subscription.pause!(by_seller: true)
+      page.refresh
+
+      expect(page).to have_button("Resume")
+
+      # Mock mailers
+      allow(CustomerLowPriorityMailer).to receive_message_chain(:subscription_resumed_by_seller, :deliver_later)
+      allow(ContactingCreatorMailer).to receive_message_chain(:subscription_resumed, :deliver_later)
+
+      click_on "Resume"
+      wait_for_ajax
+
+      expect(page).to have_alert(text: "Membership resumed")
+      expect(page).to have_button("Pause")
+      expect(@subscription.reload.paused_at).to be_nil
+
+      # Assert that emails were sent
+      expect(CustomerLowPriorityMailer).to have_received(:subscription_resumed_by_seller).with(@subscription.id)
+      expect(ContactingCreatorMailer).to have_received(:subscription_resumed).with(@subscription.id)
+    end
+  end
+
+  context "when email notifications are disabled" do
+    before do
+      @subscription.seller.update!(enable_payment_email: false)
+    end
+
+    it "does not send creator emails when buyer pauses subscription" do
+      visit "/subscriptions/#{@subscription.external_id}/manage?token=#{@subscription.token}"
+      
+      # Mock mailers
+      allow(CustomerLowPriorityMailer).to receive_message_chain(:subscription_paused, :deliver_later)
+      allow(ContactingCreatorMailer).to receive_message_chain(:subscription_paused_by_customer, :deliver_later)
+
+      click_on "Pause membership"
+      wait_for_ajax
+
+      expect(CustomerLowPriorityMailer).to have_received(:subscription_paused).with(@subscription.id)
+      expect(ContactingCreatorMailer).not_to have_received(:subscription_paused_by_customer)
+    end
+  end
+end

--- a/spec/sidekiq/recurring_charge_worker_spec.rb
+++ b/spec/sidekiq/recurring_charge_worker_spec.rb
@@ -151,6 +151,19 @@ describe RecurringChargeWorker, :vcr do
     end
   end
 
+  describe "subscription is paused" do
+    before do
+      @product = create(:product, user: create(:user))
+      @subscription = create(:subscription, user: create(:user, credit_card: create(:credit_card)), link: @product, paused_at: 1.hour.ago)
+      create(:purchase, link: @product, price_cents: @product.price_cents, is_original_subscription_purchase: true, subscription: @subscription)
+    end
+  
+    it "doesn't call charge on paused subscriptions" do
+      expect_any_instance_of(Subscription).to_not receive(:charge!)
+      described_class.new.perform(@subscription.id)
+    end
+  end
+
   describe "subscription has failed" do
     before do
       @product = create(:product, user: create(:user))


### PR DESCRIPTION
Adding the ability for buyers and sellers (with appropriate access) to pause and resume memberships - for this [issue](https://github.com/antiwork/gumroad/issues/287).

Feature: Complete subscription pause/resume system implementation

Customer pausing/resuming subscription
https://github.com/user-attachments/assets/5ba58d7c-1009-47d1-aa22-0d30bde8d618


Seller pausing/resuming subscription
https://github.com/user-attachments/assets/dbaf3ef2-d76a-41b7-a391-23278085b292


1. Foundation Layer (22664330)
* Database & Model Setup: Added pause and resume functionality to the subscription model and database schema
* This established the core data structure needed for the feature
2. Communication Layer (39217d67)
* Email Templates: Added customer and seller email contact logic and templates
* Ensures proper notification when subscriptions are paused/resumed
3. Integration Layer (766c8fff)
* Webhook Logic: Enabled webhook logic for pausing and resuming subscriptions
* Critical for handling external payment processor events and state synchronization
4. Business Logic Protection (96e97669)
* Recurring Charge Logic: Added explicit checks to prevent recurring charges on paused subscriptions
* Prevents billing customers when their subscription is paused
5. API Layer (06dd6cb8)
* Controllers & Routes: Enabled controller and routes to handle pause/resume subscription requests
* Provides the HTTP endpoints for the functionality
6. Frontend Data Layer (afbc6cfa)
* Component Props: Added paused boolean to subscription manager props
* Ensures frontend components have access to subscription pause state
7. Data Fetching (a28cb7c3)
* Backend Integration: Implemented fetching subscription status from backend for customers and sellers
* Enables real-time status display in the UI
8. Authorization Layer (a94f51d6)
* Access Control: Added policies defining who can pause or resume subscriptions
* Ensures proper permissions and security around the feature
9. User Interface (198caf89)
* UI Implementation: Built the user interface for buyers and sellers to pause/resume subscriptions
* The customer-facing component of the feature
10. Quality Assurance (878c0125)
* Testing & Previews: Added tests and previews for the new pause and resume subscription features
* Ensures feature reliability and provides development/QA tooling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enabled users and sellers to pause and resume subscriptions via the customer management interface.
  - Introduced a "paused" subscription status with corresponding UI indicators and actions.
  - Added email notifications for both customers and sellers on subscription pause and resume events, supporting user- and seller-initiated actions.

- **Bug Fixes**
  - Recurring charges are now skipped automatically for paused subscriptions.

- **Documentation**
  - Added new email templates and mailer previews for paused and resumed subscription notifications.

- **Tests**
  - Expanded test coverage for pause/resume actions, including authorization, error handling, lifecycle events, UI behavior, and background job handling.

- **Chores**
  - Updated API endpoints, routes, data models, and internal state management to support subscription pause and resume functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->