### PR TITLE
Feat: Add ISBN feature for e-publications

### DIFF
--- a/app/javascript/components/Product/index.tsx
+++ b/app/javascript/components/Product/index.tsx
@@ -114,6 +114,7 @@ export type Product = {
   sales_count: number | null;
   summary: string | null;
   attributes: { name: string; value: string }[];
+  isbn?: string | null;
   free_trial: FreeTrial | null;
   rental: Rental | null;
   recurrences: Recurrences | null;
@@ -575,7 +576,7 @@ export const Product = ({
               Watch link provided after purchase
             </div>
           ) : null}
-          {product.summary || product.attributes.length > 0 ? (
+          {product.summary || product.attributes.length > 0 || product.isbn ? (
             <div className="stack">
               {product.summary ? <p>{product.summary}</p> : null}
               {product.attributes.map(({ name, value }, idx) => (
@@ -584,6 +585,12 @@ export const Product = ({
                   <div>{value}</div>
                 </div>
               ))}
+              {product.isbn ? (
+                <div>
+                  <h5>ISBN</h5>
+                  <div>{product.isbn}</div>
+                </div>
+              ) : null}
             </div>
           ) : null}
           <ShareSection product={product} selection={selection} wishlists={wishlists} />

--- a/app/javascript/components/ProductEdit/ProductTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/index.tsx
@@ -427,15 +427,36 @@ export const ProductTab = () => {
                       : "Publicly show the number of sales on your product page"}
                   </Toggle>
                   {product.native_type !== "physical" ? (
-                    <Toggle
-                      value={product.is_epublication}
-                      onChange={(newValue) => updateProduct({ is_epublication: newValue })}
-                    >
-                      Mark product as e-publication for VAT purposes{" "}
-                      <a href="/help/article/10-dealing-with-vat" target="_blank" rel="noreferrer">
-                        Learn more
-                      </a>
-                    </Toggle>
+                    <>
+                      <Toggle
+                        value={product.is_epublication}
+                        onChange={(newValue) => updateProduct({ is_epublication: newValue })}
+                      >
+                        Mark product as e-publication for VAT purposes{" "}
+                        <a href="/help/article/10-dealing-with-vat" target="_blank" rel="noreferrer">
+                          Learn more
+                        </a>
+                      </Toggle>
+                      {product.is_epublication ? (
+                        <div className="flex flex-col gap-2">
+                          <label htmlFor={`${uid}-isbn`} className="text-sm font-medium">
+                            ISBN (optional)
+                          </label>
+                          <input
+                            id={`${uid}-isbn`}
+                            type="text"
+                            value={product.isbn || ""}
+                            onChange={(e) => updateProduct({ isbn: e.target.value || null })}
+                            placeholder="979-8-89170-497-8"
+                            className="input"
+                          />
+                          <p className="text-gray-600 text-xs">
+                            Enter the ISBN-13 for your eBook to make it discoverable on sites like GoodReads. Format: 13
+                            digits with optional hyphens.
+                          </p>
+                        </div>
+                      ) : null}
+                    </>
                   ) : null}
                   {!seller_refund_policy_enabled ? (
                     <RefundPolicySelector

--- a/app/javascript/components/ProductEdit/state.ts
+++ b/app/javascript/components/ProductEdit/state.ts
@@ -105,6 +105,7 @@ export type Product = {
   should_show_sales_count: boolean;
   hide_sold_out_variants: boolean;
   is_epublication: boolean;
+  isbn: string | null;
   product_refund_policy_enabled: boolean;
   refund_policy: RefundPolicy;
   is_published: boolean;

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -203,6 +203,7 @@ class Link < ApplicationRecord
   validate :commission_price_is_valid, if: -> { native_type == Link::NATIVE_TYPE_COMMISSION }
   validate :one_coffee_per_user, on: :create, if: -> { native_type == Link::NATIVE_TYPE_COFFEE }
   validate :quantity_enabled_state_is_allowed
+  validate :isbn_format_is_valid, if: -> { isbn.present? }
 
   validates_associated :installment_plan, message: -> (link, _) { link.installment_plan.errors.full_messages.first }
 
@@ -223,6 +224,7 @@ class Link < ApplicationRecord
   attr_json_data_accessor :excluded_sales_tax_regions, default: -> { [] }
   attr_json_data_accessor :sections, default: -> { [] }
   attr_json_data_accessor :main_section_index, default: -> { 0 }
+  attr_json_data_accessor :isbn
 
   scope :alive,                           -> { where(purchase_disabled_at: nil, banned_at: nil, deleted_at: nil) }
   scope :visible,                         -> { where(deleted_at: nil) }
@@ -1451,6 +1453,18 @@ class Link < ApplicationRecord
     def quantity_enabled_state_is_allowed
       if quantity_enabled && !can_enable_quantity?
         errors.add(:base, "Customers cannot be allowed to choose a quantity for this product.")
+      end
+    end
+
+    def isbn_format_is_valid
+      return if isbn.blank?
+
+      # Remove hyphens and spaces for validation
+      normalized_isbn = isbn.to_s.gsub(/[-\s]/, "")
+
+      # ISBN-13 format: 13 digits
+      unless normalized_isbn.match?(/\A\d{13}\z/)
+        errors.add(:isbn, "must be a valid ISBN-13 (13 digits, optionally with hyphens)")
       end
     end
 

--- a/app/policies/link_policy.rb
+++ b/app/policies/link_policy.rb
@@ -72,6 +72,7 @@ class LinkPolicy < ApplicationPolicy
       :custom_button_text_option,
       :custom_summary,
       :is_epublication,
+      :isbn,
       :display_product_reviews,
       :is_adult,
       :discover_fee_per_thousand,

--- a/app/presenters/product_presenter.rb
+++ b/app/presenters/product_presenter.rb
@@ -102,6 +102,7 @@ class ProductPresenter
         should_show_sales_count: product.should_show_sales_count,
         hide_sold_out_variants: product.hide_sold_out_variants?,
         is_epublication: product.is_epublication?,
+        isbn: product.isbn,
         product_refund_policy_enabled: product.product_refund_policy_enabled?,
         refund_policy: {
           allowed_refund_periods_in_days: RefundPolicy::ALLOWED_REFUND_PERIODS_IN_DAYS.keys.map do

--- a/app/presenters/product_presenter/product_props.rb
+++ b/app/presenters/product_presenter/product_props.rb
@@ -52,6 +52,7 @@ class ProductPresenter::ProductProps
         duration_in_months: product.duration_in_months,
         rental: product.rental,
         is_quantity_enabled: product.quantity_enabled,
+        isbn: product.isbn,
         free_trial: product.free_trial_enabled ? {
           duration: {
             unit: product.free_trial_duration_unit,

--- a/app/views/links/show.html.erb
+++ b/app/views/links/show.html.erb
@@ -1,5 +1,22 @@
 <% content_for :meta do %>
   <link href="<%= @product.long_url %>" rel="canonical">
+  <% if @product.isbn.present? %>
+    <meta property="books:isbn" content="<%= @product.isbn %>">
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Book",
+        "isbn": "<%= @product.isbn %>",
+        "name": "<%= j @product.name %>",
+        "author": {
+          "@type": "Person",
+          "name": "<%= j @product.user.name %>"
+        },
+        "description": "<%= j strip_tags(@product.description).truncate(200) %>"<% if @product.thumbnail&.url.present? %>,
+        "image": "<%= @product.thumbnail.url %>"<% end %>
+      }
+    </script>
+  <% end %>
 <% end %>
 
 <%= render("layouts/custom_styles/style") %>

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -298,6 +298,41 @@ describe Link, :vcr do
     end
   end
 
+  describe "ISBN validation" do
+    it "allows valid ISBN-13 with hyphens" do
+      product = build(:product, isbn: "979-8-89170-497-8")
+      expect(product).to be_valid
+    end
+
+    it "allows valid ISBN-13 without hyphens" do
+      product = build(:product, isbn: "9798891704978")
+      expect(product).to be_valid
+    end
+
+    it "allows ISBN to be blank" do
+      product = build(:product, isbn: nil)
+      expect(product).to be_valid
+    end
+
+    it "rejects invalid ISBN with less than 13 digits" do
+      product = build(:product, isbn: "979-8-8917")
+      expect(product).not_to be_valid
+      expect(product.errors[:isbn]).to include "must be a valid ISBN-13 (13 digits, optionally with hyphens)"
+    end
+
+    it "rejects invalid ISBN with more than 13 digits" do
+      product = build(:product, isbn: "979-8-89170-497-8-1")
+      expect(product).not_to be_valid
+      expect(product.errors[:isbn]).to include "must be a valid ISBN-13 (13 digits, optionally with hyphens)"
+    end
+
+    it "rejects ISBN with letters" do
+      product = build(:product, isbn: "979-8-ABCDE-497-8")
+      expect(product).not_to be_valid
+      expect(product.errors[:isbn]).to include "must be a valid ISBN-13 (13 digits, optionally with hyphens)"
+    end
+  end
+
   describe "callbacks" do
     describe "set_default_discover_fee_per_thousand" do
       it "sets the boosted discover fee when user has discover_boost_enabled" do


### PR DESCRIPTION
# Add ISBN Support for eBooks

## Summary

This PR implements comprehensive ISBN support for eBook products, enabling proper book metadata exposure through [schema.org](http://schema.org/) structured data. This allows book aggregators like GoodReads, Google Books, and library systems to discover and catalog Gumroad books.

Resolves: [#1145](https://github.com/antiwork/gumroad/issues/1145)

## 🔐 Core Implementation

### Database & Models

- Link Model: Added isbn field via JsonData accessor pattern (no migration required)

- ISBN Validation: Validates ISBN-13 format (13 digits with optional hyphens)

- Storage: Uses existing json_data column for zero-downtime deployment

### SEO Integration

- [schema.org/Book](http://schema.org/Book) Markup: Automated JSON-LD structured data generation

- Meta Tags: Added books:isbn meta property for crawler discovery

- Industry Standards: Follows Google Books and GoodReads indexing requirements

### User Interface

- ProductTab: ISBN input field conditionally displayed for e-publications

- Product Page: Public ISBN display in product details section

- Smart Visibility: Only shown when "Mark as e-publication" is enabled

## 🌍 Format Support

- ISBN-13 with hyphens: 979-8-89170-497-8 ✅

- ISBN-13 without hyphens: 9798891704978 ✅

- Optional field: Blank values accepted

- Validation: Clear error messages for invalid formats

## ⚡ Test Results

```

ISBN validation

✓ allows valid ISBN-13 with hyphens

✓ allows valid ISBN-13 without hyphens

✓ allows ISBN to be blank

✓ rejects invalid ISBN with less than 13 digits

✓ rejects invalid ISBN with more than 13 digits

✓ rejects ISBN with letters

6 examples, 0 failures

```
<img width="947" height="500" alt="Screenshot 2025-09-30 at 17 21 46" src="https://github.com/user-attachments/assets/7e450780-b6ca-4b6a-912d-2d203437469f" />

## ⚡ Technical Highlights

### Smart Processing

- ISBN validation only runs when value is present

- Type-safe optional field (`isbn?: string | null`) prevents coupling

- No boilerplate required in unrelated components (e.g., BundleEdit)

### SEO & Discoverability

- JSON-LD structured data for automated crawler indexing

- Proper [schema.org/Book](http://schema.org/Book) markup with author, description, and image

- Multiple discovery vectors: structured data, meta tags, visible text

### Performance & Architecture

- Zero Database Impact: Uses existing json_data column

- Backwards Compatible: No changes to existing products

- TypeScript Best Practices: Optional field design prevents ripple effects

- Loose Coupling: ISBN feature isolated to e-publication products

## 📊 How to Test

### Quick Test Flow

1. Create Product with ISBN

```bash

# Login: [seller@gumroad.com](mailto:seller@gumroad.com) / password / 2FA: 000000

```

1. Create new digital product

2. Enable "Mark as e-publication for VAT purposes"

3. Enter ISBN: 979-8-89170-497-8

4. Save product

Expected: ✅ Saves successfully, ISBN field visible only when e-publication enabled

2. Verify Public Display

1. View public product page

<img width="1510" height="799" alt="Screenshot 2025-09-30 at 17 25 27" src="https://github.com/user-attachments/assets/b894d292-8d26-441f-9251-4dd5513b2528" />

2. Check product details section

Expected: ✅ ISBN displays as: ISBN / 979-8-89170-497-8

3. Validate Structured Data (Critical)

View page source and verify JSON-LD:

```html

<script type="application/ld+json">

{

"@context": "https://schema.org/",

"@type": "Book",

"isbn": "9798891704978", (example)

"name": "Product Name",

"author": { "@type": "Person", "name": "Author" }

}

</script>

```

<img width="1510" height="799" alt="Screenshot 2025-09-30 at 17 28 39" src="https://github.com/user-attachments/assets/6ed67340-92aa-4d84-8895-bd5a79c4ef9e" />

Verify with: https://validator.schema.org/

4. Test Validation

Try invalid ISBNs:

- 979-8-8917 → ❌ Too short

- 979-8-ABCDE-497-8 → ❌ Contains letters

- ` ` (blank) → ✅ Valid (optional field)

### Automated Testing

```bash

bin/rspec spec/models/link_spec.rb:301:334

```

### Edge Cases Covered

- ✅ ISBN with/without hyphens

- ✅ Empty vs nil values

- ✅ Bundles don't break (ISBN is optional)

- ✅ Non-e-publications don't show field

- ✅ Invalid formats properly rejected

## 🚀 Deployment & Rollback

### Deployment

- Zero Downtime: No database migrations

- Backwards Compatible: Existing products unaffected

- No Feature Flags: Safe to deploy immediately

- Risk Level: Very Low

### Rollback Plan

1. Quick disable: Remove ISBN input from UI (data preserved)

2. Full rollback: Revert PR (ISBN data remains harmlessly in json_data)

### Post-Deployment Verification

1. Google Search Console: Use URL Inspection to verify Book rich results

2. Schema Validator: Test public pages at [validator.schema.org](http://validator.schema.org/)

3. GoodReads Discovery: Monitor ISBN searchability after 1-2 weeks

4. Error Monitoring: Check for validation errors in Bugsnag

## 📁 Key Files Modified

Backend:

- app/models/link.rb - ISBN field and validation

- app/policies/link_policy.rb - Permit ISBN parameter

- app/presenters/product_presenter.rb - Edit props

- app/presenters/product_presenter/product_props.rb - Display props

Frontend:

- app/javascript/components/ProductEdit/state.ts - TypeScript types

- app/javascript/components/ProductEdit/ProductTab/index.tsx - Input UI

- app/javascript/components/Product/index.tsx - Public display

Views:

- app/views/links/show.html.erb - JSON-LD structured data

Tests:

- spec/models/link_spec.rb - Validation specs