### PR TITLE
feat: Clarify Installment Plan Language on Receipts 

### DIFF
--- a/app/presenters/receipt_presenter/item_info.rb
+++ b/app/presenters/receipt_presenter/item_info.rb
@@ -257,14 +257,22 @@ class ReceiptPresenter::ItemInfo
         return if purchase.is_gift_receiver_purchase && subscription.credit_card_id.blank?
         return gift_subscription_renewal_note if subscription.gift? && subscription.credit_card_id.blank?
 
-        "You will be charged once #{recurrence_long_indicator(subscription.recurrence)}. If you would like to manage your membership you can visit #{link_to(
-            "subscription settings",
-            Rails.application.routes.url_helpers.manage_subscription_url(
-              subscription.external_id,
-              { host: UrlService.domain_with_protocol },
-            ),
-            target: "_blank"
-          )}.".html_safe
+        url = link_to(
+          "here",
+          Rails.application.routes.url_helpers.manage_subscription_url(
+            subscription.external_id,
+            host: UrlService.domain_with_protocol
+          ),
+          target: "_blank"
+        )
+
+        if subscription.is_installment_plan?
+          start_date = subscription.created_at.to_fs(:formatted_date_abbrev_month)
+          end_date = subscription.formatted_end_time_of_subscription
+          "Installment plan initiated on #{start_date}. Your final charge will be on #{end_date}. You can manage your payment settings #{url}.".html_safe
+        else
+          "You will be charged once #{recurrence_long_indicator(subscription.recurrence)}. If you would like to manage your membership you can visit #{url}.".html_safe
+        end
       end
     end
 


### PR DESCRIPTION
## Summary

This PR updates the language and layout of Installment Plan receipts to provide clearer communication and reduce confusion with recurring subscriptions.

---

## What’s Changed

- **Updated Header Text**  
  Replaces the existing text with:  
  `"Installment plan initiated on [Start Date]. Your final charge will be on [End Date]. You can manage your payment settings here."`

- **Improved Payment Section Labels**  
  - `"Today's Payment"` ➝ `"Today's Payment: 1 of 3"`  
  - `"Upcoming Payment"` ➝ `"Upcoming Payment: 2 of 3"`  

- **Final Installment Clarification**  
  On the final payment receipt, display:  
  `"This is your final payment for your installment plan. You will not be charged again."`

- **Added Payment Summary**  
  - List all previous charge dates  
  - Show total amount paid, e.g., `"Total Paid: $100.50 for Approsheets"`

---

## Why This Matters

- Prevents user confusion between installment plans and recurring memberships  
- Reduces support tickets and chargebacks  
- Builds trust with clearer expectations and transparent billing

RESOLVE #643 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added enhanced support for installment plan subscriptions, including dynamic labels for payment information and detailed notes summarizing completed installment plans.
  * Payment and renewal messages now specify installment details such as start date, final charge date, and installment numbers.

* **Bug Fixes**
  * Improved clarity and consistency in subscription management messages and payment headings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->