### PR TITLE
fix: bank account section ui for small screens 

### DIFF
--- a/app/javascript/components/Settings/PaymentsPage/BankAccountSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/BankAccountSection.tsx
@@ -939,7 +939,7 @@ const BankAccountSection = ({
         </fieldset>
         <div style={{ display: "grid", gap: "var(--spacer-2)" }}>
           {showNewBankAccount ? (
-            <div style={{ display: "grid", gap: "var(--spacer-5)", gridAutoFlow: "column", gridAutoColumns: "1fr" }}>
+            <div className="grid gap-5 grid-flow-row md:grid-flow-col auto-cols-fr">
               {user.country_code === "CA" ? (
                 <>
                   <fieldset className={cx({ danger: errorFieldNames.has("transit_number") })}>

--- a/app/javascript/components/Settings/PaymentsPage/BankAccountSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/BankAccountSection.tsx
@@ -939,7 +939,7 @@ const BankAccountSection = ({
         </fieldset>
         <div style={{ display: "grid", gap: "var(--spacer-2)" }}>
           {showNewBankAccount ? (
-            <div className="grid gap-5 grid-flow-row md:grid-flow-col auto-cols-fr">
+            <div className="grid gap-5 md:grid-flow-col md:auto-cols-fr">
               {user.country_code === "CA" ? (
                 <>
                   <fieldset className={cx({ danger: errorFieldNames.has("transit_number") })}>


### PR DESCRIPTION
Ref:- https://github.com/antiwork/gumroad/issues/864

the bank account section's ui seems off for small screens. 

#### before:

<img width="413" height="877" alt="Screenshot from 2025-09-08 21-21-00" src="https://github.com/user-attachments/assets/c920b75c-a144-4968-8b3b-383c68ffc013" />

#### after:

<img width="413" height="877" alt="image" src="https://github.com/user-attachments/assets/2ffcdb63-fdaf-4567-9d70-d3ef1bc25767" />


### AI Disclosure:-
I have not used any AI assistance in this PR
