### PR TITLE
Fix: Workflow email editor scrolls out of view when clicked

### DIFF
--- a/app/javascript/components/server-components/WorkflowsPage/index.tsx
+++ b/app/javascript/components/server-components/WorkflowsPage/index.tsx
@@ -41,7 +41,7 @@ export const Layout = ({ title, actions, navigation, children, preview }: Layout
     {preview ? (
       <div className="fixed-aside flex-1 lg:grid lg:grid-cols-[1fr_30vw]">
         <div>{children}</div>
-        <aside className="hidden lg:block" aria-label="Preview">
+        <aside className="hidden max-h-screen lg:sticky!" aria-label="Preview">
           {preview}
         </aside>
       </div>


### PR DESCRIPTION
### What

Fixes https://github.com/antiwork/gumroad/issues/1936.

This was likely broken after https://github.com/antiwork/gumroad/pull/1046.

### Screenshots

Before

https://github.com/user-attachments/assets/2b72cecf-319c-40e9-b5a8-31e87a0b429e

After

https://github.com/user-attachments/assets/adc88454-d20b-4c3f-a907-e647af5bde4b


