### PR TITLE
fix: product page layout for small screens

### DIFF
--- a/app/javascript/stylesheets/_custom_sections.scss
+++ b/app/javascript/stylesheets/_custom_sections.scss
@@ -10,11 +10,11 @@
 }
 
 .custom-sections {
-  &>* {
+  & > * {
     position: relative;
     padding-top: spacer(8);
 
-    >[role="toolbar"] {
+    > [role="toolbar"] {
       display: flex;
       gap: spacer(1);
       border: $border;
@@ -27,8 +27,8 @@
         box-shadow: box-shadow(1);
       }
 
-      >button,
-      >details>summary {
+      > button,
+      > details > summary {
         @extend %section-button;
       }
 
@@ -41,7 +41,7 @@
     }
   }
 
-  >section {
+  > section {
     display: flex;
     flex-direction: column;
     gap: spacer(6);
@@ -51,7 +51,7 @@
       position: absolute;
       top: -$border-width;
 
-      >summary {
+      > summary {
         border: $border;
         border-bottom-left-radius: border-radius(1);
         border-bottom-right-radius: border-radius(1);
@@ -64,7 +64,7 @@
         }
       }
 
-      ~.add-section {
+      ~ .add-section {
         top: 100%;
       }
     }


### PR DESCRIPTION
Ref:- https://github.com/antiwork/gumroad/issues/864

Earlier on small screens the product's preview page layout was breaking. please refer to the the attachments below.

before:
<img width="487" height="898" alt="Screenshot from 2025-09-05 00-20-18" src="https://github.com/user-attachments/assets/e4c26f83-06f8-42d4-9b40-d22c8ad6e157" />


[Screencast from 2025-09-05 00-21-05.webm](https://github.com/user-attachments/assets/32197cf2-bf87-421f-94ad-ae6820d78002)

after:
<img width="487" height="898" alt="Screenshot from 2025-09-05 00-20-30" src="https://github.com/user-attachments/assets/720bef18-8600-4139-b53e-c5872e93f9ce" />

[Screencast from 2025-09-05 00-22-07.webm](https://github.com/user-attachments/assets/d9a3cbd6-4191-4d7d-a392-053b23430f9a)

AI Disclosure:-
I have not used any AI assistance in this PR
