### PR TITLE
Add proper spacing to back to library icon on download page

### DIFF
--- a/app/javascript/components/server-components/DownloadPage/Layout.tsx
+++ b/app/javascript/components/server-components/DownloadPage/Layout.tsx
@@ -234,7 +234,7 @@ export const Layout = ({
           className="text-singleline"
         >
           <a style={{ textDecoration: "none" }} href={Routes.library_url()} title="Back to Library">
-            <Icon name="arrow-left" />
+            <Icon name="arrow-left" className="mr-1.5" />
             {headerVisible ? "Back to Library" : null}
           </a>
           {!headerVisible ? <strong>{purchase?.product_name}</strong> : null}


### PR DESCRIPTION
### Explanation of Change
Fixes the missing spacing on the Back to Library icon on the download page.

### Screenshots/Videos
<details>
<summary>Before</summary>

<img width="198" height="122" alt="image" src="https://github.com/user-attachments/assets/ff9705d4-957b-455c-90da-b08e308ca1b7" />

</details>

<details>
<summary>After</summary>

<img width="230" height="104" alt="image" src="https://github.com/user-attachments/assets/f9f9390b-c940-4bd8-9b18-e50192ff3a77" />

<img width="1408" height="796" alt="image" src="https://github.com/user-attachments/assets/75a1e7a8-df9f-46a2-9a1c-0bd287be8b39" />

</details>

### AI Disclosure
No AI tools used