### PR TITLE
Exclude deleted thumbnails from CreatorHomePresenter

### DIFF
--- a/app/presenters/creator_home_presenter.rb
+++ b/app/presenters/creator_home_presenter.rb
@@ -35,7 +35,7 @@ class CreatorHomePresenter
     product_permalinks = top_sales_data.map(&:first)
     products_by_permalink = seller.products
       .where(unique_permalink: product_permalinks)
-      .includes(thumbnail: { file_attachment: { blob: { variant_records: { image_attachment: :blob } } } })
+      .includes(thumbnail_alive: { file_attachment: { blob: { variant_records: { image_attachment: :blob } } } })
       .index_by(&:unique_permalink)
 
     sales = top_sales_data.map do |p|
@@ -45,7 +45,7 @@ class CreatorHomePresenter
       {
         "id" => product.unique_permalink,
         "name" => product.name,
-        "thumbnail" => product.thumbnail&.url,
+        "thumbnail" => product.thumbnail_alive&.url,
         "sales" => product.successful_sales_count,
         "revenue" => product.total_usd_cents,
         "visits" => product.number_of_views,

--- a/spec/presenters/creator_home_presenter_spec.rb
+++ b/spec/presenters/creator_home_presenter_spec.rb
@@ -112,6 +112,25 @@ describe CreatorHomePresenter do
       )
     end
 
+    it "excludes soft-deleted thumbnails from product data" do
+      # TODO(tech debt): Remove the top-level travel_to.
+      travel_back
+
+      product1 = create(:product, user: seller)
+      product2 = create(:product, user: seller)
+      thumbnail1 = create(:thumbnail, product: product1)
+      thumbnail2 = create(:thumbnail, product: product2)
+      thumbnail1.mark_deleted!
+
+      sales_data = presenter.creator_home_props[:sales]
+
+      product1_data = sales_data.find { |s| s["id"] == product1.unique_permalink }
+      product2_data = sales_data.find { |s| s["id"] == product2.unique_permalink }
+
+      expect(product1_data["thumbnail"]).to be_nil
+      expect(product2_data["thumbnail"]).to eq(thumbnail2.url)
+    end
+
     it "shows the 3 most sold products in past 30 days", :sidekiq_inline, :elasticsearch_wait_for_refresh do
       product1 = create(:product, user: seller)
       product2 = create(:product, user: seller)


### PR DESCRIPTION
Fixes a customer issue where we try to perform transformations on deleted thumbnails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured that only active (non-deleted) product thumbnails are shown in sales data on the creator home page.

* **Tests**
  * Added a test to confirm that soft-deleted thumbnails are excluded from product sales data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->