### PR TITLE
Require `business_name` for Japan-based businesses

### DIFF
--- a/app/javascript/components/server-components/Settings/PaymentsPage.tsx
+++ b/app/javascript/components/server-components/Settings/PaymentsPage.tsx
@@ -626,6 +626,9 @@ const PaymentsPage = (props: Props) => {
       if (!complianceInfo.business_type) {
         markFieldInvalid("business_type");
       }
+      if (!complianceInfo.business_name) {
+        markFieldInvalid("business_name");
+      }
       if (complianceInfo.business_country === "CA") {
         if (!complianceInfo.job_title) {
           markFieldInvalid("job_title");
@@ -647,20 +650,15 @@ const PaymentsPage = (props: Props) => {
         if (!complianceInfo.business_street_address_kana) {
           markFieldInvalid("business_street_address_kana");
         }
-      } else {
-        if (!complianceInfo.business_name) {
-          markFieldInvalid("business_name");
-        }
-        if (
-          !complianceInfo.business_street_address ||
-          (complianceInfo.business_country === "US" && isStreetAddressPOBox(complianceInfo.business_street_address))
-        ) {
-          markFieldInvalid("business_street_address");
-          if (complianceInfo.business_street_address) {
-            setErrorMessage({
-              message: "We require a valid physical US address. We cannot accept a P.O. Box as a valid address.",
-            });
-          }
+      } else if (
+        !complianceInfo.business_street_address ||
+        (complianceInfo.business_country === "US" && isStreetAddressPOBox(complianceInfo.business_street_address))
+      ) {
+        markFieldInvalid("business_street_address");
+        if (complianceInfo.business_street_address) {
+          setErrorMessage({
+            message: "We require a valid physical US address. We cannot accept a P.O. Box as a valid address.",
+          });
         }
       }
       if (!complianceInfo.business_city) {


### PR DESCRIPTION
Japan-based businesses were previously able to save compliance info without providing a `business_name`, only requiring `business_name_kanji` and `business_name_kana`.

This lead to a few issues:

1. The compliance info is not considered "complete" due to missing business,
2. `/settings/payments` fails to load because we always expect the business for business entities,
3. Stripe also requires the field on top of the `kanji` & `kana` versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for compliance information on the Payments page, ensuring the "business name" field is only required when appropriate and reducing redundant error checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->