### PR TITLE
 Fix(flaky test): Widget test flakes because of layout shifts as embed iframe loads

### DIFF
--- a/spec/requests/widget_spec.rb
+++ b/spec/requests/widget_spec.rb
@@ -27,6 +27,10 @@ describe "Widget Page scenario", js: true, type: :system do
       select_tab("Embed")
 
       expect(page).to have_field("Widget code", with: %(<script src="#{UrlService.root_domain_with_protocol}/js/gumroad-embed.js"></script>\n<div class="gumroad-product-embed"><a href="#{@demo_product.long_url}">Loading...</a></div>))
+
+      # wait for embed iframe to load, so no layout shift happens when hovering the copy button
+      expect(page).to have_css("iframe[src*='embed=true'][style*='height']", wait: 10)
+
       copy_button = find_button("Copy embed code")
       copy_button.hover
       expect(page).to have_content("Copy to Clipboard")


### PR DESCRIPTION
### Failing CI link: 
https://github.com/antiwork/gumroad/actions/runs/18483282953/job/52662025191#step:8:80

<img width="1081" height="309" alt="Screenshot 2025-10-15 at 1 30 22 PM" src="https://github.com/user-attachments/assets/22f936de-a3a2-4154-8078-01ff4b614b37" />

### we've applied same fix for another test of `widget_spec.rb` file in #1483 

# Problem:
- once embed page is loaded, the embed preview div is replaced by an iframe and then resized; this cause layout shift so the button can lose hover/focus state.

### in video below you can see embed iframe loading and changing it's height

https://github.com/user-attachments/assets/4017179c-cbcc-455e-b258-27d67e9b6703

# Solution:
- wait for embed-iframe to load before hovering "copy embed code" button
```rb
        # wait for embed iframe to load, so no layout shift happens when hovering the copy button
        expect(page).to have_css("iframe[src*='embed=true'][style*='height']", wait: 10)
```

### AI disclosure:
- no ai used
