### PR TITLE
Fix: Audience analytics chart-loading

### DIFF
--- a/spec/requests/analytics/audience_spec.rb
+++ b/spec/requests/analytics/audience_spec.rb
@@ -47,6 +47,8 @@ describe "Audience analytics", :js, :sidekiq_inline, :elasticsearch_wait_for_ref
 
     it "shows the chart" do
       visit audience_dashboard_path(from: "2023-12-01", to: "2023-12-31")
+      
+      expect(page).to have_css(".chart")
       expect(page).to have_css(".point", count: 31)
 
       chart = find(".chart")


### PR DESCRIPTION
Part of: #1127 

AI Disclosure: Used for only for syntax, logic and code review Manually

### PROBLEM: 
The audience analytics tests were failing due to timing issues with async chart loading in React components. Tests were asserting on chart elements before they were fully rendered.

Before:https://github.com/antiwork/gumroad/actions/runs/18168215386/job/51716559681

### ROOT CAUSE:
Async Loading: fetchAudienceDataByDate() loads data asynchronously
React Re-renders: Chart renders after data loads
Recharts Animation: Chart library has internal rendering delays

### SOLUTION:
Instead of immediately checking for data points, we now:
First wait for the chart container to be present on the page
Then wait for the data points to be loaded with the correct count
Only then proceed with the rest of the test

`  expect(page).to have_css(".chart")  `

###  How This Addresses the Issue:
Async Data Loading: fetchAudienceDataByDate() loads data asynchronously
React Re-renders: Chart renders after data loads
Recharts Animation: Chart library has internal rendering delays


Fixes: #1127 