### PR TITLE
Improvement: Show Numeric keypad Instead of default Alphabetical one in Inputs like Price, Percentage, etc.

### DIFF
--- a/app/javascript/components/CheckoutDashboard/DiscountInput.tsx
+++ b/app/javascript/components/CheckoutDashboard/DiscountInput.tsx
@@ -79,6 +79,7 @@ export const DiscountInput = ({
               {(props) => (
                 <input
                   type="text"
+                  inputMode="decimal"
                   placeholder="0"
                   disabled={discount.type !== "percent"}
                   aria-label="Percentage"

--- a/app/javascript/components/Product/ConfigurationSelector.tsx
+++ b/app/javascript/components/Product/ConfigurationSelector.tsx
@@ -755,7 +755,16 @@ export const ConfigurationSelector = React.forwardRef<
             <label htmlFor={quantityInputUID}>{product.is_multiseat_license ? "Seats" : "Quantity"}</label>
           </legend>
           <NumberInput onChange={(quantity) => update({ quantity: quantity ?? 0 })} value={selection.quantity}>
-            {(props) => <input type="number" id={quantityInputUID} {...props} min={1} max={maxQuantity ?? undefined} />}
+            {(props) => (
+              <input
+                type="number"
+                inputMode="decimal"
+                id={quantityInputUID}
+                {...props}
+                min={1}
+                max={maxQuantity ?? undefined}
+              />
+            )}
           </NumberInput>
         </fieldset>
       ) : null}

--- a/app/javascript/components/ProductEdit/ProductTab/DurationsEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/DurationsEditor.tsx
@@ -187,7 +187,13 @@ const DurationEditor = ({
                 value={duration.max_purchase_count}
               >
                 {(inputProps) => (
-                  <input id={`${uid}-max-purchase-count`} type="number" placeholder="∞" {...inputProps} />
+                  <input
+                    id={`${uid}-max-purchase-count`}
+                    type="number"
+                    inputMode="numeric"
+                    placeholder="∞"
+                    {...inputProps}
+                  />
                 )}
               </NumberInput>
             </fieldset>

--- a/app/javascript/components/ProductEdit/ProductTab/InstallmentPlanEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/InstallmentPlanEditor.tsx
@@ -43,7 +43,7 @@ export const InstallmentPlanEditor = ({
           <NumberInput value={numberOfInstallments} onChange={(value) => onNumberOfInstallmentsChange(value || 0)}>
             {(props) => (
               <div className="input">
-                <input {...props} type="number" min={2} aria-label="Number of installments" />
+                <input {...props} type="number" inputMode="numeric" min={2} aria-label="Number of installments" />
                 <label>
                   <span>equal monthly payments</span>
                 </label>

--- a/app/javascript/components/ProductEdit/ProductTab/MaxPurchaseCountToggle.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/MaxPurchaseCountToggle.tsx
@@ -34,7 +34,7 @@ export const MaxPurchaseCountToggle = ({
           <label htmlFor={`${uid}-max-purchase-count`}>Maximum number of purchases</label>
           <WithTooltip tip="Total sales">
             <NumberInput value={count} onChange={setCount}>
-              {(props) => <input id={`${uid}-max-purchase-count`} placeholder="∞" {...props} />}
+              {(props) => <input inputMode="numeric" id={`${uid}-max-purchase-count`} placeholder="∞" {...props} />}
             </NumberInput>
           </WithTooltip>
         </fieldset>

--- a/app/javascript/components/ProductEdit/ProductTab/TiersEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/TiersEditor.tsx
@@ -230,7 +230,15 @@ const TierEditor = ({
               onChange={(value) => updateTier({ max_purchase_count: value })}
               value={tier.max_purchase_count}
             >
-              {(inputProps) => <input id={`${uid}-max-purchase-count`} type="number" placeholder="∞" {...inputProps} />}
+              {(inputProps) => (
+                <input
+                  id={`${uid}-max-purchase-count`}
+                  type="number"
+                  inputMode="numeric"
+                  placeholder="∞"
+                  {...inputProps}
+                />
+              )}
             </NumberInput>
           </fieldset>
           <fieldset

--- a/app/javascript/components/ProductEdit/ProductTab/VersionsEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/VersionsEditor.tsx
@@ -188,7 +188,13 @@ const VersionEditor = ({
                 value={version.max_purchase_count}
               >
                 {(inputProps) => (
-                  <input id={`${uid}-max-purchase-count`} type="number" placeholder="∞" {...inputProps} />
+                  <input
+                    id={`${uid}-max-purchase-count`}
+                    type="number"
+                    inputMode="numeric"
+                    placeholder="∞"
+                    {...inputProps}
+                  />
                 )}
               </NumberInput>
             </fieldset>

--- a/app/javascript/components/server-components/Admin/SearchPopover.tsx
+++ b/app/javascript/components/server-components/Admin/SearchPopover.tsx
@@ -96,6 +96,7 @@ export const SearchPopover = ({ card_types }: Props) => {
               name="last_4"
               placeholder="Last 4 (7890)"
               type="number"
+              inputMode="numeric"
               defaultValue={searchParams.get("last_4") || ""}
             />
           </div>
@@ -114,6 +115,7 @@ export const SearchPopover = ({ card_types }: Props) => {
               name="price"
               placeholder="Price (9.99)"
               type="number"
+              inputMode="decimal"
               step="0.01"
               defaultValue={searchParams.get("price") || ""}
             />

--- a/app/javascript/components/server-components/Admin/SetCustomFeeForm.tsx
+++ b/app/javascript/components/server-components/Admin/SetCustomFeeForm.tsx
@@ -25,6 +25,7 @@ export const AdminSetCustomFeeForm = ({
           <input
             name="custom_fee_percent"
             type="number"
+            inputMode="decimal"
             min="0"
             max="100"
             step="0.1"

--- a/app/javascript/components/server-components/Audience/CustomersPage.tsx
+++ b/app/javascript/components/server-components/Audience/CustomersPage.tsx
@@ -1953,7 +1953,7 @@ const SeatSection = ({ seats: currentSeats, onSave }: { seats: number; onSave: (
       {isEditing ? (
         <fieldset>
           <NumberInput value={seats} onChange={(seats) => setSeats(seats ?? 0)}>
-            {(props) => <input type="number" {...props} min={1} aria-label="Seats" />}
+            {(props) => <input type="number" inputMode="numeric" {...props} min={1} aria-label="Seats" />}
           </NumberInput>
           <div
             style={{

--- a/app/javascript/components/server-components/CheckoutDashboard/DiscountsPage.tsx
+++ b/app/javascript/components/server-components/CheckoutDashboard/DiscountsPage.tsx
@@ -1108,6 +1108,7 @@ const Form = ({
                     {(props) => (
                       <input
                         id={`${uid}minimumQuantity`}
+                        inputMode="decimal"
                         placeholder="0"
                         aria-invalid={minimumQuantity.error}
                         {...props}

--- a/app/javascript/components/server-components/CollaboratorsPage.tsx
+++ b/app/javascript/components/server-components/CollaboratorsPage.tsx
@@ -547,6 +547,7 @@ const CollaboratorForm = () => {
                           <div className={cx("input", { disabled: !applyToAllProducts })}>
                             <input
                               type="text"
+                              inputMode="decimal"
                               disabled={!applyToAllProducts}
                               placeholder={`${defaultPercentCommission.value || DEFAULT_PERCENT_COMMISSION}`}
                               aria-label="Percentage"

--- a/app/javascript/components/server-components/NewProductPage.tsx
+++ b/app/javascript/components/server-components/NewProductPage.tsx
@@ -375,6 +375,7 @@ const NewProductPage = ({
                     ref={priceInputRef}
                     id={`price-${formUID}`}
                     type="text"
+                    inputMode="decimal"
                     maxLength={10}
                     placeholder="Price your product"
                     value={price}

--- a/app/javascript/components/server-components/Settings/MainPage.tsx
+++ b/app/javascript/components/server-components/Settings/MainPage.tsx
@@ -463,6 +463,7 @@ const MainPage = (props: Props) => {
                           <input
                             id={`${uid}-ppp-discount-percentage`}
                             type="text"
+                            inputMode="decimal"
                             placeholder="60"
                             disabled={props.is_form_disabled}
                             aria-label="Percentage"


### PR DESCRIPTION
ref #864 

### What PR Does?
- reduce friction for entering price, percentage, number of days, etc details by opening numeric keypad instead of default alphabetical one.
- many part of codebase was missing `inputMode="decimal"` for numeric/decimal input fields.

### AI Disclosure:
- used to quickly find where numeric input is required.

eg. 
## Before:
<img width="1290" height="2796" alt="IMG_5494" src="https://github.com/user-attachments/assets/d1fd805b-fd68-49fb-9426-e120c23cf27d" />

## After:
<img width="1290" height="2796" alt="IMG_5492" src="https://github.com/user-attachments/assets/49dc6ff4-fea1-4c4e-9d5d-a10fbc9effbd" />
