### PR TITLE
Fix product grid item columns when there's no sidebar

### DIFF
--- a/app/javascript/components/Product/CardGrid.tsx
+++ b/app/javascript/components/Product/CardGrid.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 
 import { getSearchResults, ProductFilter, SearchRequest, SearchResults } from "$app/data/search";
 import { SORT_KEYS, PROFILE_SORT_KEYS } from "$app/parsers/product";
+import { classNames } from "$app/utils/classNames";
 import { CurrencyCode, getShortCurrencySymbol } from "$app/utils/currency";
 import { asyncVoid } from "$app/utils/promise";
 import { AbortError, assertResponseError } from "$app/utils/request";
@@ -223,7 +224,12 @@ export const CardGrid = ({
   const [filetypesOpen, setFiletypesOpen] = React.useState(false);
 
   return (
-    <div className="grid grid-cols-1 items-start gap-x-16 gap-y-8 lg:grid-cols-[var(--grid-cols-sidebar)]">
+    <div
+      className={classNames(
+        "grid grid-cols-1 items-start gap-x-16 gap-y-8",
+        !hideFilters && "lg:grid-cols-[var(--grid-cols-sidebar)]",
+      )}
+    >
       {hideFilters ? null : (
         <div className="stack overflow-y-auto lg:sticky lg:inset-y-4 lg:max-h-[calc(100vh-2rem)]" aria-label="Filters">
           <header>


### PR DESCRIPTION
AI Disclosure: None

---- 

### Context
After the [removal of sidebar class](https://github.com/antiwork/gumroad/pull/1680), Products on creator's page became squashed into the sidebar, making it so hard to see product cards.
<img width="1918" height="990" alt="image" src="https://github.com/user-attachments/assets/44acd03f-6040-481c-b7bd-2d57497e0a4a" />


### Fix
Update style to work when there's no filters/sidebar.

#### After:
<img width="1917" height="967" alt="image" src="https://github.com/user-attachments/assets/4a810793-6682-4828-b0f4-c27d96b97008" />

<img width="1917" height="967" alt="image" src="https://github.com/user-attachments/assets/4ed3cb2e-4306-41bc-b508-3692652974f9" />
