### PR TITLE
fix Stripe throttling flaky test

### DIFF
--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -319,7 +319,11 @@ module StripeMerchantAccountManager
           end
 
           Rails.logger.warn "Stripe account creation rate limit hit, retrying in 1 second (attempt #{attempts}/#{max_attempts})"
-          sleep(1) # Since its 5 attemps per second, 1 second is enough to avoid rate limiting
+
+          # For test env we have 5 calls/second so, it would be 200ms. So in that case im using 400 so we can have a small buffer
+          # For prod env we have 30 calls/second so, it would be 33ms. So in that case im using 100 so we can have a small buffer
+          sleep_time = Rails.env.production? ? 0.1 : 0.4
+          sleep(sleep_time) # Since its 5 attemps per second, 1 second is enough to avoid rate limiting
         else
           raise e
         end

--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -67,7 +67,7 @@ module StripeMerchantAccountManager
       )
     end
 
-    stripe_account = Stripe::Account.create(account_params)
+    stripe_account = stripe_account_with_rate_limit(:create, [account_params])
 
     merchant_account.charge_processor_merchant_id = stripe_account.id
     merchant_account.save!
@@ -299,6 +299,31 @@ module StripeMerchantAccountManager
     unless user.stripe_account
       raise MerchantRegistrationUserNotReadyError
         .new(user.id, "does not have a Stripe merchant account")
+    end
+  end
+
+  private_class_method
+  def self.stripe_account_with_rate_limit(method, params, max_attempts: 5)
+    attempts = 0
+
+    loop do
+      attempts += 1
+
+      begin
+        return Stripe::Account.send(method, *params)
+      rescue Stripe::InvalidRequestError, Stripe::RateLimitError => e
+        if (e.code == "rate_limit") || (e.http_status == 429) || (e.is_a?(Stripe::RateLimitError)) || e.message.include?("creating accounts too quickly")
+          if attempts >= max_attempts
+            Rails.logger.error "Stripe account creation rate limit exceeded after #{max_attempts} attempts"
+            raise e
+          end
+
+          Rails.logger.warn "Stripe account creation rate limit hit, retrying in 1 second (attempt #{attempts}/#{max_attempts})"
+          sleep(1) # Since its 5 attemps per second, 1 second is enough to avoid rate limiting
+        else
+          raise e
+        end
+      end
     end
   end
 

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -11288,4 +11288,123 @@ describe StripeMerchantAccountManager, :vcr do
       end
     end
   end
+
+  describe ".stripe_account_with_rate_limit" do
+    let(:account_params) { { type: "custom", country: "US" } }
+    let(:fake_stripe_account) { double("Stripe::Account", id: "acct_test_123") }
+
+    context "when the call succeeds on first attempt" do
+      it "returns the result without retrying" do
+        expect(Stripe::Account).to receive(:send).with(:create, account_params).and_return(fake_stripe_account)
+        expect(Rails.logger).not_to receive(:warn)
+
+        result = described_class.send(:stripe_account_with_rate_limit, :create, [account_params])
+        expect(result).to eq(fake_stripe_account)
+      end
+    end
+
+    context "when rate limit error occurs" do
+      context "with Stripe::RateLimitError" do
+        it "retries with 1 second delay and succeeds" do
+          expect(Stripe::Account).to receive(:send).with(:create, account_params).and_raise(Stripe::RateLimitError.new("Rate limit exceeded"))
+          expect(Stripe::Account).to receive(:send).with(:create, account_params).and_return(fake_stripe_account)
+          expect(Rails.logger).to receive(:warn).with(/retrying in 1 second \(attempt 1\/5\)/)
+
+          result = described_class.send(:stripe_account_with_rate_limit, :create, [account_params])
+          expect(result).to eq(fake_stripe_account)
+        end
+      end
+
+      context "with Stripe::InvalidRequestError containing rate limit message" do
+        it "retries with 1 second delay and succeeds" do
+          rate_limit_error = Stripe::InvalidRequestError.new("Sorry, you're creating accounts too quickly", nil)
+          allow(rate_limit_error).to receive(:code).and_return("rate_limit")
+          allow(rate_limit_error).to receive(:http_status).and_return(429)
+
+          expect(Stripe::Account).to receive(:send).with(:create, account_params).and_raise(rate_limit_error)
+          expect(Stripe::Account).to receive(:send).with(:create, account_params).and_return(fake_stripe_account)
+          expect(Rails.logger).to receive(:warn).with(/retrying in 1 second \(attempt 1\/5\)/)
+
+          result = described_class.send(:stripe_account_with_rate_limit, :create, [account_params])
+          expect(result).to eq(fake_stripe_account)
+        end
+      end
+
+      context "with HTTP 429 status code" do
+        it "retries with 1 second delay and succeeds" do
+          error_429 = Stripe::InvalidRequestError.new("Too many requests", nil)
+          allow(error_429).to receive(:http_status).and_return(429)
+
+          expect(Stripe::Account).to receive(:send).with(:create, account_params).and_raise(error_429)
+          expect(Stripe::Account).to receive(:send).with(:create, account_params).and_return(fake_stripe_account)
+          expect(Rails.logger).to receive(:warn).with(/retrying in 1 second \(attempt 1\/5\)/)
+
+          result = described_class.send(:stripe_account_with_rate_limit, :create, [account_params])
+          expect(result).to eq(fake_stripe_account)
+        end
+      end
+    end
+
+    context "when max attempts are reached" do
+      it "raises the error after 5 attempts" do
+        rate_limit_error = Stripe::RateLimitError.new("Rate limit exceeded")
+
+        expect(Stripe::Account).to receive(:send).exactly(5).times.and_raise(rate_limit_error)
+        expect(Rails.logger).to receive(:warn).exactly(4).times
+        expect(Rails.logger).to receive(:error).with(/rate limit exceeded after 5 attempts/)
+        # Sleep is stubbed in before block to avoid Billy proxy conflicts
+
+        expect do
+          described_class.send(:stripe_account_with_rate_limit, :create, [account_params])
+        end.to raise_error(Stripe::RateLimitError, "Rate limit exceeded")
+      end
+    end
+
+    context "when non-rate-limit error occurs" do
+      it "raises the error immediately without retrying" do
+        validation_error = Stripe::InvalidRequestError.new("Invalid country", nil)
+
+        expect(Stripe::Account).to receive(:send).once.and_raise(validation_error)
+        expect(Rails.logger).not_to receive(:warn)
+
+        expect do
+          described_class.send(:stripe_account_with_rate_limit, :create, [account_params])
+        end.to raise_error(Stripe::InvalidRequestError, "Invalid country")
+      end
+    end
+
+    context "when using different Stripe methods" do
+      let(:person_params) { { first_name: "John", last_name: "Doe" } }
+      let(:fake_person) { double("Stripe::Person", id: "person_123") }
+
+      it "works with create_person method" do
+        expect(Stripe::Account).to receive(:send).with(:create_person, "acct_123", person_params).and_return(fake_person)
+
+        result = described_class.send(:stripe_account_with_rate_limit, :create_person, ["acct_123", person_params])
+        expect(result).to eq(fake_person)
+      end
+
+      it "works with update method" do
+        update_params = { business_type: "company" }
+        expect(Stripe::Account).to receive(:send).with(:update, "acct_123", update_params).and_return(fake_stripe_account)
+
+        result = described_class.send(:stripe_account_with_rate_limit, :update, ["acct_123", update_params])
+        expect(result).to eq(fake_stripe_account)
+      end
+    end
+
+    context "with custom max_attempts" do
+      it "respects the custom max_attempts parameter" do
+        rate_limit_error = Stripe::RateLimitError.new("Rate limit exceeded")
+
+        expect(Stripe::Account).to receive(:send).exactly(3).times.and_raise(rate_limit_error)
+        expect(Rails.logger).to receive(:warn).exactly(2).times
+        expect(Rails.logger).to receive(:error).with(/rate limit exceeded after 3 attempts/)
+
+        expect do
+          described_class.send(:stripe_account_with_rate_limit, :create, [account_params], max_attempts: 3)
+        end.to raise_error(Stripe::RateLimitError)
+      end
+    end
+  end
 end


### PR DESCRIPTION
AI Disclosure:
Used AI from cursor to 

FIXED: https://github.com/antiwork/gumroad/actions/runs/17506877853/job/49732084319

When we try to create a Stripe account, we encounter a throttling problem stating that we need to create a maximum of 5 per second.

My first approach was to create a VCR to handle the request, so we don't need to go there every time. However, I noticed that in `spec/requests/settings/payments_spec.rb:6`, we have `type: :system, js: true`, which means that we want to actually go to the server and retrieve the actual answer, rather than mocking it or creating a VCR. 

So, my solution for this was outside the `payments_spec.rb`.

I created a retry on `stripe_merchant_account_manager.rb` to handle throttling cases.

I created it generically, not just for `Stripe::Account.create`. I created in a way that we can use even with the other Stripe::Account methods.