### PR TITLE
CtaBar gets stuck in a loop of appearing and disappearing at scroll intersection in Safari

### DIFF
--- a/app/javascript/components/Product/Layout.tsx
+++ b/app/javascript/components/Product/Layout.tsx
@@ -258,7 +258,8 @@ const CtaBar = ({
         boxShadow: visible
           ? "0 var(--border-width) rgb(var(--color)), 0 calc(-1 * var(--border-width)) rgb(var(--color))"
           : undefined,
-        position: "sticky",
+        position: "fixed",
+        width: "100%",
         top: isDesktop ? 0 : undefined,
         bottom: isDesktop ? undefined : 0,
         // Render above the product edit button


### PR DESCRIPTION
Resolves: https://github.com/antiwork/gumroad/issues/1025

This appears to be a common issue happening with safari.

Posting a demo soon

