### PR TITLE
Center "Open in app" popup content

### DIFF
--- a/app/javascript/components/Download/OpenInAppButton.tsx
+++ b/app/javascript/components/Download/OpenInAppButton.tsx
@@ -7,6 +7,7 @@ type Props = { iosAppUrl: string; androidAppUrl: string };
 export const OpenInAppButton = ({ iosAppUrl, androidAppUrl }: Props) => (
   <Popover trigger={<span className="button">Open in app</span>}>
     <div
+      className="mx-auto"
       style={{
         display: "grid",
         textAlign: "center",


### PR DESCRIPTION
### Explanation of Change
Fixes alignment issue where the "Open in app" popup content was not centered on mobile devices.

### Screenshots/Videos
<details>
<summary>Before</summary>

![485571634-f404c9a7-0588-4d9b-be7d-2c0e7d3124f0](https://github.com/user-attachments/assets/911533d5-76c0-435e-a506-bd4ba1eca912)

https://github.com/user-attachments/assets/69e8b1d4-3989-4dec-8811-a0ac321b807b

</details>

<details>
<summary>After</summary>

https://github.com/user-attachments/assets/87ec5f92-f686-469f-893c-7cd37dec8efa

</details>

### AI Disclosure
No AI tools used