### PR TITLE
fix: Prevent page reload when clicking Copy Link button

### DIFF
--- a/app/javascript/components/AffiliatesDashboard/AffiliateSignupForm.tsx
+++ b/app/javascript/components/AffiliatesDashboard/AffiliateSignupForm.tsx
@@ -141,7 +141,7 @@ export const AffiliateSignupForm = () => {
                 />
                 {enableAffiliateLink ? (
                   <CopyToClipboard text={affiliateRequestUrl}>
-                    <button className="link">Copy link</button>
+                    <button type="button" className="link">Copy link</button>
                   </CopyToClipboard>
                 ) : null}
               </div>


### PR DESCRIPTION
Fixes https://github.com/antiwork/gumroad/issues/805

### Before

https://github.com/user-attachments/assets/7464fc0b-493c-4419-a46b-8a2552d3051d



### After

https://github.com/user-attachments/assets/6ea8b795-134f-41e4-a1b1-e343adf63b3b



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the "Copy link" button to prevent unintended form submissions when clicked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->