### PR TITLE
Retrieve product price by current currency

### DIFF
--- a/app/modules/base_price/shared.rb
+++ b/app/modules/base_price/shared.rb
@@ -100,6 +100,6 @@ module BasePrice::Shared
     end
 
     def prices_to_validate
-      prices.alive.map(&:price_cents)
+      prices.alive.where(currency: price_currency_type).pluck(:price_cents)
     end
 end

--- a/app/modules/product/prices.rb
+++ b/app/modules/product/prices.rb
@@ -321,7 +321,7 @@ module Product::Prices
 
     def prices_to_validate
       if persisted?
-        prices.alive.map(&:price_cents)
+        prices.alive.where(currency: price_currency_type).pluck(:price_cents)
       else
         price_cents_to_validate = []
         price_cents_to_validate << buy_price_cents if buyable?

--- a/app/modules/product/prices.rb
+++ b/app/modules/product/prices.rb
@@ -26,13 +26,13 @@ module Product::Prices
   def rental_price_cents
     return read_attribute(:rental_price_cents) unless persisted?
 
-    rentable? ? alive_prices.select(&:is_rental?).last.price_cents : nil
+    rentable? ? alive_prices.where(currency: price_currency_type).select(&:is_rental?).last&.price_cents : nil
   end
 
   def default_price
-    return alive_prices.select(&:is_rental?).last if rent_only?
+    return alive_prices.where(currency: price_currency_type).select(&:is_rental?).last if rent_only?
 
-    relevant_prices = alive_prices.select(&:is_buy?)
+    relevant_prices = alive_prices.where(currency: price_currency_type).select(&:is_buy?)
     relevant_prices = relevant_prices.select(&:is_default_recurrence?) if is_recurring_billing && subscription_duration.present?
     relevant_prices.last
   end

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -779,6 +779,39 @@ describe LinksController, :vcr do
         expect(@product.reload.removed_file_info_attributes).to eq %i[Size Length]
       end
 
+      describe "currency and price updates" do
+        before do
+          @product.update!(price_currency_type: "usd", price_cents: 1000)
+        end
+
+        it "changes product from USD $10 to EUR €12 and back to USD $11" do
+          expect(@product.price_currency_type).to eq "usd"
+          expect(@product.price_cents).to eq 1000
+
+          put :update, params: {
+            id: @product.unique_permalink,
+            price_currency_type: "eur",
+            price_cents: 1200
+          }, as: :json
+
+          expect(response).to be_successful
+          @product.reload
+          expect(@product.price_currency_type).to eq "eur"
+          expect(@product.price_cents).to eq 1200
+
+          put :update, params: {
+            id: @product.unique_permalink,
+            price_currency_type: "usd",
+            price_cents: 1100
+          }, as: :json
+
+          expect(response).to be_successful
+          @product.reload
+          expect(@product.price_currency_type).to eq "usd"
+          expect(@product.price_cents).to eq 1100
+        end
+      end
+
       it "sets the correct value for removed_file_info_attributes if there are none" do
         post :update, params: @params.merge({
                                               file_attributes: [

--- a/spec/controllers/purchases_controller_spec.rb
+++ b/spec/controllers/purchases_controller_spec.rb
@@ -370,7 +370,7 @@ describe PurchasesController, :vcr do
 
       context "when product is sold in a single unit currency type" do
         before do
-          @l.update!(price_cents: 1000, price_currency_type: "jpy")
+          @l.update!(price_currency_type: "jpy", price_cents: 1000)
           @p1 = create(:purchase_in_progress,
                        link: @l,
                        seller: @l.user,

--- a/spec/mailers/customer_mailer_spec.rb
+++ b/spec/mailers/customer_mailer_spec.rb
@@ -351,6 +351,7 @@ describe CustomerMailer do
 
           context "when purchase is in EUR" do
             before do
+              purchase.link.default_price.update!(currency: Currency::EUR)
               purchase.link.update!(price_currency_type: Currency::EUR)
               purchase.update!(
                 displayed_price_currency_type: Currency::EUR,

--- a/spec/models/preorder_spec.rb
+++ b/spec/models/preorder_spec.rb
@@ -529,7 +529,7 @@ describe Preorder, :vcr do
     end
 
     it "charges the card the right amount based on the exchange rate at the time of the charge" do
-      @product.update_attribute(:price_currency_type, "jpy")
+      @product.update!(price_currency_type: "jpy", price_cents: 600)
       $currency_namespace.set("JPY",  95)
       authorization_purchase = build(:purchase, link: @product, chargeable: @good_card, purchase_state: "in_progress", is_preorder_authorization: true)
       preorder = @preorder_product.build_preorder(authorization_purchase)
@@ -564,8 +564,11 @@ describe Preorder, :vcr do
     end
 
     it "charges the card the right amount based on the custom price the buyer entered at preorder time - non USD" do
-      @product.update_attribute(:customizable_price, true)
-      @product.update_attribute(:price_currency_type, "jpy")
+      @product.update!(
+        price_currency_type: "jpy",
+        price_cents: 600,
+        customizable_price: true
+      )
       $currency_namespace.set("JPY",  90)
       authorization_purchase = build(:purchase, link: @product, perceived_price_cents: 700, chargeable: @good_card,
                                                 purchase_state: "in_progress", is_preorder_authorization: true)
@@ -683,7 +686,7 @@ describe Preorder, :vcr do
     end
 
     it "charges the buyer the amount equal to the price (in yens) at the time of the preorder" do
-      @product.update_attribute(:price_currency_type, "jpy")
+      @product.update!(price_currency_type: "jpy", price_cents: 600)
       authorization_purchase = build(:purchase, link: @product, chargeable: @good_card, purchase_state: "in_progress", is_preorder_authorization: true)
       preorder = @preorder_product.build_preorder(authorization_purchase)
       preorder.authorize!

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -3561,6 +3561,7 @@ describe Purchase, :vcr do
       @purchase.country = "Germany"
 
       @purchase.link.price_currency_type = "gbp"
+      @purchase.link.price_cents = 10000
       @purchase.link.shipping_destinations << ShippingDestination.new(country_code: Product::Shipping::ELSEWHERE, one_item_rate_cents: 10_00, multiple_items_rate_cents: 5_00)
       @purchase.link.save!
 
@@ -4968,7 +4969,6 @@ describe Purchase, :vcr do
       purchase = create(:purchase)
       expect(purchase.format_price_in_currency(5_50)).to eq "$5.50"
 
-      purchase.link.update!(price_currency_type: "gbp")
       purchase.displayed_price_currency_type = "gbp"
       expect(purchase.format_price_in_currency(5_50)).to eq "£2.75"
     end
@@ -4977,7 +4977,6 @@ describe Purchase, :vcr do
       purchase = create(:membership_purchase)
       expect(purchase.format_price_in_currency(5_50)).to eq "$5.50 a month"
 
-      purchase.link.update!(price_currency_type: "eur")
       purchase.displayed_price_currency_type = "eur"
       expect(purchase.format_price_in_currency(5_50)).to eq "€2.75 a month"
     end

--- a/spec/models/subscription_plan_change_spec.rb
+++ b/spec/models/subscription_plan_change_spec.rb
@@ -90,7 +90,7 @@ describe SubscriptionPlanChange do
       expect(plan_change.formatted_display_price).to eq "$1 every 3 months"
 
       plan_change.update!(perceived_price_cents: 350, recurrence: "monthly")
-      plan_change.subscription.link.update!(price_currency_type: "eur")
+      plan_change.subscription.link.update!(price_currency_type: "eur", price_cents: 350)
       expect(plan_change.formatted_display_price).to eq "€3.50 a month"
     end
 

--- a/spec/presenters/customer_presenter_spec.rb
+++ b/spec/presenters/customer_presenter_spec.rb
@@ -336,7 +336,7 @@ describe CustomerPresenter do
     let(:purchase) { create(:physical_purchase, stripe_partially_refunded: true, chargeback_date: Time.current, created_at: 7.months.ago, card_type: CardType::PAYPAL) }
 
     before do
-      purchase.link.update!(price_currency_type: Currency::EUR)
+      purchase.link.update!(price_currency_type: Currency::EUR, price_cents: 100)
       allow_any_instance_of(Purchase).to receive(:get_rate).with(Currency::EUR).and_return(0.8)
     end
 

--- a/spec/presenters/receipt_presenter/payment_info_spec.rb
+++ b/spec/presenters/receipt_presenter/payment_info_spec.rb
@@ -131,6 +131,7 @@ describe ReceiptPresenter::PaymentInfo do
 
           context "when the purchase is in EUR" do
             before do
+              purchase.link.default_price.update!(currency: Currency::EUR)
               purchase.link.update!(price_currency_type: Currency::EUR)
               purchase.update!(
                 displayed_price_currency_type: Currency::EUR,
@@ -329,7 +330,7 @@ describe ReceiptPresenter::PaymentInfo do
 
             context "when the purchase is in EUR" do
               before do
-                purchase.link.update!(price_currency_type: Currency::EUR)
+                purchase.link.update!(price_currency_type: Currency::EUR, price_cents: 1499)
                 purchase.update!(
                   displayed_price_currency_type: Currency::EUR,
                   rate_converted_to_usd: 1.07,

--- a/spec/requests/customers/customers_spec.rb
+++ b/spec/requests/customers/customers_spec.rb
@@ -1419,7 +1419,7 @@ describe "Sales page", type: :feature, js: true do
       context "for non-USD purchases" do
         before do
           purchase1.update!(purchase_state: "in_progress", chargeable: create(:chargeable))
-          purchase1.link.update!(price_currency_type: Currency::EUR)
+          purchase1.link.update!(price_currency_type: Currency::EUR, price_cents: 100)
           purchase1.process!
           purchase1.mark_successful!
         end

--- a/spec/requests/purchases/product/shipping/shipping_offer_codes_spec.rb
+++ b/spec/requests/purchases/product/shipping/shipping_offer_codes_spec.rb
@@ -52,9 +52,14 @@ describe("Product Page - Shipping with offer codes", type: :feature, js: true, s
   it "only has the $50 offer code affect the product and not shipping and taxes" do
     @user = create(:user_with_compliance_info)
 
-    @product = create(:product, user: @user, require_shipping: true, price_cents: 100_00)
-    @product.is_physical = true
-    @product.price_currency_type = "gbp"
+    @product = create(
+      :product,
+      user: @user,
+      require_shipping: true,
+      price_cents: 100_00,
+      price_currency_type: "gbp",
+      is_physical: true
+    )
     @product.shipping_destinations << ShippingDestination.new(country_code: "US", one_item_rate_cents: 2000, multiple_items_rate_cents: 1000)
     @product.save!
 

--- a/spec/requests/purchases/product/shipping/shipping_spec.rb
+++ b/spec/requests/purchases/product/shipping/shipping_spec.rb
@@ -4,9 +4,14 @@ describe("Product Page - Shipping Scenarios", type: :feature, js: true, shipping
   it "shows the shipping in USD in the blurb and not apply taxes on top of it" do
     @user = create(:user_with_compliance_info)
 
-    @product = create(:physical_product, user: @user, require_shipping: true, price_cents: 100_00)
+    @product = create(
+      :physical_product,
+      user: @user,
+      require_shipping: true,
+      price_cents: 100_00,
+      price_currency_type: "gbp"
+    )
     @product.shipping_destinations << ShippingDestination.new(country_code: "US", one_item_rate_cents: 2000, multiple_items_rate_cents: 1000)
-    @product.price_currency_type = "gbp"
     @product.save!
 
     visit "/l/#{@product.unique_permalink}"

--- a/spec/requests/subscription/tiered_membership_spec.rb
+++ b/spec/requests/subscription/tiered_membership_spec.rb
@@ -304,7 +304,7 @@ describe "Tiered Membership Spec", type: :feature, js: true do
     context "for non-USD currency" do
       it "rounds up to the minimum product price for that currency" do
         currency = "cad"
-        change_product_currency_to(currency)
+        change_membership_product_currency_to(@product, currency)
         set_tier_price_difference_below_min_upgrade_price(currency)
         displayed_upgrade_charge_in_usd = formatted_price("usd", get_usd_cents(currency, @min_price_in_currency))
 

--- a/spec/services/purchase/create_service_spec.rb
+++ b/spec/services/purchase/create_service_spec.rb
@@ -730,7 +730,7 @@ describe Purchase::CreateService, :vcr do
   context "when the user has a different currency" do
     describe "english pound" do
       it "sets the displayed price on the purchase" do
-        product.update!(price_currency_type: :gbp)
+        product.update!(price_currency_type: :gbp, price_cents: 600)
         product.reload
 
         purchase, _ = Purchase::CreateService.new(product:, params:).perform
@@ -2491,7 +2491,7 @@ describe Purchase::CreateService, :vcr do
 
     it "allows purchases with offer codes in different currencies" do
       %i[eur gbp aud inr cad hkd sgd twd nzd].each do |currency|
-        product.update!(price_cents: 15_000, price_currency_type: currency)
+        product.update!(price_currency_type: currency, price_cents: 15_000)
         offer_code = create(:offer_code, code: currency, currency_type: currency, products: [product], amount_cents: 3_000)
         params[:purchase].merge!(
           offer_code_name: offer_code.name,
@@ -2566,7 +2566,7 @@ describe Purchase::CreateService, :vcr do
 
     it "fails if the amount paid is less than it should be in any currency" do
       %i[eur gbp aud inr cad hkd sgd twd nzd].each do |currency|
-        product.update!(price_cents: 15_000, price_currency_type: currency)
+        product.update!(price_currency_type: currency, price_cents: 15_000)
         offer_code = create(:offer_code, code: currency, currency_type: currency, products: [product], amount_cents: 3_000)
         params[:purchase].merge!(
           offer_code_name: offer_code.name,

--- a/spec/services/subscription/updater_service/tiered_membership_variant_and_price_update_spec.rb
+++ b/spec/services/subscription/updater_service/tiered_membership_variant_and_price_update_spec.rb
@@ -1046,7 +1046,7 @@ describe "Subscription::UpdaterService – Tiered Membership Variant And Price U
         context "for a product in non-USD currency" do
           it "rounds up to the minimum product price in that currency" do
             currency = "eur"
-            change_product_currency_to(currency)
+            change_membership_product_currency_to(@product, currency)
             set_tier_price_difference_below_min_upgrade_price(currency)
 
             params = {

--- a/spec/support/manage_subscription_helpers.rb
+++ b/spec/support/manage_subscription_helpers.rb
@@ -173,10 +173,10 @@ module ManageSubscriptionHelpers
     subscription
   end
 
-  def change_product_currency_to(currency)
-    @product.update!(price_currency_type: currency)
-    @product.prices.update_all(currency:)
-    @product.tiers.map { |t| t.prices.update_all(currency:) }
+  def change_membership_product_currency_to(product, currency)
+    product.prices.update_all(currency:)
+    product.update!(price_currency_type: currency)
+    product.tiers.map { |t| t.prices.update_all(currency:) }
   end
 
   def set_tier_price_difference_below_min_upgrade_price(currency)


### PR DESCRIPTION
When a product's currency is changed multiple times (e.g., USD → EUR → USD), we correctly creates separate Price records for each currency.

But retrieval methods (e.g. Link#default_price) return incorrect values because it does not consider the current currency, potentially returning the currency from one record, and dollar value from another.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for filtering product prices by currency, ensuring that displayed prices match the product's selected currency.

* **Tests**
  * Introduced new tests to verify correct price and currency updates, and to ensure accurate price selection based on currency.
  * Added test coverage for updating product prices and currencies, confirming that price changes do not affect other currencies.
  * Enhanced test setups to explicitly set price amounts alongside currencies for more accurate validation across multiple features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->