### PR TITLE
fix: Login and Create an account links not working on product page

### DIFF
--- a/app/javascript/components/ReviewForm.tsx
+++ b/app/javascript/components/ReviewForm.tsx
@@ -8,6 +8,7 @@ import { assertResponseError } from "$app/utils/request";
 import { summarizeUploadProgress } from "$app/utils/summarizeUploadProgress";
 
 import { Button } from "$app/components/Button";
+import { useAppDomain } from "$app/components/DomainSettings";
 import { useLoggedInUser } from "$app/components/LoggedInUser";
 import { RatingSelector } from "$app/components/RatingSelector";
 import { ReviewVideoRecorder } from "$app/components/ReviewForm/ReviewVideoRecorder";
@@ -104,6 +105,7 @@ export const ReviewForm = React.forwardRef<
     style?: React.CSSProperties;
   }
 >(({ permalink, purchaseId, purchaseEmailDigest, review, onChange, preview, disabledStatus, style }, ref) => {
+  const appDomain = useAppDomain();
   const [isLoading, setIsLoading] = React.useState(false);
   const [rating, setRating] = React.useState<number | null>(review?.rating ?? null);
   const [message, setMessage] = React.useState(review?.message ?? "");
@@ -297,8 +299,9 @@ export const ReviewForm = React.forwardRef<
     </>
   ) : (
     <div>
-      <a href={Routes.login_path()}>Log in</a> or <a href={Routes.signup_path()}>create an account</a> using the same
-      email address as your purchase to upload a video review.
+      <a href={Routes.login_url({ host: appDomain })}>Log in</a> or{" "}
+      <a href={Routes.signup_url({ host: appDomain })}>create an account</a> using the same email address as your
+      purchase to upload a video review.
     </div>
   );
 


### PR DESCRIPTION
# Problem
The "Login" and "Create an account" links on video review section on the product page not working

### Action Performed
1. Checkout any product without login
2. Open the Product page
3. Click "Video review'
4. Click "Login" and "Create an account" links

# Root cause analysis
The links used `Routes.login_path()` and `Routes.signup_path()` which generated relative paths based on the current subdomain (eg: seller.gumroad.com).  
As a result, users were being redirected to invalid URLs under the seller subdomain instead of the main domain
https://github.com/antiwork/gumroad/blob/7861a73e67720b14aa116e2a33817c1baf996a0b/app/javascript/components/ReviewForm.tsx#L300

# Solution
Updated the links to use `Routes.login_url({ host: appDomain })` and `Routes.signup_url({ host: appDomain })`

Same approach like we did in comment section here:
https://github.com/antiwork/gumroad/blob/7861a73e67720b14aa116e2a33817c1baf996a0b/app/javascript/components/Post/PostCommentsSection.tsx#L374-L377

# Alternative solutions
None

# Before After
## Before

https://github.com/user-attachments/assets/13f62cb9-ca65-4f70-a358-d2fe453ba1a7

## After
### Desktop

https://github.com/user-attachments/assets/0f6ca1f8-96c2-4c8b-82b6-6ecd552d5828

### Mobile

https://github.com/user-attachments/assets/31321409-9602-40ac-b0fd-2215884178a8

# AI Disclosure
No AI was used for any part of this contribution.