### PR TITLE
Spec Fix: Minio Dev Branch 

### DIFF
--- a/spec/controllers/api/mobile/url_redirects_controller_spec.rb
+++ b/spec/controllers/api/mobile/url_redirects_controller_spec.rb
@@ -198,10 +198,14 @@ describe Api::Mobile::UrlRedirectsController do
       subtitle_file_fr = create(:subtitle_file, language: "Français", url: subtitle_fr_url, product_file: file_1)
       allow(s3_object).to receive(:content_length).and_return(100, 105)
       allow(s3_object).to receive(:public_url).and_return(subtitle_en_file_path, subtitle_fr_file_path)
-      allow(s3_object).to receive(:presigned_url) do |_method, params|
-        filename = params[:response_content_disposition].match(/filename="(?<filename>.+)"/)[:filename]
-        "https://presigned.example.com/#{filename}"
-      end
+      allow(s3_object).to receive(:presigned_url)
+        .with(:get,
+              hash_including(response_content_disposition: 'attachment; filename="english.srt"'))
+        .and_return("https://presigned.example.com/english.srt")
+      allow(s3_object).to receive(:presigned_url)
+        .with(:get,
+              hash_including(response_content_disposition: 'attachment; filename="french.srt"'))
+        .and_return("https://presigned.example.com/french.srt")
       travel_to Time.current # Freeze time so we can generate the expected URL(that is based on time)
       subtitle_en_path =
         file_1.signed_download_url_for_s3_key_and_filename(subtitle_file_en.s3_key, subtitle_file_en.s3_filename,


### PR DESCRIPTION
### Problem

The spec `spec/controllers/api/mobile/url_redirects_controller_spec.rb:195` failed locally as per CI error and local error - 

https://github.com/antiwork/gumroad/actions/runs/19107742055/job/54596769004?pr=1773

<img width="1470" height="555" alt="Screenshot 2025-11-09 at 8 54 27 PM" src="https://github.com/user-attachments/assets/72084d2c-d998-4e47-9c30-60e49748ffa1" />

The spec doubles S3 so it can run in Minio mode. When MinIO is active, SignedUrlHelper asks the S3 object for a presigned URL. The original test never stubbed presigned_url, so the double raised “unexpected message” and the spec failed.

### Fix

Added a `presigned_url` stub tied to MinIO’s payload

### After

<img width="2328" height="336" alt="image" src="https://github.com/user-attachments/assets/74063f28-14e4-4fe6-a6cd-2897bd41f614" />


### AI Disclosure

- Cursor used to suggest fix
- Code changes made manually
