### PR TITLE
Correct bank code format for Moldova

### DIFF
--- a/app/models/moldova_bank_account.rb
+++ b/app/models/moldova_bank_account.rb
@@ -3,7 +3,7 @@
 class MoldovaBankAccount < BankAccount
   BANK_ACCOUNT_TYPE = "MD"
 
-  BANK_CODE_FORMAT_REGEX = /^[A-Z]{4}MDMD[A-Z0-9]{3}$/
+  BANK_CODE_FORMAT_REGEX = /^[A-Z0-9]{4}MD[A-Z0-9]{5}$/
   ACCOUNT_NUMBER_FORMAT_REGEX = /^MD\d{2}[A-Z0-9]{20}$/
   private_constant :BANK_CODE_FORMAT_REGEX, :ACCOUNT_NUMBER_FORMAT_REGEX
 

--- a/spec/models/moldova_bank_account_spec.rb
+++ b/spec/models/moldova_bank_account_spec.rb
@@ -36,9 +36,13 @@ describe MoldovaBankAccount do
   end
 
   describe "#validate_bank_code" do
-    it "allows only 11 characters in the correct format" do
+    it "allows only 8-11 characters in the correct format" do
       expect(build(:moldova_bank_account, bank_code: "AAAAMDMDXXX")).to be_valid
       expect(build(:moldova_bank_account, bank_code: "BBBBMDMDYYY")).to be_valid
+      expect(build(:moldova_bank_account, bank_code: "AGRNMD2XZZZ")).to be_valid
+      expect(build(:moldova_bank_account, bank_code: "AGRNMD2ZZ")).not_to be_valid
+      expect(build(:moldova_bank_account, bank_code: "AGRNMM2XZZZ")).not_to be_valid
+      expect(build(:moldova_bank_account, bank_code: "AGRNMD2XZZZZ")).not_to be_valid
       expect(build(:moldova_bank_account, bank_code: "AAAMDMDXXX")).not_to be_valid
       expect(build(:moldova_bank_account, bank_code: "AAAAMDMDXXXX")).not_to be_valid
     end


### PR DESCRIPTION
### What

Correct the bank/SWIFT code format validator for Moldova.

### Why

Current validator does not allow some valid values like `AGRNMD2XZZZ`.