### PR TITLE
Always show delete button for product cover on mobile

### DIFF
--- a/app/javascript/components/ProductEdit/ProductTab/CoverEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/CoverEditor.tsx
@@ -17,6 +17,7 @@ import { Progress } from "$app/components/Progress";
 import { RemoveButton } from "$app/components/RemoveButton";
 import { showAlert } from "$app/components/server-components/Alert";
 import { WithTooltip } from "$app/components/WithTooltip";
+import { useIsAboveBreakpoint } from "$app/components/useIsAboveBreakpoint";
 
 const MAX_PREVIEW_COUNT = 8;
 
@@ -263,6 +264,7 @@ const CoverTab = ({
   onClick: () => void;
   onRemove: () => void;
 }) => {
+  const isMobile = !useIsAboveBreakpoint("sm");
   const [showDelete, setShowDelete] = React.useState(false);
 
   const hasThumbnail = cover.type !== "video" && (cover.type !== "oembed" || cover.thumbnail != null);
@@ -289,7 +291,7 @@ const CoverTab = ({
         <span>{cover.type === "oembed" ? "📺" : cover.type === "video" ? "📼" : "📦"}</span>
       )}
 
-      {showDelete ? (
+      {(showDelete || isMobile) ? (
         <RemoveButton
           onClick={(evt) => {
             evt.stopPropagation();

--- a/app/javascript/components/ProductEdit/ProductTab/CoverEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/CoverEditor.tsx
@@ -264,7 +264,7 @@ const CoverTab = ({
   onClick: () => void;
   onRemove: () => void;
 }) => {
-  const isMobile = !useIsAboveBreakpoint("sm");
+  const isDesktop = useIsAboveBreakpoint("lg");
   const [showDelete, setShowDelete] = React.useState(false);
 
   const hasThumbnail = cover.type !== "video" && (cover.type !== "oembed" || cover.thumbnail != null);
@@ -291,7 +291,7 @@ const CoverTab = ({
         <span>{cover.type === "oembed" ? "📺" : cover.type === "video" ? "📼" : "📦"}</span>
       )}
 
-      {(showDelete || isMobile) ? (
+      {(showDelete || !isDesktop) ? (
         <RemoveButton
           onClick={(evt) => {
             evt.stopPropagation();


### PR DESCRIPTION
### Explanation of Change
The delete button (x) for the product cover only displayed on hover, while on mobile we can't hover, so mobile users cannot delete the product cover

This PR makes sure the delete button is always displayed for mobile users

### Videos
<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/84119fa8-79a1-4857-84ca-c6c3aa046aa0

</details>

<details>
<summary>After</summary>

https://github.com/user-attachments/assets/262b4ac0-98da-47e3-8769-4adba510e110

</details>

### AI Disclosure
No AI tools used