### PR TITLE
fix: remove unnecessary square beside volume control on video control

### DIFF
--- a/app/javascript/stylesheets/_alert.scss
+++ b/app/javascript/stylesheets/_alert.scss
@@ -6,7 +6,7 @@ $alert-icons: (
 );
 
 [role="alert"],
-[role="status"]:not(.tailwind-override) {
+[role="status"]:not(.tailwind-override):not(.jw-text-alt) {
   display: grid;
   grid-template-columns: 1fr;
   align-items: start;


### PR DESCRIPTION
# Problem

### Action Performed
1. Open product page with video cover, e.g. https://jyojyojyo.gumroad.com/l/kevuyq
2. Observe the video control area

### Actual Result
An unnecessary square appears beside the volume setting

### Expected Result
The video player control should appear without any unnecessary component

# Root cause analysis
JWPlayer renders a status element with the structure:
```
<span class="jw-text jw-reset-text jw-text-alt" role="status" dir="auto"></span>
```

The global `[role="status"]` selector in `_alert.scss` was applying alert/notification styles to all elements with `role="status"`, including JWPlayer's internal status element:

https://github.com/antiwork/gumroad/blob/a5aac11d4f4d112ce880b1ef1a379e10c34c0d4c/app/javascript/stylesheets/_alert.scss#L8-L16

The border, padding, and grid styles meant for application alerts were being applied to JWPlayer's status element, causing it to render as an unnecessary square beside the volume controls.

# Solution
Exclude `.jw-text-alt` from alert/status styles

# Before After
## Before
### Desktop
https://github.com/user-attachments/assets/24c44ac7-32de-472b-abf4-07ffcd7cf3f4

### Mobile

https://github.com/user-attachments/assets/98940df8-5186-4970-a0e2-a8ef94783ac6

## After
### Desktop

https://github.com/user-attachments/assets/aab1ab3a-1348-45ed-a658-16abe59f5ed3

### Mobile

https://github.com/user-attachments/assets/d04d526a-9bd9-47d5-90d3-1139b6d467ca

# AI Disclosure
No AI was used for any part of this contribution.

# Confirmation
I have watched the PR reviews live streaming videos