### PR TITLE
fixed the uniformity of cards under help page.

### DIFF
--- a/app/javascript/components/server-components/HelpCenter/ArticlesIndexPage.tsx
+++ b/app/javascript/components/server-components/HelpCenter/ArticlesIndexPage.tsx
@@ -45,9 +45,17 @@ const CategoryArticles = ({ category, searchTerm }: { category: Category; search
   return (
     <div className="w-full">
       <h2 className="mb-4 font-semibold">{category.title}</h2>
-      <div className="w-full grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3" style={{ display: "grid" }}>
+      <div
+        className="w-full grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3"
+        style={{ display: "grid", gridAutoRows: "160px" }}
+      >
         {category.articles.map((article) => (
-          <NavigationButton key={article.url} href={article.url} color="filled" className="!p-12 text-center !text-xl">
+          <NavigationButton
+            key={article.url}
+            href={article.url}
+            color="filled"
+            className="!box-border !flex !h-full !w-full !items-center !justify-center !p-12 text-center !text-xl"
+          >
             {renderHighlightedText(article.title, searchTerm)}
           </NavigationButton>
         ))}


### PR DESCRIPTION
The help center page at `/help` had inconsistent card heights across different sections.

## Screenshots
### Before    v/s                                                                                                      After
<img width="1916" height="947" alt="Screenshot From 2025-08-09 19-09-05" src="https://github.com/user-attachments/assets/58dc16d6-def4-47a8-8de5-2ea8d9ac8ff7" />

---

<img width="1916" height="947" alt="Screenshot From 2025-08-09 19-11-11" src="https://github.com/user-attachments/assets/f176c064-9a2c-42e0-9e70-a93ae200c75a" />

---

<img width="1916" height="947" alt="Screenshot From 2025-08-09 19-11-43" src="https://github.com/user-attachments/assets/41bb0679-f80a-4fe6-8852-641f0a13cdb8" />

---

<img width="1916" height="947" alt="Screenshot From 2025-08-09 19-15-14" src="https://github.com/user-attachments/assets/3827d411-a3f5-42db-a68f-6bb952e22ac6" />
