### PR TITLE
Unflake E2E spec due to missing taxonomy label

### DIFF
--- a/spec/requests/purchases/product/recommendations_spec.rb
+++ b/spec/requests/purchases/product/recommendations_spec.rb
@@ -89,7 +89,7 @@ describe "RecommendationsScenario", type: :feature, js: true do
   context "when a custom fee is set for the seller" do
     before do
       @recommended_product.user.update!(custom_fee_per_thousand: 50, user_risk_state: "compliant")
-      @recommended_product.update!(taxonomy: create(:taxonomy))
+      @recommended_product.update!(taxonomy: Taxonomy.find_by!(slug: "design"))
     end
 
     it "charges the regular discover fee and not custom fee" do


### PR DESCRIPTION
This fixes the failure in our E2E spec:

```
ActionView::Template::Error:
  ERROR in SERVER PRERENDERING
  Encountered error:

  Error evaluating server bundle. Check your webpack configuration.
  ===============================================================
  Caught error:
  Error: Expected root.taxonomies.294.label to be a string, got null

``` 

Taxonomy labels are maintained in 

https://github.com/antiwork/gumroad/blob/e3725cac86f4620cc12d72ff3a99c28e55e05868/app/presenters/discover/taxonomy_presenter.rb#L4-L8

Taxonomies are JSON-ified via

https://github.com/antiwork/gumroad/blob/e3725cac86f4620cc12d72ff3a99c28e55e05868/app/presenters/discover/taxonomy_presenter.rb#L327-L343

Thus, new taxonomies with labels outside of `TaxonomyPresenter::TAXONOMY_LABELS` will product a JSON with `null` label, failing the TypeScript type check, resulting in the test failure.

So, this PR fixes the failure by using an existing taxonomy rather than creating a new one.

I have also considered filtering out taxonomies with `null` labels (and logging an error to Rails & Bugsnag), but decided to keep this as-is so we can't / won't be able to ignore the big red failure in test & dev envs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated product recommendation specs to reference an existing taxonomy by slug (“design”) instead of creating a new one, improving determinism and surfacing setup issues earlier.
  * Enhances CI stability by reducing flaky test setup and making failures more explicit.
  * No changes to user-facing behavior or recommendation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->