### PR TITLE
chore(repo): add CODEOWNERS and branch protection guidance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+# See https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# Require review from security/infra on CI/workflow and security-related areas
+
+# Workflows and security scripts
+.github/workflows/* @antiwork/security @antiwork/infra
+scripts/security/* @antiwork/security @antiwork/infra
+
+# Credentials-related config
+config/credentials* @antiwork/security
+config/environments/* @antiwork/security
+
+# Default owners for repo health files
+SECURITY.md @antiwork/security
+CODE_OF_CONDUCT.md @antiwork/maintainers
+CONTRIBUTING.md @antiwork/maintainers
+

--- a/docs/maintainers/branch_protection.md
+++ b/docs/maintainers/branch_protection.md
@@ -1,0 +1,14 @@
+# Branch protection guidance
+
+We recommend marking the following checks as required on the main branch once they settle:
+
+- Secret Scan (required)
+- Tests (existing)
+- CodeQL (optional at first; consider enabling once the noise level is understood)
+
+To do this:
+
+- Settings → Branches → Branch protection rules → Edit main
+- Add required status checks by name (exactly as they appear in PR checks)
+- Enable “Require pull request reviews” with code owners for .github/workflows and scripts/security
+- Optionally require conversation resolution


### PR DESCRIPTION
Adds CODEOWNERS to require review on workflows and security-related paths, and maintainer docs describing how to set Secret Scan/Tests/CodeQL as required checks.