### PR TITLE
feat: pre-fill Forgot Password email from Login form

### DIFF
--- a/app/javascript/components/Authentication/ForgotPasswordForm.tsx
+++ b/app/javascript/components/Authentication/ForgotPasswordForm.tsx
@@ -10,9 +10,9 @@ import { showAlert } from "$app/components/server-components/Alert";
 
 type SaveState = { type: "initial" | "submitting" } | { type: "error"; message: string };
 
-export const ForgotPasswordForm = ({ onClose }: { onClose: () => void }) => {
+export const ForgotPasswordForm = ({ onClose, initialEmail }: { onClose: () => void; initialEmail?: string }) => {
   const uid = React.useId();
-  const [email, setEmail] = React.useState("");
+  const [email, setEmail] = React.useState(initialEmail ?? "");
   const [saveState, setSaveState] = React.useState<SaveState>({ type: "initial" });
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {

--- a/app/javascript/components/server-components/LoginPage.tsx
+++ b/app/javascript/components/server-components/LoginPage.tsx
@@ -59,7 +59,7 @@ export const LoginPage = ({
       headerActions={<a href={Routes.signup_path({ next })}>Sign up</a>}
     >
       {showForgotPassword ? (
-        <ForgotPasswordForm onClose={() => setShowForgotPassword(false)} />
+        <ForgotPasswordForm onClose={() => setShowForgotPassword(false)} initialEmail={email} />
       ) : (
         <form onSubmit={(e) => void handleSubmit(e)}>
           <SocialAuth />


### PR DESCRIPTION
Previously, the Forgot Password form always started with an empty email field,
forcing users to re-enter their email even if they had typed it in the login form.

This change adds an optional `initialEmail` prop to `ForgotPasswordForm` and
passes the current login email when rendering the form. Users now see their
previously entered email pre-filled, improving the user experience.

# Before

https://github.com/user-attachments/assets/c0aecc2f-e32a-4d01-b75f-ce0c21b17f3e




# After

https://github.com/user-attachments/assets/a9f45030-007a-4503-ab0a-a9664d848cba

