### PR TITLE
refactor: migrate checkout pages inline css to tailwind

### DIFF
--- a/app/javascript/components/server-components/CheckoutDashboard/DiscountsPage.tsx
+++ b/app/javascript/components/server-components/CheckoutDashboard/DiscountsPage.tsx
@@ -351,13 +351,9 @@ const DiscountsPage = ({
                       onClick={() => setSelectedOfferCodeId(offerCode.id)}
                     >
                       <td>
-                        <div style={{ display: "grid", gap: "var(--spacer-2)" }}>
+                        <div className="grid gap-2">
                           <div>
-                            <div
-                              className="pill small"
-                              style={{ marginRight: "var(--spacer-2)" }}
-                              aria-label="Offer code"
-                            >
+                            <div className="pill small mr-2" aria-label="Offer code">
                               {offerCode.code.toUpperCase()}
                             </div>
                             <b>{offerCode.name}</b>
@@ -369,8 +365,8 @@ const DiscountsPage = ({
                       </td>
                       {statistics != null ? (
                         <>
-                          <td style={{ whiteSpace: "nowrap" }}>{formatRevenue(statistics.revenue_cents)}</td>
-                          <td style={{ whiteSpace: "nowrap" }}>{formatUses(statistics.uses.total, offerCode.limit)}</td>
+                          <td className="whitespace-nowrap">{formatRevenue(statistics.revenue_cents)}</td>
+                          <td className="whitespace-nowrap">{formatUses(statistics.uses.total, offerCode.limit)}</td>
                         </>
                       ) : (
                         <>
@@ -381,10 +377,8 @@ const DiscountsPage = ({
                       <td>{`${validAt ? `${formatDate(validAt)} - ` : ""}${
                         expiresAt ? formatDate(expiresAt) : "No end date"
                       }`}</td>
-                      <td style={{ whiteSpace: "nowrap" }}>
-                        <div
-                          style={{ display: "grid", gridTemplateColumns: "min-content 1fr", gap: "var(--spacer-2)" }}
-                        >
+                      <td className="whitespace-nowrap">
+                        <div className="grid grid-cols-[min-content_1fr] gap-2">
                           {validAt && currentDate < validAt ? (
                             <>Scheduled</>
                           ) : expiresAt && currentDate > expiresAt ? (
@@ -554,10 +548,7 @@ const DiscountsPage = ({
                       ? (selectedOfferCodeStatistics.uses.products[product.id] ?? 0)
                       : null;
                   return (
-                    <div
-                      key={product.id}
-                      style={{ display: "grid", gridTemplateColumns: "1fr auto", gap: "var(--spacer-2)" }}
-                    >
+                    <div key={product.id} className="grid grid-cols-[1fr_auto] gap-2">
                       <div>
                         <h5>{product.name}</h5>
                         {uses != null ? `${uses} ${uses === 1 ? "use" : "uses"}` : null}
@@ -576,7 +567,7 @@ const DiscountsPage = ({
                 })}
               </section>
             ) : null}
-            <section className="grid auto-cols-fr grid-flow-row sm:grid-flow-col" style={{ gap: "var(--spacer-4)" }}>
+            <section className="grid auto-cols-fr grid-flow-row gap-4 sm:grid-flow-col">
               <Button onClick={() => setView("create")} disabled={!selectedOfferCode.can_update || isLoading}>
                 Duplicate
               </Button>
@@ -872,7 +863,7 @@ const Form = ({
             <legend>
               <label htmlFor={`${uid}code`}>Discount code</label>
             </legend>
-            <div style={{ display: "grid", gridTemplateColumns: "1fr auto", gap: "var(--spacer-2)" }}>
+            <div className="grid grid-cols-[1fr_auto] gap-2">
               <input
                 type="text"
                 id={`${uid}code`}
@@ -975,7 +966,7 @@ const Form = ({
               }
             />
           </fieldset>
-          <fieldset style={{ gap: "var(--spacer-4)" }}>
+          <fieldset className="gap-4">
             <legend>Settings</legend>
             <Details
               className="toggle"

--- a/app/javascript/components/server-components/CheckoutDashboard/UpsellsPage.tsx
+++ b/app/javascript/components/server-components/CheckoutDashboard/UpsellsPage.tsx
@@ -453,7 +453,7 @@ const UpsellDrawer = ({
           ))}
         </section>
       )}
-      <section style={{ display: "grid", gap: "var(--spacer-4)", gridAutoFlow: "column", gridAutoColumns: "1fr" }}>
+      <section className="grid auto-cols-fr grid-flow-col gap-4">
         <Button onClick={onCreate} disabled={isLoading || isReadOnly}>
           Duplicate
         </Button>
@@ -840,10 +840,7 @@ const Form = ({
                   />
                 </fieldset>
                 {selectedProduct ? (
-                  <div
-                    style={{ display: "grid", gridTemplateColumns: "1fr auto 1fr", gap: "var(--spacer-2)" }}
-                    aria-label="Upsell versions"
-                  >
+                  <div className="grid grid-cols-[1fr_auto_1fr] gap-2" aria-label="Upsell versions">
                     <b>Version selected</b>
                     <div />
                     <b>Version to offer</b>


### PR DESCRIPTION
part of #1055 

### Discounts Tab

| Before | After |
|--------- |---------- |
|<img width="2086" height="1440" alt="gumroad dev_checkout_discounts (2)" src="https://github.com/user-attachments/assets/66813510-faa2-46a7-94e9-033ba766ffe3" /> |<img width="2086" height="1440" alt="gumroad dev_checkout_discounts (2)" src="https://github.com/user-attachments/assets/a9f49a08-65ba-4c78-ae58-0ae057846985" /> |

### Upsells Tab
| Before | After |
|--------- |---------- |
| <img width="2086" height="1440" alt="gumroad dev_checkout_upsells" src="https://github.com/user-attachments/assets/ecda726b-1f73-46f8-97f5-f841f6c28df0" /> | <img width="2086" height="1440" alt="gumroad dev_checkout_upsells" src="https://github.com/user-attachments/assets/54b3fba4-e306-49b1-b11c-28608932e373" /> |

