### PR TITLE
Replace all help.gumroad.com links on help center

### DIFF
--- a/app/views/help_center/articles/contents/_139-how-to-cancel-your-customers-subscriptions.html.erb
+++ b/app/views/help_center/articles/contents/_139-how-to-cancel-your-customers-subscriptions.html.erb
@@ -10,7 +10,7 @@
     <p><a href="https://gumroad.com/products"><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/6246a1dd42ba434a7afe22b3/file-JIEbnRW4ab.png" %></a></p>
     <p>This option will cancel <strong>all </strong>of your current customers' memberships. They will no longer be charged, or able to access your product. Your product will no longer be public.</p>
     <h3>Fixed-length memberships</h3>
-    <p>When building your product, you can set your membership to terminate after a <a href="https://help.gumroad.com/article/141-fixed-length-subscriptions">set number of months</a>. </p>
+    <p>When building your product, you can set your membership to terminate after a <a href="278-guide-to-memberships.html#Fixed-length-memberships-8EL39">set number of months</a>. </p>
   </div>
   <div>
     <h3>Related Articles</h3>

--- a/app/views/help_center/articles/contents/_176-metadata-for-audio-files.html.erb
+++ b/app/views/help_center/articles/contents/_176-metadata-for-audio-files.html.erb
@@ -8,7 +8,7 @@
     <p> Gumroad automatically applies metadata to all <strong>MP3</strong>, <strong>WAV, </strong><strong>FLAC</strong>, and <strong>OGG</strong> files.</p>
     <p> Where does the information come from? From information you’ve already provided.</p>
     <ul>
-      <li>Your song’s (or audiobook chapter's) <strong>title</strong> is determined by the <strong>product file’s name</strong>. If you change the name of the file while editing the product, the metadata will also change. Learn more about editing products <a href="https://help.gumroad.com/article/104-styling-your-product" rel="nofollow">here</a>.</li>
+      <li>Your song’s (or audiobook chapter's) <strong>title</strong> is determined by the <strong>product file’s name</strong>. If you change the name of the file while editing the product, the metadata will also change. Learn more about editing products <a href="101-designing-your-product-page.html" rel="nofollow">here</a>.</li>
       <li>Your creator name becomes the ‘artist’ name. And if you haven’t chosen and entered a name on your Gumroad account, well, you should, but if not, we’ll leave this blank. If you still need to set a name for your account, go to your <a href="http://www.gumroad.com/settings" target="_blank">Settings menu</a>, create a <strong>Username</strong>, and click <strong>Update Account details</strong>. Then go to your Profile page and change your name.</li>
       <li>Your <strong>product’s name</strong> will become the <strong>album title</strong>.</li>
       <li>The first cover image you upload (as long as it’s a PNG or a JPG) will be encoded as the track’s cover.</li>

--- a/app/views/help_center/articles/contents/_190-how-do-i-get-a-refund.html.erb
+++ b/app/views/help_center/articles/contents/_190-how-do-i-get-a-refund.html.erb
@@ -8,7 +8,7 @@
     </ul>
     <hr role="separator">
     <h3 id="Website-purchases-YEQit">Website purchases</h3>
-    <p>When you buy a product from a Gumroad creator, Gumroad only processes payments on behalf of that creator. We allow creators on our platform to <a href="/help/../help.gumroad.com/article/51-what-is-gumroads-refund-policy.html">set their own refund policies</a> and issue their own refunds to their customers (i.e. you!).</p>
+    <p>When you buy a product from a Gumroad creator, Gumroad only processes payments on behalf of that creator. We allow creators on our platform to <a href="51-what-is-gumroads-refund-policy.html">set their own refund policies</a> and issue their own refunds to their customers (i.e. you!).</p>
     <p>Unfortunately, we can't issue an immediate refund unless the charge was <a href="https://gumroad.com/help/article/283-fraudulent-purchases">fraudulent</a> or a duplicate.</p>
     <p>Please write to us if you haven’t heard back from the creator for 30 days since first contacting them, along with the proof of correspondence. We will reach out to them and will issue a refund if they continue to be unresponsive.</p>
     <p>If you have issues with the product you've purchased through Gumroad or feel you deserve a refund, you should contact the creator of the product. </p>
@@ -20,7 +20,7 @@
     <p>If you didn’t receive a receipt, please first check the spam folder in your email inbox. If you still cannot find your receipt, please go through the steps <a href="212-i-never-received-a-receipt.html" target="_self">on this page</a>.</p>
     <br>
     <h3 id="In-App-Purchases-GL6fX">In-App purchases</h3>
-    <p>Refunds for in-app purchases are handled independently by Apple/Google support, so if you made a purchase on the <a href="/help/../help.gumroad.com/article/177-the-gumroad-dashboard-app.html#Download-the-app-a0fEa">Gumroad mobile app</a>, neither the creator nor Gumroad can refund your purchase.</p>
+    <p>Refunds for in-app purchases are handled independently by Apple/Google support, so if you made a purchase on the <a href="177-the-gumroad-dashboard-app.html#Download-the-app-a0fEa">Gumroad mobile app</a>, neither the creator nor Gumroad can refund your purchase.</p>
     <br>
     <p>If you need a refund for an in-app purchase, please contact <a href="https://support.apple.com/en-au/118223">Apple</a> (for IOS devices) or <a href="https://support.google.com/googleplay/answer/2479637?sjid=15689087848422407774-AP">Google support</a> (for Android devices).</p>
   </div>

--- a/app/views/help_center/articles/contents/_191-a-guide-to-buying-on-gumroad.html.erb
+++ b/app/views/help_center/articles/contents/_191-a-guide-to-buying-on-gumroad.html.erb
@@ -111,7 +111,7 @@
     <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/64b7a354a9d61472afe08fc3/file-ZiXZZKDuYd.png" %></figure>
     <h3 id="Your-purchase-is-complete-FnqWf">Your purchase is complete</h3>
     <p>After you've bought a product on Gumroad, you can enter a password to <a href="https://gumroad.com/signup">sign up</a> for a Gumroad account. Why would you do this? To take advantage of the <a href="https://gumroad.com/library">Gumroad Library</a>. The Library allows you to access your product at any time by logging into Gumroad. If you are buying a membership, you have to create a Gumroad account at the time of purchase.</p>
-    <p>From your Gumroad receipt, you can also easily repurchase a product, download the product, or open it in our <a href="/help/../help.gumroad.com/article/177-the-gumroad-dashboard-app.html" target="_self">iOS or Android app</a>.</p>
+    <p>From your Gumroad receipt, you can also easily repurchase a product, download the product, or open it in our <a href="177-the-gumroad-dashboard-app.html" target="_self">iOS or Android app</a>.</p>
   </div>
   <div>
     <h3>Related Articles</h3>

--- a/app/views/help_center/articles/contents/_193-my-purchase-isnt-downloading.html.erb
+++ b/app/views/help_center/articles/contents/_193-my-purchase-isnt-downloading.html.erb
@@ -3,7 +3,7 @@
   <div>
     <p>Here are the most common reasons why a download may not be working from Gumroad:</p>
     <h3>Downloading on mobile devices</h3>
-    <p>Please use our <a href="/help/../help.gumroad.com/article/177-the-gumroad-dashboard-app.html" target="_self">mobile app</a> to download files directly to your device, or:</p>
+    <p>Please use our <a href="177-the-gumroad-dashboard-app.html" target="_self">mobile app</a> to download files directly to your device, or:</p>
     <ol>
       <li>Download the files to your laptop or desktop computer</li>
       <li>Sync the files to your device. You can do this with services like iCloud, Google Drive, etc.</li>

--- a/app/views/help_center/articles/contents/_198-your-gumroad-library.html.erb
+++ b/app/views/help_center/articles/contents/_198-your-gumroad-library.html.erb
@@ -14,7 +14,7 @@
     <p>You can easily see your archived products again by clicking “Show archived only” on the left side of your screen, and unarchive them again from the three-dots menu.</p>
     <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/64b7bc79c2f5ed048130c846/file-hnL4nj8I1W.png" %></figure>
     <h3>The Gumroad mobile app</h3>
-    <p>You can also access your Library from our iOS or Android mobile app. <a href="/help/../help.gumroad.com/article/177-the-gumroad-dashboard-app.html" target="_self">Read this article</a> to know all about downloading and using our app!</p>
+    <p>You can also access your Library from our iOS or Android mobile app. <a href="177-the-gumroad-dashboard-app.html" target="_self">Read this article</a> to know all about downloading and using our app!</p>
     <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/654dedfc2d28585006d0164c/file-jcOHcoXhih.png" %></figure>
   </div>
   <div>

--- a/app/views/help_center/articles/contents/_74-the-analytics-dashboard.html.erb
+++ b/app/views/help_center/articles/contents/_74-the-analytics-dashboard.html.erb
@@ -205,7 +205,7 @@
           <td> Recurring Charge? </td>
           <td> If "0" = The item is a one-time purchase, or the  <strong>initial charge</strong> for a subscription product. <br>
             If "1" = This is an automated recurring charge for a subscription product. Note that each subsequent charge will appear on its own line.  <br>
-            For more information, see our <a href="https://help.gumroad.com/article/83-subscription-products">help center article on subscriptions.</a></td>
+            For more information, see our <a href="82-membership-products.html">help center article on subscriptions.</a></td>
         </tr>
         <tr>
           <td> Free trial purchase? </td>


### PR DESCRIPTION
This PR updates all help.gumroad.com links in the Help Center. Some links previously led to 404 (not found) pages, while others pointed to the helper homepage instead of the intended help articles.