### PR TITLE
test: Change the spec to get IFFY_TOKEN using GlobalConfig

### DIFF
--- a/spec/controllers/admin/comments_controller_spec.rb
+++ b/spec/controllers/admin/comments_controller_spec.rb
@@ -37,7 +37,7 @@ describe Admin::CommentsController do
     describe "from an external source" do
       it "creates a comment with a valid token" do
         expect do
-          post :create, params: { auth_token: Rails.application.credentials.iffy_token, comment: comment_attrs.merge(author_name: "iffy") }
+          post :create, params: { auth_token: GlobalConfig.get('IFFY_TOKEN'), comment: comment_attrs.merge(author_name: "iffy") }
         end.to change { Comment.count }.by(1)
         expect(Comment.last.content).to eq(comment_attrs[:content])
       end


### PR DESCRIPTION
Fixes: #806 

  This will take the value from .env.test file if present otherwise fallback to Rails Credentials.
  
  Here is the screen shot of the passing test after the fix. 

<img width="966" height="515" alt="Image" src="https://github.com/user-attachments/assets/b29e1ccf-d557-4bc3-b23d-3b715d570e72" />

