### PR TITLE
add custom validation back for username attribute in User model to fi…

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -786,6 +786,11 @@ class User < ApplicationRecord
     tier_pricing_enabled? ? tier >= TIER_3 : sales_cents_total >= TIER_3
   end
 
+  def read_attribute_for_validation(attr)
+    return read_attribute(attr) if attr == :username
+    super
+  end
+
   def compliance_info_resettable?
     return true if stripe_account.blank?
     return false if balances.where(merchant_account_id: stripe_account.id).exists?


### PR DESCRIPTION
removed `read_attribute_for_validation(attr)` in #487 which caused some regressions. reverting it back to fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation behavior for usernames to ensure the raw value is used during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->