### PR TITLE
refactor: use popover on analytics page

### DIFF
--- a/app/javascript/components/Analytics/LocationsTable.tsx
+++ b/app/javascript/components/Analytics/LocationsTable.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import { AnalyticsDataByState, LocationDataValue } from "$app/data/analytics";
 import { formatPriceCentsWithCurrencySymbol } from "$app/utils/currency";
 
+import { SelectPopover } from "$app/components/Analytics/SelectPopover";
 import { useClientSortingTableDriver } from "$app/components/useSortingTableDriver";
 
 type TableEntry = {
@@ -192,15 +193,15 @@ export const LocationsTable = ({
   const caption = (
     <div style={{ display: "flex", justifyContent: "space-between" }}>
       Locations
-      <select
-        aria-label="Locations"
-        style={{ width: "fit-content" }}
+      <SelectPopover
+        options={[
+          { value: "world", label: "World" },
+          { value: "us", label: "United States" },
+        ]}
         value={selected}
-        onChange={(ev) => setSelected(ev.target.value)}
-      >
-        <option value="world">World</option>
-        <option value="us">United States</option>
-      </select>
+        onChange={setSelected}
+        ariaLabel="Locations"
+      />
     </div>
   );
 

--- a/app/javascript/components/Analytics/SelectPopover.tsx
+++ b/app/javascript/components/Analytics/SelectPopover.tsx
@@ -1,0 +1,40 @@
+import * as React from "react";
+
+import { Icon } from "$app/components/Icons";
+import { Popover } from "$app/components/Popover";
+
+export interface SelectOption<T extends string> {
+  value: T;
+  label: string;
+}
+
+interface SelectPopoverProps<T extends string> {
+  options: SelectOption<T>[];
+  value: T;
+  onChange: (value: T) => void;
+  ariaLabel?: string;
+}
+
+export function SelectPopover<T extends string>({ options, value, onChange, ariaLabel }: SelectPopoverProps<T>) {
+  const selectedOption = options.find((opt) => opt.value === value);
+
+  return (
+    <Popover
+      trigger={
+        <span className="input" aria-label={ariaLabel}>
+          {selectedOption?.label || "Select..."}
+          <Icon name="outline-cheveron-down" />
+        </span>
+      }
+    >
+      <fieldset>
+        {options.map((option) => (
+          <label key={option.value}>
+            <input type="checkbox" checked={value === option.value} onChange={() => onChange(option.value)} />
+            {option.label}
+          </label>
+        ))}
+      </fieldset>
+    </Popover>
+  );
+}

--- a/app/javascript/components/server-components/AnalyticsPage.tsx
+++ b/app/javascript/components/server-components/AnalyticsPage.tsx
@@ -17,6 +17,7 @@ import { ProductsPopover } from "$app/components/Analytics/ProductsPopover";
 import { ReferrersTable } from "$app/components/Analytics/ReferrersTable";
 import { SalesChart } from "$app/components/Analytics/SalesChart";
 import { SalesQuickStats } from "$app/components/Analytics/SalesQuickStats";
+import { SelectPopover } from "$app/components/Analytics/SelectPopover";
 import { useAnalyticsDateRange } from "$app/components/Analytics/useAnalyticsDateRange";
 import { DateRangePicker } from "$app/components/DateRangePicker";
 import { Progress } from "$app/components/Progress";
@@ -149,13 +150,15 @@ const AnalyticsPage = ({ products: initialProducts, country_codes, state_names }
       actions={
         hasContent ? (
           <>
-            <select
-              aria-label="Aggregate by"
-              onChange={(e) => setAggregateBy(e.target.value === "daily" ? "daily" : "monthly")}
-            >
-              <option value="daily">Daily</option>
-              <option value="monthly">Monthly</option>
-            </select>
+            <SelectPopover
+              options={[
+                { value: "daily", label: "Daily" },
+                { value: "monthly", label: "Monthly" },
+              ]}
+              value={aggregateBy}
+              onChange={setAggregateBy}
+              ariaLabel="Aggregate by"
+            />
             <ProductsPopover products={products} setProducts={setProducts} />
             <DateRangePicker {...dateRange} />
           </>


### PR DESCRIPTION
 Before:-
On /analytics page some dropdowns are not using using the default select and option HTML  instead of following design system

![Screenshot 2025-08-31 at 6 38 17 PM](https://github.com/user-attachments/assets/a1273676-603e-402c-9366-f9b9d557af97)

![Screenshot 2025-08-31 at 7 20 19 PM](https://github.com/user-attachments/assets/3376f272-610b-4aa3-9887-c38a5381dc69)

### AI Disclosure:-

I have not used any AI assistance in this PR
