### PR TITLE
refactor: inline css to tailwind at product ShareSection

### DIFF
--- a/app/javascript/components/Product/ShareSection.tsx
+++ b/app/javascript/components/Product/ShareSection.tsx
@@ -88,7 +88,7 @@ export const ShareSection = ({
 
   return (
     <>
-      <div style={{ display: "grid", gap: "var(--spacer-2)", gridTemplateColumns: "1fr auto" }}>
+      <div className="grid !gap-2 !grid-cols-[1fr_auto]">
         <ComboBox
           input={(props) => (
             <div {...props} className="input" aria-label="Add to wishlist">

--- a/app/javascript/components/Product/ShareSection.tsx
+++ b/app/javascript/components/Product/ShareSection.tsx
@@ -88,7 +88,7 @@ export const ShareSection = ({
 
   return (
     <>
-      <div className="override grid gap-2 grid-cols-[1fr_auto]">
+      <div className="override grid grid-cols-[1fr_auto] gap-2">
         <ComboBox
           input={(props) => (
             <div {...props} className="input" aria-label="Add to wishlist">

--- a/app/javascript/components/Product/ShareSection.tsx
+++ b/app/javascript/components/Product/ShareSection.tsx
@@ -88,7 +88,7 @@ export const ShareSection = ({
 
   return (
     <>
-      <div className="grid !gap-2 !grid-cols-[1fr_auto]">
+      <div className="override grid gap-2 grid-cols-[1fr_auto]">
         <ComboBox
           input={(props) => (
             <div {...props} className="input" aria-label="Add to wishlist">


### PR DESCRIPTION
#1055 
## Description

migrated inline css to tailwind at `ShareSection.tsx`


## Screenshots

### Before
<img width="1244" height="881" alt="image" src="https://github.com/user-attachments/assets/2ba07c70-6bf3-42ad-ab69-83a5b3d08f08" />

<img width="602" height="881" alt="image" src="https://github.com/user-attachments/assets/c2a7311f-6b77-43f0-89aa-8828e0f6b0ce" />


### After

<img width="1191" height="578" alt="image" src="https://github.com/user-attachments/assets/d533ba63-f383-4307-b57c-d94c0bc31886" />

<img width="443" height="881" alt="image" src="https://github.com/user-attachments/assets/6255f9d5-bb74-4f23-b902-e7c3a1b93014" />


## AI Usage
None
