### PR TITLE
Differentiate membership vs installment in receipt

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -576,6 +576,12 @@ class Subscription < ApplicationRecord
     end
   end
 
+  def expected_completion_time
+    return nil unless has_fixed_length?
+
+    end_time_of_last_paid_period + period * remaining_charges_count
+  end
+
   def send_renewal_reminder_at
     [end_time_of_subscription - BasePrice::Recurrence.renewal_reminder_email_days(recurrence), Time.current].max
   end

--- a/app/presenters/receipt_presenter/item_info.rb
+++ b/app/presenters/receipt_presenter/item_info.rb
@@ -256,20 +256,40 @@ class ReceiptPresenter::ItemInfo
     end
 
     def manage_subscription_note
-      @_subscription_note ||= begin
-        return if subscription.blank?
-        return if purchase.is_gift_receiver_purchase && subscription.credit_card_id.blank?
-        return gift_subscription_renewal_note if subscription.gift? && subscription.credit_card_id.blank?
+      return if subscription.blank?
 
-        "You will be charged once #{recurrence_long_indicator(subscription.recurrence)}. If you would like to manage your membership you can visit #{link_to(
-            "subscription settings",
-            Rails.application.routes.url_helpers.manage_subscription_url(
-              subscription.external_id,
-              { host: UrlService.domain_with_protocol },
-            ),
-            target: "_blank"
-          )}.".html_safe
-      end
+      @_manage_subscription_note ||=
+        if subscription.is_installment_plan?
+          manage_installment_plan_note
+        else
+          manage_membership_note
+        end
+    end
+
+    def manage_membership_note
+      return if purchase.is_gift_receiver_purchase && subscription.credit_card_id.blank?
+      return gift_subscription_renewal_note if subscription.gift? && subscription.credit_card_id.blank?
+
+      <<~HTML.squish.html_safe
+        You will be charged once #{recurrence_long_indicator(subscription.recurrence)}.
+        If you would like to manage your membership you can visit
+        #{link_to("subscription settings", manage_subscription_url, target: "_blank")}.
+      HTML
+    end
+
+    def manage_installment_plan_note
+      <<~HTML.squish.html_safe
+        Installment plan initiated on #{subscription.created_at.to_fs(:formatted_date_abbrev_month)}.
+        Your final charge will be on #{subscription.expected_completion_time.to_fs(:formatted_date_abbrev_month)}.
+        You can manage your payment settings #{link_to("here", manage_subscription_url, target: "_blank")}.
+      HTML
+    end
+
+    def manage_subscription_url
+      Rails.application.routes.url_helpers.manage_subscription_url(
+        subscription.external_id,
+        { host: UrlService.domain_with_protocol },
+      )
     end
 
     def gift_subscription_renewal_note

--- a/app/presenters/receipt_presenter/item_info.rb
+++ b/app/presenters/receipt_presenter/item_info.rb
@@ -273,19 +273,23 @@ class ReceiptPresenter::ItemInfo
       <<~HTML.squish.html_safe
         You will be charged once #{recurrence_long_indicator(subscription.recurrence)}.
         If you would like to manage your membership you can visit
-        #{link_to("subscription settings", manage_subscription_url, target: "_blank")}.
+        #{link_to("subscription settings", manage_subscription_href, target: "_blank")}.
       HTML
     end
 
     def manage_installment_plan_note
+      timezone = subscription.user&.timezone
+      started_at = subscription.created_at.in_time_zone(timezone)
+      expected_ends_at = subscription.expected_completion_time.in_time_zone(timezone)
+
       <<~HTML.squish.html_safe
-        Installment plan initiated on #{subscription.created_at.to_fs(:formatted_date_abbrev_month)}.
-        Your final charge will be on #{subscription.expected_completion_time.to_fs(:formatted_date_abbrev_month)}.
-        You can manage your payment settings #{link_to("here", manage_subscription_url, target: "_blank")}.
+        Installment plan initiated on #{started_at.to_fs(:formatted_date_abbrev_month)}.
+        Your final charge will be on #{expected_ends_at.to_fs(:formatted_date_abbrev_month)}.
+        You can manage your payment settings #{link_to("here", manage_subscription_href, target: "_blank")}.
       HTML
     end
 
-    def manage_subscription_url
+    def manage_subscription_href
       Rails.application.routes.url_helpers.manage_subscription_url(
         subscription.external_id,
         { host: UrlService.domain_with_protocol },

--- a/spec/presenters/receipt_presenter/item_info_spec.rb
+++ b/spec/presenters/receipt_presenter/item_info_spec.rb
@@ -636,7 +636,7 @@ describe ReceiptPresenter::ItemInfo do
     end
 
     describe "manage_subscription_note" do
-      context "when the purchase is not a membership" do
+      context "when the purchase is not a subscription" do
         it "returns nil" do
           expect(props[:manage_subscription_note]).to be_nil
         end
@@ -694,6 +694,36 @@ describe ReceiptPresenter::ItemInfo do
               expect(props[:manage_subscription_note]).to be_nil
             end
           end
+        end
+      end
+
+      context "when the purchase is an installment plan" do
+        it "returns the installment plan manage note with dates and link" do
+          travel_to(Time.zone.parse("2025-03-14"))
+
+          product_installment_plan = create(
+            :product_installment_plan,
+            number_of_installments: 5,
+            recurrence: "monthly",
+          )
+          purchase = create(:installment_plan_purchase, link: product_installment_plan.link)
+          subscription = purchase.subscription
+          url = Rails.application.routes.url_helpers.manage_subscription_url(
+            subscription.external_id,
+            host: UrlService.domain_with_protocol,
+          )
+
+          props = described_class.new(purchase).props
+
+          url = Rails.application.routes.url_helpers.manage_subscription_url(
+            subscription.external_id,
+            host: UrlService.domain_with_protocol,
+          )
+          expect(props[:manage_subscription_note]).to eq(
+            "Installment plan initiated on Mar 14, 2025. " \
+            "Your final charge will be on Aug 14, 2025. " \
+            "You can manage your payment settings <a target=\"_blank\" href=\"#{url}\">here</a>."
+          )
         end
       end
     end

--- a/spec/presenters/receipt_presenter/item_info_spec.rb
+++ b/spec/presenters/receipt_presenter/item_info_spec.rb
@@ -708,10 +708,6 @@ describe ReceiptPresenter::ItemInfo do
           )
           purchase = create(:installment_plan_purchase, link: product_installment_plan.link)
           subscription = purchase.subscription
-          url = Rails.application.routes.url_helpers.manage_subscription_url(
-            subscription.external_id,
-            host: UrlService.domain_with_protocol,
-          )
 
           props = described_class.new(purchase).props
 

--- a/spec/requests/purchases/product/installment_plan_spec.rb
+++ b/spec/requests/purchases/product/installment_plan_spec.rb
@@ -64,6 +64,9 @@ describe "Product with installment plan", type: :feature, js: true do
     )
     expect(subscription.last_payment_option.installment_plan).to eq(installment_plan)
 
+    visit purchase.receipt_url
+    expect(page).to have_text("Installment plan initiated on #{subscription.created_at.to_fs(:formatted_date_abbrev_month)}.")
+
     travel_to(1.month.from_now)
     RecurringChargeWorker.new.perform(subscription.id)
     expect(subscription.purchases.successful.count).to eq(2)


### PR DESCRIPTION
Part of https://github.com/antiwork/gumroad/issues/643.

| Before | After |
|--------|--------|
| <img width="471" height="644" alt="image" src="https://github.com/user-attachments/assets/f419c8b8-a0be-41b1-8c8b-90499f4fc1a6" /> | <img width="483" height="646" alt="image" src="https://github.com/user-attachments/assets/893a995b-ef81-47ba-a45b-d7e170a2a3e2" /> | 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Receipt now shows installment-plan initiation and expected completion dates (timezone-aware) and a direct link to manage subscription/payment settings.
  * System displays expected completion times for fixed-length subscriptions where applicable.

* **Refactor**
  * Streamlined subscription-management message generation and centralized link handling for consistent output.

* **Tests**
  * Added coverage for expected completion timing and expanded receipt tests for installment-plan scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->