### PR TITLE
[Perf] Add font-display property to font-face declarations for better loading perf

### DIFF
--- a/app/javascript/stylesheets/_font.scss
+++ b/app/javascript/stylesheets/_font.scss
@@ -1,18 +1,21 @@
 @font-face {
   font-family: "ABC Favorit";
   src: url("~fonts/ABCFavorit-Regular.woff2");
+  font-display: swap;
 }
 
 @font-face {
   font-family: "ABC Favorit";
   src: url("~fonts/ABCFavorit-RegularItalic.woff2");
   font-style: italic;
+  font-display: swap;
 }
 
 @font-face {
   font-family: "ABC Favorit";
   src: url("~fonts/ABCFavorit-Bold.woff2");
   font-weight: 700;
+  font-display: swap;
 }
 
 @font-face {
@@ -20,4 +23,5 @@
   src: url("~fonts/ABCFavorit-BoldItalic.woff2");
   font-weight: 700;
   font-style: italic;
+  font-display: swap;
 }

--- a/public/error_pages/style.css
+++ b/public/error_pages/style.css
@@ -55,4 +55,5 @@ img {
 @font-face {
   font-family: "ABC Favorit";
   src: url("ABCFavorit-Regular.woff2");
+  font-display: swap;
 }


### PR DESCRIPTION
Consider setting font-display to swap or optional to ensure text is consistently visible. swap can be further optimized to mitigate layout shifts with font metric overrides.FCP


https://developer.chrome.com/blog/font-display

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved font loading behavior for the "ABC Favorit" font family, ensuring faster text rendering and smoother font transitions across the site, including error pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->