### PR TITLE
Feat: Add dynamic weekly creator income

### DIFF
--- a/app/views/home/about.html.erb
+++ b/app/views/home/about.html.erb
@@ -213,7 +213,8 @@
   <div class="relative bg-gray w-full">
     <div class="flex flex-col justify-center gap-8 px-8 text-center py-20 md:items-center md:gap-16 md:pt-40">
       <h1 class="text-left md:text-center text-7xl sm:text-7xl md:text-9xl lg:text-[12rem] md:leading-[0.9] font-medium">
-        $3,129,297
+        <% prev_week_payout = $redis.get(RedisKey.prev_week_payout_usd) || "3129297" %>
+        $<%= number_with_delimiter(prev_week_payout) %>
       </h1>
       <div class="text-left md:text-center text-2xl md:text-3xl max-w-screen-sm">
         The amount of income earned by Gumroad digital entrepreneurs last week.


### PR DESCRIPTION
# Display dynamic weekly earnings on /about page

Replace hardcoded $3,129,297 with actual weekly earnings data from Redis.

## Changes:
- Update about page to pull weekly earnings from `RedisKey.prev_week_payout_usd`
- Falls back to previous hardcoded value if Redis key is empty
- Uses existing `CalculatePayoutNumbersWorker` that runs 3x weekly to keep data current

## Technical details:
- Leverages existing scheduled job (runs Mon/Tue/Wed at 08:05 UTC)
- Calculates earnings for previous calendar week in America/Los_Angeles timezone
- Includes successful purchases, excludes refunds/chargebacks/bundles
- Maintains same formatting with `number_with_delimiter`

The /about page now shows real-time weekly earnings instead of a static placeholder value.