### PR TITLE
refactor: inline css to tailwind at BundleEdit share tab

### DIFF
--- a/app/javascript/components/BundleEdit/ShareTab/index.tsx
+++ b/app/javascript/components/BundleEdit/ShareTab/index.tsx
@@ -49,7 +49,7 @@ export const ShareTab = () => {
           profileSections={profileSections}
         />
         <section className="!p-4 md:!p-8">
-          <header style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+          <header className="flex items-center justify-between">
             <h2>Gumroad Discover</h2>
             <a href="/help/article/79-gumroad-discover" target="_blank" rel="noreferrer">
               Learn more


### PR DESCRIPTION
ref: #1055

### Description 

- Migrated inline css to tailwind at `index.tsx` bundle edit share tab.
- used semantic classes instead of arbitrary value.

### Before

<img width="1855" height="963" alt="image" src="https://github.com/user-attachments/assets/e9bee25a-f020-4d1f-80c4-e478f89a6033" />



### After

<img width="1855" height="963" alt="image" src="https://github.com/user-attachments/assets/6911cb9e-01ce-4192-a288-334efc310b02" />


### AI usage 
None