### PR TITLE
refactor: migrate inline styles to tailwind for wishlist

### DIFF
--- a/app/javascript/components/Wishlist/index.tsx
+++ b/app/javascript/components/Wishlist/index.tsx
@@ -117,7 +117,7 @@ const WishlistItemCard = ({
       footerAction={
         <>
           {canEdit ? (
-            <div style={{ padding: 0, display: "grid" }}>
+            <div className="override grid !p-0">
               <WithTooltip position="top" tip="Remove this product">
                 <button
                   disabled={isDeleting}
@@ -131,7 +131,7 @@ const WishlistItemCard = ({
             </div>
           ) : null}
           {item.purchasable && item.giftable ? (
-            <div style={{ padding: 0, display: "grid" }}>
+            <div className="override grid !p-0">
               <WithTooltip position="top" tip="Gift this product">
                 <a
                   aria-label="Gift this product"
@@ -147,7 +147,7 @@ const WishlistItemCard = ({
       }
       badge={
         item.purchasable ? (
-          <div style={{ position: "absolute", top: "var(--spacer-4)", right: "var(--spacer-4)" }}>
+          <div className="absolute right-4 top-4">
             <WithTooltip position="top" tip="Add to cart">
               <NavigationButton
                 href={addToCartUrl(item)}
@@ -257,8 +257,8 @@ export const Wishlist = ({
         }
       >
         {user ? (
-          <a style={{ display: "flex", alignItems: "center", gap: "var(--spacer-2)" }} href={user.profile_url}>
-            <img className="user-avatar" src={user.avatar_url} style={{ width: "var(--spacer-5)" }} />
+          <a className="flex items-center gap-2" href={user.profile_url}>
+            <img className="user-avatar !w-6" src={user.avatar_url} />
             <h4>{user.name}</h4>
           </a>
         ) : null}


### PR DESCRIPTION
### Description:

Migrate inline styles for wishlist component to tailwind.

Part of #1055 

### Before / After:

 <table>
 <tr><th>Before</th><th>After</th></tr>
 <tr>
 <td> 
<img width="1440" height="813" alt="Screenshot 2025-10-03 at 3 17 29 PM" src="https://github.com/user-attachments/assets/2e77670b-4c4b-4684-ac68-8926c7733bc6" />
</td>
  <td> 
<img width="1438" height="811" alt="a_wishlist" src="https://github.com/user-attachments/assets/70a82542-aa49-4860-a9f8-1edeb3864da1" />
 </td>
 </tr>
 <tr>
 <td>
<img width="350" height="711" alt="Screenshot 2025-10-03 at 3 17 12 PM" src="https://github.com/user-attachments/assets/46cfc2df-635f-4f0b-a292-9cf8620e0b92" />
 </td>
  <td>
<img width="350" height="699" alt="a_wishlist_m" src="https://github.com/user-attachments/assets/f1ad3555-3a74-4044-a8cd-2a954d12ba3f" />
 </td>
 </tr>
 </table>

- Dark and light theme has same colour scheme
  
> [!Note]
> AI Disclosure: No AI was used to generate any of this code.

