### PR TITLE
Defect - Move card to tailwind in admin

### DIFF
--- a/app/views/admin/links/_product.html.erb
+++ b/app/views/admin/links/_product.html.erb
@@ -1,4 +1,4 @@
-<article class="card" data-product-id="<%= product.unique_permalink %>">
+<article class="override grid gap-4 rounded border border-border bg-background p-4" data-product-id="<%= product.unique_permalink %>">
   <div class="paragraphs">
     <div style="display: flex; gap: var(--spacer-4); align-items: center">
       <%= link_to_if(product.preview_url, image_tag(cdn_url_for(product.preview_url) || asset_path("cover_placeholder.png"), style: "width: var(--form-element-height)", alt: "Preview image"), product.preview_url, target: "_blank") %>

--- a/app/views/admin/merchant_accounts/_merchant_account.html.erb
+++ b/app/views/admin/merchant_accounts/_merchant_account.html.erb
@@ -1,4 +1,4 @@
-<div class="card">
+<div class="override grid gap-4 rounded border border-border bg-background p-4">
   <div>
     <div>
       <h2>

--- a/app/views/admin/purchases/_purchase.html.erb
+++ b/app/views/admin/purchases/_purchase.html.erb
@@ -1,4 +1,4 @@
-<div class="card">
+<div class="override grid gap-4 rounded border border-border bg-background p-4">
   <div style="display: grid; gap: var(--spacer-2)">
     <h2 class="purchase-title">
       <%= link_to(purchase.formatted_display_price, admin_purchase_path(purchase)) %>

--- a/app/views/admin/users/_user.html.erb
+++ b/app/views/admin/users/_user.html.erb
@@ -1,4 +1,4 @@
-<div class="card js-admin-user" data-user-id="<%= user.id %>">
+<div class="override grid gap-4 rounded border border-border bg-background p-4 js-admin-user" data-user-id="<%= user.id %>">
   <div class="paragraphs">
     <div style="display: flex; gap: var(--spacer-4); align-items: center">
       <%= image_tag(user.avatar_url, class: "user-avatar", style: "width: var(--form-element-height)", alt: user.name) %>

--- a/app/views/admin/users/payouts/_payment.html.erb
+++ b/app/views/admin/users/payouts/_payment.html.erb
@@ -1,4 +1,4 @@
-<div class="card">
+<div class="override grid gap-4 rounded border border-border bg-background p-4">
   <div>
     <h3>
       <%= payment.displayed_amount %>


### PR DESCRIPTION
This PR is an immediate fix: the admin design is broken after merging https://github.com/antiwork/gumroad/pull/1343, because the `card` class had not been moved to Tailwind there.

#### Before
<img width="1145" height="731" alt="Screenshot 2025-10-09 at 16 07 03" src="https://github.com/user-attachments/assets/2ba9444f-1f7a-40d5-a381-65ddce9dc828" />

#### After
<img width="1140" height="776" alt="Screenshot 2025-10-09 at 16 05 36" src="https://github.com/user-attachments/assets/21160fb9-ef6b-407c-9e37-b9e06f822e57" />

---

### AI disclosure

None