### PR TITLE
Fix(ui bug): discount code page showing codes in uppercase instead of original case

### DIFF
--- a/app/javascript/components/server-components/CheckoutDashboard/DiscountsPage.tsx
+++ b/app/javascript/components/server-components/CheckoutDashboard/DiscountsPage.tsx
@@ -354,7 +354,7 @@ const DiscountsPage = ({
                         <div className="override grid gap-2">
                           <div>
                             <div className="pill small mr-2" aria-label="Offer code">
-                              {offerCode.code.toUpperCase()}
+                              {offerCode.code}
                             </div>
                             <b>{offerCode.name}</b>
                           </div>
@@ -478,14 +478,14 @@ const DiscountsPage = ({
         {selectedOfferCode ? (
           <aside>
             <header>
-              <h2>{selectedOfferCode.name || selectedOfferCode.code.toUpperCase()}</h2>
+              <h2>{selectedOfferCode.name || selectedOfferCode.code}</h2>
               <button className="close" aria-label="Close" onClick={() => setSelectedOfferCodeId(null)} />
             </header>
             <section className="stack">
               <h3>Details</h3>
               <div>
                 <h5>Code</h5>
-                <div className="pill small">{selectedOfferCode.code.toUpperCase()}</div>
+                <div className="pill small">{selectedOfferCode.code}</div>
               </div>
               <div>
                 <h5>Discount</h5>


### PR DESCRIPTION
ref #864

 ## Problem:
- we don't autoconvert discount code to uppercase in backend / frontend. we store & use in whatever case it was created.
- but discounts page was showing them in uppercase rather than original case.

https://github.com/user-attachments/assets/4da8771a-5831-46ff-b24c-84569ce05763

## Before:
<img width="1298" height="479" alt="Screenshot 2025-10-01 at 1 54 00 PM" src="https://github.com/user-attachments/assets/de9de6fd-82ef-492a-ae98-7ba462519bcc" />

## After:
<img width="1298" height="451" alt="Screenshot 2025-10-01 at 1 49 14 PM" src="https://github.com/user-attachments/assets/2f952a0e-740a-46a0-a555-4be94c62639b" />

## AI Disclosure;
- no ai used
