### PR TITLE
fix: unscrollable review section

### DIFF
--- a/app/javascript/components/Modal.tsx
+++ b/app/javascript/components/Modal.tsx
@@ -2,6 +2,7 @@ import * as Dialog from "@radix-ui/react-dialog";
 import * as React from "react";
 
 import { Icon } from "$app/components/Icons";
+import { classNames } from "$app/utils/classNames";
 
 export const Modal = ({
   title,
@@ -11,6 +12,7 @@ export const Modal = ({
   onClose,
   modal = true,
   usePortal,
+  className,
   ...props
 }: {
   title?: string;
@@ -18,13 +20,14 @@ export const Modal = ({
   footer?: React.ReactNode;
   allowClose?: boolean;
   usePortal?: boolean;
+  className?: string;
   onClose?: () => void;
 } & Omit<React.ComponentProps<typeof Dialog.Root>, "onOpenChange">) => {
   const content = (
     <>
       <Dialog.Content
         aria-modal={modal}
-        className="bg-filled fixed top-[50%] left-[50%] z-31 flex max-w-175 min-w-80 translate-[-50%] flex-col gap-4 rounded border border-border p-8 shadow-lg dark:shadow-none"
+        className={classNames( "bg-filled fixed top-[50%] left-[50%] z-31 flex max-w-175 min-w-80 translate-[-50%] flex-col gap-4 rounded border border-border p-8 shadow-lg dark:shadow-none", className)}
         onOpenAutoFocus={(e) => {
           if (!modal) e.preventDefault();
         }}

--- a/app/javascript/components/TestimonialSelectModal.tsx
+++ b/app/javascript/components/TestimonialSelectModal.tsx
@@ -109,6 +109,7 @@ export const TestimonialSelectModal = ({
           ) : null}
         </>
       }
+      className="max-h-[100vh] overflow-y-auto"
     >
       <div>
         {isLoading && state.reviews.length === 0 ? (


### PR DESCRIPTION
Part of #1866

# Summary
- The review content was overflowing when it contained too much content.  
- Fixed by adding a simple `max-h-[100vh] overflow-y-auto`.

### Before (Desktop)
https://github.com/user-attachments/assets/bc66baad-2440-480e-a941-12582c05b81c

### After (Desktop)
https://github.com/user-attachments/assets/8a2a39a7-2412-4613-8e96-6b2a3df5e324

### Mobile

**Before**  

https://github.com/user-attachments/assets/3c2427cd-5762-4855-9520-159572aacfd0



**After**  
 

https://github.com/user-attachments/assets/fdd3f9cf-3837-4ec9-8137-83b5ad948e68



---

## No Change (When Review Content Doesn’t Overflow)
### Before (No Overflow)
https://github.com/user-attachments/assets/11aa03f7-af3d-4b5c-a37c-c732e33c7114

### After (No Overflow)
https://github.com/user-attachments/assets/b2640564-31c4-43b2-a7a2-b84a394b061a

---

## AI Usage
No AI was used to generate any of this code.

## Confirmation
I have watched the Gumroad PR review live stream.

## Self-Review
I have reviewed all the code that I have written.
