### PR TITLE
fix: add vertical spacing to pagination controls

### DIFF
--- a/app/javascript/components/Pagination.tsx
+++ b/app/javascript/components/Pagination.tsx
@@ -51,7 +51,7 @@ export const Pagination = ({ pagination, pageDisplayCount = 10, onChangePage }: 
   }, [pagination, pageDisplayCount]);
 
   return (
-    <div role="navigation" aria-label="Pagination" className="pagination">
+    <div role="navigation" aria-label="Pagination" className="pagination mt-4">
       <Button small disabled={pagination.page - 1 === 0} onClick={() => onChangePage(pagination.page - 1)}>
         <Icon name="outline-cheveron-left" />
         Previous


### PR DESCRIPTION
### Explanation of Change
Added `mt-4` (top margin 1 rem) to pagination controls to ensure consistent spacing between tables and their pagination, preventing buttons from overlapping table borders.

### Screenshots/Videos
Before
<img width="1270" height="367" alt="image" src="https://github.com/user-attachments/assets/5629f93d-dd30-4f98-803b-d7a475d543f6" />

<img width="409" height="516" alt="image" src="https://github.com/user-attachments/assets/2f3bdc2a-0f91-4d7e-95f4-c2ae329e0d73" />


After
<img width="1264" height="300" alt="image" src="https://github.com/user-attachments/assets/9add5c5a-7480-40f1-bb7f-931e065a6d8a" />

<img width="392" height="523" alt="image" src="https://github.com/user-attachments/assets/b5db2ff4-280b-49c1-9142-fcacb6707a21" />

### AI Disclosure
No AI tools used