### PR TITLE
chore: migrate inline css from ProductsTable & MembershipTable to tailwind

### DIFF
--- a/app/javascript/components/ProductsPage/MembershipsTable.tsx
+++ b/app/javascript/components/ProductsPage/MembershipsTable.tsx
@@ -118,7 +118,7 @@ export const ProductsPageMembershipsTable = (props: {
               </td>
               <td className="w-full">
                 {/* Safari currently doesn't support position: relative on <tr>, so we can't use stretched-link here */}
-                <a href={membership.can_edit ? membership.edit_url : membership.url} style={{ textDecoration: "none" }}>
+                <a href={membership.can_edit ? membership.edit_url : membership.url} className="no-underline">
                   <h4>{membership.name}</h4>
                 </a>
                 <a href={membership.url} title={membership.url} target="_blank" rel="noreferrer">

--- a/app/javascript/components/ProductsPage/ProductsTable.tsx
+++ b/app/javascript/components/ProductsPage/ProductsTable.tsx
@@ -120,7 +120,7 @@ export const ProductsPageProductsTable = (props: {
               <td className="w-full">
                 <div>
                   {/* Safari currently doesn't support position: relative on <tr>, so we can't use stretched-link here */}
-                  <a href={product.can_edit ? product.edit_url : product.url} style={{ textDecoration: "none" }}>
+                  <a href={product.can_edit ? product.edit_url : product.url} className="no-underline">
                     <h4>{product.name}</h4>
                   </a>
 


### PR DESCRIPTION
ref #1055 

### AI Disclosure:
- no ai used

| **Before (Desktop)** | **After (Desktop)** |
|----------------------|---------------------|
| <img width="1596" height="829" alt="Screenshot 2025-10-04 at 6 31 52 PM" src="https://github.com/user-attachments/assets/6d8d156e-aa54-4995-bc05-790682b4d464" /> | <img width="1596" height="825" alt="Screenshot 2025-10-04 at 6 29 56 PM" src="https://github.com/user-attachments/assets/130095e8-51ec-45aa-a8c0-e467e2df265c" /> |

| **Before (Mobile)** | **After (Mobile)** |
|---------------------|--------------------|
| <img width="503" height="834" alt="Screenshot 2025-10-04 at 6 32 14 PM" src="https://github.com/user-attachments/assets/863cec5e-22fe-40ae-b682-9549570bf368" /> | <img width="496" height="845" alt="Screenshot 2025-10-04 at 6 30 14 PM" src="https://github.com/user-attachments/assets/06c0dd99-542c-4ceb-be4b-da2b6b7c8830" /> |
| <img width="496" height="831" alt="Screenshot 2025-10-04 at 6 32 32 PM" src="https://github.com/user-attachments/assets/ac0e594e-1894-4132-bcf2-70c4778c2244" /> | <img width="498" height="838" alt="Screenshot 2025-10-04 at 6 30 25 PM" src="https://github.com/user-attachments/assets/994c15f5-60b0-4e1f-b538-7d267f19ddca" /> |

