### PR TITLE
Remove dependency of obfuscate id decryption in charge_events_handler_spec

### DIFF
--- a/spec/models/concerns/purchase/charge_events_handler_spec.rb
+++ b/spec/models/concerns/purchase/charge_events_handler_spec.rb
@@ -112,11 +112,13 @@ describe Purchase::ChargeEventsHandler, :vcr do
       @l = create(:product, user: @u)
       subscription = create(:subscription)
       create(:membership_purchase, subscription:)
-      @p = create(:purchase, id: ObfuscateIds.decrypt("q3jUBQrrGrIId3SjC4VJ0g=="), link: @l, seller: @l.user, price_cents: 100,
+      purchase_external_id = "q3jUBQrrGrIId3SjC4VJ0g=="
+      @p = create(:purchase, id: ObfuscateIds.decrypt(purchase_external_id), link: @l, seller: @l.user, price_cents: 100,
                              total_transaction_cents: 100, fee_cents: 30, purchase_state: "in_progress", card_country: "IN",
                              subscription:)
-      @e = build(:charge_event_payment_failed, charge_reference: "q3jUBQrrGrIId3SjC4VJ0g==")
+      @e = build(:charge_event_payment_failed, charge_reference: purchase_external_id)
 
+      allow(Purchase).to receive(:find_by_external_id).with(purchase_external_id).and_return(@p)
       expect_any_instance_of(Purchase).to receive(:handle_event_informational!).and_call_original
       expect_any_instance_of(Subscription).to receive(:handle_purchase_failure)
     end


### PR DESCRIPTION
Resolves: https://github.com/antiwork/gumroad/issues/687 (Another part of it)

Contributors working on the open source project don't have access to the production or test's OBFUSCATE_IDS_CIPHER_KEY environment variable, which prevents them from testing ecryption functionality. This creates barriers for contributor onboarding and testing.

### Proof
#### Before
<img width="1542" height="927" alt="image" src="https://github.com/user-attachments/assets/66d65d8d-4cc3-4d18-856b-2b4cbe77ba55" />
 
#### After
Running the contained block now passes:
<img width="1542" height="927" alt="image" src="https://github.com/user-attachments/assets/cb5f92da-86ca-4fb0-a7b8-dd5eeee6425a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved clarity and consistency in test setup for payment failure scenarios.
  * Added method stubbing to enhance test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->