### PR TITLE
Fix: Add missing question marks to FAQ article titles

### DIFF
--- a/app/models/help_center/articles.yml
+++ b/app/models/help_center/articles.yml
@@ -269,7 +269,7 @@
   category_id: <%= HelpCenter::Category::RECEIPTS_AND_REFUNDS.id %>
 - id: 206
   slug: "206-how-to-open-zip-and-rar-files"
-  title: "How to open ZIP and RAR files"
+  title: "How to open ZIP and RAR files?"
   category_id: <%= HelpCenter::Category::ACCESSING_YOUR_PURCHASE.id %>
 - id: 208
   slug: "208-how-do-i-send-my-gumroad-purchase-to-my-kindle"
@@ -345,7 +345,7 @@
   category_id: <%= HelpCenter::Category::OPEN_AN_ACCOUNT.id %>
 - id: 266
   slug: "266-why-are-my-customers-purchases-failing"
-  title: "Why customer payments fail"
+  title: "Why customer payments fail?"
   category_id: <%= HelpCenter::Category::START_SELLING.id %>
 - id: 268
   slug: "268-customer-dashboard"
@@ -377,7 +377,7 @@
   category_id: <%= HelpCenter::Category::GET_PAID.id %>
 - id: 282
   slug: "282-how-do-purchases-work-for-my-customers"
-  title: "How Gumroad works for customers"
+  title: "How Gumroad works for customers?"
   category_id: <%= HelpCenter::Category::START_SELLING.id %>
 - id: 283
   slug: "283-fraudulent-purchases"

--- a/app/views/help_center/articles/contents/_266-why-are-my-customers-purchases-failing.html.erb
+++ b/app/views/help_center/articles/contents/_266-why-are-my-customers-purchases-failing.html.erb
@@ -41,7 +41,7 @@
   <div>
     <h3>Related Articles</h3>
     <ul>
-      <li><a href="282-how-do-purchases-work-for-my-customers"><span>How Gumroad works for customers</span></a></li>
+      <li><a href="282-how-do-purchases-work-for-my-customers"><span>How Gumroad works for customers?</span></a></li>
     </ul>
   </div>
 </div>

--- a/app/views/help_center/articles/contents/_275-paypal-connect.html.erb
+++ b/app/views/help_center/articles/contents/_275-paypal-connect.html.erb
@@ -75,7 +75,7 @@
     <h3>Related Articles</h3>
     <ul>
       <li><a href="66-gumroads-fees"><span>Gumroad's fees</span></a></li>
-      <li><a href="282-how-do-purchases-work-for-my-customers"><span>How Gumroad works for customers</span></a></li>
+      <li><a href="282-how-do-purchases-work-for-my-customers"><span>How Gumroad works for customers?</span></a></li>
       <li><a href="330-stripe-connect"><span>Connect your Stripe account to Gumroad</span></a></li>
     </ul>
   </div>

--- a/app/views/help_center/articles/contents/_282-how-do-purchases-work-for-my-customers.html.erb
+++ b/app/views/help_center/articles/contents/_282-how-do-purchases-work-for-my-customers.html.erb
@@ -46,7 +46,7 @@
     <ul>
       <li><a href="275-paypal-connect"><span>Adding PayPal to checkout</span></a></li>
       <li><a href="62-testing-a-purchase"><span>Testing a purchase</span></a></li>
-      <li><a href="266-why-are-my-customers-purchases-failing"><span>Why customer payments fail</span></a></li>
+      <li><a href="266-why-are-my-customers-purchases-failing"><span>Why customer payments fail?</span></a></li>
     </ul>
   </div>
 </div>

--- a/app/views/help_center/articles/contents/_62-testing-a-purchase.html.erb
+++ b/app/views/help_center/articles/contents/_62-testing-a-purchase.html.erb
@@ -29,7 +29,7 @@
     <ul>
       <li><a href="101-designing-your-product-page"><span>Checkout customization</span></a></li>
       <li><a href="247-what-your-customers-see"><span>The Gumroad Library</span></a></li>
-      <li><a href="282-how-do-purchases-work-for-my-customers"><span>How Gumroad works for customers</span></a></li>
+      <li><a href="282-how-do-purchases-work-for-my-customers"><span>How Gumroad works for customers?</span></a></li>
     </ul>
   </div>
 </div>


### PR DESCRIPTION
Ref #864 

## AI Assistance
No AI was used to generate any of this code or description.  

## Before
<img width="780" height="359" alt="Screenshot_2025-09-04_22-22-26" src="https://github.com/user-attachments/assets/23f170c9-3709-4f45-85d9-ead987611671" />


## After
<img width="802" height="368" alt="Screenshot_2025-09-04_22-25-53" src="https://github.com/user-attachments/assets/784180a7-2cce-4175-b585-fc4083a03b48" />

