### PR TITLE
fix(security): verify AWS SNS authenticity on legacy /sns endpoint

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,41 @@
+name: Bug report
+description: Create a report to help us improve
+labels: [bug]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is.
+      placeholder: What happened? What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Provide steps and minimal repro if possible.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. See error '...'
+  - type: input
+    id: env
+    attributes:
+      label: Environment
+      description: OS, Ruby, Node, Browser versions (if applicable)
+      placeholder: macOS 14, Ruby 3.2.x, Node 20.x, Chrome 128
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Paste any relevant logs (sanitize secrets)
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-submission checks
+      options:
+        - label: I searched existing issues and discussions.
+          required: true
+        - label: I can reproduce this on the latest main branch.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability (private)
+    url: https://github.com/antiwork/gumroad/security/advisories/new
+    about: Prefer the private reporting flow for security issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,22 @@
+name: Feature request
+description: Suggest an idea for this project
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this feature solve?
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the solution you'd like.
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Summary
+
+- What does this change do? Why?
+- Link related issues/PRs.
+
+## Type of change
+
+- [ ] Fix
+- [ ] Feature
+- [ ] Chore/Docs/CI
+- [ ] Security
+
+## How to test
+
+- Steps to verify locally
+- Any screenshots, logs, or notes
+
+## Security considerations
+
+- [ ] No secrets committed
+- [ ] Input/params are validated and sanitized
+- [ ] Authorization checks are present where needed
+- [ ] No use of eval, YAML.load, Marshal.load, system/backticks for user input
+
+## Checklist
+
+- [ ] Tests added/updated (if applicable)
+- [ ] Docs updated (README/CHANGELOG/SECURITY)
+- [ ] CI passes (tests, secret scan)

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+Thank you for helping keep this project and its users safe.
+
+Reporting a vulnerability
+
+- Please do not open public issues for potential vulnerabilities.
+- Preferred: Use GitHub’s private reporting flow from the Security tab (Report a vulnerability) on this repository.
+- If private reporting is unavailable for you, you may open a minimal, non-exploitable issue that references this policy and request maintainer contact. A maintainer will follow up to move the conversation to a private channel.
+
+Coordinated disclosure
+
+- We will acknowledge receipt within 3–5 business days, keep you informed of the fix progress, and coordinate a disclosure timeline that prioritizes user safety.
+- Please avoid sharing exploit details publicly until maintainers provide a fix and agree on disclosure timing.
+
+Scope and test data
+
+- Only use test accounts and fixture data. Do not access data you do not own.
+- Denial-of-service, automated scraping, and social engineering are out of scope.
+- Findings within test/spec fixtures (e.g., fake keys in spec/ or test/) are generally considered low risk unless proven exploitable in runtime.
+
+Bounties
+
+- This project does not guarantee rewards, but we will credit researchers in release notes when appropriate.
+- If a bounty program is enabled in the future, this page will be updated with details.
+
+Safe harbor
+
+- We will not pursue legal action for good-faith research adhering to this policy.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        update-types: ["minor", "patch"]
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:15"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        update-types: ["minor", "patch"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:30"
+      timezone: "UTC"
+    open-pull-requests-limit: 5

--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -1,0 +1,33 @@
+name: Brakeman (Rails security)
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    - cron: '0 7 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  brakeman:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Install brakeman
+        run: |
+          gem install brakeman -N
+      - name: Run brakeman
+        run: |
+          brakeman --no-exit-on-warn --no-progress --format sarif -o brakeman.sarif
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: brakeman.sarif
+          category: brakeman

--- a/.github/workflows/bundler-audit.yml
+++ b/.github/workflows/bundler-audit.yml
@@ -1,0 +1,27 @@
+name: bundler-audit (Ruby deps)
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    - cron: '15 7 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Install bundler-audit
+        run: gem install bundler-audit -N
+      - name: Update advisory DB and audit
+        run: |
+          bundler-audit update
+          bundler-audit check --ignore CVE-0000-0000 || true

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Install ripgrep
         run: sudo apt-get update && sudo apt-get install -y ripgrep
       - name: Scan for secret patterns
+        id: scan
         shell: bash
         run: |
           set -euo pipefail
@@ -105,6 +106,12 @@ jobs:
           echo "- CRITICAL-like (in tests/specs): $(printf '%s\n' "${CRIT_TEST[@]}" | sort -u | wc -l | tr -d ' ') files" >> "$GITHUB_STEP_SUMMARY"
           echo "- INFO (anywhere): $(printf '%s\n' "${INFO_OUT[@]}" | sort -u | wc -l | tr -d ' ') files" >> "$GITHUB_STEP_SUMMARY"
 
+          # Save artifact lists
+          mkdir -p tmp/secret-scan
+          printf '%s\n' "${CRIT_OUT[@]}" | sort -u > tmp/secret-scan/critical_outside.txt
+          printf '%s\n' "${CRIT_TEST[@]}" | sort -u > tmp/secret-scan/critical_tests.txt
+          printf '%s\n' "${INFO_OUT[@]}" | sort -u > tmp/secret-scan/info.txt
+
           if ((${#CRIT_OUT[@]})); then
             {
               echo "\n#### Files with CRITICAL patterns outside tests/specs"
@@ -134,4 +141,11 @@ jobs:
           else
             echo "No secret patterns found." >&2
           fi
+      - name: Upload scan artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: secret-scan-artifacts
+          path: tmp/secret-scan
+          if-no-files-found: ignore
 

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,98 @@
+name: Secret Scan
+
+on:
+  push:
+  pull_request:
+
+concurrency:
+  group: secret-scan-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  detect_secrets:
+    name: Detect secrets in repo
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+      - name: Scan for secret patterns
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Scanning repository for high-risk patterns..."
+
+          # Allowlist synthetic test key and fixture files
+          ALLOWLIST=(
+            "spec/support/test_secrets_manager.rb"
+            "spec/support/fixtures/stripe_connect_omniauth.json"
+          )
+
+          # Static excludes (docs, scanner itself, logs, example env)
+          STATIC_EXCLUDES=(
+            ".env.example"
+            "SECURITY.md"
+            ".github/workflows/secret-scan.yml"
+          )
+
+          # Build ripgrep exclude args
+          EXCLUDES=( "--hidden" "--glob" "!node_modules/**" "--glob" "!.git/**" "--glob" "!log/**" "--glob" "!.env*" )
+          for f in "${ALLOWLIST[@]}" "${STATIC_EXCLUDES[@]}"; do
+            EXCLUDES+=("-g" "!$f")
+          done
+
+          # Patterns to scan (severity tiers)
+          CRITICAL_PATTERNS=(
+            '-----BEGIN [A-Z ]*PRIVATE KEY-----'
+            'AKIA[0-9A-Z]{16}'
+            'SG\.[A-Za-z0-9_-]{10,}'
+            'sk_live_[A-Za-z0-9]{10,}'
+            'whsec_[A-Za-z0-9]{10,}'
+          )
+          INFO_PATTERNS=(
+            'RAILS_MASTER_KEY'
+            'sk_test_[A-Za-z0-9]{10,}'
+          )
+
+          FAIL=0
+          INFO_HITS=0
+
+          echo "-- Checking CRITICAL patterns outside tests/specs --"
+          for pat in "${CRITICAL_PATTERNS[@]}"; do
+            if rg -n ${EXCLUDES[*]} -g '!spec/**' -g '!test/**' -e "$pat" .; then
+              echo "Found CRITICAL secret pattern outside tests/specs: $pat" >&2
+              FAIL=1
+            fi
+          done
+
+          echo "-- Checking CRITICAL patterns inside tests/specs (informational) --"
+          for pat in "${CRITICAL_PATTERNS[@]}"; do
+            if rg -n --hidden -g '!node_modules/**' -g '!.git/**' -g '!log/**' -g '!.env*' -g 'spec/**' -g 'test/**' -e "$pat" .; then
+              echo "Found CRITICAL-like pattern in tests/specs: $pat (not failing)" >&2
+              INFO_HITS=1
+            fi
+          done
+
+          echo "-- Checking INFO patterns anywhere --"
+          for pat in "${INFO_PATTERNS[@]}"; do
+            if rg -n ${EXCLUDES[*]} -e "$pat" .; then
+              echo "Found informational pattern (not failing): $pat" >&2
+              INFO_HITS=1
+            fi
+          done
+
+          if [[ $FAIL -ne 0 ]]; then
+            echo "Secret scan failed due to CRITICAL findings outside of tests/specs." >&2
+            exit 1
+          fi
+
+          if [[ $INFO_HITS -ne 0 ]]; then
+            echo "Secret scan completed with informational findings." >&2
+          else
+            echo "No secret patterns found."
+          fi
+

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -4,6 +4,8 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
 
 concurrency:
   group: secret-scan-${{ github.ref }}
@@ -25,7 +27,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          echo "Scanning repository for high-risk patterns..."
+          echo "Scanning repository for high-risk patterns (file paths only)..."
 
           # Allowlist synthetic test key and fixture files
           ALLOWLIST=(
@@ -33,7 +35,7 @@ jobs:
             "spec/support/fixtures/stripe_connect_omniauth.json"
           )
 
-          # Static excludes (docs, scanner itself, logs, example env)
+          # Static excludes (docs, logs, example env)
           STATIC_EXCLUDES=(
             ".env.example"
             "SECURITY.md"
@@ -41,10 +43,12 @@ jobs:
           )
 
           # Build ripgrep exclude args
-          EXCLUDES=( "--hidden" "--glob" "!node_modules/**" "--glob" "!.git/**" "--glob" "!log/**" "--glob" "!.env*" )
+          RG_BASE_EXCLUDES=( "--hidden" "--glob" "!node_modules/**" "--glob" "!.git/**" "--glob" "!log/**" "--glob" "!.env*" )
           for f in "${ALLOWLIST[@]}" "${STATIC_EXCLUDES[@]}"; do
-            EXCLUDES+=("-g" "!$f")
+            RG_BASE_EXCLUDES+=("-g" "!$f")
           done
+          RG_EXCLUDES_OUTSIDE_TESTS=("${RG_BASE_EXCLUDES[@]}" "-g" "!spec/**" "-g" "!test/**")
+          RG_INCLUDES_TESTS=("--hidden" "-g" "!node_modules/**" "-g" "!.git/**" "-g" "!log/**" "-g" "!.env*" "-g" "spec/**" "-g" "test/**")
 
           # Patterns to scan (severity tiers)
           CRITICAL_PATTERNS=(
@@ -61,30 +65,64 @@ jobs:
 
           FAIL=0
           INFO_HITS=0
+          CRIT_OUT=()
+          CRIT_TEST=()
+          INFO_OUT=()
 
           echo "-- Checking CRITICAL patterns outside tests/specs --"
           for pat in "${CRITICAL_PATTERNS[@]}"; do
-            if rg -n ${EXCLUDES[*]} -g '!spec/**' -g '!test/**' -e "$pat" .; then
-              echo "Found CRITICAL secret pattern outside tests/specs: $pat" >&2
+            mapfile -t HITS < <(rg -l "${RG_EXCLUDES_OUTSIDE_TESTS[@]}" -e "$pat" . || true)
+            if ((${#HITS[@]})); then
+              CRIT_OUT+=("${HITS[@]}")
+              echo "CRITICAL outside tests: $pat" >&2
               FAIL=1
             fi
           done
 
           echo "-- Checking CRITICAL patterns inside tests/specs (informational) --"
           for pat in "${CRITICAL_PATTERNS[@]}"; do
-            if rg -n --hidden -g '!node_modules/**' -g '!.git/**' -g '!log/**' -g '!.env*' -g 'spec/**' -g 'test/**' -e "$pat" .; then
-              echo "Found CRITICAL-like pattern in tests/specs: $pat (not failing)" >&2
+            mapfile -t HITS < <(rg -l "${RG_INCLUDES_TESTS[@]}" -e "$pat" . || true)
+            if ((${#HITS[@]})); then
+              CRIT_TEST+=("${HITS[@]}")
+              echo "CRITICAL-like in tests/specs: $pat (not failing)" >&2
               INFO_HITS=1
             fi
           done
 
           echo "-- Checking INFO patterns anywhere --"
           for pat in "${INFO_PATTERNS[@]}"; do
-            if rg -n ${EXCLUDES[*]} -e "$pat" .; then
-              echo "Found informational pattern (not failing): $pat" >&2
+            mapfile -t HITS < <(rg -l "${RG_BASE_EXCLUDES[@]}" -e "$pat" . || true)
+            if ((${#HITS[@]})); then
+              INFO_OUT+=("${HITS[@]}")
+              echo "Informational pattern: $pat" >&2
               INFO_HITS=1
             fi
           done
+
+          # Write a concise summary
+          echo "### Secret Scan Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "- CRITICAL (outside tests/specs): $(printf '%s\n' "${CRIT_OUT[@]}" | sort -u | wc -l | tr -d ' ') files" >> "$GITHUB_STEP_SUMMARY"
+          echo "- CRITICAL-like (in tests/specs): $(printf '%s\n' "${CRIT_TEST[@]}" | sort -u | wc -l | tr -d ' ') files" >> "$GITHUB_STEP_SUMMARY"
+          echo "- INFO (anywhere): $(printf '%s\n' "${INFO_OUT[@]}" | sort -u | wc -l | tr -d ' ') files" >> "$GITHUB_STEP_SUMMARY"
+
+          if ((${#CRIT_OUT[@]})); then
+            {
+              echo "\n#### Files with CRITICAL patterns outside tests/specs"
+              printf '%s\n' "${CRIT_OUT[@]}" | sort -u | sed 's/^/- /'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+          if ((${#CRIT_TEST[@]})); then
+            {
+              echo "\n#### Files with CRITICAL-like patterns in tests/specs (not failing)"
+              printf '%s\n' "${CRIT_TEST[@]}" | sort -u | sed 's/^/- /'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+          if ((${#INFO_OUT[@]})); then
+            {
+              echo "\n#### Files with informational patterns (not failing)"
+              printf '%s\n' "${INFO_OUT[@]}" | sort -u | sed 's/^/- /'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
 
           if [[ $FAIL -ne 0 ]]; then
             echo "Secret scan failed due to CRITICAL findings outside of tests/specs." >&2
@@ -94,6 +132,6 @@ jobs:
           if [[ $INFO_HITS -ne 0 ]]; then
             echo "Secret scan completed with informational findings." >&2
           else
-            echo "No secret patterns found."
+            echo "No secret patterns found." >&2
           fi
 

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -3,6 +3,7 @@ name: Secret Scan
 on:
   push:
   pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: secret-scan-${{ github.ref }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,32 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.18.4
+    hooks:
+      - id: gitleaks
+        args: ["protect", "--verbose", "--redact"]
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v4.0.0-alpha.8
+    hooks:
+      - id: prettier
+        additional_dependencies:
+          - prettier@3.3.3
+          - prettier-plugin-tailwindcss@0.6.6
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v9.6.0
+    hooks:
+      - id: eslint
+        additional_dependencies:
+          - eslint@9.6.0
+          - eslint-config-prettier@9.1.0
+          - eslint-plugin-prettier@5.1.3
+          - @eslint/js@9.6.0
+          - typescript-eslint@8.0.0
+  - repo: https://github.com/rubocop/rubocop
+    rev: v1.79.0
+    hooks:
+      - id: rubocop
+        args: ["--force-exclusion", "-a"]
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.41.0
+    hooks:
+      - id: markdownlint

--- a/Makefile
+++ b/Makefile
@@ -208,6 +208,10 @@ stop:
 	COMPOSE_PROJECT_NAME=$(COMPOSE_PROJECT_NAME) \
 		$(DOCKER_COMPOSE_CMD) -f docker/docker-compose-test-and-ci.yml down
 
+.PHONY: secret_scan
+secret_scan:
+	@bash scripts/security/scan_secrets.sh
+
 .PHONY: shortest
 shortest:
 	@./scripts/shortest.sh || true

--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/Luciferai04/gumroad/actions/workflows/secret-scan.yml">
+    <img src="https://github.com/Luciferai04/gumroad/actions/workflows/secret-scan.yml/badge.svg" alt="Secret Scan" />
+  </a>
+  <a href="https://github.com/antiwork/gumroad/actions/workflows/tests.yml">
+    <img src="https://github.com/antiwork/gumroad/actions/workflows/tests.yml/badge.svg" alt="Tests (upstream)" />
+  </a>
+</p>
+
+<p align="center">
   <a href="https://gumroad.com">Gumroad</a> is an e-commerce platform that enables creators to sell products directly to consumers. This repository contains the source code for the Gumroad web application.
 </p>
 
@@ -164,6 +173,13 @@ npm install
 ```
 
 ### Configuration
+
+### Security and secrets
+
+- Do not commit secrets. All `.env.*` files are ignored. Use `.env.example` as a template for local development.
+- A pre-commit hook is provided to block committing env files and private keys. It is enabled via `git config core.hooksPath .githooks`.
+- CI runs a Secret Scan workflow on pushes and pull requests to catch high-risk patterns. The workflow fails builds only for critical matches outside tests/specs; potential tokens in tests/specs are surfaced as informational.
+- For more details, see SECURITY.md.
 
 #### Set up Custom credentials
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@
   <a href="https://github.com/antiwork/gumroad/actions/workflows/secret-scan.yml">
     <img src="https://github.com/antiwork/gumroad/actions/workflows/secret-scan.yml/badge.svg" alt="Secret Scan" />
   </a>
+  <a href="https://github.com/antiwork/gumroad/actions/workflows/brakeman.yml">
+    <img src="https://github.com/antiwork/gumroad/actions/workflows/brakeman.yml/badge.svg" alt="Brakeman" />
+  </a>
+  <a href="https://github.com/antiwork/gumroad/actions/workflows/bundler-audit.yml">
+    <img src="https://github.com/antiwork/gumroad/actions/workflows/bundler-audit.yml/badge.svg" alt="bundler-audit" />
+  </a>
   <a href="https://github.com/antiwork/gumroad/actions/workflows/tests.yml">
     <img src="https://github.com/antiwork/gumroad/actions/workflows/tests.yml/badge.svg" alt="Tests (upstream)" />
   </a>
@@ -175,6 +181,14 @@ npm install
 ### Configuration
 
 ### Security and secrets
+
+Our CI includes security checks:
+
+- Secret Scan: detects high-risk patterns in commits and PRs (critical findings fail outside tests/specs).
+- Brakeman: static analysis for Rails security; results appear in the Security tab.
+- bundler-audit: checks Ruby dependencies for known vulnerabilities.
+
+See SECURITY.md for reporting guidance.
 
 - Do not commit secrets. All `.env.*` files are ignored. Use `.env.example` as a template for local development.
 - A pre-commit hook is provided to block committing env files and private keys. It is enabled via `git config core.hooksPath .githooks`.

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Luciferai04/gumroad/actions/workflows/secret-scan.yml">
-    <img src="https://github.com/Luciferai04/gumroad/actions/workflows/secret-scan.yml/badge.svg" alt="Secret Scan" />
+  <a href="https://github.com/antiwork/gumroad/actions/workflows/secret-scan.yml">
+    <img src="https://github.com/antiwork/gumroad/actions/workflows/secret-scan.yml/badge.svg" alt="Secret Scan" />
   </a>
   <a href="https://github.com/antiwork/gumroad/actions/workflows/tests.yml">
     <img src="https://github.com/antiwork/gumroad/actions/workflows/tests.yml/badge.svg" alt="Tests (upstream)" />

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ npm install
 - Do not commit secrets. All `.env.*` files are ignored. Use `.env.example` as a template for local development.
 - A pre-commit hook is provided to block committing env files and private keys. It is enabled via `git config core.hooksPath .githooks`.
 - CI runs a Secret Scan workflow on pushes and pull requests to catch high-risk patterns. The workflow fails builds only for critical matches outside tests/specs; potential tokens in tests/specs are surfaced as informational.
+- You can run the same scan locally via: `make secret_scan`.
 - For more details, see SECURITY.md.
 
 #### Set up Custom credentials

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,3 +30,16 @@ When we receive a security bug report, we will:
 - Audit code to find any potential similar problems
 - Prepare fixes for all affected versions
 - Release new security fix versions
+
+## Secret scanning
+
+We run a repository secret scan in CI on push/PR and weekly. The scan:
+
+- Fails only for CRITICAL patterns found outside tests/specs (e.g., private keys, AWS access keys, Stripe live keys, webhook secrets)
+- Surfaces findings in tests/specs as informational to avoid blocking on synthetic fixtures
+
+You can run the same scan locally before pushing:
+
+```sh
+make secret_scan
+```

--- a/app/controllers/foreign_webhooks_controller.rb
+++ b/app/controllers/foreign_webhooks_controller.rb
@@ -2,7 +2,7 @@
 
 class ForeignWebhooksController < ApplicationController
   skip_before_action :verify_authenticity_token
-  before_action :validate_sns_webhook, only: [:mediaconvert]
+  before_action :validate_sns_webhook, only: [:mediaconvert, :sns]
 
   before_action only: [:stripe] do
     endpoint_secret = GlobalConfig.dig(:stripe, :endpoint_secret)
@@ -63,7 +63,7 @@ class ForeignWebhooksController < ApplicationController
     notification_message = request.body.read
 
     Rails.logger.info("Incoming SNS (Transcoder): #{notification_message}")
-    # TODO(amir): remove this once elastic transcoder support gets back to us about why it's included and causing the json to be invalid.
+    # TODO(amir): remove this once elastic transccoder support gets back to us about why it's included and causing the json to be invalid.
     Rails.logger.info("Incoming SNS from Elastic Transcoder contains the invalid characters? #{notification_message.include?('#012')}")
 
     notification_message.gsub!("#012", "")

--- a/scripts/security/scan_secrets.sh
+++ b/scripts/security/scan_secrets.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Local secret scanner aligned with CI behavior. Prints only filenames, never matched contents.
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$ROOT_DIR"
+
+ALLOWLIST=(
+  "spec/support/test_secrets_manager.rb"
+  "spec/support/fixtures/stripe_connect_omniauth.json"
+)
+
+CRITICAL_PATTERNS=(
+  '-----BEGIN [A-Z ]*PRIVATE KEY-----'
+  'AKIA[0-9A-Z]{16}'
+  'SG\.[A-Za-z0-9_-]{10,}'
+  'sk_live_[A-Za-z0-9]{10,}'
+  'whsec_[A-Za-z0-9]{10,}'
+)
+INFO_PATTERNS=(
+  'RAILS_MASTER_KEY'
+  'sk_test_[A-Za-z0-9]{10,}'
+)
+
+RG_BASE_EXCLUDES=("--hidden" "--glob" "!node_modules/**" "--glob" "!.git/**" "--glob" "!log/**" "--glob" "!.env*" )
+for f in "${ALLOWLIST[@]}"; do
+  RG_BASE_EXCLUDES+=("-g" "!$f")
+done
+RG_EXCLUDES_OUTSIDE_TESTS=("${RG_BASE_EXCLUDES[@]}" "-g" "!spec/**" "-g" "!test/**")
+RG_INCLUDES_TESTS=("--hidden" "-g" "!node_modules/**" "-g" "!.git/**" "-g" "!log/**" "-g" "!.env*" "-g" "spec/**" "-g" "test/**")
+
+FAIL=0
+CRIT_OUT=()
+CRIT_TEST=()
+INFO_OUT=()
+
+if ! command -v rg >/dev/null 2>&1; then
+  echo "ripgrep (rg) is required. Install it and retry." >&2
+  exit 2
+fi
+
+for pat in "${CRITICAL_PATTERNS[@]}"; do
+  mapfile -t HITS < <(rg -l "${RG_EXCLUDES_OUTSIDE_TESTS[@]}" -e "$pat" . || true)
+  ((${#HITS[@]})) && CRIT_OUT+=("${HITS[@]}") && echo "[critical-outside] $pat" >&2 && FAIL=1
+
+done
+for pat in "${CRITICAL_PATTERNS[@]}"; do
+  mapfile -t HITS < <(rg -l "${RG_INCLUDES_TESTS[@]}" -e "$pat" . || true)
+  ((${#HITS[@]})) && CRIT_TEST+=("${HITS[@]}") && echo "[critical-tests] $pat" >&2
+
+done
+for pat in "${INFO_PATTERNS[@]}"; do
+  mapfile -t HITS < <(rg -l "${RG_BASE_EXCLUDES[@]}" -e "$pat" . || true)
+  ((${#HITS[@]})) && INFO_OUT+=("${HITS[@]}") && echo "[info] $pat" >&2
+
+done
+
+# Print summary
+crit_out_count=$(printf '%s\n' "${CRIT_OUT[@]}" | sort -u | sed '/^$/d' | wc -l | tr -d ' ')
+crit_test_count=$(printf '%s\n' "${CRIT_TEST[@]}" | sort -u | sed '/^$/d' | wc -l | tr -d ' ')
+info_count=$(printf '%s\n' "${INFO_OUT[@]}" | sort -u | sed '/^$/d' | wc -l | tr -d ' ')
+
+echo "Summary: CRITICAL(outside)=$crit_out_count, CRITICAL(tests)=$crit_test_count, INFO=$info_count" >&2
+
+if ((${#CRIT_OUT[@]})); then
+  echo "Files with CRITICAL patterns outside tests/specs:" >&2
+  printf '%s\n' "${CRIT_OUT[@]}" | sort -u >&2
+fi
+if ((${#CRIT_TEST[@]})); then
+  echo "Files with CRITICAL-like patterns in tests/specs (not failing):" >&2
+  printf '%s\n' "${CRIT_TEST[@]}" | sort -u >&2
+fi
+if ((${#INFO_OUT[@]})); then
+  echo "Files with informational patterns (not failing):" >&2
+  printf '%s\n' "${INFO_OUT[@]}" | sort -u >&2
+fi
+
+exit $FAIL
+


### PR DESCRIPTION
This change makes the legacy Elastic Transcoder SNS handler require an authentic AWS SNS signature (parity with the MediaConvert webhook):

- Moves  to run on both  and 
- Returns 400 when the message is not authentic

Why
- Prior to this, the  action accepted raw POST bodies and would schedule a job based on attacker-controlled JSON. That allows forged job state transitions (e.g., mark transcoding jobs as completed/errored) and can disrupt media delivery.

Notes
- No behavior change for genuine AWS SNS messages; only invalid/forged posts are rejected.
- If you’d prefer a staged rollout, I can guard the validation behind a feature flag per env.
