### PR TITLE
chore: migrate _containers.scss to tailwind

### DIFF
--- a/app/javascript/packs/admin.scss
+++ b/app/javascript/packs/admin.scss
@@ -10,7 +10,6 @@
 @import "../stylesheets/alert";
 @import "../stylesheets/button";
 @include buttons;
-@import "../stylesheets/containers";
 @import "../stylesheets/dropdown";
 @import "../stylesheets/figure";
 @import "../stylesheets/forms";

--- a/app/javascript/packs/design.scss
+++ b/app/javascript/packs/design.scss
@@ -16,7 +16,6 @@
 @import "../stylesheets/cart";
 @import "../stylesheets/chart";
 @import "../stylesheets/carousel";
-@import "../stylesheets/containers";
 @import "../stylesheets/comment";
 @import "../stylesheets/custom_sections";
 @import "../stylesheets/discover";

--- a/app/javascript/packs/email.scss
+++ b/app/javascript/packs/email.scss
@@ -13,7 +13,6 @@ $light-body-bg: #ffffff;
 @import "../stylesheets/alert";
 @import "../stylesheets/button";
 @include buttons;
-@import "../stylesheets/containers";
 @import "../stylesheets/forms";
 @import "../stylesheets/grid";
 @import "../stylesheets/pill";

--- a/app/javascript/stylesheets/tailwind.components.css
+++ b/app/javascript/stylesheets/tailwind.components.css
@@ -1,0 +1,13 @@
+@layer components {
+  .paragraphs {
+    @apply flex flex-col gap-[var(--spacer-4)];
+  }
+
+  .input-with-button {
+    @apply grid grid-flow-col grid-cols-[1fr] auto-cols-max items-center gap-[var(--spacer-3)];
+  }
+
+  .button-group {
+    @apply flex flex-wrap gap-[var(--spacer-2)];
+  }
+}

--- a/app/javascript/stylesheets/tailwind.css
+++ b/app/javascript/stylesheets/tailwind.css
@@ -1,6 +1,8 @@
 @layer theme, base, components, utilities;
 @import "tailwindcss/theme.css" layer(theme);
 @import "tailwindcss/utilities.css" source(none); /* Should be layer(utilties) but that conflicts with the legacy non-layer CSS */
+@import "./tailwind.components.css";
+
 /*
  * By default Tailwind checks all files in the project for classes, but in Gumroad that causes performance issues.
  * Whitelisting source directories solves the issue, but we need to keep the list up to date to cover all frontend code.


### PR DESCRIPTION
part of: #1055 

# Description

this PR migrates _containers.scss to tailwind

## Before V/S After

| Before | After |
| -- | -- |
|  |  |
|  |  |
|  |  |
|  |  |
|  |  |
|  |  |
|  |  |