### PR TITLE
fix: Prevent "Manage membership" button text from breaking into multiple lines

### DIFF
--- a/app/javascript/components/Product/index.tsx
+++ b/app/javascript/components/Product/index.tsx
@@ -649,7 +649,7 @@ const ExistingPurchaseStack = ({
               <h5>{purchase.membership.tier_name}</h5>
               {purchase.total_price_including_tax_and_shipping}
             </div>
-            <div>
+            <div className="flex-col *:w-full sm:flex-row">
               <NavigationButton
                 href={purchase.membership.manage_url}
                 target="_blank"


### PR DESCRIPTION
### Explanation of Change
Fix button styling so that the "Manage membership" text stays on a single line and buttons remain properly aligned on mobile

### Screenshots/Videos
Before
<img width="388" height="676" alt="image" src="https://github.com/user-attachments/assets/66ee59dd-cefe-45ef-ac2d-69a31453166b" />

After
<img width="398" height="681" alt="image" src="https://github.com/user-attachments/assets/1ded5a03-c5c4-4919-bb63-25af2d045677" />

<img width="1459" height="739" alt="image" src="https://github.com/user-attachments/assets/d0f24148-750a-4611-a173-57265f531aff" />

### AI Disclosure
No AI tools used


