### PR TITLE
fix: "text" field type used instead of "number" for price input

### DIFF
--- a/app/javascript/components/server-components/NewProductPage.tsx
+++ b/app/javascript/components/server-components/NewProductPage.tsx
@@ -375,11 +375,15 @@ const NewProductPage = ({
                     ref={priceInputRef}
                     id={`price-${formUID}`}
                     type="text"
+                    inputMode="decimal"
                     maxLength={10}
                     placeholder="Price your product"
                     value={price}
                     onChange={(e) => {
-                      setPrice(e.target.value);
+                      let newValue = e.target.value;
+                      newValue = newValue.replace(/[.,]+/gu, ".");
+                      newValue = newValue.replace(/[^0-9.]/gu, "");
+                      setPrice(newValue);
                       errors.delete("price");
                     }}
                     autoComplete="off"


### PR DESCRIPTION
ref #864 

## Before: (allowed to set text as price, and no error)
https://github.com/user-attachments/assets/ffd850f7-5cf5-4fae-a9e1-b058ec80b625

## After: only numbers allowed
https://github.com/user-attachments/assets/8e3719fa-3f7a-40bd-86d3-dd10ef8cf07f

