### PR TITLE
refactor: inline css to tailwind at UpsellSelectModal

### DIFF
--- a/app/javascript/components/UpsellSelectModal.tsx
+++ b/app/javascript/components/UpsellSelectModal.tsx
@@ -169,7 +169,7 @@ export const UpsellSelectModal = ({
           }
         >
           {discount && selectedProduct ? (
-            <div className="dropdown" style={{ maxWidth: "400px" }}>
+            <div className="dropdown !max-w-sm">
               <DiscountInput
                 discount={discount}
                 setDiscount={(newDiscount: InputtedDiscount) => setDiscount(newDiscount)}


### PR DESCRIPTION
ref: #1055

### Description 

- Migrated inline css to tailwind at `UpsellSelectModal.tsx`
- used semantic classes instead of arbitrary value.

### Before

[Screencast from 2025-10-02 21-37-44.webm](https://github.com/user-attachments/assets/c0591b49-84f2-4760-9ea0-bd63cd80060c)

[Screencast from 2025-10-02 21-42-06.webm](https://github.com/user-attachments/assets/62c9c70a-9730-48a0-a1c4-e7695085c27e)


### After

[Screencast from 2025-10-02 21-38-17.webm](https://github.com/user-attachments/assets/02bafeb9-6036-419d-95f4-2a83ff462258)

[Screencast from 2025-10-02 21-41-12.webm](https://github.com/user-attachments/assets/af936536-54e5-4253-8424-8ba52f87b55c)


### AI usage 
None