### PR TITLE
fix: add vertical spacing to pagination controls

### DIFF
--- a/app/javascript/components/server-components/AffiliatedPage.tsx
+++ b/app/javascript/components/server-components/AffiliatedPage.tsx
@@ -110,7 +110,7 @@ const AffiliatedProductsTable = ({
   }, [sort]);
 
   return (
-    <>
+    <section className="paragraphs">
       <table aria-live="polite" aria-busy={isLoading}>
         <thead>
           <tr>
@@ -173,7 +173,7 @@ const AffiliatedProductsTable = ({
       {pagination.pages > 1 ? (
         <Pagination onChangePage={(page) => loadAffiliatedProducts(page, sort)} pagination={pagination} />
       ) : null}
-    </>
+    </section>
   );
 };
 

--- a/app/javascript/components/server-components/Audience/CustomersPage.tsx
+++ b/app/javascript/components/server-components/Audience/CustomersPage.tsx
@@ -438,7 +438,7 @@ const CustomersPage = ({
       />
       <section className="p-4 md:p-8">
         {customers.length > 0 ? (
-          <>
+          <section className="paragraphs">
             <table aria-live="polite" aria-busy={isLoading}>
               <caption>{`All sales (${count})`}</caption>
               <thead>
@@ -551,7 +551,7 @@ const CustomersPage = ({
             {pagination && pagination.pages > 1 ? (
               <Pagination onChangePage={asyncVoid(loadCustomers)} pagination={pagination} />
             ) : null}
-          </>
+          </section>
         ) : (
           <div className="placeholder">
             <figure>

--- a/app/javascript/components/server-components/CheckoutDashboard/DiscountsPage.tsx
+++ b/app/javascript/components/server-components/CheckoutDashboard/DiscountsPage.tsx
@@ -326,7 +326,7 @@ const DiscountsPage = ({
     >
       <section className="p-4 md:p-8">
         {offerCodes.length > 0 ? (
-          <>
+          <section className="paragraphs">
             <table aria-live="polite" aria-busy={isLoading}>
               <thead>
                 <tr>
@@ -458,7 +458,7 @@ const DiscountsPage = ({
                 pagination={pagination}
               />
             ) : null}
-          </>
+          </section>
         ) : (
           <div className="placeholder">
             <figure>

--- a/app/javascript/components/server-components/CheckoutDashboard/UpsellsPage.tsx
+++ b/app/javascript/components/server-components/CheckoutDashboard/UpsellsPage.tsx
@@ -236,7 +236,7 @@ const UpsellsPage = (props: {
     >
       <section className="p-4 md:p-8">
         {upsells.length > 0 ? (
-          <>
+          <section className="paragraphs">
             <table aria-busy={isLoading} aria-label="Upsells">
               <thead>
                 <tr>
@@ -292,7 +292,7 @@ const UpsellsPage = (props: {
                 pagination={pagination}
               />
             ) : null}
-          </>
+          </section>
         ) : (
           <div className="placeholder">
             <figure>


### PR DESCRIPTION
### Explanation of Change

Added spacing between the table and the pagination control on the following pages:

https://gumroad.com/products/affiliated
https://gumroad.com/customers
https://gumroad.com/checkout/discounts
https://gumroad.com/checkout/upsells

Related to https://github.com/antiwork/gumroad/pull/1390

### Screenshots/Videos
Before 
<img width="1267" height="158" alt="image" src="https://github.com/user-attachments/assets/00be85c4-86a7-4cc1-a7a5-e74c20916dab" />


After
<img width="1257" height="199" alt="image" src="https://github.com/user-attachments/assets/73cb88cd-7d78-45db-9b9d-7a3be2be49f8" />


### AI Disclosure
No AI tools used