### PR TITLE
fix css warning

### DIFF
--- a/app/javascript/stylesheets/_modal.scss
+++ b/app/javascript/stylesheets/_modal.scss
@@ -5,9 +5,6 @@ dialog {
   border-radius: border-radius(1);
   padding: spacer(6);
 
-  @media (prefers-color-scheme: dark) {
-    box-shadow: none;
-  }
   // cannot use display: grid here because safari
   display: flex;
   flex-direction: column;
@@ -20,6 +17,10 @@ dialog {
   min-width: size(20);
   max-width: size(43.75);
   gap: spacer(4);
+
+  @media (prefers-color-scheme: dark) {
+    box-shadow: none;
+  }
 
   &::backdrop {
     background: $backdrop-bg;


### PR DESCRIPTION
AI Disclosure
No AI used

What?
PR #1345 introduced some css changes that caused continuous css warnings due to the ordering

<img width="1156" height="942" alt="Screenshot 2025-09-27 at 6 19 19 PM" src="https://github.com/user-attachments/assets/7bd20b37-c684-4aa1-88aa-18b925427a90" />
