### PR TITLE
bug: allow free product purchase on zero tip

### DIFF
--- a/app/javascript/components/Checkout/payment.ts
+++ b/app/javascript/components/Checkout/payment.ts
@@ -174,15 +174,15 @@ export function computeTip(state: State) {
 
 export function computeTipForPrice(state: State, price: number, permalink: string | undefined = undefined) {
   if (!isTippingEnabled(state)) return null;
-  if (state.tip.type === "fixed") {
+  if (state.tip.type === "fixed" && state.tip.amount === null) {
+    return 0;
+  } else if (state.tip.type === "fixed") {
     const totalPrice = getTotalPriceFromProducts(state);
     if (totalPrice === 0) {
       return computeTipForFreeCart(state, permalink);
     }
-
     return Math.round((state.tip.amount ?? 0) * (price / totalPrice));
   }
-
   return Math.round((state.tip.percentage / 100) * price);
 }
 
@@ -270,7 +270,6 @@ export function createReducer(initial: {
       if ((field.type === "terms" || field.required) && !state.customFieldValues[field.key])
         errors.add(`customFields.${field.key}`);
     }
-    if (isTippingEnabled(state) && state.tip.type === "fixed" && state.tip.amount === null) errors.add("tip");
     if (
       requiresPayment(state) &&
       state.paymentMethod !== "stripePaymentRequest" &&

--- a/spec/requests/purchases/tipping_spec.rb
+++ b/spec/requests/purchases/tipping_spec.rb
@@ -130,6 +130,22 @@ describe("Product checkout with tipping", type: :system, js: true) do
     let(:free_product2) { create(:product, name: "Free Product 2", user: seller, price_cents: 0) }
     let(:free_product3) { create(:product, name: "Free Product 3", user: seller2, price_cents: 0) }
 
+    it "allows the buyer to purchase without a tip" do
+      visit free_product1.long_url
+      add_to_cart(free_product1, pwyw_price: 0)
+
+      fill_in "Email address", with: "test@gumroad.com"
+      click_on "Get"
+
+      expect(page).to have_alert(text: "Your purchase was successful! We sent a receipt to test@gumroad.com.")
+
+      last_purchase = Purchase.last
+      expect(last_purchase).to be_successful
+      expect(last_purchase.link).to eq(free_product1)
+      expect(last_purchase.price_cents).to eq(0)
+      expect(last_purchase.tip).to be_nil
+    end
+
     it "only allows the buyer to tip a fixed amount" do
       visit free_product2.long_url
       add_to_cart(free_product2, pwyw_price: 0)


### PR DESCRIPTION
Ref:
- #864 

Allow free cart purchase to pass through without a tip

### Before

https://github.com/user-attachments/assets/2e3a1fa6-1c0d-4b4a-803b-ec8174986bee

### After

https://github.com/user-attachments/assets/fd4c7ca5-c65a-4c52-865c-4c0e9f87fbc4

### Specs Added
1. `spec/requests/purchases/tipping_spec.rb:133 > allows the buyer to purchase without a tip`
<img width="853" height="272" alt="specs_passing_zero" src="https://github.com/user-attachments/assets/f15c9785-3039-4dd7-bdb3-cbd4aa12e9b6" />

### AI Usage
None