### PR TITLE
fix: prevent form submission with invalid State placeholder (#1885)

### DIFF
--- a/app/javascript/components/Settings/PaymentsPage/AccountDetailsSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/AccountDetailsSection.tsx
@@ -316,7 +316,7 @@ const AccountDetailsSection = ({
                   value={complianceInfo.business_state || "State"}
                   onChange={(evt) => updateComplianceInfo({ business_state: evt.target.value })}
                 >
-                  <option disabled>State</option>
+                  <option disabled value="State">State</option>
                   {states.us.map((state) => (
                     <option key={state.code} value={state.code}>
                       {state.name}
@@ -358,7 +358,7 @@ const AccountDetailsSection = ({
                   value={complianceInfo.business_state || "State"}
                   onChange={(evt) => updateComplianceInfo({ business_state: evt.target.value })}
                 >
-                  <option disabled>State</option>
+                  <option disabled value="State">State</option>
                   {states.au.map((state) => (
                     <option key={state.code} value={state.code}>
                       {state.name}
@@ -379,7 +379,7 @@ const AccountDetailsSection = ({
                   value={complianceInfo.business_state || "State"}
                   onChange={(evt) => updateComplianceInfo({ business_state: evt.target.value })}
                 >
-                  <option disabled>State</option>
+                  <option disabled value="State">State</option>
                   {states.mx.map((state) => (
                     <option key={state.code} value={state.code}>
                       {state.name}
@@ -834,7 +834,7 @@ const AccountDetailsSection = ({
               value={complianceInfo.state || "State"}
               onChange={(evt) => updateComplianceInfo({ state: evt.target.value })}
             >
-              <option disabled>State</option>
+              <option disabled value="State">State</option>
               {states.us.map((state) => (
                 <option key={state.code} value={state.code}>
                   {state.name}
@@ -876,7 +876,7 @@ const AccountDetailsSection = ({
               value={complianceInfo.state || "State"}
               onChange={(evt) => updateComplianceInfo({ state: evt.target.value })}
             >
-              <option disabled>State</option>
+              <option disabled value="State">State</option>
               {states.au.map((state) => (
                 <option key={state.code} value={state.code}>
                   {state.name}
@@ -897,7 +897,7 @@ const AccountDetailsSection = ({
               value={complianceInfo.state || "State"}
               onChange={(evt) => updateComplianceInfo({ state: evt.target.value })}
             >
-              <option disabled>State</option>
+              <option disabled value="State">State</option>
               {states.mx.map((state) => (
                 <option key={state.code} value={state.code}>
                   {state.name}
@@ -960,7 +960,7 @@ const AccountDetailsSection = ({
               value={complianceInfo.state || "State"}
               onChange={(evt) => updateComplianceInfo({ state: evt.target.value })}
             >
-              <option disabled>State</option>
+              <option disabled value="State">State</option>
               {states.br.map((state) => (
                 <option key={state.code} value={state.code}>
                   {state.name}

--- a/app/javascript/components/server-components/Settings/PaymentsPage.tsx
+++ b/app/javascript/components/server-components/Settings/PaymentsPage.tsx
@@ -596,7 +596,7 @@ const PaymentsPage = (props: Props) => {
     if (!complianceInfo.city) {
       markFieldInvalid("city");
     }
-    if (complianceInfo.country !== null && complianceInfo.country in props.states && !complianceInfo.state) {
+    if (complianceInfo.country !== null && complianceInfo.country in props.states && (!complianceInfo.state || complianceInfo.state === "State")) {
       markFieldInvalid("state");
     }
     if (!complianceInfo.zip_code && complianceInfo.country !== "BW") {
@@ -668,7 +668,7 @@ const PaymentsPage = (props: Props) => {
       if (
         complianceInfo.business_country !== null &&
         complianceInfo.business_country in props.states &&
-        !complianceInfo.business_state
+        (!complianceInfo.business_state || complianceInfo.business_state === "State")
       ) {
         markFieldInvalid("business_state");
       }


### PR DESCRIPTION
Fixes issue where users could submit payment settings form without selecting a valid state. The placeholder option 'State' was being treated as a valid value, resulting in invalid address data on Stripe.

Changes:
- Added explicit value='State' attribute to all 7 state dropdown placeholder options in AccountDetailsSection.tsx
- Enhanced validation logic in PaymentsPage.tsx to explicitly reject 'State' as an invalid value for both individual and business state fields

This ensures proper validation and prevents invalid data submission to Stripe.

Resolves #1885