### PR TITLE
chore(dev): remove local Docker volumes on stop to support clean all-in-one setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ local:
 
 stop_local:
 	COMPOSE_PROJECT_NAME=$(COMPOSE_PROJECT_NAME) \
-		$(DOCKER_COMPOSE_CMD) -f docker/$(LOCAL_DOCKER_COMPOSE_CONFIG) down
+		$(DOCKER_COMPOSE_CMD) -f docker/$(LOCAL_DOCKER_COMPOSE_CONFIG) down --volumes
 
 
 


### PR DESCRIPTION
chore(dev): remove local Docker volumes on stop to support clean all-in-one setup

Part of the submission: https://github.com/antiwork/gumroad/pull/1690
Issue: https://github.com/antiwork/gumroad/issues/865

## Problem

The `stop_local` Makefile target previously used:

```makefile
$(DOCKER_COMPOSE_CMD) -f docker/$(LOCAL_DOCKER_COMPOSE_CONFIG) down
```

which stopped the containers but **left all named and anonymous Docker volumes** intact.  
This caused data (e.g., database, Redis, or cache volumes) to persist between runs, making it difficult to get a clean environment when rebuilding or running the app in an all-in-one Docker setup with volumes.

## Solution

Updated the `stop_local` command to include the `--volumes` flag:

```makefile
$(DOCKER_COMPOSE_CMD) -f docker/$(LOCAL_DOCKER_COMPOSE_CONFIG) down --volumes
```

This ensures all associated volumes are removed when stopping the local stack, providing a clean reset for developers and making future all-in-one Docker workflows easier to maintain.

## Result

**Before:**
> `docker compose down` stopped containers but left old volumes intact.  
> Data persisted across runs.

<img width="1253" height="337" alt="stop_local_before" src="https://github.com/user-attachments/assets/1537fce0-7bd4-4324-acca-702163ff0b1f" />

**After:**
> `docker compose down --volumes` now removes all containers and volumes,  
> ensuring a fully clean local environment.

<img width="1256" height="321" alt="stop_local" src="https://github.com/user-attachments/assets/4b656363-c71a-41da-8ad1-846a263da9bb" />

## AI Disclosure

GPT-5 was used only for help writing this PR description.