### PR TITLE
Fix: AWS S3 301 redirection when uploading a file locally

### DIFF
--- a/app/javascript/components/useConfigureEvaporate.ts
+++ b/app/javascript/components/useConfigureEvaporate.ts
@@ -21,6 +21,7 @@ export const useConfigureEvaporate = (props: Props) => {
         bucket,
         fetchCurrentServerTimeUrl: Routes.s3_utility_current_utc_time_string_path(),
         maxFileSize: MAX_FILE_SIZE,
+        cloudfront: `https://${bucket}.s3.amazonaws.com`,
       }),
     [props.aws_access_key_id, bucket],
   );

--- a/app/javascript/types/evaporate.d.ts
+++ b/app/javascript/types/evaporate.d.ts
@@ -19,6 +19,7 @@ declare module "$vendor/evaporate.cjs" {
       bucket: string;
       fetchCurrentServerTimeUrl: string;
       maxFileSize?: number;
+      cloudfront?: string;
     });
 
     add(params: UploadParams): string | number;


### PR DESCRIPTION
Fixes: #1467 

The problem:

> When using AWS S3 locally, I encounter a 301 Permanent Redirect error.
> This happens because the current version of EvaporateJS is generating URLs in the format:
> https://s3.amazonaws.com/<bucket-name>
> However, AWS now requires the bucket-style endpoint:
> https://<bucket-name>.s3.amazonaws.com

The solution: 
> A proposed solution is to bump evaporate js to latest version as they started to support cloudfront prop, which will make it work.

In this repo, EvaporateJS has not been installed as a package and has rather been vendored
So, simply upgrading EvaporateJS wouldn't have worked

Instead I have modified the types declaration file and the config file to handle the new `cloudfront` parameter, which will fix the issue that had arisen before.

Kindly check, and let me know if any other changes are required from my side!
Excited to submit my first PR to this repo!