### PR TITLE
Refactor: Convert grid inline styles to Tailwind in VersionsEditor.

### DIFF
--- a/app/javascript/components/ProductEdit/ProductTab/VersionsEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/VersionsEditor.tsx
@@ -10,6 +10,7 @@ import { Version, useProductEditContext } from "$app/components/ProductEdit/stat
 import { Drawer, ReorderingHandle, SortableList } from "$app/components/SortableList";
 import { Toggle } from "$app/components/Toggle";
 import { WithTooltip } from "$app/components/WithTooltip";
+import cx from "classnames";
 
 let newVersionId = 0;
 
@@ -170,7 +171,7 @@ const VersionEditor = ({
               onChange={(evt) => updateVersion({ description: evt.target.value })}
             />
           </fieldset>
-          <section style={{ display: "grid", gap: "var(--spacer-5)", gridAutoFlow: "column", alignItems: "flex-end" }}>
+          <section className={cx("grid", "gap-[var(--spacer-5)]", "grid-flow-col", "items-end")}>
             <fieldset>
               <label htmlFor={`${uid}-price`}>Additional amount</label>
               <PriceInput


### PR DESCRIPTION
ref: #1055 

#### Description
Convert grid inline styles to Tailwind in VersionsEditor.

**Before:**

**Desktop**
Dark:
<img width="803" height="590" alt="Screenshot 2025-10-04 at 12 07 42 AM" src="https://github.com/user-attachments/assets/5c30f3f9-0fb7-45b2-984c-8af1c71ac0d3" />

Light:
<img width="809" height="595" alt="Screenshot 2025-10-04 at 12 07 58 AM" src="https://github.com/user-attachments/assets/f86ec6fd-d832-499b-a976-918925ff854b" />

**Mobile**
<img width="368" height="543" alt="Screenshot 2025-10-04 at 12 13 14 AM" src="https://github.com/user-attachments/assets/af0d46c9-38c6-46c2-bfe8-2462ab0ebb18" />

**After**

Dark:
<img width="803" height="590" alt="Screenshot 2025-10-04 at 12 07 42 AM" src="https://github.com/user-attachments/assets/5c30f3f9-0fb7-45b2-984c-8af1c71ac0d3" />

Light:
<img width="809" height="595" alt="Screenshot 2025-10-04 at 12 07 58 AM" src="https://github.com/user-attachments/assets/f86ec6fd-d832-499b-a976-918925ff854b" />

**Mobile**
<img width="368" height="543" alt="Screenshot 2025-10-04 at 12 13 14 AM" src="https://github.com/user-attachments/assets/af0d46c9-38c6-46c2-bfe8-2462ab0ebb18" />

#### AI disclosure

No AI was used to generate any of this code.

#### Self-Review

I have self-reviewed all the code that I have written.