### PR TITLE
Temporary workaround for Nginx HTTP challenge sync issue

### DIFF
--- a/spec/services/ssl_certificates/base_spec.rb
+++ b/spec/services/ssl_certificates/base_spec.rb
@@ -34,7 +34,7 @@ describe SslCertificates::Base do
       expect(@obj.send(:acme_url)).to eq "https://test.api.letsencrypt.org/directory"
       expect(@obj.send(:invalid_domain_cache_expires_in)).to eq 8.hours.seconds
       expect(@obj.send(:max_retries)).to eq 10
-      expect(@obj.send(:nginx_sync_duration)).to eq 30.seconds
+      expect(@obj.send(:nginx_sync_duration)).to eq 300.seconds
       expect(@obj.send(:rate_limit)).to eq 300
       expect(@obj.send(:rate_limit_hours)).to eq 3.hours.seconds
       expect(@obj.send(:renew_in)).to eq 60.days.seconds

--- a/spec/support/fixtures/ssl_certificates.yml.erb
+++ b/spec/support/fixtures/ssl_certificates.yml.erb
@@ -3,7 +3,7 @@ development: &development
   acme_url: "https://test.api.letsencrypt.org/directory"
   invalid_domain_cache_expires_in: <%= 8.hours %>
   max_retries: 10
-  nginx_sync_duration: <%= 30.seconds %>
+  nginx_sync_duration: <%= 300.seconds %>
   rate_limit: 300 # 300 new certificate orders per account per 3 hours - https://letsencrypt.org/docs/rate-limits/
   rate_limit_hours: <%= 3.hours %>
   renew_in: <%= 60.days %>


### PR DESCRIPTION
Will configure to serve HTTP challenge via Redis in a separate PR.