### PR TITLE
fix header navigation text wrapping on smaller viewports

### DIFF
--- a/app/views/home/shared/_nav.html.erb
+++ b/app/views/home/shared/_nav.html.erb
@@ -22,8 +22,7 @@
         is_current ? 'border-black' : 'border-transparent'
       } #{
         is_current ? 'lg:bg-black lg:text-white dark:lg:bg-white dark:lg:text-black' : 'lg:bg-transparent lg:text-black dark:lg:text-white'
-      } bg-black p-4 text-lg text-white no-underline transition-all duration-200 hover:border-black lg:w-auto lg:rounded-full lg:py-2 lg:px-4 dark:text-white lg:dark:hover:border-white/[.35]"
-    end
+      } bg-black p-4 text-lg text-white no-underline transition-all duration-200 hover:border-black lg:w-auto lg:rounded-full lg:py-2 lg:px-4 dark:text-white lg:dark:hover:border-white/[.35] whitespace-nowrap"    end
   end
 
   def logo_link(options = {})


### PR DESCRIPTION
ref #864 

## Problem
On Safari, when the viewport width is between 1023px and 1104px (e.g. Nest Hub resolution), the tiles wrap incorrectly, causing text to break across multiple lines.

## before

<img width="718" height="671" alt="Screenshot 2025-09-12 at 3 24 33 AM" src="https://github.com/user-attachments/assets/6af8e341-f40e-4bb0-ab9f-4b4894e50990" />

## after

<img width="720" height="670" alt="Screenshot 2025-09-12 at 3 25 55 AM" src="https://github.com/user-attachments/assets/c61b8b35-120c-4699-a49e-60e2dac45d64" />


## AI Usage
No AI was used to generate any of this code.

## Self-Review
I have self-reviewed all the code that I have written.
