### PR TITLE
Fix(flaky test): profile section test - sync. ES indexing using Link.import

### DIFF
--- a/spec/requests/products/show/sections_spec.rb
+++ b/spec/requests/products/show/sections_spec.rb
@@ -7,7 +7,7 @@ describe "Profile settings on product pages", type: :system, js: true do
   let(:seller) { create(:user) }
   let(:product) { create(:product, user: seller) }
 
-  it "renders sections correctly when the user is logged out", :elasticsearch_wait_for_refresh do
+  it "renders sections correctly when the user is logged out" do
     products = create_list(:product, 3, user: seller)
     Link.import(refresh: true, force: true)
 

--- a/spec/requests/products/show/sections_spec.rb
+++ b/spec/requests/products/show/sections_spec.rb
@@ -9,6 +9,8 @@ describe "Profile settings on product pages", type: :system, js: true do
 
   it "renders sections correctly when the user is logged out", :elasticsearch_wait_for_refresh do
     products = create_list(:product, 3, user: seller)
+    Link.import(refresh: true, force: true)
+
     create(:seller_profile_products_section, seller:)
     section1 = create(:seller_profile_products_section, seller:, product:, header: "Section 1", shown_products: products.map(&:id))
 


### PR DESCRIPTION

This flaky spec was addressed by @binary-koan in PR https://github.com/antiwork/gumroad/pull/1243 which got merged on (13 September), but the test is still flaky and resulted in failure in this CI run on (16 September) below:

https://github.com/antiwork/gumroad/actions/runs/17758950657/job/50467656115?pr=1233#step:8:232
<img width="1134" height="249" alt="Screenshot 2025-09-22 at 1 22 16 PM" src="https://github.com/user-attachments/assets/9c7d95e1-26ab-4928-83bf-ff4eb4e9ceb9" />

### Problem:
- most probably elastic search indexing for product failed for some reason and reindexing got queued which executes after 5 second delay 
this runs via after_commit hook for in create_list,
```

class ProductIndexingService
  def self.perform(product:, action:, attributes_to_update: [], on_failure: :raise)
    case action
    when "index"
      product.__elasticsearch__.index_document
    when "update"
      return if attributes_to_update.empty?

      attributes = product.build_search_update(attributes_to_update)
      product.__elasticsearch__.update_document_attributes(attributes.as_json)
    end
  rescue
    if on_failure == :async
      SendToElasticsearchWorker.perform_in(5.seconds, product.id, action, attributes_to_update)
      Rails.logger.error("Failed to #{action} product #{product.id} (#{attributes_to_update.join(", ")}), queued job instead")
    else
      raise
    end
  end
end
```
- or, race condition between first indexing attempt and visiting page, which is not expected to happen because of `:elasticsearch_wait_for_refresh` tag


### Solution:
```rb
 Link.import(refresh: true, force: true)
```
- to eliminate the possibility that the first indexing attempt fails and gets queued 
This is Common Pattern of reindexing used in Specs which involves product creation and require elasticsearch_indexing to be finished before assertions: (some examples)

<img width="1006" height="503" alt="Screenshot 2025-09-22 at 11 34 28 AM" src="https://github.com/user-attachments/assets/56a8cf50-8963-4398-be2a-fd5100fe702c" />

<img width="989" height="289" alt="Screenshot 2025-09-22 at 11 35 59 AM" src="https://github.com/user-attachments/assets/d3d110e7-71b0-48b8-9b6c-3ba27de00550" />

<img width="1018" height="431" alt="Screenshot 2025-09-22 at 11 22 14 AM" src="https://github.com/user-attachments/assets/6966be53-e002-4e5c-9f3b-7e8675bb0895" />

ref #1127 

### AI Disclosure:
- cursor for understanding the code
