### PR TITLE
Add SearchAction to Discovery page

### DIFF
--- a/app/views/discover/index.html.erb
+++ b/app/views/discover/index.html.erb
@@ -4,6 +4,19 @@
 <% end %>
 <% end %>
 
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "url": "<%= request.base_url %>/",
+  "potentialAction": {
+    "@type": "SearchAction",
+    "target": "<%= request.base_url %>/discover?query={search_term_string}",
+    "query-input": "required name=search_term_string"
+  }
+}
+</script>
+
 <%= load_pack("discover") %>
 <div>
   <%= react_component "Discover", props: @react_discover_props, prerender: true %>

--- a/app/views/discover/index.html.erb
+++ b/app/views/discover/index.html.erb
@@ -4,17 +4,21 @@
 <% end %>
 <% end %>
 
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "WebSite",
-  "url": "<%= request.base_url %>/",
-  "potentialAction": {
-    "@type": "SearchAction",
-    "target": "<%= request.base_url %>/discover?query={search_term_string}",
-    "query-input": "required name=search_term_string"
+<%
+search_action_data = {
+  "@context" => "https://schema.org",
+  "@type" => "WebSite",
+  "url" => root_url,
+  "potentialAction" => {
+    "@type" => "SearchAction",
+    "target" => "#{discover_url}?query={search_term_string}",
+    "query-input" => "required name=search_term_string"
   }
 }
+%>
+
+<script type="application/ld+json">
+<%= search_action_data.to_json.html_safe %>
 </script>
 
 <%= load_pack("discover") %>


### PR DESCRIPTION
Resolves: https://github.com/antiwork/gumroad/issues/617

This SearchAction structured data tells search engines that your website has search functionality and provides them with the correct URL pattern to use. This can enable search engines to display a search box directly in search results for your site, improving user experience and potentially increasing click-through rates.

The search action will work with the existing Discover page search functionality, allowing users to search for products directly from search engine results pages.

### Screenshots
Proving that its recognized.:
<img width="1918" height="751" alt="image" src="https://github.com/user-attachments/assets/9d272488-e6f5-47b3-974f-e7d68caa51f5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured data to the Discover page to help search engines better understand and index the site's search functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->