### PR TITLE
feat: add tax inclusive pricing option for products

### DIFF
--- a/app/business/sales_tax/sales_tax_calculator.rb
+++ b/app/business/sales_tax/sales_tax_calculator.rb
@@ -41,7 +41,15 @@ class SalesTaxCalculator
     return SalesTaxCalculation.zero_tax(price_cents) if tax_rate.nil?
     return SalesTaxCalculation.zero_tax(price_cents) unless tax_eligible?
 
-    tax_amount_cents = price_cents * tax_rate.combined_rate
+    if product.tax_inclusive?
+      # For tax-inclusive pricing, calculate tax as a portion of the displayed price
+      # tax_amount = price_cents * (tax_rate / (1 + tax_rate))
+      tax_amount_cents = (price_cents * tax_rate.combined_rate / (1 + tax_rate.combined_rate)).round
+    else
+      # For tax-exclusive pricing, calculate tax as an addition to the price
+      tax_amount_cents = price_cents * tax_rate.combined_rate
+    end
+
     SalesTaxCalculation.new(price_cents:,
                             tax_cents: tax_amount_cents,
                             zip_tax_rate: tax_rate,
@@ -101,7 +109,16 @@ class SalesTaxCalculator
         jurisdiction_city: taxjar_response_json["jurisdictions"]["city"]
       }
 
-      tax_amount_cents = (taxjar_response_json["amount_to_collect"] * 100.0).round.to_d
+      if product.tax_inclusive?
+        # For tax-inclusive pricing, calculate tax as a portion of the displayed price
+        # TaxJar returns the tax amount to collect, but for inclusive pricing we need to calculate
+        # the tax portion of the displayed price
+        tax_rate = taxjar_response_json["rate"]
+        tax_amount_cents = (price_cents * tax_rate / (1 + tax_rate)).round.to_d
+      else
+        # For tax-exclusive pricing, use the tax amount from TaxJar
+        tax_amount_cents = (taxjar_response_json["amount_to_collect"] * 100.0).round.to_d
+      end
 
       SalesTaxCalculation.new(price_cents:,
                               tax_cents: tax_amount_cents,

--- a/app/business/sales_tax/sales_tax_calculator.rb
+++ b/app/business/sales_tax/sales_tax_calculator.rb
@@ -42,11 +42,8 @@ class SalesTaxCalculator
     return SalesTaxCalculation.zero_tax(price_cents) unless tax_eligible?
 
     if product.tax_inclusive?
-      # For tax-inclusive pricing, calculate tax as a portion of the displayed price
-      # tax_amount = price_cents * (tax_rate / (1 + tax_rate))
       tax_amount_cents = (price_cents * tax_rate.combined_rate / (1 + tax_rate.combined_rate)).round
     else
-      # For tax-exclusive pricing, calculate tax as an addition to the price
       tax_amount_cents = price_cents * tax_rate.combined_rate
     end
 
@@ -110,13 +107,9 @@ class SalesTaxCalculator
       }
 
       if product.tax_inclusive?
-        # For tax-inclusive pricing, calculate tax as a portion of the displayed price
-        # TaxJar returns the tax amount to collect, but for inclusive pricing we need to calculate
-        # the tax portion of the displayed price
         tax_rate = taxjar_response_json["rate"]
         tax_amount_cents = (price_cents * tax_rate / (1 + tax_rate)).round.to_d
       else
-        # For tax-exclusive pricing, use the tax amount from TaxJar
         tax_amount_cents = (taxjar_response_json["amount_to_collect"] * 100.0).round.to_d
       end
 

--- a/app/controllers/customer_surcharge_controller.rb
+++ b/app/controllers/customer_surcharge_controller.rb
@@ -22,7 +22,11 @@ class CustomerSurchargeController < ApplicationController
       shipping_rate += get_usd_cents(product.price_currency_type, surcharges[:shipping_rate])
       tax_cents = tax_result.tax_cents
       if tax_cents > 0
-        tax_rate += tax_cents
+        if product.tax_inclusive?
+          tax_included_rate += tax_cents
+        else
+          tax_rate += tax_cents
+        end
       end
       subtotal += tax_result.price_cents
     end

--- a/app/javascript/components/BundleEdit/ProductTab/index.tsx
+++ b/app/javascript/components/BundleEdit/ProductTab/index.tsx
@@ -95,6 +95,8 @@ export const ProductTab = () => {
                 installment_plan: { ...bundle.installment_plan, number_of_installments: value },
               })
             }
+            taxInclusive={bundle.tax_inclusive}
+            setTaxInclusive={(taxInclusive) => updateBundle({ tax_inclusive: taxInclusive })}
           />
         </section>
         <ThumbnailEditor

--- a/app/javascript/components/BundleEdit/state.ts
+++ b/app/javascript/components/BundleEdit/state.ts
@@ -76,6 +76,7 @@ export type Bundle = {
   products: BundleProduct[];
   public_files: PublicFileWithStatus[];
   audio_previews_enabled: boolean;
+  tax_inclusive: boolean;
 };
 
 export const computeStandalonePrice = (bundleProduct: BundleProduct) =>

--- a/app/javascript/components/ProductEdit/ProductTab/PriceEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/PriceEditor.tsx
@@ -21,6 +21,8 @@ export const PriceEditor = ({
   onAllowInstallmentPlanChange,
   onNumberOfInstallmentsChange,
   currencyCodeSelector,
+  taxInclusive,
+  setTaxInclusive,
 }: {
   priceCents: number;
   suggestedPriceCents: number | null;
@@ -35,6 +37,8 @@ export const PriceEditor = ({
   onAllowInstallmentPlanChange: (allowed: boolean) => void;
   onNumberOfInstallmentsChange: (numberOfInstallments: number) => void;
   currencyCodeSelector?: { options: CurrencyCode[]; onChange: (currencyCode: CurrencyCode) => void };
+  taxInclusive: boolean;
+  setTaxInclusive: (taxInclusive: boolean) => void;
 }) => {
   const uid = React.useId();
 
@@ -48,6 +52,9 @@ export const PriceEditor = ({
         onChange={(newAmount) => setPriceCents(newAmount ?? 0)}
         currencyCodeSelector={currencyCodeSelector}
       />
+      <Toggle value={taxInclusive} onChange={setTaxInclusive}>
+        Price includes tax
+      </Toggle>
       <Details
         className="toggle"
         open={isPWYW}

--- a/app/javascript/components/ProductEdit/ProductTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/index.tsx
@@ -292,6 +292,8 @@ export const ProductTab = () => {
                           installment_plan: { ...product.installment_plan, number_of_installments: value },
                         })
                       }
+                      taxInclusive={product.tax_inclusive}
+                      setTaxInclusive={(taxInclusive) => updateProduct({ tax_inclusive: taxInclusive })}
                     />
                     {product.native_type === "commission" ? (
                       <p

--- a/app/javascript/components/ProductEdit/state.ts
+++ b/app/javascript/components/ProductEdit/state.ts
@@ -142,6 +142,7 @@ export type Product = {
   public_files: PublicFileWithStatus[];
   audio_previews_enabled: boolean;
   community_chat_enabled: boolean | null;
+  tax_inclusive: boolean;
 } & (
   | { native_type: "call"; variants: Duration[] }
   | { native_type: "membership"; variants: Tier[] }

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -400,7 +400,7 @@ class Link < ApplicationRecord
   def publish!
     enforce_shipping_destinations_presence!
     enforce_user_email_confirmation!
-    # enforce_merchant_account_exits_for_new_users!
+    enforce_merchant_account_exits_for_new_users!
 
     if auto_transcode_videos?
       transcode_videos!

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -40,6 +40,7 @@ class Link < ApplicationRecord
             31 => :DEPRECATED_excluded_from_mobile_app_discover,
             32 => :moderated_by_iffy,
             33 => :hide_sold_out_variants,
+            34 => :tax_inclusive,
             :column => "flags",
             :flag_query_mode => :bit_operator,
             check_for_column: false
@@ -298,6 +299,7 @@ class Link < ApplicationRecord
   alias super_as_json as_json
 
   before_create :set_default_discover_fee_per_thousand
+  before_create :set_default_tax_inclusive
   after_create :initialize_tier_if_needed
   after_create :add_to_profile_sections
   after_create :initialize_suggested_amount_if_needed!
@@ -306,6 +308,10 @@ class Link < ApplicationRecord
 
   def set_default_discover_fee_per_thousand
     self.discover_fee_per_thousand = DEFAULT_BOOSTED_DISCOVER_FEE_PER_THOUSAND if user.discover_boost_enabled?
+  end
+
+  def set_default_tax_inclusive
+    self.tax_inclusive = true
   end
 
   def initialize_tier_if_needed
@@ -394,7 +400,7 @@ class Link < ApplicationRecord
   def publish!
     enforce_shipping_destinations_presence!
     enforce_user_email_confirmation!
-    enforce_merchant_account_exits_for_new_users!
+    # enforce_merchant_account_exits_for_new_users!
 
     if auto_transcode_videos?
       transcode_videos!

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -3282,7 +3282,7 @@ class Purchase < ApplicationRecord
       end
 
       self.was_purchase_taxable = gumroad_tax_cents > 0 || tax_cents > 0
-      self.was_tax_excluded_from_price = true
+      self.was_tax_excluded_from_price = !link.tax_inclusive?
     end
 
     def calculate_shipping

--- a/app/policies/link_policy.rb
+++ b/app/policies/link_policy.rb
@@ -91,6 +91,7 @@ class LinkPolicy < ApplicationPolicy
       :require_shipping,
       :is_multiseat_license,
       :community_chat_enabled,
+      :tax_inclusive,
       refund_policy: [
         :max_refund_period_in_days,
         :title,

--- a/app/presenters/bundle_presenter.rb
+++ b/app/presenters/bundle_presenter.rb
@@ -48,6 +48,7 @@ class BundlePresenter
         display_product_reviews: bundle.display_product_reviews,
         is_adult: bundle.is_adult,
         discover_fee_per_thousand: bundle.discover_fee_per_thousand,
+        tax_inclusive: bundle.tax_inclusive?,
         section_ids: profile_sections.filter_map { |section| section.external_id if section.shown_products.include?(bundle.id) },
         is_published: !bundle.draft && bundle.alive?,
         products: bundle.bundle_products.alive.in_order.includes(:variant, product: ProductPresenter::ASSOCIATIONS_FOR_CARD).map { self.class.bundle_product(product: _1.product, quantity: _1.quantity, selected_variant_id: _1.variant&.external_id) },

--- a/app/presenters/product_presenter.rb
+++ b/app/presenters/product_presenter.rb
@@ -103,6 +103,7 @@ class ProductPresenter
         hide_sold_out_variants: product.hide_sold_out_variants?,
         is_epublication: product.is_epublication?,
         product_refund_policy_enabled: product.product_refund_policy_enabled?,
+        tax_inclusive: product.tax_inclusive?,
         refund_policy: {
           allowed_refund_periods_in_days: RefundPolicy::ALLOWED_REFUND_PERIODS_IN_DAYS.keys.map do
             {

--- a/spec/business/sales_tax/sales_tax_calculator_spec.rb
+++ b/spec/business/sales_tax/sales_tax_calculator_spec.rb
@@ -42,6 +42,44 @@ describe SalesTaxCalculator do
       compare_calculations(expected: SalesTaxCalculation.zero_tax(0), actual: sales_tax)
     end
 
+    describe "tax-inclusive pricing" do
+      let(:tax_rate) { 0.10 } # 10% tax rate
+      let(:price_cents) { 1000 } # $10.00
+      let(:zip_tax_rate) { create(:zip_tax_rate, country: "US", state: "CA", zip_code: "94107", combined_rate: tax_rate) }
+      let(:product) { create(:product, user: @seller, tax_inclusive: true) }
+
+      before do
+        zip_tax_rate
+      end
+
+      it "calculates tax as a portion of the displayed price for tax-inclusive products" do
+        # For tax-inclusive pricing: tax = price * (rate / (1 + rate))
+        # tax = 1000 * (0.10 / (1 + 0.10)) = 1000 * (0.10 / 1.10) = 90.91 cents
+        expected_tax_cents = (price_cents * tax_rate / (1 + tax_rate)).round
+
+        sales_tax = SalesTaxCalculator.new(product: product,
+                                           price_cents: price_cents,
+                                           buyer_location: { postal_code: "94107", country: "US" }).calculate
+
+        expect(sales_tax.tax_cents).to eq(expected_tax_cents)
+        expect(sales_tax.price_cents).to eq(price_cents)
+      end
+
+      it "calculates tax as an addition to the price for tax-exclusive products" do
+        product.update!(tax_inclusive: false)
+        # For tax-exclusive pricing: tax = price * rate
+        # tax = 1000 * 0.10 = 100 cents
+        expected_tax_cents = (price_cents * tax_rate).round
+
+        sales_tax = SalesTaxCalculator.new(product: product,
+                                           price_cents: price_cents,
+                                           buyer_location: { postal_code: "94107", country: "US" }).calculate
+
+        expect(sales_tax.tax_cents).to eq(expected_tax_cents)
+        expect(sales_tax.price_cents).to eq(price_cents)
+      end
+    end
+
     it "returns zero tax if product is physical and in the EU" do
       create(:zip_tax_rate, country: "DE", zip_code: nil, state: nil)
 

--- a/spec/business/sales_tax/sales_tax_calculator_spec.rb
+++ b/spec/business/sales_tax/sales_tax_calculator_spec.rb
@@ -53,8 +53,6 @@ describe SalesTaxCalculator do
       end
 
       it "calculates tax as a portion of the displayed price for tax-inclusive products" do
-        # For tax-inclusive pricing: tax = price * (rate / (1 + rate))
-        # tax = 1000 * (0.10 / (1 + 0.10)) = 1000 * (0.10 / 1.10) = 90.91 cents
         expected_tax_cents = (price_cents * tax_rate / (1 + tax_rate)).round
 
         sales_tax = SalesTaxCalculator.new(product: product,
@@ -67,8 +65,6 @@ describe SalesTaxCalculator do
 
       it "calculates tax as an addition to the price for tax-exclusive products" do
         product.update!(tax_inclusive: false)
-        # For tax-exclusive pricing: tax = price * rate
-        # tax = 1000 * 0.10 = 100 cents
         expected_tax_cents = (price_cents * tax_rate).round
 
         sales_tax = SalesTaxCalculator.new(product: product,

--- a/spec/models/purchase/purchase_taxation_spec.rb
+++ b/spec/models/purchase/purchase_taxation_spec.rb
@@ -141,6 +141,54 @@ describe "PurchaseTaxation", :vcr do
         end
       end
 
+      describe "tax-inclusive pricing" do
+        before(:context) do
+          @tax_state = "CA"
+          @tax_zip = "94107"
+          @tax_country = "US"
+          @tax_combined_rate = 0.10
+          @tax_is_seller_responsible = true
+        end
+
+        describe "with tax-inclusive product" do
+          before(:context) do
+            @purchase_country = "United States"
+            @purchase_chargeable_country = "US"
+            @purchase_ip_country = "United States"
+            @purchase_transaction_amount = 10_00
+          end
+
+          before(:example) do
+            @product.update!(tax_inclusive: true)
+          end
+
+          it "sets was_tax_excluded_from_price to false for tax-inclusive products" do
+            expect(@purchase.was_purchase_taxable).to be(true)
+            expect(@purchase.was_tax_excluded_from_price).to be(false)
+            expect(@purchase.zip_tax_rate).to eq(@zip_tax_rate)
+          end
+        end
+
+        describe "with tax-exclusive product" do
+          before(:context) do
+            @purchase_country = "United States"
+            @purchase_chargeable_country = "US"
+            @purchase_ip_country = "United States"
+            @purchase_transaction_amount = 11_00
+          end
+
+          before(:example) do
+            @product.update!(tax_inclusive: false)
+          end
+
+          it "sets was_tax_excluded_from_price to true for tax-exclusive products" do
+            expect(@purchase.was_purchase_taxable).to be(true)
+            expect(@purchase.was_tax_excluded_from_price).to be(true)
+            expect(@purchase.zip_tax_rate).to eq(@zip_tax_rate)
+          end
+        end
+      end
+
       describe "location verification with available zip tax entry" do
         before(:context) do
           @tax_combined_rate = 0.22


### PR DESCRIPTION
Fixes #698 

### Summary

Added the option to toggle tax-inclusive pricing for products, and it defaults to true for new products.

### Video


https://github.com/user-attachments/assets/a1e59c28-24bd-4024-8ef6-1ad4adc2b6f8



### Passing Tests

<img width="1470" height="880" alt="Screenshot 2025-09-10 at 9 41 25 PM" src="https://github.com/user-attachments/assets/ac3b6765-c198-4927-82cf-d71e0d4d2b06" />


## AI Disclosure

Used AI to ensure test coverage