### PR TITLE
Add config to run Helper locally alongside Gumroad

### DIFF
--- a/bin/generate_ssl_certificates
+++ b/bin/generate_ssl_certificates
@@ -35,4 +35,13 @@ mkcert gumroad.dev "*.gumroad.dev"
 mv gumroad.dev+1.pem gumroad_dev.crt
 mv gumroad.dev+1-key.pem gumroad_dev.key
 
+# Check if HELPER_WIDGET_HOST exists in .env.development and generate helperai.dev certs
+if [[ -f "../../../.env" ]] && grep -q "HELPER_WIDGET_HOST" "../../../.env"; then
+  echo "HELPER_WIDGET_HOST found in .env, generating certificates for helperai.dev..."
+  mkcert helperai.dev "*.helperai.dev"
+  mv helperai.dev+1.pem helperai_dev.crt
+  mv helperai.dev+1-key.pem helperai_dev.key
+  echo "SSL certificates for helperai.dev generated successfully!"
+fi
+
 echo "SSL certificates generated successfully in docker/local-nginx/certs/"

--- a/docker/docker-compose-local.yml
+++ b/docker/docker-compose-local.yml
@@ -45,6 +45,7 @@ services:
     image: nginx:1.23.3
     volumes:
       - ./local-nginx/gumroad_dev.conf:/etc/nginx/conf.d/default.conf:Z
+      - ./local-nginx/helperai_dev.conf:/etc/nginx/conf.d/helperai_dev.conf:Z
       - ./local-nginx/certs:/etc/ssl/certs/:Z
     ports:
       - 80:80
@@ -52,6 +53,8 @@ services:
       - 443:443
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    labels:
+      com.antiwork.helper.proxy: "true"
 
 volumes:
   elasticsearch7data:

--- a/docker/local-nginx/helperai_dev.conf
+++ b/docker/local-nginx/helperai_dev.conf
@@ -1,0 +1,74 @@
+# Mostly copied from https://github.com/antiwork/helper/blob/main/scripts/docker/local-nginx/helperai_dev.conf
+# Allows running local Helper and Gumroad simultaneously.
+
+upstream helper_app {
+  server host.docker.internal:3010;
+}
+
+server {
+  listen 443 ssl;
+
+  server_name helperai.dev;
+
+  ssl_certificate /etc/ssl/certs/helperai_dev.crt;
+  ssl_certificate_key /etc/ssl/certs/helperai_dev.key;
+
+  client_max_body_size 10M;
+  large_client_header_buffers 8 32k;
+
+  location /_next/webpack-hmr {
+    proxy_pass http://helper_app;
+
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_read_timeout 86400;
+  }
+
+  location / {
+    proxy_pass http://helper_app;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $http_host;
+    proxy_set_header  X-Forwarded-Proto $scheme;
+    proxy_set_header  X-Forwarded-Ssl on;
+    proxy_set_header  X-Forwarded-Port $server_port;
+    proxy_set_header  X-Forwarded-Host $host;
+    proxy_redirect off;
+
+    # SSE configurations
+    proxy_set_header Connection '';
+    proxy_http_version 1.1;
+    chunked_transfer_encoding off;
+    proxy_buffering off;
+    proxy_cache off;
+
+    keepalive_timeout 75;
+    proxy_read_timeout 120;
+
+    proxy_buffers           16 64k;
+    proxy_buffer_size       64k;
+    client_body_buffer_size 128k;
+  }
+}
+
+server {
+  listen 443 ssl;
+  server_name supabase.helperai.dev;
+
+  ssl_certificate /etc/ssl/certs/helperai_dev.crt;
+  ssl_certificate_key /etc/ssl/certs/helperai_dev.key;
+
+  location / {
+    proxy_pass https://host.docker.internal:54321;
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_buffering off;
+    proxy_cache off;
+  }
+}

--- a/docs/helper_widget.md
+++ b/docs/helper_widget.md
@@ -1,0 +1,19 @@
+## Helper Widget
+
+We've embedded a support portal using the Helper API to assist Gumroad creators with platform-related questions. To run the widget locally, you'll also need to run the [Helper](https://github.com/antiwork/helper) app locally.
+
+Once you have Helper working, you can run it alongside Gumroad by doing the following:
+
+1. Add the following to your `.env` file:
+   ```
+   HELPER_WIDGET_HOST=https://helperai.dev
+   # If you aren't using the default seeds for Helper, change this to your own widgetHMACSecret.
+   HELPER_WIDGET_SECRET=9cff9d28-7333-4e29-8f01-c2945f1a887f
+   ```
+2. Re-run `bin/generate_ssl_certificates` in Gumroad.
+3. Run `make local` in Gumroad. (It's important to run this **before** starting either Gumroad or Helper.)
+   - If you get errors, try running `pnpm nginx:stop` in Helper first.
+4. Run `bin/dev` in Gumroad.
+5. Run `pnpm dev` in Helper.
+
+The Helper app will be available at `https://helperai.dev`, and the integrated support portal will be available at `https://gumroad.dev/support`.


### PR DESCRIPTION
Both apps need a local nginx proxy to use their HTTPS dev domains. This adds helperai.dev config to the Gumroad nginx (since Gumroad is the one embedding Helper) so when running them side by side both will work.

Paired with https://github.com/antiwork/helper/pull/980