### PR TITLE
fix: Display seller username when seller name is empty in library page

### DIFF
--- a/app/presenters/library_presenter.rb
+++ b/app/presenters/library_presenter.rb
@@ -41,8 +41,8 @@ class LibraryPresenter
       next if purchase.link.is_recurring_billing && !purchase.subscription.alive?
 
       product = purchase.link
-      product_seller_data[product.user.id] ||= product.user.name && product.user.username && {
-        name: product.user.name,
+      product_seller_data[product.user.id] ||= product.user.username && {
+        name: product.user.name || product.user.username,
         profile_url: product.user.profile_url(recommended_by: "library"),
         avatar_url: product.user.avatar_url
       }

--- a/spec/presenters/library_presenter_spec.rb
+++ b/spec/presenters/library_presenter_spec.rb
@@ -66,6 +66,19 @@ describe LibraryPresenter do
       expect(purchases[0][:creator]).to be_nil
     end
 
+    it "handles users without a name set" do
+      creator.update(name: nil)
+      purchases, _ = described_class.new(buyer).library_cards
+
+      expect(purchases[0][:product][:creator]).to eq(
+        {
+          name: creator.username,
+          profile_url: creator.profile_url(recommended_by: "library"),
+          avatar_url: ActionController::Base.helpers.asset_url("gumroad-default-avatar-5.png")
+        }
+      )
+    end
+
     context "when a user has purchased a subscription multiple times" do
       let!(:purchase_2) do
         create(:membership_purchase, link: product, purchaser: buyer).tap { _1.create_url_redirect! }


### PR DESCRIPTION
# Problem
When a seller hasn’t set their Name in their profile settings, the seller name section on the customer’s Library page appears blank

### Action Performed
1. Purchase this product https://jyojyojyo.gumroad.com/l/kevuyq , or any other product where the seller name not set yet
2. Open Library page https://gumroad.com/library and find that product/purchase

### Why
Seller name is optional, new sellers may not have set a name yet.

# Root cause analysis
Previously, we only set `product_seller_data` if both `product.user.name` and `product.user.username` existed:

https://github.com/antiwork/gumroad/blob/a1135dd391d5fc8c0a2bb2bc64c05d7f62c04247/app/presenters/library_presenter.rb#L44-L45

This meant that if the seller didn’t have a name, their details were never set.

Additionally, the seller’s display name was always taken from `product.user.name` without falling back to their username.

# Solution
Set seller name to `product.user.name` and fallback to `product.user.username` if seller name not set yet

We do the same approach here on checkout
https://github.com/antiwork/gumroad/blob/a1135dd391d5fc8c0a2bb2bc64c05d7f62c04247/app/presenters/checkout_presenter.rb#L290-L291

# Alternative solutions
None

# Before After
### Desktop Dark Mode
| Before | After |
|-----------|-----------|
|  <img width="1103" height="793" alt="image" src="https://github.com/user-attachments/assets/6c6fc207-6071-4107-b421-00a23cb77140" />  |  <img width="1103" height="792" alt="image" src="https://github.com/user-attachments/assets/9e241bc0-d37e-4755-ae99-2712ce3cc231" />  |

### Desktop Light Mode
| Before | After |
|-----------|-----------|
|  <img width="1101" height="796" alt="image" src="https://github.com/user-attachments/assets/9df28316-b630-4049-acaa-f8901fb0b8ac" />  |  <img width="1105" height="794" alt="image" src="https://github.com/user-attachments/assets/efadbbd6-bd7d-49e8-abaf-423331119ce1" />  |

### Mobile Dark Mode
| Before | After |
|-----------|-----------|
| <img width="386" height="673" alt="image" src="https://github.com/user-attachments/assets/a014e773-34f2-4252-97cf-55e4d165b5b1" /> | <img width="382" height="672" alt="image" src="https://github.com/user-attachments/assets/ab988591-5e77-44bb-b6c9-6e8b32511650" /> |

### Mobile Light Mode
| Before | After |
|-----------|-----------|
|  <img width="384" height="672" alt="image" src="https://github.com/user-attachments/assets/946c3768-9965-492e-9d35-54eae454354f" />  |  <img width="381" height="670" alt="image" src="https://github.com/user-attachments/assets/45520cde-c561-4b56-8101-82024e2aa3ad" />  |

# Test Results
<img width="761" height="164" alt="image" src="https://github.com/user-attachments/assets/d23ad66e-19c8-42f1-9260-47b19599e802" />

# AI Disclosure
No AI was used for any part of this contribution.