### PR TITLE
Fix broken Gumroad logo in unauthenticated help center

### DIFF
--- a/app/javascript/components/server-components/support/Header.tsx
+++ b/app/javascript/components/server-components/support/Header.tsx
@@ -7,6 +7,7 @@ import { register } from "$app/utils/serverComponentUtil";
 import { Button } from "$app/components/Button";
 import { UnreadTicketsBadge } from "$app/components/support/UnreadTicketsBadge";
 import { useOriginalLocation } from "$app/components/useOriginalLocation";
+import logo from "$assets/images/logo.svg";
 
 export function SupportHeader({
   onOpenNewTicket,
@@ -24,7 +25,7 @@ export function SupportHeader({
       <h1 className="hidden group-[.sidebar-nav]/body:block">Help</h1>
       <h1 className="group-[.sidebar-nav]/body:hidden">
         <a href={Routes.root_path()} className="flex items-center">
-          <img src="logo.svg" alt="Gumroad" className="h-8 dark:invert" width={32} height={32} />
+          <img src={logo} alt="Gumroad" className="h-8 w-auto dark:invert" />
         </a>
       </h1>
       <div className="actions">

--- a/app/javascript/components/server-components/support/Header.tsx
+++ b/app/javascript/components/server-components/support/Header.tsx
@@ -7,6 +7,7 @@ import { register } from "$app/utils/serverComponentUtil";
 import { Button } from "$app/components/Button";
 import { UnreadTicketsBadge } from "$app/components/support/UnreadTicketsBadge";
 import { useOriginalLocation } from "$app/components/useOriginalLocation";
+
 import logo from "$assets/images/logo.svg";
 
 export function SupportHeader({


### PR DESCRIPTION
## What
<img width="1377" height="548" alt="Screenshot 2025-08-28 at 4 16 28 PM" src="https://github.com/user-attachments/assets/33c93d31-c525-4a06-a40b-c5ffb48ae8cb" />

## Why
Logo is not currently displaying correctly on the logged-out version of [gumroad.com/help](gumroad.com/help)

## AI disclaimer
Generated by Cursor, then edited.