### PR TITLE
chore: migrate _figure.scss to tailwind css

### DIFF
--- a/app/views/admin/block_email_domains/_form.html.erb
+++ b/app/views/admin/block_email_domains/_form.html.erb
@@ -11,17 +11,17 @@
       enter what is to the right of
       <code>@</code> character.
     </p>
-    <figure class="code">
-      <figcaption>
+    <figure class="rounded overflow-hidden border bg-background">
+      <figcaption class="p-4">
         Example with comma-separated items
       </figcaption>
-      <pre>example.com, example.net, list.example.org</pre>
+      <pre class="p-4 bg-foreground/10 overflow-x-auto border-t">example.com, example.net, list.example.org</pre>
     </figure>
-    <figure class="code">
-      <figcaption>
+    <figure class="rounded overflow-hidden border bg-background">
+      <figcaption class="p-4">
         Example with items separated by newline
       </figcaption>
-      <pre>example.com
+      <pre class="p-4 bg-foreground/10 overflow-x-auto border-t">example.com
 example.net
 list.example.org</pre>
     </figure>

--- a/app/views/admin/suspend_users/show.html.erb
+++ b/app/views/admin/suspend_users/show.html.erb
@@ -6,18 +6,18 @@
       To suspend users for terms of service violations, please enter IDs of those users separated by comma or newline.
     </header>
 
-    <figure class="code">
-      <figcaption>
+        <figure class="rounded overflow-hidden border bg-background">
+      <figcaption class="p-4">
         Example with comma-separated items
       </figcaption>
-      <pre>3322133, 3738461, 4724778</pre>
+      <pre class="p-4 bg-foreground/10 overflow-x-auto border-t">3322133, 3738461, 4724778</pre>
     </figure>
 
-    <figure class="code">
-      <figcaption>
+        <figure class="rounded overflow-hidden border bg-background">
+      <figcaption class="p-4">
         Example with items separated by newline
       </figcaption>
-      <pre>3322133
+      <pre class="p-4 bg-foreground/10 overflow-x-auto border-t">3322133
 3738461
 4724778</pre>
     </figure>

--- a/app/views/public/api/_method.html.erb
+++ b/app/views/public/api/_method.html.erb
@@ -5,8 +5,8 @@
       <span><%= method[:path] %></span>
     </p>
     <p><%= method[:description].html_safe %></p>
-    <figure class="code">
-      <pre tabindex="0"><a><%= method[:is_oauth].present? ? "https://gumroad.com#{method[:path]}" : "https://api.gumroad.com/v2#{method[:path]}" %></a></pre>
+    <figure class="rounded overflow-hidden border bg-background">
+      <pre class="p-4 bg-foreground/10 overflow-x-auto" tabindex="0"><a><%= method[:is_oauth].present? ? "https://gumroad.com#{method[:path]}" : "https://api.gumroad.com/v2#{method[:path]}" %></a></pre>
     </figure>
     <% if method[:parameters_layout].present? %>
       <div class="parameters">
@@ -15,15 +15,15 @@
       </div>
     <% end %>
     <% if method[:curl_layout].present? %>
-      <figure class="code">
-        <figcaption>cURL example</figcaption>
-        <pre tabindex="0"><%= render "public/api/curl/#{method[:curl_layout]}" %></pre>
+      <figure class="rounded overflow-hidden border bg-background">
+        <figcaption class="p-4">cURL example</figcaption>
+        <pre class="p-4 bg-foreground/10 overflow-x-auto border-t" tabindex="0"><%= render "public/api/curl/#{method[:curl_layout]}" %></pre>
       </figure>
     <% end %>
     <% if method[:response_layout].present? %>
-      <figure class="code">
-        <figcaption>Example response:</figcaption>
-        <pre tabindex="0"><%= render "public/api/response/#{method[:response_layout]}" %></pre>
+      <figure class="rounded overflow-hidden border bg-background">
+        <figcaption class="p-4">Example response:</figcaption>
+        <pre class="p-4 bg-foreground/10 overflow-x-auto border-t" tabindex="0"><%= render "public/api/response/#{method[:response_layout]}" %></pre>
       </figure>
     <% end %>
   </div>

--- a/app/views/public/api/shared/_errors.html.erb
+++ b/app/views/public/api/shared/_errors.html.erb
@@ -28,8 +28,8 @@
         <br>
       </p>
       <p>To help you further, we provide a JSON object that goes more in-depth about the problem that led to the failed request. Errors responses from the api will follow the following format.</p>
-      <figure class="code">
-        <pre>
+      <figure class="rounded overflow-hidden border bg-background">
+        <pre class="p-4 bg-foreground/10 overflow-x-auto">
 {
   "success": false,
   "message": "The product could not be found."


### PR DESCRIPTION
Fixes: https://github.com/antiwork/gumroad/issues/1409

Migrated all `figure.code` styling from `_figure.scss` to Tailwind CSS across 4 ERB files, removing few lines of SCSS and enabling future removal of `_figure.scss`.

```
// From _definitions.scss
$grays: (0.1, 0.2, 0.5);  // Array of opacity values

@function gray($index, $name: "color") {
  @return rgb(var(--#{$name}) / nth($grays, $index));
}
```

So gray(1) means:

- Take the 1st value from $grays array = 0.1
- Use default color = "color"
- Result: rgb(var(--color) / 0.1)
- `--color` = current text color in the context
- `rgb(var(--color) / 0.1)` = text color at 10% opacity
- From tailwind translation: 

```
// From tailwind.config.js
colors: {
  foreground: "rgb(var(--color))",  // foreground = text color
}
```

**Before Code**

```
/* BEFORE - SCSS */
figure.code {
  border: $border;
  @include bg-color(filled);
  border-radius: border-radius(1);
  overflow: hidden;

  figcaption {
    padding: spacer(4);
  }

  pre {
    padding: spacer(4);
    background-color: gray(1);
    overflow-x: auto;
  }

  > :not(:first-child) {
    border-top: $border;
  }
}
```

**After Code**

```
<!-- AFTER - Tailwind -->
<figure class="rounded overflow-hidden border bg-background">
  <figcaption class="p-4">Caption</figcaption>
  <pre class="p-4 bg-foreground/10 overflow-x-auto border-t">Code</pre>
</figure>
```

### **Color Mapping**
| SCSS Function | Tailwind Class | CSS Output | Description |
|---------------|----------------|------------|-------------|
| `@include bg-color(filled)` | `bg-background` | `rgb(var(--filled))` | Theme-aware background |
| `gray(1)` | `bg-foreground/10` | `rgb(var(--color) / 0.1)` | 10% opacity text color |
| `$border` | `border` | `rgb(var(--color) / var(--border-alpha))` | Theme border |

### **Spacing & Layout**
| SCSS | Tailwind | CSS Value |
|------|----------|-----------|
| `padding: spacer(4)` | `p-4` | `1rem` |
| `border-radius: border-radius(1)` | `rounded` | `0.25rem` |
| `overflow: hidden` | `overflow-hidden` | `hidden` |
| `overflow-x: auto` | `overflow-x-auto` | `auto` |
| `border-top: $border` | `border-t` | Top border |


## **Testing URLs**

### **Public API Documentation**
```
http://gumroad.dev/api
http://gumroad.dev/api#api-errors
```
**Features:** API endpoint URLs, cURL examples, response samples

### **Admin Tools (Admin Auth Required)**
```
http://gumroad.dev/admin/block_email_domains
http://gumroad.dev/admin/unblock_email_domains  
http://gumroad.dev/admin/suspend_users
```
**Features:** Input format examples for domain/user management

The critical insight was mapping SCSS's `gray(1)` function:
```scss
gray(1) → rgb(var(--color) / 0.1)
```
To Tailwind's opacity shorthand:
```html
bg-foreground/10 → rgb(var(--color) / 0.1)
```

This preserves the **context-aware** coloring where code backgrounds subtly match the current text color at 10% opacity, creating consistent visual hierarchy across different theme contexts.

***

**_errors.html.erb**

### Before

<img width="1641" height="689" alt="image" src="https://github.com/user-attachments/assets/48b37164-1378-4354-b8a3-7f0984d5676f" />

### After


<img width="1649" height="692" alt="image" src="https://github.com/user-attachments/assets/f492006b-a37d-49e0-814d-adb30960a824" />


***


**_method.html.erb**

### Before

<img width="1634" height="703" alt="image" src="https://github.com/user-attachments/assets/3d5f015c-6559-490a-99cd-5bc7a9787009" />


### After

<img width="1635" height="684" alt="image" src="https://github.com/user-attachments/assets/868e2065-1b9a-4bc7-a1a8-95766e2602a5" />


***

**_form.html.erb**

### Before

<img width="1630" height="729" alt="image" src="https://github.com/user-attachments/assets/1ebf38f8-e7f2-4965-b104-9e90df533f61" />

<img width="1640" height="712" alt="image" src="https://github.com/user-attachments/assets/6cf04dc8-281f-419c-aede-f836c72c6572" />


### After

<img width="1631" height="662" alt="image" src="https://github.com/user-attachments/assets/2c9adeb9-f5e3-42f0-89cb-e59b41999ae3" />


<img width="1638" height="712" alt="image" src="https://github.com/user-attachments/assets/00a94550-95e5-4984-a40c-288dc47b98a6" />


***

**_show.html.erb**

### Before

<img width="1626" height="617" alt="image" src="https://github.com/user-attachments/assets/6f702901-56ff-4e24-9aa1-7acfa463c9c5" />


### After

<img width="1622" height="816" alt="image" src="https://github.com/user-attachments/assets/e702c0a3-4c38-4698-b52a-17c405310a24" />


***


AI Disclosure:
GitHub copilot used to brainstorm
