### PR TITLE
Chore: Migrate _placeholder.scss to to tailwind.

### DIFF
--- a/app/javascript/components/Placeholder.tsx
+++ b/app/javascript/components/Placeholder.tsx
@@ -1,0 +1,28 @@
+import cx from "classnames";
+import * as React from "react";
+
+type PlaceholderProps = {
+  children: React.ReactNode;
+  className?: string;
+};
+
+export const Placeholder = ({ children, className }: PlaceholderProps) => {
+  return (
+    <div
+      className={cx(
+        "override",
+        "border border-dashed border-black/[var(--border-alpha)] dark:border-white/[var(--border-alpha)]",
+        "rounded",
+        "p-8",
+        "bg-white dark:bg-black",
+        "gap-3",
+        "grid",
+        "text-center",
+        "justify-items-center",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+};

--- a/app/javascript/components/server-components/WorkflowsPage/WorkflowList.tsx
+++ b/app/javascript/components/server-components/WorkflowsPage/WorkflowList.tsx
@@ -11,6 +11,7 @@ import { Button } from "$app/components/Button";
 import { Icon } from "$app/components/Icons";
 import { useLoggedInUser } from "$app/components/LoggedInUser";
 import { Modal } from "$app/components/Modal";
+import { Placeholder } from "$app/components/Placeholder";
 import { showAlert } from "$app/components/server-components/Alert";
 import { Layout } from "$app/components/server-components/WorkflowsPage";
 
@@ -91,7 +92,7 @@ const WorkflowList = () => {
         </div>
       ) : (
         <div className="p-4 md:p-8">
-          <div className="placeholder">
+          <Placeholder>
             <figure>
               <img src={placeholder} />
             </figure>
@@ -101,7 +102,7 @@ const WorkflowList = () => {
             <a href="/help/article/131-using-workflows-to-send-automated-updates" target="_blank" rel="noreferrer">
               Learn more about workflows
             </a>
-          </div>
+          </Placeholder>
         </div>
       )}
     </Layout>
@@ -182,7 +183,7 @@ const WorkflowRow = ({
   ) : (
     <section className="paragraphs" key={workflow.external_id}>
       {header}
-      <div className="placeholder">
+      <Placeholder>
         <h4>
           <>
             No emails yet,{" "}
@@ -191,7 +192,7 @@ const WorkflowRow = ({
             </Link>
           </>
         </h4>
-      </div>
+      </Placeholder>
     </section>
   );
 };


### PR DESCRIPTION
ref: #1055

Description
Migrate _placeholder.scss to tailwind

#### Page: https://gumroad.dev/workflows (Empty state)

### Before

**Dark theme**
Desktop
<img width="1440" height="900" alt="Screenshot 2025-10-07 at 9 47 16 PM" src="https://github.com/user-attachments/assets/c52b08fd-f858-4afc-885e-b67cbb558b6f" />

**Light theme**

Desktop:
<img width="1440" height="900" alt="Screenshot 2025-10-07 at 9 49 08 PM" src="https://github.com/user-attachments/assets/82603083-fdb1-4375-9881-27bff3eb839c" />

Mobile:
<img width="380" height="813" alt="Screenshot 2025-10-07 at 9 50 26 PM" src="https://github.com/user-attachments/assets/1dfb41fe-ce3a-46e2-ae0f-ffcc4d718101" />


### After

**Dark theme**
Desktop
<img width="1440" height="900" alt="Screenshot 2025-10-07 at 9 47 16 PM" src="https://github.com/user-attachments/assets/c52b08fd-f858-4afc-885e-b67cbb558b6f" />

**Light theme**

Desktop:
<img width="1440" height="900" alt="Screenshot 2025-10-07 at 9 49 08 PM" src="https://github.com/user-attachments/assets/82603083-fdb1-4375-9881-27bff3eb839c" />

Mobile:
<img width="380" height="813" alt="Screenshot 2025-10-07 at 9 50 26 PM" src="https://github.com/user-attachments/assets/1dfb41fe-ce3a-46e2-ae0f-ffcc4d718101" />







