### PR TITLE
Revert "Remove cached_alive_product_files in favor of Rails' associat…

### DIFF
--- a/app/modules/with_product_files_many_to_many.rb
+++ b/app/modules/with_product_files_many_to_many.rb
@@ -9,6 +9,5 @@ module WithProductFilesManyToMany
   included do
     include WithProductFiles
     has_and_belongs_to_many :product_files
-    has_and_belongs_to_many :alive_product_files, -> { alive.in_order }, class_name: "ProductFile"
   end
 end

--- a/app/presenters/paginated_installments_presenter.rb
+++ b/app/presenters/paginated_installments_presenter.rb
@@ -17,7 +17,7 @@ class PaginatedInstallmentsPresenter
 
   def props
     if query.blank?
-      installments = Installment.includes(:installment_rule, :alive_product_files).all
+      installments = Installment.includes(:installment_rule).all
       installments = installments.ordered_updates(seller, type).public_send(type)
       installments = installments.unscope(:order).order("installment_rules.to_be_published_at ASC") if type == Installment::SCHEDULED
       pagination, installments = pagy(installments, page:, limit: PER_PAGE, overflow: :empty_page)
@@ -36,7 +36,7 @@ class PaginatedInstallmentsPresenter
         sort: [:_score, { created_at: :desc }, { id: :desc }]
       }
       es_search = InstallmentSearchService.search(search_options)
-      installments = es_search.records.includes(:alive_product_files).load
+      installments = es_search.records.load
       can_paginate_further = es_search.results.total > (offset + PER_PAGE)
       pagiation_metadata = { count: es_search.results.total, next: can_paginate_further ? page + 1 : nil }
     end

--- a/spec/requests/products/dropbox_spec.rb
+++ b/spec/requests/products/dropbox_spec.rb
@@ -29,7 +29,8 @@ describe "Dropbox uploads", type: :feature, js: true do
     sleep 0.5 # wait for the editor to update the content
     save_change
     expect(product.reload.alive_product_files.count).to eq 2
-    expect(product.alive_product_files.map(&:display_name)).to eq(%w(Download-Card SmallTestFile))
+    expect(product.alive_product_files.first.display_name).to eq("Download-Card")
+    expect(product.alive_product_files.last.display_name).to eq("SmallTestFile")
     expect(product.alive_rich_contents.sole.description).to match_array([
                                                                           { "type" => "fileEmbed", "attrs" => { "id" => product.alive_product_files.first.external_id, "uid" => anything, "collapsed" => false } },
                                                                           { "type" => "fileEmbed", "attrs" => { "id" => product.alive_product_files.last.external_id, "uid" => anything, "collapsed" => false } },


### PR DESCRIPTION
…ion cache (#565)"

refs https://anti--work.slack.com/archives/C08A273MA15/p1751819921919489

- this reverts commit a81bac13bfb1ccfa30b692540d2c52821d4f3346
- something in this change is causing a couple of extremely heavy DB queries to be produced, which are dragging down the performance of the scheduled emails page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved performance by introducing manual caching for alive product files and updating cache invalidation logic.
  * Removed scoped associations for alive product files to streamline data access.

* **Bug Fixes**
  * Adjusted test assertions for product file display names to improve test clarity and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->