### PR TITLE
Fix: Offer code not applied to non-first installments

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -3324,7 +3324,7 @@ class Purchase < ApplicationRecord
     def validate_offer_code
       return if errors.present?
       # accept the offer code that was used when the buyer preordered/subscribed
-      return if is_preorder_charge? || is_recurring_subscription_charge || is_gift_receiver_purchase
+      return if is_preorder_charge? || is_recurring_subscription_charge || is_gift_receiver_purchase || is_installment_payment
       return if discount_code.blank?
 
       if offer_code.nil?


### PR DESCRIPTION
### Problem
When an offer code has a maximum usage limit, it is applied correctly to the first installment but not to subsequent installments if the offer code's max usage count is reached during this time.
- Customer starts an installment purchase using a valid offer code
- The first installment reflects the discount 
- Subsequent installments do not apply the discount if the code's max usage count is exceeded in the meantime 

### Root Cause:
The issue occurs because subsequent installment purchases go through Purchase#validate_offer_code which re-validates the offer code's current availability. Even though the original purchase was valid, the validation fails if other customers have used up the offer code's max purchase count in the meantime.
                     - Initial installment purchase: Validates offer code, counts toward usage 
                    - Subsequent installment purchases: Still validates offer code, but doesn't count toward usage 
                    - The validation fails because OTHER customers used up the limit
       
## Solution
Skip offer code validation for installment payments, similar to how recurring subscription charges .

### Code Change:

# app/models/purchase.rb 
# BEFORE:
`return if is_preorder_charge? || is_recurring_subscription_charge || is_gift_receiver_purchase`

# AFTER:
`return if is_preorder_charge? || is_recurring_subscription_charge || is_gift_receiver_purchase || is_installment_payment`

###  How It Works
1. *Initial Installment Purchase*: Offer code is validated normally (ensuring it was valid at that time)
2. *Subsequent Installment Purchases*: Skip validation, use cached discount from original purchase
3. *Regular Purchases*: Still validate normally.

### AI Disclosure
Used Cursor  for Codebase navigation and Root cause identification

Fixes: #1410 