### PR TITLE
Ensure remove button positions correctly on product covers

### DIFF
--- a/app/javascript/components/ProductEdit/ProductTab/CoverEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/CoverEditor.tsx
@@ -272,7 +272,8 @@ const CoverTab = ({
   return (
     <Button
       onClick={onClick}
-      style={{ cursor: "move", padding: hasThumbnail ? "unset" : undefined, position: "relative" }}
+      className="relative"
+      style={{ cursor: "move", padding: hasThumbnail ? "unset" : undefined }}
       onMouseEnter={() => setShowDelete(true)}
       onMouseLeave={() => setShowDelete(false)}
       role="tab"


### PR DESCRIPTION
### Explanation of Change
When uploading multiple product covers on mobile, a red "X" button appears incorrectly in the top-right corner of the page instead of being positioned relative to the cover thumbnails

### Screenshots/Videos
<details>
<summary>Before</summary>

<img width="326" height="687" alt="Screenshot 2025-09-08 at 08 28 13" src="https://github.com/user-attachments/assets/f3b3eda1-26de-4cb8-b937-cf83f239b2b7" />


</details>

<details>
<summary>After</summary>

<img width="323" height="676" alt="image" src="https://github.com/user-attachments/assets/99524294-8bd9-4bef-9d1d-47243dbdfc79" />

</details>

### AI Disclosure
No AI tools used