### PR TITLE
Fix/ai new product disclaimer

### DIFF
--- a/app/javascript/components/NewProductPage.tsx
+++ b/app/javascript/components/NewProductPage.tsx
@@ -299,7 +299,7 @@ const NewProductPage = ({
               {ai_generation_enabled && aiPromoVisible ? (
                 <div
                   role="status"
-                  className="override grid grid-cols-[auto_1fr_auto] items-start gap-4 rounded-lg !border-pink bg-pink/20 p-6"
+                  className="tailwind-override grid grid-cols-[auto_1fr_auto] items-start gap-4 rounded-lg !border-pink bg-pink/20 p-6"
                 >
                   <img src={hands} alt="Hands" className="h-12 w-12 self-center" />
                   <div>

--- a/app/javascript/stylesheets/_alert.scss
+++ b/app/javascript/stylesheets/_alert.scss
@@ -6,7 +6,7 @@ $alert-icons: (
 );
 
 [role="alert"],
-[role="status"]:not(.override) {
+[role="status"]:not(.tailwind-override) {
   display: grid;
   grid-template-columns: 1fr;
   align-items: start;


### PR DESCRIPTION
### AI Disclosure

- [x] No AI was used

### Technical changes

Introduced a temporary `.tailwind-override` utility on the `[role=status]` CSS selector that we'll remove when it is migrated to TailwindCSS

### Before

![IMG_1124](https://github.com/user-attachments/assets/32689043-d843-4259-a522-d71eadc45196)

### After
<img width="1615" height="860" alt="Screenshot 2025-10-20 at 16 22 00" src="https://github.com/user-attachments/assets/9c05e8fa-56c8-4e49-891b-f14fa86e08f3" />
<img width="487" height="849" alt="Screenshot 2025-10-20 at 16 22 51" src="https://github.com/user-attachments/assets/fd57c69e-33c2-4af8-910e-16c02910fc6e" />
