### PR TITLE
fix(receipts): improve installment plan language 

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -191,12 +191,12 @@ class Subscription < ApplicationRecord
 
   def price
     payment_option = last_payment_option || fetch_last_payment_option
-    payment_option.price
+    payment_option&.price
   end
 
   def current_subscription_price_cents
     if is_installment_plan
-      original_purchase.minimum_paid_price_cents
+      original_purchase.displayed_price_cents
     else
       discount_applies_to_next_charge? ?
         original_purchase.displayed_price_cents :
@@ -617,9 +617,9 @@ class Subscription < ApplicationRecord
 
   def recurrence
     if is_installment_plan
-      last_payment_option.installment_plan.recurrence
+      last_payment_option&.installment_plan&.recurrence || "monthly"
     else
-      price.recurrence
+      price&.recurrence || "monthly"
     end
   end
 
@@ -848,6 +848,8 @@ class Subscription < ApplicationRecord
 
   def discount_applies_to_next_charge?
     return true if is_installment_plan
+
+    return true if original_purchase.nil?
 
     duration_in_billing_cycles = original_purchase.purchase_offer_code_discount&.duration_in_billing_cycles
     return true if duration_in_billing_cycles.blank?

--- a/spec/presenters/receipt_presenter/payment_info_spec.rb
+++ b/spec/presenters/receipt_presenter/payment_info_spec.rb
@@ -259,25 +259,52 @@ describe ReceiptPresenter::PaymentInfo do
               purchase.subscription.update!(charge_occurrence_count: 2)
             end
 
-            it "returns today's payment attributes" do
+            it "returns today's payment attributes with installment numbering" do
               purchase.subscription.original_purchase.reload
               expect(today_payment_attributes).to eq(
                 [
-                  { label: "Today's payment", value: nil },
+                  { label: "Today's payment: 1 of 2", value: nil },
                   { label: "Membership product", value: "$19.98" },
                   { label: nil, value: link_to("Generate invoice", invoice_url) },
                 ]
               )
             end
 
-            it "returns upcoming payment attributes" do
+            it "returns upcoming payment attributes with installment numbering" do
               purchase.subscription.original_purchase.reload
               expect(upcoming_payment_attributes).to eq(
                 [
-                  { label: "Upcoming payment", value: nil },
+                  { label: "Upcoming payment: 2 of 2", value: nil },
                   { label: "Membership product", value: "$19.98 on Feb 1, 2023" },
                 ]
               )
+            end
+
+            context "when there are 3 total installments" do
+              before do
+                purchase.subscription.update!(charge_occurrence_count: 3)
+              end
+
+              it "returns correct numbering for today's payment" do
+                purchase.subscription.original_purchase.reload
+                expect(today_payment_attributes).to eq(
+                  [
+                    { label: "Today's payment: 1 of 3", value: nil },
+                    { label: "Membership product", value: "$19.98" },
+                    { label: nil, value: link_to("Generate invoice", invoice_url) },
+                  ]
+                )
+              end
+
+              it "returns correct numbering for upcoming payment" do
+                purchase.subscription.original_purchase.reload
+                expect(upcoming_payment_attributes).to eq(
+                  [
+                    { label: "Upcoming payment: 2 of 3", value: nil },
+                    { label: "Membership product", value: "$19.98 on Feb 1, 2023" },
+                  ]
+                )
+              end
             end
           end
 

--- a/spec/requests/purchases/installment_plan_receipt_spec.rb
+++ b/spec/requests/purchases/installment_plan_receipt_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe("Installment plan receipt functionality", type: :feature, js: true) do
+  let(:product) { create(:product, :with_installment_plan, user: seller) }
+  let(:seller) { create(:user) }
+  let(:purchaser) { create(:user) }
+
+  before do
+    product.installment_plan.update!(number_of_installments: 3, recurrence: "monthly")
+
+    allow(GlobalConfig).to receive(:dig)
+      .with(:secure_external_id, default: {})
+      .and_return({
+                    primary_key_version: "1",
+                    keys: { "1" => "a" * 32 }
+                  })
+
+    allow(Stripe::Balance).to receive(:retrieve).and_return(
+      double("balance", available: [double("available_balance", amount: 100000, currency: "usd")])
+    )
+  end
+
+  describe "first installment payment receipt" do
+    let(:purchase) { create(:installment_plan_purchase, link: product, purchaser: purchaser) }
+
+    before do
+      create(:url_redirect, purchase: purchase)
+      purchase.subscription.update!(charge_occurrence_count: 3)
+    end
+
+    it "shows installment numbering and new messaging" do
+      visit receipt_purchase_url(purchase.external_id, host: "#{PROTOCOL}://#{DOMAIN}")
+      expect(page).to have_content("Confirm your email address")
+
+      fill_in "Email address:", with: purchase.email
+      click_button "View receipt"
+
+      expect(page).to have_content("Today's payment: 1 of 3")
+      expect(page).to have_content("Upcoming payment: 2 of 3")
+
+      expect(page).to have_content("Installment plan initiated on")
+      expect(page).to have_content("Your final charge will be on")
+      expect(page).to have_content("You can manage your payment settings")
+      expect(page).to have_link("here")
+
+      expect(page).not_to have_content("You will be charged once a month")
+      expect(page).not_to have_content("subscription settings")
+    end
+  end
+
+  describe "second installment payment receipt" do
+    let(:original_purchase) { create(:installment_plan_purchase, link: product, purchaser: purchaser) }
+    let(:second_purchase) { create(:recurring_installment_plan_purchase, link: product, subscription: original_purchase.subscription, purchaser: purchaser, created_at: original_purchase.created_at + 1.month) }
+
+    before do
+      create(:url_redirect, purchase: second_purchase)
+      original_purchase.subscription.update!(charge_occurrence_count: 3)
+    end
+
+    it "shows correct numbering for second payment" do
+      visit receipt_purchase_url(second_purchase.external_id, host: "#{PROTOCOL}://#{DOMAIN}")
+      expect(page).to have_content("Confirm your email address")
+
+      fill_in "Email address:", with: second_purchase.email
+      click_button "View receipt"
+
+      expect(page).to have_content("Today's payment: 2 of 3")
+      expect(page).to have_content("Upcoming payment: 3 of 3")
+
+      expect(page).to have_content("Installment plan initiated on")
+      expect(page).to have_content("Your final charge will be on")
+    end
+  end
+
+  describe "final installment payment receipt" do
+    let(:subscription) { create(:subscription, link: product, user: purchaser, is_installment_plan: true, charge_occurrence_count: 3) }
+    let(:original_purchase) { create(:installment_plan_purchase, link: product, purchaser: purchaser, price_cents: 10_00, subscription: subscription) }
+    let(:second_purchase) { create(:recurring_installment_plan_purchase, link: product, subscription: subscription, purchaser: purchaser, price_cents: 10_00, created_at: original_purchase.created_at + 1.month) }
+    let(:final_purchase) { create(:recurring_installment_plan_purchase, link: product, subscription: subscription, purchaser: purchaser, price_cents: 10_00, created_at: original_purchase.created_at + 2.months) }
+
+    before do
+      original_purchase
+      second_purchase
+      final_purchase
+
+      create(:url_redirect, purchase: final_purchase)
+      subscription.reload
+    end
+
+    it "shows final payment messaging" do
+      visit receipt_purchase_url(final_purchase.external_id, host: "#{PROTOCOL}://#{DOMAIN}")
+      expect(page).to have_content("Confirm your email address")
+
+      fill_in "Email address:", with: final_purchase.email
+      click_button "View receipt"
+
+      expect(page).not_to have_content("Today's payment:")
+      expect(page).not_to have_content("Upcoming payment")
+
+      expect(page).to have_content("This is your final payment for your installment plan")
+      expect(page).to have_content("You will not be charged again")
+      expect(page).to have_content("Payment history:")
+      expect(page).to have_content("Total amount paid:")
+      expect(page).to have_content("$30")
+
+      expect(page).not_to have_content("Your final charge will be on")
+      expect(page).not_to have_content("You can manage your payment settings")
+    end
+  end
+end


### PR DESCRIPTION
Solves #643 

 ### What I did
  Improve installment plan receipt language by replacing unclear "recurring subscription" messaging with specific installment terminology..

 ###  How
  - installment_plan_note: Shows initiation date and final charge date
  - installment_final_payment_note: Displays complete payment history and total
  - Payment numbering: "Today's payment: 1 of 3", "Upcoming payment: 2 of 3"
  - Fixed subscription pricing bug where upcoming installments showed wrong
  amounts
  
  ### Output 
  
<img width="1426" height="991" alt="Screenshot 2025-07-30 at 8 36 11 AM" src="https://github.com/user-attachments/assets/bc1298fd-ff92-455a-94e4-414695266f00" />

### Testing 
Ran all the test cases , below is the output

For - `spec/presenters/receipt_presenter/item_info_spec.rb`
<img width="962" height="521" alt="Screenshot 2025-07-30 at 9 01 00 AM" src="https://github.com/user-attachments/assets/e44d1938-8a32-446c-a098-59c6f2665737" />

For - ` spec/presenters/receipt_presenter/payment_info_spec.rb`

<img width="817" height="831" alt="Screenshot 2025-07-30 at 9 01 49 AM" src="https://github.com/user-attachments/assets/a041ac4f-c6b6-46d1-9675-907f466ddb0d" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced subscription receipts to display detailed installment plan information, including payment history, total paid, and final payment notices for fixed-length subscriptions.
  * Payment labels now dynamically indicate installment progress (e.g., "Today's payment: 1 of 3") for installment plans.

* **Bug Fixes**
  * Improved handling of missing or incomplete subscription data to prevent errors and ensure accurate messaging.

* **Tests**
  * Expanded and updated test coverage for installment plan scenarios and dynamic payment labels.
  * Added feature tests covering receipt displays for first, intermediate, and final installment payments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->