### PR TITLE
Fix PayPal payment hanging with incomplete form

### DIFF
--- a/app/javascript/components/Checkout/PaymentForm.tsx
+++ b/app/javascript/components/Checkout/PaymentForm.tsx
@@ -874,7 +874,7 @@ const NativePayPal = ({ implementation }: { implementation: PayPalNamespace }) =
     if (state.status.type === "input") payPromise.reject(new Error());
     else payPromise.resolve();
     setPayPromise(null);
-  }, [state.status.type]);
+  }, [state.status.type, payPromise]);
 
   const stateRef = useRefToLatest(state);
 


### PR DESCRIPTION
This was a pain to track down...

I also tried really hard to add a E2E test for this (no such tests exist at the moment), but for some reasons I can't click into the PayPal buttons within the PayPal iframe :( 

Maybe migrating to `react-paypal-js` will help, but likely non-trivial as we will need to test the change carefully to ensure there are no behavior changes before and after.

Related PayPal SDK documentation: https://developer.paypal.com/docs/checkout/standard/customize/validate-user-input/#asynchronous-validation-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of payment status updates in the checkout process, ensuring more accurate handling of payment outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->