### PR TITLE
Speed up product-level support email reads/writes

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -498,9 +498,13 @@ class User < ApplicationRecord
 
     products
       .where.not(support_email: nil)
-      .group_by(&:support_email)
-      .map do |email, products|
-        { email:, product_ids: products.map(&:external_id) }
+      .pluck(:support_email, :id)
+      .group_by { |support_email, _| support_email }
+      .map do |email, pairs|
+        {
+          email:,
+          product_ids: pairs.map { |_, id| Link.to_external_id(id) }
+        }
       end
   end
 

--- a/app/modules/external_id.rb
+++ b/app/modules/external_id.rb
@@ -12,12 +12,20 @@ module ExternalId
   end
 
   class_methods do
-    def find_by_external_id(id)
-      find_by(id: ObfuscateIds.decrypt(id))
+    def to_external_id(id)
+      ObfuscateIds.encrypt(id)
     end
 
-    def find_by_external_id!(id)
-      find_by!(id: ObfuscateIds.decrypt(id))
+    def from_external_id(external_id)
+      ObfuscateIds.decrypt(external_id)
+    end
+
+    def find_by_external_id(external_id)
+      find_by(id: from_external_id(external_id))
+    end
+
+    def find_by_external_id!(external_id)
+      find_by!(id: from_external_id(external_id))
     end
 
     def find_by_external_id_numeric(id)
@@ -28,8 +36,8 @@ module ExternalId
       find_by!(id: ObfuscateIds.decrypt_numeric(id))
     end
 
-    def by_external_ids(ids)
-      where(id: Array.wrap(ids).map { |id| ObfuscateIds.decrypt(id) })
+    def by_external_ids(external_ids)
+      where(id: Array.wrap(external_ids).map { from_external_id(it) })
     end
   end
 end

--- a/app/services/product/bulk_update_support_email_service.rb
+++ b/app/services/product/bulk_update_support_email_service.rb
@@ -42,7 +42,7 @@ class Product::BulkUpdateSupportEmailService
 
     def clear_existing_support_emails!
       @user.products
-        .by_external_ids(affected_product_ids).invert_where
+        .where.not(id: affected_product_ids.map { Link.from_external_id(it) })
         .where.not(support_email: nil)
         .update_all(support_email: nil)
     end

--- a/spec/services/product/bulk_update_support_email_service_spec.rb
+++ b/spec/services/product/bulk_update_support_email_service_spec.rb
@@ -9,7 +9,7 @@ describe Product::BulkUpdateSupportEmailService do
   let!(:product2) { create(:product, user:, support_email: "old2@example.com") }
   let!(:product3) { create(:product, user:, support_email: "old3@example.com") }
 
-  let(:other_user_product) { create(:product) }
+  let(:other_user_product) { create(:product, support_email: "other@example.com") }
 
   before { Feature.activate_user(:product_level_support_emails, user) }
 
@@ -81,10 +81,10 @@ describe Product::BulkUpdateSupportEmailService do
       ]
 
       service = described_class.new(user, entries)
-      service.perform
 
-      expect(product1.reload.support_email).to eq("new1@example.com")
-      expect(other_user_product.reload.support_email).to be_nil
+      expect { service.perform }
+        .to change { product1.reload.support_email }.to("new1@example.com")
+        .and not_change { other_user_product.reload.support_email }
     end
 
     context "when user does not have product_level_support_emails enabled" do


### PR DESCRIPTION
I did a couple of `EXPLAINS` in the prod table now that the new column is live, the read/write queries should be fine as-is with the existing indices. 