### PR TITLE
refactor: inline css to tailwind at BundleProductSelector

### DIFF
--- a/app/javascript/components/BundleEdit/ContentTab/BundleProductSelector.tsx
+++ b/app/javascript/components/BundleEdit/ContentTab/BundleProductSelector.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 
 import { BundleProduct } from "$app/components/BundleEdit/state";
 import { Thumbnail } from "$app/components/Product/Thumbnail";
-import { classNames } from "$app/utils/classNames";
 
 export const BundleProductSelector = ({
   bundleProduct,


### PR DESCRIPTION
#1055 
## Description

migrated inline css to tailwind at `BundleProductSelector.tsx`


## Screenshots

### Before
<img width="1647" height="805" alt="image" src="https://github.com/user-attachments/assets/53d54b50-1f3c-4629-acf1-5533d51b590d" />

<img width="422" height="889" alt="image" src="https://github.com/user-attachments/assets/a14adec4-1ec8-4299-96d1-ffe8decaff98" />

### After
<img width="1647" height="805" alt="image" src="https://github.com/user-attachments/assets/d8557ddb-408f-4033-bc45-bc3743b2e269" />


<img width="422" height="889" alt="image" src="https://github.com/user-attachments/assets/796fac8b-f809-4974-8c96-63b5aa18f043" />




## AI Usage
None
