### PR TITLE
fix: Keep copy link icon right-aligned for long product titles

### DIFF
--- a/app/javascript/components/server-components/CheckoutDashboard/DiscountsPage.tsx
+++ b/app/javascript/components/server-components/CheckoutDashboard/DiscountsPage.tsx
@@ -554,7 +554,10 @@ const DiscountsPage = ({
                       ? (selectedOfferCodeStatistics.uses.products[product.id] ?? 0)
                       : null;
                   return (
-                    <div key={product.id}>
+                    <div
+                      key={product.id}
+                      style={{ display: "grid", gridTemplateColumns: "1fr auto", gap: "var(--spacer-2)" }}
+                    >
                       <div>
                         <h5>{product.name}</h5>
                         {uses != null ? `${uses} ${uses === 1 ? "use" : "uses"}` : null}


### PR DESCRIPTION
Fixes https://github.com/antiwork/gumroad/issues/843

### Before

<img width="534" height="514" alt="Image" src="https://github.com/user-attachments/assets/b0642c47-4675-4473-9205-350514b7414d" />

### After

<img width="534" height="459" alt="image" src="https://github.com/user-attachments/assets/1eb9b144-f44d-4ef8-ad47-231807b72451" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated Discounts page to a two-column grid per product entry.
  - Left column shows product name and usage; right column pins the copy action for quick access.
  - Improves readability, alignment, and spacing for a cleaner, more consistent layout.
  - Enhances usability on varied screen sizes without altering behavior or data.
  - Purely visual; no workflow changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->