### PR TITLE
fix: Product list not refreshing immediately after adding or changing products

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -221,7 +221,7 @@ class LinksController < ApplicationController
     on_profile = search_params[:user_id].present?
     if on_profile
       user = User.find_by_external_id(search_params[:user_id])
-      section = user && user.seller_profile_products_sections.on_profile.find_by_external_id(search_params[:section_id])
+      section = user && user.seller_profile_products_sections.find_by_external_id(search_params[:section_id])
       return render json: { total: 0, filetypes_data: [], tags_data: [], products: [] } if section.nil?
       search_params[:section] = section
       search_params[:is_alive_on_profile] = true


### PR DESCRIPTION
### Explanation of Change
On the Product page, the product list does not update instantly after adding or modifying selected products, a page refresh is required.

The problem is in this part of the controller code:
https://github.com/antiwork/gumroad/blob/401b83e6899ef4244cf2fa57fe591b50f9db6286/app/controllers/links_controller.rb#L224-L225

Here, the scope `on_profile` filters only sections where `product_id: nil`
However, on the Product page, sections are tied to a specific product (i.e. product_id is present), so section will always be nil.

Because of that, the API always returns 0:
<img width="179" height="96" alt="image" src="https://github.com/user-attachments/assets/677600e8-b0d7-42d0-8972-1518e120bede" />

### Screenshots/Videos
Before

https://github.com/user-attachments/assets/5f1c8ab9-3292-4405-9acc-ec82ce2849a9



After

https://github.com/user-attachments/assets/61385538-bf58-483b-bb69-f9df897808ae



### AI Disclosure
No AI tools used


