### PR TITLE
Fix: 2FA token validation failing with whitespace

### DIFF
--- a/app/javascript/components/server-components/TwoFactorAuthenticationPage.tsx
+++ b/app/javascript/components/server-components/TwoFactorAuthenticationPage.tsx
@@ -31,7 +31,8 @@ export const TwoFactorAuthenticationPage = ({
     e.preventDefault();
     setLoginState({ type: "submitting" });
     try {
-      const { redirectLocation } = await twoFactorLogin({ user_id, token, next });
+      const trimmedToken = token.trim();
+      const { redirectLocation } = await twoFactorLogin({ user_id, token: trimmedToken, next });
       window.location.href = redirectLocation;
     } catch (e) {
       assertResponseError(e);


### PR DESCRIPTION
ref #864 
## Problem
Two-factor authentication was failing when users entered valid tokens with leading or trailing whitespace. The system was performing exact string matching without trimming spaces, causing legitimate authentication attempts to fail.

## before

https://github.com/user-attachments/assets/426a660d-64c7-4ce6-9fe1-86fde2a98bf9


## after

https://github.com/user-attachments/assets/92ce38d1-b5ef-4cba-936c-cfb12f39c955


This improves the user experience by preventing authentication failures due to accidental whitespace input.

## AI Usage
No AI was used to generate any of this code.

## Self-Review
I have self-reviewed all the code that I have written.