### PR TITLE
Update support.md

### DIFF
--- a/docs/support.md
+++ b/docs/support.md
@@ -252,7 +252,7 @@ end
 Subscription.find(SUBSCRIPTION_ID).user_requested_cancellation_at
 ```
 
-### Cancel all active subscriptions for a user
+### CAUTION: Cancel all active subscriptions for a creator
 
 ```ruby
 User.find_by_email("creator@example.com").links.each do |product|


### PR DESCRIPTION
What: changes "cancel all active subscriptions for a user" to "cancel all active subscriptions for a creator" with an additional CAUTION label. 

Why: this script can cancel all of a creator's active subscriptions, and should be used with caution under certain circumstances only. 