### PR TITLE
Disabled computing description for Discover cards

### DIFF
--- a/app/controllers/discover_controller.rb
+++ b/app/controllers/discover_controller.rb
@@ -41,6 +41,7 @@ class DiscoverController < ApplicationController
         request:,
         recommended_by: RecommendationType::GUMROAD_SEARCH_RECOMMENDATION,
         target: Product::Layout::DISCOVER,
+        compute_description: false,
         query: params[:query]
       )
     end


### PR DESCRIPTION
- we don't show the description on this page so we can disable calculating it and save ~20% of the load time

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal handling of product descriptions in the discovery section. No visible changes to end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->