### PR TITLE
fix: nav not closing on selection | small screen

### DIFF
--- a/app/javascript/components/Nav.tsx
+++ b/app/javascript/components/Nav.tsx
@@ -76,6 +76,7 @@ type Props = {
 
 export const Nav = ({ title, children, footer, compact }: Props) => {
   const [open, setOpen] = React.useState(false);
+  const handleClose = () => setOpen(false);
 
   return (
     <nav aria-label="Main" className={cx({ compact, open })}>
@@ -91,7 +92,7 @@ export const Nav = ({ title, children, footer, compact }: Props) => {
           <span className="logo-full">&nbsp;</span>
         </a>
       </header>
-      {children}
+      <div onClick={handleClose}>{children}</div>
       <footer>{footer}</footer>
     </nav>
   );


### PR DESCRIPTION
Ref:- https://github.com/antiwork/gumroad/issues/864

On small screens, the navigation menu remains open after selecting a link.
This PR ensures that the nav automatically collapses when any navigation link is clicked.

before:

[Screencast from 2025-09-26 00-10-20.webm](https://github.com/user-attachments/assets/85d45373-8a22-440c-9c43-92158530af87)


after:

[Screencast from 2025-09-26 00-11-01.webm](https://github.com/user-attachments/assets/1af3fad9-75a0-47f2-a16d-0b84007e4b1c)

[Screencast from 2025-09-26 00-12-27.webm](https://github.com/user-attachments/assets/bdcc5c64-33d6-4184-92c7-7b5917ce7e25)

AI Disclosure:-
I have not used any AI assistance in this PR
