### PR TITLE
[Flaky] Fix two flakies in spec/requests/purchases/product/payment_errors_spec.rb

### DIFF
--- a/app/javascript/components/Checkout/PaymentForm.tsx
+++ b/app/javascript/components/Checkout/PaymentForm.tsx
@@ -600,12 +600,7 @@ const CustomerDetails = () => {
         <GiftForm isMembership={state.products[0]?.nativeType === "membership"} />
       ) : null}
       <div>
-        <Button
-          data-testid="pay-button"
-          color="primary"
-          onClick={() => dispatch({ type: "offer" })}
-          disabled={isSubmitDisabled(state)}
-        >
+        <Button color="primary" onClick={() => dispatch({ type: "offer" })} disabled={isSubmitDisabled(state)}>
           {payLabel}
         </Button>
       </div>

--- a/spec/requests/purchases/product/payment_errors_spec.rb
+++ b/spec/requests/purchases/product/payment_errors_spec.rb
@@ -65,15 +65,15 @@ describe("Purchase from a product page", type: :system, js: true) do
     fill_in "ZIP code", with: "94107"
 
     fill_in_credit_card(number: "", expiry: "", cvc: "")
-    find('[data-testid="pay-button"]').click
+    click_button "Pay", exact: true
     expect(page).to have_selector("[aria-label='Card information'][aria-invalid='true']")
 
     fill_in_credit_card(expiry: "", cvc: "")
-    find('[data-testid="pay-button"]').click
+    click_button "Pay", exact: true
     expect(page).to have_selector("[aria-label='Card information'][aria-invalid='true']")
 
     fill_in_credit_card(cvc: "")
-    find('[data-testid="pay-button"]').click
+    click_button "Pay", exact: true
     expect(page).to have_selector("[aria-label='Card information'][aria-invalid='true']")
 
     check_out(@product)
@@ -104,41 +104,41 @@ describe("Purchase from a product page", type: :system, js: true) do
     visit product.long_url
     add_to_cart(product)
 
-    find('[data-testid="pay-button"]').click
+    click_button "Pay", exact: true
     within_fieldset "Card information" do
       within_frame { expect_focused find_field("Card number") }
     end
 
     fill_in_credit_card(expiry: nil, cvc: nil)
-    find('[data-testid="pay-button"]').click
+    click_button "Pay", exact: true
     within_fieldset "Card information" do
       within_frame { expect_focused find_field("MM / YY") }
     end
 
     fill_in_credit_card(cvc: nil)
-    find('[data-testid="pay-button"]').click
+    click_button "Pay", exact: true
     within_fieldset "Card information" do
       within_frame { expect_focused find_field("CVC") }
     end
 
     fill_in_credit_card
-    find('[data-testid="pay-button"]').click
+    click_button "Pay", exact: true
     expect_focused find_field("Your email address")
 
     fill_in "Your email address", with: "gumroad@example.com"
-    find('[data-testid="pay-button"]').click
+    click_button "Pay", exact: true
     expect_focused find_field("Full name")
 
     fill_in "Full name", with: "G McGumroadson"
-    find('[data-testid="pay-button"]').click
+    click_button "Pay", exact: true
     expect_focused find_field("Street address")
 
     fill_in "Street address", with: "123 Main St"
-    find('[data-testid="pay-button"]').click
+    click_button "Pay", exact: true
     expect_focused find_field("City")
 
     fill_in "City", with: "San Francisco"
-    find('[data-testid="pay-button"]').click
+    click_button "Pay", exact: true
     expect_focused find_field("ZIP code")
   end
 end


### PR DESCRIPTION
Ref: https://github.com/antiwork/gumroad/issues/1127


AI Disclosure: None

### Root cause
We have a button "Pay" and another button "PayPal"
Capybara uses a substring match by default, case-insensitive.
So `click_on "Pay"` will match "Paypal" because "Pay" is contained at the start of "Paypal"

This will make UI assertions fail with
```rb
     Capybara::ElementNotFound:
       Unable to find field "Full name" that is not disabled
```
<img width="1315" height="878" alt="image" src="https://github.com/user-attachments/assets/14daa2dc-3dfa-42ea-abf8-f4795d8ed056" />

### Fix
Use `exact_match: true`


