### PR TITLE
fix: Product section error messages on Become an Affiliate page not auto-scrolling into view

### DIFF
--- a/app/javascript/components/GlobalAffiliates.tsx
+++ b/app/javascript/components/GlobalAffiliates.tsx
@@ -146,6 +146,14 @@ const ProductEligibilitySection = ({
     error: null,
   });
 
+  const errorRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    if (result.error && errorRef.current) {
+      errorRef.current.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [result.error]);
+
   return (
     <section className="!p-4 md:!p-8">
       <header>
@@ -239,7 +247,7 @@ const ProductEligibilitySection = ({
         </div>
       ) : null}
       {result.error ? (
-        <div role="alert" className={result.error.type}>
+        <div ref={errorRef} role="alert" className={result.error.type}>
           {result.error.message}
         </div>
       ) : null}


### PR DESCRIPTION
### Explanation of Change
Ensure error messages automatically display without requiring manual scroll on Product URL field

### Screenshots/Videos
Before

https://github.com/user-attachments/assets/30aa3fac-4ebb-464b-9562-b4a796a91aeb



After

https://github.com/user-attachments/assets/cfe20c36-e106-40b4-a04b-1cd7ae818b9d

### AI Disclosure
No AI tools used


