### PR TITLE
Convert inline styles to tailwind for TestimonialsSelectModal.

### DIFF
--- a/app/javascript/components/TestimonialSelectModal.tsx
+++ b/app/javascript/components/TestimonialSelectModal.tsx
@@ -129,7 +129,7 @@ export const TestimonialSelectModal = ({
               />
               <p>Select all</p>
             </div>
-            <section className="paragraphs mt-[var(--spacer-2)]">
+            <section className="paragraphs mt-2">
               {state.reviews.map((review) => (
                 <SelectableReviewCard
                   key={review.id}


### PR DESCRIPTION
ref: #1055 

#### Description
Migrated inline css to tailwind at TestimonialsSelectModal.

**Before:**

**Desktop**
Dark:
<img width="851" height="810" alt="Screenshot 2025-10-03 at 10 36 52 PM" src="https://github.com/user-attachments/assets/eeab1572-5de3-4a5e-96a9-7f2b42b7b6f0" />
Light:
<img width="750" height="746" alt="Screenshot 2025-10-03 at 10 37 31 PM" src="https://github.com/user-attachments/assets/4693da72-33f1-40c0-9679-ae344ae9cda0" />

Mobile:
<img width="377" height="815" alt="Screenshot 2025-10-03 at 10 41 04 PM" src="https://github.com/user-attachments/assets/b0a4fd57-ff4d-4a77-b7cd-a17411979086" />

**After**

**Desktop**
Dark:
<img width="851" height="810" alt="Screenshot 2025-10-03 at 10 36 52 PM" src="https://github.com/user-attachments/assets/54546115-df9e-4535-9bd0-f57b46f88728" />

Light:
<img width="750" height="746" alt="Screenshot 2025-10-03 at 10 37 31 PM" src="https://github.com/user-attachments/assets/355cfb26-1f6a-48f9-b4f6-1ad23b7e26d1" />

**Mobile**

<img width="377" height="815" alt="Screenshot 2025-10-03 at 10 41 04 PM" src="https://github.com/user-attachments/assets/a6a09816-4d61-415a-8a11-4e4739da8fd6" />

#### AI disclosure

No AI was used to generate any of this code.

#### Self-Review

I have self-reviewed all the code that I have written.
