### PR TITLE
Remove unused methods from User model

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -462,10 +462,6 @@ class User < ApplicationRecord
     currency.upcase
   end
 
-  def debit_card_payout_supported?
-    max_payment_amount_cents < StripePayoutProcessor::DEBIT_CARD_PAYOUT_MAX
-  end
-
   # Public: Get the maximum product price for a user.
   # This is the maximum price that a user can receive in payment for a product.
   # The function returns nil if there is no maximum.
@@ -493,10 +489,6 @@ class User < ApplicationRecord
 
       product.update!(purchasing_power_parity_disabled: should_disable) unless should_disable && product.purchasing_power_parity_disabled?
     end
-  end
-
-  def all_alive_memberships
-    links.alive.not_archived.is_tiered_membership
   end
 
   def save_external_id
@@ -568,10 +560,6 @@ class User < ApplicationRecord
 
   def is_buyer?
     !links.exists? && purchases.successful.exists?
-  end
-
-  def is_creator?
-    !buyer_signup || links.exists?
   end
 
   def is_affiliate?
@@ -802,11 +790,6 @@ class User < ApplicationRecord
 
   def auto_transcode_videos?
     tier_pricing_enabled? ? tier >= TIER_3 : sales_cents_total >= TIER_3
-  end
-
-  def read_attribute_for_validation(attr)
-    return read_attribute(attr) if attr == :username
-    super
   end
 
   def compliance_info_resettable?
@@ -1049,28 +1032,6 @@ class User < ApplicationRecord
       products.find_each do |product|
         product.enqueue_index_update_for(change_list)
       end
-    end
-
-    def products_sorted_by_reviews_count_desc
-      sorted_product_ids = links.select(:id, :unique_permalink, :flags).sort_by do |product|
-        # Consider reviews count of the products as 0 for sorting if they have display_product_reviews? set to false
-        # so that when sorted by reviews count on the user profile page
-        # they show up *after* all the other products for whom ratings are displayed.
-        reviews_count_for_sorting = product.display_product_reviews? ? -product.reviews_count : 0
-        [reviews_count_for_sorting, product.unique_permalink]
-      end.map(&:id)
-      links.ordered_by_ids(sorted_product_ids)
-    end
-
-    def products_sorted_by_average_rating_desc
-      # Consider average rating of the products as 0 for sorting if they have display_product_reviews? set to false
-      # so that when sorted by average rating on the user profile page
-      # they show up *after* all the other products for whom ratings are displayed.
-      sorted_product_ids = links.select(:id, :unique_permalink, :flags).sort_by do |product|
-        average_rating_for_sorting = product.display_product_reviews? ? -product.average_rating : 0
-        [average_rating_for_sorting, product.unique_permalink]
-      end.map(&:id)
-      links.ordered_by_ids(sorted_product_ids)
     end
 
     def make_affiliate_of_the_matching_approved_affiliate_requests


### PR DESCRIPTION
## Remove unused methods from User model

This PR cleans up 6 unused methods from the User model

### **Removed methods**
- **`debit_card_payout_supported?`** - Was checking against StripePayoutProcessor::DEBIT_CARD_PAYOUT_MAX but never actually called anywhere
- **`all_alive_memberships`** - Returned tiered membership products but wasn't being used
- **`is_creator?`** - Logic based on buyer_signup flag and links existence, but redundant since we have other ways to determine this
- **`read_attribute_for_validation`** - Override for username validation that's no longer needed
- **`products_sorted_by_reviews_count_desc`** and **`products_sorted_by_average_rating_desc`** - Private sorting methods that aren't called by any public methods

### **Why this is safe**
Thoroughly searched the entire codebase and found zero references to any of these methods. They appear to be leftover from older functionality that was refactored but the methods weren't cleaned up. 

Verified by running specs. Also no tests were actually testing these deleted methods since they had no test coverage.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed support for certain user role checks and product sorting options related to reviews and ratings. Some membership and payout-related functionalities were also removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->