### PR TITLE
Improved payout pause messaging to distinguish between Stripe and admin-initiated pauses

### DIFF
--- a/app/business/payments/payouts/payouts.rb
+++ b/app/business/payments/payouts/payouts.rb
@@ -16,8 +16,8 @@ class Payouts
     end
 
     if user.payouts_paused?
-      paused_by = user.payouts_paused_internally? ? "admin" : "creator"
-      user.add_payout_note(content: "Payout on #{payout_date} was skipped because payouts on the account were paused by #{paused_by == 'admin' ? 'the admin' : 'you'}.") if add_comment
+      payouts_paused_by = user.payouts_paused_by_source == User::PAYOUT_PAUSE_SOURCE_STRIPE ? "payout processor" : user.payouts_paused_by_source
+      user.add_payout_note(content: "Payout on #{payout_date} was skipped because payouts on the account were paused by the #{payouts_paused_by}.") if add_comment
       return false
     end
 

--- a/app/controllers/admin/users/payouts_controller.rb
+++ b/app/controllers/admin/users/payouts_controller.rb
@@ -81,13 +81,26 @@ class Admin::Users::PayoutsController < Admin::BaseController
   end
 
   def pause
-    @user.update!(payouts_paused_internally: true)
+    reason = params.require(:pause_payouts).permit(:reason)[:reason]
+    @user.update!(payouts_paused_internally: true, payouts_paused_by: current_user.id)
+    @user.comments.create!(
+      author_id: current_user.id,
+      content: reason,
+      comment_type: Comment::COMMENT_TYPE_PAYOUTS_PAUSED
+    ) if reason.present?
 
     render json: { success: true, message: "User's payouts paused" }
   end
 
   def resume
-    @user.update!(payouts_paused_internally: false)
+    render json: { success: false } and return unless @user.payouts_paused_internally?
+
+    @user.update!(payouts_paused_internally: false, payouts_paused_by: nil)
+    @user.comments.create!(
+      author_id: current_user.id,
+      content: "Payouts resumed.",
+      comment_type: Comment::COMMENT_TYPE_PAYOUTS_RESUMED
+    )
 
     render json: { success: true, message: "User's payouts resumed" }
   end

--- a/app/javascript/components/server-components/Admin/PausePayoutsForm.tsx
+++ b/app/javascript/components/server-components/Admin/PausePayoutsForm.tsx
@@ -1,0 +1,66 @@
+import * as React from "react";
+import { createCast } from "ts-safe-cast";
+
+import { register } from "$app/utils/serverComponentUtil";
+
+import { Form } from "$app/components/Admin/Form";
+import { showAlert } from "$app/components/server-components/Alert";
+
+export const AdminPausePayoutsForm = ({
+  user_id,
+  payouts_paused_by,
+  reason,
+}: {
+  user_id: number;
+  payouts_paused_by: "stripe" | "admin" | "system" | "user" | null;
+  reason: string | null;
+}) => {
+  const admin_can_resume_payouts = payouts_paused_by && ["admin", "system", "stripe"].includes(payouts_paused_by);
+
+  return (
+    <Form
+      url={
+        admin_can_resume_payouts
+          ? Routes.resume_admin_user_payouts_path(user_id)
+          : Routes.pause_admin_user_payouts_path(user_id)
+      }
+      method="POST"
+      confirmMessage={`Are you sure you want to ${admin_can_resume_payouts ? "resume" : "pause"} payouts for user ${user_id}?`}
+      onSuccess={() => showAlert(admin_can_resume_payouts ? "Payouts resumed" : "Payouts paused", "success")}
+    >
+      {(isLoading) => (
+        <fieldset>
+          <div className="input-with-button" style={{ alignItems: "end" }}>
+            {payouts_paused_by === "admin" ? (
+              <p>Payouts are currently paused by Gumroad admin. Reason: {reason}</p>
+            ) : payouts_paused_by === "system" ? (
+              <p>Payouts are currently automatically paused by the system. See comments below for details.</p>
+            ) : payouts_paused_by === "stripe" ? (
+              <p>Payouts are currently paused by Stripe because of pending verification requirements.</p>
+            ) : (
+              <div style={{ display: "grid", gap: "var(--spacer-2)" }}>
+                {payouts_paused_by === "user" && <p>Payouts are currently paused by the creator.</p>}
+                <textarea
+                  name="pause_payouts[reason]"
+                  rows={2}
+                  placeholder="Add a reason for pausing payouts. It'll be displayed to the user on their dashboard."
+                />
+              </div>
+            )}
+            <button type="submit" className="button" disabled={isLoading}>
+              {isLoading
+                ? admin_can_resume_payouts
+                  ? "Resuming Payouts"
+                  : "Pausing Payouts"
+                : admin_can_resume_payouts
+                  ? "Resume Payouts"
+                  : "Pause Payouts"}
+            </button>
+          </div>
+        </fieldset>
+      )}
+    </Form>
+  );
+};
+
+export default register({ component: AdminPausePayoutsForm, propParser: createCast() });

--- a/app/javascript/components/server-components/BalancePage.tsx
+++ b/app/javascript/components/server-components/BalancePage.tsx
@@ -603,6 +603,8 @@ const BalancePage = ({
   next_payout_period_data,
   processing_payout_periods_data,
   payouts_status,
+  payouts_paused_by,
+  payouts_paused_for_reason,
   past_payout_period_data,
   instant_payout,
   show_instant_payouts_notice,
@@ -614,6 +616,8 @@ const BalancePage = ({
     | null;
   processing_payout_periods_data: PayoutPeriodData[];
   payouts_status: "paused" | "payable";
+  payouts_paused_by: "stripe" | "admin" | "system" | "user" | null;
+  payouts_paused_for_reason: string | null;
   past_payout_period_data: PayoutPeriodData[];
   instant_payout: {
     payable_amount_cents: number;
@@ -854,7 +858,27 @@ const BalancePage = ({
         {payouts_status === "paused" ? (
           <div className="warning" role="status">
             <p>
-              <strong>Your payouts have been paused.</strong>
+              {payouts_paused_by === "stripe" ? (
+                <strong>
+                  Your payouts are currently paused by our payment processor. Please check your{" "}
+                  <a href="/settings/payments">Payment Settings</a> for any verification requirements.
+                </strong>
+              ) : payouts_paused_by === "admin" ? (
+                <strong>
+                  Your payouts have been paused by Gumroad admin.
+                  {payouts_paused_for_reason ? ` Reason for pause: ${payouts_paused_for_reason}` : null}
+                </strong>
+              ) : payouts_paused_by === "system" ? (
+                <strong>
+                  Your payouts have been automatically paused for a security review and will be resumed once the review
+                  completes.
+                </strong>
+              ) : (
+                <strong>
+                  You have paused your payouts. Please go to <a href="/settings/payments">Payment Settings</a> to resume
+                  payouts.
+                </strong>
+              )}
             </p>
           </div>
         ) : null}

--- a/app/javascript/components/server-components/Settings/PaymentsPage.tsx
+++ b/app/javascript/components/server-components/Settings/PaymentsPage.tsx
@@ -144,6 +144,8 @@ type Props = {
   saved_card: SavedCreditCard | null;
   formatted_balance_to_forfeit: string | null;
   payouts_paused_internally: boolean;
+  payouts_paused_by: "stripe" | "admin" | "system" | "user" | null;
+  payouts_paused_for_reason: string | null;
   payouts_paused_by_user: boolean;
   payout_threshold_cents: number;
   minimum_payout_threshold_cents: number;
@@ -820,6 +822,31 @@ const PaymentsPage = (props: Props) => {
         />
       ) : null}
       <form ref={formRef}>
+        {props.payouts_paused_by !== null ? (
+          <div className="warning" role="status" style={{ marginBottom: "var(--spacer-7)" }}>
+            <p>
+              {props.payouts_paused_by === "stripe" ? (
+                <strong>
+                  Your payouts are currently paused by our payment processor. Please check for any pending verification
+                  requirements below.
+                </strong>
+              ) : props.payouts_paused_by === "admin" ? (
+                <strong>
+                  Your payouts have been paused by Gumroad admin.
+                  {props.payouts_paused_for_reason ? ` Reason for pause: ${props.payouts_paused_for_reason}` : null}
+                </strong>
+              ) : props.payouts_paused_by === "system" ? (
+                <strong>
+                  Your payouts have been automatically paused for a security review and will be resumed once the review
+                  completes.
+                </strong>
+              ) : (
+                <strong>You have paused your payouts.</strong>
+              )}
+            </p>
+          </div>
+        ) : null}
+
         <section>
           <header>
             <h2>Verification</h2>
@@ -936,7 +963,17 @@ const PaymentsPage = (props: Props) => {
               )}
             </fieldset>
             {props.payouts_paused_internally ? (
-              <WithTooltip tip="Your payouts were paused by our payment processor. Please update your information below.">
+              <WithTooltip
+                tip={
+                  props.payouts_paused_by === "stripe"
+                    ? "Your payouts are currently paused by our payment processor. Please check for any pending verification requirements above."
+                    : props.payouts_paused_by === "admin"
+                      ? `Your payouts have been paused by Gumroad admin.${props.payouts_paused_for_reason && ` Reason for pause: ${props.payouts_paused_for_reason}`}`
+                      : props.payouts_paused_by === "system"
+                        ? "Your payouts have been automatically paused for a security review and will be resumed once the review completes."
+                        : null
+                }
+              >
                 {payoutsPausedToggle}
               </WithTooltip>
             ) : (

--- a/app/javascript/packs/admin_review.ts
+++ b/app/javascript/packs/admin_review.ts
@@ -9,6 +9,7 @@ import AdminChangeEmailForm from "$app/components/server-components/Admin/Change
 import AdminFlagForFraudForm from "$app/components/server-components/Admin/FlagForFraudForm";
 import AdminManualPayoutForm from "$app/components/server-components/Admin/ManualPayoutForm";
 import AdminMassTransferPurchasesForm from "$app/components/server-components/Admin/MassTransferPurchasesForm";
+import AdminPausePayoutsForm from "$app/components/server-components/Admin/PausePayoutsForm";
 import AdminProductAttributesAndInfo from "$app/components/server-components/Admin/ProductAttributesAndInfo";
 import AdminProductPurchases from "$app/components/server-components/Admin/ProductPurchases";
 import AdminProductStats from "$app/components/server-components/Admin/ProductStats";
@@ -26,6 +27,7 @@ ReactOnRails.register({
   AdminFlagForFraudForm,
   AdminManualPayoutForm,
   AdminMassTransferPurchasesForm,
+  AdminPausePayoutsForm,
   AdminProductAttributesAndInfo,
   AdminProductPurchases,
   AdminProductStats,

--- a/app/javascript/ssr.ts
+++ b/app/javascript/ssr.ts
@@ -11,6 +11,7 @@ import AdminFlagForFraudForm from "$app/components/server-components/Admin/FlagF
 import AdminManualPayoutForm from "$app/components/server-components/Admin/ManualPayoutForm";
 import AdminMassTransferPurchasesForm from "$app/components/server-components/Admin/MassTransferPurchasesForm";
 import AdminNav from "$app/components/server-components/Admin/Nav";
+import AdminPausePayoutsForm from "$app/components/server-components/Admin/PausePayoutsForm";
 import AdminProductAttributesAndInfo from "$app/components/server-components/Admin/ProductAttributesAndInfo";
 import AdminProductPurchases from "$app/components/server-components/Admin/ProductPurchases";
 import AdminProductStats from "$app/components/server-components/Admin/ProductStats";
@@ -110,6 +111,7 @@ ReactOnRails.register({
   AdminManualPayoutForm,
   AdminMassTransferPurchasesForm,
   AdminNav,
+  AdminPausePayoutsForm,
   AdminProductAttributesAndInfo,
   AdminProductPurchases,
   AdminProductStats,

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -15,6 +15,8 @@ class Comment < ApplicationRecord
   COMMENT_TYPE_SUSPENSION_NOTE = "suspension_note"
   COMMENT_TYPE_BALANCE_FORFEITED = "balance_forfeited"
   COMMENT_TYPE_COUNTRY_CHANGED = "country_changed"
+  COMMENT_TYPE_PAYOUTS_PAUSED = "payouts_paused"
+  COMMENT_TYPE_PAYOUTS_RESUMED = "payouts_resumed"
   RISK_STATE_COMMENT_TYPES = [COMMENT_TYPE_COMPLIANT, COMMENT_TYPE_ON_PROBATION, COMMENT_TYPE_FLAGGED, COMMENT_TYPE_SUSPENDED]
   MAX_ALLOWED_DEPTH = 4 # Depth of a root comment starts with 0.
 
@@ -39,6 +41,8 @@ class Comment < ApplicationRecord
 
   scope :with_type_payout_note, -> { where(comment_type: COMMENT_TYPE_PAYOUT_NOTE) }
   scope :with_type_on_probation, -> { where(comment_type: COMMENT_TYPE_ON_PROBATION) }
+  scope :with_type_payouts_paused, -> { where(comment_type: COMMENT_TYPE_PAYOUTS_PAUSED) }
+  scope :with_type_payouts_resumed, -> { where(comment_type: COMMENT_TYPE_PAYOUTS_RESUMED) }
 
   def mark_subtree_deleted!
     transaction do

--- a/app/models/concerns/purchase/blockable.rb
+++ b/app/models/concerns/purchase/blockable.rb
@@ -181,7 +181,7 @@ module Purchase::Blockable
 
       failed_price_cents = failed_seller_purchases.sum(:price_cents)
       if failed_price_cents > max_seller_failed_purchases_price_cents
-        seller.update!(payouts_paused_internally: true)
+        seller.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_SYSTEM)
 
         failed_price_amount = MoneyFormatter.format(failed_price_cents, :usd, no_cents_if_whole: true, symbol: true)
         seller.comments.create(

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -154,6 +154,7 @@ class User < ApplicationRecord
   attr_json_data_accessor :payout_threshold_cents, default: -> { minimum_payout_threshold_cents }
   attr_json_data_accessor :payout_frequency, default: User::PayoutSchedule::WEEKLY
   attr_json_data_accessor :custom_fee_per_thousand
+  attr_json_data_accessor :payouts_paused_by
 
   validates :username, uniqueness: { case_sensitive: true },
                        length: { minimum: 3, maximum: 20 },
@@ -868,6 +869,20 @@ class User < ApplicationRecord
 
   def payouts_paused?
     payouts_paused_internally? || payouts_paused_by_user?
+  end
+
+  def payouts_paused_by_source
+    return nil unless payouts_paused?
+
+    if payouts_paused_internally?
+      [PAYOUT_PAUSE_SOURCE_STRIPE, PAYOUT_PAUSE_SOURCE_SYSTEM].include?(payouts_paused_by) ? payouts_paused_by : PAYOUT_PAUSE_SOURCE_ADMIN
+    elsif payouts_paused_by_user?
+      PAYOUT_PAUSE_SOURCE_USER
+    end
+  end
+
+  def payouts_paused_for_reason
+    payouts_paused_by_source == PAYOUT_PAUSE_SOURCE_ADMIN ? comments.with_type_payouts_paused.last&.content : nil
   end
 
   def made_a_successful_sale_with_a_stripe_connect_or_paypal_connect_account?

--- a/app/modules/user/risk.rb
+++ b/app/modules/user/risk.rb
@@ -205,6 +205,11 @@ module User::Risk
       end
   end
 
+  PAYOUT_PAUSE_SOURCES = %w[stripe admin system user].freeze
+  PAYOUT_PAUSE_SOURCES.each do |source|
+    self.const_set("PAYOUT_PAUSE_SOURCE_#{source.upcase}", source)
+  end
+
   class_methods do
     def refund_queue(from_date = 7.days.ago)
       user_ids = MONGO_DATABASE[MongoCollections::USER_SUSPENSION_TIME]

--- a/app/presenters/payouts_presenter.rb
+++ b/app/presenters/payouts_presenter.rb
@@ -23,6 +23,8 @@ class PayoutsPresenter
         item.merge(has_stripe_connect: seller.stripe_connect_account.present?)
       end,
       payouts_status: seller.payouts_status,
+      payouts_paused_by: seller.payouts_paused_by_source,
+      payouts_paused_for_reason: seller.payouts_paused_for_reason,
       past_payout_period_data: past_payouts.map { payout_period_data(seller, _1) },
       instant_payout: seller.instant_payouts_supported? ? {
         payable_amount_cents: seller.instantly_payable_unpaid_balance_cents,

--- a/app/presenters/settings_presenter.rb
+++ b/app/presenters/settings_presenter.rb
@@ -220,6 +220,8 @@ class SettingsPresenter
       saved_card: CheckoutPresenter.saved_card(seller.credit_card),
       formatted_balance_to_forfeit: seller.formatted_balance_to_forfeit(:country_change),
       payouts_paused_internally: seller.payouts_paused_internally?,
+      payouts_paused_by: seller.payouts_paused_by_source,
+      payouts_paused_for_reason: seller.payouts_paused_for_reason,
       payouts_paused_by_user: seller.payouts_paused_by_user?,
       payout_threshold_cents: seller.minimum_payout_amount_cents,
       minimum_payout_threshold_cents: seller.minimum_payout_threshold_cents,

--- a/app/views/admin/users/_user_permission_payouts.html.erb
+++ b/app/views/admin/users/_user_permission_payouts.html.erb
@@ -8,7 +8,7 @@
 
   <hr>
   <div style="display: grid; gap: var(--spacer-4); grid-template-columns: repeat(auto-fit, minmax(var(--dynamic-grid), 1fr)); place-items: flex-start">
-    <div class="paragraphs">
+    <div class="paragraphs" style="width: 100%">
       <h3>Payout info</h3>
       <div>
         <% case %>
@@ -22,13 +22,8 @@
           This user has no payout method.
         <% end %>
       </div>
-      <div class="button-group">
-        <% if user.payouts_paused? %>
-          <%= admin_action label: "Resume payouts", url: resume_admin_user_payouts_path(user), loading: "Resuming payouts...", done: "Payouts resumed!", success_message: "Payouts resumed!" %>
-        <% else %>
-          <%= admin_action label: "Pause payouts", url: pause_admin_user_payouts_path(user), loading: "Pausing payouts...", done: "Payouts paused!", success_message: "Payouts paused!", outline: true, color: "warning" %>
-        <% end %>
-      </div>
+      <hr>
+      <%= react_component "AdminPausePayoutsForm", props: { user_id: user.id, payouts_paused_by: user.payouts_paused_by_source, reason: user.comments.with_type_payouts_paused.last&.content }, prerender: true %>
 
       <% last_payout_to_user = user.payments.last %>
       <% if last_payout_to_user.nil? || %w(completed failed returned reversed cancelled).include?(last_payout_to_user.state) %>

--- a/app/views/help_center/articles/contents/_281-payout-delays.html.erb
+++ b/app/views/help_center/articles/contents/_281-payout-delays.html.erb
@@ -35,7 +35,9 @@
     <h3>Reason 4: There is an issue with your verification</h3>
     <figure><%= image_tag "help_center/stripe-verification-ui.png" %></figure>
     <p>Payouts may be paused by our payment processor if you have not completed your account's identity or business verification. You can check your <a href="https://gumroad.com/settings/payments">Payment Settings</a> page for details on what is missing or why your verification is failing.</p>
-    <h3>Reason 5: Today <em>might not</em> actually be your pay day</h3>
+    <h3>Reason 5: Your payouts are paused</h3>
+    <p>Your payouts may be paused by the Gumroad administrator for a security review or if there is any unusual activity detected on the account. You can check your <a href="https://gumroad.com/settings/payments">Payment Settings</a> page for details on why your payouts have been paused.</p>
+    <h3>Reason 6: Today <em>might not</em> actually be your pay day</h3>
     <p> We often have creators write in asking why they had not been paid on a Friday, and when we investigate the situation we see that they were not, in fact, supposed to have received money. </p>
     <p> As per <a href="13-getting-paid.html">Getting Paid</a>, we pay out every Friday for all sales made <em>up to the previous Friday</em>. For example:</p>
     <ul>
@@ -44,7 +46,7 @@
     </ul>
     <p> In other words, that means the money sent out to you on a Friday has to have come from a sale that is <em>at least 7 days old</em>. If you make a sale on a Tuesday, you would not be receiving the profits from that sale three days later, unfortunately. You would have to wait until the following Friday to be paid out. In visual terms: </p>
     <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/6260e1386c886c75aabe8dd4/file-2RvnwJQNOe.png" %></figure>
-    <h3>Reason 6: Your sales are not legitimate (or made by yourself)</h3>
+    <h3>Reason 7: Your sales are not legitimate (or made by yourself)</h3>
     <p> Another reason your account may be stuck in review is that you are purchasing your own products. We understand you might do this to "test" our payment system or to boost your products on Discover, but purchases made by the creator are not considered legitimate sales, so they do not get paid out even after reaching a $10 balance. Our banking partners view these transactions as a form of money laundering, and we are required to refund them when we find them. </p>
     <p> Only sales made by real customers count as legitimate, and we only process payouts for those. To get paid, focus on making real sales to real customers. </p>
   </div>

--- a/spec/models/concerns/purchase/blockable_spec.rb
+++ b/spec/models/concerns/purchase/blockable_spec.rb
@@ -579,6 +579,7 @@ describe Purchase::Blockable do
           purchase.mark_failed!
 
           expect(seller.reload.payouts_paused_internally).to be(false)
+          expect(seller.payouts_paused_by_source).to be nil
         end
       end
 
@@ -589,6 +590,7 @@ describe Purchase::Blockable do
           purchase.mark_failed!
 
           expect(seller.reload.payouts_paused_internally).to be(false)
+          expect(seller.payouts_paused_by_source).to be nil
         end
       end
 
@@ -602,6 +604,7 @@ describe Purchase::Blockable do
           old_purchase.mark_failed!
 
           expect(old_seller.reload.payouts_paused_internally).to be(false)
+          expect(old_seller.payouts_paused_by_source).to be nil
         end
 
         it "does not create a comment" do
@@ -622,6 +625,7 @@ describe Purchase::Blockable do
           newer_purchase.mark_failed!
 
           expect(newer_seller.reload.payouts_paused_internally).to be(true)
+          expect(newer_seller.payouts_paused_by_source).to eq(User::PAYOUT_PAUSE_SOURCE_SYSTEM)
         end
       end
 
@@ -631,6 +635,7 @@ describe Purchase::Blockable do
           purchase.mark_failed!
 
           expect(seller.reload.payouts_paused_internally).to be(false)
+          expect(seller.payouts_paused_by_source).to be nil
         end
       end
 
@@ -640,6 +645,7 @@ describe Purchase::Blockable do
           purchase.mark_failed!
 
           expect(seller.reload.payouts_paused_internally).to be(true)
+          expect(seller.payouts_paused_by_source).to eq(User::PAYOUT_PAUSE_SOURCE_SYSTEM)
         end
 
         it "creates a comment with the failed amount" do
@@ -659,6 +665,7 @@ describe Purchase::Blockable do
               create_list(:failed_purchase, 3, link: product, price_cents: 250, created_at: 61.minutes.ago)
               purchase.mark_failed!
               expect(seller.reload.payouts_paused_internally).to be(false)
+              expect(seller.payouts_paused_by_source).to be nil
             end
           end
         end
@@ -677,6 +684,7 @@ describe Purchase::Blockable do
             purchase.mark_failed!
 
             expect(seller.reload.payouts_paused_internally).to be(false)
+            expect(seller.payouts_paused_by_source).to be nil
           end
         end
 
@@ -687,6 +695,7 @@ describe Purchase::Blockable do
             purchase.mark_failed!
 
             expect(seller.reload.payouts_paused_internally).to be(true)
+            expect(seller.payouts_paused_by_source).to eq(User::PAYOUT_PAUSE_SOURCE_SYSTEM)
           end
         end
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3092,6 +3092,89 @@ describe User, :vcr do
     end
   end
 
+  describe "#payouts_paused_by_source" do
+    let!(:seller) { create(:user) }
+
+    it "returns source as admin if payouts are paused internally by an admin" do
+      seller.update!(payouts_paused_internally: true)
+      expect(seller.payouts_paused_by_source).to eq(User::PAYOUT_PAUSE_SOURCE_ADMIN)
+
+      seller.update!(payouts_paused_internally: true, payouts_paused_by: 1)
+      expect(seller.payouts_paused_by_source).to eq(User::PAYOUT_PAUSE_SOURCE_ADMIN)
+    end
+
+    it "returns source as stripe if payouts are paused internally by stripe" do
+      seller.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_STRIPE)
+      expect(seller.payouts_paused_by_source).to eq(User::PAYOUT_PAUSE_SOURCE_STRIPE)
+    end
+
+    it "returns source as system if payouts are automatically paused internally" do
+      seller.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_SYSTEM)
+      expect(seller.payouts_paused_by_source).to eq(User::PAYOUT_PAUSE_SOURCE_SYSTEM)
+    end
+
+    it "returns source as user if payouts are paused by seller" do
+      seller.update!(payouts_paused_internally: false, payouts_paused_by_user: true, payouts_paused_by: nil)
+      expect(seller.payouts_paused_by_source).to eq(User::PAYOUT_PAUSE_SOURCE_USER)
+    end
+
+    it "returns source as admin if payouts are paused by seller as well as admin" do
+      seller.update!(payouts_paused_internally: true, payouts_paused_by_user: true, payouts_paused_by: User.last.id)
+      expect(seller.payouts_paused_by_source).to eq(User::PAYOUT_PAUSE_SOURCE_ADMIN)
+    end
+
+    it "returns source as stripe if payouts are paused by seller as well as stripe" do
+      seller.update!(payouts_paused_internally: true, payouts_paused_by_user: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_STRIPE)
+      expect(seller.payouts_paused_by_source).to eq(User::PAYOUT_PAUSE_SOURCE_STRIPE)
+    end
+
+    it "returns source as system if payouts are paused by seller as well as system" do
+      seller.update!(payouts_paused_internally: true, payouts_paused_by_user: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_SYSTEM)
+      expect(seller.payouts_paused_by_source).to eq(User::PAYOUT_PAUSE_SOURCE_SYSTEM)
+    end
+  end
+
+  describe "#payouts_paused_for_reason" do
+    let!(:seller) { create(:user) }
+
+    it "returns nil if payouts are not paused internally" do
+      expect(seller.payouts_paused_for_reason).to be nil
+    end
+
+    it "returns nil if payouts are paused by admin but there are no corresponding comments" do
+      seller.update!(payouts_paused_internally: true, payouts_paused_by: User.last.id)
+      expect(seller.reload.payouts_paused_by_source).to eq(User::PAYOUT_PAUSE_SOURCE_ADMIN)
+      expect(seller.payouts_paused_for_reason).to be nil
+    end
+
+    it "returns the content of the last comment of payouts_paused type if payouts are paused by admin" do
+      seller.update!(payouts_paused_internally: true, payouts_paused_by: User.last.id)
+      seller.comments.create!(
+        author_id: User.last.id,
+        content: "Chargeback rate too high.",
+        comment_type: Comment::COMMENT_TYPE_PAYOUTS_PAUSED
+      )
+      expect(seller.reload.payouts_paused_by_source).to eq(User::PAYOUT_PAUSE_SOURCE_ADMIN)
+      expect(seller.payouts_paused_for_reason).to eq("Chargeback rate too high.")
+    end
+
+    it "returns nil if payouts are not paused by admin" do
+      seller.comments.create!(
+        author_id: User.last.id,
+        content: "Chargeback rate too high.",
+        comment_type: Comment::COMMENT_TYPE_PAYOUTS_PAUSED
+      )
+
+      seller.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_STRIPE)
+      expect(seller.reload.payouts_paused_by_source).to eq(User::PAYOUT_PAUSE_SOURCE_STRIPE)
+      expect(seller.payouts_paused_for_reason).to be nil
+
+      seller.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_SYSTEM)
+      expect(seller.reload.payouts_paused_by_source).to eq(User::PAYOUT_PAUSE_SOURCE_SYSTEM)
+      expect(seller.payouts_paused_for_reason).to be nil
+    end
+  end
+
   describe "#minimum_payout_amount_cents" do
     let(:user) { create(:user) }
 

--- a/spec/presenters/settings_presenter_spec.rb
+++ b/spec/presenters/settings_presenter_spec.rb
@@ -535,6 +535,8 @@ describe SettingsPresenter do
         saved_card: nil,
         formatted_balance_to_forfeit: nil,
         payouts_paused_internally: false,
+        payouts_paused_by: nil,
+        payouts_paused_for_reason: nil,
         payouts_paused_by_user: false,
         payout_threshold_cents: 1000,
         minimum_payout_threshold_cents: 1000,
@@ -792,6 +794,51 @@ describe SettingsPresenter do
 
       it "returns true for can_connect_stripe" do
         expect(presenter.payments_props[:user][:can_connect_stripe]).to eq(true)
+      end
+    end
+
+    context "when seller's payouts are paused" do
+      it "returns the payout pause source and reason if present" do
+        seller.update!(payouts_paused_internally: true)
+        expect(presenter.payments_props[:payouts_paused_internally]).to be(true)
+        expect(presenter.payments_props[:payouts_paused_by_user]).to be(false)
+        expect(presenter.payments_props[:payouts_paused_by]).to eq(User::PAYOUT_PAUSE_SOURCE_ADMIN)
+        expect(presenter.payments_props[:payouts_paused_for_reason]).to eq(nil)
+
+        seller.update!(payouts_paused_internally: true, payouts_paused_by: User.last.id)
+        seller.comments.create!(
+          author_id: User.last.id,
+          content: "Chargeback rate too high.",
+          comment_type: Comment::COMMENT_TYPE_PAYOUTS_PAUSED
+        )
+        expect(presenter.payments_props[:payouts_paused_internally]).to be(true)
+        expect(presenter.payments_props[:payouts_paused_by_user]).to be(false)
+        expect(presenter.payments_props[:payouts_paused_by]).to eq(User::PAYOUT_PAUSE_SOURCE_ADMIN)
+        expect(presenter.payments_props[:payouts_paused_for_reason]).to eq("Chargeback rate too high.")
+
+        seller.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_STRIPE)
+        expect(presenter.payments_props[:payouts_paused_internally]).to be(true)
+        expect(presenter.payments_props[:payouts_paused_by_user]).to be(false)
+        expect(presenter.payments_props[:payouts_paused_by]).to eq(User::PAYOUT_PAUSE_SOURCE_STRIPE)
+        expect(presenter.payments_props[:payouts_paused_for_reason]).to eq(nil)
+
+        seller.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_SYSTEM)
+        expect(presenter.payments_props[:payouts_paused_by]).to eq(User::PAYOUT_PAUSE_SOURCE_SYSTEM)
+        expect(presenter.payments_props[:payouts_paused_internally]).to be(true)
+        expect(presenter.payments_props[:payouts_paused_by_user]).to be(false)
+        expect(presenter.payments_props[:payouts_paused_for_reason]).to eq(nil)
+
+        seller.update!(payouts_paused_internally: false, payouts_paused_by_user: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_USER)
+        expect(presenter.payments_props[:payouts_paused_by]).to eq(User::PAYOUT_PAUSE_SOURCE_USER)
+        expect(presenter.payments_props[:payouts_paused_internally]).to be(false)
+        expect(presenter.payments_props[:payouts_paused_by_user]).to be(true)
+        expect(presenter.payments_props[:payouts_paused_for_reason]).to eq(nil)
+
+        seller.update!(payouts_paused_internally: false, payouts_paused_by_user: false, payouts_paused_by: nil)
+        expect(presenter.payments_props[:payouts_paused_internally]).to be(false)
+        expect(presenter.payments_props[:payouts_paused_by_user]).to be(false)
+        expect(presenter.payments_props[:payouts_paused_by]).to eq(nil)
+        expect(presenter.payments_props[:payouts_paused_for_reason]).to eq(nil)
       end
     end
   end


### PR DESCRIPTION
Closes #545 

Improve the payout pause messaging to distinguish between different types of payout pauses:

- Stripe-initiated pauses: `Your payouts are currently paused by our payment processor. Please check your Payment Settings for any verification requirements.`
- Admin-initiated pauses: `Your payouts have been paused by Gumroad admin. Reason for pause: [admin note]`
- System-initiated automatic pauses: `Your payouts have been automatically paused for a security review and will be resumed once the review completes.`
- User-initiated pauses: `You have paused your payouts. Please go to Payment Settings to resume payouts.`

### Post deploy
- [ ] Set the appropriate payout pause source (Stripe / admin / system) for existing accounts with paused payouts

## Screenshots

### Admin section

- **Allow admins to enter a reason for pausing payouts**
<img width="562" height="233" alt="Screenshot 2025-08-22 at 9 38 12 PM" src="https://github.com/user-attachments/assets/e5d7f21c-76d3-4125-94d1-afbe3e56cb4d" />

- **Display the reason for current payout pause to admin**
<img width="563" height="210" alt="Screenshot 2025-08-22 at 9 52 57 PM" src="https://github.com/user-attachments/assets/2edd0195-eadf-4a49-8385-77c12283ec89" />


### Payouts page

- **When payouts are paused by Gumroad admin**
<img width="1184" height="662" alt="Screenshot 2025-08-22 at 9 54 06 PM" src="https://github.com/user-attachments/assets/43529cbf-39ff-4207-aa66-81533935fd9f" />

- **When payouts are paused by Stripe**
<img width="1161" height="652" alt="Screenshot 2025-08-22 at 9 57 21 PM" src="https://github.com/user-attachments/assets/a41de866-ba55-4d89-b2dc-67904dbe50ef" />

- **When payouts are automatically paused by the system due to unusual activity**
<img width="1181" height="674" alt="Screenshot 2025-08-22 at 9 55 59 PM" src="https://github.com/user-attachments/assets/e05416f8-86a0-49f9-9a98-c92a2405ab77" />

- **When payouts are paused by seller themselves**
<img width="1170" height="655" alt="Screenshot 2025-08-22 at 9 58 05 PM" src="https://github.com/user-attachments/assets/6433171e-5802-4519-974e-02a74851b151" />

### Payment Settings page
- **When payouts are paused by Gumroad admin**
<img width="1178" height="771" alt="Screenshot 2025-08-22 at 10 00 22 PM" src="https://github.com/user-attachments/assets/e4d35dc3-6d0e-4a07-b50f-91e1581ea677" />

- **When payouts are paused by Stripe**
<img width="975" height="760" alt="Screenshot 2025-08-22 at 10 03 55 PM" src="https://github.com/user-attachments/assets/3de1b5c3-7f67-4b68-bac2-cdc65f8b4290" />

- **When payouts are automatically paused by the system due to unusual activity**
<img width="1080" height="750" alt="Screenshot 2025-08-22 at 10 01 35 PM" src="https://github.com/user-attachments/assets/99d565a3-a551-466d-899f-ca947a0dcd35" />

- **When payouts are paused by seller themselves**
<img width="1201" height="666" alt="Screenshot 2025-08-22 at 9 59 17 PM" src="https://github.com/user-attachments/assets/76e91865-4b0e-49ac-bcbe-e061c5a6bd0a" />
