### PR TITLE
[Flaky] Fix tipping specs

### DIFF
--- a/app/javascript/components/Checkout/PaymentForm.tsx
+++ b/app/javascript/components/Checkout/PaymentForm.tsx
@@ -1222,7 +1222,7 @@ export const PaymentForm = ({
           </div>
         </div>
       ) : null}
-      {isTippingEnabled(state) ? <TipSelector key="tip-editor" /> : null}
+      {isTippingEnabled(state) ? <TipSelector /> : null}
       {isTestPurchase || !requiresPayment(state) ? (
         <>
           <EmailAddress />

--- a/app/javascript/components/Checkout/PaymentForm.tsx
+++ b/app/javascript/components/Checkout/PaymentForm.tsx
@@ -597,7 +597,6 @@ const CustomerDetails = () => {
           </div>
         </div>
       ) : null}
-      {isTippingEnabled(state) ? <TipSelector /> : null}
       {state.products.length === 1 && state.products[0]?.canGift && !state.products[0]?.payInInstallments ? (
         <GiftForm isMembership={state.products[0]?.nativeType === "membership"} />
       ) : null}
@@ -1017,7 +1016,6 @@ const PayPal = () => {
   return (
     <>
       <SharedInputs />
-      {isTippingEnabled(state) ? <TipSelector /> : null}
       <div>
         {nativePaypal && implementation === "native" ? (
           <NativePayPal implementation={nativePaypal} />
@@ -1162,7 +1160,6 @@ const StripePaymentRequest = () => {
   return (
     <>
       <SharedInputs />
-      {isTippingEnabled(state) ? <TipSelector /> : null}
       <div>
         <Button color="primary" onClick={() => dispatch({ type: "offer" })} disabled={isSubmitDisabled(state)}>
           {payLabel}
@@ -1225,6 +1222,7 @@ export const PaymentForm = ({
           </div>
         </div>
       ) : null}
+      {isTippingEnabled(state) ? <TipSelector key="tip-editor" /> : null}
       {isTestPurchase || !requiresPayment(state) ? (
         <>
           <EmailAddress />


### PR DESCRIPTION
AI Disclosure: None
Self review: Done
Ref: https://github.com/antiwork/gumroad/issues/1127


### Issue
When entering a value (e.g. typing `1` or `0`) in the `TipEditor` input, the element immediately lost focus, preventing the rest of the input from being entered, and hence breaks the assertions.

Case 1:
`fill_in "Tip", with: 0.99` this won't fill anything because the element loses focus after you write "0".
  
<img width="1440" height="900" alt="failures_r_spec_example_groups_product_checkout_with_tipping_when_the_cart_is_free_for_single_creator_applies_full_tip_to_first_product_when_tip_meets_minimum_688" src="https://github.com/user-attachments/assets/497936e0-a2a2-46cd-888a-2d68fc701789" />

Case 2: 
`fill_in "Tip", with: 1.98`, this won't work because it will lose focus after writing "1"
<img width="1440" height="900" alt="failures_r_spec_example_groups_product_checkout_with_tipping_when_the_cart_is_free_for_multiple_creators_distributes_tip_per_creator_to_first_product_from_each_when_tip_meets_minimum_627" src="https://github.com/user-attachments/assets/4574589a-d8d4-47f8-94c6-a5953de96af6" />

Many failures on master
https://github.com/antiwork/gumroad/actions/runs/18288372661
https://github.com/antiwork/gumroad/actions/runs/18286847406
https://github.com/antiwork/gumroad/actions/runs/18287440097

### Root cause
This happened because updating the tip state triggered a conditional re-render in the checkout flow.
Specifically, the TipEditor was originally rendered inside components that were part of a conditional branch (e.g. FreePurchase, CreditCard, PayPal).

The <TipEditor /> lived inside mutually exclusive React subtrees controlled by a conditional:

```tsx
{!requiresPayment(state) ? (
  <FreePurchase tipSelector={...} />
) : (
  <CreditCard tipSelector={...} />
)}
```

Each branch was a different component instance, so React could not reuse the same TipEditor DOM node between them.
Even with useMemo or useCallback, the rendered element was still destroyed when the parent subtree was unmounted.

### Solution
The TipEditor (or TipSelector) was lifted to a stable part of the React tree - outside the conditional branch - so that it remains mounted across payment method switches.

Another solution is to do some hack in specs like pasting to avoid the behavior, but anyway it's a bad DX currently regardless of specs.

### Videos

#### Before
https://www.loom.com/share/7077249c0b504613ad6ccf17df497610
#### After
https://www.loom.com/share/bff20dec5b0b4bc4882fea564ee9862a
