### PR TITLE
fix: loader alignment at blog post page

### DIFF
--- a/app/javascript/components/server-components/GumroadBlog/PostPage.tsx
+++ b/app/javascript/components/server-components/GumroadBlog/PostPage.tsx
@@ -55,7 +55,7 @@ const PostPage = ({
           <h1 className="mb-4">{subject}</h1>
           <time className="text-dark-gray">{publishedAtFormatted}</time>
         </header>
-        <div className="mx-auto mt-6 grid max-w-3xl gap-6 border-t py-12 text-xl justify-items-center">
+        <div className="mx-auto mt-6 grid max-w-3xl justify-items-center gap-6 border-t py-12 text-xl">
           {pageLoaded ? null : <LoadingSpinner width="2em" />}
           <EditorContent className="rich-text" editor={editor} />
 


### PR DESCRIPTION
Ref:- https://github.com/antiwork/gumroad/issues/864

### Description 

- fixes the alignment of loading spinner at blog post page

### Screenshots

**before**:

[Screencast from 2025-10-02 17-46-35.webm](https://github.com/user-attachments/assets/ad496fe2-1116-4377-8d7b-bfe411f980ae)

[Screencast from 2025-10-02 17-52-42.webm](https://github.com/user-attachments/assets/6c88b5d5-fd08-455d-a462-d807482fc475)

**after**:

[Screencast from 2025-10-02 17-45-57.webm](https://github.com/user-attachments/assets/2ce1587f-6b88-4be3-92ee-42dd0cda5fb0)

[Screencast from 2025-10-02 17-52-00.webm](https://github.com/user-attachments/assets/1f179233-9b45-4a50-b14d-dfc7536bac7b)



AI Disclosure:-
I have not used any AI assistance in this PR
