### PR TITLE
refactor (password-input): migrate inline styles to tailwind

### DIFF
--- a/app/javascript/components/PasswordInput.tsx
+++ b/app/javascript/components/PasswordInput.tsx
@@ -56,7 +56,7 @@ export const PasswordInput = React.forwardRef<HTMLInputElement, PasswordInputPro
         onClick={togglePasswordVisibility}
         role="button"
         tabIndex={0}
-        style={{ cursor: "pointer", userSelect: "none" }}
+        className="cursor-pointer select-none"
         aria-label={showPassword ? "Hide password" : "Show password"}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") {


### PR DESCRIPTION
### Description:

Migrate inline styles for password input component to tailwind

Part of #1055 

### Before / After:


1. Login View

 <table>
 <tr><th>Before</th><th>After</th></tr>
 <tr>
 <td> 
<img width="1200" height="750" alt="b_login_d" src="https://github.com/user-attachments/assets/008d76a6-49c4-43b3-805c-2aece011a983" />
</td>
  <td> 
<img width="1200" height="750" alt="a_login" src="https://github.com/user-attachments/assets/dc21a9e1-71a5-4ad7-936d-cced2ef88ae5" />
 </td>
 </tr>
 <tr>
 <td>
<img width="350" height="761" alt="b_login_m" src="https://github.com/user-attachments/assets/6ba3946d-f89b-497c-a679-722a18bb81b5" />
 </td>
  <td>
<img width="350" height="761" alt="a_login_m" src="https://github.com/user-attachments/assets/496ec8b2-0d2e-47a3-9851-d873a956bcbd" />
 </td>
 </tr>
 </table>

2. Signup View 

 <table>
 <tr><th>Before</th><th>After</th></tr>
 <tr>
 <td> 
<img width="1200" height="750" alt="b_singup_d" src="https://github.com/user-attachments/assets/e34ceb69-2bf8-4834-afda-f4e409f8fcf8" />
</td>
  <td> 
<img width="1200" height="750" alt="a_signup" src="https://github.com/user-attachments/assets/349eb848-a94e-4de9-a1ed-3f5116bfb87e" />

 </td>
 </tr>
 <tr>
 <td>
<img width="350" height="776" alt="b_signup_m" src="https://github.com/user-attachments/assets/934c2a4c-5e12-4666-91d7-fd93968aa0f1" />

 </td>
  <td>
<img width="350" height="777" alt="a_signup_m" src="https://github.com/user-attachments/assets/0f629d57-c548-4730-a418-070da6f10a9d" />

 </td>
 </tr>
 </table>

- Changes doesn't affect any theme colour scheme
  
> [!Note]
> AI Disclosure: No AI was used to generate any of this code.

