### PR TITLE
fix: tooltip screen overflow at product share

### DIFF
--- a/app/javascript/components/ProductEdit/Layout.tsx
+++ b/app/javascript/components/ProductEdit/Layout.tsx
@@ -234,7 +234,7 @@ export const Layout = ({
                   <Icon name="link" />
                 </Button>
               </CopyToClipboard>
-              <CopyToClipboard text={checkoutUrl} copyTooltip="Copy checkout URL">
+              <CopyToClipboard text={checkoutUrl} copyTooltip="Copy checkout URL" tooltipPosition="left">
                 <Button>
                   <Icon name="cart-plus" />
                 </Button>


### PR DESCRIPTION
Ref:- https://github.com/antiwork/gumroad/issues/864

fixes the screen overflow caused by the share - tooltip. 

before:

[Screencast from 2025-09-24 22-08-07.webm](https://github.com/user-attachments/assets/eaa23251-58c6-406e-8cc7-c0fb025fcf40)

after:

[Screencast from 2025-09-24 22-08-56.webm](https://github.com/user-attachments/assets/6ebb753e-5637-4cb7-842d-b0378bb01abb)



AI Disclosure:-
I have not used any AI assistance in this PR
