### PR TITLE
fix: Style fix for CtaBar component

### DIFF
--- a/app/javascript/components/Product/Layout.tsx
+++ b/app/javascript/components/Product/Layout.tsx
@@ -264,11 +264,9 @@ const CtaBar = ({
         boxShadow: visible
           ? "0 var(--border-width) rgb(var(--color)), 0 calc(-1 * var(--border-width)) rgb(var(--color))"
           : undefined,
-        position: "fixed",
+        position: "sticky",
         top: isDesktop ? 0 : undefined,
         bottom: isDesktop ? undefined : 0,
-        left: 0,
-        right: 0,
         // Render above the product edit button
         zIndex: "var(--z-index-menubar)",
         marginTop: hasHero ? "var(--border-width)" : undefined,


### PR DESCRIPTION
## Before
Changed position from `fixed` to `sticky` for the CtaBar component. The fixed positioning was removing it from the document flow, causing it not to occupy layout space and allowing other components to render underneath it.

## Before
https://github.com/user-attachments/assets/e116ac31-703b-4c63-b4cc-f1d7b1af61a8

## After

https://github.com/user-attachments/assets/6f357988-aed0-45f5-a541-5be828d9f724

## Mobile View
<img width="426" height="814" alt="Screenshot 2025-10-14 at 7 45 33 PM" src="https://github.com/user-attachments/assets/7458273d-3bb2-4701-8f43-94ba371330fd" />

## Use of AI
None
