### PR TITLE
fix: prevent alert message truncation on mobile

### DIFF
--- a/app/javascript/components/server-components/Alert.tsx
+++ b/app/javascript/components/server-components/Alert.tsx
@@ -43,7 +43,7 @@ const Alert = ({ initial }: { initial: AlertPayload | null }) => {
     <div
       role="alert"
       className={cx(
-        "bg-filled fixed left-1/2 top-4 w-max max-w-[calc(100vw-2rem)] px-4 py-2",
+        "bg-filled fixed left-1/2 top-4 w-max max-w-[calc(100vw-2rem)] px-4 py-2 md:max-w-sm",
         alert?.status,
         isVisible ? "visible" : "invisible",
       )}

--- a/app/javascript/components/server-components/Alert.tsx
+++ b/app/javascript/components/server-components/Alert.tsx
@@ -43,7 +43,7 @@ const Alert = ({ initial }: { initial: AlertPayload | null }) => {
     <div
       role="alert"
       className={cx(
-        "bg-filled fixed left-1/2 top-4 min-w-max max-w-sm px-4 py-2",
+        "bg-filled fixed left-1/2 top-4 w-max max-w-[calc(100vw-2rem)] px-4 py-2",
         alert?.status,
         isVisible ? "visible" : "invisible",
       )}


### PR DESCRIPTION
### Explanation of Change
Error messages in alerts were being truncated on mobile devices, particularly noticeable when users duplicate a product.

Offending PR https://github.com/antiwork/gumroad/pull/1269

### Screenshots/Videos
Before

<img width="391" height="681" alt="Screenshot 2025-09-19 at 14 42 52" src="https://github.com/user-attachments/assets/c8790016-1466-4553-b5aa-ef9a39024a66" />

After
Mobile:
<img width="447" height="705" alt="image" src="https://github.com/user-attachments/assets/72e805ff-46bf-4073-8f0b-7baef9037930" />

Desktop:
<img width="1470" height="618" alt="Screenshot 2025-09-19 at 14 41 34" src="https://github.com/user-attachments/assets/d4b9fd44-661a-426c-b295-88dde30051c6" />


### AI Disclosure
No AI tools used


