### PR TITLE
Fix: Hide empty customer name cell in mobile sales view

### DIFF
--- a/app/javascript/components/server-components/Audience/CustomersPage.tsx
+++ b/app/javascript/components/server-components/Audience/CustomersPage.tsx
@@ -122,6 +122,7 @@ const CustomersPage = ({
 }) => {
   const currentSeller = useCurrentSeller();
   const userAgentInfo = useUserAgentInfo();
+  const isMobile = userAgentInfo.isMobile;
 
   const [{ customers, pagination, count }, setState] = React.useState<{
     customers: Customer[];
@@ -457,7 +458,7 @@ const CustomersPage = ({
                         ) : null}
                         {customer.email.length <= 30 ? customer.email : `${customer.email.slice(0, 27)}...`}
                       </td>
-                      <td>{customer.name}</td>
+                      {isMobile ? customer.name ? <td>{customer.name}</td> : null : <td>{customer.name}</td>}
                       <td>
                         {customer.product.name}
                         {customer.subscription?.is_installment_plan ? (


### PR DESCRIPTION
This empty block in Sales section has annoyed me for 3 years. Little did i know i would get a chance to fix it.

### Problem

I have been using gumroad for 3 years and with 4 different accounts. Almost 80% percent of my sales were from free products. When a product is free that means the buyer doesn't need to enter their name during checkout therefore this block (customer.name field between email of the customer and product name) remains empty (refer attached image). Scrolling through Sales section in mobile view is not a good experience. 

I believe most of the gumroad users face this.

### Solution

Updated the <td> rendering logic so that:

- Mobile: renders the customer.name cell only if a name is present
- Desktop/tablet: still renders the cell regardless (unchanged)

This removes empty block on mobile view, making the ui cleaner without affecting layout and logic elsewhere.

**File Changed:**
`app/javascript/components/server-components/Audience/CustomersPage.tsx`

 **Image:**
![salespage](https://github.com/user-attachments/assets/4957a3a8-627f-49bc-bf8e-75e12d1c9f41)
