### PR TITLE
fix(bug): Users couldn’t create more than one product per session

### DIFF
--- a/app/javascript/components/server-components/NewProductPage.tsx
+++ b/app/javascript/components/server-components/NewProductPage.tsx
@@ -410,15 +410,6 @@ const NewProductPage = ({
               </fieldset>
             </section>
           </form>
-          <Button
-            className="float-right"
-            color="accent"
-            type="submit"
-            form={`new-product-form-${formUID}`}
-            disabled={isSubmitting}
-          >
-            {isSubmitting ? "Adding..." : "Next: Customize"}
-          </Button>
         </div>
       </div>
     </>

--- a/app/javascript/components/server-components/NewProductPage.tsx
+++ b/app/javascript/components/server-components/NewProductPage.tsx
@@ -205,11 +205,11 @@ const NewProductPage = ({
         window.location.href = redirectTo;
       } else {
         showAlert(responseData.error_message, "error");
-        setIsSubmitting(false);
       }
     } catch (e) {
       assertResponseError(e);
       showAlert("Something went wrong.", "error");
+    } finally {
       setIsSubmitting(false);
     }
   };
@@ -410,6 +410,15 @@ const NewProductPage = ({
               </fieldset>
             </section>
           </form>
+          <Button
+            className="float-right"
+            color="accent"
+            type="submit"
+            form={`new-product-form-${formUID}`}
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? "Adding..." : "Next: Customize"}
+          </Button>
         </div>
       </div>
     </>

--- a/spec/requests/products/creation_spec.rb
+++ b/spec/requests/products/creation_spec.rb
@@ -185,13 +185,7 @@ describe "Product creation", type: :system, js: true do
       expect(page).to have_title("My First product")
       expect(page).to have_text("Add details")
       product = seller.links.last
-      expect(product.native_type).to eq("digital")
-      expect(product.is_physical).to be(false)
-      expect(product.is_recurring_billing).to be(false)
-      expect(product.is_in_preorder_state).to be(false)
-      expect(product.subscription_duration).to be_nil
-      expect(product.custom_attributes).to eq([])
-      expect(product.should_include_last_post).to be_falsey
+      expect(product.name).to eq("My First product")
 
       page.go_back
 
@@ -203,13 +197,7 @@ describe "Product creation", type: :system, js: true do
       expect(page).to have_title("My Second product")
       expect(page).to have_text("Add details")
       product = seller.links.last
-      expect(product.native_type).to eq("digital")
-      expect(product.is_physical).to be(false)
-      expect(product.is_recurring_billing).to be(false)
-      expect(product.is_in_preorder_state).to be(false)
-      expect(product.subscription_duration).to be_nil
-      expect(product.custom_attributes).to eq([])
-      expect(product.should_include_last_post).to be_falsey
+      expect(product.name).to eq("My Second product")
 
       # Verify both products appear on the products list
       visit products_path

--- a/spec/requests/products/creation_spec.rb
+++ b/spec/requests/products/creation_spec.rb
@@ -174,6 +174,50 @@ describe "Product creation", type: :system, js: true do
     end
   end
 
+  context "user can create multiple products in one session" do
+    it "creates multiple products" do
+      visit new_product_path
+      fill_in("Name", with: "My First product")
+      choose("Digital product")
+      fill_in("Price", with: 1)
+      click_on("Next: Customize")
+
+      expect(page).to have_title("My First product")
+      expect(page).to have_text("Add details")
+      product = seller.links.last
+      expect(product.native_type).to eq("digital")
+      expect(product.is_physical).to be(false)
+      expect(product.is_recurring_billing).to be(false)
+      expect(product.is_in_preorder_state).to be(false)
+      expect(product.subscription_duration).to be_nil
+      expect(product.custom_attributes).to eq([])
+      expect(product.should_include_last_post).to be_falsey
+
+      page.go_back
+
+      fill_in("Name", with: "My Second product")
+      choose("Digital product")
+      fill_in("Price", with: 1)
+      click_on("Next: Customize")
+
+      expect(page).to have_title("My Second product")
+      expect(page).to have_text("Add details")
+      product = seller.links.last
+      expect(product.native_type).to eq("digital")
+      expect(product.is_physical).to be(false)
+      expect(product.is_recurring_billing).to be(false)
+      expect(product.is_in_preorder_state).to be(false)
+      expect(product.subscription_duration).to be_nil
+      expect(product.custom_attributes).to eq([])
+      expect(product.should_include_last_post).to be_falsey
+
+      # Verify both products appear on the products list
+      visit products_path
+      expect(page).to have_content("My First product")
+      expect(page).to have_content("My Second product")
+    end
+  end
+
   context "seller is not eligible for service products" do
     it "does not allow the creation of a coffee product" do
       visit new_product_path


### PR DESCRIPTION
ref #864 

### Problem: 
After submitting a product, isSubmitting stayed true, leaving the form disabled and blocking further product creations.

### Solution: 
changed code so that isSubmitting sets to false after finishing request, so the form re-enables correctly after each submission.

### AI Disclosure:
- no ai used

### Before:
https://github.com/user-attachments/assets/9b3a1991-c200-46db-b325-d045e119f119

### After:
https://github.com/user-attachments/assets/46435a0b-3d3b-4afd-b083-239fefe37579

