### PR TITLE
Fix customers email text timing issue

### DIFF
--- a/spec/requests/customers/customers_spec.rb
+++ b/spec/requests/customers/customers_spec.rb
@@ -738,7 +738,7 @@ describe "Sales page", type: :system, js: true do
             click_on "Save"
           end
         end
-        expect(page).to have_alert(text: "Email updated successfully.")
+        expect(page).to have_alert(text: "Email updated successfully.", wait: 10)
 
         refresh
         find(:table_row, { "Name" => "Customer 1" }).click
@@ -751,7 +751,7 @@ describe "Sales page", type: :system, js: true do
         end
         within_section "Bundle Product 1", section_element: :aside do
           within_section "Email", section_element: :section do
-            expect(page).to have_text("customer2@gumroad.com")
+            expect(page).to have_text("customer2@gumroad.com", wait: 10)
           end
         end
 
@@ -765,7 +765,7 @@ describe "Sales page", type: :system, js: true do
         end
         within_section "Bundle Product 2", section_element: :aside do
           within_section "Email", section_element: :section do
-            expect(page).to have_text("customer2@gumroad.com")
+            expect(page).to have_text("customer2@gumroad.com", wait: 10)
           end
         end
 


### PR DESCRIPTION
Fix customers email text timing issue flaky test

## Before (failed test run)
https://github.com/antiwork/gumroad/actions/runs/17499348012/job/49708578467

## After (successful test run)
[Will be updated after CI runs]

## Local reproduction
The test failure could not be reproduced locally. However, the fix addresses the flakiness by ensuring the email update operation completes and the updated email text is properly displayed before assertions.

## How the proposed changes fix the flakiness in CI
The test was failing because it was checking for the updated email text before the email update operation had fully completed and the UI had refreshed. The fix adds explicit waits using `wait: 10` to ensure the success alert appears and the updated email text is visible before making assertions, preventing race conditions between the update operation and the text verification.

## Changes Made
- Added wait for success alert to ensure email update completes
- Added waits for email text expectations to ensure UI is updated

This addresses the flakiness issues mentioned in https://github.com/antiwork/gumroad/issues/1127.

## AI Disclosure
No AI tool used.