### PR TITLE
fix: prevent loading spinner clipping during file upload

### DIFF
--- a/app/javascript/components/LoadingSpinner.tsx
+++ b/app/javascript/components/LoadingSpinner.tsx
@@ -4,7 +4,10 @@ import { classNames } from "$app/utils/classNames";
 
 export const LoadingSpinner = ({ className, ...props }: React.HTMLAttributes<HTMLElement>) => (
   <div
-    className={classNames("inline-block size-[1em] animate-spin bg-(image:--loading-spinner) bg-cover", className)}
+    className={classNames(
+      "inline-block size-[1em] shrink-0 animate-spin bg-(image:--loading-spinner) bg-cover",
+      className,
+    )}
     role="progressbar"
     {...props}
   />


### PR DESCRIPTION
# Problem
The loading spinner appears cut off/clipped while uploading files on the product content page, only on certain screen sizes.

### Action Performed
1. Create/edit a product https://gumroad.com/products
2. Upload any file
3. Observe the loading spinner during the upload process

# Root cause analysis
The issue was introduced in [this PR](https://github.com/antiwork/gumroad/pull/1754)

The LoadingSpinner component was being rendered inside a flex container without the `flex-shrink: 0` property. By default, flex items have `flex-shrink: 1`, which allows them to shrink below their intrinsic size when the flex container runs out of space

# Solution
Added the `shrink-0` class to the LoadingSpinner component. This applies `flex-shrink: 0` to prevent the spinner from being compressed in flex containers, ensuring it maintains its full size

# Before After
### Desktop Dark Mode
| Before | After |
|-----------|-----------|
|  <img width="1141" height="752" alt="image" src="https://github.com/user-attachments/assets/b9eaa5e1-2148-4316-9d85-2b41cb7c6329" />  |  <img width="1142" height="716" alt="image" src="https://github.com/user-attachments/assets/d3c56497-8a44-44e0-893a-ed147be2880c" />  |

### Desktop Light Mode
| Before | After |
|-----------|-----------|
|  <img width="1137" height="763" alt="image" src="https://github.com/user-attachments/assets/fab8b315-537f-4e82-a5b2-a3b37e7b611e" />  |  <img width="1140" height="725" alt="image" src="https://github.com/user-attachments/assets/236c3a00-e10c-4bf1-8f72-c1a1b94bef9b" />  |

### Mobile Dark Mode (No issue)
| Before | After |
|-----------|-----------|
| <img width="314" height="668" alt="image" src="https://github.com/user-attachments/assets/1e8d04db-5b83-44c3-b815-5e25f4630403" /> | <img width="318" height="670" alt="image" src="https://github.com/user-attachments/assets/9fce812d-e7c2-4355-965c-a63a64edc563" /> |

### Mobile Light Mode (No issue)
| Before | After |
|-----------|-----------|
|  <img width="312" height="671" alt="image" src="https://github.com/user-attachments/assets/18c52a2b-3d66-42ef-8c43-41993103a959" />  |  <img width="316" height="670" alt="image" src="https://github.com/user-attachments/assets/e572c7a2-af44-4c72-8560-8388500e4fc6" />  |

## Video Before

https://github.com/user-attachments/assets/82073055-846d-4095-9a23-7a1a85f3c228

## Video After

https://github.com/user-attachments/assets/7f859723-8acc-475c-a3d2-e06f0b2b33cf

# AI Disclosure
No AI was used for any part of this contribution.

# Confirmation
I have watched the Gumroad PR reviews live streaming video