### PR TITLE
Fix: Lock installment schedules at purchase time; add backfill and tests

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -70,6 +70,7 @@ class Purchase < ApplicationRecord
   attr_json_data_accessor :perceived_price_cents
   attr_json_data_accessor :recommender_model_name
   attr_json_data_accessor :custom_fee_per_thousand
+  attr_json_data_accessor :installment_payment_schedule_cents
 
   belongs_to :link, optional: true
   has_one :url_redirect
@@ -3386,6 +3387,13 @@ class Purchase < ApplicationRecord
       return unless is_installment_payment
 
       nth_installment = subscription&.purchases&.successful&.count || 0
+
+      # snapshot of the schedule captured at time of original purchase,
+      schedule_snapshot = installment_payment_schedule_cents.presence || subscription&.original_purchase&.installment_payment_schedule_cents
+      if schedule_snapshot.present? && schedule_snapshot.is_a?(Array)
+        return schedule_snapshot[nth_installment] || schedule_snapshot.last
+      end
+
       installment_payments = fetch_installment_plan.calculate_installment_payment_price_cents(total_price_cents)
       installment_payments[nth_installment] || installment_payments.last
     end

--- a/app/models/purchase_installments_spec.rb
+++ b/app/models/purchase_installments_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Purchase, type: :model do
+  describe "installment schedule snapshot" do
+    it "uses snapshot on the purchase when present and ignores later product changes" do
+      product = build(:product, :with_installment_plan, price_cents: 19_700, native_type: Link::NATIVE_TYPE_DIGITAL)
+      original_purchase = Purchase.new(link: product, displayed_price_cents: 19_700)
+      original_purchase.is_installment_payment = true
+      original_purchase.installment_plan = product.installment_plan
+      original_purchase.installment_payment_schedule_cents = [9_900, 9_800]
+
+      subscription = Subscription.new(link: product, is_installment_plan: true)
+      allow(subscription).to receive_message_chain(:purchases, :successful, :count).and_return(1)
+      allow(subscription).to receive(:original_purchase).and_return(original_purchase)
+
+      next_charge = Purchase.new(link: product, displayed_price_cents: 19_700, subscription: subscription)
+      next_charge.is_installment_payment = true
+      next_charge.installment_plan = product.installment_plan
+
+      # Should take the 2nd entry of the snapshot (index 1)
+      expect(next_charge.send(:calculate_installment_payment_price_cents, 19_700)).to eq(9_800)
+
+      # Mutate product/plan and ensure snapshot still rules
+      product.price_cents = 99_999
+      product.installment_plan.number_of_installments = 3
+      expect(next_charge.send(:calculate_installment_payment_price_cents, 19_700)).to eq(9_800)
+    end
+
+    it "falls back to original_purchase snapshot when current purchase has none" do
+      product = build(:product, :with_installment_plan, price_cents: 19_700, native_type: Link::NATIVE_TYPE_DIGITAL)
+      original_purchase = Purchase.new(link: product, displayed_price_cents: 19_700)
+      original_purchase.is_installment_payment = true
+      original_purchase.installment_plan = product.installment_plan
+      original_purchase.installment_payment_schedule_cents = [10_000, 9_700]
+
+      subscription = Subscription.new(link: product, is_installment_plan: true)
+      allow(subscription).to receive_message_chain(:purchases, :successful, :count).and_return(1)
+      allow(subscription).to receive(:original_purchase).and_return(original_purchase)
+
+      next_charge = Purchase.new(link: product, displayed_price_cents: 19_700, subscription: subscription)
+      next_charge.is_installment_payment = true
+      next_charge.installment_plan = product.installment_plan
+
+      expect(next_charge.send(:calculate_installment_payment_price_cents, 19_700)).to eq(9_700)
+    end
+  end
+end
+
+

--- a/app/services/backfill_installment_payment_schedules_service.rb
+++ b/app/services/backfill_installment_payment_schedules_service.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class BackfillInstallmentPaymentSchedulesService
+  def perform(batch_size: 500)
+    scope = Subscription
+      .joins(:original_purchase)
+      .where("subscriptions.flags & ? > 0", Subscription.flag_mapping["flags"][:is_installment_plan])
+      .merge(Subscription.active)
+
+    scope.find_in_batches(batch_size: batch_size) do |subscriptions|
+      subscriptions.each do |subscription|
+        original = subscription.original_purchase
+        next if original.installment_payment_schedule_cents.present?
+        next unless original.link&.installment_plan.present?
+
+        schedule = original.link.installment_plan
+          .calculate_installment_payment_price_cents(original.displayed_price_cents)
+        original.installment_payment_schedule_cents = schedule
+        original.save!
+      end
+    end
+  end
+end
+
+

--- a/app/services/purchase/base_service.rb
+++ b/app/services/purchase/base_service.rb
@@ -50,6 +50,12 @@ class Purchase::BaseService
         price: purchase.price,
         installment_plan: purchase.is_installment_payment ? purchase.link.installment_plan : nil
       )
+      # snapshot the installment schedule so price doesn't change mid subscription
+      if purchase.is_installment_payment
+        schedule = purchase.link.installment_plan.calculate_installment_payment_price_cents(purchase.displayed_price_cents)
+        purchase.installment_payment_schedule_cents = schedule
+      end
+
       subscription.save!
       subscription.purchases << [purchase, giftee_purchase].compact
     end


### PR DESCRIPTION
Fix #1409 

### Summary
- Fixes installment plans updating retroactively when product price or number of installments changes.
- Locks remaining installments to the original purchase agreement by snapshotting the schedule.

### What changed
- Snapshot per-installment schedule at purchase time and use it for all future charges.
- Prefer `purchase.installment_payment_schedule_cents`; fallback to `subscription.original_purchase.installment_payment_schedule_cents`.
- Adds a one-time backfill to populate snapshots for existing active installment plans.
- Adds focused unit tests for snapshot behavior.

### Why
- Creators reported that changing a product’s price or installment count affected customers mid-plan. This violates expected behavior and buyer trust.

### Files
- app/models/purchase.rb
- app/services/purchase/base_service.rb
- app/services/backfill_installment_payment_schedules_service.rb
- spec/models/purchase_installments_spec.rb

### Ops notes
- After deploy, run the backfill once:
```bash
DISABLE_SPRING=1 bin/rails runner 'BackfillInstallmentPaymentSchedulesService.new.perform'
```

### QA
- New purchases on installment plans should record a schedule and keep it stable if the product’s price or installment count changes later.
- Existing active installment subscriptions should keep their remaining charges stable after running the backfill.

