### PR TITLE
refactor(specs): reduce flakiness in inertia_pages_spec.rb

### DIFF
--- a/spec/system/inertia_pages_spec.rb
+++ b/spec/system/inertia_pages_spec.rb
@@ -3,6 +3,65 @@
 require "spec_helper"
 
 RSpec.describe "Inertia Pages", type: :system, js: true do
+  include CapybaraHelpers
+
+  # Helper method to execute fetch with automatic tracking of async requests
+  def fetch_with_tracking(url, result_variable, default_value = {})
+    page.execute_script(<<~JS)
+      window.#{result_variable} = null;
+      window.__activeRequests = true;
+      fetch('#{url}')
+        .then(response => response.json())
+        .then(data => {
+          window.#{result_variable} = data;
+          window.__activeRequests = false;
+        })
+        .catch(error => {
+          window.#{result_variable} = #{default_value.to_json};
+          window.__activeRequests = false;
+        });
+    JS
+
+    # Wait for the async operation to complete
+    wait_for_ajax
+
+    # Return the variable value
+    page.evaluate_script("window.#{result_variable}")
+  end
+
+  # Helper method to verify Inertia component
+  def verify_inertia_component(expected_component)
+    expect(page).to have_css("[data-page]")
+    page_data = JSON.parse(page.find("[data-page]")["data-page"])
+    expect(page_data["component"]).to eq(expected_component)
+  end
+
+  # Helper method to wait for page content and verify Inertia
+  def expect_page_with_inertia(content, component = nil, wait_time: 10)
+    expect(page).to have_content(content, wait: wait_time)
+    verify_inertia_component(component) if component
+  end
+
+  # Helper method to test API endpoint
+  def test_api_endpoint(url, variable_name, default_value = {})
+    data = fetch_with_tracking(url, variable_name, default_value)
+    expect(data).not_to be_nil
+    data
+  end
+
+  # Helper method for common page visit pattern
+  def visit_and_expect(path, content, component = nil)
+    visit path
+    expect_page_with_inertia(content, component)
+  end
+
+  # Helper method to just verify Inertia component without content check
+  def verify_inertia_page_only(component, wait_time: 10)
+    expect(page).to have_css("[data-page]", wait: wait_time)
+    page_data = JSON.parse(page.find("[data-page]")["data-page"])
+    expect(page_data["component"]).to eq(component)
+  end
+
   let(:user) { create(:named_seller) }
   let(:seller) { user }
 
@@ -12,51 +71,21 @@ RSpec.describe "Inertia Pages", type: :system, js: true do
 
   describe "Dashboard page" do
     it "renders the dashboard with key metrics" do
-      visit dashboard_path
-
-      # Wait for Inertia to load and check for actual content
-      expect(page).to have_content("Welcome to Gumroad", wait: 10)
+      visit_and_expect(dashboard_path, "Welcome to Gumroad", "Dashboard/index")
 
       # Check for dashboard elements that actually exist
       expect(page).to have_content("Balance")
       expect(page).to have_content("Create your first product")
-
-      # Verify the page is using Inertia
-      expect(page).to have_css("[data-page]")
-      page_data = JSON.parse(page.find("[data-page]")["data-page"])
-      expect(page_data["component"]).to eq("Dashboard/index")
     end
 
     it "displays revenue metrics correctly" do
-      visit dashboard_path
-
-      expect(page).to have_content("Total earnings")
+      visit_and_expect(dashboard_path, "Total earnings", "Dashboard/index")
       expect(page).to have_content("$0")
-
-      # Verify Inertia component structure
-      expect(page).to have_css("[data-page]")
-      page_data = JSON.parse(page.find("[data-page]")["data-page"])
-      expect(page_data["component"]).to eq("Dashboard/index")
     end
 
     it "handles AJAX requests for dashboard metrics" do
       visit dashboard_path
-
-      # Test customers count endpoint with proper waiting
-      page.execute_script("
-        window.customersCount = null;
-        fetch('/dashboard/customers_count')
-          .then(response => response.json())
-          .then(data => window.customersCount = data.value || 0)
-          .catch(error => window.customersCount = 0)
-      ")
-
-      # Wait for the async operation to complete
-      expect(page).to have_content("Welcome to Gumroad", wait: 5)
-      sleep(2)
-
-      customers_count = page.evaluate_script("window.customersCount")
-      expect(customers_count).not_to be_nil
+      test_api_endpoint('/dashboard/customers_count', 'customersCount', 0)
     end
   end
 
@@ -66,62 +95,26 @@ RSpec.describe "Inertia Pages", type: :system, js: true do
     let!(:membership) { create(:product, user: seller, name: "Membership 1") }
 
     it "renders the products dashboard" do
-      visit products_path
-
-      expect(page).to have_content("Products")
+      visit_and_expect(products_path, "Products", "Products/index")
       expect(page).to have_content("Product 1")
       expect(page).to have_content("Product 2")
-
-      # Verify Inertia component
-      expect(page).to have_css("[data-page]")
-      page_data = JSON.parse(page.find("[data-page]")["data-page"])
-      expect(page_data["component"]).to eq("Products/index")
     end
 
     it "displays both products and memberships" do
       visit products_path
-
-      expect(page).to have_content("Product 1", wait: 10)
+      expect_page_with_inertia("Product 1")
       expect(page).to have_content("Product 2")
       expect(page).to have_content("Membership 1")
     end
 
     it "handles product pagination" do
       visit products_path
-
-      # Test pagination API endpoint with proper waiting
-      page.execute_script("
-        window.paginationData = null;
-        fetch('/products/products_paged?page=2')
-          .then(response => response.json())
-          .then(data => window.paginationData = data)
-          .catch(error => window.paginationData = { entries: [] })
-      ")
-
-      # Wait for async operation
-      sleep(2)
-
-      pagination_data = page.evaluate_script("window.paginationData")
-      expect(pagination_data).not_to be_nil
+      test_api_endpoint('/products/products_paged?page=2', 'paginationData', { entries: [] })
     end
 
     it "supports product search" do
       visit products_path
-
-      # Test search functionality via API with proper waiting
-      page.execute_script("
-        window.searchResults = null;
-        fetch('/products/products_paged?query=Product%201')
-          .then(response => response.json())
-          .then(data => window.searchResults = data)
-          .catch(error => window.searchResults = { entries: [] })
-      ")
-
-      # Wait for async operation
-      sleep(2)
-
-      search_results = page.evaluate_script("window.searchResults")
-      expect(search_results).not_to be_nil
+      test_api_endpoint('/products/products_paged?query=Product%201', 'searchResults', { entries: [] })
     end
   end
 
@@ -136,59 +129,68 @@ RSpec.describe "Inertia Pages", type: :system, js: true do
 
     it "renders the analytics dashboard" do
       visit analytics_path
-
-      # Check for any content that indicates the page loaded
-      expect(page).to have_css("body", wait: 10)
-
-      # Verify Inertia component
-      expect(page).to have_css("[data-page]")
+      verify_inertia_page_only("Analytics/index")
     end
 
     it "loads analytics data via API endpoints" do
       visit analytics_path
-
-      # Test data by date endpoint with proper waiting
-      page.execute_script("
-        window.analyticsData = null;
-        fetch('/analytics/data_by_date?start_time=#{1.week.ago.to_date}&end_time=#{Date.current}')
-          .then(response => response.json())
-          .then(data => window.analyticsData = data)
-          .catch(error => window.analyticsData = { revenue_data: [] })
-      ")
-
-      # Wait for async operation
-      sleep(2)
-
-      analytics_data = page.evaluate_script("window.analyticsData")
-      expect(analytics_data).not_to be_nil
+      test_api_endpoint(
+        "/analytics/data_by_date?start_time=#{1.week.ago.to_date}&end_time=#{Date.current}",
+        'analyticsData',
+        { revenue_data: [] }
+      )
     end
 
     it "handles different analytics views" do
       visit analytics_path
 
-      # Test data by state endpoint with proper waiting
-      page.execute_script("
-        window.stateData = null;
-        fetch('/analytics/data_by_state?start_time=#{1.week.ago.to_date}&end_time=#{Date.current}')
-          .then(response => response.json())
-          .then(data => window.stateData = data)
-          .catch(error => window.stateData = { state_data: [] })
-      ")
+      # Add a helper method for multiple concurrent requests
+      def fetch_multiple_endpoints
+        time_params = "start_time=#{1.week.ago.to_date}&end_time=#{Date.current}"
 
-      # Test referral data endpoint with proper waiting
-      page.execute_script("
-        window.referralData = null;
-        fetch('/analytics/referral_data?start_time=#{1.week.ago.to_date}&end_time=#{Date.current}')
-          .then(response => response.json())
-          .then(data => window.referralData = data)
-          .catch(error => window.referralData = { referral_data: [] })
-      ")
+        page.execute_script(<<~JS)
+          window.__activeRequests = 2;
 
-      # Wait for async operations
-      sleep(2)
+          // State data request
+          window.stateData = null;
+          fetch('/analytics/data_by_state?#{time_params}')
+            .then(response => response.json())
+            .then(data => {
+              window.stateData = data;
+              window.__activeRequests--;
+            })
+            .catch(error => {
+              window.stateData = { state_data: [] };
+              window.__activeRequests--;
+            });
 
-      state_data = page.evaluate_script("window.stateData")
-      referral_data = page.evaluate_script("window.referralData")
+          // Referral data request
+          window.referralData = null;
+          fetch('/analytics/referral_data?#{time_params}')
+            .then(response => response.json())
+            .then(data => {
+              window.referralData = data;
+              window.__activeRequests--;
+            })
+            .catch(error => {
+              window.referralData = { referral_data: [] };
+              window.__activeRequests--;
+            });
+        JS
+
+        # Wait for both requests to complete
+        page.document.synchronize do
+          raise Capybara::ElementNotFound unless page.evaluate_script("window.__activeRequests === 0")
+        end
+
+        # Return results
+        [
+          page.evaluate_script("window.stateData"),
+          page.evaluate_script("window.referralData")
+        ]
+      end
+
+      state_data, referral_data = fetch_multiple_endpoints
 
       expect(state_data).not_to be_nil
       expect(referral_data).not_to be_nil
@@ -212,75 +214,32 @@ RSpec.describe "Inertia Pages", type: :system, js: true do
 
     it "renders the customers dashboard" do
       visit customers_path
-
-      expect(page).to have_content("Sales", wait: 10)
-
-      # Verify Inertia component
-      expect(page).to have_css("[data-page]")
+      expect_page_with_inertia("Sales")
     end
 
     it "displays customer information" do
       visit customers_path
-
-      expect(page).to have_content("Sales", wait: 10)
+      expect_page_with_inertia("Sales")
       expect(page).to have_content("Manage all of your sales")
     end
 
     it "handles customer pagination and filtering" do
       visit customers_path
-
-      # Test pagination endpoint with proper waiting
-      page.execute_script("
-        window.customersData = null;
-        fetch('/customers/paged?page=1')
-          .then(response => response.json())
-          .then(data => window.customersData = data)
-          .catch(error => window.customersData = { customers: [] })
-      ")
-
-      # Wait for async operation
-      sleep(2)
-
-      customers_data = page.evaluate_script("window.customersData")
-      expect(customers_data).not_to be_nil
+      test_api_endpoint('/customers/paged?page=1', 'customersData', { customers: [] })
     end
 
     it "supports customer search and filtering" do
       visit customers_path
-
-      # Test search functionality with proper waiting
-      page.execute_script("
-        window.searchResults = null;
-        fetch('/customers/paged?query=customer@example.com')
-          .then(response => response.json())
-          .then(data => window.searchResults = data)
-          .catch(error => window.searchResults = { customers: [] })
-      ")
-
-      # Wait for async operation
-      sleep(2)
-
-      search_results = page.evaluate_script("window.searchResults")
-      expect(search_results).not_to be_nil
+      test_api_endpoint('/customers/paged?query=customer@example.com', 'searchResults', { customers: [] })
     end
 
     it "loads customer details" do
       visit customers_path
-
-      # Test customer charges endpoint with proper waiting
-      page.execute_script("
-        window.customerCharges = null;
-        fetch('/customers/customer_charges?purchase_id=test123&purchase_email=test@example.com')
-          .then(response => response.json())
-          .then(data => window.customerCharges = data)
-          .catch(error => window.customerCharges = [])
-      ")
-
-      # Wait for async operation
-      sleep(2)
-
-      customer_charges = page.evaluate_script("window.customerCharges")
-      expect(customer_charges).not_to be_nil
+      test_api_endpoint(
+        '/customers/customer_charges?purchase_id=test123&purchase_email=test@example.com',
+        'customerCharges',
+        []
+      )
     end
   end
 
@@ -294,57 +253,27 @@ RSpec.describe "Inertia Pages", type: :system, js: true do
     end
 
     it "renders the payouts dashboard" do
-      visit balance_path
-
-      expect(page).to have_content("Payouts", wait: 10)
-
-      # Verify Inertia component
-      expect(page).to have_css("[data-page]")
-      page_data = JSON.parse(page.find("[data-page]")["data-page"])
-      expect(page_data["component"]).to eq("Payouts/index")
+      visit_and_expect(balance_path, "Payouts", "Payouts/index")
     end
 
     it "displays payout information" do
       visit balance_path
-
-      expect(page).to have_content("Payouts", wait: 10)
+      expect_page_with_inertia("Payouts")
     end
 
     it "handles payout pagination" do
       visit balance_path
-
-      # Test payments pagination endpoint with proper waiting
-      page.execute_script("
-        window.paymentsData = null;
-        fetch('/balance/payments_paged?page=1')
-          .then(response => response.json())
-          .then(data => window.paymentsData = data)
-          .catch(error => window.paymentsData = { payouts: [] })
-      ")
-
-      # Wait for async operation
-      sleep(2)
-
-      payments_data = page.evaluate_script("window.paymentsData")
-      expect(payments_data).not_to be_nil
+      test_api_endpoint('/balance/payments_paged?page=1', 'paymentsData', { payouts: [] })
     end
   end
 
   describe "Collaborators page" do
     it "renders the collaborators page" do
-      visit collaborators_path
-
-      expect(page).to have_content("Collaborators", wait: 10)
-
-      # Verify Inertia component
-      expect(page).to have_css("[data-page]")
-      page_data = JSON.parse(page.find("[data-page]")["data-page"])
-      expect(page_data["component"]).to eq("Collaborators/index")
+      visit_and_expect(collaborators_path, "Collaborators", "Collaborators/index")
     end
 
     it "displays collaborators interface" do
       visit collaborators_path
-
       # Since this is a simpler page, just verify it loads without errors
       expect(page).not_to have_content("Error")
       expect(page).not_to have_content("500")
@@ -355,17 +284,15 @@ RSpec.describe "Inertia Pages", type: :system, js: true do
     let!(:product) { create(:product, user: seller, name: "Navigation Test Product") }
 
     it "handles navigation between Inertia pages without full page reloads" do
-      visit dashboard_path
-      expect(page).to have_content("Welcome to Gumroad", wait: 10)
+      visit_and_expect(dashboard_path, "Welcome to Gumroad")
 
       # Navigate to products page if the link exists
       if page.has_link?("Products")
         click_link "Products"
-        expect(page).to have_content("Products", wait: 10)
+        expect_page_with_inertia("Products")
       else
         # If no Products link, just visit the products page directly
-        visit products_path
-        expect(page).to have_content("Products", wait: 10)
+        visit_and_expect(products_path, "Products")
       end
 
       # Verify we're still in an Inertia context
@@ -373,18 +300,13 @@ RSpec.describe "Inertia Pages", type: :system, js: true do
     end
 
     it "preserves scroll position during navigation" do
-      visit products_path
-      expect(page).to have_content("Products", wait: 10)
-
+      visit_and_expect(products_path, "Products")
       # Test that Inertia progress bar is configured
-      # Just verify the page loads without errors
       expect(page).to have_css("[data-page]")
     end
 
     it "handles form submissions via Inertia" do
-      visit products_path
-      expect(page).to have_content("Products", wait: 10)
-
+      visit_and_expect(products_path, "Products")
       # Verify CSRF token is present for forms (not requiring visibility)
       expect(page).to have_css('meta[name="csrf-token"]', visible: false)
     end
@@ -410,8 +332,7 @@ RSpec.describe "Inertia Pages", type: :system, js: true do
   describe "Performance and loading" do
     it "loads pages within acceptable time limits" do
       start_time = Time.current
-      visit dashboard_path
-      expect(page).to have_content("Welcome to Gumroad", wait: 10)
+      visit_and_expect(dashboard_path, "Welcome to Gumroad")
       load_time = Time.current - start_time
 
       expect(load_time).to be < 10.seconds


### PR DESCRIPTION
Under #1127 

This PR refactors `spec/system/inertia_pages_spec.rb` to reduce flakiness, eliminate code duplication and improve maintainability by extracting common test patterns into reusable helper methods.

#### Flakiness Improvements
- Improved flakiness, addressed the most common sources of flakiness (arbitrary sleeps, inconsistent waiting).
- Eliminated manual sleep() calls - Replaced with proper wait_for_ajax
- Centralized timeout handling - All waits now go through helper methods
- Better async operation handling - Improved `fetch_with_tracking` method
- Consistent waiting patterns - No more arbitrary sleep durations

#### Before:
- Repetitive 6-8 line blocks for Inertia component verification
- Duplicate API endpoint testing patterns
- Scattered wait: 10 timeouts throughout tests
- Manual page visit + content verification patterns repeated 15+ times
<img width="1824" height="1424" alt="image" src="https://github.com/user-attachments/assets/68f613f6-7521-4e2f-823b-7d51ee5e418a" />

#### After:
- new helper methods that encapsulate common patterns
- **Performance**: This refactoring also reduces test execution time by ~12 seconds
<img width="1824" height="1424" alt="image" src="https://github.com/user-attachments/assets/c49b728f-b91e-4b98-8e49-080601d8e1c8" />

AI Disclosure

used AI to understanding the current state of tests, which then are reviewed and implemented by me.
