### PR TITLE
fix: license key overflow on customer details page

### DIFF
--- a/app/javascript/components/server-components/Audience/CustomersPage.tsx
+++ b/app/javascript/components/server-components/Audience/CustomersPage.tsx
@@ -1944,7 +1944,7 @@ const LicenseSection = ({ license, onSave }: { license: License; onSave: (enable
         <h3>License key</h3>
       </header>
       <div>
-        <pre>
+        <pre className="whitespace-pre-wrap">
           <code>{license.key}</code>
         </pre>
       </div>


### PR DESCRIPTION
### Explanation of Change
Fix license key overflow on the customer details page to ensure it wraps properly and remains fully visible on mobile. 

### Screenshots/Videos
Before
<img width="374" height="644" alt="image" src="https://github.com/user-attachments/assets/4cf46b3a-4986-44bb-b0bc-da5f406cb59e" />

After
<img width="403" height="651" alt="image" src="https://github.com/user-attachments/assets/5021812e-0479-4e9c-a7c9-86ed3c4302ad" />

### AI Disclosure
No AI tools used