### PR TITLE
fix: Add margins to Widgets, Ping, and API pages

### DIFF
--- a/app/javascript/components/Developer/Tabs.tsx
+++ b/app/javascript/components/Developer/Tabs.tsx
@@ -1,7 +1,7 @@
+import cx from "classnames";
 import * as React from "react";
 
-import { Tabs as UITabs, Tab } from "$app/components/ui/Tabs";
-
+import { Button } from "../Button";
 import { Icon } from "../Icons";
 
 export type Tab = "overlay" | "embed";
@@ -17,16 +17,18 @@ export const Tabs = ({
   overlayTabpanelUID?: string;
   embedTabpanelUID?: string;
 }) => {
-  const selectTab = (evt: React.MouseEvent<HTMLAnchorElement>, tab: Tab) => {
+  const selectTab = (evt: React.MouseEvent<HTMLButtonElement>, tab: Tab) => {
     evt.preventDefault();
     setTab(tab);
   };
 
   return (
-    <UITabs>
-      <Tab
+    <div className="tab-buttons" role="tablist">
+      <Button
         onClick={(evt) => selectTab(evt, "overlay")}
-        isSelected={tab === "overlay"}
+        className={cx(tab === "overlay" ? "selected" : null)}
+        role="tab"
+        aria-selected={tab === "overlay"}
         aria-controls={overlayTabpanelUID}
       >
         <Icon name="stickies" />
@@ -34,14 +36,20 @@ export const Tabs = ({
           <h4 className="tab-title">Modal Overlay</h4>
           <small>Pop up product information with a familiar and trusted buying experience.</small>
         </div>
-      </Tab>
-      <Tab onClick={(evt) => selectTab(evt, "embed")} isSelected={tab === "embed"} aria-controls={embedTabpanelUID}>
+      </Button>
+      <Button
+        onClick={(evt) => selectTab(evt, "embed")}
+        className={cx(tab === "embed" ? "selected" : null)}
+        role="tab"
+        aria-selected={tab === "embed"}
+        aria-controls={embedTabpanelUID}
+      >
         <Icon name="code-square" />
         <div>
           <h4 className="tab-title">Embed</h4>
           <small>Embed on your website, blog posts & more.</small>
         </div>
-      </Tab>
-    </UITabs>
+      </Button>
+    </div>
   );
 };

--- a/app/javascript/components/server-components/Developer/WidgetsPage.tsx
+++ b/app/javascript/components/server-components/Developer/WidgetsPage.tsx
@@ -47,73 +47,75 @@ export const WidgetsPage = ({ display_product_select, products, affiliated_produ
 
   return (
     <Layout currentPage="widgets">
-      <form>
-        <section>
-          <header>
-            <h3>Share your product</h3>
-            <p>
-              You can easily bring the Gumroad purchase page right into your site, without directing your buyers
-              elsewhere.{" "}
-              <a href="/help/article/44-build-gumroad-into-your-website" target="_blank" rel="noreferrer">
-                Learn more
-              </a>
-            </p>
-          </header>
-          <div>
-            <Widgets
-              display_product_select={display_product_select}
-              products={products}
-              affiliated_products={affiliated_products}
-              default_product={default_product}
-            />
-          </div>
-        </section>
-        {currentSeller ? (
+      <div className="p-4 md:p-8">
+        <form>
           <section>
             <header>
-              <h3>Subscribe form</h3>
+              <h3>Share your product</h3>
               <p>
-                Share your subscribe form on any website or blog using an embed or URL.{" "}
-                <a href="/help/article/170-audience" target="_blank" rel="noreferrer">
+                You can easily bring the Gumroad purchase page right into your site, without directing your buyers
+                elsewhere.{" "}
+                <a href="/help/article/44-build-gumroad-into-your-website" target="_blank" rel="noreferrer">
                   Learn more
                 </a>
               </p>
             </header>
-            <fieldset>
-              <legend>
-                <label htmlFor={copyButtonUID}>Share your subscribe page and grow your audience</label>
-              </legend>
-              <CopyToClipboard
-                text={Routes.custom_domain_subscribe_url({ host: currentSeller.subdomain })}
-                copyTooltip="Copy link"
-                tooltipPosition="bottom"
-              >
-                <Button id={copyButtonUID} color="primary">
-                  <Icon name="link" />
-                  Copy link
-                </Button>
-              </CopyToClipboard>
-            </fieldset>
-            <fieldset>
-              <legend>
-                <label htmlFor={FOLLOW_FORM_EMBED_INPUT_ID}>Test your subscribe form with your email</label>
-              </legend>
-              <FollowFormEmbed sellerId={currentSeller.id} preview />
-            </fieldset>
-            <fieldset>
-              <legend>
-                <label htmlFor={followFormEmbedUID}>Subscribe form embed code</label>
-                <CopyToClipboard text={followFormEmbedHTML} copyTooltip="Copy to Clipboard" tooltipPosition="top">
-                  <button type="button" className="link">
-                    Copy embed code
-                  </button>
-                </CopyToClipboard>
-              </legend>
-              <textarea id={followFormEmbedUID} value={followFormEmbedHTML} readOnly />
-            </fieldset>
+            <div>
+              <Widgets
+                display_product_select={display_product_select}
+                products={products}
+                affiliated_products={affiliated_products}
+                default_product={default_product}
+              />
+            </div>
           </section>
-        ) : null}
-      </form>
+          {currentSeller ? (
+            <section>
+              <header>
+                <h3>Subscribe form</h3>
+                <p>
+                  Share your subscribe form on any website or blog using an embed or URL.{" "}
+                  <a href="/help/article/170-audience" target="_blank" rel="noreferrer">
+                    Learn more
+                  </a>
+                </p>
+              </header>
+              <fieldset>
+                <legend>
+                  <label htmlFor={copyButtonUID}>Share your subscribe page and grow your audience</label>
+                </legend>
+                <CopyToClipboard
+                  text={Routes.custom_domain_subscribe_url({ host: currentSeller.subdomain })}
+                  copyTooltip="Copy link"
+                  tooltipPosition="bottom"
+                >
+                  <Button id={copyButtonUID} color="primary">
+                    <Icon name="link" />
+                    Copy link
+                  </Button>
+                </CopyToClipboard>
+              </fieldset>
+              <fieldset>
+                <legend>
+                  <label htmlFor={FOLLOW_FORM_EMBED_INPUT_ID}>Test your subscribe form with your email</label>
+                </legend>
+                <FollowFormEmbed sellerId={currentSeller.id} preview />
+              </fieldset>
+              <fieldset>
+                <legend>
+                  <label htmlFor={followFormEmbedUID}>Subscribe form embed code</label>
+                  <CopyToClipboard text={followFormEmbedHTML} copyTooltip="Copy to Clipboard" tooltipPosition="top">
+                    <button type="button" className="link">
+                      Copy embed code
+                    </button>
+                  </CopyToClipboard>
+                </legend>
+                <textarea id={followFormEmbedUID} value={followFormEmbedHTML} readOnly />
+              </fieldset>
+            </section>
+          ) : null}
+        </form>
+      </div>
     </Layout>
   );
 };

--- a/app/javascript/components/server-components/Developer/WidgetsPage.tsx
+++ b/app/javascript/components/server-components/Developer/WidgetsPage.tsx
@@ -47,75 +47,73 @@ export const WidgetsPage = ({ display_product_select, products, affiliated_produ
 
   return (
     <Layout currentPage="widgets">
-      <div className="p-4 md:p-8">
-        <form>
-          <section>
+      <form>
+        <section className="!p-4 md:!p-8">
+          <header>
+            <h3>Share your product</h3>
+            <p>
+              You can easily bring the Gumroad purchase page right into your site, without directing your buyers
+              elsewhere.{" "}
+              <a href="/help/article/44-build-gumroad-into-your-website" target="_blank" rel="noreferrer">
+                Learn more
+              </a>
+            </p>
+          </header>
+          <div>
+            <Widgets
+              display_product_select={display_product_select}
+              products={products}
+              affiliated_products={affiliated_products}
+              default_product={default_product}
+            />
+          </div>
+        </section>
+        {currentSeller ? (
+          <section className="!p-4 md:!p-8">
             <header>
-              <h3>Share your product</h3>
+              <h3>Subscribe form</h3>
               <p>
-                You can easily bring the Gumroad purchase page right into your site, without directing your buyers
-                elsewhere.{" "}
-                <a href="/help/article/44-build-gumroad-into-your-website" target="_blank" rel="noreferrer">
+                Share your subscribe form on any website or blog using an embed or URL.{" "}
+                <a href="/help/article/170-audience" target="_blank" rel="noreferrer">
                   Learn more
                 </a>
               </p>
             </header>
-            <div>
-              <Widgets
-                display_product_select={display_product_select}
-                products={products}
-                affiliated_products={affiliated_products}
-                default_product={default_product}
-              />
-            </div>
-          </section>
-          {currentSeller ? (
-            <section>
-              <header>
-                <h3>Subscribe form</h3>
-                <p>
-                  Share your subscribe form on any website or blog using an embed or URL.{" "}
-                  <a href="/help/article/170-audience" target="_blank" rel="noreferrer">
-                    Learn more
-                  </a>
-                </p>
-              </header>
-              <fieldset>
-                <legend>
-                  <label htmlFor={copyButtonUID}>Share your subscribe page and grow your audience</label>
-                </legend>
-                <CopyToClipboard
-                  text={Routes.custom_domain_subscribe_url({ host: currentSeller.subdomain })}
-                  copyTooltip="Copy link"
-                  tooltipPosition="bottom"
-                >
-                  <Button id={copyButtonUID} color="primary">
-                    <Icon name="link" />
-                    Copy link
-                  </Button>
+            <fieldset>
+              <legend>
+                <label htmlFor={copyButtonUID}>Share your subscribe page and grow your audience</label>
+              </legend>
+              <CopyToClipboard
+                text={Routes.custom_domain_subscribe_url({ host: currentSeller.subdomain })}
+                copyTooltip="Copy link"
+                tooltipPosition="bottom"
+              >
+                <Button id={copyButtonUID} color="primary">
+                  <Icon name="link" />
+                  Copy link
+                </Button>
+              </CopyToClipboard>
+            </fieldset>
+            <fieldset>
+              <legend>
+                <label htmlFor={FOLLOW_FORM_EMBED_INPUT_ID}>Test your subscribe form with your email</label>
+              </legend>
+              <FollowFormEmbed sellerId={currentSeller.id} preview />
+            </fieldset>
+            <fieldset>
+              <legend>
+                <label htmlFor={followFormEmbedUID}>Subscribe form embed code</label>
+                <CopyToClipboard text={followFormEmbedHTML} copyTooltip="Copy to Clipboard" tooltipPosition="top">
+                  <button type="button" className="link">
+                    Copy embed code
+                  </button>
                 </CopyToClipboard>
-              </fieldset>
-              <fieldset>
-                <legend>
-                  <label htmlFor={FOLLOW_FORM_EMBED_INPUT_ID}>Test your subscribe form with your email</label>
-                </legend>
-                <FollowFormEmbed sellerId={currentSeller.id} preview />
-              </fieldset>
-              <fieldset>
-                <legend>
-                  <label htmlFor={followFormEmbedUID}>Subscribe form embed code</label>
-                  <CopyToClipboard text={followFormEmbedHTML} copyTooltip="Copy to Clipboard" tooltipPosition="top">
-                    <button type="button" className="link">
-                      Copy embed code
-                    </button>
-                  </CopyToClipboard>
-                </legend>
-                <textarea id={followFormEmbedUID} value={followFormEmbedHTML} readOnly />
-              </fieldset>
-            </section>
-          ) : null}
-        </form>
-      </div>
+              </legend>
+              <textarea id={followFormEmbedUID} value={followFormEmbedHTML} readOnly />
+            </fieldset>
+          </section>
+        ) : null}
+      </form>
     </Layout>
   );
 };

--- a/app/views/public/api.html.erb
+++ b/app/views/public/api.html.erb
@@ -1,4 +1,4 @@
-<main>
+<main class="p-4 md:p-8">
   <%= load_pack("api") %>
   <div>
     <div class="with-sidebar">

--- a/app/views/public/ping.html.erb
+++ b/app/views/public/ping.html.erb
@@ -1,4 +1,4 @@
-<main>
+<main class="p-4 md:p-8">
   <div>
     <form>
       <section class="container">


### PR DESCRIPTION
### Explanation of Change
Add margins to Widgets, Ping, and API pages to make it consistent with other pages

### Screenshots/Videos
Before
<img width="1424" height="793" alt="image" src="https://github.com/user-attachments/assets/1aaa82ed-c521-4735-9e33-c3aa9aedca3e" />

<img width="1414" height="789" alt="image" src="https://github.com/user-attachments/assets/9253f86b-b930-4a9d-8e6d-3fbb66ceb302" />


<img width="1415" height="798" alt="image" src="https://github.com/user-attachments/assets/387f98f4-48b2-43c1-b8b1-1e61ecafef31" />


After

<img width="1412" height="744" alt="image" src="https://github.com/user-attachments/assets/f04b3f6c-3444-4207-9941-3b3ef3b26a20" />

<img width="1413" height="747" alt="image" src="https://github.com/user-attachments/assets/28a94dba-9352-465f-959a-65845073384c" />

<img width="1411" height="745" alt="image" src="https://github.com/user-attachments/assets/b2796e71-8b15-4fbb-a3c2-b209c56920bc" />


### AI Disclosure
No AI tools used


