### PR TITLE
refactor: dashboard inline style tailwind css

### DIFF
--- a/app/javascript/components/server-components/DashboardPage.tsx
+++ b/app/javascript/components/server-components/DashboardPage.tsx
@@ -351,7 +351,7 @@ export const DashboardPage = ({
                   <span>{gettingStartedMinimized ? "Show more" : "Show less"}</span>
                   <Icon
                     name={gettingStartedMinimized ? "arrows-expand" : "arrows-collapse"}
-                    className="w-5 h-5"
+                    className="!w-5 !h-5"
                   />
                 </a>
               </div>


### PR DESCRIPTION
Part of https://github.com/antiwork/gumroad/issues/1055

Migrated inline CSS styles to Tailwind CSS classes in the Dashboard page's "Getting Started" section, improving code consistency and maintainability while preserving exact visual appearance.

The changes affect **Show More** part where the icon size as been set to `!w-5 !h-5` and the parent **anchor** tag CSS properties migrated to tailwind.

### **CSS Property Mappings:**
- `display: "flex"` → `flex`
- `alignItems: "center"` → `items-center` 
- `gap: "var(--spacer-1)"` → `gap-1` (0.25rem)
- `width: "20px", height: "20px"` → `!w-5 !h-5` (1.25rem each)

Based on `$spacers: sizes(0.25, 0.5, 0.75, 1, 1.5, 2, 3, 4)` in `_definitions.scss`:
- `var(--spacer-1)` = 0.25rem (4px) → Tailwind `gap-1`
- `20px` = 1.25rem → Tailwind `w-5` and `h-5`

**Q. Why use important tailwind override like `!w-5` ?**
Ans: The base `_icons.scss` has default width as **1em** for any icon. The current icon uses **width as 1em** from `%icon` from mentioned scss file and requires `!important` (current changes) or some custom css class for icon sizing which seems unnecessary for this case.

## Desktop

### Before (dark mode)

<img width="1392" height="313" alt="image" src="https://github.com/user-attachments/assets/6dfb717f-ad52-4395-9c7f-38193f4c17dc" />

### Before (light mode)

<img width="1400" height="303" alt="image" src="https://github.com/user-attachments/assets/f8aed4ce-d18f-46f0-8f5a-af3c50274aba" />


### After (dark mode)

<img width="1401" height="312" alt="image" src="https://github.com/user-attachments/assets/89463511-6316-48ff-aafb-e44a867099b1" />

### After (light mode)

<img width="1397" height="301" alt="image" src="https://github.com/user-attachments/assets/b8332497-9a34-4682-ba1e-729357a9b4e3" />


***

## Mobile

### Before (dark mode)

<img width="368" height="698" alt="image" src="https://github.com/user-attachments/assets/900c3641-94b2-415e-a2ea-f4a4c6178309" />


### Before (light mode)

<img width="367" height="693" alt="image" src="https://github.com/user-attachments/assets/fd0b8eaf-92a8-4b80-b9ae-cede2760ca30" />

### After (dark mode)

<img width="369" height="703" alt="image" src="https://github.com/user-attachments/assets/5ee73664-862b-49a5-8fb4-1d2fbc7dff90" />

### After (light mode)

<img width="369" height="698" alt="image" src="https://github.com/user-attachments/assets/2a76d20c-a839-4f6f-99c2-dba8aae1d53a" />



AI Disclosure:
No AI used