### PR TITLE
fix: broken page list section on download page

### DIFF
--- a/app/javascript/components/server-components/DownloadPage/WithContent.tsx
+++ b/app/javascript/components/server-components/DownloadPage/WithContent.tsx
@@ -27,7 +27,6 @@ import { FileEmbed } from "$app/components/ProductEdit/ContentTab/FileEmbed";
 import { showAlert } from "$app/components/server-components/Alert";
 import { LicenseKey } from "$app/components/TiptapExtensions/LicenseKey";
 import { PostsProvider } from "$app/components/TiptapExtensions/Posts";
-import { Tabs, Tab } from "$app/components/ui/Tabs";
 import { useAddThirdPartyAnalytics } from "$app/components/useAddThirdPartyAnalytics";
 import { useIsAboveBreakpoint } from "$app/components/useIsAboveBreakpoint";
 import { useOriginalLocation } from "$app/components/useOriginalLocation";
@@ -280,17 +279,22 @@ const WithContent = ({
       }
       pageList={
         showPageList && isDesktop ? (
-          <Tabs className="pagelist" aria-label="Table of Contents">
+          <div role="tablist" className="pagelist" aria-label="Table of Contents">
             {pages.map((page, index) => (
-              <Tab key={page.page_id} isSelected={index === activePageIndex} onClick={() => setActivePageIndex(index)}>
+              <div
+                key={page.page_id}
+                role="tab"
+                aria-selected={index === activePageIndex}
+                onClick={() => setActivePageIndex(index)}
+              >
                 <Icon
                   name={pageIcons[index] ?? "file-text"}
                   aria-label={pageIcons[index] ? PAGE_ICON_LABEL[pageIcons[index]] : "file-text"}
                 />
                 <span className="content">{page.title ?? "Untitled"}</span>
-              </Tab>
+              </div>
             ))}
-          </Tabs>
+          </div>
         ) : null
       }
     >


### PR DESCRIPTION
Follow up of [this PR](https://github.com/antiwork/gumroad/pull/1289)

Fixes the same issue as [this PR](https://github.com/antiwork/gumroad/pull/1289) but on Download Page

cc @binary-koan 


Before (page list not displayed)
<img width="427" height="467" alt="image" src="https://github.com/user-attachments/assets/a1a3c71d-1faa-4035-8732-42377b772363" />


After
<img width="411" height="522" alt="image" src="https://github.com/user-attachments/assets/1687e0b0-d4c1-4130-9972-60c03b2d2eec" />
