### PR TITLE
fix sidebar menu not auto-closing on navigation clicks

### DIFF
--- a/app/javascript/components/Nav.tsx
+++ b/app/javascript/components/Nav.tsx
@@ -36,8 +36,20 @@ export const NavLink = ({
     ? "page"
     : undefined;
 
+  const navContext = React.useContext(NavContext);
+
+  const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    if (navContext) {
+      navContext.closeMenu();
+    }
+
+    if (onClick) {
+      onClick(event);
+    }
+  };
+
   return (
-    <a aria-current={ariaCurrent} href={href} title={text} onClick={onClick} className="flex items-center">
+    <a aria-current={ariaCurrent} href={href} title={text} onClick={handleClick} className="flex items-center">
       {icon ? <Icon name={icon} /> : null}
       {text}
       {badge ? (
@@ -74,26 +86,50 @@ type Props = {
   compact?: boolean;
 };
 
+type NavContextValue = {
+  closeMenu: () => void;
+};
+
+const NavContext = React.createContext<NavContextValue | null>(null);
+
+export const useNavContext = () => {
+  const context = React.useContext(NavContext);
+  if (!context) {
+    throw new Error('useNavContext must be used within a Nav component');
+  }
+  return context;
+};
+
 export const Nav = ({ title, children, footer, compact }: Props) => {
   const [open, setOpen] = React.useState(false);
 
+  const closeMenu = React.useCallback(() => {
+    setOpen(false);
+  }, []);
+
+  const contextValue: NavContextValue = React.useMemo(() => ({
+    closeMenu,
+  }), [closeMenu]);
+
   return (
-    <nav aria-label="Main" className={cx({ compact, open })}>
-      <div className="navbar">
-        <a href={Routes.root_url()}>
-          <span className="logo-g">&nbsp;</span>
-        </a>
-        <h1>{title}</h1>
-        <button className="toggle" onClick={() => setOpen(!open)} />
-      </div>
-      <header>
-        <a href={Routes.root_url()} aria-label="Dashboard">
-          <span className="logo-full">&nbsp;</span>
-        </a>
-      </header>
-      {children}
-      <footer>{footer}</footer>
-    </nav>
+    <NavContext.Provider value={contextValue}>
+      <nav aria-label="Main" className={cx({ compact, open })}>
+        <div className="navbar">
+          <a href={Routes.root_url()}>
+            <span className="logo-g">&nbsp;</span>
+          </a>
+          <h1>{title}</h1>
+          <button className="toggle" onClick={() => setOpen(!open)} />
+        </div>
+        <header>
+          <a href={Routes.root_url()} aria-label="Dashboard">
+            <span className="logo-full">&nbsp;</span>
+          </a>
+        </header>
+        {children}
+        <footer>{footer}</footer>
+      </nav>
+    </NavContext.Provider>
   );
 };
 

--- a/app/javascript/components/client-components/Nav/index.tsx
+++ b/app/javascript/components/client-components/Nav/index.tsx
@@ -17,7 +17,7 @@ import { useCurrentSeller } from "$app/components/CurrentSeller";
 import { useAppDomain, useDiscoverUrl } from "$app/components/DomainSettings";
 import { Icon } from "$app/components/Icons";
 import { useLoggedInUser } from "$app/components/LoggedInUser";
-import { Nav as NavFramework, NavLink } from "$app/components/Nav";
+import { Nav as NavFramework, NavLink, useNavContext } from "$app/components/Nav";
 import { useRunOnce } from "$app/components/useRunOnce";
 
 type Props = {
@@ -43,6 +43,7 @@ export const ClientNavLink = ({
   onClick?: (event: React.MouseEvent) => void;
 }) => {
   const currentPath = window.location.href;
+  const { closeMenu } = useNavContext();
 
   const ariaCurrent = [href, ...additionalPatterns].some((pattern) => {
     const escaped = escapeRegExp(pattern);
@@ -51,8 +52,17 @@ export const ClientNavLink = ({
     ? "page"
     : undefined;
 
+    const handleClick = (event: React.MouseEvent) => {
+      closeMenu();
+
+      if (onClick) {
+        onClick(event);
+      }
+    };
+
+
   return (
-    <Link aria-current={ariaCurrent} href={href} title={text} {...(onClick && { onClick })}>
+    <Link aria-current={ariaCurrent} href={href} title={text} onClick={handleClick}>
       {icon ? <Icon name={icon} /> : null}
       {text}
       {badge ? (


### PR DESCRIPTION
ref #864 

## Summary
The sidebar navigation menu previously failed to close automatically when users clicked on items like "Products," causing a poor user experience, on mobile devices, where manual closure was required. 

## before


https://github.com/user-attachments/assets/4fb8f0a6-8f25-49a4-a222-a20caf565b20



## after



https://github.com/user-attachments/assets/5cdc7153-493f-44f7-894b-e9f4b00f00c7



## AI Usage
No AI was used to generate any of this code.

## Self-Review
I have self-reviewed all the code that I have written.