### PR TITLE
Refactor: Convert grid inline styles to Tailwind in DurationsEditor.

### DIFF
--- a/app/javascript/components/ProductEdit/ProductTab/DurationsEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/DurationsEditor.tsx
@@ -169,7 +169,7 @@ const DurationEditor = ({
               onChange={(evt) => updateDuration({ description: evt.target.value })}
             />
           </fieldset>
-          <section className="!grid grid-flow-col items-end gap-6">
+          <section className="override grid grid-flow-col items-end gap-6">
             <fieldset>
               <label htmlFor={`${uid}-price`}>Additional amount</label>
               <PriceInput


### PR DESCRIPTION
ref: #1055 

#### Description
Convert grid inline styles to Tailwind in DurationsEditor.

**Before:**

**Desktop**
Dark:
<img width="809" height="599" alt="Screenshot 2025-10-03 at 11 56 03 PM" src="https://github.com/user-attachments/assets/35011be2-207e-43c6-866c-fa6c7de72f24" />

Light:
<img width="803" height="585" alt="Screenshot 2025-10-03 at 11 56 39 PM" src="https://github.com/user-attachments/assets/756df221-e307-4944-a7b3-d71014feed56" />

**Mobile**
<img width="375" height="549" alt="Screenshot 2025-10-03 at 11 57 13 PM" src="https://github.com/user-attachments/assets/5df59b60-1879-41fc-a1c7-5bb145936c74" />

**Desktop**
Dark:
<img width="791" height="594" alt="Screenshot 2025-10-03 at 11 59 06 PM" src="https://github.com/user-attachments/assets/913e0253-7942-4727-a9af-d1129c964c19" />

Light:
<img width="793" height="594" alt="Screenshot 2025-10-03 at 11 59 37 PM" src="https://github.com/user-attachments/assets/769a4269-b6aa-4675-99fc-4c0616a6c590" />

**Mobile**
<img width="363" height="541" alt="Screenshot 2025-10-04 at 12 00 11 AM" src="https://github.com/user-attachments/assets/5e4a4206-f3ed-4210-a34f-4a200c8322a9" />

#### AI disclosure

No AI was used to generate any of this code.

#### Self-Review

I have self-reviewed all the code that I have written.

