### PR TITLE
Add fallback configuration for Webpack in common.js

### DIFF
--- a/config/webpack/common.js
+++ b/config/webpack/common.js
@@ -134,9 +134,9 @@ const config = {
       $assets: path.join(rootPath, "app/assets"),
     },
     fallback: {
-      "tty": false,
-      "os": false,
-      "util": false,
+      tty: false,
+      os: false,
+      util: false,
     },
   },
 

--- a/config/webpack/common.js
+++ b/config/webpack/common.js
@@ -133,6 +133,11 @@ const config = {
       $app: path.join(rootPath, "app/javascript"),
       $assets: path.join(rootPath, "app/assets"),
     },
+    fallback: {
+      "tty": false,
+      "os": false,
+      "util": false,
+    },
   },
 
   // Remove when migrated to React 18


### PR DESCRIPTION
Added `resolve.fallback` in `config/webpack/common.js` to disable automatic polyfills for unused Node.js core modules (`tty`, `os`, `util`).  

This prevents Webpack build errors from dependencies referencing these modules and avoids unnecessary bundle bloat.

Fix for these errors:

```
ERROR in ../../../node_modules/supports-color/index.js 3:12-26
Module not found: Error: Can't resolve 'tty' in '/Users/ershad/code/antiwork/gumroad/node_modules/supports-color'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
	- add a fallback 'resolve.fallback: { "tty": require.resolve("tty-browserify") }'
	- install 'tty-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
	resolve.fallback: { "tty": false }
resolve 'tty' in '/Users/ershad/code/antiwork/gumroad/node_modules/supports-color'
```