### PR TITLE
Remove unnecessary dot from "Learn more" hyperlinks

### DIFF
--- a/app/javascript/components/server-components/AnalyticsPage.tsx
+++ b/app/javascript/components/server-components/AnalyticsPage.tsx
@@ -213,7 +213,7 @@ const AnalyticsPage = ({ products: initialProducts, country_codes, state_names }
               you see what's working, and what could be working better.
             </p>
             <a href="/help/article/74-the-analytics-dashboard" target="_blank" rel="noreferrer">
-              Learn more about the analytics dashboard.
+              Learn more about the analytics dashboard
             </a>
           </div>
         </div>

--- a/app/javascript/components/server-components/DashboardPage.tsx
+++ b/app/javascript/components/server-components/DashboardPage.tsx
@@ -149,7 +149,7 @@ const Greeter = () => (
       Create your first product
     </NavigationButton>
     <a href="/help/article/149-adding-a-product" target="_blank" rel="noreferrer">
-      Learn more about creating products.
+      Learn more about creating products
     </a>
   </div>
 );

--- a/app/javascript/components/server-components/ReviewsPage.tsx
+++ b/app/javascript/components/server-components/ReviewsPage.tsx
@@ -146,7 +146,7 @@ const ReviewsPage = ({
               Discover products
             </NavigationButton>
             <a href="/help/article/344-rate-and-review-your-purchase" target="_blank" rel="noreferrer">
-              Learn more about reviews.
+              Learn more about reviews
             </a>
           </div>
         ) : (


### PR DESCRIPTION
### Explanation of Change

Fixes a UI issue where the "Learn more" hyperlinks on the Dashboard, Analytics, and Reviews pages incorrectly included a trailing dot

Follow up of [this PR](https://github.com/antiwork/gumroad/pull/1115)

### Screenshots/Videos
<details>
<summary>Before</summary>

<img width="1080" height="505" alt="image" src="https://github.com/user-attachments/assets/97b4db97-be38-496f-8986-94c19c592820" />

<img width="1111" height="516" alt="image" src="https://github.com/user-attachments/assets/c7272654-c20b-4146-9579-2a93fb32806a" />


</details>

<details>
<summary>After</summary>

<img width="1115" height="519" alt="image" src="https://github.com/user-attachments/assets/4239b734-ece3-4d1a-af71-762d9073fa17" />

<img width="1085" height="503" alt="image" src="https://github.com/user-attachments/assets/be758179-a3d2-4336-8af2-ad0819f51ea3" />

</details>

### Test Results
<!-- Add test results here -->

### AI Disclosure
No AI tools used