### PR TITLE
chore: migrates gumroad blog PostPage from inline css to tailwind

### DIFF
--- a/app/javascript/components/server-components/GumroadBlog/PostPage.tsx
+++ b/app/javascript/components/server-components/GumroadBlog/PostPage.tsx
@@ -16,7 +16,7 @@ import { useRunOnce } from "$app/components/useRunOnce";
 const BackToBlog = ({ className }: { className?: string }) => (
   <div className={cx("scoped-tailwind-preflight", className)}>
     <a href="/blog" className="text-pink-600 hover:text-pink-800 mt-4 flex items-center font-medium">
-      <Icon name="arrow-left" className="mr-1.5" style={{ width: 18, height: 18 }} />
+      <Icon name="arrow-left" className="mr-1.5 w-[18px] h-[18px]" />
       Back to Blog
     </a>
   </div>
@@ -63,10 +63,9 @@ const PostPage = ({
             <div className="grid">
               <p>
                 <a
-                  className="button accent"
+                  className="button accent whitespace-normal"
                   href={call_to_action.url}
                   target="_blank"
-                  style={{ whiteSpace: "normal" }}
                   rel="noopener noreferrer"
                 >
                   {call_to_action.text}


### PR DESCRIPTION
ref #1055 

## AI Disclosure:
- no AI used

| **Before (Desktop)** | **After (Desktop)** |
|----------------------|---------------------|
| <img width="1512" height="693" alt="Screenshot 2025-10-04 at 5 16 47 PM" src="https://github.com/user-attachments/assets/b8d9f0fc-821b-471d-a9bb-c9d8ad1533e5" /> | <img width="1511" height="701" alt="Screenshot 2025-10-04 at 5 11 03 PM" src="https://github.com/user-attachments/assets/fe1b4019-ccf8-4242-b9c2-59d624698197" /> |
| <img width="1512" height="982" alt="Screenshot 2025-10-04 at 5 17 18 PM" src="https://github.com/user-attachments/assets/73f16261-ab0d-4807-a202-7f4a16af2985" /> | <img width="1512" height="818" alt="Screenshot 2025-10-04 at 5 11 22 PM" src="https://github.com/user-attachments/assets/93106943-51b8-43a1-b7ca-e8f7cfe2be3d" /> |

| **Before (Mobile)** | **After (Mobile)** |
|---------------------|--------------------|
| <img width="486" height="869" alt="Screenshot 2025-10-04 at 5 17 37 PM" src="https://github.com/user-attachments/assets/9a2eede2-c485-45bd-8274-79e79c5d811c" /> | <img width="486" height="862" alt="Screenshot 2025-10-04 at 5 12 05 PM" src="https://github.com/user-attachments/assets/6a5ede34-c243-4ba5-a08d-53764ad81f34" /> |
| <img width="491" height="865" alt="Screenshot 2025-10-04 at 5 17 33 PM" src="https://github.com/user-attachments/assets/d94feb72-487b-487e-8e22-30a4da60f795" /> | <img width="498" height="856" alt="Screenshot 2025-10-04 at 5 12 15 PM" src="https://github.com/user-attachments/assets/ed23038a-8cd2-42c5-a178-0917d15f3d64" /> |
