### PR TITLE
Auto-top up Stripe test account for E2E tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -148,6 +148,18 @@ RSpec.configure do |config|
     ].each(&:join)
   end
 
+  config.before(:suite) do
+    examples = RSpec.world.filtered_examples.values.flatten
+
+    if examples.any? { |ex| ex.metadata[:type] == :feature }
+      begin
+        StripeBalanceEnforcer.ensure_sufficient_balance
+      rescue StandardError => e
+        warn "Stripe balance check failed: #{e.class} #{e.message}"
+      end
+    end
+  end
+
   config.before(:all) do |example|
     $spec_example_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     print "#{example.class.description}: "

--- a/spec/support/stripe_balance_enforcer.rb
+++ b/spec/support/stripe_balance_enforcer.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require_relative "stripe_charges_helper"
+require_relative "stripe_payment_method_helper"
+
+# Ensures that the Stripe test account has a sufficient balance to run the
+# suite (e.g. instant payout E2E tests).
+class StripeBalanceEnforcer
+  include StripeChargesHelper
+
+  # As of July 2025, running the suite requires a balance of ~$70.
+  DEFAULT_MINIMUM_BALANCE_CENTS = 70_00 * 100
+
+  def self.ensure_sufficient_balance(minimum_balance_cents = DEFAULT_MINIMUM_BALANCE_CENTS)
+    new(minimum_balance_cents).ensure_sufficient_balance
+  end
+
+  def initialize(minimum_balance_cents)
+    @minimum_balance_cents = minimum_balance_cents
+  end
+
+  private_class_method :new
+
+  def ensure_sufficient_balance
+    top_up! if insufficient_balance?
+  end
+
+  private
+
+  attr_reader :minimum_balance_cents
+
+  def insufficient_balance?
+    current_balance_cents < minimum_balance_cents
+  end
+
+  def current_balance_cents
+    balance = Stripe::Balance.retrieve
+    usd_balance = balance.available.find { |b| b["currency"] == "usd" }
+    usd_balance ? usd_balance["amount"] : 0
+  end
+
+  def top_up!
+    available_balance_card = StripePaymentMethodHelper.success_available_balance
+    payment_method_id = available_balance_card.to_stripejs_payment_method_id
+
+    create_stripe_charge(
+      payment_method_id,
+      amount: 999_999_99,
+      currency: "usd",
+      confirm: true
+    )
+  end
+end

--- a/spec/support/stripe_balance_enforcer.rb
+++ b/spec/support/stripe_balance_enforcer.rb
@@ -26,28 +26,27 @@ class StripeBalanceEnforcer
   end
 
   private
+    attr_reader :minimum_balance_cents
 
-  attr_reader :minimum_balance_cents
+    def insufficient_balance?
+      current_balance_cents < minimum_balance_cents
+    end
 
-  def insufficient_balance?
-    current_balance_cents < minimum_balance_cents
-  end
+    def current_balance_cents
+      balance = Stripe::Balance.retrieve
+      usd_balance = balance.available.find { |b| b["currency"] == "usd" }
+      usd_balance ? usd_balance["amount"] : 0
+    end
 
-  def current_balance_cents
-    balance = Stripe::Balance.retrieve
-    usd_balance = balance.available.find { |b| b["currency"] == "usd" }
-    usd_balance ? usd_balance["amount"] : 0
-  end
+    def top_up!
+      available_balance_card = StripePaymentMethodHelper.success_available_balance
+      payment_method_id = available_balance_card.to_stripejs_payment_method_id
 
-  def top_up!
-    available_balance_card = StripePaymentMethodHelper.success_available_balance
-    payment_method_id = available_balance_card.to_stripejs_payment_method_id
-
-    create_stripe_charge(
-      payment_method_id,
-      amount: 999_999_99,
-      currency: "usd",
-      confirm: true
-    )
-  end
+      create_stripe_charge(
+        payment_method_id,
+        amount: 999_999_99,
+        currency: "usd",
+        confirm: true
+      )
+    end
 end

--- a/spec/support/stripe_balance_enforcer.rb
+++ b/spec/support/stripe_balance_enforcer.rb
@@ -8,7 +8,8 @@ require_relative "stripe_payment_method_helper"
 class StripeBalanceEnforcer
   include StripeChargesHelper
 
-  # As of July 2025, running the suite requires a balance of ~$70.
+  # As of July 2025, running the suite requires a balance of ~$70. 100x that as
+  # a buffer should be sufficient for the foreseeable future.
   DEFAULT_MINIMUM_BALANCE_CENTS = 70_00 * 100
 
   def self.ensure_sufficient_balance(minimum_balance_cents = DEFAULT_MINIMUM_BALANCE_CENTS)
@@ -44,6 +45,8 @@ class StripeBalanceEnforcer
 
       create_stripe_charge(
         payment_method_id,
+        # This is the maximum amount that can be charged per transaction. Use
+        # the largest possible value to reduce top up frequency.
         amount: 999_999_99,
         currency: "usd",
         confirm: true


### PR DESCRIPTION
Some E2E specs (e.g. instant payout flows) require the Stripe test account to have sufficient funds.

The StripeBalanceEnforcer automatically tops up the test account balance when running feature specs.

This prevents flaky test failures and reduces manual intervention needed to maintain the test environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated check to ensure the Stripe test account has a sufficient balance before running feature tests. If the balance is low, a top-up is triggered automatically.
  * Warning messages are displayed if any issues occur during the balance check process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->