### PR TITLE
Fix video infinite loop after long pause

### DIFF
--- a/app/javascript/components/server-components/VideoStreamPlayer.tsx
+++ b/app/javascript/components/server-components/VideoStreamPlayer.tsx
@@ -146,6 +146,19 @@ export const VideoStreamPlayer = ({
         }
         isInitialSeekDone = true;
       });
+
+      player.on("error", (error) => {
+        if (error.code === 403 || error.code === 410) {
+          const currentPosition = player.getPosition();
+          const currentItem = player.getPlaylistItem();
+          
+          player.load([currentItem]);
+          
+          player.once("ready", () => {
+            player.seek(currentPosition);
+          });
+        }
+      });
     };
 
     void createPlayer();


### PR DESCRIPTION
Part of : #790

AI Disclosure: Used for only for syntax, logic and code review Manually

### Problem

When users pause a video for approximately 10 minutes and then resume playback, the video gets stuck in an infinite buffering loop, requiring a full page refresh to fix. This interrupts the user experience and causes users to lose their place in the video.

### Solution

Added a simple error handler to the JWPlayer that detects expired HLS URLs and automatically recovers by reloading the video with a fresh URL while preserving the user's playback position.

player.on("error", (error) => {
  if (error.code === 403 || error.code === 410) {
    const currentPosition = player.getPosition();
    const currentItem = player.getPlaylistItem();
    player.load([currentItem]);
    player.once("ready", () => {
      player.seek(currentPosition);
    });
  }
});

How it works?

1. Detects when video URL expires (403/410 error)
2. Saves your current position in the video
3. Reloads the video with a fresh URL

Fixes #790 