### PR TITLE
fix: align rich text editor spacing to prevent toolbar overlap

### DIFF
--- a/app/javascript/stylesheets/_rich_text.scss
+++ b/app/javascript/stylesheets/_rich_text.scss
@@ -3,6 +3,7 @@
   .ProseMirror {
     > * {
       margin-bottom: spacer(4);
+      margin-top: spacer(4);
     }
   }
 


### PR DESCRIPTION
### Explanation of Change
Added proper vertical spacing to Rich Text editor content to prevent the toolbar from overlapping and ensure consistent alignment

### Screenshots/Videos
Before
<img width="1470" height="396" alt="image" src="https://github.com/user-attachments/assets/6a7f11c3-aaa0-41fe-bf0e-36dc27043ef2" />

After
<img width="1470" height="488" alt="Screenshot 2025-09-29 at 11 08 15" src="https://github.com/user-attachments/assets/288a4f5a-5e34-457f-8ed5-311c9f513aac" />

<img width="924" height="142" alt="image" src="https://github.com/user-attachments/assets/3ad2c02f-a296-473a-970a-24a370df39be" />

### AI Disclosure
No AI tools used


