### PR TITLE
Remove affiliate terms link

### DIFF
--- a/app/javascript/components/GlobalAffiliates.tsx
+++ b/app/javascript/components/GlobalAffiliates.tsx
@@ -42,13 +42,6 @@ const DiscoverLinkSection = ({
           </CopyToClipboard>
         </div>
         <small>
-          By sharing an affiliate link, you agree to our{" "}
-          <a className="text-muted" target="_blank" href="https://gumroad.com/affiliates" rel="noreferrer">
-            Affiliate Terms
-          </a>
-          .
-        </small>
-        <small>
           You will be attributed any sales you referred within {cookieExpiryDays} days, even if they're for different
           products you linked to.
         </small>


### PR DESCRIPTION
### Explanation of Change
The Gumroad Affiliate Program Service Agreement page no longer exists, and on clicking "Affiliate Terms" link, it navigates to the affiliate dashboard

In 2024, here is what the Gumroad Affiliate Program Service Agreement page looks like https://web.archive.org/web/20240425135210/https://gumroad.com/affiliates

So I think we can remove the "By sharing an affiliate link, you agree to our Affiliate Terms." since we no longer have the Gumroad Affiliate Program Service Agreement page

### Screenshots
<details>
<summary>Before</summary>

<img width="2940" height="1492" alt="image" src="https://github.com/user-attachments/assets/59d86e3d-e7d9-4760-a73d-65321c8c8afc" />

</details>

<details>
<summary>After</summary>

Desktop Light Mode
<img width="2940" height="1492" alt="image" src="https://github.com/user-attachments/assets/e7acf182-b669-4dba-b239-745dbb22cd40" />

Desktop Dark Mode
<img width="2940" height="1492" alt="image" src="https://github.com/user-attachments/assets/3dd94d71-3cae-49ed-8fcd-2284785142a8" />

Mobile Light Mode
<img width="608" height="1316" alt="image" src="https://github.com/user-attachments/assets/81c3535f-76e2-4655-a839-b7485e437521" />

Mobile Dark Mode
<img width="608" height="1316" alt="image" src="https://github.com/user-attachments/assets/13570f0a-6dab-4006-aabf-8e34836a65d8" />

</details>

### AI Disclosure
No AI tools used