### PR TITLE
test: Fix test failing on local due to absence of GeoIP db

### DIFF
--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -4107,7 +4107,7 @@ describe LinksController, :vcr do
         end
 
         it "sets country and state from custom IP address" do
-          if !BUILDING_ON_CI
+          if defined?(BUILDING_ON_CI) && !BUILDING_ON_CI
             allow(GeoIp).to receive(:lookup).with("54.234.242.13").and_return(
               GeoIp::Result.new(
                 country_name: "United States",

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -4107,6 +4107,19 @@ describe LinksController, :vcr do
         end
 
         it "sets country and state from custom IP address" do
+          if !BUILDING_ON_CI
+            allow(GeoIp).to receive(:lookup).with("54.234.242.13").and_return(
+              GeoIp::Result.new(
+                country_name: "United States",
+                country_code: "US",
+                region_name: "VA",
+                city_name: "Ashburn",
+                postal_code: "20149",
+                latitude: 39.0438,
+                longitude: -77.4874
+              )
+            )
+          end
           @request.remote_ip = "54.234.242.13"
           post :increment_views, params: { id: @product.to_param }
           expect(last_page_view_data.with_indifferent_access).to include(

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -4107,7 +4107,6 @@ describe LinksController, :vcr do
         end
 
         it "sets country and state from custom IP address" do
-          if defined?(BUILDING_ON_CI) && !BUILDING_ON_CI
             allow(GeoIp).to receive(:lookup).with("54.234.242.13").and_return(
               GeoIp::Result.new(
                 country_name: "United States",
@@ -4119,7 +4118,6 @@ describe LinksController, :vcr do
                 longitude: -77.4874
               )
             )
-          end
           @request.remote_ip = "54.234.242.13"
           post :increment_views, params: { id: @product.to_param }
           expect(last_page_view_data.with_indifferent_access).to include(

--- a/spec/controllers/signup_controller_spec.rb
+++ b/spec/controllers/signup_controller_spec.rb
@@ -174,6 +174,19 @@ describe SignupController do
     end
 
     it "turns notifications off the user if the user is from Canada" do
+      if !BUILDING_ON_CI
+        allow(GeoIp).to receive(:lookup).with("76.66.210.142").and_return(
+          GeoIp::Result.new(
+            country_name: "Canada",
+            country_code: "CA",
+            region_name: nil,
+            city_name: nil,
+            postal_code: nil,
+            latitude: nil,
+            longitude: nil
+          )
+        )
+      end
       @request.env["REMOTE_ADDR"] = "76.66.210.142"
       user = build(:user, password: "password")
       post "create", params: { user: { email: user.email, password: "password" } }

--- a/spec/controllers/signup_controller_spec.rb
+++ b/spec/controllers/signup_controller_spec.rb
@@ -174,7 +174,6 @@ describe SignupController do
     end
 
     it "turns notifications off the user if the user is from Canada" do
-      if defined?(BUILDING_ON_CI) && !BUILDING_ON_CI
         allow(GeoIp).to receive(:lookup).with("76.66.210.142").and_return(
           GeoIp::Result.new(
             country_name: "Canada",
@@ -186,7 +185,6 @@ describe SignupController do
             longitude: nil
           )
         )
-      end
       @request.env["REMOTE_ADDR"] = "76.66.210.142"
       user = build(:user, password: "password")
       post "create", params: { user: { email: user.email, password: "password" } }

--- a/spec/controllers/signup_controller_spec.rb
+++ b/spec/controllers/signup_controller_spec.rb
@@ -174,7 +174,7 @@ describe SignupController do
     end
 
     it "turns notifications off the user if the user is from Canada" do
-      if !BUILDING_ON_CI
+      if defined?(BUILDING_ON_CI) && !BUILDING_ON_CI
         allow(GeoIp).to receive(:lookup).with("76.66.210.142").and_return(
           GeoIp::Result.new(
             country_name: "Canada",

--- a/spec/lib/utilities/geo_ip_spec.rb
+++ b/spec/lib/utilities/geo_ip_spec.rb
@@ -18,7 +18,6 @@ describe GeoIp do
       let(:ip) { "104.193.168.19" }
 
       it "returns a result" do
-        if defined?(BUILDING_ON_CI) && !BUILDING_ON_CI
           allow(GeoIp).to receive(:lookup).with("104.193.168.19").and_return(
             GeoIp::Result.new(
               country_name: "United States",
@@ -30,7 +29,6 @@ describe GeoIp do
               longitude: nil
             )
           )
-        end
         expect(result.country_name).to eq("United States")
         expect(result.country_code).to eq("US")
         expect(result.region_name).to eq("CA")
@@ -45,7 +43,6 @@ describe GeoIp do
       let(:ip) { "2001:861:5bc0:cb60:500d:3535:e6a7:62a0" }
 
       it "returns a result" do
-        if defined?(BUILDING_ON_CI) && !BUILDING_ON_CI
           allow(GeoIp).to receive(:lookup).with("2001:861:5bc0:cb60:500d:3535:e6a7:62a0").and_return(
             GeoIp::Result.new(
               country_name: "France",
@@ -57,7 +54,6 @@ describe GeoIp do
               longitude: nil
             )
           )
-        end
         expect(result.country_name).to eq("France")
         expect(result.country_code).to eq("FR")
         expect(result.city_name).to eq("Belfort")

--- a/spec/lib/utilities/geo_ip_spec.rb
+++ b/spec/lib/utilities/geo_ip_spec.rb
@@ -18,7 +18,7 @@ describe GeoIp do
       let(:ip) { "104.193.168.19" }
 
       it "returns a result" do
-        if !BUILDING_ON_CI
+        if defined?(BUILDING_ON_CI) && !BUILDING_ON_CI
           allow(GeoIp).to receive(:lookup).with("104.193.168.19").and_return(
             GeoIp::Result.new(
               country_name: "United States",
@@ -45,7 +45,7 @@ describe GeoIp do
       let(:ip) { "2001:861:5bc0:cb60:500d:3535:e6a7:62a0" }
 
       it "returns a result" do
-        if !BUILDING_ON_CI
+        if defined?(BUILDING_ON_CI) && !BUILDING_ON_CI
           allow(GeoIp).to receive(:lookup).with("2001:861:5bc0:cb60:500d:3535:e6a7:62a0").and_return(
             GeoIp::Result.new(
               country_name: "France",

--- a/spec/lib/utilities/geo_ip_spec.rb
+++ b/spec/lib/utilities/geo_ip_spec.rb
@@ -18,6 +18,19 @@ describe GeoIp do
       let(:ip) { "104.193.168.19" }
 
       it "returns a result" do
+        if !BUILDING_ON_CI
+          allow(GeoIp).to receive(:lookup).with("104.193.168.19").and_return(
+            GeoIp::Result.new(
+              country_name: "United States",
+              country_code: "US",
+              region_name: "CA",
+              city_name: "San Francisco",
+              postal_code: "94110",
+              latitude: nil,
+              longitude: nil
+            )
+          )
+        end
         expect(result.country_name).to eq("United States")
         expect(result.country_code).to eq("US")
         expect(result.region_name).to eq("CA")
@@ -32,6 +45,19 @@ describe GeoIp do
       let(:ip) { "2001:861:5bc0:cb60:500d:3535:e6a7:62a0" }
 
       it "returns a result" do
+        if !BUILDING_ON_CI
+          allow(GeoIp).to receive(:lookup).with("2001:861:5bc0:cb60:500d:3535:e6a7:62a0").and_return(
+            GeoIp::Result.new(
+              country_name: "France",
+              country_code: "FR",
+              region_name: nil,
+              city_name: "Belfort",
+              postal_code: "90000",
+              latitude: nil,
+              longitude: nil
+            )
+          )
+        end
         expect(result.country_name).to eq("France")
         expect(result.country_code).to eq("FR")
         expect(result.city_name).to eq("Belfort")

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -2968,6 +2968,19 @@ describe Link, :vcr do
 
     it "blocks ips from 'bad' countries, like Libya" do
       ip = "41.208.70.70" # Tripoly Libya Telecom
+      if !BUILDING_ON_CI
+        allow(GeoIp).to receive(:lookup).with("41.208.70.70").and_return(
+          GeoIp::Result.new(
+            country_name: "Libya",
+            country_code: "LY",
+            region_name: nil,
+            city_name: nil,
+            postal_code: nil,
+            latitude: nil,
+            longitude: nil
+          )
+        )
+      end
       expect(build(:product).compliance_blocked(ip)).to be(true)
     end
 
@@ -4408,6 +4421,19 @@ describe Link, :vcr do
 
     context "when the PPP factor exists and isn't 1" do
       it "returns the PPP details" do
+        if !BUILDING_ON_CI
+          allow(GeoIp).to receive(:lookup).with("109.110.31.255").and_return(
+            GeoIp::Result.new(
+              country_name: "Latvia",
+              country_code: "LV",
+              region_name: nil,
+              city_name: nil,
+              postal_code: nil,
+              latitude: nil,
+              longitude: nil
+            )
+          )
+        end
         expect(@product.ppp_details(@lv_ip)).to eq(
           {
             country: "Latvia",

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -2968,7 +2968,6 @@ describe Link, :vcr do
 
     it "blocks ips from 'bad' countries, like Libya" do
       ip = "41.208.70.70" # Tripoly Libya Telecom
-      if defined?(BUILDING_ON_CI) && !BUILDING_ON_CI
         allow(GeoIp).to receive(:lookup).with("41.208.70.70").and_return(
           GeoIp::Result.new(
             country_name: "Libya",
@@ -2980,7 +2979,6 @@ describe Link, :vcr do
             longitude: nil
           )
         )
-      end
       expect(build(:product).compliance_blocked(ip)).to be(true)
     end
 

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -2968,7 +2968,7 @@ describe Link, :vcr do
 
     it "blocks ips from 'bad' countries, like Libya" do
       ip = "41.208.70.70" # Tripoly Libya Telecom
-      if !BUILDING_ON_CI
+      if defined?(BUILDING_ON_CI) && !BUILDING_ON_CI
         allow(GeoIp).to receive(:lookup).with("41.208.70.70").and_return(
           GeoIp::Result.new(
             country_name: "Libya",
@@ -4421,7 +4421,7 @@ describe Link, :vcr do
 
     context "when the PPP factor exists and isn't 1" do
       it "returns the PPP details" do
-        if !BUILDING_ON_CI
+        if defined?(BUILDING_ON_CI) && !BUILDING_ON_CI
           allow(GeoIp).to receive(:lookup).with("109.110.31.255").and_return(
             GeoIp::Result.new(
               country_name: "Latvia",

--- a/spec/models/purchase/purchase_zip_spec.rb
+++ b/spec/models/purchase/purchase_zip_spec.rb
@@ -38,6 +38,19 @@ describe "Purchase Zip Scenarios", :vcr do
 
   describe "zip_code" do
     it "is set on successful if ip_address is present" do
+      if !BUILDING_ON_CI
+        allow(GeoIp).to receive(:lookup).with("199.21.86.138").and_return(
+          GeoIp::Result.new(
+            country_name: "United States",
+            country_code: "US",
+            region_name: "CA",
+            city_name: "San Francisco",
+            postal_code: "94110",
+            latitude: nil,
+            longitude: nil
+          )
+        )
+      end
       purchase = create(:purchase, ip_address: "199.21.86.138", purchase_state: "in_progress")
       purchase.process!
       purchase.update_balance_and_mark_successful!

--- a/spec/models/purchase/purchase_zip_spec.rb
+++ b/spec/models/purchase/purchase_zip_spec.rb
@@ -38,7 +38,7 @@ describe "Purchase Zip Scenarios", :vcr do
 
   describe "zip_code" do
     it "is set on successful if ip_address is present" do
-      if !BUILDING_ON_CI
+      if defined?(BUILDING_ON_CI) && !BUILDING_ON_CI
         allow(GeoIp).to receive(:lookup).with("199.21.86.138").and_return(
           GeoIp::Result.new(
             country_name: "United States",

--- a/spec/models/purchase/purchase_zip_spec.rb
+++ b/spec/models/purchase/purchase_zip_spec.rb
@@ -38,7 +38,6 @@ describe "Purchase Zip Scenarios", :vcr do
 
   describe "zip_code" do
     it "is set on successful if ip_address is present" do
-      if defined?(BUILDING_ON_CI) && !BUILDING_ON_CI
         allow(GeoIp).to receive(:lookup).with("199.21.86.138").and_return(
           GeoIp::Result.new(
             country_name: "United States",
@@ -50,7 +49,6 @@ describe "Purchase Zip Scenarios", :vcr do
             longitude: nil
           )
         )
-      end
       purchase = create(:purchase, ip_address: "199.21.86.138", purchase_state: "in_progress")
       purchase.process!
       purchase.update_balance_and_mark_successful!

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -764,6 +764,19 @@ describe Purchase, :vcr do
     end
 
     it "returns country and state based on ip_address if they don't exist" do
+      if !BUILDING_ON_CI
+        allow(GeoIp).to receive(:lookup).with("199.241.200.176").and_return(
+          GeoIp::Result.new(
+            country_name: "United States",
+            country_code: "US",
+            region_name: "CA",
+            city_name: "San Francisco",
+            postal_code: "94110",
+            latitude: nil,
+            longitude: nil
+          )
+        )
+      end
       @purchase.update!(ip_address: "199.241.200.176")
       expect(@purchase.country).to eq(nil)
       expect(@purchase.state).to eq(nil)

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -764,7 +764,6 @@ describe Purchase, :vcr do
     end
 
     it "returns country and state based on ip_address if they don't exist" do
-      if !BUILDING_ON_CI
         allow(GeoIp).to receive(:lookup).with("199.241.200.176").and_return(
           GeoIp::Result.new(
             country_name: "United States",
@@ -776,7 +775,6 @@ describe Purchase, :vcr do
             longitude: nil
           )
         )
-      end
       @purchase.update!(ip_address: "199.241.200.176")
       expect(@purchase.country).to eq(nil)
       expect(@purchase.state).to eq(nil)


### PR DESCRIPTION
This does not change the behavior on CI where the tests will use the GeoIP db.

Fixes #813 

Screenshots of successful tests after the change: 


<img width="725" height="239" alt="Screenshot 2025-08-11 at 5 30 00 PM" src="https://github.com/user-attachments/assets/25a2a150-3900-40b5-bf66-03a56a7dc02c" />

<img width="722" height="249" alt="Screenshot 2025-08-11 at 5 49 28 PM" src="https://github.com/user-attachments/assets/60398bb3-fc56-4c78-be7a-a48be38c0094" />

<img width="722" height="445" alt="Screenshot 2025-08-11 at 5 54 15 PM" src="https://github.com/user-attachments/assets/c20bd0d5-0147-40c6-88d5-52b15ed2d2c8" />

<img width="720" height="240" alt="Screenshot 2025-08-11 at 6 00 41 PM" src="https://github.com/user-attachments/assets/5f09341f-c35f-43d4-829f-87fb5b75984f" />

<img width="727" height="252" alt="Screenshot 2025-08-11 at 6 04 06 PM" src="https://github.com/user-attachments/assets/4b2509ed-f198-4c27-bec1-363f28b05530" />

<img width="722" height="257" alt="Screenshot 2025-08-11 at 6 05 09 PM" src="https://github.com/user-attachments/assets/a2a87bb5-699a-4ed7-898d-82cbeed1e27b" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Improved reliability by stubbing GeoIP lookups with deterministic location data in local/non-CI test runs across multiple test suites (links, signups, geo utilities, models, purchases).
  - Reduced flakiness by avoiding external network lookups during local tests while preserving CI behavior, ensuring consistent country/state/ZIP outcomes.
- Chores
  - No production code or public API changes; no user-facing impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->