### PR TITLE
Auto-remove LowBalanceFraudCheck probation when balance exceeds $100

### DIFF
--- a/app/models/concerns/user/low_balance_fraud_check.rb
+++ b/app/models/concerns/user/low_balance_fraud_check.rb
@@ -10,7 +10,6 @@ module User::LowBalanceFraudCheck
   private_constant :LOW_BALANCE_PROBATION_WAIT_TIME
 
   LOW_BALANCE_FRAUD_CHECK_AUTHOR_NAME = "LowBalanceFraudCheck"
-  private_constant :LOW_BALANCE_FRAUD_CHECK_AUTHOR_NAME
 
   def enable_refunds!
     self.refunds_disabled = false

--- a/app/sidekiq/update_seller_refund_eligibility_job.rb
+++ b/app/sidekiq/update_seller_refund_eligibility_job.rb
@@ -13,5 +13,19 @@ class UpdateSellerRefundEligibilityJob
     elsif unpaid_balance_cents < -10000 && !user.refunds_disabled?
       user.disable_refunds!
     end
+
+    # Auto-remove LowBalanceFraudCheck probation when balance exceeds $100
+    if unpaid_balance_cents > 100_00 && user.on_probation? && was_probated_by_low_balance_fraud_check?(user)
+      user.mark_compliant!(author_name: User::LowBalanceFraudCheck::LOW_BALANCE_FRAUD_CHECK_AUTHOR_NAME)
+    end
+  end
+
+  private
+
+  def was_probated_by_low_balance_fraud_check?(user)
+    user.comments
+        .with_type_on_probation
+        .where(author_name: User::LowBalanceFraudCheck::LOW_BALANCE_FRAUD_CHECK_AUTHOR_NAME)
+        .exists?
   end
 end

--- a/spec/sidekiq/update_seller_refund_eligibility_job_spec.rb
+++ b/spec/sidekiq/update_seller_refund_eligibility_job_spec.rb
@@ -52,4 +52,42 @@ describe UpdateSellerRefundEligibilityJob do
       expect { perform }.to change { user.reload.refunds_disabled? }.from(false).to(true)
     end
   end
+
+  context "when user is on probation due to LowBalanceFraudCheck" do
+    before do
+      user.put_on_probation(author_name: User::LowBalanceFraudCheck::LOW_BALANCE_FRAUD_CHECK_AUTHOR_NAME, content: "Test probation")
+      user.disable_refunds!
+    end
+
+    it "removes probation and marks compliant when balance exceeds $100" do
+      # Current balance is $99.99
+      create(:balance, user: user, amount_cents: 99_99)
+      expect { perform }.not_to change { user.reload.user_risk_state }
+
+      # Current balance is $100
+      create(:balance, user: user, amount_cents: 1)
+      expect { perform }.not_to change { user.reload.user_risk_state }
+
+      # Current balance is $100.01
+      create(:balance, user: user, amount_cents: 1)
+      expect { perform }.to change { user.reload.user_risk_state }.from("on_probation").to("compliant")
+      expect(user.comments.last.author_name).to eq(User::LowBalanceFraudCheck::LOW_BALANCE_FRAUD_CHECK_AUTHOR_NAME)
+    end
+
+    it "also enables refunds when marking compliant" do
+      create(:balance, user: user, amount_cents: 100_01)
+      expect { perform }.to change { user.reload.refunds_disabled? }.from(true).to(false)
+    end
+  end
+
+  context "when user is on probation for other reasons" do
+    before do
+      user.put_on_probation(author_name: "OtherReason", content: "Different probation reason")
+    end
+
+    it "does not remove probation even when balance exceeds $100" do
+      create(:balance, user: user, amount_cents: 100_01)
+      expect { perform }.not_to change { user.reload.user_risk_state }
+    end
+  end
 end


### PR DESCRIPTION
## summary
- automatically removes LowBalanceFraudCheck probation when user balance goes above $100
- extends existing UpdateSellerRefundEligibilityJob to check for this condition

## implementation details
- when balance changes and exceeds $100, check if user is on probation due to LowBalanceFraudCheck
- if yes, mark user as compliant automatically  
- only affects users specifically probated by the LowBalanceFraudCheck system
- reuses existing job that already handles balance-based state changes

## testing
- added tests to verify probation is removed when balance > $100
- added tests to ensure other probation reasons are not affected
- tests confirm refunds are also re-enabled when marking compliant

Fixes #1884