### PR TITLE
fix: link pointer is shown instead of caret or text cursor in search field

### DIFF
--- a/app/javascript/components/Discover/Search.tsx
+++ b/app/javascript/components/Discover/Search.tsx
@@ -71,6 +71,7 @@ export const Search = ({ query, setQuery }: { query?: string | undefined; setQue
           <input
             {...props}
             type="search"
+            className="!cursor-text"
             placeholder="Search products"
             aria-label="Search products"
             value={enteredQuery}


### PR DESCRIPTION
ref #864 

### What PR does?
- makes text cursor visible on search field instead of pointer cursor.

###Ai disclosure:
- no AI used

# Before:
https://github.com/user-attachments/assets/f2956693-beb2-4954-a64b-bf082d815b0c

# After:
https://github.com/user-attachments/assets/4de6a954-7c03-4303-9883-f44231fd7a25



