### PR TITLE
Add missing S3 bucket setup guide to `windows.md`

### DIFF
--- a/docs/development/windows.md
+++ b/docs/development/windows.md
@@ -134,11 +134,38 @@ npm install
 
 ### Optional: Create `.env` file
 
-Copy the example and fill in secrets (if needed):
+App can be booted without any custom credentials. But if you would like to use services that require custom credentials (e.g. S3, Stripe, Resend, etc.), you can copy the `.env.example` file to `.env` and fill in the values.:
 
 ```bash
 cp .env.example .env
 ```
+
+#### S3 Bucket Setup
+
+After configuring your AWS credentials, you need to create the specific S3 buckets required for development. The application uses hardcoded bucket names as defined in `config/initializers/aws.rb`:
+
+**Required S3 Buckets:**
+
+- `gumroad_dev` - Main storage bucket for development
+- `gumroad-dev-public-storage` - Public storage bucket for development
+
+**Create the buckets using AWS CLI:**
+
+```bash
+aws s3 mb s3://gumroad_dev
+aws s3 mb s3://gumroad-dev-public-storage
+```
+
+**Or create them via AWS Console:**
+
+1. Go to the [S3 Console](https://console.aws.amazon.com/s3/)
+2. Click "Create bucket"
+3. Enter bucket name: `gumroad_dev`
+4. Choose your preferred region (should match `AWS_DEFAULT_REGION`)
+5. Keep default settings and create the bucket
+6. Repeat steps 2-5 for `gumroad-dev-public-storage`
+
+> **Note:** These exact bucket names are required because they are hardcoded in the application configuration. Using different names will result in `AccessDenied` errors during file uploads.
 
 ### SSL Certificates with `mkcert`
 


### PR DESCRIPTION
The `windows.md` guide was missing the S3 bucket setup instructions that are already included in `README.md`.
This PR adds the S3 setup guide to `windows.md` to keep the documentation consistent and complete.