### PR TITLE
Add support controller spec

### DIFF
--- a/gumroad/spec/controllers/support_controller_spec.rb
+++ b/gumroad/spec/controllers/support_controller_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "shared_examples/sellers_base_controller_concern"
+require "shared_examples/authorize_called"
+
+describe SupportController do
+  it_behaves_like "inherits from Sellers::BaseController"
+
+  let(:seller) { create(:named_seller) }
+
+  include_context "with user signed in as admin for seller"
+
+  it_behaves_like "authorize called for controller", SupportPolicy do
+    let(:record) { :support }
+  end
+
+  describe "GET index" do
+    it "returns http success and assigns props" do
+      allow(controller).to receive(:helper_widget_host).and_return("https://help.example.test")
+      allow(controller).to receive(:helper_session).and_return({ "session_id" => "abc123" })
+
+      get :index
+
+      expect(response).to be_successful
+      expect(assigns[:props]).to eq(
+        host: "https://help.example.test",
+        session: { "session_id" => "abc123" }
+      )
+    end
+  end
+end
+


### PR DESCRIPTION
Add a spec for `SupportController` to test its inheritance, authorization, and React component props.

---
<a href="https://cursor.com/background-agent?bcId=bc-a900df91-f845-4d37-b858-306b5ee0e342">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a900df91-f845-4d37-b858-306b5ee0e342">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

