### PR TITLE
fix: missing style on ratingStars div

### DIFF
--- a/app/javascript/components/server-components/Audience/CustomersPage.tsx
+++ b/app/javascript/components/server-components/Audience/CustomersPage.tsx
@@ -1740,7 +1740,10 @@ const ReviewSection = ({
     <h3>Review</h3>
     <section>
       <h5>Rating</h5>
-      <div aria-label={`${review.rating} ${review.rating === 1 ? "star" : "stars"}`}>
+      <div
+        className="flex shrink-0 items-center gap-1"
+        aria-label={`${review.rating} ${review.rating === 1 ? "star" : "stars"}`}
+      >
         <RatingStars rating={review.rating} />
       </div>
     </section>


### PR DESCRIPTION
ref #864 

there was a missing styling.the rating stars have no gap and is tightly layout.
we have applied the same styling here to make it consistent with the rest rating components 

| Before | After | Dark Mode |
|------------|-----------------|-----------------|
| <img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/93e6ee1f-cd18-4d1a-a539-3e691474ca36" />| <img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/f59dac91-b20f-4ba0-be09-6f5bbad8189c" /> | <img width="1512" height="982" alt="Screenshot 2025-10-03 at 11 16 45 PM" src="https://github.com/user-attachments/assets/01e0e1a8-610d-4e49-ba4b-a99011b75924" /> |

## use of ai
none
