### PR TITLE
Remove unexpected character from features page

### DIFF
--- a/app/views/home/features.html.erb
+++ b/app/views/home/features.html.erb
@@ -174,7 +174,6 @@
     <button class="h-4 w-4 rounded-full border border-black border-solid" data-carousel-indicator data-slide="3"></button>
   </div>
 </div>
-¸
 <%= render "home/shared/carousel" %>
 
 <%= render "home/shared/section_header",


### PR DESCRIPTION
### Explanation of Change
Removes an unexpected "¸" character that was appearing on the left side of the features page.

### Screenshots/Videos
Before
<img width="410" height="498" alt="Screenshot 2025-09-10 at 09 40 23" src="https://github.com/user-attachments/assets/4e16450e-a610-4ee8-9560-c3703c1681b6" />

After
<img width="402" height="469" alt="image" src="https://github.com/user-attachments/assets/e1794380-2302-4209-9f77-3267809a032e" />


### AI Disclosure
No AI tools used