### PR TITLE
feat: Apply tip to one product when all of the products in the cart are free

### DIFF
--- a/app/javascript/components/Checkout/payment.ts
+++ b/app/javascript/components/Checkout/payment.ts
@@ -171,18 +171,42 @@ export function computeTip(state: State) {
   return Math.round((state.tip.percentage / 100) * getTotalPriceFromProducts(state));
 }
 
-export function computeTipForPrice(state: State, price: number) {
+interface ProductForTip {
+  permalink: string;
+}
+
+export function computeTipForPrice(state: State, price: number, product?: ProductForTip) {
   if (!isTippingEnabled(state)) return null;
   if (state.tip.type === "fixed") {
     const totalPrice = getTotalPriceFromProducts(state);
     if (totalPrice === 0) {
-      return Math.round((state.tip.amount ?? 0) / state.products.length);
+      return computeTipForFreeProducts(state, price, product);
     }
 
     return Math.round((state.tip.amount ?? 0) * (price / totalPrice));
   }
 
   return Math.round((state.tip.percentage / 100) * price);
+}
+
+function computeTipForFreeProducts(state: State, _price: number, product?: ProductForTip) {
+  if (!product) {
+    const tipAmount = state.tip.type === "fixed" ? (state.tip.amount ?? 0) : 0;
+    return Math.round(tipAmount / state.products.length);
+  }
+
+  const firstProduct = state.products[0];
+  if (!firstProduct) {
+    return 0;
+  }
+  const isFirstProductSelected = firstProduct.permalink === product.permalink;
+
+  if (isFirstProductSelected) {
+    const tipAmount = state.tip.type === "fixed" ? (state.tip.amount ?? 0) : 0;
+    return tipAmount;
+  }
+
+  return 0;
 }
 
 export function getTotalPrice(state: State) {
@@ -209,7 +233,8 @@ export const loadSurcharges = (state: State) => {
     products: state.products.map((item) => ({
       permalink: item.permalink,
       quantity: item.quantity,
-      price: item.hasFreeTrial && !isGift ? 0 : Math.round(item.price + (computeTipForPrice(state, item.price) ?? 0)),
+      price:
+        item.hasFreeTrial && !isGift ? 0 : Math.round(item.price + (computeTipForPrice(state, item.price, item) ?? 0)),
       subscription_id: item.subscription_id,
       recommended_by: item.recommended_by,
     })),

--- a/app/javascript/components/server-components/CheckoutPage.tsx
+++ b/app/javascript/components/server-components/CheckoutPage.tsx
@@ -399,8 +399,8 @@ export const CheckoutPage = ({
 
           const tipCents =
             item.pay_in_installments && item.product.installment_plan
-              ? computeTipForPrice(state, discountedPriceTotal)
-              : computeTipForPrice(state, discountedPriceToChargeNow);
+              ? computeTipForPrice(state, discountedPriceTotal, item.product)
+              : computeTipForPrice(state, discountedPriceToChargeNow, item.product);
 
           return {
             permalink: item.product.permalink,

--- a/spec/requests/purchases/tipping_spec.rb
+++ b/spec/requests/purchases/tipping_spec.rb
@@ -310,6 +310,56 @@ describe("Product checkout with tipping", type: :system, js: true) do
     end
   end
 
+  context "when all products in the cart are free" do
+    let(:free_product1) { create(:product, name: "Free Product 1", user: seller, price_cents: 0) }
+    let(:free_product2) { create(:product, name: "Free Product 2", user: seller, price_cents: 0) }
+    let(:another_seller) { create(:named_seller, :eligible_for_service_products, tipping_enabled: true) }
+    let(:free_product3) { create(:product, name: "Free Product 3", user: another_seller, price_cents: 0) }
+
+    it "applies tip to one product in cart when all products are free" do
+      visit free_product1.long_url
+      add_to_cart(free_product1, pwyw_price: 0)
+      visit free_product2.long_url
+      add_to_cart(free_product2, pwyw_price: 0)
+      visit free_product3.long_url
+      add_to_cart(free_product3, pwyw_price: 0)
+      fill_checkout_form(free_product1)
+
+      expect(page).to have_text("Subtotal US$0", normalize_ws: true)
+      expect(page).to have_text("Total US$0", normalize_ws: true)
+
+      choose "Other"
+      fill_in "Tip", with: 15
+
+      expect(page).to have_text("Subtotal US$0", normalize_ws: true)
+      expect(page).to have_text("Tip US$15", normalize_ws: true)
+      expect(page).to have_text("Total US$15", normalize_ws: true)
+      click_on "Pay"
+
+      expect(page).to have_alert(text: "Your purchase was successful! We sent a receipt to test@gumroad.com.")
+
+      # Check that purchases were created successfully
+      purchases = Purchase.last(3)
+      expect(purchases).to all(be_successful)
+
+      # Find purchases by product
+      purchase1 = purchases.find { |p| p.link == free_product1 }
+      purchase2 = purchases.find { |p| p.link == free_product2 }
+      purchase3 = purchases.find { |p| p.link == free_product3 }
+
+      # First product in cart should get the entire tip
+      expect(purchase1.price_cents).to eq(1500) # Full $15 tip
+      expect(purchase1.tip.value_cents).to eq(1500)
+
+      # Other products should get no tip
+      expect(purchase2.price_cents).to eq(0)
+      expect(purchase2.tip).to be_nil
+
+      expect(purchase3.price_cents).to eq(0)
+      expect(purchase3.tip).to be_nil
+    end
+  end
+
   context "when the product is a commission" do
     let(:commission_product) { create(:commission_product) }
 


### PR DESCRIPTION
Fixes #840 

### Summary

Have shifted the added tip to be applied to the first product in the cart when all the products in the cart are free.

### Video

Before:


https://github.com/user-attachments/assets/3570581e-a8e5-4f83-8600-0e60f3eea078


After


https://github.com/user-attachments/assets/794eb17b-3ba8-4e00-8141-8a620bf52265


### Tests

Have added a request spec for it `bundle rspec spec/requests/purchases/tipping_spec.rb:313 --format html --out rspec_results.html`

<details>
  <summary>test run screenshot</summary>
<img width="1470" height="285" alt="Screenshot 2025-09-16 at 2 47 09 PM" src="https://github.com/user-attachments/assets/69dcb8d9-6156-4e1e-a039-c1751dd71853" />
</details>




### AI Disclosure

No AI Used