### PR TITLE
Add filtering and bulk resend for missed posts by workflow/product category

### DIFF
--- a/app/javascript/components/Audience/CustomersPage.tsx
+++ b/app/javascript/components/Audience/CustomersPage.tsx
@@ -691,10 +691,12 @@ const CustomerDrawer = ({
 
   const [loadingId, setLoadingId] = React.useState<string | null>(null);
   const [missedPosts, setMissedPosts] = React.useState<MissedPost[] | null>(null);
+  const [selectedMissedPostsFilter, setSelectedMissedPostsFilter] = React.useState<string>("All missed emails");
   const [shownMissedPosts, setShownMissedPosts] = React.useState(PAGE_SIZE);
   const [emails, setEmails] = React.useState<CustomerEmail[] | null>(null);
   const [shownEmails, setShownEmails] = React.useState(PAGE_SIZE);
   const sentEmailIds = React.useRef<Set<string>>(new Set());
+  const [isResendingAll, setIsResendingAll] = React.useState(false);
   useRunOnce(() => {
     getMissedPosts(customer.id, customer.email).then(setMissedPosts, (e: unknown) => {
       assertResponseError(e);
@@ -717,6 +719,48 @@ const CustomerDrawer = ({
       showAlert(e.message, "error");
     }
     setLoadingId(null);
+  };
+
+  const missedPostsCategories = React.useMemo(() => {
+    if (!missedPosts) return [];
+    const categories = Array.from(new Set(missedPosts.map(post => post.category)));
+    return ["All missed emails", ...categories.filter(cat => cat !== "All missed emails")];
+  }, [missedPosts]);
+
+  const filteredMissedPosts = React.useMemo(() => {
+    if (!missedPosts) return null;
+    if (selectedMissedPostsFilter === "All missed emails") return missedPosts;
+    return missedPosts.filter(post => post.category === selectedMissedPostsFilter);
+  }, [missedPosts, selectedMissedPostsFilter]);
+
+
+  const onResendAll = async () => {
+    if (!filteredMissedPosts || filteredMissedPosts.length === 0) return;
+
+    setIsResendingAll(true);
+    let successCount = 0;
+    let errorCount = 0;
+
+    for (const post of filteredMissedPosts) {
+      if (sentEmailIds.current.has(post.id)) continue;
+
+      try {
+        await resendPost(customer.id, post.id);
+        sentEmailIds.current.add(post.id);
+        successCount++;
+      } catch (e) {
+        errorCount++;
+      }
+    }
+
+    setIsResendingAll(false);
+
+    if (successCount > 0) {
+      showAlert(`Successfully resent ${successCount} email${successCount > 1 ? 's' : ''}`, "success");
+    }
+    if (errorCount > 0) {
+      showAlert(`Failed to resend ${errorCount} email${errorCount > 1 ? 's' : ''}`, "error");
+    }
   };
 
   const [productPurchases, setProductPurchases] = React.useState<Customer[]>([]);
@@ -1206,7 +1250,22 @@ const CustomerDrawer = ({
           </header>
           {missedPosts ? (
             <>
-              {missedPosts.slice(0, shownMissedPosts).map((post) => (
+              <section>
+                <Select
+                  inputId="missed-posts-filter"
+                  instanceId="missed-posts-filter"
+                  isMulti={false}
+                  options={missedPostsCategories.map((category) => ({ id: category, label: category }))}
+                  value={{ id: selectedMissedPostsFilter, label: selectedMissedPostsFilter }}
+                  onChange={(option) => {
+                    if (option) {
+                      setSelectedMissedPostsFilter(option.id);
+                      setShownMissedPosts(PAGE_SIZE);
+                    }
+                  }}
+                />
+              </section>
+              {filteredMissedPosts && filteredMissedPosts.slice(0, shownMissedPosts).map((post) => (
                 <section key={post.id}>
                   <div>
                     <h5>
@@ -1218,19 +1277,31 @@ const CustomerDrawer = ({
                   </div>
                   <Button
                     color="primary"
-                    disabled={!!loadingId || sentEmailIds.current.has(post.id)}
+                    disabled={!!loadingId || sentEmailIds.current.has(post.id) || isResendingAll}
                     onClick={() => void onSend(post.id, "post")}
                   >
-                    {sentEmailIds.current.has(post.id) ? "Sent" : loadingId === post.id ? "Sending...." : "Send"}
+                    {sentEmailIds.current.has(post.id) ? "Sent" : loadingId === post.id ? "Sending...." : "Resend"}
                   </Button>
                 </section>
               ))}
-              {shownMissedPosts < missedPosts.length ? (
+              {filteredMissedPosts && shownMissedPosts < filteredMissedPosts.length ? (
                 <section>
                   <Button
                     onClick={() => setShownMissedPosts((prevShownMissedPosts) => prevShownMissedPosts + PAGE_SIZE)}
                   >
                     Show more
+                  </Button>
+                </section>
+              ) : null}
+              {filteredMissedPosts && filteredMissedPosts.length > 0 ? (
+                <section>
+                  <Button
+                    color="accent"
+                    disabled={isResendingAll || !!loadingId || filteredMissedPosts.every(post => sentEmailIds.current.has(post.id))}
+                    onClick={() => void onResendAll()}
+                    style={{ width: "100%" }}
+                  >
+                    {isResendingAll ? "Resending..." : "Resend all"}
                   </Button>
                 </section>
               ) : null}

--- a/app/javascript/data/customers.ts
+++ b/app/javascript/data/customers.ts
@@ -194,6 +194,9 @@ export type MissedPost = {
   name: string;
   url: string;
   published_at: string;
+  workflow_name: string | null;
+  product_name: string | null;
+  category: string;
 };
 export const getMissedPosts = (purchaseId: string, purchaseEmail: string) =>
   request({

--- a/app/presenters/customer_presenter.rb
+++ b/app/presenters/customer_presenter.rb
@@ -8,13 +8,16 @@ class CustomerPresenter
   end
 
   def missed_posts
-    posts = Installment.missed_for_purchase(purchase).order(published_at: :desc)
+    posts = Installment.missed_for_purchase(purchase).includes(:workflow, :link).order(published_at: :desc)
     posts.map do |post|
       {
         id: post.external_id,
         name: post.name,
         url: post.full_url,
         published_at: post.published_at,
+        workflow_name: post.workflow&.name,
+        product_name: post.link&.name,
+        category: determine_post_category(post),
       }
     end
   end
@@ -173,6 +176,12 @@ class CustomerPresenter
   end
 
   private
+    def determine_post_category(post)
+      return post.workflow.name if post.workflow.present?
+      return post.link.name if post.link.present?
+      "All missed emails"
+    end
+
     def file_details(file)
       {
         id: file.signed_id,

--- a/spec/controllers/customers_controller_spec.rb
+++ b/spec/controllers/customers_controller_spec.rb
@@ -373,9 +373,15 @@ describe CustomersController, :vcr, type: :controller, inertia: true do
       expect(response.parsed_body[0]["name"]).to eq(@post2.name)
       expect(response.parsed_body[0]["published_at"].to_date).to eq(@post2.published_at.to_date)
       expect(response.parsed_body[0]["url"]).to eq(custom_domain_view_post_url(host: seller.subdomain_with_protocol, slug: @post2.slug))
+      expect(response.parsed_body[0]["workflow_name"]).to be_nil
+      expect(response.parsed_body[0]["product_name"]).to eq(@product.name)
+      expect(response.parsed_body[0]["category"]).to eq(@product.name)
       expect(response.parsed_body[1]["name"]).to eq(@post3.name)
       expect(response.parsed_body[1]["published_at"].to_date).to eq(@post3.published_at.to_date)
       expect(response.parsed_body[1]["url"]).to eq(custom_domain_view_post_url(host: seller.subdomain_with_protocol, slug: @post3.slug))
+      expect(response.parsed_body[1]["workflow_name"]).to be_nil
+      expect(response.parsed_body[1]["product_name"]).to eq(@product.name)
+      expect(response.parsed_body[1]["category"]).to eq(@product.name)
       expect(response.parsed_body[2]).to eq(nil)
     end
 

--- a/spec/requests/customers/customers_spec.rb
+++ b/spec/requests/customers/customers_spec.rb
@@ -531,6 +531,60 @@ describe "Sales page", type: :system, js: true do
         expect(page).to have_alert(text: "You are not eligible to resend this email.")
         expect(EmailInfo.last.installment).to be_nil
       end
+
+      it "filters missed posts by workflow category" do
+        workflow = create(:workflow, seller:, name: "Welcome Series", published_at: Time.current)
+        create(:installment, workflow:, seller:, published_at: Time.current, name: "Welcome Email")
+        create(:installment, link: product1, published_at: Time.current, name: "Product Update")
+
+        allow_any_instance_of(User).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE)
+        stripe_connect_account = create(:merchant_account_stripe_connect, user: seller)
+        create(:purchase, seller:, link: product1, merchant_account: stripe_connect_account)
+
+        visit customers_path
+        find(:table_row, { "Name" => "Customer 1" }).click
+        within_section "Product 1", section_element: :aside do
+          within_section "Send missed posts", section_element: :section do
+            expect(page).to have_select("missed-posts-filter")
+            expect(page).to have_section("Welcome Email")
+            expect(page).to have_section("Product Update")
+
+            select "Welcome Series", from: "missed-posts-filter"
+            expect(page).to have_section("Welcome Email")
+            expect(page).to_not have_section("Product Update")
+          end
+        end
+      end
+
+      it "resends all filtered posts" do
+        workflow = create(:workflow, seller:, name: "Feedback", published_at: Time.current)
+        create(:installment, workflow:, seller:, published_at: Time.current, name: "Feedback Email 1")
+        create(:installment, workflow:, seller:, published_at: Time.current, name: "Feedback Email 2")
+
+        allow_any_instance_of(User).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE)
+        stripe_connect_account = create(:merchant_account_stripe_connect, user: seller)
+        create(:purchase, seller:, link: product1, merchant_account: stripe_connect_account)
+
+        visit customers_path
+        find(:table_row, { "Name" => "Customer 1" }).click
+        within_section "Product 1", section_element: :aside do
+          within_section "Send missed posts", section_element: :section do
+            select "Feedback", from: "missed-posts-filter"
+            click_on "Resend all"
+            expect(page).to have_button("Resending...", disabled: true)
+          end
+        end
+
+        expect(page).to have_alert(text: "Successfully resent 2 emails")
+        within_section "Send missed posts", section_element: :section do
+          within_section "Feedback Email 1" do
+            expect(page).to have_button("Sent", disabled: true)
+          end
+          within_section "Feedback Email 2" do
+            expect(page).to have_button("Sent", disabled: true)
+          end
+        end
+      end
     end
 
     describe "receipts" do


### PR DESCRIPTION
## Fixes: #1814 

## **What we did:**

- Added a filtering dropdown to the missed posts section in the customer drawer, allowing creators to filter and bulk resend emails by category (workflow or product).
- Backend Changes:
- Modified CustomerPresenter#missed_posts to include workflow_name, product_name, and category fields in the API response
- Added determine_post_category helper method to automatically categorize posts based on their workflow or product association

## Ai Discolsure
None. All code written by me

## Livestream Viewing Confirmation
Have watched both the live streams end-to-end

## Video
**Before:**

https://github.com/user-attachments/assets/6fb19a73-ed8a-4c0d-a37b-1938a155b704


**After:**
 Dark Mode

https://github.com/user-attachments/assets/d632ffb0-b7aa-467e-afc6-168349c37427

Light Mode

https://github.com/user-attachments/assets/3dede081-4740-4266-8082-779b5057e47a



