### PR TITLE
Fix: Preview section at content tab for bundle product

### DIFF
--- a/app/javascript/components/BundleEdit/ContentTab/index.tsx
+++ b/app/javascript/components/BundleEdit/ContentTab/index.tsx
@@ -68,7 +68,7 @@ export const ContentTab = () => {
   return (
     <Layout
       preview={
-        <div>
+        <div className="flex flex-col gap-6 p-6">
           <header>
             <h1>Library</h1>
           </header>


### PR DESCRIPTION
#864 

Reopen : #1501 

## Description

### Problem
- the preview section has no padding and gap.

### Fix
- added `p-6` and `gap-6`


## Screenshots

### Before

<img width="1845" height="970" alt="image" src="https://github.com/user-attachments/assets/f7bf2056-2ad9-4ae5-a5be-3ba3c0a5756d" />


### After

<img width="1845" height="970" alt="Screenshot from 2025-10-09 19-54-13" src="https://github.com/user-attachments/assets/c8140f3b-5ee7-49fa-a559-dccf07aa1554" />


## AI Usage
None
