### PR TITLE
Improvements to invoice generation page.

### DIFF
--- a/app/javascript/components/server-components/GenerateInvoicePage.tsx
+++ b/app/javascript/components/server-components/GenerateInvoicePage.tsx
@@ -66,6 +66,14 @@ const GenerateInvoicePage = ({
 
   const [downloadUrl, setDownloadUrl] = React.useState<string | null>(null);
 
+  const euCountries = [
+    "AT", "BE", "BG", "HR", "CY", "CZ", "DK", "EE", "FI", "FR", 
+    "DE", "GR", "HU", "IE", "IT", "LV", "LT", "LU", "MT", "NL", 
+    "PL", "PT", "RO", "SK", "SI", "ES", "SE"
+  ];
+
+  const isEuCountry = euCountries.includes(country.value);
+
   const handleDownload = async () => {
     setFullName((prev) => ({ ...prev, error: !prev.value.length }));
     setStreetAddress((prev) => ({ ...prev, error: !prev.value.length }));
@@ -87,7 +95,7 @@ const GenerateInvoicePage = ({
         email,
         full_name: fullName.value,
         business_name: businessName.value,
-        vat_id: form_info.display_vat_id ? vatId : null,
+        vat_id: (form_info.display_vat_id || isEuCountry) ? vatId : null,
         street_address: streetAddress.value,
         city: city.value,
         state: state.value,
@@ -137,12 +145,20 @@ const GenerateInvoicePage = ({
               onChange={(e) => setBusinessName({ value: e.target.value })}
             />
           </fieldset>
-          {form_info.display_vat_id ? (
+          {(form_info.display_vat_id || isEuCountry) ? (
             <fieldset>
               <legend>
-                <label htmlFor="chargeable_vat_id">{form_info.vat_id_label}</label>
+                <label htmlFor="chargeable_vat_id">
+                  {form_info.display_vat_id ? form_info.vat_id_label : "VAT ID"}
+                </label>
               </legend>
-              <input id="chargeable_vat_id" type="text" value={vatId} onChange={(e) => setVatId(e.target.value)} />
+              <input 
+                id="chargeable_vat_id" 
+                type="text" 
+                placeholder={form_info.display_vat_id ? "" : "VAT ID (optional)"}
+                value={vatId} 
+                onChange={(e) => setVatId(e.target.value)} 
+              />
             </fieldset>
           ) : null}
           <fieldset className={cx({ danger: streetAddress.error })}>
@@ -243,6 +259,11 @@ const GenerateInvoicePage = ({
             {businessName.value.length ? (
               <div>
                 {businessName.value}
+              </div>
+            ) : null}
+            {(form_info.display_vat_id || isEuCountry) && vatId.length ? (
+              <div>
+                VAT ID: {vatId}
               </div>
             ) : null}
             <div style={{ opacity: streetAddress.value.length ? undefined : "var(--disabled-opacity)" }}>

--- a/app/javascript/components/server-components/GenerateInvoicePage.tsx
+++ b/app/javascript/components/server-components/GenerateInvoicePage.tsx
@@ -69,11 +69,15 @@ const GenerateInvoicePage = ({
     setFullName((prev) => ({ ...prev, error: !prev.value.length }));
     setStreetAddress((prev) => ({ ...prev, error: !prev.value.length }));
     setCity((prev) => ({ ...prev, error: !prev.value.length }));
-    setState((prev) => ({ ...prev, error: !prev.value.length }));
+    setState((prev) => ({ ...prev, error: country.value === "US" && !prev.value.length }));
     setZipCode((prev) => ({ ...prev, error: !prev.value.length }));
     setCountry((prev) => ({ ...prev, error: !prev.value.length }));
 
-    if ([fullName, streetAddress, city, state, zipCode, country].some((field) => !field.value.length)) return;
+    const requiredFields = [fullName, streetAddress, city, zipCode, country];
+    if (country.value === "US") {
+      requiredFields.push(state);
+    }
+    if (requiredFields.some((field) => !field.value.length)) return;
 
     setIsLoading(true);
     try {
@@ -139,7 +143,7 @@ const GenerateInvoicePage = ({
               onChange={(e) => setStreetAddress({ value: e.target.value })}
             />
           </fieldset>
-          <div style={{ display: "grid", gap: "var(--spacer-2)", gridTemplateColumns: "2fr 1fr 1fr" }}>
+          <div style={{ display: "grid", gap: "var(--spacer-2)", gridTemplateColumns: country.value === "US" ? "2fr 1fr 1fr" : "1fr 1fr" }}>
             <fieldset className={cx({ danger: city.error })}>
               <label htmlFor="city">City</label>
               <input
@@ -150,16 +154,18 @@ const GenerateInvoicePage = ({
                 onChange={(e) => setCity({ value: e.target.value })}
               />
             </fieldset>
-            <fieldset className={cx({ danger: state.error })}>
-              <label htmlFor="state">State</label>
-              <input
-                id="state"
-                type="text"
-                placeholder="State"
-                value={state.value}
-                onChange={(e) => setState({ value: e.target.value })}
-              />
-            </fieldset>
+            {country.value === "US" ? (
+              <fieldset className={cx({ danger: state.error })}>
+                <label htmlFor="state">State</label>
+                <input
+                  id="state"
+                  type="text"
+                  placeholder="State"
+                  value={state.value}
+                  onChange={(e) => setState({ value: e.target.value })}
+                />
+              </fieldset>
+            ) : null}
             <fieldset className={cx({ danger: zipCode.error })}>
               <label htmlFor="zip_code">ZIP code</label>
               <input
@@ -227,11 +233,13 @@ const GenerateInvoicePage = ({
             </div>
             <div>
               <span style={{ opacity: city.value.length ? undefined : "var(--disabled-opacity)" }}>
-                {`${city.value || "San Francisco"},`}
+                {`${city.value || "San Francisco"}${country.value === "US" ? "," : ""}`}
               </span>{" "}
-              <span style={{ opacity: state.value.length ? undefined : "var(--disabled-opacity)" }}>
-                {state.value || "CA"}
-              </span>{" "}
+              {country.value === "US" ? (
+                <span style={{ opacity: state.value.length ? undefined : "var(--disabled-opacity)" }}>
+                  {state.value || "CA"}
+                </span>
+              ) : null}{" "}
               <span style={{ opacity: zipCode.value.length ? undefined : "var(--disabled-opacity)" }}>
                 {zipCode.value || "94107"}
               </span>

--- a/app/javascript/components/server-components/GenerateInvoicePage.tsx
+++ b/app/javascript/components/server-components/GenerateInvoicePage.tsx
@@ -53,6 +53,7 @@ const GenerateInvoicePage = ({
   const [isLoading, setIsLoading] = React.useState(false);
 
   const [fullName, setFullName] = React.useState<FieldState>({ value: form_info.data.full_name ?? "" });
+  const [businessName, setBusinessName] = React.useState<FieldState>({ value: "" });
   const [vatId, setVatId] = React.useState("");
   const [streetAddress, setStreetAddress] = React.useState<FieldState>({
     value: form_info.data.street_address ?? "",
@@ -85,6 +86,7 @@ const GenerateInvoicePage = ({
         id,
         email,
         full_name: fullName.value,
+        business_name: businessName.value,
         vat_id: form_info.display_vat_id ? vatId : null,
         street_address: streetAddress.value,
         city: city.value,
@@ -123,6 +125,16 @@ const GenerateInvoicePage = ({
               type="text"
               value={fullName.value}
               onChange={(e) => setFullName({ value: e.target.value })}
+            />
+          </fieldset>
+          <fieldset>
+            <label htmlFor="business_name">Business name</label>
+            <input
+              id="business_name"
+              placeholder="Business name (optional)"
+              type="text"
+              value={businessName.value}
+              onChange={(e) => setBusinessName({ value: e.target.value })}
             />
           </fieldset>
           {form_info.display_vat_id ? (
@@ -228,6 +240,11 @@ const GenerateInvoicePage = ({
             <div style={{ opacity: fullName.value.length ? undefined : "var(--disabled-opacity)" }}>
               {fullName.value || "Edgar Gumstein"}
             </div>
+            {businessName.value.length ? (
+              <div>
+                {businessName.value}
+              </div>
+            ) : null}
             <div style={{ opacity: streetAddress.value.length ? undefined : "var(--disabled-opacity)" }}>
               {streetAddress.value || "123 Gum Road"}
             </div>

--- a/app/javascript/components/server-components/GenerateInvoicePage.tsx
+++ b/app/javascript/components/server-components/GenerateInvoicePage.tsx
@@ -270,7 +270,7 @@ const GenerateInvoicePage = ({
           </Button>
         </footer>
       </main>
-      <footer style={{ textAlign: "center", padding: "var(--spacer-4)" }}>
+      <footer style={{ display: "flex", justifyContent: "center", alignItems: "center", gap: "0.5ch", padding: "var(--spacer-4)" }}>
         Powered by <span className="logo-full" />
       </footer>
     </>

--- a/app/javascript/components/server-components/GenerateInvoicePage.tsx
+++ b/app/javascript/components/server-components/GenerateInvoicePage.tsx
@@ -54,7 +54,7 @@ const GenerateInvoicePage = ({
 
   const [fullName, setFullName] = React.useState<FieldState>({ value: form_info.data.full_name ?? "" });
   const [businessName, setBusinessName] = React.useState<FieldState>({ value: "" });
-  const [vatId, setVatId] = React.useState("");
+  const [businessId, setBusinessId] = React.useState("");
   const [streetAddress, setStreetAddress] = React.useState<FieldState>({
     value: form_info.data.street_address ?? "",
   });
@@ -66,13 +66,116 @@ const GenerateInvoicePage = ({
 
   const [downloadUrl, setDownloadUrl] = React.useState<string | null>(null);
 
-  const euCountries = [
-    "AT", "BE", "BG", "HR", "CY", "CZ", "DK", "EE", "FI", "FR", 
-    "DE", "GR", "HU", "IE", "IT", "LV", "LT", "LU", "MT", "NL", 
-    "PL", "PT", "RO", "SK", "SI", "ES", "SE"
+  const businessIdCountries = [
+    // EU countries
+    "AT",
+    "BE",
+    "BG",
+    "HR",
+    "CY",
+    "CZ",
+    "DK",
+    "EE",
+    "FI",
+    "FR",
+    "DE",
+    "GR",
+    "HU",
+    "IE",
+    "IT",
+    "LV",
+    "LT",
+    "LU",
+    "MT",
+    "NL",
+    "PL",
+    "PT",
+    "RO",
+    "SK",
+    "SI",
+    "ES",
+    "SE",
+    // Other European countries
+    "GB",
+    "NO",
+    "CH",
+    "IS",
+    // Commonwealth & English-speaking
+    "CA",
+    "AU",
+    "NZ",
+    "ZA",
+    // Other major economies
+    "JP",
+    "KR",
+    "IN",
+    "BR",
+    "MX",
   ];
 
-  const isEuCountry = euCountries.includes(country.value);
+  const getBusinessIdLabel = (countryCode: string): string => {
+    switch (countryCode) {
+      // EU countries
+      case "AT":
+      case "BE":
+      case "BG":
+      case "HR":
+      case "CY":
+      case "CZ":
+      case "DK":
+      case "EE":
+      case "FI":
+      case "FR":
+      case "DE":
+      case "GR":
+      case "HU":
+      case "IE":
+      case "IT":
+      case "LV":
+      case "LT":
+      case "LU":
+      case "MT":
+      case "NL":
+      case "PL":
+      case "PT":
+      case "RO":
+      case "SK":
+      case "SI":
+      case "ES":
+      case "SE":
+        return "VAT ID";
+      case "GB":
+        return "GB VAT";
+      case "NO":
+        return "MVA";
+      case "CH":
+        return "MWST/TVA";
+      case "IS":
+        return "VSK";
+      case "CA":
+        return "GST/HST";
+      case "AU":
+        return "ABN";
+      case "NZ":
+        return "GST";
+      case "ZA":
+        return "VAT vendor";
+      case "JP":
+        return "Consumption tax";
+      case "KR":
+        return "VAT registration";
+      case "IN":
+        return "GST";
+      case "BR":
+        return "CNPJ";
+      case "MX":
+        return "RFC";
+      default:
+        return "Business ID";
+    }
+  };
+
+  const shouldShowBusinessId = businessIdCountries.includes(country.value);
 
   const handleDownload = async () => {
     setFullName((prev) => ({ ...prev, error: !prev.value.length }));
@@ -95,7 +198,7 @@ const GenerateInvoicePage = ({
         email,
         full_name: fullName.value,
         business_name: businessName.value,
-        vat_id: (form_info.display_vat_id || isEuCountry) ? vatId : null,
+        business_id: form_info.display_vat_id || shouldShowBusinessId ? businessId : null,
         street_address: streetAddress.value,
         city: city.value,
         state: state.value,
@@ -145,19 +248,19 @@ const GenerateInvoicePage = ({
               onChange={(e) => setBusinessName({ value: e.target.value })}
             />
           </fieldset>
-          {(form_info.display_vat_id || isEuCountry) ? (
+          {form_info.display_vat_id || shouldShowBusinessId ? (
             <fieldset>
               <legend>
-                <label htmlFor="chargeable_vat_id">
-                  {form_info.display_vat_id ? form_info.vat_id_label : "VAT ID"}
+                <label htmlFor="chargeable_business_id">
+                  {form_info.display_vat_id ? form_info.vat_id_label : getBusinessIdLabel(country.value)}
                 </label>
               </legend>
-              <input 
-                id="chargeable_vat_id" 
-                type="text" 
-                placeholder={form_info.display_vat_id ? "" : "VAT ID (optional)"}
-                value={vatId} 
-                onChange={(e) => setVatId(e.target.value)} 
+              <input
+                id="chargeable_business_id"
+                type="text"
+                placeholder={form_info.display_vat_id ? "" : `${getBusinessIdLabel(country.value)} (optional)`}
+                value={businessId}
+                onChange={(e) => setBusinessId(e.target.value)}
               />
             </fieldset>
           ) : null}
@@ -171,7 +274,13 @@ const GenerateInvoicePage = ({
               onChange={(e) => setStreetAddress({ value: e.target.value })}
             />
           </fieldset>
-          <div style={{ display: "grid", gap: "var(--spacer-2)", gridTemplateColumns: country.value === "US" ? "2fr 1fr 1fr" : "1fr 1fr" }}>
+          <div
+            style={{
+              display: "grid",
+              gap: "var(--spacer-2)",
+              gridTemplateColumns: country.value === "US" ? "2fr 1fr 1fr" : "1fr 1fr",
+            }}
+          >
             <fieldset className={cx({ danger: city.error })}>
               <label htmlFor="city">City</label>
               <input
@@ -256,14 +365,10 @@ const GenerateInvoicePage = ({
             <div style={{ opacity: fullName.value.length ? undefined : "var(--disabled-opacity)" }}>
               {fullName.value || "Edgar Gumstein"}
             </div>
-            {businessName.value.length ? (
+            {businessName.value.length ? <div>{businessName.value}</div> : null}
+            {(form_info.display_vat_id || shouldShowBusinessId) && businessId.length ? (
               <div>
-                {businessName.value}
-              </div>
-            ) : null}
-            {(form_info.display_vat_id || isEuCountry) && vatId.length ? (
-              <div>
-                VAT ID: {vatId}
+                {getBusinessIdLabel(country.value)}: {businessId}
               </div>
             ) : null}
             <div style={{ opacity: streetAddress.value.length ? undefined : "var(--disabled-opacity)" }}>
@@ -316,7 +421,15 @@ const GenerateInvoicePage = ({
           </Button>
         </footer>
       </main>
-      <footer style={{ display: "flex", justifyContent: "center", alignItems: "center", gap: "0.5ch", padding: "var(--spacer-4)" }}>
+      <footer
+        style={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          gap: "0.5ch",
+          padding: "var(--spacer-4)",
+        }}
+      >
         Powered by <span className="logo-full" />
       </footer>
     </>

--- a/app/javascript/data/invoice.ts
+++ b/app/javascript/data/invoice.ts
@@ -6,6 +6,7 @@ export const sendInvoice = async ({
   id,
   email,
   full_name,
+  business_name,
   vat_id,
   street_address,
   city,
@@ -17,6 +18,7 @@ export const sendInvoice = async ({
   id: string;
   email: string;
   full_name: string;
+  business_name?: string;
   vat_id: null | string;
   street_address: string;
   city: string;
@@ -33,6 +35,7 @@ export const sendInvoice = async ({
       id,
       email,
       full_name,
+      business_name,
       vat_id,
       street_address,
       city,

--- a/app/javascript/data/invoice.ts
+++ b/app/javascript/data/invoice.ts
@@ -7,7 +7,7 @@ export const sendInvoice = async ({
   email,
   full_name,
   business_name,
-  vat_id,
+  business_id,
   street_address,
   city,
   state,
@@ -19,7 +19,7 @@ export const sendInvoice = async ({
   email: string;
   full_name: string;
   business_name?: string;
-  vat_id: null | string;
+  business_id: null | string;
   street_address: string;
   city: string;
   state: string;
@@ -36,7 +36,7 @@ export const sendInvoice = async ({
       email,
       full_name,
       business_name,
-      vat_id,
+      business_id,
       street_address,
       city,
       state,

--- a/app/javascript/stylesheets/_stack.scss
+++ b/app/javascript/stylesheets/_stack.scss
@@ -76,7 +76,6 @@
 }
 
 main.stack {
-  height: min-content;
   margin: spacer(4) auto;
   max-width: $main-stack-width;
   width: calc(100% - 2 * #{spacer(4)});


### PR DESCRIPTION
## Problem
There are some problems with the invoice generation page that makes it quite complicated for businesses to continue paying for products on gumroad.

- "Business name" field is missing
- "VAT" field is missing
- State is shown even for non-US countries
- "power by gumroad" footer is show in the middle of page on Firefox 

![powered-by-gumroad](https://github.com/user-attachments/assets/a1953409-615a-41ab-8b8a-04a7e6815d5d)


## Proposed Solution

1. Make the main contain scrollable, so footer can be properly placed on a bottom for all browsers (tested on chrome, firefox)
2. Show state field only if United States is selected as a country
3. Add optional "Business Name" field
4. Add optional "Business ID" field, depending on a country selected label will change a proper name.
### **European Union (27 countries)**
- Standardized VAT ID format (e.g., DE123456789, FR12345678901)
- Cross-border VAT reporting requirements

### **Post-Brexit UK**
- GB VAT numbers (separate from EU system)
- Format: GB123456789

### **Other European Countries (Non-EU)**
- **Norway** - MVA numbers
- **Switzerland** - MWST/TVA numbers  
- **Iceland** - VSK numbers

### **Commonwealth & English-speaking**
- **Canada** - GST/HST numbers
- **Australia** - ABN (Australian Business Number) for GST
- **New Zealand** - GST numbers
- **South Africa** - VAT vendor numbers

### **Other Major Economies**
- **Japan** - Consumption tax registration
- **South Korea** - VAT registration numbers
- **India** - GST numbers
- **Brazil** - CNPJ for tax purposes
- **Mexico** - RFC (tax ID)



## Preview

[![Gumroad Generate Invoice page](https://img.youtube.com/vi/THRHl-C0rhs/0.jpg)](https://www.youtube.com/watch?v=THRHl-C0rhs)


## Testing
If you run project locally, open this link in browser:
https://gumroad.dev/purchases/_8BSwwFdLk9hVbpOK_eCpQ==/generate_invoice?email=gumbuyer9%40gumroad.com

## Open issue
I was unable to verify that PDF generation actually works. This feature requires having correct AWS credentials, otherwise following error appears:

```ruby
#<Aws::Errors::MissingCredentialsError: unable to sign request without credentials set>
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional "Business name" field to the invoice form and preview.
  - VAT ID field now appears for EU customers as well as when specifically enabled.

- **Improvements**
  - "State" field is only required and shown for US addresses, with corresponding validation and layout adjustments.
  - Invoice preview address formatting now adapts based on country selection.
  - Footer styling updated for improved alignment and spacing.

- **Style**
  - Adjusted layout behavior by removing explicit height setting from the main content area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->