### PR TITLE
fix: add section overlay

### DIFF
--- a/app/javascript/components/Profile/EditSections.tsx
+++ b/app/javascript/components/Profile/EditSections.tsx
@@ -632,7 +632,7 @@ export const AddSectionButton = ({ position, index }: { index: number } & Pick<P
       onToggle={setOpen}
       position={position}
       aria-label="Add section"
-      className="add-section"
+      className="add-section z-0"
       trigger={<Icon name="plus" />}
     >
       <div role="menu" onClick={() => setOpen(false)}>


### PR DESCRIPTION
ref: #864 

# Description

Fixed add-section css for the icon

old
<img width="1920" height="595" alt="Screenshot from 2025-10-07 09-52-19" src="https://github.com/user-attachments/assets/b529bfd0-f971-4f6e-a948-713288a22671" />

new
<img width="1920" height="595" alt="Screenshot from 2025-10-07 09-49-52" src="https://github.com/user-attachments/assets/757c6353-c8e8-41b5-bc45-f05502604f14" />
