### PR TITLE
fix: remove extra dot at checkout page

### DIFF
--- a/app/javascript/components/server-components/CheckoutDashboard/UpsellsPage.tsx
+++ b/app/javascript/components/server-components/CheckoutDashboard/UpsellsPage.tsx
@@ -302,7 +302,7 @@ const UpsellsPage = (props: {
               New upsell
             </Button>
             <a href="/help/article/331-creating-upsells" target="_blank" rel="noreferrer">
-              Learn more about upsells.
+              Learn more about upsells
             </a>
           </div>
         )}


### PR DESCRIPTION
Ref:- https://github.com/antiwork/gumroad/issues/864

Removed an unnecessary dot in the upsell checkout ui.

before: 
<img width="1450" height="780" alt="Screenshot from 2025-09-04 19-53-34" src="https://github.com/user-attachments/assets/2f74334f-5935-44f3-89fa-444a10e6c9b6" />


after:
<img width="1192" height="609" alt="Screenshot from 2025-09-04 19-54-17" src="https://github.com/user-attachments/assets/a30f1e4a-bf3a-4963-81e2-36f9a621d1a0" />

