### PR TITLE
feat: Add product name and creator name to global affiliate sale emails

### DIFF
--- a/app/mailers/affiliate_mailer.rb
+++ b/app/mailers/affiliate_mailer.rb
@@ -191,6 +191,10 @@ class AffiliateMailer < ApplicationMailer
     end
 
     def notify_global_affiliate_of_sale
+      @seller = @purchase.seller
+      @seller_name = @seller.name_or_username
+      @product_name = @purchase.link.name
+
       @subject = "You helped make a sale through the global affiliate program."
       mail to: @affiliate.affiliate_user.form_email,
            subject: @subject,

--- a/app/views/affiliate_mailer/notify_global_affiliate_of_sale.html.erb
+++ b/app/views/affiliate_mailer/notify_global_affiliate_of_sale.html.erb
@@ -1,9 +1,9 @@
 <%= header_section(@subject) %>
 <div>
   <% if @purchase.is_free_trial_purchase? %>
-    <p>A creator just made a sale thanks to you! The purchase price was <%= @purchase_price_formatted %>. If the subscriber continues with their subscription after their free trial has expired on <%= @free_trial_end_date %>, we will update your balance to reflect your <%= @affiliate_percentage_text %> commission net of fees (<%= @affiliate_amount_formatted %>). <%= @recurring_commission_text %></p>
+    <p><%= @seller_name %> just made a sale of <%= @product_name %> thanks to you! The purchase price was <%= @purchase_price_formatted %>. If the subscriber continues with their subscription after their free trial has expired on <%= @free_trial_end_date %>, we will update your balance to reflect your <%= @affiliate_percentage_text %> commission net of fees (<%= @affiliate_amount_formatted %>). <%= @recurring_commission_text %></p>
   <% else %>
-    <p>A creator just made a sale thanks to you! The purchase price was <%= @purchase_price_formatted %>. We've updated your balance to reflect your <%= @affiliate_percentage_text %> commission net of fees (<%= @affiliate_amount_formatted %>). <%= @recurring_commission_text %></p>
+    <p><%= @seller_name %> just made a sale of <%= @product_name %> thanks to you! The purchase price was <%= @purchase_price_formatted %>. We've updated your balance to reflect your <%= @affiliate_percentage_text %> commission net of fees (<%= @affiliate_amount_formatted %>). <%= @recurring_commission_text %></p>
   <% end %>
   <p>Thanks for being a part of the team.</p>
 </div>

--- a/spec/mailers/affiliate_mailer_spec.rb
+++ b/spec/mailers/affiliate_mailer_spec.rb
@@ -62,7 +62,7 @@ describe AffiliateMailer do
     context "for a global affiliate" do
       let(:affiliate) { create(:user).global_affiliate }
       let(:email_subject) { "You helped make a sale through the global affiliate program." }
-      let(:email_body) { "A creator just made a sale thanks to you!" }
+      let(:email_body) { "#{seller.name_or_username} just made a sale of #{product_name} thanks to you!" }
 
       it_behaves_like "notifies affiliate of a sale"
     end


### PR DESCRIPTION
Add specific sale details to global affiliate notifications to reduce confusion. Previously showed generic "A creator just made a sale thanks to you!" message. Now shows "[Creator Name] just made a sale of [Product Name] thanks to you!" with actual creator and product names.

- Add @seller_name and @product_name variables to notify_global_affiliate_of_sale method
- Update email template to display specific creator and product information
- Update test expectations to verify new detailed message content

Addresses issue #1791: Global affiliate emails now include same level of detail as direct affiliate notifications for better user experience.