### PR TITLE
Feat/restrict paypal payout method earnings threshold

### DIFF
--- a/app/business/payments/merchant_registration/implementations/paypal/paypal_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/paypal/paypal_merchant_account_manager.rb
@@ -41,6 +41,7 @@ class PaypalMerchantAccountManager
                               send_email_confirmation_notification: true,
                               create_new: true)
     return "There was an error connecting your PayPal account with Gumroad." if user.blank? || paypal_merchant_id.blank?
+    return "PayPal Connect requires $100 in earnings and one completed payout for users in your country." unless user.eligible_for_paypal_connect?
 
     paypal_merchant_accounts = user.merchant_accounts
                                    .where(charge_processor_id: PaypalChargeProcessor.charge_processor_id)

--- a/app/business/payments/merchant_registration/implementations/paypal/paypal_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/paypal/paypal_merchant_account_manager.rb
@@ -41,7 +41,7 @@ class PaypalMerchantAccountManager
                               send_email_confirmation_notification: true,
                               create_new: true)
     return "There was an error connecting your PayPal account with Gumroad." if user.blank? || paypal_merchant_id.blank?
-    return "PayPal Connect requires $100 in earnings and one completed payout for users in your country." unless user.eligible_for_paypal_connect?
+    return "PayPal Connect requires $100 in earnings and one completed payout for users in your country." unless user.eligible_for_paypal_payout?
 
     paypal_merchant_accounts = user.merchant_accounts
                                    .where(charge_processor_id: PaypalChargeProcessor.charge_processor_id)

--- a/app/controllers/paypal_controller.rb
+++ b/app/controllers/paypal_controller.rb
@@ -3,6 +3,7 @@
 class PaypalController < ApplicationController
   before_action :authenticate_user!, only: [:connect, :disconnect]
   before_action :validate_paypal_connect_enabled, only: %i[connect]
+  before_action :validate_paypal_connect_eligible, only: %i[connect]
   before_action :validate_paypal_disconnect_allowed, only: %i[disconnect]
   after_action :verify_authorized, only: [:connect, :disconnect]
 
@@ -87,6 +88,12 @@ class PaypalController < ApplicationController
       return if current_seller.paypal_connect_enabled?
 
       redirect_to settings_payments_path, notice: "Your PayPal account could not be connected because this PayPal integration is not supported in your country."
+    end
+
+    def validate_paypal_connect_eligible
+      return if current_seller.eligible_for_paypal_connect?
+
+      redirect_to settings_payments_path, notice: "PayPal Connect requires $100 in earnings and one completed payout for users in your country."
     end
 
     def validate_paypal_disconnect_allowed

--- a/app/controllers/paypal_controller.rb
+++ b/app/controllers/paypal_controller.rb
@@ -91,7 +91,7 @@ class PaypalController < ApplicationController
     end
 
     def validate_paypal_connect_eligible
-      return if current_seller.eligible_for_paypal_connect?
+      return if current_seller.eligible_for_paypal_payout?
 
       redirect_to settings_payments_path, notice: "PayPal Connect requires $100 in earnings and one completed payout for users in your country."
     end

--- a/app/javascript/components/Settings/PaymentsPage/PayPalConnectSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/PayPalConnectSection.tsx
@@ -15,6 +15,9 @@ export type PayPalConnect = {
   needs_email_confirmation: boolean;
   unsupported_countries: string[];
   allow_paypal_connect: boolean;
+  show_paypal_connect: boolean;
+  eligible_for_paypal_connect: boolean;
+  paypal_connect_restriction_message: string | null;
   paypal_disconnect_allowed: boolean;
 };
 
@@ -58,17 +61,25 @@ const PayPalConnectSection = ({
               supported in every country except {paypalConnect.unsupported_countries.join(", ")}.
             </p>
             <p>{connectAccountFeeInfoText}</p>
-            {paypalConnect.allow_paypal_connect ? (
-              <div>
-                <a
-                  className="button button-paypal paypal-connect"
-                  href={Routes.connect_paypal_path({
-                    referer: Routes.settings_payments_path(),
-                  })}
-                  inert={isFormDisabled}
-                >
-                  Connect with Paypal
-                </a>
+            <div>
+              <a
+                className={`button button-paypal paypal-connect ${!paypalConnect.allow_paypal_connect ? "button-disabled" : ""}`}
+                href={
+                  paypalConnect.allow_paypal_connect
+                    ? Routes.connect_paypal_path({
+                        referer: Routes.settings_payments_path(),
+                      })
+                    : undefined
+                }
+                inert={isFormDisabled || !paypalConnect.allow_paypal_connect}
+                style={!paypalConnect.allow_paypal_connect ? { pointerEvents: "none", opacity: 0.5 } : undefined}
+              >
+                Connect with Paypal
+              </a>
+            </div>
+            {paypalConnect.paypal_connect_restriction_message ? (
+              <div role="alert" className="warning">
+                {paypalConnect.paypal_connect_restriction_message}
               </div>
             ) : null}
           </>

--- a/app/javascript/components/Settings/PaymentsPage/PayPalConnectSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/PayPalConnectSection.tsx
@@ -16,8 +16,6 @@ export type PayPalConnect = {
   unsupported_countries: string[];
   allow_paypal_connect: boolean;
   show_paypal_connect: boolean;
-  eligible_for_paypal_connect: boolean;
-  paypal_connect_restriction_message: string | null;
   paypal_disconnect_allowed: boolean;
 };
 
@@ -63,25 +61,15 @@ const PayPalConnectSection = ({
             <p>{connectAccountFeeInfoText}</p>
             <div>
               <a
-                className={`button button-paypal paypal-connect ${!paypalConnect.allow_paypal_connect ? "button-disabled" : ""}`}
-                href={
-                  paypalConnect.allow_paypal_connect
-                    ? Routes.connect_paypal_path({
-                        referer: Routes.settings_payments_path(),
-                      })
-                    : undefined
-                }
-                inert={isFormDisabled || !paypalConnect.allow_paypal_connect}
-                style={!paypalConnect.allow_paypal_connect ? { pointerEvents: "none", opacity: 0.5 } : undefined}
+                className="button button-paypal paypal-connect"
+                href={Routes.connect_paypal_path({
+                  referer: Routes.settings_payments_path(),
+                })}
+                inert={isFormDisabled}
               >
                 Connect with Paypal
               </a>
             </div>
-            {paypalConnect.paypal_connect_restriction_message ? (
-              <div role="alert" className="warning">
-                {paypalConnect.paypal_connect_restriction_message}
-              </div>
-            ) : null}
           </>
         ) : paypalConnect.charge_processor_verified ? (
           <>

--- a/app/javascript/components/Settings/PaymentsPage/PayPalEmailSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/PayPalEmailSection.tsx
@@ -13,6 +13,7 @@ const PayPalEmailSection = ({
   feeInfoText,
   updatePayoutMethod,
   errorFieldNames,
+  isEligibleForPayPalPayout,
 }: {
   countrySupportsNativePayouts: boolean;
   showPayPalPayoutsFeeNote: boolean;
@@ -23,42 +24,51 @@ const PayPalEmailSection = ({
   feeInfoText: string;
   updatePayoutMethod: (payoutMethod: PayoutMethod) => void;
   errorFieldNames: Set<FormFieldName>;
+  isEligibleForPayPalPayout: boolean;
 }) => {
   const uid = React.useId();
   return (
     <section style={{ display: "grid", gap: "var(--spacer-6)" }}>
-      {showPayPalPayoutsFeeNote ? (
-        <div className="info" role="status">
-          PayPal payouts are subject to a 2% processing fee.
-        </div>
-      ) : null}
-      <div>{feeInfoText}</div>
-      <div>
-        {countrySupportsNativePayouts && !isFormDisabled ? (
-          <button className="link" onClick={() => updatePayoutMethod("bank")}>
-            Switch to direct deposit
-          </button>
-        ) : null}
-        <fieldset className={cx({ danger: errorFieldNames.has("paypal_email_address") })}>
-          <legend>
-            <label htmlFor={`${uid}-paypal-email`}>PayPal Email</label>
-          </legend>
-          <input
-            type="email"
-            id={`${uid}-paypal-email`}
-            placeholder="PayPal Email"
-            value={paypalEmailAddress || ""}
-            disabled={isFormDisabled}
-            aria-invalid={errorFieldNames.has("paypal_email_address")}
-            onChange={(evt) => setPaypalEmailAddress(evt.target.value)}
-          />
-        </fieldset>
-        {hasConnectedStripe ? (
-          <div role="alert" className="warning">
-            You cannot change your payout method to PayPal because you have a stripe account connected.
+      {isEligibleForPayPalPayout ? (
+        <>
+          {showPayPalPayoutsFeeNote ? (
+            <div className="info" role="status">
+              PayPal payouts are subject to a 2% processing fee.
+            </div>
+          ) : null}
+          <div>{feeInfoText}</div>
+          <div>
+            {countrySupportsNativePayouts && !isFormDisabled ? (
+              <button className="link" onClick={() => updatePayoutMethod("bank")}>
+                Switch to direct deposit
+              </button>
+            ) : null}
+            <fieldset className={cx({ danger: errorFieldNames.has("paypal_email_address") })}>
+              <legend>
+                <label htmlFor={`${uid}-paypal-email`}>PayPal Email</label>
+              </legend>
+              <input
+                type="email"
+                id={`${uid}-paypal-email`}
+                placeholder="PayPal Email"
+                value={paypalEmailAddress || ""}
+                disabled={isFormDisabled}
+                aria-invalid={errorFieldNames.has("paypal_email_address")}
+                onChange={(evt) => setPaypalEmailAddress(evt.target.value)}
+              />
+            </fieldset>
+            {hasConnectedStripe ? (
+              <div role="alert" className="warning">
+                You cannot change your payout method to PayPal because you have a stripe account connected.
+              </div>
+            ) : null}
           </div>
-        ) : null}
-      </div>
+        </>
+      ) : (
+        <div role="alert" className="warning">
+          PayPal requires $100 in earnings and one completed payout for users in your country.
+        </div>
+      )}
     </section>
   );
 };

--- a/app/javascript/components/server-components/Settings/PaymentsPage.tsx
+++ b/app/javascript/components/server-components/Settings/PaymentsPage.tsx
@@ -1073,7 +1073,7 @@ const PaymentsPage = (props: Props) => {
             )}
           </section>
         </section>
-        {props.paypal_connect.allow_paypal_connect ? (
+        {props.paypal_connect.show_paypal_connect ? (
           <PayPalConnectSection
             paypalConnect={props.paypal_connect}
             isFormDisabled={props.is_form_disabled}

--- a/app/javascript/components/server-components/Settings/PaymentsPage.tsx
+++ b/app/javascript/components/server-components/Settings/PaymentsPage.tsx
@@ -121,6 +121,7 @@ type Props = {
   paypal_address: string | null;
   stripe_connect: StripeConnect;
   paypal_connect: PayPalConnect;
+  paypal_payout_method_available: boolean;
   fee_info: {
     card_fee_info_text: string;
     paypal_fee_info_text: string;
@@ -1047,9 +1048,11 @@ const PaymentsPage = (props: Props) => {
                 feeInfoText={props.fee_info.paypal_fee_info_text}
                 updatePayoutMethod={updatePayoutMethod}
                 errorFieldNames={errorFieldNames}
+                isEligibleForPayPalPayout={props.paypal_payout_method_available}
               />
             ) : null}
-            {selectedPayoutMethod !== "stripe" ? (
+            {selectedPayoutMethod !== "stripe" &&
+            (selectedPayoutMethod !== "paypal" || props.paypal_payout_method_available) ? (
               <AccountDetailsSection
                 user={props.user}
                 complianceInfo={complianceInfo}
@@ -1064,16 +1067,16 @@ const PaymentsPage = (props: Props) => {
                 errorFieldNames={errorFieldNames}
                 payoutMethod={selectedPayoutMethod}
               />
-            ) : (
+            ) : selectedPayoutMethod === "stripe" ? (
               <StripeConnectSection
                 stripeConnect={props.stripe_connect}
                 isFormDisabled={props.is_form_disabled}
                 connectAccountFeeInfoText={props.fee_info.connect_account_fee_info_text}
               />
-            )}
+            ) : null}
           </section>
         </section>
-        {props.paypal_connect.show_paypal_connect ? (
+        {props.paypal_connect.show_paypal_connect && props.paypal_payout_method_available ? (
           <PayPalConnectSection
             paypalConnect={props.paypal_connect}
             isFormDisabled={props.is_form_disabled}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -897,6 +897,13 @@ class User < ApplicationRecord
     has_completed_payouts?
   end
 
+  def eligible_for_paypal_connect?
+    return true unless signed_up_from_morocco? || signed_up_from_egypt? || signed_up_from_algeria?
+    return false if sales_cents_total < Installment::MINIMUM_SALES_CENTS_VALUE
+
+    has_completed_payouts?
+  end
+
   LAST_ALLOWED_TIME_FOR_PRODUCT_LEVEL_REFUND_POLICY = Time.new(2025, 3, 31).end_of_day
 
   def account_level_refund_policy_delayed?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -897,7 +897,7 @@ class User < ApplicationRecord
     has_completed_payouts?
   end
 
-  def eligible_for_paypal_connect?
+  def eligible_for_paypal_payout?
     return true unless signed_up_from_morocco? || signed_up_from_egypt? || signed_up_from_algeria?
     return false if sales_cents_total < Installment::MINIMUM_SALES_CENTS_VALUE
 

--- a/app/presenters/settings_presenter.rb
+++ b/app/presenters/settings_presenter.rb
@@ -209,6 +209,7 @@ class SettingsPresenter
       paypal_address: seller.payment_address,
       show_verification_section: seller.user_compliance_info_requests.requested.present? && seller.stripe_account.present? && Pundit.policy!(pundit_user, [:settings, :payments, seller]).update?,
       paypal_connect:,
+      paypal_payout_method_available: seller.eligible_for_paypal_payout?,
       fee_info: fee_info(user_compliance_info),
       user: user_details(user_compliance_info),
       compliance_info: compliance_info_details(user_compliance_info),
@@ -376,10 +377,8 @@ class SettingsPresenter
       end
 
       {
-        allow_paypal_connect: Pundit.policy!(pundit_user, [:settings, :payments, seller]).paypal_connect? && seller.paypal_connect_enabled? && seller.eligible_for_paypal_connect?,
+        allow_paypal_connect: Pundit.policy!(pundit_user, [:settings, :payments, seller]).paypal_connect? && seller.paypal_connect_enabled? && seller.eligible_for_paypal_payout?,
         show_paypal_connect: Pundit.policy!(pundit_user, [:settings, :payments, seller]).paypal_connect? && seller.paypal_connect_enabled?,
-        eligible_for_paypal_connect: seller.eligible_for_paypal_connect?,
-        paypal_connect_restriction_message: seller.eligible_for_paypal_connect? ? nil : "PayPal Connect requires $100 in earnings and one completed payout for users in your country.",
         unsupported_countries: PaypalMerchantAccountManager::COUNTRY_CODES_NOT_SUPPORTED_BY_PCP.map { |code| ISO3166::Country[code].common_name },
         email: paypal_merchant_account_email,
         charge_processor_merchant_id: paypal_merchant_account&.charge_processor_merchant_id,

--- a/app/presenters/settings_presenter.rb
+++ b/app/presenters/settings_presenter.rb
@@ -376,7 +376,10 @@ class SettingsPresenter
       end
 
       {
-        allow_paypal_connect: Pundit.policy!(pundit_user, [:settings, :payments, seller]).paypal_connect? && seller.paypal_connect_enabled?,
+        allow_paypal_connect: Pundit.policy!(pundit_user, [:settings, :payments, seller]).paypal_connect? && seller.paypal_connect_enabled? && seller.eligible_for_paypal_connect?,
+        show_paypal_connect: Pundit.policy!(pundit_user, [:settings, :payments, seller]).paypal_connect? && seller.paypal_connect_enabled?,
+        eligible_for_paypal_connect: seller.eligible_for_paypal_connect?,
+        paypal_connect_restriction_message: seller.eligible_for_paypal_connect? ? nil : "PayPal Connect requires $100 in earnings and one completed payout for users in your country.",
         unsupported_countries: PaypalMerchantAccountManager::COUNTRY_CODES_NOT_SUPPORTED_BY_PCP.map { |code| ISO3166::Country[code].common_name },
         email: paypal_merchant_account_email,
         charge_processor_merchant_id: paypal_merchant_account&.charge_processor_merchant_id,

--- a/spec/business/payments/merchant_registration/paypal/paypal_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/paypal/paypal_merchant_account_manager_spec.rb
@@ -240,5 +240,55 @@ describe PaypalMerchantAccountManager, :vcr do
       expect(old_records.count).to eq(0)
       expect(creator.merchant_account("paypal").charge_processor_merchant_id).to eq(new_paypal_merchant_id)
     end
+
+    context "when user is not eligible for PayPal Connect" do
+      it "returns eligibility error for users from Morocco without sufficient earnings" do
+        creator = create(:user)
+        create(:user_compliance_info_empty, user: creator, country: "Morocco")
+        allow(creator).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE - 1)
+
+        result = subject.update_merchant_account(user: creator, paypal_merchant_id: "GSQ5PDPXZCWGW")
+        expect(result).to eq("PayPal Connect requires $100 in earnings and one completed payout for users in your country.")
+      end
+
+      it "returns eligibility error for users from Egypt without sufficient earnings" do
+        creator = create(:user)
+        create(:user_compliance_info_empty, user: creator, country: "Egypt")
+        allow(creator).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE - 1)
+
+        result = subject.update_merchant_account(user: creator, paypal_merchant_id: "GSQ5PDPXZCWGW")
+        expect(result).to eq("PayPal Connect requires $100 in earnings and one completed payout for users in your country.")
+      end
+
+      it "returns eligibility error for users from Algeria without sufficient earnings" do
+        creator = create(:user)
+        create(:user_compliance_info_empty, user: creator, country: "Algeria")
+        allow(creator).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE - 1)
+
+        result = subject.update_merchant_account(user: creator, paypal_merchant_id: "GSQ5PDPXZCWGW")
+        expect(result).to eq("PayPal Connect requires $100 in earnings and one completed payout for users in your country.")
+      end
+
+      it "allows connection for eligible users from restricted countries" do
+        creator = create(:user)
+        create(:user_compliance_info_empty, user: creator, country: "Morocco")
+        create(:payment_completed, user: creator)
+        allow(creator).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE)
+
+        expect do
+          subject.update_merchant_account(user: creator, paypal_merchant_id: "GSQ5PDPXZCWGW")
+        end.to change { creator.merchant_accounts.charge_processor_verified.paypal.count }.by(1)
+      end
+
+      it "allows connection for users from non-restricted countries regardless of earnings" do
+        creator = create(:user)
+        create(:user_compliance_info_empty, user: creator, country: "United States")
+        allow(creator).to receive(:sales_cents_total).and_return(0)
+
+        expect do
+          subject.update_merchant_account(user: creator, paypal_merchant_id: "GSQ5PDPXZCWGW")
+        end.to change { creator.merchant_accounts.charge_processor_verified.paypal.count }.by(1)
+      end
+    end
   end
 end

--- a/spec/controllers/paypal_controller_spec.rb
+++ b/spec/controllers/paypal_controller_spec.rb
@@ -120,6 +120,58 @@ describe PaypalController, :vcr do
         expect(flash[:notice]).to eq("Invalid request. Please try again later.")
       end
     end
+
+    context "when user is from Morocco and not eligible" do
+      before do
+        create(:user_compliance_info_empty, user: @user, country: "Morocco")
+        allow(@user).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE - 1)
+      end
+
+      it "redirects to settings payments path with eligibility error" do
+        get :connect
+        expect(response).to redirect_to(settings_payments_path)
+        expect(flash[:notice]).to eq("PayPal Connect requires $100 in earnings and one completed payout for users in your country.")
+      end
+    end
+
+    context "when user is from Egypt and not eligible" do
+      before do
+        create(:user_compliance_info_empty, user: @user, country: "Egypt")
+        allow(@user).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE - 1)
+      end
+
+      it "redirects to settings payments path with eligibility error" do
+        get :connect
+        expect(response).to redirect_to(settings_payments_path)
+        expect(flash[:notice]).to eq("PayPal Connect requires $100 in earnings and one completed payout for users in your country.")
+      end
+    end
+
+    context "when user is from Algeria and not eligible" do
+      before do
+        create(:user_compliance_info_empty, user: @user, country: "Algeria")
+        allow(@user).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE - 1)
+      end
+
+      it "redirects to settings payments path with eligibility error" do
+        get :connect
+        expect(response).to redirect_to(settings_payments_path)
+        expect(flash[:notice]).to eq("PayPal Connect requires $100 in earnings and one completed payout for users in your country.")
+      end
+    end
+
+    context "when user is from Morocco and eligible" do
+      before do
+        create(:user_compliance_info_empty, user: @user, country: "Morocco")
+        create(:payment_completed, user: @user)
+        allow(@user).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE)
+      end
+
+      it "allows connection and redirects to paypal url" do
+        get :connect
+        expect(response).to redirect_to(partner_referral_success_response[:redirect_url])
+      end
+    end
   end
 
   describe "#disconnect" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3323,7 +3323,7 @@ describe User, :vcr do
     end
   end
 
-  describe "#eligible_for_paypal_connect?" do
+  describe "#eligible_for_paypal_payout?" do
     let(:user) { create(:user) }
 
     context "when user is from Morocco" do
@@ -3334,18 +3334,18 @@ describe User, :vcr do
       it "returns true when user has made minimum required sales and has completed payouts" do
         create(:payment_completed, user:)
         allow(user).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE)
-        expect(user.eligible_for_paypal_connect?).to eq(true)
+        expect(user.eligible_for_paypal_payout?).to eq(true)
       end
 
       it "returns false when user has not made minimum required sales" do
         create(:payment_completed, user:)
         allow(user).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE - 1)
-        expect(user.eligible_for_paypal_connect?).to eq(false)
+        expect(user.eligible_for_paypal_payout?).to eq(false)
       end
 
       it "returns false when user has not completed payouts" do
         allow(user).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE)
-        expect(user.eligible_for_paypal_connect?).to eq(false)
+        expect(user.eligible_for_paypal_payout?).to eq(false)
       end
     end
 
@@ -3357,18 +3357,18 @@ describe User, :vcr do
       it "returns true when user has made minimum required sales and has completed payouts" do
         create(:payment_completed, user:)
         allow(user).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE)
-        expect(user.eligible_for_paypal_connect?).to eq(true)
+        expect(user.eligible_for_paypal_payout?).to eq(true)
       end
 
       it "returns false when user has not made minimum required sales" do
         create(:payment_completed, user:)
         allow(user).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE - 1)
-        expect(user.eligible_for_paypal_connect?).to eq(false)
+        expect(user.eligible_for_paypal_payout?).to eq(false)
       end
 
       it "returns false when user has not completed payouts" do
         allow(user).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE)
-        expect(user.eligible_for_paypal_connect?).to eq(false)
+        expect(user.eligible_for_paypal_payout?).to eq(false)
       end
     end
 
@@ -3380,18 +3380,18 @@ describe User, :vcr do
       it "returns true when user has made minimum required sales and has completed payouts" do
         create(:payment_completed, user:)
         allow(user).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE)
-        expect(user.eligible_for_paypal_connect?).to eq(true)
+        expect(user.eligible_for_paypal_payout?).to eq(true)
       end
 
       it "returns false when user has not made minimum required sales" do
         create(:payment_completed, user:)
         allow(user).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE - 1)
-        expect(user.eligible_for_paypal_connect?).to eq(false)
+        expect(user.eligible_for_paypal_payout?).to eq(false)
       end
 
       it "returns false when user has not completed payouts" do
         allow(user).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE)
-        expect(user.eligible_for_paypal_connect?).to eq(false)
+        expect(user.eligible_for_paypal_payout?).to eq(false)
       end
     end
 
@@ -3402,7 +3402,7 @@ describe User, :vcr do
 
       it "returns true regardless of sales amount or completed payouts" do
         allow(user).to receive(:sales_cents_total).and_return(0)
-        expect(user.eligible_for_paypal_connect?).to eq(true)
+        expect(user.eligible_for_paypal_payout?).to eq(true)
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3323,6 +3323,90 @@ describe User, :vcr do
     end
   end
 
+  describe "#eligible_for_paypal_connect?" do
+    let(:user) { create(:user) }
+
+    context "when user is from Morocco" do
+      before do
+        create(:user_compliance_info_empty, user:, country: "Morocco")
+      end
+
+      it "returns true when user has made minimum required sales and has completed payouts" do
+        create(:payment_completed, user:)
+        allow(user).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE)
+        expect(user.eligible_for_paypal_connect?).to eq(true)
+      end
+
+      it "returns false when user has not made minimum required sales" do
+        create(:payment_completed, user:)
+        allow(user).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE - 1)
+        expect(user.eligible_for_paypal_connect?).to eq(false)
+      end
+
+      it "returns false when user has not completed payouts" do
+        allow(user).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE)
+        expect(user.eligible_for_paypal_connect?).to eq(false)
+      end
+    end
+
+    context "when user is from Egypt" do
+      before do
+        create(:user_compliance_info_empty, user:, country: "Egypt")
+      end
+
+      it "returns true when user has made minimum required sales and has completed payouts" do
+        create(:payment_completed, user:)
+        allow(user).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE)
+        expect(user.eligible_for_paypal_connect?).to eq(true)
+      end
+
+      it "returns false when user has not made minimum required sales" do
+        create(:payment_completed, user:)
+        allow(user).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE - 1)
+        expect(user.eligible_for_paypal_connect?).to eq(false)
+      end
+
+      it "returns false when user has not completed payouts" do
+        allow(user).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE)
+        expect(user.eligible_for_paypal_connect?).to eq(false)
+      end
+    end
+
+    context "when user is from Algeria" do
+      before do
+        create(:user_compliance_info_empty, user:, country: "Algeria")
+      end
+
+      it "returns true when user has made minimum required sales and has completed payouts" do
+        create(:payment_completed, user:)
+        allow(user).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE)
+        expect(user.eligible_for_paypal_connect?).to eq(true)
+      end
+
+      it "returns false when user has not made minimum required sales" do
+        create(:payment_completed, user:)
+        allow(user).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE - 1)
+        expect(user.eligible_for_paypal_connect?).to eq(false)
+      end
+
+      it "returns false when user has not completed payouts" do
+        allow(user).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE)
+        expect(user.eligible_for_paypal_connect?).to eq(false)
+      end
+    end
+
+    context "when user is from other countries" do
+      before do
+        create(:user_compliance_info_empty, user:, country: "United States")
+      end
+
+      it "returns true regardless of sales amount or completed payouts" do
+        allow(user).to receive(:sales_cents_total).and_return(0)
+        expect(user.eligible_for_paypal_connect?).to eq(true)
+      end
+    end
+  end
+
   describe "#has_all_eligible_refund_policies_as_no_refunds?" do
     let(:seller) { create(:named_seller) }
     let(:product1) { create(:product, user: seller) }

--- a/spec/presenters/settings_presenter_spec.rb
+++ b/spec/presenters/settings_presenter_spec.rb
@@ -436,6 +436,9 @@ describe SettingsPresenter do
         show_verification_section: false,
         paypal_connect: {
           allow_paypal_connect: false,
+          show_paypal_connect: false,
+          eligible_for_paypal_connect: true,
+          paypal_connect_restriction_message: nil,
           unsupported_countries: PaypalMerchantAccountManager::COUNTRY_CODES_NOT_SUPPORTED_BY_PCP.map { |code| ISO3166::Country[code].common_name },
           email: nil,
           charge_processor_merchant_id: nil,
@@ -628,6 +631,7 @@ describe SettingsPresenter do
                                                                                                             }),
                                              paypal_connect: @base_props[:paypal_connect].merge({
                                                                                                   allow_paypal_connect: true,
+                                                                                                  show_paypal_connect: true,
                                                                                                 }),
                                              aus_backtax_details: @base_props[:aus_backtax_details].merge({
                                                                                                             legal_entity_name: @user_compliance_info.first_and_last_name,
@@ -654,6 +658,9 @@ describe SettingsPresenter do
 
         paypal_connect_details = @base_us_props[:paypal_connect].merge({
                                                                          allow_paypal_connect: true,
+                                                                         show_paypal_connect: true,
+                                                                         eligible_for_paypal_connect: true,
+                                                                         paypal_connect_restriction_message: nil,
                                                                          email: paypal_connect_account.paypal_account_details["primary_email"],
                                                                          charge_processor_merchant_id: paypal_connect_account.charge_processor_merchant_id,
                                                                          charge_processor_verified: true,

--- a/spec/presenters/settings_presenter_spec.rb
+++ b/spec/presenters/settings_presenter_spec.rb
@@ -437,8 +437,6 @@ describe SettingsPresenter do
         paypal_connect: {
           allow_paypal_connect: false,
           show_paypal_connect: false,
-          eligible_for_paypal_connect: true,
-          paypal_connect_restriction_message: nil,
           unsupported_countries: PaypalMerchantAccountManager::COUNTRY_CODES_NOT_SUPPORTED_BY_PCP.map { |code| ISO3166::Country[code].common_name },
           email: nil,
           charge_processor_merchant_id: nil,
@@ -659,8 +657,6 @@ describe SettingsPresenter do
         paypal_connect_details = @base_us_props[:paypal_connect].merge({
                                                                          allow_paypal_connect: true,
                                                                          show_paypal_connect: true,
-                                                                         eligible_for_paypal_connect: true,
-                                                                         paypal_connect_restriction_message: nil,
                                                                          email: paypal_connect_account.paypal_account_details["primary_email"],
                                                                          charge_processor_merchant_id: paypal_connect_account.charge_processor_merchant_id,
                                                                          charge_processor_verified: true,

--- a/test_paypal_scenarios.rb
+++ b/test_paypal_scenarios.rb
@@ -1,0 +1,73 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Test PayPal Connect scenarios
+user = User.find_by(email: "seller@gumroad.com")
+puts "=== STARTING STATE ==="
+puts "Country: #{user.alive_user_compliance_info&.country}"
+puts "Earnings: $#{user.sales_cents_total / 100.0}"
+puts "Has completed payouts? #{user.has_completed_payouts?}"
+puts "Eligible? #{user.eligible_for_paypal_payout?}"
+
+puts "\n=== TEST CASE 1: Adding earnings above $100 ==="
+product = user.products.first || user.products.create!(
+  name: "Test Product",
+  price_cents: 10000,
+  summary: "Test",
+  content_type: Product::ContentType::DIGITAL
+)
+
+_sale = Sale.create!(
+  user: user,
+  product: product,
+  price_cents: 15000,  # $150
+  gumroad_fee_cents: 1500,
+  seller_earnings_cents: 13500,
+  sales_tax_cents: 0,
+  currency: "usd"
+)
+
+user.reload
+puts "Earnings: $#{user.sales_cents_total / 100.0}"
+puts "Has completed payouts? #{user.has_completed_payouts?}"
+puts "Eligible? #{user.eligible_for_paypal_payout?}"
+
+puts "\n=== TEST CASE 2: Adding completed payout ==="
+_payment = Payment.create!(
+  user: user,
+  amount_cents: 13500,
+  state: "completed",
+  currency: "usd"
+)
+
+user.reload
+puts "Earnings: $#{user.sales_cents_total / 100.0}"
+puts "Has completed payouts? #{user.has_completed_payouts?}"
+puts "Eligible? #{user.eligible_for_paypal_payout?}"
+
+puts "\n=== TEST CASE 3: Change to US with $0 earnings ==="
+user_compliance_info = user.fetch_or_build_user_compliance_info
+user_compliance_info.dup_and_save! do |new_info|
+  new_info.country = "United States"
+  new_info.json_data = {}
+end
+
+user.sales.destroy_all
+user.payments.destroy_all
+user.reload
+
+puts "Country: #{user.alive_user_compliance_info.country}"
+puts "Earnings: $#{user.sales_cents_total / 100.0}"
+puts "Has completed payouts? #{user.has_completed_payouts?}"
+puts "Eligible? #{user.eligible_for_paypal_payout?}"
+
+puts "\n=== RESET TO ALGERIA ==="
+user_compliance_info = user.fetch_or_build_user_compliance_info
+user_compliance_info.dup_and_save! do |new_info|
+  new_info.country = "Algeria"
+  new_info.json_data = {}
+end
+
+user.reload
+puts "Country: #{user.alive_user_compliance_info.country}"
+puts "Reset complete!"


### PR DESCRIPTION
## Fixes #722

This PR enhances the PayPal payout method restriction for users from Morocco, Egypt, and Algeria who haven't met the $100 earnings + 1 completed payout requirements.

### Difference from Alternative Implementation (PR #761)
Instead of just disabling the PayPal Connect button, this implementation disables the entire PayPal payout method completely:

- **Hiding entire PayPal-related UI sections** for ineligible users
- **Showing warning message only** when PayPal payout method is selected
- **Completely removing** PayPal Connect section and account details fields

### Implementation Details
- Renamed `eligible_for_paypal_connect?` → `eligible_for_paypal_payout?` for accuracy
- Updated all references across controllers, presenters, services, and tests
- Enhanced PaymentsPage to conditionally show/hide PayPal UI sections
- Updated PayPalEmailSection to show restriction message instead of input fields

### User Experience
For ineligible users:
- ✅ PayPal payout method button remains visible
- ⚠️ When selected, shows only yellow warning message
- 🚫 PayPal Connect section completely hidden
- 🚫 Account details section hidden when PayPal selected

For eligible users: No changes - everything works as before.