### PR TITLE
fix: add missing tooltip to search icon 

### DIFF
--- a/app/javascript/components/server-components/CheckoutDashboard/DiscountsPage.tsx
+++ b/app/javascript/components/server-components/CheckoutDashboard/DiscountsPage.tsx
@@ -39,6 +39,7 @@ import { useUserAgentInfo } from "$app/components/UserAgent";
 import { useSortingTableDriver, Sort } from "$app/components/useSortingTableDriver";
 
 import placeholder from "$assets/images/placeholders/discounts.png";
+import { WithTooltip } from "$app/components/WithTooltip";
 
 type Product = {
   id: string;
@@ -287,9 +288,11 @@ const DiscountsPage = ({
             onToggle={setIsSearchPopoverOpen}
             aria-label="Search"
             trigger={
-              <div className="button">
-                <Icon name="solid-search" />
-              </div>
+                <WithTooltip tip="Search" position="bottom">
+                <div className="button">
+                  <Icon name="solid-search" />
+                </div>
+              </WithTooltip>
             }
           >
             <div className="input">

--- a/app/javascript/components/server-components/CheckoutDashboard/DiscountsPage.tsx
+++ b/app/javascript/components/server-components/CheckoutDashboard/DiscountsPage.tsx
@@ -288,7 +288,7 @@ const DiscountsPage = ({
             onToggle={setIsSearchPopoverOpen}
             aria-label="Search"
             trigger={
-                <WithTooltip tip="Search" position="bottom">
+              <WithTooltip tip="Search" position="bottom">
                 <div className="button">
                   <Icon name="solid-search" />
                 </div>

--- a/app/javascript/components/server-components/CheckoutDashboard/UpsellsPage.tsx
+++ b/app/javascript/components/server-components/CheckoutDashboard/UpsellsPage.tsx
@@ -207,11 +207,11 @@ const UpsellsPage = (props: {
             onToggle={setIsSearchPopoverOpen}
             aria-label="Search"
             trigger={
-               <WithTooltip tip="Search" position="bottom">
-                             <div className="button">
-                               <Icon name="solid-search" />
-                             </div>
-                           </WithTooltip>
+              <WithTooltip tip="Search" position="bottom">
+                <div className="button">
+                  <Icon name="solid-search" />
+                </div>
+              </WithTooltip>
             }
           >
             <div className="input">

--- a/app/javascript/components/server-components/CheckoutDashboard/UpsellsPage.tsx
+++ b/app/javascript/components/server-components/CheckoutDashboard/UpsellsPage.tsx
@@ -38,6 +38,7 @@ import { useDebouncedCallback } from "$app/components/useDebouncedCallback";
 import { Sort, useSortingTableDriver } from "$app/components/useSortingTableDriver";
 
 import placeholder from "$assets/images/placeholders/upsells.png";
+import { WithTooltip } from "$app/components/WithTooltip";
 
 type Variant = {
   id: string;
@@ -206,9 +207,11 @@ const UpsellsPage = (props: {
             onToggle={setIsSearchPopoverOpen}
             aria-label="Search"
             trigger={
-              <div className="button">
-                <Icon name="solid-search" />
-              </div>
+               <WithTooltip tip="Search" position="bottom">
+                             <div className="button">
+                               <Icon name="solid-search" />
+                             </div>
+                           </WithTooltip>
             }
           >
             <div className="input">


### PR DESCRIPTION
Ref:- https://github.com/antiwork/gumroad/issues/864

Added tooltip to the existing search icon to improve usability ( checkout page ).  
improves consistency.

#### before:


[Screencast from 2025-09-07 20-40-53.webm](https://github.com/user-attachments/assets/ca795bef-ac77-410b-87e9-f2233575a497)

#### after:

[Screencast from 2025-09-07 20-41-47.webm](https://github.com/user-attachments/assets/12108dcf-b172-4d38-979a-912d51621921)

### AI Disclosure:-
I have not used any AI assistance in this PR
