### PR TITLE
fix: Show "Add Password" label for users logged in with a social provider

### DIFF
--- a/app/javascript/components/server-components/Settings/PasswordPage.tsx
+++ b/app/javascript/components/server-components/Settings/PasswordPage.tsx
@@ -58,7 +58,7 @@ const PasswordPage = (props: Props) => {
       >
         <section className="!p-4 md:!p-8">
           <header>
-            <h2>Change password</h2>
+            <h2>{requireOldPassword ? "Change password" : "Add password"}</h2>
           </header>
           {requireOldPassword ? (
             <fieldset>
@@ -87,7 +87,13 @@ const PasswordPage = (props: Props) => {
           <fieldset>
             <div>
               <Button type="submit" color="accent" disabled={isSaving}>
-                {isSaving ? "Changing..." : "Change password"}
+                {isSaving
+                  ? requireOldPassword
+                    ? "Changing..."
+                    : "Adding..."
+                  : requireOldPassword
+                    ? "Change password"
+                    : "Add password"}
               </Button>
             </div>
           </fieldset>

--- a/spec/requests/settings/password_spec.rb
+++ b/spec/requests/settings/password_spec.rb
@@ -17,6 +17,15 @@ describe("Password Settings Scenario", type: :system, js: true) do
       login_as user
     end
 
+    it "shows 'Add password' UI elements when setting password for the first time" do
+      visit settings_password_path
+
+      expect(page).to have_css("h2", text: "Add password")
+      expect(page).to have_button("Add password")
+      expect(page).to have_field("Add password")
+      expect(page).not_to have_field("Old password")
+    end
+
     it "doesn't allow setting a new password with a value that was found in the password breaches" do
       visit settings_password_path
 
@@ -29,7 +38,7 @@ describe("Password Settings Scenario", type: :system, js: true) do
       vcr_turned_on do
         VCR.use_cassette("Add Password-with a compromised password") do
           with_real_pwned_password_check do
-            click_on("Change password")
+            click_on("Add password")
             wait_for_ajax
           end
         end
@@ -50,7 +59,7 @@ describe("Password Settings Scenario", type: :system, js: true) do
       vcr_turned_on do
         VCR.use_cassette("Add Password-with a not compromised password") do
           with_real_pwned_password_check do
-            click_on("Change password")
+            click_on("Add password")
             wait_for_ajax
           end
         end
@@ -65,6 +74,15 @@ describe("Password Settings Scenario", type: :system, js: true) do
 
     before(:each) do
       login_as user
+    end
+
+    it "shows 'Change password' UI elements when updating existing password" do
+      visit settings_password_path
+
+      expect(page).to have_css("h2", text: "Change password")
+      expect(page).to have_button("Change password")
+      expect(page).to have_field("Old password")
+      expect(page).to have_field("New password")
     end
 
     it "validates the new password length" do


### PR DESCRIPTION
### Explanation of Change
Fix incorrect label by showing "Add Password" instead of "Change Password" for users authenticated via a social provider who don’t yet have a password.

### Screenshots/Videos
Before
<img width="1470" height="416" alt="image" src="https://github.com/user-attachments/assets/09f20fcb-7eac-442e-92b6-70bed6c18aae" />


After
<img width="1470" height="429" alt="image" src="https://github.com/user-attachments/assets/dd62be19-20e9-4f14-b1da-483eead59049" />

### Test Result
<img width="986" height="494" alt="image" src="https://github.com/user-attachments/assets/a0370c97-8903-46dc-82a7-c78e94b07770" />


### AI Disclosure
No AI tools used


