### PR TITLE
Make `OfferCode#user_id` non-nullable

### DIFF
--- a/app/models/offer_code.rb
+++ b/app/models/offer_code.rb
@@ -19,7 +19,7 @@ class OfferCode < ApplicationRecord
   stripped_fields :code
 
   has_and_belongs_to_many :products, class_name: "Link", join_table: "offer_codes_products", association_foreign_key: "product_id"
-  belongs_to :user, optional: true
+  belongs_to :user
   has_many :purchases
   has_many :purchases_that_count_towards_offer_code_uses, -> { counts_towards_offer_code_uses }, class_name: "Purchase"
   has_one :upsell

--- a/db/migrate/20250816055312_make_offer_code_user_id_non_nullable.rb
+++ b/db/migrate/20250816055312_make_offer_code_user_id_non_nullable.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class MakeOfferCodeUserIdNonNullable < ActiveRecord::Migration[7.1]
+  def change
+    change_column_null :offer_codes, :user_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_04_25_212934) do
+ActiveRecord::Schema[7.1].define(version: 2025_08_16_055312) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -1210,7 +1210,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_25_212934) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.integer "amount_percentage"
-    t.integer "user_id"
+    t.integer "user_id", null: false
     t.string "currency_type"
     t.string "code"
     t.boolean "universal", default: false, null: false


### PR DESCRIPTION
We already set this all the time when creating `OfferCode` entries, and there are no `null` records in the database.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved validation: Offer codes must now be linked to a user account, preventing creation or use of unattached codes.
- Bug Fixes
  - Eliminates orphaned offer codes by requiring an associated user, reducing errors and ambiguity.
- Chores
  - Backend now enforces the user requirement at the database level for stronger data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->