### PR TITLE
fix: pricing page  section

### DIFF
--- a/app/views/home/pricing.html.erb
+++ b/app/views/home/pricing.html.erb
@@ -76,15 +76,15 @@
         </p>
       </div>
       <ul class="grid grid-cols-1 gap-3 pl-0 text-lg md:grid-cols-2">
-        <li class="flex items-center gap-2">
+        <li class="flex items-center gap-4">
           <span>→</span>
           No more tax headaches - we handle everything
         </li>
-        <li class="flex items-center gap-2">
+        <li class="flex items-center gap-4">
           <span>→</span>
           Simplified global selling - we manage international tax compliance
         </li>
-        <li class="flex items-center gap-2">
+        <li class="flex items-center gap-4">
           <span>→</span>
           More time for creating - less time dealing with paperwork
         </li>


### PR DESCRIPTION
Ref:- https://github.com/antiwork/gumroad/issues/864

fixes the text gap at ` What this means for you` section 

before:

<img width="408" height="535" alt="image" src="https://github.com/user-attachments/assets/51a6f37b-732f-450e-b237-a61b642fe7ec" />

after:

<img width="408" height="535" alt="image" src="https://github.com/user-attachments/assets/b5157a88-7dd8-4828-a070-3ac0718195ca" />


AI Disclosure:-
I have not used any AI assistance in this PR
