### PR TITLE
fix: auto-close mobile nav on navigation.

### DIFF
--- a/app/javascript/components/client-components/Nav/index.tsx
+++ b/app/javascript/components/client-components/Nav/index.tsx
@@ -51,8 +51,17 @@ export const ClientNavLink = ({
     ? "page"
     : undefined;
 
+  const handleClick = (event: React.MouseEvent) => {
+    if (onClick) onClick(event);
+    const nav = document.querySelector("nav");
+    const toggleButton = nav?.querySelector("button.toggle") as HTMLButtonElement;
+    if (nav?.classList.contains("open") && toggleButton) {
+      toggleButton.click();
+    }
+  };
+
   return (
-    <Link aria-current={ariaCurrent} href={href} title={text} {...(onClick && { onClick })}>
+    <Link aria-current={ariaCurrent} href={href} title={text} onClick={handleClick}>
       {icon ? <Icon name={icon} /> : null}
       {text}
       {badge ? (


### PR DESCRIPTION
ref https://github.com/antiwork/gumroad/issues/864

Summary -> 

- Mobile nav stayed open when clicking certain nav items that use client-side navigation (Products, Collaborators, Sales,    Analytics, Payouts). Other items (Checkout , Emails, Workflows) works fine because they reload the page.

- Fixed by auto-clicking the nav close button when these items are clicked, ensuring the nav closes properly on all navigation.
  
Before - 

https://github.com/user-attachments/assets/ba3d57f9-9d2f-48b1-8583-57bd3a491702

After - 

https://github.com/user-attachments/assets/9fd287d4-1008-4a15-9719-d27882cb7435

AI disclosure -
No AI tool is being used.