### PR TITLE
Prevent navigation on failed publish product

### DIFF
--- a/app/javascript/components/ProductEdit/Layout.tsx
+++ b/app/javascript/components/ProductEdit/Layout.tsx
@@ -149,6 +149,8 @@ export const Layout = ({
       if (tab === "share") {
         if (product.native_type === "coffee") navigate.current(rootPath);
         else navigate.current(`${rootPath}/content`);
+      } else {
+        navigate.current(`${rootPath}/share`)
       }
     } catch (e) {
       assertResponseError(e);
@@ -249,7 +251,7 @@ export const Layout = ({
                 <Button
                   color="accent"
                   disabled={isBusy}
-                  onClick={() => void setPublished(true).then(() => navigate.current(`${rootPath}/share`))}
+                  onClick={() => void setPublished(true)}
                 >
                   {isPublishing ? "Publishing..." : "Publish and continue"}
                 </Button>

--- a/spec/requests/products/edit/edit_spec.rb
+++ b/spec/requests/products/edit/edit_spec.rb
@@ -467,6 +467,7 @@ describe("Product Edit Scenario", type: :system, js: true) do
     within :alert, text: "To publish a product, we need you to have an email. Set an email to continue." do
       expect(page).to have_link("Set an email", href: settings_main_url(host: UrlService.domain_with_protocol))
     end
+    expect(page).to have_current_path(edit_link_path(product.unique_permalink) + "/content")
     expect(page).to have_button "Publish and continue"
     expect(product.reload.alive?).to be(false)
   end


### PR DESCRIPTION
### Explanation of Change
Fixed an issue where users were navigated to the /share page even when publishing the product failed (e.g., email not verified). Now, users remain on the /content page if publishing is unsuccessful

### Screenshots/Videos
<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/4284194c-d6a3-4df8-8009-6ebea6efafff

</details>

<details>
<summary>After</summary>

https://github.com/user-attachments/assets/09ad5d03-3cae-4239-9d96-85d19a281e2f

</details>

### Test Results
<img width="569" height="144" alt="image" src="https://github.com/user-attachments/assets/6d0cd4a9-0bc7-4af9-9049-1af80e1202dd" />

### AI Disclosure
No AI tools used

