### PR TITLE
Fix(flaky test): product edit spec flakes because of ambiguous selector

### DIFF
--- a/spec/requests/products/edit/edit_spec.rb
+++ b/spec/requests/products/edit/edit_spec.rb
@@ -147,9 +147,11 @@ describe("Product Edit Scenario", type: :system, js: true) do
     fill_in "Fixed amount", with: "1"
     click_on "Insert"
 
-    within_section "Sample product", section_element: :article do
-      expect(page).to have_text("5.0 (1)", normalize_ws: true)
-      expect(page).to have_text("$10 $9")
+    within("[aria-label='Description']") do
+      within_section "Sample product", section_element: :article do
+        expect(page).to have_text("5.0 (1)", normalize_ws: true)
+        expect(page).to have_text("$10 $9")
+      end
     end
 
     click_on "Save"


### PR DESCRIPTION
## Failing CI logs: (failed 2 times in past 2 days)
1. https://github.com/antiwork/gumroad/actions/runs/18059306924/job/51393430029?pr=1374#step:8:233
2. https://github.com/antiwork/gumroad/actions/runs/18012411273/job/51248955540#step:8:227

<img width="788" height="238" alt="Screenshot 2025-09-27 at 9 33 21 PM" src="https://github.com/user-attachments/assets/9ba7ca59-9a76-4490-bd92-ca34a9caf245" />

# Problem:
- on product edit page we have multiple text matching "Sample Product" due to which test fails with message
 ` Ambiguous match, found 3 elements matching visible section "Sample product"`
### Screenshot from CI logs:
<img width="1440" height="900" alt="failures_r_spec_example_groups_product_edit_scenario_allows_creating_and_deleting_an_upsell_in_the_product_description_829" src="https://github.com/user-attachments/assets/abdefc41-a0dd-4ec3-8a5c-fed5f6e68300" />

# Solution:
- make selector more specific with 
```rb
    within("[aria-label='Description']") do
 ...
   end
```


### passes in local run after fix
<img width="756" height="129" alt="Screenshot 2025-09-27 at 9 46 59 PM" src="https://github.com/user-attachments/assets/2f37d3ad-9cb1-47ea-b5e9-d1ed446546cf" />

ref #1127 

# AI Disclosure:
- no AI used.