### PR TITLE
perf(home): lazy-load non-critical images in features and testimonials

### DIFF
--- a/app/views/home/features.html.erb
+++ b/app/views/home/features.html.erb
@@ -7,32 +7,32 @@
   <div class="relative z-10 flex h-full flex-col justify-between border border-black bg-pink rounded-full px-8">
     <div class="-mt-3 justify-between px-32 flex">
       <div class="flex h-6 items-center bg-pink pr-6 gap-x-3">
-        <%= image_tag "features/arrowhead-right.svg", class: "h-6 w-6 -translate-x-3 -translate-y-px" %>
+        <%= image_tag "features/arrowhead-right.svg", class: "h-6 w-6 -translate-x-3 -translate-y-px", loading: "lazy", decoding: "async" %>
         <div class="text-xl xl:text-2xl">Open Account</div>
       </div>
       <div class="flex h-6 items-center bg-pink pr-6 gap-x-3">
-        <%= image_tag "features/arrowhead-right.svg", class: "h-6 w-6 -translate-x-3 -translate-y-px" %>
+        <%= image_tag "features/arrowhead-right.svg", class: "h-6 w-6 -translate-x-3 -translate-y-px", loading: "lazy", decoding: "async" %>
         <div class="text-xl xl:text-2xl">Add Product</div>
       </div>
       <div class="flex h-6 items-center bg-pink pr-6 gap-x-3">
-        <%= image_tag "features/arrowhead-right.svg", class: "h-6 w-6 -translate-x-3 -translate-y-px" %>
+        <%= image_tag "features/arrowhead-right.svg", class: "h-6 w-6 -translate-x-3 -translate-y-px", loading: "lazy", decoding: "async" %>
         <div class="text-xl xl:text-2xl">Start Selling</div>
       </div>
     </div>
     <div class="flex justify-around space-x-4">
-      <%= image_tag "features/drawing-and-painting.svg" %>
-      <%= image_tag "features/design-and-tech.svg" %>
-      <%= image_tag "features/books-and-writing.svg" %>
-      <%= image_tag "features/games.svg" %>
+      <%= image_tag "features/drawing-and-painting.svg", loading: "lazy", decoding: "async" %>
+      <%= image_tag "features/design-and-tech.svg", loading: "lazy", decoding: "async" %>
+      <%= image_tag "features/books-and-writing.svg", loading: "lazy", decoding: "async" %>
+      <%= image_tag "features/games.svg", loading: "lazy", decoding: "async" %>
     </div>
     <div class="-mb-3 justify-between px-32 flex">
       <div class="flex h-6 items-center bg-pink pl-6 gap-x-3">
         <div class="text-xl xl:text-2xl">Repeat</div>
-        <%= image_tag "features/arrowhead-right.svg", class: "h-6 w-6 translate-x-3 translate-y-px rotate-180", alt: "" %>
+        <%= image_tag "features/arrowhead-right.svg", class: "h-6 w-6 translate-x-3 translate-y-px rotate-180", alt: "", loading: "lazy", decoding: "async" %>
       </div>
       <div class="flex h-6 items-center bg-pink pl-6 gap-x-3">
         <div class="text-xl xl:text-2xl">Get paid</div>
-        <%= image_tag "features/arrowhead-right.svg", class: "h-6 w-6 translate-x-3  translate-y-px rotate-180", alt: "" %>
+        <%= image_tag "features/arrowhead-right.svg", class: "h-6 w-6 translate-x-3  translate-y-px rotate-180", alt: "", loading: "lazy", decoding: "async" %>
       </div>
     </div>
   </div>
@@ -40,27 +40,39 @@
 <div class="pointer-events-none absolute inset-0 overflow-visible z-10">
   <%= image_tag "features/feature-receipt-1.svg",
     class: "absolute -left-16 top-0 h-32 w-32 lg:left-24 lg:top-32 lg:h-56 lg:w-56",
-    alt: "Feature receipt illustration 1"
+    alt: "Feature receipt illustration 1",
+    loading: "lazy",
+    decoding: "async"
   %>
   <%= image_tag "features/feature-receipt-2.svg",
     class: "override hidden absolute top-1/2 -left-12 :h-56 w-56 lg:block",
-    alt: "Feature receipt illustration 2"
+    alt: "Feature receipt illustration 2",
+    loading: "lazy",
+    decoding: "async"
   %>
   <%= image_tag "features/feature-receipt-3.svg",
     class: "absolute -left-24 bottom-0 h-32 w-32 lg:left-20 lg:-bottom-24 lg:h-56 lg:w-56",
-    alt: "Feature receipt illustration 3"
+    alt: "Feature receipt illustration 3",
+    loading: "lazy",
+    decoding: "async"
   %>
   <%= image_tag "features/feature-receipt-11.svg",
     class: "absolute -right-24 bottom-0 h-32 w-32 lg:right-64 lg:-bottom-24 lg:h-48 lg:w-48",
-    alt: "Feature receipt illustration 1"
+    alt: "Feature receipt illustration 1",
+    loading: "lazy",
+    decoding: "async"
   %>
   <%= image_tag "features/feature-receipt-5.svg",
     class: "override hidden absolute top-1/2 right-16 h-48 w-48 lg:block",
-    alt: "Feature receipt illustration 5"
+    alt: "Feature receipt illustration 5",
+    loading: "lazy",
+    decoding: "async"
   %>
   <%= image_tag "features/feature-receipt-4.svg",
     class: "absolute -right-20 top-0 h-32 w-32 lg:right-32 lg:top-32 lg:h-48 lg:w-48",
-    alt: "Feature receipt illustration 4"
+    alt: "Feature receipt illustration 4",
+    loading: "lazy",
+    decoding: "async"
   %>
 </div>
 <% end %>
@@ -74,8 +86,8 @@
 <div class="flex flex-col overflow-hidden border-y border-black lg:flex-row">
   <div class="flex items-center justify-center border-b border-black bg-orange p-8 py-16 sm:p-12 md:p-16 lg:order-2 lg:w-1/2 lg:border-b-0 lg:border-l xl:p-32">
     <div class="relative">
-      <%= image_tag "features/home-feature-4.svg", class: "h-auto w-full", data: { parallax: true }, alt: "Illustration showing customizable store options" %>
-      <%= image_tag "features/thumbsup.svg", class: "absolute -bottom-28 -left-10 w-24 transform-gpu md:-bottom-24 md:-left-32 md:w-44", data: { parallax: true }, alt: "Thumbs up icon" %>
+      <%= image_tag "features/home-feature-4.svg", class: "h-auto w-full", data: { parallax: true }, alt: "Illustration showing customizable store options", loading: "lazy", decoding: "async" %>
+      <%= image_tag "features/thumbsup.svg", class: "absolute -bottom-28 -left-10 w-24 transform-gpu md:-bottom-24 md:-left-32 md:w-44", data: { parallax: true }, alt: "Thumbs up icon", loading: "lazy", decoding: "async" %>
     </div>
   </div>
   <div class="flex items-center justify-center bg-black p-8 py-16 text-white sm:p-12 md:p-16 lg:w-1/2 xl:p-32">
@@ -186,7 +198,7 @@
 <div class="flex flex-col overflow-hidden border-t border-black lg:flex-row">
   <div class="flex items-center justify-center border-b border-black bg-purple p-8 py-16 sm:p-12 md:p-16 lg:w-1/2 lg:border-b-0 lg:border-r xl:p-32">
     <div class="relative max-w-xl">
-      <%= image_tag "features/features-3.svg", class: "h-auto w-full", data: { parallax: true }, alt: "Illustration showing payment integrations" %>
+      <%= image_tag "features/features-3.svg", class: "h-auto w-full", data: { parallax: true }, alt: "Illustration showing payment integrations", loading: "lazy", decoding: "async" %>
     </div>
   </div>
   <div class="flex items-center justify-center bg-black p-8 py-16 text-white sm:p-12 md:p-16 lg:w-1/2 xl:p-32">
@@ -222,7 +234,7 @@
 <div class="flex flex-col overflow-hidden border-t border-black lg:flex-row">
   <div class="flex items-center justify-center border-b border-black bg-purple lg:order-2 lg:w-1/2 lg:border-b-0 lg:border-l">
     <div class="relative">
-      <%= image_tag "features/features-4.svg", class: "h-auto w-full", data: { parallax: true }, alt: "Illustration showing payment integrations" %>
+      <%= image_tag "features/features-4.svg", class: "h-auto w-full", data: { parallax: true }, alt: "Illustration showing payment integrations", loading: "lazy", decoding: "async" %>
     </div>
   </div>
   <div class="flex items-center justify-center bg-black p-8 py-16 text-white sm:p-12 md:p-16 lg:w-1/2 xl:p-32">
@@ -250,7 +262,7 @@
 <div class="flex flex-col overflow-hidden border-y border-black lg:flex-row-reverse">
   <div class="flex items-center justify-center border-b border-black bg-purple p-8 py-16 sm:p-12 md:p-16 lg:order-2 lg:w-1/2 lg:border-b-0 lg:border-r xl:p-32">
     <div class="relative max-w-xl">
-      <%= image_tag "features/features-5.svg", class: "h-auto w-full", data: { parallax: true }, alt: "Illustration showing license keys" %>
+      <%= image_tag "features/features-5.svg", class: "h-auto w-full", data: { parallax: true }, alt: "Illustration showing license keys", loading: "lazy", decoding: "async" %>
     </div>
   </div>
   <div class="flex items-center justify-center bg-black p-8 py-16 text-white sm:p-12 md:p-16 lg:w-1/2 xl:p-32">
@@ -292,9 +304,9 @@
 <div class="flex flex-col overflow-hidden border-t border-black lg:flex-row">
   <div class="flex items-center justify-center border-b border-black bg-orange p-8 py-16 sm:p-12 md:p-16 lg:w-1/2 lg:border-b-0 lg:border-r xl:p-32">
     <div class="relative">
-      <%= image_tag "features/features-6.svg", alt: "Illustration showing various creator tools and features", class: "h-auto w-full", data: { parallax: true } %>
-      <%= image_tag "features/easy.svg", alt: "Easy sticker with handwritten text", class: "absolute -right-10 -top-10 w-32 transform-gpu parallax-coins md:w-36", data: { parallax: true } %>
-      <%= image_tag "features/price-tag.svg", alt: "Decorative price tag sticker with handwritten text", class: "absolute -bottom-10 -left-10 w-40 transform-gpu parallax-coins md:w-48", data: { parallax: true } %>
+      <%= image_tag "features/features-6.svg", alt: "Illustration showing various creator tools and features", class: "h-auto w-full", data: { parallax: true }, loading: "lazy", decoding: "async" %>
+      <%= image_tag "features/easy.svg", alt: "Easy sticker with handwritten text", class: "absolute -right-10 -top-10 w-32 transform-gpu parallax-coins md:w-36", data: { parallax: true }, loading: "lazy", decoding: "async" %>
+      <%= image_tag "features/price-tag.svg", alt: "Decorative price tag sticker with handwritten text", class: "absolute -bottom-10 -left-10 w-40 transform-gpu parallax-coins md:w-48", data: { parallax: true }, loading: "lazy", decoding: "async" %>
     </div>
   </div>
 
@@ -333,8 +345,8 @@
     <div class="absolute inset-0" role="presentation" aria-hidden="true" style="background: url(<%= asset_path('features/blob-bg.svg') %>) center no-repeat; background-size: cover;"></div>
     <div class="relative p-8 sm:p-12 md:p-16 xl:p-32">
       <div class="relative max-w-2xl">
-        <%= image_tag "features/sales-graph.svg", alt: "Interactive graph showing sales analytics and growth metrics", class: "h-auto w-full", data: { parallax: true } %>
-        <%= image_tag "features/clapping.svg", alt: "Decorative clapping hands sticker celebrating success", class: "absolute -bottom-24 -right-8 w-32 transform-gpu sm:-bottom-20 sm:-right-20 sm:w-52 md:-bottom-24 md:-right-24 lg:-bottom-24 lg:-right-24", data: { parallax: true } %>
+        <%= image_tag "features/sales-graph.svg", alt: "Interactive graph showing sales analytics and growth metrics", class: "h-auto w-full", data: { parallax: true }, loading: "lazy", decoding: "async" %>
+        <%= image_tag "features/clapping.svg", alt: "Decorative clapping hands sticker celebrating success", class: "absolute -bottom-24 -right-8 w-32 transform-gpu sm:-bottom-20 sm:-right-20 sm:w-52 md:-bottom-24 md:-right-24 lg:-bottom-24 lg:-right-24", data: { parallax: true }, loading: "lazy", decoding: "async" %>
       </div>
     </div>
   </div>

--- a/app/views/home/shared/_testimonial_slide.html.erb
+++ b/app/views/home/shared/_testimonial_slide.html.erb
@@ -5,6 +5,8 @@
         src="<%= image_url %>"
         alt="<%= name %> portrait"
         class="w-full max-w-xs lg:max-w-sm xl:max-w-xl"
+        loading="lazy"
+        decoding="async"
       >
       <a
         href="<%= profile_url %>"
@@ -14,6 +16,10 @@
           src="<%= image_path("logo-g.svg") %>"
           alt="Gumroad icon"
           class="w-9 h-9"
+          width="36"
+          height="36"
+          loading="lazy"
+          decoding="async"
         >
         <span class="text-lg font-medium"><%= username %></span>
       </a>


### PR DESCRIPTION
- Add loading="lazy" and decoding="async" to non-critical SVGs on home features.
- Lazy-load testimonial portraits and add explicit dimensions to the small icon to reduce CLS.
- No visual or semantic changes.

**Verification:**

1. Tested on desktop and mobile viewports.
2. Confirmed no layout shifts or a11y regressions.


### Testing with Network (initial load) 
Before

https://github.com/user-attachments/assets/40afc322-c7b6-41a3-a04d-c2081999c368



After


https://github.com/user-attachments/assets/1ddef323-cc44-4a3a-b080-1a078c604dbf


**Scope:**

Views only: home/features, home/shared/_testimonial_slide.

Ref:  #864 

No AI used