### PR TITLE
feat(payouts): display error message to seller when payout fails

### DIFF
--- a/app/helpers/payouts_helper.rb
+++ b/app/helpers/payouts_helper.rb
@@ -183,10 +183,9 @@ module PayoutsHelper
   end
 
   private
-
   def get_payout_note(user)
     # First, check for recent failed payments (within last 30 days)
-    recent_failed_payment = user.payments.failed.displayable.where('created_at > ?', 30.days.ago).order(created_at: :desc).first
+    recent_failed_payment = user.payments.failed.displayable.where("created_at > ?", 30.days.ago).order(created_at: :desc).first
     last_successful_payment = user.payments.completed_or_processing.last
 
     if recent_failed_payment.present? &&
@@ -198,7 +197,7 @@ module PayoutsHelper
       if failure_reason.present?
         # Format the reason text to be user-friendly
         if recent_failed_payment.processor == PayoutProcessorType::PAYPAL
-          reason_text = failure_reason.split(': ').last || failure_reason
+          reason_text = failure_reason.split(": ").last || failure_reason
         else
           reason_text = failure_reason
         end

--- a/app/helpers/payouts_helper.rb
+++ b/app/helpers/payouts_helper.rb
@@ -197,7 +197,7 @@ module PayoutsHelper
       if failure_reason.present?
         # Format the reason text to be user-friendly
         if recent_failed_payment.processor == PayoutProcessorType::PAYPAL
-          reason_text = failure_reason.split(": ").last || failure_reason
+          reason_text = failure_reason.split(": ").last
         else
           reason_text = failure_reason
         end

--- a/app/helpers/payouts_helper.rb
+++ b/app/helpers/payouts_helper.rb
@@ -68,13 +68,7 @@ module PayoutsHelper
       payout_period_data[:status] = "not_payable"
     end
 
-    last_payout_note = user.comments.with_type_payout_note.where(author_id: GUMROAD_ADMIN_ID).where.not("content like 'Payout via PayPal%'").last
-    payout_period_data[:payout_note] = \
-      if last_payout_note.present? && last_payout_note.created_at.to_i > user.payments.completed_or_processing.last&.created_at.to_i
-        last_payout_note.content.gsub("via Stripe ", "")
-      else
-        nil
-      end
+    payout_period_data[:payout_note] = get_payout_note(user)
 
     payout_period_data
   end
@@ -185,6 +179,43 @@ module PayoutsHelper
           { payout_method_type: "none" }
         end
       end
+    end
+  end
+
+  private
+
+  def get_payout_note(user)
+    # First, check for recent failed payments (within last 30 days)
+    recent_failed_payment = user.payments.failed.displayable.where('created_at > ?', 30.days.ago).order(created_at: :desc).first
+    last_successful_payment = user.payments.completed_or_processing.last
+
+    if recent_failed_payment.present? &&
+       (last_successful_payment.nil? || recent_failed_payment.created_at > last_successful_payment.created_at)
+
+      # Get the failure reason
+      failure_reason = recent_failed_payment.humanized_failure_reason
+
+      if failure_reason.present?
+        # Format the reason text to be user-friendly
+        if recent_failed_payment.processor == PayoutProcessorType::PAYPAL
+          reason_text = failure_reason.split(': ').last || failure_reason
+        else
+          reason_text = failure_reason
+        end
+
+        return "A recent payment attempt failed due to #{reason_text.downcase}. The balance has been carried over and will be included in your next payout."
+      else
+        return "A recent payment attempt failed. The balance has been carried over and will be included in your next payout."
+      end
+    end
+
+    # If no recent failed payment, check for payout notes
+    last_payout_note = user.comments.with_type_payout_note.where(author_id: GUMROAD_ADMIN_ID).where.not("content like 'Payout via PayPal%'").last
+
+    if last_payout_note.present? && last_payout_note.created_at.to_i > (last_successful_payment&.created_at.to_i || 0)
+      last_payout_note.content.gsub("via Stripe ", "")
+    else
+      nil
     end
   end
 end

--- a/spec/helpers/payouts_helper_spec.rb
+++ b/spec/helpers/payouts_helper_spec.rb
@@ -361,4 +361,71 @@ describe PayoutsHelper do
       end
     end
   end
+
+  describe "get_payout_note" do
+    let(:user) { create(:singaporean_user_with_compliance_info) }
+
+    it "returns failed payment message when recent payment failed" do
+      failed_payment = create(:payment_failed, user:, failure_reason: "insufficient_funds", created_at: 1.day.ago)
+
+      result = helper.send(:get_payout_note, user)
+
+      expect(result).to eq("A recent payment attempt failed due to insufficient_funds. The balance has been carried over and will be included in your next payout.")
+    end
+
+    it "returns failed payment message for PayPal with formatted reason" do
+      failed_payment = create(:payment_failed, user:, processor: PayoutProcessorType::PAYPAL, failure_reason: "PAYPAL 1002: Sender has insufficient funds", created_at: 1.day.ago)
+
+      result = helper.send(:get_payout_note, user)
+
+      expect(result).to eq("A recent payment attempt failed due to sender has insufficient funds. The balance has been carried over and will be included in your next payout.")
+    end
+
+    it "returns failed payment message for PayPal with malformed reason" do
+      failed_payment = create(:payment_failed, user:, processor: PayoutProcessorType::PAYPAL, failure_reason: "PAYPAL 1002", created_at: 1.day.ago)
+
+      result = helper.send(:get_payout_note, user)
+
+      expect(result).to eq("A recent payment attempt failed due to paypal 1002. The balance has been carried over and will be included in your next payout.")
+    end
+
+    it "returns generic failed payment message when no specific reason" do
+      failed_payment = create(:payment_failed, user:, failure_reason: nil, created_at: 1.day.ago)
+
+      result = helper.send(:get_payout_note, user)
+
+      expect(result).to eq("A recent payment attempt failed. The balance has been carried over and will be included in your next payout.")
+    end
+
+    it "returns payout note when no recent failed payment" do
+      user.add_payout_note(content: "Payout skipped because account balance was too low")
+
+      result = helper.send(:get_payout_note, user)
+
+      expect(result).to eq("Payout skipped because account balance was too low")
+    end
+
+    it "returns nil when failed payment is too old" do
+      failed_payment = create(:payment_failed, user:, failure_reason: "insufficient_funds", created_at: 31.days.ago)
+
+      result = helper.send(:get_payout_note, user)
+
+      expect(result).to be_nil
+    end
+
+    it "returns nil when no failed payment and no payout note" do
+      result = helper.send(:get_payout_note, user)
+
+      expect(result).to be_nil
+    end
+
+    it "prefers failed payment message over payout note" do
+      user.add_payout_note(content: "Payout skipped because account balance was too low")
+      failed_payment = create(:payment_failed, user:, failure_reason: "insufficient_funds", created_at: 1.day.ago)
+
+      result = helper.send(:get_payout_note, user)
+
+      expect(result).to eq("A recent payment attempt failed due to insufficient_funds. The balance has been carried over and will be included in your next payout.")
+    end
+  end
 end


### PR DESCRIPTION
## Summary
Implements feature #568 to display error messages to sellers when payouts fail.

## Changes
- Added `get_payout_note` method to PayoutsHelper that checks for recent failed payments
- Display user-friendly failure messages with specific reasons when available
- Show message: "A recent payment attempt failed due to `<reason>`. The balance has been carried over and will be included in your next payout."
- Only show failures from last 30 days that are more recent than last successful payment
- Handle both PayPal and Stripe failure reasons appropriately
- Added comprehensive test coverage for all failure scenarios
- Integrate seamlessly with existing payout note display system

## Testing
- ✅ Added 8 test cases covering all failure scenarios
- ✅ Tests cover PayPal/Stripe differences, old failures, missing reasons, etc.
- ✅ Follows existing test patterns and guidelines
- ✅ Uses proper factory methods and descriptive test names

## Implementation Details
- Messages automatically appear on `/payouts` page in existing payout note section
- No frontend changes required - uses existing UI infrastructure
- Graceful fallback to existing payout notes when no recent failures
- Time-limited to recent failures (30 days) to avoid showing stale messages

Fixes #568

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced payout note display to prioritize recent failed payments with clearer, user-friendly messages tailored to different failure scenarios.

* **Tests**
  * Added comprehensive tests to verify accurate payout note messages across various payment failure cases and user notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->