### PR TITLE
fix: removed redundant back button

### DIFF
--- a/app/javascript/components/server-components/GumroadBlog/PostPage.tsx
+++ b/app/javascript/components/server-components/GumroadBlog/PostPage.tsx
@@ -55,7 +55,7 @@ const PostPage = ({
           <h1 className="mb-4">{subject}</h1>
           <time className="text-dark-gray">{publishedAtFormatted}</time>
         </header>
-        <div className="mx-auto grid max-w-3xl gap-6 border-b py-12 text-xl">
+        <div className="mx-auto grid max-w-3xl gap-6 border-t mt-6 py-12 text-xl">
           {pageLoaded ? null : <LoadingSpinner width="2em" />}
           <EditorContent className="rich-text" editor={editor} />
 
@@ -75,7 +75,6 @@ const PostPage = ({
             </div>
           ) : null}
         </div>
-        <BackToBlog />
       </div>
     </div>
   );


### PR DESCRIPTION
Ref:- https://github.com/antiwork/gumroad/issues/864

removed the redundant "Back to Blog" option.

before:

<img width="766" height="921" alt="image" src="https://github.com/user-attachments/assets/28203504-3dfb-4a45-b938-32300bfc38b9" />


after:

<img width="766" height="921" alt="image" src="https://github.com/user-attachments/assets/902db73c-9f3d-432c-8d6d-494c40c15f38" />


[Screencast from 2025-09-24 23-37-14.webm](https://github.com/user-attachments/assets/71705694-c800-4baf-b89b-829bc7c9dfd3)

AI Disclosure:-
I have not used any AI assistance in this PR
