### PR TITLE
Fixed browser theme dependent text on Small Bets page

### DIFF
--- a/app/views/home/small_bets.html.erb
+++ b/app/views/home/small_bets.html.erb
@@ -371,7 +371,7 @@
   <div class="flex flex-col gap-8 max-w-5xl mx-auto lg:items-center">
     <h1 class="font-medium text-center text-4xl sm:text-5xl lg:text-7xl"> Ready to turn that <br> $1 into $1000?</h1>
     <%= render "home/shared/button", text: "Join Small Bets", url: "https://smallbets.com/join" %>
-    <div class="text-lg text-[#7f4874] text-center">
+    <div class="text-lg text-dark-gray text-center">
     Join <span class="font-medium text-black">6,947 amazing people</span> and get immediate access to our support network.
     </div>
   </div>

--- a/app/views/home/small_bets.html.erb
+++ b/app/views/home/small_bets.html.erb
@@ -372,7 +372,7 @@
     <h1 class="font-medium text-center text-4xl sm:text-5xl lg:text-7xl"> Ready to turn that <br> $1 into $1000?</h1>
     <%= render "home/shared/button", text: "Join Small Bets", url: "https://smallbets.com/join" %>
     <div class="text-lg text-dark-gray text-center">
-    Join <span class="font-medium text-black">6,947 amazing people</span> and get immediate access to our support network.
+    Join <span class="font-semibold">6,947 amazing people</span> and get immediate access to our support network.
     </div>
   </div>
 </section>

--- a/app/views/home/small_bets.html.erb
+++ b/app/views/home/small_bets.html.erb
@@ -17,7 +17,7 @@
             variant: "light",
             size: "default" %>
       </div>
-      <div class="text-lg text-[#7f7f7f]">
+      <div class="text-lg text-dark-gray/50">
         Join <span class="font-medium text-black">6,947 amazing people</span> and get
         immediate access <br class="hidden sm:block"> to our support network.
       </div>

--- a/app/views/home/small_bets.html.erb
+++ b/app/views/home/small_bets.html.erb
@@ -17,7 +17,7 @@
             variant: "light",
             size: "default" %>
       </div>
-      <div class="text-lg text-muted">
+      <div class="text-lg text-[#7f7f7f]">
         Join <span class="font-medium text-black">6,947 amazing people</span> and get
         immediate access <br class="hidden sm:block"> to our support network.
       </div>
@@ -371,7 +371,7 @@
   <div class="flex flex-col gap-8 max-w-5xl mx-auto lg:items-center">
     <h1 class="font-medium text-center text-4xl sm:text-5xl lg:text-7xl"> Ready to turn that <br> $1 into $1000?</h1>
     <%= render "home/shared/button", text: "Join Small Bets", url: "https://smallbets.com/join" %>
-    <div class="text-lg text-muted text-center">
+    <div class="text-lg text-[#7f4874] text-center">
     Join <span class="font-medium text-black">6,947 amazing people</span> and get immediate access to our support network.
     </div>
   </div>


### PR DESCRIPTION
# Fixed Small Bets page gray text displayed incorrectly due to how tailwind text-muted works. 

## Bug Description

When the user enters the page https://gumroad.com/small-bets using a browser with darkmode enabled, the gray text on both CTAs gets really light and unreadable.

![obraz](https://github.com/user-attachments/assets/d9ffe994-ad16-455b-ac57-0bb8ca3a8b6d)
![obraz](https://github.com/user-attachments/assets/fba62809-cc3a-421f-a193-2668ff430e45)

## Root Cause Analysis

The text in the original version had a tailwind class "text-muted" assigned to it. Under the hood it applies following styling to the gray text:

`color: rgb(var(--color)/0.5);`

The thing is that --color variable is subject to lightmode darkmode changes on user browsers. Since Gumroad doesn't have a darkmode version, it is safe to just hardcode the color to ensure it works on both themes.

## Changes

Two lines changed in small_bets.html.erb in order to explicitly declare gray text color.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated text color styling for invitation messages on the Small Bets page for improved visual clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->