### PR TITLE
Bank account fields alignment on mobile

### DIFF
--- a/app/javascript/components/Settings/PaymentsPage/BankAccountSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/BankAccountSection.tsx
@@ -939,7 +939,7 @@ const BankAccountSection = ({
         </fieldset>
         <div style={{ display: "grid", gap: "var(--spacer-2)" }}>
           {showNewBankAccount ? (
-            <div style={{ display: "grid", gap: "var(--spacer-5)", gridAutoFlow: "column", gridAutoColumns: "1fr" }}>
+            <div className="grid gap-5 md:grid-flow-col md:auto-cols-fr">
               {user.country_code === "CA" ? (
                 <>
                   <fieldset className={cx({ danger: errorFieldNames.has("transit_number") })}>


### PR DESCRIPTION
### Explanation of Change
Fixes an issue where the bank account fields on the Payment settings page are misaligned on mobile

### Screenshots/Videos
<details>
<summary>Before</summary>

<img width="831" height="273" alt="image" src="https://github.com/user-attachments/assets/0325aa2e-ab3c-4b63-9486-b1b752e7648d" />

<img width="367" height="317" alt="Screenshot 2025-09-09 at 09 07 38" src="https://github.com/user-attachments/assets/c574529a-efc7-4846-98ce-7f81c70a18d2" />

</details>

<details>
<summary>After</summary>

<img width="327" height="340" alt="Screenshot 2025-09-09 at 09 07 09" src="https://github.com/user-attachments/assets/3ab493bc-b15d-455d-99ba-f86890e87e3d" />
<img width="919" height="286" alt="Screenshot 2025-09-09 at 09 06 56" src="https://github.com/user-attachments/assets/48f47df5-b9f8-4cbf-925e-f7f91f3a4e3c" />


</details>

### AI Disclosure
No AI tools used