### PR TITLE
feat(audience): Add customer download counts in dashboard drawer

### DIFF
--- a/app/javascript/components/server-components/Audience/CustomersPage.tsx
+++ b/app/javascript/components/server-components/Audience/CustomersPage.tsx
@@ -904,6 +904,12 @@ const CustomerDrawer = ({
           <h5>{customer.is_multiseat_license ? "Seats" : "Quantity"}</h5>
           {customer.quantity}
         </div>
+        {customer.product.native_type !== "coffee" && !customer.is_bundle_purchase ? (
+          <div>
+            <h5>Download count</h5>
+            {customer.download_count}
+          </div>
+        ) : null}
         <div>
           <h5>Price</h5>
           <div>

--- a/app/javascript/data/customers.ts
+++ b/app/javascript/data/customers.ts
@@ -125,6 +125,7 @@ export type Customer = {
     term: string | null;
     content: string | null;
   } | null;
+  download_count: number;
 };
 
 export type Query = {

--- a/app/presenters/customer_presenter.rb
+++ b/app/presenters/customer_presenter.rb
@@ -145,6 +145,7 @@ class CustomerPresenter
         term: utm_link.utm_term,
         content: utm_link.utm_content,
       } : nil,
+      download_count: purchase.url_redirect&.uses || 0,
     }
   end
 

--- a/spec/presenters/customer_presenter_spec.rb
+++ b/spec/presenters/customer_presenter_spec.rb
@@ -124,6 +124,7 @@ describe CustomerPresenter do
           has_options: true,
           option: purchase1.variant_attributes.first.to_option,
           utm_link: nil,
+          download_count: 0,
         }
       )
 
@@ -192,6 +193,7 @@ describe CustomerPresenter do
           has_options: true,
           option: purchase2.variant_attributes.first.to_option,
           utm_link: nil,
+          download_count: 0,
         }
       )
     end
@@ -328,6 +330,29 @@ describe CustomerPresenter do
           ProductReviewVideoPresenter.new(alive_approved_video).props(pundit_user:),
           ProductReviewVideoPresenter.new(alive_pending_video).props(pundit_user:),
         )
+      end
+    end
+
+    context "purchase has downloads" do
+      let(:purchase) { create(:purchase) }
+      let(:url_redirect) { create(:url_redirect, purchase:, uses: 5) }
+
+      before do
+        purchase.update!(url_redirect:)
+      end
+
+      it "includes the download count" do
+        props = described_class.new(purchase: purchase.reload).customer(pundit_user:)
+        expect(props[:download_count]).to eq(5)
+      end
+    end
+
+    context "purchase without url_redirect" do
+      let(:purchase) { create(:purchase) }
+
+      it "returns 0 for download count" do
+        props = described_class.new(purchase:).customer(pundit_user:)
+        expect(props[:download_count]).to eq(0)
       end
     end
   end


### PR DESCRIPTION
Fixes: #1562 
## Summary
Added download count display in the Customers dashboard drawer to help sellers detect illegal file sharing and verify customer download activity.

## What & Why
**Problem:** Sellers had no way to see how many times customers downloaded their products, making it impossible to detect if customers were sharing download links illegally or to verify refund claims about never downloading.

**Solution:** Surface the existing `url_redirects.uses` data in the Customer drawer UI.

## AI Disclosure
AI assistance was used for:
Codebase analysis to understand the data flow from Purchase → UrlRedirect → CustomerPresenter → CustomerDrawer
Writing test cases and ensuring proper coverage for the new functionality
Tools used: Cursor with Claude Sonnet 4.5


## Before

https://github.com/user-attachments/assets/35fdf09d-d385-4600-ba24-7c09c6ed0602


## After
https://github.com/user-attachments/assets/a3b0e21b-95c2-4ab9-a0ed-f3a3fa1f008e

