### PR TITLE
chore: spacing between title and actions

### DIFF
--- a/app/javascript/components/ui/PageHeader.tsx
+++ b/app/javascript/components/ui/PageHeader.tsx
@@ -12,7 +12,7 @@ export const PageHeader = React.forwardRef<
   }
 >(({ title, actions, children, className }, ref) => (
   <header className={classNames("flex flex-col gap-4 border-b border-border p-4 md:p-8", className)} ref={ref}>
-    <div className="flex items-center justify-between">
+    <div className="flex items-center justify-between gap-2">
       <h1 className="!hidden text-2xl sm:!block">{title}</h1>
       <div className="override grid flex-1 grid-cols-2 gap-2 has-[>*:only-child]:grid-cols-1 sm:flex sm:flex-none md:-my-2">
         {actions}


### PR DESCRIPTION
ref #864

## Summary
Better spacing between header and title in `ProductEdit` page

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
<tr>
<td>
<img width="1835" height="959" alt="Screenshot 2025-10-02 at 1 19 17 PM" src="https://github.com/user-attachments/assets/469b80d2-baaa-431b-a287-ddf5c88f5dc3" />


</td>
<td>
<img width="1832" height="959" alt="Screenshot 2025-10-02 at 1 26 05 PM" src="https://github.com/user-attachments/assets/e6629ef6-65db-4500-bb90-983ba6c37e20" />



</td>
</tr>
</tbody>
</table>

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
<tr>
<td>

<img width="1012" height="958" alt="Screenshot 2025-10-02 at 1 20 51 PM" src="https://github.com/user-attachments/assets/f1f2bfb0-6df2-417e-9600-f62c178dc1a8" />

</td>
<td>

<img width="1010" height="961" alt="Screenshot 2025-10-02 at 1 25 48 PM" src="https://github.com/user-attachments/assets/6a04cd84-b511-472b-8595-e2fd9a69b4c3" />


</td>
</tr>


</tbody>
</table>

## AI Usage
No AI was used to generate any of this code 

## Self-Review
I have self-reviewed all the code that I have written.
