### PR TITLE
fix: product title truncation in product selection dropdown

### DIFF
--- a/app/javascript/components/Profile/EditSections.tsx
+++ b/app/javascript/components/Profile/EditSections.tsx
@@ -357,7 +357,7 @@ const ProductsSettings = ({ section }: { section: ProductsSection }) => {
               <label role="listitem" key={product.id} style={{ border: product.chosen ? "var(--border)" : undefined }}>
                 <div className="content">
                   {section.default_product_sort === "page_layout" ? <div aria-grabbed={product.chosen} /> : null}
-                  <span className="text-singleline">{product.name}</span>
+                  <span className="line-clamp-3">{product.name}</span>
                 </div>
                 <div className="actions">
                   <input


### PR DESCRIPTION
### Explanation of Change
On the product selection dropdown, the product title is restricted to one line, causing version identifiers or other differentiating parts of the name to be cut off. For example:
- FocusFlow – Productivity Planner v1.0  
- FocusFlow – Productivity Planner v2.0  
- FocusFlow – Productivity Planner v3.0  

All appear nearly identical at a glance, making it easy to select the wrong product.

Updated it to limit the product title to max 3 lines in this product selection dropdown.

### Screenshots/Videos
Before
<img width="1420" height="771" alt="image" src="https://github.com/user-attachments/assets/9c4a182b-0cb7-42d8-a294-fcae881368e7" />
<img width="317" height="672" alt="image" src="https://github.com/user-attachments/assets/ae5ec635-6d02-4da7-b852-e65c786b8467" />


After
<img width="1470" height="792" alt="image" src="https://github.com/user-attachments/assets/58193ecb-6a88-45a3-bf4a-0c9861c1f705" />
<img width="323" height="668" alt="image" src="https://github.com/user-attachments/assets/0ea132b9-2a16-4de1-bf86-d49992de3028" />


### AI Disclosure
No AI tools used
