### PR TITLE
Fix incorrect grid Tailwind CSS migration

### DIFF
--- a/app/javascript/components/server-components/CheckoutDashboard/DiscountsPage.tsx
+++ b/app/javascript/components/server-components/CheckoutDashboard/DiscountsPage.tsx
@@ -378,7 +378,7 @@ const DiscountsPage = ({
                         expiresAt ? formatDate(expiresAt) : "No end date"
                       }`}</td>
                       <td className="whitespace-nowrap">
-                        <div className="grid grid-cols-[min-content_1fr] gap-2">
+                        <div className="override grid grid-cols-[min-content_1fr] gap-2">
                           {validAt && currentDate < validAt ? (
                             <>Scheduled</>
                           ) : expiresAt && currentDate > expiresAt ? (
@@ -549,7 +549,7 @@ const DiscountsPage = ({
                       ? (selectedOfferCodeStatistics.uses.products[product.id] ?? 0)
                       : null;
                   return (
-                    <div key={product.id} className="grid grid-cols-[1fr_auto] gap-2">
+                    <div key={product.id} className="override grid grid-cols-[1fr_auto] gap-2">
                       <div>
                         <h5>{product.name}</h5>
                         {uses != null ? `${uses} ${uses === 1 ? "use" : "uses"}` : null}
@@ -864,7 +864,7 @@ const Form = ({
             <legend>
               <label htmlFor={`${uid}code`}>Discount code</label>
             </legend>
-            <div className="grid grid-cols-[1fr_auto] gap-2">
+            <div className="override grid grid-cols-[1fr_auto] gap-2">
               <input
                 type="text"
                 id={`${uid}code`}

--- a/app/javascript/components/server-components/CheckoutDashboard/UpsellsPage.tsx
+++ b/app/javascript/components/server-components/CheckoutDashboard/UpsellsPage.tsx
@@ -435,8 +435,7 @@ const UpsellDrawer = ({
           <span>{selectedUpsell.paused ? "Paused" : "Live"}</span>
         </div>
       </section>
-      {/* Can't use Tailwind `grid` yet, because we have a conflicting `grid` definition in `_grid.scss`. */}
-      <section style={{ display: "grid" }} className="auto-cols-fr grid-flow-col gap-4">
+      <section className="override grid auto-cols-fr grid-flow-col gap-4">
         <Button onClick={onTogglePause} disabled={isLoading || isReadOnly}>
           {selectedUpsell.paused ? "Resume upsell" : "Pause upsell"}
         </Button>
@@ -491,8 +490,7 @@ const UpsellDrawer = ({
           ))}
         </section>
       )}
-      {/* Can't use Tailwind `grid` yet, because we have a conflicting `grid` definition in `_grid.scss`. */}
-      <section style={{ display: "grid" }} className="auto-cols-fr grid-flow-col gap-4">
+      <section className="override grid auto-cols-fr grid-flow-col gap-4">
         <Button onClick={onCreate} disabled={isLoading || isReadOnly}>
           Duplicate
         </Button>
@@ -895,7 +893,7 @@ const Form = ({
                   />
                 </fieldset>
                 {selectedProduct ? (
-                  <div className="grid grid-cols-[1fr_auto_1fr] gap-2" aria-label="Upsell versions">
+                  <div className="override grid grid-cols-[1fr_auto_1fr] gap-2" aria-label="Upsell versions">
                     <b>Version selected</b>
                     <div />
                     <b>Version to offer</b>

--- a/app/javascript/stylesheets/_definitions.scss
+++ b/app/javascript/stylesheets/_definitions.scss
@@ -190,6 +190,16 @@ $z-indices: (
   text-overflow: ellipsis;
 }
 
+@keyframes loading {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0.3;
+  }
+}
+
 @mixin dummy {
   background-color: gray(1);
   animation: loading 1s infinite linear alternate;

--- a/app/javascript/stylesheets/_grid.scss
+++ b/app/javascript/stylesheets/_grid.scss
@@ -1,13 +1,3 @@
-@keyframes loading {
-  from {
-    opacity: 1;
-  }
-
-  to {
-    opacity: 0.3;
-  }
-}
-
 .grid:not(.override) {
   display: grid;
   grid-template-columns: repeat(

--- a/spec/support/preview_box_helpers.rb
+++ b/spec/support/preview_box_helpers.rb
@@ -2,6 +2,7 @@
 
 module PreviewBoxHelpers
   def in_preview(&block)
+    scroll_to find("aside", text: "Preview")
     within_section "Preview", section_element: :aside do
       block.call
     end


### PR DESCRIPTION
We have a conflicting `grid` definition at:

https://github.com/antiwork/gumroad/blob/fea1277fa0c6c5e8e0ed827228c724f7768b0bf6/app/javascript/stylesheets/_grid.scss#L11-L22

This applies more than what the Tailwind `grid` does.

Adding `grid override` prevents our custom styling from being applied.

| Before | After |
|--------|--------|
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/15c6ba81-5785-4d33-b9f3-482652886154" /> |  <img width="400" alt="image" src="https://github.com/user-attachments/assets/12cd8cb4-9156-4e20-a390-4a6154b2f906" />  | 