### PR TITLE
feat(api): add POST /v2/sales/:id/resend_receipt (v2) — resend purchase receipt

### DIFF
--- a/app/controllers/api/v2/sales_controller.rb
+++ b/app/controllers/api/v2/sales_controller.rb
@@ -4,6 +4,7 @@ class Api::V2::SalesController < Api::V2::BaseController
   before_action(only: [:index, :show]) { doorkeeper_authorize! :view_sales }
   before_action(only: [:mark_as_shipped]) { doorkeeper_authorize! :mark_sales_as_shipped }
   before_action(only: [:refund]) { doorkeeper_authorize! :refund_sales }
+  before_action(only: [:resend_receipt]) { doorkeeper_authorize! :view_sales }
   before_action :set_page, only: :index
 
   RESULTS_PER_PAGE = 10
@@ -117,6 +118,14 @@ class Api::V2::SalesController < Api::V2::BaseController
     else
       error_with_sale(purchase)
     end
+  end
+
+  def resend_receipt
+    purchase = current_resource_owner.sales.find_by_external_id(params[:id])
+    return error_with_sale if purchase.nil?
+
+    purchase.resend_receipt
+    success_with_object(:sale, { message: "Receipt resent successfully to #{purchase.email}" })
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,7 @@ Rails.application.routes.draw do
         member do
           put :mark_as_shipped
           put :refund
+          post :resend_receipt
         end
       end
       resources :payouts, only: [:index, :show]

--- a/spec/controllers/api/v2/sales_controller_spec.rb
+++ b/spec/controllers/api/v2/sales_controller_spec.rb
@@ -589,4 +589,112 @@ describe Api::V2::SalesController do
       end
     end
   end
+
+  describe "POST 'resend_receipt'" do
+    before do
+      @purchase = create(:purchase, purchaser: @purchaser, link: @product)
+      @params = { id: @purchase.external_id }
+    end
+
+    describe "when logged in with view_sales scope" do
+      before do
+        @token = create("doorkeeper/access_token", application: @app,
+                                                   resource_owner_id: @seller.id,
+                                                   scopes: "view_sales")
+        @params.merge!(access_token: @token.token)
+      end
+
+      it "successfully resends receipt for a valid sale" do
+        expect_any_instance_of(Purchase).to receive(:resend_receipt)
+        
+        post :resend_receipt, params: @params
+        
+        expect(response).to be_successful
+        expect(response.parsed_body).to eq({
+          "success" => true,
+          "message" => "Receipt resent successfully to #{@purchase.email}"
+        })
+      end
+
+      it "handles resending receipt for gift purchases" do
+        gift_purchase = create(:gift_sender_purchase_successful, purchaser: @purchaser, link: @product)
+        
+        expect_any_instance_of(Purchase).to receive(:resend_receipt)
+        
+        post :resend_receipt, params: @params.merge(id: gift_purchase.external_id)
+        
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to eq true
+        expect(response.parsed_body["message"]).to include("Receipt resent successfully")
+      end
+
+      it "handles resending receipt for preorder purchases" do
+        preorder_purchase = create(:preorder_authorization_successful, purchaser: @purchaser, link: @product)
+        
+        expect_any_instance_of(Purchase).to receive(:resend_receipt)
+        
+        post :resend_receipt, params: @params.merge(id: preorder_purchase.external_id)
+        
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to eq true
+      end
+
+      it "returns error for non-existent sale" do
+        post :resend_receipt, params: @params.merge(id: "non-existent-id")
+        
+        expect(response.parsed_body).to eq({
+          "success" => false,
+          "message" => "The sale was not found."
+        })
+      end
+
+      it "does not allow resending receipt for someone else's sale" do
+        post :resend_receipt, params: @params.merge(id: @purchase_by_seller.external_id)
+        
+        expect(response.parsed_body).to eq({
+          "success" => false,
+          "message" => "The sale was not found."
+        })
+      end
+
+      it "works for various purchase states" do
+        %w(successful gift_receiver_purchase_successful).each do |purchase_state|
+          purchase = create(:purchase, link: @product, seller: @seller, purchase_state: purchase_state)
+          
+          expect_any_instance_of(Purchase).to receive(:resend_receipt)
+          
+          post :resend_receipt, params: @params.merge(id: purchase.external_id)
+          
+          expect(response).to be_successful
+          expect(response.parsed_body["success"]).to eq true
+        end
+      end
+    end
+
+    describe "when not logged in with view_sales scope" do
+      before do
+        @token = create("doorkeeper/access_token", application: @app,
+                                                   resource_owner_id: @seller.id,
+                                                   scopes: "view_sales")
+        @params.merge!(access_token: @token.token)
+      end
+
+      it "the response is 403 forbidden for incorrect scope" do
+        # Create token without view_sales scope
+        wrong_token = create("doorkeeper/access_token", application: @app,
+                                                       resource_owner_id: @seller.id,
+                                                       scopes: "edit_products")
+        
+        post :resend_receipt, params: @params.merge(access_token: wrong_token.token)
+        expect(response.code).to eq "403"
+      end
+    end
+
+    describe "when not authenticated" do
+      it "returns 401 unauthorized" do
+        post :resend_receipt, params: { id: @purchase.external_id }
+        expect(response.code).to eq "401"
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #855.

This adds an API v2 endpoint for creators/support to resend a purchase receipt via the API.

### Endpoint
- **Route:** POST `/v2/sales/:id/resend_receipt`
- **Auth scope:** `view_sales` (same scope used for viewing sales / customer-service actions)
- **Path param:** `:id` — sale external ID
- **Body:** none (token-based OAuth as usual)
- **Response (200):**
  {
    "success": true,
    "message": "Receipt resent successfully to <email>"
  }

### Errors
- **401** when token missing/invalid or scope not granted
- **404** when sale not found or not owned by the current resource owner

### Implementation notes
- Reuses existing `Purchase#resend_receipt` so PDF stamping / preorder / gift flows follow existing logic.
- Non-UI change; no screenshots needed.
- (Optional) happy to add basic throttling to prevent abuse if maintainers prefer.

### Tests
- Request specs:
  - happy path (regular purchase)
  - wrong owner (scoped to `current_resource_owner`)
  - unauthenticated
  - wrong scope
  - (if applicable) preorder + gift variants