### PR TITLE
Fix: Don't show custom fields on manage membership page

### DIFF
--- a/app/javascript/components/server-components/SubscriptionManager.tsx
+++ b/app/javascript/components/server-components/SubscriptionManager.tsx
@@ -6,7 +6,7 @@ import { confirmLineItem } from "$app/data/purchase";
 import { cancelSubscriptionByUser, updateSubscription } from "$app/data/subscription";
 import { SavedCreditCard } from "$app/parsers/card";
 import { Discount } from "$app/parsers/checkout";
-import { CustomFieldDescriptor, ProductNativeType } from "$app/parsers/product";
+import { ProductNativeType } from "$app/parsers/product";
 import {
   CurrencyCode,
   formatPriceCentsWithCurrencySymbol,
@@ -46,7 +46,6 @@ type Props = {
     name: string;
     native_type: ProductNativeType;
     require_shipping: boolean;
-    custom_fields: CustomFieldDescriptor[];
     supports_paypal: "native" | "braintree" | null;
     creator: Creator;
     currency_code: CurrencyCode;
@@ -194,7 +193,7 @@ const SubscriptionManager = ({
     price: Math.round(amountDueToday / product.exchange_rate),
     payInInstallments: subscription.is_installment_plan,
     requireShipping: product.require_shipping,
-    customFields: product.custom_fields,
+    customFields: [],
     bundleProductCustomFields: [],
     supportsPaypal: product.supports_paypal,
     testPurchase: subscription.is_test,

--- a/app/presenters/checkout_presenter.rb
+++ b/app/presenters/checkout_presenter.rb
@@ -182,7 +182,7 @@ class CheckoutPresenter
     {
       **checkout_common,
       product: {
-        **product_common(product, recommended_by: nil),
+        **product_common(product, recommended_by: nil).except(:custom_fields),
         native_type: product.native_type,
         require_shipping: product.require_shipping?,
         recurrences: subscription.is_installment_plan ? [] : prices

--- a/spec/presenters/checkout_presenter_spec.rb
+++ b/spec/presenters/checkout_presenter_spec.rb
@@ -576,7 +576,6 @@ describe CheckoutPresenter do
                                  },
                                  require_shipping: false,
                                  shippable_country_codes: [],
-                                 custom_fields: [],
                                  currency_code: "usd",
                                  permalink: @product.unique_permalink,
                                  options: [{


### PR DESCRIPTION
Fixes: #1321 

## What PR Does?
Hide custom fields from the manage membership page.
### Why
Not useful to show and leads to customer support issues

## Before: 

https://github.com/user-attachments/assets/f9fb3966-57d2-48ca-94dc-9488398c898e

## After:

https://github.com/user-attachments/assets/ed42a0a4-2718-43c9-9150-9f58ee0cdd9c


### AI Disclosure: 
- no AI used