### PR TITLE
[Flaky] Fix update upsell flaky spec

### DIFF
--- a/spec/requests/checkout/upsells_spec.rb
+++ b/spec/requests/checkout/upsells_spec.rb
@@ -516,9 +516,9 @@ describe("Checkout upsells page", type: :system, js: true) do
       find(:table_row, { "Upsell" => "Upsell 1" }).click
       click_on "Edit"
 
-      fill_in "Name", with: "Complete course upsell"
-      fill_in "Offer text", with: "Enhance your learning experience"
-      fill_in "Offer description", with: "You'll enjoy a range of exclusive features, including..."
+      fill_in "Name", with: "Complete course upsell", fill_options: { clear: :backspace }
+      fill_in "Offer text", with: "Enhance your learning experience", fill_options: { clear: :backspace }
+      fill_in "Offer description", with: "You'll enjoy a range of exclusive features, including...", fill_options: { clear: :backspace }
 
       choose "Replace the version selected with another version of the same product"
 


### PR DESCRIPTION
AI Disclosure: None
Self review: Done
Ref: https://github.com/antiwork/gumroad/issues/1127

### Root cause
Capybara partially writes the text, which then fails the expection.

- Text being cut off mid-sentence (e.g., "You'..." instead of "You'll enjoy a range of exclusive features, including...")
- Only first word being filled (e.g., "Enhance" instead of "Enhance your learning experience")

<img width="1553" height="970" alt="image" src="https://github.com/user-attachments/assets/5b89638b-8717-49c1-9456-9175c108a3dc" />

### Proposed solution

Added `fill_options: { clear: :backspace }` to affected calls



### Screenshots:
#### Before (2 failures out of 10)
<img width="1553" height="891" alt="image" src="https://github.com/user-attachments/assets/b38fc538-e0d6-42d9-97f3-4d6005a1de3b" />

#### After (All green)
10 runs
<img width="1541" height="532" alt="image" src="https://github.com/user-attachments/assets/34bc1d5d-d3f8-42d8-821f-728bd6ddadc3" />
20 runs
<img width="1446" height="485" alt="image" src="https://github.com/user-attachments/assets/7b5c0895-f124-4476-9bcc-cdf8ff7de030" />


### Example failures:
https://github.com/antiwork/gumroad/actions/runs/18172352914/job/51730686238
(There are more, I will update this section later)