### PR TITLE
Update broken EU VAT rates link in help center

### DIFF
--- a/app/views/help_center/articles/contents/_10-dealing-with-vat.html.erb
+++ b/app/views/help_center/articles/contents/_10-dealing-with-vat.html.erb
@@ -9,7 +9,7 @@
     <p>For all sales to EU and UK buyers, Gumroad acts as the 'merchant of record' for the sale, making Gumroad responsible for collecting and remitting VAT. </p>
     <p><b>Note: </b>We do not collect VAT on physical products. VAT due on physical products is paid by the buyer on the inbound shipment receipt.</p>
     <h3>Reduced VAT for e-publications</h3>
-    <p>Since 2015, many EU countries have <a href="https://ec.europa.eu/taxation_customs/tic/public/vatRates/vatrates.html">reduced their local VAT rates</a> for e-publications.</p>
+    <p>Since 2015, many EU countries have <a href="https://taxation-customs.ec.europa.eu/taxation/vat/vat-directive/vat-rates_en">reduced their local VAT rates</a> for e-publications.</p>
     <p>The EU defines E-publications as:</p>
     <ul>
       <li>Books, </li>


### PR DESCRIPTION
Broken link: https://ec.europa.eu/taxation_customs/tic/public/vatRates/vatrates.html

New link: https://taxation-customs.ec.europa.eu/taxation/vat/vat-directive/vat-rates_en