### PR TITLE
feat(tax): Add tax-inclusive pricing support with default for new 

### DIFF
--- a/app/business/sales_tax/sales_tax_calculation.rb
+++ b/app/business/sales_tax/sales_tax_calculation.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 class SalesTaxCalculation
-  attr_reader :price_cents, :tax_cents, :zip_tax_rate, :business_vat_status, :used_taxjar, :gumroad_is_mpf, :taxjar_info, :is_quebec
+  attr_reader :price_cents, :tax_cents, :net_price_cents, :zip_tax_rate, :business_vat_status, :used_taxjar, :gumroad_is_mpf, :taxjar_info, :is_quebec
 
-  def initialize(price_cents:, tax_cents:, zip_tax_rate:, business_vat_status: nil, used_taxjar: false, gumroad_is_mpf: false, taxjar_info: nil, is_quebec: false)
+  def initialize(price_cents:, tax_cents:, zip_tax_rate:, net_price_cents: nil, business_vat_status: nil, used_taxjar: false, gumroad_is_mpf: false, taxjar_info: nil, is_quebec: false)
     @price_cents = price_cents
-    @tax_cents = tax_cents
+    @tax_cents = tax_cents.is_a?(BigDecimal) ? tax_cents.to_i : tax_cents
+    @net_price_cents = net_price_cents || price_cents # Default to price_cents for backward compatibility
     @zip_tax_rate = zip_tax_rate
     @business_vat_status = business_vat_status
     @used_taxjar = used_taxjar
@@ -31,6 +32,7 @@ class SalesTaxCalculation
     {
       price_cents:,
       tax_cents:,
+      net_price_cents:,
       business_vat_status:,
       has_vat_id_input: has_vat_id_input?
     }

--- a/app/business/sales_tax/sales_tax_calculator.rb
+++ b/app/business/sales_tax/sales_tax_calculator.rb
@@ -44,7 +44,6 @@ class SalesTaxCalculator
     # Input validation for edge cases
     combined_rate = tax_rate.combined_rate
     raise SalesTaxCalculatorValidationError, "Tax rate must be between 0 and 1" unless combined_rate >= 0 && combined_rate <= 1
-    raise SalesTaxCalculatorValidationError, "Invalid tax rate configuration" if combined_rate == -1
 
     if product.tax_inclusive
       # For tax-inclusive pricing: extract tax from the price using BigDecimal for precision
@@ -134,6 +133,7 @@ class SalesTaxCalculator
         # For tax-inclusive pricing with TaxJar: the price_cents already includes tax
         # TaxJar tells us the tax amount, so net price = price - tax
         net_price_cents = price_cents - tax_amount_cents
+        raise SalesTaxCalculatorValidationError, "Net price must be positive" if net_price_cents <= 0
       else
         # For tax-exclusive pricing: net price equals the price (tax added on top)
         net_price_cents = price_cents

--- a/app/business/sales_tax/sales_tax_calculator.rb
+++ b/app/business/sales_tax/sales_tax_calculator.rb
@@ -41,9 +41,36 @@ class SalesTaxCalculator
     return SalesTaxCalculation.zero_tax(price_cents) if tax_rate.nil?
     return SalesTaxCalculation.zero_tax(price_cents) unless tax_eligible?
 
-    tax_amount_cents = price_cents * tax_rate.combined_rate
+    # Input validation for edge cases
+    combined_rate = tax_rate.combined_rate
+    raise SalesTaxCalculatorValidationError, "Tax rate must be between 0 and 1" unless combined_rate >= 0 && combined_rate <= 1
+    raise SalesTaxCalculatorValidationError, "Invalid tax rate configuration" if combined_rate == -1
+
+    if product.tax_inclusive
+      # For tax-inclusive pricing: extract tax from the price using BigDecimal for precision
+      # tax_amount = price_with_tax / (1 + tax_rate) * tax_rate
+      price_decimal = BigDecimal(price_cents.to_s)
+      rate_decimal = BigDecimal(combined_rate.to_s)
+      
+      # Calculate tax amount with proper precision
+      tax_amount_decimal = price_decimal * rate_decimal / (BigDecimal("1") + rate_decimal)
+      tax_amount_cents = tax_amount_decimal.round(0).to_i
+      net_price_cents = price_cents - tax_amount_cents
+      
+      # Ensure net price is positive
+      raise SalesTaxCalculatorValidationError, "Net price must be positive" if net_price_cents <= 0
+    else
+      # For tax-exclusive pricing: add tax to the price (current behavior)
+      price_decimal = BigDecimal(price_cents.to_s)
+      rate_decimal = BigDecimal(combined_rate.to_s)
+      tax_amount_decimal = price_decimal * rate_decimal
+      tax_amount_cents = tax_amount_decimal.round(0).to_i
+      net_price_cents = price_cents
+    end
+
     SalesTaxCalculation.new(price_cents:,
                             tax_cents: tax_amount_cents,
+                            net_price_cents:,
                             zip_tax_rate: tax_rate,
                             business_vat_status: @buyer_vat_id.present? ? :invalid : nil,
                             is_quebec:)
@@ -102,9 +129,19 @@ class SalesTaxCalculator
       }
 
       tax_amount_cents = (taxjar_response_json["amount_to_collect"] * 100.0).round.to_d
+      
+      if product.tax_inclusive
+        # For tax-inclusive pricing with TaxJar: the price_cents already includes tax
+        # TaxJar tells us the tax amount, so net price = price - tax
+        net_price_cents = price_cents - tax_amount_cents
+      else
+        # For tax-exclusive pricing: net price equals the price (tax added on top)
+        net_price_cents = price_cents
+      end
 
       SalesTaxCalculation.new(price_cents:,
                               tax_cents: tax_amount_cents,
+                              net_price_cents:,
                               zip_tax_rate: nil,
                               business_vat_status: buyer_vat_id.present? ? :invalid : nil,
                               used_taxjar: true,
@@ -115,6 +152,7 @@ class SalesTaxCalculator
 
     def validate
       raise SalesTaxCalculatorValidationError, "Price (cents) should be an Integer" unless @price_cents.is_a? Integer
+      raise SalesTaxCalculatorValidationError, "Price (cents) must be positive" unless @price_cents > 0
       raise SalesTaxCalculatorValidationError, "Buyer Location should be a Hash" unless @buyer_location.is_a? Hash
       raise SalesTaxCalculatorValidationError, "Product should be a Link instance" unless @product.is_a? Link
     end

--- a/app/business/sales_tax/sales_tax_calculator.rb
+++ b/app/business/sales_tax/sales_tax_calculator.rb
@@ -132,7 +132,7 @@ class SalesTaxCalculator
       if product.tax_inclusive
         # For tax-inclusive pricing with TaxJar: the price_cents already includes tax
         # TaxJar tells us the tax amount, so net price = price - tax
-        net_price_cents = price_cents - tax_amount_cents
+        net_price_cents = (price_cents - tax_amount_cents).to_i
         raise SalesTaxCalculatorValidationError, "Net price must be positive" if net_price_cents <= 0
       else
         # For tax-exclusive pricing: net price equals the price (tax added on top)

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -121,6 +121,7 @@ class LinksController < ApplicationController
     @product.taxonomy = Taxonomy.find_by(slug: "other")
     @product.is_bundle = @product.native_type == Link::NATIVE_TYPE_BUNDLE
     @product.json_data[:custom_button_text_option] = "donate_prompt" if @product.native_type == Link::NATIVE_TYPE_COFFEE
+    @product.tax_inclusive = true unless params[:link]&.key?(:tax_inclusive)
 
     begin
       @product.save!
@@ -601,7 +602,7 @@ class LinksController < ApplicationController
                                    :should_include_last_post, :should_show_all_posts, :should_show_sales_count, :duration_in_months,
                                    :free_trial_enabled, :free_trial_duration_amount, :free_trial_duration_unit,
                                    :is_adult, :is_epublication, :product_refund_policy_enabled, :seller_refund_policy_enabled,
-                                   :refund_policy, :taxonomy_id)
+                                   :refund_policy, :taxonomy_id, :tax_inclusive)
     end
 
     def paged_params

--- a/app/modules/product/prices.rb
+++ b/app/modules/product/prices.rb
@@ -128,15 +128,31 @@ module Product::Prices
   # For tax-exclusive products, returns the same as display_price_cents.
   def net_price_cents_for_tax_rate(tax_rate)
     return display_price_cents unless tax_inclusive && tax_rate&.combined_rate
-
-    # For tax-inclusive pricing: net_price = price_with_tax / (1 + tax_rate)
-    display_price_cents / (1 + tax_rate.combined_rate)
+    
+    # Input validation for edge cases (matching SalesTaxCalculator patterns)
+    combined_rate = tax_rate.combined_rate
+    return display_price_cents unless combined_rate >= 0 && combined_rate <= 1
+    return display_price_cents if combined_rate == -1
+    
+    # For tax-inclusive pricing: extract net price using BigDecimal for precision
+    # net_price = price_with_tax / (1 + tax_rate)
+    price_decimal = BigDecimal(display_price_cents.to_s)
+    rate_decimal = BigDecimal(combined_rate.to_s)
+    
+    # Calculate net price with proper precision
+    net_price_decimal = price_decimal / (BigDecimal("1") + rate_decimal)
+    net_price_cents = net_price_decimal.round(0).to_i
+    
+    # Ensure net price is positive
+    return display_price_cents if net_price_cents <= 0
+    
+    net_price_cents
   end
 
   # Public: Returns formatted net price (excluding tax) for tax-inclusive products
   def net_price_formatted_for_tax_rate(tax_rate, additional_attrs = {})
-    net_price = net_price_cents_for_tax_rate(tax_rate)
-    display_price_for_price_cents(net_price, additional_attrs)
+    net_price_cents = net_price_cents_for_tax_rate(tax_rate)
+    display_price_for_price_cents(net_price_cents, additional_attrs)
   end
 
   def min_price_formatted

--- a/app/modules/product/prices.rb
+++ b/app/modules/product/prices.rb
@@ -124,6 +124,21 @@ module Product::Prices
     CURRENCY_CHOICES[price_currency_type]
   end
 
+  # Public: Returns the net price (excluding tax) for tax-inclusive products.
+  # For tax-exclusive products, returns the same as display_price_cents.
+  def net_price_cents_for_tax_rate(tax_rate)
+    return display_price_cents unless tax_inclusive && tax_rate&.combined_rate
+
+    # For tax-inclusive pricing: net_price = price_with_tax / (1 + tax_rate)
+    display_price_cents / (1 + tax_rate.combined_rate)
+  end
+
+  # Public: Returns formatted net price (excluding tax) for tax-inclusive products
+  def net_price_formatted_for_tax_rate(tax_rate, additional_attrs = {})
+    net_price = net_price_cents_for_tax_rate(tax_rate)
+    display_price_for_price_cents(net_price, additional_attrs)
+  end
+
   def min_price_formatted
     MoneyFormatter.format(currency["min_price"], price_currency_type.to_sym, no_cents_if_whole: true, symbol: true)
   end

--- a/app/modules/product/prices.rb
+++ b/app/modules/product/prices.rb
@@ -132,7 +132,6 @@ module Product::Prices
     # Input validation for edge cases (matching SalesTaxCalculator patterns)
     combined_rate = tax_rate.combined_rate
     return display_price_cents unless combined_rate >= 0 && combined_rate <= 1
-    return display_price_cents if combined_rate == -1
     
     # For tax-inclusive pricing: extract net price using BigDecimal for precision
     # net_price = price_with_tax / (1 + tax_rate)

--- a/db/migrate/20250728212103_add_tax_inclusive_to_links.rb
+++ b/db/migrate/20250728212103_add_tax_inclusive_to_links.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddTaxInclusiveToLinks < ActiveRecord::Migration[6.1]
+  def change
+    add_column :links, :tax_inclusive, :boolean, default: true, null: false
+    
+    # Set existing records to false to maintain current tax-exclusive behavior
+    reversible do |dir|
+      dir.up do
+        execute "UPDATE links SET tax_inclusive = false"
+      end
+    end
+    
+    # Add index for potential performance queries on tax_inclusive
+    add_index :links, :tax_inclusive
+  end
+end

--- a/spec/business/sales_tax/sales_tax_calculation_spec.rb
+++ b/spec/business/sales_tax/sales_tax_calculation_spec.rb
@@ -28,6 +28,20 @@ describe SalesTaxCalculation do
 
       expect(actual_hash[:price_cents]).to eq(100)
       expect(actual_hash[:tax_cents]).to eq(10)
+      expect(actual_hash[:net_price_cents]).to eq(100) # Default to price_cents for backward compatibility
+      expect(actual_hash[:has_vat_id_input]).to be(false)
+    end
+
+    it "serializes a tax calculation with explicit net_price_cents" do
+      zip_tax_rate = create(:zip_tax_rate, is_seller_responsible: 0)
+      actual_hash = SalesTaxCalculation.new(price_cents: 100,
+                                            tax_cents: 10,
+                                            net_price_cents: 90,
+                                            zip_tax_rate:).to_hash
+
+      expect(actual_hash[:price_cents]).to eq(100)
+      expect(actual_hash[:tax_cents]).to eq(10)
+      expect(actual_hash[:net_price_cents]).to eq(90)
       expect(actual_hash[:has_vat_id_input]).to be(false)
     end
 

--- a/spec/business/sales_tax/sales_tax_calculator_spec.rb
+++ b/spec/business/sales_tax/sales_tax_calculator_spec.rb
@@ -2302,7 +2302,7 @@ describe SalesTaxCalculator do
         # Mock TaxJar response - in real scenario, TaxJar would calculate based on the price
         allow_any_instance_of(TaxjarApi).to receive(:calculate_tax_for_order).and_return({
           "rate" => 0.1025,
-          "amount_to_collect" => 93.87, # Tax amount for $1000 inclusive price
+          "amount_to_collect" => 0.93, # Tax amount for $10 inclusive price (~10% tax rate)
           "breakdown" => {
             "state_tax_rate" => 0.065,
             "county_tax_rate" => 0.003,
@@ -2318,7 +2318,7 @@ describe SalesTaxCalculator do
           }
         })
 
-        expected_tax_cents = 9387 # $93.87 in cents
+        expected_tax_cents = 93 # $0.93 in cents  
         expected_net_price_cents = 1000 - expected_tax_cents # For tax-inclusive: net = price - tax
 
         calculation = SalesTaxCalculator.new(

--- a/spec/business/sales_tax/sales_tax_calculator_spec.rb
+++ b/spec/business/sales_tax/sales_tax_calculator_spec.rb
@@ -2216,8 +2216,184 @@ describe SalesTaxCalculator do
 
     expect(actual.price_cents).to eq(expected.price_cents)
     expect(actual.tax_cents).to eq(expected.tax_cents)
+    expect(actual.net_price_cents).to eq(expected.net_price_cents)
     expect(actual.zip_tax_rate).to eq(expected.zip_tax_rate)
     expect(actual.used_taxjar).to eq(expected.used_taxjar)
     expect(actual.taxjar_info).to eq(expected.taxjar_info)
+  end
+
+  describe "tax-inclusive pricing" do
+    before(:each) do
+      @seller = create(:user)
+    end
+
+    context "with lookup table calculation" do
+      it "calculates tax correctly for tax-inclusive product" do
+        tax_rate = create(:zip_tax_rate, country: "ES", zip_code: nil, state: nil, combined_rate: 0.21, is_seller_responsible: false)
+        tax_inclusive_product = create(:product, user: @seller, tax_inclusive: true, price_cents: 1000)
+
+        # For tax-inclusive: tax = price_with_tax / (1 + rate) * rate
+        # tax = 1000 / (1 + 0.21) * 0.21 = 1000 / 1.21 * 0.21 ≈ 173.55
+        expected_tax_cents = (1000 / (1 + 0.21) * 0.21).round
+        expected_net_price_cents = 1000 - expected_tax_cents
+
+        expected_calculation = SalesTaxCalculation.new(
+          price_cents: 1000,
+          tax_cents: expected_tax_cents,
+          net_price_cents: expected_net_price_cents,
+          zip_tax_rate: tax_rate
+        )
+
+        actual_calculation = SalesTaxCalculator.new(
+          product: tax_inclusive_product,
+          price_cents: 1000,
+          buyer_location: { country: "ES" }
+        ).calculate
+
+        compare_calculations(expected: expected_calculation, actual: actual_calculation)
+      end
+
+      it "calculates tax correctly for tax-exclusive product (existing behavior)" do
+        tax_rate = create(:zip_tax_rate, country: "ES", zip_code: nil, state: nil, combined_rate: 0.21, is_seller_responsible: false)
+        tax_exclusive_product = create(:product, user: @seller, tax_inclusive: false, price_cents: 1000)
+
+        # For tax-exclusive: tax = price * rate (existing behavior)
+        expected_tax_cents = (1000 * 0.21).round
+        expected_net_price_cents = 1000 # net price equals price for tax-exclusive
+
+        expected_calculation = SalesTaxCalculation.new(
+          price_cents: 1000,
+          tax_cents: expected_tax_cents,
+          net_price_cents: expected_net_price_cents,
+          zip_tax_rate: tax_rate
+        )
+
+        actual_calculation = SalesTaxCalculator.new(
+          product: tax_exclusive_product,
+          price_cents: 1000,
+          buyer_location: { country: "ES" }
+        ).calculate
+
+        compare_calculations(expected: expected_calculation, actual: actual_calculation)
+      end
+
+      it "returns zero tax for tax-inclusive product when no tax applies" do
+        tax_inclusive_product = create(:product, user: @seller, tax_inclusive: true, price_cents: 1000)
+
+        calculation = SalesTaxCalculator.new(
+          product: tax_inclusive_product,
+          price_cents: 1000,
+          buyer_location: { country: "ZZ" }
+        ).calculate
+
+        compare_calculations(expected: SalesTaxCalculation.zero_tax(1000), actual: calculation)
+      end
+    end
+
+    context "with TaxJar calculation", :vcr do
+      before do
+        @creator = create(:user_with_compliance_info)
+        @tax_inclusive_product = create(:physical_product, user: @creator, require_shipping: true, price_cents: 1000, tax_inclusive: true)
+        @tax_inclusive_product.shipping_destinations << ShippingDestination.new(country_code: "US", one_item_rate_cents: 100, multiple_items_rate_cents: 200)
+        @tax_inclusive_product.save!
+      end
+
+      it "calculates tax correctly for tax-inclusive product with TaxJar" do
+        # Mock TaxJar response - in real scenario, TaxJar would calculate based on the price
+        allow_any_instance_of(TaxjarApi).to receive(:calculate_tax_for_order).and_return({
+          "rate" => 0.1025,
+          "amount_to_collect" => 93.87, # Tax amount for $1000 inclusive price
+          "breakdown" => {
+            "state_tax_rate" => 0.065,
+            "county_tax_rate" => 0.003,
+            "city_tax_rate" => 0.0115,
+            "gst_tax_rate" => nil,
+            "pst_tax_rate" => nil,
+            "qst_tax_rate" => nil
+          },
+          "jurisdictions" => {
+            "state" => "WA",
+            "county" => "KING",
+            "city" => "SEATTLE"
+          }
+        })
+
+        expected_tax_cents = 9387 # $93.87 in cents
+        expected_net_price_cents = 1000 - expected_tax_cents # For tax-inclusive: net = price - tax
+
+        calculation = SalesTaxCalculator.new(
+          product: @tax_inclusive_product,
+          price_cents: 1000,
+          shipping_cents: 100,
+          quantity: 1,
+          buyer_location: { postal_code: "98121", country: "US" }
+        ).calculate
+
+        expect(calculation.price_cents).to eq(1000)
+        expect(calculation.tax_cents).to eq(expected_tax_cents)
+        expect(calculation.net_price_cents).to eq(expected_net_price_cents)
+        expect(calculation.used_taxjar).to be(true)
+      end
+    end
+
+    context "edge cases" do
+      before(:each) do
+        @seller = create(:user)
+      end
+
+      it "handles zero tax rate for tax-inclusive product" do
+        create(:zip_tax_rate, country: "ES", zip_code: nil, state: nil, combined_rate: 0.0, is_seller_responsible: false)
+        tax_inclusive_product = create(:product, user: @seller, tax_inclusive: true, price_cents: 1000)
+
+        calculation = SalesTaxCalculator.new(
+          product: tax_inclusive_product,
+          price_cents: 1000,
+          buyer_location: { country: "ES" }
+        ).calculate
+
+        # With 0% tax rate, net price should equal total price
+        expect(calculation.price_cents).to eq(1000)
+        expect(calculation.tax_cents).to eq(0)
+        expect(calculation.net_price_cents).to eq(1000)
+      end
+
+      it "handles very small tax rates for tax-inclusive product" do
+        tax_rate = create(:zip_tax_rate, country: "ES", zip_code: nil, state: nil, combined_rate: 0.001, is_seller_responsible: false)
+        tax_inclusive_product = create(:product, user: @seller, tax_inclusive: true, price_cents: 1000)
+
+        expected_tax_cents = (1000 / (1 + 0.001) * 0.001).round
+        expected_net_price_cents = 1000 - expected_tax_cents
+
+        calculation = SalesTaxCalculator.new(
+          product: tax_inclusive_product,
+          price_cents: 1000,
+          buyer_location: { country: "ES" }
+        ).calculate
+
+        expect(calculation.price_cents).to eq(1000)
+        expect(calculation.tax_cents).to eq(expected_tax_cents)
+        expect(calculation.net_price_cents).to eq(expected_net_price_cents)
+      end
+
+      it "handles high tax rates for tax-inclusive product" do
+        tax_rate = create(:zip_tax_rate, country: "ES", zip_code: nil, state: nil, combined_rate: 0.50, is_seller_responsible: false)
+        tax_inclusive_product = create(:product, user: @seller, tax_inclusive: true, price_cents: 1500)
+
+        expected_tax_cents = (1500 / (1 + 0.50) * 0.50).round
+        expected_net_price_cents = 1500 - expected_tax_cents
+
+        calculation = SalesTaxCalculator.new(
+          product: tax_inclusive_product,
+          price_cents: 1500,
+          buyer_location: { country: "ES" }
+        ).calculate
+
+        expect(calculation.price_cents).to eq(1500)
+        expect(calculation.tax_cents).to eq(expected_tax_cents)
+        expect(calculation.net_price_cents).to eq(expected_net_price_cents)
+        # Verify the calculation is approximately correct: net + tax ≈ total
+        expect(calculation.net_price_cents + calculation.tax_cents).to be_within(1).of(1500)
+      end
+    end
   end
 end

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -3010,6 +3010,30 @@ describe LinksController, :vcr do
         expect(link.reload.preorder_link.present?).to be(false)
       end
 
+      it "sets tax_inclusive to true by default for new products" do
+        params = { price_cents: 100, name: "test link" }
+        post :create, params: { format: :json, link: params }
+        expect(response.parsed_body["success"]).to be(true)
+        link = seller.links.last
+        expect(link.tax_inclusive).to be(true)
+      end
+
+      it "allows explicit tax_inclusive setting" do
+        params = { price_cents: 100, name: "test link", tax_inclusive: false }
+        post :create, params: { format: :json, link: params }
+        expect(response.parsed_body["success"]).to be(true)
+        link = seller.links.last
+        expect(link.tax_inclusive).to be(false)
+      end
+
+      it "maintains tax_inclusive true when explicitly set" do
+        params = { price_cents: 100, name: "test link", tax_inclusive: true }
+        post :create, params: { format: :json, link: params }
+        expect(response.parsed_body["success"]).to be(true)
+        link = seller.links.last
+        expect(link.tax_inclusive).to be(true)
+      end
+
       it "is able to set currency type" do
         params = { price_cents: 100, name: "test link", url: @s3_url, price_currency_type: "jpy" }
         post :create, params: { format: :json, link: params }

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -5299,4 +5299,50 @@ describe Link, :vcr do
       end
     end
   end
+
+  describe "tax-inclusive pricing methods" do
+    describe "#net_price_cents_for_tax_rate" do
+      it "returns display_price_cents for tax-exclusive products" do
+        product = create(:product, tax_inclusive: false, price_cents: 1000)
+        tax_rate = double(combined_rate: 0.21)
+
+        expect(product.net_price_cents_for_tax_rate(tax_rate)).to eq(1000)
+      end
+
+      it "returns display_price_cents when tax_rate is nil" do
+        product = create(:product, tax_inclusive: true, price_cents: 1000)
+
+        expect(product.net_price_cents_for_tax_rate(nil)).to eq(1000)
+      end
+
+      it "calculates net price for tax-inclusive products" do
+        product = create(:product, tax_inclusive: true, price_cents: 1000)
+        tax_rate = double(combined_rate: 0.21)
+
+        # For tax-inclusive: net_price = price_with_tax / (1 + tax_rate)
+        expected_net_price = 1000 / (1 + 0.21)
+        expect(product.net_price_cents_for_tax_rate(tax_rate)).to eq(expected_net_price)
+      end
+
+      it "handles zero tax rate for tax-inclusive products" do
+        product = create(:product, tax_inclusive: true, price_cents: 1000)
+        tax_rate = double(combined_rate: 0.0)
+
+        expect(product.net_price_cents_for_tax_rate(tax_rate)).to eq(1000)
+      end
+    end
+
+    describe "#net_price_formatted_for_tax_rate" do
+      it "formats net price correctly" do
+        product = create(:product, tax_inclusive: true, price_cents: 1000, price_currency_type: "usd")
+        tax_rate = double(combined_rate: 0.20)
+
+        # Mock the display_price_for_price_cents method behavior
+        expected_net_price = 1000 / (1 + 0.20)
+        allow(product).to receive(:display_price_for_price_cents).with(expected_net_price, {}).and_return("$8.33")
+
+        expect(product.net_price_formatted_for_tax_rate(tax_rate)).to eq("$8.33")
+      end
+    end
+  end
 end

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -5320,7 +5320,7 @@ describe Link, :vcr do
         tax_rate = double(combined_rate: 0.21)
 
         # For tax-inclusive: net_price = price_with_tax / (1 + tax_rate)
-        expected_net_price = 1000 / (1 + 0.21)
+        expected_net_price = (1000 / (1 + 0.21)).round
         expect(product.net_price_cents_for_tax_rate(tax_rate)).to eq(expected_net_price)
       end
 


### PR DESCRIPTION
### What
Allow products to have tax-inclusive pricing. Default to this for new products.

### Why
This is legally required or expected in many countries and may increase conversion.

### Related Issue
Closes antiwork/gumroad#698



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced support for tax-inclusive pricing on products, allowing prices to include tax by default.
  * Added display and calculation of net price (excluding tax) for tax-inclusive products.
  * Products now have a "tax_inclusive" attribute, which can be set during creation.

* **Bug Fixes**
  * Improved input validation for tax calculations, ensuring prices and tax rates are within valid ranges.

* **Tests**
  * Expanded test coverage for tax-inclusive pricing scenarios, including edge cases and controller behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->