### PR TITLE
fix: Align "Leave team" button

### DIFF
--- a/app/javascript/components/server-components/Settings/TeamPage.tsx
+++ b/app/javascript/components/server-components/Settings/TeamPage.tsx
@@ -332,14 +332,11 @@ const TeamMembersSection = ({
               </td>
               <td data-label="Role">
                 {memberInfo.leave_team_option ? (
-                  <Button
-                    color="danger"
-                    disabled={loading}
-                    style={{ float: "right" }}
-                    onClick={() => setConfirming(memberInfo)}
-                  >
-                    {memberInfo.leave_team_option.label}
-                  </Button>
+                  <div className="flex justify-end">
+                    <Button color="danger" disabled={loading} onClick={() => setConfirming(memberInfo)}>
+                      {memberInfo.leave_team_option.label}
+                    </Button>
+                  </div>
                 ) : (
                   <Select
                     instanceId={memberInfo.id}


### PR DESCRIPTION
### Explanation of Change
Fix mobile layout by replacing `float-right` with a `flex justify-end` wrapper to properly align the "Leave team" button

### Screenshots/Videos
Before
<img width="347" height="324" alt="image" src="https://github.com/user-attachments/assets/f548f329-eef6-460c-ae43-6cb9441c8855" />


After

<img width="351" height="271" alt="image" src="https://github.com/user-attachments/assets/0d7184d5-ea12-4332-8fa6-3fe50a400b83" />

<img width="985" height="213" alt="image" src="https://github.com/user-attachments/assets/ce234fff-753d-46e6-8c99-afc81eb83d7b" />


### AI Disclosure
No AI tools used


