### PR TITLE
Fix / Improvement: Prevent selecting the same product in both bought & not bought filters

### DIFF
--- a/app/javascript/components/DateInput.tsx
+++ b/app/javascript/components/DateInput.tsx
@@ -34,6 +34,11 @@ export const DateInput = ({
       defaultValue={formatDate(value)}
       min={min ? formatDate(min) : undefined}
       max={max ? formatDate(max) : undefined}
+      style={{
+        WebkitAppearance: "none",
+        MozAppearance: "textfield",
+        ...rest.style,
+      }}
       onBlur={(e) => {
         let parsed = parseISO(e.target.value);
         if (seller && withTime) parsed = fromZonedTime(parsed, seller.timeZone.name);


### PR DESCRIPTION
ref #864 

### Problem:
- products which added in bought filter, also selectable in not bought filter

### Solution:
The "bought" selector now hides products already chosen in the "not bought" list, and vice-versa.

### AI Disclosure:
- no AI used

### Before:
https://github.com/user-attachments/assets/35649b7d-ac7b-40e3-9a01-e28cf6e326f7

### After:
https://github.com/user-attachments/assets/26adeee4-cbf4-4821-8af6-b02d6eb8b397

