### PR TITLE
Fix critical flaky test: Capybara::Ambiguous error in edit_spec.rb

### DIFF
--- a/spec/requests/products/edit/edit_spec.rb
+++ b/spec/requests/products/edit/edit_spec.rb
@@ -147,7 +147,7 @@ describe("Product Edit Scenario", type: :feature, js: true) do
     fill_in "Fixed amount", with: "1"
     click_on "Insert"
 
-    within_section "Sample product", section_element: :article do
+    within_section "Sample product", section_element: :article, match: :first do
       expect(page).to have_text("5.0 (1)", normalize_ws: true)
       expect(page).to have_text("$10 $9")
     end
@@ -229,7 +229,7 @@ describe("Product Edit Scenario", type: :feature, js: true) do
     fill_in "Fixed amount", with: "1"
     click_on "Insert"
 
-    within_section "Sample product", section_element: :article do
+    within_section "Sample product", section_element: :article, match: :first do
       expect(page).to have_selector("span", text: "(#{variant1.name})")
       expect(page).to have_text("5.0 (1)", normalize_ws: true)
       expect(page).to have_text("$10 $9")
@@ -284,7 +284,7 @@ describe("Product Edit Scenario", type: :feature, js: true) do
     fill_in "Fixed amount", with: "1"
     click_on "Insert"
 
-    within_section "Sample product", section_element: :article do
+    within_section "Sample product", section_element: :article, match: :first do
       expect(page).to have_text("5.0 (1)", normalize_ws: true)
       expect(page).to have_text("$10 $9")
     end


### PR DESCRIPTION
Part of https://github.com/antiwork/gumroad/issues/1127

AI Disclosure: Used for only for syntax,  logic and code review Manually

### Problem

The issue was caused by **ambiguous selectors** in Capybara tests. When multiple elements on the page matched the same selector `"Sample product"`, Capybara couldn't determine which element to interact with, causing the test to fail randomly.

### Before :https://github.com/antiwork/gumroad/actions/runs/17774406227/job/50518712928

within_section "Sample product", section_element: :article do
  expect(page).to have_text("5.0 (1)", normalize_ws: true)
  expect(page).to have_text("$10 $9")
end

###  Solution

Added `match: :first` parameter to all `within_section` calls to explicitly tell Capybara to use the first matching element, eliminating the ambiguity.

After (Fixed Code):

within_section "Sample product", section_element: :article, **match: :first do**
  expect(page).to have_text("5.0 (1)", normalize_ws: true)
  expect(page).to have_text("$10 $9")
end

### How This Addresses the Issue
Eliminates Ambiguity: `match: :first` ensures Capybara always selects the first matching element
    

Fixes #1127