### PR TITLE
feat(864): add tab space insertion support in rich text editor

### DIFF
--- a/app/javascript/components/RichTextEditor.tsx
+++ b/app/javascript/components/RichTextEditor.tsx
@@ -272,6 +272,19 @@ export const useRichTextEditor = ({
           event.preventDefault();
           return true;
         },
+        keydown(_, event) {
+          if (!editor) {
+            return false;
+          }
+
+          if (event.key === "Tab") {
+            event.preventDefault();
+            editor.chain().focus().insertContent("    ").run();
+            return true;
+          }
+
+          return false;
+        },
       },
     },
     content,


### PR DESCRIPTION
part of: #864 

# Descrption

This PR adds the ability to insert spaces when pressing the Tab key inside the RichTextEditor. It improves text editing experience for code blocks and other content where indentation is required.

