### PR TITLE
Feat: Add churn analytics

### DIFF
--- a/app/controllers/churn_controller.rb
+++ b/app/controllers/churn_controller.rb
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+
+class ChurnController < Sellers::BaseController
+  before_action :set_body_id_as_app
+  before_action :check_payment_details, only: :index
+  before_action :set_time_range, only: :data
+
+  def index
+    authorize :analytics, :index?
+
+    @churn_props = ChurnPresenter.new(seller: current_seller).page_props
+  end
+
+  def data
+    authorize :analytics, :index?
+
+    aggregate_by = params[:aggregate_by] == "monthly" ? "monthly" : "daily"
+
+    subscription_products = current_seller.products_for_creator_analytics
+                                        .select { |p| p.is_recurring_billing? || p.is_tiered_membership? }
+
+    products = if params[:product_ids].present?
+      subscription_products.select { |p| params[:product_ids].include?(p.external_id) }
+    else
+      subscription_products
+    end
+
+    service_data = CreatorAnalytics::Churn.new(
+      user: current_seller,
+      products: products,
+      dates: (@start_date..@end_date).to_a,
+      aggregate_by: aggregate_by
+    ).data
+
+    total_stats = calculate_total_stats_from_data(service_data.values)
+
+    data_source = lambda do |start_date, end_date, agg, prods|
+      CreatorAnalytics::Churn.new(
+        user: current_seller,
+        products: (prods.presence || subscription_products),
+        dates: (start_date..end_date).to_a,
+        aggregate_by: agg
+      ).data
+    end
+
+    last_period_stats = calculate_last_period_stats(current_seller, @start_date, @end_date, aggregate_by, products, data_source)
+
+    date_keys, formatted_dates = format_dates_for_display(@start_date, @end_date, aggregate_by)
+    by_date_arrays = build_by_date_arrays(date_keys, service_data)
+
+    analytics_data = {
+      dates: formatted_dates,
+      start_date: formatted_dates.first,
+      end_date: formatted_dates.last,
+      by_date: by_date_arrays,
+      total: total_stats,
+      last_period: last_period_stats,
+      first_sale_date: format_first_sale_date(current_seller)
+    }
+
+    render json: analytics_data
+  end
+
+  protected
+    def set_title
+      @title = "Analytics"
+    end
+
+    def set_time_range
+      begin
+        end_time = Date.parse(strip_timestamp_location(params[:end_time]))
+        start_date = Date.parse(strip_timestamp_location(params[:start_time]))
+      rescue StandardError
+        end_time = Date.current
+        start_date = end_time.ago(29.days).to_date
+      end
+
+      first_sale_created_at = current_seller.first_sale_created_at_for_analytics
+      earliest_date = if first_sale_created_at
+        first_sale_created_at.in_time_zone(current_seller.timezone).to_date
+      else
+        current_seller.created_at.in_time_zone(current_seller.timezone).to_date
+      end
+
+      today = Date.current
+      earliest_date = [earliest_date, today].min
+      @start_date = start_date.clamp(earliest_date, today)
+      @end_date = end_time.clamp(@start_date, today)
+    end
+
+  private
+    ZERO_STATS = {
+      churned_users: 0,
+      revenue_lost_cents: 0,
+      churn_rate: 0.0,
+      avg_active_base: 0
+    }.freeze
+
+    def calculate_total_stats_from_data(periods_data)
+      return ZERO_STATS if periods_data.empty?
+
+      total_churned = periods_data.sum { |p| p[:churned_users] || 0 }
+      total_revenue_lost = periods_data.sum { |p| p[:revenue_lost_cents] || 0 }
+
+      periods_with_base = periods_data.select { |p| (p[:active_subscribers] || 0) > 0 }
+      avg_churn_rate = if periods_with_base.any?
+        total_weighted = periods_with_base.sum { |p| (p[:churn_rate] || 0) * (p[:active_subscribers] || 0) }
+        base_sum = periods_with_base.sum { |p| p[:active_subscribers] || 0 }
+        (base_sum > 0 ? (total_weighted / base_sum).round(2) : 0.0)
+      else
+        0.0
+      end
+      avg_churn_rate = avg_churn_rate.clamp(0.0, 100.0)
+
+      active_bases = periods_data.map { |p| p[:active_subscribers] || 0 }
+      avg_active_base = active_bases.empty? ? 0 : (active_bases.sum / active_bases.size.to_f)
+
+      {
+        churned_users: total_churned,
+        revenue_lost_cents: total_revenue_lost,
+        churn_rate: avg_churn_rate,
+        avg_active_base: avg_active_base.to_i
+      }
+    end
+
+    def calculate_last_period_stats(user, start_date, end_date, aggregate_by, products, data_source)
+      last_start, last_end = calculate_last_period_dates(start_date, end_date, aggregate_by)
+
+      first_sale_created_at = user.first_sale_created_at_for_analytics
+      if first_sale_created_at
+        earliest_date = first_sale_created_at.in_time_zone(user.timezone).to_date
+        return ZERO_STATS if last_start < earliest_date
+      end
+      return ZERO_STATS if last_start >= last_end
+
+      last_period_data = data_source.call(last_start, last_end, aggregate_by, products)
+      calculate_total_stats_from_data(last_period_data.values)
+    rescue => e
+      Rails.logger.warn("Failed to calculate last period churn stats: #{e.message}")
+      ZERO_STATS
+    end
+
+    def calculate_last_period_dates(start_date, end_date, aggregate_by)
+      if aggregate_by == "monthly"
+        months = (end_date.year - start_date.year) * 12 + (end_date.month - start_date.month) + 1
+        last_end = start_date.beginning_of_month - 1.day
+        last_start = (last_end + 1.day - months.months).beginning_of_month
+      else
+        days = (end_date - start_date).to_i + 1
+        last_end = start_date - 1.day
+        last_start = last_end - (days - 1).days
+      end
+      [last_start, last_end]
+    end
+
+    def format_dates_for_display(start_date, end_date, aggregate_by)
+      if aggregate_by == "monthly"
+        date_keys = (start_date..end_date).to_a.group_by { |d| d.strftime("%Y-%m") }.keys.sort
+        formatted = date_keys.map { |ym| Date.strptime("#{ym}-01", "%Y-%m-%d").strftime("%B %Y") }
+      else
+        date_keys = (start_date..end_date).to_a.map(&:to_s)
+        formatted = date_keys.map do |d|
+          date = Date.parse(d)
+          date.strftime("%A, %B #{date.day.ordinalize}")
+        end
+      end
+      [date_keys, formatted]
+    end
+
+    def build_by_date_arrays(date_keys, service_data)
+      churned = []
+      revenue = []
+      churn_rate = []
+      date_keys.each do |key|
+        data = service_data[key]
+        churned << (data ? data[:churned_users] : 0)
+        revenue << (data ? data[:revenue_lost_cents] : 0)
+        churn_rate << (data ? data[:churn_rate] : 0.0)
+      end
+      { churn_rate: churn_rate, churned_users: churned, revenue_lost_cents: revenue }
+    end
+
+    def format_first_sale_date(user)
+      first_sale_created_at = user.first_sale_created_at_for_analytics
+      return nil unless first_sale_created_at
+      first_sale_created_at.in_time_zone(user.timezone).strftime("%B %d, %Y")
+    end
+end

--- a/app/javascript/components/Analytics/AnalyticsLayout.tsx
+++ b/app/javascript/components/Analytics/AnalyticsLayout.tsx
@@ -9,7 +9,7 @@ export const AnalyticsLayout = ({
   children,
   actions,
 }: {
-  selectedTab: "following" | "sales" | "utm_links";
+  selectedTab: "following" | "sales" | "utm_links" | "churn";
   children: React.ReactNode;
   actions?: React.ReactNode;
 }) => {
@@ -26,6 +26,9 @@ export const AnalyticsLayout = ({
           </a>
           <a href={Routes.sales_dashboard_path()} role="tab" aria-selected={selectedTab === "sales"}>
             Sales
+          </a>
+          <a href={Routes.churn_dashboard_path()} role="tab" aria-selected={selectedTab === "churn"}>
+            Churn
           </a>
           {user.policies.utm_link.index ? (
             <a href={Routes.utm_links_dashboard_path()} role="tab" aria-selected={selectedTab === "utm_links"}>

--- a/app/javascript/components/Analytics/ChurnChart.tsx
+++ b/app/javascript/components/Analytics/ChurnChart.tsx
@@ -1,0 +1,72 @@
+import * as React from "react";
+import { XAxis, YAxis, Line, Area } from "recharts";
+
+import { formatPriceCentsWithCurrencySymbol } from "$app/utils/currency";
+
+import useChartTooltip from "$app/components/Analytics/useChartTooltip";
+import { Chart, xAxisProps, yAxisProps, lineProps } from "$app/components/Chart";
+
+export type ChurnDataPoint = {
+  churn_rate: number;
+  churned_users: number;
+  revenue_lost_cents: number;
+  title: string;
+  label: string;
+};
+
+const ChartTooltip = ({ data }: { data: ChurnDataPoint }) => (
+  <>
+    <div>
+      <strong>{data.churn_rate.toFixed(1)}%</strong> churn
+    </div>
+    {data.churned_users > 0 ? (
+      <div>
+        <strong>{data.churned_users}</strong> {data.churned_users === 1 ? "cancellation" : "cancellations"}
+      </div>
+    ) : null}
+    {data.revenue_lost_cents > 0 ? (
+      <div>
+        <strong>
+          {formatPriceCentsWithCurrencySymbol("usd", data.revenue_lost_cents, {
+            symbolFormat: "short",
+            noCentsIfWhole: true,
+          })}
+        </strong>{" "}
+        revenue lost
+      </div>
+    ) : null}
+    <time>{data.title}</time>
+  </>
+);
+
+export const ChurnChart = ({ data }: { data: ChurnDataPoint[] }) => {
+  const { tooltip, containerRef, dotRef, events } = useChartTooltip();
+  const tooltipData = tooltip ? data[tooltip.index] : null;
+
+  const maxChurnRate = data.length > 0 ? Math.max(...data.map((d) => d.churn_rate)) : 0;
+  const yAxisMax = Math.max(4, Math.ceil(maxChurnRate * 1.2));
+
+  return (
+    <Chart
+      color="info"
+      containerRef={containerRef}
+      tooltip={tooltipData ? <ChartTooltip data={tooltipData} /> : null}
+      tooltipPosition={tooltip?.position ?? null}
+      data={data}
+      {...events}
+    >
+      <XAxis {...xAxisProps} dataKey="label" />
+      <YAxis {...yAxisProps} orientation="left" tickFormatter={(value: number) => `${value}%`} domain={[0, yAxisMax]} />
+      <YAxis {...yAxisProps} yAxisId="rightPlaceholder" orientation="right" tick={false} width={40} domain={[0, 1]} />
+      <Area
+        type="monotone"
+        dataKey="churn_rate"
+        stroke="none"
+        fill="rgba(var(--accent) / 0.1)"
+        dot={false}
+        isAnimationActive={false}
+      />
+      <Line {...lineProps(dotRef, data.length)} dataKey="churn_rate" stroke="rgb(var(--accent))" />
+    </Chart>
+  );
+};

--- a/app/javascript/components/Analytics/ChurnQuickStats.tsx
+++ b/app/javascript/components/Analytics/ChurnQuickStats.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+
+import { formatPriceCentsWithCurrencySymbol } from "$app/utils/currency";
+
+import { Stats } from "$app/components/Stats";
+
+export type ChurnTotals = {
+  churn_rate: number;
+  last_period_churn_rate: number;
+  revenue_lost_cents: number;
+  churned_users: number;
+};
+
+export const ChurnQuickStats = ({ total }: { total: ChurnTotals | undefined }) => (
+  <div className="stats-grid">
+    <Stats title={<>Churn rate</>} value={total ? `${total.churn_rate.toFixed(1)}%` : ""} />
+    <Stats title={<>Last period churn rate</>} value={total ? `${total.last_period_churn_rate.toFixed(1)}%` : ""} />
+    <Stats
+      title={<>Revenue lost</>}
+      value={
+        total
+          ? formatPriceCentsWithCurrencySymbol("usd", total.revenue_lost_cents, {
+              symbolFormat: "short",
+              noCentsIfWhole: true,
+            })
+          : ""
+      }
+    />
+    <Stats title={<>Churned users</>} value={total ? total.churned_users.toLocaleString() : ""} />
+  </div>
+);

--- a/app/javascript/components/Chart.tsx
+++ b/app/javascript/components/Chart.tsx
@@ -15,21 +15,37 @@ type DotProps = {
   fill: string;
 };
 
+type ChartColor = "accent" | "info" | (string & {});
+
 export const Chart = ({
   aspect,
   containerRef,
   tooltipPosition,
   tooltip,
+  color = "accent",
   ...props
 }: {
   aspect?: number;
   containerRef: React.RefObject<HTMLDivElement>;
   tooltipPosition: { left: number; top: number } | null;
   tooltip: React.ReactNode;
+  color?: ChartColor;
 } & React.ComponentPropsWithoutRef<typeof ComposedChart>) => {
   const uid = React.useId();
+
+  // Scope this chart's accent to the chosen color
+  const rootStyle = React.useMemo(() => {
+    if (color && color !== "accent") {
+      return {
+        "--accent": `var(--${color})`,
+        "--contrast-accent": `var(--contrast-${color})`,
+      } satisfies React.CSSProperties;
+    }
+    return undefined;
+  }, [color]);
+
   return (
-    <section className="chart" aria-describedby={tooltip ? uid : undefined}>
+    <section className="chart" style={rootStyle} aria-describedby={tooltip ? uid : undefined}>
       <div style={{ position: "relative" }}>
         <ResponsiveContainer aspect={aspect ?? 1092 / 450} ref={containerRef}>
           <ComposedChart margin={{ top: 32, right: 0, bottom: 16, left: 0 }} {...props} />

--- a/app/javascript/components/server-components/ChurnPage.tsx
+++ b/app/javascript/components/server-components/ChurnPage.tsx
@@ -1,0 +1,124 @@
+import { lightFormat } from "date-fns";
+import * as React from "react";
+import { createCast } from "ts-safe-cast";
+
+import { fetchChurnData, ChurnData } from "$app/data/churn_analytics";
+import { AbortError } from "$app/utils/request";
+import { register } from "$app/utils/serverComponentUtil";
+
+import { AnalyticsLayout } from "$app/components/Analytics/AnalyticsLayout";
+import { ChurnChart, ChurnDataPoint } from "$app/components/Analytics/ChurnChart";
+import { ChurnQuickStats, ChurnTotals } from "$app/components/Analytics/ChurnQuickStats";
+import { ProductsPopover } from "$app/components/Analytics/ProductsPopover";
+import { useAnalyticsDateRange } from "$app/components/Analytics/useAnalyticsDateRange";
+import { DateRangePicker } from "$app/components/DateRangePicker";
+import { Progress } from "$app/components/Progress";
+import { showAlert } from "$app/components/server-components/Alert";
+
+type Product = {
+  name: string;
+  id: string;
+  alive: boolean;
+  unique_permalink: string;
+};
+
+const ChurnPage = ({ products: initialProducts }: { products: Product[] }) => {
+  const dateRange = useAnalyticsDateRange();
+  const [products, setProducts] = React.useState(initialProducts.map((p) => ({ ...p, selected: p.alive })));
+  const [aggregateBy, setAggregateBy] = React.useState<"daily" | "monthly">("daily");
+
+  const [dataByDate, setDataByDate] = React.useState<ChurnData | null>(null);
+
+  const startTime = lightFormat(dateRange.from, "yyyy-MM-dd");
+  const endTime = lightFormat(dateRange.to, "yyyy-MM-dd");
+
+  const selectedProductIds = React.useMemo(() => products.filter((p) => p.selected).map((p) => p.id), [products]);
+
+  const hasSelectedProducts = selectedProductIds.length > 0;
+
+  const activeRequest = React.useRef<AbortController | null>(null);
+  React.useEffect(() => {
+    const loadData = async () => {
+      try {
+        if (activeRequest.current) activeRequest.current.abort();
+        setDataByDate(null);
+
+        const requestParams = hasSelectedProducts
+          ? { startTime, endTime, aggregateBy, productIds: selectedProductIds }
+          : { startTime, endTime, aggregateBy };
+
+        const req = fetchChurnData(requestParams);
+        activeRequest.current = req.abort;
+        const json = await req.response;
+        setDataByDate(json);
+        activeRequest.current = null;
+      } catch (error) {
+        if (error instanceof AbortError) return;
+        showAlert("Sorry, something went wrong. Please try again.", "error");
+      }
+    };
+    void loadData();
+  }, [startTime, endTime, aggregateBy, selectedProductIds, hasSelectedProducts]);
+
+  const totals: ChurnTotals | undefined = dataByDate
+    ? {
+        churn_rate: dataByDate.total.churn_rate,
+        last_period_churn_rate: dataByDate.last_period?.churn_rate || 0,
+        revenue_lost_cents: dataByDate.total.revenue_lost_cents,
+        churned_users: dataByDate.total.churned_users,
+      }
+    : undefined;
+
+  const chartData: ChurnDataPoint[] = React.useMemo(() => {
+    if (!dataByDate) return [];
+    return dataByDate.dates.map((date, index) => ({
+      churn_rate: dataByDate.by_date.churn_rate[index] || 0,
+      churned_users: dataByDate.by_date.churned_users[index] || 0,
+      revenue_lost_cents: dataByDate.by_date.revenue_lost_cents[index] || 0,
+      title: date,
+      label: index === 0 ? dataByDate.start_date : index === dataByDate.dates.length - 1 ? dataByDate.end_date : "",
+    }));
+  }, [dataByDate]);
+
+  return (
+    <AnalyticsLayout
+      selectedTab="churn"
+      actions={
+        <>
+          <select
+            aria-label="Aggregate by"
+            value={aggregateBy}
+            onChange={(e) => setAggregateBy(e.target.value === "daily" ? "daily" : "monthly")}
+          >
+            <option value="daily">Daily</option>
+            <option value="monthly">Monthly</option>
+          </select>
+          <ProductsPopover products={products} setProducts={setProducts} />
+          <DateRangePicker {...dateRange} />
+        </>
+      }
+    >
+      {hasSelectedProducts ? (
+        <div style={{ display: "grid", gap: "var(--spacer-7)" }}>
+          <ChurnQuickStats total={totals} />
+          {chartData.length ? (
+            <ChurnChart data={chartData} />
+          ) : (
+            <div className="input">
+              <Progress width="1em" />
+              Loading chart...
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="input" style={{ textAlign: "center", padding: "var(--spacer-7)" }}>
+          <p style={{ color: "var(--muted)", margin: 0 }}>
+            No products selected. Please select at least one product to view churn analytics.
+          </p>
+        </div>
+      )}
+    </AnalyticsLayout>
+  );
+};
+
+export default register({ component: ChurnPage, propParser: createCast<{ products: Product[] }>() });

--- a/app/javascript/data/churn_analytics.ts
+++ b/app/javascript/data/churn_analytics.ts
@@ -1,0 +1,59 @@
+import { cast } from "ts-safe-cast";
+
+import { request } from "$app/utils/request";
+
+type ByDateArray = number[];
+
+export type ChurnData = {
+  dates: string[];
+  start_date: string;
+  end_date: string;
+  by_date: {
+    churn_rate: ByDateArray;
+    churned_users: ByDateArray;
+    revenue_lost_cents: ByDateArray;
+  };
+  total: {
+    churn_rate: number;
+    churned_users: number;
+    revenue_lost_cents: number;
+  };
+  last_period?: {
+    churn_rate: number;
+    churned_users: number;
+    revenue_lost_cents: number;
+  };
+};
+
+export const fetchChurnData = ({
+  startTime,
+  endTime,
+  aggregateBy = "daily",
+  productIds,
+}: {
+  startTime: string;
+  endTime: string;
+  aggregateBy?: "daily" | "monthly";
+  productIds?: string[];
+}) => {
+  const abort = new AbortController();
+  const params: Record<string, string | string[]> = {
+    start_time: startTime,
+    end_time: endTime,
+    aggregate_by: aggregateBy,
+  };
+
+  if (productIds && productIds.length > 0) {
+    params.product_ids = productIds;
+  }
+
+  const response = request({
+    method: "GET",
+    accept: "json",
+    url: Routes.analytics_churn_data_path(params),
+    abortSignal: abort.signal,
+  })
+    .then((r) => r.json())
+    .then((json) => cast<ChurnData>(json));
+  return { response, abort };
+};

--- a/app/javascript/packs/churn.js
+++ b/app/javascript/packs/churn.js
@@ -1,0 +1,9 @@
+import ReactOnRails from "react-on-rails";
+
+import BasePage from "$app/utils/base_page";
+
+import ChurnPage from "$app/components/server-components/ChurnPage";
+
+BasePage.initialize();
+
+ReactOnRails.default.register({ ChurnPage });

--- a/app/javascript/ssr.ts
+++ b/app/javascript/ssr.ts
@@ -36,6 +36,7 @@ import DiscountsPage from "$app/components/server-components/CheckoutDashboard/D
 import FormPage from "$app/components/server-components/CheckoutDashboard/FormPage";
 import UpsellsPage from "$app/components/server-components/CheckoutDashboard/UpsellsPage";
 import CheckoutPage from "$app/components/server-components/CheckoutPage";
+import ChurnPage from "$app/components/server-components/ChurnPage";
 import CollaboratorsPage from "$app/components/server-components/CollaboratorsPage";
 import CollabsPage from "$app/components/server-components/CollabsPage";
 import CommunitiesPage from "$app/components/server-components/CommunitiesPage";
@@ -201,4 +202,5 @@ ReactOnRails.register({
   WishlistsPage,
   WorkflowsPage,
   UtmLinksPage,
+  ChurnPage,
 });

--- a/app/presenters/churn_presenter.rb
+++ b/app/presenters/churn_presenter.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class ChurnPresenter
+  def initialize(seller:)
+    @seller = seller
+  end
+
+  def page_props
+    {
+      products: subscription_products.map { product_props(_1) }
+    }
+  end
+
+  private
+    attr_reader :seller
+
+    def subscription_products
+      seller.products_for_creator_analytics.select { |p| p.is_recurring_billing? || p.is_tiered_membership? }
+    end
+
+    def product_props(product)
+      { id: product.external_id, alive: product.alive?, unique_permalink: product.unique_permalink, name: product.name }
+    end
+end

--- a/app/services/creator_analytics/churn.rb
+++ b/app/services/creator_analytics/churn.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+class CreatorAnalytics::Churn
+  def initialize(user:, products:, dates:, aggregate_by: "daily")
+    @user = user
+    @products = products
+    @dates = constrain_dates(dates)
+    @aggregate_by = aggregate_by
+    build_query
+  end
+
+  def data
+    calendar_interval = @aggregate_by == "monthly" ? "month" : "day"
+    date_format = @aggregate_by == "monthly" ? "yyyy-MM" : "yyyy-MM-dd"
+
+    sources = [
+      { date: { date_histogram: { time_zone: @user.timezone_formatted_offset, field: "subscription_deactivated_at", calendar_interval: calendar_interval, format: date_format } } }
+    ]
+    churn_data = paginate(sources:).each_with_object({}) do |bucket, result|
+      result[bucket["key"]["date"]] = {
+        churned_users: bucket["doc_count"],
+        revenue_lost_cents: bucket["revenue_lost"]["value"].to_i,
+      }
+    end
+
+    period_dates = generate_period_dates
+
+    active_counts = bulk_active_subscribers
+
+    period_dates.each do |period_key, _period_date|
+      churned_users = churn_data.dig(period_key, :churned_users) || 0
+
+      active_subscribers = active_counts[period_key] || 0
+
+      churn_rate = active_subscribers.positive? ? (churned_users.to_f / active_subscribers * 100).round(2) : 0.0
+
+      if churn_data[period_key]
+        churn_data[period_key][:churn_rate] = churn_rate
+        churn_data[period_key][:active_subscribers] = active_subscribers
+      else
+        churn_data[period_key] = {
+          churned_users: 0,
+          revenue_lost_cents: 0,
+          churn_rate: churn_rate,
+          active_subscribers: active_subscribers
+        }
+      end
+    end
+
+    churn_data
+  end
+
+  private
+    def constrain_dates(dates)
+      today_date = Time.now.in_time_zone(@user.timezone).to_date
+
+      first_sale_created_at = @user.first_sale_created_at_for_analytics
+      earliest_meaningful_date = if first_sale_created_at
+        first_sale_created_at.in_time_zone(@user.timezone).to_date
+      else
+        @user.created_at.in_time_zone(@user.timezone).to_date
+      end
+
+      constrained_start = dates.first.clamp(earliest_meaningful_date, today_date)
+      constrained_end = dates.last.clamp(constrained_start, today_date)
+
+      (constrained_start..constrained_end).to_a
+    end
+
+    def generate_period_dates
+      period_dates = {}
+
+      if @aggregate_by == "monthly"
+        @dates.group_by { |date| date.strftime("%Y-%m") }.each do |month_key, month_dates|
+          period_dates[month_key] = month_dates.last
+        end
+      else
+        @dates.each do |date|
+          date_key = date.strftime("%Y-%m-%d")
+          period_dates[date_key] = date
+        end
+      end
+
+      period_dates
+    end
+
+    # Returns a hash date_key => active_subscriber_count
+    def bulk_active_subscribers
+      period_dates = generate_period_dates
+
+      filters_hash = {}
+      period_dates.each do |period_key, period_date|
+        start_dt = @aggregate_by == "monthly" ? period_date.beginning_of_month : period_date
+
+        filters_hash[period_key] = {
+          bool: {
+            must: [
+              { exists: { field: "subscription_id" } },
+              { term: { selected_flags: "is_original_subscription_purchase" } }
+            ],
+            filter: [
+              { terms: { product_id: @products.map(&:id) } },
+              { range: { created_at: { lt: start_dt.beginning_of_day.iso8601 } } }
+            ],
+            should: [
+              { bool: { must_not: { exists: { field: "subscription_deactivated_at" } } } },
+              { range: { subscription_deactivated_at: { gte: start_dt.beginning_of_day.iso8601 } } }
+            ],
+            minimum_should_match: 1
+          }
+        }
+      end
+
+      body = {
+        query: { bool: { must: [{ exists: { field: "subscription_id" } }, { term: { selected_flags: "is_original_subscription_purchase" } }], filter: [{ terms: { product_id: @products.map(&:id) } }] } },
+        size: 0,
+        aggs: {
+          active_subscribers: {
+            filters: {
+              filters: filters_hash
+            },
+            aggs: {
+              unique_subscriptions: { cardinality: { field: "subscription_id" } }
+            }
+          }
+        }
+      }
+
+      response = Purchase.search(body).aggregations.active_subscribers.buckets
+
+      response.transform_values { |data| data.unique_subscriptions.value.to_i }
+    end
+
+    def build_query
+      search_service = PurchaseSearchService.new(Purchase::CHARGED_SALES_SEARCH_OPTIONS)
+      @query = search_service.body[:query]
+
+      @query[:bool][:must] << { exists: { field: "subscription_deactivated_at" } }
+      @query[:bool][:must] << { term: { selected_flags: "is_original_subscription_purchase" } }
+      @query[:bool][:filter] << { terms: { product_id: @products.map(&:id) } }
+      @query[:bool][:filter] << { range: { subscription_deactivated_at: { time_zone: @user.timezone_formatted_offset, gte: @dates.first.to_s, lte: @dates.last.to_s } } }
+    end
+
+    def paginate(sources:)
+      after_key = nil
+      body = build_body(sources)
+      buckets = []
+      loop do
+        body[:aggs][:composite_agg][:composite][:after] = after_key if after_key
+        response_agg = Purchase.search(body).aggregations.composite_agg
+        buckets += response_agg.buckets
+        break if response_agg.buckets.size < ES_MAX_BUCKET_SIZE
+        after_key = response_agg["after_key"]
+      end
+      buckets
+    end
+
+    def build_body(sources)
+      {
+        query: @query,
+        size: 0,
+        aggs: {
+          composite_agg: {
+            composite: { size: ES_MAX_BUCKET_SIZE, sources: },
+            aggs: {
+              revenue_lost: { sum: { field: "price_cents" } },
+            },
+          },
+        },
+      }
+    end
+end

--- a/app/views/churn/index.html.erb
+++ b/app/views/churn/index.html.erb
@@ -1,0 +1,3 @@
+<%= load_pack("churn") %>
+
+<%= react_component "ChurnPage", props: @churn_props, prerender: true %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -759,6 +759,8 @@ Rails.application.routes.draw do
     get "/analytics/data/by_date", to: "analytics#data_by_date", as: "analytics_data_by_date"
     get "/analytics/data/by_state", to: "analytics#data_by_state", as: "analytics_data_by_state"
     get "/analytics/data/by_referral", to: "analytics#data_by_referral", as: "analytics_data_by_referral"
+    get "/dashboard/churn", to: "churn#index", as: :churn_dashboard
+    get "/analytics/churn/data", to: "churn#data", as: "analytics_churn_data"
 
     # audience
     get "/audience" => redirect("/dashboard/audience")


### PR DESCRIPTION
### Description
This PR addresses https://github.com/antiwork/gumroad/issues/13
This PR introduces the core functionality for churn analytics in a smaller, more reviewable scope compared to the previous PR https://github.com/antiwork/gumroad/pull/462

**What's Included**
 - Churn chart visualization and quick stats.
 - Churn calculation logic using Elasticsearch data (no caching layer).
 
 **What's Not Included (Deferred to Future PRs)**
 - Caching layer for large sellers.
 - Sidekiq worker and scheduled jobs for pre-computing metrics.
 
 **Preview**
 
https://github.com/user-attachments/assets/ca4e0357-a54a-4257-b1db-037a4e58a16b


 **Calculations**
 Churn Rate (%) = (Churned Users in Period / Active Subscribers at Period Start) × 100 [For daily and monthly calculation]

Average Churn Rate (%) = (Σ(Period Churn Rate × Period Active Subscribers)) / Σ(Period Active Subscribers) [For total stats]

Revenue Lost = Σ(price_cents of all churned subscriptions in period)
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Churn analytics dashboard with a new Churn tab.
  - Interactive chart showing churn rate over time with tooltips.
  - Quick stats: churn rate, last period churn rate, revenue lost, churned users.
  - Date range picker with daily/monthly aggregation.
  - Product filtering to focus analytics on selected items.
  - Server-side rendering for faster initial load.
- Enhancements
  - Charts now support color theming for improved visual clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->