### PR TITLE
Update table of contents Popover position on product content page

### DIFF
--- a/app/javascript/components/server-components/DownloadPage/WithContent.tsx
+++ b/app/javascript/components/server-components/DownloadPage/WithContent.tsx
@@ -341,7 +341,7 @@ const WithContent = ({
           {isDesktop ? null : (
             <Popover
               aria-label="Table of Contents"
-              position="top"
+              position="bottom"
               trigger={
                 <div className="button">
                   <Icon name="unordered-list" />


### PR DESCRIPTION
### Explanation of Change

Fixes the Popover cropping issue on the product content page for mobile users
Previously, the Popover was positioned at the top, causing it to be cropped by the header
Now, changing the position to `bottom` ensures the Popover fully displays all pages list

### Screenshots/Videos
Before


https://github.com/user-attachments/assets/569f2b82-3eb0-4a6b-9450-05f9254b0667



After

https://github.com/user-attachments/assets/292f7e32-a38f-44d6-9022-0892060b5a7a

### AI Disclosure
No AI tools used