### PR TITLE
fix: remove character "`"

### DIFF
--- a/app/javascript/components/ActivityFeed.tsx
+++ b/app/javascript/components/ActivityFeed.tsx
@@ -57,7 +57,7 @@ export const ActivityFeed = ({ items }: { items: ActivityItem[] }) => {
             <span>
               {" "}
               For now, <a href={Routes.products_path()}>create a product</a> or{" "}
-              <a href={Routes.settings_profile_path()}>customize your profile</a>`
+              <a href={Routes.settings_profile_path()}>customize your profile</a>
             </span>
           ) : null}
         </p>


### PR DESCRIPTION

Ref:- https://github.com/antiwork/gumroad/issues/864

Splitting my PR https://github.com/antiwork/gumroad/pull/1092

If you look closely at the bottom line "Followers and sales will show up here as they come in." there is an extra character "`" at the end

Before:-
![Screenshot 2025-08-31 at 6 36 04 PM](https://github.com/user-attachments/assets/8f9b3468-b59a-4d21-821d-bb7981343ae2)

After:-

![Screenshot 2025-08-31 at 7 22 50 PM](https://github.com/user-attachments/assets/5ade0724-133b-4c29-99b6-22460dc2343e)

### AI Disclosure:-

I have not used any AI assistance in this PR