### PR TITLE
fix: Restore underline styling for links

### DIFF
--- a/app/javascript/components/AffiliatesDashboard/AffiliateSignupForm.tsx
+++ b/app/javascript/components/AffiliatesDashboard/AffiliateSignupForm.tsx
@@ -144,7 +144,7 @@ export const AffiliateSignupForm = () => {
                 />
                 {enableAffiliateLink ? (
                   <CopyToClipboard text={affiliateRequestUrl}>
-                    <button type="button" className="link">
+                    <button type="button" className="underline">
                       Copy link
                     </button>
                   </CopyToClipboard>

--- a/app/javascript/components/BundleEdit/ContentTab/BundleProductItem.tsx
+++ b/app/javascript/components/BundleEdit/ContentTab/BundleProductItem.tsx
@@ -116,7 +116,7 @@ export const BundleProductItem = ({
                 </li>
               ) : null}
               <li>
-                <button className="link" onClick={removeBundleProduct}>
+                <button className="underline" onClick={removeBundleProduct}>
                   Remove
                 </button>
               </li>

--- a/app/javascript/components/Checkout/CreditCardInput.tsx
+++ b/app/javascript/components/Checkout/CreditCardInput.tsx
@@ -36,7 +36,7 @@ export const CreditCardInput = ({
       <legend>
         <label>Card information</label>
         {savedCreditCard ? (
-          <button className="link" disabled={disabled} onClick={() => setUseSavedCard(!useSavedCard)}>
+          <button className="font-normal underline" disabled={disabled} onClick={() => setUseSavedCard(!useSavedCard)}>
             {useSavedCard ? "Use a different card?" : "Use saved card"}
           </button>
         ) : null}

--- a/app/javascript/components/Checkout/GiftForm.tsx
+++ b/app/javascript/components/Checkout/GiftForm.tsx
@@ -66,7 +66,7 @@ export const GiftForm = ({ isMembership }: { isMembership: boolean }) => {
             <div role="alert" className="info">
               <div>
                 {gift.name}'s email has been hidden for privacy purposes.{" "}
-                <button className="link" onClick={() => setCancellingPresetGift(true)}>
+                <button className="underline" onClick={() => setCancellingPresetGift(true)}>
                   Cancel gift option
                 </button>
               </div>

--- a/app/javascript/components/Checkout/index.tsx
+++ b/app/javascript/components/Checkout/index.tsx
@@ -539,7 +539,7 @@ const CartItemComponent = ({
               ) : null}
               <li>
                 <button
-                  className="link"
+                  className="underline"
                   onClick={() => {
                     const newItems = cart.items.filter((i) => i !== item);
 

--- a/app/javascript/components/Developer/CodeContainer.tsx
+++ b/app/javascript/components/Developer/CodeContainer.tsx
@@ -17,7 +17,7 @@ export const CodeContainer = ({ codeToCopy }: { codeToCopy: string }) => {
       <legend>
         <label htmlFor={uid}>Copy and paste this code into your website</label>
         <CopyToClipboard tooltipPosition="bottom" text={codeToCopy}>
-          <button type="button" className="link">
+          <button type="button" className="font-normal underline">
             Copy embed code
           </button>
         </CopyToClipboard>

--- a/app/javascript/components/Download/FileList.tsx
+++ b/app/javascript/components/Download/FileList.tsx
@@ -666,7 +666,7 @@ const VideoEmbedPreview = ({
       />
       <TrackClick eventName="watch" resourceId={file.id}>
         <button
-          className="link"
+          className="underline"
           style={{
             position: "absolute",
             top: "50%",

--- a/app/javascript/components/NewProductPage.tsx
+++ b/app/javascript/components/NewProductPage.tsx
@@ -310,7 +310,7 @@ const NewProductPage = ({
                       Learn more
                     </a>
                   </div>
-                  <button className="link col-start-3! self-center" onClick={() => void dismissAiPromo()}>
+                  <button className="col-start-3! self-center underline" onClick={() => void dismissAiPromo()}>
                     close
                   </button>
                 </div>

--- a/app/javascript/components/Post/PostCommentsSection.tsx
+++ b/app/javascript/components/Post/PostCommentsSection.tsx
@@ -289,7 +289,7 @@ const CommentContainer = ({ comment, upsertComment, confirmCommentDeletion }: Co
         )}
         {replyDraft == null && comment.depth < max_allowed_depth ? (
           <footer>
-            <button className="link" onClick={() => setReplyDraft("")}>
+            <button className="underline" onClick={() => setReplyDraft("")}>
               Reply
             </button>
           </footer>

--- a/app/javascript/components/Product/CardGrid.tsx
+++ b/app/javascript/components/Product/CardGrid.tsx
@@ -142,7 +142,7 @@ const FilterCheckboxes = ({
         </label>
       ))}
       {filters.length > 5 && !showingAll ? (
-        <button className="link" onClick={() => setShowingAll(true)}>
+        <button className="underline" onClick={() => setShowingAll(true)}>
           Show more
         </button>
       ) : null}
@@ -237,7 +237,7 @@ export const CardGrid = ({
             {title ?? "Filters"}
             {anyFilters ? (
               <div className="text-right">
-                <button className="link" onClick={resetFilters}>
+                <button className="underline" onClick={resetFilters}>
                   Clear
                 </button>
               </div>

--- a/app/javascript/components/Product/index.tsx
+++ b/app/javascript/components/Product/index.tsx
@@ -769,7 +769,7 @@ const Reviews = ({
             />
           ))}
           {state.pagination.page < state.pagination.pages ? (
-            <button className="link" onClick={() => void loadNextPage()} disabled={isLoading}>
+            <button className="underline" onClick={() => void loadNextPage()} disabled={isLoading}>
               Load more
             </button>
           ) : null}

--- a/app/javascript/components/ProductEdit/ContentTab/FileEmbed.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/FileEmbed.tsx
@@ -369,7 +369,7 @@ const FileEmbedNodeView = ({ node, editor, getPos, updateAttributes }: NodeViewP
                   }}
                 />
                 <button
-                  className="link"
+                  className="underline"
                   style={{
                     position: "absolute",
                     top: "50%",
@@ -453,7 +453,7 @@ const FileEmbedNodeView = ({ node, editor, getPos, updateAttributes }: NodeViewP
 
                 {file.is_streamable && isComplete ? (
                   <li>
-                    <button className="link" onClick={() => setExpanded(!expanded)}>
+                    <button className="underline" onClick={() => setExpanded(!expanded)}>
                       {file.subtitle_files.length}{" "}
                       {file.subtitle_files.length === 1 ? "closed caption" : "closed captions"}
                     </button>

--- a/app/javascript/components/ProductEdit/ProductTab/CustomPermalinkInput.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/CustomPermalinkInput.tsx
@@ -24,7 +24,7 @@ export const CustomPermalinkInput = ({
       <legend>
         <label htmlFor={uid}>URL</label>
         <CopyToClipboard text={url}>
-          <button type="button" className="link">
+          <button type="button" className="font-normal underline">
             Copy URL
           </button>
         </CopyToClipboard>

--- a/app/javascript/components/ProductEdit/ProductTab/TiersEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/TiersEditor.tsx
@@ -438,7 +438,7 @@ You can modify or cancel your membership at any time.`;
             </strong>{" "}
             <button
               type="button"
-              className="link"
+              className="underline"
               onClick={() =>
                 void sendSamplePriceChangeEmail({
                   productPermalink: uniquePermalink,

--- a/app/javascript/components/ProductEdit/ProductTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/index.tsx
@@ -97,7 +97,7 @@ export const ProductTab = () => {
                   <strong>Your AI product is ready!</strong> Take a moment to check out the product and content tabs.
                   Tweak things and make it your own—this is your time to shine!
                 </div>
-                <button className="link col-start-3! self-center" onClick={() => setShowAiNotification(false)}>
+                <button className="col-start-3! self-center underline" onClick={() => setShowAiNotification(false)}>
                   close
                 </button>
               </div>
@@ -127,7 +127,7 @@ export const ProductTab = () => {
                   <legend>
                     <label htmlFor={`${uid}-url`}>URL</label>
                     <CopyToClipboard text={url}>
-                      <button type="button" className="link">
+                      <button type="button" className="font-normal underline">
                         Copy URL
                       </button>
                     </CopyToClipboard>

--- a/app/javascript/components/ProductEdit/ShareTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ShareTab/index.tsx
@@ -137,7 +137,7 @@ const DiscoverEligibilityPromo = () => {
         .
       </div>
       <button
-        className="link close"
+        className="close underline"
         onClick={() => {
           localStorage.setItem("showDiscoverEligibilityPromo", "false");
           setShow(false);

--- a/app/javascript/components/ReviewForm.tsx
+++ b/app/javascript/components/ReviewForm.tsx
@@ -276,7 +276,7 @@ export const ReviewForm = React.forwardRef<
         videoState.kind === "recorded" ? videoState.file.size : 0,
       )}{" "}
       -{" "}
-      <button onClick={cancelUpload} type="button" className="link">
+      <button onClick={cancelUpload} type="button" className="underline">
         Cancel
       </button>
     </div>

--- a/app/javascript/components/ReviewVideoPlayer.tsx
+++ b/app/javascript/components/ReviewVideoPlayer.tsx
@@ -52,7 +52,7 @@ export const ReviewVideoPlayer = ({ videoId, thumbnail }: { videoId: string; thu
           <img src={thumbnail} loading="lazy" className="absolute h-full w-full rounded-t bg-black object-cover" />
         ) : null}
         <button
-          className="link absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"
+          className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 underline"
           onClick={() => void onPlay()}
           aria-label="Watch"
           disabled={loading}

--- a/app/javascript/components/Settings/PaymentsPage/PayPalEmailSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/PayPalEmailSection.tsx
@@ -37,7 +37,7 @@ const PayPalEmailSection = ({
       <div className="whitespace-pre-line">{feeInfoText}</div>
       <div>
         {countrySupportsNativePayouts && !isFormDisabled ? (
-          <button className="link" onClick={() => updatePayoutMethod("bank")}>
+          <button className="underline" onClick={() => updatePayoutMethod("bank")}>
             Switch to direct deposit
           </button>
         ) : null}

--- a/app/javascript/components/server-components/Audience/CustomersPage.tsx
+++ b/app/javascript/components/server-components/Audience/CustomersPage.tsx
@@ -1467,7 +1467,7 @@ const AddressSection = ({
             <br />
             {currentAddress.country}
           </p>
-          <button className="link" onClick={() => setIsEditing(true)}>
+          <button className="underline" onClick={() => setIsEditing(true)}>
             Edit
           </button>
         </div>
@@ -1600,7 +1600,7 @@ const EmailSection = ({
         <section>
           <h5>{currentEmail}</h5>
           {onSave ? (
-            <button className="link" onClick={() => setIsEditing(true)}>
+            <button className="underline" onClick={() => setIsEditing(true)}>
               Edit
             </button>
           ) : (
@@ -1864,7 +1864,7 @@ const OptionSection = ({
           ) : (
             <>
               <h5>{option?.name ?? "None selected"}</h5>
-              <button className="link" onClick={() => setIsEditing(true)}>
+              <button className="underline" onClick={() => setIsEditing(true)}>
                 Edit
               </button>
             </>
@@ -2011,7 +2011,7 @@ const SeatSection = ({ seats: currentSeats, onSave }: { seats: number; onSave: (
       ) : (
         <section>
           <h5>{seats}</h5>
-          <button className="link" onClick={() => setIsEditing(true)}>
+          <button className="underline" onClick={() => setIsEditing(true)}>
             Edit
           </button>
         </section>
@@ -2298,7 +2298,7 @@ const ChargeRow = ({
           {purchase.chargedback ? <span className="pill small">Chargedback</span> : null}
         </section>
         {!purchase.refunded && !purchase.chargedback && purchase.amount_refundable > 0 ? (
-          <button className="link" onClick={() => setIsRefunding((prev) => !prev)}>
+          <button className="underline" onClick={() => setIsRefunding((prev) => !prev)}>
             Refund Options
           </button>
         ) : null}

--- a/app/javascript/components/server-components/Developer/WidgetsPage.tsx
+++ b/app/javascript/components/server-components/Developer/WidgetsPage.tsx
@@ -104,7 +104,7 @@ export const WidgetsPage = ({ display_product_select, products, affiliated_produ
               <legend>
                 <label htmlFor={followFormEmbedUID}>Subscribe form embed code</label>
                 <CopyToClipboard text={followFormEmbedHTML} copyTooltip="Copy to Clipboard" tooltipPosition="top">
-                  <button type="button" className="link">
+                  <button type="button" className="font-normal underline">
                     Copy embed code
                   </button>
                 </CopyToClipboard>

--- a/app/javascript/components/server-components/LibraryPage.tsx
+++ b/app/javascript/components/server-components/LibraryPage.tsx
@@ -375,7 +375,7 @@ const LibraryPage = ({ results, creators, bundles, reviews_page_enabled, followi
               You have {archivedCount} archived purchase{archivedCount === 1 ? "" : "s"}.{" "}
               <button
                 type="button"
-                className="link"
+                className="underline"
                 onClick={() => dispatch({ type: "update-search", search: { showArchivedOnly: true } })}
               >
                 Click here to view
@@ -393,7 +393,7 @@ const LibraryPage = ({ results, creators, bundles, reviews_page_enabled, followi
                     : "No products found"}
                 </div>
                 {isDesktop ? null : (
-                  <button className="link" onClick={() => setMobileFiltersExpanded(!mobileFiltersExpanded)}>
+                  <button className="underline" onClick={() => setMobileFiltersExpanded(!mobileFiltersExpanded)}>
                     Filter
                   </button>
                 )}
@@ -493,7 +493,7 @@ const LibraryPage = ({ results, creators, bundles, reviews_page_enabled, followi
                       ))}
                       <div>
                         {creators.length > 5 && !showingAllCreators ? (
-                          <button className="link" onClick={() => setShowingAllCreators(true)}>
+                          <button className="underline" onClick={() => setShowingAllCreators(true)}>
                             Show more
                           </button>
                         ) : null}

--- a/app/javascript/components/server-components/LoginPage.tsx
+++ b/app/javascript/components/server-components/LoginPage.tsx
@@ -90,7 +90,7 @@ export const LoginPage = ({
             <fieldset>
               <legend>
                 <label htmlFor={`${uid}-password`}>Password</label>
-                <button type="button" className="link" onClick={() => setShowForgotPassword(true)}>
+                <button type="button" className="font-normal underline" onClick={() => setShowForgotPassword(true)}>
                   Forgot your password?
                 </button>
               </legend>

--- a/app/javascript/components/server-components/Settings/MainPage.tsx
+++ b/app/javascript/components/server-components/Settings/MainPage.tsx
@@ -162,13 +162,13 @@ const MainPage = (props: Props) => {
                 This email address has not been confirmed yet.{" "}
                 {resentConfirmationEmail ? null : (
                   <button
-                    className="link"
+                    className="underline"
                     onClick={(e) => {
                       e.preventDefault();
                       void resendConfirmationEmail();
                     }}
                   >
-                    {isResendingConfirmationEmail ? "Resending..." : <strong>Resend confirmation?</strong>}
+                    {isResendingConfirmationEmail ? "Resending..." : "Resend confirmation?"}
                   </button>
                 )}
               </small>
@@ -583,7 +583,7 @@ const InvalidateActiveSessionsSection = () => {
   return (
     <section className="p-4! md:p-8!">
       <fieldset>
-        <button className="link" type="button" onClick={() => setIsConfirmationDialogOpen(true)}>
+        <button className="underline" type="button" onClick={() => setIsConfirmationDialogOpen(true)}>
           Sign out from all active sessions
         </button>
         <small>You will be signed out from all your active sessions including this session.</small>

--- a/app/javascript/components/server-components/SubscriptionManagerMagicLink.tsx
+++ b/app/javascript/components/server-components/SubscriptionManagerMagicLink.tsx
@@ -80,7 +80,7 @@ const SubscriptionManagerMagicLink = ({
                 {user_emails.length > 1 ? (
                   <>
                     Can't see the email? Please check your spam folder.{" "}
-                    <button className="link" onClick={() => setHasSentEmail(false)}>
+                    <button className="underline" onClick={() => setHasSentEmail(false)}>
                       Click here to choose another email
                     </button>{" "}
                     or try resending the link below.


### PR DESCRIPTION
## What
Replaced `link` class on button elements with Tailwind's `underline` to restore expected link styling.

## Why
Buttons using the `link` class no longer have underlined text, making it unclear you can click. (See #1724 for example).

## Screenshots
Not including all 30+ instances

<img width="1433" height="748" alt="Screenshot 2025-10-20 at 11 32 14 PM" src="https://github.com/user-attachments/assets/37f9b04c-5d6d-4821-b4f5-2442ffea7232" />
<img width="997" height="824" alt="Screenshot 2025-10-20 at 11 33 08 PM" src="https://github.com/user-attachments/assets/b9858443-c033-41c0-8a83-101ec3127c1e" />


## AI disclosure
Cursor to quickly update instances