### PR TITLE
Fix Webpack 5 build by adding missing core module polyfills

### DIFF
--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -22,6 +22,11 @@ export default async () => {
         "react-dom/server": "react-dom/server.browser",
         "@rails/activestorage": false,
       },
+      fallback: {
+        tty: false,
+        os: false,
+        util: false,
+      },
     },
     target: "es2019", // most recent supported ES version by the libv8-node gem
   });


### PR DESCRIPTION
Based on #1184, fixes #1125.