### PR TITLE
Hide search icon when there is no subscriber data

### DIFF
--- a/app/javascript/components/server-components/FollowersPage.tsx
+++ b/app/javascript/components/server-components/FollowersPage.tsx
@@ -120,27 +120,29 @@ export const FollowersPage = ({ followers: initialFollowers, per_page, total }: 
       title="Subscribers"
       actions={
         <>
-          <Popover
-            open={searchBoxOpen}
-            onToggle={setSearchBoxOpen}
-            aria-label="Search"
-            trigger={
-              <WithTooltip tip="Search" position="bottom">
-                <div className="button">
-                  <Icon name="solid-search" />
-                </div>
-              </WithTooltip>
-            }
-          >
-            <input
-              ref={searchInputRef}
-              value={searchQuery}
-              autoFocus
-              type="text"
-              placeholder="Search followers"
-              onChange={(evt) => setSearchQuery(evt.target.value)}
-            />
-          </Popover>
+          {(followers.length > 0 || searchQuery.length > 0) && (
+            <Popover
+              open={searchBoxOpen}
+              onToggle={setSearchBoxOpen}
+              aria-label="Search"
+              trigger={
+                <WithTooltip tip="Search" position="bottom">
+                  <div className="button">
+                    <Icon name="solid-search" />
+                  </div>
+                </WithTooltip>
+              }
+            >
+              <input
+                ref={searchInputRef}
+                value={searchQuery}
+                autoFocus
+                type="text"
+                placeholder="Search followers"
+                onChange={(evt) => setSearchQuery(evt.target.value)}
+              />
+            </Popover>
+          )}
           <Popover
             aria-label="Export"
             trigger={


### PR DESCRIPTION
### Explanation of Change
Hide the search icon when there is no subscriber data

For the export icon, I don't think we need to hide it, since it can export customers & affiliates as well

### Screenshots/Videos
Before
<img width="1207" height="743" alt="image" src="https://github.com/user-attachments/assets/a0e6af5a-f99e-4b2b-a52c-6d12e6aa32ed" />

After (the search icon hided if no subscriber, and still displayed on empty search results)
<img width="1204" height="746" alt="image" src="https://github.com/user-attachments/assets/8003095a-aced-4630-b04d-7d59803278a9" />

<img width="1148" height="744" alt="image" src="https://github.com/user-attachments/assets/9caf90b1-f553-423a-9229-3236f908ec7a" />


### AI Disclosure
No AI tools used