### PR TITLE
fix: "Discover more" button on reviews page redirects

### DIFF
--- a/app/javascript/components/server-components/ReviewsPage.tsx
+++ b/app/javascript/components/server-components/ReviewsPage.tsx
@@ -5,7 +5,7 @@ import { ProductNativeType } from "$app/parsers/product";
 import { register } from "$app/utils/serverComponentUtil";
 
 import { Button, NavigationButton } from "$app/components/Button";
-import { useDomains } from "$app/components/DomainSettings";
+import { useDiscoverUrl } from "$app/components/DomainSettings";
 import { Icon } from "$app/components/Icons";
 import { Layout } from "$app/components/Library/Layout";
 import { Popover } from "$app/components/Popover";
@@ -54,7 +54,7 @@ const ReviewsPage = ({
   purchases: { id: string; email_digest: string; product: Product }[];
   following_wishlists_enabled: boolean;
 }) => {
-  const { rootDomain } = useDomains();
+  const discoverUrl = useDiscoverUrl();
 
   const [reviews, setReviews] = React.useState(initialReviews);
   const [purchases, setPurchases] = React.useState(initialPurchases);
@@ -128,7 +128,7 @@ const ReviewsPage = ({
         <section>
           <div className="placeholder">
             <h2>You've reviewed all your products!</h2>
-            <NavigationButton href={Routes.root_url({ host: rootDomain })} color="accent">
+            <NavigationButton href={discoverUrl} color="accent">
               Discover more
             </NavigationButton>
           </div>
@@ -142,7 +142,7 @@ const ReviewsPage = ({
             </figure>
             <h2>You haven't bought anything... yet!</h2>
             Once you do, it'll show up here so you can review them.
-            <NavigationButton href={Routes.root_url({ host: rootDomain })} color="accent">
+            <NavigationButton href={discoverUrl} color="accent">
               Discover products
             </NavigationButton>
             <a href="#" data-helper-prompt="What are reviews and how can I remove reviews I've written?">

--- a/spec/requests/library_spec.rb
+++ b/spec/requests/library_spec.rb
@@ -536,7 +536,7 @@ describe("Library Scenario", type: :feature, js: true) do
         expect(page.current_path).to eq(reviews_path)
 
         expect(page).to have_text("You've reviewed all your products!")
-        expect(page).to have_link("Discover more", href: root_url(host: ROOT_DOMAIN))
+        expect(page).to have_link("Discover more", href: discover_url(host: DISCOVER_DOMAIN))
 
         within find("tr", text: "Product 0") do
           expect(page).to have_image(src: thumbnail.url)
@@ -651,7 +651,7 @@ describe("Library Scenario", type: :feature, js: true) do
         visit reviews_path
         expect(page).to have_text("You haven't bought anything... yet!")
         expect(page).to have_text("Once you do, it'll show up here so you can review them.")
-        expect(page).to have_link("Discover products", href: root_url(host: ROOT_DOMAIN))
+        expect(page).to have_link("Discover products", href: discover_url(host: DISCOVER_DOMAIN))
       end
     end
   end


### PR DESCRIPTION
Fixes https://github.com/antiwork/gumroad/issues/830

### Before

https://github.com/user-attachments/assets/ecd21cff-de22-4b80-893e-2c413b9c6e8b


### After

https://github.com/user-attachments/assets/e67af3fe-b8cd-40a4-a133-f19e7effd86b


### Test Results
<img width="719" height="178" alt="Screenshot 2025-08-12 at 17 03 49" src="https://github.com/user-attachments/assets/1e35eccb-3e4f-4443-96ea-423431cc676e" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Reviews page links to direct to the correct Discover domain, ensuring “You’ve reviewed all your products!” and “Discover products” actions navigate to the intended discovery experience.

* **Tests**
  * Aligned test expectations with the updated discovery links to reflect the correct destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->