### PR TITLE
chore: Replace inline style with Tailwind className in Checkout/CustomFields

### DIFF
--- a/app/javascript/components/Checkout/CustomFields.tsx
+++ b/app/javascript/components/Checkout/CustomFields.tsx
@@ -43,7 +43,7 @@ const CustomField = ({ field, fieldKey }: { field: CustomFieldDescriptor; fieldK
               onChange={(e) =>
                 dispatch({ type: "set-custom-field", key: fieldKey, value: e.target.checked ? "true" : "" })
               }
-              className={cx("m-0")}
+              className="m-0"
               disabled={isProcessing(state)}
             />
             {field.required ? field.name : `${field.name} (optional)`}
@@ -62,7 +62,7 @@ const CustomField = ({ field, fieldKey }: { field: CustomFieldDescriptor; fieldK
               onChange={(e) =>
                 dispatch({ type: "set-custom-field", key: fieldKey, value: e.target.checked ? "true" : "" })
               }
-              className={cx("m-0")}
+              className="m-0"
               disabled={isProcessing(state)}
             />
             I accept


### PR DESCRIPTION
ref: #1055 

#### Description
Migrated inline css to tailwind at TestimonialsSelectModal.

**Before:**

**Desktop**
Dark:
<img width="806" height="752" alt="Screenshot 2025-10-03 at 11 25 30 PM" src="https://github.com/user-attachments/assets/b7261d15-3a2b-4714-bbb4-d72a2826faa1" />

Light:
<img width="808" height="752" alt="Screenshot 2025-10-03 at 11 26 19 PM" src="https://github.com/user-attachments/assets/7c3509b7-29c4-4063-ad3b-67722a7df28d" />

Mobile:
<img width="377" height="685" alt="Screenshot 2025-10-03 at 11 27 14 PM" src="https://github.com/user-attachments/assets/5ecd8722-c61d-4390-be59-5cf5650f483f" />

**After:**
**Desktop**
Dark:
<img width="806" height="752" alt="Screenshot 2025-10-03 at 11 25 30 PM" src="https://github.com/user-attachments/assets/b7261d15-3a2b-4714-bbb4-d72a2826faa1" />

Light:
<img width="808" height="752" alt="Screenshot 2025-10-03 at 11 26 19 PM" src="https://github.com/user-attachments/assets/7c3509b7-29c4-4063-ad3b-67722a7df28d" />

Mobile:
<img width="377" height="685" alt="Screenshot 2025-10-03 at 11 27 14 PM" src="https://github.com/user-attachments/assets/5ecd8722-c61d-4390-be59-5cf5650f483f" />

#### AI disclosure

No AI was used to generate any of this code.

#### Self-Review

I have self-reviewed all the code that I have written.