### PR TITLE
Fix url_redirects_controller_spec to work with MinIO URLs

### DIFF
--- a/spec/controllers/url_redirects_controller_spec.rb
+++ b/spec/controllers/url_redirects_controller_spec.rb
@@ -803,7 +803,12 @@ describe UrlRedirectsController do
       loc = response.location
       expect(loc.include?(FILE_DOWNLOAD_DISTRIBUTION_URL)).to be(true)
       expect(loc.include?(s3_path)).to be(true)
-      expect(loc.include?("verify=")).to be(true)
+
+      if USING_MINIO
+        expect(loc.include?("X-Amz-Signature=")).to be(true)
+      else
+        expect(loc.include?("verify=")).to be(true)
+      end
     end
 
     it "marks the url_redirect as seen" do
@@ -1474,8 +1479,15 @@ describe UrlRedirectsController do
           get :read, params: { id: @token, product_file_id: @product.product_files.first.external_id }
           expect(response).to be_successful
           expect(assigns(:hide_layouts)).to eq(true)
-          expect(assigns(:read_url)).to include("cache_group=read")
-          expect(assigns(:read_url)).to include("staging-files.gumroad.com")
+
+          if USING_MINIO
+            expect(assigns(:read_url)).to include("X-Amz-Signature=")
+            expect(assigns(:read_url)).to include(S3_BUCKET)
+          else
+            expect(assigns(:read_url)).to include("cache_group=read")
+            expect(assigns(:read_url)).to include("staging-files.gumroad.com")
+          end
+
           expect(response.body).to have_selector("h1", text: "The Works of Edgar Gumstein")
         end
 


### PR DESCRIPTION
Part of #1864 #1773
## Ai Discolsure
None. All code written by me

## Livestream Viewing Confirmation
Have watched both the live streams end-to-end


## **Spec failing**
<img width="2135" height="730" alt="image" src="https://github.com/user-attachments/assets/359495e5-cfd5-4647-bf82-593de4775182" />

## Screenshot
<img width="917" height="324" alt="image" src="https://github.com/user-attachments/assets/1574fa0e-2184-4ccc-a0d9-1601463ad6be" />
