### PR TITLE
feat(dev): allow ANYCABLE_HOST to be overridden for Docker support

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -3,4 +3,4 @@ webpack: npm run setup && ./bin/shakapacker-dev-server
 webpack-ssr: WEBPACK_SSR=true ./bin/shakapacker --watch
 sidekiq: RAILS_MAX_THREADS=5 USE_DB_WORKER_REPLICAS=true bundle exec sidekiq -q critical -q default -q low -q mongo
 anycable_rpc: ANYCABLE_SECRET="anycable-local-secret" ANYCABLE_RPC_HOST="localhost:50051" bundle exec anycable
-anycable_ws: ANYCABLE_HOST="cable.gumroad.dev" ANYCABLE_PORT="8080" ANYCABLE_RPC_HOST="localhost:50051" ANYCABLE_SECRET="anycable-local-secret" ANYCABLE_BROADCAST_ADAPTER="http,redisx" ANYCABLE_PUBSUB="redis" ANYCABLE_BROKER="memory" ANYCABLE_METRICS_PORT="8080" ANYCABLE_LOG_LEVEL="debug" ANYCABLE_DEBUG=true bin/anycable-go
+anycable_ws: ANYCABLE_HOST="${ANYCABLE_HOST:-cable.gumroad.dev}" ANYCABLE_PORT="8080" ANYCABLE_RPC_HOST="localhost:50051" ANYCABLE_SECRET="anycable-local-secret" ANYCABLE_BROADCAST_ADAPTER="http,redisx" ANYCABLE_PUBSUB="redis" ANYCABLE_BROKER="memory" ANYCABLE_METRICS_PORT="8080" ANYCABLE_LOG_LEVEL="debug" ANYCABLE_DEBUG=true bin/anycable-go


### PR DESCRIPTION
feat(dev): make ANYCABLE_HOST configurable for Docker compatibility

Part of the submission: https://github.com/antiwork/gumroad/pull/1690
Issue: https://github.com/antiwork/gumroad/issues/865

## Problem

The `anycable_ws` process in `Procfile.dev` currently uses a fixed hostname (`cable.gumroad.dev`), which limits flexibility for different environments.
To support containerized development, the WebSocket server needs to be able to bind to `0.0.0.0` when running inside Docker.

## Solution

Updated the `anycable_ws` process in `Procfile.dev` to allow `ANYCABLE_HOST` to be overridden through an environment variable, without changing its default value:

```bash
ANYCABLE_HOST="${ANYCABLE_HOST:-cable.gumroad.dev}"
```

This makes the host configurable for Docker setups (`ANYCABLE_HOST=0.0.0.0`) while maintaining the same default behavior for local development.

## Result

**Before:**

> Handle WebSocket connections at http://cable.gumroad.dev:8080/cable

<img width="1279" height="354" alt="anycable_ws_before" src="https://github.com/user-attachments/assets/7a0df3b7-249c-4df0-890e-8827fdd5d1e4" />

**After:**

> Handle WebSocket connections at http://0.0.0.0:8080/cable

<img width="1279" height="352" alt="anycable_ws" src="https://github.com/user-attachments/assets/f86b1612-1d8c-4925-98ff-5cac90e48d82" />

## AI Disclosure

GPT-5 was used only for help writing this PR description.