### PR TITLE
Fix UTM links element not found

### DIFF
--- a/spec/requests/analytics/utm_links_spec.rb
+++ b/spec/requests/analytics/utm_links_spec.rb
@@ -863,7 +863,10 @@ describe "UTM links", :js, type: :system do
 
       visit seller1_utm_link.short_url
       wait_for_ajax
+      expect(page).to have_selector("body", wait: 5)
       seller1_utm_link_visit = seller1_utm_link.utm_link_visits.last
+      expect(page).to have_content("Product 1 by Seller 1", wait: 10)
+      expect(page).to have_link("Product 1 by Seller 1", wait: 5)
       click_on "Product 1 by Seller 1"
       click_on "Add to cart"
       visit product2.long_url


### PR DESCRIPTION
Fix UTM links element not found flaky test

## Before (failed test run)
https://github.com/antiwork/gumroad/actions/runs/17563311810/job/49885083645?pr=1173

## After (successful test run)
[Will be updated after CI runs]

## Local reproduction
The test failure could not be reproduced locally. However, the fix addresses the flakiness by ensuring the link element is fully loaded and clickable before attempting to click it.

## How the proposed changes fix the flakiness in CI
The test was failing because it was trying to click on a link before the element was fully rendered and clickable. The fix adds explicit waits for the page body, content, and link element to be present using Capybara's `have_selector`, `have_content`, and `have_link` matchers with appropriate wait times before attempting to click it, ensuring the element is ready for interaction.

## Changes Made
- Added explicit wait for page body to be loaded
- Added explicit wait for content to be present
- Added explicit wait for link element to be clickable
- Minimal change to prevent flaky test failures

This addresses the flakiness issues mentioned in https://github.com/antiwork/gumroad/issues/1127.

## AI Disclosure
No AI tool used