### PR TITLE
Gumroad logo href should go to Gumroad's discover 

### DIFF
--- a/app/javascript/components/Discover/Layout.tsx
+++ b/app/javascript/components/Discover/Layout.tsx
@@ -137,7 +137,7 @@ export const Layout: React.FC<{
 
   const logoLink = (
     <a
-      href={Routes.discover_path()}
+      href={Routes.discover_url({ host: discoverDomain })}
       className="logo-full flex aspect-[157/22] !w-[245px] flex-shrink-0 items-center"
       aria-label="Gumroad"
     />

--- a/spec/requests/discover/discover_domain_spec.rb
+++ b/spec/requests/discover/discover_domain_spec.rb
@@ -61,8 +61,6 @@ describe "DiscoverDomainScenario", type: :feature, js: true do
       end
 
       wait_for_ajax
-      expect(page).to have_css(%{a.logo-full[aria-label="Gumroad"][href="https://#{@discover_domain}:#{@port}/discover"]})
-      expect(page).not_to have_css(%{a.logo-full[aria-label="Gumroad"][href="https://#{@product1.user.username}.gumroad.com:#{@port}/discover"]})
       expect do
         add_to_cart(@product1, cart: true)
         check_out(@product1, credit_card: { number: "4000002500003155" }, sca: true)

--- a/spec/requests/discover/discover_domain_spec.rb
+++ b/spec/requests/discover/discover_domain_spec.rb
@@ -61,6 +61,8 @@ describe "DiscoverDomainScenario", type: :feature, js: true do
       end
 
       wait_for_ajax
+      expect(page).to have_css('a.logo-full[aria-label="Gumroad"][href="https://test.gumroad.com:31337/discover"]')
+      expect(page).not_to have_css(%{a.logo-full[aria-label="Gumroad"][href="https://#{@product1.user.username}.gumroad.com:31337/discover"]})
       expect do
         add_to_cart(@product1, cart: true)
         check_out(@product1, credit_card: { number: "4000002500003155" }, sca: true)

--- a/spec/requests/discover/discover_domain_spec.rb
+++ b/spec/requests/discover/discover_domain_spec.rb
@@ -61,8 +61,8 @@ describe "DiscoverDomainScenario", type: :feature, js: true do
       end
 
       wait_for_ajax
-      expect(page).to have_css('a.logo-full[aria-label="Gumroad"][href="https://test.gumroad.com:31337/discover"]')
-      expect(page).not_to have_css(%{a.logo-full[aria-label="Gumroad"][href="https://#{@product1.user.username}.gumroad.com:31337/discover"]})
+      expect(page).to have_css(%{a.logo-full[aria-label="Gumroad"][href="https://#{@discover_domain}:#{@port}/discover"]})
+      expect(page).not_to have_css(%{a.logo-full[aria-label="Gumroad"][href="https://#{@product1.user.username}.gumroad.com:#{@port}/discover"]})
       expect do
         add_to_cart(@product1, cart: true)
         check_out(@product1, credit_card: { number: "4000002500003155" }, sca: true)


### PR DESCRIPTION
### Problem
When you click on Gumroad's logo on a discover page of custom seller, it takes you to a non existing page.

### Fix
Modified it to redirect to Gumroad's discover page to increase exposure of other products and hence increase revenue.

### Screenshots
#### Before
![image](https://github.com/user-attachments/assets/d3eb2efa-cb4c-4fa2-b530-5f5d1436db3a)

#### After
![image](https://github.com/user-attachments/assets/1c88b57d-60d8-4b23-95c5-c57620a723f4)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the logo link in the Discover layout to direct users to a full URL with a specified domain, instead of a relative path.  
* **Tests**
  * Enhanced tests to verify correct branding link URLs during the purchase flow on the Discover domain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->