### PR TITLE
Draft: Adding Billing section for Settings page

### DIFF
--- a/app/controllers/settings/billing_controller.rb
+++ b/app/controllers/settings/billing_controller.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class Settings::BillingController < Sellers::BaseController
+  before_action :authorize
+
+  def show
+    @title = "Billing"
+    @react_component_props = SettingsPresenter.new(pundit_user:).billing_props
+  end
+
+  def update
+    billing_detail = current_seller.billing_detail || current_seller.build_billing_detail
+
+    if billing_detail.update(billing_detail_params)
+      render json: { success: true }
+    else
+      render json: { success: false, error_message: billing_detail.errors.full_messages.to_sentence }
+    end
+  end
+
+  private
+
+  def billing_detail_params
+    params.require(:billing_detail).permit(
+      :full_name,
+      :business_name,
+      :business_id,
+      :street_address,
+      :city,
+      :state,
+      :zip_code,
+      :country_code,
+      :additional_notes
+    )
+  end
+
+  def authorize
+    super([:settings, :billing])
+  end
+end

--- a/app/javascript/components/Settings/Layout.tsx
+++ b/app/javascript/components/Settings/Layout.tsx
@@ -10,6 +10,7 @@ const PAGE_TITLES = {
   profile: "Profile",
   team: "Team",
   payments: "Payments",
+  billing: "Billing",
   authorized_applications: "Applications",
   password: "Password",
   third_party_analytics: "Third-party analytics",

--- a/app/javascript/components/server-components/GenerateInvoicePage.tsx
+++ b/app/javascript/components/server-components/GenerateInvoicePage.tsx
@@ -66,6 +66,14 @@ const GenerateInvoicePage = ({
 
   const [downloadUrl, setDownloadUrl] = React.useState<string | null>(null);
 
+  const euCountries = [
+    "AT", "BE", "BG", "HR", "CY", "CZ", "DK", "EE", "FI", "FR", 
+    "DE", "GR", "HU", "IE", "IT", "LV", "LT", "LU", "MT", "NL", 
+    "PL", "PT", "RO", "SK", "SI", "ES", "SE"
+  ];
+
+  const isEuCountry = euCountries.includes(country.value);
+
   const handleDownload = async () => {
     setFullName((prev) => ({ ...prev, error: !prev.value.length }));
     setStreetAddress((prev) => ({ ...prev, error: !prev.value.length }));
@@ -87,7 +95,7 @@ const GenerateInvoicePage = ({
         email,
         full_name: fullName.value,
         business_name: businessName.value,
-        vat_id: form_info.display_vat_id ? vatId : null,
+        vat_id: (form_info.display_vat_id || isEuCountry) ? vatId : null,
         street_address: streetAddress.value,
         city: city.value,
         state: state.value,
@@ -137,12 +145,20 @@ const GenerateInvoicePage = ({
               onChange={(e) => setBusinessName({ value: e.target.value })}
             />
           </fieldset>
-          {form_info.display_vat_id ? (
+          {(form_info.display_vat_id || isEuCountry) ? (
             <fieldset>
               <legend>
-                <label htmlFor="chargeable_vat_id">{form_info.vat_id_label}</label>
+                <label htmlFor="chargeable_vat_id">
+                  {form_info.display_vat_id ? form_info.vat_id_label : "VAT ID"}
+                </label>
               </legend>
-              <input id="chargeable_vat_id" type="text" value={vatId} onChange={(e) => setVatId(e.target.value)} />
+              <input 
+                id="chargeable_vat_id" 
+                type="text" 
+                placeholder={form_info.display_vat_id ? "" : "VAT ID (optional)"}
+                value={vatId} 
+                onChange={(e) => setVatId(e.target.value)} 
+              />
             </fieldset>
           ) : null}
           <fieldset className={cx({ danger: streetAddress.error })}>
@@ -243,6 +259,11 @@ const GenerateInvoicePage = ({
             {businessName.value.length ? (
               <div>
                 {businessName.value}
+              </div>
+            ) : null}
+            {(form_info.display_vat_id || isEuCountry) && vatId.length ? (
+              <div>
+                VAT ID: {vatId}
               </div>
             ) : null}
             <div style={{ opacity: streetAddress.value.length ? undefined : "var(--disabled-opacity)" }}>

--- a/app/javascript/components/server-components/GenerateInvoicePage.tsx
+++ b/app/javascript/components/server-components/GenerateInvoicePage.tsx
@@ -69,11 +69,15 @@ const GenerateInvoicePage = ({
     setFullName((prev) => ({ ...prev, error: !prev.value.length }));
     setStreetAddress((prev) => ({ ...prev, error: !prev.value.length }));
     setCity((prev) => ({ ...prev, error: !prev.value.length }));
-    setState((prev) => ({ ...prev, error: !prev.value.length }));
+    setState((prev) => ({ ...prev, error: country.value === "US" && !prev.value.length }));
     setZipCode((prev) => ({ ...prev, error: !prev.value.length }));
     setCountry((prev) => ({ ...prev, error: !prev.value.length }));
 
-    if ([fullName, streetAddress, city, state, zipCode, country].some((field) => !field.value.length)) return;
+    const requiredFields = [fullName, streetAddress, city, zipCode, country];
+    if (country.value === "US") {
+      requiredFields.push(state);
+    }
+    if (requiredFields.some((field) => !field.value.length)) return;
 
     setIsLoading(true);
     try {
@@ -139,7 +143,7 @@ const GenerateInvoicePage = ({
               onChange={(e) => setStreetAddress({ value: e.target.value })}
             />
           </fieldset>
-          <div style={{ display: "grid", gap: "var(--spacer-2)", gridTemplateColumns: "2fr 1fr 1fr" }}>
+          <div style={{ display: "grid", gap: "var(--spacer-2)", gridTemplateColumns: country.value === "US" ? "2fr 1fr 1fr" : "1fr 1fr" }}>
             <fieldset className={cx({ danger: city.error })}>
               <label htmlFor="city">City</label>
               <input
@@ -150,16 +154,18 @@ const GenerateInvoicePage = ({
                 onChange={(e) => setCity({ value: e.target.value })}
               />
             </fieldset>
-            <fieldset className={cx({ danger: state.error })}>
-              <label htmlFor="state">State</label>
-              <input
-                id="state"
-                type="text"
-                placeholder="State"
-                value={state.value}
-                onChange={(e) => setState({ value: e.target.value })}
-              />
-            </fieldset>
+            {country.value === "US" ? (
+              <fieldset className={cx({ danger: state.error })}>
+                <label htmlFor="state">State</label>
+                <input
+                  id="state"
+                  type="text"
+                  placeholder="State"
+                  value={state.value}
+                  onChange={(e) => setState({ value: e.target.value })}
+                />
+              </fieldset>
+            ) : null}
             <fieldset className={cx({ danger: zipCode.error })}>
               <label htmlFor="zip_code">ZIP code</label>
               <input
@@ -227,11 +233,13 @@ const GenerateInvoicePage = ({
             </div>
             <div>
               <span style={{ opacity: city.value.length ? undefined : "var(--disabled-opacity)" }}>
-                {`${city.value || "San Francisco"},`}
+                {`${city.value || "San Francisco"}${country.value === "US" ? "," : ""}`}
               </span>{" "}
-              <span style={{ opacity: state.value.length ? undefined : "var(--disabled-opacity)" }}>
-                {state.value || "CA"}
-              </span>{" "}
+              {country.value === "US" ? (
+                <span style={{ opacity: state.value.length ? undefined : "var(--disabled-opacity)" }}>
+                  {state.value || "CA"}
+                </span>
+              ) : null}{" "}
               <span style={{ opacity: zipCode.value.length ? undefined : "var(--disabled-opacity)" }}>
                 {zipCode.value || "94107"}
               </span>

--- a/app/javascript/components/server-components/GenerateInvoicePage.tsx
+++ b/app/javascript/components/server-components/GenerateInvoicePage.tsx
@@ -53,6 +53,7 @@ const GenerateInvoicePage = ({
   const [isLoading, setIsLoading] = React.useState(false);
 
   const [fullName, setFullName] = React.useState<FieldState>({ value: form_info.data.full_name ?? "" });
+  const [businessName, setBusinessName] = React.useState<FieldState>({ value: "" });
   const [vatId, setVatId] = React.useState("");
   const [streetAddress, setStreetAddress] = React.useState<FieldState>({
     value: form_info.data.street_address ?? "",
@@ -85,6 +86,7 @@ const GenerateInvoicePage = ({
         id,
         email,
         full_name: fullName.value,
+        business_name: businessName.value,
         vat_id: form_info.display_vat_id ? vatId : null,
         street_address: streetAddress.value,
         city: city.value,
@@ -123,6 +125,16 @@ const GenerateInvoicePage = ({
               type="text"
               value={fullName.value}
               onChange={(e) => setFullName({ value: e.target.value })}
+            />
+          </fieldset>
+          <fieldset>
+            <label htmlFor="business_name">Business name</label>
+            <input
+              id="business_name"
+              placeholder="Business name (optional)"
+              type="text"
+              value={businessName.value}
+              onChange={(e) => setBusinessName({ value: e.target.value })}
             />
           </fieldset>
           {form_info.display_vat_id ? (
@@ -228,6 +240,11 @@ const GenerateInvoicePage = ({
             <div style={{ opacity: fullName.value.length ? undefined : "var(--disabled-opacity)" }}>
               {fullName.value || "Edgar Gumstein"}
             </div>
+            {businessName.value.length ? (
+              <div>
+                {businessName.value}
+              </div>
+            ) : null}
             <div style={{ opacity: streetAddress.value.length ? undefined : "var(--disabled-opacity)" }}>
               {streetAddress.value || "123 Gum Road"}
             </div>

--- a/app/javascript/components/server-components/GenerateInvoicePage.tsx
+++ b/app/javascript/components/server-components/GenerateInvoicePage.tsx
@@ -270,7 +270,7 @@ const GenerateInvoicePage = ({
           </Button>
         </footer>
       </main>
-      <footer style={{ textAlign: "center", padding: "var(--spacer-4)" }}>
+      <footer style={{ display: "flex", justifyContent: "center", alignItems: "center", gap: "0.5ch", padding: "var(--spacer-4)" }}>
         Powered by <span className="logo-full" />
       </footer>
     </>

--- a/app/javascript/components/server-components/GenerateInvoicePage.tsx
+++ b/app/javascript/components/server-components/GenerateInvoicePage.tsx
@@ -54,7 +54,7 @@ const GenerateInvoicePage = ({
 
   const [fullName, setFullName] = React.useState<FieldState>({ value: form_info.data.full_name ?? "" });
   const [businessName, setBusinessName] = React.useState<FieldState>({ value: "" });
-  const [vatId, setVatId] = React.useState("");
+  const [businessId, setBusinessId] = React.useState("");
   const [streetAddress, setStreetAddress] = React.useState<FieldState>({
     value: form_info.data.street_address ?? "",
   });
@@ -66,13 +66,116 @@ const GenerateInvoicePage = ({
 
   const [downloadUrl, setDownloadUrl] = React.useState<string | null>(null);
 
-  const euCountries = [
-    "AT", "BE", "BG", "HR", "CY", "CZ", "DK", "EE", "FI", "FR", 
-    "DE", "GR", "HU", "IE", "IT", "LV", "LT", "LU", "MT", "NL", 
-    "PL", "PT", "RO", "SK", "SI", "ES", "SE"
+  const businessIdCountries = [
+    // EU countries
+    "AT",
+    "BE",
+    "BG",
+    "HR",
+    "CY",
+    "CZ",
+    "DK",
+    "EE",
+    "FI",
+    "FR",
+    "DE",
+    "GR",
+    "HU",
+    "IE",
+    "IT",
+    "LV",
+    "LT",
+    "LU",
+    "MT",
+    "NL",
+    "PL",
+    "PT",
+    "RO",
+    "SK",
+    "SI",
+    "ES",
+    "SE",
+    // Other European countries
+    "GB",
+    "NO",
+    "CH",
+    "IS",
+    // Commonwealth & English-speaking
+    "CA",
+    "AU",
+    "NZ",
+    "ZA",
+    // Other major economies
+    "JP",
+    "KR",
+    "IN",
+    "BR",
+    "MX",
   ];
 
-  const isEuCountry = euCountries.includes(country.value);
+  const getBusinessIdLabel = (countryCode: string): string => {
+    switch (countryCode) {
+      // EU countries
+      case "AT":
+      case "BE":
+      case "BG":
+      case "HR":
+      case "CY":
+      case "CZ":
+      case "DK":
+      case "EE":
+      case "FI":
+      case "FR":
+      case "DE":
+      case "GR":
+      case "HU":
+      case "IE":
+      case "IT":
+      case "LV":
+      case "LT":
+      case "LU":
+      case "MT":
+      case "NL":
+      case "PL":
+      case "PT":
+      case "RO":
+      case "SK":
+      case "SI":
+      case "ES":
+      case "SE":
+        return "VAT ID";
+      case "GB":
+        return "GB VAT";
+      case "NO":
+        return "MVA";
+      case "CH":
+        return "MWST/TVA";
+      case "IS":
+        return "VSK";
+      case "CA":
+        return "GST/HST";
+      case "AU":
+        return "ABN";
+      case "NZ":
+        return "GST";
+      case "ZA":
+        return "VAT vendor";
+      case "JP":
+        return "Consumption tax";
+      case "KR":
+        return "VAT registration";
+      case "IN":
+        return "GST";
+      case "BR":
+        return "CNPJ";
+      case "MX":
+        return "RFC";
+      default:
+        return "Business ID";
+    }
+  };
+
+  const shouldShowBusinessId = businessIdCountries.includes(country.value);
 
   const handleDownload = async () => {
     setFullName((prev) => ({ ...prev, error: !prev.value.length }));
@@ -95,7 +198,7 @@ const GenerateInvoicePage = ({
         email,
         full_name: fullName.value,
         business_name: businessName.value,
-        vat_id: (form_info.display_vat_id || isEuCountry) ? vatId : null,
+        business_id: form_info.display_vat_id || shouldShowBusinessId ? businessId : null,
         street_address: streetAddress.value,
         city: city.value,
         state: state.value,
@@ -145,19 +248,19 @@ const GenerateInvoicePage = ({
               onChange={(e) => setBusinessName({ value: e.target.value })}
             />
           </fieldset>
-          {(form_info.display_vat_id || isEuCountry) ? (
+          {form_info.display_vat_id || shouldShowBusinessId ? (
             <fieldset>
               <legend>
-                <label htmlFor="chargeable_vat_id">
-                  {form_info.display_vat_id ? form_info.vat_id_label : "VAT ID"}
+                <label htmlFor="chargeable_business_id">
+                  {form_info.display_vat_id ? form_info.vat_id_label : getBusinessIdLabel(country.value)}
                 </label>
               </legend>
-              <input 
-                id="chargeable_vat_id" 
-                type="text" 
-                placeholder={form_info.display_vat_id ? "" : "VAT ID (optional)"}
-                value={vatId} 
-                onChange={(e) => setVatId(e.target.value)} 
+              <input
+                id="chargeable_business_id"
+                type="text"
+                placeholder={form_info.display_vat_id ? "" : `${getBusinessIdLabel(country.value)} (optional)`}
+                value={businessId}
+                onChange={(e) => setBusinessId(e.target.value)}
               />
             </fieldset>
           ) : null}
@@ -171,7 +274,13 @@ const GenerateInvoicePage = ({
               onChange={(e) => setStreetAddress({ value: e.target.value })}
             />
           </fieldset>
-          <div style={{ display: "grid", gap: "var(--spacer-2)", gridTemplateColumns: country.value === "US" ? "2fr 1fr 1fr" : "1fr 1fr" }}>
+          <div
+            style={{
+              display: "grid",
+              gap: "var(--spacer-2)",
+              gridTemplateColumns: country.value === "US" ? "2fr 1fr 1fr" : "1fr 1fr",
+            }}
+          >
             <fieldset className={cx({ danger: city.error })}>
               <label htmlFor="city">City</label>
               <input
@@ -256,14 +365,10 @@ const GenerateInvoicePage = ({
             <div style={{ opacity: fullName.value.length ? undefined : "var(--disabled-opacity)" }}>
               {fullName.value || "Edgar Gumstein"}
             </div>
-            {businessName.value.length ? (
+            {businessName.value.length ? <div>{businessName.value}</div> : null}
+            {(form_info.display_vat_id || shouldShowBusinessId) && businessId.length ? (
               <div>
-                {businessName.value}
-              </div>
-            ) : null}
-            {(form_info.display_vat_id || isEuCountry) && vatId.length ? (
-              <div>
-                VAT ID: {vatId}
+                {getBusinessIdLabel(country.value)}: {businessId}
               </div>
             ) : null}
             <div style={{ opacity: streetAddress.value.length ? undefined : "var(--disabled-opacity)" }}>
@@ -316,7 +421,15 @@ const GenerateInvoicePage = ({
           </Button>
         </footer>
       </main>
-      <footer style={{ display: "flex", justifyContent: "center", alignItems: "center", gap: "0.5ch", padding: "var(--spacer-4)" }}>
+      <footer
+        style={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          gap: "0.5ch",
+          padding: "var(--spacer-4)",
+        }}
+      >
         Powered by <span className="logo-full" />
       </footer>
     </>

--- a/app/javascript/components/server-components/Settings/BillingSettingsPage.tsx
+++ b/app/javascript/components/server-components/Settings/BillingSettingsPage.tsx
@@ -1,0 +1,248 @@
+import * as React from "react";
+import { cast } from "ts-safe-cast";
+
+import { SettingPage } from "$app/parsers/settings";
+import { asyncVoid } from "$app/utils/promise";
+import { request, assertResponseError } from "$app/utils/request";
+
+import { showAlert } from "$app/components/server-components/Alert";
+import { Layout } from "$app/components/Settings/Layout";
+
+type Props = {
+  settings_pages: SettingPage[];
+  is_form_disabled: boolean;
+  billing_detail: {
+    full_name: string | null;
+    business_name: string | null;
+    business_id: string | null;
+    street_address: string | null;
+    city: string | null;
+    state: string | null;
+    zip_code: string | null;
+    country_code: string | null;
+    additional_notes: string | null;
+  };
+  countries: Record<string, string>;
+  states: { code: string; name: string }[];
+};
+
+function BillingSettingsPage(props: Props) {
+  const uid = React.useId();
+  const [isSaving, setIsSaving] = React.useState(false);
+  const [billingDetails, setBillingDetails] = React.useState({
+    full_name: props.billing_detail.full_name || "",
+    business_name: props.billing_detail.business_name || "",
+    business_id: props.billing_detail.business_id || "",
+    street_address: props.billing_detail.street_address || "",
+    city: props.billing_detail.city || "",
+    state: props.billing_detail.state || "",
+    zip_code: props.billing_detail.zip_code || "",
+    country_code: props.billing_detail.country_code || "",
+    additional_notes: props.billing_detail.additional_notes || "",
+  });
+
+  const updateBillingDetails = (details: Partial<typeof billingDetails>) =>
+    setBillingDetails((prev) => ({ ...prev, ...details }));
+
+  const onSave = asyncVoid(async () => {
+    if (props.is_form_disabled) return;
+
+    setIsSaving(true);
+
+    try {
+      const response = await request({
+        url: "/settings/billing",
+        method: "PUT",
+        accept: "json",
+        data: { billing_detail: billingDetails },
+      });
+      const responseData = cast<{ success: true } | { success: false; error_message: string }>(await response.json());
+      if (responseData.success) {
+        showAlert("Your billing details have been updated!", "success");
+      } else {
+        showAlert(responseData.error_message, "error");
+      }
+    } catch (e) {
+      assertResponseError(e);
+      showAlert("Sorry, something went wrong. Please try again.", "error");
+    }
+
+    setIsSaving(false);
+  });
+
+  return (
+    <Layout
+      pages={props.settings_pages}
+      currentPage="billing"
+      onSave={onSave}
+      canUpdate={!props.is_form_disabled && !isSaving}
+    >
+      <section style={{ display: "grid", gridTemplateColumns: "1fr 2fr", gap: "var(--spacer-4)" }}>
+        <div>
+          <h2>Personal information</h2>
+          <div>Enter your full legal name as it appears on official documents.</div>
+        </div>
+        <div>
+          <fieldset>
+            <legend>
+              <label htmlFor={`${uid}-full-name`}>Full name</label>
+            </legend>
+            <input
+              type="text"
+              id={`${uid}-full-name`}
+              value={billingDetails.full_name}
+              onChange={(e) => updateBillingDetails({ full_name: e.target.value })}
+              disabled={props.is_form_disabled}
+              required
+            />
+          </fieldset>
+        </div>
+      </section>
+      <section style={{ display: "grid", gridTemplateColumns: "1fr 2fr", gap: "var(--spacer-4)" }}>
+        <div>
+          <h2>Business information</h2>
+          <div>If you're running a business, provide your business details and tax registration information.</div>
+        </div>
+        <div>
+          <fieldset>
+            <legend>
+              <label htmlFor={`${uid}-business-name`}>Business name</label>
+            </legend>
+            <input
+              type="text"
+              id={`${uid}-business-name`}
+              value={billingDetails.business_name}
+              onChange={(e) => updateBillingDetails({ business_name: e.target.value })}
+              disabled={props.is_form_disabled}
+              placeholder="Optional"
+            />
+          </fieldset>
+          <fieldset>
+            <legend>
+              <label htmlFor={`${uid}-business-id`}>Business ID</label>
+            </legend>
+            <input
+              type="text"
+              id={`${uid}-business-id`}
+              value={billingDetails.business_id}
+              onChange={(e) => updateBillingDetails({ business_id: e.target.value })}
+              disabled={props.is_form_disabled}
+              placeholder="VAT ID, GST number, etc."
+            />
+          </fieldset>
+        </div>
+      </section>
+      <section style={{ display: "grid", gridTemplateColumns: "1fr 2fr", gap: "var(--spacer-4)" }}>
+        <div>
+          <h2>Address</h2>
+          <div>Enter your complete billing address. This information will be used for tax and billing purposes.</div>
+        </div>
+        <div>
+          <fieldset>
+            <legend>
+              <label htmlFor={`${uid}-street-address`}>Street address</label>
+            </legend>
+            <input
+              type="text"
+              id={`${uid}-street-address`}
+              value={billingDetails.street_address}
+              onChange={(e) => updateBillingDetails({ street_address: e.target.value })}
+              disabled={props.is_form_disabled}
+              required
+            />
+          </fieldset>
+          <fieldset>
+            <legend>
+              <label htmlFor={`${uid}-city`}>City</label>
+            </legend>
+            <input
+              type="text"
+              id={`${uid}-city`}
+              value={billingDetails.city}
+              onChange={(e) => updateBillingDetails({ city: e.target.value })}
+              disabled={props.is_form_disabled}
+              required
+            />
+          </fieldset>
+          <fieldset>
+            <legend>
+              <label htmlFor={`${uid}-country`}>Country</label>
+            </legend>
+            <select
+              id={`${uid}-country`}
+              value={billingDetails.country_code}
+              onChange={(e) => updateBillingDetails({ country_code: e.target.value })}
+              disabled={props.is_form_disabled}
+              required
+            >
+              <option value="">Select a country</option>
+              {Object.entries(props.countries).map(([code, name]) => (
+                <option key={code} value={code}>
+                  {name}
+                </option>
+              ))}
+            </select>
+          </fieldset>
+          {billingDetails.country_code === "US" && (
+            <fieldset>
+              <legend>
+                <label htmlFor={`${uid}-state`}>State</label>
+              </legend>
+              <select
+                id={`${uid}-state`}
+                value={billingDetails.state}
+                onChange={(e) => updateBillingDetails({ state: e.target.value })}
+                disabled={props.is_form_disabled}
+                required
+              >
+                <option value="">Select a state</option>
+                {props.states.map((state) => (
+                  <option key={state.code} value={state.code}>
+                    {state.name}
+                  </option>
+                ))}
+              </select>
+            </fieldset>
+          )}
+          <fieldset>
+            <legend>
+              <label htmlFor={`${uid}-zip-code`}>ZIP code</label>
+            </legend>
+            <input
+              type="text"
+              id={`${uid}-zip-code`}
+              value={billingDetails.zip_code}
+              onChange={(e) => updateBillingDetails({ zip_code: e.target.value })}
+              disabled={props.is_form_disabled}
+              required
+            />
+          </fieldset>
+        </div>
+      </section>
+      <section style={{ display: "grid", gridTemplateColumns: "1fr 2fr", gap: "var(--spacer-4)" }}>
+        <div>
+          <h2>Additional information</h2>
+          <div>Include any additional notes or special instructions for your billing details.</div>
+        </div>
+        <div>
+          <fieldset>
+            <legend>
+              <label htmlFor={`${uid}-additional-notes`}>Additional notes</label>
+            </legend>
+            <textarea
+              id={`${uid}-additional-notes`}
+              value={billingDetails.additional_notes}
+              onChange={(e) => updateBillingDetails({ additional_notes: e.target.value })}
+              disabled={props.is_form_disabled}
+              rows={3}
+              placeholder="Optional additional information"
+            />
+            <small>Any additional information for your billing details</small>
+          </fieldset>
+        </div>
+      </section>
+    </Layout>
+  );
+}
+
+export default BillingSettingsPage;

--- a/app/javascript/data/invoice.ts
+++ b/app/javascript/data/invoice.ts
@@ -6,6 +6,7 @@ export const sendInvoice = async ({
   id,
   email,
   full_name,
+  business_name,
   vat_id,
   street_address,
   city,
@@ -17,6 +18,7 @@ export const sendInvoice = async ({
   id: string;
   email: string;
   full_name: string;
+  business_name?: string;
   vat_id: null | string;
   street_address: string;
   city: string;
@@ -33,6 +35,7 @@ export const sendInvoice = async ({
       id,
       email,
       full_name,
+      business_name,
       vat_id,
       street_address,
       city,

--- a/app/javascript/data/invoice.ts
+++ b/app/javascript/data/invoice.ts
@@ -7,7 +7,7 @@ export const sendInvoice = async ({
   email,
   full_name,
   business_name,
-  vat_id,
+  business_id,
   street_address,
   city,
   state,
@@ -19,7 +19,7 @@ export const sendInvoice = async ({
   email: string;
   full_name: string;
   business_name?: string;
-  vat_id: null | string;
+  business_id: null | string;
   street_address: string;
   city: string;
   state: string;
@@ -36,7 +36,7 @@ export const sendInvoice = async ({
       email,
       full_name,
       business_name,
-      vat_id,
+      business_id,
       street_address,
       city,
       state,

--- a/app/javascript/packs/settings.ts
+++ b/app/javascript/packs/settings.ts
@@ -2,10 +2,11 @@ import ReactOnRails from "react-on-rails";
 
 import BasePage from "$app/utils/base_page";
 
+import BillingSettingsPage from "$app/components/server-components/Settings/BillingSettingsPage";
 import MainSettingsPage from "$app/components/server-components/Settings/MainPage";
 import TeamSettingsPage from "$app/components/server-components/Settings/TeamPage";
 import ThirdPartyAnalyticsSettingsPage from "$app/components/server-components/Settings/ThirdPartyAnalyticsPage";
 
 BasePage.initialize();
 
-ReactOnRails.register({ MainSettingsPage, TeamSettingsPage, ThirdPartyAnalyticsSettingsPage });
+ReactOnRails.register({ BillingSettingsPage, MainSettingsPage, TeamSettingsPage, ThirdPartyAnalyticsSettingsPage });

--- a/app/javascript/parsers/settings.ts
+++ b/app/javascript/parsers/settings.ts
@@ -3,6 +3,7 @@ export type SettingPage =
   | "profile"
   | "team"
   | "payments"
+  | "billing"
   | "authorized_applications"
   | "password"
   | "third_party_analytics"

--- a/app/javascript/ssr.ts
+++ b/app/javascript/ssr.ts
@@ -81,6 +81,7 @@ import SecureRedirectPage from "$app/components/server-components/SecureRedirect
 import AdvancedSettingsPage from "$app/components/server-components/Settings/AdvancedPage";
 import ApplicationEditPage from "$app/components/server-components/Settings/AdvancedPage/EditApplicationPage";
 import AuthorizedApplicationsSettingsPage from "$app/components/server-components/Settings/AuthorizedApplicationsPage";
+import BillingSettingsPage from "$app/components/server-components/Settings/BillingSettingsPage";
 import MainSettingsPage from "$app/components/server-components/Settings/MainPage";
 import PasswordSettingsPage from "$app/components/server-components/Settings/PasswordPage";
 import PaymentsSettingsPage from "$app/components/server-components/Settings/PaymentsPage";
@@ -131,6 +132,7 @@ ReactOnRails.register({
   AudiencePage,
   AuthorizedApplicationsSettingsPage,
   BalancePage,
+  BillingSettingsPage,
   BundleEditPage,
   CheckoutPage,
   CollaboratorsPage,

--- a/app/javascript/stylesheets/_stack.scss
+++ b/app/javascript/stylesheets/_stack.scss
@@ -76,7 +76,6 @@
 }
 
 main.stack {
-  height: min-content;
   margin: spacer(4) auto;
   max-width: $main-stack-width;
   width: calc(100% - 2 * #{spacer(4)});

--- a/app/models/billing_detail.rb
+++ b/app/models/billing_detail.rb
@@ -1,0 +1,7 @@
+class BillingDetail < ApplicationRecord
+  belongs_to :purchaser, class_name: "User"
+  
+  validates :full_name, :street_address, :city, :zip_code, :country_code, presence: true
+  validates :state, presence: true, if: -> { country_code == "US" }
+  validates :country_code, length: { is: 2 }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -55,6 +55,7 @@ class User < ApplicationRecord
 
   # Associate with CustomDomain.alive objects
   has_one :custom_domain, -> { alive }
+  has_one :billing_detail, foreign_key: :purchaser_id, dependent: :destroy
 
   has_many :orders, foreign_key: :purchaser_id
   has_many :purchases, foreign_key: :purchaser_id

--- a/app/policies/settings/billing_policy.rb
+++ b/app/policies/settings/billing_policy.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Settings::BillingPolicy < ApplicationPolicy
+  def show?
+    true
+  end
+
+  def update?
+    true
+  end
+end

--- a/app/presenters/settings_presenter.rb
+++ b/app/presenters/settings_presenter.rb
@@ -14,6 +14,7 @@ class SettingsPresenter
     authorized_applications
     password
     third_party_analytics
+    billing
     advanced
   ).freeze
 
@@ -29,7 +30,7 @@ class SettingsPresenter
       case page
       when "main", "payments", "password", "third_party_analytics", "advanced"
         Pundit.policy!(pundit_user, [:settings, page.to_sym, seller]).show?
-      when "profile"
+      when "profile", "billing"
         Pundit.policy!(pundit_user, [:settings, page.to_sym]).show?
       when "team"
         Pundit.policy!(pundit_user, [:settings, :team, seller]).show?
@@ -225,6 +226,28 @@ class SettingsPresenter
       minimum_payout_threshold_cents: seller.minimum_payout_threshold_cents,
       payout_frequency: seller.payout_frequency,
       payout_frequency_daily_supported: seller.instant_payouts_supported?,
+    }
+  end
+
+  def billing_props
+    billing_detail = seller.billing_detail || seller.build_billing_detail
+    
+    {
+      settings_pages: pages,
+      is_form_disabled: !Pundit.policy!(pundit_user, [:settings, :billing]).update?,
+      billing_detail: {
+        full_name: billing_detail.full_name,
+        business_name: billing_detail.business_name,
+        business_id: billing_detail.business_id,
+        street_address: billing_detail.street_address,
+        city: billing_detail.city,
+        state: billing_detail.state,
+        zip_code: billing_detail.zip_code,
+        country_code: billing_detail.country_code,
+        additional_notes: billing_detail.additional_notes,
+      },
+      countries: Compliance::Countries.for_select.to_h,
+      states: states,
     }
   end
 

--- a/app/views/settings/billing/show.html.erb
+++ b/app/views/settings/billing/show.html.erb
@@ -1,0 +1,2 @@
+<%= load_pack("settings") %>
+<%= react_component "BillingSettingsPage", props: @react_component_props, prerender: true %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -445,6 +445,7 @@ Rails.application.routes.draw do
         get :paypal_connect
         post :remove_credit_card
       end
+      resource :billing, only: %i[show update], controller: "billing"
       resource :stripe, controller: :stripe, only: [] do
         collection do
           post :disconnect

--- a/db/migrate/20250629131242_create_billing_details.rb
+++ b/db/migrate/20250629131242_create_billing_details.rb
@@ -1,0 +1,18 @@
+class CreateBillingDetails < ActiveRecord::Migration[7.1]
+  def change
+    create_table :billing_details do |t|
+      t.references :purchaser, null: false, foreign_key: { to_table: :users }
+      t.string :full_name, null: false
+      t.string :business_name
+      t.string :business_id, comment: "Business tax registration ID - can store various types of tax IDs depending on country: VAT ID (EU countries), GST number (Australia, Canada, India), RFC (Mexico), ABN (Australia), CNPJ (Brazil), GB VAT (UK), or other business tax registration numbers"
+      t.string :street_address, null: false
+      t.string :city, null: false
+      t.string :state
+      t.string :zip_code, null: false
+      t.string :country_code, null: false
+      t.text :additional_notes
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_04_25_212934) do
+ActiveRecord::Schema[7.1].define(version: 2025_06_29_131242) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -316,6 +316,22 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_25_212934) do
     t.integer "base_variant_id"
     t.index ["base_variant_id"], name: "index_purchases_variants_on_variant_id"
     t.index ["purchase_id"], name: "index_purchases_variants_on_purchase_id"
+  end
+
+  create_table "billing_details", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "purchaser_id", null: false
+    t.string "full_name", null: false
+    t.string "business_name"
+    t.string "business_id", comment: "Business tax registration ID - can store various types of tax IDs depending on country: VAT ID (EU countries), GST number (Australia, Canada, India), RFC (Mexico), ABN (Australia), CNPJ (Brazil), GB VAT (UK), or other business tax registration numbers"
+    t.string "street_address", null: false
+    t.string "city", null: false
+    t.string "state"
+    t.string "zip_code", null: false
+    t.string "country_code", null: false
+    t.text "additional_notes"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["purchaser_id"], name: "index_billing_details_on_purchaser_id"
   end
 
   create_table "blocked_customer_objects", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -2717,4 +2733,5 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_25_212934) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "billing_details", "users", column: "purchaser_id"
 end

--- a/spec/controllers/settings/billing_controller_spec.rb
+++ b/spec/controllers/settings/billing_controller_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "shared_examples/sellers_base_controller_concern"
+require "shared_examples/authorize_called"
+
+describe Settings::BillingController do
+  it_behaves_like "inherits from Sellers::BaseController"
+
+  let(:seller) { create(:named_seller) }
+
+  before do
+    sign_in seller
+  end
+
+  it_behaves_like "authorize called for controller", Settings::BillingPolicy do
+    let(:record) { :billing }
+  end
+
+  describe "GET show" do
+    include_context "with user signed in as admin for seller"
+
+    let(:pundit_user) { SellerContext.new(user: user_with_role_for_seller, seller:) }
+
+    it "returns http success and assigns correct instance variables" do
+      get :show
+
+      expect(response).to be_successful
+      expect(assigns[:react_component_props]).to eq(SettingsPresenter.new(pundit_user:).billing_props)
+    end
+  end
+
+  describe "PUT update" do
+    let(:billing_detail_params) do
+      {
+        full_name: "John Doe",
+        business_name: "Acme Corp",
+        business_id: "VAT123456",
+        street_address: "123 Main St",
+        city: "New York",
+        state: "NY",
+        zip_code: "10001",
+        country_code: "US",
+        additional_notes: "Test notes"
+      }
+    end
+
+    context "when creating new billing details" do
+      it "creates billing details and returns success" do
+        expect {
+          put :update, params: { billing_detail: billing_detail_params }, format: :json
+        }.to change(BillingDetail, :count).by(1)
+
+        expect(response.parsed_body["success"]).to be(true)
+        
+        billing_detail = seller.reload.billing_detail
+        expect(billing_detail.full_name).to eq("John Doe")
+        expect(billing_detail.business_name).to eq("Acme Corp")
+        expect(billing_detail.street_address).to eq("123 Main St")
+      end
+    end
+
+    context "when updating existing billing details" do
+      let!(:existing_billing_detail) do
+        create(:billing_detail, purchaser: seller, full_name: "Old Name")
+      end
+
+      it "updates existing billing details and returns success" do
+        expect {
+          put :update, params: { billing_detail: billing_detail_params }, format: :json
+        }.not_to change(BillingDetail, :count)
+
+        expect(response.parsed_body["success"]).to be(true)
+        expect(existing_billing_detail.reload.full_name).to eq("John Doe")
+      end
+    end
+
+    context "when validation fails" do
+      let(:invalid_params) do
+        { full_name: "", street_address: "", city: "", zip_code: "", country_code: "" }
+      end
+
+      it "returns error message" do
+        put :update, params: { billing_detail: invalid_params }, format: :json
+
+        expect(response.parsed_body["success"]).to be(false)
+        expect(response.parsed_body["error_message"]).to be_present
+      end
+    end
+  end
+end

--- a/spec/factories/billing_details.rb
+++ b/spec/factories/billing_details.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :billing_detail do
+    association :purchaser, factory: :user
+    full_name { "John Doe" }
+    business_name { "Acme Corporation" }
+    business_id { "VAT123456789" }
+    street_address { "123 Main Street" }
+    city { "New York" }
+    state { "NY" }
+    zip_code { "10001" }
+    country_code { "US" }
+    additional_notes { "Additional billing information" }
+
+    trait :without_business do
+      business_name { nil }
+      business_id { nil }
+    end
+
+    trait :non_us do
+      state { nil }
+      country_code { "CA" }
+      zip_code { "M5V 3A8" }
+      city { "Toronto" }
+    end
+
+    trait :minimal do
+      business_name { nil }
+      business_id { nil }
+      additional_notes { nil }
+    end
+  end
+end

--- a/spec/models/billing_detail_spec.rb
+++ b/spec/models/billing_detail_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+RSpec.describe BillingDetail, type: :model do
+  let(:user) { create(:user) }
+
+  describe "validations" do
+    it "requires all mandatory fields and shows validation errors when only purchaser_id is provided" do
+      billing_detail = BillingDetail.new(purchaser: user)
+      
+      expect(billing_detail).not_to be_valid
+      expect(billing_detail.errors[:full_name]).to include("can't be blank")
+      expect(billing_detail.errors[:street_address]).to include("can't be blank")
+      expect(billing_detail.errors[:city]).to include("can't be blank")
+      expect(billing_detail.errors[:zip_code]).to include("can't be blank")
+      expect(billing_detail.errors[:country_code]).to include("can't be blank")
+    end
+
+    it "successfully saves when all required fields are provided" do
+      billing_detail = BillingDetail.new(
+        purchaser: user,
+        full_name: "John Doe",
+        street_address: "123 Main St",
+        city: "San Francisco",
+        zip_code: "94107",
+        country_code: "US",
+        state: "CA"
+      )
+      
+      expect(billing_detail).to be_valid
+      expect(billing_detail.save).to be true
+    end
+
+    it "requires state when country is US" do
+      billing_detail = BillingDetail.new(
+        purchaser: user,
+        full_name: "John Doe",
+        street_address: "123 Main St",
+        city: "San Francisco",
+        zip_code: "94107",
+        country_code: "US"
+      )
+      
+      expect(billing_detail).not_to be_valid
+      expect(billing_detail.errors[:state]).to include("can't be blank")
+    end
+
+    it "does not require state when country is not US" do
+      billing_detail = BillingDetail.new(
+        purchaser: user,
+        full_name: "John Doe",
+        street_address: "123 Main St",
+        city: "London",
+        zip_code: "SW1A 1AA",
+        country_code: "GB"
+      )
+      
+      expect(billing_detail).to be_valid
+      expect(billing_detail.save).to be true
+    end
+
+    it "validates country_code length" do
+      billing_detail = BillingDetail.new(
+        purchaser: user,
+        full_name: "John Doe",
+        street_address: "123 Main St",
+        city: "San Francisco",
+        zip_code: "94107",
+        country_code: "USA"
+      )
+      
+      expect(billing_detail).not_to be_valid
+      expect(billing_detail.errors[:country_code]).to include("is the wrong length (should be 2 characters)")
+    end
+  end
+end

--- a/spec/policies/settings/billing_policy_spec.rb
+++ b/spec/policies/settings/billing_policy_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Settings::BillingPolicy do
+  subject { described_class }
+
+  let(:user) { create(:user) }
+  let(:seller) { create(:named_seller) }
+
+  permissions :show? do
+    it "grants access to any user" do
+      expect(subject).to permit(SellerContext.new(user:, seller:), nil)
+    end
+  end
+
+  permissions :update? do
+    it "grants access to any user" do
+      expect(subject).to permit(SellerContext.new(user:, seller:), nil)
+    end
+  end
+end


### PR DESCRIPTION
This is a follow-up to the invoicing page improvements — see #423. If that PR is not approved and merged, there's no need to approve this one either.

This PR serves primarily to open a discussion on how a billing page might look and work. Still has code from #423 PR.

## Problem Statement
The main issue for business buyers is that Gumroad doesn't retain billing-related information. As a result, buyers must repeatedly re-enter billing details to generate invoices. The absence of this information also prevents Gumroad from sending invoices automatically once a payment has been made.

## Proposal
This is my first take so far, just to open a discussion on this topic.

But the overall scope for this MR is:
1. Create a `BillingDetails` model that stores all information required to issue an invoice.
2. Build a Settings → Billing page that allows users to enter and store these details.
3. Automatically populate the invoice generation page with this data (if present).

![Screenshot 2025-06-29 at 23-27-34 Billing](https://github.com/user-attachments/assets/5e89ee0c-7b39-4248-9077-32dd47bb7ec8)


## Follow-up improvements
(This is not part of this PR — just a list of potential follow-up work.)

In the next stage of billing-related improvements, it would be nice to:
- Automatically send through email the invoice PDF when a payment occurs. (so buyers can forward those to accounting software/accountant)
- Allow the user to choose how frequently they want to receive invoices (e.g., after every purchase or as a monthly summary).
- Provide a full list of invoices that have previously been generated
