### PR TITLE
Fix thumbnail placeholder background opacity

### DIFF
--- a/app/javascript/components/ui/Placeholder.tsx
+++ b/app/javascript/components/ui/Placeholder.tsx
@@ -12,7 +12,7 @@ type PlaceholderProps = React.PropsWithChildren<{
 const Placeholder: React.FC<PlaceholderProps> = ({ className, children, ...rest }) => (
   <div
     className={classNames(
-      "bg-filled grid justify-items-center gap-3 rounded border border-dashed border-border p-6 text-center",
+      "grid justify-items-center gap-3 rounded border border-dashed border-border bg-background p-6 text-center",
       "[&>.icon]:text-xl",
       className,
     )}


### PR DESCRIPTION
Fixes a regression from https://github.com/antiwork/gumroad/pull/1686; inspired by https://github.com/antiwork/gumroad/pull/1897

### Before

<img width="1413" height="321" alt="Screenshot 2025-11-09 at 00 13 13" src="https://github.com/user-attachments/assets/0ac2517c-c2ea-4004-8650-b7697c574e39" />

### After

<img width="1414" height="317" alt="Screenshot 2025-11-09 at 00 11 13" src="https://github.com/user-attachments/assets/03872f96-9479-4feb-a673-dc468b6ef94f" />

## AI Disclosure

Just Cursor autocompletions