### PR TITLE
Fix the help center spec failing on main

### DIFF
--- a/spec/requests/help_center_spec.rb
+++ b/spec/requests/help_center_spec.rb
@@ -6,6 +6,11 @@ describe "Help Center", type: :system, js: true do
   let(:seller) { create(:named_seller) }
 
   before do
+    allow(GlobalConfig).to receive(:get).with("RECAPTCHA_LOGIN_SITE_KEY")
+    allow(GlobalConfig).to receive(:get).with("ENTERPRISE_RECAPTCHA_API_KEY")
+    allow(GlobalConfig).to receive(:get).with("HELPER_WIDGET_SECRET").and_return("test_secret")
+    allow(GlobalConfig).to receive(:get).with("HELPER_WIDGET_HOST").and_return("https://helper.test")
+
     stub_request(:post, "https://helper.test/api/widget/session")
       .to_return(
         status: 200,


### PR DESCRIPTION
Spec introduced in [this commit](https://github.com/antiwork/gumroad/commit/e465d26cd7ea763d317c8b985c0ab9c6bdd33c6a), has been consistently failing.

Ref failures:
- https://github.com/antiwork/gumroad/actions/runs/17613306950/job/50040650109
- https://github.com/antiwork/gumroad/actions/runs/17615474107/job/50047824009
- https://github.com/antiwork/gumroad/actions/runs/17618031772/job/50058636377