### PR TITLE
Fix(home): Prevent background shift when toggling mobile menu

### DIFF
--- a/app/views/home/shared/_nav.html.erb
+++ b/app/views/home/shared/_nav.html.erb
@@ -100,7 +100,7 @@
 
   <%= toggle_button %>
 </div>
-<div class="override hidden justify-between border-b border-black flex-col top-20 left-0 right-0 z-50 sticky bg-black dark:border-white/[.35]" id="mobile-menu">
+<div class="override hidden justify-between border-b border-black flex-col top-20 left-0 right-0 z-50 fixed bg-black dark:border-white/[.35]" id="mobile-menu">
   <%= nav_links %>
   <%= auth_links %>
 </div>


### PR DESCRIPTION
Fixed background shift on mobile menu toggle by switching #mobile-menu from sticky to fixed.

Before:
https://github.com/user-attachments/assets/270c8c0b-6647-4fde-83dc-0802b17da71f
After:
https://github.com/user-attachments/assets/f60d8c74-096c-4c3c-8580-4867baa971d9

Is this eligible for a bounty? antiwork/flexile#911

