### PR TITLE
chore: use `action_mailer.preview_paths` instead of deprecated `action_mailer.preview_path`

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -45,7 +45,7 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = false
 
   config.action_mailer.perform_caching = false
-  config.action_mailer.preview_path = "#{Rails.root}/lib/mailer_previews"
+  config.action_mailer.preview_paths << "#{Rails.root}/lib/mailer_previews"
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   config.action_mailer.asset_host = "#{PROTOCOL}://#{DOMAIN}"


### PR DESCRIPTION
`action_mailer.preview_path` is deprecated since Rails 7.1. Ref: https://github.com/rails/rails/pull/31595

This can reduce the following deprecated message.

```
DEPRECATION WARNING: Using preview_path= option is deprecated and will be removed in Rails 7.2. Please use preview_paths= instead.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved configuration for mailer previews in the development environment, allowing support for multiple preview directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->