### PR TITLE
Fixed reloading of user products for creator analytics

### DIFF
--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -18,7 +18,7 @@ class AnalyticsController < Sellers::BaseController
     authorize :analytics, :index?
 
     if Feature.active?(:use_creator_analytics_web_in_controller)
-      data = creator_analytics_web.by_date
+      data = creator_analytics_web.by_date(dates: (@start_date .. @end_date).to_a)
     else
       data = CreatorAnalytics::CachingProxy.new(current_seller).data_for_dates(@start_date, @end_date, by: :date)
     end
@@ -29,7 +29,7 @@ class AnalyticsController < Sellers::BaseController
     authorize :analytics, :index?
 
     if Feature.active?(:use_creator_analytics_web_in_controller)
-      data = creator_analytics_web.by_state
+      data = creator_analytics_web.by_state(dates: (@start_date .. @end_date).to_a)
     else
       data = CreatorAnalytics::CachingProxy.new(current_seller).data_for_dates(@start_date, @end_date, by: :state)
     end
@@ -40,7 +40,7 @@ class AnalyticsController < Sellers::BaseController
     authorize :analytics, :index?
 
     if Feature.active?(:use_creator_analytics_web_in_controller)
-      data = creator_analytics_web.by_referral
+      data = creator_analytics_web.by_referral(dates: (@start_date .. @end_date).to_a)
     else
       data = CreatorAnalytics::CachingProxy.new(current_seller).data_for_dates(@start_date, @end_date, by: :referral)
     end
@@ -61,7 +61,7 @@ class AnalyticsController < Sellers::BaseController
     end
 
     def creator_analytics_web
-      CreatorAnalytics::Web.new(user: current_seller, dates: (@start_date .. @end_date).to_a)
+      @creator_analytics_web ||= CreatorAnalytics::Web.new(user: current_seller)
     end
 
     def set_title

--- a/app/services/creator_analytics/caching_proxy.rb
+++ b/app/services/creator_analytics/caching_proxy.rb
@@ -8,6 +8,7 @@ class CreatorAnalytics::CachingProxy
 
   def initialize(user)
     @user = user
+    @analytics_web = CreatorAnalytics::Web.new(user: @user)
   end
 
   # Proxy for cached values of CreatorAnalytics::Web#by_(date|state|referral)
@@ -101,7 +102,7 @@ class CreatorAnalytics::CachingProxy
 
     # Direct proxy for CreatorAnalytics::Web
     def analytics_data(start_date, end_date, by: :date)
-      CreatorAnalytics::Web.new(user: @user, dates: (start_date .. end_date).to_a).public_send("by_#{by}")
+      @analytics_web.public_send("by_#{by}", dates: (start_date .. end_date).to_a)
     end
 
     # Fetches and caches the analytics data for one specific date

--- a/app/services/creator_analytics/web.rb
+++ b/app/services/creator_analytics/web.rb
@@ -1,20 +1,19 @@
 # frozen_string_literal: true
 
 class CreatorAnalytics::Web
-  def initialize(user:, dates:)
+  def initialize(user:)
     @user = user
-    @dates = dates
   end
 
-  def by_date
-    views_data = product_page_views.by_product_and_date
-    sales_data = sales.by_product_and_date
-    result = result_metadata
+  def by_date(dates:)
+    views_data = product_page_views(dates).by_product_and_date
+    sales_data = sales(dates).by_product_and_date
+    result = result_metadata(dates)
     result[:by_date] = { views: {}, sales: {}, totals: {} }
 
     %i[views sales totals].each do |type|
       product_permalinks.each do |product_id, product_permalink|
-        result[:by_date][type][product_permalink] = dates_strings.map do |date|
+        result[:by_date][type][product_permalink] = dates_strings(dates).map do |date|
           case type
           when :views then views_data[[product_id, date]]
           when :sales then sales_data.dig([product_id, date], :count)
@@ -27,9 +26,9 @@ class CreatorAnalytics::Web
     result
   end
 
-  def by_state
-    views_data = product_page_views.by_product_and_country_and_state
-    sales_data = sales.by_product_and_country_and_state
+  def by_state(dates:)
+    views_data = product_page_views(dates).by_product_and_country_and_state
+    sales_data = sales(dates).by_product_and_country_and_state
     result = { by_state: { views: {}, sales: {}, totals: {} } }
     usa = "United States"
 
@@ -69,64 +68,64 @@ class CreatorAnalytics::Web
     result
   end
 
-  def by_referral
-    views_data = product_page_views.by_product_and_referrer_and_date
-    sales_data = sales.by_product_and_referrer_and_date
-    result = result_metadata
+  def by_referral(dates:)
+    views_data = product_page_views(dates).by_product_and_referrer_and_date
+    sales_data = sales(dates).by_product_and_referrer_and_date
+    result = result_metadata(dates)
     result[:by_referral] = { views: {}, sales: {}, totals: {} }
 
     views_data.each do |(product_id, referrer, date), count|
       product_permalink = product_permalinks[product_id]
       referrer_name = referrer_domain_to_name(referrer)
       result[:by_referral][:views][product_permalink] ||= {}
-      result[:by_referral][:views][product_permalink][referrer_name] ||= [0] * dates_strings.size
-      result[:by_referral][:views][product_permalink][referrer_name][dates_strings.index(date)] = count
+      result[:by_referral][:views][product_permalink][referrer_name] ||= [0] * dates_strings(dates).size
+      result[:by_referral][:views][product_permalink][referrer_name][dates_strings(dates).index(date)] = count
     end
 
     sales_data.each do |(product_id, referrer, date), values|
       product_permalink = product_permalinks[product_id]
       referrer_name = referrer_domain_to_name(referrer)
       result[:by_referral][:sales][product_permalink] ||= {}
-      result[:by_referral][:sales][product_permalink][referrer_name] ||= [0] * dates_strings.size
-      result[:by_referral][:sales][product_permalink][referrer_name][dates_strings.index(date)] = values[:count]
+      result[:by_referral][:sales][product_permalink][referrer_name] ||= [0] * dates_strings(dates).size
+      result[:by_referral][:sales][product_permalink][referrer_name][dates_strings(dates).index(date)] = values[:count]
       result[:by_referral][:totals][product_permalink] ||= {}
-      result[:by_referral][:totals][product_permalink][referrer_name] ||= [0] * dates_strings.size
-      result[:by_referral][:totals][product_permalink][referrer_name][dates_strings.index(date)] = values[:total]
+      result[:by_referral][:totals][product_permalink][referrer_name] ||= [0] * dates_strings(dates).size
+      result[:by_referral][:totals][product_permalink][referrer_name][dates_strings(dates).index(date)] = values[:total]
     end
 
     result
   end
 
   private
-    def result_metadata
+    def result_metadata(dates)
       metadata = {
-        dates_and_months: D3.date_month_domain(@dates),
-        start_date: D3.formatted_date(@dates.first),
-        end_date: D3.formatted_date(@dates.last),
+        dates_and_months: D3.date_month_domain(dates),
+        start_date: D3.formatted_date(dates.first),
+        end_date: D3.formatted_date(dates.last),
       }
       first_sale_created_at = @user.first_sale_created_at_for_analytics
       metadata[:first_sale_date] = D3.formatted_date_with_timezone(first_sale_created_at, @user.timezone) if first_sale_created_at
       metadata
     end
 
-    def product_page_views
-      CreatorAnalytics::ProductPageViews.new(user: @user, products:, dates: @dates)
+    def product_page_views(dates)
+      CreatorAnalytics::ProductPageViews.new(user: @user, products:, dates:)
     end
 
-    def sales
-      CreatorAnalytics::Sales.new(user: @user, products:, dates: @dates)
+    def sales(dates)
+      CreatorAnalytics::Sales.new(user: @user, products:, dates:)
     end
 
     def products
-      @_products ||= @user.products_for_creator_analytics.load
+      @user.products_for_creator_analytics.load
     end
 
     def product_permalinks
       @_product_id_to_permalink ||= products.to_h { |product| [product.id, product.unique_permalink] }
     end
 
-    def dates_strings
-      @_dates_strings ||= @dates.map(&:to_s)
+    def dates_strings(dates)
+      dates.map(&:to_s)
     end
 
     def referrer_domain_to_name(referrer_domain)

--- a/spec/services/creator_analytics/caching_proxy_spec.rb
+++ b/spec/services/creator_analytics/caching_proxy_spec.rb
@@ -15,7 +15,8 @@ describe CreatorAnalytics::CachingProxy do
     end
 
     def web_data(by, start_date, end_date)
-      CreatorAnalytics::Web.new(user: @user, dates: (start_date .. end_date).to_a).public_send("by_#{by}")
+      web = CreatorAnalytics::Web.new(user: @user)
+      web.public_send("by_#{by}", dates: (start_date .. end_date).to_a)
     end
 
     it "returns merged mix of cached and generated data" do
@@ -237,10 +238,15 @@ describe CreatorAnalytics::CachingProxy do
       user = create(:user, timezone: "London")
       start_date, end_date = Date.new(2019, 1, 1), Date.new(2019, 1, 7)
       dates = (start_date .. end_date).to_a
-      expect(CreatorAnalytics::Web).to receive(:new).with(user:, dates:).thrice.and_call_original
-      expect_any_instance_of(CreatorAnalytics::Web).to receive(:by_date).and_call_original
-      expect_any_instance_of(CreatorAnalytics::Web).to receive(:by_state).and_call_original
-      expect_any_instance_of(CreatorAnalytics::Web).to receive(:by_referral).and_call_original
+
+      # Web instance should be created once in the proxy's initialize
+      web_instance = instance_double(CreatorAnalytics::Web)
+      expect(CreatorAnalytics::Web).to receive(:new).with(user:).once.and_return(web_instance)
+
+      # Each by_* method should be called with dates parameter
+      expect(web_instance).to receive(:by_date).with(dates:).and_return({})
+      expect(web_instance).to receive(:by_state).with(dates:).and_return({})
+      expect(web_instance).to receive(:by_referral).with(dates:).and_return({})
 
       service = described_class.new(user)
       service.send(:analytics_data, start_date, end_date, by: :date)

--- a/spec/services/creator_analytics/web_spec.rb
+++ b/spec/services/creator_analytics/web_spec.rb
@@ -6,10 +6,8 @@ describe CreatorAnalytics::Web do
   before do
     @user = create(:user, timezone: "UTC")
     @products = create_list(:product, 2, user: @user)
-    @service = described_class.new(
-      user: @user,
-      dates: (Date.new(2021, 1, 1) .. Date.new(2021, 1, 3)).to_a
-    )
+    @service = described_class.new(user: @user)
+    @dates = (Date.new(2021, 1, 1) .. Date.new(2021, 1, 3)).to_a
 
     add_page_view(@products[0], Time.utc(2021, 1, 1))
     add_page_view(@products[0], Time.utc(2021, 1, 3), country: "France")
@@ -43,7 +41,7 @@ describe CreatorAnalytics::Web do
         }
       }
 
-      expect(@service.by_date).to eq(expected_result)
+      expect(@service.by_date(dates: @dates)).to eq(expected_result)
     end
   end
 
@@ -84,7 +82,7 @@ describe CreatorAnalytics::Web do
         }
       }
 
-      expect(@service.by_state).to eq(expected_result)
+      expect(@service.by_state(dates: @dates)).to eq(expected_result)
     end
   end
 
@@ -130,7 +128,7 @@ describe CreatorAnalytics::Web do
         }
       }
 
-      expect(@service.by_referral).to eq(expected_result)
+      expect(@service.by_referral(dates: @dates)).to eq(expected_result)
     end
   end
 end


### PR DESCRIPTION
- because of how the code is structured, we end up loading the products relation on
  a user multiple times
- we can avoid that by restructuring the code to have a singleton wrapper web class
  and then pass around the dates individually