### PR TITLE
fix: link for logo at discover page

### DIFF
--- a/app/javascript/components/Discover/Layout.tsx
+++ b/app/javascript/components/Discover/Layout.tsx
@@ -137,7 +137,7 @@ export const Layout: React.FC<{
 
   const logoLink = (
     <a
-      href={Routes.discover_url({ host: discoverDomain })}
+      href={Routes.root_url({ host: discoverDomain })}
       className="logo-full flex aspect-[157/22] !w-[245px] flex-shrink-0 items-center"
       aria-label="Gumroad"
     />


### PR DESCRIPTION
Ref:- https://github.com/antiwork/gumroad/issues/864

Fix the LogoLink to root url same as other pages.

**before:**

[Screencast from 2025-09-26 00-40-28.webm](https://github.com/user-attachments/assets/b770be28-38a6-4684-baa4-851b281115cb)



**after:**

[Screencast from 2025-09-26 00-41-03.webm](https://github.com/user-attachments/assets/e176cde7-a01f-4442-a807-fbb6f0794c86)


AI Disclosure:-
I have not used any AI assistance in this PR
