### PR TITLE
Fix header navigation text wrapping on smaller viewports

### DIFF
--- a/app/views/home/shared/_nav.html.erb
+++ b/app/views/home/shared/_nav.html.erb
@@ -22,7 +22,7 @@
         is_current ? 'border-black' : 'border-transparent'
       } #{
         is_current ? 'lg:bg-black lg:text-white dark:lg:bg-white dark:lg:text-black' : 'lg:bg-transparent lg:text-black dark:lg:text-white'
-      } bg-black p-4 text-lg text-white no-underline transition-all duration-200 hover:border-black lg:w-auto lg:rounded-full lg:py-2 lg:px-4 dark:text-white lg:dark:hover:border-white/[.35]"
+      } bg-black p-4 text-lg text-white no-underline transition-all duration-200 hover:border-black lg:w-auto lg:rounded-full lg:py-2 lg:px-4 dark:text-white lg:dark:hover:border-white/[.35] whitespace-nowrap"
     end
   end
 


### PR DESCRIPTION
Fixing this [issue](https://github.com/antiwork/gumroad/issues/1160) 

### Problem 
Navigation items in the header ("Discover", "Blog", etc) were wrapping to multiple lines on smaller viewports (between 1104 and 1023 pixels, e.g. on a `Nest Device`), causing text to break awkwardly (e.g., "Discov" on first line, "er" on second line).

### Solution
Added `whitespace-nowrap` Tailwind CSS class to the `nav_link` function in `app/views/home/shared/_nav.html.erb` to prevent text wrapping.

### Screenshots
**Before:**
<img width="1048" height="730" alt="before" src="https://github.com/user-attachments/assets/868d329a-bb98-4460-8f2e-67d14e1e1ab6" />
**After:** Navigation items staying on single line
<img width="1055" height="736" alt="after" src="https://github.com/user-attachments/assets/8a0d751d-86dd-4397-8606-f853e3d095de" />

### Changes
- Modified the `nav_link` helper function to include `whitespace-nowrap` class
- Ensures all navigation items maintain single-line display regardless of viewport size

### AI Usage ⚠️
Used it for writing better english (PR description) and also to verify that nothing unexpected was impacted by these changes.

### Recordings
Before fix:
https://drive.google.com/file/d/16G5uTPnXm924n7LxExr88FhX-sJMPXT-/view

After fix:
https://drive.google.com/file/d/1iU2C7T59VmXrVFJvXunrp_zZIwUtvBwZ/view?usp=drive_link
