### PR TITLE
Remove dependency of obfuscate id encryption in stripe_charge_processor_spec

### DIFF
--- a/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
@@ -237,7 +237,7 @@ describe StripeChargeProcessor, :vcr do
 
       # Charge where transfer_group does not match but metadata matches
       allow_any_instance_of(Purchase).to receive(:id).and_return(1234567890)
-      allow_any_instance_of(Purchase).to receive(:external_id).and_return(ObfuscateIds.encrypt(115780))
+      allow_any_instance_of(Purchase).to receive(:external_id).and_return("6RNPNSondrJ8t9SqSjxTjw==")
 
       charge = subject.search_charge(purchase: create(:purchase, created_at: Time.zone.at(1621973384)))
 


### PR DESCRIPTION
Resolves: https://github.com/antiwork/gumroad/issues/687 (Another part of it)

Contributors working on the open source project don't have access to the production or test's OBFUSCATE_IDS_CIPHER_KEY environment variable, which prevents them from testing ecryption functionality. This creates barriers for contributor onboarding and testing.

<img width="1551" height="361" alt="image" src="https://github.com/user-attachments/assets/d7e68dad-a09d-472d-bb13-cf60849df866" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test data for charge search scenarios to use a fixed identifier value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->