### PR TITLE
Add archived purchases banner to library view

### DIFF
--- a/app/javascript/components/server-components/LibraryPage.tsx
+++ b/app/javascript/components/server-components/LibraryPage.tsx
@@ -263,8 +263,9 @@ const LibraryPage = ({ results, creators, bundles, reviews_page_enabled, followi
   const isDesktop = useIsAboveBreakpoint("lg");
   const [mobileFiltersExpanded, setMobileFiltersExpanded] = React.useState(false);
   const [showingAllCreators, setShowingAllCreators] = React.useState(false);
-  const hasArchivedProducts = results.some((result) => result.purchase.is_archived);
-  const showArchivedNotice = !state.search.showArchivedOnly && !results.some((result) => !result.purchase.is_archived);
+  const hasArchivedProducts = state.results.some((result) => result.purchase.is_archived);
+  const archivedCount = state.results.filter((result) => result.purchase.is_archived).length;
+  const showArchivedNotice = !state.search.showArchivedOnly && !state.results.some((result) => !result.purchase.is_archived);
   const hasParams =
     state.search.showArchivedOnly || state.search.query || state.search.creators.length || state.search.bundles.length;
   const [deleting, setDeleting] = React.useState<Result | null>(null);
@@ -290,11 +291,11 @@ const LibraryPage = ({ results, creators, bundles, reviews_page_enabled, followi
     url.searchParams.delete("purchase_id");
     window.history.replaceState(window.history.state, "", url.toString());
     if (purchaseIds.length > 0) {
-      const email = results.find(({ purchase }) => purchase.id === purchaseIds[0])?.purchase.email;
+      const email = state.results.find(({ purchase }) => purchase.id === purchaseIds[0])?.purchase.email;
       if (email) showAlert(`Your purchase was successful! We sent a receipt to ${email}.`, "success");
 
       for (const purchaseId of purchaseIds) {
-        const product = results.find(({ purchase }) => purchase.id === purchaseId)?.product;
+        const product = state.results.find(({ purchase }) => purchase.id === purchaseId)?.product;
         if (!product) continue;
 
         if (product.has_third_party_analytics)
@@ -315,12 +316,12 @@ const LibraryPage = ({ results, creators, bundles, reviews_page_enabled, followi
       followingWishlistsEnabled={following_wishlists_enabled}
     >
       <section className="products-section__container">
-        {results.length === 0 || showArchivedNotice ? (
-          <div className="placeholder">
+        {state.results.length === 0 || showArchivedNotice ? (
+          <div className={`placeholder ${hasArchivedProducts && !state.search.showArchivedOnly ? "mb-12" : ""}`}>
             <figure>
               <img src={placeholder} />
             </figure>
-            {results.length === 0 ? (
+            {state.results.length === 0 ? (
               <>
                 <h2 className="library-header">You haven't bought anything... yet!</h2>
                 Once you do, it'll show up here so you can download, watch, read, or listen to all your purchases.
@@ -344,8 +345,24 @@ const LibraryPage = ({ results, creators, bundles, reviews_page_enabled, followi
             )}
           </div>
         ) : null}
+        {archivedCount > 0 && !state.search.showArchivedOnly ? (
+          <div className="placeholder mb-12">
+            <p>
+              You have {archivedCount} archived purchase{archivedCount === 1 ? "" : "s"}-{" "}
+              <button
+                className="link"
+                onClick={(e) => {
+                  e.preventDefault();
+                  dispatch({ type: "update-search", search: { showArchivedOnly: true } });
+                }}
+              >
+                click here to view
+              </button>
+            </p>
+          </div>
+        ) : null}
         <div className="with-sidebar">
-          {!showArchivedNotice && (hasParams || hasArchivedProducts || results.length > 9) ? (
+          {!showArchivedNotice && (hasParams || hasArchivedProducts || state.results.length > 9) ? (
             <div className="stack">
               <header>
                 <div>

--- a/spec/requests/library_spec.rb
+++ b/spec/requests/library_spec.rb
@@ -182,6 +182,94 @@ describe("Library Scenario", type: :feature, js: true) do
     expect(page).to have_product_card(purchase.link)
   end
 
+  it "shows archived purchases banner with count when user has archived purchases" do
+    active_purchase = create(:purchase, purchaser: @user)
+    archived_purchase1 = create(:purchase, purchaser: @user, is_archived: true)
+    archived_purchase2 = create(:purchase, purchaser: @user, is_archived: true)
+    Link.import(refresh: true, force: true)
+
+    visit "/library"
+
+    expect(page).to have_text("You have 2 archived purchases")
+
+    expect(page).to have_product_card(active_purchase.link)
+
+    click_on "click here to view"
+    expect(page.current_url).to include("show_archived_only=true")
+
+    expect(page).to have_product_card(archived_purchase1.link)
+    expect(page).to have_product_card(archived_purchase2.link)
+
+    expect(page).to_not have_text("You have 2 archived purchases.")
+  end
+
+  it "does not show banner when user has no archived purchases" do
+    create(:purchase, purchaser: @user)
+    Link.import(refresh: true, force: true)
+
+    visit "/library"
+
+    expect(page).to_not have_text("You have 0 archived purchases.")
+  end
+
+  it "shows singular grammar when user has exactly 1 archived purchase" do
+    active_purchase = create(:purchase, purchaser: @user)
+    archived_purchase = create(:purchase, purchaser: @user, is_archived: true)
+    Link.import(refresh: true, force: true)
+
+    visit "/library"
+
+    expect(page).to have_text("You have 1 archived purchase")
+    expect(page).to have_product_card(active_purchase.link)
+
+    click_on "click here to view"
+    expect(page.current_url).to include("show_archived_only=true")
+    expect(page).to have_product_card(archived_purchase.link)
+  end
+
+  it "shows 'You've archived all your products.' when all purchases are archived" do
+    archived_1 = create(:purchase, purchaser: @user, is_archived: true)
+    archived_2 = create(:purchase, purchaser: @user, is_archived: true)
+    Link.import(refresh: true, force: true)
+
+    visit "/library"
+
+    expect(page).to have_selector(".library-header", text: "You've archived all your products.")
+    click_on "See archive"
+    expect(page).to have_product_card(archived_1.link)
+    expect(page).to have_product_card(archived_2.link)
+  end
+
+  it "does not show banner when viewing archived purchases via param" do
+    create(:purchase, purchaser: @user, is_archived: true)
+    Link.import(refresh: true, force: true)
+
+    visit "/library?show_archived_only=true"
+
+    expect(page).to_not have_text("archived purchase")
+  end
+
+  it "updates banner count after archiving an active purchase (on reload)" do
+    active_product_1 = create(:product, name: "Alpha Product")
+    active_product_2 = create(:product, name: "Beta Product")
+    active_1 = create(:purchase, purchaser: @user, link: active_product_1)
+    active_2 = create(:purchase, purchaser: @user, link: active_product_2)
+    Link.import(refresh: true, force: true)
+
+    visit "/library"
+    expect(page).to_not have_text("archived purchase")
+
+    card = find_product_card(active_1.link)
+    card.hover
+    within(card) do
+      find('[aria-label="Open product action menu"]', visible: :visible).click
+    end
+    click_on "Archive"
+
+    expect(page).to have_text("You have 1 archived purchase")
+    expect(page).to have_product_card(active_2.link)
+  end
+
   it "lists the same product several times if purchased several times" do
     products = create_list(:product, 2, name: "MyProduct")
     category = create(:variant_category, link: products[0])


### PR DESCRIPTION
Fixes https://github.com/antiwork/gumroad/issues/816

After:
<img width="1187" height="650" alt="Screenshot 2025-08-11 at 23 49 46" src="https://github.com/user-attachments/assets/1ca5f7d4-cc14-4cc6-ae43-7e2464a35582" />

No image version of https://github.com/antiwork/gumroad/pull/819

The styling aligned with other banner across the site, like the following:
<img width="1277" height="186" alt="image" src="https://github.com/user-attachments/assets/141e661f-2cfe-4d7a-8139-7b472401049d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an archived purchases banner showing the exact count with proper singular/plural grammar.
  - Provides a quick action to view archived items; supports an archived-only view (also via URL parameter).
  - Adjusted spacing and placeholders when archived items exist for a cleaner layout.

- Refactor
  - Migrated page to centralized internal state for more consistent UI behavior without changing public interfaces.

- Tests
  - Expanded test coverage for banner visibility, pluralization, archived-only view, and state after archiving actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->