### PR TITLE
feat: yoyo auto scroll

### DIFF
--- a/app/javascript/components/Product/Layout.tsx
+++ b/app/javascript/components/Product/Layout.tsx
@@ -223,16 +223,6 @@ const CtaBar = ({
     new IntersectionObserver(
       ([entry]) => {
         if (!entry) return;
-        // @ts-expect-error: Fixes issue on Safari where the page gets scrolled up/down by the height of the CTA bar when it disappears/appears, resulting on an infinite loop of the CTA bar being shown/hidden.
-        if (window.safari !== undefined && isDesktop) {
-          const main = document.querySelector("main");
-          if (ref.current && ctaButtonRef.current && main && entry.rootBounds) {
-            if (entry.boundingClientRect.top < main.getBoundingClientRect().top)
-              // We use 1.9 here (instead of 2) because it empirically does a better job of eliminating
-              // the infinite scroll jumping described above.
-              main.scrollBy(0, ((entry.isIntersecting ? -1 : 1) * entry.boundingClientRect.height) / 1.9);
-          }
-        }
 
         setVisible(!entry.isIntersecting);
       },
@@ -258,9 +248,11 @@ const CtaBar = ({
         boxShadow: visible
           ? "0 var(--border-width) rgb(var(--color)), 0 calc(-1 * var(--border-width)) rgb(var(--color))"
           : undefined,
-        position: "sticky",
+        position: "fixed",
         top: isDesktop ? 0 : undefined,
         bottom: isDesktop ? undefined : 0,
+        left: 0,
+        right: 0,
         // Render above the product edit button
         zIndex: "var(--z-index-menubar)",
         marginTop: hasHero ? "var(--border-width)" : undefined,


### PR DESCRIPTION
Resolves https://github.com/antiwork/gumroad/issues/1025

### Explanation
- We're using `sticky` for the CTA container, it causes the page to scroll when the CTA appears/disappears, which we try to work-around by adding [this "offsetting" scroll](https://github.com/antiwork/gumroad/blob/75c333ead130e1a1a99d5b17515c57db5421fe66/app/javascript/components/Product/Layout.tsx#L227). But it's not a complete fix and causes this yo-yo autoscrolling problem.

### Solution
- We need to remove the work-around for Safari, and use `position: "fixed"` with `left: 0`, `right: 0` for the CTA instead. Using `position: "fixed"` helps the CTA to stay outside of the document flow and does not lead to scrolling of the page when the CTA appears/disappears, and works consistently across all browsers.

### Before
https://github.com/user-attachments/assets/05c87f41-2794-40ed-9943-7ee64c9a11bb

### After
https://github.com/user-attachments/assets/3ca52825-a2b6-4878-a23b-a7e341073bea

### UX variations
**Desktop/Light Mode**
<img width="1418" height="922" alt="Screenshot 2025-08-28 at 9 01 52 PM" src="https://github.com/user-attachments/assets/fe8ad9c2-375d-4952-89f2-98b4aa5fdfa7" />

**Dark Mode**
<img width="1415" height="821" alt="Screenshot 2025-08-28 at 9 02 20 PM" src="https://github.com/user-attachments/assets/654c175e-98e7-469b-b4a9-40402d335e06" />

**Mobile**
<img width="323" height="702" alt="Screenshot 2025-08-28 at 9 03 41 PM" src="https://github.com/user-attachments/assets/c75282ed-fb14-4825-bea2-6f49787130dd" />

### AI usage
Cursor was used to understand the root cause. The code change was made manually by me.

### E2e tests
No E2e tests were added/updated because this is just janky UI behavior. All elements are still visible and the page is still usable, core features are working as expected.