### PR TITLE
Migrate inline css from Remove and Delete buttons to tailwind

### DIFF
--- a/app/javascript/components/Profile/EditSections.tsx
+++ b/app/javascript/components/Profile/EditSections.tsx
@@ -265,7 +265,7 @@ export const SectionLayout = ({
             <h5>{linkCopied ? "Copied!" : "Copy link"}</h5>
             <Icon name="link" />
           </button>
-          <button onClick={() => void remove()} style={{ color: "rgb(var(--danger))" }}>
+          <button onClick={() => void remove()} className="text-danger">
             <h5>Remove</h5>
             <Icon name="trash2" />
           </button>

--- a/app/javascript/components/TiptapExtensions/NodeActionsMenu.tsx
+++ b/app/javascript/components/TiptapExtensions/NodeActionsMenu.tsx
@@ -59,7 +59,7 @@ export const NodeActionsMenu = ({
               </div>
             ))}
             <div
-              style={{ color: "rgb(var(--danger))" }}
+              className="text-danger"
               onClick={() => editor.commands.deleteSelection()}
               role="menuitem"
             >

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -73,6 +73,7 @@ export default {
         background: "rgb(var(--filled))",
         foreground: "rgb(var(--color))",
         border: "rgb(var(--color) / var(--border-alpha))",
+        danger: "rgb(var(--danger))",
       },
       boxShadow: {
         DEFAULT: "0.25rem 0.25rem 0 currentColor",


### PR DESCRIPTION
Ref #1055 

## Demo (No visual changes)
### `NodeActionsMenu.tsx`
|Before|After|
|-|-|
|<img width="294" height="312" alt="image" src="https://github.com/user-attachments/assets/6cb2fdb3-5286-4665-a558-5902e8ddda96" /> | <img width="309" height="402" alt="image" src="https://github.com/user-attachments/assets/4d2484ad-bddb-4143-a850-81e6b2385b41" />
| <img width="294" height="312" alt="image" src="https://github.com/user-attachments/assets/c920150d-08ad-43e3-9370-b28663caaa8a" />| <img width="309" height="402" alt="image" src="https://github.com/user-attachments/assets/041c2c8a-ea49-4981-aa8c-847c72d45086" />


### `EditSections.tsx` (No dark mode)
 |Before|After|
|-|-|
|<img width="332" height="276" alt="image" src="https://github.com/user-attachments/assets/e15fc724-701f-4a1c-9e2b-dce1ac6c0719" /> | <img width="332" height="276" alt="image" src="https://github.com/user-attachments/assets/d2a518f9-07d0-4c02-ae51-c1bb9fca23fe" />

## AI Disclosure 
No usage of AI
