### PR TITLE
Fix typo in "Issuing a refund" article

### DIFF
--- a/app/javascript/components/server-components/FollowersPage.tsx
+++ b/app/javascript/components/server-components/FollowersPage.tsx
@@ -171,7 +171,7 @@ export const FollowersPage = ({ followers: initialFollowers, per_page, total }: 
       <div>
         {loading ? (
           <div className="flex justify-center">
-          <Progress width="5rem" />
+            <Progress width="5rem" />
           </div>
         ) : followers.length > 0 ? (
           <div>

--- a/app/views/help_center/articles/contents/_47-how-to-refund-a-customer.html.erb
+++ b/app/views/help_center/articles/contents/_47-how-to-refund-a-customer.html.erb
@@ -18,14 +18,13 @@
     <p>Go to your <a href="https://gumroad.com/customers">Sales dashboard</a> and click on the sale to open the customer drawer. Then scroll down and click the <strong>Refund fully</strong> button:</p>
     <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/6385991eb3261c24b49eda78/file-v3dx5aMJjS.png" %></figure>
     <p>We charge and refund customers in USD. The amount customers receive back in their local currency may be different than what they initially paid due to differences in exchange rates.</p>
-    <br>
     <h3 id="partial">Partial refund</h3>
     <p>To issue a partial refund, enter the amount to be refunded in the ‘Refund’ box and click <strong>Issue partial refund</strong>.  </p>
     <p>Your customer will still have access to their content after a partial refund.</p>
     <p>If it is a Membership that is pending cancellation and has 'Members will lose access when their Membership ends' toggled on, issuing a partial refund will end the Membership and revoke the customer's access.</p>
     <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/62469f0eab585b230a8a7601/file-nnUgqbE3pw.gif" %></figure>
     <h3 id="paypal">PayPal refund</h3>
-    <p>If you refund a <a href="275-paypal-connect">PayPal Connect</a> purchase, PayPal keeps its fees on the sale but refunds 100% of the amount to the customer. In this case, you would be responsible for Gumroad and PayPal's fees.</p>p>
+    <p>If you refund a <a href="275-paypal-connect">PayPal Connect</a> purchase, PayPal keeps its fees on the sale but refunds 100% of the amount to the customer. In this case, you would be responsible for Gumroad and PayPal's fees.</p>
     <h3 id="after">After issuing a refund</h3>
     <p>Customers receive an email confirmation after a refund is issued. Credit card funds usually take 5-10 business days to appear on the buyer’s account while PayPal refunds are immediate. </p>
     <p>In the case of a full refund, customers will no longer be able to access the content or receive the respective product’s updates.</p>
@@ -34,7 +33,6 @@
     <p>If you have less money in your Gumroad balance than the refund amount, your balance will go negative. We recover this negative balance either from your future sales or by debiting your payout bank account.</p>
     <p>Your subsequent payouts will go through only once your net balance goes back above $10.</p>
     <p>If you are planning a large volume of refunds, please <a href="20-how-do-i-contact-gumroad.html#">let us know</a> in advance to prevent account suspension.</p>
-    <br>
     <h3 id="Refund-fees-hk-4p">Refund fees</h3>
     <p>We don't refund any <a href="https://gumroad.com/help/article/66-gumroads-fees.html">fees</a> when processing refunds.</p>
   </div>


### PR DESCRIPTION
Delete `p>` typo, and excess line breaks

<img width="1632" height="304" alt="Screenshot 15 41 on 2025-09-09" src="https://github.com/user-attachments/assets/9ac54fb8-1c71-4499-a56b-3176cbf91882" />
