### PR TITLE
Revert "fix(CheckoutPage): hide percentage options for free cart"

### DIFF
--- a/app/javascript/components/Checkout/PaymentForm.tsx
+++ b/app/javascript/components/Checkout/PaymentForm.tsx
@@ -48,7 +48,6 @@ import {
   requiresReusablePaymentMethod,
   isSubmitDisabled,
   isTippingEnabled,
-  getTotalPriceFromProducts,
 } from "$app/components/Checkout/payment";
 import { Icon } from "$app/components/Icons";
 import { useLoggedInUser } from "$app/components/LoggedInUser";
@@ -728,7 +727,7 @@ const CreditCard = () => {
 const TipSelector = () => {
   const [state, dispatch] = useState();
   const errors = getErrors(state);
-  const showPercentageOptions = getTotalPriceFromProducts(state) > 0;
+  const showPercentageOptions = state.surcharges.type === "loaded" ? state.surcharges.result.subtotal > 0 : true;
 
   React.useEffect(() => {
     if (!showPercentageOptions && state.tip.type === "percentage")

--- a/app/javascript/components/Checkout/payment.ts
+++ b/app/javascript/components/Checkout/payment.ts
@@ -155,7 +155,7 @@ export function isSubmitDisabled(state: State) {
   return isProcessing(state) || state.surcharges.type !== "loaded" || emailTypoBlocking;
 }
 
-export const getTotalPriceFromProducts = (state: State) => state.products.reduce((sum, item) => sum + item.price, 0);
+const getTotalPriceFromProducts = (state: State) => state.products.reduce((sum, item) => sum + item.price, 0);
 
 export function isTippingEnabled(state: State) {
   return (

--- a/spec/requests/purchases/tipping_spec.rb
+++ b/spec/requests/purchases/tipping_spec.rb
@@ -143,11 +143,6 @@ describe("Product checkout with tipping", type: :system, js: true) do
 
       fill_in "Tip", with: 5
 
-      expect(page).not_to have_radio_button("0%")
-      expect(page).not_to have_radio_button("10%")
-      expect(page).not_to have_radio_button("20%")
-      expect(page).not_to have_radio_button("Other")
-
       fill_checkout_form(free_product2)
 
       expect(page).to have_text("Subtotal US$0", normalize_ws: true)


### PR DESCRIPTION
Reverts antiwork/gumroad#1395

Addresses the context described in https://github.com/antiwork/gumroad/issues/1619