### PR TITLE
Send a notification email to sellers about PayPal payouts removal

### DIFF
--- a/app/mailers/contacting_creator_mailer.rb
+++ b/app/mailers/contacting_creator_mailer.rb
@@ -513,6 +513,11 @@ class ContactingCreatorMailer < ApplicationMailer
     @subject = "Important: Upcoming refund policy changes effective January 1, 2025"
   end
 
+  def paypal_suspension_notification(user_id)
+    @seller = User.find(user_id)
+    @subject = "Important: Update Your Payout Method on Gumroad"
+  end
+
   def ping_endpoint_failure(user_id, ping_url, response_code)
     @seller = User.find(user_id)
     @ping_url = redact_ping_url(ping_url)

--- a/app/services/onetime/notify_sellers_about_paypal_payouts_removal.rb
+++ b/app/services/onetime/notify_sellers_about_paypal_payouts_removal.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class Onetime::NotifySellersAboutPaypalPayoutsRemoval
+  def self.process
+    User.alive.not_suspended
+        .where("users.id > ?", $redis.get("notified_paypal_removal_till_user_id").to_i)
+        .joins(:user_compliance_infos)
+        .where("user_compliance_info.deleted_at IS NULL AND user_compliance_info.country IN (?)", User::Compliance.const_get(:SUPPORTED_COUNTRIES).map(&:common_name) - ["India", "United Arab Emirates"])
+        .joins(:payments)
+        .where("payments.processor = 'paypal' AND payments.state = 'completed' and payments.created_at > ?", Date.new(2025, 1, 1))
+        .order("users.id")
+        .select("users.id")
+        .distinct
+        .each do |user|
+      ReplicaLagWatcher.watch
+      ContactingCreatorMailer.paypal_suspension_notification(user.id).deliver_later
+      $redis.set("notified_paypal_removal_till_user_id", user.id)
+    end
+  end
+end

--- a/app/views/contacting_creator_mailer/paypal_suspension_notification.html.erb
+++ b/app/views/contacting_creator_mailer/paypal_suspension_notification.html.erb
@@ -1,6 +1,6 @@
 <div>
   <p>Hello <%= @seller.name_or_username %>,</p>
-  <p>We wanted to inform you that PayPal has suspended Gumroad's use of their service. As a result, we can no longer process payouts to PayPal accounts.</p>
+  <p>We wanted to inform you that PayPal has suspended Gumroad's use of their service. As a result, we can no longer process payouts to PayPal accounts in your country.</p>
   <p>We've invested heavily in direct bank transfers for nearly every country. We encourage you to connect a bank account directly to your Gumroad account to ensure uninterrupted payouts.</p>
 
   <p>
@@ -13,7 +13,6 @@
     </ol>
   </p>
 
-  <p>If you're based in a country where we don't yet support direct bank transfers (such as Brazil), you can change your country to one where you have identity verification and a bank account. This will allow you to receive payouts through direct bank transfer.</p>
   <p>We apologize for any inconvenience this may cause. Our team is working diligently to ensure smooth payouts for all our creators.</p>
   <p>If you have any questions or need assistance, please don't hesitate to contact our support team.</p>
   <p>Thank you for your understanding and continued support.</p>

--- a/lib/mailer_previews/contacting_creator_mailer_preview.rb
+++ b/lib/mailer_previews/contacting_creator_mailer_preview.rb
@@ -204,6 +204,10 @@ class ContactingCreatorMailerPreview < ActionMailer::Preview
     ContactingCreatorMailer.upcoming_refund_policy_change(User.last&.id)
   end
 
+  def paypal_suspension_notification
+    ContactingCreatorMailer.paypal_suspension_notification(User.last&.id)
+  end
+
   def ping_endpoint_failure
     ContactingCreatorMailer.ping_endpoint_failure(User.last&.id, "https://example.com/webhook", 500)
   end

--- a/spec/services/onetime/notify_sellers_about_paypal_payouts_removal_spec.rb
+++ b/spec/services/onetime/notify_sellers_about_paypal_payouts_removal_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Onetime::NotifySellersAboutPaypalPayoutsRemoval do
+  before do
+    @eligible_seller_1 = create(:user_with_compliance_info)
+    create(:payment_completed, user: @eligible_seller_1, created_at: Date.new(2025, 2, 10))
+
+    @eligible_seller_2 = create(:user)
+    create(:user_compliance_info_singapore, user: @eligible_seller_2)
+    create(:payment_completed, user: @eligible_seller_2, created_at: Date.new(2025, 7, 7))
+
+    @eligible_seller_3 = create(:user)
+    create(:user_compliance_info_canada, user: @eligible_seller_3)
+    create(:payment_completed, user: @eligible_seller_3, created_at: Date.new(2025, 2, 5))
+
+    @eligible_seller_4 = create(:user)
+    create(:user_compliance_info, country: "France", user: @eligible_seller_4)
+    create(:payment_completed, user: @eligible_seller_4, created_at: Date.new(2025, 4, 15))
+
+    @ineligible_seller_1 = create(:user)
+    create(:user_compliance_info_uae, user: @ineligible_seller_1)
+    create(:payment_completed, user: @ineligible_seller_1, created_at: Date.new(2025, 5, 20))
+
+    @ineligible_seller_2 = create(:user)
+    create(:user_compliance_info, user: @ineligible_seller_2, country: "India")
+    create(:payment_completed, user: @ineligible_seller_2, created_at: Date.new(2025, 3, 25))
+
+    @ineligible_seller_3 = create(:user_with_compliance_info)
+    create(:payment_completed,
+           user: @ineligible_seller_3,
+           processor: PayoutProcessorType::STRIPE,
+           stripe_transfer_id: "t_12345",
+           stripe_connect_account_id: "acct_12345",
+           created_at: Date.new(2025, 3, 25))
+
+    @ineligible_seller_4 = create(:user_with_compliance_info)
+    create(:payment_completed, user: @ineligible_seller_4, created_at: Date.new(2024, 12, 31))
+
+    @ineligible_seller_5 = create(:user_with_compliance_info)
+    create(:payment_failed, user: @ineligible_seller_5, created_at: Date.new(2025, 5, 20))
+
+    @ineligible_seller_6 = create(:user_with_compliance_info)
+  end
+
+  it "enqueues the email for correct sellers with proper arguments" do
+    expect do
+      described_class.process
+    end.to have_enqueued_mail(ContactingCreatorMailer, :paypal_suspension_notification).with(@eligible_seller_1.id).once
+       .and have_enqueued_mail(ContactingCreatorMailer, :paypal_suspension_notification).with(@eligible_seller_2.id).once
+       .and have_enqueued_mail(ContactingCreatorMailer, :paypal_suspension_notification).with(@eligible_seller_3.id).once
+       .and have_enqueued_mail(ContactingCreatorMailer, :paypal_suspension_notification).with(@eligible_seller_4.id).once
+       .and have_enqueued_mail(ContactingCreatorMailer, :paypal_suspension_notification).with(@ineligible_seller_1.id).exactly(0).times
+       .and have_enqueued_mail(ContactingCreatorMailer, :paypal_suspension_notification).with(@ineligible_seller_2.id).exactly(0).times
+       .and have_enqueued_mail(ContactingCreatorMailer, :paypal_suspension_notification).with(@ineligible_seller_3.id).exactly(0).times
+       .and have_enqueued_mail(ContactingCreatorMailer, :paypal_suspension_notification).with(@ineligible_seller_4.id).exactly(0).times
+       .and have_enqueued_mail(ContactingCreatorMailer, :paypal_suspension_notification).with(@ineligible_seller_5.id).exactly(0).times
+       .and have_enqueued_mail(ContactingCreatorMailer, :paypal_suspension_notification).with(@ineligible_seller_6.id).exactly(0).times
+
+    expect($redis.get("notified_paypal_removal_till_user_id").to_i).to eq @eligible_seller_4.id
+  end
+
+  context "when email has already been sent to some sellers" do
+    before do
+      $redis.set("notified_paypal_removal_till_user_id", @eligible_seller_2.id)
+    end
+
+    it "does not enqueue for sellers who have already been sent the email" do
+      expect($redis.get("notified_paypal_removal_till_user_id").to_i).to eq @eligible_seller_2.id
+
+      expect do
+        described_class.process
+      end.to have_enqueued_mail(ContactingCreatorMailer, :paypal_suspension_notification).with(@eligible_seller_1.id).exactly(0).times
+         .and have_enqueued_mail(ContactingCreatorMailer, :paypal_suspension_notification).with(@eligible_seller_2.id).exactly(0).times
+         .and have_enqueued_mail(ContactingCreatorMailer, :paypal_suspension_notification).with(@eligible_seller_3.id).once
+         .and have_enqueued_mail(ContactingCreatorMailer, :paypal_suspension_notification).with(@eligible_seller_4.id).once
+         .and have_enqueued_mail(ContactingCreatorMailer, :paypal_suspension_notification).with(@ineligible_seller_1.id).exactly(0).times
+         .and have_enqueued_mail(ContactingCreatorMailer, :paypal_suspension_notification).with(@ineligible_seller_2.id).exactly(0).times
+         .and have_enqueued_mail(ContactingCreatorMailer, :paypal_suspension_notification).with(@ineligible_seller_3.id).exactly(0).times
+         .and have_enqueued_mail(ContactingCreatorMailer, :paypal_suspension_notification).with(@ineligible_seller_4.id).exactly(0).times
+         .and have_enqueued_mail(ContactingCreatorMailer, :paypal_suspension_notification).with(@ineligible_seller_5.id).exactly(0).times
+         .and have_enqueued_mail(ContactingCreatorMailer, :paypal_suspension_notification).with(@ineligible_seller_6.id).exactly(0).times
+
+      expect($redis.get("notified_paypal_removal_till_user_id").to_i).to eq @eligible_seller_4.id
+    end
+  end
+end


### PR DESCRIPTION
### What

Send a notification email to sellers about PayPal payouts removal

### Why

PayPal payouts are disabled for sellers in countries where bank payouts are supported (except India), so need to send out a notification email to the affected sellers so they can submit their bank information.

### Post deploy
- [ ] Run `Onetime::NotifySellersAboutPaypalPayoutsRemoval.process` to send out the notification emails (`ContactingCreatorMailer#paypal_suspension_notification`) to affected sellers
- [ ] Remove the onetime service and mailer code after sending the emails

### Screenshot

<img width="535" height="876" alt="Screenshot 2025-09-10 at 7 32 25 PM" src="https://github.com/user-attachments/assets/1f78e6e5-1fe3-41c3-ad77-723cf8c7ac81" />