### PR TITLE
fix: replace sleep with proper waiting in system tests

### DIFF
--- a/spec/system/inertia_pages_spec.rb
+++ b/spec/system/inertia_pages_spec.rb
@@ -52,8 +52,12 @@ RSpec.describe "Inertia Pages", type: :system, js: true do
       ")
 
       # Wait for the async operation to complete
-      expect(page).to have_content("Welcome to Gumroad", wait: 5)
-      sleep(2)
+      expect(page).to have_content("Welcome to Gumroad", wait: 10)
+      
+      # Wait for the AJAX request to complete using Capybara's wait mechanism
+      Timeout.timeout(Capybara.default_max_wait_time) do
+        loop until page.evaluate_script("window.customersCount !== null")
+      end
 
       customers_count = page.evaluate_script("window.customersCount")
       expect(customers_count).not_to be_nil
@@ -98,8 +102,10 @@ RSpec.describe "Inertia Pages", type: :system, js: true do
           .catch(error => window.paginationData = { entries: [] })
       ")
 
-      # Wait for async operation
-      sleep(2)
+      # Wait for async operation using Capybara's wait mechanism
+      Timeout.timeout(Capybara.default_max_wait_time) do
+        loop until page.evaluate_script("window.paginationData !== null")
+      end
 
       pagination_data = page.evaluate_script("window.paginationData")
       expect(pagination_data).not_to be_nil
@@ -117,8 +123,10 @@ RSpec.describe "Inertia Pages", type: :system, js: true do
           .catch(error => window.searchResults = { entries: [] })
       ")
 
-      # Wait for async operation
-      sleep(2)
+      # Wait for async operation using Capybara's wait mechanism
+      Timeout.timeout(Capybara.default_max_wait_time) do
+        loop until page.evaluate_script("window.searchResults !== null")
+      end
 
       search_results = page.evaluate_script("window.searchResults")
       expect(search_results).not_to be_nil
@@ -156,8 +164,10 @@ RSpec.describe "Inertia Pages", type: :system, js: true do
           .catch(error => window.analyticsData = { revenue_data: [] })
       ")
 
-      # Wait for async operation
-      sleep(2)
+      # Wait for async operation using Capybara's wait mechanism
+      Timeout.timeout(Capybara.default_max_wait_time) do
+        loop until page.evaluate_script("window.analyticsData !== null")
+      end
 
       analytics_data = page.evaluate_script("window.analyticsData")
       expect(analytics_data).not_to be_nil
@@ -184,8 +194,10 @@ RSpec.describe "Inertia Pages", type: :system, js: true do
           .catch(error => window.referralData = { referral_data: [] })
       ")
 
-      # Wait for async operations
-      sleep(2)
+      # Wait for async operations using Capybara's wait mechanism
+      Timeout.timeout(Capybara.default_max_wait_time) do
+        loop until page.evaluate_script("window.stateData !== null && window.referralData !== null")
+      end
 
       state_data = page.evaluate_script("window.stateData")
       referral_data = page.evaluate_script("window.referralData")
@@ -238,8 +250,10 @@ RSpec.describe "Inertia Pages", type: :system, js: true do
           .catch(error => window.customersData = { customers: [] })
       ")
 
-      # Wait for async operation
-      sleep(2)
+      # Wait for async operation using Capybara's wait mechanism
+      Timeout.timeout(Capybara.default_max_wait_time) do
+        loop until page.evaluate_script("window.customersData !== null")
+      end
 
       customers_data = page.evaluate_script("window.customersData")
       expect(customers_data).not_to be_nil
@@ -257,8 +271,10 @@ RSpec.describe "Inertia Pages", type: :system, js: true do
           .catch(error => window.searchResults = { customers: [] })
       ")
 
-      # Wait for async operation
-      sleep(2)
+      # Wait for async operation using Capybara's wait mechanism
+      Timeout.timeout(Capybara.default_max_wait_time) do
+        loop until page.evaluate_script("window.searchResults !== null")
+      end
 
       search_results = page.evaluate_script("window.searchResults")
       expect(search_results).not_to be_nil
@@ -276,8 +292,10 @@ RSpec.describe "Inertia Pages", type: :system, js: true do
           .catch(error => window.customerCharges = [])
       ")
 
-      # Wait for async operation
-      sleep(2)
+      # Wait for async operation using Capybara's wait mechanism
+      Timeout.timeout(Capybara.default_max_wait_time) do
+        loop until page.evaluate_script("window.customerCharges !== null")
+      end
 
       customer_charges = page.evaluate_script("window.customerCharges")
       expect(customer_charges).not_to be_nil
@@ -322,8 +340,10 @@ RSpec.describe "Inertia Pages", type: :system, js: true do
           .catch(error => window.paymentsData = { payouts: [] })
       ")
 
-      # Wait for async operation
-      sleep(2)
+      # Wait for async operation using Capybara's wait mechanism
+      Timeout.timeout(Capybara.default_max_wait_time) do
+        loop until page.evaluate_script("window.paymentsData !== null")
+      end
 
       payments_data = page.evaluate_script("window.paymentsData")
       expect(payments_data).not_to be_nil


### PR DESCRIPTION
## Fix Flaky System Tests in Inertia Pages Spec

### Part of #1127

### Problem
The `spec/system/inertia_pages_spec.rb` tests have been failing intermittently in CI, causing builds on the main branch to fail sporadically. The root cause is the use of arbitrary `sleep(2)` delays to wait for asynchronous JavaScript operations to complete.

### Related GitHub Actions Failures
- Build #2490: https://github.com/antiwork/gumroad/actions/runs/17499348012
- Build #2471: https://github.com/antiwork/gumroad/actions/runs/17477451152
- Build #2459: https://github.com/antiwork/gumroad/actions/runs/17471381385

### Solution
Replace all `sleep()` calls with proper Capybara waiting mechanisms that poll for conditions to be met, eliminating race conditions.

### Changes Made
- Replaced 9 instances of `sleep(2)` with `Timeout.timeout` and polling loops
- Wait for async JavaScript operations by checking for non-null values
- Use Capybara's default_max_wait_time (25 seconds) as the timeout limit

### Before (Flaky)

**GitHub Actions Failure**: https://github.com/antiwork/gumroad/actions/runs/17499348012/job/49708578466

<img width="923" height="547" alt="Screenshot 2025-09-05 at 11 33 50 PM" src="https://github.com/user-attachments/assets/7bf510f1-f671-45fb-9eba-713f4a72492a" />

### After

<img width="1243" height="548" alt="Screenshot 2025-09-05 at 11 36 03 PM" src="https://github.com/user-attachments/assets/a66a7c1b-e9f4-45f7-ab4c-8e52c681ff7b" />
