### PR TITLE
feat: highlight selected product row

### DIFF
--- a/app/javascript/components/ProductsPage/ProductsTable.tsx
+++ b/app/javascript/components/ProductsPage/ProductsTable.tsx
@@ -31,6 +31,7 @@ export const ProductsPageProductsTable = (props: {
     pagination: props.pagination,
     isLoading: false,
   });
+  const [selectedProduct, setSelectedProduct] = React.useState<Product | null>(null);
   const activeRequest = React.useRef<{ cancel: () => void } | null>(null);
   const tableRef = React.useRef<HTMLTableElement>(null);
   const { locale } = useUserAgentInfo();
@@ -46,6 +47,8 @@ export const ProductsPageProductsTable = (props: {
     setState((prevState) => ({ ...prevState, isLoading: true }));
     try {
       activeRequest.current?.cancel();
+
+      setSelectedProduct(null);
 
       const request = getPagedProducts({
         page,
@@ -107,7 +110,12 @@ export const ProductsPageProductsTable = (props: {
 
         <tbody>
           {products.map((product) => (
-            <tr key={product.id}>
+            <tr
+              key={product.id}
+              aria-selected={product.id === selectedProduct?.id}
+              onClick={() => setSelectedProduct(product)}
+              onMouseOut={() => setSelectedProduct(null)}
+            >
               <td className="icon-cell">
                 {product.thumbnail ? (
                   <a href={product.can_edit ? product.edit_url : product.url}>


### PR DESCRIPTION
ref: #864 

# Description

- Added visual highlighting for the selected product row in the Products table.
- Highlights row on click and clears highlight on mouse out.
- Improves usability by making it easier to see which product is currently selected.

old
<img width="1920" height="1080" alt="Screenshot from 2025-10-06 13-42-34" src="https://github.com/user-attachments/assets/bf80b4be-f7a5-4524-8cf4-e7c1743fb0f1" />

new
<img width="1920" height="1080" alt="Screenshot from 2025-10-06 13-41-38" src="https://github.com/user-attachments/assets/32a304a8-b574-4b4b-bb0f-96fec1230b2f" />
