### PR TITLE
Rich text overlay fix

### DIFF
--- a/app/javascript/components/Profile/EditSections.tsx
+++ b/app/javascript/components/Profile/EditSections.tsx
@@ -498,7 +498,7 @@ const RichTextSectionView = ({ section }: { section: RichTextSection }) => {
           <RichTextEditorToolbar editor={editor} productId={section.id} />
         </div>
       ) : null}
-      <EditorContent editor={editor} className="rich-text p-1" />
+      <EditorContent editor={editor} className="rich-text lg:p-1" />
     </SectionLayout>
   );
 };


### PR DESCRIPTION
ref: #864 
Re opened: #1555 

### fix: Add padding to rich text editor in profile on large screens.

# Problem

The text inside the rich text editor on the profile page was misaligned and appeared too close to the edges on larger screens, making the layout inconsistent with other sections.

### Action Performed
1. Navigate to the profile page.
2. Edit any section that contains a rich text editor.
3. Observe the text alignment on large screens.

# Root cause analysis
The `EditorContent` component lacked proper padding for large screens (`lg:` breakpoint).  
Without spacing, the editor content touched the container edges, leading to poor visual spacing.

# Solution
Added responsive padding (`lg:p-1`) to the `EditorContent` component to ensure consistent spacing and visual balance on larger screens.

# Screenshots

| Before | After |
| -- | -- |
| <img width="1917" height="1006" alt="Screenshot from 2025-10-14 08-53-06" src="https://github.com/user-attachments/assets/97f00511-a23f-410a-8b7e-e4f7aae09b05" /> | <img width="1917" height="1006" alt="Screenshot from 2025-10-14 08-52-42" src="https://github.com/user-attachments/assets/57f1ff9a-9387-4a9b-9687-edf2d0d9eeae" /> |
## no changes for mobile view
| Before | After |
| -- | -- |
| <img width="407" height="887" alt="Screenshot from 2025-10-14 08-52-21" src="https://github.com/user-attachments/assets/c7281097-9419-4af7-a5e6-1c04c12efc86" /> | <img width="407" height="887" alt="Screenshot from 2025-10-14 08-52-21" src="https://github.com/user-attachments/assets/8b0b66d5-978d-4572-9e04-a00ef5f6137b" /> |

# Self Review
I have reviewed the code that I have written.

# AI Disclosure
No usage of AI.

