### PR TITLE
chore: removed unnecessary vcr record: once override 

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -264,7 +264,7 @@ RSpec.configure do |config|
   config.around(:each, :shipping) do |example|
     vcr_turned_on do
       only_matching_vcr_request_from(["easypost", "taxjar"]) do
-        VCR.use_cassette("ShippingScenarios/#{example.description}", record: :once) do
+        VCR.use_cassette("ShippingScenarios/#{example.description}") do
           # Debug flaky specs.
           puts "*" * 100
           puts example.full_description
@@ -281,7 +281,7 @@ RSpec.configure do |config|
   config.around(:each, :taxjar) do |example|
     vcr_turned_on do
       only_matching_vcr_request_from(["taxjar"]) do
-        VCR.use_cassette("Taxjar/#{example.description}", record: :once) do
+        VCR.use_cassette("Taxjar/#{example.description}") do
           example.run
         end
       end


### PR DESCRIPTION
ref comment https://github.com/antiwork/gumroad/pull/1536#issuecomment-3435839772

Removed the unnecessary vcr record :once override to attempt to fix the flaky shipping order tests - https://github.com/antiwork/gumroad/actions/runs/18683902807/job/53274175842?pr=1716 , now the global default of record :none on the CI will be used

### Tests
Passing shipping specific flaky tests

<img width="841" height="170" alt="Screenshot 2025-10-23 at 7 28 51 PM" src="https://github.com/user-attachments/assets/c099ce14-d33d-495f-bef0-86f801b289c3" />


### AI Disclosure
None

### Livestream Viewing Confirmation

- Have watched both the live streams end-to-end
- Followed all the guidelines asked in them
