### PR TITLE
feat: currency aware price sorting and indexing for products

### DIFF
--- a/app/modules/product/prices.rb
+++ b/app/modules/product/prices.rb
@@ -258,9 +258,9 @@ module Product::Prices
         get_usd_cents(currency_type, price_cents)
       rescue => e
         Rails.logger.warn("Currency conversion failed for product #{id}, currency #{currency_type}: #{e.message}")
-        price_cents
+        nil
       end
-    end.uniq
+    end.compact.uniq
   end
 
   private

--- a/app/modules/product/prices.rb
+++ b/app/modules/product/prices.rb
@@ -240,6 +240,29 @@ module Product::Prices
     available_prices.uniq
   end
 
+  def available_price_usd_cents
+    available_prices = available_price_cents
+    return [] if available_prices.empty?
+
+    available_prices.map do |price_cents|
+      get_usd_cents(currency_type, price_cents)
+    end.uniq
+  end
+
+  def available_price_usd_cents_with_fallback
+    available_prices = available_price_cents
+    return [] if available_prices.empty?
+
+    available_prices.map do |price_cents|
+      begin
+        get_usd_cents(currency_type, price_cents)
+      rescue => e
+        Rails.logger.warn("Currency conversion failed for product #{id}, currency #{currency_type}: #{e.message}")
+        price_cents
+      end
+    end.uniq
+  end
+
   private
     # Private: Called only on create to instantiate Price object(s) and associate it to the newly created product.
     def associate_price

--- a/app/modules/product/prices.rb
+++ b/app/modules/product/prices.rb
@@ -241,6 +241,7 @@ module Product::Prices
   end
 
   def available_price_usd_cents
+    puts "HIT available_price_usd_cents"
     available_prices = available_price_cents
     return [] if available_prices.empty?
 

--- a/app/modules/product/prices.rb
+++ b/app/modules/product/prices.rb
@@ -241,7 +241,6 @@ module Product::Prices
   end
 
   def available_price_usd_cents
-    puts "HIT available_price_usd_cents"
     available_prices = available_price_cents
     return [] if available_prices.empty?
 

--- a/app/modules/product/prices.rb
+++ b/app/modules/product/prices.rb
@@ -245,7 +245,7 @@ module Product::Prices
     return [] if available_prices.empty?
 
     available_prices.map do |price_cents|
-      get_usd_cents(currency_type, price_cents)
+      get_usd_cents(price_currency_type, price_cents)
     end.uniq
   end
 
@@ -255,9 +255,9 @@ module Product::Prices
 
     available_prices.map do |price_cents|
       begin
-        get_usd_cents(currency_type, price_cents)
+        get_usd_cents(price_currency_type, price_cents)
       rescue => e
-        Rails.logger.warn("Currency conversion failed for product #{id}, currency #{currency_type}: #{e.message}")
+        Rails.logger.warn("Currency conversion failed for product #{id}, currency #{price_currency_type}: #{e.message}")
         nil
       end
     end.compact.uniq

--- a/app/modules/product/searchable.rb
+++ b/app/modules/product/searchable.rb
@@ -3,6 +3,8 @@
 module Product::Searchable
   extend ActiveSupport::Concern
 
+
+
   # we want to show 9 tags, but this is used as an array indexing which starts at 0
   MAX_NUMBER_OF_TAGS = 8
   RECOMMENDED_PRODUCTS_PER_PAGE = 9
@@ -11,7 +13,7 @@ module Product::Searchable
   ATTRIBUTE_TO_SEARCH_FIELDS_MAP = {
     "name" => ["name", "rated_as_adult"],
     "description" => ["description", "rated_as_adult"],
-    "price_cents" => ["price_cents", "available_price_cents"],
+    "price_cents" => ["price_cents", "available_price_cents", "available_price_usd_cents"],
     "purchase_disabled_at" => ["is_recommendable", "is_alive_on_profile", "is_alive"],
     "deleted_at" => ["is_recommendable", "is_alive_on_profile", "is_alive"],
     "banned_at" => ["is_recommendable", "is_alive_on_profile", "is_alive"],
@@ -40,6 +42,7 @@ module Product::Searchable
     filetypes
     price_cents
     available_price_cents
+    available_price_usd_cents
     updated_at
     creator_external_id
     content_updated_at
@@ -125,6 +128,7 @@ module Product::Searchable
         indexes :is_alive, type: :boolean
         indexes :price_cents, type: :long
         indexes :available_price_cents, type: :long
+        indexes :available_price_usd_cents, type: :long
         indexes :recommendable, type: :text do # unused
           indexes :keyword, type: :keyword, ignore_above: 256
         end
@@ -306,8 +310,8 @@ module Product::Searchable
           when ProductSortKey::HOT_AND_NEW
             by :sales_volume, order: "desc"
           when ProductSortKey::NEWEST           then by :created_at,     order: "desc"
-          when ProductSortKey::AVAILABLE_PRICE_DESCENDING, ProductSortKey::PRICE_DESCENDING then by :available_price_cents,    order: "desc", mode: "min"
-          when ProductSortKey::AVAILABLE_PRICE_ASCENDING, ProductSortKey::PRICE_ASCENDING  then by :available_price_cents,    order: "asc", mode: "min"
+          when ProductSortKey::AVAILABLE_PRICE_DESCENDING, ProductSortKey::PRICE_DESCENDING then by :available_price_usd_cents, order: "desc", mode: "min"
+          when ProductSortKey::AVAILABLE_PRICE_ASCENDING, ProductSortKey::PRICE_ASCENDING  then by :available_price_usd_cents, order: "asc", mode: "min"
           when ProductSortKey::IS_RECOMMENDABLE_DESCENDING then by :is_recommendable,    order: "desc"
           when ProductSortKey::IS_RECOMMENDABLE_ASCENDING  then by :is_recommendable,    order: "asc"
           when ProductSortKey::REVENUE_ASCENDING   then by :sales_volume,    order: "asc"
@@ -464,6 +468,7 @@ module Product::Searchable
       when "reviews_count"     then reviews_count
       when "price_cents"       then price_cents
       when "available_price_cents" then available_price_cents
+      when "available_price_usd_cents" then available_price_usd_cents_with_fallback
       when "is_physical"       then is_physical
       when "is_subscription"   then is_recurring_billing
       when "is_bundle"         then is_bundle

--- a/app/modules/product/searchable.rb
+++ b/app/modules/product/searchable.rb
@@ -310,8 +310,8 @@ module Product::Searchable
           when ProductSortKey::HOT_AND_NEW
             by :sales_volume, order: "desc"
           when ProductSortKey::NEWEST           then by :created_at,     order: "desc"
-          when ProductSortKey::AVAILABLE_PRICE_DESCENDING, ProductSortKey::PRICE_DESCENDING then by :available_price_usd_cents, order: "desc", mode: "min"
-          when ProductSortKey::AVAILABLE_PRICE_ASCENDING, ProductSortKey::PRICE_ASCENDING  then by :available_price_usd_cents, order: "asc", mode: "min"
+          when ProductSortKey::AVAILABLE_PRICE_DESCENDING, ProductSortKey::PRICE_DESCENDING then by :available_price_usd_cents_with_fallback, order: "desc", mode: "min"
+          when ProductSortKey::AVAILABLE_PRICE_ASCENDING, ProductSortKey::PRICE_ASCENDING  then by :available_price_usd_cents_with_fallback, order: "asc", mode: "min"
           when ProductSortKey::IS_RECOMMENDABLE_DESCENDING then by :is_recommendable,    order: "desc"
           when ProductSortKey::IS_RECOMMENDABLE_ASCENDING  then by :is_recommendable,    order: "asc"
           when ProductSortKey::REVENUE_ASCENDING   then by :sales_volume,    order: "asc"

--- a/app/modules/product/searchable.rb
+++ b/app/modules/product/searchable.rb
@@ -310,8 +310,8 @@ module Product::Searchable
           when ProductSortKey::HOT_AND_NEW
             by :sales_volume, order: "desc"
           when ProductSortKey::NEWEST           then by :created_at,     order: "desc"
-          when ProductSortKey::AVAILABLE_PRICE_DESCENDING, ProductSortKey::PRICE_DESCENDING then by :available_price_usd_cents_with_fallback, order: "desc", mode: "min"
-          when ProductSortKey::AVAILABLE_PRICE_ASCENDING, ProductSortKey::PRICE_ASCENDING  then by :available_price_usd_cents_with_fallback, order: "asc", mode: "min"
+          when ProductSortKey::AVAILABLE_PRICE_DESCENDING, ProductSortKey::PRICE_DESCENDING then by :available_price_usd_cents, order: "desc", mode: "min"
+          when ProductSortKey::AVAILABLE_PRICE_ASCENDING, ProductSortKey::PRICE_ASCENDING  then by :available_price_usd_cents, order: "asc", mode: "min"
           when ProductSortKey::IS_RECOMMENDABLE_DESCENDING then by :is_recommendable,    order: "desc"
           when ProductSortKey::IS_RECOMMENDABLE_ASCENDING  then by :is_recommendable,    order: "asc"
           when ProductSortKey::REVENUE_ASCENDING   then by :sales_volume,    order: "asc"

--- a/app/sidekiq/update_currencies_worker.rb
+++ b/app/sidekiq/update_currencies_worker.rb
@@ -11,5 +11,7 @@ class UpdateCurrenciesWorker
     rates.each do |currency, rate|
       currency_namespace.set(currency.to_s, rate)
     end
+
+    UpdateProductUsdPricesWorker.perform_async
   end
 end

--- a/app/sidekiq/update_product_usd_prices_worker.rb
+++ b/app/sidekiq/update_product_usd_prices_worker.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class UpdateProductUsdPricesWorker
+  include Sidekiq::Job
+  sidekiq_options retry: 3, queue: :low
+
+  def perform
+    puts "Starting USD price update for products..."
+
+    batch_size = 1000
+    processed = 0
+
+    Link.find_in_batches(batch_size: batch_size) do |batch|
+      batch.each do |product|
+        begin
+          product.__elasticsearch__.index_document
+          processed += 1
+        rescue => e
+          Rails.logger.error("Failed to update USD prices for product #{product.id}: #{e.message}")
+        end
+      end
+
+      puts "Processed #{processed} products..."
+    end
+
+    puts "USD price update complete! Processed #{processed} products."
+  end
+end

--- a/app/sidekiq/update_product_usd_prices_worker.rb
+++ b/app/sidekiq/update_product_usd_prices_worker.rb
@@ -5,12 +5,12 @@ class UpdateProductUsdPricesWorker
   sidekiq_options retry: 3, queue: :low
 
   def perform
-    puts "Starting USD price update for products..."
+    Rails.logger.info("Starting USD price update for products...")
 
     batch_size = 1000
     processed = 0
 
-    Link.find_in_batches(batch_size: batch_size) do |batch|
+    Product.find_in_batches(batch_size: batch_size) do |batch|
       batch.each do |product|
         begin
           product.__elasticsearch__.index_document
@@ -20,9 +20,9 @@ class UpdateProductUsdPricesWorker
         end
       end
 
-      puts "Processed #{processed} products..."
+      Rails.logger.info("Processed #{processed} products...")
     end
 
-    puts "USD price update complete! Processed #{processed} products."
+    Rails.logger.info("USD price update complete! Processed #{processed} products.")
   end
 end

--- a/spec/requests/discover/filtering_spec.rb
+++ b/spec/requests/discover/filtering_spec.rb
@@ -192,8 +192,7 @@ describe("Discover - Filtering scenarios", js: true, type: :feature) do
     eur_product = create(:product, name: "Currency Test Product EUR", price_cents: 900, price_currency_type: "eur")
     gbp_product = create(:product, name: "Currency Test Product GBP", price_cents: 800, price_currency_type: "gbp")
 
-    index_model_records(Link)
-    expect(UpdateProductUsdPricesWorker.jobs.size).to eq(1)
+    index_model_records(Product)
 
     visit discover_url(host: discover_host)
     fill_in("Search products", with: "Currency Test Product\n")

--- a/spec/requests/discover/filtering_spec.rb
+++ b/spec/requests/discover/filtering_spec.rb
@@ -67,6 +67,7 @@ describe("Discover - Filtering scenarios", js: true, type: :feature) do
 
     index_model_records(Purchase)
     index_model_records(Link)
+    expect(UpdateProductUsdPricesWorker.jobs.size).to eq(1)
   end
 
   it "filters products by filetype" do

--- a/spec/requests/discover/filtering_spec.rb
+++ b/spec/requests/discover/filtering_spec.rb
@@ -67,7 +67,6 @@ describe("Discover - Filtering scenarios", js: true, type: :feature) do
 
     index_model_records(Purchase)
     index_model_records(Link)
-    expect(UpdateProductUsdPricesWorker.jobs.size).to eq(1)
   end
 
   it "filters products by filetype" do
@@ -194,6 +193,7 @@ describe("Discover - Filtering scenarios", js: true, type: :feature) do
     gbp_product = create(:product, name: "Currency Test Product GBP", price_cents: 800, price_currency_type: "gbp")
 
     index_model_records(Link)
+    expect(UpdateProductUsdPricesWorker.jobs.size).to eq(1)
 
     visit discover_url(host: discover_host)
     fill_in("Search products", with: "Currency Test Product\n")

--- a/spec/requests/discover/filtering_spec.rb
+++ b/spec/requests/discover/filtering_spec.rb
@@ -181,6 +181,41 @@ describe("Discover - Filtering scenarios", js: true, type: :feature) do
     expect_product_cards_in_order([@similar_product_3, @product, @similar_product_4, @similar_product_2, @similar_product_1])
   end
 
+  it "sorts products by USD price across different currencies" do
+    # Stub currency rates for deterministic conversion
+    allow_any_instance_of(CurrencyHelper).to receive(:get_rate).with("usd").and_return("1.0")
+    allow_any_instance_of(CurrencyHelper).to receive(:get_rate).with("eur").and_return("1.1")
+    allow_any_instance_of(CurrencyHelper).to receive(:get_rate).with("gbp").and_return("1.3")
+
+    # Create products in different currencies
+    usd_product = create(:product, name: "Currency Test Product USD", price_cents: 1000, price_currency_type: "usd")
+    eur_product = create(:product, name: "Currency Test Product EUR", price_cents: 900, price_currency_type: "eur")
+    gbp_product = create(:product, name: "Currency Test Product GBP", price_cents: 800, price_currency_type: "gbp")
+
+    index_model_records(Link)
+
+    visit discover_url(host: discover_host)
+    fill_in("Search products", with: "Currency Test Product\n")
+    wait_for_ajax
+
+    # USD: 1000, EUR: 900*1.1=990, GBP: 800*1.3=1040
+    choose "Price (Low to High)"
+    wait_for_ajax
+    expect_product_cards_in_order([
+      eur_product,
+      usd_product,
+      gbp_product
+    ])
+
+    choose "Price (High to Low)"
+    wait_for_ajax
+    expect_product_cards_in_order([
+      gbp_product,
+      usd_product,
+      eur_product
+    ])
+  end
+
   it "filters products by price" do
     visit discover_url(host: discover_host)
     fill_in("Search products", with: "product\n")


### PR DESCRIPTION
The sorting in discover page search results doesn't sort properly. 

<img width="1822" height="983" alt="image" src="https://github.com/user-attachments/assets/5db3ac12-94af-45a6-b969-9b7b6843ea42" />

For price: high to low or low to high sorting, it sorts on the basis of price number. Currency is not taken into consideration.

For example:
Consider 3 products. Product 1=₹100000, Product 2=$99999 and Product 3=€99000.

When sort is set to price:high to low, gumroad sorts them ₹100000 > $99999 > €99000. It doesn't consider currency and gives incorrect sort.

But in reality, €99000 > $99999 > ₹100000.

This PR fixes it by storing product's usd equivalent value and then sorting according to it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for searching and sorting products by their available USD prices.
  * Introduced a new background job to update product USD prices in batches.
* **Improvements**
  * Product search and sorting by price now use USD values for greater consistency.
  * Product USD prices are automatically updated after currency rates are refreshed.
* **Tests**
  * Added tests to verify product sorting by USD price across different currencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->