### PR TITLE
fix(payments): prevent submission when no valid state is selected

### DIFF
--- a/app/javascript/components/server-components/Settings/PaymentsPage.tsx
+++ b/app/javascript/components/server-components/Settings/PaymentsPage.tsx
@@ -596,8 +596,14 @@ const PaymentsPage = (props: Props) => {
     if (!complianceInfo.city) {
       markFieldInvalid("city");
     }
-    if (complianceInfo.country !== null && complianceInfo.country in props.states && !complianceInfo.state) {
+    if (
+      complianceInfo.country !== null &&
+      complianceInfo.country.toLowerCase() in props.states &&
+      (!complianceInfo.state || complianceInfo.state === "State" || complianceInfo.state === "Province")
+    ) {
       markFieldInvalid("state");
+      setErrorMessage({ message: "Please select a valid state." });
+
     }
     if (!complianceInfo.zip_code && complianceInfo.country !== "BW") {
       markFieldInvalid("zip_code");
@@ -667,10 +673,14 @@ const PaymentsPage = (props: Props) => {
       }
       if (
         complianceInfo.business_country !== null &&
-        complianceInfo.business_country in props.states &&
-        !complianceInfo.business_state
+        complianceInfo.business_country.toLowerCase() in props.states &&
+        (!complianceInfo.business_state ||
+          complianceInfo.business_state === "State" ||
+          complianceInfo.business_state === "Province")
       ) {
         markFieldInvalid("business_state");
+        setErrorMessage({ message: "Please select a valid state." });
+
       }
       if (!complianceInfo.business_zip_code && props.user.country_code !== "BW") {
         markFieldInvalid("business_zip_code");

--- a/spec/requests/settings/payments_spec.rb
+++ b/spec/requests/settings/payments_spec.rb
@@ -315,6 +315,86 @@ describe("Payments Settings Scenario", type: :system, js: true) do
       expect(find_button("Disconnect Stripe account", disabled: true)[:disabled]).to eq "true"
     end
 
+    it "does not allow saving placeholder state values" do
+      visit settings_payments_path
+
+      fill_in("First name", with: "barnabas")
+      fill_in("Last name", with: "barnabastein")
+      fill_in("Address", with: "address_full_match")
+      fill_in("City", with: "barnabasville")
+      select("State", from: "State")
+      fill_in("ZIP code", with: "12345")
+      fill_in("Phone number", with: "(502) 254-1982")
+
+      fill_in("Pay to the order of", with: "barnabas ngagy")
+      fill_in("Routing number", with: "110000000")
+      fill_in("Account number", with: "000123456789")
+      fill_in("Confirm account number", with: "000123456789")
+
+      select("1", from: "Day")
+      select("January", from: "Month")
+      select("1980", from: "Year")
+      fill_in("Last 4 digits of SSN", with: "1235")
+
+      expect do
+        click_on("Update settings")
+        expect(page).to have_status(text: "Please select a valid state.")
+      end.to_not change { @user.alive_user_compliance_info.reload.state }
+
+      # Select a valid state
+      select("California", from: "State")
+      expect do
+        click_on("Update settings")
+        wait_for_ajax
+        expect(page).to have_alert(text: "Thanks! You're all set.")
+      end.to change { @user.alive_user_compliance_info.reload.state }.to("CA")
+    end
+
+    it "does not allow saving placeholder state values for business" do
+      visit settings_payments_path
+
+      choose("Business")
+      fill_in("Legal business name", with: "Acme")
+      select("LLC", from: "Type")
+      find_field("Address", match: :first).set("123 North street")
+      find_field("City", match: :first).set("Barnesville")
+      find_field("State", match: :first).select("State") 
+      find_field("ZIP code", match: :first).set("12345")
+      fill_in("Business phone number", with: "15052229876")
+      fill_in("Business Tax ID (EIN, or SSN for sole proprietors)", with: "123456789")
+
+      fill_in("First name", with: "barnabas")
+      fill_in("Last name", with: "barnabastein")
+      all('input[id$="creator-street-address"]').last.set("address_full_match")
+      all('input[id$="creator-city"]').last.set("barnabasville")
+      all('select[id$="creator-state"]').last.select("California")
+      all('input[id$="creator-zip-code"]').last.set("12345")
+      fill_in("Phone number", with: "(502) 254-1982")
+
+      fill_in("Pay to the order of", with: "barnabas ngagy")
+      fill_in("Routing number", with: "110000000")
+      fill_in("Account number", with: "000123456789")
+      fill_in("Confirm account number", with: "000123456789")
+
+      select("1", from: "Day")
+      select("January", from: "Month")
+      select("1980", from: "Year")
+      fill_in("Last 4 digits of SSN", with: "1235")
+
+      expect do
+        click_on("Update settings")
+        expect(page).to have_status(text: "Please select a valid state.")
+      end.to_not change { @user.alive_user_compliance_info.reload.business_state }
+
+      # Select a valid state for business
+      find_field("State", match: :first).select("California")
+      expect do
+        click_on("Update settings")
+        wait_for_ajax
+        expect(page).to have_alert(text: "Thanks! You're all set.")
+      end.to change { @user.alive_user_compliance_info.reload.business_state }.to("CA")
+    end
+
     describe "US-based creator with information set" do
       before do
         create(:ach_account_stripe_succeed, user: @user)


### PR DESCRIPTION
ref #1885 

## Summary
Previously, the form accepted the placeholder "State" as a valid value, resulting in incomplete account information. The validation checked only for empty or null values, not for placeholder text. This fix ensures that users must select an actual state before submitting the form.

## Before

https://github.com/user-attachments/assets/456c1977-b111-4c3b-9be3-550f431b98d0

## After

## Individual

https://github.com/user-attachments/assets/a93ebbb2-b318-46a5-b741-d649f77338fd 

## Business

https://github.com/user-attachments/assets/fe35ec87-cfc9-4727-af1e-692551cd38d1

<img width="781" height="154" alt="Screenshot 2025-11-05 at 8 11 34 PM" src="https://github.com/user-attachments/assets/8d3ca83e-12d5-40f3-bff5-15878fe2f733" />



## AI Usage
No AI was used to generate any of this code.

## Confirmation
I have watched the Gumroad PR reviews live streaming video.

## Self-Review
I have self-reviewed all the code that I have written.