### PR TITLE
Fix(flaky test): communities test flakes because of race condition between unread message count update & test assertions

### DIFF
--- a/spec/requests/communities_spec.rb
+++ b/spec/requests/communities_spec.rb
@@ -470,12 +470,11 @@ describe "Communities", :js, type: :system do
           expect(page).to have_link("Mastering Rails", href: community_path(seller.external_id, community.external_id))
           expect(page).to have_link("Scaling web apps", href: community_path(seller.external_id, community2.external_id))
           community1_link_element = find_link("Mastering Rails")
-          within community1_link_element do
-            within "[aria-label='Unread message count']" do
-              expect(page).to have_text("2")
-            end
-          end
           expect(community1_link_element["aria-selected"]).to eq("true")
+          within community1_link_element do
+            # Wait for the unread message count to disappear as IntersectionObserver marks message as read
+            expect(page).to_not have_selector("[aria-label='Unread message count']", wait: 10)
+          end
           community2_link_element = find_link("Scaling web apps")
 
           # Wait for the unread count to be rendered by the React component
@@ -586,8 +585,8 @@ describe "Communities", :js, type: :system do
           expect(page).not_to have_link("The ultimate guide to design systems")
           expect(find_link("Mastering Rails")["aria-selected"]).to eq("true")
 
-          # Wait for the unread count to be rendered by the React component
-          expect(page).to have_selector("[aria-label='Unread message count']", text: "2", wait: 10)
+          # Wait for the unread message count to disappear as IntersectionObserver marks message as read
+          expect(page).to_not have_selector("[aria-label='Unread message count']", wait: 10)
         end
       end
 
@@ -620,8 +619,8 @@ describe "Communities", :js, type: :system do
           expect(page).not_to have_link("Mastering Rails")
           expect(find_link("The ultimate guide to design systems")["aria-selected"]).to eq("true")
 
-          # Wait for the unread count to be rendered by the React component
-          expect(page).to have_selector("[aria-label='Unread message count']", text: "1", wait: 10)
+          # Wait for the unread message count to disappear as IntersectionObserver marks message as read
+          expect(page).not_to have_selector("[aria-label='Unread message count']", wait: 10)
         end
       end
 


### PR DESCRIPTION
ref: #1127 

## Failing CI link:
https://github.com/antiwork/gumroad/actions/runs/18114254496/job/51547068781#step:8:81
<img width="1091" height="238" alt="Screenshot 2025-10-04 at 12 09 44 AM" src="https://github.com/user-attachments/assets/a412400a-7c05-4812-be09-20fad27ec6c5" />

## Problem:
- when the messages becomes visible, intersectionObserver api triggers request to "unread message count" to 0. 
- problem was our tests were asserting "unread message count" to be "2".
- There is a race condition when asserting the unread message count: it may be 2 if the mark-as-read request hasn't finished yet, or 0 if the request has completed.
- because of this test was flaky

code where we mark viewed messages as read:
```tsx
// communityview.tsx
  const debouncedMarkAsRead = React.useMemo(
    () =>
      debounce((communityId: string, messageId: string, messageCreatedAt: string) => {
        if (!communityId || !messageId) return;
        activeMarkAsReadRequest.current?.cancel();
        const request = markCommunityChatMessagesAsRead({ communityId, messageId });
        activeMarkAsReadRequest.current = request;
        request.response
          .then((response) => {
            updateCommunity(communityId, {
              unread_count: response.unread_count,
              last_read_community_chat_message_created_at: messageCreatedAt,
            });
          })
          .catch((e: unknown) => {
            if (!(e instanceof AbortError))
              showAlert("Failed to mark the message as read. Please try again later.", "error");
          });
      }, 500),
    [],
  );
```

## Solution:
- when messages for a community tab are visible, then assert that "unread message count" is not shown.
(unread message count goes 0 as mark as read request finishes, and we don't show unread message count when its '0')
```rb
            # Wait for the unread message count to disappear as IntersectionObserver marks message as read
            expect(page).to_not have_selector("[aria-label='Unread message count']", wait: 10)
```

## After: Local run
<img width="1186" height="483" alt="Screenshot 2025-10-03 at 11 44 20 PM" src="https://github.com/user-attachments/assets/e0a67682-f39e-4c71-be86-1528b2699568" />



### AI disclosure
- no AI used