### PR TITLE
Fix(flaky test): upsell creation test flakes because checkout preview not updating unless visible into viewport.

### DIFF
--- a/spec/requests/checkout/upsells_spec.rb
+++ b/spec/requests/checkout/upsells_spec.rb
@@ -187,6 +187,7 @@ describe("Checkout upsells page", type: :system, js: true) do
 
       select_combo_box_option search: "Product 1", from: "Apply to this product"
       select_combo_box_option search: "Untitled 1", from: "Version to offer for Untitled 2"
+      scroll_to(find("[aria-label='Preview']"))
       in_preview do
         within_modal "Enhance your learning experience" do
           expect(page).to have_radio_button("Untitled 1", text: "$10")
@@ -197,6 +198,7 @@ describe("Checkout upsells page", type: :system, js: true) do
         click_on "Clear value"
       end
       select_combo_box_option search: "Untitled 2", from: "Version to offer for Untitled 1"
+      scroll_to(find("[aria-label='Preview']"))
       in_preview do
         within_modal "Enhance your learning experience" do
           expect(page).to have_radio_button("Untitled 2", text: "$15")


### PR DESCRIPTION
ref #1127  

## Failing CI logs: (27 sept)
1. https://github.com/antiwork/gumroad/actions/runs/18061727813/job/51399537482#step:8:76
2. https://github.com/antiwork/gumroad/actions/runs/18061287671/job/51397975059#step:8:76
3. https://github.com/antiwork/gumroad/actions/runs/18061615329/job/51398900348#step:8:76
4. https://github.com/antiwork/gumroad/actions/runs/18060257426/job/51395633561#step:8:76
<img width="1063" height="226" alt="Screenshot 2025-09-28 at 6 58 54 PM" src="https://github.com/user-attachments/assets/c170cc93-75b0-43f3-9835-c3081ef15ab4" />


## Problem: (explained in video)
upsell creation test flakes because checkout preview not updating unless visible into viewport

https://github.com/user-attachments/assets/62396943-fffe-46d0-9b04-f1683e8ee657

## Solution:
- scroll so that preview section is visible using 
```rb
scroll_to(find("[aria-label='Preview']"))
```

## After Fix: 
https://github.com/user-attachments/assets/12a4c6d2-60b9-411c-83a1-c478d32df98d

### AI Disclosure:
- no AI used
