### PR TITLE
Display error message to the seller when a payout fails

### DIFF
--- a/app/controllers/balance_controller.rb
+++ b/app/controllers/balance_controller.rb
@@ -43,7 +43,7 @@ class BalanceController < Sellers::BaseController
 
     def fetch_payouts
       payouts = current_seller.payments
-        .completed
+        .completed_or_failed
         .displayable
         .order(created_at: :desc)
 

--- a/app/helpers/payouts_helper.rb
+++ b/app/helpers/payouts_helper.rb
@@ -109,7 +109,7 @@ module PayoutsHelper
     payout_period_data[:status] = payment.state
     payout_period_data[:payment_external_id] = payment.external_id
     payout_period_data[:type] = payment.payout_type || Payouts::PAYOUT_TYPE_STANDARD
-
+    payout_period_data[:displayable_failure_reason] = payment.displayable_failure_reason
     payout_period_data[:payout_note] = nil
 
     balance_ids = payment.balances.map(&:id)

--- a/app/javascript/components/server-components/BalancePage.tsx
+++ b/app/javascript/components/server-components/BalancePage.tsx
@@ -181,12 +181,12 @@ type CurrentPayoutsDataWithUserNotPayable = {
   has_stripe_connect: boolean;
 };
 
-type CurrentPayoutStatus = "paused" | "payable" | "processing" | "completed";
+type CurrentPayoutStatus = "paused" | "payable" | "processing" | "completed" | "failed";
 type PayoutType = "standard" | "instant";
 
 type CurrentPeriodPayoutData = (
   | { status: "processing"; payment_external_id: string; arrival_date: string | null; type: PayoutType }
-  | { status: Exclude<CurrentPayoutStatus, "processing" | "completed"> }
+  | { status: Exclude<CurrentPayoutStatus, "processing" | "completed" | "failed"> }
 ) & {
   has_stripe_connect: boolean;
   should_be_shown_currencies_always: boolean;
@@ -214,7 +214,7 @@ type CurrentPeriodPayoutData = (
 };
 
 type PastPeriodPayoutsData = {
-  status: "completed";
+  status: "completed" | "failed";
   should_be_shown_currencies_always: boolean;
   displayable_payout_period_range: string;
   payout_currency: string;
@@ -289,6 +289,8 @@ const Period = ({ payoutPeriodData }: { payoutPeriodData: PayoutPeriodData }) =>
         return `Next payout: ${payoutDateFormatted}`;
       case "paused":
         return "Next payout: paused";
+      case "failed":
+        return "Failed";
       case "completed":
         return payoutDateFormatted;
     }
@@ -305,7 +307,7 @@ const Period = ({ payoutPeriodData }: { payoutPeriodData: PayoutPeriodData }) =>
           gap: "var(--spacer-4)",
         }}
       >
-        {payoutPeriodData.status === "completed" ? <span>{heading}</span> : <h2>{heading}</h2>}
+        {payoutPeriodData.status === "completed" ? <span>{heading}</span> : <h3>{heading}</h3>}
         {"type" in payoutPeriodData && payoutPeriodData.type === "instant" ? (
           <div className="pill small">Instant</div>
         ) : null}
@@ -323,6 +325,11 @@ const Period = ({ payoutPeriodData }: { payoutPeriodData: PayoutPeriodData }) =>
           </WithTooltip>
         ) : null}
       </div>
+      {payoutPeriodData.status === "failed" ? (
+        <div className="text-gray-500 italic">
+          This failed payout's balance is being carried over to your next payout.
+        </div>
+      ) : null}
       <div className="stack" style={{ marginTop: "var(--spacer-4)" }}>
         <div>
           <h4>Sales</h4>

--- a/app/javascript/components/server-components/BalancePage.tsx
+++ b/app/javascript/components/server-components/BalancePage.tsx
@@ -240,6 +240,7 @@ type PastPeriodPayoutsData = {
   stripe_connect_payout_cents: number;
   loan_repayment_cents: number;
   type: PayoutType;
+  displayable_failure_reason: string | null;
 };
 
 // TODO: move BankAccount|PaypalAccount out of CurrentPayoutsDataAndPaymentMethodWithUserPayable
@@ -251,6 +252,30 @@ export type PastPayoutsDataAndPaymentMethod = PastPeriodPayoutsData &
   (LegacyNotAvailableAccount | BankAccount | PaypalAccount | StripeConnectAccount);
 
 type PayoutPeriodData = CurrentPayoutsDataAndPaymentMethodWithUserPayable | PastPayoutsDataAndPaymentMethod;
+
+const PayoutPeriodHeading = ({ payoutPeriodData }: { payoutPeriodData: PayoutPeriodData }) => {
+  const message = React.useMemo(() => {
+    switch (payoutPeriodData.status) {
+      case "processing":
+        return `Processing`;
+      case "payable":
+        return `Scheduled`;
+      case "paused":
+        return "Paused";
+      case "failed":
+        return "Failed";
+      case "completed":
+        return `Paid on ${payoutPeriodData.arrival_date}`;
+    }
+  }, [payoutPeriodData]);
+
+  return (
+    <div className="flex gap-1">
+      <h3>{payoutPeriodData.payout_date_formatted}</h3>
+      <div className="rounded border border-black bg-white p-1 text-[12px] font-normal leading-[120%]">{message}</div>
+    </div>
+  );
+};
 const Period = ({ payoutPeriodData }: { payoutPeriodData: PayoutPeriodData }) => {
   const { should_be_shown_currencies_always: showUSDSuffix } = payoutPeriodData;
   const [isCSVDownloadInProgress, setIsCSVDownloadInProgress] = React.useState(false);
@@ -281,23 +306,6 @@ const Period = ({ payoutPeriodData }: { payoutPeriodData: PayoutPeriodData }) =>
     setIsCSVDownloadInProgress(false);
   });
 
-  function currentPayoutHeading(payoutStatus: CurrentPayoutStatus, payoutDateFormatted: string) {
-    switch (payoutStatus) {
-      case "processing":
-        return `Payout initiated on ${payoutDateFormatted}`;
-      case "payable":
-        return `Next payout: ${payoutDateFormatted}`;
-      case "paused":
-        return "Next payout: paused";
-      case "failed":
-        return "Failed";
-      case "completed":
-        return payoutDateFormatted;
-    }
-  }
-
-  const heading = currentPayoutHeading(payoutPeriodData.status, payoutPeriodData.payout_date_formatted);
-
   return (
     <section aria-label="Payout period">
       <div
@@ -307,7 +315,7 @@ const Period = ({ payoutPeriodData }: { payoutPeriodData: PayoutPeriodData }) =>
           gap: "var(--spacer-4)",
         }}
       >
-        {payoutPeriodData.status === "completed" ? <span>{heading}</span> : <h3>{heading}</h3>}
+        <PayoutPeriodHeading payoutPeriodData={payoutPeriodData} />
         {"type" in payoutPeriodData && payoutPeriodData.type === "instant" ? (
           <div className="pill small">Instant</div>
         ) : null}
@@ -326,8 +334,14 @@ const Period = ({ payoutPeriodData }: { payoutPeriodData: PayoutPeriodData }) =>
         ) : null}
       </div>
       {payoutPeriodData.status === "failed" ? (
-        <div className="text-gray-500 italic">
-          This failed payout's balance is being carried over to your next payout.
+        <div role="status" className="warning my-4">
+          <div>
+            This payout failed due to{" "}
+            <span className="font-semibold underline">
+              {payoutPeriodData.displayable_failure_reason ?? "unknown error"}
+            </span>
+            . It will be included in your next payout automatically once verification is complete.
+          </div>
         </div>
       ) : null}
       <div className="stack" style={{ marginTop: "var(--spacer-4)" }}>

--- a/app/javascript/components/server-components/BalancePage.tsx
+++ b/app/javascript/components/server-components/BalancePage.tsx
@@ -272,7 +272,9 @@ const PayoutPeriodHeading = ({ payoutPeriodData }: { payoutPeriodData: PayoutPer
   return (
     <div className="flex gap-1">
       <h3>{payoutPeriodData.payout_date_formatted}</h3>
-      <div className="rounded border border-black bg-white p-1 text-[12px] font-normal leading-[120%]">{message}</div>
+      <div className="self-center rounded border border-black bg-white p-1 text-[12px] font-normal leading-[120%] text-black">
+        {message}
+      </div>
     </div>
   );
 };

--- a/app/javascript/components/server-components/BalancePage.tsx
+++ b/app/javascript/components/server-components/BalancePage.tsx
@@ -346,7 +346,7 @@ const Period = ({ payoutPeriodData }: { payoutPeriodData: PayoutPeriodData }) =>
             <span className="font-semibold underline">
               {payoutPeriodData.displayable_failure_reason ?? "unknown error"}
             </span>
-            . It will be included in your next payout automatically once verification is complete.
+            . The amount will be included in your next payout automatically once verification is complete.
           </div>
         </div>
       ) : null}

--- a/app/javascript/components/server-components/BalancePage.tsx
+++ b/app/javascript/components/server-components/BalancePage.tsx
@@ -264,8 +264,12 @@ const PayoutPeriodHeading = ({ payoutPeriodData }: { payoutPeriodData: PayoutPer
         return "Paused";
       case "failed":
         return "Failed";
-      case "completed":
-        return `Paid on ${payoutPeriodData.arrival_date}`;
+      case "completed": {
+        if ("arrival_date" in payoutPeriodData && payoutPeriodData.arrival_date) {
+          return `Paid on ${payoutPeriodData.arrival_date}`;
+        }
+        return "Paid";
+      }
     }
   }, [payoutPeriodData]);
 

--- a/app/models/concerns/payment/failure_reason.rb
+++ b/app/models/concerns/payment/failure_reason.rb
@@ -137,6 +137,16 @@ module Payment::FailureReason
   }
   private_constant :STRIPE_FAILURE_SOLUTIONS
 
+  def displayable_failure_reason
+    return nil unless failure_reason.present?
+
+    if processor == PayoutProcessorType::PAYPAL
+      PAYPAL_MASS_PAY[failure_reason] || failure_reason
+    elsif processor == PayoutProcessorType::STRIPE
+      STRIPE_FAILURE_SOLUTIONS[failure_reason] || failure_reason
+    end
+  end
+
   private
     def add_payment_failure_reason_comment
       return unless failure_reason.present?

--- a/app/models/concerns/payment/failure_reason.rb
+++ b/app/models/concerns/payment/failure_reason.rb
@@ -143,7 +143,9 @@ module Payment::FailureReason
     if processor == PayoutProcessorType::PAYPAL
       PAYPAL_MASS_PAY[failure_reason] || failure_reason
     elsif processor == PayoutProcessorType::STRIPE
-      STRIPE_FAILURE_SOLUTIONS[failure_reason] || failure_reason
+      STRIPE_FAILURE_SOLUTIONS[failure_reason]&.dig(:reason) || failure_reason
+    else
+      failure_reason
     end
   end
 

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -115,6 +115,7 @@ class Payment < ApplicationRecord
   scope :processing,              -> { where(state: "processing") }
   scope :completed,               -> { where(state: "completed") }
   scope :completed_or_processing, -> { where("state = 'completed' or state = 'processing'") }
+  scope :completed_or_failed,     -> { where("state = 'completed' or state = 'failed'") }
   scope :failed,                  -> { where(state: "failed").order(id: :desc) }
   scope :failed_cannot_pay,       -> { failed.where(failure_reason: "cannot_pay") }
   scope :displayable,             -> { where("created_at >= ?", PayoutsHelper::OLDEST_DISPLAYABLE_PAYOUT_PERIOD_END_DATE) }

--- a/spec/requests/balance_pages_spec.rb
+++ b/spec/requests/balance_pages_spec.rb
@@ -241,7 +241,7 @@ describe "Balance Pages Scenario", js: true, type: :feature do
         visit balance_path
 
         expect(page).to have_text("Failed")
-        expect(page).to have_text("This payout failed due to the bank account has been closed. It will be included in your next payout automatically once verification is complete.")
+        expect(page).to have_text("This payout failed due to the bank account has been closed. The amount will be included in your next payout automatically once verification is complete.")
       end
 
       it "shows completed payments for creator-owned Stripe Connect payouts" do

--- a/spec/requests/balance_pages_spec.rb
+++ b/spec/requests/balance_pages_spec.rb
@@ -234,6 +234,50 @@ describe "Balance Pages Scenario", js: true, type: :feature do
         expect(page).not_to have_text("Expected deposit on")
       end
 
+      it "shows failed payments for creator-owned Stripe Connect payouts" do
+        merchant_account = create(:merchant_account_stripe_connect, user: seller)
+        create(:payment, user: seller)
+
+        data = {
+          should_be_shown_currencies_always: true,
+          displayable_payout_period_range: "Activity up to May 6th, 2022",
+          payout_date_formatted: "May 14th, 2022",
+          payout_currency: "USD",
+          payout_cents: 3293600,
+          payout_displayed_amount: "$90.70 USD",
+          is_processing: true,
+          arrival_date: nil,
+          status: "failed",
+          payment_external_id: "l5C1XQfr2TG3WXcGY7YrUg==",
+          sales_cents: 10000,
+          refunds_cents: 0,
+          chargebacks_cents: 0,
+          credits_cents: 0,
+          loan_repayment_cents: 0,
+          fees_cents: 930,
+          taxes_cents: 0,
+          discover_fees_cents: 0,
+          direct_fees_cents: 0,
+          discover_sales_count: 0,
+          direct_sales_count: 0,
+          affiliate_credits_cents: 0,
+          affiliate_fees_cents: 0,
+          paypal_payout_cents: 0,
+          stripe_connect_payout_cents: 0,
+          stripe_connect_account_id: merchant_account.charge_processor_merchant_id,
+          payout_method_type: "stripe_connect",
+          payout_note: "Payout via Stripe on May 14th, 2022 failed because the bank account has been closed. Solution: Use another bank account.",
+          type: Payouts::PAYOUT_TYPE_STANDARD,
+          has_stripe_connect: true
+        }
+        allow_any_instance_of(UserBalanceStatsService).to receive(:payout_period_data).and_return(data)
+
+        visit balance_path
+        expect(page).to have_text("Stripe account: #{merchant_account.charge_processor_merchant_id}")
+        expect(page).not_to have_text("Expected deposit on")
+        expect(page).to have_text("Failed")
+      end
+
       it "shows completed payments for creator-owned Stripe Connect payouts" do
         merchant_account = create(:merchant_account_stripe_connect, user: seller)
         create(:payment_completed, user: seller)

--- a/spec/requests/balance_pages_spec.rb
+++ b/spec/requests/balance_pages_spec.rb
@@ -235,47 +235,13 @@ describe "Balance Pages Scenario", js: true, type: :feature do
       end
 
       it "shows failed payments for creator-owned Stripe Connect payouts" do
-        merchant_account = create(:merchant_account_stripe_connect, user: seller)
-        create(:payment, user: seller)
-
-        data = {
-          should_be_shown_currencies_always: true,
-          displayable_payout_period_range: "Activity up to May 6th, 2022",
-          payout_date_formatted: "May 14th, 2022",
-          payout_currency: "USD",
-          payout_cents: 3293600,
-          payout_displayed_amount: "$90.70 USD",
-          is_processing: true,
-          arrival_date: nil,
-          status: "failed",
-          payment_external_id: "l5C1XQfr2TG3WXcGY7YrUg==",
-          sales_cents: 10000,
-          refunds_cents: 0,
-          chargebacks_cents: 0,
-          credits_cents: 0,
-          loan_repayment_cents: 0,
-          fees_cents: 930,
-          taxes_cents: 0,
-          discover_fees_cents: 0,
-          direct_fees_cents: 0,
-          discover_sales_count: 0,
-          direct_sales_count: 0,
-          affiliate_credits_cents: 0,
-          affiliate_fees_cents: 0,
-          paypal_payout_cents: 0,
-          stripe_connect_payout_cents: 0,
-          stripe_connect_account_id: merchant_account.charge_processor_merchant_id,
-          payout_method_type: "stripe_connect",
-          payout_note: "Payout via Stripe on May 14th, 2022 failed because the bank account has been closed. Solution: Use another bank account.",
-          type: Payouts::PAYOUT_TYPE_STANDARD,
-          has_stripe_connect: true
-        }
-        allow_any_instance_of(UserBalanceStatsService).to receive(:payout_period_data).and_return(data)
+        create(:merchant_account_stripe_connect, user: seller)
+        create(:payment_failed, processor: "STRIPE", failure_reason: "account_closed", user: seller)
 
         visit balance_path
-        expect(page).to have_text("Stripe account: #{merchant_account.charge_processor_merchant_id}")
-        expect(page).not_to have_text("Expected deposit on")
+
         expect(page).to have_text("Failed")
+        expect(page).to have_text("This payout failed due to the bank account has been closed. It will be included in your next payout automatically once verification is complete.")
       end
 
       it "shows completed payments for creator-owned Stripe Connect payouts" do


### PR DESCRIPTION
Resolves: https://github.com/antiwork/gumroad/issues/568

![image](https://github.com/user-attachments/assets/1acbfaa4-5331-4e86-9fbc-53f4046c1b27)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying failed payouts alongside completed payouts in the balance page.
  * Introduced an informational message for failed payouts, indicating the balance will be carried over to the next payout.
  * Added user-friendly failure reasons for payouts to improve clarity on failure causes.

* **Bug Fixes**
  * Ensured failed payouts are now visible in payout history.

* **Tests**
  * Added tests to verify correct display and handling of failed payouts in the user interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->