### PR TITLE
fix(ui): align "start selling" button structure and improve responsiveness

### DIFF
--- a/app/views/home/about.html.erb
+++ b/app/views/home/about.html.erb
@@ -309,8 +309,8 @@
   </div>
 
   <div class="px-8 py-16 lg:px-[4vw] lg:py-24">
-    <div class="flex flex-col lg:flex-row gap-8 lg:gap-16 max-w-5xl mx-auto lg:items-center">
-      <h1 class="font-medium text-4xl sm:text-5xl lg:text-6xl"> Share your work. <br> Someone out there needs it.</h1>
+    <div class="flex flex-col lg:flex-col gap-8 lg:gap-16 max-w-5xl mx-auto lg:items-center">
+      <h1 class="font-medium text-4xl sm:text-5xl lg:text-7xl text-center"> Share your work. <br> Someone out there needs it.</h1>
       <%= render "home/shared/button", text: "Start selling", url: new_user_registration_path %>
     </div>
   </div>


### PR DESCRIPTION
ref #864 

## Summary
Updated the "Start Selling" button on the home page to use the same structure as the features page, with display: flex and flex-direction: column for better vertical stacking. This ensures the button layout is consistent and adapts well to different screen sizes.

## features page
<img width="1511" height="742" alt="Screenshot 2025-09-11 at 8 19 33 PM" src="https://github.com/user-attachments/assets/505089ac-d42f-490c-a616-cfd4f4c929a7" />


## home page 
## before

<img width="1512" height="666" alt="before1" src="https://github.com/user-attachments/assets/8fa03a23-8175-4853-9e70-eecf73056696" />

## after

<img width="1512" height="668" alt="after1" src="https://github.com/user-attachments/assets/c8013d6c-a0e0-493c-a21c-75f86149ca82" />


## before

<img width="961" height="625" alt="before 2" src="https://github.com/user-attachments/assets/1ae12751-96dd-4bb4-92c7-076ae5fca9d1" />

## after

<img width="959" height="626" alt="after 2" src="https://github.com/user-attachments/assets/e3b7a35e-fc58-4d83-a0fe-e1fdbb900fd6" />


## before

<img width="385" height="513" alt="before3" src="https://github.com/user-attachments/assets/d9f6f089-b86d-485f-9897-03d06900fb19" />


## after

<img width="384" height="514" alt="after3" src="https://github.com/user-attachments/assets/15588c38-9afc-48f2-8081-a6648a56a4e7" />


## before

<img width="218" height="468" alt="before 4" src="https://github.com/user-attachments/assets/8a285e17-fef1-45b1-ba9e-77daf45d0789" />


## after

<img width="215" height="466" alt="after4" src="https://github.com/user-attachments/assets/0da22c16-870e-4d2e-90fb-d8154a3a190f" />

## AI Usage
No AI was used to generate any of this code.

## Self-Review
I have self-reviewed all the code that I have written.
