### PR TITLE
Unflake reset_admin_action_call_counts_job_spec

### DIFF
--- a/app/sidekiq/reset_admin_action_call_counts_job.rb
+++ b/app/sidekiq/reset_admin_action_call_counts_job.rb
@@ -11,7 +11,7 @@ class ResetAdminActionCallCountsJob
       AdminActionCallInfo.destroy_all
       Admin::BaseController.descendants.each do |controller_class|
         controller_class.public_instance_methods(false).each do |action_name|
-          AdminActionCallInfo.create!(controller_name: controller_class.name, action_name:)
+          AdminActionCallInfo.create_or_find_by!(controller_name: controller_class.name, action_name:)
         end
       end
     end

--- a/spec/controllers/admin/base_controller_spec.rb
+++ b/spec/controllers/admin/base_controller_spec.rb
@@ -130,33 +130,6 @@ describe Admin::BaseController do
   end
 
   describe "user_not_authorized" do
-    class DummyPolicy < ApplicationPolicy
-      def index_with_policy?
-        false
-      end
-    end
-
-    controller(Admin::BaseController) do
-      def index
-        render json: { success: true }
-      end
-
-      def index_with_policy
-        authorize :dummy
-
-        render json: { success: true }
-      end
-    end
-
-    before do
-      routes.draw do
-        namespace :admin do
-          get :index, to: "base#index"
-          get :index_with_policy, to: "base#index_with_policy"
-        end
-      end
-    end
-
     before do
       sign_in admin_user
     end


### PR DESCRIPTION
```
rspec ./spec/sidekiq/reset_admin_action_call_counts_job_spec.rb:7
```

This spec is flakey with:

```
     Failure/Error: AdminActionCallInfo.create!(controller_name: controller_class.name, action_name:)

     ActiveRecord::RecordNotUnique:
       Mysql2::Error: Duplicate entry 'Admin::BaseController-index_with_policy' for key 'admin_action_call_infos.index_admin_action_call_infos_on_controller_name_and_action_name'
```

This is because:

- `AdminActionCallInfo` has a unique index on [:controller_name, :action_name], so trying to create a duplicate record fails with `ActiveRecord::RecordNotUnique`.
- `controllers/admin/base_controller_spec` creates two anonymous controllers with the same method name, thus violating the unique constraint when they're ran together.

This is fixed with:

- `create_or_find_by!` instead of `create!`. We don't really care about dupes as it's practically impossible in prod.
- Remove the unnecessary / dupe declaration in `controllers/admin/base_controller_spec`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the process for resetting admin action call counts to prevent errors from duplicate records.

* **Tests**
  * Simplified and cleaned up authorization tests by removing redundant test setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->