### PR TITLE
Remove legacy `offer_code_name` param usage

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -97,7 +97,7 @@ class OrdersController < ApplicationController
         :url_parameters, :is_gift, :giftee_email, :giftee_id, :gift_note, :referrer,
         purchase: [:full_name, :street_address, :city, :state, :zip_code, :country],
         # Individual purchase params
-        line_items: [:uid, :permalink, :perceived_price_cents, :price_range, :offer_code_name, :discount_code, :is_preorder, :quantity, :call_start_time,
+        line_items: [:uid, :permalink, :perceived_price_cents, :price_range, :discount_code, :is_preorder, :quantity, :call_start_time,
                      :was_product_recommended, :recommended_by, :referrer, :is_rental, :is_multi_buy,
                      :was_discover_fee_charged, :price_cents, :tax_cents, :gumroad_tax_cents, :shipping_cents, :price_id, :affiliate_id, :url_parameters, :is_purchasing_power_parity_discounted,
                      :recommender_model_name, :tip_cents, :pay_in_installments,

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -414,7 +414,7 @@ class Purchase < ApplicationRecord
             :flag_query_mode => :bit_operator,
             check_for_column: false
 
-  attr_accessor :chargeable, :card_data_handling_error, :save_card, :price_range, :friend_actions, :offer_code_name,
+  attr_accessor :chargeable, :card_data_handling_error, :save_card, :price_range, :friend_actions,
                 :discount_code, :url_parameters, :purchaser_plugins, :is_automatic_charge, :sales_tax_country_code_election, :business_vat_id,
                 :save_shipping_address, :flow_of_funds, :prorated_discount_price_cents,
                 :original_variant_attributes, :original_price, :is_updated_original_subscription_purchase,

--- a/app/services/purchase/create_service.rb
+++ b/app/services/purchase/create_service.rb
@@ -13,10 +13,6 @@ class Purchase::CreateService < Purchase::BaseService
     @product = product
     @params = params
     @purchase_params = params[:purchase]
-    # TODO discount codes cleanup
-    if @purchase_params[:offer_code_name].present?
-      @purchase_params[:discount_code] = @purchase_params.delete(:offer_code_name)
-    end
     @gift_params = params[:gift].presence
     @buyer = buyer
   end

--- a/spec/services/order/confirm_service_spec.rb
+++ b/spec/services/order/confirm_service_spec.rb
@@ -104,7 +104,7 @@ describe Order::ConfirmService, :vcr do
 
     it "returns purchase error responses and offer codes in case of SCA failure with offer codes applied" do
       offer_code = create(:offer_code, user: seller, products: [product_1, product_2])
-      params[:purchase][:offer_code_name] = offer_code.code
+      params[:purchase][:discount_code] = offer_code.code
       params[:line_items].each { _1[:perceived_price_cents] -= 100 }
 
       expect(Purchase::ConfirmService).to receive(:new).exactly(2).times.and_call_original

--- a/spec/services/purchase/create_service_spec.rb
+++ b/spec/services/purchase/create_service_spec.rb
@@ -433,7 +433,7 @@ describe Purchase::CreateService, :vcr do
             price_cents: 100,
           }
         ]
-        params[:purchase][:offer_code_name] = offer_code.code
+        params[:purchase][:discount_code] = offer_code.code
       end
 
       it "creates the purchase" do
@@ -462,7 +462,7 @@ describe Purchase::CreateService, :vcr do
             price_cents: 100,
           }
         ]
-        params[:purchase][:offer_code_name] = offer_code.code
+        params[:purchase][:discount_code] = offer_code.code
       end
 
       it "creates the purchase" do
@@ -1185,7 +1185,6 @@ describe Purchase::CreateService, :vcr do
     it "counts a successful preorder towards the offer code's max purchase count" do
       offer_code = create(:offer_code, products: [product_in_preorder], amount_cents: 200, max_purchase_count: 1)
       preorder_params[:purchase][:discount_code] = offer_code.code
-      preorder_params[:purchase][:offer_code_name] = offer_code.name
       preorder_params[:purchase][:perceived_price_cents] = 400
 
       purchase, _ = Purchase::CreateService.new(
@@ -2059,7 +2058,7 @@ describe Purchase::CreateService, :vcr do
     context "with offer codes" do
       let(:offer_code) { create(:offer_code, products: [product], amount_cents: 200, max_purchase_count: 1) }
       before :each do
-        gift_params[:purchase].merge!(offer_code_name: offer_code.name, discount_code: offer_code.code, perceived_price_cents: price - 200)
+        gift_params[:purchase].merge!(discount_code: offer_code.code, perceived_price_cents: price - 200)
       end
 
       it "allows gifting until the offer code is used up" do
@@ -2415,7 +2414,6 @@ describe Purchase::CreateService, :vcr do
       offer_code = create(:offer_code, products: [product], amount_cents: discount_cents)
 
       params[:purchase].merge!(
-        offer_code_name: offer_code.name,
         discount_code: offer_code.code,
         perceived_price_cents: discounted_price,
       )
@@ -2437,7 +2435,6 @@ describe Purchase::CreateService, :vcr do
       offer_code = create(:universal_offer_code, code: "uni", user:, amount_cents: discount_cents)
 
       params[:purchase].merge!(
-        offer_code_name: offer_code.name,
         discount_code: offer_code.code,
         perceived_price_cents: discounted_price,
       )
@@ -2453,7 +2450,6 @@ describe Purchase::CreateService, :vcr do
       offer_code = create(:offer_code, products: [product], amount_cents: discount_cents, code: "ÕËëæç")
 
       params[:purchase].merge!(
-        offer_code_name: offer_code.name,
         discount_code: offer_code.code,
         perceived_price_cents: discounted_price,
       )
@@ -2471,7 +2467,6 @@ describe Purchase::CreateService, :vcr do
       offer_code = create(:offer_code, products: [product], amount_cents: 151)
 
       params[:purchase].merge!(
-        offer_code_name: offer_code.name,
         discount_code: offer_code.code,
         perceived_price_cents: 350 - 151,
         price_range: 1.99
@@ -2494,7 +2489,6 @@ describe Purchase::CreateService, :vcr do
         product.update!(price_currency_type: currency, price_cents: 15_000)
         offer_code = create(:offer_code, code: currency, currency_type: currency, products: [product], amount_cents: 3_000)
         params[:purchase].merge!(
-          offer_code_name: offer_code.name,
           discount_code: offer_code.code,
           perceived_price_cents: 12_000,
           price_range: 120,
@@ -2518,7 +2512,6 @@ describe Purchase::CreateService, :vcr do
       offer_code = create(:offer_code, products: [product], amount_cents: discount_cents)
 
       params[:purchase].merge!(
-        offer_code_name: offer_code.name,
         discount_code: offer_code.code,
         perceived_price_cents: discounted_price
       )
@@ -2532,7 +2525,6 @@ describe Purchase::CreateService, :vcr do
       offer_code = create(:offer_code, products: [product], amount_cents: discount_cents, deleted_at: Time.current)
 
       params[:purchase].merge!(
-        offer_code_name: offer_code.name,
         discount_code: offer_code.code,
         perceived_price_cents: discounted_price
       )
@@ -2548,7 +2540,6 @@ describe Purchase::CreateService, :vcr do
       offer_code = create(:offer_code, products: [product], amount_cents: discount_cents)
 
       params[:purchase].merge!(
-        offer_code_name: offer_code.name,
         discount_code: offer_code.code,
         perceived_price_cents: discounted_price
       )
@@ -2569,7 +2560,6 @@ describe Purchase::CreateService, :vcr do
         product.update!(price_currency_type: currency, price_cents: 15_000)
         offer_code = create(:offer_code, code: currency, currency_type: currency, products: [product], amount_cents: 3_000)
         params[:purchase].merge!(
-          offer_code_name: offer_code.name,
           discount_code: offer_code.code,
           perceived_price_cents: 12_000,
           price_range: 119.99
@@ -2587,7 +2577,6 @@ describe Purchase::CreateService, :vcr do
       create(:purchase, offer_code:)
 
       params[:purchase].merge!(
-        offer_code_name: offer_code.name,
         discount_code: offer_code.code,
         perceived_price_cents: discounted_price,
         price_range: 1,


### PR DESCRIPTION
Came across this when looking into the discount persistence issue for upsells.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Checkout now uses a single “Discount code” field (replaces the previous “Offer code” input).
  - Added options to save shipping address and enter a business VAT ID for invoicing.
  - Enhanced payment and subscription flexibility: support for installment plans, plan changes, automatic charges, and setting up future charges.
  - Improved tax handling with selectable tax country.
  - Additional parameters enable more tailored purchase flows and integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->