### PR TITLE
Fix typo in 'Chargebacks on Gumroad' article

### DIFF
--- a/app/views/help_center/articles/contents/_134-how-does-gumroad-handle-chargebacks.html.erb
+++ b/app/views/help_center/articles/contents/_134-how-does-gumroad-handle-chargebacks.html.erb
@@ -14,7 +14,7 @@
       <li><a href="#Multiple-Chargebacks-Xqzl6" target="_self">Multiple chargebacks</a></li>
       <li><a href="#Reverse-Chargebacks-vs-Repurchasing--Numu" target="_self">Reverse chargebacks vs repurchasing</a></li>
       <li><a href="#How-Can-I-Lower-My-Chargeback-Rate--Xm9k2" target="_self">How Can I Lower My Chargeback Rate?</a></li>
-      <li><a href="#FAQs-gv1pb" target="_self">FAQ's</a></li>i>
+      <li><a href="#FAQs-gv1pb" target="_self">FAQ's</a></li>
     </ul>
     <h3 id="Whats-a-chargeback-YN1sf">What's a chargeback?</h3>
     <p>A chargeback (also known as a charge dispute or reversal) occurs when a customer asks their credit card provider to cancel a transaction. This isn't a refund request through Gumroad; it's the card provider forcibly reversing the payment.</p>


### PR DESCRIPTION
Delete rogue `i>` in the ToC

<img width="329" height="180" alt="image" src="https://github.com/user-attachments/assets/bf3dd732-1064-42a6-822b-0d6fd7e19274" />
