### PR TITLE
Migrate products page inline css to tailwind

### DIFF
--- a/app/javascript/components/server-components/ProductsPage.tsx
+++ b/app/javascript/components/server-components/ProductsPage.tsx
@@ -24,7 +24,7 @@ const ProductsPage = ({
   setEnableArchiveTab?: (enable: boolean) => void;
   type?: Tab;
 }) => (
-  <div className="grid gap-7">
+  <div className="!grid !gap-12">
     {memberships.length > 0 ? (
       <ProductsPageMembershipsTable
         query={query}

--- a/app/javascript/components/server-components/ProductsPage.tsx
+++ b/app/javascript/components/server-components/ProductsPage.tsx
@@ -24,7 +24,7 @@ const ProductsPage = ({
   setEnableArchiveTab?: (enable: boolean) => void;
   type?: Tab;
 }) => (
-  <div style={{ display: "grid", gap: "var(--spacer-7)" }}>
+  <div className="grid gap-7">
     {memberships.length > 0 ? (
       <ProductsPageMembershipsTable
         query={query}

--- a/app/javascript/components/server-components/ProductsPage.tsx
+++ b/app/javascript/components/server-components/ProductsPage.tsx
@@ -24,7 +24,7 @@ const ProductsPage = ({
   setEnableArchiveTab?: (enable: boolean) => void;
   type?: Tab;
 }) => (
-  <div className="!grid !gap-12">
+  <div className="grid !gap-12">
     {memberships.length > 0 ? (
       <ProductsPageMembershipsTable
         query={query}


### PR DESCRIPTION
Ref #1055


## Demo (No visual changes - Products Page)
### Desktop
| Before | After| 
|-|-|
| <img width="1683" height="890" alt="before-pro-d" src="https://github.com/user-attachments/assets/1284d6c1-9843-49f5-bd37-904561cf379d" /> | <img width="1683" height="890" alt="after-products-pc" src="https://github.com/user-attachments/assets/2f8321e2-2d31-44d3-9a4e-87f2a50ec84f" />
| <img width="1683" height="890" alt="before-pro-l" src="https://github.com/user-attachments/assets/71a0fe14-84e6-4d8d-a50d-ee09f29d7229" /> |<img width="1683" height="890" alt="after-pr-light" src="https://github.com/user-attachments/assets/b86375e8-10b2-4c97-bec4-b1813d5332a8" />


### Mobile
| Before | After| 
|-|-|
|<img width="403" height="838" alt="Screenshot From 2025-10-05 17-48-34" src="https://github.com/user-attachments/assets/24a56bbf-30a4-4020-b693-0bfc2996f7df" /> | <img width="403" height="838" alt="after-mb-dark" src="https://github.com/user-attachments/assets/4dba7e81-1e8a-4232-8a9d-bbe8e09d8165" />
| <img width="403" height="838" alt="Screenshot From 2025-10-05 17-49-56" src="https://github.com/user-attachments/assets/9f412623-8469-4671-810c-a3a163b84b51" /> | <img width="403" height="838" alt="after-mb-light" src="https://github.com/user-attachments/assets/ebce50ff-46d3-417a-a6c0-554707d0e63f" />




## AI Disclosure
No usage of AI