### PR TITLE
Remove merchant_of_record_fee feature flag

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -3178,10 +3178,8 @@ class Purchase < ApplicationRecord
         else
           fixed_processor_fee_cents
         end
-      elsif Feature.active?(:merchant_of_record_fee, seller)
-        was_discover_fee_charged? ? 0 : GUMROAD_FIXED_FEE_CENTS + fixed_processor_fee_cents
       else
-        fixed_processor_fee_cents
+        was_discover_fee_charged? ? 0 : GUMROAD_FIXED_FEE_CENTS + fixed_processor_fee_cents
       end
 
       self.fee_cents = variable_fee_cents + fixed_fee_cents
@@ -3194,11 +3192,7 @@ class Purchase < ApplicationRecord
       elsif is_preorder_charge?
         preorder.authorization_purchase.discover_fee_per_thousand - (flat_fee_applicable? ? (custom_fee_per_thousand.presence || GUMROAD_DISCOVER_EXTRA_FEE_PER_THOUSAND) + PROCESSOR_FEE_PER_THOUSAND : 0)
       else
-        if Feature.active?(:merchant_of_record_fee, seller)
-          GUMROAD_DISCOVER_FEE_PER_THOUSAND - (custom_fee_per_thousand.presence || GUMROAD_DISCOVER_EXTRA_FEE_PER_THOUSAND) - (charged_using_gumroad_merchant_account? ? PROCESSOR_FEE_PER_THOUSAND : 0)
-        else
-          link.discover_fee_per_thousand - (flat_fee_applicable? ? (custom_fee_per_thousand.presence || GUMROAD_DISCOVER_EXTRA_FEE_PER_THOUSAND) : 0)
-        end
+        GUMROAD_DISCOVER_FEE_PER_THOUSAND - (custom_fee_per_thousand.presence || GUMROAD_DISCOVER_EXTRA_FEE_PER_THOUSAND) - (charged_using_gumroad_merchant_account? ? PROCESSOR_FEE_PER_THOUSAND : 0)
       end
     end
 

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -968,7 +968,7 @@ class Subscription < ApplicationRecord
     end
 
     def enable_mor_fee
-      self.mor_fee_applicable = Feature.active?(:merchant_of_record_fee, seller)
+      self.mor_fee_applicable = true
     end
 
     def assign_seller

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -181,7 +181,6 @@ RSpec.configure do |config|
       log_email_events
       follow_wishlists
       seller_refund_policy_new_users_enabled
-      merchant_of_record_fee
       paypal_payout_fee
     ].each do |feature|
       Feature.activate(feature)


### PR DESCRIPTION
The feature has already been fully enabled for a while, feature flag is no longer needed.

<img width="278" height="71" alt="Screenshot 2025-08-05 at 10 53 42 AM" src="https://github.com/user-attachments/assets/c4fdbbcf-09b9-437b-b560-db516b3dbadb" />
