### PR TITLE
Remove cached_alive_product_files in favor of Rails' association cache

### DIFF
--- a/app/modules/with_product_files.rb
+++ b/app/modules/with_product_files.rb
@@ -5,18 +5,10 @@ module WithProductFiles
     base.class_eval do
       has_many :product_files
       has_many :product_files_archives
+      has_many :alive_product_files, -> { alive.in_order }, class_name: "ProductFile"
       has_many :product_folders, -> { alive }, foreign_key: :product_id
-      attr_accessor :cached_alive_product_files, :cached_rich_content_files_and_folders
+      attr_accessor :cached_rich_content_files_and_folders
     end
-  end
-
-  # Public: Returns a potentially cached list of alive files associated with the product.
-  #
-  # Retrieving the list of files from the same Link object happens often within certain controller actions.
-  # Use this method in order to hit the db once and cache the results on the Link object and reuse them later.
-  # Call this method only if you're sure that you're not changing the files within the same action.
-  def alive_product_files
-    cached_alive_product_files || self.cached_alive_product_files = product_files.alive.in_order.to_a
   end
 
   def has_files?
@@ -72,7 +64,7 @@ module WithProductFiles
     end
 
     (existing_files - files_to_keep).each(&:mark_deleted)
-    self.cached_alive_product_files = nil
+    alive_product_files.reset
     generate_entity_archive! if is_a?(Installment) && needs_updated_entity_archive?
 
     link.content_updated_at = Time.current if new_product_files.any?(&:link_id?)

--- a/app/modules/with_product_files_many_to_many.rb
+++ b/app/modules/with_product_files_many_to_many.rb
@@ -9,5 +9,6 @@ module WithProductFilesManyToMany
   included do
     include WithProductFiles
     has_and_belongs_to_many :product_files
+    has_and_belongs_to_many :alive_product_files, -> { alive.in_order }, class_name: "ProductFile"
   end
 end

--- a/app/presenters/paginated_installments_presenter.rb
+++ b/app/presenters/paginated_installments_presenter.rb
@@ -17,7 +17,7 @@ class PaginatedInstallmentsPresenter
 
   def props
     if query.blank?
-      installments = Installment.includes(:installment_rule).all
+      installments = Installment.includes(:installment_rule, :alive_product_files).all
       installments = installments.ordered_updates(seller, type).public_send(type)
       installments = installments.unscope(:order).order("installment_rules.to_be_published_at ASC") if type == Installment::SCHEDULED
       pagination, installments = pagy(installments, page:, limit: PER_PAGE, overflow: :empty_page)
@@ -36,7 +36,7 @@ class PaginatedInstallmentsPresenter
         sort: [:_score, { created_at: :desc }, { id: :desc }]
       }
       es_search = InstallmentSearchService.search(search_options)
-      installments = es_search.records.load
+      installments = es_search.records.includes(:alive_product_files).load
       can_paginate_further = es_search.results.total > (offset + PER_PAGE)
       pagiation_metadata = { count: es_search.results.total, next: can_paginate_further ? page + 1 : nil }
     end

--- a/spec/requests/products/dropbox_spec.rb
+++ b/spec/requests/products/dropbox_spec.rb
@@ -29,8 +29,7 @@ describe "Dropbox uploads", type: :feature, js: true do
     sleep 0.5 # wait for the editor to update the content
     save_change
     expect(product.reload.alive_product_files.count).to eq 2
-    expect(product.alive_product_files.first.display_name).to eq("Download-Card")
-    expect(product.alive_product_files.last.display_name).to eq("SmallTestFile")
+    expect(product.alive_product_files.map(&:display_name)).to eq(%w(Download-Card SmallTestFile))
     expect(product.alive_rich_contents.sole.description).to match_array([
                                                                           { "type" => "fileEmbed", "attrs" => { "id" => product.alive_product_files.first.external_id, "uid" => anything, "collapsed" => false } },
                                                                           { "type" => "fileEmbed", "attrs" => { "id" => product.alive_product_files.last.external_id, "uid" => anything, "collapsed" => false } },


### PR DESCRIPTION
Rails already caches the ActiveModel associations on the same object.

Furthermore we can leverage `includes` preloading to remove a N+1 (e.g. on the email-related pages in this case).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized loading of product files by leveraging built-in association caching and eager loading, resulting in more efficient access to alive product files.

* **Tests**
  * Simplified test assertions for verifying the display names of uploaded product files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->