### PR TITLE
Fix: Failing Empty Product Reviews test

### DIFF
--- a/spec/requests/products/edit/edit_spec.rb
+++ b/spec/requests/products/edit/edit_spec.rb
@@ -954,7 +954,7 @@ describe("Product Edit Scenario", type: :system, js: true) do
     end
 
     within_modal "Insert reviews" do
-      expect(page).to have_text("No written reviews yet")
+      expect(page).to have_text("No reviews with text or video yet.")
       expect(page).not_to have_button "Insert"
       click_on "Cancel"
     end
@@ -1009,7 +1009,7 @@ describe("Product Edit Scenario", type: :system, js: true) do
     end
 
     within_modal "Insert reviews" do
-      expect(page).to have_text("No written reviews yet")
+      expect(page).to have_text("No reviews with text or video yet.")
       expect(page).not_to have_button "Insert"
       click_on "Cancel"
     end


### PR DESCRIPTION
Ref https://github.com/antiwork/gumroad/issues/1127

### AI Disclosure

None

### Recent Failed runs on main 

https://github.com/antiwork/gumroad/actions/runs/18228618920/job/51906635692
https://github.com/antiwork/gumroad/actions/runs/18227514194/job/51903392332

### Cause and Fix

this PR https://github.com/antiwork/gumroad/pull/1484 updated the empty reviews text but didn't update in the test

### Test Pases

## Before
<img width="1213" height="625" alt="Screenshot 2025-10-03 at 11 16 13 PM" src="https://github.com/user-attachments/assets/970fd7c6-4286-41bc-bdef-fc6a5f5540c1" />

## After
<img width="1213" height="625" alt="Screenshot 2025-10-03 at 11 16 47 PM" src="https://github.com/user-attachments/assets/a185770a-8ccc-4f77-8c3f-4346f6ae1700" />





