### PR TITLE
Removed unnecessary S3 request for non-US users

### DIFF
--- a/app/presenters/creator_home_presenter.rb
+++ b/app/presenters/creator_home_presenter.rb
@@ -65,6 +65,8 @@ class CreatorHomePresenter
       end
     end
 
+    previous_year = Time.current.prev_year.year
+
     {
       name: seller.alive_user_compliance_info&.first_name || "",
       has_sale:,
@@ -78,7 +80,7 @@ class CreatorHomePresenter
       sales:,
       activity_items:,
       stripe_verification_message:,
-      show_1099_download_notice: seller.tax_form_1099_download_url(year: Time.current.prev_year.year).present?,
+      show_1099_download_notice: seller.eligible_for_1099?(previous_year) && seller.tax_form_1099_download_url(year: previous_year).present?,
     }
   end
 

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -138,14 +138,24 @@ describe "Dashboard", js: true, type: :feature do
   end
 
   describe "tax form download notice" do
-    it "displays a 1099 form ready notice with a link to download" do
+    it "displays a 1099 form ready notice with a link to download if eligible" do
       download_url = "https://s3.amazonaws.com/gumroad-specs/attachments/23b2d41ac63a40b5afa1a99bf38a0982/original/nyt.pdf"
+      allow_any_instance_of(User).to receive(:eligible_for_1099?).and_return(true)
       allow_any_instance_of(User).to receive(:tax_form_1099_download_url).and_return(download_url)
 
       visit dashboard_path
 
       expect(page).to have_text("Your 1099 tax form for #{Time.current.prev_year.year} is ready!")
       expect(page).to have_link("Click here to download", href: dashboard_download_tax_form_path)
+    end
+
+    it "does not display a 1099 form ready notice if not eligible" do
+      allow_any_instance_of(User).to receive(:eligible_for_1099?).and_return(false)
+
+      visit dashboard_path
+
+      expect(page).not_to have_text("Your 1099 tax form for #{Time.current.prev_year.year} is ready!")
+      expect(page).not_to have_link("Click here to download", href: dashboard_download_tax_form_path)
     end
   end
 end


### PR DESCRIPTION
- we're currently doing an S3 request when loading the dashboard to get the content length of the 1099 form
- this is slow
- if the user is non-US, this form doesn't exist, so the request fails and this isn't cached
- moreover, we don't even need this form for non-US, so we can just check this and do away with the request completely

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The 1099 download notice will now only appear if you are eligible for the 1099 form for the previous year and the form is available for download.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->