### PR TITLE
Prevent deleted products from appearing in Best Selling section

### DIFF
--- a/app/presenters/creator_home_presenter.rb
+++ b/app/presenters/creator_home_presenter.rb
@@ -36,6 +36,7 @@ class CreatorHomePresenter
     products_by_permalink = seller.products
       .where(unique_permalink: product_permalinks)
       .includes(thumbnail_alive: { file_attachment: { blob: { variant_records: { image_attachment: :blob } } } })
+      .select(&:alive?)
       .index_by(&:unique_permalink)
 
     sales = top_sales_data.map do |p|

--- a/spec/presenters/creator_home_presenter_spec.rb
+++ b/spec/presenters/creator_home_presenter_spec.rb
@@ -131,6 +131,20 @@ describe CreatorHomePresenter do
       expect(product2_data["thumbnail"]).to eq(thumbnail2.url)
     end
 
+    it "excludes deleted products from the Best Selling section", :sidekiq_inline, :elasticsearch_wait_for_refresh do
+      active_product = create(:product, user: seller, price_cents: 1000)
+      deleted_product = create(:product, user: seller, price_cents: 2000)
+
+      create_list(:purchase, 3, link: active_product, price_cents: active_product.price_cents, created_at: 1.day.ago)
+      create_list(:purchase, 5, link: deleted_product, price_cents: deleted_product.price_cents, created_at: 2.days.ago)
+
+      deleted_product.update!(deleted_at: Time.current)
+
+      sales_data = presenter.creator_home_props[:sales]
+      expect(sales_data.map { |p| p["id"] }).to contain_exactly(active_product.unique_permalink)
+      expect(sales_data).not_to include(hash_including("id" => deleted_product.unique_permalink))
+    end
+
     it "shows the 3 most sold products in past 30 days", :sidekiq_inline, :elasticsearch_wait_for_refresh do
       product1 = create(:product, user: seller)
       product2 = create(:product, user: seller)


### PR DESCRIPTION
## What
This PR fixes an issue where deleted products were still appearing in the Best Selling section of the dashboard.

## Changes
- Modified `CreatorHomePresenter#creator_home_props` to filter out non-alive products
- Added test coverage to ensure deleted products don't appear in the Best Selling section

## Test Result
<img width="602" height="161" alt="image" src="https://github.com/user-attachments/assets/8d546497-058b-4111-9fa3-8fc0455255e6" />

Fixes https://github.com/antiwork/gumroad/issues/887

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Best Selling section now excludes deleted products, ensuring only active items appear in sales listings and metrics.

* **Tests**
  * Added coverage to verify deleted products are not included in Best Selling results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->