### PR TITLE
Disable throttling of occluded windows

### DIFF
--- a/spec/support/capybara_driver.rb
+++ b/spec/support/capybara_driver.rb
@@ -7,6 +7,8 @@ Capybara.register_driver :chrome do |app|
   options.add_emulation(device_metrics: { width: 1440, height: 900, touch: false })
   options.add_preference("intl.accept_languages", "en-US")
   options.logging_prefs = { driver: "DEBUG" }
+  # https://peter.sh/experiments/chromium-command-line-switches/#disable-backgrounding-occluded-windows
+  options.add_argument("--disable-backgrounding-occluded-windows")
 
   Capybara::Selenium::Driver.new(app,
                                  browser: :chrome,


### PR DESCRIPTION
**Related to #1127** 

## Demo

https://github.com/user-attachments/assets/97537832-0143-4489-be64-3c806f92d86a

## What

When running Capybara specs in headful mode, some tests (e.g., those using the `have_alert` assertion) can fail if another window on the machine obscures the Chrome window.

This PR sets a Chromium flag to prevent Chrome from throttling the tab in such cases.

## AI Usage

No usage.

## References

https://github.com/teamcapybara/capybara/issues/2796#issuecomment-2678172710