### PR TITLE
Fix flaky profile sections and UTM links specs

### DIFF
--- a/spec/requests/analytics/utm_links_spec.rb
+++ b/spec/requests/analytics/utm_links_spec.rb
@@ -844,7 +844,7 @@ describe "UTM links", :js, type: :system do
       expect(utm_link.reload.unique_clicks).to eq(1)
     end
 
-    it "attributes all qualified purchases to respective UTM link visits when buying multiple products" do
+    it "attributes all qualified purchases to respective UTM link visits when buying multiple products", :elasticsearch_wait_for_refresh do
       seller2 = create(:user)
       Feature.activate_user(:utm_links, seller2)
 

--- a/spec/requests/products/show/sections_spec.rb
+++ b/spec/requests/products/show/sections_spec.rb
@@ -7,7 +7,7 @@ describe "Profile settings on product pages", type: :system, js: true do
   let(:seller) { create(:user) }
   let(:product) { create(:product, user: seller) }
 
-  it "renders sections correctly when the user is logged out" do
+  it "renders sections correctly when the user is logged out", :elasticsearch_wait_for_refresh do
     products = create_list(:product, 3, user: seller)
     create(:seller_profile_products_section, seller:)
     section1 = create(:seller_profile_products_section, seller:, product:, header: "Section 1", shown_products: products.map(&:id))
@@ -54,7 +54,7 @@ describe "Profile settings on product pages", type: :system, js: true do
     end
   end
 
-  it "allows editing sections when the user is logged in" do
+  it "allows editing sections when the user is logged in", :elasticsearch_wait_for_refresh do
     login_as seller
     product2 = create(:product, user: seller, name: "Product 2")
     visit short_link_path(product)


### PR DESCRIPTION
Ref: #1127 

Caused by a race condition where Elasticsearch may not have finished indexing by the time we load the page. `elasticsearch_wait_for_refresh` should fix this, but couldn't easily reproduce locally so will keep an eye on it.