### PR TITLE
Add validation to `max_refund_period_in_days` on `PurchaseRefundPolicy`

### DIFF
--- a/spec/models/purchase_refund_policy_spec.rb
+++ b/spec/models/purchase_refund_policy_spec.rb
@@ -11,6 +11,64 @@ describe PurchaseRefundPolicy do
       expect(refund_policy.errors.details[:purchase].first[:error]).to eq :blank
       expect(refund_policy.errors.details[:title].first[:error]).to eq :blank
     end
+
+    describe "max_refund_period_in_days validation" do
+      let(:purchase) { create(:purchase) }
+
+      context "when created after MAX_REFUND_PERIOD_IN_DAYS_INTRODUCED_ON" do
+        before do
+          travel_to PurchaseRefundPolicy::MAX_REFUND_PERIOD_IN_DAYS_INTRODUCED_ON + 1.day
+        end
+
+        after do
+          travel_back
+        end
+
+        it "requires max_refund_period_in_days to be present" do
+          refund_policy = build(:purchase_refund_policy, purchase:, title: "30-day money back guarantee", max_refund_period_in_days: nil)
+
+          expect(refund_policy.valid?).to be false
+          expect(refund_policy.errors.details[:max_refund_period_in_days].first[:error]).to eq :blank
+        end
+
+        it "allows valid max_refund_period_in_days values" do
+          refund_policy = build(:purchase_refund_policy, purchase:, title: "30-day money back guarantee", max_refund_period_in_days: 30)
+
+          expect(refund_policy.valid?).to be true
+        end
+      end
+
+      context "when created before MAX_REFUND_PERIOD_IN_DAYS_INTRODUCED_ON" do
+        before do
+          travel_to PurchaseRefundPolicy::MAX_REFUND_PERIOD_IN_DAYS_INTRODUCED_ON - 1.day
+        end
+
+        after do
+          travel_back
+        end
+
+        it "does not require max_refund_period_in_days to be present" do
+          refund_policy = build(:purchase_refund_policy, purchase:, title: "30-day money back guarantee", max_refund_period_in_days: nil)
+
+          expect(refund_policy.valid?).to be true
+        end
+
+        it "allows max_refund_period_in_days to be nil" do
+          refund_policy = build(:purchase_refund_policy, purchase:, title: "30-day money back guarantee", max_refund_period_in_days: nil)
+
+          expect(refund_policy.valid?).to be true
+        end
+      end
+
+      context "when created_at is nil (new record)" do
+        it "requires max_refund_period_in_days to be present" do
+          refund_policy = build(:purchase_refund_policy, purchase:, title: "30-day money back guarantee", max_refund_period_in_days: nil)
+
+          expect(refund_policy.valid?).to be false
+          expect(refund_policy.errors.details[:max_refund_period_in_days].first[:error]).to eq :blank
+        end
+      end
+    end
   end
 
   describe "stripped_fields" do
@@ -36,43 +94,95 @@ describe PurchaseRefundPolicy do
     let(:product_refund_policy) { create(:product_refund_policy, product:) }
     let(:purchase) { create(:purchase, link: product) }
 
-    describe "#product_refund_policy_title" do
-      let(:refund_policy) do
-        purchase.create_purchase_refund_policy!(
-          title: product_refund_policy.title,
-          fine_print: product_refund_policy.fine_print
-        )
-      end
-
-      it "returns the product refund policy title" do
-        expect(refund_policy.product_refund_policy_title).to eq product_refund_policy.title
-      end
-    end
 
     describe "#different_than_product_refund_policy?" do
-      context "when title matches product refund policy title" do
+      context "when no product refund policy exists" do
         let(:refund_policy) do
           purchase.create_purchase_refund_policy!(
-            title: product_refund_policy.title,
-            fine_print: product_refund_policy.fine_print
-          )
-        end
-
-        it "returns false" do
-          expect(refund_policy.different_than_product_refund_policy?).to be false
-        end
-      end
-
-      context "when title differs from product refund policy title" do
-        let(:refund_policy) do
-          purchase.create_purchase_refund_policy!(
-            title: "Custom Refund Policy",
-            fine_print: product_refund_policy.fine_print
+            title: "30-day money back guarantee",
+            fine_print: "This is a purchase-level refund policy",
+            max_refund_period_in_days: 30
           )
         end
 
         it "returns true" do
           expect(refund_policy.different_than_product_refund_policy?).to be true
+        end
+      end
+
+      context "when max_refund_period_in_days is present" do
+        let(:product_refund_policy) { create(:product_refund_policy, product:, max_refund_period_in_days: 30) }
+
+        before do
+          product.update!(product_refund_policy:)
+        end
+
+        context "when max_refund_period_in_days matches product refund policy" do
+          let(:refund_policy) do
+            purchase.create_purchase_refund_policy!(
+              title: "Different title",
+              fine_print: "Different fine print",
+              max_refund_period_in_days: 30
+            )
+          end
+
+          it "returns false" do
+            expect(refund_policy.different_than_product_refund_policy?).to be false
+          end
+        end
+
+        context "when max_refund_period_in_days differs from product refund policy" do
+          let(:refund_policy) do
+            purchase.create_purchase_refund_policy!(
+              title: "Same title",
+              fine_print: "Same fine print",
+              max_refund_period_in_days: 14
+            )
+          end
+
+          it "returns true" do
+            expect(refund_policy.different_than_product_refund_policy?).to be true
+          end
+        end
+      end
+
+      context "when max_refund_period_in_days is not present" do
+        let(:product_refund_policy) { create(:product_refund_policy, product:, title: "30-day money back guarantee") }
+
+        before do
+          product.update!(product_refund_policy:)
+        end
+
+        context "when title matches product refund policy title" do
+          let(:refund_policy) do
+            build(
+              :purchase_refund_policy,
+              purchase:,
+              title: "30-day money back guarantee",
+              fine_print: "Different fine print",
+              max_refund_period_in_days: nil
+            )
+          end
+
+          it "returns false" do
+            expect(refund_policy.different_than_product_refund_policy?).to be false
+          end
+        end
+
+        context "when title differs from product refund policy title" do
+          let(:refund_policy) do
+            build(
+              :purchase_refund_policy,
+              purchase:,
+              title: "Custom Refund Policy",
+              fine_print: "Same fine print",
+              max_refund_period_in_days: nil
+            )
+          end
+
+          it "returns true" do
+            expect(refund_policy.different_than_product_refund_policy?).to be true
+          end
         end
       end
     end

--- a/spec/support/factories/purchase_refund_policies.rb
+++ b/spec/support/factories/purchase_refund_policies.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     purchase
     title { "30-day money back guarantee" }
     fine_print { "This is a purchase-level refund policy" }
+    max_refund_period_in_days { 30 }
   end
 end


### PR DESCRIPTION
Part of https://github.com/antiwork/gumroad/issues/1047


- [x] Add validation for `max_refund_period_in_days` on `PurchaseRefundPolicy`
- [x] Update `PurchaseRefundPolicy#different_than_product_refund_policy?` to use `mas_refund_period_in_days`