### PR TITLE
fix(mobile): prevent floating CTA bar from hiding content.

### DIFF
--- a/app/javascript/components/Product/Layout.tsx
+++ b/app/javascript/components/Product/Layout.tsx
@@ -173,19 +173,20 @@ export const Layout = (
         configurationSelectorRef={configurationSelectorRef}
         hasHero={!!hasHero}
       />
-      {"products" in props ? (
-        <SectionEditor props={props}>{productView}</SectionEditor>
-      ) : props.sections.length > 0 ? (
-        props.sections.map((section, i) => (
-          <React.Fragment key={section.id}>
-            {i === main_section_index ? mainSection : null}
-            <Section section={section} {...props} />
-            {main_section_index >= props.sections.length && i === props.sections.length - 1 ? mainSection : null}
-          </React.Fragment>
-        ))
-      ) : (
-        mainSection
-      )}
+      <div style={{ paddingBottom: "120px" }} className="lg:pb-0">        {"products" in props ? (
+          <SectionEditor props={props}>{productView}</SectionEditor>
+        ) : props.sections.length > 0 ? (
+          props.sections.map((section, i) => (
+            <React.Fragment key={section.id}>
+              {i === main_section_index ? mainSection : null}
+              <Section section={section} {...props} />
+              {main_section_index >= props.sections.length && i === props.sections.length - 1 ? mainSection : null}
+            </React.Fragment>
+          ))
+        ) : (
+          mainSection
+        )}
+      </div>
     </>
   );
 };


### PR DESCRIPTION
ref #864

## Summary
Added mobile-specific padding to product pages to prevent the floating CTA bar from hiding content at the page bottom, improving mobile UX and content accessibility.


## Before

https://github.com/user-attachments/assets/34e6ad5e-59b7-4796-9953-975375e34de3

https://github.com/user-attachments/assets/83f3f83f-7958-43e3-a56e-57bfbeeded54


## After

https://github.com/user-attachments/assets/7755d65f-ba1d-404f-8530-12c786a56549


## AI Usage
No AI was used to generate any of this code.

## Self-Review
I have self-reviewed all the code that I have written.