### PR TITLE
Show tax collected by Gumroad in payout and sales CSVs

### DIFF
--- a/app/modules/purchase/accounting.rb
+++ b/app/modules/purchase/accounting.rb
@@ -16,7 +16,7 @@ class Purchase
     end
 
     def tax_dollars
-      convert_cents_to_dollars(tax_cents)
+      convert_cents_to_dollars(gumroad_responsible_for_tax? ? gumroad_tax_cents : tax_cents)
     end
 
     def shipping_dollars

--- a/spec/modules/purchase/accounting_spec.rb
+++ b/spec/modules/purchase/accounting_spec.rb
@@ -24,9 +24,18 @@ describe Purchase::Accounting do
   describe "#tax_dollars" do
     it "returns tax_cents in dollars" do
       purchase = create(:purchase)
+      allow(purchase).to receive(:gumroad_tax_cents).and_return(0)
       allow(purchase).to receive(:tax_cents).and_return(1234)
 
       expect(purchase.tax_dollars).to eq(12.34)
+    end
+
+    it "returns gumroad_tax_cents in dollars if present" do
+      purchase = create(:purchase)
+      allow(purchase).to receive(:gumroad_tax_cents).and_return(5678)
+      allow(purchase).to receive(:tax_cents).and_return(0)
+
+      expect(purchase.tax_dollars).to eq(56.78)
     end
   end
 

--- a/spec/services/exports/purchase_export_service_spec.rb
+++ b/spec/services/exports/purchase_export_service_spec.rb
@@ -279,6 +279,28 @@ describe Exports::PurchaseExportService do
         expect(field_value(row, "Tax Included in Price?")).to eq("0")
       end
 
+      it "has subtotal that does not include the tax collected by Gumroad" do
+        @purchase.was_purchase_taxable = true
+        @purchase.was_tax_excluded_from_price = true
+        @purchase.gumroad_tax_cents = 1_80
+        @purchase.save!
+
+        row = last_data_row
+        expect(field_value(row, "Subtotal ($)")).to eq("100.0")
+        expect(field_value(totals_row, "Subtotal ($)")).to eq("100.0")
+        expect(field_value(row, "Taxes ($)")).to eq("1.8")
+        expect(field_value(totals_row, "Taxes ($)")).to eq("1.8")
+        expect(field_value(row, "Shipping ($)")).to eq("0.0")
+        expect(field_value(totals_row, "Shipping ($)")).to eq("0.0")
+        expect(field_value(row, "Sale Price ($)")).to eq("100.0")
+        expect(field_value(totals_row, "Sale Price ($)")).to eq("100.0")
+        expect(field_value(row, "Fees ($)")).to eq("0.31")
+        expect(field_value(totals_row, "Fees ($)")).to eq("0.31")
+        expect(field_value(row, "Net Total ($)")).to eq("99.69")
+        expect(field_value(totals_row, "Net Total ($)")).to eq("99.69")
+        expect(field_value(row, "Tax Included in Price?")).to eq("0")
+      end
+
       describe "tax type" do
         tax_type_test_cases = [
           { country: "IT", rate: 0.22, excluded: nil, expected_type: "VAT" },


### PR DESCRIPTION
### What

Show the tax collected and remitted by Gumroad (like EU VAT, AU GST, etc.) in the "Taxes" column of exported sales and payout CSVs. 

### Why

- As of now the "Taxes" column only shows the `purchase.tax_cents` tax value i.e. if seller is responsible for the collection and remittance of the tax. But most of the tax is now collected and remitted by Gumroad since becoming MoR, and is saved in `purchase.gumroad_tax_cents` so we should be displaying those taxes under the "Taxes" column.
- [Issue reported on Slack](https://anti--work.slack.com/archives/C08A273MA15/p1754468160849059): 
  <img width="1100" height="289" alt="Screenshot 2025-10-07 at 5 10 33 PM" src="https://github.com/user-attachments/assets/1d397498-0bf5-4863-a452-b50b280d6d48" />