### PR TITLE
fix: display "All products" label for universal upsells

### DIFF
--- a/app/javascript/components/server-components/CheckoutDashboard/UpsellsPage.tsx
+++ b/app/javascript/components/server-components/CheckoutDashboard/UpsellsPage.tsx
@@ -406,16 +406,22 @@ const UpsellDrawer = ({
       {selectedUpsell.cross_sell ? (
         <section className="stack">
           <h3>Selected products</h3>
-          {selectedUpsell.selected_products.map(({ id, name }) => (
-            <div key={id}>
-              <div>
-                <h5>{name}</h5>
-                {statistics
-                  ? `${statistics.uses.selected_products[id] ?? 0} ${(statistics.uses.selected_products[id] ?? 0) === 1 ? "use" : "uses"} from this product`
-                  : null}
-              </div>
+          {selectedUpsell.universal ? (
+            <div>
+              <h5>All products</h5>
             </div>
-          ))}
+          ) : (
+            selectedUpsell.selected_products.map(({ id, name }) => (
+              <div key={id}>
+                <div>
+                  <h5>{name}</h5>
+                  {statistics
+                    ? `${statistics.uses.selected_products[id] ?? 0} ${(statistics.uses.selected_products[id] ?? 0) === 1 ? "use" : "uses"} from this product`
+                    : null}
+                </div>
+              </div>
+            ))
+          )}
         </section>
       ) : (
         <section className="stack">

--- a/spec/requests/checkout/upsells_spec.rb
+++ b/spec/requests/checkout/upsells_spec.rb
@@ -11,6 +11,7 @@ describe("Checkout upsells page", type: :system, js: true) do
   let!(:upsell1) { create(:upsell, product: product1, variant: product1.alive_variants.second, name: "Upsell 1", seller:, cross_sell: true, offer_code: create(:offer_code, user: seller, products: [product1]), updated_at: 2.days.ago) }
   let!(:upsell2) { create(:upsell, product: product2, name: "Upsell 2", seller:, updated_at: 1.day.ago) }
   let!(:upsell2_variant) { create(:upsell_variant, upsell: upsell2, selected_variant: product2.alive_variants.first, offered_variant: product2.alive_variants.second) }
+  let!(:universal_upsell) { create(:upsell, product: product1, name: "Universal Upsell", seller:, cross_sell: true, universal: true) }
 
   before do
     product1.alive_variants.second.update!(price_difference_cents: 500)
@@ -94,27 +95,12 @@ describe("Checkout upsells page", type: :system, js: true) do
         expect(page).to have_button("Duplicate")
         expect(page).to have_button("Delete")
       end
-    end
 
-    it "displays 'All products' for universal upsells" do
-      create(:upsell,
-             product: product1,
-             variant: product1.alive_variants.second,
-             name: "Universal Upsell",
-             seller: seller,
-             cross_sell: true,
-             universal: true,
-             offer_code: create(:offer_code, user: seller, products: [product1])
-      )
-
-      visit checkout_upsells_path
-
-      upsell_row = find(:table_row, { "Upsell" => "Universal Upsell" })
-      upsell_row.click
-
+      universal_upsell_row = find(:table_row, { "Upsell" => "Universal Upsell" })
+      universal_upsell_row.click
       within_section "Universal Upsell", section_element: :aside do
         within_section "Selected products" do
-          expect(page).to have_content("All productss")
+          expect(page).to have_content("All products")
         end
       end
     end

--- a/spec/requests/checkout/upsells_spec.rb
+++ b/spec/requests/checkout/upsells_spec.rb
@@ -120,7 +120,10 @@ describe("Checkout upsells page", type: :system, js: true) do
     end
 
     describe "sorting and pagination" do
-      before { stub_const("Checkout::UpsellsController::PER_PAGE", 1) }
+      before do
+        stub_const("Checkout::UpsellsController::PER_PAGE", 1)
+        universal_upsell.destroy!
+      end
 
       it "sorts and paginates the upsells" do
         visit checkout_upsells_path

--- a/spec/requests/checkout/upsells_spec.rb
+++ b/spec/requests/checkout/upsells_spec.rb
@@ -96,6 +96,29 @@ describe("Checkout upsells page", type: :system, js: true) do
       end
     end
 
+    it "displays 'All products' for universal upsells" do
+      create(:upsell,
+             product: product1,
+             variant: product1.alive_variants.second,
+             name: "Universal Upsell",
+             seller: seller,
+             cross_sell: true,
+             universal: true,
+             offer_code: create(:offer_code, user: seller, products: [product1])
+      )
+
+      visit checkout_upsells_path
+
+      upsell_row = find(:table_row, { "Upsell" => "Universal Upsell" })
+      upsell_row.click
+
+      within_section "Universal Upsell", section_element: :aside do
+        within_section "Selected products" do
+          expect(page).to have_content("All productss")
+        end
+      end
+    end
+
     context "when the creator has no upsells" do
       it "displays a placeholder message" do
         login_as create(:user)


### PR DESCRIPTION
### Explanation of Change
Fixes an issue where the selected products field appeared empty in the upsell detail view when "All products" was selected. Now, it displays "All products" to clearly indicate the upsell applies to all products

### Screenshots/Videos
Before
<img width="588" height="744" alt="image" src="https://github.com/user-attachments/assets/7da473ed-1250-4b4e-afc8-806c6ec460f0" />

<img width="827" height="152" alt="image" src="https://github.com/user-attachments/assets/a9d0a0cf-aedb-4b01-8455-f863eeff8b8d" />


After

<img width="592" height="748" alt="image" src="https://github.com/user-attachments/assets/311fb71a-04c0-496e-80f0-2d232b519f0e" />


### Test Results
<img width="616" height="163" alt="image" src="https://github.com/user-attachments/assets/551acb2f-6efc-49f9-bc9a-17ebf0b56a66" />

### AI Disclosure
No AI tools used


