### PR TITLE
[SEO] Add structured data for product show page

### DIFF
--- a/app/javascript/components/Product/index.tsx
+++ b/app/javascript/components/Product/index.tsx
@@ -745,10 +745,6 @@ const Reviews = ({
           {`${formatOrderOfMagnitude(ratings.count, 1)} ${ratings.count === 1 ? "rating" : "ratings"}`})
         </div>
       </header>
-      <div itemProp="aggregateRating" itemType="https://schema.org/AggregateRating" itemScope hidden>
-        <div itemProp="reviewCount">{ratings.count}</div>
-        <div itemProp="ratingValue">{ratings.average}</div>
-      </div>
       <section className="histogram" aria-label="Ratings histogram">
         {([4, 3, 2, 1, 0] as const).map((rating) => (
           <RatingsHistogramRow rating={rating + 1} percentage={ratings.percentages[rating]} key={rating} />

--- a/app/views/links/show.html.erb
+++ b/app/views/links/show.html.erb
@@ -6,6 +6,56 @@
 
 <%= render("shared/js_needed_notice") %>
 
+<% structured_data = {
+  "@context" => "https://schema.org",
+  "@type" => "Product",
+  "name" => @product.name,
+  "description" => @product.custom_summary.presence || strip_tags(@product.html_safe_description).truncate(160),
+  "url" => @product.long_url,
+  "offers" => {
+    "@type" => "Offer",
+    "price" => (@product.price_cents / 100.0).to_s,
+    "priceCurrency" => @product.price_currency_type.upcase,
+    "availability" => @product.alive? && !@product.draft ? @product.max_purchase_count.present? ? "https://schema.org/LimitedAvailability" : "https://schema.org/InStock" : "https://schema.org/OutOfStock"
+  },
+  "category" => @product.taxonomy&.slug || @product.native_type.humanize,
+  "productID" => @product.external_id,
+} %>
+
+<% if @product.thumbnail&.alive&.url %>
+  <% structured_data["image"] = @product.thumbnail.alive.url %>
+<% end %>
+
+<% if @product.user %>
+  <% structured_data["seller"] = {
+    "@type" => "Person",
+    "name" => @product.user.display_name
+  } %>
+<% end %>
+
+<% if @product.display_product_reviews? && @product.rating_stats[:count] > 0 %>
+  <% rating_stats = @product.rating_stats %>
+  <% structured_data["aggregateRating"] = {
+    "@type" => "AggregateRating",
+    "ratingValue" => rating_stats[:average].to_s,
+    "reviewCount" => rating_stats[:count].to_s,
+    "bestRating" => "5",
+    "worstRating" => "1"
+  } %>
+<% end %>
+
+<% if @product.native_type == "digital" %>
+  <% structured_data["additionalType"] = "https://schema.org/DigitalDocument" %>
+<% elsif @product.native_type == "course" %>
+  <% structured_data["additionalType"] = "https://schema.org/Course" %>
+<% elsif @product.native_type == "ebook" %>
+  <% structured_data["additionalType"] = "https://schema.org/Book" %>
+<% end %>
+
+<script type="application/ld+json">
+<%= structured_data.to_json.html_safe %>
+</script>
+
 <%= load_pack("product") %>
 <% if params[:layout] == "profile" %>
   <%= react_component "ProfileProductPage", props: @product_props.merge({ creator_profile: ProfilePresenter.new(pundit_user:, seller: @product.user).creator_profile }), prerender: true %>


### PR DESCRIPTION
Usage of AI: Just for self-review

### Motivation
Currently, we aren't using structured data properly, which hurts SEO results and affects our revenue 💲💲

For example, on the product page we only show review data, and it is still missing some keys...

![image](https://github.com/user-attachments/assets/403e74af-29ff-4d0f-a318-b6a26472614c)

 
### Solution
Use ld+json format for structured data in views which will give much better flexibility for defining schemas
![image](https://github.com/user-attachments/assets/05a0fbfd-ae6c-4f86-ba00-985a2b51311b)


> [!NOTE]  
> I proposed this change few months ago but we were busy with higher priority tasks

