### PR TITLE
Fix to handle easypost flakiness in specs

### DIFF
--- a/spec/support/checkout_helpers.rb
+++ b/spec/support/checkout_helpers.rb
@@ -154,8 +154,11 @@ module CheckoutHelpers
       click_on is_free ? "Get" : "Pay", exact: true
 
       if should_verify_address
-        expect(page).to have_text("We are unable to verify your shipping address. Is your address correct?")
-        click_on "Yes, it is"
+        if page.has_text?("We are unable to verify your shipping address. Is your address correct?")
+          click_on "Yes, it is"
+        elsif page.has_text?("You entered this address:") && page.has_text?("We recommend using this format:")
+          click_on "No, continue"
+        end
       end
 
       within_sca_frame { click_on sca ? "Complete" : "Fail" } unless sca.nil?


### PR DESCRIPTION
### What

Looks like for the same physical address, EasyPost sometimes responds with a corrected address and other times says the address is invalid without a corrected suggestion, which is causing specs to fail. Changed to handle both cases.

### Why

This should fix the following failures:
- `./spec/requests/purchases/product/taxes_spec.rb:2311 # Product Page - Tax Scenarios Kenya Tax when collect_tax_ke feature flag is on does not apply tax for physical products` (ref [failed CI run](https://github.com/antiwork/gumroad/actions/runs/17653788939/job/50171677826))
- `./spec/requests/purchases/product/taxes_spec.rb:3622 # Product Page - Tax Scenarios Turkey Tax when collect_tax_tr feature flag is on does not apply tax for physical products` (ref [failed CI run](https://github.com/antiwork/gumroad/actions/runs/17617477563/job/50056929694))

<img width="1422" height="520" alt="Screenshot 2025-09-12 at 2 55 03 PM" src="https://github.com/user-attachments/assets/e204cc77-a358-4ad9-9769-b20a82603f71" />

Related #1127 
