### PR TITLE
Fix: month names in dropdown

### DIFF
--- a/app/javascript/components/Settings/PaymentsPage/AccountDetailsSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/AccountDetailsSection.tsx
@@ -1058,7 +1058,7 @@ const AccountDetailsSection = ({
               <option disabled>Month</option>
               {Array.from({ length: 12 }, (_, i) => i + 1).map((month) => (
                 <option key={month} value={month}>
-                  {month}
+                  {new Date(2000, month - 1, 1).toLocaleString("en-US", { month: "long" })}
                 </option>
               ))}
             </select>


### PR DESCRIPTION
ref #864

Months are shown as numbers currently, fixed it to show month names

### Before

<img width="1470" height="825" alt="Screenshot 2025-09-24 at 10 46 41 PM" src="https://github.com/user-attachments/assets/29dc0301-4dd7-4776-b6bd-bad06a293439" />


### After

<img width="1464" height="825" alt="Screenshot 2025-09-24 at 10 45 36 PM" src="https://github.com/user-attachments/assets/9a5e2707-f71f-4291-b3af-a025546cb116" />


### AI disclosure
No AI used