### PR TITLE
Enhance phone number validation for Canadian overlay

### DIFF
--- a/app/javascript/components/server-components/Settings/PaymentsPage.tsx
+++ b/app/javascript/components/server-components/Settings/PaymentsPage.tsx
@@ -296,7 +296,17 @@ const PaymentsPage = (props: Props) => {
   const validatePhoneNumber = (input: string | null, country_code: string | null) => {
     const countryCode: CountryCode = cast(country_code);
     try {
-      return input && parsePhoneNumber(input, countryCode).isValid();
+      if (!input) return false;
+
+      const parsedNumber = parsePhoneNumber(input, countryCode);
+
+      // Handle not-yet-supported Canadian overlay (e.g., +1 942)
+      if (/^\+1942\d{7,10}$/u.test(parsedNumber.number) && countryCode === "CA") {
+        // +1 942 is a new Toronto overlay (effective April 2025)
+        return true;
+      }
+
+      return parsedNumber.isValid();
     } catch {
       return false;
     }


### PR DESCRIPTION
Resolves: https://github.com/antiwork/gumroad/issues/1587
AI Disclosure: Only on Toronto's phone format
Self review: Done

---

### Context
Toronto got a new region code recently
https://www.cbc.ca/news/canada/toronto/toronto-new-area-code-942-1.7519264

and it's not yet updated on most phone validation libraries.
<img width="1111" height="836" alt="image" src="https://github.com/user-attachments/assets/e0f7edd9-c2f7-40cc-89db-ee1e10540f90" />

### Solution

Add a condition to skip validation for Toronto's region for now.

#### Demo
https://www.loom.com/share/feeb2f1ae8284d5e8180c015b4c4bbfa