### PR TITLE
feat: add tax-inclusive pricing support for products

### DIFF
--- a/app/controllers/customer_surcharge_controller.rb
+++ b/app/controllers/customer_surcharge_controller.rb
@@ -22,7 +22,11 @@ class CustomerSurchargeController < ApplicationController
       shipping_rate += get_usd_cents(product.price_currency_type, surcharges[:shipping_rate])
       tax_cents = tax_result.tax_cents
       if tax_cents > 0
-        tax_rate += tax_cents
+        if product.tax_inclusive
+          tax_included_rate += tax_cents
+        else
+          tax_rate += tax_cents
+        end
       end
       subtotal += tax_result.price_cents
     end

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -606,7 +606,7 @@ class LinksController < ApplicationController
                                    :should_include_last_post, :should_show_all_posts, :should_show_sales_count, :duration_in_months,
                                    :free_trial_enabled, :free_trial_duration_amount, :free_trial_duration_unit,
                                    :is_adult, :is_epublication, :product_refund_policy_enabled, :seller_refund_policy_enabled,
-                                   :refund_policy, :taxonomy_id)
+                                   :refund_policy, :taxonomy_id, :tax_inclusive)
     end
 
     def paged_params

--- a/app/javascript/components/BundleEdit/ProductTab/index.tsx
+++ b/app/javascript/components/BundleEdit/ProductTab/index.tsx
@@ -95,6 +95,8 @@ export const ProductTab = () => {
                 installment_plan: { ...bundle.installment_plan, number_of_installments: value },
               })
             }
+            taxInclusive={bundle.tax_inclusive}
+            setTaxInclusive={(taxInclusive) => updateBundle({ tax_inclusive: taxInclusive })}
           />
         </section>
         <ThumbnailEditor

--- a/app/javascript/components/BundleEdit/state.ts
+++ b/app/javascript/components/BundleEdit/state.ts
@@ -76,6 +76,7 @@ export type Bundle = {
   products: BundleProduct[];
   public_files: PublicFileWithStatus[];
   audio_previews_enabled: boolean;
+  tax_inclusive?: boolean;
 };
 
 export const computeStandalonePrice = (bundleProduct: BundleProduct) =>

--- a/app/javascript/components/ProductEdit/ProductTab/PriceEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/PriceEditor.tsx
@@ -21,6 +21,8 @@ export const PriceEditor = ({
   onAllowInstallmentPlanChange,
   onNumberOfInstallmentsChange,
   currencyCodeSelector,
+  taxInclusive,
+  setTaxInclusive,
 }: {
   priceCents: number;
   suggestedPriceCents: number | null;
@@ -35,6 +37,8 @@ export const PriceEditor = ({
   onAllowInstallmentPlanChange: (allowed: boolean) => void;
   onNumberOfInstallmentsChange: (numberOfInstallments: number) => void;
   currencyCodeSelector?: { options: CurrencyCode[]; onChange: (currencyCode: CurrencyCode) => void };
+  taxInclusive?: boolean;
+  setTaxInclusive?: (taxInclusive: boolean) => void;
 }) => {
   const uid = React.useId();
 
@@ -93,6 +97,18 @@ export const PriceEditor = ({
           onNumberOfInstallmentsChange={onNumberOfInstallmentsChange}
         />
       ) : null}
+      {setTaxInclusive !== undefined && (
+        <div className="toggle" style={{ marginTop: "var(--spacer-6)" }}>
+          <Toggle value={taxInclusive ?? true} onChange={setTaxInclusive}>
+            <a data-helper-prompt="What is tax-inclusive pricing and how does it work?">
+              Tax-inclusive pricing
+            </a>
+          </Toggle>
+          <p className="field-hint">
+            When enabled, the price you set includes all applicable taxes. This is standard in most countries outside the US.
+          </p>
+        </div>
+      )}
     </fieldset>
   );
 };

--- a/app/javascript/components/ProductEdit/ProductTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/index.tsx
@@ -292,6 +292,8 @@ export const ProductTab = () => {
                           installment_plan: { ...product.installment_plan, number_of_installments: value },
                         })
                       }
+                      taxInclusive={product.tax_inclusive}
+                      setTaxInclusive={(taxInclusive) => updateProduct({ tax_inclusive: taxInclusive })}
                     />
                     {product.native_type === "commission" ? (
                       <p

--- a/app/javascript/components/ProductEdit/state.ts
+++ b/app/javascript/components/ProductEdit/state.ts
@@ -142,6 +142,7 @@ export type Product = {
   public_files: PublicFileWithStatus[];
   audio_previews_enabled: boolean;
   community_chat_enabled: boolean | null;
+  tax_inclusive: boolean;
 } & (
   | { native_type: "call"; variants: Duration[] }
   | { native_type: "membership"; variants: Tier[] }

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -3298,7 +3298,7 @@ class Purchase < ApplicationRecord
       end
 
       self.was_purchase_taxable = gumroad_tax_cents > 0 || tax_cents > 0
-      self.was_tax_excluded_from_price = true
+      self.was_tax_excluded_from_price = !link.tax_inclusive
     end
 
     def calculate_shipping

--- a/app/policies/link_policy.rb
+++ b/app/policies/link_policy.rb
@@ -91,6 +91,7 @@ class LinkPolicy < ApplicationPolicy
       :require_shipping,
       :is_multiseat_license,
       :community_chat_enabled,
+      :tax_inclusive,
       refund_policy: [
         :max_refund_period_in_days,
         :title,

--- a/app/presenters/product_presenter.rb
+++ b/app/presenters/product_presenter.rb
@@ -195,6 +195,7 @@ class ProductPresenter
         public_files: product.alive_public_files.attached.map { PublicFilePresenter.new(public_file: _1).props },
         audio_previews_enabled: Feature.active?(:audio_previews, product.user),
         community_chat_enabled: Feature.active?(:communities, product.user) ? product.community_chat_enabled? : nil,
+        tax_inclusive: product.tax_inclusive,
       },
       id: product.external_id,
       unique_permalink: product.unique_permalink,

--- a/app/presenters/product_presenter/product_props.rb
+++ b/app/presenters/product_presenter/product_props.rb
@@ -40,6 +40,7 @@ class ProductPresenter::ProductProps
         price_cents: product.price_cents,
         rental_price_cents: product.rental_price_cents,
         pwyw: product.customizable_price ? { suggested_price_cents: product.suggested_price_cents } : nil,
+        tax_inclusive: product.tax_inclusive,
         **ProductPresenter::InstallmentPlanProps.new(product:).props,
         is_legacy_subscription: product.is_legacy_subscription?,
         is_tiered_membership: product.is_tiered_membership,

--- a/db/migrate/20250801093136_add_tax_inclusive_to_links.rb
+++ b/db/migrate/20250801093136_add_tax_inclusive_to_links.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddTaxInclusiveToLinks < ActiveRecord::Migration[7.1]
+  def up
+    # Add tax_inclusive column with default true for new products
+    add_column :links, :tax_inclusive, :boolean, default: true, null: false
+    add_index :links, :tax_inclusive
+
+    # Update existing products to be tax-exclusive (backward compatibility)
+    # Only products created before this migration should default to false
+    Link.where("created_at < ?", Time.current).update_all(tax_inclusive: false)
+  end
+
+  def down
+    remove_column :links, :tax_inclusive
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_04_25_212934) do
+ActiveRecord::Schema[7.1].define(version: 2025_08_01_093136) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -1110,10 +1110,12 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_25_212934) do
     t.bigint "taxonomy_id"
     t.string "native_type", default: "digital", null: false
     t.integer "discover_fee_per_thousand", default: 100, null: false
+    t.boolean "tax_inclusive", default: true, null: false
     t.index ["banned_at"], name: "index_links_on_banned_at"
     t.index ["custom_permalink"], name: "index_links_on_custom_permalink", length: 191
     t.index ["deleted_at"], name: "index_links_on_deleted_at"
     t.index ["showcaseable"], name: "index_links_on_showcaseable"
+    t.index ["tax_inclusive"], name: "index_links_on_tax_inclusive"
     t.index ["taxonomy_id"], name: "index_links_on_taxonomy_id"
     t.index ["unique_permalink"], name: "index_links_on_unique_permalink", length: 191
     t.index ["user_id", "updated_at"], name: "index_links_on_user_id_and_updated_at"

--- a/spec/business/sales_tax/sales_tax_calculator_bundle_spec.rb
+++ b/spec/business/sales_tax/sales_tax_calculator_bundle_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe SalesTaxCalculator do
+  describe "tax-inclusive pricing for bundles" do
+    before(:each) do
+      @seller = create(:user)
+    end
+
+    describe "bundle tax calculations" do
+      it "calculates tax correctly for tax-inclusive bundles" do
+        tax_rate = create(:zip_tax_rate, country: "DE", zip_code: nil, state: nil, combined_rate: 0.19, is_seller_responsible: false)
+        bundle = create(:product, user: @seller, price_cents: 2380, tax_inclusive: true, is_bundle: true)
+
+        calculator = SalesTaxCalculator.new(
+          product: bundle,
+          price_cents: 2380,
+          buyer_location: { country: "DE" }
+        )
+
+        result = calculator.calculate
+
+        # For 19% tax rate: tax = 2380 * (0.19 / 1.19) = 380
+        expect(result.tax_cents.round).to eq(380)
+        expect(result.price_cents).to eq(2380)
+      end
+
+      it "calculates tax correctly for tax-exclusive bundles" do
+        tax_rate = create(:zip_tax_rate, country: "DE", zip_code: nil, state: nil, combined_rate: 0.19, is_seller_responsible: false)
+        bundle = create(:product, user: @seller, price_cents: 2000, tax_inclusive: false, is_bundle: true)
+
+        calculator = SalesTaxCalculator.new(
+          product: bundle,
+          price_cents: 2000,
+          buyer_location: { country: "DE" }
+        )
+
+        result = calculator.calculate
+
+        # For 19% tax rate on 2000: tax = 2000 * 0.19 = 380
+        expect(result.tax_cents).to eq(380)
+        expect(result.price_cents).to eq(2000)
+      end
+
+    end
+  end
+end

--- a/spec/business/sales_tax/sales_tax_calculator_tax_inclusive_spec.rb
+++ b/spec/business/sales_tax/sales_tax_calculator_tax_inclusive_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe SalesTaxCalculator do
+  describe "tax-inclusive pricing" do
+    before(:each) do
+      @seller = create(:user)
+    end
+
+    describe "with lookup table" do
+      it "calculates tax correctly for tax-inclusive pricing in EU" do
+        tax_rate = create(:zip_tax_rate, country: "DE", zip_code: nil, state: nil, combined_rate: 0.19, is_seller_responsible: false)
+        product = create(:product, user: @seller, price_cents: 1190, tax_inclusive: true)
+
+        calculator = SalesTaxCalculator.new(
+          product: product,
+          price_cents: 1190,
+          buyer_location: { country: "DE" }
+        )
+
+        result = calculator.calculate
+
+        # For 19% tax rate: tax = 1190 * (0.19 / 1.19) = 190
+        expect(result.tax_cents.round).to eq(190)
+        expect(result.price_cents).to eq(1190)
+      end
+
+      it "calculates tax correctly for tax-exclusive pricing in EU" do
+        tax_rate = create(:zip_tax_rate, country: "DE", zip_code: nil, state: nil, combined_rate: 0.19, is_seller_responsible: false)
+        product = create(:product, user: @seller, price_cents: 1000, tax_inclusive: false)
+
+        calculator = SalesTaxCalculator.new(
+          product: product,
+          price_cents: 1000,
+          buyer_location: { country: "DE" }
+        )
+
+        result = calculator.calculate
+
+        # For 19% tax rate on 1000: tax = 1000 * 0.19 = 190
+        expect(result.tax_cents).to eq(190)
+        expect(result.price_cents).to eq(1000)
+      end
+
+      it "calculates tax correctly for tax-inclusive pricing with 25% rate" do
+        tax_rate = create(:zip_tax_rate, country: "SE", zip_code: nil, state: nil, combined_rate: 0.25, is_seller_responsible: false)
+        product = create(:product, user: @seller, price_cents: 1250, tax_inclusive: true)
+
+        calculator = SalesTaxCalculator.new(
+          product: product,
+          price_cents: 1250,
+          buyer_location: { country: "SE" }
+        )
+
+        result = calculator.calculate
+
+        # For 25% tax rate: tax = 1250 * (0.25 / 1.25) = 250
+        expect(result.tax_cents).to eq(250)
+        expect(result.price_cents).to eq(1250)
+      end
+    end
+
+  end
+end

--- a/spec/controllers/customer_surcharge_controller_tax_inclusive_spec.rb
+++ b/spec/controllers/customer_surcharge_controller_tax_inclusive_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe CustomerSurchargeController do
+  describe "GET #calculate_all with tax-inclusive pricing" do
+    before(:each) do
+      @seller = create(:user)
+    end
+
+    it "returns tax in tax_included_cents for tax-inclusive products" do
+      product = create(:product, user: @seller, price_cents: 1190, tax_inclusive: true)
+      tax_rate = create(:zip_tax_rate, country: "DE", zip_code: nil, state: nil, combined_rate: 0.19, is_seller_responsible: false)
+
+      post :calculate_all, params: {
+        products: [{
+          permalink: product.unique_permalink,
+          quantity: 1,
+          price: "1190"
+        }],
+        country: "DE",
+        postal_code: "10115"
+      }, as: :json
+
+      json_response = JSON.parse(response.body)
+      
+      expect(json_response["tax_cents"]).to eq(0)
+      expect(json_response["tax_included_cents"]).to eq(190) # 1190 * (0.19 / 1.19)
+      expect(json_response["subtotal"]).to eq(1190)
+    end
+
+    it "returns tax in tax_cents for tax-exclusive products" do
+      product = create(:product, user: @seller, price_cents: 1000, tax_inclusive: false)
+      tax_rate = create(:zip_tax_rate, country: "DE", zip_code: nil, state: nil, combined_rate: 0.19, is_seller_responsible: false)
+
+      post :calculate_all, params: {
+        products: [{
+          permalink: product.unique_permalink,
+          quantity: 1,
+          price: "1000"
+        }],
+        country: "DE",
+        postal_code: "10115"
+      }, as: :json
+
+      json_response = JSON.parse(response.body)
+      
+      expect(json_response["tax_cents"]).to eq(190) # 1000 * 0.19
+      expect(json_response["tax_included_cents"]).to eq(0)
+      expect(json_response["subtotal"]).to eq(1000)
+    end
+
+    it "handles mixed tax-inclusive and tax-exclusive products" do
+      inclusive_product = create(:product, user: @seller, price_cents: 1190, tax_inclusive: true)
+      exclusive_product = create(:product, user: @seller, price_cents: 1000, tax_inclusive: false)
+      tax_rate = create(:zip_tax_rate, country: "DE", zip_code: nil, state: nil, combined_rate: 0.19, is_seller_responsible: false)
+
+      post :calculate_all, params: {
+        products: [
+          {
+            permalink: inclusive_product.unique_permalink,
+            quantity: 1,
+            price: "1190"
+          },
+          {
+            permalink: exclusive_product.unique_permalink,
+            quantity: 1,
+            price: "1000"
+          }
+        ],
+        country: "DE",
+        postal_code: "10115"
+      }, as: :json
+
+      json_response = JSON.parse(response.body)
+      
+      expect(json_response["tax_cents"]).to eq(190) # Only from exclusive product
+      expect(json_response["tax_included_cents"]).to eq(190) # Only from inclusive product
+      expect(json_response["subtotal"]).to eq(2190) # 1190 + 1000
+    end
+  end
+end


### PR DESCRIPTION
## Summary

  This PR implements tax-inclusive pricing for products, allowing sellers to set prices that include tax (common in EU, Australia, and other regions).

  Closes #698

  ## Changes

  ### Backend
  - Added `tax_inclusive` boolean column to `links` table
  - New products default to tax-inclusive (`true`)
  - Existing products remain tax-exclusive (`false`) for backward compatibility
  - Updated `SalesTaxCalculator` to handle both pricing models:
    - Tax-inclusive: Extracts tax from total price
    - Tax-exclusive: Adds tax on top of price
  - Modified purchase processing to respect product's tax setting

  ### Frontend
  - Added "Tax-inclusive pricing" toggle in product edit form
  - Shows helpful description about tax-inclusive pricing
  - Checkout displays "Tax (included)" for inclusive products

  ### Testing
  - Unit tests for tax calculations with various tax rates
  - Controller tests for checkout API endpoints

  ## Video Demo

  Creating new tax inclusive products

  https://github.com/user-attachments/assets/425dff78-d7db-47b0-b961-9471f9c6baf7

  Old products view (without tax inclusivity)

  https://github.com/user-attachments/assets/728a8fa4-6c84-4a5e-a648-25d48ad86799

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tax-inclusive pricing for products and bundles, allowing prices to include applicable taxes.
  * Introduced a toggle in the product and bundle editors to enable or disable tax-inclusive pricing, with explanatory hints.
  * Product and purchase details now indicate whether tax is included in the price.
  * Tax calculations and surcharge computations distinguish between tax-inclusive and tax-exclusive pricing, showing separate tax amounts accordingly.

* **Bug Fixes**
  * Improved accuracy of tax calculations for both tax-inclusive and tax-exclusive products and bundles.

* **Chores**
  * Database updated with a migration adding a tax-inclusive flag to products, including indexing and data backfill.
  * Added comprehensive tests covering tax-inclusive pricing scenarios for products, bundles, and surcharge calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->