### PR TITLE
fix: add horizontal padding on affiliates page form

### DIFF
--- a/app/javascript/components/server-components/AffiliateRequestPage.tsx
+++ b/app/javascript/components/server-components/AffiliateRequestPage.tsx
@@ -54,7 +54,7 @@ const AffiliateRequestPage = ({ creator_profile }: Props) => {
   return (
     <Layout creatorProfile={creator_profile}>
       <PageHeader title={`Become an affiliate for ${creator_profile.name}`} />
-      <form className="border-b border-border pt-8">
+      <form className="border-b border-border px-4 pt-8">
         <section>
           <header>
             <div className="paragraphs">


### PR DESCRIPTION
### Explanation of Change
Adds horizontal padding to the affiliates page form to ensure proper margin on mobile devices

### Screenshots/Videos
Before
<img width="324" height="675" alt="image" src="https://github.com/user-attachments/assets/ab718d15-ff53-4d3c-8da2-4d823ba58dbd" />

After
<img width="327" height="673" alt="image" src="https://github.com/user-attachments/assets/f0f4581f-50e8-4039-bb5d-1e932771dca8" />


### AI Disclosure
No AI tools used


