### PR TITLE
fix flakey test in widget

### DIFF
--- a/spec/requests/widget_spec.rb
+++ b/spec/requests/widget_spec.rb
@@ -78,10 +78,10 @@ describe "Widget Page scenario", js: true, type: :system do
         select_tab("Embed")
         expect(page).to have_field("Widget code", with: %(<script src="#{@base_url}/js/gumroad-embed.js"></script>\n<div class="gumroad-product-embed"><a href="#{@product.long_url}">Loading...</a></div>))
 
-        expect(page).not_to have_content("Copy to Clipboard")
         copy_button = find_button("Copy embed code")
+        expect(copy_button).not_to have_tooltip(text: "Copy to Clipboard")
         copy_button.hover
-        expect(page).to have_content("Copy to Clipboard")
+        expect(copy_button).to have_tooltip(text: "Copy to Clipboard")
 
         copy_button.click
         expect(page).to have_content("Copied!")
@@ -92,7 +92,7 @@ describe "Widget Page scenario", js: true, type: :system do
         expect(page).not_to have_content("Copied!")
 
         copy_button.hover
-        expect(page).to have_content("Copy to Clipboard")
+        expect(copy_button).to have_tooltip(text: "Copy to Clipboard")
       end
     end
 


### PR DESCRIPTION
Part of #1127 

AI Disclosure:
No AI was used 

Before:
Failing on some runs : https://github.com/antiwork/gumroad/actions/runs/17560826334/job/49876970600#logs
Also fails on local
<img width="998" height="678" alt="Screenshot 2025-09-09 at 1 11 21 AM" src="https://github.com/user-attachments/assets/7e051202-7cbe-4f6c-8706-7c4c159db5fb" />

After:
<img width="1636" height="480" alt="image" src="https://github.com/user-attachments/assets/1b59dc87-f93c-4993-8214-5e6c93375a2e" />

How does the PR fix the flakeyness:
This PR fixes the test flakiness by replacing broad matchers like `have_content` with targeted assertions such as `have_tooltip`  within specific sections. This way, the test only passes when the expected text is shown in the correct, visible UI element, making it more reliable and accurately reflecting the user experience.

I have run this multiple times > 10 times on the local to ensure the stability . 