### PR TITLE
Remove unnecessary search icon on Become an Affiliate page

### DIFF
--- a/app/javascript/components/server-components/AffiliatedPage.tsx
+++ b/app/javascript/components/server-components/AffiliatedPage.tsx
@@ -294,7 +294,7 @@ const AffiliatedPage = ({
           </Button>
         ) : (
           <>
-            <Search onSearch={handleSearch} value={state.query} />
+            {initialAffiliatedProducts.length > 0 && <Search onSearch={handleSearch} value={state.query} />}
             <WithTooltip position="bottom" tip={affiliatesDisabledReason}>
               <Button color="accent" disabled={affiliatesDisabledReason !== null} onClick={() => toggleOpen(true)}>
                 Gumroad affiliate


### PR DESCRIPTION
### Explanation of Change
Removed the unnecessary search icon on the Become an Affiliate page

### Screenshots/Videos
<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/f305c093-bf90-465c-9550-cc7066b073e3

</details>

<details>
<summary>After</summary>

https://github.com/user-attachments/assets/01f0db5b-2e07-4a8a-b0c7-addccae02196

</details>

### AI Disclosure
No AI tools used