### PR TITLE
Close action menu after unarchiving and redirect

### DIFF
--- a/app/javascript/components/server-components/LibraryPage.tsx
+++ b/app/javascript/components/server-components/LibraryPage.tsx
@@ -60,6 +60,7 @@ export const Card = ({
   onDelete: (confirm?: boolean) => void;
 }) => {
   const { product, purchase } = result;
+  const [isPopoverOpen, setIsPopoverOpen] = React.useState(false);
 
   const toggleArchived = asyncVoid(async () => {
     const data = { purchase_id: result.purchase.id, is_archived: !result.purchase.is_archived };
@@ -67,6 +68,7 @@ export const Card = ({
       await setPurchaseArchived(data);
       onArchive();
       showAlert(result.purchase.is_archived ? "Product unarchived!" : "Product archived!", "success");
+      setIsPopoverOpen(false);
     } catch (e) {
       assertResponseError(e);
       showAlert("Something went wrong.", "error");
@@ -99,7 +101,12 @@ export const Card = ({
         ) : (
           <div className="user" />
         )}
-        <Popover aria-label="Open product action menu" trigger={<Icon name="three-dots" />}>
+        <Popover
+          aria-label="Open product action menu"
+          trigger={<Icon name="three-dots" />}
+          open={isPopoverOpen}
+          onToggle={setIsPopoverOpen}
+        >
           <div role="menu">
             <div role="menuitem" onClick={toggleArchived}>
               <Icon name="archive" />


### PR DESCRIPTION
### Explanation of Change
Fixes a bug where the action menu stayed open after unarchiving the last archived product and redirecting to the unarchived list.

### Screenshots/Videos
<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/d3817ffd-ccfd-40ce-81d2-98293c2a94ba

</details>

<details>
<summary>After</summary>

https://github.com/user-attachments/assets/7a0ef573-8151-48e8-bac1-608314904cbb

</details>

### AI Disclosure
No AI tools used