### PR TITLE
feat(payouts): Better payout pause messaging

### DIFF
--- a/app/controllers/admin/users/payouts_controller.rb
+++ b/app/controllers/admin/users/payouts_controller.rb
@@ -81,13 +81,31 @@ class Admin::Users::PayoutsController < Admin::BaseController
   end
 
   def pause
-    @user.update!(payouts_paused_internally: true)
+    reason = params[:reason].presence || "Manual pause by admin"
+
+    @user.update!(
+      payouts_paused_internally: true,
+      payout_pause_source: "admin",
+      payout_pause_reason: reason
+    )
+
+    @user.add_payout_note(
+      content: "Payouts paused by #{current_user.name} (ID: #{current_user.id}): #{reason}"
+    )
 
     render json: { success: true, message: "User's payouts paused" }
   end
 
   def resume
-    @user.update!(payouts_paused_internally: false)
+    @user.update!(
+      payouts_paused_internally: false,
+      payout_pause_source: nil,
+      payout_pause_reason: nil
+    )
+
+    @user.add_payout_note(
+      content: "Payouts resumed by #{current_user.name} (ID: #{current_user.id})"
+    )
 
     render json: { success: true, message: "User's payouts resumed" }
   end

--- a/app/javascript/components/server-components/BalancePage.tsx
+++ b/app/javascript/components/server-components/BalancePage.tsx
@@ -603,6 +603,8 @@ const BalancePage = ({
   next_payout_period_data,
   processing_payout_periods_data,
   payouts_status,
+  payout_pause_source,
+  payout_pause_reason,
   past_payout_period_data,
   instant_payout,
   show_instant_payouts_notice,
@@ -614,6 +616,8 @@ const BalancePage = ({
     | null;
   processing_payout_periods_data: PayoutPeriodData[];
   payouts_status: "paused" | "payable";
+  payout_pause_source: string | null;
+  payout_pause_reason: string | null;
   past_payout_period_data: PayoutPeriodData[];
   instant_payout: {
     payable_amount_cents: number;
@@ -854,7 +858,23 @@ const BalancePage = ({
         {payouts_status === "paused" ? (
           <div className="warning" role="status">
             <p>
-              <strong>Your payouts have been paused.</strong>
+              <strong>
+                {payout_pause_source === "stripe"
+                  ? "Your payouts have been paused by our payment processor."
+                  : payout_pause_source === "admin"
+                    ? `Your payouts have been paused by Gumroad support${payout_pause_reason ? `: ${payout_pause_reason}` : "."}`
+                    : payout_pause_source === "user"
+                      ? "You have paused your payouts."
+                      : payout_pause_source === "system"
+                        ? `Your payouts have been automatically paused${payout_pause_reason ? `: ${payout_pause_reason}` : " for security review."}`
+                        : "Your payouts have been paused."}
+              </strong>
+              {payout_pause_source === "stripe" && (
+                <>
+                  {" "}
+                  Please check your <a href="/settings/payments">Payment Settings</a> for verification requirements.
+                </>
+              )}
             </p>
           </div>
         ) : null}

--- a/app/javascript/components/server-components/Settings/PaymentsPage.tsx
+++ b/app/javascript/components/server-components/Settings/PaymentsPage.tsx
@@ -145,6 +145,8 @@ type Props = {
   formatted_balance_to_forfeit: string | null;
   payouts_paused_internally: boolean;
   payouts_paused_by_user: boolean;
+  payout_pause_source: string | null;
+  payout_pause_reason: string | null;
   payout_threshold_cents: number;
   minimum_payout_threshold_cents: number;
   payout_frequency: PayoutFrequency;
@@ -936,7 +938,17 @@ const PaymentsPage = (props: Props) => {
               )}
             </fieldset>
             {props.payouts_paused_internally ? (
-              <WithTooltip tip="Your payouts were paused by our payment processor. Please update your information below.">
+              <WithTooltip
+                tip={
+                  props.payout_pause_source === "stripe"
+                    ? "Your payouts were paused by our payment processor. Please update your verification information below."
+                    : props.payout_pause_source === "admin"
+                      ? `Your payouts were paused by Gumroad support${props.payout_pause_reason ? `: ${props.payout_pause_reason}` : "."}`
+                      : props.payout_pause_source === "system"
+                        ? `Your payouts were automatically paused${props.payout_pause_reason ? `: ${props.payout_pause_reason}` : " for security review."}`
+                        : "Your payouts were paused by our payment processor. Please update your information below."
+                }
+              >
                 {payoutsPausedToggle}
               </WithTooltip>
             ) : (

--- a/app/presenters/payouts_presenter.rb
+++ b/app/presenters/payouts_presenter.rb
@@ -23,6 +23,8 @@ class PayoutsPresenter
         item.merge(has_stripe_connect: seller.stripe_connect_account.present?)
       end,
       payouts_status: seller.payouts_status,
+      payout_pause_source: seller.payout_pause_source,
+      payout_pause_reason: seller.payout_pause_reason,
       past_payout_period_data: past_payouts.map { payout_period_data(seller, _1) },
       instant_payout: seller.instant_payouts_supported? ? {
         payable_amount_cents: seller.instantly_payable_unpaid_balance_cents,

--- a/app/presenters/settings_presenter.rb
+++ b/app/presenters/settings_presenter.rb
@@ -221,6 +221,8 @@ class SettingsPresenter
       formatted_balance_to_forfeit: seller.formatted_balance_to_forfeit(:country_change),
       payouts_paused_internally: seller.payouts_paused_internally?,
       payouts_paused_by_user: seller.payouts_paused_by_user?,
+      payout_pause_source: seller.payout_pause_source,
+      payout_pause_reason: seller.payout_pause_reason,
       payout_threshold_cents: seller.minimum_payout_amount_cents,
       minimum_payout_threshold_cents: seller.minimum_payout_threshold_cents,
       payout_frequency: seller.payout_frequency,

--- a/app/views/help_center/articles/contents/_281-payout-delays.html.erb
+++ b/app/views/help_center/articles/contents/_281-payout-delays.html.erb
@@ -34,7 +34,14 @@
       Email us and we can look into it for you.</p>
     <h3>Reason 4: There is an issue with your verification</h3>
     <figure><%= image_tag "help_center/stripe-verification-ui.png" %></figure>
-    <p>Payouts may be paused by our payment processor if you have not completed your account's identity or business verification. You can check your <a href="https://gumroad.com/settings/payments">Payment Settings</a> page for details on what is missing or why your verification is failing.</p>
+    <p>Payouts may be paused by our payment processor (Stripe) if you have not completed your account's identity or business verification. When this happens, you'll see a message indicating that your payouts were paused by our payment processor. You can check your <a href="https://gumroad.com/settings/payments">Payment Settings</a> page for details on what is missing or why your verification is failing.</p>
+    <p><strong>Types of payout pauses:</strong></p>
+    <ul>
+      <li><strong>Payment processor pause:</strong> Stripe has paused your payouts due to verification requirements or compliance issues. You'll need to update your information in Payment Settings.</li>
+      <li><strong>Gumroad support pause:</strong> Our support team has manually paused your payouts, usually with a specific reason provided. Contact support for more information.</li>
+      <li><strong>Self-pause:</strong> You have chosen to pause your own payouts through your Payment Settings.</li>
+      <li><strong>Security review pause:</strong> Payouts were automatically paused due to unusual activity for security review.</li>
+    </ul>
     <h3>Reason 5: Today <em>might not</em> actually be your pay day</h3>
     <p> We often have creators write in asking why they had not been paid on a Friday, and when we investigate the situation we see that they were not, in fact, supposed to have received money. </p>
     <p> As per <a href="13-getting-paid.html">Getting Paid</a>, we pay out every Friday for all sales made <em>up to the previous Friday</em>. For example:</p>

--- a/db/migrate/20250807203250_add_payout_pause_source_to_users.rb
+++ b/db/migrate/20250807203250_add_payout_pause_source_to_users.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AddPayoutPauseSourceToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :payout_pause_source, :string
+    add_column :users, :payout_pause_reason, :text
+    add_index :users, :payout_pause_source
+
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          UPDATE users#{' '}
+          SET payout_pause_source = 'admin'#{' '}
+          WHERE (flags & POW(2, 20)) != 0
+        SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_04_25_212934) do
+ActiveRecord::Schema[7.1].define(version: 2025_08_07_203250) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -2505,6 +2505,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_25_212934) do
     t.string "notification_content_type", default: "application/x-www-form-urlencoded"
     t.string "google_uid"
     t.integer "purchasing_power_parity_limit"
+    t.string "payout_pause_source"
+    t.text "payout_pause_reason"
     t.index ["account_created_ip"], name: "index_users_on_account_created_ip"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", length: 191
     t.index ["created_at"], name: "index_users_on_created_at"
@@ -2516,6 +2518,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_25_212934) do
     t.index ["last_sign_in_ip"], name: "index_users_on_last_sign_in_ip"
     t.index ["name"], name: "index_users_on_name"
     t.index ["payment_address", "user_risk_state"], name: "index_users_on_payment_address_and_user_risk_state"
+    t.index ["payout_pause_source"], name: "index_users_on_payout_pause_source"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token"
     t.index ["support_email"], name: "index_users_on_support_email"
     t.index ["tos_violation_reason"], name: "index_users_on_tos_violation_reason"

--- a/spec/business/payments/payouts/payouts_spec.rb
+++ b/spec/business/payments/payouts/payouts_spec.rb
@@ -449,14 +449,14 @@ describe Payouts do
         seller = create(:compliant_user, payment_address: "seller@gr.co")
         create(:user_compliance_info, user: seller)
         create(:balance, user: seller, date: Date.today - 3, amount_cents: 1000)
-        seller.update!(payouts_paused_internally: true)
+        seller.update!(payouts_paused_internally: true, payout_pause_source: "admin")
 
         expect do
           described_class.create_payments_for_balances_up_to_date_for_users(Date.today - 1, PayoutProcessorType::PAYPAL, [seller])
         end.to change { seller.comments.with_type_payout_note.count }.by(1)
 
         date = Time.current.to_fs(:formatted_date_full_month)
-        content = "Payout on #{date} was skipped because payouts on the account were paused by the admin."
+        content = "Payout on #{date} was skipped because payouts were paused by Gumroad support for administrative review."
         expect(seller.comments.with_type_payout_note.last.content).to eq(content)
       end
     end


### PR DESCRIPTION
This resolves https://github.com/antiwork/gumroad/issues/545

<img width="3456" height="2234" alt="CleanShot 2025-08-07 at 14 33 13@2x" src="https://github.com/user-attachments/assets/9a60995e-436f-425a-a420-7498e71c0481" />
<img width="3306" height="1570" alt="CleanShot 2025-08-07 at 15 00 16@2x" src="https://github.com/user-attachments/assets/bcedda67-7548-4f24-9b66-ed8a6ffc15c0" />

Two failing tests due to missing Paypal & Stripe credentials.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed explanations for payout pauses, showing users the specific reason and source (e.g., payment processor, admin, user, system) in the Balance and Payments Settings pages.
  * Users and admins can now see and manage payout pause reasons, with clearer messaging and tracking for each pause event.

* **Bug Fixes**
  * Improved accuracy and clarity of payout pause notifications and notes.

* **Documentation**
  * Updated help center article to explain all types of payout pauses and their meanings.

* **Chores**
  * Database updated with new fields to store payout pause source and reason for each user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->