### PR TITLE
Fix ambiguous command match

### DIFF
--- a/spec/requests/balance_pages_spec.rb
+++ b/spec/requests/balance_pages_spec.rb
@@ -729,7 +729,7 @@ describe "Balance Pages Scenario", js: true, type: :system do
           visit balance_path
 
           expect(page).to have_status(text: "You have $10.00 available for instant payout: No need to wait—get paid now!")
-          click_on "Get paid!"
+          click_on "Get paid!", match: :first
           within_modal "Instant payout" do
             expect(page).to have_text("You can request instant payouts 24/7, including weekends and holidays. Funds typically appear in your bank account within 30 minutes, though some payouts may take longer to be credited.")
             expect(page).to have_select("Pay out balance up to", selected: Date.current.strftime("%B %-d, %Y"))
@@ -741,9 +741,9 @@ describe "Balance Pages Scenario", js: true, type: :system do
           end
           expect(page).to_not have_modal("Instant payout")
 
-          click_on "Get paid!"
+          click_on "Get paid!", match: :first
           within_modal "Instant payout" do
-            click_on "Get paid!"
+            click_on "Get paid!", match: :first
           end
 
           current_date = Time.current.strftime("%B #{Time.current.day.ordinalize}, %Y")
@@ -788,7 +788,7 @@ describe "Balance Pages Scenario", js: true, type: :system do
           visit balance_path
 
           expect(page).to have_status(text: "You have $15,000.00 available for instant payout: No need to wait—get paid now!")
-          click_on "Get paid!"
+          click_on "Get paid!", match: :first
           within_modal "Instant payout" do
             expect(page).to have_text("You can request instant payouts 24/7, including weekends and holidays. Funds typically appear in your bank account within 30 minutes, though some payouts may take longer to be credited.")
             expect(page).to have_text("Sent to Test Bank", normalize_ws: true)
@@ -801,7 +801,7 @@ describe "Balance Pages Scenario", js: true, type: :system do
             select "January 2, 2025", from: "Pay out balance up to"
             click_on "Cancel"
           end
-          click_on "Get paid!"
+          click_on "Get paid!", match: :first
           within_modal "Instant payout" do
             expect(page).to have_text("Amount $9,000", normalize_ws: true)
             expect(page).to have_text("Instant payout fee (3%) -$262.14", normalize_ws: true)
@@ -810,7 +810,7 @@ describe "Balance Pages Scenario", js: true, type: :system do
             select "January 1, 2025", from: "Pay out balance up to"
             click_on "Cancel"
           end
-          click_on "Get paid!"
+          click_on "Get paid!", match: :first
           within_modal "Instant payout" do
             expect(page).to have_text("Amount $5,000", normalize_ws: true)
             expect(page).to have_text("Instant payout fee (3%) -$145.64", normalize_ws: true)


### PR DESCRIPTION
Fix ambiguous command match

This PR fixes flaky test failures in the balance pages spec by addressing ambiguous command matching issues.

## Before (failed test run)

The following test was failing intermittently in CI:

**Test**: `spec/requests/balance_pages_spec.rb#L681` - "Balance Pages Scenario index page instant payout when user's balance is greater than the maximum instant payout amount but a single balance does not exceed the maximum instant payout amount displays a notice and allows instant payouts"

**Error**: `Capybara::Ambiguous: Ambiguous match, found 2 elements matching visible command "Get paid!"`

**Specific failure from GitHub Actions:**
- Job: https://github.com/antiwork/gumroad/actions/runs/17164102586/job/48700714779
- Error occurred when test tried to click "Get paid!" button but found multiple matching elements

## After (successful test run)

The tests should now pass consistently by:

1. Using `match: :first` to handle multiple "Get paid!" buttons on the page
2. Following Capybara's standard approach for ambiguous element selection

## Changes Made

* **spec/requests/balance_pages_spec.rb**: Added `match: :first` to all 6 instances of `click_on "Get paid!"` calls

## Validation

The approach used (`match: :first`) is already established in the codebase:
- Same file uses `match: :first` at line 138
- Standard Capybara approach for handling ambiguous elements

This addresses the flakiness issues mentioned in https://github.com/antiwork/gumroad/issues/1127.

## AI Disclosure

No AI tools used