### PR TITLE
chore: migrates ToggleSettingRow from inline css to tailwindcss

### DIFF
--- a/app/javascript/components/SettingRow.tsx
+++ b/app/javascript/components/SettingRow.tsx
@@ -18,7 +18,7 @@ export const ToggleSettingRow = ({ label, value, help, onChange, dropdown, disab
       {help?.url ? (
         <>
           {" "}
-          <a href={help.url} target="_blank" rel="noopener noreferrer" className="learn-more" style={{ flexShrink: 0 }}>
+          <a href={help.url} target="_blank" rel="noopener noreferrer" className="learn-more flex-shrink-0">
             {help.label}
           </a>
         </>


### PR DESCRIPTION
fix: #1055 

| **Before (Desktop)** | **Before (Phone)** |
|-----------------------|--------------------|
| <img width="1311" height="488" alt="Screenshot 2025-10-04 at 12 29 56 PM" src="https://github.com/user-attachments/assets/e48633fd-ddbe-4c81-9f8b-d1df5e0bd0c9" /> | <img width="493" height="831" alt="Screenshot 2025-10-04 at 12 30 26 PM" src="https://github.com/user-attachments/assets/31eed6c5-da60-4bac-8f67-61a33a0c944f" /> |

| **After (Desktop)** | **After (Phone)** |
|----------------------|-------------------|
| <img width="1483" height="534" alt="Screenshot 2025-10-04 at 12 31 34 PM" src="https://github.com/user-attachments/assets/650c2dc6-0073-4d94-af35-c47f00c803e2" /> | <img width="496" height="815" alt="Screenshot 2025-10-04 at 12 31 28 PM" src="https://github.com/user-attachments/assets/610474e6-dbb1-45d6-b72c-32efed35858c" /> |



## AI Disclosure:
- no AI used.