### PR TITLE
Fix missing flash message when sales export is queued for email

### DIFF
--- a/app/javascript/components/server-components/Audience/CustomersPage.tsx
+++ b/app/javascript/components/server-components/Audience/CustomersPage.tsx
@@ -3,7 +3,7 @@ import cx from "classnames";
 import { lightFormat, subMonths } from "date-fns";
 import { format } from "date-fns-tz";
 import * as React from "react";
-import { createCast } from "ts-safe-cast";
+import { createCast, cast } from "ts-safe-cast";
 
 import {
   Address,
@@ -221,6 +221,8 @@ const CustomersPage = ({
 
   const [from, setFrom] = React.useState(subMonths(new Date(), 1));
   const [to, setTo] = React.useState(new Date());
+  const [csrfToken, setCsrfToken] = React.useState("");
+  useRunOnce(() => setCsrfToken(cast(document.querySelector("meta[name=csrf-token]")?.getAttribute("content"))));
 
   const exportNames = React.useMemo(
     () =>
@@ -405,18 +407,24 @@ const CustomersPage = ({
                   : "This will download a CSV with each purchase on its own row."}
               </div>
               <DateRangePicker from={from} to={to} setFrom={setFrom} setTo={setTo} />
-              <NavigationButton
-                color="primary"
-                href={Routes.export_purchases_path({
-                  format: "csv",
-                  start_time: lightFormat(from, "yyyy-MM-dd"),
-                  end_time: lightFormat(to, "yyyy-MM-dd"),
-                  product_ids: includedProductIds,
-                  variant_ids: includedVariantIds,
-                })}
+              <form
+                action={Routes.export_purchases_path({ format: "csv" })}
+                method="post"
+                style={{ display: "contents" }}
               >
-                Download
-              </NavigationButton>
+                <input type="hidden" name="authenticity_token" value={csrfToken} />
+                <input type="hidden" name="start_time" value={lightFormat(from, "yyyy-MM-dd")} />
+                <input type="hidden" name="end_time" value={lightFormat(to, "yyyy-MM-dd")} />
+                {includedProductIds.map((id) => (
+                  <input key={`product_${id}`} type="hidden" name="product_ids[]" value={id} />
+                ))}
+                {includedVariantIds.map((id) => (
+                  <input key={`variant_${id}`} type="hidden" name="variant_ids[]" value={id} />
+                ))}
+                <Button type="submit" color="primary">
+                  Download
+                </Button>
+              </form>
             </div>
           </Popover>
         </div>


### PR DESCRIPTION
## Problem
When exporting sales data that exceeds the synchronous export threshold (2,000 records), users expect to see a flash message indicating that the export will be emailed to them. However, this alert was not appearing.

## Root Cause
The export functionality was using a `NavigationButton` with an `href` attribute, which performs a GET request. GET requests for file downloads cannot properly handle redirects with flash messages when the export gets queued for background processing.

## Solution
Changed the export form from a GET request to a POST form submission:

- Replaced `NavigationButton` with `<form>` element using POST method
- Added proper CSRF token handling via `document.querySelector("meta[name=csrf-token]")`
- Maintained correct parameter format (`product_ids[]` and `variant_ids[]`)
- Preserved all existing functionality

## Testing
✅ **Small Dataset (≤2,000 records):** Direct download works as expected
✅ **Large Dataset (>2,000 records):** Flash message properly displays: *"You will receive an email in your inbox with the data you've requested shortly."*

## Screenshots
Before:
<img width="1035" height="479" alt="image" src="https://github.com/user-attachments/assets/dddcdd2c-3607-4740-a596-91614e678625" />

After:
<img width="1241" height="602" alt="image" src="https://github.com/user-attachments/assets/fa385ac5-997a-4b10-9333-ff7fb1a0e776" />


Fixes #649

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the export CSV functionality to use a secure POST form submission with CSRF protection.
  * The export form now includes options for date range and specific product or variant selection.

* **Style**
  * Improved layout by ensuring the export form does not affect the page structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->