### PR TITLE
fix: Sort by status in Upsells page

### DIFF
--- a/app/javascript/components/server-components/CheckoutDashboard/UpsellsPage.tsx
+++ b/app/javascript/components/server-components/CheckoutDashboard/UpsellsPage.tsx
@@ -71,7 +71,7 @@ export type Upsell = {
   }[];
 };
 
-export type SortKey = "name" | "revenue" | "uses";
+export type SortKey = "name" | "revenue" | "uses" | "status";
 export type QueryParams = {
   sort: Sort<SortKey> | null;
   query: string | null;
@@ -266,7 +266,7 @@ const UpsellsPage = (props: {
                   <th {...thProps("name")}>Upsell</th>
                   <th {...thProps("revenue")}>Revenue</th>
                   <th {...thProps("uses")}>Uses</th>
-                  <th {...thProps("uses")}>Status</th>
+                  <th {...thProps("status")}>Status</th>
                 </tr>
               </thead>
               <tbody>

--- a/app/models/concerns/upsell/sorting.rb
+++ b/app/models/concerns/upsell/sorting.rb
@@ -3,7 +3,7 @@
 module Upsell::Sorting
   extend ActiveSupport::Concern
 
-  SORT_KEYS = ["name", "revenue", "uses"]
+  SORT_KEYS = ["name", "revenue", "uses", "status"]
 
   SORT_KEYS.each do |key|
     const_set(key.upcase, key)
@@ -23,6 +23,8 @@ module Upsell::Sorting
         left_outer_joins(:purchases_that_count_towards_volume)
           .group(:id)
           .order("SUM(purchases.quantity) #{direction}")
+      when STATUS
+        order(paused: direction)
       else
         all
       end


### PR DESCRIPTION
### Explanation of Change
The "Status" column in the Upsells page wasn't properly sorting by the upsell's active/paused status. Instead, it was falling back to sorting by "uses"

### Screenshots/Videos
Before

https://github.com/user-attachments/assets/76ecb1c6-ed21-4df3-b8eb-46152c472ea2

After

https://github.com/user-attachments/assets/ee2d0a61-e97b-4e28-8714-99defae57678

### AI Disclosure
No AI tools used