### PR TITLE
Hide search icon when no upsell available

### DIFF
--- a/app/javascript/components/server-components/CheckoutDashboard/UpsellsPage.tsx
+++ b/app/javascript/components/server-components/CheckoutDashboard/UpsellsPage.tsx
@@ -201,30 +201,32 @@ const UpsellsPage = (props: {
       pages={props.pages}
       actions={
         <>
-          <Popover
-            open={isSearchPopoverOpen}
-            onToggle={setIsSearchPopoverOpen}
-            aria-label="Search"
-            trigger={
-              <div className="button">
+          {upsells.length > 0 && (
+            <Popover
+              open={isSearchPopoverOpen}
+              onToggle={setIsSearchPopoverOpen}
+              aria-label="Search"
+              trigger={
+                <div className="button">
+                  <Icon name="solid-search" />
+                </div>
+              }
+            >
+              <div className="input">
                 <Icon name="solid-search" />
+                <input
+                  ref={searchInputRef}
+                  type="text"
+                  placeholder="Search"
+                  value={searchQuery ?? ""}
+                  onChange={(evt) => {
+                    setSearchQuery(evt.target.value);
+                    debouncedLoadUpsells();
+                  }}
+                />
               </div>
-            }
-          >
-            <div className="input">
-              <Icon name="solid-search" />
-              <input
-                ref={searchInputRef}
-                type="text"
-                placeholder="Search"
-                value={searchQuery ?? ""}
-                onChange={(evt) => {
-                  setSearchQuery(evt.target.value);
-                  debouncedLoadUpsells();
-                }}
-              />
-            </div>
-          </Popover>
+            </Popover>
+          )}
           <Button color="accent" onClick={() => setView("create")} disabled={isReadOnly}>
             New upsell
           </Button>


### PR DESCRIPTION
### Explanation of Change
Hide the search icon when there are no upsell items available

### Screenshots/Videos
Before
<img width="1345" height="745" alt="image" src="https://github.com/user-attachments/assets/39e7bd4e-6df0-40df-8c3f-773489fa9066" />

After
<img width="1348" height="744" alt="image" src="https://github.com/user-attachments/assets/df0cdd4d-b372-4350-b247-7ac752967c95" />


### AI Disclosure
No AI tools used