### PR TITLE
Hide custom fields on manage membership page

### DIFF
--- a/app/javascript/components/server-components/SubscriptionManager.tsx
+++ b/app/javascript/components/server-components/SubscriptionManager.tsx
@@ -194,7 +194,7 @@ const SubscriptionManager = ({
     price: Math.round(amountDueToday / product.exchange_rate),
     payInInstallments: subscription.is_installment_plan,
     requireShipping: product.require_shipping,
-    customFields: product.custom_fields,
+    customFields: [], // Don't show custom fields on manage membership page
     bundleProductCustomFields: [],
     supportsPaypal: product.supports_paypal,
     testPurchase: subscription.is_test,


### PR DESCRIPTION
## summary 
- hides custom fields from manage membership page
- fixes confusion where users could edit fields but changes didn't save

## problem
- custom fields from checkout were showing on manage membership page
- users could edit them and click "update membership" 
- but changes weren't saved, causing support tickets

## fix
- pass empty array for customFields to PaymentForm in SubscriptionManager
- simple one-line change that prevents display of custom fields
- custom fields still work normally during checkout

Fixes #1321