### PR TITLE
Prevent product name and question mark from wrapping in delete confirmation

### DIFF
--- a/app/javascript/components/server-components/DownloadPage/Layout.tsx
+++ b/app/javascript/components/server-components/DownloadPage/Layout.tsx
@@ -364,9 +364,9 @@ const PurchaseDeleteButton = ({
           </>
         }
       >
-        <>
+        <span className="inline">
           Are you sure you want to delete <b>{product_name ?? ""}</b>?
-        </>
+        </span>
       </Modal>
     </>
   );


### PR DESCRIPTION
### Explanation of Change
Fixes a UI bug in the delete confirmation modal where the product name and the trailing question mark were rendered on separate lines

### Screenshots/Videos
Before
<img width="411" height="318" alt="image" src="https://github.com/user-attachments/assets/a9897ff1-0f2f-4b7a-8118-507f2efc402a" />

After
<img width="508" height="264" alt="image" src="https://github.com/user-attachments/assets/02b67b6c-459e-4372-aeca-df1f75d75a99" />


### AI Disclosure
No AI tools used