### PR TITLE
Fix some specs that are consistently failing on main

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2142,7 +2142,7 @@ describe User, :vcr do
       before do
         user.check_merchant_account_is_linked = true
         user.save
-
+        create(:user_compliance_info, user:)
         @merchant_account = create(:merchant_account_paypal, user:)
       end
 
@@ -2162,6 +2162,10 @@ describe User, :vcr do
     end
 
     context "when a merchant account is not connected" do
+      before do
+        Feature.deactivate(:disable_braintree_sales)
+      end
+
       it "returns true for non-complaint user" do
         expect(user.alive_user_compliance_info).to be_nil
         expect(user.pay_with_paypal_enabled?).to be(true)

--- a/spec/presenters/checkout_presenter_spec.rb
+++ b/spec/presenters/checkout_presenter_spec.rb
@@ -93,7 +93,7 @@ describe CheckoutPresenter do
             require_shipping: false,
             shippable_country_codes: [],
             custom_fields: [],
-            supports_paypal: "braintree",
+            supports_paypal: nil,
             has_offer_codes: false,
             has_tipping_enabled: false,
             analytics: product.analytics_data,
@@ -340,6 +340,8 @@ describe CheckoutPresenter do
       let!(:product) { create(:product) }
 
       it "returns nil for supports_paypal when the creator does not have their PayPal account connected" do
+        Feature.deactivate(:disable_braintree_sales)
+
         expect(@instance.checkout_props(params: { product: product.unique_permalink }, browser_guid:)[:add_products].first[:product][:supports_paypal]).to eq "braintree"
 
         Feature.activate(:disable_paypal_sales)
@@ -362,6 +364,7 @@ describe CheckoutPresenter do
     context "when PayPal Connect sales are disabled" do
       before do
         Feature.activate(:disable_paypal_connect_sales)
+        Feature.deactivate(:disable_braintree_sales)
       end
 
       context "when the product is a recurring subscription" do
@@ -517,7 +520,7 @@ describe CheckoutPresenter do
                                product: {
                                  name: @product.name,
                                  native_type: @product.native_type,
-                                 supports_paypal: "braintree",
+                                 supports_paypal: nil,
                                  creator: {
                                    id: @product.user.external_id,
                                    name: @product.user.username,

--- a/spec/requests/checkout/payment_spec.rb
+++ b/spec/requests/checkout/payment_spec.rb
@@ -5,6 +5,7 @@ require "spec_helper"
 describe "Checkout payment", :js, type: :system do
   before do
     @product = create(:product, price_cents: 1000)
+    Feature.deactivate(:disable_braintree_sales)
   end
 
   it "shows native, braintree, or no paypal button depending on availability" do

--- a/spec/requests/customers/customers_spec.rb
+++ b/spec/requests/customers/customers_spec.rb
@@ -740,6 +740,8 @@ describe "Sales page", type: :system, js: true do
         end
         expect(page).to have_alert(text: "Email updated successfully.")
 
+        refresh
+        find(:table_row, { "Name" => "Customer 1" }).click
         within_section "Bundle", section_element: :aside do
           within_section "Content", section_element: :section do
             within_section "Bundle Product 1" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -199,6 +199,7 @@ RSpec.configure do |config|
       follow_wishlists
       seller_refund_policy_new_users_enabled
       paypal_payout_fee
+      disable_braintree_sales
     ].each do |feature|
       Feature.activate(feature)
     end


### PR DESCRIPTION
Try to fix the following specs that are consistently failing on the `main` branch (failed in all of the last 5 commits):

- `spec/requests/purchases/product/upsell_spec.rb:102 # Product checkout with upsells when the product has a cross-sell when the buyer tips allows the buyer to accept the cross-sell at checkout`
- `spec/requests/purchases/product/payment_errors_spec.rb:96 # Purchase from a product page focuses the correct fields with errors` and `spec/requests/purchases/product/payment_errors_spec.rb:61`
- `spec/requests/customers/customers_spec.rb:727 # Sales page drawer bundle products updates the email for all bundle purchases`

Related: #1127