### PR TITLE
fix: bottom link text at library page

### DIFF
--- a/app/javascript/components/server-components/LibraryPage.tsx
+++ b/app/javascript/components/server-components/LibraryPage.tsx
@@ -501,6 +501,7 @@ const LibraryPage = ({ results, creators, bundles, reviews_page_enabled, followi
               ) : null}
             </div>
           ) : null}
+          <div>
           <div className="product-card__column product-card__grid product-card-grid">
             {filteredResults.slice(0, resultsLimit).map((result) => (
               <Card
@@ -517,6 +518,12 @@ const LibraryPage = ({ results, creators, bundles, reviews_page_enabled, followi
               />
             ))}
           </div>
+          <div style={{ marginTop: "20px", textAlign: "center" }}>
+            <a href="/help/article/198-your-gumroad-library" target="_blank" rel="noreferrer">
+              Need help with your Library?
+            </a>
+          </div>
+          </div>
         </div>
         <DeleteProductModal
           deleting={deleting}
@@ -526,11 +533,7 @@ const LibraryPage = ({ results, creators, bundles, reviews_page_enabled, followi
             setDeleting(null);
           }}
         />
-        <div style={{ marginTop: "20px", textAlign: "center" }}>
-          <a href="/help/article/198-your-gumroad-library" target="_blank" rel="noreferrer">
-            Need help with your Library?
-          </a>
-        </div>
+
       </section>
     </Layout>
   );


### PR DESCRIPTION
Ref:- https://github.com/antiwork/gumroad/issues/864

fix the alignment of the link text at the bottom of library page. ( align it to center )

before:


<img width="1851" height="966" alt="Screenshot from 2025-09-07 13-09-20" src="https://github.com/user-attachments/assets/41fcfdb3-73b0-40f6-bc5b-87da3280bee4" />



after:

<img width="1851" height="966" alt="Screenshot from 2025-09-07 13-10-02" src="https://github.com/user-attachments/assets/e8b1a722-3ebc-44f3-9d5d-71891ce35ccf" />




AI Disclosure:-
I have not used any AI assistance in this PR
