### PR TITLE
devcontainer: add minimal VS Code dev container and README link

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,31 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-22.04
+
+ARG RUBY_VERSION=3.4.3
+ARG NODE_VERSION=20.17.0
+
+# Install dependencies
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    build-essential git curl ca-certificates make \
+    libssl-dev libreadline-dev zlib1g-dev libyaml-dev libxml2-dev libxslt1-dev \
+    libvips libvips-dev imagemagick ffmpeg \
+    mysql-client \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install rbenv + Ruby
+RUN git clone https://github.com/rbenv/rbenv.git ~/.rbenv \
+  && echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc \
+  && echo 'eval "$(rbenv init - bash)"' >> ~/.bashrc \
+  && git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build \
+  && ~/.rbenv/bin/rbenv install -s ${RUBY_VERSION} \
+  && ~/.rbenv/bin/rbenv global ${RUBY_VERSION}
+
+# Install Node via n
+RUN curl -fsSL https://raw.githubusercontent.com/tj/n/master/bin/n -o /usr/local/bin/n \
+  && chmod +x /usr/local/bin/n \
+  && n ${NODE_VERSION}
+
+# Yarn via corepack
+RUN corepack enable
+
+WORKDIR /workspaces/gumroad
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "name": "Gumroad",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": ["rebornix.ruby", "Shopify.ruby-lsp", "esbenp.prettier-vscode", "dbaeumer.vscode-eslint"]
+    }
+  },
+  "forwardPorts": [3000, 3001, 6379, 9200, 27017, 3306],
+  "postCreateCommand": "bash .devcontainer/post-create.sh"
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install bundler and project gems (without production/staging)
+if ! command -v bundler >/dev/null 2>&1; then
+  gem install bundler
+fi
+bundle config --local without production staging || true
+bundle install
+
+# Install JS deps
+npm install
+
+# Show quick tips
+cat <<'EOT'
+Dev container ready.
+- Start services on your host (or within a separate terminal) with: make local
+- Prepare DB: bin/rails db:prepare
+- Start app: bin/dev
+EOT
+

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@
   - [Resetting Elasticsearch indices](#resetting-elasticsearch-indices)
   - [Push Notifications](#push-notifications)
   - [Common Development Tasks](#common-development-tasks)
-  - [Linting](#linting)
+- [Linting](#linting)
+- [Dev Container (optional)](#dev-container-optional)
 
 ## Getting Started
 
@@ -226,6 +227,11 @@ If you are on Linux, or installed Docker via a package manager on a mac, you may
 
 This command will not terminate. You run this in one tab and start the application in another tab.
 If you want to run Docker services in the background, use `LOCAL_DETACHED=true make local` instead.
+
+#### Dev Container (optional)
+
+- Open the repository in VS Code and run "Dev Containers: Reopen in Container".
+- The container includes Ruby and Node toolchains plus common extensions. You’ll still run services via `make local` on your host.
 
 #### Set up the database
 


### PR DESCRIPTION
This PR introduces a lightweight Dev Container setup for contributors who prefer VS Code’s devcontainers.

- Base image: Ubuntu 22.04 with Ruby and Node toolchains
- Installs common libs used by the app (libvips, ImageMagick, ffmpeg, mysql-client)
- post-create script installs bundler, gems (without production/staging), and npm deps
- Adds a short section in README under ‘Dev Container (optional)’

This is strictly optional and doesn’t change any runtime/CI behavior.