### PR TITLE
fix: loading spinner at followers page

### DIFF
--- a/app/javascript/components/server-components/FollowersPage.tsx
+++ b/app/javascript/components/server-components/FollowersPage.tsx
@@ -170,7 +170,9 @@ export const FollowersPage = ({ followers: initialFollowers, per_page, total }: 
     >
       <div>
         {loading ? (
+          <div className="flex justify-center">
           <Progress width="5rem" />
+          </div>
         ) : followers.length > 0 ? (
           <div>
             <table>


### PR DESCRIPTION
Ref:- https://github.com/antiwork/gumroad/issues/864

Fix the alignment of the Loading spinner at the Followers page. ( align it to center ). 

before:


<img width="1851" height="966" alt="Screenshot from 2025-09-07 15-04-58" src="https://github.com/user-attachments/assets/16a23a93-b5a7-4d68-8a05-b808cecc250d" />

<img width="604" height="905" alt="image" src="https://github.com/user-attachments/assets/1d16aa6b-63ce-437e-b6d2-121cbf89b760" />



after:

<img width="1851" height="966" alt="Screenshot from 2025-09-07 15-08-24" src="https://github.com/user-attachments/assets/ec216533-c36b-4119-af16-e65095e6e60f" />


<img width="604" height="905" alt="image" src="https://github.com/user-attachments/assets/05e05fb8-cd5e-4dce-bc2a-752dd6ea95f4" />


AI Disclosure:-
I have not used any AI assistance in this PR
