### PR TITLE
fix: country selection modal close redirect

### DIFF
--- a/app/javascript/components/server-components/CountrySelectionModal.tsx
+++ b/app/javascript/components/server-components/CountrySelectionModal.tsx
@@ -49,7 +49,14 @@ export const CountrySelectionModal = ({ country: initialCountry, countries }: Pr
     <div>
       <Modal
         open
-        onClose={() => (window.location.href = Routes.dashboard_path())}
+        onClose={() => {
+          const referrer = document.referrer;
+          if (referrer && new URL(referrer).origin === window.location.origin) {
+            window.history.back();
+          } else {
+            window.location.href = Routes.dashboard_path();
+          }
+        }}
         title="Where are you located?"
         footer={
           <Button color="accent" disabled={checked.length !== checkboxes.length || saving} onClick={() => void save()}>

--- a/spec/requests/settings/payments_spec.rb
+++ b/spec/requests/settings/payments_spec.rb
@@ -5667,6 +5667,28 @@ describe("Payments Settings Scenario", type: :feature, js: true) do
     end
   end
 
+  describe "Country selection modal" do
+    before do
+      @user = create(:named_user, payment_address: nil)
+      login_as @user
+    end
+
+    it "navigates back to previous page when modal is closed" do
+      visit settings_main_path
+      find('a[role="tab"]', text: "Payments").click
+      expect(page).to have_content("Where are you located?")
+      find("button[aria-label='Close']").click
+      expect(page).to have_current_path(settings_main_path)
+    end
+
+    it "navigates to dashboard page when modal is closed and no previous page exists" do
+      visit settings_payments_path
+      expect(page).to have_content("Where are you located?")
+      find("button[aria-label='Close']").click
+      expect(page).to have_current_path(dashboard_path)
+    end
+  end
+
   describe "Taxes collection section" do
     before do
       @creator = create(:user_with_compliance_info, name: "Chuck Bartowski", au_backtax_sales_cents: 30000_00, au_backtax_owed_cents: 2727_27)


### PR DESCRIPTION
Fixes https://github.com/antiwork/gumroad/issues/780

### What’s Changed
This updates the `onClose` behavior for the “Where are you located?” modal.

### Before
Clicking the X on the modal always redirected users to the dashboard, even if they had navigated there from somewhere else in the app.

https://github.com/user-attachments/assets/1191b36d-ebae-4519-b767-98801ca5a43d

### After
Now, when clicking the X:
1. If the user came from a page within the same site, it takes them back to that page
2. If not (e.g. they opened the modal directly or came from an external site), it redirects to the dashboard

https://github.com/user-attachments/assets/87fe9799-bc83-4b73-8641-bcf16bb8127d

### Why
Redirecting users to the home page every time felt a bit jarring. This change makes the experience smoother by sending users back to where they came from when possible.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **New Features**
  * Improved modal close behavior to better handle navigation. When closing the country selection modal, users are now returned to their previous page if they came from within the site, rather than always being redirected to the dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->