### PR TITLE
Fix TypeScript config to resolve missing module types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5412,6 +5412,7 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
       "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "clsx": "^2.1.1"
       },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "noEmit": true,
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",               // ✅ switched from "bundler" to "node"
     "module": "es2020",
     "target": "es2021",
     "strict": true,
@@ -17,7 +17,8 @@
     "paths": {
       "$app/*": ["./app/javascript/*"]
     },
-    "typeRoots": ["./node_modules/@types", "./app/javascript/types"],
+    // ✅ removed restrictive "typeRoots"
+    // so TS can see types declared in node_modules packages
     "types": [
       "grecaptcha",
       "facebook-pixel",


### PR DESCRIPTION
fix #864
### Summary
This PR updates the TypeScript configuration to fix errors when importing
`class-variance-authority` and `@radix-ui/react-slot`. Both packages already
ship their own `.d.ts` files in `dist/`, but TypeScript was not resolving them
because of restrictive compiler options.

### Changes
- Switched `moduleResolution` from `"bundler"` to `"node"`
  - Ensures TypeScript respects `"types"` fields in package.json.
- Removed the `"typeRoots"` override
  - Allowed TypeScript to properly resolve type declarations shipped by
    installed packages.

### Result
- `TS2307: Cannot find module 'class-variance-authority'` and
  `TS2307: Cannot find module '@radix-ui/react-slot'` are resolved.
- Frontend build now compiles successfully with full type support.

### Before 
<img width="1366" height="720" alt="Screenshot 2025-09-19 002528" src="https://github.com/user-attachments/assets/d960e9b2-7068-48d6-ab11-26116a276d27" />

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/37f2c167-bac1-458f-a08a-03d2aa588063" />

### After
<img width="1366" height="720" alt="image" src="https://github.com/user-attachments/assets/4fe7eb78-14be-49bb-ab07-e3e6be4ee391" />

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/efb1e428-510f-4c87-a9ab-c2246638cafa" />


### Notes
- No runtime code was changed.
- This is a frontend build fix only; backend (Rails) is unaffected.
- If we adopt newer TypeScript `"bundler"` resolution in the future, we should
  re-test compatibility with packages that rely on `"types"` in package.json.

### AI disclosure
AI-assisted: This PR description and suggested changes were drafted with the help of an AI.

