### PR TITLE
Add structured data to the profile page

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -8,7 +8,7 @@ person_data = {
   "@type" => "Person",
   "name" => @profile_props[:creator_profile][:name],
   "image" => @profile_props[:creator_profile][:avatar_url],
-  "url" => @profile_props[:creator_profile][:subdomain] ? "https://#{@profile_props[:creator_profile][:subdomain]}" : nil,
+  "url" => @profile_props[:creator_profile][:subdomain],
   "description" => @profile_props[:bio]
 }.compact
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -6,14 +6,14 @@
 person_data = {
   "@context" => "https://schema.org",
   "@type" => "Person",
-  "name" => @profile_props[:creator_profile][:name],
-  "image" => @profile_props[:creator_profile][:avatar_url],
-  "url" => @profile_props[:creator_profile][:subdomain],
-  "description" => @profile_props[:bio]
+  "name" => @profile_props.dig(:creator_profile, :name),
+  "image" => @profile_props.dig(:creator_profile, :avatar_url),
+  "url" => @profile_props.dig(:creator_profile, :subdomain),
+  "description" => @profile_props.dig(:bio)
 }.compact
 
-if @profile_props[:creator_profile][:twitter_handle].present?
-  person_data["sameAs"] = ["https://twitter.com/#{@profile_props[:creator_profile][:twitter_handle]}"]
+if (twitter_handle = @profile_props.dig(:creator_profile, :twitter_handle)).present?
+  person_data["sameAs"] = ["https://twitter.com/#{twitter_handle}"]
 end
 %>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,24 @@
 <%= load_pack("user") %>
 <%= render("layouts/custom_styles/style") %>
 
+
+<%
+person_data = {
+  "@context" => "https://schema.org",
+  "@type" => "Person",
+  "name" => @profile_props[:creator_profile][:name],
+  "image" => @profile_props[:creator_profile][:avatar_url],
+  "url" => @profile_props[:creator_profile][:subdomain] ? "https://#{@profile_props[:creator_profile][:subdomain]}" : nil,
+  "description" => @profile_props[:bio]
+}.compact
+
+if @profile_props[:creator_profile][:twitter_handle].present?
+  person_data["sameAs"] = ["https://twitter.com/#{@profile_props[:creator_profile][:twitter_handle]}"]
+end
+%>
+
+<script type="application/ld+json">
+<%= person_data.to_json.html_safe %>
+</script>
+
 <%= react_component "Profile", props: @profile_props, prerender: true %>


### PR DESCRIPTION
I've added comprehensive JSON-LD structured data for the profile page.
This structured data will help search engines understand that this is a creator's profile page and provide rich information about the person, potentially enabling enhanced search results and better SEO for creator profiles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured data (JSON-LD) for user profiles to enhance search engine visibility and provide richer search results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->