### PR TITLE
Add empty state for TestimonialSelectModal

### DIFF
--- a/app/javascript/components/TestimonialSelectModal.tsx
+++ b/app/javascript/components/TestimonialSelectModal.tsx
@@ -99,7 +99,11 @@ export const TestimonialSelectModal = ({
         <>
           <Button onClick={onClose}>Cancel</Button>
           {state.reviews.length > 0 ? (
-            <Button color="primary" onClick={() => onInsert(selectedReviewIds)}>
+            <Button
+              color="primary"
+              onClick={() => onInsert(selectedReviewIds)}
+              disabled={selectedReviewIds.length === 0}
+            >
               Insert
             </Button>
           ) : null}

--- a/app/javascript/components/TestimonialSelectModal.tsx
+++ b/app/javascript/components/TestimonialSelectModal.tsx
@@ -4,6 +4,7 @@ import { Review as ReviewType, getReviews } from "$app/data/product_reviews";
 import { assertResponseError } from "$app/utils/request";
 
 import { Button } from "$app/components/Button";
+import { LoadingSpinner } from "$app/components/LoadingSpinner";
 import { Modal } from "$app/components/Modal";
 import { PaginationProps } from "$app/components/Pagination";
 import { Review } from "$app/components/Review";
@@ -84,40 +85,52 @@ export const TestimonialSelectModal = ({
       footer={
         <>
           <Button onClick={onClose}>Cancel</Button>
-          <Button color="primary" onClick={() => onInsert(selectedReviewIds)}>
-            Insert
-          </Button>
+          {state.reviews.length > 0 ? (
+            <Button color="primary" onClick={() => onInsert(selectedReviewIds)}>
+              Insert
+            </Button>
+          ) : null}
         </>
       }
     >
       <div>
-        <div className="flex flex-row items-center gap-2">
-          <input
-            type="checkbox"
-            role="checkbox"
-            checked={selectedReviewIds.length === state.reviews.length && state.reviews.length > 0}
-            onChange={toggleSelectAll}
-            aria-label="Select all reviews"
-          />
-          <p>Select all</p>
-        </div>
-        <section className="paragraphs" style={{ marginTop: "var(--spacer-2)" }}>
-          {state.reviews.map((review) => (
-            <SelectableReviewCard
-              key={review.id}
-              review={review}
-              isSelected={selectedReviewIds.includes(review.id)}
-              onSelect={() => toggleReviewSelection(review.id)}
-            />
-          ))}
-          {hasMorePages ? (
-            <div className="mt-4">
-              <Button onClick={handleLoadMore} disabled={isLoading}>
-                {isLoading ? "Loading..." : "Load more"}
-              </Button>
+        {isLoading && state.reviews.length === 0 ? (
+          <div className="flex items-center justify-center">
+            <LoadingSpinner width="2em" />
+          </div>
+        ) : !isLoading && state.reviews.length === 0 ? (
+          <p>No written reviews yet</p>
+        ) : (
+          <>
+            <div className="flex flex-row items-center gap-2">
+              <input
+                type="checkbox"
+                role="checkbox"
+                checked={selectedReviewIds.length === state.reviews.length && state.reviews.length > 0}
+                onChange={toggleSelectAll}
+                aria-label="Select all reviews"
+              />
+              <p>Select all</p>
             </div>
-          ) : null}
-        </section>
+            <section className="paragraphs" style={{ marginTop: "var(--spacer-2)" }}>
+              {state.reviews.map((review) => (
+                <SelectableReviewCard
+                  key={review.id}
+                  review={review}
+                  isSelected={selectedReviewIds.includes(review.id)}
+                  onSelect={() => toggleReviewSelection(review.id)}
+                />
+              ))}
+              {hasMorePages ? (
+                <div className="mt-4">
+                  <Button onClick={handleLoadMore} disabled={isLoading}>
+                    {isLoading ? "Loading..." : "Load more"}
+                  </Button>
+                </div>
+              ) : null}
+            </section>
+          </>
+        )}
       </div>
     </Modal>
   );

--- a/app/javascript/components/TestimonialSelectModal.tsx
+++ b/app/javascript/components/TestimonialSelectModal.tsx
@@ -116,7 +116,7 @@ export const TestimonialSelectModal = ({
             <LoadingSpinner width="2em" />
           </div>
         ) : !isLoading && state.reviews.length === 0 ? (
-          <p>No written reviews yet</p>
+          <p>No reviews with text or video yet.</p>
         ) : (
           <>
             <div className="flex flex-row items-center gap-2">

--- a/app/javascript/components/TestimonialSelectModal.tsx
+++ b/app/javascript/components/TestimonialSelectModal.tsx
@@ -9,7 +9,6 @@ import { Modal } from "$app/components/Modal";
 import { PaginationProps } from "$app/components/Pagination";
 import { Review } from "$app/components/Review";
 import { showAlert } from "$app/components/server-components/Alert";
-import { useRunOnce } from "$app/components/useRunOnce";
 
 export const TestimonialSelectModal = ({
   isOpen,
@@ -31,6 +30,7 @@ export const TestimonialSelectModal = ({
     pagination: null,
   });
   const [isLoading, setIsLoading] = React.useState(false);
+  const hasLoadedOnOpen = React.useRef(false);
 
   const loadReviews = async (page = 1) => {
     setIsLoading(true);
@@ -49,9 +49,22 @@ export const TestimonialSelectModal = ({
     }
   };
 
-  useRunOnce(() => {
-    void loadReviews(1);
-  });
+  const resetState = () => {
+    setState({ reviews: [], pagination: null });
+    setSelectedReviewIds([]);
+  };
+
+  React.useEffect(() => {
+    if (isOpen && !hasLoadedOnOpen.current) {
+      hasLoadedOnOpen.current = true;
+      void loadReviews(1);
+    }
+
+    if (!isOpen) {
+      hasLoadedOnOpen.current = false;
+      resetState();
+    }
+  }, [isOpen]);
 
   const handleLoadMore = () => {
     if (state.pagination) {

--- a/spec/requests/products/edit/edit_spec.rb
+++ b/spec/requests/products/edit/edit_spec.rb
@@ -942,10 +942,7 @@ describe("Product Edit Scenario", type: :system, js: true) do
   it "allows creating and deleting a testimonial in the product rich content" do
     product = create(:product, user: seller, name: "Sample product", price_cents: 1000)
     purchase1 = create(:purchase, link: product, email: "reviewer1@example.com", full_name: "Reviewer 1")
-    review1 = create(:product_review, purchase: purchase1, rating: 5, message: "This is amazing! Highly recommended.")
-
     purchase2 = create(:purchase, link: product, email: "reviewer2@example.com", full_name: "Reviewer 2")
-    review2 = create(:product_review, purchase: purchase2, rating: 4, message: "Very good product with great features.")
 
     visit edit_link_path(product.unique_permalink)
     select_tab "Content"
@@ -957,6 +954,20 @@ describe("Product Edit Scenario", type: :system, js: true) do
     end
 
     within_modal "Insert reviews" do
+      expect(page).to have_text("No written reviews yet")
+      expect(page).not_to have_button "Insert"
+      click_on "Cancel"
+    end
+
+    review1 = create(:product_review, purchase: purchase1, rating: 5, message: "This is amazing! Highly recommended.")
+    review2 = create(:product_review, purchase: purchase2, rating: 4, message: "Very good product with great features.")
+
+    select_disclosure "Insert" do
+      click_on "Review"
+    end
+
+    within_modal "Insert reviews" do
+      expect(page).to have_button "Insert", disabled: true
       check "Select all"
       click_on "Insert"
     end
@@ -987,10 +998,7 @@ describe("Product Edit Scenario", type: :system, js: true) do
   it "allows creating and deleting a testimonial in the product description" do
     product = create(:product, user: seller, name: "Sample product", price_cents: 1000)
     purchase1 = create(:purchase, link: product, email: "reviewer1@example.com", full_name: "Reviewer 1")
-    review1 = create(:product_review, purchase: purchase1, rating: 5, message: "This is amazing! Highly recommended.")
-
     purchase2 = create(:purchase, link: product, email: "reviewer2@example.com", full_name: "Reviewer 2")
-    review2 = create(:product_review, purchase: purchase2, rating: 4, message: "Very good product with great features.")
 
     visit edit_link_path(product.unique_permalink)
 
@@ -1001,6 +1009,20 @@ describe("Product Edit Scenario", type: :system, js: true) do
     end
 
     within_modal "Insert reviews" do
+      expect(page).to have_text("No written reviews yet")
+      expect(page).not_to have_button "Insert"
+      click_on "Cancel"
+    end
+
+    review1 = create(:product_review, purchase: purchase1, rating: 5, message: "This is amazing! Highly recommended.")
+    review2 = create(:product_review, purchase: purchase2, rating: 4, message: "Very good product with great features.")
+
+    select_disclosure "Insert" do
+      click_on "Review"
+    end
+
+    within_modal "Insert reviews" do
+      expect(page).to have_button "Insert", disabled: true
       check "Select all"
       click_on "Insert"
     end


### PR DESCRIPTION
- Updated the empty state `TestimonialSelectModal` to let the user know that there are no reviews with text or video yet.
- Only try to load reviews after opening `TestimonialSelectModal` (instead of on page load)
- Disable `Insert` button when nothing is selected

<img width="800" alt="image" src="https://github.com/user-attachments/assets/eaeea5e2-97ff-4177-a9a5-95f85dc85455" />
