### PR TITLE
Update seed data to be eligible for Discover

### DIFF
--- a/db/seeds/020_development_staging/01_users.rb
+++ b/db/seeds/020_development_staging/01_users.rb
@@ -10,6 +10,7 @@ if seller.blank?
   seller.is_team_member = true
   seller.has_payout_privilege = true
   seller.has_risk_privilege = true
+  seller.user_risk_state = "compliant"
   seller.password = SecureRandom.hex(24)
 
   # Make seller eligible for service products
@@ -39,6 +40,7 @@ TeamMembership::ROLES.excluding(TeamMembership::ROLE_OWNER).each do |role|
     name: "#{role.humanize}ForSeller",
     username: "#{role}forseller",
     confirmed_at: Time.current,
+    user_risk_state: "compliant",
     password: SecureRandom.hex(24)
   )
 

--- a/db/seeds/030_development/products.rb
+++ b/db/seeds/030_development/products.rb
@@ -12,7 +12,7 @@ def load_products
       username: "gumbo#{i}",
       email: "gumbo#{i}@gumroad.com",
       password: SecureRandom.hex(24),
-      user_risk_state: "not_reviewed",
+      user_risk_state: "compliant",
       confirmed_at: Time.current
     )
     # Skip validations to set a pwned but easy password
@@ -41,7 +41,7 @@ def load_products
       username: "gumbuyer#{i}",
       email: "gumbuyer#{i}@gumroad.com",
       password: SecureRandom.hex(24),
-      user_risk_state: "not_reviewed",
+      user_risk_state: "compliant",
       confirmed_at: Time.current
     )
     # Skip validations to set a pwned but easy password


### PR DESCRIPTION
https://github.com/antiwork/gumroad/pull/754 tightened eligibility for Discover such that:

- The product must have at least 1 successful sale
- The seller must have already been marked as compliant

This prevented seed data in development from showing up in Discover.

This change addresses this in two ways:

- Seed purchases are created with a 100% off discount so it is easy to set up (i.e. without needing setting up any payment processors). The added benefit is that purchases are in `successful` state, and shows up in Library and other places.
- All seed users are explicitly marked as compliant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * In development/staging, seeded purchases are now 100% free via an automatic universal discount, and complete successfully by default for faster demo flows.

* Chores
  * Seeded seller and buyer accounts now start in a compliant risk state to prevent review-related blocks during demos.
  * Improved seeding reliability with stricter create/update operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->