### PR TITLE
Fix Nginx startup failure due to missing helperai.dev certificates

### DIFF
--- a/bin/generate_ssl_certificates
+++ b/bin/generate_ssl_certificates
@@ -35,13 +35,10 @@ mkcert gumroad.dev "*.gumroad.dev"
 mv gumroad.dev+1.pem gumroad_dev.crt
 mv gumroad.dev+1-key.pem gumroad_dev.key
 
-# Check if HELPER_WIDGET_HOST exists in .env.development and generate helperai.dev certs
-if [[ -f "../../../.env" ]] && grep -q "HELPER_WIDGET_HOST" "../../../.env"; then
-  echo "HELPER_WIDGET_HOST found in .env, generating certificates for helperai.dev..."
-  mkcert helperai.dev "*.helperai.dev"
-  mv helperai.dev+1.pem helperai_dev.crt
-  mv helperai.dev+1-key.pem helperai_dev.key
-  echo "SSL certificates for helperai.dev generated successfully!"
-fi
+echo "Generating certificates for helperai.dev..."
+mkcert helperai.dev "*.helperai.dev"
+mv helperai.dev+1.pem helperai_dev.crt
+mv helperai.dev+1-key.pem helperai_dev.key
+echo "SSL certificates for helperai.dev generated successfully!"
 
 echo "SSL certificates generated successfully in docker/local-nginx/certs/"


### PR DESCRIPTION
**AI Disclosure**
No AI was used to generate any part

**What ?**
The `generate_ssl_certificates` script only created `helperai.dev` certificates when `HELPER_WIDGET_HOST` was set in the .env file. However, the docker-compose configuration always included the helperai_dev Nginx config, leading to a container failure when the certificate was not present.

```yml
  nginx:
    image: nginx:1.23.3
    volumes:
      - ./local-nginx/gumroad_dev.conf:/etc/nginx/conf.d/default.conf:Z
      - ./local-nginx/helperai_dev.conf:/etc/nginx/conf.d/helperai_dev.conf:Z
      - ./local-nginx/certs:/etc/ssl/certs/:Z
    ports:
```

<img width="834" height="206" alt="Screenshot 2025-08-31 at 12 06 14 PM" src="https://github.com/user-attachments/assets/1636fe9e-ca3d-4205-8cd9-ff0fae6fd155" />


**The fix**
The script has been updated to always generate the `helperai.dev` certificates, regardless of environment variables. This ensures Nginx starts reliably without requiring extra configuration.