### PR TITLE
fix: removed text overflow causing design inconsistency

### DIFF
--- a/app/javascript/components/Select.tsx
+++ b/app/javascript/components/Select.tsx
@@ -212,7 +212,7 @@ const MenuList = <IsMulti extends boolean>(props: MenuListProps<Option, IsMulti>
 
 const MultiValue = <IsMulti extends boolean>(props: MultiValueProps<Option, IsMulti>) => (
   <div {...props.removeProps}>
-    <button className="pill primary dismissable">{props.data.label}</button>
+    <button className="pill primary dismissable max-w-[90%]">{props.data.label}</button>
   </div>
 );
 


### PR DESCRIPTION
ref #864

## Summary
Product with large names are overflowing `Select` container as a result the `close` button isn't visible

Before : 
 
 

https://github.com/user-attachments/assets/466e7ab5-432c-45e4-bbcc-660a733bd252



After : 


https://github.com/user-attachments/assets/30747cda-c792-45aa-8ca5-320fb2cb64bd


## AI Usage
No AI was used to generate any of this code 

## Self-Review
I have self-reviewed all the code that I have written.
