### PR TITLE
Fix payment field focus timing

### DIFF
--- a/spec/requests/purchases/product/payment_errors_spec.rb
+++ b/spec/requests/purchases/product/payment_errors_spec.rb
@@ -123,22 +123,27 @@ describe("Purchase from a product page", type: :system, js: true) do
 
     fill_in_credit_card
     click_on "Pay"
+    expect(page).to have_field("Your email address", disabled: false)
     expect_focused find_field("Your email address")
 
     fill_in "Your email address", with: "gumroad@example.com"
     click_on "Pay"
+    expect(page).to have_field("Full name", disabled: false)
     expect_focused find_field("Full name")
 
     fill_in "Full name", with: "G McGumroadson"
     click_on "Pay"
+    expect(page).to have_field("Street address", disabled: false)
     expect_focused find_field("Street address")
 
     fill_in "Street address", with: "123 Main St"
     click_on "Pay"
+    expect(page).to have_field("City", disabled: false)
     expect_focused find_field("City")
 
     fill_in "City", with: "San Francisco"
     click_on "Pay"
+    expect(page).to have_field("ZIP code", disabled: false)
     expect_focused find_field("ZIP code")
   end
 end


### PR DESCRIPTION
Fix payment field focus timing

Fixes flaky test failure in payment errors spec by adding field enabling checks before focus assertions.

**Failed test**: `spec/requests/purchases/product/payment_errors_spec.rb#L96` - "Purchase from a product page focuses the correct fields with errors"

**Error**: `Capybara::ElementNotFound: Unable to find field "Full name" that is not disabled`

**Failed job**: https://github.com/antiwork/gumroad/actions/runs/17552896114/job/49849930032

**Root cause**: Test attempts to focus on form fields before they become enabled through asynchronous validation.

**Solution**: Added `expect(page).to have_field("[field_name]", disabled: false)` before each `expect_focused find_field("[field_name])` call for all form validation steps.

**Validation**: This approach is already used throughout the codebase in files like:
- `spec/requests/checkout/payment_spec.rb` (lines 38, 50, 62, 69, 79, 84)
- `spec/requests/purchases/product/purchase/purchase_spec.rb` (line 79)
- `spec/requests/products/show/show_spec.rb` (line 627)

This addresses the flakiness issues mentioned in https://github.com/antiwork/gumroad/issues/1127.

**AI Disclosure**: No AI tools used