### PR TITLE
refactor: review component inline css to tailwind

### DIFF
--- a/app/javascript/components/Review.tsx
+++ b/app/javascript/components/Review.tsx
@@ -58,14 +58,14 @@ export const Review = ({
         </span>
         {review.message ? <p className="m-0">{review.message}</p> : null}
         {review.video ? <ReviewVideoPlayer videoId={review.video.id} thumbnail={review.video.thumbnail_url} /> : null}
-        <section className="flex gap-1 items-center flex-wrap">
+        <section className="flex flex-wrap items-center gap-1">
           <ReviewUserAttribution avatarUrl={review.rater.avatar_url} name={review.rater.name} isBuyer />
         </section>
       </section>
       {review.response && !isEditing && !hideResponse ? (
-        <section className="override grid gap-2 ml-4">
+        <section className="override ml-4 grid gap-2">
           <p className="m-0">{review.response.message}</p>
-          <section className="flex gap-1 items-center flex-wrap">
+          <section className="flex flex-wrap items-center gap-1">
             {seller ? <ReviewUserAttribution avatarUrl={seller.avatar_url} name={seller.name} /> : null}
             <span className="pill small">Creator</span>
           </section>


### PR DESCRIPTION
ref: #1055

### Description 
Migrated inline css to tailwind at `Review.tsx`


### Before
<img width="1149" height="942" alt="Screenshot from 2025-10-02 20-45-36" src="https://github.com/user-attachments/assets/65696018-e484-45a9-a1c6-725d984ae5d7" />

<img width="1149" height="942" alt="Screenshot from 2025-10-02 20-45-47" src="https://github.com/user-attachments/assets/f749fa17-fdac-45a8-9c13-bb4b9e447197" />
<img width="1149" height="797" alt="Screenshot from 2025-10-02 20-45-57" src="https://github.com/user-attachments/assets/7a33f7bb-20e7-4ffa-b56a-cf5265663b19" />

[Screencast from 2025-10-02 21-08-25.webm](https://github.com/user-attachments/assets/0eb5c631-f4eb-4c9b-9239-0bc4d7c5e070)



### After
<img width="1149" height="933" alt="Screenshot from 2025-10-02 20-46-20" src="https://github.com/user-attachments/assets/80a0bfc1-37b4-4b8f-b112-21f3511f0b83" />

<img width="1149" height="933" alt="Screenshot from 2025-10-02 20-46-29" src="https://github.com/user-attachments/assets/efabb961-b1ce-4c8b-bff8-461c2ddef295" />
<img width="1149" height="933" alt="Screenshot from 2025-10-02 20-46-43" src="https://github.com/user-attachments/assets/d03752cd-51d9-49ba-982f-dfcab0521b42" />

[Screencast from 2025-10-02 21-07-34.webm](https://github.com/user-attachments/assets/6ae76550-1822-4368-a858-f0b8a51e7e2b)


### AI usage 
None