### PR TITLE
fix: ensure consistent collapse all behavior for thumbnails

### DIFF
--- a/app/javascript/components/ProductEdit/ContentTab/FileEmbed.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/FileEmbed.tsx
@@ -498,11 +498,12 @@ const FileEmbedNodeView = ({ node, editor, getPos, updateAttributes }: NodeViewP
                     role="menuitem"
                     onClick={() => {
                       editor.commands.command(({ tr }) => {
+                        const targetState = !node.attrs.collapsed;
                         tr.doc.descendants((node, pos) => {
-                          if (node.type.name === FileEmbed.name) {
+                          if (node.type.name === FileEmbed.name && node.attrs.collapsed !== targetState) {
                             tr.setNodeMarkup(pos, null, {
                               ...node.attrs,
-                              collapsed: !node.attrs.collapsed,
+                              collapsed: targetState,
                             });
                           }
                         });


### PR DESCRIPTION
### Explanation of Change
Fixes an issue with the "Collapse all thumbnails" functionality in the product content editor where clicking the button would cause inconsistent behavior with already collapsed items.

### Screenshots/Videos
Before

https://github.com/user-attachments/assets/3c5eddea-7502-40b3-9eff-f827451d6606



After

https://github.com/user-attachments/assets/cde36ebd-a49f-47b3-b0a6-d749dbd8b1ac


### AI Disclosure
No AI tools used


