### PR TITLE
Enhance PaypalChargeProcessor spec with mock setups 

### DIFF
--- a/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
@@ -49,6 +49,9 @@ describe PaypalChargeProcessor, :vcr do
       before do
         @purchase = create(:purchase_with_balance, id: 1001)
         allow_any_instance_of(Purchase).to receive(:fight_chargeback).and_return(true)
+        allow_any_instance_of(Purchase).to receive(:secure_external_id).and_return("sample-secure-id")
+        allow(Purchase).to receive(:find_by_external_id).and_return(@purchase)
+        allow(DisputeEvidence).to receive(:create_from_dispute!).and_return nil
       end
 
       describe "reversal and reversal cancelled events" do


### PR DESCRIPTION
Closes: https://github.com/antiwork/gumroad/issues/687

Contributors working on the open source project don't have access to the production or test's OBFUSCATE_IDS_CIPHER_KEY environment variable, which prevents them from testing invoice decryption functionality. This creates barriers for contributor onboarding and testing.

### Solution:
Stub `Purchase.find_by_external_id` to return the the object that we wanted (in this case it's the purchase)



<img width="1496" height="267" alt="image" src="https://github.com/user-attachments/assets/fb22dbd9-236e-47c1-8b6a-5e4318cec817" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for PayPal payment events by adding new stubs for purchase identification and dispute evidence creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->