### PR TITLE
fix: tooltip screen overflow at bundle product edit

### DIFF
--- a/app/javascript/components/BundleEdit/Layout.tsx
+++ b/app/javascript/components/BundleEdit/Layout.tsx
@@ -125,7 +125,7 @@ export const Layout = ({
                 {isPublishing ? "Unpublishing..." : "Unpublish"}
               </Button>
               {saveButton}
-              <CopyToClipboard text={url} copyTooltip="Copy product URL">
+              <CopyToClipboard text={url} copyTooltip="Copy product URL" tooltipPosition="left">
                 <Button>
                   <Icon name="link" />
                 </Button>


### PR DESCRIPTION
#864 
## Description

### Problem
- the `copy product url` tooltip was causing screen overflow

### Fix
- changed the tooltip position to left.


## Screenshots

### Before

[Screencast from 2025-10-03 15-53-32.webm](https://github.com/user-attachments/assets/25cb6bec-ab2c-42d7-91ae-b14118e126ab)


### After


[Screencast from 2025-10-03 15-51-31.webm](https://github.com/user-attachments/assets/4023d9dd-0bfb-487d-a86a-975d053f28f4)



## AI Usage
None
