### PR TITLE
refactor: migrate inline css to tailwind for thumbnail editor

### DIFF
--- a/app/javascript/components/ProductEdit/ProductTab/ThumbnailEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/ThumbnailEditor.tsx
@@ -74,7 +74,7 @@ export const ThumbnailEditor = ({
 
   return (
     <section className="!p-4 md:!p-8">
-      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+      <div className="flex items-center justify-between">
         <h2>Thumbnail</h2>
         <a href="/help/article/60-adding-a-cover-image" target="_blank" rel="noreferrer">
           Learn more


### PR DESCRIPTION
### Description:

Migrate inline styles for thumbnail editor component to tailwind.

Part of #1055 

### Before / After:

 <table>
 <tr><th>Before</th><th>After</th></tr>
 <tr>
 <td> 
<img width="1438" height="811" alt="b_thumbnail_d" src="https://github.com/user-attachments/assets/88fdf544-b4f0-4a2d-ba86-35d7d3ce6fe9" />

</td>
  <td> 
<img width="1440" height="811" alt="a_thumbnail_d" src="https://github.com/user-attachments/assets/04b9fb42-3aeb-489f-9b45-b1fa41ed850d" />
 </td>
 </tr>
 <tr>
 <td>
<img width="1436" height="812" alt="b_thumbnail_l" src="https://github.com/user-attachments/assets/c17431e9-5031-4cf0-a789-5cd4fea534d1" />
 </td>
  <td>
<img width="1440" height="812" alt="a_thumbnail_l" src="https://github.com/user-attachments/assets/4cfca490-04c0-4f80-a3d5-ab12a595bcef" />
 </td>
 </tr>
 </table>

 <table>
 <tr><th>Before</th><th>After</th></tr>
 <tr>
 <td> 
<img width="300" height="auto" alt="b_thumbnail_m_d" src="https://github.com/user-attachments/assets/484034e2-f505-4d9e-90be-70f17e8021da" />
</td>
  <td> 
<img width="300" height="auto" alt="a_thumbnail_m_d" src="https://github.com/user-attachments/assets/63157a72-d955-498c-8ac2-ecd4a77aeb21" />
 </td>
 </tr>
 <tr>
 <td>
<img width="300" height="auto" alt="b_thumbnail_m_l" src="https://github.com/user-attachments/assets/1b4771c8-9541-4f68-a2ea-198b4c12aca2" />
 </td>
  <td>
<img width="300" height="auto" alt="a_thumbnail_m_l" src="https://github.com/user-attachments/assets/f3ca4213-ea99-4fd4-a5cd-31e3daa9781a" />
 </td>
 </tr>
 </table>

  
> [!Note]
> AI Disclosure: No AI was used to generate any of this code.

