### PR TITLE
fix: tooltip position for small screen at product edit

### DIFF
--- a/app/javascript/components/ProductEdit/Layout.tsx
+++ b/app/javascript/components/ProductEdit/Layout.tsx
@@ -24,6 +24,7 @@ import { useRefToLatest } from "$app/components/useRefToLatest";
 import { WithTooltip } from "$app/components/WithTooltip";
 
 import { FileEntry, useProductEditContext } from "./state";
+import { useIsAboveBreakpoint } from "$app/components/useIsAboveBreakpoint";
 
 export const useProductUrl = (params = {}) => {
   const { product, uniquePermalink } = useProductEditContext();
@@ -140,6 +141,7 @@ export const Layout = ({
   const tab = match?.handle ?? "product";
 
   const navigate = useRefToLatest(useNavigate());
+  const isDesktop = useIsAboveBreakpoint("lg");
 
   const [isPublishing, setIsPublishing] = React.useState(false);
   const setPublished = async (published: boolean) => {
@@ -234,7 +236,7 @@ export const Layout = ({
                   <Icon name="link" />
                 </Button>
               </CopyToClipboard>
-              <CopyToClipboard text={checkoutUrl} copyTooltip="Copy checkout URL" tooltipPosition="left">
+              <CopyToClipboard text={checkoutUrl} copyTooltip="Copy checkout URL" tooltipPosition={isDesktop ? "left" : "bottom"}>
                 <Button>
                   <Icon name="cart-plus" />
                 </Button>


### PR DESCRIPTION
#864 

## Description

### Problem
- the tooltip was positioned left on small screen.
- was introduced in #1336

### Fix
- positioned bottom for small screens and left for rest.


## Screenshots

### Before

[Screencast from 2025-10-09 21-39-59.webm](https://github.com/user-attachments/assets/bc11851e-41a6-4eed-a9d4-795293d7e6ed)

[Screencast from 2025-10-09 21-40-22.webm](https://github.com/user-attachments/assets/15a17189-b6ab-4a73-9a72-06f63e18513c)

### After

[Screencast from 2025-10-09 21-38-52.webm](https://github.com/user-attachments/assets/7ef8449b-837c-464d-bc0e-bbb0de7a4dfd)

[Screencast from 2025-10-09 21-40-51.webm](https://github.com/user-attachments/assets/dac178aa-ebdd-4991-bf0f-527b78be9b97)

## AI Usage
None
