### PR TITLE
Fix to allow updating payout related info when a debit card is connected

### DIFF
--- a/app/javascript/components/server-components/Settings/PaymentsPage.tsx
+++ b/app/javascript/components/server-components/Settings/PaymentsPage.tsx
@@ -712,10 +712,8 @@ const PaymentsPage = (props: Props) => {
 
     let cardData;
     if (selectedPayoutMethod === "card") {
-      if (!debitCard) {
+      if (!debitCard || debitCard.type === "saved") {
         cardData = null;
-      } else if (debitCard.type === "saved") {
-        cardData = {};
       } else {
         try {
           cardData = await prepareCardTokenForPayouts({ cardElement: debitCard.element });

--- a/spec/requests/settings/payments_spec.rb
+++ b/spec/requests/settings/payments_spec.rb
@@ -215,6 +215,25 @@ describe("Payments Settings Scenario", type: :feature, js: true) do
       expect(bank_account.account_number_last_four).to eq("8210")
     end
 
+    it "allows the creator to update other info when they have a debit card connected" do
+      creator = create(:user, payment_address: nil)
+      create(:user_compliance_info, user: creator, phone: "+15022541982")
+      create(:card_bank_account, user: creator)
+      expect(creator.payout_frequency).to eq(User::PayoutSchedule::WEEKLY)
+
+      login_as creator
+      visit settings_payments_path
+      expect(page).to have_select("Schedule", selected: "Weekly")
+      select "Monthly", from: "Schedule"
+
+      click_on "Update settings"
+
+      expect(page).to have_alert(text: "Thanks! You're all set.")
+      expect(creator.reload.payout_frequency).to eq(User::PayoutSchedule::MONTHLY)
+      refresh
+      expect(page).to have_select("Schedule", selected: "Monthly")
+    end
+
     it "allows the creator to connect their Stripe account if they are from Brazil" do
       visit settings_payments_path
       expect(page).not_to have_field("Stripe")


### PR DESCRIPTION
**Reported issue:** Error when trying to update payout frequency with a debit card connected:

<img width="2438" height="1042" alt="Screenshot 11 11 on 2025-08-05" src="https://github.com/user-attachments/assets/d7ac9c2c-2b85-45b1-a408-276ab243a672" />
