### PR TITLE
Prevent "Support tickets" tab from truncating on mobile

### DIFF
--- a/app/javascript/components/server-components/support/Header.tsx
+++ b/app/javascript/components/server-components/support/Header.tsx
@@ -41,7 +41,7 @@ export function SupportHeader({
         ) : null}
       </div>
       {hasHelperSession ? (
-        <div role="tablist">
+        <div role="tablist" className="col-span-full">
           <a
             href={Routes.help_center_root_path()}
             role="tab"


### PR DESCRIPTION
### Explanation of Change
This PR resolves a usability issue in the Help Center where the "Support tickets" tab label was truncated on smaller screens, forcing users to scroll horizontally even though there was available blank space to the right.

### Screenshots/Videos
<details>
<summary>Before</summary>

<img width="377" height="649" alt="484062406-efa96bfc-6813-4e16-8ba7-9a3539db1857" src="https://github.com/user-attachments/assets/694332f3-f22a-4ed9-b520-6ab0c4d38fee" />

<img width="327" height="680" alt="Screenshot 2025-09-01 at 20 25 34" src="https://github.com/user-attachments/assets/6f800365-a7c0-4580-b339-927d8cf754ba" />

<img width="327" height="682" alt="Screenshot 2025-09-01 at 20 25 39" src="https://github.com/user-attachments/assets/2e52974e-be73-4143-bc4e-98dd1884f89e" />


</details>

<details>
<summary>After</summary>

<img width="323" height="675" alt="Screenshot 2025-09-01 at 20 24 05" src="https://github.com/user-attachments/assets/4465a10f-1dfb-4efa-a784-b0a62b8aaa39" />

<img width="322" height="679" alt="Screenshot 2025-09-01 at 20 24 27" src="https://github.com/user-attachments/assets/1e8a3c6e-e878-4d69-8720-55eb4521b1fc" />

</details>

### AI Disclosure
No AI tools used