### PR TITLE
fix: Add consistent mobile margins on Coffee product page

### DIFF
--- a/app/javascript/components/server-components/Profile/CoffeePage.tsx
+++ b/app/javascript/components/server-components/Profile/CoffeePage.tsx
@@ -77,7 +77,7 @@ export const CoffeeProduct = ({
     </>
   );
   return (
-    <section style={{ display: "grid", gap: "var(--spacer-7)", alignContent: "center", flexGrow: 1 }}>
+    <section className="px-4" style={{ display: "grid", gap: "var(--spacer-7)", alignContent: "center", flexGrow: 1 }}>
       <section style={{ display: "grid", gap: "var(--spacer-6)" }}>
         <h1>{product.name}</h1>
         {product.description_html ? <h3 dangerouslySetInnerHTML={{ __html: product.description_html }} /> : null}


### PR DESCRIPTION
### Explanation of Change
Fixes Coffee product page on mobile by adding consistent left & right padding like other product pages.

### Screenshots/Videos
Before
<img width="347" height="786" alt="image" src="https://github.com/user-attachments/assets/25ee6b41-bce5-4c1e-b9a5-de282657c7f0" />

After
<img width="346" height="764" alt="image" src="https://github.com/user-attachments/assets/49a7761f-ac15-4617-8789-daa6bdb6eaa9" />


### AI Disclosure
No AI tools used


