### PR TITLE
Fix rapid “yo-yo” auto-scroll on product page (Safari browser) 

### DIFF
--- a/app/javascript/components/Product/Layout.tsx
+++ b/app/javascript/components/Product/Layout.tsx
@@ -223,17 +223,6 @@ const CtaBar = ({
     new IntersectionObserver(
       ([entry]) => {
         if (!entry) return;
-        // @ts-expect-error: Fixes issue on Safari where the page gets scrolled up/down by the height of the CTA bar when it disappears/appears, resulting on an infinite loop of the CTA bar being shown/hidden.
-        if (window.safari !== undefined && isDesktop) {
-          const main = document.querySelector("main");
-          if (ref.current && ctaButtonRef.current && main && entry.rootBounds) {
-            if (entry.boundingClientRect.top < main.getBoundingClientRect().top)
-              // We use 1.9 here (instead of 2) because it empirically does a better job of eliminating
-              // the infinite scroll jumping described above.
-              main.scrollBy(0, ((entry.isIntersecting ? -1 : 1) * entry.boundingClientRect.height) / 1.9);
-          }
-        }
-
         setVisible(!entry.isIntersecting);
       },
       { threshold: 0.5 },
@@ -258,7 +247,8 @@ const CtaBar = ({
         boxShadow: visible
           ? "0 var(--border-width) rgb(var(--color)), 0 calc(-1 * var(--border-width)) rgb(var(--color))"
           : undefined,
-        position: "sticky",
+        position: "fixed",
+        width: "100%",
         top: isDesktop ? 0 : undefined,
         bottom: isDesktop ? undefined : 0,
         // Render above the product edit button


### PR DESCRIPTION
## Explanation of Change

- **Removed Safari-specific scroll adjustment logic**  
  The logic intended to fix scroll behavior in Safari was causing an infinite loop of the CTA bar being shown and hidden, resulting in the "yo-yo" effect.

- **Updated CTA bar positioning**  
  Changed the CTA bar's CSS `position` property from `sticky` to `fixed` and set its `width` to `100%` to ensure consistent behavior across all browsers.


**Before:**  


https://github.com/user-attachments/assets/8ea5d4f3-e40c-4cda-beac-4a6844a34fb4



**After:**  


https://github.com/user-attachments/assets/b89498c0-c0e3-4a07-8066-dc1d6b1f3115



## AI Disclosure

No AI tools were used.

Fixes #1025 
