### PR TITLE
fix(discover): block spam products without sales from Discover

### DIFF
--- a/app/modules/product/recommendations.rb
+++ b/app/modules/product/recommendations.rb
@@ -14,7 +14,9 @@ module Product::Recommendations
       not_archived: !archived?,
       reviews_displayed: display_product_reviews?,
       not_sold_out: max_purchase_count.present? ? sales_count_for_inventory < max_purchase_count : true,
-      taxonomy_filled: taxonomy.present?
+      taxonomy_filled: taxonomy.present?,
+      has_sales: sales.exists?,
+      risk_verified: user.compliant?
     }
 
     user.recommendable_reasons.each do |reason, value|


### PR DESCRIPTION
Solves #682 

### What I did
Block spammy products without sales from appearing on Discover by adding two new recommendation
  
 ###  How
  Added two new recommendation filters to `Product::Recommendations`:

  1. **`has_sales: sales.exists?`** - Blocks products without any sales
  2. **`risk_verified: user.compliant?`** - Blocks non-compliant users' products
  
  ### Testing 
  
  Ran all the test cases , below is the output 
<img width="1501" height="803" alt="image" src="https://github.com/user-attachments/assets/ee7db86b-dd66-460d-a75f-bf0663ad85ed" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Product recommendations now consider sales history and user compliance status when determining recommendability.

* **Tests**
  * Added tests to verify recommendation behavior for products without sales and for products owned by non-compliant users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->