### PR TITLE
Update purchase_info_for_product_page to exclude gift receiver purchase when queried with browser_guid

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -826,7 +826,11 @@ class Link < ApplicationRecord
 
     eligible_purchases = Purchase.none
     eligible_purchases = requested_user.purchases.where(link: self) if requested_user
-    eligible_purchases = sales.where(browser_guid:, purchaser_id: nil) if browser_guid && eligible_purchases.blank?
+
+    # When a gift purchase is made, we set the same browser_guid for the gifter and giftee purchases.
+    # When fetching purchases using browser_guid, exclude gift receiver purchases so that we won't show
+    # the giftee purchase to gifter on the same browser.
+    eligible_purchases = sales.not_is_gift_receiver_purchase.where(browser_guid:, purchaser_id: nil) if browser_guid && eligible_purchases.blank?
 
     eligible_purchases = if is_in_preorder_state
       eligible_purchases.preorder_authorization_successful_or_gift

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -4085,7 +4085,7 @@ describe Link, :vcr do
         context "when there is a previous purchase received as a gift with the browser guid" do
           let!(:purchase) { create(:purchase, :gift_receiver, link: product) }
           it "returns the purchase" do
-            expect(product.purchase_info_for_product_page(user, purchase.browser_guid)[:id]).to eq(purchase.external_id)
+            expect(product.purchase_info_for_product_page(user, purchase.browser_guid)).to eq(nil)
           end
         end
       end
@@ -4135,8 +4135,8 @@ describe Link, :vcr do
 
         context "when there is a previous purchase received as a gift with the browser guid" do
           let!(:purchase) { create(:purchase, :gift_receiver, link: product) }
-          it "returns the purchase" do
-            expect(product.purchase_info_for_product_page(user, purchase.browser_guid)[:id]).to eq(purchase.external_id)
+          it "returns nil" do
+            expect(product.purchase_info_for_product_page(user, purchase.browser_guid)).to eq(nil)
           end
         end
       end
@@ -4162,8 +4162,8 @@ describe Link, :vcr do
 
         context "when there is a previous purchase received as a gift with the browser guid" do
           let!(:purchase) { create(:preorder_authorization_purchase, :gift_receiver, link: product) }
-          it "returns the purchase" do
-            expect(product.purchase_info_for_product_page(user, purchase.browser_guid)[:id]).to eq(purchase.external_id)
+          it "returns nil" do
+            expect(product.purchase_info_for_product_page(user, purchase.browser_guid)).to eq(nil)
           end
         end
       end


### PR DESCRIPTION
Solving the issue reported by @michellelarney 