### PR TITLE
feat(tax forms): download tax forms from dashboard

### DIFF
--- a/app/javascript/components/server-components/DashboardPage.tsx
+++ b/app/javascript/components/server-components/DashboardPage.tsx
@@ -19,6 +19,7 @@ import { GettingStartedIconProps } from "$app/components/icons/getting-started/G
 import { MakeAccountIcon } from "$app/components/icons/getting-started/MakeAccountIcon";
 import { SmallBetsIcon } from "$app/components/icons/getting-started/SmallBetsIcon";
 import { useLoggedInUser } from "$app/components/LoggedInUser";
+import { DownloadTaxFormsPopover } from "$app/components/server-components/DashboardPage/DownloadTaxFormsPopover";
 import { Stats } from "$app/components/Stats";
 import { useUserAgentInfo } from "$app/components/UserAgent";
 import { useRunOnce } from "$app/components/useRunOnce";
@@ -59,6 +60,9 @@ type Props = {
   };
   activity_items: ActivityItem[];
   stripe_verification_message?: string | null;
+  tax_forms: {
+    [year: number]: string;
+  };
   show_1099_download_notice: boolean;
 };
 type TableProps = { sales: ProductRow[] };
@@ -296,6 +300,7 @@ export const DashboardPage = ({
   activity_items,
   balances,
   stripe_verification_message,
+  tax_forms,
   show_1099_download_notice,
 }: Props) => {
   const loggedInUser = useLoggedInUser();
@@ -318,6 +323,9 @@ export const DashboardPage = ({
           {name ? `Hey, ${name}! ` : null}
           {has_sale ? "Welcome back to Gumroad." : "Welcome to Gumroad."}
         </h1>
+        <div className="actions flex gap-2">
+          {Object.keys(tax_forms).length > 0 && <DownloadTaxFormsPopover taxForms={tax_forms} />}
+        </div>
       </header>
       <div className="main-app-content" style={{ display: "grid", gap: "var(--spacer-7)" }}>
         {stripe_verification_message ? (

--- a/app/javascript/components/server-components/DashboardPage.tsx
+++ b/app/javascript/components/server-components/DashboardPage.tsx
@@ -60,9 +60,7 @@ type Props = {
   };
   activity_items: ActivityItem[];
   stripe_verification_message?: string | null;
-  tax_forms: {
-    [year: number]: string;
-  };
+  tax_forms: Record<number, string>;
   show_1099_download_notice: boolean;
 };
 type TableProps = { sales: ProductRow[] };

--- a/app/javascript/components/server-components/DashboardPage/DownloadTaxFormsPopover.tsx
+++ b/app/javascript/components/server-components/DashboardPage/DownloadTaxFormsPopover.tsx
@@ -1,0 +1,108 @@
+import * as React from "react";
+
+import { Button } from "$app/components/Button";
+import { Icon } from "$app/components/Icons";
+import { LoadingSpinner } from "$app/components/LoadingSpinner";
+import { Popover } from "$app/components/Popover";
+import { showAlert } from "$app/components/server-components/Alert";
+
+type Props = {
+  taxForms: {
+    [year: number]: string;
+  };
+};
+
+export const DownloadTaxFormsPopover = ({ taxForms }: Props) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [isDownloading, setIsDownloading] = React.useState(false);
+  const [selectedYears, setSelectedYears] = React.useState<Set<number>>(new Set());
+
+  const handleDownload = () => {
+    setIsDownloading(true);
+    try {
+      if (selectedYears.size === 0) {
+        showAlert("Please select at least one tax year to download.", "error");
+        return;
+      }
+      selectedYears.forEach((year) => {
+        window.open(taxForms[year], "_blank", "noopener,noreferrer");
+      });
+      setIsOpen(false);
+    } catch {
+      showAlert("Sorry, something went wrong. Please try again.", "error");
+    }
+    setIsDownloading(false);
+  };
+
+  const toggleSelectAll = () => {
+    setSelectedYears((prev) => new Set(prev.size === Object.keys(taxForms).length ? [] : Object.keys(taxForms)));
+  };
+
+  return (
+    <Popover
+      aria-label="Download tax forms"
+      open={isOpen}
+      onToggle={(open: boolean) => {
+        setIsOpen(open);
+        if (open) {
+          setSelectedYears(new Set());
+        }
+      }}
+      trigger={
+        <Button aria-label="Tax forms">
+          <span>Tax forms</span>
+          <Icon name="download" />
+        </Button>
+      }
+    >
+      {isOpen ? (
+        <div className="max-w-[300px] sm:max-w-full space-y-4">
+          {Object.keys(taxForms).length === 0 ? (
+            <section className="text-muted">No tax forms available.</section>
+          ) : (
+            <>
+              <header>
+                <p className="mb-1">
+                  <strong>Download tax forms</strong>
+                </p>
+                <p>Select the tax years you want to download.</p>
+              </header>
+
+              <section className="relative -mx-4 max-h-[300px] max-w-none overflow-y-auto border-b p-4">
+                <fieldset>
+                  {Object.keys(taxForms).sort().reverse().map((year) => (
+                    <label key={year}>
+                      <input
+                        type="checkbox"
+                        checked={selectedYears.has(year)}
+                        onChange={(event) => {
+                          const newSelectedYears = new Set(selectedYears);
+                          if (event.target.checked) {
+                            newSelectedYears.add(year);
+                          } else {
+                            newSelectedYears.delete(year);
+                          }
+                          setSelectedYears(newSelectedYears);
+                        }}
+                      />
+                      {year}
+                    </label>
+                  ))}
+                </fieldset>
+              </section>
+
+              <footer className="flex gap-4">
+                <Button className="flex-1" disabled={isDownloading} onClick={toggleSelectAll}>
+                  {selectedYears.size === Object.keys(taxForms).length ? "Deselect all" : "Select all"}
+                </Button>
+                <Button className="flex-1" color="primary" disabled={isDownloading} onClick={handleDownload}>
+                  {isDownloading ? <LoadingSpinner /> : "Download"}
+                </Button>
+              </footer>
+            </>
+          )}
+        </div>
+      ) : null}
+    </Popover>
+  );
+};

--- a/app/javascript/components/server-components/DashboardPage/DownloadTaxFormsPopover.tsx
+++ b/app/javascript/components/server-components/DashboardPage/DownloadTaxFormsPopover.tsx
@@ -2,23 +2,18 @@ import * as React from "react";
 
 import { Button } from "$app/components/Button";
 import { Icon } from "$app/components/Icons";
-import { LoadingSpinner } from "$app/components/LoadingSpinner";
 import { Popover } from "$app/components/Popover";
 import { showAlert } from "$app/components/server-components/Alert";
 
 type Props = {
-  taxForms: {
-    [year: number]: string;
-  };
+  taxForms: Record<number, string>;
 };
 
 export const DownloadTaxFormsPopover = ({ taxForms }: Props) => {
   const [isOpen, setIsOpen] = React.useState(false);
-  const [isDownloading, setIsDownloading] = React.useState(false);
   const [selectedYears, setSelectedYears] = React.useState<Set<number>>(new Set());
 
   const handleDownload = () => {
-    setIsDownloading(true);
     try {
       if (selectedYears.size === 0) {
         showAlert("Please select at least one tax year to download.", "error");
@@ -31,7 +26,6 @@ export const DownloadTaxFormsPopover = ({ taxForms }: Props) => {
     } catch {
       showAlert("Sorry, something went wrong. Please try again.", "error");
     }
-    setIsDownloading(false);
   };
 
   const toggleSelectAll = () => {
@@ -92,11 +86,11 @@ export const DownloadTaxFormsPopover = ({ taxForms }: Props) => {
               </section>
 
               <footer className="flex gap-4">
-                <Button className="flex-1" disabled={isDownloading} onClick={toggleSelectAll}>
+                <Button className="flex-1" onClick={toggleSelectAll}>
                   {selectedYears.size === Object.keys(taxForms).length ? "Deselect all" : "Select all"}
                 </Button>
-                <Button className="flex-1" color="primary" disabled={isDownloading} onClick={handleDownload}>
-                  {isDownloading ? <LoadingSpinner /> : "Download"}
+                <Button className="flex-1" color="primary" disabled={selectedYears.size === 0} onClick={handleDownload}>
+                  Download
                 </Button>
               </footer>
             </>

--- a/app/presenters/creator_home_presenter.rb
+++ b/app/presenters/creator_home_presenter.rb
@@ -65,7 +65,10 @@ class CreatorHomePresenter
       end
     end
 
-    previous_year = Time.current.prev_year.year
+    tax_forms = (Time.current.year.downto(seller.created_at.year)).each_with_object({}) do |year, hash|
+      url = seller.eligible_for_1099?(year) ? seller.tax_form_1099_download_url(year: year) : nil
+      hash[year] = url if url.present?
+    end
 
     {
       name: seller.alive_user_compliance_info&.first_name || "",
@@ -80,7 +83,8 @@ class CreatorHomePresenter
       sales:,
       activity_items:,
       stripe_verification_message:,
-      show_1099_download_notice: seller.eligible_for_1099?(previous_year) && seller.tax_form_1099_download_url(year: previous_year).present?,
+      tax_forms:,
+      show_1099_download_notice: tax_forms[Time.current.prev_year.year].present?
     }
   end
 

--- a/spec/presenters/creator_home_presenter_spec.rb
+++ b/spec/presenters/creator_home_presenter_spec.rb
@@ -297,22 +297,25 @@ describe CreatorHomePresenter do
       end
 
       it "includes tax forms since the seller's account was created" do
-        expect(presenter.creator_home_props[:tax_forms]).to eq({
-          2022 => download_url,
-          2021 => download_url,
-          2020 => download_url,
-        })
+        expect(presenter.creator_home_props[:tax_forms]).to eq(
+          {
+            2022 => download_url,
+            2021 => download_url,
+            2020 => download_url,
+          }
+        )
       end
 
       it "only includes years where the seller is eligible for a 1099" do
-        allow(seller).to receive(:eligible_for_1099?).do |year:|
+        allow(seller).to receive(:eligible_for_1099?) do |year|
           [2022, 2021].include?(year)
         end
 
-        expect(presenter.creator_home_props[:tax_forms]).to eq({
-          2022 => download_url,
-          2021 => download_url,
-        })
+        expect(presenter.creator_home_props[:tax_forms]).to eq(
+          {
+            2022 => download_url,
+            2021 => download_url,
+          })
       end
 
       it "only includes years that have downloadable tax forms" do
@@ -320,9 +323,11 @@ describe CreatorHomePresenter do
           year == 2021 ? download_url : nil
         end
 
-        expect(presenter.creator_home_props[:tax_forms]).to eq({
-          2021 => download_url,
-        })
+        expect(presenter.creator_home_props[:tax_forms]).to eq(
+          {
+            2021 => download_url,
+          }
+        )
       end
     end
   end

--- a/spec/presenters/creator_home_presenter_spec.rb
+++ b/spec/presenters/creator_home_presenter_spec.rb
@@ -286,5 +286,44 @@ describe CreatorHomePresenter do
         end
       end
     end
+
+    describe "tax forms" do
+      download_url = "https://s3.amazonaws.com/gumroad-specs/attachments/23b2d41ac63a40b5afa1a99bf38a0982/original/nyt.pdf"
+
+      before do
+        seller.update!(created_at: 2.years.ago)
+        allow(seller).to receive(:eligible_for_1099?).and_return(true)
+        allow(seller).to receive(:tax_form_1099_download_url).and_return(download_url)
+      end
+
+      it "includes tax forms since the seller's account was created" do
+        expect(presenter.creator_home_props[:tax_forms]).to eq({
+          2022 => download_url,
+          2021 => download_url,
+          2020 => download_url,
+        })
+      end
+
+      it "only includes years where the seller is eligible for a 1099" do
+        allow(seller).to receive(:eligible_for_1099?).do |year:|
+          [2022, 2021].include?(year)
+        end
+
+        expect(presenter.creator_home_props[:tax_forms]).to eq({
+          2022 => download_url,
+          2021 => download_url,
+        })
+      end
+
+      it "only includes years that have downloadable tax forms" do
+        allow(seller).to receive(:tax_form_1099_download_url) do |year:|
+          year == 2021 ? download_url : nil
+        end
+
+        expect(presenter.creator_home_props[:tax_forms]).to eq({
+          2021 => download_url,
+        })
+      end
+    end
   end
 end

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -138,6 +138,10 @@ describe "Dashboard", js: true, type: :feature do
   end
 
   describe "tax form download notice" do
+    before do
+      seller.update!(created_at: 1.year.ago)
+    end
+
     it "displays a 1099 form ready notice with a link to download if eligible" do
       download_url = "https://s3.amazonaws.com/gumroad-specs/attachments/23b2d41ac63a40b5afa1a99bf38a0982/original/nyt.pdf"
       allow_any_instance_of(User).to receive(:eligible_for_1099?).and_return(true)
@@ -157,5 +161,68 @@ describe "Dashboard", js: true, type: :feature do
       expect(page).not_to have_text("Your 1099 tax form for #{Time.current.prev_year.year} is ready!")
       expect(page).not_to have_link("Click here to download", href: dashboard_download_tax_form_path)
     end
+  end
+
+  describe "download tax forms button" do
+    download_url = "https://s3.amazonaws.com/gumroad-specs/attachments/23b2d41ac63a40b5afa1a99bf38a0982/original/nyt.pdf"
+
+    before do
+      seller.update!(created_at: 1.year.ago)
+      allow(seller).to receive(:eligible_for_1099?).and_return(true)
+      allow(seller).to receive(:tax_form_1099_download_url).and_return(download_url)
+    end
+
+    it "displays button when there are tax forms" do
+      visit dashboard_path
+
+      expect(page).to have_button("Tax forms")
+    end
+
+    it "opens a popover with a checkbox for each year with a tax form" do
+      visit dashboard_path
+
+      click_button("Tax forms")
+
+      expect(page).to have_text("Download tax forms")
+      expect(page).to have_text("Select the tax years you want to download.")
+      expect(page).to have_unchecked_field(Time.current.year.to_s)
+      expect(page).to have_unchecked_field(Time.current.prev_year.year.to_s)
+    end
+
+    it "allows selecting all yearsand deselecting all years" do
+      visit dashboard_path
+
+      click_button("Tax forms")
+      click_button("Select all")
+
+      expect(page).to have_checked_field(Time.current.year.to_s)
+      expect(page).to have_checked_field(Time.current.prev_year.year.to_s)
+
+      click_button("Deselect all")
+
+      expect(page).to have_unchecked_field(Time.current.year.to_s)
+      expect(page).to have_unchecked_field(Time.current.prev_year.year.to_s)
+    end
+
+    it "downloads selected tax forms" do
+      visit dashboard_path
+
+      click_button("Tax forms")
+      check(Time.current.prev_year.year.to_s)
+      new_window = window_opened_by { click_button("Download") }
+
+      within_window new_window do
+        expect(current_url).to eq(download_url)
+      end
+    end
+
+    it "does not display button if there are no tax forms" do
+      allow(seller).to receive(:eligible_for_1099?).and_return(false)
+
+      visit dashboard_path
+
+      expect(page).not_to have_button("Tax forms")
+    end
+
   end
 end

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -225,6 +225,5 @@ describe "Dashboard", js: true, type: :feature do
 
       expect(page).not_to have_button("Tax forms")
     end
-
   end
 end

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -139,6 +139,7 @@ describe "Dashboard", js: true, type: :feature do
 
   describe "tax form download notice" do
     before do
+      freeze_time
       seller.update!(created_at: 1.year.ago)
     end
 
@@ -167,6 +168,7 @@ describe "Dashboard", js: true, type: :feature do
     download_url = "https://s3.amazonaws.com/gumroad-specs/attachments/23b2d41ac63a40b5afa1a99bf38a0982/original/nyt.pdf"
 
     before do
+      freeze_time
       seller.update!(created_at: 1.year.ago)
       allow(seller).to receive(:eligible_for_1099?).and_return(true)
       allow(seller).to receive(:tax_form_1099_download_url).and_return(download_url)
@@ -189,7 +191,7 @@ describe "Dashboard", js: true, type: :feature do
       expect(page).to have_unchecked_field(Time.current.prev_year.year.to_s)
     end
 
-    it "allows selecting all yearsand deselecting all years" do
+    it "allows selecting all years and deselecting all years" do
       visit dashboard_path
 
       click_button("Tax forms")


### PR DESCRIPTION
## What
Part of #106 
Adds button to dashboard to download tax forms from S3. [Here are the mocks.](https://www.figma.com/design/imrSLaVgcJX5gS24AL4CUi/Make-tax-forms-downloadable-in-Dashboard)

|screenshot|recording|scroll functionality|
|---|---|---|
|<img width="378" height="352" alt="image" src="https://github.com/user-attachments/assets/e572ccbf-8cca-422a-bcd1-717a4068f336" />|<video src="https://github.com/user-attachments/assets/07fee63f-1c95-4fcb-90de-0ccef01c2f8c" />|<video src="https://github.com/user-attachments/assets/d9df2edb-6a9e-4e02-912a-25d5868d0b80" />|

## Open questions (answered ✅) 

I'm looking for opinions on the backend implementation before I write tests.

### How do tax forms get uploaded into the S3 bucket?
My PR assumes that there is a process that downloads tax forms annually to an S3 bucket, based on the code here:
https://github.com/antiwork/gumroad/blob/db9f00f26d0235238a46ab5ef11473dc8257370e/app/models/user.rb#L920-L923

However, I couldn't find the code/script where this happens. If this assumption is not accurate, or doesn't cover tax forms for all years, we need to find a different approach.

## Other approaches investigated
I investigated the following options to see how we could deliver 1099s directly from Stripe.

<details>
<summary>Stripe's Tax Forms API</summary>
Not publicly available. Seems like the best way to support the functionality we want when it is available.
</details>

<details>
<summary>Stripe's Reporting API</summary>
Seemed promising but does not support 1099s. 

- I ran the CLI command `stripe reporting report_types list` to see a list of report_types that Stripe supports through the report runs endpoint, and 1099s were not among them.
- I ran the CLI command below for a Stripe account that does have an auto-generated 1099 tax document, and confirmed that it didn't show up in the report_runs endpoint:
<code>
stripe reporting report_runs list --api-key={API_KEY}

{
  "object": "list",
  "data": [],
  "has_more": false,
  "url": "/v1/reporting/report_runs"
}
</code>

- I manually created a 1099 for a connected account in the Stripe sandbox that I'm using in my dev environment. It showed up in 1099s, but not when listing report runs.
 
<img width="1420" height="743" alt="image" src="https://github.com/user-attachments/assets/0d7d7665-5b7d-428b-b7da-e3597901b270" />

  - **In a Stripe sandbox, I could not find a way to trigger an 'automated' 1099 run for _connected_ accounts like how Stripe does in January.** Tried test clocks to do this. If we want to be really sure, perhaps someone on the Gumroad team can run this CLI command, filling in the account ID with a connected account that has autogenerated 1099s: `stripe reporting report_runs list --api-key={GUMROAD_STRIPE_API_KEY} --stripe-account {SELLER_STRIPE_ACCOUNT_ID}`
</details>

<details>
<summary>Stripe Embedded Component: Documents</summary>
Source: https://docs.stripe.com/connect/deliver-tax-forms#file-deliver-embedded

- Seems like a no-go because we would not have the ability to filter out other documents (like tax invoices). If Gumroad seller connected accounts don't have any other documents, maybe this could work?
- Also, we cannot customize the component to look like the current mocks, so we'd need to be ok with a totally different UI. Maybe we could use this component in the future Tax center instead (issue #551)
</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Introduced a "Tax forms" button on the dashboard, allowing users to download available tax forms for multiple years.
  * Added a popover interface to select and download tax forms by year, with options to select/deselect all years and download selected forms.

* **Bug Fixes**
  * Improved handling of tax form eligibility and availability for multiple years.

* **Tests**
  * Added and updated tests to verify the display, selection, and download of tax forms, as well as eligibility scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->