### PR TITLE
chore: migrates withTooltip from inline CSS to tailwind

### DIFF
--- a/app/javascript/components/WithTooltip.tsx
+++ b/app/javascript/components/WithTooltip.tsx
@@ -17,7 +17,7 @@ export const WithTooltip = ({ tip, children, position, className }: Props) => {
 
   return (
     <span className={cx("has-tooltip", position, className)}>
-      <span aria-describedby={id} style={{ display: "contents" }}>
+      <span aria-describedby={id} className="contents">
         {children}
       </span>
       <span role="tooltip" id={id}>


### PR DESCRIPTION
ref: #1055 

### AI Disclosure:
- no AI used

| **Before (Desktop)** | **Before (Mobile)** |
|----------------------|---------------------|
| <img width="1512" height="982" alt="Screenshot 2025-10-04 at 1 03 09 PM" src="https://github.com/user-attachments/assets/ebff4d58-dc53-4343-8545-6b927becb0cd" /> | <img width="501" height="858" alt="Screenshot 2025-10-04 at 1 04 28 PM" src="https://github.com/user-attachments/assets/6391d065-34bb-40cf-a7eb-96df5367d5e6" /> |

| **After (Desktop)** | **After (Mobile)** |
|---------------------|--------------------|
| <img width="1512" height="982" alt="Screenshot 2025-10-04 at 12 57 21 PM" src="https://github.com/user-attachments/assets/b6a87dc3-d590-403d-9327-ae85effd0bca" /> | <img width="503" height="852" alt="Screenshot 2025-10-04 at 12 58 43 PM" src="https://github.com/user-attachments/assets/03f5c333-fa16-474d-9038-6aaf71b05850" /> |
