### PR TITLE
fix: aggregate selector style at Analytics/Sales

### DIFF
--- a/app/javascript/components/server-components/AnalyticsPage.tsx
+++ b/app/javascript/components/server-components/AnalyticsPage.tsx
@@ -23,6 +23,8 @@ import { Progress } from "$app/components/Progress";
 import { showAlert } from "$app/components/server-components/Alert";
 
 import placeholder from "$assets/images/placeholders/sales.png";
+import { Popover } from "$app/components/Popover";
+import { Icon } from "$app/components/Icons";
 
 export type Product = {
   name: string;
@@ -149,14 +151,41 @@ const AnalyticsPage = ({ products: initialProducts, country_codes, state_names }
       actions={
         hasContent ? (
           <>
-            <select
-              aria-label="Aggregate by"
-              onChange={(e) => setAggregateBy(e.target.value === "daily" ? "daily" : "monthly")}
-              className="w-auto"
+            <Popover
+              trigger={
+                <span className="input">
+                  <div className="fake-input">
+                    {aggregateBy === "daily" ? "Daily" : "Monthly"}
+                  </div>
+                  <Icon name="outline-cheveron-down" />
+                </span>
+              }
             >
-              <option value="daily">Daily</option>
-              <option value="monthly">Monthly</option>
-            </select>
+              <div className="stack">
+                <div>
+                  <fieldset>
+                    <label>
+                      <input
+                        type="radio"
+                        name="aggregate"
+                        checked={aggregateBy === "daily"}
+                        onChange={() => setAggregateBy("daily")}
+                      />
+                      Daily
+                    </label>
+                    <label>
+                      <input
+                        type="radio"
+                        name="aggregate"
+                        checked={aggregateBy === "monthly"}
+                        onChange={() => setAggregateBy("monthly")}
+                      />
+                      Monthly
+                    </label>
+                  </fieldset>
+                </div>
+              </div>
+            </Popover>
             <ProductsPopover products={products} setProducts={setProducts} />
             <DateRangePicker {...dateRange} />
           </>


### PR DESCRIPTION
Ref:- https://github.com/antiwork/gumroad/issues/864

fix the style of selector to default.

before:
<img width="1643" height="968" alt="image" src="https://github.com/user-attachments/assets/a3dce25f-d4dc-4d90-9068-0b8df4144a15" />


after:
<img width="1643" height="968" alt="image" src="https://github.com/user-attachments/assets/7dbec579-d145-454e-be72-2608be8c13de" />




AI Disclosure:-
I have not used any AI assistance in this PR
