### PR TITLE
updated sensitive parameters for filtering in logs, specs created

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -5,5 +5,10 @@
 # Configure parameters to be partially matched (e.g. passw matches password) and filtered from the log file.
 # Use this to limit dissemination of sensitive information.
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
-Rails.application.config.filter_parameters += %i[password cc_number number expiry_date cc_expiry cvc account_number account_number_repeated passphrase
-                                                 chargeable tax_id individual_tax_id business_tax_id ssn_first_three ssn_middle_two ssn_last_four]
+Rails.application.config.filter_parameters += %i[
+  password cc_number number expiry_date cc_expiry cvc account_number account_number_repeated passphrase
+  chargeable tax_id individual_tax_id business_tax_id ssn_first_three ssn_middle_two ssn_last_four
+  secret token auth authentication authorization bearer oauth access_token refresh_token
+  api_key private_key public_key certificate cert key_id session_id csrf_token
+  pin cvv security_code verification_code otp two_factor
+]

--- a/spec/initializers/filter_parameter_logging_spec.rb
+++ b/spec/initializers/filter_parameter_logging_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "FilterParameterLogging" do
+  describe "parameter filtering configuration" do
+    let(:filter) { ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters) }
+
+    it "includes comprehensive sensitive parameter filtering" do
+      # Test that our configuration includes the expected sensitive parameters
+      expected_sensitive_params = %w[
+        password secret token auth authorization api_key private_key public_key
+        certificate key_id session_id csrf_token pin cvv security_code
+        verification_code otp two_factor cc_number access_token refresh_token
+      ]
+
+      filter_parameters = Rails.application.config.filter_parameters.map(&:to_s)
+
+      expected_sensitive_params.each do |param|
+        expect(filter_parameters).to include(param)
+      end
+    end
+
+    it "filters sensitive parameters in nested structures" do
+      params = {
+        user: {
+          name: "John",
+          password: "secret123",
+          api_key: "sk_test_123"
+        },
+        payment: { cc_number: "4111111111111111", amount: 1000 }
+      }
+
+      filtered = filter.filter(params)
+
+      expect(filtered[:user][:name]).to eq("John")
+      expect(filtered[:user][:password]).to eq("[FILTERED]")
+      expect(filtered[:user][:api_key]).to eq("[FILTERED]")
+      expect(filtered[:payment][:cc_number]).to eq("[FILTERED]")
+      expect(filtered[:payment][:amount]).to eq(1000)
+    end
+
+    it "preserves non-sensitive parameters" do
+      params = { username: "john_doe", email: "test@example.com", price_cents: 1000 }
+      filtered = filter.filter(params)
+      expect(filtered).to eq(params)
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/antiwork/gumroad/issues/1359

**Enhanced Parameter Filtering Configuration**

Updated `filter_parameter_logging.rb` to include additional sensitive parameters for filtering:

```
secret, token, auth, authorization, api_key, private_key, public_key, certificate, key_id, session_id, csrf_token, pin, cvv, security_code, verification_code, otp, two_factor, cc_number, access_token, refresh_token.
```

Created focussed test `filter_parameter_logging_spec.rb` to validate - 
- presence of sensitive params in config
- proper filtering of sensitive parameters in nested structures
- preservation of non-sensitive parameters.

Commad to test working of spec file - `bundle exec rspec spec/initializers/filter_parameter_logging_spec.rb`

<img width="1320" height="494" alt="image" src="https://github.com/user-attachments/assets/7b152ee1-9552-4030-99c0-b0ae2f7e33cf" />


AI disclosure:
Copilot used to suggest filter parameters