### PR TITLE
remove tech debt: 4 deads methods in ruby backend and specs for couple of them

### DIFF
--- a/app/javascript/data/paypal.ts
+++ b/app/javascript/data/paypal.ts
@@ -45,8 +45,6 @@ export const createBillingAgreement = async (billingAgreementTokenId: string): P
   }
 };
 
-type PaypalOrderResponse = { id: string; payer: { email_address: string; address: { country_code: string } } };
-
 export type LineItemInfoForNativePayPalCheckout = {
   external_id: string;
   permalink: string;

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -841,19 +841,6 @@ class Link < ApplicationRecord
     variants
   end
 
-  def serialized_shipping_destinations
-    {
-      destinations: shipping_destinations.alive.map do |shipping_destination|
-        {
-          country_code: shipping_destination.country_code,
-          name: shipping_destination.country_name,
-          one_item_rate: shipping_destination.displayed_one_item_rate(price_currency_type, with_symbol: false),
-          multiple_items_rate: shipping_destination.displayed_multiple_items_rate(price_currency_type, with_symbol: false)
-        }
-      end
-    }
-  end
-
   def reorder_previews(preview_positions)
     asset_previews.alive.each do |preview|
       position = preview_positions[preview.guid].try(:to_i)

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -534,10 +534,6 @@ class Link < ApplicationRecord
     twitter_url(long_url, social_share_text)
   end
 
-  def facebook_share_url(title: true)
-    title ? facebook_url(long_url, social_share_text) : facebook_url(long_url)
-  end
-
   def social_share_text
     if user.twitter_handle.present?
       return "I pre-ordered #{name} from @#{user.twitter_handle} on @Gumroad" if is_in_preorder_state

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -864,29 +864,6 @@ class Link < ApplicationRecord
     end
   end
 
-  def offer_code_info(code)
-    offer_code_params = {}
-    if code.present?
-      offer_code = find_offer_code(code:)
-      offer_code_error_message = nil
-      if offer_code.nil?
-        offer_code_error_message = "Sorry, the discount code you wish to use is invalid."
-      elsif !offer_code.is_valid_for_purchase?
-        offer_code_error_message = "Sorry, the discount code you wish to use has expired."
-      end
-
-      if offer_code_error_message.present?
-        offer_code_params[:is_valid] = false
-        offer_code_params[:error_message] = offer_code_error_message
-      else
-        offer_code_params[:is_valid] = true
-        offer_code_params[:amount] = offer_code.amount
-        offer_code_params[:is_percent] = offer_code.is_percent?
-      end
-    end
-    offer_code_params
-  end
-
   def find_offer_code(code:)
     offer_codes.alive.find_by_code(code) ||
       user.offer_codes.universal_with_matching_currency(price_currency_type).alive.find_by_code(code)

--- a/app/modules/user/social_facebook.rb
+++ b/app/modules/user/social_facebook.rb
@@ -7,18 +7,6 @@ module User::SocialFacebook
     base.extend(FacebookClassMethods)
   end
 
-  def facebook_name
-    if facebook_uid
-      begin
-        User.fb_object(facebook_uid, token: User.fb_app_access_token)["name"]
-      rescue Koala::Facebook::ClientError, *INTERNET_EXCEPTIONS
-        name
-      end
-    else
-      name
-    end
-  end
-
   def renew_facebook_access_token
     oauth = Koala::Facebook::OAuth.new(FACEBOOK_APP_ID, FACEBOOK_APP_SECRET)
     new_token = oauth.exchange_access_token(facebook_access_token)

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -3217,44 +3217,7 @@ describe Link, :vcr do
     end
   end
 
-  describe "#offer_code_info" do
-    let(:offer_code) { create(:offer_code, products: [link], max_purchase_count: 1) }
 
-    describe "when offer code exist" do
-      it "returns amount, is_valid true , and is_percent false if offer code is valid" do
-        allow(offer_code).to receive(:is_valid_for_purchase?).and_return(true)
-
-        expect(link.offer_code_info(offer_code.code)).to eq(is_valid: true, amount: 100, is_percent: false)
-      end
-
-      it "returns sold out message and is_valid false if offer code is sold out" do
-        create(:purchase, offer_code:)
-
-        expect(link.offer_code_info(offer_code.code)).to eq(is_valid: false, error_message: "Sorry, the discount code you wish to use has expired.")
-      end
-
-      it "returns the alive offer code, not the deleted one" do
-        offer_code.update_column(:deleted_at, Time.current)
-        create(:offer_code, products: [link], code: offer_code.code)
-
-        expect(link.offer_code_info(offer_code.code)).to eq(is_valid: true, amount: 100, is_percent: false)
-      end
-
-      it "returns the universal offer code" do
-        universal_offer_code = create(:universal_offer_code, user: link.user, code: "code")
-
-        expect(link.offer_code_info(universal_offer_code.code)).to eq(is_valid: true, amount: 100, is_percent: false)
-      end
-    end
-
-    it "returns error message and is_valid false if offer code doesn't exist" do
-      expect(link.offer_code_info("invalid")).to eq(is_valid: false, error_message: "Sorry, the discount code you wish to use is invalid.")
-    end
-
-    it "returns empty hash if offer code is not given" do
-      expect(link.offer_code_info(nil)).to eq({})
-    end
-  end
 
   describe "offer_code creation" do
     before :each do

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -3732,24 +3732,6 @@ describe Link, :vcr do
     end
   end
 
-  describe ".facebook_share_url" do
-    context "when title is true" do
-      it "generates the facebook share url" do
-        product = create(:product, name: "you & i")
-
-        expect(product.facebook_share_url).to eq "https://www.facebook.com/sharer/sharer.php?u=#{product.long_url}&quote=I+got+you+%26+i+on+%40Gumroad"
-      end
-    end
-
-    context "when title is false" do
-      it "generates the facebook share url" do
-        product = create(:product, name: "you & i")
-
-        expect(product.facebook_share_url(title: false)).to eq "https://www.facebook.com/sharer/sharer.php?u=#{product.long_url}"
-      end
-    end
-  end
-
   describe "duration_multiple_of_price_options" do
     before do
       @product = create(:subscription_product, subscription_duration: "yearly", duration_in_months: 12)


### PR DESCRIPTION
This PR deletes four obsolete pieces of code.

## Why `offer_code_info` and it's specs were removed:



1. **Dead Code Verified**: Used Debride + manual verification + comprehensive search (`git grep`, `ripgrep`, symbol search) found zero production usage - only method definition + 6 obsolete test cases remained
2. **Superseded by Modern Service**: `OfferCodeDiscountComputingService` handles all discount code logic across 6+ production files (controllers, services, presenters)
3. **Limited Functionality**: Old method only handled single products with basic validation (2 error types vs 6 in replacement)
4. **Enhanced Replacement**: New service supports bundles, quantity limits, comprehensive error handling, and better cart performance
5. **Architecture Improvement**: Moved from legacy model method to dedicated service class following Single Responsibility Principle


## Remove serialized_shipping_destinations
1. Conducted comprehnsive search across entire codebase using both exact string matching (grep_search) and semantic code search (codebase_search) to confirm it was completely unused. 

2. The search revealed only the method definition itself with zero actual calls to it anywhere in Ruby, JavaScript, TypeScript, or test files. While **shipping destinations functionality** is actively used throughout the app, the codebase has evolved to handle this data serialization through other approaches, making this helper method redundant dead code.
3.  This also had zero test coverage
4.  Removing it cleans up the codebase without any risk since there are no dependencies on this specific serialization format.


## remove facebook_share_url and it's specs

Justification: 

1. exhaustive search confirms it has no calls in the codebase.


2. Superseded by 
**New React approach:**
```typescript
// app/javascript/components/FacebookShareButton.tsx
const shareUrl = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(url)}&quote=${encodeURIComponent(text)}`;
```

**Active Usage in Production:**
- `ProductEdit/ShareTab/index.tsx` - Product editing interface
- `BundleEdit/ShareTab/index.tsx` - Bundle editing interface



## Remove facebook_name method

**Justification:**

1. **Dead Code Verified**: Comprehensive search using `grep_search`, `codebase_search`, and manual verification across Ruby files, tests, views, and serializers found zero usage - only the method definition remained in `User::SocialFacebook` module.

2. **Legacy Functionality**: Method was designed to fetch Facebook user names via Graph API (`User.fb_object(facebook_uid, token: User.fb_app_access_token)["name"]`) but is no longer needed by any current Facebook integration workflows.

3. **No Test Coverage**: Method had no associated test cases, indicating it was already considered obsolete.

4. **Facebook Integration Still Active**: Core Facebook OAuth functionality remains intact through `find_for_facebook_oauth`, `query_fb_graph`, and other actively used methods in the same module - only this specific name-fetching helper was unused.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed Facebook sharing and offer code functionality from the Link model.
	- Eliminated Facebook name retrieval from user social features.
- **Tests**
	- Removed related tests for offer code information and Facebook share URL generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->