### PR TITLE
fix: make Delete button red on Your Applications list

### DIFF
--- a/app/javascript/components/Settings/AdvancedPage/ApplicationsSection.tsx
+++ b/app/javascript/components/Settings/AdvancedPage/ApplicationsSection.tsx
@@ -69,7 +69,7 @@ const ApplicationRow = ({ application, onRemove }: { application: Application; o
       </div>
       <div className="actions">
         <NavigationButton href={Routes.oauth_application_path(application.id)}>Edit</NavigationButton>
-        <Button outline color="danger" onClick={deleteApp}>
+        <Button color="danger" onClick={deleteApp}>
           Delete
         </Button>
       </div>


### PR DESCRIPTION
### Explanation of Change
This PR updates the Delete button on the Your Applications list to use a red style for better clarity and visual feedback

### Screenshots/Videos
Before
<img width="914" height="218" alt="image" src="https://github.com/user-attachments/assets/582580ab-922a-4350-bf58-e65aa6158f49" />

After
<img width="898" height="214" alt="image" src="https://github.com/user-attachments/assets/7cb371d1-4470-491e-97ee-88a35a240286" />


### AI Disclosure
No AI tools used


