### PR TITLE
Discover page sorting fix

### DIFF
--- a/app/models/base_variant.rb
+++ b/app/models/base_variant.rb
@@ -203,7 +203,7 @@ class BaseVariant < ApplicationRecord
 
     def update_product_search_index
       if link.present? && saved_change_to_price_difference_cents?
-        link.enqueue_index_update_for(["available_price_cents"])
+        link.enqueue_index_update_for(["available_price_cents", "available_price_usd_cents"])
       end
     end
 

--- a/app/modules/base_price/shared.rb
+++ b/app/modules/base_price/shared.rb
@@ -42,7 +42,7 @@ module BasePrice::Shared
     prices_to_delete = prices.alive.where(recurrence: recurrences_to_delete)
     prices_to_delete.map(&:mark_deleted!)
 
-    enqueue_index_update_for(["price_cents", "available_price_cents"]) if prices_to_delete.any?
+    enqueue_index_update_for(["price_cents", "available_price_cents", "available_price_usd_cents"]) if prices_to_delete.any?
 
     save!
   end
@@ -94,7 +94,7 @@ module BasePrice::Shared
 
         if changed
           alive_prices.reset
-          enqueue_index_update_for(["price_cents", "available_price_cents"])
+          enqueue_index_update_for(["price_cents", "available_price_cents", "available_price_usd_cents"])
         end
       end
     end

--- a/app/modules/product/prices.rb
+++ b/app/modules/product/prices.rb
@@ -240,6 +240,11 @@ module Product::Prices
     available_prices.uniq
   end
 
+  # Returns available prices normalized to USD cents for currency-aware comparisons/sorting in search index
+  def available_price_usd_cents
+    available_price_cents.map { |price_cents| get_usd_cents(price_currency_type, price_cents) }.uniq
+  end
+
   private
     # Private: Called only on create to instantiate Price object(s) and associate it to the newly created product.
     def associate_price

--- a/app/modules/product/searchable.rb
+++ b/app/modules/product/searchable.rb
@@ -40,6 +40,7 @@ module Product::Searchable
     filetypes
     price_cents
     available_price_cents
+    available_price_usd_cents
     updated_at
     creator_external_id
     content_updated_at
@@ -125,6 +126,7 @@ module Product::Searchable
         indexes :is_alive, type: :boolean
         indexes :price_cents, type: :long
         indexes :available_price_cents, type: :long
+        indexes :available_price_usd_cents, type: :long
         indexes :recommendable, type: :text do # unused
           indexes :keyword, type: :keyword, ignore_above: 256
         end
@@ -306,8 +308,8 @@ module Product::Searchable
           when ProductSortKey::HOT_AND_NEW
             by :sales_volume, order: "desc"
           when ProductSortKey::NEWEST           then by :created_at,     order: "desc"
-          when ProductSortKey::AVAILABLE_PRICE_DESCENDING, ProductSortKey::PRICE_DESCENDING then by :available_price_cents,    order: "desc", mode: "min"
-          when ProductSortKey::AVAILABLE_PRICE_ASCENDING, ProductSortKey::PRICE_ASCENDING  then by :available_price_cents,    order: "asc", mode: "min"
+          when ProductSortKey::AVAILABLE_PRICE_DESCENDING, ProductSortKey::PRICE_DESCENDING then by :available_price_usd_cents,    order: "desc", mode: "min"
+          when ProductSortKey::AVAILABLE_PRICE_ASCENDING, ProductSortKey::PRICE_ASCENDING  then by :available_price_usd_cents,    order: "asc", mode: "min"
           when ProductSortKey::IS_RECOMMENDABLE_DESCENDING then by :is_recommendable,    order: "desc"
           when ProductSortKey::IS_RECOMMENDABLE_ASCENDING  then by :is_recommendable,    order: "asc"
           when ProductSortKey::REVENUE_ASCENDING   then by :sales_volume,    order: "asc"
@@ -464,6 +466,7 @@ module Product::Searchable
       when "reviews_count"     then reviews_count
       when "price_cents"       then price_cents
       when "available_price_cents" then available_price_cents
+      when "available_price_usd_cents" then available_price_usd_cents
       when "is_physical"       then is_physical
       when "is_subscription"   then is_recurring_billing
       when "is_bundle"         then is_bundle

--- a/db/migrate/20250819000000_add_available_price_usd_cents_to_product_index.rb
+++ b/db/migrate/20250819000000_add_available_price_usd_cents_to_product_index.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddAvailablePriceUsdCentsToProductIndex < ActiveRecord::Migration[6.1]
+class AddAvailablePriceUsdCentsToProductIndex < ActiveRecord::Migration[7.1]
   def up
     EsClient.indices.put_mapping(
       index: Link.index_name,
@@ -12,5 +12,3 @@ class AddAvailablePriceUsdCentsToProductIndex < ActiveRecord::Migration[6.1]
     )
   end
 end
-
-

--- a/db/migrate/20250819000000_add_available_price_usd_cents_to_product_index.rb
+++ b/db/migrate/20250819000000_add_available_price_usd_cents_to_product_index.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddAvailablePriceUsdCentsToProductIndex < ActiveRecord::Migration[6.1]
+  def up
+    EsClient.indices.put_mapping(
+      index: Link.index_name,
+      body: {
+        properties: {
+          available_price_usd_cents: { type: "long" }
+        }
+      }
+    )
+  end
+end
+
+

--- a/spec/requests/discover/price_sorting_spec.rb
+++ b/spec/requests/discover/price_sorting_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Discover - Currency-aware price sorting", js: true, type: :feature do
+  let(:discover_host) { UrlService.discover_domain_with_protocol }
+
+  before do
+    # Stub obfuscation keys required by presenters during page render
+    stub_const("ObfuscateIds::CIPHER_KEY", "a" * 32)
+    stub_const("ObfuscateIds::NUMERIC_CIPHER_KEY", 123456789)
+
+    # Deterministic exchange rates for the test run
+    ns = Redis::Namespace.new(:currencies, redis: $redis)
+    ns.set("USD", "1.0")
+    ns.set("EUR", "0.9")   # €1 = $1.11
+    ns.set("JPY", "150")   # ¥150 = $1.00
+
+    # Ensure no preview processing flakiness in CI
+    allow_any_instance_of(Link).to receive(:update_asset_preview)
+  end
+
+  def create_currency_product(name:, currency:, cents:)
+    create(
+      :product,
+      :recommendable,
+      :with_design_taxonomy,
+      name: name,
+      price_currency_type: currency,
+      price_cents: cents,
+      user: create(:compliant_user, name: "CurSorter")
+    )
+  end
+
+  it "sorts by normalized USD price across currencies for asc and desc" do
+    # Local prices all set to the same numeric value in their own currency
+    # With rates above, normalized order should be: EUR (€5 > $5 > ¥500)
+    eur = create_currency_product(name: "Beautiful EUR", currency: "eur", cents: 500) # €5.00
+    usd = create_currency_product(name: "Beautiful USD", currency: "usd", cents: 500) # $5.00
+    jpy = create_currency_product(name: "Beautiful JPY", currency: "jpy", cents: 500) # ¥500
+
+    # Index products into ES
+    index_model_records(Link)
+
+    visit discover_url(host: discover_host, query: "Beautiful", sort: ProductSortKey::PRICE_DESCENDING)
+
+    # High to Low: €5 > $5 > ¥500 with our seeded rates
+    # High to Low via query parameter
+    expect_product_cards_in_order([eur, usd, jpy])
+
+    # Low to High: ¥500 < $5 < €5 with our seeded rates
+    visit discover_url(host: discover_host, query: "Beautiful", sort: ProductSortKey::PRICE_ASCENDING)
+    expect_product_cards_in_order([jpy, usd, eur])
+  end
+
+  it "reflects exchange-rate changes after reindexing (not raw local cents)" do
+    eur = create_currency_product(name: "Beautiful EUR", currency: "eur", cents: 500) # €5.00
+    usd = create_currency_product(name: "Beautiful USD", currency: "usd", cents: 500) # $5.00
+    jpy = create_currency_product(name: "Beautiful JPY", currency: "jpy", cents: 500) # ¥500
+
+    index_model_records(Link)
+
+    # Initial order with EUR=0.9, JPY=150 ⇒ EUR > USD > JPY
+    visit discover_url(host: discover_host, query: "Beautiful", sort: ProductSortKey::PRICE_DESCENDING)
+    expect_product_cards_in_order([eur, usd, jpy])
+
+    # Change EUR rate to make € cheaper than $ and ¥; reindex to refresh normalized field
+    ns = Redis::Namespace.new(:currencies, redis: $redis)
+    ns.set("EUR", "2.0") # €1 = $0.50 now
+    eur.__elasticsearch__.index_document
+    Link.__elasticsearch__.refresh_index!
+
+    # New expected order: USD ($5) > JPY (~$3.33) > EUR ($2.50)
+    visit discover_url(host: discover_host, query: "Beautiful", sort: ProductSortKey::PRICE_DESCENDING)
+    expect_product_cards_in_order([usd, jpy, eur])
+  end
+
+  it "handles a mix of currencies plus a higher local price correctly" do
+    # Mixed set where local values differ to cover more scenarios
+    # Using the same seeded rates, compute expected normalization
+    high_usd = create_currency_product(name: "Beautiful USD High", currency: "usd", cents: 1000) # $10.00
+    eur = create_currency_product(name: "Beautiful EUR Mid", currency: "eur", cents: 700)       # €7.00 -> $7.77
+    jpy = create_currency_product(name: "Beautiful JPY Low", currency: "jpy", cents: 900)       # ¥900 -> $6.00
+
+    index_model_records(Link)
+
+    visit discover_url(host: discover_host, query: "Beautiful", sort: ProductSortKey::PRICE_DESCENDING)
+
+    # High to Low: $10 > €7 > ¥900
+    # High to Low via query parameter
+    expect_product_cards_in_order([high_usd, eur, jpy])
+
+    # Low to High
+    # Low to High via query parameter
+    visit discover_url(host: discover_host, query: "Beautiful", sort: ProductSortKey::PRICE_ASCENDING)
+    expect_product_cards_in_order([jpy, eur, high_usd])
+  end
+end
+
+


### PR DESCRIPTION
When discover products are sorted "Price: high to low" or vice versa, they are being sorted just by the numbers. Currency is not taken into consideration.

The problem is products are being sorted based on cents value.

**Example 1:**
product 1 is 10usd=1000 cents 
product 2 is 10jpy=1000cents 
product 3 is 10eur=1000cents

Although their price is different, they are being treated as same cause their cents value is same.

---

**Example 2:**
Consider 3 products. Product 1=₹100000, Product 2=$99999 and Product 3=€99000.

When sort is set to price: high to low, gumroad sorts them ₹100000 > $99999 > €99000. It doesn't consider currency and gives incorrect sort.

But in reality, €99000 > $99999 > ₹100000.

This PR fixes it by storing product's usd equivalent value and then sorting according to it.

---

**Before:**
(Here currency is not taken into consideration, they are being sorted based on amount number)

<img width="1920" height="1028" alt="before" src="https://github.com/user-attachments/assets/1dbbd24c-e5b1-48c2-b1ec-b98d673ea23f" />


### Solution

- Added a new normalized field available_price_usd_cents computed via CurrencyHelper#get_usd_cents.
- Indexed that field in Elasticsearch (mapping + SEARCH_FIELDS).
- Switched Discover sort keys (price asc/desc) to use available_price_usd_cents (with mode: "min").
- Hooked all price/variant updates to reindex and keep available_price_usd_cents fresh.
- Added an e2e spec proving correct cross currency ordering and behavior when rates change.

ES previously sorted on available_price_cents (currency agnostic), causing the wrong order.

For production: Run ES mapping migration, then reindex to populate available_price_usd_cents for existing products. Batchwise reindexing is recommended. New products are indexed with USD values automatically.

For testing locally, old exchange rates were used (available in backup_rates.json). In production, live rates will be used using Open Exchange Rates apis.

---

**After (Sort: Price low to high):**

Changed a product price to ₹80 and checked sorting locally, for context ₹80 = 0.92USD

<img width="1920" height="1038" alt="after" src="https://github.com/user-attachments/assets/6a3e987f-e5d7-4e28-8e9b-7024b03976f6" />

---

**After (Sort: Price high to low):**

Changed the price of 2 existing products to ¥500 and €5. Also created a new $10 product.

For context (for testing, exchange rates used are):
1usd = ¥78
1usd = €0.81

Therefore, $10 > ¥500 > €5

 
<img width="1920" height="1038" alt="after1" src="https://github.com/user-attachments/assets/ca507c0c-c7a9-4352-9a82-4fd8ad31bdd0" />

---

**E2E spec:**

`bundle exec rspec spec/requests/discover/price_sorting_spec.rb`

Output:

`3 examples, 0 failures`

<img width="1920" height="1028" alt="test" src="https://github.com/user-attachments/assets/76f6273b-be77-41fa-bbec-87cc95b903f8" />


