### PR TITLE
Feature/installment plan receipts language

### DIFF
--- a/app/presenters/receipt_presenter/item_info.rb
+++ b/app/presenters/receipt_presenter/item_info.rb
@@ -264,8 +264,10 @@ class ReceiptPresenter::ItemInfo
 
         if subscription.is_installment_plan?
           initiated_on = subscription.created_at.to_fs(:formatted_date_abbrev_month)
-          final_charge_on = subscription.end_time_of_subscription.to_fs(:formatted_date_abbrev_month)
-          "Installment plan initiated on #{initiated_on}. Your final charge will be on #{final_charge_on}. You can manage your payment settings #{link_to(
+          final_charge_date = subscription.created_at + ((subscription.charge_occurrence_count - 1) * subscription.period)
+          final_charge_on = final_charge_date.to_fs(:formatted_date_abbrev_month)
+          tense = subscription.charges_completed? ? "was" : "will be"
+          "Installment plan initiated on #{initiated_on}. Your final charge #{tense} on #{final_charge_on}. You can manage your payment settings #{link_to(
             "here",
             manage_url,
             target: "_blank"

--- a/app/presenters/receipt_presenter/item_info.rb
+++ b/app/presenters/receipt_presenter/item_info.rb
@@ -257,14 +257,26 @@ class ReceiptPresenter::ItemInfo
         return if purchase.is_gift_receiver_purchase && subscription.credit_card_id.blank?
         return gift_subscription_renewal_note if subscription.gift? && subscription.credit_card_id.blank?
 
-        "You will be charged once #{recurrence_long_indicator(subscription.recurrence)}. If you would like to manage your membership you can visit #{link_to(
-            "subscription settings",
-            Rails.application.routes.url_helpers.manage_subscription_url(
-              subscription.external_id,
-              { host: UrlService.domain_with_protocol },
-            ),
+        manage_url = Rails.application.routes.url_helpers.manage_subscription_url(
+          subscription.external_id,
+          { host: UrlService.domain_with_protocol },
+        )
+
+        if subscription.is_installment_plan?
+          initiated_on = subscription.created_at.to_fs(:formatted_date_abbrev_month)
+          final_charge_on = subscription.end_time_of_subscription.to_fs(:formatted_date_abbrev_month)
+          "Installment plan initiated on #{initiated_on}. Your final charge will be on #{final_charge_on}. You can manage your payment settings #{link_to(
+            "here",
+            manage_url,
             target: "_blank"
           )}.".html_safe
+        else
+          "You will be charged once #{recurrence_long_indicator(subscription.recurrence)}. If you would like to manage your membership you can visit #{link_to(
+              "subscription settings",
+              manage_url,
+              target: "_blank"
+            )}.".html_safe
+        end
       end
     end
 

--- a/app/presenters/receipt_presenter/payment_info.rb
+++ b/app/presenters/receipt_presenter/payment_info.rb
@@ -24,6 +24,7 @@ class ReceiptPresenter::PaymentInfo
 
   def notes
     [
+      installment_plan_final_payment_note,
       recurring_subscription_notes,
       usd_currency_note,
       credit_card_note
@@ -154,7 +155,7 @@ class ReceiptPresenter::PaymentInfo
       return unless any_upcoming_payments?
 
       {
-        label: "Today's payment",
+      label: todays_payment_heading_with_installment_number,
         value: nil
       }
     end
@@ -217,10 +218,7 @@ class ReceiptPresenter::PaymentInfo
     end
 
     def upcoming_payment_heading_attribute
-      {
-        label: "Upcoming #{"payment".pluralize(upcoming_price_attributes.size)}",
-        value: nil
-      }
+    { label: upcoming_payment_heading_with_installment_number, value: nil }
     end
 
     def today_membership_paid_until_attribute
@@ -254,6 +252,41 @@ class ReceiptPresenter::PaymentInfo
         .map { upcoming_price_attribute(_1) }
         .compact
     end
+
+  def installment_index_and_total
+    subscription = chargeable.respond_to?(:subscription) ? chargeable.subscription : nil
+    return [nil, nil] unless subscription&.has_fixed_length? && subscription.is_installment_plan?
+
+    completed = subscription.purchases.successful.count
+    total = subscription.charge_occurrence_count
+    [completed, total]
+  end
+
+  def todays_payment_heading_with_installment_number
+    index, total = installment_index_and_total
+    return "Today's payment" unless index && total
+    "Today's payment: #{index} of #{total}"
+  end
+
+  def upcoming_payment_heading_with_installment_number
+    index, total = installment_index_and_total
+    return "Upcoming #{"payment".pluralize(upcoming_price_attributes.size)}" unless index && total
+    next_index = [index + 1, total].min
+    "Upcoming payment: #{next_index} of #{total}"
+  end
+
+  def installment_plan_final_payment_note
+    return nil unless chargeable.respond_to?(:subscription)
+    subscription = chargeable.subscription
+    return nil unless subscription&.is_installment_plan?
+    return nil unless subscription.charges_completed?
+
+    charges = subscription.purchases.successful.order(:created_at)
+    dates = charges.map { |p| (p.succeeded_at || p.created_at).to_fs(:formatted_date_abbrev_month) }
+    total_cents = charges.sum(&:total_transaction_cents)
+
+    "This is your final payment for your installment plan. You will not be charged again. Charges on #{dates.join(", ")}. Total paid: #{formatted_dollar_amount(total_cents)}."
+  end
 
     def upcoming_price_attribute(purchase)
       if purchase.is_commission_deposit_purchase?

--- a/app/presenters/receipt_presenter/payment_info.rb
+++ b/app/presenters/receipt_presenter/payment_info.rb
@@ -276,16 +276,25 @@ class ReceiptPresenter::PaymentInfo
   end
 
   def installment_plan_final_payment_note
-    return nil unless chargeable.respond_to?(:subscription)
+    return [] unless chargeable.respond_to?(:subscription)
     subscription = chargeable.subscription
-    return nil unless subscription&.is_installment_plan?
-    return nil unless subscription.charges_completed?
+    return [] unless subscription&.is_installment_plan?
+    return [] unless subscription.charges_completed?
 
     charges = subscription.purchases.successful.order(:created_at)
     dates = charges.map { |p| (p.succeeded_at || p.created_at).to_fs(:formatted_date_abbrev_month) }
     total_cents = charges.sum(&:total_transaction_cents)
 
-    "This is your final payment for your installment plan. You will not be charged again. Charges on #{dates.join(", ")}. Total paid: #{formatted_dollar_amount(total_cents)}."
+    formatted_dates = if dates.size > 1
+      "#{dates[0..-2].join(", ")}, and #{dates.last}"
+    else
+      dates.first
+    end
+
+    [
+      "This is your final payment for your installment plan with charges on #{formatted_dates}. You will not be charged again.",
+      "Total paid: #{formatted_dollar_amount(total_cents)}."
+    ]
   end
 
     def upcoming_price_attribute(purchase)

--- a/spec/requests/purchases/receipt_installment_plan_spec.rb
+++ b/spec/requests/purchases/receipt_installment_plan_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Installment plan receipt", type: :feature, js: true do
+  let(:first_purchase) { create(:installment_plan_purchase) }
+  let(:subscription) { first_purchase.subscription }
+  let(:product) { first_purchase.link }
+  let(:manage_subscription_url) { Rails.application.routes.url_helpers.manage_subscription_url(subscription.external_id, host: "#{PROTOCOL}://#{DOMAIN}") }
+
+  before do
+    create(:url_redirect, purchase: first_purchase)
+
+    allow(GlobalConfig).to receive(:dig)
+      .with(:secure_external_id, default: {})
+      .and_return({
+                    primary_key_version: "1",
+                    keys: { "1" => "a" * 32 }
+                  })
+  end
+
+  it "shows updated messaging and installment counters; shows final payment note on last receipt" do
+    visit receipt_purchase_url(first_purchase.external_id, host: "#{PROTOCOL}://#{DOMAIN}")
+    expect(page).to have_content("Confirm your email address")
+    fill_in "Email address:", with: first_purchase.email
+    click_button "View receipt"
+
+    expect(page).to have_text("Today's payment: 1 of 3")
+    expect(page).to have_text("Upcoming payment: 2 of 3")
+    expect(page).to have_text("Installment plan initiated on", normalize_ws: true)
+    expect(page).to have_text("Your final charge will be on", normalize_ws: true)
+    expect(page).to have_link("here", href: manage_subscription_url)
+
+    second_purchase = create(:recurring_installment_plan_purchase,
+                           subscription: subscription,
+                           link: product,
+                           created_at: 1.month.from_now)
+
+    visit receipt_purchase_url(second_purchase.external_id, host: "#{PROTOCOL}://#{DOMAIN}")
+    expect(page).to have_content("Confirm your email address")
+    fill_in "Email address:", with: second_purchase.email
+    click_button "View receipt"
+
+    expect(page).to have_text("Today's payment: 2 of 3")
+    expect(page).to have_text("Upcoming payment: 3 of 3")
+
+    third_purchase = create(:recurring_installment_plan_purchase,
+                          subscription: subscription,
+                          link: product,
+                          created_at: 2.months.from_now)
+
+    visit receipt_purchase_url(third_purchase.external_id, host: "#{PROTOCOL}://#{DOMAIN}")
+    expect(page).to have_content("Confirm your email address")
+    fill_in "Email address:", with: third_purchase.email
+    click_button "View receipt"
+
+    expect(page).to have_text("This is your final payment for your installment plan. You will not be charged again")
+    expect(page).to have_text("Total paid", normalize_ws: true)
+  end
+end

--- a/spec/requests/purchases/receipt_installment_plan_spec.rb
+++ b/spec/requests/purchases/receipt_installment_plan_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe "Installment plan receipt", type: :feature, js: true do
-  let(:first_purchase) { create(:installment_plan_purchase) }
+  let(:first_purchase) { create(:installment_plan_purchase, state: "successful", succeeded_at: Time.current) }
   let(:subscription) { first_purchase.subscription }
   let(:product) { first_purchase.link }
   let(:manage_subscription_url) { Rails.application.routes.url_helpers.manage_subscription_url(subscription.external_id, host: "#{PROTOCOL}://#{DOMAIN}") }
@@ -34,7 +34,9 @@ describe "Installment plan receipt", type: :feature, js: true do
     second_purchase = create(:recurring_installment_plan_purchase,
                            subscription: subscription,
                            link: product,
-                           created_at: 1.month.from_now)
+                           created_at: 1.month.from_now,
+                           succeeded_at: 1.month.from_now,
+                           state: "successful")
 
     visit receipt_purchase_url(second_purchase.external_id, host: "#{PROTOCOL}://#{DOMAIN}")
     expect(page).to have_content("Confirm your email address")
@@ -47,14 +49,19 @@ describe "Installment plan receipt", type: :feature, js: true do
     third_purchase = create(:recurring_installment_plan_purchase,
                           subscription: subscription,
                           link: product,
-                          created_at: 2.months.from_now)
+                          created_at: 2.months.from_now,
+                          succeeded_at: 2.months.from_now,
+                          state: "successful")
 
     visit receipt_purchase_url(third_purchase.external_id, host: "#{PROTOCOL}://#{DOMAIN}")
     expect(page).to have_content("Confirm your email address")
     fill_in "Email address:", with: third_purchase.email
     click_button "View receipt"
 
-    expect(page).to have_text("This is your final payment for your installment plan. You will not be charged again")
-    expect(page).to have_text("Total paid", normalize_ws: true)
+    expect(page).to have_text("Your final charge was on", normalize_ws: true)
+    expect(page).to have_text("This is your final payment for your installment plan with charges on", normalize_ws: true)
+    expect(page).to have_text(", and ", normalize_ws: true)
+    expect(page).to have_text("You will not be charged again", normalize_ws: true)
+    expect(page).to have_text("Total paid:", normalize_ws: true)
   end
 end


### PR DESCRIPTION
**Closes #643**

### What Changed

Updated installment plan receipt messaging to include plan-specific details.

**Changes:**
- Replace "You will be charged once a month..." with "Installment plan initiated on [date]. Your final charge will be on [end date]"
- Add payment counters: "Today's payment: 1 of 3", "Upcoming payment: 2 of 3" 
- Add final payment note: "This is your final payment for your installment plan. You will not be charged again" with charge history and total

### Screenshots

**Before:**
<img width="485" height="575" alt="before1" src="https://github.com/user-attachments/assets/c4868e32-107b-450e-96d5-3803166e1262" />
<img width="474" height="677" alt="before2" src="https://github.com/user-attachments/assets/6cc44171-716d-4782-9e17-a6c86d8ff45e" />

**After:**
#### Initial purchase (1/3)
<img width="472" height="579" alt="after1" src="https://github.com/user-attachments/assets/06329913-5be3-47cd-a325-2747ca1aac8e" />
<img width="463" height="677" alt="after2" src="https://github.com/user-attachments/assets/2a549380-6075-431c-80ef-7b0391f348ae" />

#### Recurring purchase (2/3)
<img width="484" height="825" alt="after3" src="https://github.com/user-attachments/assets/58290fbb-65ee-4493-9792-aca35e104bd1" />
<img width="471" height="439" alt="after4" src="https://github.com/user-attachments/assets/02a03930-e0ec-4942-a503-94ceedb0cf9d" />

#### Final purchase (3/3)
<img width="472" height="743" alt="after5" src="https://github.com/user-attachments/assets/be6ced16-16c9-49c9-8563-ada6436a4608" />
<img width="476" height="439" alt="after6" src="https://github.com/user-attachments/assets/8783f94e-e58d-473a-a40e-eef70d2e6a45" />

### Testing

`spec/presenters/receipt_presenter_spec.rb`
<img width="912" height="740" alt="Screenshot 2025-08-08 at 6 16 39 PM" src="https://github.com/user-attachments/assets/3fd34d00-8165-44c0-8b58-ba5532a20fe5" />

`spec/requests/purchases/receipt_installment_plan_spec.rb`
<img width="912" height="740" alt="Screenshot 2025-08-08 at 7 13 46 PM" src="https://github.com/user-attachments/assets/262c22f6-3db2-43e2-83b5-221dedd6159e" />
