### PR TITLE
Ensure "Load more" reviews button is not hidden by "Add to cart" CTA on mobile

### DIFF
--- a/app/javascript/components/Product/Layout.tsx
+++ b/app/javascript/components/Product/Layout.tsx
@@ -159,7 +159,7 @@ export const Layout = (
     </>
   );
 
-  const mainSection = <section>{productView}</section>;
+  const mainSection = <section className="mb-20 lg:mb-0">{productView}</section>;
 
   return (
     <>


### PR DESCRIPTION
### Explanation of Change
Fixes an issue where the “Load more” button in product reviews was hidden behind the sticky “Add to cart” button on mobile

### Screenshots/Videos
<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/3a6bface-51d0-496b-87ee-7c1c8ca67e0d

</details>

<details>
<summary>After</summary>

https://github.com/user-attachments/assets/664951c3-0244-46d5-ac41-3130abc54140

</details>

### AI Disclosure
No AI tools used