### PR TITLE
Fix discover layout Gumroad's logo for light backgrounds

### DIFF
--- a/app/javascript/components/Discover/Layout.tsx
+++ b/app/javascript/components/Discover/Layout.tsx
@@ -12,8 +12,6 @@ import { useDomains } from "$app/components/DomainSettings";
 import { Icon } from "$app/components/Icons";
 import { useIsAboveBreakpoint } from "$app/components/useIsAboveBreakpoint";
 
-import logo from "$assets/images/logo.svg";
-
 const UserActionButtons: React.FC = () => {
   const currentSeller = useCurrentSeller();
 
@@ -138,9 +136,11 @@ export const Layout: React.FC<{
   const userActionButtons = <UserActionButtons />;
 
   const logoLink = (
-    <a href={Routes.discover_path()} className="flex flex-shrink-0 items-center">
-      <img src={logo} alt="Gumroad" className="h-7 md:h-8 dark:invert" />
-    </a>
+    <a
+      href={Routes.discover_path()}
+      className="logo-full flex aspect-[157/22] !w-[245px] flex-shrink-0 items-center"
+      aria-label="Gumroad"
+    />
   );
   const searchBar = (
     <div className="min-w-0 flex-grow">


### PR DESCRIPTION
We added `dark:invert` in [this PR](https://github.com/antiwork/gumroad/pull/222) which led to making Gumroad logo not visible on white background.

### Screenshot
#### Before (Notice how its still inverted even for white background making it invisible)
![image](https://github.com/user-attachments/assets/c85dd0a8-0eaf-455f-9e67-60f40512e1f4)
![image](https://github.com/user-attachments/assets/076194b7-667d-40d6-92f8-8f26b8afbbc5)

#### After
![image](https://github.com/user-attachments/assets/d30de754-b601-4ae0-9e8f-3d6d7d72de94)
![image](https://github.com/user-attachments/assets/ad5b2796-b024-41c9-8bed-c4a39e7f898e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the logo area in the Discover layout for improved styling and accessibility, replacing the image with a styled anchor element featuring enhanced CSS classes and an aria-label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->