### PR TITLE
Fix Discover link on Discover-layout product pages

### DIFF
--- a/app/javascript/components/Discover/Layout.tsx
+++ b/app/javascript/components/Discover/Layout.tsx
@@ -137,7 +137,7 @@ export const Layout: React.FC<{
 
   const logoLink = (
     <a
-      href={Routes.discover_path()}
+      href={Routes.discover_url({ host: discoverDomain })}
       className="logo-full flex aspect-[157/22] !w-[245px] flex-shrink-0 items-center"
       aria-label="Gumroad"
     />

--- a/spec/requests/discover/discover_spec.rb
+++ b/spec/requests/discover/discover_spec.rb
@@ -372,6 +372,10 @@ describe("Discover", js: true, type: :feature) do
     find_product_card(product).click
     expect(page).to have_current_path(/^\/l\/#{product.unique_permalink}\?layout=discover&recommended_by=search/)
     expect(page).to have_link("Sam Smith", href: "http://sam.test.gumroad.com:31337/?recommended_by=search")
+
+    # Clicking the logo should take you back to Discover home page.
+    click_on "Gumroad"
+    expect(page).to have_text("On the market")
   end
 
   it "displays thumbnail in preview if available" do


### PR DESCRIPTION
The logo link in the Discover layout was using a relative path which breaks when accessed from custom domains (e.g. Discover-layout product pages).

Originally proposed via https://github.com/antiwork/gumroad/pull/566.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the logo link in the Discover layout to direct users to the correct home page URL.

* **Tests**
  * Added a test to verify that clicking the logo on the product detail page correctly returns users to the Discover home page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->