### PR TITLE
Extract Admin refund queue to its own RESTful enpoint

### DIFF
--- a/app/controllers/admin/refund_queues_controller.rb
+++ b/app/controllers/admin/refund_queues_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class Admin::RefundQueuesController < Admin::BaseController
+  def show
+    @title = "Refund queue"
+    @users = User.refund_queue.with_attached_avatar.includes(:admin_manageable_user_memberships, :links, :purchases)
+
+    render inertia: "Admin/RefundQueues/Show",
+           props: {
+             users: @users.map { |user| user.as_json(admin: true, impersonatable: policy([:admin, :impersonators, user]).create?) }
+           },
+           legacy_template: "admin/users/refund_queue"
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -35,17 +35,6 @@ class Admin::UsersController < Admin::BaseController
     render json: { success: false, message: e.message }
   end
 
-  def refund_queue
-    @title = "Refund queue"
-    @users = User.refund_queue.with_attached_avatar.includes(:admin_manageable_user_memberships, :links, :purchases)
-
-    render inertia: "Admin/RefundQueues/Show",
-           props: {
-             users: @users.map { |user| user.as_json(admin: true, impersonatable: policy([:admin, :impersonators, user]).create?) }
-           },
-           legacy_template: "admin/users/refund_queue"
-  end
-
   def enable
     @user.reactivate!
     render json: { success: true }

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -70,6 +70,7 @@ namespace :admin do
   resource :block_email_domains, only: [:show, :update]
   resource :unblock_email_domains, only: [:show, :update]
   resource :suspend_users, only: [:show, :update]
+  resource :refund_queue, only: [:show]
 
   resources :affiliates, only: [:index, :show], defaults: { format: "html" }
 
@@ -150,6 +151,5 @@ namespace :admin do
 
   scope module: "users" do
     post :block_ip_address
-    get :refund_queue
   end
 end

--- a/spec/controllers/admin/refund_queues_controller_spec.rb
+++ b/spec/controllers/admin/refund_queues_controller_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "shared_examples/admin_base_controller_concern"
+require "inertia_rails/rspec"
+
+describe Admin::RefundQueuesController, type: :controller, inertia: true do
+  render_views
+
+  it_behaves_like "inherits from Admin::BaseController"
+
+  let(:admin_user) { create(:admin_user) }
+  let(:users) { create_list(:user, 3) }
+
+  before(:each) do
+    sign_in admin_user
+  end
+
+  describe "GET show" do
+    before do
+      allow(User).to receive(:refund_queue).and_return(User.where(id: users.map(&:id)))
+    end
+
+    it "renders the page" do
+      get :show
+
+      expect(response).to be_successful
+      expect(inertia.component).to eq "Admin/RefundQueues/Show"
+
+      props = inertia.props
+      expect(props[:title]).to eq("Refund queue")
+      expect(props[:users]).to match_array([
+                                             hash_including(id: users[0].id),
+                                             hash_including(id: users[1].id),
+                                             hash_including(id: users[2].id)
+                                           ])
+    end
+  end
+end


### PR DESCRIPTION
### Context

Follow up of a [discussion](https://github.com/antiwork/gumroad/pull/1721#discussion_r2442571966)

- We're extracting the Admin's refund queue endpoint to is own RESTful controller action
- The route path and url helper does not change
- Added controller tests
- This endpoint listing user cards, it will enable re-usability later

### AI Disclosure

No AI was used.

