### PR TITLE
Fix flaky tooltip test in widget_spec.rb

### DIFF
--- a/spec/requests/widget_spec.rb
+++ b/spec/requests/widget_spec.rb
@@ -91,6 +91,9 @@ describe "Widget Page scenario", js: true, type: :system do
         expect(page).not_to have_content("Copy to Clipboard")
         expect(page).not_to have_content("Copied!")
 
+        # Wait for the tooltip state to fully reset before testing again
+        expect(copy_button).not_to have_tooltip(text: "Copied!")
+
         copy_button.hover
         expect(copy_button).to have_tooltip(text: "Copy to Clipboard")
       end


### PR DESCRIPTION
Ref https://github.com/antiwork/gumroad/issues/1127

Failing Test - 

https://github.com/antiwork/gumroad/actions/runs/18228618920/job/51906635609

### Problem
The test "allows creator to copy embed code of the product" was flaky due to timing issues with tooltip state transitions. After clicking the copy button, the tooltip changes to "Copied!" and when hovering elsewhere and back, it should return to "Copy to Clipboard". However, there was a timing condition where we instantly hover back to tooltip.

### Solution

To fix this, I use  Capybara's built-in waiting:  `expect(...).not_to have_tooltip(...)` to wait for condition to be true.
Added an explicit wait condition to ensure the tooltip state has fully reset before testing the final hover:

`expect(copy_button).not_to have_tooltip(text: "Copied!")`

This ensures that the "Copied!" tooltip is no longer visible before testing that hovering again shows "Copy to Clipboard".

### Before

<img width="1016" height="503" alt="image" src="https://github.com/user-attachments/assets/8487405f-e01d-45ce-9363-eb0bbe8f412e" />


### After

<img width="1491" height="427" alt="image" src="https://github.com/user-attachments/assets/2a7aed4d-4f99-4d29-ad27-dd1c1e791d25" />


AI Disclosure:
GitHub copilot to brainstorm