### PR TITLE
fix: preserve formatting and spacing in affiliate promotion content

### DIFF
--- a/app/javascript/components/server-components/AffiliatesPage.tsx
+++ b/app/javascript/components/server-components/AffiliatesPage.tsx
@@ -44,6 +44,7 @@ import { buildStaticRouter, GlobalProps, register } from "$app/utils/serverCompo
 import { isUrlValid } from "$app/utils/url";
 
 import { AffiliateSignupForm, ProductRow } from "$app/components/AffiliatesDashboard/AffiliateSignupForm";
+import { Breaklines } from "$app/components/Breaklines";
 import { Button } from "$app/components/Button";
 import { CopyToClipboard } from "$app/components/CopyToClipboard";
 import { Icon } from "$app/components/Icons";
@@ -271,7 +272,7 @@ const AffiliateRequestsTable = ({
                 </td>
 
                 <td data-label="Promotion">
-                  <pre className="whitespace-pre-wrap">{affiliateRequest.promotion}</pre>
+                  <Breaklines text={affiliateRequest.promotion} />
                 </td>
 
                 <td data-label="Date">{parseISO(affiliateRequest.date).toLocaleDateString(userAgentInfo.locale)}</td>


### PR DESCRIPTION
### Explanation of Change
Ensures affiliate promotion content retains proper spacing and line breaks by rendering with pre-wrap formatting. 

### Screenshots/Videos
The content on form
<img width="1470" height="786" alt="image" src="https://github.com/user-attachments/assets/f3aa6133-8353-497b-8dc3-68a0e6f8affb" />

Before
<img width="1470" height="493" alt="image" src="https://github.com/user-attachments/assets/761e9319-36b5-4c6e-80ad-16b05320564c" />
<img width="372" height="640" alt="image" src="https://github.com/user-attachments/assets/1dff45cb-32be-451b-b84e-19d19340e2cc" />

After
<img width="1470" height="572" alt="image" src="https://github.com/user-attachments/assets/c167db20-2968-4ae4-b1ce-da4d4eb6edfb" />
<img width="333" height="629" alt="image" src="https://github.com/user-attachments/assets/e36e36ab-e06a-42ce-bf35-42ca63b03e7d" />


### AI Disclosure
No AI tools used


