### PR TITLE
Update README.md with missing dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,7 @@ We use [pdftk](https://www.pdflabs.com/tools/pdftk-server/) to stamp PDF files w
 #### wkhtmltopdf
 
 While generating invoices, to convert HTML to PDF, PDFKit expects [wkhtmltopdf](https://wkhtmltopdf.org/) to be installed on your system. [Download](https://wkhtmltopdf.org/downloads.html) and install the version 0.12.6 for your platform. 
-
 - **Note** similar to pdftk, this may also be blocked by Apple's firewall on MacOS. Follow a similar process as above.
-
   
 ### Installation
 


### PR DESCRIPTION
Fixes #757 . Added missing dependency required by PDFKit to convert HTML to PDF.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the README to add a prerequisite section for installing `wkhtmltopdf` (version 0.12.6) for PDF generation.
  * Provided a download link and instructions for resolving MacOS firewall issues with `wkhtmltopdf`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->