### PR TITLE
fix: add consistent padding to Charge page

### DIFF
--- a/app/javascript/components/Public/LookupLayout.tsx
+++ b/app/javascript/components/Public/LookupLayout.tsx
@@ -5,6 +5,7 @@ import { lookupCharges, lookupPaypalCharges } from "$app/data/charge"
 import { assertResponseError } from "$app/utils/request"
 
 import { showAlert } from "$app/components/server-components/Alert"
+import { PageHeader } from "$app/components/ui/PageHeader"
 
 const LookupLayout = ({ children, title, type }: {
   children?: React.ReactNode
@@ -80,12 +81,10 @@ const LookupLayout = ({ children, title, type }: {
 
   return (
     <div>
-      <header>
-        <h1>{title}</h1>
-      </header>
+      <PageHeader title={title} className="border-b-0 sm:border-b" />
       <div>
         {success !== null && (
-          <div ref={messageRef} style={{ marginBottom: "var(--spacer-7)" }}>
+          <div ref={messageRef} className="p-4! md:p-8!">
             {success ? (
               <div className="success" role="status">
                 We were able to find a match! It has been emailed to you. Sorry about the inconvenience.
@@ -115,7 +114,7 @@ const LookupLayout = ({ children, title, type }: {
           evt.preventDefault();
           void handleCardLookup();
         }}>
-          <section>
+          <section className="p-4! md:p-8!">
             <header>
               <h2>{type === "charge" ? "What was I charged for?" : "Look up your license key"}</h2>
               {type === "charge" ? "Fill out this form and we'll send you a receipt for your charge." : "We'll send you a receipt including your license key."}
@@ -158,7 +157,7 @@ const LookupLayout = ({ children, title, type }: {
           evt.preventDefault();
           void handlePaypalLookup();
         }}>
-          <section>
+          <section className="p-4! md:p-8!">
             <header>
               <h2>Did you pay with PayPal?</h2>
               Enter the invoice ID from PayPal's email receipt and we'll look it up.

--- a/app/javascript/components/server-components/Public/ChargePage.tsx
+++ b/app/javascript/components/server-components/Public/ChargePage.tsx
@@ -8,7 +8,7 @@ const ChargePage = () => (
     type="charge"
   >
     <form>
-      <section>
+      <section className="p-4! md:p-8!">
         <header>
           <h2>Who/what is Gumroad?</h2>
         </header>
@@ -19,7 +19,7 @@ const ChargePage = () => (
       </section>
     </form>
     <form>
-      <section>
+      <section className="p-4! md:p-8!">
         <header>
           <h2>
             <a href="/help/article/214-why-was-i-charged-by-gumroad" target="_blank" rel="noreferrer">


### PR DESCRIPTION
# Problem
Missing margin on Charge page

### Action Performed
1. Go to https://gumroad.com/charge

# Root cause analysis
This issue was introduced in this PR https://github.com/antiwork/gumroad/pull/1046

Where we removed the Layout CSS, and added the padding to each section on each page, like [this](https://github.com/antiwork/gumroad/pull/1046/files#diff-edff7f2b380ae935879f5d22882238b44e834be7743e68a059eb10da54f46516L102-R102)

But, we are not updating the Charge page

# Solution
Added `className="p-4! md:p-8!"` to all sections on the Charge page, like we did in other pages, for example on `ThirdPartyAnalyticsPage.tsx` here:
https://github.com/antiwork/gumroad/blob/9fbc9634f14025138473d3149a92dc42f6081721/app/javascript/components/server-components/Settings/ThirdPartyAnalyticsPage.tsx#L72

I also changed the header to use the `PageHeader`, to make it consistent with other pages, for example on `DashboardPage.tsx` here:
https://github.com/antiwork/gumroad/blob/401b83e6899ef4244cf2fa57fe591b50f9db6286/app/javascript/components/server-components/DashboardPage.tsx#L316-L320

# Before After
### Desktop Dark Mode
| Before | After |
|-----------|-----------|
|  <img width="1470" height="804" alt="image" src="https://github.com/user-attachments/assets/ad0924c8-c29b-4af4-a2a7-c8ed6853b1aa" />  |  <img width="1470" height="792" alt="image" src="https://github.com/user-attachments/assets/8caf7028-a15f-4a89-99c6-bc1e876e7fb4" />  |

### Desktop Light Mode
| Before | After |
|-----------|-----------|
|  <img width="1470" height="795" alt="image" src="https://github.com/user-attachments/assets/591b9795-43d7-4c97-ad10-31dfebdc0d57" />  |  <img width="1470" height="797" alt="image" src="https://github.com/user-attachments/assets/3b091adc-858f-447c-8cea-20150c293a79" />  |

### Mobile Dark Mode
| Before | After |
|-----------|-----------|
| <img width="325" height="687" alt="image" src="https://github.com/user-attachments/assets/a2964e55-34bd-4482-8957-725f8b515d37" /> | <img width="315" height="673" alt="image" src="https://github.com/user-attachments/assets/65586784-3953-4c01-b503-8b2cdc8c8920" /> |

### Mobile Light Mode
| Before | After |
|-----------|-----------|
|  <img width="391" height="678" alt="image" src="https://github.com/user-attachments/assets/6888e3f9-65c9-4772-bcc4-339375205ba7" />  |  <img width="381" height="671" alt="image" src="https://github.com/user-attachments/assets/39657437-1212-4de4-ba25-02f9f9ae7419" />  |

# AI Disclosure
No AI was used for any part of this contribution.

# Confirmation
I have watched the PR reviews live streaming videos