### PR TITLE
chore(tech debt): refactor price handling in models and services

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -320,7 +320,7 @@ class Link < ApplicationRecord
       default_tier.save_recurring_prices!(
         subscription_duration.to_s => {
           enabled: true,
-          price: formatted_dollar_amount(initial_price_cents)
+          price_cents: initial_price_cents.to_i
         }
       )
     end
@@ -748,11 +748,8 @@ class Link < ApplicationRecord
       next if destination.try(:[], "country_code").blank?
 
       shipping_destination = ShippingDestination.find_or_create_by(country_code: destination["country_code"], link_id: id)
-      # TODO: :product_edit_react cleanup
       one_item_rate_cents = destination["one_item_rate_cents"]
       multiple_items_rate_cents = destination["multiple_items_rate_cents"]
-      one_item_rate_cents ||= string_to_price_cents(price_currency_type, destination["one_item_rate"])
-      multiple_items_rate_cents ||= string_to_price_cents(price_currency_type, destination["multiple_items_rate"])
 
       begin
         shipping_destination.one_item_rate_cents = one_item_rate_cents

--- a/app/models/variant.rb
+++ b/app/models/variant.rb
@@ -61,11 +61,7 @@ class Variant < BaseVariant
             enabled: true,
             price_cents: price.price_cents,
             suggested_price_cents: price.suggested_price_cents,
-            # TODO: :product_edit_react cleanup
-            price: price.price_formatted_without_symbol,
           }
-          # TODO: :product_edit_react cleanup
-          recurrence_price_values[recurrence][:suggested_price] = price.suggested_price_formatted_without_symbol if price.suggested_price_cents.present?
         else
           recurrence_price_values[recurrence] = {
             enabled: false

--- a/app/models/variant_price.rb
+++ b/app/models/variant_price.rb
@@ -9,17 +9,7 @@ class VariantPrice < BasePrice
 
   delegate :link, to: :variant
 
-  def price_formatted_without_symbol
-    return "" if price_cents.blank?
 
-    display_price_for_price_cents(price_cents, symbol: false)
-  end
-
-  def suggested_price_formatted_without_symbol
-    return nil if suggested_price_cents.blank?
-
-    display_price_for_price_cents(suggested_price_cents, symbol: false)
-  end
 
   private
     def display_price_for_price_cents(price_cents, additional_attrs = {})

--- a/app/modules/base_price/recurrence.rb
+++ b/app/modules/base_price/recurrence.rb
@@ -38,8 +38,7 @@ module BasePrice::Recurrence
   }.freeze
 
   PERMITTED_PARAMS = ALLOWED_RECURRENCES.inject({}) do |c, recurrence|
-    # TODO: :product_edit_react cleanup
-    c.merge!(recurrence.to_sym => [:enabled, :price, :price_cents, :suggested_price, :suggested_price_cents])
+    c.merge!(recurrence.to_sym => [:enabled, :price_cents, :suggested_price_cents])
   end.freeze
 
   def self.all

--- a/app/modules/base_price/shared.rb
+++ b/app/modules/base_price/shared.rb
@@ -18,18 +18,13 @@ module BasePrice::Shared
     enabled_recurrences = recurrence_price_values.select { |_, attributes| attributes[:enabled].to_s == "true" }
 
     enabled_recurrences.each do |recurrence, attributes|
-      price = attributes[:price]
-      # TODO: :product_edit_react cleanup
-      if price.blank? && attributes[:price_cents].blank?
+      if attributes[:price_cents].blank?
         errors.add(:base, "Please provide a price for all selected payment options.")
         raise Link::LinkInvalid
       end
-      # TODO: :product_edit_react cleanup
-      price_cents = attributes[:price_cents] || clean_price(price)
+      price_cents = attributes[:price_cents]
 
-      suggested_price = attributes[:suggested_price]
-      # TODO: :product_edit_react cleanup
-      suggested_price_cents = attributes[:suggested_price_cents] || (suggested_price.present? ? clean_price(suggested_price) : nil)
+      suggested_price_cents = attributes[:suggested_price_cents]
       create_or_update_new_price!(
         price_cents:,
         suggested_price_cents:,

--- a/app/modules/variant/prices.rb
+++ b/app/modules/variant/prices.rb
@@ -14,10 +14,7 @@ module Variant::Prices
       # create prices for product with price_cents == 0
       product_recurrence_price_values = recurrence_price_values.each_with_object({}) do |(recurrence, recurrence_attributes), values|
         product_recurrence_attributes = recurrence_attributes.dup
-        # TODO: :product_edit_react cleanup
-        product_recurrence_attributes[:price] = "0" if recurrence_attributes[:price].present?
         product_recurrence_attributes[:price_cents] = 0 if recurrence_attributes[:price_cents].present?
-        product_recurrence_attributes[:suggested_price] = "0" if recurrence_attributes[:suggested_price].present?
         product_recurrence_attributes[:suggested_price_cents] = 0 if recurrence_attributes[:suggested_price_cents].present?
         values[recurrence] = product_recurrence_attributes
       end

--- a/app/services/product/save_integrations_service.rb
+++ b/app/services/product/save_integrations_service.rb
@@ -22,7 +22,6 @@ class Product::SaveIntegrationsService
           integration = product.find_integration_by_name(name)
           integration_class = Integration.class_for(name)
           integration = integration_class.new if integration.blank?
-          # TODO: :product_edit_react cleanup
           integration_details = params_for_type.delete(:integration_details) || {}
           integration.assign_attributes(
             **params_for_type.slice(

--- a/app/services/product/variant_category_updater_service.rb
+++ b/app/services/product/variant_category_updater_service.rb
@@ -85,7 +85,6 @@ class Product::VariantCategoryUpdaterService
 
       Integration::ALL_NAMES.each do |name|
         integration = product.find_integration_by_name(name)
-        # TODO: :product_edit_react cleanup
         if (option.dig(:integrations, name) == "1" || option.dig(:integrations, name) == true) && integration.present?
           enabled_integrations << integration
         end

--- a/app/services/product/variants_updater_service.rb
+++ b/app/services/product/variants_updater_service.rb
@@ -49,19 +49,12 @@ class Product::VariantsUpdaterService
 
       variant_array = params.is_a?(Hash) ? params.values : params
       variant_array.map do |variant|
-        # TODO: product_edit_react cleanup
         options = variant[:options].is_a?(Hash) ? variant[:options].values : variant[:options]
         {
           title: variant[:name],
           id: variant[:id],
           options: options&.map do |option|
             new_option = option.slice(:id, :temp_id, :name, :description, :url, :customizable_price, :recurrence_price_values, :max_purchase_count, :integrations, :rich_content, :apply_price_changes_to_existing_memberships, :subscription_price_change_effective_date, :subscription_price_change_message, :duration_in_minutes)
-
-            # TODO: :product_edit_react cleanup
-            if option[:price_difference_cents].present?
-              option[:price] = option[:price_difference_cents]
-              option[:price] /= 100.0 unless @product.single_unit_currency?
-            end
 
             new_option.merge!(price_difference: option[:price])
             if price_change_settings = option.dig(:settings, :apply_price_changes_to_existing_memberships)

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -3568,9 +3568,9 @@ describe LinksController, :vcr do
 
         it "renders schema.org item props for single-tier membership product" do
           recurrence_price_values = {
-            BasePrice::Recurrence::MONTHLY => { enabled: true, price: 2.5 },
-            BasePrice::Recurrence::BIANNUALLY => { enabled: true, price: 15 },
-            BasePrice::Recurrence::YEARLY => { enabled: true, price: 30 },
+            BasePrice::Recurrence::MONTHLY => { enabled: true, price_cents: 250 },
+            BasePrice::Recurrence::BIANNUALLY => { enabled: true, price_cents: 1500 },
+            BasePrice::Recurrence::YEARLY => { enabled: true, price_cents: 3000 },
           }
           product = create(:membership_product, user: @user)
           product.default_tier.save_recurring_prices!(recurrence_price_values)
@@ -3586,8 +3586,8 @@ describe LinksController, :vcr do
 
         it "renders schema.org item props for multi-tier membership product" do
           recurrence_price_values = [
-            { BasePrice::Recurrence::MONTHLY => { enabled: true, price: 2.5 } },
-            { BasePrice::Recurrence::MONTHLY => { enabled: true, price: 5 } }
+            { BasePrice::Recurrence::MONTHLY => { enabled: true, price_cents: 250 } },
+            { BasePrice::Recurrence::MONTHLY => { enabled: true, price_cents: 500 } }
           ]
           product = create(:membership_product_with_preset_tiered_pricing, recurrence_price_values:, user: @user)
           get :show, params: { id: product.unique_permalink }

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -2317,7 +2317,7 @@ describe Link, :vcr do
                     "product_files_ids" => [],
                     "is_customizable_price" => false,
                     "recurrence_price_values" => {
-                      "monthly" => { enabled: true, price: "1", price_cents: 100, suggested_price_cents: nil },
+                      "monthly" => { enabled: true, price_cents: 100, suggested_price_cents: nil },
                       "quarterly" => { enabled: false },
                       "biannually" => { enabled: false },
                       "yearly" => { enabled: false },

--- a/spec/models/variant_price_spec.rb
+++ b/spec/models/variant_price_spec.rb
@@ -73,36 +73,4 @@ describe VariantPrice do
       end
     end
   end
-
-  describe "#price_formatted_without_symbol" do
-    it "returns the formatted price without a symbol" do
-      price = create(:variant_price, price_cents: 299)
-
-      expect(price.price_formatted_without_symbol).to eq "2.99"
-    end
-
-    context "when price_cents is blank" do
-      it "returns an empty string" do
-        price = build(:variant_price, price_cents: nil)
-
-        expect(price.price_formatted_without_symbol).to eq ""
-      end
-    end
-  end
-
-  describe "#suggested_price_formatted_without_symbol" do
-    it "returns the formatted suggested price without a symbol" do
-      price = create(:variant_price, suggested_price_cents: 299)
-
-      expect(price.suggested_price_formatted_without_symbol).to eq "2.99"
-    end
-
-    context "when suggested_price_cents is blank" do
-      it "returns nil" do
-        price = build(:variant_price, suggested_price_cents: nil)
-
-        expect(price.suggested_price_formatted_without_symbol).to eq nil
-      end
-    end
-  end
 end

--- a/spec/models/variant_spec.rb
+++ b/spec/models/variant_spec.rb
@@ -533,8 +533,8 @@ describe Variant do
 
           expect(variant_hash["is_customizable_price"]).to eq true
           expect(prices_hash["monthly"][:enabled]).to eq true
-          expect(prices_hash["monthly"][:price]).to eq "3"
-          expect(prices_hash["monthly"][:suggested_price]).to eq "5"
+          expect(prices_hash["monthly"][:price_cents]).to eq 300
+          expect(prices_hash["monthly"][:suggested_price_cents]).to eq 500
         end
       end
 
@@ -549,8 +549,8 @@ describe Variant do
 
           expect(variant_hash["is_customizable_price"]).to eq false
           expect(prices_hash["monthly"][:enabled]).to eq true
-          expect(prices_hash["monthly"][:price]).to eq "3"
-          expect(prices_hash["monthly"].has_key?(:suggested_price)).to be false
+          expect(prices_hash["monthly"][:price_cents]).to eq 300
+          expect(prices_hash["monthly"].has_key?(:suggested_price_cents)).to be false
         end
       end
 
@@ -564,7 +564,7 @@ describe Variant do
         monthly_price_hash = variant_hash["recurrence_price_values"]["monthly"]
 
         expect(monthly_price_hash[:enabled]).to eq false
-        expect(monthly_price_hash[:price]).to be_nil
+        expect(monthly_price_hash[:price_cents]).to be_nil
       end
     end
 
@@ -700,14 +700,13 @@ describe Variant do
       @recurrence_price_values = {
         BasePrice::Recurrence::MONTHLY => {
           enabled: true,
-          price: "20",
-          suggested_price: "25",
+          price_cents: 2000,
           suggested_price_cents: 2500,
         },
         BasePrice::Recurrence::YEARLY => {
           enabled: true,
           price_cents: 9999,
-          suggested_price: ""
+          suggested_price_cents: nil
         },
         BasePrice::Recurrence::BIANNUALLY => { enabled: false }
       }
@@ -764,13 +763,13 @@ describe Variant do
         updated_recurrence_prices = @recurrence_price_values.merge(
           BasePrice::Recurrence::MONTHLY => {
             enabled: true,
-            price: "25",
-            suggested_price: "30"
+            price_cents: 2500,
+            suggested_price_cents: 3000
           },
           BasePrice::Recurrence::QUARTERLY => {
             enabled: true,
-            price: "70",
-            suggested_price: "75"
+            price_cents: 7000,
+            suggested_price_cents: 7500
           }
         )
 
@@ -801,7 +800,7 @@ describe Variant do
     context "missing price" do
       it "raises an error" do
         invalid_values = @recurrence_price_values
-        invalid_values[BasePrice::Recurrence::MONTHLY].delete(:price)
+        invalid_values[BasePrice::Recurrence::MONTHLY].delete(:price_cents)
 
         expect do
           @variant.save_recurring_prices!(invalid_values)
@@ -811,7 +810,7 @@ describe Variant do
 
     context "with price that is too low" do
       it "raises an error" do
-        @recurrence_price_values[BasePrice::Recurrence::MONTHLY][:price] = "0.98"
+        @recurrence_price_values[BasePrice::Recurrence::MONTHLY][:price_cents] = 98
 
         expect do
           @variant.save_recurring_prices!(@recurrence_price_values)
@@ -821,7 +820,7 @@ describe Variant do
 
     context "with price that is too high" do
       it "raises an error" do
-        @recurrence_price_values[BasePrice::Recurrence::MONTHLY][:price] = "5000.01"
+        @recurrence_price_values[BasePrice::Recurrence::MONTHLY][:price_cents] = 500001
 
         expect do
           @variant.save_recurring_prices!(@recurrence_price_values)

--- a/spec/modules/product/prices_spec.rb
+++ b/spec/modules/product/prices_spec.rb
@@ -220,8 +220,8 @@ describe Product::Prices do
       context "when product has multiple tiers" do
         let(:recurrence_price_values) do
           [
-            { BasePrice::Recurrence::MONTHLY => { enabled: true, price: 10 } },
-            { BasePrice::Recurrence::MONTHLY => { enabled: true, price: 2 } }
+            { BasePrice::Recurrence::MONTHLY => { enabled: true, price_cents: 1000 } },
+            { BasePrice::Recurrence::MONTHLY => { enabled: true, price_cents: 200 } }
           ]
         end
         let(:product) { create(:membership_product_with_preset_tiered_pricing, recurrence_price_values:) }
@@ -279,8 +279,8 @@ describe Product::Prices do
     it "returns formatted display_price" do
       digital_product = create(:product, price_cents: 5_00)
       recurrence_price_values =             [
-        { BasePrice::Recurrence::MONTHLY => { enabled: true, price: 10 } },
-        { BasePrice::Recurrence::MONTHLY => { enabled: true, price: 2 } }
+        { BasePrice::Recurrence::MONTHLY => { enabled: true, price_cents: 1000 } },
+        { BasePrice::Recurrence::MONTHLY => { enabled: true, price_cents: 200 } }
       ]
       membership_product = create(:membership_product_with_preset_tiered_pricing, recurrence_price_values:)
 
@@ -307,8 +307,8 @@ describe Product::Prices do
     context "for a tiered membership" do
       before :each do
         recurrence_price_values =             [
-          { BasePrice::Recurrence::MONTHLY => { enabled: true, price: 3 }, BasePrice::Recurrence::YEARLY => { enabled: true, price: 30 } },
-          { BasePrice::Recurrence::MONTHLY => { enabled: true, price: 5 }, BasePrice::Recurrence::YEARLY => { enabled: true, price: 50 } }
+          { BasePrice::Recurrence::MONTHLY => { enabled: true, price_cents: 300 }, BasePrice::Recurrence::YEARLY => { enabled: true, price_cents: 3000 } },
+          { BasePrice::Recurrence::MONTHLY => { enabled: true, price_cents: 500 }, BasePrice::Recurrence::YEARLY => { enabled: true, price_cents: 5000 } }
         ]
         @product = create(:membership_product_with_preset_tiered_pricing, recurrence_price_values:, subscription_duration: BasePrice::Recurrence::YEARLY)
       end
@@ -350,7 +350,7 @@ describe Product::Prices do
         context "with a single price" do
           before :each do
             @first_tier = @product.tiers.find_by!(name: "First Tier")
-            @first_tier.save_recurring_prices!({ BasePrice::Recurrence::YEARLY => { enabled: true, price: 2 } })
+            @first_tier.save_recurring_prices!({ BasePrice::Recurrence::YEARLY => { enabled: true, price_cents: 200 } })
             expect(@first_tier.prices.alive.count).to eq 1
           end
 
@@ -491,11 +491,11 @@ describe Product::Prices do
         recurrence_price_values = {
           BasePrice::Recurrence::MONTHLY => {
             enabled: true,
-            price: "5"
+            price_cents: 500
           },
           BasePrice::Recurrence::YEARLY => {
             enabled: true,
-            price: "40"
+            price_cents: 4000
           }
         }
 
@@ -511,11 +511,11 @@ describe Product::Prices do
         recurrence_price_values = {
           BasePrice::Recurrence::MONTHLY => {
             enabled: true,
-            price: "5"
+            price_cents: 500
           },
           BasePrice::Recurrence::QUARTERLY => {
             enabled: true,
-            price: "12"
+            price_cents: 1200
           }
         }
         @subscription_product.save_subscription_prices_and_duration!(recurrence_price_values:,
@@ -530,7 +530,7 @@ describe Product::Prices do
         recurrence_price_values = {
           BasePrice::Recurrence::QUARTERLY => {
             enabled: true,
-            price: "12"
+            price_cents: 1200
           }
         }
 
@@ -544,11 +544,11 @@ describe Product::Prices do
         recurrence_price_values = {
           BasePrice::Recurrence::MONTHLY => {
             enabled: true,
-            price: "5"
+            price_cents: 500
           },
           BasePrice::Recurrence::QUARTERLY => {
             enabled: true,
-            price: ""
+            price_cents: nil
           }
         }
 
@@ -565,11 +565,11 @@ describe Product::Prices do
         recurrence_price_values = {
           BasePrice::Recurrence::MONTHLY => {
             enabled: true,
-            price: "5"
+            price_cents: 500
           },
           BasePrice::Recurrence::QUARTERLY => {
             enabled: true,
-            price: "12"
+            price_cents: 1200
           }
         }
         @subscription_product.save_subscription_prices_and_duration!(recurrence_price_values:,
@@ -585,11 +585,11 @@ describe Product::Prices do
         recurrence_price_values = {
           BasePrice::Recurrence::MONTHLY => {
             enabled: true,
-            price: "5"
+            price_cents: 500
           },
           BasePrice::Recurrence::QUARTERLY => {
             enabled: true,
-            price: "" # Invalid
+            price_cents: nil # Invalid
           }
         }
 
@@ -605,7 +605,7 @@ describe Product::Prices do
         recurrence_price_values = {
           BasePrice::Recurrence::MONTHLY => {
             enabled: true,
-            price: "12"
+            price_cents: 1200
           }
         }
 
@@ -625,13 +625,13 @@ describe Product::Prices do
       @recurrence_price_values = {
         BasePrice::Recurrence::MONTHLY => {
           enabled: true,
-          price: "20",
-          suggested_price: "25"
+          price_cents: 2000,
+          suggested_price_cents: 2500
         },
         BasePrice::Recurrence::YEARLY => {
           enabled: true,
-          price: "99.99",
-          suggested_price: ""
+          price_cents: 9999,
+          suggested_price_cents: nil
         },
         BasePrice::Recurrence::BIANNUALLY => { enabled: false }
       }
@@ -673,13 +673,13 @@ describe Product::Prices do
         updated_recurrence_prices = @recurrence_price_values.merge(
           BasePrice::Recurrence::MONTHLY => {
             enabled: true,
-            price: "25",
-            suggested_price: "30"
+            price_cents: 2500,
+            suggested_price_cents: 3000
           },
           BasePrice::Recurrence::QUARTERLY => {
             enabled: true,
-            price: "70",
-            suggested_price: "75"
+            price_cents: 7000,
+            suggested_price_cents: 7500
           }
         )
 
@@ -698,7 +698,7 @@ describe Product::Prices do
     context "missing price" do
       it "raises an error" do
         invalid_values = @recurrence_price_values
-        invalid_values[BasePrice::Recurrence::MONTHLY].delete(:price)
+        invalid_values[BasePrice::Recurrence::MONTHLY].delete(:price_cents)
 
         expect do
           @product.save_recurring_prices!(invalid_values)

--- a/spec/requests/products/edit/membership_tiers_spec.rb
+++ b/spec/requests/products/edit/membership_tiers_spec.rb
@@ -437,13 +437,11 @@ describe("Product Edit Memberships", type: :feature, js: true) do
               "monthly" => {
                 enabled: true,
                 price_cents: 300,
-                price: "3",
                 suggested_price_cents: nil,
               },
               "quarterly" => {
                 enabled: true,
                 price_cents: 500,
-                price: "5",
                 suggested_price_cents: nil,
               },
               "biannually" => { enabled: false },
@@ -469,7 +467,6 @@ describe("Product Edit Memberships", type: :feature, js: true) do
               "monthly" => {
                 enabled: true,
                 price_cents: 300,
-                price: "3",
                 suggested_price_cents: nil,
               },
               "quarterly" => { enabled: false },
@@ -477,7 +474,6 @@ describe("Product Edit Memberships", type: :feature, js: true) do
               "yearly" => {
                 enabled: true,
                 price_cents: 1300,
-                price: "13",
                 suggested_price_cents: nil,
               },
               "every_two_years" => { enabled: false },
@@ -548,7 +544,6 @@ describe("Product Edit Memberships", type: :feature, js: true) do
                 "monthly" => {
                   enabled: true,
                   price_cents: 300,
-                  price: "3",
                   suggested_price_cents: nil,
                 },
                 "quarterly" => { enabled: false },
@@ -564,9 +559,7 @@ describe("Product Edit Memberships", type: :feature, js: true) do
                 "monthly" => {
                   enabled: true,
                   price_cents: 500,
-                  price: "5",
                   suggested_price_cents: 1000,
-                  suggested_price: "10"
                 },
                 "quarterly" => { enabled: false },
                 "biannually" => { enabled: false },

--- a/spec/requests/purchases/product/offer_codes_tiered_membership_spec.rb
+++ b/spec/requests/purchases/product/offer_codes_tiered_membership_spec.rb
@@ -24,7 +24,7 @@ describe("Offer-code usage from product page for tiered membership", type: :feat
     before do
       tier_category = product.tier_category
       @first_tier = tier_category.variants.first
-      @first_tier.save_recurring_prices!("monthly" => { enabled: true, price: 2 }, "yearly" => { enabled: true, price: 10 })
+      @first_tier.save_recurring_prices!("monthly" => { enabled: true, price_cents: 200 }, "yearly" => { enabled: true, price_cents: 1000 })
       @second_tier = tier_category.variants.last
       @second_tier.mark_deleted
     end

--- a/spec/requests/purchases/product/subscription_purchases_spec.rb
+++ b/spec/requests/purchases/product/subscription_purchases_spec.rb
@@ -25,8 +25,8 @@ describe("Subscription Purchases from the product page", type: :feature, js: tru
 
     context "with multiple recurrences" do
       before do
-        @first_tier.save_recurring_prices!("monthly" => { enabled: true, price: 2 }, "yearly" => { enabled: true, price: 10 })
-        @second_tier.save_recurring_prices!("monthly" => { enabled: true, price: 3 }, "yearly" => { enabled: true, price: 14 })
+        @first_tier.save_recurring_prices!("monthly" => { enabled: true, price_cents: 200 }, "yearly" => { enabled: true, price_cents: 1000 })
+        @second_tier.save_recurring_prices!("monthly" => { enabled: true, price_cents: 300 }, "yearly" => { enabled: true, price_cents: 1400 })
       end
 
       it "allows to switch the recurrence and shows tiers' prices for that recurrence" do
@@ -65,7 +65,7 @@ describe("Subscription Purchases from the product page", type: :feature, js: tru
       context "when a tier has pay-what-you-want enabled" do
         before do
           @second_tier.update!(customizable_price: true)
-          @second_tier.save_recurring_prices!("monthly" => { enabled: true, price: 3, suggested_price: 5 }, "yearly" => { enabled: true, price: 14, suggested_price: 20 })
+          @second_tier.save_recurring_prices!("monthly" => { enabled: true, price_cents: 300, suggested_price_cents: 500 }, "yearly" => { enabled: true, price_cents: 1400, suggested_price_cents: 2000 })
         end
 
         it "reflects PWYW-ability in the price tag of that tier (and that tier only)" do

--- a/spec/shared_examples/with_sorting_and_pagination.rb
+++ b/spec/shared_examples/with_sorting_and_pagination.rb
@@ -127,8 +127,8 @@ RSpec.shared_context "with products and memberships" do |archived: false|
       recurrence_values = BasePrice::Recurrence.all.index_with do |recurrence_key|
         {
           enabled: true,
-          price: "8",
-          suggested_price: "8.5"
+          price_cents: 800,
+          suggested_price_cents: 850
         }
       end
       tier.save_recurring_prices!(recurrence_values)

--- a/spec/support/manage_subscription_helpers.rb
+++ b/spec/support/manage_subscription_helpers.rb
@@ -10,24 +10,24 @@ module ManageSubscriptionHelpers
 
     @product = create(:membership_product_with_preset_tiered_pricing, recommendable ? :recommendable : nil, recurrence_price_values: [
                         {
-                          BasePrice::Recurrence::MONTHLY => { enabled: true, price: 3 },
-                          BasePrice::Recurrence::QUARTERLY => { enabled: true, price: 5.99 },
-                          BasePrice::Recurrence::YEARLY => { enabled: true, price: 10 },
-                          BasePrice::Recurrence::EVERY_TWO_YEARS => { enabled: true, price: 18 },
+                          BasePrice::Recurrence::MONTHLY => { enabled: true, price_cents: 300 },
+                          BasePrice::Recurrence::QUARTERLY => { enabled: true, price_cents: 599 },
+                          BasePrice::Recurrence::YEARLY => { enabled: true, price_cents: 1000 },
+                          BasePrice::Recurrence::EVERY_TWO_YEARS => { enabled: true, price_cents: 1800 },
                         },
                         # more expensive tier
                         {
-                          BasePrice::Recurrence::MONTHLY => { enabled: true, price: 5 },
-                          BasePrice::Recurrence::QUARTERLY => { enabled: true, price: 10.50 },
-                          BasePrice::Recurrence::YEARLY => { enabled: true, price: 20 },
-                          BasePrice::Recurrence::EVERY_TWO_YEARS => { enabled: true, price: 35 },
+                          BasePrice::Recurrence::MONTHLY => { enabled: true, price_cents: 500 },
+                          BasePrice::Recurrence::QUARTERLY => { enabled: true, price_cents: 1050 },
+                          BasePrice::Recurrence::YEARLY => { enabled: true, price_cents: 2000 },
+                          BasePrice::Recurrence::EVERY_TWO_YEARS => { enabled: true, price_cents: 3500 },
                         },
                         # cheaper tier
                         {
-                          BasePrice::Recurrence::MONTHLY => { enabled: true, price: 2.50 },
-                          BasePrice::Recurrence::QUARTERLY => { enabled: true, price: 4 },
-                          BasePrice::Recurrence::YEARLY => { enabled: true, price: 7.75 },
-                          BasePrice::Recurrence::EVERY_TWO_YEARS => { enabled: true, price: 15 },
+                          BasePrice::Recurrence::MONTHLY => { enabled: true, price_cents: 250 },
+                          BasePrice::Recurrence::QUARTERLY => { enabled: true, price_cents: 400 },
+                          BasePrice::Recurrence::YEARLY => { enabled: true, price_cents: 775 },
+                          BasePrice::Recurrence::EVERY_TWO_YEARS => { enabled: true, price_cents: 1500 },
                         },
                       ])
     @monthly_product_price = @product.prices.alive.find_by!(recurrence: BasePrice::Recurrence::MONTHLY)


### PR DESCRIPTION
# Remove legacy price formatting code from recurrence price handling

This PR cleans up deprecated price string formatting code that was left over from the product edit React migration. 

## What changed

• **Models** (`link.rb`, `variant.rb`, `variant_price.rb`) - Removed `price_formatted_without_symbol` methods and string price handling
• **Modules** (`base_price/`, `variant/prices.rb`) - Updated to only accept `price_cents` and `suggested_price_cents` parameters  
• **Services** (`product/*_service.rb`) - Cleaned up TODO comments and legacy price conversion logic
• **Tests** - Updated all assertions to use cents-based values instead of formatted strings

## Why it's safe to remove

The removed code was handling legacy `:price` and `:suggested_price` string parameters that are no longer sent from the frontend. All current price handling goes through `price_cents` and `suggested_price_cents`, so removing the string formatting layer should not break stuff.

We kept the core utility methods like `formatted_dollar_amount` and `string_to_price_cents` since they're still used elsewhere in the codebase for display and other price conversions.

## How we verified

Ran `bundle exec rspec spec/models/` - 
Ran `bundle exec rspec spec/modules/` - 
Ran `bundle exec rspec spec/services/product/` 
Searched codebase for any remaining references to deleted methods

Low confidence in tests because many tests fail due to not having API keys.

The cleanup removes ~100 lines of unused code while maintaining all existing functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Refactor**
  * Updated all price-related fields to use integer values in cents (e.g., `price_cents`, `suggested_price_cents`) instead of string-based dollar amounts throughout the application.
  * Removed support for string-based price keys and related formatting methods.

* **Tests**
  * Updated all test data and expectations to use cents-based price fields.
  * Removed tests related to deprecated string-based price formatting methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->