### PR TITLE
Clear comment input field after posting a comment

### DIFF
--- a/app/javascript/components/Post/PostCommentsSection.tsx
+++ b/app/javascript/components/Post/PostCommentsSection.tsx
@@ -113,6 +113,7 @@ export const PostCommentsSection = ({ paginated_comments }: Props) => {
       });
       showAlert("Successfully posted your comment", "success");
       upsertComment(comment);
+      setDraft(null);
     } catch (e) {
       assertResponseError(e);
       showAlert(`An error occurred while posting your comment - ${e.message}`, "error");


### PR DESCRIPTION
### Explanation of Change
Fixes an issue where the comment input field was not cleared after posting a comment.

### Screenshots/Videos
<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/4c217e14-4492-4e80-a3f9-82bbff87acae

</details>

<details>
<summary>After</summary>

https://github.com/user-attachments/assets/7a73b658-4e55-42e3-9c37-43c49ab3f893

</details>

### AI Disclosure
No AI tools used