### PR TITLE
chore: added spacing between scrollbar and Tab elements in small devices

### DIFF
--- a/app/javascript/components/server-components/EmailsPage/index.tsx
+++ b/app/javascript/components/server-components/EmailsPage/index.tsx
@@ -87,7 +87,7 @@ export const Layout = ({
           </>
         }
       >
-        <Tabs className="sm:pb-0 pb-4">
+        <Tabs>
           {TABS.map((tab) =>
             tab === "subscribers" ? (
               <Tab href={Routes.followers_path()} isSelected={false} key={tab}>

--- a/app/javascript/components/ui/Tabs.tsx
+++ b/app/javascript/components/ui/Tabs.tsx
@@ -8,7 +8,7 @@ export const Tabs = ({
   className,
   ...props
 }: { children: React.ReactNode } & React.HTMLProps<HTMLDivElement>) => (
-  <div role="tablist" className={classNames("flex gap-3 overflow-x-auto", className)} {...props}>
+  <div role="tablist" className={classNames("flex gap-3 overflow-x-auto pb-4 sm:pb-0", className)} {...props}>
     {children}
   </div>
 );


### PR DESCRIPTION
ref #864

## Summary
Added better padding between scrollbar and Tab elements in small devices

###    Emails Page
<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>

  <tbody>
<tr>
<td>
<img width="363" height="746" alt="Screenshot 2025-10-02 at 12 56 09 PM" src="https://github.com/user-attachments/assets/bb74cf09-8c1f-486a-a2f7-2ad9463d2375" />

</td>
<td>
<img width="362" height="750" alt="Screenshot 2025-10-02 at 1 05 11 PM" src="https://github.com/user-attachments/assets/ce8ce13c-8f73-4147-acd1-1260e7894c72" />


</td>
</tr>


</tbody>
</table>


###    Settings Page
<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>

  <tbody>
<tr>
<td>
<img width="351" height="752" alt="Screenshot 2025-10-02 at 2 40 41 PM" src="https://github.com/user-attachments/assets/4bf8fba6-4ed8-45ac-8eeb-089e461cdf4a" />

</td>
<td>
<img width="357" height="747" alt="Screenshot 2025-10-02 at 2 40 56 PM" src="https://github.com/user-attachments/assets/2d45e54a-a57f-420e-b4fd-e7488a78796c" />



</td>
</tr>


</tbody>
</table>


## AI Usage
No AI was used to generate any of this code 

## Self-Review
I have self-reviewed all the code that I have written.
