### PR TITLE
Ensure filter modal maintains full height on sales page

### DIFF
--- a/app/javascript/components/server-components/Audience/CustomersPage.tsx
+++ b/app/javascript/components/server-components/Audience/CustomersPage.tsx
@@ -244,7 +244,7 @@ const CustomersPage = ({
   const timeZoneAbbreviation = format(new Date(), "z", { timeZone: currentSeller.timeZone.name });
 
   return (
-    <main>
+    <main className="h-full">
       <header>
         <h1>Sales</h1>
         <div className="actions">


### PR DESCRIPTION
### Explanation of Change
This PR fixes a layout issue where the filter modal on the Sales page would shrink when a filter resulted in only a few customers being displayed.

### Screenshots/Videos
<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/03ca7985-b7c5-47cd-9bd1-b756c73f2509

</details>

<details>
<summary>After</summary>

https://github.com/user-attachments/assets/5e62e3e2-dcc3-4e25-80e2-7ed8b903920d

https://github.com/user-attachments/assets/5770a52b-3c2b-45b6-b386-9a9a03337ba0

</details>

### AI Disclosure
No AI tools used