### PR TITLE
fix: delay between modal and its backdrop

### DIFF
--- a/app/javascript/components/Modal.tsx
+++ b/app/javascript/components/Modal.tsx
@@ -17,7 +17,7 @@ export const Modal = ({
 }) => {
   const dispatchClose = () => allowClose && onClose?.();
   const ref = React.useRef<HTMLDialogElement | null>(null);
-  const [supportsNative, setSupportsNative] = React.useState(false);
+  const [supportsNative, setSupportsNative] = React.useState<boolean | null>(null);
   React.useEffect(() => {
     if (!ref.current) return;
     if (supportsNative) {
@@ -38,7 +38,7 @@ export const Modal = ({
 
   return (
     <dialog
-      open={supportsNative ? undefined : open}
+      open={supportsNative === false ? open : undefined}
       ref={ref}
       onClick={(e) => {
         if (!ref.current) return;


### PR DESCRIPTION
ref #864 
there was a delay when we route to the payment tab. the backdrop was showing in a delay manner.
before:

https://github.com/user-attachments/assets/8f19e8da-51c4-47dc-9873-b38016aa9e53


after:

https://github.com/user-attachments/assets/71b9cd40-d185-4704-ac2a-8cd84e3a8403

## use of ai
>claude-4-sonnet 

in understanding the problem 