### PR TITLE
Only allow business bank accounts and individual PayPal in UAE

### DIFF
--- a/app/javascript/components/Settings/PaymentsPage/AccountDetailsSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/AccountDetailsSection.tsx
@@ -5,12 +5,7 @@ import { cast } from "ts-safe-cast";
 
 import { Button } from "$app/components/Button";
 import { Icon } from "$app/components/Icons";
-import {
-  ComplianceInfo,
-  FormFieldName,
-  PayoutMethod,
-  User,
-} from "$app/components/server-components/Settings/PaymentsPage";
+import { ComplianceInfo, FormFieldName, User } from "$app/components/server-components/Settings/PaymentsPage";
 
 const AccountDetailsSection = ({
   user,
@@ -24,7 +19,6 @@ const AccountDetailsSection = ({
   canadaBusinessTypes,
   states,
   errorFieldNames,
-  payoutMethod,
 }: {
   user: User;
   complianceInfo: ComplianceInfo;
@@ -45,7 +39,6 @@ const AccountDetailsSection = ({
     br: { code: string; name: string }[];
   };
   errorFieldNames: Set<FormFieldName>;
-  payoutMethod: PayoutMethod;
 }) => {
   const uid = React.useId();
 
@@ -60,47 +53,49 @@ const AccountDetailsSection = ({
 
   return (
     <section className="override grid gap-8">
-      <section>
-        <fieldset>
-          <legend>
-            <label>Account type</label>
-            <a href="/help/article/260-your-payout-settings-page">What type of account should I choose?</a>
-          </legend>
-        </fieldset>
-        <div className="radio-buttons" role="radiogroup">
-          <Button
-            role="radio"
-            key="individual"
-            aria-checked={!complianceInfo.is_business}
-            onClick={() => updateComplianceInfo({ is_business: false })}
-            disabled={isFormDisabled}
-          >
-            <Icon name="person" />
-            <div>
-              <h4>Individual</h4>
-              When you are selling as yourself
-            </div>
-          </Button>
-          <Button
-            role="radio"
-            key="business"
-            aria-checked={complianceInfo.is_business}
-            onClick={() =>
-              updateComplianceInfo({
-                is_business: true,
-                business_country: complianceInfo.business_country ?? complianceInfo.country,
-              })
-            }
-            disabled={isFormDisabled}
-          >
-            <Icon name="shop-window" />
-            <div>
-              <h4>Business</h4>
-              When you are selling as a business
-            </div>
-          </Button>
-        </div>
-      </section>
+      {(complianceInfo.is_business ? complianceInfo.business_country !== "AE" : complianceInfo.country !== "AE") ? (
+        <section>
+          <fieldset>
+            <legend>
+              <label>Account type</label>
+              <a href="/help/article/260-your-payout-settings-page">What type of account should I choose?</a>
+            </legend>
+          </fieldset>
+          <div className="radio-buttons" role="radiogroup">
+            <Button
+              role="radio"
+              key="individual"
+              aria-checked={!complianceInfo.is_business}
+              onClick={() => updateComplianceInfo({ is_business: false })}
+              disabled={isFormDisabled}
+            >
+              <Icon name="person" />
+              <div>
+                <h4>Individual</h4>
+                When you are selling as yourself
+              </div>
+            </Button>
+            <Button
+              role="radio"
+              key="business"
+              aria-checked={complianceInfo.is_business}
+              onClick={() =>
+                updateComplianceInfo({
+                  is_business: true,
+                  business_country: complianceInfo.business_country ?? complianceInfo.country,
+                })
+              }
+              disabled={isFormDisabled}
+            >
+              <Icon name="shop-window" />
+              <div>
+                <h4>Business</h4>
+                When you are selling as a business
+              </div>
+            </Button>
+          </div>
+        </section>
+      ) : null}
       {complianceInfo.is_business ? (
         <section className="override grid gap-8">
           <div
@@ -630,11 +625,6 @@ const AccountDetailsSection = ({
         </section>
       ) : null}
       <section className="override grid gap-8">
-        {payoutMethod !== "paypal" && user.country_code === "AE" && !complianceInfo.is_business ? (
-          <div role="status" className="danger">
-            <div>Individual accounts from the UAE are not supported. Please use a business account.</div>
-          </div>
-        ) : null}
         <div style={{ display: "grid", gap: "var(--spacer-5)", gridAutoFlow: "column", gridAutoColumns: "1fr" }}>
           <fieldset className={cx({ danger: errorFieldNames.has("first_name") })}>
             <legend>

--- a/app/javascript/components/server-components/Settings/PaymentsPage.tsx
+++ b/app/javascript/components/server-components/Settings/PaymentsPage.tsx
@@ -234,6 +234,13 @@ const PaymentsPage = (props: Props) => {
   const updatePayoutMethod = (newPayoutMethod: PayoutMethod) => {
     setSelectedPayoutMethod(newPayoutMethod);
     setErrorFieldNames(new Set());
+    if (props.user.country_code === "AE") {
+      if (newPayoutMethod === "paypal") {
+        updateComplianceInfo({ is_business: false });
+      } else if (newPayoutMethod === "bank") {
+        updateComplianceInfo({ is_business: true });
+      }
+    }
   };
 
   const [payoutsPausedByUser, setPayoutsPausedByUser] = React.useState(props.payouts_paused_by_user);
@@ -245,11 +252,6 @@ const PaymentsPage = (props: Props) => {
 
   const [complianceInfo, setComplianceInfo] = React.useState(props.compliance_info);
   const updateComplianceInfo = (newComplianceInfo: Partial<ComplianceInfo>) => {
-    if (props.user.country_code === "AE") {
-      if (!complianceInfo.is_business && newComplianceInfo.is_business) updatePayoutMethod("bank");
-      else if (complianceInfo.is_business && "is_business" in newComplianceInfo && !newComplianceInfo.is_business)
-        updatePayoutMethod("paypal");
-    }
     if (
       props.user.country_code &&
       newComplianceInfo.updated_country_code &&
@@ -1135,7 +1137,6 @@ const PaymentsPage = (props: Props) => {
                 canadaBusinessTypes={props.canada_business_types}
                 states={props.states}
                 errorFieldNames={errorFieldNames}
-                payoutMethod={selectedPayoutMethod}
               />
             ) : (
               <StripeConnectSection

--- a/app/presenters/settings_presenter.rb
+++ b/app/presenters/settings_presenter.rb
@@ -329,8 +329,8 @@ class SettingsPresenter
       bank_account = seller.active_bank_account
 
       {
-        show_bank_account: bank_account.present? || seller.native_payouts_supported?,
-        show_paypal: seller.payment_address.present? || !seller.native_payouts_supported?,
+        show_bank_account: bank_account.present? || seller.native_payouts_supported? || seller.signed_up_from_united_arab_emirates?,
+        show_paypal: seller.payment_address.present? || !seller.native_payouts_supported? || seller.signed_up_from_united_arab_emirates?,
         card_data_handling_mode: CardDataHandlingMode.get_card_data_handling_mode(seller),
         is_a_card: bank_account.is_a?(CardBankAccount),
         card: bank_account.is_a?(CardBankAccount) ? {

--- a/app/services/update_payout_method.rb
+++ b/app/services/update_payout_method.rb
@@ -169,7 +169,7 @@ class UpdatePayoutMethod
 
       return { error: :provide_valid_email_prompt } unless EmailFormatValidator.valid?(payment_address)
       return { error: :provide_ascii_only_email_prompt } unless payment_address.ascii_only?
-      return { error: :paypal_payouts_not_supported } if user.alive_user_compliance_info.blank? || user.native_payouts_supported?
+      return { error: :paypal_payouts_not_supported } unless paypal_payouts_supported?
 
       user.payment_address = payment_address
       user.save!
@@ -191,5 +191,9 @@ class UpdatePayoutMethod
       bank_account_type = params[:bank_account][:type]
       permitted_params = BANK_ACCOUNT_TYPES[bank_account_type][:permitted_params]
       params[:bank_account].permit(*permitted_params)
+    end
+
+    def paypal_payouts_supported?
+      !user.native_payouts_supported? || (params.dig(:user, :country) == Compliance::Countries::ARE.alpha2 && !params.dig(:user, :is_business))
     end
 end


### PR DESCRIPTION
### What 

Remove the `Individual` / `Business` selectors from the payout settings page for UAE accounts, and show business fields by default if "Bank Account" is selected and individual fields if "PayPal" is selected.

### Why

- Ref [Slack discussion](https://anti--work.slack.com/archives/C08A273MA15/p1759489363305679?thread_ts=1759456270.888649&cid=C08A273MA15)
- Since bank account payouts are only supported for businesses due to local restrictions on individual accounts in the UAE, we only support bank for businesses and PayPal for individuals.