### PR TITLE
fix: Content page input padding and border.

### DIFF
--- a/app/javascript/components/TiptapExtensions/TextInputNodeView.tsx
+++ b/app/javascript/components/TiptapExtensions/TextInputNodeView.tsx
@@ -26,12 +26,10 @@ export const TextInputNodeView = ({ editor, node, updateAttributes }: NodeViewPr
               className="border-0"
               style={{
                 background: "none",
-                padding: 0,
                 margin: 0,
                 font: "inherit",
                 color: "inherit",
                 outline: "none",
-                borderRadius: 0,
               }}
             />
             {type === "shortAnswer" ? <input {...sharedProps} /> : <textarea {...sharedProps} />}


### PR DESCRIPTION
ref: #864

### Summary
Content page input padding and border issue fix.

Before:

Desktop:

https://github.com/user-attachments/assets/ceb12670-04ba-46c3-b19a-93bf76f23cf8



Mobile:
<img width="366" height="808" alt="Screenshot 2025-10-02 at 10 38 56 PM" src="https://github.com/user-attachments/assets/91667c6f-e36c-4f6d-8543-e943fcf65004" />

After:
Desktop:
**Dark**

https://github.com/user-attachments/assets/4e4166d5-b551-49cd-b130-d27d3a6d1967


**Light**

https://github.com/user-attachments/assets/c7b67c85-4a36-42ce-b5d3-655d836b402e

**Mobile**
<img width="364" height="807" alt="Screenshot 2025-10-02 at 10 43 28 PM" src="https://github.com/user-attachments/assets/d25040b6-c404-4540-82c7-43b59ef3150e" />

> AI Disclosure

No AI was used to generate any of this code.

> Self-Review

I have self-reviewed all the code that I have written.