### PR TITLE
Fix(flaky test): product edit spec flakes because of ambiguous selector

### DIFF
--- a/spec/requests/products/edit/edit_spec.rb
+++ b/spec/requests/products/edit/edit_spec.rb
@@ -147,7 +147,6 @@ describe("Product Edit Scenario", type: :system, js: true) do
     fill_in "Fixed amount", with: "1"
     click_on "Insert"
 
-
     within("[aria-label='Description']") do
       within_section "Sample product", section_element: :article do
         expect(page).to have_text("5.0 (1)", normalize_ws: true)


### PR DESCRIPTION
## Failing CI logs: 
1. https://github.com/antiwork/gumroad/actions/runs/18059306924/job/51393430029?pr=1374#step:8:233
2. https://github.com/antiwork/gumroad/actions/runs/18012411273/job/51248955540#step:8:227

<img width="788" height="238" alt="Screenshot 2025-09-27 at 9 33 21 PM" src="https://github.com/user-attachments/assets/9ba7ca59-9a76-4490-bd92-ca34a9caf245" />

# Problem:
- on product edit page we have 3 article containing "Sample Product" text due to which test fails with message
 ` Ambiguous match, found 3 elements matching visible section "Sample product"`
<img width="936" height="609" alt="Screenshot 2025-09-30 at 10 30 50 AM" src="https://github.com/user-attachments/assets/9c655f19-9dd2-4e2f-bfbe-d9a58b7e3f80" />

# Solution:
- make selector more specific with 
```rb
    within("[aria-label='Description']") do
 ...
   end
```


### passes in local run after fix
<img width="756" height="129" alt="Screenshot 2025-09-27 at 9 46 59 PM" src="https://github.com/user-attachments/assets/2f37d3ad-9cb1-47ea-b5e9-d1ed446546cf" />

ref #1127 

# AI Disclosure:
- cursor used for debugging