### PR TITLE
Extract installation of image libraries into helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,36 +84,25 @@ brew services stop mysql@8.0
     - `apt install libmysqlclient-dev`
   - Percona Toolkit: https://www.percona.com/doc/percona-toolkit/LATEST/installation.html
 
-#### Image Processing Libraries
+#### System libraries
 
-##### ImageMagick
+The app requires several system libraries for image processing. You can install them with a helper script:
 
-We use `imagemagick` for preview editing.
+```
+bin/install_deps.sh
+```
 
-- For MacOS: `brew install imagemagick`
-- For Linux: `sudo apt-get install imagemagick`
+The script works for ubuntu-like distros (with apt) and macOS. It will try to detect your OS, but if it fails you can force it:
 
-##### libvips
+```
+bin/install_deps.sh --ubuntu
+bin/install_deps.sh --macos
+```
 
-For newer image formats we use `libvips` for image processing with ActiveStorage.
+If on windows, run it under the WSL ubuntu shell. On ubuntu, it will prompt for the sudo password at the beginning.
 
-- For MacOS: `brew install libvips`
-- For Linux: `sudo apt-get install libvips-dev`
-
-#### FFmpeg
-
-We use `ffprobe` that comes with `FFmpeg` package to fetch metadata from video files.
-
-- For MacOS: `brew install ffmpeg`
-- For Linux: `sudo apt-get install ffmpeg`
-
-#### PDFtk
-
-We use [pdftk](https://www.pdflabs.com/tools/pdftk-server/) to stamp PDF files with the Gumroad logo and the buyers' emails.
-
-- For MacOS: Download from [here](https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/pdftk_server-2.02-mac_osx-10.11-setup.pkg)
-  - **Note:** pdftk may be blocked by Apple's firewall. If this happens, go to Settings > Privacy & Security and click "Open Anyways" to allow the installation.
-- For Linux: `sudo apt-get install pdftk`
+##### MacOS only
+[pdftk](https://www.pdflabs.com/tools/pdftk-server/) for mac is available as a GUI installer, so it needs to be installed manually. [Download from here](https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/pdftk_server-2.02-mac_osx-10.11-setup.pkg). The domain may be blocked by Apple's firewall - if this happens, go to Settings > Privacy & Security and click "Open Anyways" to allow the installation.
 
 ### Installation
 

--- a/bin/install_deps.sh
+++ b/bin/install_deps.sh
@@ -1,0 +1,87 @@
+
+#!/usr/bin/env bash
+set -eo pipefail
+
+# Installation script for MacOS and Ubuntu system dependencies,
+# via the corresponding package managers.
+#
+# Usage: ./install_deps.sh [--macos|--ubuntu]
+# If no argument is provided, OS will be auto-detected
+
+
+# Helper functions
+command_exists() { command -v "$1" >/dev/null 2>&1; }
+
+# Colors for output
+green="\033[0;32m"
+red="\033[0;31m"
+yellow="\033[0;33m"
+reset="\033[0m"
+
+header() { echo -e "${green}==> $1${reset}"; }
+info() { echo -e "${yellow}==>    $1${reset}"; }
+error() { echo -e "${red}==> $1${reset}"; }
+
+# Parse command line arguments
+parse_args() {
+  if [[ $# -eq 0 ]]; then
+    return
+  fi
+
+  case "$1" in
+    --macos)
+      echo "macos"
+      ;;
+    --ubuntu)
+      echo "ubuntu"
+      ;;
+    *)
+      error "Unknown argument: $1"
+      error "Usage: $0 [--macos|--ubuntu]"
+      exit 1
+      ;;
+  esac
+}
+
+detect_os() {
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    echo "macos"
+  elif [[ -f /etc/os-release ]]; then
+    source /etc/os-release
+    if [[ "$ID" == "ubuntu" ]]; then
+      echo "ubuntu"
+    else
+      error "Unsupported OS: $ID"
+      exit 1
+    fi
+  else
+    error "Could not detect OS"
+    exit 1
+  fi
+}
+
+# Select OS: from CL argument, or auto-detection
+MANUAL_OS=$(parse_args "$@")
+if [[ -n "$MANUAL_OS" ]]; then
+  OS="$MANUAL_OS"
+  header "Using manually specified OS: $OS"
+else
+  OS=$(detect_os)
+  header "Detected OS: $OS"
+fi
+
+# INSTALL IMAGE PROCESSING LIBRARIES
+# We use imagemagick for preview editing.
+# For newer image formats we use libvips for image processing with ActiveStorage.
+# We use ffprobe that comes with FFmpeg package to fetch metadata from video files.
+# We use pdftk to stamp PDF files with the Gumroad logo and the buyers' emails.
+# Note: on MacOS pdftk needs to be installed manually, see README file.
+header "Installing image processing libraries..."
+if [[ "$OS" == "macos" ]]; then
+  brew install imagemagick libvips ffmpeg # No pdftk
+elif [[ "$OS" == "ubuntu" ]]; then
+  sudo apt install -y imagemagick libvips-dev ffmpeg pdftk
+fi
+
+
+header "Setup complete!"


### PR DESCRIPTION
Last week I made PR where I extracted all of the prerequisite installation steps from the readme into a helper script, see https://github.com/antiwork/gumroad/pull/691.

However, the resulting script was a little dense, so I was suggested to break it into smaller PRs to ease reviewing & merging.

In this first step, I've included just the image libraries bit out of the readme and into the helper script. 

This change on its own is a bit pointless, since it just moves a couple of lines from the readme into a script - it doesn't really save any time, and it adds complexity. But the plan is, in successive PRs, to bring into the script [the rest of the changes in the big PR](https://github.com/antiwork/gumroad/pull/691): installation of ruby, node, the DB libraries and some other little bits. So ultimately, the whole prerequisites section will just be "run this script". The readme will be cleaner, and the setup process easier, faster and more consistent.
