### PR TITLE
Bump libphonenumber to latest version and fix deprecation warnings

### DIFF
--- a/app/javascript/components/Settings/PaymentsPage/AccountDetailsSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/AccountDetailsSection.tsx
@@ -1,5 +1,5 @@
 import cx from "classnames";
-import { CountryCode, parsePhoneNumber } from "libphonenumber-js";
+import { CountryCode, parsePhoneNumberWithError } from "libphonenumber-js";
 import * as React from "react";
 import { cast } from "ts-safe-cast";
 
@@ -52,7 +52,7 @@ const AccountDetailsSection = ({
   const formatPhoneNumber = (phoneNumber: string, country_code: string | null) => {
     try {
       const countryCode: CountryCode = cast(country_code);
-      return parsePhoneNumber(phoneNumber, countryCode).format("E.164");
+      return parsePhoneNumberWithError(phoneNumber, countryCode).format("E.164");
     } catch {
       return phoneNumber;
     }

--- a/app/javascript/components/server-components/Settings/PaymentsPage.tsx
+++ b/app/javascript/components/server-components/Settings/PaymentsPage.tsx
@@ -1,6 +1,6 @@
 import { StripeCardElement } from "@stripe/stripe-js";
 import cx from "classnames";
-import { CountryCode, parsePhoneNumber } from "libphonenumber-js";
+import { CountryCode, parsePhoneNumberWithError } from "libphonenumber-js";
 import * as React from "react";
 import { cast, createCast } from "ts-safe-cast";
 
@@ -296,7 +296,7 @@ const PaymentsPage = (props: Props) => {
   const validatePhoneNumber = (input: string | null, country_code: string | null) => {
     const countryCode: CountryCode = cast(country_code);
     try {
-      return input && parsePhoneNumber(input, countryCode).isValid();
+      return input && parsePhoneNumberWithError(input, countryCode).isValid();
     } catch {
       return false;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "jquery": "^3.6.3",
         "js-yaml": "^4.1.0",
         "json-schema-to-ts": "^3.0.0",
-        "libphonenumber-js": "^1.10.15",
+        "libphonenumber-js": "^1.12.23",
         "lodash": "^4.17.21",
         "lowlight": "^3.0.0",
         "mailcheck": "^1.1.1",
@@ -9944,9 +9944,9 @@
       }
     },
     "node_modules/libphonenumber-js": {
-      "version": "1.11.11",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.11.11.tgz",
-      "integrity": "sha512-mF3KaORjJQR6JBNcOkluDcJKhtoQT4VTLRMrX1v/wlBayL4M8ybwEDeryyPcrSEJmD0rVwHUbBarpZwN5NfPFQ==",
+      "version": "1.12.23",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.23.tgz",
+      "integrity": "sha512-RN3q3gImZ91BvRDYjWp7ICz3gRn81mW5L4SW+2afzNCC0I/nkXstBgZThQGTE3S/9q5J90FH4dP+TXx8NhdZKg==",
       "license": "MIT"
     },
     "node_modules/lilconfig": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "jquery": "^3.6.3",
     "js-yaml": "^4.1.0",
     "json-schema-to-ts": "^3.0.0",
-    "libphonenumber-js": "^1.10.15",
+    "libphonenumber-js": "^1.12.23",
     "lodash": "^4.17.21",
     "lowlight": "^3.0.0",
     "mailcheck": "^1.1.1",


### PR DESCRIPTION
Resolves: https://github.com/antiwork/gumroad/issues/1587
AI Disclosure: None
Self review: Done

---

### Context
This PR updates the libphonenumber-js dependency to the latest version to ensure correct validation and parsing of recently introduced phone number formats in the Toronto region.

More details on the changelog:
https://gitlab.com/catamphetamine/libphonenumber-js/-/blob/master/CHANGELOG.md?ref_type=heads

### Demo
[bump lib.webm](https://github.com/user-attachments/assets/f569275d-f0ec-403d-92e2-a4f8e383864c)
