### PR TITLE
fix: add consistent padding to Edit Application page

### DIFF
--- a/app/javascript/components/server-components/Settings/AdvancedPage/EditApplicationPage.tsx
+++ b/app/javascript/components/server-components/Settings/AdvancedPage/EditApplicationPage.tsx
@@ -23,7 +23,7 @@ type Props = {
 const EditApplicationPage = ({ settings_pages, application }: Props) => (
   <Layout currentPage="advanced" pages={settings_pages}>
     <form>
-      <section>
+      <section className="!p-4 md:!p-8">
         <header>
           <h2>Edit application</h2>
         </header>


### PR DESCRIPTION
### Explanation of Change
This PR adds consistent spacing to the Edit Application page for improved readability and design consistency

### Screenshots/Videos
Before
<img width="1470" height="790" alt="image" src="https://github.com/user-attachments/assets/9d2f8bf2-8b1e-47b1-8e30-a9ad0b312e61" />
<img width="331" height="677" alt="image" src="https://github.com/user-attachments/assets/1a4d8064-15a3-4eff-a60d-efb485307f1f" />

After
<img width="330" height="674" alt="image" src="https://github.com/user-attachments/assets/91fc63cc-1bf1-4065-a365-97b8b014613f" />
<img width="1470" height="800" alt="image" src="https://github.com/user-attachments/assets/379183af-d291-4803-ab6a-bc0ed8145498" />

### AI Disclosure
No AI tools used


