### PR TITLE
Replace `.link` class with Tailwind `underline` utility in Settings MainPage

### DIFF
--- a/app/javascript/components/server-components/Settings/MainPage.tsx
+++ b/app/javascript/components/server-components/Settings/MainPage.tsx
@@ -162,7 +162,7 @@ const MainPage = (props: Props) => {
                 This email address has not been confirmed yet.{" "}
                 {resentConfirmationEmail ? null : (
                   <button
-                    className="link"
+                    className="underline"
                     onClick={(e) => {
                       e.preventDefault();
                       void resendConfirmationEmail();
@@ -583,7 +583,7 @@ const InvalidateActiveSessionsSection = () => {
   return (
     <section className="!p-4 md:!p-8">
       <fieldset>
-        <button className="link" type="button" onClick={() => setIsConfirmationDialogOpen(true)}>
+        <button className="underline" type="button" onClick={() => setIsConfirmationDialogOpen(true)}>
           Sign out from all active sessions
         </button>
         <small>You will be signed out from all your active sessions including this session.</small>


### PR DESCRIPTION
Fixes: https://github.com/antiwork/gumroad/issues/1055


This PR migrates two instances of the legacy SCSS `.link` class to the native Tailwind `underline` utility in the Settings main page component, demonstrating a simple, low-risk pattern for incremental SCSS-to-Tailwind migration.

### Why This Change Works

The `.link` class in our SCSS (_global.scss) is defined as:
```scss
.link {
  @extend a;  // Inherits: color, text-decoration: underline, cursor: pointer
}
```

Since `<button>` elements already have `cursor: pointer` by default, the only visual effect of `.link` is adding `text-decoration: underline` and inheriting color from parent. The Tailwind `underline` utility provides identical behavior:
```css
.underline { text-decoration-line: underline; }
```

**Note** - `underline` : Preserves the element's natural color inheritance from its **parent**

This change is functionally independent and scope set to settings page only. Look for **Resend Confirmation?** and **Sign out from all active sessions** text for verification.

### Before

#### Desktop View

<img width="1588" height="546" alt="image" src="https://github.com/user-attachments/assets/4c227cf6-5d06-4a79-8160-6276239086c1" />


<img width="1853" height="957" alt="image" src="https://github.com/user-attachments/assets/6663062e-1617-4903-b29c-a3219f3b5e92" />

<img width="1855" height="414" alt="image" src="https://github.com/user-attachments/assets/bbf736aa-3e06-4143-9ecc-29ea29a51b07" />


#### Mobile View

<img width="386" height="862" alt="image" src="https://github.com/user-attachments/assets/4a04ae84-538b-4036-9cef-650216e5af8b" />

<img width="384" height="863" alt="image" src="https://github.com/user-attachments/assets/05f4cce6-7b7e-45ff-a30a-910db982c6fc" />


***

### After

#### Desktop View

<img width="1572" height="587" alt="image" src="https://github.com/user-attachments/assets/3492b5de-0902-4f91-a33f-9ee1d11d12f2" />

<img width="1854" height="938" alt="image" src="https://github.com/user-attachments/assets/3b1a36f1-ace0-43ab-8d25-6d833730c821" />


<img width="1848" height="376" alt="image" src="https://github.com/user-attachments/assets/d6ac9cc8-20aa-479d-8ccf-782a5596cfee" />


#### Mobile View

<img width="385" height="838" alt="image" src="https://github.com/user-attachments/assets/5b701abd-9e39-4c29-ac2b-d42da2e7d01e" />


<img width="383" height="864" alt="image" src="https://github.com/user-attachments/assets/4c127d1a-1c95-4fed-8124-59501503f2df" />


AI Disclosure:
No AI used



