### PR TITLE
fix: Ensure license key is readable on mobile

### DIFF
--- a/app/views/customer_mailer/receipt/_item.html.erb
+++ b/app/views/customer_mailer/receipt/_item.html.erb
@@ -22,7 +22,7 @@
 
   <% if item_props[:license_key].present? %>
     <h4>License key</h4>
-    <pre style="text-align: center">
+    <pre style="text-align: center; white-space: pre-wrap;">
       <code><%= item_props[:license_key] %></code>
     </pre>
   <% end %>


### PR DESCRIPTION
### Explanation of Change
Addresses the issue where the license key on the receipt page would overflow its container and become unreadable on mobile devices

### Screenshots/Videos
Before
<img width="389" height="674" alt="Screenshot 2025-09-24 at 12 03 58" src="https://github.com/user-attachments/assets/9d586d08-6aef-487a-b261-b38e51a2ff2b" />


After
<img width="411" height="690" alt="Screenshot 2025-09-24 at 12 01 35" src="https://github.com/user-attachments/assets/ca168743-20f4-4aeb-87ef-196c00c55c2c" />


### AI Disclosure
No AI tools used


