### PR TITLE
chore: migrate inline css to tailwind in email pages

### DIFF
--- a/app/javascript/components/server-components/EmailsPage/DraftsTab.tsx
+++ b/app/javascript/components/server-components/EmailsPage/DraftsTab.tsx
@@ -115,12 +115,7 @@ export const DraftsTab = () => {
       <div className="space-y-4 p-4 md:p-8">
         {installments.length > 0 ? (
           <>
-            <table
-              aria-label="Drafts"
-              style={{ marginBottom: "var(--spacer-4)" }}
-              aria-live="polite"
-              aria-busy={isLoading}
-            >
+            <table aria-label="Drafts" className="mb-4" aria-live="polite" aria-busy={isLoading}>
               <thead>
                 <tr>
                   <th>Subject</th>
@@ -141,11 +136,11 @@ export const DraftsTab = () => {
                     <td
                       data-label="Audience"
                       aria-busy={audienceCountValue(audienceCounts, installment.external_id) === null}
-                      style={{ whiteSpace: "nowrap" }}
+                      className="whitespace-nowrap"
                     >
                       {audienceCountValue(audienceCounts, installment.external_id)}
                     </td>
-                    <td data-label="Last edited" style={{ whiteSpace: "nowrap" }}>
+                    <td data-label="Last edited" className="whitespace-nowrap">
                       {formatDistanceToNow(installment.updated_at)} ago
                     </td>
                   </tr>
@@ -184,7 +179,7 @@ export const DraftsTab = () => {
                     })}
                   </div>
                 </div>
-                <div style={{ display: "grid", gridAutoFlow: "column", gap: "var(--spacer-4)" }}>
+                <div className="grid grid-flow-col gap-4">
                   {selectedInstallment.send_emails ? <ViewEmailButton installment={selectedInstallment} /> : null}
                   {selectedInstallment.shown_on_profile ? (
                     <NavigationButton href={selectedInstallment.full_url} target="_blank" rel="noopener noreferrer">
@@ -193,7 +188,7 @@ export const DraftsTab = () => {
                     </NavigationButton>
                   ) : null}
                 </div>
-                <div style={{ display: "grid", gridAutoFlow: "column", gap: "var(--spacer-4)" }}>
+                <div className="grid grid-flow-col gap-4">
                   <NewEmailButton copyFrom={selectedInstallment.external_id} />
                   <EditEmailButton id={selectedInstallment.external_id} />
                   <Button

--- a/app/javascript/components/server-components/EmailsPage/PublishedTab.tsx
+++ b/app/javascript/components/server-components/EmailsPage/PublishedTab.tsx
@@ -97,12 +97,7 @@ export const PublishedTab = () => {
       <div className="space-y-4 p-4 md:p-8">
         {installments.length > 0 ? (
           <>
-            <table
-              aria-label="Published"
-              aria-live="polite"
-              aria-busy={isLoading}
-              style={{ marginBottom: "var(--spacer-4)" }}
-            >
+            <table aria-label="Published" aria-live="polite" aria-busy={isLoading} className="mb-4">
               <thead>
                 <tr>
                   <th>Subject</th>
@@ -112,11 +107,7 @@ export const PublishedTab = () => {
                   <th>Clicks</th>
                   <th>
                     Views{" "}
-                    <div
-                      className="has-tooltip top"
-                      aria-describedby={`views-tooltip-${uid}`}
-                      style={{ whiteSpace: "normal" }}
-                    >
+                    <div className="has-tooltip top whitespace-normal" aria-describedby={`views-tooltip-${uid}`}>
                       <Icon name="info-circle" />
                       <div role="tooltip" id={`views-tooltip-${uid}`}>
                         Views only apply to emails published on your profile.
@@ -133,7 +124,7 @@ export const PublishedTab = () => {
                     onClick={() => setSelectedInstallmentId(installment.external_id)}
                   >
                     <td data-label="Subject">{installment.name}</td>
-                    <td data-label="Date" style={{ whiteSpace: "nowrap" }}>
+                    <td data-label="Date" className="whitespace-nowrap">
                       {new Date(installment.published_at).toLocaleDateString(userAgentInfo.locale, {
                         day: "numeric",
                         month: "short",
@@ -141,31 +132,24 @@ export const PublishedTab = () => {
                         timeZone: currentSeller.timeZone.name,
                       })}
                     </td>
-                    <td data-label="Emailed" style={{ whiteSpace: "nowrap" }}>
+                    <td data-label="Emailed" className="whitespace-nowrap">
                       {installment.send_emails ? formatStatNumber({ value: installment.sent_count }) : "n/a"}
                     </td>
-                    <td data-label="Opened" style={{ whiteSpace: "nowrap" }}>
+                    <td data-label="Opened" className="whitespace-nowrap">
                       {installment.send_emails
                         ? formatStatNumber({ value: installment.open_rate, suffix: "%" })
                         : "n/a"}
                     </td>
-                    <td data-label="Clicks" style={{ whiteSpace: "nowrap" }}>
+                    <td data-label="Clicks" className="whitespace-nowrap">
                       {installment.clicked_urls.length > 0 ? (
                         <span className="has-tooltip" aria-describedby={`url-clicks-${installment.external_id}`}>
                           {formatStatNumber({ value: installment.click_count })}
-                          <div
-                            role="tooltip"
-                            id={`url-clicks-${installment.external_id}`}
-                            style={{ padding: 0, width: "20rem" }}
-                          >
+                          <div role="tooltip" id={`url-clicks-${installment.external_id}`} className="w-[20rem] p-0">
                             <table>
                               <tbody>
                                 {installment.clicked_urls.map(({ url, count }) => (
                                   <tr key={`${installment.external_id}-${url}`}>
-                                    <th
-                                      scope="row"
-                                      style={{ whiteSpace: "break-spaces", maxWidth: "calc(20rem * 0.7)" }}
-                                    >
+                                    <th scope="row" className="max-w-[calc(20rem*0.7)] whitespace-break-spaces">
                                       {url}
                                     </th>
                                     <td>{formatStatNumber({ value: count })}</td>
@@ -179,7 +163,7 @@ export const PublishedTab = () => {
                         formatStatNumber({ value: installment.click_count })
                       )}
                     </td>
-                    <td data-label="Views" style={{ whiteSpace: "nowrap" }}>
+                    <td data-label="Views" className="whitespace-nowrap">
                       {formatStatNumber({
                         value: installment.view_count,
                         placeholder: "n/a",
@@ -237,7 +221,7 @@ export const PublishedTab = () => {
                     })}
                   </div>
                 </div>
-                <div style={{ display: "grid", gridAutoFlow: "column", gap: "var(--spacer-4)" }}>
+                <div className="grid grid-flow-col gap-4">
                   {selectedInstallment.send_emails ? <ViewEmailButton installment={selectedInstallment} /> : null}
                   {selectedInstallment.shown_on_profile ? (
                     <NavigationButton href={selectedInstallment.full_url} target="_blank" rel="noopener noreferrer">
@@ -246,7 +230,7 @@ export const PublishedTab = () => {
                     </NavigationButton>
                   ) : null}
                 </div>
-                <div style={{ display: "grid", gridAutoFlow: "column", gap: "var(--spacer-4)" }}>
+                <div className="grid grid-flow-col gap-4">
                   <NewEmailButton copyFrom={selectedInstallment.external_id} />
                   <EditEmailButton id={selectedInstallment.external_id} />
                   <Button

--- a/app/javascript/components/server-components/EmailsPage/ScheduledTab.tsx
+++ b/app/javascript/components/server-components/EmailsPage/ScheduledTab.tsx
@@ -129,7 +129,7 @@ export const ScheduledTab = () => {
         {installments.length > 0 ? (
           <>
             {Object.keys(installmentsByDate).map((date) => (
-              <table key={date} className="mb-8" aria-live="polite" aria-busy={isLoading}>
+              <table key={date} className="mb-16" aria-live="polite" aria-busy={isLoading}>
                 <caption>Scheduled for {date}</caption>
                 <thead>
                   <tr>

--- a/app/javascript/components/server-components/EmailsPage/ScheduledTab.tsx
+++ b/app/javascript/components/server-components/EmailsPage/ScheduledTab.tsx
@@ -129,7 +129,7 @@ export const ScheduledTab = () => {
         {installments.length > 0 ? (
           <>
             {Object.keys(installmentsByDate).map((date) => (
-              <table key={date} style={{ marginBottom: "var(--spacer-8)" }} aria-live="polite" aria-busy={isLoading}>
+              <table key={date} className="mb-8" aria-live="polite" aria-busy={isLoading}>
                 <caption>Scheduled for {date}</caption>
                 <thead>
                   <tr>
@@ -151,11 +151,11 @@ export const ScheduledTab = () => {
                       <td
                         data-label="Audience"
                         aria-busy={audienceCountValue(audienceCounts, installment.external_id) === null}
-                        style={{ whiteSpace: "nowrap" }}
+                        className="whitespace-nowrap"
                       >
                         {audienceCountValue(audienceCounts, installment.external_id)}
                       </td>
-                      <td data-label="Delivery Time" style={{ whiteSpace: "nowrap" }}>
+                      <td data-label="Delivery Time" className="whitespace-nowrap">
                         {new Date(installment.to_be_published_at).toLocaleTimeString(userAgentInfo.locale, {
                           hour: "numeric",
                           minute: "numeric",
@@ -199,7 +199,7 @@ export const ScheduledTab = () => {
                     })}
                   </div>
                 </div>
-                <div style={{ display: "grid", gridAutoFlow: "column", gap: "var(--spacer-4)" }}>
+                <div className="grid grid-flow-col gap-4">
                   {selectedInstallment.send_emails ? <ViewEmailButton installment={selectedInstallment} /> : null}
                   {selectedInstallment.shown_on_profile ? (
                     <NavigationButton href={selectedInstallment.full_url} target="_blank" rel="noopener noreferrer">
@@ -208,7 +208,7 @@ export const ScheduledTab = () => {
                     </NavigationButton>
                   ) : null}
                 </div>
-                <div style={{ display: "grid", gridAutoFlow: "column", gap: "var(--spacer-4)" }}>
+                <div className="grid grid-flow-col gap-4">
                   <NewEmailButton copyFrom={selectedInstallment.external_id} />
                   <EditEmailButton id={selectedInstallment.external_id} />
                   <Button

--- a/app/javascript/components/server-components/FollowersPage.tsx
+++ b/app/javascript/components/server-components/FollowersPage.tsx
@@ -199,7 +199,7 @@ export const FollowersPage = ({ followers: initialFollowers, per_page, total }: 
               </tbody>
             </table>
             {page * per_page < totalFilteredCount ? (
-              <Button color="primary" onClick={() => void loadFollowers(searchQuery, page + 1)} className="mt-5">
+              <Button color="primary" onClick={() => void loadFollowers(searchQuery, page + 1)} className="mt-6">
                 Load more
               </Button>
             ) : null}

--- a/app/javascript/components/server-components/FollowersPage.tsx
+++ b/app/javascript/components/server-components/FollowersPage.tsx
@@ -199,11 +199,7 @@ export const FollowersPage = ({ followers: initialFollowers, per_page, total }: 
               </tbody>
             </table>
             {page * per_page < totalFilteredCount ? (
-              <Button
-                color="primary"
-                onClick={() => void loadFollowers(searchQuery, page + 1)}
-                style={{ marginTop: "var(--spacer-5)" }}
-              >
+              <Button color="primary" onClick={() => void loadFollowers(searchQuery, page + 1)} className="mt-5">
                 Load more
               </Button>
             ) : null}
@@ -222,7 +218,7 @@ export const FollowersPage = ({ followers: initialFollowers, per_page, total }: 
                         color="danger"
                         onClick={() => void removeFollower(selectedFollower.id)}
                         disabled={removing}
-                        style={{ marginTop: "var(--spacer-2)" }}
+                        className="mt-2"
                       >
                         {removing ? "Removing..." : "Remove follower"}
                       </Button>


### PR DESCRIPTION
ref #1055

## Screenshots

### Published Tab
| Before | After |
| ---------- | --------- |
|<img width="3072" height="1728" alt="image" src="https://github.com/user-attachments/assets/cc144031-078a-4d5c-842d-cca78d9fc7c4" /> | <img width="3072" height="1728" alt="image" src="https://github.com/user-attachments/assets/cd43b8b6-9861-4004-bb1c-b8ddf993b969" /> |

### Scheduled Tab
| Before | After |
| ---------- | --------- |
| <img width="3072" height="1728" alt="Screenshot from 2025-09-24 21-20-00" src="https://github.com/user-attachments/assets/3ffa072c-84a4-4bbe-9cd2-4202c65ab829" />  | <img width="3072" height="1728" alt="image" src="https://github.com/user-attachments/assets/eff6f963-6f92-4ab7-afc0-b6b9545a9ab9" /> |

### Drafts Tab
| Before | After |
| ---------- | --------- |
| <img width="3072" height="1728" alt="image" src="https://github.com/user-attachments/assets/6c28d313-a3cf-4893-854b-ef805e674875" /> | <img width="3072" height="1728" alt="Screenshot from 2025-09-24 21-20-05" src="https://github.com/user-attachments/assets/605f2f17-fa14-4b1f-b569-d6d7557fda97" /> |

### Subscribe Tab 
| Before | After |
| ---------- | --------- |
| <img width="3072" height="1728" alt="image" src="https://github.com/user-attachments/assets/67807eda-4a43-428a-bc13-89a348c26716" /> | <img width="3072" height="1728" alt="Screenshot from 2025-09-24 21-20-14" src="https://github.com/user-attachments/assets/444c0653-8a72-4454-a727-f9a0dc2e23b1" /> |


