### PR TITLE
Fix to include Connect sales fees under direct and discover fee heads in the payout table

### DIFF
--- a/app/helpers/payouts_helper.rb
+++ b/app/helpers/payouts_helper.rb
@@ -119,6 +119,7 @@ module PayoutsHelper
 
     if payment.gumroad_fee_cents.present?
       payout_period_data[:fees_cents] = payout_period_data[:fees_cents].to_i + payment.gumroad_fee_cents
+      payout_period_data[:direct_fees_cents] = payout_period_data[:direct_fees_cents].to_i + payment.gumroad_fee_cents
     end
 
     payout_period_data.merge(payout_method_details(payment:))

--- a/app/javascript/components/server-components/BalancePage.tsx
+++ b/app/javascript/components/server-components/BalancePage.tsx
@@ -351,10 +351,12 @@ const Period = ({ payoutPeriodData }: { payoutPeriodData: PayoutPeriodData }) =>
                       fees{" "}
                     </a>
                   </h4>
-                  <small>
-                    on {payoutPeriodData.discover_sales_count}{" "}
-                    {payoutPeriodData.discover_sales_count === 1 ? "sale" : "sales"}
-                  </small>
+                  {payoutPeriodData.discover_sales_count > 0 ? (
+                    <small>
+                      on {payoutPeriodData.discover_sales_count}{" "}
+                      {payoutPeriodData.discover_sales_count === 1 ? "sale" : "sales"}
+                    </small>
+                  ) : null}
                 </div>
                 <div>{formatNegativeDollarAmount(payoutPeriodData.discover_fees_cents)}</div>
               </div>
@@ -368,10 +370,12 @@ const Period = ({ payoutPeriodData }: { payoutPeriodData: PayoutPeriodData }) =>
                       fees{" "}
                     </a>
                   </h4>
-                  <small>
-                    on {payoutPeriodData.direct_sales_count}{" "}
-                    {payoutPeriodData.direct_sales_count === 1 ? "sale" : "sales"}
-                  </small>
+                  {payoutPeriodData.direct_sales_count > 0 ? (
+                    <small>
+                      on {payoutPeriodData.direct_sales_count}{" "}
+                      {payoutPeriodData.direct_sales_count === 1 ? "sale" : "sales"}
+                    </small>
+                  ) : null}
                 </div>
                 <div>{formatNegativeDollarAmount(payoutPeriodData.direct_fees_cents)}</div>
               </div>

--- a/spec/modules/user/stats_spec.rb
+++ b/spec/modules/user/stats_spec.rb
@@ -601,16 +601,20 @@ describe User::Stats, :vcr do
         it "returns overall sales stats from paypal direct sales during the duration" do
           paypal_sales_data = @creator.paypal_sales_data_for_duration(start_date: @payout_start_date, end_date: @payout_end_date)
 
-          expect(paypal_sales_data).to eq ({
-            sales_cents: 325_00,
-            refunds_cents: 155_00,
-            chargebacks_cents: 160_00,
-            credits_cents: 0,
-            fees_cents: 126,
-            taxes_cents: 0,
-            affiliate_credits_cents: 0,
-            affiliate_fees_cents: -1_06
-          })
+          expect(paypal_sales_data).to eq({
+                                            sales_cents: 325_00,
+                                            refunds_cents: 155_00,
+                                            chargebacks_cents: 160_00,
+                                            credits_cents: 0,
+                                            fees_cents: 126,
+                                            direct_fees_cents: 126,
+                                            discover_fees_cents: 0,
+                                            direct_sales_count: 4,
+                                            discover_sales_count: 0,
+                                            taxes_cents: 0,
+                                            affiliate_credits_cents: 0,
+                                            affiliate_fees_cents: -1_06
+                                          })
         end
       end
 
@@ -827,18 +831,22 @@ describe User::Stats, :vcr do
 
       describe "#stripe_connect_sales_data_for_duration" do
         it "returns overall sales stats from Stripe Connect direct sales during the duration" do
-          paypal_sales_data = @creator.stripe_connect_sales_data_for_duration(start_date: @payout_start_date, end_date: @payout_end_date)
+          stripe_connect_sales_data = @creator.stripe_connect_sales_data_for_duration(start_date: @payout_start_date, end_date: @payout_end_date)
 
-          expect(paypal_sales_data).to eq ({
-            sales_cents: 325_00,
-            refunds_cents: 155_00,
-            chargebacks_cents: 160_00,
-            credits_cents: 0,
-            fees_cents: 126,
-            taxes_cents: 0,
-            affiliate_credits_cents: 0,
-            affiliate_fees_cents: -1_06
-          })
+          expect(stripe_connect_sales_data).to eq({
+                                                    sales_cents: 325_00,
+                                                    refunds_cents: 155_00,
+                                                    chargebacks_cents: 160_00,
+                                                    credits_cents: 0,
+                                                    fees_cents: 126,
+                                                    direct_fees_cents: 126,
+                                                    discover_fees_cents: 0,
+                                                    direct_sales_count: 4,
+                                                    discover_sales_count: 0,
+                                                    taxes_cents: 0,
+                                                    affiliate_credits_cents: 0,
+                                                    affiliate_fees_cents: -1_06
+                                                  })
         end
       end
 

--- a/spec/requests/balance_pages_spec.rb
+++ b/spec/requests/balance_pages_spec.rb
@@ -644,7 +644,7 @@ describe "Balance Pages Scenario", js: true, type: :system do
           expect(page).to have_text("Payout initiated on #{current_date} Instant", normalize_ws: true)
           expect(page).to have_text("Sales $0.00", normalize_ws: true)
           expect(page).to have_text("Credits $10.00", normalize_ws: true)
-          expect(page).to have_text("Fees - $0.29", normalize_ws: true)
+          expect(page).to have_text("Direct sales fees - $0.29", normalize_ws: true)
           expect(page).to have_text("Expected deposit to Bank of America on #{current_date} Routing number: 110000000 Account: ******6789 $9.70", normalize_ws: true)
         end
       end
@@ -844,7 +844,7 @@ describe "Balance Pages Scenario", js: true, type: :system do
         expect(latest_payout).to have_text("Refunds - $15.00", normalize_ws: true)
         expect(latest_payout).to have_text("Chargebacks - $10.00", normalize_ws: true)
         expect(latest_payout).not_to have_text("Discover sales fees", normalize_ws: true)
-        expect(latest_payout).to have_text("Direct sales fees on 4 sales - $4.77", normalize_ws: true)
+        expect(latest_payout).to have_text("Direct sales fees on 6 sales - $7.02", normalize_ws: true)
         expect(latest_payout).to have_text("Loan repayments - $1.50", normalize_ws: true)
         expect(latest_payout).to have_text("Affiliate or collaborator fees paid - $2.55", normalize_ws: true)
         expect(latest_payout).to have_text("PayPal payouts - $10.20", normalize_ws: true) # Remove (?) from this line


### PR DESCRIPTION
This fixes the reported issue of payout breakdown math being incorrect for a creator. The issue was because Gumroad fee from their PayPal and Stripe Connect sales was not being included in the direct and discover fees heads.