### PR TITLE
Fix(flaky tests): Stub Circle API rate limiter in tests to prevent flaky failures

### DIFF
--- a/spec/support/circle_rate_limit_stub.rb
+++ b/spec/support/circle_rate_limit_stub.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  config.around(:each) do |example|
+    RSpec::Mocks.with_temporary_scope do
+      allow_any_instance_of(CircleApi).to receive(:rate_limited_call).and_wrap_original do |_, &blk|
+        blk.call
+      end
+      example.run
+    end
+  end
+end


### PR DESCRIPTION
# Problem:
- `circle_integrations_spec.rb` is too flaky, and flaked too many times in recent days
### CI Logs: (24-25 sept)
https://github.com/antiwork/gumroad/actions/runs/18002319844/job/51214787740#step:8:329
https://github.com/antiwork/gumroad/actions/runs/17966175569/job/51099381992#step:8:315
https://github.com/antiwork/gumroad/actions/runs/17972326625/job/51118688114#step:8:345
<img width="1084" height="187" alt="Screenshot 2025-09-25 at 9 18 12 PM" src="https://github.com/user-attachments/assets/93f83003-a9f0-429f-aeff-f04c92109f33" />


# Root Cause: (most probably)
- we have rate limit for circle (100 requests per 60s) which is not stubbed for tests
```
    def rate_limited_call(&block)
      key = "CIRCLE_API_RATE_LIMIT"
      ratelimit = Ratelimit.new(key, { redis: $redis })

      ratelimit.exec_within_threshold key, threshold: 100, interval: 60 do
        ratelimit.add(key)
        block.call
      end
    end 
```
- In CI, multiple specs and workers can exceed this threshold quickly.
- When the limit is hit, the controller returns success: false, the React selects don’t render, and test fails.
- i've considered all other cases for this test to fails, but none seems to cause an issue except this rate limiting problem
- i've tested locally multiple times with and without rate-limiting stub and it passes all tests in both cases because running individual test never caused rate limit.

# Solution:
- stub the circle rate limiter for testing.

ref #1127 

### AI Disclosure:
- cursor used to implement stub, i reviewed the code and also tested, it's working fine.

