### PR TITLE
fix: Add missing Edit button on Coffee product page for consistency

### DIFF
--- a/app/javascript/components/server-components/Profile/CoffeePage.tsx
+++ b/app/javascript/components/server-components/Profile/CoffeePage.tsx
@@ -4,13 +4,18 @@ import { createCast } from "ts-safe-cast";
 import { CreatorProfile } from "$app/parsers/profile";
 import { register } from "$app/utils/serverComponentUtil";
 
+import { NavigationButton } from "$app/components/Button";
+import { useAppDomain } from "$app/components/DomainSettings";
+import { Icon } from "$app/components/Icons";
 import { Product, Props as ProductProps, Purchase } from "$app/components/Product";
 import { ConfigurationSelector, PriceSelection } from "$app/components/Product/ConfigurationSelector";
 import { CtaButton, getCtaName } from "$app/components/Product/CtaButton";
 import { Layout as ProfileLayout } from "$app/components/Profile/Layout";
 import { showAlert } from "$app/components/server-components/Alert";
+import { useIsAboveBreakpoint } from "$app/components/useIsAboveBreakpoint";
 import { useOriginalLocation } from "$app/components/useOriginalLocation";
 import { useRunOnce } from "$app/components/useRunOnce";
+import { WithTooltip } from "$app/components/WithTooltip";
 
 type Props = ProductProps & {
   creator_profile: CreatorProfile;
@@ -76,8 +81,25 @@ export const CoffeeProduct = ({
       />
     </>
   );
+
+  const isDesktop = useIsAboveBreakpoint("lg");
+  const appDomain = useAppDomain();
+
   return (
     <section className="px-4" style={{ display: "grid", gap: "var(--spacer-7)", alignContent: "center", flexGrow: 1 }}>
+      {product.can_edit ? (
+        <div className="!fixed right-3 top-5 z-30 !p-0 lg:left-3 lg:right-auto lg:top-3">
+          <WithTooltip tip="Edit product" position={isDesktop ? "right" : "left"}>
+            <NavigationButton
+              color="filled"
+              href={Routes.edit_link_url({ id: product.permalink }, { host: appDomain })}
+              aria-label="Edit product"
+            >
+              <Icon name="pencil" />
+            </NavigationButton>
+          </WithTooltip>
+        </div>
+      ) : null}
       <section className="override grid gap-8">
         <h1>{product.name}</h1>
         {product.description_html ? <h3 dangerouslySetInnerHTML={{ __html: product.description_html }} /> : null}

--- a/spec/requests/purchases/product/coffee_spec.rb
+++ b/spec/requests/purchases/product/coffee_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 
 describe "Coffee", type: :system, js: true do
   let(:seller) { create(:named_seller, :eligible_for_service_products) }
+  let(:other_user) { create(:user) }
   let(:coffee) do
     create(
       :product,
@@ -136,6 +137,22 @@ describe "Coffee", type: :system, js: true do
       expect(page).to have_selector("h1", text: "Buy me a coffee!")
       expect(page).to have_link("test@example.com", href: "mailto:test@example.com")
       expect(page).not_to have_text('<a href="mailto:test@example.com"')
+    end
+  end
+
+  context "edit button" do
+    it "shows edit button to product owner" do
+      sign_in seller
+      visit coffee.long_url
+
+      expect(page).to have_selector("[aria-label='Edit product']")
+    end
+
+    it "does not show edit button to other users" do
+      sign_in other_user
+      visit coffee.long_url
+
+      expect(page).to_not have_selector("[aria-label='Edit product']")
     end
   end
 end


### PR DESCRIPTION
### Explanation of Change
Ensure Coffee product pages display the Edit button so sellers can update details directly without extra navigation

### Screenshots/Videos
Before
<img width="1470" height="797" alt="image" src="https://github.com/user-attachments/assets/4f61f9e6-28e8-4c59-8805-a45578560ce1" />

After
<img width="1470" height="796" alt="image" src="https://github.com/user-attachments/assets/50c983ed-e784-452a-8760-14ac7d8c710a" />

<img width="409" height="755" alt="image" src="https://github.com/user-attachments/assets/65071a72-381e-4838-82b6-58190476ff06" />

### Test Results
<img width="549" height="230" alt="image" src="https://github.com/user-attachments/assets/90a176a4-b4a7-4dfb-b3b5-4f0c6e96fa10" />

### AI Disclosure
No AI tools used


