### PR TITLE
fix #864 : text ovelay on profile page

### DIFF
--- a/app/javascript/components/Profile/EditSections.tsx
+++ b/app/javascript/components/Profile/EditSections.tsx
@@ -498,7 +498,7 @@ const RichTextSectionView = ({ section }: { section: RichTextSection }) => {
           <RichTextEditorToolbar editor={editor} productId={section.id} />
         </div>
       ) : null}
-      <EditorContent editor={editor} className="rich-text" />
+      <EditorContent editor={editor} className="rich-text p-1" />
     </SectionLayout>
   );
 };


### PR DESCRIPTION
ref: #864 

# Description

Fixed text overlay on profle page

old
<img width="1920" height="595" alt="Screenshot from 2025-10-06 23-09-41" src="https://github.com/user-attachments/assets/b44e2d63-ca52-4433-b525-1bd95f485bc1" />

new
<img width="1920" height="595" alt="Screenshot from 2025-10-06 23-07-32" src="https://github.com/user-attachments/assets/0f329101-9b83-4a73-91cc-42d7a7a4e924" />
