### PR TITLE
Fix: Color contrast for Dark mode + minor width issue in Help center page

### DIFF
--- a/app/views/help_center/categories/show.html.erb
+++ b/app/views/help_center/categories/show.html.erb
@@ -7,7 +7,7 @@
     <% @category.articles.each do |article| %>
       <div class="flex items-center space-x-3">
         <%= link_to article,
-                    class: "text-gray-900 hover:text-blue-600 hover:underline font-medium flex items-center gap-2 w-full" do %>
+                    class: "text-gray-900 dark:text-white hover:text-blue-600 hover:underline font-medium flex items-center gap-2 w-fit" do %>
           <svg class="w-5 h-5 text-gray-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
           </svg>


### PR DESCRIPTION
1. There was no style written for text color in dark mode. 
2. The `w-full` class was causing a issue when we hover in the white space,  the text hover class was getting activated due to it ( shown in before video below). we have made it as `w-fit` to tackle it. 

## Before
https://github.com/user-attachments/assets/0316dcfc-efcb-43eb-849a-67385b4e475e

## After

### Light Mode
https://github.com/user-attachments/assets/ea7bef5b-8a7a-4d0a-9e22-2bc131759ffa


### Dark Mode
https://github.com/user-attachments/assets/1a2629d4-c1eb-47a5-8c8f-07e222ea1914


## Use of AI 
none