### PR TITLE
chore: remove _image_uploader.scss import

### DIFF
--- a/app/javascript/packs/design.scss
+++ b/app/javascript/packs/design.scss
@@ -25,7 +25,6 @@
 @import "../stylesheets/figure";
 @import "../stylesheets/forms";
 @import "../stylesheets/grid";
-@import "../stylesheets/image_uploader";
 @import "../stylesheets/modal";
 @import "../stylesheets/nav";
 @import "../stylesheets/nested_menu";


### PR DESCRIPTION
Desc:

Remove import for _image_uploader.scss . Linked to #1411 