### PR TITLE
fix: action popup remaining open after duplicating a discount

### DIFF
--- a/app/javascript/components/server-components/CheckoutDashboard/DiscountsPage.tsx
+++ b/app/javascript/components/server-components/CheckoutDashboard/DiscountsPage.tsx
@@ -425,6 +425,7 @@ const DiscountsPage = ({
                                 role="menuitem"
                                 inert={!offerCode.can_update || isLoading}
                                 onClick={() => {
+                                  setPopoverOfferCodeId(null);
                                   setSelectedOfferCodeId(offerCode.id);
                                   setView("create");
                                 }}
@@ -439,6 +440,7 @@ const DiscountsPage = ({
                                 onClick={asyncVoid(async () => {
                                   try {
                                     setIsLoading(true);
+                                    setPopoverOfferCodeId(null);
                                     await deleteOfferCode(offerCode.id);
                                   } catch (e) {
                                     assertResponseError(e);


### PR DESCRIPTION
Fixes https://github.com/antiwork/gumroad/issues/849

### Before

https://github.com/user-attachments/assets/82d4269e-cc91-4884-aeef-9d227b8cbd98



### After


https://github.com/user-attachments/assets/de86009e-87f3-40d7-a431-fd639286c122



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Discount actions popover now closes immediately when duplicating a discount, preventing lingering UI during follow-up steps.
  - Discount actions popover now closes immediately when deleting a discount, avoiding stale or confusing UI while the action completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->