### PR TITLE
Retain original discount for upsells if it's better

### DIFF
--- a/app/javascript/components/server-components/CheckoutDashboard/UpsellsPage.tsx
+++ b/app/javascript/components/server-components/CheckoutDashboard/UpsellsPage.tsx
@@ -910,6 +910,10 @@ const Form = ({
               }}
               accept={() => {}}
               decline={() => {}}
+              cart={{
+                items: [previewCartItem],
+                discountCodes: [],
+              }}
             />
           ) : (
             <UpsellModal

--- a/app/services/offer_code_discount_computing_service.rb
+++ b/app/services/offer_code_discount_computing_service.rb
@@ -28,7 +28,7 @@ class OfferCodeDiscountComputingService
       if eligible?(offer_code, purchase_quantity)
         track_usage(offer_code, purchase_quantity)
         products_data[link.unique_permalink] = { discount: offer_code.discount }
-        apply_to_applicable_replacement_cross_sells(products_data, link, offer_code)
+        optimistically_apply_to_applicable_cross_sells(products_data, link, offer_code)
       else
         track_ineligibility(offer_code, purchase_quantity)
       end
@@ -128,11 +128,14 @@ class OfferCodeDiscountComputingService
         .find { @product_level_ineligibilities[it] }
     end
 
-    def apply_to_applicable_replacement_cross_sells(products_data, link, offer_code)
+    # This is optimistic because additive cross-sells may not meet the minimum
+    # purchase quantity or the discount code may have been used up. The discount
+    # will still be validated and updated during checkout, where the buyer will
+    # be able to see the correct discount and adjust accordingly.
+    def optimistically_apply_to_applicable_cross_sells(products_data, link, offer_code)
       discount = offer_code.discount
 
       link.cross_sells
-        .filter(&:replace_selected_products)
         .filter { |cross_sell| offer_code.applicable?(cross_sell.product) }
         .each do |cross_sell|
           products_data[cross_sell.product.unique_permalink] = { discount: }

--- a/app/services/offer_code_discount_computing_service.rb
+++ b/app/services/offer_code_discount_computing_service.rb
@@ -28,6 +28,7 @@ class OfferCodeDiscountComputingService
       if eligible?(offer_code, purchase_quantity)
         track_usage(offer_code, purchase_quantity)
         products_data[link.unique_permalink] = { discount: offer_code.discount }
+        apply_to_applicable_replacement_cross_sells(products_data, link, offer_code)
       else
         track_ineligibility(offer_code, purchase_quantity)
       end
@@ -44,6 +45,7 @@ class OfferCodeDiscountComputingService
 
     def links
       @_links ||= Link.visible
+        .includes({ cross_sells: :product })
         .where(unique_permalink: products.values.map { it[:permalink] })
     end
 
@@ -124,5 +126,16 @@ class OfferCodeDiscountComputingService
 
       PRODUCT_LEVEL_INELIGIBILITIES_BY_DISPLAY_PRIORITY
         .find { @product_level_ineligibilities[it] }
+    end
+
+    def apply_to_applicable_replacement_cross_sells(products_data, link, offer_code)
+      discount = offer_code.discount
+
+      link.cross_sells
+        .filter(&:replace_selected_products)
+        .filter { |cross_sell| offer_code.applicable?(cross_sell.product) }
+        .each do |cross_sell|
+          products_data[cross_sell.product.unique_permalink] = { discount: }
+        end
     end
 end

--- a/app/services/purchase/create_service.rb
+++ b/app/services/purchase/create_service.rb
@@ -97,7 +97,11 @@ class Purchase::CreateService < Purchase::BaseService
             end
           end
 
-          purchase.offer_code = upsell.offer_code unless params[:is_purchasing_power_parity_discounted]
+          # The original discount is retained if it is better than the upsell
+          # discount. The client can't automatically set the upsell discount
+          # because it doesn't have a "code". Thus, upsell discount should only
+          # be applied when the purchase does not already have a discount code.
+          purchase.offer_code ||= upsell.offer_code unless params[:is_purchasing_power_parity_discounted]
         end
         purchase.build_upsell_purchase(
           upsell:,

--- a/spec/requests/purchases/product/upsell_spec.rb
+++ b/spec/requests/purchases/product/upsell_spec.rb
@@ -241,12 +241,16 @@ describe("Product checkout with upsells", type: :feature, js: true) do
       within_modal "Replacement cross-sell" do
         expect(page).to have_text("This offer will only last for a few weeks.")
         expect(page).to have_section("Offered product")
-        expect(page).to have_selector("[itemprop='price']", text: "$4 $3.50")
+        # The modal shows original discount that is better than the replacement
+        # cross-sell discount.
+        expect(page).to have_selector("[itemprop='price']", text: "$4 $3")
         click_on "Upgrade"
       end
 
       expect(page).to have_section("Offered product")
       expect(page).to_not have_section("Selected product 1")
+      # Cart retains the original discount code after accepting the replacement
+      # cross-sell.
       expect(page).to have_selector("[aria-label='Discount code']", text: better_discount_code.code)
       expect(page).to have_text("US$-1")
 
@@ -257,7 +261,7 @@ describe("Product checkout with upsells", type: :feature, js: true) do
 
       purchase = Purchase.last
       expect(purchase.link).to eq(product)
-      expect(purchase.price_cents).to eq(100)
+      expect(purchase.price_cents).to eq(300)
       expect(purchase.offer_code).to eq(better_discount_code)
       expect(purchase.upsell_purchase.selected_product).to eq(selected_product1)
       expect(purchase.upsell_purchase.upsell).to eq(replacement_cross_sell)

--- a/spec/requests/purchases/product/upsell_spec.rb
+++ b/spec/requests/purchases/product/upsell_spec.rb
@@ -187,10 +187,12 @@ describe("Product checkout with upsells", type: :feature, js: true) do
   end
 
   context "when the product has a replacement cross-sell" do
-    let(:product) { create(:product, user: seller, name: "Offered product", price_cents: 200) }
-    let(:selected_product1) { create(:product, user: seller, name: "Selected product 1") }
-    let(:selected_product2) { create(:product, user: seller, name: "Selected product 2") }
-    let!(:replacement_cross_sell) { create(:upsell, text: "Replacement cross-sell", seller:, product:, variant: product.alive_variants.first, selected_products: [selected_product1, selected_product2], offer_code: build(:offer_code, user: seller, products: [product], amount_cents: 100), cross_sell: true, replace_selected_products: true) }
+    let(:product) { create(:product, user: seller, name: "Offered product", price_cents: 400) }
+    let(:selected_product1) { create(:product, user: seller, name: "Selected product 1", price_cents: 200) }
+    let(:selected_product2) { create(:product, user: seller, name: "Selected product 2", price_cents: 200) }
+    let!(:replacement_cross_sell) { create(:upsell, text: "Replacement cross-sell", seller:, product:, variant: product.alive_variants.first, selected_products: [selected_product1, selected_product2], offer_code: build(:offer_code, user: seller, products: [product], amount_cents: 50), cross_sell: true, replace_selected_products: true) }
+
+    let(:better_discount_code) { create(:offer_code, code: "betterdiscount", user: seller, universal: true, amount_cents: 100) }
 
     it "removes the selected products when the buyer accepts the cross-sell" do
       visit selected_product1.long_url
@@ -205,13 +207,15 @@ describe("Product checkout with upsells", type: :feature, js: true) do
       within_modal "Replacement cross-sell" do
         expect(page).to have_text("This offer will only last for a few weeks.")
         expect(page).to have_section("Offered product")
-        expect(page).to have_selector("[itemprop='price']", text: "$2 $1")
+        expect(page).to have_selector("[itemprop='price']", text: "$4 $3.50")
         click_on "Upgrade"
       end
 
       expect(page).to have_section("Offered product")
       expect(page).to_not have_section("Selected product 1")
       expect(page).to_not have_section("Selected product 2")
+      expect(page).to_not have_selector("[aria-label='Discount code']")
+      expect(page).to have_text("US$-0.50")
 
       expect(page).to have_alert(text: "Your purchase was successful! We sent a receipt to test@gumroad.com.")
 
@@ -221,9 +225,41 @@ describe("Product checkout with upsells", type: :feature, js: true) do
 
       purchase = Purchase.last
       expect(purchase.link).to eq(product)
-      expect(purchase.price_cents).to eq(100)
+      expect(purchase.price_cents).to eq(350)
       expect(purchase.offer_code).to eq(replacement_cross_sell.offer_code)
       expect(purchase.upsell_purchase.selected_product).to eq(selected_product2)
+      expect(purchase.upsell_purchase.upsell).to eq(replacement_cross_sell)
+    end
+
+    it "retains the original discount code if it's better than the replacement cross-sell discount" do
+      visit "#{selected_product1.long_url}/#{better_discount_code.code}"
+      add_to_cart(selected_product1, offer_code: better_discount_code)
+
+      fill_checkout_form(selected_product1)
+      click_on "Pay"
+
+      within_modal "Replacement cross-sell" do
+        expect(page).to have_text("This offer will only last for a few weeks.")
+        expect(page).to have_section("Offered product")
+        expect(page).to have_selector("[itemprop='price']", text: "$4 $3.50")
+        click_on "Upgrade"
+      end
+
+      expect(page).to have_section("Offered product")
+      expect(page).to_not have_section("Selected product 1")
+      expect(page).to have_selector("[aria-label='Discount code']", text: better_discount_code.code)
+      expect(page).to have_text("US$-1")
+
+      expect(page).to have_alert(text: "Your purchase was successful! We sent a receipt to test@gumroad.com.")
+
+      expect(page).to have_section("Offered product")
+      expect(page).to_not have_section("Selected product 1")
+
+      purchase = Purchase.last
+      expect(purchase.link).to eq(product)
+      expect(purchase.price_cents).to eq(100)
+      expect(purchase.offer_code).to eq(better_discount_code)
+      expect(purchase.upsell_purchase.selected_product).to eq(selected_product1)
       expect(purchase.upsell_purchase.upsell).to eq(replacement_cross_sell)
     end
 

--- a/spec/requests/purchases/product/upsell_spec.rb
+++ b/spec/requests/purchases/product/upsell_spec.rb
@@ -152,6 +152,57 @@ describe("Product checkout with upsells", type: :feature, js: true) do
       expect(purchase.upsell_purchase).to be_nil
       expect(purchase.variant_attributes.first).to eq(selected_product.alive_variants.first)
     end
+
+    context "when the buyer has a better discount code" do
+      let!(:cross_sell) { nil }  # Override global cross_sell to avoid conflicts
+      let!(:additive_cross_sell) { create(:upsell, text: "Cross-sell", description: "Check out this awesome cross-sell!", seller:, product:, variant: product.alive_variants.first, selected_products: [selected_product], cross_sell: true, replace_selected_products: false) }
+      let(:better_discount_code) { create(:offer_code, code: "betterdiscount", user: seller, universal: true, amount_cents: 100) }
+
+      before do
+        product.update!(price_cents: 400)
+        selected_product.update!(price_cents: 200)
+      end
+
+      it "applies applicable discount codes to non-replacement cross-sells" do
+        visit "#{selected_product.long_url}/#{better_discount_code.code}"
+        add_to_cart(selected_product, offer_code: better_discount_code)
+
+        fill_checkout_form(selected_product)
+        click_on "Pay"
+
+        within_modal "Cross-sell" do
+          expect(page).to have_text("Check out this awesome cross-sell!")
+          expect(page).to have_section("Offered product")
+          # The modal shows the original discount applied to the cross-sell
+          expect(page).to have_selector("[itemprop='price']", text: "$4 $3")
+          click_on "Add to cart"
+        end
+
+        expect(page).to have_section("Offered product")
+        expect(page).to have_section("Product")
+        # Cart retains the original discount code and applies it to both products
+        expect(page).to have_selector("[aria-label='Discount code']", text: better_discount_code.code)
+        # $1 off each product
+        expect(page).to have_text("US$-2")
+
+        expect(page).to have_alert(text: "Your purchase was successful! We sent a receipt to test@gumroad.com.")
+
+        expect(page).to have_section("Offered product")
+        expect(page).to have_section("Product")
+
+        selected_purchase = selected_product.sales.last
+        offered_purchase = product.sales.last
+
+        expect(selected_purchase.price_cents).to eq(100) # $200 - $100 discount
+        expect(selected_purchase.offer_code).to eq(better_discount_code)
+        expect(selected_purchase.upsell_purchase).to be_nil
+
+        expect(offered_purchase.price_cents).to eq(300) # $400 - $100 discount
+        expect(offered_purchase.offer_code).to eq(better_discount_code)
+        expect(offered_purchase.upsell_purchase.selected_product).to eq(selected_product)
+        expect(offered_purchase.upsell_purchase.upsell).to eq(additive_cross_sell)
+      end
+    end
   end
 
   context "when the product has a universal cross-sell" do
@@ -192,8 +243,6 @@ describe("Product checkout with upsells", type: :feature, js: true) do
     let(:selected_product2) { create(:product, user: seller, name: "Selected product 2", price_cents: 200) }
     let!(:replacement_cross_sell) { create(:upsell, text: "Replacement cross-sell", seller:, product:, variant: product.alive_variants.first, selected_products: [selected_product1, selected_product2], offer_code: build(:offer_code, user: seller, products: [product], amount_cents: 50), cross_sell: true, replace_selected_products: true) }
 
-    let(:better_discount_code) { create(:offer_code, code: "betterdiscount", user: seller, universal: true, amount_cents: 100) }
-
     it "removes the selected products when the buyer accepts the cross-sell" do
       visit selected_product1.long_url
       add_to_cart(selected_product1)
@@ -231,40 +280,44 @@ describe("Product checkout with upsells", type: :feature, js: true) do
       expect(purchase.upsell_purchase.upsell).to eq(replacement_cross_sell)
     end
 
-    it "retains the original discount code if it's better than the replacement cross-sell discount" do
-      visit "#{selected_product1.long_url}/#{better_discount_code.code}"
-      add_to_cart(selected_product1, offer_code: better_discount_code)
+    context "when the buyer has a better discount code" do
+      let(:better_discount_code) { create(:offer_code, code: "betterdiscount", user: seller, universal: true, amount_cents: 100) }
 
-      fill_checkout_form(selected_product1)
-      click_on "Pay"
+      it "retains the original discount code if it's better than the replacement cross-sell discount" do
+        visit "#{selected_product1.long_url}/#{better_discount_code.code}"
+        add_to_cart(selected_product1, offer_code: better_discount_code)
 
-      within_modal "Replacement cross-sell" do
-        expect(page).to have_text("This offer will only last for a few weeks.")
+        fill_checkout_form(selected_product1)
+        click_on "Pay"
+
+        within_modal "Replacement cross-sell" do
+          expect(page).to have_text("This offer will only last for a few weeks.")
+          expect(page).to have_section("Offered product")
+          # The modal shows original discount that is better than the replacement
+          # cross-sell discount.
+          expect(page).to have_selector("[itemprop='price']", text: "$4 $3")
+          click_on "Upgrade"
+        end
+
         expect(page).to have_section("Offered product")
-        # The modal shows original discount that is better than the replacement
-        # cross-sell discount.
-        expect(page).to have_selector("[itemprop='price']", text: "$4 $3")
-        click_on "Upgrade"
+        expect(page).to_not have_section("Selected product 1")
+        # Cart retains the original discount code after accepting the replacement
+        # cross-sell.
+        expect(page).to have_selector("[aria-label='Discount code']", text: better_discount_code.code)
+        expect(page).to have_text("US$-1")
+
+        expect(page).to have_alert(text: "Your purchase was successful! We sent a receipt to test@gumroad.com.")
+
+        expect(page).to have_section("Offered product")
+        expect(page).to_not have_section("Selected product 1")
+
+        purchase = Purchase.last
+        expect(purchase.link).to eq(product)
+        expect(purchase.price_cents).to eq(300)
+        expect(purchase.offer_code).to eq(better_discount_code)
+        expect(purchase.upsell_purchase.selected_product).to eq(selected_product1)
+        expect(purchase.upsell_purchase.upsell).to eq(replacement_cross_sell)
       end
-
-      expect(page).to have_section("Offered product")
-      expect(page).to_not have_section("Selected product 1")
-      # Cart retains the original discount code after accepting the replacement
-      # cross-sell.
-      expect(page).to have_selector("[aria-label='Discount code']", text: better_discount_code.code)
-      expect(page).to have_text("US$-1")
-
-      expect(page).to have_alert(text: "Your purchase was successful! We sent a receipt to test@gumroad.com.")
-
-      expect(page).to have_section("Offered product")
-      expect(page).to_not have_section("Selected product 1")
-
-      purchase = Purchase.last
-      expect(purchase.link).to eq(product)
-      expect(purchase.price_cents).to eq(300)
-      expect(purchase.offer_code).to eq(better_discount_code)
-      expect(purchase.upsell_purchase.selected_product).to eq(selected_product1)
-      expect(purchase.upsell_purchase.upsell).to eq(replacement_cross_sell)
     end
 
     context "selected product is free and offered product is paid" do

--- a/spec/services/offer_code_discount_computing_service_spec.rb
+++ b/spec/services/offer_code_discount_computing_service_spec.rb
@@ -216,4 +216,97 @@ describe OfferCodeDiscountComputingService do
       expect(result[:products_data]).to eq({})
     end
   end
+
+  context "when product has replacement cross-sells" do
+    let(:cross_sell_product1) { create(:product, user: seller, price_cents: 3000) }
+    let(:cross_sell_product2) { create(:product, user: seller, price_cents: 4000) }
+    let(:non_applicable_cross_sell_product) { create(:product, user: seller, price_cents: 5000) }
+    let!(:replacement_cross_sell1) do
+      create(:upsell,
+             seller: seller,
+             product: cross_sell_product1,
+             cross_sell: true,
+             replace_selected_products: true,
+             selected_products: [product]
+      )
+    end
+    let!(:replacement_cross_sell2) do
+      create(:upsell,
+             seller: seller,
+             product: cross_sell_product2,
+             cross_sell: true,
+             replace_selected_products: true,
+             selected_products: [product]
+      )
+    end
+    let!(:non_replacement_cross_sell) do
+      create(:upsell,
+             seller: seller,
+             product: non_applicable_cross_sell_product,
+             cross_sell: true,
+             replace_selected_products: false,
+             selected_products: [product]
+      )
+    end
+
+    context "universal offer code" do
+      let(:universal_offer_code_for_cross_sells) { create(:universal_offer_code, user: seller, amount_percentage: 50, amount_cents: nil, currency_type: "usd") }
+
+      it "applies discount to main product and applicable replacement cross-sells" do
+        result = OfferCodeDiscountComputingService.new(universal_offer_code_for_cross_sells.code, products_data).process
+
+        expect(result[:products_data]).to include(
+          product.unique_permalink => {
+            discount: hash_including(
+              type: "percent",
+              percents: 50
+            )
+          },
+          cross_sell_product1.unique_permalink => {
+            discount: hash_including(
+              type: "percent",
+              percents: 50
+            )
+          },
+          cross_sell_product2.unique_permalink => {
+            discount: hash_including(
+              type: "percent",
+              percents: 50
+            )
+          }
+        )
+        expect(result[:products_data])
+          .not_to include(non_applicable_cross_sell_product.unique_permalink)
+        expect(result[:products_data])
+          .not_to include(non_replacement_cross_sell.product.unique_permalink)
+        expect(result[:error_code]).to be_nil
+      end
+    end
+
+    context "product-specific offer code" do
+      let(:specific_offer_code) { create(:offer_code, user: seller, products: [product, cross_sell_product1], amount_percentage: 25, amount_cents: nil, currency_type: "usd") }
+
+      it "applies discount only to applicable products including cross-sells" do
+        result = OfferCodeDiscountComputingService.new(specific_offer_code.code, products_data).process
+
+        expect(result[:products_data]).to include(
+          product.unique_permalink => {
+            discount: hash_including(
+              type: "percent",
+              percents: 25
+            )
+          },
+          cross_sell_product1.unique_permalink => {
+            discount: hash_including(
+              type: "percent",
+              percents: 25
+            )
+          }
+        )
+        expect(result[:products_data]).not_to include(cross_sell_product2.unique_permalink)
+        expect(result[:products_data]).not_to include(non_applicable_cross_sell_product.unique_permalink)
+        expect(result[:error_code]).to be_nil
+      end
+    end
+  end
 end

--- a/spec/services/offer_code_discount_computing_service_spec.rb
+++ b/spec/services/offer_code_discount_computing_service_spec.rb
@@ -217,10 +217,10 @@ describe OfferCodeDiscountComputingService do
     end
   end
 
-  context "when product has replacement cross-sells" do
+  context "when product has cross-sells" do
     let(:cross_sell_product1) { create(:product, user: seller, price_cents: 3000) }
     let(:cross_sell_product2) { create(:product, user: seller, price_cents: 4000) }
-    let(:non_applicable_cross_sell_product) { create(:product, user: seller, price_cents: 5000) }
+    let(:additive_cross_sell_product) { create(:product, user: seller, price_cents: 5000) }
     let!(:replacement_cross_sell1) do
       create(:upsell,
              seller: seller,
@@ -239,10 +239,10 @@ describe OfferCodeDiscountComputingService do
              selected_products: [product]
       )
     end
-    let!(:non_replacement_cross_sell) do
+    let!(:additive_cross_sell) do
       create(:upsell,
              seller: seller,
-             product: non_applicable_cross_sell_product,
+             product: additive_cross_sell_product,
              cross_sell: true,
              replace_selected_products: false,
              selected_products: [product]
@@ -252,7 +252,7 @@ describe OfferCodeDiscountComputingService do
     context "universal offer code" do
       let(:universal_offer_code_for_cross_sells) { create(:universal_offer_code, user: seller, amount_percentage: 50, amount_cents: nil, currency_type: "usd") }
 
-      it "applies discount to main product and applicable replacement cross-sells" do
+      it "applies discount to main product and all applicable cross-sells" do
         result = OfferCodeDiscountComputingService.new(universal_offer_code_for_cross_sells.code, products_data).process
 
         expect(result[:products_data]).to include(
@@ -275,10 +275,14 @@ describe OfferCodeDiscountComputingService do
             )
           }
         )
-        expect(result[:products_data])
-          .not_to include(non_applicable_cross_sell_product.unique_permalink)
-        expect(result[:products_data])
-          .not_to include(non_replacement_cross_sell.product.unique_permalink)
+        expect(result[:products_data]).to include(
+          additive_cross_sell.product.unique_permalink => {
+            discount: hash_including(
+              type: "percent",
+              percents: 50
+            )
+          }
+        )
         expect(result[:error_code]).to be_nil
       end
     end
@@ -304,7 +308,7 @@ describe OfferCodeDiscountComputingService do
           }
         )
         expect(result[:products_data]).not_to include(cross_sell_product2.unique_permalink)
-        expect(result[:products_data]).not_to include(non_applicable_cross_sell_product.unique_permalink)
+        expect(result[:products_data]).not_to include(additive_cross_sell_product.unique_permalink)
         expect(result[:error_code]).to be_nil
       end
     end

--- a/spec/services/purchase/create_service_spec.rb
+++ b/spec/services/purchase/create_service_spec.rb
@@ -353,6 +353,29 @@ describe Purchase::CreateService, :vcr do
         end
       end
     end
+
+    context "when the purchase already has an offer code" do
+      let(:existing_offer_code) { create(:offer_code, user:, products: [product], amount_cents: 200, code: "existing789") }
+
+      before do
+        params[:purchase][:offer_code] = existing_offer_code
+      end
+
+      it "retains the existing offer code instead of using the upsell offer code" do
+        purchase, error = Purchase::CreateService.new(
+          product:,
+          params:,
+          buyer:
+        ).perform
+
+        expect(purchase.upsell_purchase.upsell).to eq(cross_sell)
+        expect(purchase.upsell_purchase.selected_product).to eq(selected_product)
+        expect(purchase.offer_code).to eq(existing_offer_code)
+        expect(purchase.purchase_offer_code_discount.offer_code).to eq(existing_offer_code)
+        expect(purchase.purchase_offer_code_discount.offer_code_amount).to eq(200)
+        expect(error).to be_nil
+      end
+    end
   end
 
   describe "bundle purchases" do

--- a/spec/support/fixtures/vcr_cassettes/Purchase_CreateService/when_the_purchase_has_a_cross-sell/when_the_purchase_already_has_an_offer_code/retains_the_existing_offer_code_instead_of_using_the_upsell_offer_code.yml
+++ b/spec/support/fixtures/vcr_cassettes/Purchase_CreateService/when_the_purchase_has_a_cross-sell/when_the_purchase_already_has_an_offer_code/retains_the_existing_offer_code_instead_of_using_the_upsell_offer_code.yml
@@ -1,0 +1,136 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[number]=4242+4242+4242+4242&card[exp_month]=12&card[exp_year]=2025&card[cvc]=123&billing_details[address][postal_code]=<STRONGBOX_GENERAL_PASSWORD>5
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Idempotency-Key:
+      - db132484-b2a6-4259-9e2f-cdd7b452b8ff
+      Stripe-Version:
+      - 2023-10-16; risk_in_requirements_beta=v1
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        KMBP.local 24.5.0 Darwin Kernel Version 24.5.0: Tue Apr 22 19:54:25 PDT 2025;
+        root:xnu-11417.121.6~2/RELEASE_ARM64_T6020 arm64","hostname":"KMBP.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 16 Aug 2025 08:46:06 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1065'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=Uga3J0St6sV4J3cDBJo9bcuqkYeNRTARcE-pUnVcgf8SDnZFkB4cINnlpviGQBhbE93RkIqes8u36igt
+      Idempotency-Key:
+      - db132484-b2a6-4259-9e2f-cdd7b452b8ff
+      Original-Request:
+      - req_SpGak3xMkXnENn
+      Request-Id:
+      - req_SpGak3xMkXnENn
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - 2023-10-16; risk_in_requirements_beta=v1
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - ABGHIJ
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_0RwfkY9e1RjUNIyYefPTcrk6",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": "<STRONGBOX_GENERAL_PASSWORD>5",
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": "unchecked",
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 12,
+            "exp_year": 2025,
+            "fingerprint": "W691J2Ye3VDoq6Ij",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1755333966,
+          "customer": null,
+          "livemode": false,
+          "metadata": {},
+          "type": "card"
+        }
+  recorded_at: Sat, 16 Aug 2025 08:46:06 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
(Hopefully, this is pretty short and easy to follow thanks to [a separate no-op refactor](https://github.com/antiwork/gumroad/pull/870).)

See https://github.com/antiwork/gumroad/issues/264.

We already try to choose the better discount between the existing discount codes and the upsell's offer. 

https://github.com/antiwork/gumroad/blob/f8007a21bf54ff8d0f52a83336cde0097098e804/app/javascript/components/Checkout/cartState.ts#L144-L174

However, the calculation **does NOT know how existing codes apply to the upsell’s products**, so the system mistakenly thinks that none of the existing discount codes apply to the new item.

Even if the correct discount is calculated and preserved, it will be **removed or replaced unconditionally** when creating the purchase:

https://github.com/antiwork/gumroad/blob/f8007a21bf54ff8d0f52a83336cde0097098e804/app/services/purchase/create_service.rb#L100


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Cross-sell modal now uses your current cart to show accurate, cart-aware pricing.
  - Cross-sell discounts are surfaced earlier in the checkout experience.

- Bug Fixes
  - Preserves your existing discount code during upsell flows, avoiding unwanted overrides.
  - Correctly displays original vs. discounted cross-sell prices, including replacement scenarios.

- Tests
  - Expanded end-to-end coverage for discount interactions across cross-sell and replacement flows.
  - Added service-level tests for discount propagation to cross-sell items.
  - Recorded payment method fixture for checkout scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->