### PR TITLE
Remove unnecessary popover from wishlist action

### DIFF
--- a/app/javascript/components/server-components/WishlistsPage.tsx
+++ b/app/javascript/components/server-components/WishlistsPage.tsx
@@ -9,7 +9,6 @@ import { Button } from "$app/components/Button";
 import { Icon } from "$app/components/Icons";
 import { Layout } from "$app/components/Library/Layout";
 import { Modal } from "$app/components/Modal";
-import { Popover } from "$app/components/Popover";
 import { showAlert } from "$app/components/server-components/Alert";
 import { Toggle } from "$app/components/Toggle";
 import { WithTooltip } from "$app/components/WithTooltip";
@@ -116,13 +115,9 @@ const WishlistsPage = ({
                   </td>
                   <td>
                     <div className="actions">
-                      <Popover aria-label="Actions" trigger={<Icon name="three-dots" />}>
-                        <div role="menu">
-                          <div role="menuitem" className="danger" onClick={() => setConfirmingDeleteWishlist(wishlist)}>
-                            <Icon name="trash2" /> Delete
-                          </div>
-                        </div>
-                      </Popover>
+                      <Button color="danger" outline aria-label="Delete wishlist" onClick={() => setConfirmingDeleteWishlist(wishlist)}>
+                        <Icon name="trash2" />
+                      </Button>
                     </div>
                   </td>
                 </tr>

--- a/spec/requests/wishlists/wishlist_index_spec.rb
+++ b/spec/requests/wishlists/wishlist_index_spec.rb
@@ -31,9 +31,7 @@ describe "Wishlist index page", :js, type: :system do
     visit wishlists_path
 
     within find(:table_row, { "Name" => wishlist.name }) do
-      select_disclosure "Actions" do
-        click_on "Delete"
-      end
+      find("button[aria-label='Delete wishlist']").click
     end
 
     click_on "Yes, delete"


### PR DESCRIPTION
### Explanation of Change
Removed the three-dots popover menu from wishlist items since it only contained a single action (Delete). Replacing it with a direct delete button improves usability by reducing one step for the user.

### Screenshots
<details>
<summary>Before</summary>

<img width="2940" height="1492" alt="image" src="https://github.com/user-attachments/assets/afec4e57-19d0-4716-b857-de91a4e5467f" />

</details>

<details>
<summary>After</summary>

Desktop Light Mode
<img width="2940" height="1492" alt="image" src="https://github.com/user-attachments/assets/e68d6fcc-dd8f-418e-a37c-1b2fa1eb966e" />

Desktop Dark Mode
<img width="2940" height="1492" alt="image" src="https://github.com/user-attachments/assets/2ae213f0-5c10-4985-b746-8e065982cd46" />

Mobile Light Mode
<img width="608" height="1316" alt="image" src="https://github.com/user-attachments/assets/a16fa5bc-b532-4e88-a68a-27a373621d62" />

Mobile Dark Mode
<img width="608" height="1316" alt="image" src="https://github.com/user-attachments/assets/189915d8-ba87-4c92-b063-cc0a381356bc" />

</details>

### Test Results
<img width="532" height="135" alt="image" src="https://github.com/user-attachments/assets/95692689-dae0-4830-8457-0b6916e69e6d" />

### AI Disclosure
No AI tools used