### PR TITLE
fix: call booking notice text uses "amount" instead of "time" in call product creation form field

### DIFF
--- a/app/javascript/components/ProductEdit/ProductTab/CallLimitationsEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/CallLimitationsEditor.tsx
@@ -73,7 +73,7 @@ export const CallLimitationsEditor = ({
             </div>
           )}
         </NumberInput>
-        <small>Minimum amount of notice required when booking a call</small>
+        <small>Minimum notice time required when booking a call</small>
       </fieldset>
       <fieldset>
         <label htmlFor={`${uid}-daily-limit`}>Daily limit</label>


### PR DESCRIPTION
ref #864 

### What PR Does?
- Changes "Minimum amount of notice required when booking a call" to "Minimum notice time required when booking a call"


### AI Disclosure:
- no AI used

## Before:
<img width="669" height="309" alt="Screenshot 2025-09-23 at 2 48 22 AM" src="https://github.com/user-attachments/assets/0e560f9d-3eec-4763-8c80-ca7b4cec3b22" />


## After:
<img width="653" height="386" alt="Screenshot 2025-09-23 at 2 50 55 AM" src="https://github.com/user-attachments/assets/17be1156-1230-44f0-a6fc-e174dfc27427" />

