### PR TITLE
ci(security): add Secret Scan workflow and README section

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,98 @@
+name: Secret Scan
+
+on:
+  push:
+  pull_request:
+
+concurrency:
+  group: secret-scan-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  detect_secrets:
+    name: Detect secrets in repo
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+      - name: Scan for secret patterns
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Scanning repository for high-risk patterns..."
+
+          # Allowlist synthetic test key and fixture files
+          ALLOWLIST=(
+            "spec/support/test_secrets_manager.rb"
+            "spec/support/fixtures/stripe_connect_omniauth.json"
+          )
+
+          # Static excludes (docs, scanner itself, logs, example env)
+          STATIC_EXCLUDES=(
+            ".env.example"
+            "SECURITY.md"
+            ".github/workflows/secret-scan.yml"
+          )
+
+          # Build ripgrep exclude args
+          EXCLUDES=( "--hidden" "--glob" "!node_modules/**" "--glob" "!.git/**" "--glob" "!log/**" "--glob" "!.env*" )
+          for f in "${ALLOWLIST[@]}" "${STATIC_EXCLUDES[@]}"; do
+            EXCLUDES+=("-g" "!$f")
+          done
+
+          # Patterns to scan (severity tiers)
+          CRITICAL_PATTERNS=(
+            '-----BEGIN [A-Z ]*PRIVATE KEY-----'
+            'AKIA[0-9A-Z]{16}'
+            'SG\.[A-Za-z0-9_-]{10,}'
+            'sk_live_[A-Za-z0-9]{10,}'
+            'whsec_[A-Za-z0-9]{10,}'
+          )
+          INFO_PATTERNS=(
+            'RAILS_MASTER_KEY'
+            'sk_test_[A-Za-z0-9]{10,}'
+          )
+
+          FAIL=0
+          INFO_HITS=0
+
+          echo "-- Checking CRITICAL patterns outside tests/specs --"
+          for pat in "${CRITICAL_PATTERNS[@]}"; do
+            if rg -n ${EXCLUDES[*]} -g '!spec/**' -g '!test/**' -e "$pat" .; then
+              echo "Found CRITICAL secret pattern outside tests/specs: $pat" >&2
+              FAIL=1
+            fi
+          done
+
+          echo "-- Checking CRITICAL patterns inside tests/specs (informational) --"
+          for pat in "${CRITICAL_PATTERNS[@]}"; do
+            if rg -n --hidden -g '!node_modules/**' -g '!.git/**' -g '!log/**' -g '!.env*' -g 'spec/**' -g 'test/**' -e "$pat" .; then
+              echo "Found CRITICAL-like pattern in tests/specs: $pat (not failing)" >&2
+              INFO_HITS=1
+            fi
+          done
+
+          echo "-- Checking INFO patterns anywhere --"
+          for pat in "${INFO_PATTERNS[@]}"; do
+            if rg -n ${EXCLUDES[*]} -e "$pat" .; then
+              echo "Found informational pattern (not failing): $pat" >&2
+              INFO_HITS=1
+            fi
+          done
+
+          if [[ $FAIL -ne 0 ]]; then
+            echo "Secret scan failed due to CRITICAL findings outside of tests/specs." >&2
+            exit 1
+          fi
+
+          if [[ $INFO_HITS -ne 0 ]]; then
+            echo "Secret scan completed with informational findings." >&2
+          else
+            echo "No secret patterns found."
+          fi
+

--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/Luciferai04/gumroad/actions/workflows/secret-scan.yml">
+    <img src="https://github.com/Luciferai04/gumroad/actions/workflows/secret-scan.yml/badge.svg" alt="Secret Scan" />
+  </a>
+  <a href="https://github.com/antiwork/gumroad/actions/workflows/tests.yml">
+    <img src="https://github.com/antiwork/gumroad/actions/workflows/tests.yml/badge.svg" alt="Tests (upstream)" />
+  </a>
+</p>
+
+<p align="center">
   <a href="https://gumroad.com">Gumroad</a> is an e-commerce platform that enables creators to sell products directly to consumers. This repository contains the source code for the Gumroad web application.
 </p>
 
@@ -164,6 +173,13 @@ npm install
 ```
 
 ### Configuration
+
+### Security and secrets
+
+- Do not commit secrets. All `.env.*` files are ignored. Use `.env.example` as a template for local development.
+- A pre-commit hook is provided to block committing env files and private keys. It is enabled via `git config core.hooksPath .githooks`.
+- CI runs a Secret Scan workflow on pushes and pull requests to catch high-risk patterns. The workflow fails builds only for critical matches outside tests/specs; potential tokens in tests/specs are surfaced as informational.
+- For more details, see SECURITY.md.
 
 #### Set up Custom credentials
 


### PR DESCRIPTION
This PR adds a light-weight Secret Scan workflow leveraging ripgrep with severity tiers.

Key points:
- Fails only for CRITICAL patterns found outside tests/specs.
- Surfaces potential tokens in tests/specs as informational to avoid blocking on synthetic fixtures.
- Excludes logs, .env*, docs; includes small allowlist for known fixtures.
- Adds a short Security section to README referencing SECURITY.md and the scan behavior.

Follow-ups (optional):
- Extend allowlist if more synthetic fixtures are identified.
- Consider adding workflow_dispatch in the future if manual reruns are desired.

CI: badge will appear once merged.
