### PR TITLE
feat: add ISBN support for ebooks and indexing

### DIFF
--- a/app/javascript/components/Product/index.tsx
+++ b/app/javascript/components/Product/index.tsx
@@ -113,6 +113,7 @@ export type Product = {
   native_type: ProductNativeType;
   sales_count: number | null;
   summary: string | null;
+  isbn?: string | null;
   attributes: { name: string; value: string }[];
   free_trial: FreeTrial | null;
   rental: Rental | null;
@@ -575,9 +576,15 @@ export const Product = ({
               Watch link provided after purchase
             </div>
           ) : null}
-          {product.summary || product.attributes.length > 0 ? (
+          {product.summary || product.isbn || product.attributes.length > 0 ? (
             <div className="stack">
               {product.summary ? <p>{product.summary}</p> : null}
+              {product.isbn ? (
+                <div>
+                  <h5>ISBN</h5>
+                  <div>{product.isbn}</div>
+                </div>
+              ) : null}
               {product.attributes.map(({ name, value }, idx) => (
                 <div key={idx}>
                   <h5>{name}</h5>

--- a/app/javascript/components/ProductEdit/ProductPreview.tsx
+++ b/app/javascript/components/ProductEdit/ProductPreview.tsx
@@ -137,6 +137,7 @@ export const ProductPreview = ({ showRefundPolicyModal }: { showRefundPolicyModa
     bundle_products: [],
     public_files: product.public_files,
     audio_previews_enabled: product.audio_previews_enabled,
+    ...(product.native_type === "ebook" && product.isbn && { isbn: product.isbn }),
   };
 
   return product.native_type === "coffee" ? (

--- a/app/javascript/components/ProductEdit/ProductTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/index.tsx
@@ -202,7 +202,7 @@ export const ProductTab = () => {
                 />
                 {product.native_type === "ebook" ? (
                   <fieldset>
-                    <label htmlFor={`${uid}-isbn`}>ISBN (optional)</label>
+                    <label htmlFor={`${uid}-isbn`}>ISBN</label>
                     <input
                       id={`${uid}-isbn`}
                       type="text"

--- a/app/javascript/components/ProductEdit/ProductTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/index.tsx
@@ -200,6 +200,18 @@ export const ProductTab = () => {
                   value={product.custom_summary}
                   onChange={(value) => updateProduct({ custom_summary: value })}
                 />
+                {product.native_type === "ebook" ? (
+                  <fieldset>
+                    <label htmlFor={`${uid}-isbn`}>ISBN (optional)</label>
+                    <input
+                      id={`${uid}-isbn`}
+                      type="text"
+                      value={product.isbn || ""}
+                      placeholder="Enter ISBN-10 or ISBN-13"
+                      onChange={(evt) => updateProduct({ isbn: evt.target.value })}
+                    />
+                  </fieldset>
+                ) : null}
                 <AttributesEditor
                   customAttributes={product.custom_attributes}
                   setCustomAttributes={(custom_attributes) => updateProduct({ custom_attributes })}

--- a/app/javascript/components/ProductEdit/state.ts
+++ b/app/javascript/components/ProductEdit/state.ts
@@ -97,6 +97,7 @@ export type Product = {
   installment_plan: InstallmentPlan | null;
   custom_button_text_option: CustomButtonTextOption | null;
   custom_summary: string | null;
+  isbn: string | null;
   custom_attributes: Attribute[];
   file_attributes: Attribute[];
   max_purchase_count: number | null;

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -205,11 +205,13 @@ class Link < ApplicationRecord
   validate :commission_price_is_valid, if: -> { native_type == Link::NATIVE_TYPE_COMMISSION }
   validate :one_coffee_per_user, on: :create, if: -> { native_type == Link::NATIVE_TYPE_COFFEE }
   validate :quantity_enabled_state_is_allowed
+  validate :isbn_format_is_valid, if: -> { isbn.present? && native_type == NATIVE_TYPE_EBOOK }
 
   validates_associated :installment_plan, message: -> (link, _) { link.installment_plan.errors.full_messages.first }
 
   before_save :downcase_filetype
   before_save :remove_xml_tags
+  before_save :normalize_isbn
   after_save :set_customizable_price
   after_update :invalidate_cache, if: ->(link) { (link.saved_changes.keys - PURCHASE_PROPERTIES).present? }
   after_update :create_licenses_for_existing_customers,
@@ -229,6 +231,7 @@ class Link < ApplicationRecord
   scope :alive,                           -> { where(purchase_disabled_at: nil, banned_at: nil, deleted_at: nil) }
   scope :visible,                         -> { where(deleted_at: nil) }
   scope :visible_and_not_archived,        -> { visible.not_archived }
+  scope :with_isbn, ->(isbn) { where(isbn: isbn.to_s.gsub(/[-\s]/, '')) if isbn.present? }
   scope :by_user,                         ->(user) { where(user.present? ? { user_id: user.id } : "1 = 1") }
   scope :by_general_permalink,            ->(permalink) { where("unique_permalink = ? OR custom_permalink = ?", permalink, permalink) }
   scope :by_unique_permalinks,            ->(permalinks) { where("unique_permalink IN (?)", permalinks) }
@@ -1236,6 +1239,12 @@ class Link < ApplicationRecord
       return if description.blank?
 
       self.description = description.gsub(/<!--\?xml.+\?-->|<!--\[if gte mso.+<!\[endif\]-->/m, "")
+    end
+
+    def normalize_isbn
+      return if isbn.blank?
+      
+      self.isbn = isbn.gsub(/[^0-9X]/i, '').upcase
     end
 
     def generate_unique_permalink

--- a/app/modules/product/validations.rb
+++ b/app/modules/product/validations.rb
@@ -85,4 +85,45 @@ module Product::Validations
 
       errors.add(:base, "Calls must have at least one duration")
     end
+
+    def isbn_format_is_valid
+      return if isbn.blank?
+      
+      clean_isbn = isbn.gsub(/[^0-9X]/i, '').upcase
+      
+      if clean_isbn.length == 10
+        errors.add(:base, "Invalid ISBN-10 format") unless valid_isbn_10?(clean_isbn)
+      elsif clean_isbn.length == 13
+        errors.add(:base, "Invalid ISBN-13 format") unless valid_isbn_13?(clean_isbn)
+      else
+        errors.add(:base, "ISBN must be 10 or 13 digits long")
+      end
+    end
+
+    def valid_isbn_10?(isbn)
+      return false if isbn.length != 10
+      return false unless isbn[0..8].match?(/\A\d{9}\z/) && isbn[9].match?(/\A[\dXx]\z/)
+      
+      sum = 0
+      (0..8).each { |i| sum += isbn[i].to_i * (10 - i) }
+      
+      check_digit = isbn[9].upcase
+      calculated_check = (11 - (sum % 11)) % 11
+      expected_check = calculated_check == 10 ? 'X' : calculated_check.to_s
+      
+      check_digit == expected_check
+    end
+
+    def valid_isbn_13?(isbn)
+      return false if isbn.length != 13
+      return false unless isbn.match?(/\A\d{13}\z/)
+      
+      sum = 0
+      (0..11).each { |i| sum += isbn[i].to_i * (i.even? ? 1 : 3) }
+      
+      check_digit = isbn[12].to_i
+      calculated_check = (10 - (sum % 10)) % 10
+      
+      check_digit == calculated_check
+    end
 end

--- a/app/policies/link_policy.rb
+++ b/app/policies/link_policy.rb
@@ -71,6 +71,7 @@ class LinkPolicy < ApplicationPolicy
       :hide_sold_out_variants,
       :custom_button_text_option,
       :custom_summary,
+      :isbn,
       :is_epublication,
       :display_product_reviews,
       :is_adult,

--- a/app/presenters/product_presenter.rb
+++ b/app/presenters/product_presenter.rb
@@ -94,6 +94,7 @@ class ProductPresenter
         **ProductPresenter::InstallmentPlanProps.new(product:).props,
         custom_button_text_option: product.custom_button_text_option.presence,
         custom_summary: product.custom_summary,
+        isbn: product.isbn,
         custom_attributes: product.custom_attributes,
         file_attributes: product.file_info_for_product_page.map { { name: _1.to_s, value: _2 } },
         max_purchase_count: product.max_purchase_count,

--- a/app/presenters/product_presenter/product_props.rb
+++ b/app/presenters/product_presenter/product_props.rb
@@ -34,6 +34,7 @@ class ProductPresenter::ProductProps
         streamable: product.streamable?,
         sales_count: cached_sales_count,
         summary: product.custom_summary.presence,
+        isbn: product.isbn.presence,
         attributes: attributes_props,
         description_html: product.html_safe_description,
         currency_code: product.price_currency_type.downcase,

--- a/app/views/links/show.html.erb
+++ b/app/views/links/show.html.erb
@@ -1,5 +1,27 @@
 <% content_for :meta do %>
   <link href="<%= @product.long_url %>" rel="canonical">
+  
+  <% if @product.native_type == "ebook" && @product.isbn.present? %>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Book",
+      "name": "<%= j @product.name %>",
+      "description": "<%= j strip_tags(@product.description).truncate(160) %>",
+      "isbn": "<%= j @product.isbn %>",
+      "bookFormat": "https://schema.org/EBook",
+      "url": "<%= @product.long_url %>",
+      "author": {
+        "@type": "Person",
+        "name": "<%= j @product.user.name %>"
+      },
+      "publisher": {
+        "@type": "Organization", 
+        "name": "<%= j @product.user.name %>"
+      }
+    }
+    </script>
+  <% end %>
 <% end %>
 
 <%= render("layouts/custom_styles/style") %>

--- a/db/migrate/20251002043627_add_isbn_to_links.rb
+++ b/db/migrate/20251002043627_add_isbn_to_links.rb
@@ -1,0 +1,6 @@
+class AddIsbnToLinks < ActiveRecord::Migration[7.1]
+  def change
+    add_column :links, :isbn, :string, limit: 20
+    add_index :links, :isbn
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_09_25_161102) do
+ActiveRecord::Schema[7.1].define(version: 2025_10_02_043627) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -1111,9 +1111,11 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_25_161102) do
     t.string "native_type", default: "digital", null: false
     t.integer "discover_fee_per_thousand", default: 100, null: false
     t.string "support_email"
+    t.string "isbn"
     t.index ["banned_at"], name: "index_links_on_banned_at"
     t.index ["custom_permalink"], name: "index_links_on_custom_permalink", length: 191
     t.index ["deleted_at"], name: "index_links_on_deleted_at"
+    t.index ["isbn"], name: "index_links_on_isbn"
     t.index ["showcaseable"], name: "index_links_on_showcaseable"
     t.index ["taxonomy_id"], name: "index_links_on_taxonomy_id"
     t.index ["unique_permalink"], name: "index_links_on_unique_permalink", length: 191

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -751,6 +751,11 @@ describe LinksController, :vcr do
         expect(@product.product_refund_policy).to be_nil
       end
 
+      it "updates the product ISBN" do
+        put :update, params: @params.merge(isbn: "978-0123456786"), as: :json
+        expect(@product.reload.isbn).to eq "978-0123456786"
+      end
+
       context "when seller_refund_policy_disabled_for_all feature flag is set to true" do
         before do
           Feature.activate(:seller_refund_policy_disabled_for_all)

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -5157,6 +5157,25 @@ describe Link, :vcr do
     end
   end
 
+  describe "isbn validations" do
+    let(:product) { build(:product, native_type: "ebook") }
+
+    it "accepts valid ISBN-10" do
+      product.isbn = "0123456789"
+      expect(product).to be_valid
+    end
+
+    it "accepts valid ISBN-13" do
+      product.isbn = "9780123456786"
+      expect(product).to be_valid
+    end
+
+    it "rejects invalid ISBN" do
+      product.isbn = "invalid"
+      expect(product).not_to be_valid
+    end
+  end
+
   describe "#can_gift?" do
     let(:product) { build(:product) }
 

--- a/spec/requests/products/isbn_spec.rb
+++ b/spec/requests/products/isbn_spec.rb
@@ -17,7 +17,7 @@ describe "ISBN functionality", type: :system, js: true do
       fill_in("Price", with: 1)
       click_on("Next: Customize")
 
-      expect(page).to have_field("ISBN (optional)")
+      expect(page).to have_field("ISBN")
     end
 
     it "saves ISBN for ebook products" do
@@ -27,8 +27,8 @@ describe "ISBN functionality", type: :system, js: true do
       fill_in("Price", with: 1)
       click_on("Next: Customize")
 
-      fill_in("ISBN (optional)", with: "978-0-123456-47-2")
-      click_on("Save changes")
+      fill_in("ISBN", with: "978-0-123456-47-2")
+      click_on("Save and continue")
 
       wait_for_ajax
 
@@ -41,7 +41,7 @@ describe "ISBN functionality", type: :system, js: true do
       
       visit ebook.long_url
 
-      expect(page).to have_xpath("//script[@type='application/ld+json']")
+      expect(page).to have_xpath("//script[@type='application/ld+json']", visible: false)
       
       json_ld = page.find("script[type='application/ld+json']", visible: false).text(:all)
       structured_data = JSON.parse(json_ld)

--- a/spec/requests/products/isbn_spec.rb
+++ b/spec/requests/products/isbn_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "ISBN functionality", type: :system, js: true do
+  let(:seller) { create(:named_seller) }
+
+  before do
+    login_as seller
+  end
+
+  describe "ebook ISBN editing" do
+    it "shows ISBN field for ebook products" do
+      visit new_product_path
+      fill_in("Name", with: "Test Ebook")
+      choose("E-book")
+      fill_in("Price", with: 1)
+      click_on("Next: Customize")
+
+      expect(page).to have_field("ISBN (optional)")
+    end
+
+    it "saves ISBN for ebook products" do
+      visit new_product_path
+      fill_in("Name", with: "Test Ebook with ISBN")
+      choose("E-book")
+      fill_in("Price", with: 1)
+      click_on("Next: Customize")
+
+      fill_in("ISBN (optional)", with: "978-0-123456-47-2")
+      click_on("Save changes")
+
+      wait_for_ajax
+
+      product = seller.links.last
+      expect(product.isbn).to eq("9780123456472")
+    end
+
+    it "includes JSON-LD structured data for ebooks with ISBN" do
+      ebook = create(:product, user: seller, native_type: "ebook", isbn: "9780123456472")
+      
+      visit ebook.long_url
+
+      expect(page).to have_xpath("//script[@type='application/ld+json']")
+      
+      json_ld = page.find("script[type='application/ld+json']", visible: false).text(:all)
+      structured_data = JSON.parse(json_ld)
+      
+      expect(structured_data["@type"]).to eq("Book")
+      expect(structured_data["isbn"]).to eq("9780123456472")
+    end
+  end
+end


### PR DESCRIPTION
<p>
fixes: #1145
</p>

<h2>Description</h2>
<p>
  This PR enables eBook creators on Gumroad to add ISBNs to their products for improved discoverability. 
  When an ISBN is provided, it is included in the product page’s structured data (JSON-LD), 
  making it indexable by search engines and platforms such as Goodreads.
</p>
<h2>Video</h2>
<h3>Before</h3>
No isbn field
<img width="1710" height="952" alt="Screenshot 2025-10-03 at 12 41 07 AM" src="https://github.com/user-attachments/assets/62fa30f1-9af5-475c-9f5d-6afcc9694faf" />

<h3>After</h3>

https://github.com/user-attachments/assets/2ba3f89a-86d6-469d-b76a-9f5f440decb5



<h2>AI Disclosure</h2>
<p>
  I used Cursor for assistance in understanding the changes and reviewed all modifications myself.
</p>
