### PR TITLE
fix: restrict pointer cursor to clickable icons in collaborator actions

### DIFF
--- a/app/javascript/components/server-components/CollaboratorsPage.tsx
+++ b/app/javascript/components/server-components/CollaboratorsPage.tsx
@@ -250,7 +250,7 @@ const Collaborators = () => {
                       {collaborator.invitation_accepted ? <>Accepted</> : <>Pending</>}
                     </td>
                     <td>
-                      <div className="actions" onClick={(e) => e.stopPropagation()}>
+                      <div className="actions cursor-default" onClick={(e) => e.stopPropagation()}>
                         <Link
                           to={`/collaborators/${collaborator.id}/edit`}
                           className="button"


### PR DESCRIPTION
ref: #864 

# Description

This PR improves user experience in the collaborators table by restricting the mouse pointer cursor to only the clickable edit link and delete button icons within the actions column. This avoids cursor jankiness where the pointer appeared over non-clickable areas around the icons. 

## old vs new

| Old | New |
|----------|----------|
| <img width="400" height="500" alt="old" src="https://github.com/user-attachments/assets/a2e2dd33-775f-4dff-896f-2b52a76f0650" /> | <img width="400" height="500" alt="new" src="https://github.com/user-attachments/assets/af7789a9-fad0-4103-8494-2ab32dd14110" /> |
| <img width="400" height="500" alt="Screenshot from 2025-10-09 20-43-16" src="https://github.com/user-attachments/assets/b00f0993-0e30-4bba-abca-0d279e49449f" /> | <img width="400" height="500" alt="Screenshot from 2025-10-09 20-41-47" src="https://github.com/user-attachments/assets/57f6be8b-c393-4b6d-a756-8f2a90f967d1" /> |

# AI Disclosure
No usage of AI
