### PR TITLE
Add missing space before help link in ToggleSettingRow

### DIFF
--- a/app/javascript/components/SettingRow.tsx
+++ b/app/javascript/components/SettingRow.tsx
@@ -16,9 +16,12 @@ export const ToggleSettingRow = ({ label, value, help, onChange, dropdown, disab
     <Toggle value={value} onChange={onChange} disabled={Boolean(disabled)}>
       {label}
       {help?.url ? (
-        <a href={help.url} target="_blank" rel="noopener noreferrer" className="learn-more" style={{ flexShrink: 0 }}>
-          {help.label}
-        </a>
+        <>
+          {" "}
+          <a href={help.url} target="_blank" rel="noopener noreferrer" className="learn-more" style={{ flexShrink: 0 }}>
+            {help.label}
+          </a>
+        </>
       ) : null}
     </Toggle>
   );


### PR DESCRIPTION
### Explanation of Change
Added a space before the help link in ToggleSettingRow to ensure the description text and "Learn more" hyperlink are visually separated

### Screenshots/Videos
Before

<img width="639" height="206" alt="image" src="https://github.com/user-attachments/assets/756e6d75-8300-476e-bd09-4d5d46dc5d34" />

After

<img width="614" height="183" alt="image" src="https://github.com/user-attachments/assets/4d6c14d9-a078-4bae-b762-826e04079b39" />

### AI Disclosure
No AI tools used