### PR TITLE
Improve logic fetching max_refund_period_in_days for PurchaseRefundPolicy records

### DIFF
--- a/app/models/purchase_refund_policy.rb
+++ b/app/models/purchase_refund_policy.rb
@@ -17,6 +17,9 @@ class PurchaseRefundPolicy < ApplicationRecord
   end
 
   def determine_max_refund_period_in_days
+    previous_value = determine_max_refund_period_in_days_from_previous_policy
+    return previous_value if previous_value.present?
+
     return 0 if title.match?(/no refunds|final|no returns/i)
 
     exact_match = find_exact_match_by_title
@@ -70,6 +73,17 @@ class PurchaseRefundPolicy < ApplicationRecord
     end
 
     prompt
+  end
+
+  # Avoid calling AI if possible by checking the product refund policy, and previous purchase refund policies
+  def determine_max_refund_period_in_days_from_previous_policy
+    product_refund_policy = purchase.link.product_refund_policy
+    return product_refund_policy.max_refund_period_in_days if product_refund_policy.title == title
+
+    other_purchase_refund_policy = PurchaseRefundPolicy.joins(:purchase).where(purchases: { link_id: purchase.link_id }).where.not(id: id).where(title:).first
+    return other_purchase_refund_policy.max_refund_period_in_days if other_purchase_refund_policy.present?
+
+    nil
   end
 
   private


### PR DESCRIPTION
Part of https://github.com/antiwork/gumroad/issues/1047, follow-up on https://github.com/antiwork/gumroad/pull/1050
`
The one-time script uses AI (OpenAI `gpt-4o-mini`) to determine the value for `max_refund_period_in_days`). With the number of records we have in production, the cost of running this script could be significant.

This PR adds new logic that tries to determine the value for `max_refund_period_in_days` in 2 ways before using AI (which should reduce the use of AI significantly):
* refund policy on the product, if the refund policy `title` hasn't changed
* the first `PurchaseRefundPolicy` record that has the same title, and a value set for `max_refund_period_in_days`
