### PR TITLE
Improvement/fix: don't reset/update price & error if clicked on same product tier as previously selected

### DIFF
--- a/app/javascript/components/Product/ConfigurationSelector.tsx
+++ b/app/javascript/components/Product/ConfigurationSelector.tsx
@@ -710,7 +710,7 @@ export const ConfigurationSelector = React.forwardRef<
                 selected={option.id === selection.optionId}
                 onClick={() => {
                   if (option.id === selection.optionId) return;
-                  update({ optionId: option.id, price: { value: selection.price.value, error: false } });
+                  update({ optionId: option.id, price: { value: null, error: false } });
                 }}
                 priceCents={basePriceCents + computeOptionPrice(option, selection.recurrence)}
                 name={option.name}


### PR DESCRIPTION
ref #864 

### what PR does?
- prevent price & error getting reset if clicked on same product tier as previously selected

### Before:
https://github.com/user-attachments/assets/bc62334b-a784-4a59-a27f-f9b37c711f0b

## After:
https://github.com/user-attachments/assets/56428ae4-1e48-400b-b07e-4801f7a670a0


### AI disclosure:
- no AI used