### PR TITLE
Scope Tailwild `group/body` to stop bleed-through

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <%= render("layouts/application/head") %>
-  <% bclass = [] %>
+  <% bclass = ["group/body"] %>
   <% bclass.push "mac" if request.headers["User-Agent"]&.include? "Macintosh" %>
   <% bclass.push(@body_class) if @body_class %>
   <% show_nav = !@hide_layouts && user_signed_in? %>

--- a/app/views/layouts/help_center.html.erb
+++ b/app/views/layouts/help_center.html.erb
@@ -19,8 +19,8 @@
 <% content_for :content do %>
   <main>
     <header>
-      <h1 class="group-[.sidebar-nav]:block hidden">Help</h1>
-      <h1 class="group-[.sidebar-nav]:hidden">
+      <h1 class="group-[.sidebar-nav]/body:block hidden">Help</h1>
+      <h1 class="group-[.sidebar-nav]/body:hidden">
         <%= link_to root_path, class: "flex items-center" do %>
           <%= image_tag "logo.svg", alt: "Gumroad", class: "dark:invert h-8" %>
         <% end %>


### PR DESCRIPTION
The `<body>` element used the generic `group` class so that we could flip layout-wide styles when a state class such as `.sidebar-nav` is applied. Because Tailwind treats **any** ancestor with `group` the same, every component that relied on `group-hover`, `group-focus`, etc. also saw the body and sometimes activated unexpectedly.

This was caught and removed in
https://github.com/antiwork/gumroad/pull/349.

Tailwind 3 lets us create **named groups** (`group/<name>`). By changing the body class to `group/body` and updating the variants to `group-[.sidebar-nav]/body:*` we:

* keep the ability to toggle global UI when `.sidebar-nav` is added
* isolate the body state from component-level `group-*` interactions
* make the intent explicit and easier to read in markup
* avoid future collisions with other unnamed groups

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated default CSS classes for the main layout to always include a specific class.
  * Adjusted header element visibility in the Help Center based on refined CSS group variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->