### PR TITLE
Fix: Automatic VAT Exemption for Recurring Subscription Charges

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -929,11 +929,22 @@ class Subscription < ApplicationRecord
     end
 
     def get_vat_id_from_original_purchase(purchase)
+      vat_id = nil
+      
       if original_purchase.purchase_sales_tax_info&.business_vat_id
-        purchase.business_vat_id = original_purchase.purchase_sales_tax_info.business_vat_id
+        vat_id = original_purchase.purchase_sales_tax_info.business_vat_id
       elsif original_purchase.refunds.where("gumroad_tax_cents > 0").where("amount_cents = 0").exists?
-        purchase.business_vat_id = original_purchase.refunds.where("gumroad_tax_cents > 0").where("amount_cents = 0").first.business_vat_id
+        vat_id = original_purchase.refunds.where("gumroad_tax_cents > 0").where("amount_cents = 0").first.business_vat_id
       end
+      
+      return unless vat_id
+      
+      purchase.business_vat_id = vat_id
+      
+      if purchase.purchase_sales_tax_info.present?
+        purchase.purchase_sales_tax_info.business_vat_id = vat_id
+        purchase.purchase_sales_tax_info.save!
+      end
     end
 
     def schedule_member_cancellation_workflow_jobs


### PR DESCRIPTION
### Problem:
First Month:  VAT ID validated → VAT correctly exempted → Charged €100
Second Month:  Charged €119 (€100 + €19 VAT) - VAT ID lost!
Every Month After:  Keep getting charged VAT incorrectly

### Root Cause:
The `get_vat_id_from_original_purchase()` method  correctly retrieves the VAT ID from the original purchase and sets it on purchase.business_vat_id.
BUT - business_vat_id is just an attr_accessor (temporary variable, not saved to database)!

The real issue: We're re-validating an ALREADY VALIDATED VAT ID, and when that fails , the VAT exemption breaks.

### The Solution
File: app/models/subscription.rb - Modified get_vat_id_from_original_purchase() method
 added 4 lines (944-947) to directly persist the VAT ID to the database, bypassing unreliable re-validation
 
-  How This Addresses The Issue:
                 For recurring charges, we should TRUST the already-validated VAT ID from the original purchase.

-   Flow Now

                 Original purchase: VAT ID goes through full validation 
                Recurring charges: Copy the trusted VAT ID directly to database 
                Skip re-validation: No dependence on flaky EU VIES service 
               Sales tax calculator: Sees VAT ID in database → Exempts VAT → Works perfectly 
               

- What This Fixes:

Customer provided VAT ID during checkout → Persists to ALL future charges
Customer got VAT refund and added VAT ID later → Still persists
No more failed charges due to VIES API timeouts
No more manual refunds needed

- AI Disclosure
Used Claude Sonnet 4.5 for Codebase navigation and  Root cause identification


Fixes: #721 