### PR TITLE
fix: Center-align the new workflow checkbox and label.

### DIFF
--- a/app/javascript/components/server-components/WorkflowsPage/WorkflowForm.tsx
+++ b/app/javascript/components/server-components/WorkflowsPage/WorkflowForm.tsx
@@ -422,7 +422,7 @@ const WorkflowForm = () => {
               )}
             </div>
             {wasPublishedPreviously || formState.trigger === "abandoned_cart" ? null : (
-              <label>
+              <label className="items-center">
                 <input
                   type="checkbox"
                   checked={formState.sendToPastCustomers}


### PR DESCRIPTION
ref: #864

Summary
Center align new workflow checkbox and label.

Before:
**Desktop**
<img width="1440" height="900" alt="Screenshot 2025-10-02 at 6 18 15 PM" src="https://github.com/user-attachments/assets/85e98534-504e-4dde-9c6f-c9d2d1028468" />

**Mobile**
<img width="364" height="785" alt="Screenshot 2025-10-02 at 6 29 18 PM" src="https://github.com/user-attachments/assets/b7f74853-d4b1-4b0f-add5-39d63dc6cef4" />

After:
**Desktop**
<img width="1427" height="893" alt="Screenshot 2025-10-02 at 6 27 00 PM" src="https://github.com/user-attachments/assets/ce557818-7666-44bc-ba77-3aa59b2f1273" />

**Mobile**
<img width="378" height="787" alt="Screenshot 2025-10-02 at 6 28 32 PM" src="https://github.com/user-attachments/assets/371e09d1-ef52-480d-af56-230311d66e32" />

> AI Disclosure

No AI was used to generate any of this code.
