### PR TITLE
Add tags-ignore for production in GitHub Actions workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,8 @@ name: Tests
 
 on:
   push:
+    branches:
+      - **
     tags-ignore:
       - production-*
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,9 +3,9 @@ name: Tests
 on:
   push:
     branches:
-      - **
+      - '**'
     tags-ignore:
-      - production-*
+      - 'production-*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,8 @@ name: Tests
 
 on:
   push:
+    tags-ignore:
+      - production-*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
It currently runs a duplicate test build after deployment when `production-*` tags are pushed.

Thanks to @hchhabra for finding the issue! [[internal slack](https://anti--work.slack.com/archives/C01B70APF9P/p1757526608595319?thread_ts=1756999224.152189&cid=C01B70APF9P)]