### PR TITLE
fix(CheckoutPage): hide percentage options for free cart

### DIFF
--- a/app/javascript/components/Checkout/PaymentForm.tsx
+++ b/app/javascript/components/Checkout/PaymentForm.tsx
@@ -48,6 +48,7 @@ import {
   requiresReusablePaymentMethod,
   isSubmitDisabled,
   isTippingEnabled,
+  getTotalPriceFromProducts,
 } from "$app/components/Checkout/payment";
 import { Icon } from "$app/components/Icons";
 import { useLoggedInUser } from "$app/components/LoggedInUser";
@@ -727,7 +728,7 @@ const CreditCard = () => {
 const TipSelector = () => {
   const [state, dispatch] = useState();
   const errors = getErrors(state);
-  const showPercentageOptions = state.surcharges.type === "loaded" ? state.surcharges.result.subtotal > 0 : true;
+  const showPercentageOptions = getTotalPriceFromProducts(state) > 0;
 
   React.useEffect(() => {
     if (!showPercentageOptions && state.tip.type === "percentage")

--- a/app/javascript/components/Checkout/payment.ts
+++ b/app/javascript/components/Checkout/payment.ts
@@ -155,7 +155,7 @@ export function isSubmitDisabled(state: State) {
   return isProcessing(state) || state.surcharges.type !== "loaded" || emailTypoBlocking;
 }
 
-const getTotalPriceFromProducts = (state: State) => state.products.reduce((sum, item) => sum + item.price, 0);
+export const getTotalPriceFromProducts = (state: State) => state.products.reduce((sum, item) => sum + item.price, 0);
 
 export function isTippingEnabled(state: State) {
   return (

--- a/spec/requests/purchases/tipping_spec.rb
+++ b/spec/requests/purchases/tipping_spec.rb
@@ -143,6 +143,11 @@ describe("Product checkout with tipping", type: :system, js: true) do
 
       fill_in "Tip", with: 5
 
+      expect(page).not_to have_radio_button("0%")
+      expect(page).not_to have_radio_button("10%")
+      expect(page).not_to have_radio_button("20%")
+      expect(page).not_to have_radio_button("Other")
+
       fill_checkout_form(free_product2)
 
       expect(page).to have_text("Subtotal US$0", normalize_ws: true)


### PR DESCRIPTION
### Ref
- #864

Percentage options will only be visible when total price from products is greater than 0

### Before

https://github.com/user-attachments/assets/9dc864d6-b893-48da-96c3-9d13f63e677c

### After

https://github.com/user-attachments/assets/1ebde146-7797-4597-8e53-8a219be84560

### AI Usage
None
