### PR TITLE
Fix Capybara::Ambiguous error in product edit upsell test

### DIFF
--- a/spec/requests/products/edit/edit_spec.rb
+++ b/spec/requests/products/edit/edit_spec.rb
@@ -147,9 +147,12 @@ describe("Product Edit Scenario", type: :system, js: true) do
     fill_in "Fixed amount", with: "1"
     click_on "Insert"
 
-    within_section "Sample product", section_element: :article do
-      expect(page).to have_text("5.0 (1)", normalize_ws: true)
-      expect(page).to have_text("$10 $9")
+    # Scope to the rich text editor's textarea and match the upsell card's productid
+    within ".textarea" do
+      within_section "Sample product", section_element: :article, productid: product.external_id do
+        expect(page).to have_text("5.0 (1)", normalize_ws: true)
+        expect(page).to have_text("$10 $9")
+      end
     end
 
     click_on "Save"


### PR DESCRIPTION
Fix flakey tests #1127

**Fix:**
Scoped `within_section` in *"allows creating and deleting an upsell in the product description"* to `.textarea` and added `productid: product.external_id` to avoid `Capybara::Ambiguous` errors.

**Testing:**

* Passed locally with `bundle exec rspec spec/requests/products/edit/edit_spec.rb:133
* Full file also passed.
* Simulated CI with Knapsack Pro to confirm stability.

**Next:**
Run in CI to verify the fix.
