### PR TITLE
fix: empty product thumbnail background on edit page

### DIFF
--- a/app/javascript/components/ImageUploader.tsx
+++ b/app/javascript/components/ImageUploader.tsx
@@ -42,7 +42,7 @@ export const ImageUploader = ({
           <LoadingSpinner className="size-8" />
         </Placeholder>
       ) : imageUrl == null ? (
-        <Placeholder className="aspect-square items-center" style={{ background }}>
+        <Placeholder className="aspect-square items-center" noBackground style={{ background }}>
           <label className="button primary">
             <input
               type="file"

--- a/app/javascript/components/ui/Placeholder.tsx
+++ b/app/javascript/components/ui/Placeholder.tsx
@@ -7,12 +7,14 @@ type PlaceholderProps = React.PropsWithChildren<{
   role?: string;
   "aria-label"?: string;
   style?: React.CSSProperties;
+  noBackground?: boolean;
 }>;
 
-const Placeholder: React.FC<PlaceholderProps> = ({ className, children, ...rest }) => (
+const Placeholder: React.FC<PlaceholderProps> = ({ className, children, noBackground, ...rest }) => (
   <div
     className={classNames(
-      "bg-filled grid justify-items-center gap-3 rounded border border-dashed border-border p-6 text-center",
+      "grid justify-items-center gap-3 rounded border border-dashed border-border p-6 text-center",
+      !noBackground && "bg-filled",
       "[&>.icon]:text-xl",
       className,
     )}


### PR DESCRIPTION
# Problem
After the `_placeholder.scss` migration, the thumbnail placeholder on the product edit page is displayed with full opacity, different from the original design

### Action Performed
1. Go to product edit page
2. Scroll down to Thumbnail section
3. Observe that the image placeholder displayed with full opacity

### Original design (Before CSS migration)

<img width="1039" height="799" alt="Screenshot 2025-11-05 at 19 48 53" src="https://github.com/user-attachments/assets/9abae43f-d111-4db4-94b5-f8ec63164f9e" />

# Root cause analysis

Related PR https://github.com/antiwork/gumroad/pull/1686

We always include `bg-filled` on Placeholder component

https://github.com/antiwork/gumroad/blob/6a54b92818c428104c3bb8221fc5b09496a2f4ea/app/javascript/components/ui/Placeholder.tsx#L12-L15

https://github.com/antiwork/gumroad/blob/6a54b92818c428104c3bb8221fc5b09496a2f4ea/app/javascript/stylesheets/_global.scss#L238-L241

The `background-blend-mode: overlay;` style seems to be ignoring the opacity setting

# Solution
Add new prop on Placeholder component: `noBackground`

Make the `bg-filled` class applied by default on the Placeholder component, but exclude it when the `noBackground` prop is set to true. And on ImageUploader placeholder, pass `noBackground` `true`

# Before After
### Desktop Dark Mode
| Before | After |
|-----------|-----------|
|  <img width="1470" height="797" alt="image" src="https://github.com/user-attachments/assets/1de9d20e-742a-4680-8e99-aa7febb1530b" />  |  <img width="1470" height="795" alt="image" src="https://github.com/user-attachments/assets/53e5cfbe-b5c1-4b11-bc2c-4c61a59ba63f" />  |

### Desktop Light Mode
| Before | After |
|-----------|-----------|
|  <img width="1470" height="797" alt="image" src="https://github.com/user-attachments/assets/d8481709-2b6a-4873-a30c-a8acb1d0375d" />  |  <img width="1470" height="794" alt="image" src="https://github.com/user-attachments/assets/ef139b98-9c56-42c6-8717-782afb91caa3" />  |

### Mobile Dark Mode
| Before | After |
|-----------|-----------|
| <img width="309" height="660" alt="image" src="https://github.com/user-attachments/assets/117e2690-c456-47bf-843c-11e7b305a221" /> | <img width="310" height="661" alt="image" src="https://github.com/user-attachments/assets/af8ebf26-442b-441e-9e89-3fccf73b2d59" /> |

### Mobile Light Mode
| Before | After |
|-----------|-----------|
|  <img width="308" height="662" alt="image" src="https://github.com/user-attachments/assets/859fde54-3214-4e3f-8b73-e2c53b94e9c4" />  |  <img width="312" height="665" alt="image" src="https://github.com/user-attachments/assets/8d1c81c6-3edd-40ff-87f5-b33e34468ccc" />  |

# AI Disclosure
No AI was used for any part of this contribution.

# Confirmation
I have watched the Gumroad PR reviews live streaming video