### PR TITLE
[Perf] lazy-loading offscreen and hidden images for show product page

### DIFF
--- a/app/javascript/components/Product/Covers/Image.tsx
+++ b/app/javascript/components/Product/Covers/Image.tsx
@@ -4,13 +4,22 @@ import { AssetPreview } from "$app/parsers/product";
 
 import { DEFAULT_IMAGE_WIDTH } from "./";
 
-type Props = { cover: AssetPreview; dimensions: { height: number; width: number } | null };
-const Image = ({ cover, dimensions }: Props) => (
+type Props = {
+  cover: AssetPreview;
+  dimensions: { height: number; width: number } | null;
+  fetchPriority?: "high" | "low" | "auto";
+  loading?: "eager" | "lazy";
+  alt?: string | undefined;
+};
+const Image = ({ cover, dimensions, alt, loading, fetchPriority = "auto" }: Props) => (
   <img
     className="preview"
     src={dimensions == null || dimensions.width > DEFAULT_IMAGE_WIDTH ? cover.original_url : cover.url}
     itemProp="image"
     style={{ maxWidth: "100%" }}
+    alt={alt}
+    fetchPriority={fetchPriority}
+    loading={loading}
   />
 );
 

--- a/app/javascript/components/Product/Covers/index.tsx
+++ b/app/javascript/components/Product/Covers/index.tsx
@@ -21,6 +21,7 @@ export const Covers = ({
   closeButton,
   className,
   isThumbnail,
+  alt,
   style,
 }: {
   covers: AssetPreview[];
@@ -30,6 +31,7 @@ export const Covers = ({
   className?: string;
   isThumbnail?: boolean;
   style?: CSSProperties;
+  alt?: string | undefined;
 }) => {
   useOnChange(() => {
     if (!covers.some((cover) => cover.id === activeCoverId)) setActiveCoverId(covers[0]?.id ?? null);
@@ -62,8 +64,8 @@ export const Covers = ({
         }}
         onScroll={handleScroll}
       >
-        {covers.map((cover) => (
-          <CoverItem cover={cover} key={cover.id} />
+        {covers.map((cover, idx) => (
+          <CoverItem cover={cover} key={cover.id} isFirstItem={idx === 0} alt={alt} />
         ))}
       </div>
       {covers.length > 1 && activeCover?.type !== "oembed" && activeCover?.type !== "video" ? (
@@ -98,7 +100,15 @@ const PreviewArrow = ({ direction, onClick }: { direction: "previous" | "next"; 
   />
 );
 
-const CoverItem = ({ cover }: { cover: AssetPreview }) => {
+const CoverItem = ({
+  cover,
+  isFirstItem,
+  alt,
+}: {
+  cover: AssetPreview;
+  isFirstItem: boolean;
+  alt?: string | undefined;
+}) => {
   const containerRef = React.useRef<HTMLDivElement>(null);
   const dimensions = useElementDimensions(containerRef);
   const width = dimensions?.width;
@@ -125,7 +135,17 @@ const CoverItem = ({ cover }: { cover: AssetPreview }) => {
             height: cover.native_height * ratio,
           };
     if (cover.type === "image") {
-      coverComponent = <Image cover={cover} dimensions={dimensions} />;
+      // Eager load (with high fetch priority) the first image in the carousel and lazy
+      // load the other images for better LCP
+      coverComponent = (
+        <Image
+          alt={alt}
+          cover={cover}
+          dimensions={dimensions}
+          fetchPriority={isFirstItem ? "high" : "low"}
+          loading={isFirstItem ? "eager" : "lazy"}
+        />
+      );
     } else if (cover.type === "oembed") {
       coverComponent = <Embed cover={cover} dimensions={dimensions} />;
     } else {

--- a/app/javascript/components/Product/index.tsx
+++ b/app/javascript/components/Product/index.tsx
@@ -316,7 +316,7 @@ export const Product = ({
 
   return (
     <article className="product">
-      <Covers covers={product.covers} mainCoverId={product.main_cover_id} />
+      <Covers covers={product.covers} mainCoverId={product.main_cover_id} alt={product.name} />
       {product.quantity_remaining !== null ? (
         <div className="ribbon">{`${product.quantity_remaining} left`}</div>
       ) : null}
@@ -597,12 +597,13 @@ export const Product = ({
   );
 };
 
-const Covers = ({ covers, mainCoverId }: { covers: AssetPreview[]; mainCoverId: string | null }) => {
+const Covers = ({ covers, mainCoverId, alt }: { covers: AssetPreview[]; mainCoverId: string | null; alt: string }) => {
   const [activeCoverId, setActiveCoverId] = React.useState(mainCoverId);
   useOnChange(() => setActiveCoverId(mainCoverId), [mainCoverId]);
 
   return (
     <CoversComponent
+      alt={alt}
       covers={covers}
       activeCoverId={activeCoverId}
       setActiveCoverId={setActiveCoverId}


### PR DESCRIPTION
To improve the performance of the show product page, we need to lazy load all of hidden & off-screen images.
This should result in a better LCP & FCP and avoids enormous network payloads 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Metrics (Local metrics may not be very accurate)
#### Before
<img width="1761" height="860" alt="image" src="https://github.com/user-attachments/assets/97c6e441-190b-4568-8af7-cee5456827d6" />

#### After
<img width="1761" height="860" alt="image" src="https://github.com/user-attachments/assets/00dcd48c-d4f7-4288-b14a-04e0faec21f7" />


## Summary by CodeRabbit

* **New Features**
  * Added support for image loading priority and lazy/eager loading, improving performance of product cover images.
  * Image components now accept and display alternative text for better accessibility.

* **Enhancements**
  * The first image in product cover carousels loads eagerly with high priority; subsequent images load lazily with low priority.
  * Product cover images now use the product name as alt text for improved screen reader support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->