### PR TITLE
fix: Hide filter section when all archived products are deleted

### DIFF
--- a/app/javascript/components/server-components/LibraryPage.tsx
+++ b/app/javascript/components/server-components/LibraryPage.tsx
@@ -382,7 +382,9 @@ const LibraryPage = ({ results, creators, bundles, reviews_page_enabled, followi
           </div>
         ) : null}
         <div className="with-sidebar">
-          {!showArchivedNotice && (hasParams || archivedCount > 0 || state.results.length > 9) ? (
+          {!showArchivedNotice &&
+          (hasParams || archivedCount > 0 || state.results.length > 9) &&
+          state.results.length > 0 ? (
             <div className="stack">
               <header>
                 <div>

--- a/spec/requests/library_spec.rb
+++ b/spec/requests/library_spec.rb
@@ -264,6 +264,29 @@ describe("Library Scenario", type: :system, js: true) do
     expect(page).to have_status(text: "You have 2 archived purchases. Click here to view")
   end
 
+  it "hides filter section when last archived product is deleted" do
+    product = create(:product, name: "Test Product")
+    purchase = create(:purchase, purchaser: @user, link: product, is_archived: true)
+    Link.import(refresh: true, force: true)
+
+    visit "/library?show_archived_only=true"
+
+    expect(page).to have_product_card(purchase.link)
+    expect(page).to have_css(".with-sidebar")
+
+    within find_product_card(purchase.link).hover do
+      find_and_click "[aria-label='Open product action menu']"
+      click_on "Delete"
+    end
+    expect(page).to have_text("Are you sure you want to delete #{purchase.link_name}?")
+    click_on "Confirm"
+
+    wait_for_ajax
+
+    expect(page).to have_text("You haven't bought anything... yet!")
+    expect(page).to_not have_css(".with-sidebar")
+  end
+
   it "lists the same product several times if purchased several times" do
     products = create_list(:product, 2, name: "MyProduct")
     category = create(:variant_category, link: products[0])


### PR DESCRIPTION
### Explanation of Change
Filter still visible after deleting all archived products, updated UI to hide filter section and show only empty state when no products remain

### Screenshots/Videos
Before

https://github.com/user-attachments/assets/404874a1-db50-4886-b2da-1e1a5d6dd759

After

https://github.com/user-attachments/assets/9d73e116-5052-4d4c-bf90-fdff9e1fa6be

### Test Results
<img width="611" height="174" alt="image" src="https://github.com/user-attachments/assets/c08e46ab-0580-4903-b151-7100b4ac3bdd" />

### AI Disclosure
No AI tools used