### PR TITLE
Reduced payouts page pagination to 3 past payments

### DIFF
--- a/app/controllers/balance_controller.rb
+++ b/app/controllers/balance_controller.rb
@@ -5,7 +5,7 @@ class BalanceController < Sellers::BaseController
   include PayoutsHelper
   include Pagy::Backend
 
-  PAST_PAYMENTS_PER_PAGE = 5
+  PAST_PAYMENTS_PER_PAGE = 3
 
   before_action :set_body_id_as_app
   before_action :set_on_balance_page


### PR DESCRIPTION
- collecting the data for every past payment can be quite heavy and we probably don't need to show more than 3 at any one time, as we provide a "show more" button for the power users

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reduced the number of past payments displayed per page from five to three in the payouts section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->