### PR TITLE
fix: Rapid “yo-yo” auto-scroll on product page (Safari browser)

### DIFF
--- a/app/javascript/components/Product/Layout.tsx
+++ b/app/javascript/components/Product/Layout.tsx
@@ -223,16 +223,6 @@ const CtaBar = ({
     new IntersectionObserver(
       ([entry]) => {
         if (!entry) return;
-        // @ts-expect-error: Fixes issue on Safari where the page gets scrolled up/down by the height of the CTA bar when it disappears/appears, resulting on an infinite loop of the CTA bar being shown/hidden.
-        if (window.safari !== undefined && isDesktop) {
-          const main = document.querySelector("main");
-          if (ref.current && ctaButtonRef.current && main && entry.rootBounds) {
-            if (entry.boundingClientRect.top < main.getBoundingClientRect().top)
-              // We use 1.9 here (instead of 2) because it empirically does a better job of eliminating
-              // the infinite scroll jumping described above.
-              main.scrollBy(0, ((entry.isIntersecting ? -1 : 1) * entry.boundingClientRect.height) / 1.9);
-          }
-        }
 
         setVisible(!entry.isIntersecting);
       },
@@ -251,7 +241,7 @@ const CtaBar = ({
         overflow: "hidden",
         padding: 0,
         border: "none",
-        height: visible ? height : 0,
+        height,
         transition: "var(--transition-duration)",
         flexShrink: 0,
         order: isDesktop ? undefined : 1,
@@ -259,7 +249,7 @@ const CtaBar = ({
           ? "0 var(--border-width) rgb(var(--color)), 0 calc(-1 * var(--border-width)) rgb(var(--color))"
           : undefined,
         position: "sticky",
-        top: isDesktop ? 0 : undefined,
+        top: isDesktop ? (visible ? 0 : -height) : undefined,
         bottom: isDesktop ? undefined : 0,
         // Render above the product edit button
         zIndex: "var(--z-index-menubar)",


### PR DESCRIPTION
### Explanation of Change
Fixes an issue in Safari (macOS) where the product page would enter a rapid “yo-yo” auto-scroll loop when a specific section came into view.

The problem was caused by how we toggled the CTA bar’s visibility:
```
height: visible ? height : 0
```
Changing the element’s height triggered layout shifts that Safari attempted to correct, leading to a continuous scroll feedback loop.


We now position the CTA bar using `top` instead of dynamically changing its height:
```
top: isDesktop ? (visible ? 0 : -height) : undefined
```

This prevents layout shifts while still achieving the same show/hide behavior.


### Screenshots/Videos
<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/ffe7a08a-ca4e-4c75-b3b2-d98b81fafc9b

</details>

<details>
<summary>After</summary>

Safari

https://github.com/user-attachments/assets/cc1851a2-fbfc-4507-b581-1fdb0f73689a

Chrome

https://github.com/user-attachments/assets/b7512f47-7305-4178-9170-faff991180d5


</details>

### AI Disclosure
No AI tools used

Fixes https://github.com/antiwork/gumroad/issues/1025
