### PR TITLE
Disable PayPal payouts for countries supported by Stripe

### DIFF
--- a/app/controllers/settings/payments_controller.rb
+++ b/app/controllers/settings/payments_controller.rb
@@ -187,6 +187,8 @@ class Settings::PaymentsController < Sellers::BaseController
         render json: { success: false, error_message: "Please provide a valid email address." }
       when :provide_ascii_only_email_prompt
         render json: { success: false, error_message: "Email address cannot contain non-ASCII characters" }
+      when :paypal_payouts_not_supported
+        render json: { success: false, error_message: "PayPal payouts are not supported in your country." }
       end
 
       false

--- a/app/javascript/components/Settings/PaymentsPage/BankAccountSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/BankAccountSection.tsx
@@ -696,6 +696,7 @@ export type BankAccount =
 
 export type BankAccountDetails = {
   show_bank_account: boolean;
+  show_paypal: boolean;
   is_a_card: boolean;
   routing_number: string | null;
   account_number_visual: string | null;

--- a/app/javascript/components/server-components/Settings/PaymentsPage.tsx
+++ b/app/javascript/components/server-components/Settings/PaymentsPage.tsx
@@ -222,11 +222,9 @@ const PaymentsPage = (props: Props) => {
         ? "card"
         : props.bank_account_details.account_number_visual !== null
           ? "bank"
-          : props.paypal_address !== null
+          : props.bank_account_details.show_paypal
             ? "paypal"
-            : props.bank_account_details.show_bank_account
-              ? "bank"
-              : "paypal",
+            : "bank",
   );
   const updatePayoutMethod = (newPayoutMethod: PayoutMethod) => {
     setSelectedPayoutMethod(newPayoutMethod);
@@ -986,18 +984,20 @@ const PaymentsPage = (props: Props) => {
                   ) : null}
                 </>
               ) : null}
-              <Button
-                role="radio"
-                key="paypal"
-                aria-checked={selectedPayoutMethod === "paypal"}
-                onClick={() => updatePayoutMethod("paypal")}
-                disabled={props.is_form_disabled}
-              >
-                <Icon name="shop-window" />
-                <div>
-                  <h4>PayPal</h4>
-                </div>
-              </Button>
+              {props.bank_account_details.show_paypal ? (
+                <Button
+                  role="radio"
+                  key="paypal"
+                  aria-checked={selectedPayoutMethod === "paypal"}
+                  onClick={() => updatePayoutMethod("paypal")}
+                  disabled={props.is_form_disabled}
+                >
+                  <Icon name="shop-window" />
+                  <div>
+                    <h4>PayPal</h4>
+                  </div>
+                </Button>
+              ) : null}
               {props.user.country_code === "BR" ||
               props.user.can_connect_stripe ||
               props.stripe_connect.has_connected_stripe ? (

--- a/app/presenters/settings_presenter.rb
+++ b/app/presenters/settings_presenter.rb
@@ -326,6 +326,7 @@ class SettingsPresenter
 
       {
         show_bank_account: bank_account.present? || seller.native_payouts_supported?,
+        show_paypal: seller.payment_address.present? || !seller.native_payouts_supported?,
         card_data_handling_mode: CardDataHandlingMode.get_card_data_handling_mode(seller),
         is_a_card: bank_account.is_a?(CardBankAccount),
         card: bank_account.is_a?(CardBankAccount) ? {

--- a/app/services/update_payout_method.rb
+++ b/app/services/update_payout_method.rb
@@ -169,6 +169,7 @@ class UpdatePayoutMethod
 
       return { error: :provide_valid_email_prompt } unless EmailFormatValidator.valid?(payment_address)
       return { error: :provide_ascii_only_email_prompt } unless payment_address.ascii_only?
+      return { error: :paypal_payouts_not_supported } if user.alive_user_compliance_info.blank? || user.native_payouts_supported?
 
       user.payment_address = payment_address
       user.save!

--- a/spec/controllers/settings/payments_controller_spec.rb
+++ b/spec/controllers/settings/payments_controller_spec.rb
@@ -997,11 +997,28 @@ describe Settings::PaymentsController, :vcr do
         expect(response.parsed_body["error_message"]).to eq("Email address cannot contain non-ASCII characters")
       end
 
+      it "fails if bank payouts are supported in seller's country" do
+        put :update, xhr: true, params: { payment_address: "sebastian@example.com" }
+
+        expect(response.parsed_body["success"]).to be(false)
+        expect(response.parsed_body["error_message"]).to eq("PayPal payouts are not supported in your country.")
+      end
+
+      it "succeeds if bank payouts are not supported in seller's country" do
+        user.alive_user_compliance_info.dup_and_save { |nuci| nuci.country = "Brazil" }
+
+        put :update, xhr: true, params: { payment_address: "sebastian@example.com" }
+
+        expect(response.parsed_body["success"]).to be(true)
+        expect(user.reload.payment_address).to eq("sebastian@example.com")
+      end
+
       it "resumes payouts if account is not flagged or suspended" do
         user.update!(payment_address: "")
         stripe_account = create(:merchant_account_stripe, user: user)
         create(:user_compliance_info_request, user: user, field_needed: UserComplianceInfoFields::Individual::TAX_ID)
         user.update!(payouts_paused_internally: true)
+        user.alive_user_compliance_info.dup_and_save { |nuci| nuci.country = "Brazil" }
 
         put :update, xhr: true, params: { payment_address: "sebastian@example.com" }
 
@@ -1016,6 +1033,7 @@ describe Settings::PaymentsController, :vcr do
         stripe_account = create(:merchant_account_stripe, user: user)
         create(:user_compliance_info_request, user: user, field_needed: UserComplianceInfoFields::Individual::TAX_ID)
         user.update!(payouts_paused_internally: true)
+        user.alive_user_compliance_info.dup_and_save { |nuci| nuci.country = "Brazil" }
 
         put :update, xhr: true, params: { payment_address: "sebastian@example.com" }
 

--- a/spec/presenters/settings_presenter_spec.rb
+++ b/spec/presenters/settings_presenter_spec.rb
@@ -450,6 +450,7 @@ describe SettingsPresenter do
         ip_country_code: nil,
         bank_account_details: {
           show_bank_account: false,
+          show_paypal: true,
           card_data_handling_mode: "stripejs.0",
           is_a_card: false,
           card: nil,
@@ -651,6 +652,7 @@ describe SettingsPresenter do
                                              compliance_info: @compliance_info_details,
                                              bank_account_details: @base_props[:bank_account_details].merge({
                                                                                                               show_bank_account: true,
+                                                                                                              show_paypal: false,
                                                                                                             }),
                                              paypal_connect: @base_props[:paypal_connect].merge({
                                                                                                   show_paypal_connect: true,
@@ -698,6 +700,7 @@ describe SettingsPresenter do
 
         bank_account_details = @base_us_props[:bank_account_details].merge({
                                                                              show_bank_account: true,
+                                                                             show_paypal: false,
                                                                              routing_number: active_bank_account.routing_number,
                                                                              account_number_visual: active_bank_account.account_number_visual,
                                                                              bank_account: {
@@ -817,6 +820,27 @@ describe SettingsPresenter do
 
       it "returns true for can_connect_stripe" do
         expect(presenter.payments_props[:user][:can_connect_stripe]).to eq(true)
+      end
+    end
+
+    context "when the seller can receive PayPal payouts" do
+      it "returns true for show_paypal if country does not support bank payouts" do
+        create(:user_compliance_info, user: seller, country: "Brazil")
+        seller.update!(payment_address: nil)
+
+        expect(presenter.payments_props[:bank_account_details][:show_paypal]).to eq(true)
+      end
+
+      it "returns true for show_paypal if seller already has a PayPal payment address setup" do
+        create(:user_compliance_info, user: seller, country: "United States")
+        seller.update!(payment_address: nil)
+        expect(presenter.payments_props[:bank_account_details][:show_paypal]).to eq(false)
+
+        seller.update!(payment_address: "payme@example.com")
+        expect(presenter.payments_props[:bank_account_details][:show_paypal]).to eq(true)
+
+        seller.update!(payment_address: "")
+        expect(presenter.payments_props[:bank_account_details][:show_paypal]).to eq(false)
       end
     end
   end


### PR DESCRIPTION
### What

- Remove PayPal payout option for sellers from countries where bank payouts are supported
- Continue supporting PayPal payouts for sellers who are already on it

### Why

Closes #881 