### PR TITLE
Bug - alert is shown only once

### DIFF
--- a/app/javascript/components/ClientAlertProvider.tsx
+++ b/app/javascript/components/ClientAlertProvider.tsx
@@ -36,6 +36,7 @@ export const ClientAlertProvider = ({ children }: { children: React.ReactNode })
         message,
         status: status === "error" ? "danger" : status,
         html: options.html ?? false,
+        timestamp: Date.now(),
       };
 
       setState({


### PR DESCRIPTION
This PR brings back the timestamp in the alert payload to force the re-rendering of the Alert component, allowing it to show the flash message as many times as needed instead of previously only being rendered once.

### Before

https://github.com/user-attachments/assets/9ac95972-70fc-4b23-acfc-4ca530092095

### After

https://github.com/user-attachments/assets/9a6dab31-df4e-4665-b3a1-dfc464596c96

### AI Disclosure

None
