### PR TITLE
Fix #864: Delete button color fix

### DIFF
--- a/app/javascript/components/server-components/WishlistsPage.tsx
+++ b/app/javascript/components/server-components/WishlistsPage.tsx
@@ -117,7 +117,6 @@ const WishlistsPage = ({
                     <div className="actions">
                       <Button
                         color="danger"
-                        outline
                         aria-label="Delete wishlist"
                         onClick={() => setConfirmingDeleteWishlist(wishlist)}
                       >


### PR DESCRIPTION
Fixed delete button color on wishlist page.

Before:
<img width="891" height="281" alt="Screenshot from 2025-10-06 10-20-39" src="https://github.com/user-attachments/assets/282ddc57-d631-4a63-b0a5-aa197a0b550b" />

After:
<img width="891" height="281" alt="Screenshot from 2025-10-06 10-22-05" src="https://github.com/user-attachments/assets/eb48c20a-8695-401b-854a-344a01f1c785" />


Closes part of #864 