### PR TITLE
Fixed duplicate description sanitization calculation

### DIFF
--- a/app/modules/twitter_cards.rb
+++ b/app/modules/twitter_cards.rb
@@ -5,10 +5,13 @@ module TwitterCards
 
   module_function
 
-  def twitter_product_card(link)
+  def twitter_product_card(link, product_description: nil)
     card = "summary"
     preview = {}
-    description = if link.description.present?
+
+    description = if product_description.present?
+      product_description
+    elsif link.description.present?
       link.plaintext_description
     else
       "Available on Gumroad"

--- a/app/views/layouts/application/_head.html.erb
+++ b/app/views/layouts/application/_head.html.erb
@@ -42,7 +42,7 @@
       <% og_image_alt = "" %>
     <% end %>
     <meta content="<%= FACEBOOK_OG_NAMESPACE %>:product" property="og:type">
-    <%= twitter_product_card(@product).html_safe %>
+    <%= twitter_product_card(@product, product_description:).html_safe %>
     <% @product.display_asset_previews.select { |asset| asset.file.image? }.each do |asset| %>
       <link rel="preload" as="image" href="<%= asset.url %>">
     <% end %>

--- a/spec/modules/twitter_cards_spec.rb
+++ b/spec/modules/twitter_cards_spec.rb
@@ -71,6 +71,18 @@ describe TwitterCards, :vcr do
       metas = TwitterCards.twitter_product_card(link)
       expect(metas).to match(link.main_preview.url)
     end
+
+    it "uses the card description if provided" do
+      link = build(:product, unique_permalink: "abcABC")
+      metas = TwitterCards.twitter_product_card(link, product_description: "This is a test description")
+      expect(metas).to match('<meta property="twitter:description" value="This is a test description"')
+    end
+
+    it "uses the link description if no card description is provided" do
+      link = build(:product, unique_permalink: "abcABC", description: "This is a test description")
+      metas = TwitterCards.twitter_product_card(link)
+      expect(metas).to match('<meta property="twitter:description" value="This is a test description"')
+    end
   end
 
   describe "#twitter_post_card" do


### PR DESCRIPTION
- we can do away with one of the (heavy) sanitization calculations by doing it once and then passing the result around
- this saves around 8% CPU time per page load

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Twitter product card meta tags to prioritize an explicitly provided product description when available.
* **Bug Fixes**
  * Ensured correct description content appears in Twitter product cards based on new precedence rules.
* **Tests**
  * Added tests to verify correct selection of product descriptions in Twitter card meta tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->