### PR TITLE
fix: prevent form submission with invalid state/business type placeholders (closes #1885)

### DIFF
--- a/app/javascript/components/Settings/PaymentsPage/AccountDetailsSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/AccountDetailsSection.tsx
@@ -125,10 +125,10 @@ const AccountDetailsSection = ({
                   required={complianceInfo.is_business}
                   disabled={isFormDisabled}
                   aria-invalid={errorFieldNames.has("business_type")}
-                  value={complianceInfo.business_type || "Type"}
+                  value={complianceInfo.business_type || ""}
                   onChange={(evt) => updateComplianceInfo({ business_type: evt.target.value })}
                 >
-                  <option disabled>Type</option>
+                  <option value="" disabled>Type</option>
                   {uaeBusinessTypes.map((businessType) => (
                     <option key={businessType.code} value={businessType.code}>
                       {businessType.name}
@@ -141,10 +141,10 @@ const AccountDetailsSection = ({
                   required={complianceInfo.is_business}
                   disabled={isFormDisabled}
                   aria-invalid={errorFieldNames.has("business_type")}
-                  value={complianceInfo.business_type || "Type"}
+                  value={complianceInfo.business_type || ""}
                   onChange={(evt) => updateComplianceInfo({ business_type: evt.target.value })}
                 >
-                  <option disabled>Type</option>
+                  <option value="" disabled>Type</option>
                   {indiaBusinessTypes.map((businessType) => (
                     <option key={businessType.code} value={businessType.code}>
                       {businessType.name}
@@ -157,10 +157,10 @@ const AccountDetailsSection = ({
                   required={complianceInfo.is_business}
                   disabled={isFormDisabled}
                   aria-invalid={errorFieldNames.has("business_type")}
-                  value={complianceInfo.business_type || "Type"}
+                  value={complianceInfo.business_type || ""}
                   onChange={(evt) => updateComplianceInfo({ business_type: evt.target.value })}
                 >
-                  <option disabled>Type</option>
+                  <option value="" disabled>Type</option>
                   {canadaBusinessTypes.map((businessType) => (
                     <option key={businessType.code} value={businessType.code}>
                       {businessType.name}
@@ -171,12 +171,12 @@ const AccountDetailsSection = ({
                 <select
                   id={`${uid}-business-type`}
                   disabled={isFormDisabled}
-                  value={complianceInfo.business_type || "Type"}
+                  value={complianceInfo.business_type || ""}
                   required
                   aria-invalid={errorFieldNames.has("business_type")}
                   onChange={(evt) => updateComplianceInfo({ business_type: evt.target.value })}
                 >
-                  <option disabled>Type</option>
+                  <option value="" disabled>Type</option>
                   <option value="llc">LLC</option>
                   <option value="partnership">Partnership</option>
                   <option value="profit">Non Profit</option>
@@ -313,10 +313,10 @@ const AccountDetailsSection = ({
                   required={complianceInfo.is_business}
                   disabled={isFormDisabled}
                   aria-invalid={errorFieldNames.has("business_state")}
-                  value={complianceInfo.business_state || "State"}
+                  value={complianceInfo.business_state || ""}
                   onChange={(evt) => updateComplianceInfo({ business_state: evt.target.value })}
                 >
-                  <option disabled>State</option>
+                  <option value="" disabled>State</option>
                   {states.us.map((state) => (
                     <option key={state.code} value={state.code}>
                       {state.name}
@@ -334,10 +334,10 @@ const AccountDetailsSection = ({
                   required={complianceInfo.is_business}
                   disabled={isFormDisabled}
                   aria-invalid={errorFieldNames.has("business_state")}
-                  value={complianceInfo.business_state || "Province"}
+                  value={complianceInfo.business_state || ""}
                   onChange={(evt) => updateComplianceInfo({ business_state: evt.target.value })}
                 >
-                  <option disabled>Province</option>
+                  <option value="" disabled>Province</option>
                   {states.ca.map((state) => (
                     <option key={state.code} value={state.code}>
                       {state.name}
@@ -355,10 +355,10 @@ const AccountDetailsSection = ({
                   required={complianceInfo.is_business}
                   disabled={isFormDisabled}
                   aria-invalid={errorFieldNames.has("business_state")}
-                  value={complianceInfo.business_state || "State"}
+                  value={complianceInfo.business_state || ""}
                   onChange={(evt) => updateComplianceInfo({ business_state: evt.target.value })}
                 >
-                  <option disabled>State</option>
+                  <option value="" disabled>State</option>
                   {states.au.map((state) => (
                     <option key={state.code} value={state.code}>
                       {state.name}
@@ -376,10 +376,10 @@ const AccountDetailsSection = ({
                   required={complianceInfo.is_business}
                   disabled={isFormDisabled}
                   aria-invalid={errorFieldNames.has("business_state")}
-                  value={complianceInfo.business_state || "State"}
+                  value={complianceInfo.business_state || ""}
                   onChange={(evt) => updateComplianceInfo({ business_state: evt.target.value })}
                 >
-                  <option disabled>State</option>
+                  <option value="" disabled>State</option>
                   {states.mx.map((state) => (
                     <option key={state.code} value={state.code}>
                       {state.name}
@@ -397,10 +397,10 @@ const AccountDetailsSection = ({
                   required={complianceInfo.is_business}
                   disabled={isFormDisabled}
                   aria-invalid={errorFieldNames.has("business_state")}
-                  value={complianceInfo.business_state || "Province"}
+                  value={complianceInfo.business_state || ""}
                   onChange={(evt) => updateComplianceInfo({ business_state: evt.target.value })}
                 >
-                  <option disabled>Province</option>
+                  <option value="" disabled>Province</option>
                   {states.ae.map((state) => (
                     <option key={state.code} value={state.code}>
                       {state.name}
@@ -418,10 +418,10 @@ const AccountDetailsSection = ({
                   required={complianceInfo.is_business}
                   disabled={isFormDisabled}
                   aria-invalid={errorFieldNames.has("business_state")}
-                  value={complianceInfo.business_state || "County"}
+                  value={complianceInfo.business_state || ""}
                   onChange={(evt) => updateComplianceInfo({ business_state: evt.target.value })}
                 >
-                  <option disabled>County</option>
+                  <option value="" disabled>County</option>
                   {states.ir.map((state) => (
                     <option key={state.code} value={state.code}>
                       {state.name}
@@ -831,10 +831,10 @@ const AccountDetailsSection = ({
               required
               disabled={isFormDisabled}
               aria-invalid={errorFieldNames.has("state")}
-              value={complianceInfo.state || "State"}
+              value={complianceInfo.state || ""}
               onChange={(evt) => updateComplianceInfo({ state: evt.target.value })}
             >
-              <option disabled>State</option>
+              <option value="" disabled>State</option>
               {states.us.map((state) => (
                 <option key={state.code} value={state.code}>
                   {state.name}
@@ -852,10 +852,10 @@ const AccountDetailsSection = ({
               required
               disabled={isFormDisabled}
               aria-invalid={errorFieldNames.has("state")}
-              value={complianceInfo.state || "Province"}
+              value={complianceInfo.state || ""}
               onChange={(evt) => updateComplianceInfo({ state: evt.target.value })}
             >
-              <option disabled>Province</option>
+              <option value="" disabled>Province</option>
               {states.ca.map((state) => (
                 <option key={state.code} value={state.code}>
                   {state.name}
@@ -873,10 +873,10 @@ const AccountDetailsSection = ({
               required
               disabled={isFormDisabled}
               aria-invalid={errorFieldNames.has("state")}
-              value={complianceInfo.state || "State"}
+              value={complianceInfo.state || ""}
               onChange={(evt) => updateComplianceInfo({ state: evt.target.value })}
             >
-              <option disabled>State</option>
+              <option value="" disabled>State</option>
               {states.au.map((state) => (
                 <option key={state.code} value={state.code}>
                   {state.name}
@@ -894,10 +894,10 @@ const AccountDetailsSection = ({
               required
               disabled={isFormDisabled}
               aria-invalid={errorFieldNames.has("state")}
-              value={complianceInfo.state || "State"}
+              value={complianceInfo.state || ""}
               onChange={(evt) => updateComplianceInfo({ state: evt.target.value })}
             >
-              <option disabled>State</option>
+              <option value="" disabled>State</option>
               {states.mx.map((state) => (
                 <option key={state.code} value={state.code}>
                   {state.name}
@@ -915,10 +915,10 @@ const AccountDetailsSection = ({
               required
               disabled={isFormDisabled}
               aria-invalid={errorFieldNames.has("state")}
-              value={complianceInfo.state || "Province"}
+              value={complianceInfo.state || ""}
               onChange={(evt) => updateComplianceInfo({ state: evt.target.value })}
             >
-              <option disabled>Province</option>
+              <option value="" disabled>Province</option>
               {states.ae.map((state) => (
                 <option key={state.code} value={state.code}>
                   {state.name}
@@ -936,10 +936,10 @@ const AccountDetailsSection = ({
               required
               disabled={isFormDisabled}
               aria-invalid={errorFieldNames.has("state")}
-              value={complianceInfo.state || "County"}
+              value={complianceInfo.state || ""}
               onChange={(evt) => updateComplianceInfo({ state: evt.target.value })}
             >
-              <option disabled>County</option>
+              <option value="" disabled>County</option>
               {states.ir.map((state) => (
                 <option key={state.code} value={state.code}>
                   {state.name}
@@ -957,10 +957,10 @@ const AccountDetailsSection = ({
               required
               disabled={isFormDisabled}
               aria-invalid={errorFieldNames.has("state")}
-              value={complianceInfo.state || "State"}
+              value={complianceInfo.state || ""}
               onChange={(evt) => updateComplianceInfo({ state: evt.target.value })}
             >
-              <option disabled>State</option>
+              <option value="" disabled>State</option>
               {states.br.map((state) => (
                 <option key={state.code} value={state.code}>
                   {state.name}

--- a/app/javascript/components/server-components/Settings/PaymentsPage.tsx
+++ b/app/javascript/components/server-components/Settings/PaymentsPage.tsx
@@ -596,7 +596,7 @@ const PaymentsPage = (props: Props) => {
     if (!complianceInfo.city) {
       markFieldInvalid("city");
     }
-    if (complianceInfo.country !== null && complianceInfo.country in props.states && !complianceInfo.state) {
+    if (complianceInfo.country !== null && complianceInfo.country.toLowerCase() in props.states && !complianceInfo.state) {
       markFieldInvalid("state");
     }
     if (!complianceInfo.zip_code && complianceInfo.country !== "BW") {
@@ -667,7 +667,7 @@ const PaymentsPage = (props: Props) => {
       }
       if (
         complianceInfo.business_country !== null &&
-        complianceInfo.business_country in props.states &&
+        complianceInfo.business_country.toLowerCase() in props.states &&
         !complianceInfo.business_state
       ) {
         markFieldInvalid("business_state");


### PR DESCRIPTION
**What I Fixed**

Payment settings form was accepting dropdown placeholders ("State", "Province", "Type") as valid values and submitting them to Stripe.

**Changes Made**

**17 dropdowns fixed:**

- 13 state/province/county dropdowns (US, CA, AU, MX, AE, IE, BR) - **from issue #1885**
- 4 business type dropdowns (UAE, India, Canada, generic) - **found and fixed (not in original issue)**

**Technical fixes:**

1. Changed dropdown defaults: `|| "State"` → `|| ""`
2. Added `value=""` to placeholder options: `<option disabled>` → `<option value="" disabled>`
3. **Fixed critical validation bug:** `country in states` → `country.toLowerCase() in states` - validation was completely broken due to case mismatch ("US" vs "us")

**Impact**

- ✅ State validation now actually works (was silently failing before)
- ✅ Business type validation now works (same bug pattern)
- ✅ Prevents invalid data being sent to Stripe

Closes #1885