### PR TITLE
fix: Prevent action button labels from wrapping into two lines on mobile

### DIFF
--- a/app/javascript/components/server-components/CheckoutDashboard/UpsellsPage.tsx
+++ b/app/javascript/components/server-components/CheckoutDashboard/UpsellsPage.tsx
@@ -490,7 +490,7 @@ const UpsellDrawer = ({
           ))}
         </section>
       )}
-      <section className="override grid auto-cols-fr grid-flow-col gap-4">
+      <section className="override grid auto-cols-fr grid-flow-row gap-4 sm:grid-flow-col">
         <Button onClick={onCreate} disabled={isLoading || isReadOnly}>
           Duplicate
         </Button>


### PR DESCRIPTION
### Explanation of Change
Ensures action button labels in the upsell detail modal stay on a single line on mobile devices

### Screenshots/Videos
Before
<img width="376" height="654" alt="image" src="https://github.com/user-attachments/assets/9bc7b999-fca4-44b2-ba37-9dfe3dd991cf" />

After
<img width="363" height="642" alt="image" src="https://github.com/user-attachments/assets/20e4f22a-b45b-4b0f-b311-839a0b820b32" />


### AI Disclosure
No AI tools used


