### PR TITLE
`first_email` excludes workflow installments

### DIFF
--- a/app/presenters/creator_home_presenter.rb
+++ b/app/presenters/creator_home_presenter.rb
@@ -22,7 +22,7 @@ class CreatorHomePresenter
       "first_product" => seller.links.visible.exists?,
       "first_sale" => has_sale,
       "first_payout" => seller.has_payout_information?,
-      "first_email" => seller.installments.send_emails.exists?,
+      "first_email" => seller.installments.not_workflow_installment.send_emails.exists?,
       "purchased_small_bets" => seller.purchased_small_bets?,
     }
 

--- a/spec/presenters/creator_home_presenter_spec.rb
+++ b/spec/presenters/creator_home_presenter_spec.rb
@@ -49,6 +49,11 @@ describe CreatorHomePresenter do
       )
     end
 
+    it "doesn't consider workflow installments for first_email" do
+      create(:installment, seller:, workflow_id: 1)
+      expect(presenter.creator_home_props[:getting_started_stats]["first_email"]).to eq(false)
+    end
+
     it "doesn't consider bundle product purchases for first_sale" do
       create(:purchase, :from_seller, seller:, is_bundle_product_purchase: true)
       expect(presenter.creator_home_props[:getting_started_stats]["first_sale"]).to eq(false)


### PR DESCRIPTION
Noticed this on my personal account where _Making waves_ is marked as _done_ even if I haven't sent any emails.

It turned out that it was including workflow installments, like _Abandoned cart`.


<img width="2362" height="464" alt="CleanShot 2025-08-27 at 17 21 43@2x" src="https://github.com/user-attachments/assets/2dce6518-653d-475d-9b7f-0266a5f03949" />

```
PRODUCTION irb(main):019> user.installments.send_emails.size
=> 1
PRODUCTION irb(main):020> user.installments.send_emails.first.workflow.present?
=> true
PRODUCTION irb(main):021> user.installments.send_emails.first.workflow.name
=> "Abandoned cart"
```