### PR TITLE
refactor: inline css to tailwind at PasswordInput

### DIFF
--- a/app/javascript/components/PasswordInput.tsx
+++ b/app/javascript/components/PasswordInput.tsx
@@ -56,7 +56,7 @@ export const PasswordInput = React.forwardRef<HTMLInputElement, PasswordInputPro
         onClick={togglePasswordVisibility}
         role="button"
         tabIndex={0}
-        style={{ cursor: "pointer", userSelect: "none" }}
+        className="cursor-pointer select-none"
         aria-label={showPassword ? "Hide password" : "Show password"}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") {


### PR DESCRIPTION
ref: #1055

### Description 
Migrated inline css to tailwind at `PasswordInput.tsx`


### Before

[Screencast from 2025-10-02 20-11-08.webm](https://github.com/user-attachments/assets/c0b7fe1d-88d6-48ea-b636-a421a73143bc)


### After

[Screencast from 2025-10-02 20-10-23.webm](https://github.com/user-attachments/assets/75c14ecd-23ea-42c2-94c9-08de209e8904)


### AI usage 
None