### PR TITLE
chore: Migrate from CSS to tailwindcss for Profile.

### DIFF
--- a/app/javascript/components/server-components/Profile/index.tsx
+++ b/app/javascript/components/server-components/Profile/index.tsx
@@ -65,7 +65,7 @@ const PublicProfile = (props: Props) => {
       {props.bio || props.tabs.length > 1 ? (
         <header className="grid grid-cols-1 gap-4 border-b border-border px-4 py-8">
           {props.bio ? (
-            <h1 style={{ whiteSpace: "pre-line" }}>
+            <h1 className="whitespace-pre-line">
               <AutoLink text={props.bio} />
             </h1>
           ) : null}


### PR DESCRIPTION
ref: #1055 

#### Description
Migrated inline css to tailwind at Profile `index.tsx`.

> We’re not displaying previews on mobile screens, so no screenshots are attached for mobile views.

**Before:**

Dark:
<img width="1438" height="898" alt="Screenshot 2025-10-02 at 9 22 45 PM" src="https://github.com/user-attachments/assets/e07d49e1-39a1-4b87-9916-c77f08a76e29" />

Light:
<img width="1440" height="900" alt="Screenshot 2025-10-02 at 9 27 45 PM" src="https://github.com/user-attachments/assets/a24b76ef-d062-4245-a741-60947bd97f4a" />

**After:**

Dark:
<img width="1438" height="898" alt="Screenshot 2025-10-02 at 9 27 11 PM" src="https://github.com/user-attachments/assets/6a00a1a8-ffc7-4773-aaf3-06db0b0764d3" />

Light:
<img width="1440" height="900" alt="Screenshot 2025-10-02 at 9 27 45 PM" src="https://github.com/user-attachments/assets/bc718272-3dda-4527-8dac-0973abd11e22" />

#### AI disclosure

No AI was used to generate any of this code.