### PR TITLE
fix: replaced inline styles of `_user.html.erb` with Tailwind CSS

### DIFF
--- a/app/views/admin/users/_user.html.erb
+++ b/app/views/admin/users/_user.html.erb
@@ -1,8 +1,8 @@
 <div class="card js-admin-user" data-user-id="<%= user.id %>">
   <div class="paragraphs">
-    <div style="display: flex; gap: var(--spacer-4); align-items: center">
+    <div class="flex items-center gap-4">
       <%= image_tag(user.avatar_url, class: "user-avatar", style: "width: var(--form-element-height)", alt: user.name) %>
-      <div style="display: grid; gap: var(--spacer-2)">
+      <div class="grid gap-2">
         <h2>
           <% if is_affiliate_user %>
             <%= link_to_unless_current(h(user_name(user)), admin_affiliate_url(user)) %>


### PR DESCRIPTION
Part of fix: https://github.com/antiwork/gumroad/issues/1055

Migrate inline CSS styles to Tailwind CSS classes in the admin user view file `app/views/admin/users/_user.html.erb`

## Changes
- Replace inline flex styles with `flex items-center gap-4` utility classes
- Replace inline grid styles with `grid gap-2` utility classes
- Remove dependency on CSS variables `--spacer-4` and `--spacer-2`
- Maintain identical visual layout and spacing


### Technical Mapping:

| Before (CSS Variables) | After (Tailwind) | Purpose |
|------------------------|------------------|---------|
| `display: flex` | `flex` | Flexbox display |
| `align-items: center` | `items-center` | Vertical alignment |
| `gap: var(--spacer-4)` | `gap-4` | 1rem spacing |
| `display: grid` | `grid` | Grid display |
| `gap: var(--spacer-2)` | `gap-2` | 0.5rem spacing |


### Before (light mode)

<img width="1121" height="227" alt="image" src="https://github.com/user-attachments/assets/6ebb30ab-d679-4a34-b6b8-0a48fd2c4760" />

### Before (dark mode)

<img width="939" height="238" alt="image" src="https://github.com/user-attachments/assets/3fe99027-02f5-43e3-84bd-2f5e55cd683b" />


### After (light mode)

<img width="1037" height="227" alt="image" src="https://github.com/user-attachments/assets/3f169325-bb04-4f9b-8515-a6d9a094e1b6" />


### After (dark mode)

<img width="995" height="241" alt="image" src="https://github.com/user-attachments/assets/01fa8f11-cf7e-49ca-ba2a-a4433ad6a9ba" />


***


## Mobile

### Before (dark mode)

<img width="361" height="698" alt="image" src="https://github.com/user-attachments/assets/91910ce0-2e3c-4808-b004-97f34908549b" />


### Before (light mode)

<img width="366" height="701" alt="image" src="https://github.com/user-attachments/assets/f6adc50a-cde4-4a3c-a26f-c331768251ae" />

### After (dark mode)

<img width="366" height="698" alt="image" src="https://github.com/user-attachments/assets/66082d22-aa8f-42d7-9a13-01719348f152" />

### After (light mode)

<img width="368" height="705" alt="image" src="https://github.com/user-attachments/assets/d3ad24b0-bac5-4d4b-9bdf-932dc9371438" />


AI Disclosure:
No AI Used