### PR TITLE
Fix: Keep balance adjustment credits internal during payout method ch…

### DIFF
--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -24,6 +24,19 @@ class Credit < ApplicationRecord
   validate :validate_associated_entity
 
   attr_json_data_accessor :stripe_loan_paydown_id
+  attr_json_data_accessor :internal
+
+  scope :internal, -> { where("json_data->'$.internal' = true") }
+  scope :displayable, -> { where("json_data->'$.internal' IS NULL OR json_data->'$.internal' = false") }
+
+  def internal?
+    internal == true
+  end
+
+  def mark_as_internal!
+    self.internal = true
+    save!
+  end
 
   def self.create_for_credit!(user:, amount_cents:, crediting_user:)
     credit = new

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -132,7 +132,7 @@ class Payment < ApplicationRecord
   end
 
   def credits
-    Credit.where(balance_id: balances)
+    Credit.displayable.where(balance_id: balances)
   end
 
   def credit_amount_cents

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -958,12 +958,14 @@ class User < ApplicationRecord
       # Add a negative credit to make zero the balance currently held against creator's Stripe account.
       amount_cents_usd = balances_to_transfer.sum(:amount_cents)
       amount_cents_holding_currency = balances_to_transfer.sum(:holding_amount_cents)
-      Credit.create_for_balance_change_on_stripe_account!(amount_cents_holding_currency: -amount_cents_holding_currency,
+      negative_credit = Credit.create_for_balance_change_on_stripe_account!(amount_cents_holding_currency: -amount_cents_holding_currency,
                                                           merchant_account: stripe_account,
                                                           amount_cents_usd: -amount_cents_usd)
+      negative_credit.update!(internal: true)
 
       # Add a positive credit for the same amount against Gumroad's Stripe account.
-      Credit.create_for_credit!(user: self, amount_cents: amount_cents_usd, crediting_user: User.find(GUMROAD_ADMIN_ID))
+      positive_credit = Credit.create_for_credit!(user: self, amount_cents: amount_cents_usd, crediting_user: User.find(GUMROAD_ADMIN_ID))
+      positive_credit.update!(internal: true)
 
       # Actually transfer the money from creator's Stripe account to Gumroad's Stripe account.
       TransferStripeConnectAccountBalanceToGumroadJob.perform_async(stripe_account.id, amount_cents_usd)

--- a/app/modules/user/stats.rb
+++ b/app/modules/user/stats.rb
@@ -211,6 +211,7 @@ module User::Stats
 
   def credits_cents_for_balances(balance_ids)
     credits
+      .displayable
       .where(financing_paydown_purchase_id: nil)
       .where(fee_retention_refund_id: nil)
       .where(balance_id: balance_ids)

--- a/app/services/exports/payouts/base.rb
+++ b/app/services/exports/payouts/base.rb
@@ -55,7 +55,7 @@ class Exports::Payouts::Base
           data << summarize_affiliate_credit(bal, affiliate_credit_cents)
         end
 
-        Credit.where(balance: bal).find_each do |credit|
+        Credit.displayable.where(balance: bal).find_each do |credit|
           next if credit.fee_retention_refund.present? && credit.amount_cents <= 0
 
           amount = (credit.amount_cents / 100.0).round(2)


### PR DESCRIPTION
Changes

- Add internal flag to Credit model using json_data accessor
- Mark positive and negative balance adjustment credits as internal in transfer_stripe_balance_to_gumroad_account!
- Update all credit display logic to exclude internal credits (Payment, User::Stats, payout exports)
- Prevents confusing credit entries from appearing in user payout statements
- Reduces user confusion and support tickets when payout method is changed from Stripe Connect to PayPal

Fixes issue where users see negative credits without context in their payouts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the ability to mark credits as internal, allowing for better categorization and filtering.

* **Bug Fixes**
  * Updated credit-related queries and calculations throughout the app to exclude internal credits from user-facing views and exports, ensuring only displayable credits are shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->