### PR TITLE
fix: spacing issue for edit application section

### DIFF
--- a/app/javascript/components/server-components/Settings/AdvancedPage/EditApplicationPage.tsx
+++ b/app/javascript/components/server-components/Settings/AdvancedPage/EditApplicationPage.tsx
@@ -23,7 +23,7 @@ type Props = {
 const EditApplicationPage = ({ settings_pages, application }: Props) => (
   <Layout currentPage="advanced" pages={settings_pages}>
     <form>
-      <section className="!p-4 md:!p-8">
+      <section className="p-4! md:p-8!">
         <header>
           <h2>Edit application</h2>
         </header>


### PR DESCRIPTION
### Description:

Add padding for section on edit application page.

Part of #864 

### Before / After:

 <table>
 <tr><th>Before</th><th>After</th></tr>
 <tr>
 <td> 
<img width="1440" height="900" alt="b_dk_edit_app" src="https://github.com/user-attachments/assets/1ce26355-19fd-433a-b6a1-721ed0c77a4f" />
</td>
  <td> 
<img width="1440" height="900" alt="a_dk_edit_app" src="https://github.com/user-attachments/assets/e9368a38-b623-48c2-bd65-72dde6cc8510" />
 </td>
 </tr>
 <tr>
 <td>
<img width="1440" height="900" alt="b_lg_edit_app" src="https://github.com/user-attachments/assets/1c04eb4b-182d-499d-80cb-d334ffff114f" />
 </td>
  <td>
<img width="1440" height="900" alt="a_lg_edit_app" src="https://github.com/user-attachments/assets/2af5d692-00cb-4280-9417-0195113a6308" />
 </td>
 </tr>
 <tr>
 <td>
<img width="378" height="665" alt="b_dk_sm_edit_app" src="https://github.com/user-attachments/assets/745ef868-129d-45e8-8d43-f9e1f03a0fb6" />
 </td>
  <td>
<img width="375" height="666" alt="a_dk_sm_edit_app" src="https://github.com/user-attachments/assets/548e24b2-7f41-4756-8211-49aeeb6f3afb" />
 </td>
 </tr>
 <tr>
 <td>
<img width="377" height="668" alt="b_lg_sm_edit_app" src="https://github.com/user-attachments/assets/ef6edb41-48bf-4b8a-bf0f-efd5facac2cd" />
 </td>
  <td>
<img width="374" height="667" alt="a_lg_sm_edit_app" src="https://github.com/user-attachments/assets/2562ed24-fa5b-4e90-afff-c78b4e6e9133" />
 </td>
 </tr>
 </table>
  
> [!Note]
> AI Disclosure: No AI was used to generate any of this code.

