### PR TITLE
fix: Block Ineligible and Spammy Products from Appearing on Discover

### DIFF
--- a/app/modules/product/recommendations.rb
+++ b/app/modules/product/recommendations.rb
@@ -14,7 +14,10 @@ module Product::Recommendations
       not_archived: !archived?,
       reviews_displayed: display_product_reviews?,
       not_sold_out: max_purchase_count.present? ? sales_count_for_inventory < max_purchase_count : true,
-      taxonomy_filled: taxonomy.present?
+      taxonomy_filled: taxonomy.present?,
+      has_sales: sales.exists?,
+      seller_compliant: user.compliant?,
+      not_affiliate_only: !(self_service_affiliate_products.enabled.exists? && product_files.alive.none?)
     }
 
     user.recommendable_reasons.each do |reason, value|


### PR DESCRIPTION
## Summary

This PR adds backend validation to improve the quality of product recommendations on the Discover page.  
Only products with real engagement and from compliant sellers will now be eligible for recommendation.

---

## What’s Changed

- Added backend checks to ensure only products that:
  - Have at least one sale
  - Are from compliant sellers
  - Do not consist solely of affiliate links

  are marked as recommendable for Discover.

- Products that:
  - Have no sales
  - Are from non-compliant sellers
  - Contain only affiliate links without original content

  are now excluded from Discover results.

---

## Test Coverage

- Extended tests to confirm:
  - Products without sales are not recommendable
  - Products from non-compliant sellers are excluded
  - Valid and compliant products with sales remain eligible
  
  
  RESOLVES #682 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded product recommendation reasons to include checks for sales activity, seller compliance, and affiliate-only status.

* **Tests**
  * Added new test cases to verify product recommendability based on sales presence, seller compliance, and affiliate-only conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->