### PR TITLE
[Perf] Fix N+1 issues - Part 1

### DIFF
--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -82,7 +82,7 @@ class SignupController < Devise::RegistrationsController
       purchase&.attach_to_user_and_card(@user, chargeable, card_data_handling_mode)
 
       if params[:user][:email].present?
-        Purchase.where(email: params[:user][:email], purchaser_id: nil).each do |past_purchase|
+        Purchase.where(email: params[:user][:email], purchaser_id: nil).includes(:preorder).each do |past_purchase|
           past_purchase.attach_to_user_and_card(@user, chargeable, card_data_handling_mode)
         end
       end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -789,8 +789,9 @@ class Link < ApplicationRecord
   def variant_list(seller = nil)
     return { categories: [], skus: [], skus_enabled: } if variant_categories_alive.empty?
 
+    categories_with_preloaded_variants = variant_categories_alive.includes(variants: :product_files)
     variants = { categories:
-      variant_categories_alive.each_with_index.map do |category, i|
+      categories_with_preloaded_variants.each_with_index.map do |category, i|
         {
           id: category.external_id,
           i:,

--- a/app/presenters/user_memberships_presenter.rb
+++ b/app/presenters/user_memberships_presenter.rb
@@ -10,7 +10,10 @@ class UserMembershipsPresenter
   end
 
   def props
-    user_memberships = pundit_user.user.user_memberships_not_deleted_and_ordered
+    user_memberships = pundit_user.user.user_memberships
+      .not_deleted
+      .includes(seller: { avatar_attachment: :blob })
+      .order(last_accessed_at: :desc, created_at: :desc)
 
     validate_user_memberships!(user_memberships)
     build_user_memberships_props(user_memberships, pundit_user.seller)


### PR DESCRIPTION
Cherry-picked some changes from https://github.com/antiwork/gumroad/pull/648/

This pull request focuses on optimizing database queries by eager loading associated records to improve performance and reduce N+1 query issues. The changes primarily affect how related data is fetched in controllers, models, and presenters.

