### PR TITLE
fix: missing gap on share actions in product page popover

### DIFF
--- a/app/javascript/components/Product/ShareSection.tsx
+++ b/app/javascript/components/Product/ShareSection.tsx
@@ -149,7 +149,7 @@ export const ShareSection = ({
             </WithTooltip>
           }
         >
-          <div className="grid grid-cols-1">
+          <div className="grid grid-cols-1 gap-4">
             <TwitterShareButton url={product.long_url} text={`Buy ${product.name} on @Gumroad`} />
             <FacebookShareButton url={product.long_url} text={product.name} />
             <CopyToClipboard text={product.long_url} copyTooltip="Copy product URL">


### PR DESCRIPTION
# Problem
Missing gap on share actions in product page popover

### Action Performed
1. Navigate to https://jyojyojyo.gumroad.com/l/kevuyq
2. Click the share icon button
3. Observe that the share action buttons (Twitter, Facebook, Copy link) have no margin/spacing between them

# Root cause analysis
The issue was introduced in [PR #1626](https://github.com/antiwork/gumroad/pull/1626)

In that PR, we removed _grid.css, which previously applied a default `gap: spacer(4);`

After the removal, we forgot to manually add a gap in [ShareSection.tsx](https://github.com/antiwork/gumroad/blob/a5aac11d4f4d112ce880b1ef1a379e10c34c0d4c/app/javascript/components/Product/ShareSection.tsx#L152), resulting in missing spacing between elements.

# Solution
Added `gap-4` to the grid container to restore the original `spacer(4)` spacing

# Before After
### Desktop
| Before | After |
|-----------|-----------|
|  <img width="1470" height="796" alt="image" src="https://github.com/user-attachments/assets/201d49b4-069b-4af5-89a8-7f88f694d619" />  |  <img width="1470" height="792" alt="image" src="https://github.com/user-attachments/assets/a6c2d37c-cceb-4570-a5c0-99b6e532c1f7" />  |

### Mobile
| Before | After |
|-----------|-----------|
|  <img width="316" height="670" alt="image" src="https://github.com/user-attachments/assets/4126dd64-130f-4a0a-b9af-40008c2e2a88" />  |  <img width="319" height="674" alt="image" src="https://github.com/user-attachments/assets/fa6becd3-2305-4c4f-9a27-a4d751631d61" />  |

# Video After Fix
https://github.com/user-attachments/assets/13440e5f-1e33-4631-be8f-6d27f597b0e3

# AI Disclosure
No AI was used for any part of this contribution.

# Confirmation
I have watched the PR reviews live streaming videos