### PR TITLE
Fix incorrect email limitation note in 'Starting an email newsletter' help doc

### DIFF
--- a/app/views/help_center/articles/contents/_170-audience.html.erb
+++ b/app/views/help_center/articles/contents/_170-audience.html.erb
@@ -16,7 +16,7 @@
       </li>
     </ul>
     <div class="callout-red">
-      <p><b>⚠️ Note: </b>Until you've earned $100 after fees, you will only be allowed to send 100 emails at a time. This limitation is in place to prevent spam and protect Gumroad's email reputation. </p>
+      <p><b>⚠️ Note: </b>You cannot send emails until you've earned $100 after fees and received a payout. This limitation is in place to prevent spam and protect Gumroad's email reputation. </p>
     </div>
     <p>A subscriber on Gumroad is someone you can send email notifications or updates to via <a href="169-how-to-send-an-update">Emails</a> or <a href="131-using-workflows-to-send-automated-updates">Workflows</a>. Subscribers may or may not be your customers yet.</p>
     <p>To see a list of your subscribers, simply go to <a href="https://gumroad.com/followers">this page</a> from where you can export a CSV of your followers or remove an email from your list.</p>


### PR DESCRIPTION
We only allow sending emails after $100 in net earnings and a payout. [Starting an email newsletter](https://gumroad.com/help/article/170-audience) currently says that you can send upto 100 emails until then which is incorrect. 