### PR TITLE
fix: Restrict thumbnail uploads to image files only

### DIFF
--- a/app/javascript/components/ProductEdit/ContentTab/FileEmbed.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/FileEmbed.tsx
@@ -214,7 +214,9 @@ const FileEmbedNodeView = ({ node, editor, getPos, updateAttributes }: NodeViewP
     const thumbnail = files?.[0];
     if (thumbnail) uploadThumbnail(thumbnail);
   };
-  const thumbnailInput = <input type="file" accept="image/*" onChange={(e) => onThumbnailSelected(e.target.files)} />;
+  const thumbnailInput = (
+    <input type="file" accept=".jpg,.jpeg,.png,.gif" onChange={(e) => onThumbnailSelected(e.target.files)} />
+  );
 
   const removeSubtitle = (url: string) =>
     updateFile({ subtitle_files: file.subtitle_files.filter((subtitle) => subtitle.url !== url) });


### PR DESCRIPTION
### Explanation of Change
Update thumbnail input to only allow image file selection using accept="image/*"

### Screenshots/Videos
Before

https://github.com/user-attachments/assets/a39d2a6b-2165-4704-aa7d-156f94dd6f83

After

https://github.com/user-attachments/assets/4f52eddd-b4d5-4610-b9f0-f045e4148f2f

### AI Disclosure
No AI tools used