### PR TITLE
Fix review selection modal scrolling and Safari review loading issues

### DIFF
--- a/app/javascript/components/Product/index.tsx
+++ b/app/javascript/components/Product/index.tsx
@@ -288,6 +288,21 @@ export const Product = ({
       addThirdPartyAnalytics({ permalink: product.permalink, location: "product" });
   });
 
+  // Fix for Safari review cards not loading
+  React.useEffect(() => {
+    if (pageLoaded && descriptionEditor && product.description_html) {
+      const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+      if (isSafari) {
+        // Safari needs a small delay to properly initialize review cards
+        const timeoutId = setTimeout(() => {
+          // Force re-initialization of content to ensure review cards are processed
+          descriptionEditor.commands.setContent(product.description_html);
+        }, 50);
+        return () => clearTimeout(timeoutId);
+      }
+    }
+  }, [pageLoaded, descriptionEditor, product.description_html]);
+
   const isBundle = product.bundle_products.length > 0;
   if (isBundle) basePriceCents = getStandalonePrice(product);
 

--- a/app/javascript/components/TestimonialSelectModal.tsx
+++ b/app/javascript/components/TestimonialSelectModal.tsx
@@ -110,7 +110,7 @@ export const TestimonialSelectModal = ({
         </>
       }
     >
-      <div>
+      <div className="flex max-h-[60vh] flex-col">
         {isLoading && state.reviews.length === 0 ? (
           <div className="flex items-center justify-center">
             <LoadingSpinner className="size-8" />
@@ -119,7 +119,7 @@ export const TestimonialSelectModal = ({
           <p>No reviews with text or video yet.</p>
         ) : (
           <>
-            <div className="flex flex-row items-center gap-2">
+            <div className="flex flex-row items-center gap-2 pb-2">
               <input
                 type="checkbox"
                 role="checkbox"
@@ -129,7 +129,7 @@ export const TestimonialSelectModal = ({
               />
               <p>Select all</p>
             </div>
-            <section className="paragraphs" style={{ marginTop: "var(--spacer-2)" }}>
+            <section className="paragraphs overflow-y-auto" style={{ marginTop: "var(--spacer-2)" }}>
               {state.reviews.map((review) => (
                 <SelectableReviewCard
                   key={review.id}

--- a/app/javascript/utils/request.ts
+++ b/app/javascript/utils/request.ts
@@ -59,6 +59,7 @@ export const request = async (settings: RequestSettings): Promise<Response> => {
       body: data,
       headers,
       signal: settings.abortSignal ?? null,
+      credentials: "same-origin",
     });
     if (response.status >= 500) throw new ResponseError();
     // We rate limit some endpoints to prevent brute force attacks. See config/initializers/rack_attack.rb


### PR DESCRIPTION
## Summary
1. fixed review selection modal that couldn't scroll when too many reviews
2. fixed safari not showing review embeds on published pages

## Fixes

### 1. review selection modal scrolling
- added max height of 60% screen to the modal
- made the review list scrollable with overflow-y-auto
- now users can scroll through all reviews and reach the insert button

### 2. safari review loading  
- safari wasn't processing review-card elements properly
- added a 50ms delay for safari only
- then force the editor to re-parse the content
- this makes review cards show up correctly on safari

Fixes #1866