### PR TITLE
Fix tooltip causing horizontal page scroll

### DIFF
--- a/app/javascript/components/BundleEdit/Layout.tsx
+++ b/app/javascript/components/BundleEdit/Layout.tsx
@@ -16,6 +16,7 @@ import { Preview } from "$app/components/Preview";
 import { showAlert } from "$app/components/server-components/Alert";
 import { PageHeader } from "$app/components/ui/PageHeader";
 import { Tabs, Tab } from "$app/components/ui/Tabs";
+import { useIsAboveBreakpoint } from "$app/components/useIsAboveBreakpoint";
 import { WithTooltip } from "$app/components/WithTooltip";
 
 export const useProductUrl = (params = {}) => {
@@ -43,6 +44,8 @@ export const Layout = ({
 
   const [match] = useMatches();
   const tab = match?.handle ?? "product";
+
+  const isDesktop = useIsAboveBreakpoint("lg");
 
   const [isSaving, setIsSaving] = React.useState(false);
   const handleSave = async () => {
@@ -125,7 +128,7 @@ export const Layout = ({
                 {isPublishing ? "Unpublishing..." : "Unpublish"}
               </Button>
               {saveButton}
-              <CopyToClipboard text={url} copyTooltip="Copy product URL">
+              <CopyToClipboard text={url} copyTooltip="Copy product URL" tooltipPosition={isDesktop ? "left" : "bottom"}>
                 <Button>
                   <Icon name="link" />
                 </Button>


### PR DESCRIPTION
Ref #864 

- The tooltip is positioned on the `left` on desktop and at the `bottom` on mobile.

## Demo
### Desktop
#### Before
[before-tooltip.webm](https://github.com/user-attachments/assets/e39b47c5-568b-4659-b060-980e13dec3c0)
#### After
[after-tooltip.webm](https://github.com/user-attachments/assets/46b7fe6d-81fd-4876-a52c-599c1f42d9e9)

### Mobile
| Before | After | 
| -| -|
| <img width="461" height="665" alt="image" src="https://github.com/user-attachments/assets/89bc763a-9b1a-410f-89ac-f6c54ed729a3" /> | <img width="461" height="665" alt="image" src="https://github.com/user-attachments/assets/b1dabe32-e921-41c1-be31-e55096a8c775" />
|<img width="461" height="665" alt="image" src="https://github.com/user-attachments/assets/292e57cf-1b2d-467e-89bd-d9458f8e6ed2" /> | <img width="461" height="665" alt="image" src="https://github.com/user-attachments/assets/1ce37daf-d3ff-4fe7-883a-bcf9bbd6ddec" />




## AI Disclosure
GitHub copilot for refactor, reviewed by me.