### PR TITLE
Make discount input fields visible in Insert Upsell Modal on mobile

### DIFF
--- a/app/javascript/components/CheckoutDashboard/DiscountInput.tsx
+++ b/app/javascript/components/CheckoutDashboard/DiscountInput.tsx
@@ -24,7 +24,7 @@ export const DiscountInput = ({
 }) => {
   const fixedAmountFieldset = (
     <fieldset className={cx({ danger: discount.type === "cents" && discount.error })}>
-      <div style={{ display: "grid", gap: "var(--spacer-4)", gridTemplateColumns: "auto 1fr", alignItems: "center" }}>
+      <div className="grid items-center gap-4 md:!grid-cols-[auto,1fr]">
         <label>
           <input
             type="radio"
@@ -58,7 +58,7 @@ export const DiscountInput = ({
       }}
     >
       <fieldset className={cx({ danger: discount.type === "percent" && discount.error })}>
-        <div style={{ display: "grid", gap: "var(--spacer-4)", gridTemplateColumns: "auto 1fr", alignItems: "center" }}>
+        <div className="grid items-center gap-4 md:!grid-cols-[auto,1fr]">
           <label>
             <input
               type="radio"


### PR DESCRIPTION
### Explanation of Change
Fixes an issue where Input fields in the Insert Upsell Modal (for percentage and fixed amount discounts) are properly visible on mobile.

### Screenshots/Videos
Before


https://github.com/user-attachments/assets/e36d2587-93c7-4b24-ad2d-b8a642d8f6ed



After

https://github.com/user-attachments/assets/ca445ee4-32b2-41d9-af7e-06137969c3bc


### AI Disclosure
No AI tools used