### PR TITLE
Fix signed url helper spec for dev environment

### DIFF
--- a/app/helpers/signed_url_helper.rb
+++ b/app/helpers/signed_url_helper.rb
@@ -10,11 +10,6 @@ module SignedUrlHelper
   private_constant :CF_WORKER_CACHE_KEY
 
   def signed_download_url_for_s3_key_and_filename(s3_key, s3_filename, is_video: false, expires_in: nil, cache_group: nil)
-    # For local MinIO, use S3 presigned URLs instead of Cloudflare or CloudFront
-    if USING_MINIO
-      return minio_presigned_url(s3_key, s3_filename, is_video, expires_in)
-    end
-
     content_length, public_url_path = Rails.cache.fetch("content_length_public_url_path_#{S3_BUCKET}_#{s3_key}") do
       obj = Aws::S3::Resource.new.bucket(S3_BUCKET).object(s3_key)
       [obj.content_length, obj.public_url]
@@ -54,18 +49,6 @@ module SignedUrlHelper
   end
 
   private
-    def minio_presigned_url(s3_key, s3_filename, is_video, expires_in)
-      obj = Aws::S3::Resource.new.bucket(S3_BUCKET).object(s3_key)
-      content_length = obj.content_length
-      expires_in ||= is_video ? SIGNED_VIDEO_URL_VALID_FOR : signed_url_validity_time_for_file_size(content_length)
-
-      obj.presigned_url(
-        :get,
-        expires_in: expires_in.to_i,
-        response_content_disposition: "attachment; filename=\"#{s3_filename}\""
-      )
-    end
-
     def signed_url_validity_time_for_file_size(file_size)
       return SIGNED_S3_URL_VALID_FOR_MINIMUM unless file_size
       valid_for = [(file_size / 1_024 / 50).seconds, SIGNED_S3_URL_VALID_FOR_MINIMUM].max

--- a/spec/helpers/signed_url_helper_spec.rb
+++ b/spec/helpers/signed_url_helper_spec.rb
@@ -33,14 +33,14 @@ describe SignedUrlHelper do
     allow(@s3_object_double).to receive(:content_length).and_return(8_000_000_000)
 
     expect(signed_download_url_for_s3_key_and_filename(@file.s3_key, @file.s3_filename, cache_group: "read"))
-      .to match(/cloudfront\.net.*cache_group=read/)
+      .to match(/#{Regexp.escape(CLOUDFRONT_DOWNLOAD_DISTRIBUTION_URL)}.*cache_group=read/o)
   end
 
   it "returns a Cloudflare read url with the proper cache_group paramter if file size < 8GB" do
     allow(@s3_object_double).to receive(:content_length).and_return(1_000_000_000)
 
     expect(signed_download_url_for_s3_key_and_filename(@file.s3_key, @file.s3_filename, cache_group: "read"))
-      .to match(/staging-files\.gumroad\.com.*cache_group=read.*verify=/)
+      .to match(/#{Regexp.escape(CLOUDFRONT_DOWNLOAD_DISTRIBUTION_URL)}.*cache_group=read.*verify=/o)
   end
 
   it "contains the cache_key parameter in the query string for files with specific extensions" do
@@ -54,7 +54,7 @@ describe SignedUrlHelper do
       file = create(:product_file, url: URI.parse(file_path).to_s)
 
       expect(signed_download_url_for_s3_key_and_filename(file.s3_key, file.s3_filename))
-          .to match(/staging-files\.gumroad\.com.*cache_key=caIWHGT4Qhqo6KoxDMNXwQ.*/)
+          .to match(/#{Regexp.escape(CLOUDFRONT_DOWNLOAD_DISTRIBUTION_URL)}.*cache_key=caIWHGT4Qhqo6KoxDMNXwQ.*/o)
     end
   end
 


### PR DESCRIPTION
## AI Disclosure
No AI was used

## Description
The `signed_url_helper_specs` are failing because of the minio helper that was added to skip cloudfront and cloudfront URL's in local. However since the variables are updated in `config/initializers/aws.rb` for minio environment this helper is not necessary. 

Expecting the right url's in the specs was the only change required to get the tests working. 

<img width="2696" height="736" alt="image" src="https://github.com/user-attachments/assets/5e74c65a-ca6f-4580-bd29-ef2db5721dc2" />


## Tests on local
<img width="1574" height="234" alt="image" src="https://github.com/user-attachments/assets/59f33e37-50f8-4095-b8bc-dc53e7ac1816" />

<img width="1542" height="242" alt="image" src="https://github.com/user-attachments/assets/f052fa63-dd01-42b2-92a0-2ab691c02344" />

