### PR TITLE
Fix: Custom Fields not updating when edited in Manage Membership page

### DIFF
--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -498,7 +498,8 @@ class PurchasesController < ApplicationController
                                                    :braintree_device_data, :braintree_transient_customer_store_key, :use_existing_card,
                                                    :price_range, :perceived_price_cents, :perceived_upgrade_price_cents, :quantity,
                                                    :declined, stripe_error: {}, variants: [], contact_info: [:email, :full_name,
-                                                                                                             :street_address, :city, :state, :zip_code, :country]).to_h
+                                                                                                             :street_address, :city, :state, :zip_code, :country],
+                                                   custom_fields: [:id, :value]).to_h
     end
 
     def hide_layouts

--- a/app/javascript/data/subscription.ts
+++ b/app/javascript/data/subscription.ts
@@ -47,6 +47,7 @@ export type UpdateSubscriptionPayload = {
   perceived_upgrade_price_cents: number;
   // for PWYW tier
   price_range?: number | undefined;
+  custom_fields?: { id: string; value: string | boolean }[];
 };
 
 export const updateSubscription = async (

--- a/app/presenters/checkout_presenter.rb
+++ b/app/presenters/checkout_presenter.rb
@@ -190,6 +190,9 @@ class CheckoutPresenter
                        .map { |price| { id: price.external_id, recurrence: price.recurrence, price_cents: price.price_cents } },
         options:,
       },
+      existing_custom_field_values: subscription.original_purchase.purchase_custom_fields.map do |field|
+        { id: field.custom_field.external_id, value: field.value }
+      end,
       contact_info: {
         email: subscription.email,
         full_name: subscription.original_purchase.full_name || "",


### PR DESCRIPTION
Fix #1321 

### Before

https://github.com/user-attachments/assets/93a9662f-047d-4bed-b6f2-135240234baf

### After

https://github.com/user-attachments/assets/94251d38-2a6e-4844-b8ad-5edbe2225f4a

### Test

<img width="1470" height="420" alt="Screenshot 2025-09-29 at 5 33 44 PM" src="https://github.com/user-attachments/assets/702dcfdb-1203-4e2f-8fff-96b3652e9cef" />

### AI Disclosure

Used AI for finding the fix and also writing tests