### PR TITLE
fix: broken link in article 156

### DIFF
--- a/app/views/help_center/articles/contents/_156-gumroad-and-adult-content.html.erb
+++ b/app/views/help_center/articles/contents/_156-gumroad-and-adult-content.html.erb
@@ -24,7 +24,7 @@
       <li>Adult comics with nudity or sexual acts</li>
       <li>Cosplay/boudoir/lewd photography that's focused on sexually explicit poses or activity </li>
       <li>Sexual coaching services or explicit instructional content that is meant for gratification purposes rather than educational</li>
-      <li>VR Chat avatars displayed in compromising or sexual positions, or avatars that advertise NSFW uses or modifications like, for example, "breast expansions" where the purpose of such a modification is understood to be <i>solely </i>for titillation or part of an overall sexually explicit character. For further explanation, <a href="#Is-my-product-NSFW--Gvqdd">see below</a>.</li>
+      <li>VR Chat avatars displayed in compromising or sexual positions, or avatars that advertise NSFW uses or modifications like, for example, "breast expansions" where the purpose of such a modification is understood to be <i>solely </i>for titillation or part of an overall sexually explicit character. For further explanation, <a href="#Is-my-product-NSFW">see below</a>.</li>
     </ul>
     <h3 id="Selling-NSFW">Selling NSFW Work</h3>
     <p>Some adult content is allowed on Gumroad. For just one example, we are allowed to process sales for cosplay/pinup creators whose content is focused more on <i>cosplay, </i>rather than erotic or nude photography that simply happens to feature some cosplay. </p>


### PR DESCRIPTION
# Problem
'See below' link in help article 156 (Adult content on Gumroad) is broken and not navigating correctly

### Action Performed
1. Go to https://gumroad.com/help/article/156-gumroad-and-adult-content
2. Find and click `See below` link

# Root cause analysis
The link used `#Is-my-product-NSFW--Gvqdd` which doesn't match the actual section ID `#Is-my-product-NSFW`
https://github.com/antiwork/gumroad/blob/6a54b92818c428104c3bb8221fc5b09496a2f4ea/app/views/help_center/articles/contents/_156-gumroad-and-adult-content.html.erb#L27

https://github.com/antiwork/gumroad/blob/6a54b92818c428104c3bb8221fc5b09496a2f4ea/app/views/help_center/articles/contents/_156-gumroad-and-adult-content.html.erb#L41

# Solution
Updated the anchor link from `#Is-my-product-NSFW--Gvqdd` to `#Is-my-product-NSFW`

# Before After
## Before

https://github.com/user-attachments/assets/4930adb1-3302-40c9-842f-7de010f9db58

## After
### Desktop Dark Mode

https://github.com/user-attachments/assets/4700ee10-44f1-46f8-aa08-491b7748f2b5

### Desktop Light Mode

https://github.com/user-attachments/assets/5ef0adc4-1123-48c8-b76e-e9d392143986

### Mobile Dark Mode

https://github.com/user-attachments/assets/a1ed2868-573e-4227-8cf2-0943b906a1c4

### Mobile Light Mode

https://github.com/user-attachments/assets/ba3a7344-a639-4837-8fb7-b9e857dbe8f2

# AI Disclosure
No AI was used for any part of this contribution.

# Confirmation
I have watched the Gumroad PR reviews live streaming video