### PR TITLE
Fix embed add to cart element not found

### DIFF
--- a/spec/requests/embed_spec.rb
+++ b/spec/requests/embed_spec.rb
@@ -114,7 +114,10 @@ describe "Embed scenario", type: :system, js: true do
     it "successfully credits the affiliate commission for the product bought using its affiliated product URL" do
       visit(create_embed_page(product, url: direct_affiliate.referral_url_for_product(product), outbound: false))
 
-      within_frame { click_on "Add to cart" }
+      within_frame { 
+        expect(page).to have_content("Add to cart", wait: 10)
+        click_on "Add to cart" 
+      }
 
       check_out(product)
 


### PR DESCRIPTION
Fix embed add to cart element not found flaky test

## Before (failed test run)
https://github.com/antiwork/gumroad/actions/runs/17563311810/job/49885083805?pr=1173

## After (successful test run)
[Will be updated after CI runs]

## Local reproduction
The test failure could not be reproduced locally. However, the fix addresses the flakiness by ensuring the "Add to cart" button is fully loaded within the frame before attempting to click it.

## How the proposed changes fix the flakiness in CI
The test was failing because it was trying to click on the "Add to cart" button within a frame before the element was fully rendered. The fix adds an explicit wait for the "Add to cart" content to be present using `expect(page).to have_content("Add to cart", wait: 10)` before attempting to click it, ensuring the element is ready for interaction within the frame context.

## Changes Made
- Added explicit wait for "Add to cart" content to be present within frame
- Minimal change to prevent flaky test failures

This addresses the flakiness issues mentioned in https://github.com/antiwork/gumroad/issues/1127.

## AI Disclosure
No AI tool used.