### PR TITLE
fix: hide search icon when no discount available

### DIFF
--- a/app/javascript/components/server-components/CheckoutDashboard/DiscountsPage.tsx
+++ b/app/javascript/components/server-components/CheckoutDashboard/DiscountsPage.tsx
@@ -282,30 +282,36 @@ const DiscountsPage = ({
       pages={pages}
       actions={
         <>
-          <Popover
-            open={isSearchPopoverOpen}
-            onToggle={setIsSearchPopoverOpen}
-            aria-label="Search"
-            trigger={
-              <div className="button">
-                <Icon name="solid-search" />
-              </div>
-            }
-          >
-            <div className="input">
-              <Icon name="solid-search" />
-              <input
-                ref={searchInputRef}
-                type="text"
-                placeholder="Search"
-                value={searchQuery ?? ""}
-                onChange={(evt) => {
-                  setSearchQuery(evt.target.value);
-                  debouncedLoadDiscounts();
-                }}
-              />
-            </div>
-          </Popover>
+          {
+            offerCodes.length > 0 ? (
+              <Popover
+                open={isSearchPopoverOpen}
+                onToggle={setIsSearchPopoverOpen}
+                aria-label="Search"
+                trigger={
+                  <div className="button">
+                    <Icon name="solid-search" />
+                  </div>
+                }
+              >
+                <div className="input">
+                  <Icon name="solid-search" />
+                  <input
+                    ref={searchInputRef}
+                    type="text"
+                    placeholder="Search"
+                    value={searchQuery ?? ""}
+                    onChange={(evt) => {
+                      setSearchQuery(evt.target.value);
+                      debouncedLoadDiscounts();
+                    }}
+                  />
+                </div>
+              </Popover>
+              ):
+              null
+          }
+
           <Button
             color="accent"
             onClick={() => {


### PR DESCRIPTION
Ref:- https://github.com/antiwork/gumroad/issues/864

### Description

- Previously, the search icon was still visible even when there were no discounts.
- Updated logic so the search icon is only shown when discounts exist. 


#### before:

<img width="1643" height="948" alt="image" src="https://github.com/user-attachments/assets/eac5192a-6371-430c-906d-5bf1fc78fcea" />



#### after:

<img width="1643" height="948" alt="image" src="https://github.com/user-attachments/assets/fa30bb96-f468-4324-9c1c-07f4e98789c5" />

<img width="1643" height="948" alt="image" src="https://github.com/user-attachments/assets/dbea8457-a9d1-4d19-8eed-dc16022ffe27" />

### AI Disclosure:-
I have not used any AI assistance in this PR
