### PR TITLE
fix: prevent discount detail modal from flashing when deleting via menu

### DIFF
--- a/app/javascript/components/server-components/CheckoutDashboard/DiscountsPage.tsx
+++ b/app/javascript/components/server-components/CheckoutDashboard/DiscountsPage.tsx
@@ -427,7 +427,8 @@ const DiscountsPage = ({
                                 role="menuitem"
                                 className="danger"
                                 inert={!offerCode.can_update || isLoading}
-                                onClick={asyncVoid(async () => {
+                                onClick={asyncVoid(async (e) => {
+                                  e.stopPropagation();
                                   try {
                                     setIsLoading(true);
                                     setPopoverOfferCodeId(null);


### PR DESCRIPTION
### Explanation of Change
Fixed an issue where the discount detail modal briefly appeared when deleting a discount via the menu by adding `e.stopPropagation()` to the Delete button’s click handler, preventing the event from bubbling to the parent

### Screenshots/Videos
Before

https://github.com/user-attachments/assets/1de3f0be-7970-47eb-b25d-395fbddb0f05

After

https://github.com/user-attachments/assets/72ad16de-88fb-4c61-8bce-9ddfb456bcb4

### AI Disclosure
No AI tools used


