### PR TITLE
feat(dev): make Webpack dev server host configurable for Docker support

### DIFF
--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -24,7 +24,7 @@ export default configs.map((config, idx) =>
         ? {
             compress: dev_server.compress,
             allowedHosts: dev_server.allowed_hosts,
-            host: dev_server.host,
+            host: process.env.SHAKAPACKER_DEV_SERVER_HOST || dev_server.host,
             port: dev_server.port,
             server: dev_server.server,
             hot: dev_server.hmr,


### PR DESCRIPTION
feat(dev): make Webpack dev server host configurable for Docker support

Part of the submission: https://github.com/antiwork/gumroad/pull/1690
Issue: https://github.com/antiwork/gumroad/issues/865

## Problem

The Webpack dev server host was hardcoded to `gumroad.dev`, which limits flexibility in environments like Docker.  
For containerized development, the dev server needs to be able to bind to `0.0.0.0` so that it’s accessible from outside the container.

## Solution

Updated the Webpack config to allow overriding the dev server host through an environment variable:

```js
host: process.env.SHAKAPACKER_DEV_SERVER_HOST || dev_server.host,
```

This makes the host configurable at runtime without changing the default behavior.  
By default, the dev server still runs on `gumroad.dev`, but developers can now set:

```bash
SHAKAPACKER_DEV_SERVER_HOST=0.0.0.0
```

to make it listen on all network interfaces when running inside Docker.

## Result

**Before:**
> Server: https://gumroad.dev:3035/  
> Loopback: https://127.0.0.1:3035/

<img width="725" height="59" alt="webpack_before" src="https://github.com/user-attachments/assets/40f6e9e8-4b7c-41e2-8d5b-614b04cb17a6" />

**After:**
> Loopback: https://localhost:3035/, https://[::1]:3035/  
> On Your Network (IPv4): https://172.19.0.7:3035/

<img width="726" height="60" alt="webpack" src="https://github.com/user-attachments/assets/d97d8218-a4b9-4400-b590-3b94ea6eaaea" />

## AI Disclosure

GPT-5 was used only for help writing this PR description.
