### PR TITLE
Refactor: Convert flex inline styles to Tailwind in ThumbnailEditor.

### DIFF
--- a/app/javascript/components/ProductEdit/ProductTab/ThumbnailEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/ThumbnailEditor.tsx
@@ -10,6 +10,7 @@ import { assertResponseError } from "$app/utils/request";
 
 import { ImageUploader } from "$app/components/ImageUploader";
 import { showAlert } from "$app/components/server-components/Alert";
+import cx from "classnames";
 
 const nativeTypeThumbnails = require.context("$assets/images/native_types/thumbnails/");
 
@@ -74,7 +75,7 @@ export const ThumbnailEditor = ({
 
   return (
     <section className="!p-4 md:!p-8">
-      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+      <div className={cx("flex", "justify-between", "items-center")}>
         <h2>Thumbnail</h2>
         <a href="/help/article/60-adding-a-cover-image" target="_blank" rel="noreferrer">
           Learn more


### PR DESCRIPTION
ref: #1055 

#### Description
Convert flex inline styles to Tailwind in ThumbnailEditor.

**Before:**

**Desktop**
Dark:
<img width="803" height="323" alt="Screenshot 2025-10-04 at 1 23 18 AM" src="https://github.com/user-attachments/assets/67a62933-4fba-4cab-811b-4d6fff106ae9" />

Light:
<img width="806" height="324" alt="Screenshot 2025-10-04 at 1 23 03 AM" src="https://github.com/user-attachments/assets/3c2ac9f8-0ba8-4d2c-a336-70e013c5323b" />

**Mobile**
<img width="376" height="625" alt="Screenshot 2025-10-04 at 1 23 33 AM" src="https://github.com/user-attachments/assets/b4ab7983-12f6-4898-84ba-7a3a9ea34373" />

**After**
Dark:
<img width="803" height="323" alt="Screenshot 2025-10-04 at 1 23 18 AM" src="https://github.com/user-attachments/assets/95b44104-4f45-4d48-9835-ae114ca24f9f" />

Light:
<img width="807" height="324" alt="Screenshot 2025-10-04 at 12 35 36 AM" src="https://github.com/user-attachments/assets/0fa2fe9c-0021-4a9f-94a0-ee02966ac6c5" />

**Mobile**
<img width="376" height="625" alt="Screenshot 2025-10-04 at 1 23 33 AM" src="https://github.com/user-attachments/assets/d9967148-3422-4957-9476-deb26b4bdf5d" />

#### AI disclosure

No AI was used to generate any of this code.

#### Self-Review

I have self-reviewed all the code that I have written.
