### PR TITLE
fix: action button label wrapping issue on mobile discount detail modal

### DIFF
--- a/app/javascript/components/server-components/CheckoutDashboard/DiscountsPage.tsx
+++ b/app/javascript/components/server-components/CheckoutDashboard/DiscountsPage.tsx
@@ -577,7 +577,8 @@ const DiscountsPage = ({
               </section>
             ) : null}
             <section
-              style={{ display: "grid", gap: "var(--spacer-4)", gridAutoFlow: "column", gridAutoColumns: "1fr" }}
+              className="grid grid-flow-row sm:grid-flow-col auto-cols-fr"
+              style={{ gap: "var(--spacer-4)" }}
             >
               <Button onClick={() => setView("create")} disabled={!selectedOfferCode.can_update || isLoading}>
                 Duplicate


### PR DESCRIPTION
Fixes https://github.com/antiwork/gumroad/issues/847

### Before 
<img width="432" height="745" alt="Screenshot 2025-08-13 at 16 21 08" src="https://github.com/user-attachments/assets/d0cb8d5b-a71c-4b8a-a8fc-a89c39053c06" />


### After
<img width="437" height="746" alt="Screenshot 2025-08-13 at 16 20 57" src="https://github.com/user-attachments/assets/083c0d6d-d76b-42f2-804f-7a0739106dd2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive layout on the Discounts page by switching to responsive grid classes.
  * On mobile, sections stack vertically; from small screens upward, they align in columns with equal widths.
  * Enhanced spacing and alignment for the list section and action buttons (Duplicate, Edit, Delete) for a cleaner UI.
  * Visual/layout changes only—no impact on data, functionality, or interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->