### PR TITLE
fix: prevent admin search duplication

### DIFF
--- a/app/javascript/components/Admin/SearchPopover.tsx
+++ b/app/javascript/components/Admin/SearchPopover.tsx
@@ -37,7 +37,7 @@ const SearchPopover = () => {
 
   const initialQueries = getInitialQuery();
 
-  const { data, setData, get } = useForm({
+  const { data, setData } = useForm({
     user_query: initialQueries.user_query,
     purchase_query: initialQueries.purchase_query,
     affiliate_query: initialQueries.affiliate_query,
@@ -74,10 +74,8 @@ const SearchPopover = () => {
       url.searchParams.set(key, value);
     });
 
-    get(url.toString(), {
-      onBefore: () => resetOtherQueryFields(queryParam),
-      onSuccess: () => setOpen(false),
-    });
+    resetOtherQueryFields(queryParam);
+    window.location.href = url.toString();
   };
 
   const submitForm = (e: React.FormEvent<HTMLFormElement>, endpoint: string, attribute: keyof typeof data | null) => {


### PR DESCRIPTION
fix #1879 

## Summary
When searching for a user from /admin, duplicate user cards appeared in a modal overlay. This occurred because Inertia's get() method with partial prop updates caused the search results to render as an overlay instead of performing a full page transition. The issue was resolved by switching from Inertia get() to window.location.href for full page navigation in SearchPopover.

## Before

https://github.com/user-attachments/assets/5182bf98-be0c-4e82-8bd6-e5ec77050d69

## After

https://github.com/user-attachments/assets/3c01dd77-04cd-4e9e-844b-adc500f7b9ea

## AI Usage
No AI was used to generate any of this code.

## Confirmation
I have watched the Gumroad PR reviews live streaming video.

## Self-Review
I have self-reviewed all the code that I have written.