### PR TITLE
fix: Discount status not updating to expired after usage limit is reached

### DIFF
--- a/app/javascript/components/server-components/CheckoutDashboard/DiscountsPage.tsx
+++ b/app/javascript/components/server-components/CheckoutDashboard/DiscountsPage.tsx
@@ -381,7 +381,8 @@ const DiscountsPage = ({
                         <div className="override grid grid-cols-[min-content_1fr] gap-2">
                           {validAt && currentDate < validAt ? (
                             <>Scheduled</>
-                          ) : expiresAt && currentDate > expiresAt ? (
+                          ) : (expiresAt && currentDate > expiresAt) ||
+                            (statistics && offerCode.limit && statistics.uses.total >= offerCode.limit) ? (
                             <>Expired</>
                           ) : (
                             <>Live</>

--- a/spec/requests/checkout/discounts_spec.rb
+++ b/spec/requests/checkout/discounts_spec.rb
@@ -880,6 +880,30 @@ describe("Checkout discounts page", type: :system, js: true) do
     end
   end
 
+  describe "discount status updates when usage limit is reached" do
+    let!(:limited_offer) { create(:offer_code, name: "Limited Discount", code: "LIMITED1", user: seller, max_purchase_count: 1, amount_cents: 100) }
+
+    it "changes status from Live to Expired when usage limit is reached" do
+      visit checkout_discounts_path
+
+      within find(:table_row, { "Discount" => "Limited Discount" }) do
+        expect(page).to have_text("$1 off")
+        expect(page).to have_text("0/1")
+        expect(page).to have_text("Live")
+      end
+
+      create(:purchase, link: product1, offer_code: limited_offer)
+
+      visit checkout_discounts_path
+
+      within find(:table_row, { "Discount" => "Limited Discount" }) do
+        expect(page).to have_text("$1 off")
+        expect(page).to have_text("1/1")
+        expect(page).to have_text("Expired")
+      end
+    end
+  end
+
   describe "searching" do
     before do
       create(:offer_code, user: seller, name: "Discount 4", code: "discount4", universal: true)


### PR DESCRIPTION
### Explanation of Change
Discount used up but still marked as "Live", updated logic to automatically mark discounts as "Expired" once usage limit is reached.

### Screenshots/Videos
Before
<img width="1268" height="330" alt="image" src="https://github.com/user-attachments/assets/f3f5e6ad-00d2-4998-94bf-3fb257163fd3" />

After
<img width="1271" height="343" alt="image" src="https://github.com/user-attachments/assets/a82f6e80-4809-44e7-83fd-844d258f6e4b" />


### Test Results
<img width="776" height="178" alt="image" src="https://github.com/user-attachments/assets/7e3e189f-a010-43f4-9ac4-7eb5635cc8fb" />

### AI Disclosure
No AI tools used
