### PR TITLE
refactor: inline css to tailwind at Search discover page

### DIFF
--- a/app/javascript/components/Discover/Search.tsx
+++ b/app/javascript/components/Discover/Search.tsx
@@ -61,7 +61,7 @@ export const Search = ({ query, setQuery }: { query?: string | undefined; setQue
 
   return (
     <ComboBox
-      style={{ flex: 1 }}
+      className="flex-1"
       open={autocompleteOpen ? options.length > 0 : false}
       onToggle={setAutocompleteOpen}
       editable


### PR DESCRIPTION
ref: #1055

### Description 

- Migrated inline css to tailwind at `Search.tsx` at Discover page.


### Before
<img width="417" height="884" alt="image" src="https://github.com/user-attachments/assets/fbfb5653-b200-4e6e-98c4-122b4e3b622f" />


<img width="1845" height="971" alt="image" src="https://github.com/user-attachments/assets/8a3b59fe-cd13-46cd-8d92-58c3a06b2678" />


### After
<img width="525" height="936" alt="image" src="https://github.com/user-attachments/assets/36335310-9e78-47f5-90af-61906a96b430" />

<img width="1845" height="971" alt="image" src="https://github.com/user-attachments/assets/1a661fa4-7598-45c5-97da-c59eab42ae19" />


### AI usage 
None