### PR TITLE
Fix: Prevent payment form submission with placeholder state values

### DIFF
--- a/app/controllers/settings/payments_controller.rb
+++ b/app/controllers/settings/payments_controller.rb
@@ -13,6 +13,14 @@ class Settings::PaymentsController < Sellers::BaseController
   def update
     return render(json: { success: false, error_message: "You have to confirm your email address before you can do that." }) unless current_seller.email.present?
     return unless current_seller.fetch_or_build_user_compliance_info.country.present?
+    
+    # Validate state placeholders
+    if params.dig(:user, :state).in?(["State", "Province", "County"])
+      return render(json: { success: false, error_message: "Please select a valid state or province." })
+    end
+    if params.dig(:user, :business_state).in?(["State", "Province", "County"])
+      return render(json: { success: false, error_message: "Please select a valid state or province for your business address." })
+    end
 
     compliance_info = current_seller.fetch_or_build_user_compliance_info
 

--- a/app/javascript/components/Settings/PaymentsPage/AccountDetailsSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/AccountDetailsSection.tsx
@@ -125,10 +125,10 @@ const AccountDetailsSection = ({
                   required={complianceInfo.is_business}
                   disabled={isFormDisabled}
                   aria-invalid={errorFieldNames.has("business_type")}
-                  value={complianceInfo.business_type || "Type"}
+                  value={complianceInfo.business_type || ""}
                   onChange={(evt) => updateComplianceInfo({ business_type: evt.target.value })}
                 >
-                  <option disabled>Type</option>
+                  <option value="" disabled>Type</option>
                   {uaeBusinessTypes.map((businessType) => (
                     <option key={businessType.code} value={businessType.code}>
                       {businessType.name}
@@ -141,10 +141,10 @@ const AccountDetailsSection = ({
                   required={complianceInfo.is_business}
                   disabled={isFormDisabled}
                   aria-invalid={errorFieldNames.has("business_type")}
-                  value={complianceInfo.business_type || "Type"}
+                  value={complianceInfo.business_type || ""}
                   onChange={(evt) => updateComplianceInfo({ business_type: evt.target.value })}
                 >
-                  <option disabled>Type</option>
+                  <option value="" disabled>Type</option>
                   {indiaBusinessTypes.map((businessType) => (
                     <option key={businessType.code} value={businessType.code}>
                       {businessType.name}
@@ -157,10 +157,10 @@ const AccountDetailsSection = ({
                   required={complianceInfo.is_business}
                   disabled={isFormDisabled}
                   aria-invalid={errorFieldNames.has("business_type")}
-                  value={complianceInfo.business_type || "Type"}
+                  value={complianceInfo.business_type || ""}
                   onChange={(evt) => updateComplianceInfo({ business_type: evt.target.value })}
                 >
-                  <option disabled>Type</option>
+                  <option value="" disabled>Type</option>
                   {canadaBusinessTypes.map((businessType) => (
                     <option key={businessType.code} value={businessType.code}>
                       {businessType.name}
@@ -171,12 +171,12 @@ const AccountDetailsSection = ({
                 <select
                   id={`${uid}-business-type`}
                   disabled={isFormDisabled}
-                  value={complianceInfo.business_type || "Type"}
+                  value={complianceInfo.business_type || ""}
                   required
                   aria-invalid={errorFieldNames.has("business_type")}
                   onChange={(evt) => updateComplianceInfo({ business_type: evt.target.value })}
                 >
-                  <option disabled>Type</option>
+                  <option value="" disabled>Type</option>
                   <option value="llc">LLC</option>
                   <option value="partnership">Partnership</option>
                   <option value="profit">Non Profit</option>
@@ -313,10 +313,10 @@ const AccountDetailsSection = ({
                   required={complianceInfo.is_business}
                   disabled={isFormDisabled}
                   aria-invalid={errorFieldNames.has("business_state")}
-                  value={complianceInfo.business_state || "State"}
+                  value={complianceInfo.business_state || ""}
                   onChange={(evt) => updateComplianceInfo({ business_state: evt.target.value })}
                 >
-                  <option disabled>State</option>
+                  <option value="" disabled>State</option>
                   {states.us.map((state) => (
                     <option key={state.code} value={state.code}>
                       {state.name}
@@ -334,10 +334,10 @@ const AccountDetailsSection = ({
                   required={complianceInfo.is_business}
                   disabled={isFormDisabled}
                   aria-invalid={errorFieldNames.has("business_state")}
-                  value={complianceInfo.business_state || "Province"}
+                  value={complianceInfo.business_state || ""}
                   onChange={(evt) => updateComplianceInfo({ business_state: evt.target.value })}
                 >
-                  <option disabled>Province</option>
+                  <option value="" disabled>Province</option>
                   {states.ca.map((state) => (
                     <option key={state.code} value={state.code}>
                       {state.name}
@@ -355,10 +355,10 @@ const AccountDetailsSection = ({
                   required={complianceInfo.is_business}
                   disabled={isFormDisabled}
                   aria-invalid={errorFieldNames.has("business_state")}
-                  value={complianceInfo.business_state || "State"}
+                  value={complianceInfo.business_state || ""}
                   onChange={(evt) => updateComplianceInfo({ business_state: evt.target.value })}
                 >
-                  <option disabled>State</option>
+                  <option value="" disabled>State</option>
                   {states.au.map((state) => (
                     <option key={state.code} value={state.code}>
                       {state.name}
@@ -376,10 +376,10 @@ const AccountDetailsSection = ({
                   required={complianceInfo.is_business}
                   disabled={isFormDisabled}
                   aria-invalid={errorFieldNames.has("business_state")}
-                  value={complianceInfo.business_state || "State"}
+                  value={complianceInfo.business_state || ""}
                   onChange={(evt) => updateComplianceInfo({ business_state: evt.target.value })}
                 >
-                  <option disabled>State</option>
+                  <option value="" disabled>State</option>
                   {states.mx.map((state) => (
                     <option key={state.code} value={state.code}>
                       {state.name}
@@ -397,10 +397,10 @@ const AccountDetailsSection = ({
                   required={complianceInfo.is_business}
                   disabled={isFormDisabled}
                   aria-invalid={errorFieldNames.has("business_state")}
-                  value={complianceInfo.business_state || "Province"}
+                  value={complianceInfo.business_state || ""}
                   onChange={(evt) => updateComplianceInfo({ business_state: evt.target.value })}
                 >
-                  <option disabled>Province</option>
+                  <option value="" disabled>Province</option>
                   {states.ae.map((state) => (
                     <option key={state.code} value={state.code}>
                       {state.name}
@@ -418,10 +418,10 @@ const AccountDetailsSection = ({
                   required={complianceInfo.is_business}
                   disabled={isFormDisabled}
                   aria-invalid={errorFieldNames.has("business_state")}
-                  value={complianceInfo.business_state || "County"}
+                  value={complianceInfo.business_state || ""}
                   onChange={(evt) => updateComplianceInfo({ business_state: evt.target.value })}
                 >
-                  <option disabled>County</option>
+                  <option value="" disabled>County</option>
                   {states.ir.map((state) => (
                     <option key={state.code} value={state.code}>
                       {state.name}
@@ -826,15 +826,15 @@ const AccountDetailsSection = ({
             <legend>
               <label htmlFor={`${uid}-creator-state`}>State</label>
             </legend>
-            <select
+             <select
               id={`${uid}-creator-state`}
               required
               disabled={isFormDisabled}
               aria-invalid={errorFieldNames.has("state")}
-              value={complianceInfo.state || "State"}
+              value={complianceInfo.state || ""}
               onChange={(evt) => updateComplianceInfo({ state: evt.target.value })}
             >
-              <option disabled>State</option>
+              <option value="" disabled>State</option>
               {states.us.map((state) => (
                 <option key={state.code} value={state.code}>
                   {state.name}
@@ -852,10 +852,10 @@ const AccountDetailsSection = ({
               required
               disabled={isFormDisabled}
               aria-invalid={errorFieldNames.has("state")}
-              value={complianceInfo.state || "Province"}
+              value={complianceInfo.state || ""}
               onChange={(evt) => updateComplianceInfo({ state: evt.target.value })}
             >
-              <option disabled>Province</option>
+              <option value="" disabled>Province</option>
               {states.ca.map((state) => (
                 <option key={state.code} value={state.code}>
                   {state.name}
@@ -873,10 +873,10 @@ const AccountDetailsSection = ({
               required
               disabled={isFormDisabled}
               aria-invalid={errorFieldNames.has("state")}
-              value={complianceInfo.state || "State"}
+              value={complianceInfo.state || ""}
               onChange={(evt) => updateComplianceInfo({ state: evt.target.value })}
             >
-              <option disabled>State</option>
+              <option value="" disabled>State</option>
               {states.au.map((state) => (
                 <option key={state.code} value={state.code}>
                   {state.name}
@@ -894,10 +894,10 @@ const AccountDetailsSection = ({
               required
               disabled={isFormDisabled}
               aria-invalid={errorFieldNames.has("state")}
-              value={complianceInfo.state || "State"}
+              value={complianceInfo.state || ""}
               onChange={(evt) => updateComplianceInfo({ state: evt.target.value })}
             >
-              <option disabled>State</option>
+              <option value="" disabled>State</option>
               {states.mx.map((state) => (
                 <option key={state.code} value={state.code}>
                   {state.name}
@@ -915,10 +915,10 @@ const AccountDetailsSection = ({
               required
               disabled={isFormDisabled}
               aria-invalid={errorFieldNames.has("state")}
-              value={complianceInfo.state || "Province"}
+              value={complianceInfo.state || ""}
               onChange={(evt) => updateComplianceInfo({ state: evt.target.value })}
             >
-              <option disabled>Province</option>
+              <option value="" disabled>Province</option>
               {states.ae.map((state) => (
                 <option key={state.code} value={state.code}>
                   {state.name}
@@ -936,10 +936,10 @@ const AccountDetailsSection = ({
               required
               disabled={isFormDisabled}
               aria-invalid={errorFieldNames.has("state")}
-              value={complianceInfo.state || "County"}
+              value={complianceInfo.state || ""}
               onChange={(evt) => updateComplianceInfo({ state: evt.target.value })}
             >
-              <option disabled>County</option>
+              <option value="" disabled>County</option>
               {states.ir.map((state) => (
                 <option key={state.code} value={state.code}>
                   {state.name}
@@ -957,10 +957,10 @@ const AccountDetailsSection = ({
               required
               disabled={isFormDisabled}
               aria-invalid={errorFieldNames.has("state")}
-              value={complianceInfo.state || "State"}
+              value={complianceInfo.state || ""}
               onChange={(evt) => updateComplianceInfo({ state: evt.target.value })}
             >
-              <option disabled>State</option>
+              <option value="" disabled>State</option>
               {states.br.map((state) => (
                 <option key={state.code} value={state.code}>
                   {state.name}
@@ -1038,10 +1038,10 @@ const AccountDetailsSection = ({
               required
               aria-label="Month"
               aria-invalid={errorFieldNames.has("dob_month")}
-              value={complianceInfo.dob_month || "Month"}
+              value={complianceInfo.dob_month || ""}
               onChange={(evt) => updateComplianceInfo({ dob_month: Number(evt.target.value) })}
             >
-              <option disabled>Month</option>
+              <option value="" disabled>Month</option>
               {Array.from({ length: 12 }, (_, i) => i + 1).map((month) => (
                 <option key={month} value={month}>
                   {new Date(2000, month - 1, 1).toLocaleString("en-US", { month: "long" })}
@@ -1059,10 +1059,10 @@ const AccountDetailsSection = ({
               required
               aria-label="Day"
               aria-invalid={errorFieldNames.has("dob_day")}
-              value={complianceInfo.dob_day || "Day"}
+              value={complianceInfo.dob_day || ""}
               onChange={(evt) => updateComplianceInfo({ dob_day: Number(evt.target.value) })}
             >
-              <option disabled>Day</option>
+              <option value="" disabled>Day</option>
               {Array.from({ length: 31 }, (_, i) => i + 1).map((day) => (
                 <option key={day} value={day}>
                   {day}
@@ -1077,10 +1077,10 @@ const AccountDetailsSection = ({
               required
               aria-label="Year"
               aria-invalid={errorFieldNames.has("dob_year")}
-              value={complianceInfo.dob_year || "Year"}
+              value={complianceInfo.dob_year || ""}
               onChange={(evt) => updateComplianceInfo({ dob_year: Number(evt.target.value) })}
             >
-              <option disabled>Year</option>
+              <option value="" disabled>Year</option>
               {Array.from({ length: minDobYear - 1900 }, (_, i) => i + 1900).map((year) => (
                 <option key={year} value={year}>
                   {year}
@@ -1103,10 +1103,10 @@ const AccountDetailsSection = ({
               id={`${uid}-nationality`}
               disabled={isFormDisabled}
               aria-invalid={errorFieldNames.has("nationality")}
-              value={complianceInfo.nationality || "Nationality"}
+              value={complianceInfo.nationality || ""}
               onChange={(evt) => updateComplianceInfo({ nationality: evt.target.value })}
             >
-              <option disabled>Nationality</option>
+              <option value="" disabled>Nationality</option>
               {Object.entries(countries).map(([code, name]) => (
                 <option key={code} value={code} disabled={name.includes("(not supported)")}>
                   {name}

--- a/app/javascript/components/Settings/PaymentsPage/BankAccountSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/BankAccountSection.tsx
@@ -1454,9 +1454,9 @@ const BankAccountSection = ({
                       disabled={isFormDisabled}
                       aria-invalid={errorFieldNames.has("account_type")}
                       onChange={(evt) => updateBankAccount({ account_type: evt.target.value })}
-                      value={(bankAccount?.type === "ChileBankAccount" && bankAccount.account_type) || "Select"}
+                      value={(bankAccount?.type === "ChileBankAccount" && bankAccount.account_type) || ""}
                     >
-                      <option disabled>Select</option>
+                      <option value="" disabled>Select</option>
                       <option key="checking" value="checking">
                         Checking
                       </option>
@@ -1493,9 +1493,9 @@ const BankAccountSection = ({
                       disabled={isFormDisabled}
                       aria-invalid={errorFieldNames.has("account_type")}
                       onChange={(evt) => updateBankAccount({ account_type: evt.target.value })}
-                      value={(bankAccount?.type === "ColombiaBankAccount" && bankAccount.account_type) || "Select"}
+                      value={(bankAccount?.type === "ColombiaBankAccount" && bankAccount.account_type) || ""}
                     >
-                      <option disabled>Select</option>
+                      <option value="" disabled>Select</option>
                       <option key="savings" value="savings">
                         Savings
                       </option>

--- a/app/javascript/components/server-components/Settings/PaymentsPage.tsx
+++ b/app/javascript/components/server-components/Settings/PaymentsPage.tsx
@@ -596,7 +596,14 @@ const PaymentsPage = (props: Props) => {
     if (!complianceInfo.city) {
       markFieldInvalid("city");
     }
-    if (complianceInfo.country !== null && complianceInfo.country in props.states && !complianceInfo.state) {
+    if (
+      complianceInfo.country !== null && 
+      complianceInfo.country in props.states && 
+      (!complianceInfo.state || 
+       complianceInfo.state === "State" || 
+       complianceInfo.state === "Province" || 
+       complianceInfo.state === "County")
+    ) {
       markFieldInvalid("state");
     }
     if (!complianceInfo.zip_code && complianceInfo.country !== "BW") {
@@ -606,13 +613,13 @@ const PaymentsPage = (props: Props) => {
       markFieldInvalid("phone");
       setErrorMessage({ message: 'Please enter your full phone number, starting with a "+" and your country code.' });
     }
-    if (complianceInfo.dob_day === 0) {
+    if (complianceInfo.dob_day === 0 || complianceInfo.dob_day === "Day") {
       markFieldInvalid("dob_day");
     }
-    if (complianceInfo.dob_month === 0) {
+    if (complianceInfo.dob_month === 0 || complianceInfo.dob_month === "Month") {
       markFieldInvalid("dob_month");
     }
-    if (complianceInfo.dob_year === 0) {
+    if (complianceInfo.dob_year === 0 || complianceInfo.dob_year === "Year") {
       markFieldInvalid("dob_year");
     }
     if (
@@ -624,7 +631,7 @@ const PaymentsPage = (props: Props) => {
       markFieldInvalid("individual_tax_id");
     }
     if (complianceInfo.is_business) {
-      if (!complianceInfo.business_type) {
+      if (!complianceInfo.business_type || complianceInfo.business_type === "Type") {
         markFieldInvalid("business_type");
       }
       if (!complianceInfo.business_name) {
@@ -668,7 +675,10 @@ const PaymentsPage = (props: Props) => {
       if (
         complianceInfo.business_country !== null &&
         complianceInfo.business_country in props.states &&
-        !complianceInfo.business_state
+        (!complianceInfo.business_state ||
+         complianceInfo.business_state === "State" ||
+         complianceInfo.business_state === "Province" ||
+         complianceInfo.business_state === "County")
       ) {
         markFieldInvalid("business_state");
       }


### PR DESCRIPTION
## summary
- prevents users from submitting payment settings form with placeholder state values
- adds validation to check for "State", "Province", "County" placeholder values
- shows error when these placeholders are selected instead of real states

## problem
- users could submit form with "State" as the selected value
- this sent invalid data to stripe (showing "State: State" in stripe dashboard)
- affected both personal and business addresses

## fix
- added frontend validation in PaymentsPage.tsx
- checks if state value is one of the placeholder strings
- marks field as invalid and prevents form submission
- works for all countries (US states, Canadian provinces, etc)

Fixes #1885