### PR TITLE
refactor - flakiness of spec/requests/admin/affiliates_spec.rb

### DIFF
--- a/spec/requests/admin/affiliates_spec.rb
+++ b/spec/requests/admin/affiliates_spec.rb
@@ -7,23 +7,14 @@ describe "Admin::AffiliatesController Scenario", type: :system, js: true do
   let(:affiliate_user) { create(:affiliate_user) }
 
   before do
-    # Set up required configuration values for tests using environment variables
-    ENV["IFFY_TOKEN"] = "test_iffy_token"
-    ENV["OBFUSCATE_IDS_CIPHER_KEY"] = "test_cipher_key_32_characters_long"
-    ENV["OBFUSCATE_IDS_NUMERIC_CIPHER_KEY"] = "123456789"
+    # Mock the request_from_iffy? method to return false
+    allow_any_instance_of(Admin::BaseController).to receive(:request_from_iffy?).and_return(false)
 
-    # Stub the ObfuscateIds module constants directly since they're loaded at class definition time
+    # Stub the ObfuscateIds module constants since the view uses obfuscated IDs
     stub_const("ObfuscateIds::CIPHER_KEY", "test_cipher_key_32_characters_long")
     stub_const("ObfuscateIds::NUMERIC_CIPHER_KEY", 123456789)
 
     login_as(admin)
-  end
-
-  after do
-    # Clean up environment variables to avoid side effects
-    ENV.delete("IFFY_TOKEN")
-    ENV.delete("OBFUSCATE_IDS_CIPHER_KEY")
-    ENV.delete("OBFUSCATE_IDS_NUMERIC_CIPHER_KEY")
   end
 
   context "when user has no affiliated products" do


### PR DESCRIPTION
Under #1127 

### Root Cause of Test Failures
- [See](https://github.com/antiwork/gumroad/pull/1134#issuecomment-3259744894)
    
  
 ### Before 
 
<img width="805" height="548" alt="Screenshot 2025-09-05 at 23 58 43" src="https://github.com/user-attachments/assets/945fa8f5-8906-474c-b08b-8d85ce15c272" />

### After
<img width="804" height="530" alt="Screenshot 2025-09-05 at 23 58 30" src="https://github.com/user-attachments/assets/afec016b-0199-4cec-95da-80f90d7e4bad" />


AI Disclosure

used AI to understanding the current state of tests, which then are reviewed and implemented by me.

---
CI failing - https://github.com/antiwork/gumroad/actions/runs/17442296747/job/49528859787#step:8:279
