### PR TITLE
fix(styles): make currency selector readable in dark mode

### DIFF
--- a/app/javascript/stylesheets/_pill.scss
+++ b/app/javascript/stylesheets/_pill.scss
@@ -37,6 +37,13 @@ $pill-icons: (
       width: 100%;
       opacity: 0;
       cursor: pointer;
+      color: var(--color);
+      background-color: full-color(filled);
+      
+      option {
+        color: var(--color);
+        background-color: full-color(filled);
+      }
     }
   }
 


### PR DESCRIPTION
Change:
Set color and background-color on `.pill.select` select and its option elements to use theme variables (var(--color) and full-color(filled)).
Reason:
Native <select> dropdowns weren’t inheriting theme colors.
Since the <select> inside `.pill.select` is set to opacity: 0, this caused gray text on white background in dark mode.

Before:
<img width="825" height="860" alt="image" src="https://github.com/user-attachments/assets/43eb199b-d912-4024-9c32-bd8796f0f92c" />
After:
<img width="743" height="836" alt="image" src="https://github.com/user-attachments/assets/71f65cb2-1b8f-4d82-a2a4-e84a657675f5" />