### PR TITLE
fix navbar element spacing on mobile screens

### DIFF
--- a/app/views/home/shared/_nav.html.erb
+++ b/app/views/home/shared/_nav.html.erb
@@ -75,10 +75,10 @@
 %>
 
 <div class="justify-between bg-white border-b border-black top-0 left-0 right-0 z-50 pr-4 pl-4 h-20 sticky flex lg:pl-8 lg:pr-0 dark:bg-black dark:border-b-white/35">
-  <div class="flex items-center">
-    <%= logo_link(class: "flex items-center", image_class: "h-8") %>
+  <div class="flex items-center gap-2">
+    <%= logo_link(class: "flex items-center", image_class: "h-7 lg:h-8") %>
 
-    <%= link_to "https://github.com/antiwork/gumroad", target: "_blank", rel: "noopener noreferrer", class: "ml-3 flex items-center gap-1.5 rounded-full p-1.5 border border-black no-underline dark:border-white/35 hover:bg-gray-100 dark:hover:bg-gray-700 text-black dark:text-white hover:-translate-x-[2px] hover:-translate-y-[2px] hover:shadow-[2px_2px_0_0_rgba(0,0,0,1)] dark:hover:shadow-[2px_2px_0_0_rgba(255,255,255,0.35)] transition-all duration-100", aria: { label: "Visit Gumroad on GitHub" }, data: { github_stars: true } do %>
+    <%= link_to "https://github.com/antiwork/gumroad", target: "_blank", rel: "noopener noreferrer", class: "flex gap-1.5 rounded-full p-1.5 border border-black no-underline dark:border-white/35 hover:bg-gray-100 dark:hover:bg-gray-700 text-black dark:text-white hover:-translate-x-[2px] hover:-translate-y-[2px] hover:shadow-[2px_2px_0_0_rgba(0,0,0,1)] dark:hover:shadow-[2px_2px_0_0_rgba(255,255,255,0.35)] transition-all duration-100", aria: { label: "Visit Gumroad on GitHub" }, data: { github_stars: true } do %>
       <svg width="20" height="20" viewBox="0 0 98 96" xmlns="http://www.w3.org/2000/svg" class="fill-current">
         <path fill-rule="evenodd" clip-rule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z" fill="currentColor"/>
       </svg>


### PR DESCRIPTION
## Issue
On some mobile screens, the GitHub stars button and hamburger menu were positioned too close together, causing poor visual spacing and potential overlap.


| Before | After |
|:--:|:--:|
| <img width="392" height="675" alt="Screenshot 2025-10-11 at 7 13 52 PM" src="https://github.com/user-attachments/assets/e70cc091-12aa-47cc-a3d6-b1144b639f36" /> | <img width="391" height="669" alt="Screenshot 2025-10-11 at 7 13 26 PM" src="https://github.com/user-attachments/assets/2c587052-53cd-42b6-925a-61c05105fdd3" /> |

##

<img width="1512" height="817" alt="Screenshot 2025-10-12 at 8 19 31 PM" src="https://github.com/user-attachments/assets/0d97630b-ea63-457b-8859-10c53ed48bdb" />

##

https://github.com/user-attachments/assets/35855412-fcdf-4490-b44e-ffb2b08d5c8d





## AI Usage
No AI was used to generate any of this code.

## Self-Review
I have self-reviewed all the code that I have written.