### PR TITLE
Fix: hide Share tooltip when product Share popover/modal is open

### DIFF
--- a/app/javascript/components/Popover.tsx
+++ b/app/javascript/components/Popover.tsx
@@ -51,6 +51,14 @@ export const Popover = ({
     if (focusElement instanceof HTMLElement) focusElement.focus();
   }, [open]);
 
+  React.useEffect(() => {
+    const summaryEl = ref.current?.querySelector("summary") ?? null;
+    const triggerTooltip = summaryEl?.querySelector(".has-tooltip") as HTMLElement | null;
+    if (!triggerTooltip) return;
+    if (open) triggerTooltip.classList.add("popover-open");
+    else triggerTooltip.classList.remove("popover-open");
+  }, [open]);
+
   return (
     <Details
       className={cx("popover toggle", position, className)}

--- a/app/javascript/stylesheets/_tooltip.scss
+++ b/app/javascript/stylesheets/_tooltip.scss
@@ -80,4 +80,10 @@
       display: block;
     }
   }
+
+  &.popover-open {
+    [role="tooltip"] {
+      display: none !important;
+    }
+  }
 }


### PR DESCRIPTION
ref #864 
## Issue
On the product page, the Share tooltip stayed visible behind the Share popover and wasn’t disabled when the popover opened. 
## Fix
The popover now toggles a popover-open class on the trigger’s tooltip wrapper while open, and CSS hides the tooltip during that state; the tooltip returns to normal once the popover closes.

## before

https://github.com/user-attachments/assets/36a99bfc-9084-4406-96d9-f780f24aaa90

## after

https://github.com/user-attachments/assets/d1a449d5-162c-4340-94db-a6aef49c0f43


## AI Usage
No AI was used to generate any of this code.

## Self-Review
I have self-reviewed all the code that I have written.
