### PR TITLE
Add transactions in payout API v2 response

### DIFF
--- a/app/controllers/api/v2/payouts_controller.rb
+++ b/app/controllers/api/v2/payouts_controller.rb
@@ -60,7 +60,7 @@ class Api::V2::PayoutsController < Api::V2::BaseController
     payout = current_resource_owner.payments.find_by_external_id(params[:id])
     if payout
       include_sales = doorkeeper_token.scopes.include?("view_sales")
-      success_with_payout(payout.as_json(include_sales: include_sales))
+      success_with_payout(payout.as_json(include_sales: include_sales, include_transactions: include_sales))
     else
       error_with_payout
     end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -208,7 +208,15 @@ class Payment < ApplicationRecord
       json[:disputed_sales] = disputed_sales.map(&:external_id)
     end
 
+    if options[:include_transactions]
+      json[:transactions] = transactions
+    end
+
     json
+  end
+
+  def transactions
+    @transactions ||= Exports::Payouts::Data.new(id).perform
   end
 
   def successful_sales

--- a/app/services/exports/payouts/data.rb
+++ b/app/services/exports/payouts/data.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Exports::Payouts::Data < Exports::Payouts::Base
+  def perform
+    payout_data
+  end
+end

--- a/spec/controllers/api/v2/payouts_controller_spec.rb
+++ b/spec/controllers/api/v2/payouts_controller_spec.rb
@@ -422,7 +422,7 @@ describe Api::V2::PayoutsController do
           @params.merge!(access_token: @token.token)
         end
 
-        it "includes sales in the payout response when sales exist" do
+        it "includes sales & transactions in the payout response when sales exist" do
           product = create(:product, user: @seller)
           balance = create(:balance, user: @seller)
           @payout.balances = [balance]
@@ -436,19 +436,27 @@ describe Api::V2::PayoutsController do
           expect(response_payout).to have_key("sales")
           expect(response_payout["sales"]).to be_an(Array)
           expect(response_payout["sales"].length).to eq(1)
+          expect(response_payout["transactions"]).to be_an(Array)
+          expect(response_payout).to have_key("transactions")
+          expect(response_payout["transactions"].length).to eq(1)
 
           sale_id = response_payout["sales"].first
           expect(sale_id).to be_a(String)
           expect(sale_id).to eq(successful_sale.external_id)
+          first_transaction = response_payout["transactions"].first
+          expect(first_transaction[0]).to eq("Sale")
         end
 
-        it "includes sales array even when no sales exist" do
+        it "includes sales & transactions arrays even when no sales exist" do
           get :show, params: @params
 
           response_payout = response.parsed_body["payout"]
           expect(response_payout).to have_key("sales")
           expect(response_payout["sales"]).to be_an(Array)
           expect(response_payout["sales"]).to be_empty
+          expect(response_payout).to have_key("transactions")
+          expect(response_payout["transactions"]).to be_an(Array)
+          expect(response_payout["transactions"]).to be_empty
         end
       end
 
@@ -458,7 +466,7 @@ describe Api::V2::PayoutsController do
           @params.merge!(access_token: @token.token)
         end
 
-        it "excludes sales from the payout response" do
+        it "excludes sales & transactions from the payout response" do
           product = create(:product, user: @seller)
           balance = create(:balance, user: @seller)
           @payout.balances = [balance]
@@ -470,15 +478,17 @@ describe Api::V2::PayoutsController do
 
           response_payout = response.parsed_body["payout"]
           expect(response_payout).not_to have_key("sales")
+          expect(response_payout).not_to have_key("transactions")
         end
 
-        it "returns standard payout data without sales key" do
+        it "returns standard payout data without sales & transaction keys" do
           get :show, params: @params
 
           response_payout = response.parsed_body["payout"]
           expected_keys = %w[id amount currency status created_at processed_at payment_processor bank_account_visual paypal_email]
           expect(response_payout.keys).to match_array(expected_keys)
           expect(response_payout).not_to have_key("sales")
+          expect(response_payout).not_to have_key("transactions")
         end
       end
 


### PR DESCRIPTION
Resolves: https://github.com/antiwork/gumroad/issues/1670
AI Disclosure: none

--- 

### Context
We need to include transactions in payouts API v2 the same way we export it in the CSV.

### Solution
- [x] Add transactions key if view_sales scope
- [x] Add service that exposes the data we use in the CSV
- [x] Update specs