### PR TITLE
Spec Fix: Minio url_redirects_controller_spec:195

### DIFF
--- a/spec/controllers/api/mobile/url_redirects_controller_spec.rb
+++ b/spec/controllers/api/mobile/url_redirects_controller_spec.rb
@@ -136,6 +136,14 @@ describe Api::Mobile::UrlRedirectsController do
     let(:subtitle_en_url) { "#{subtitle_url_bucket_url}#{subtitle_en_file_path}" }
     let(:subtitle_fr_url) { "#{subtitle_url_bucket_url}#{subtitle_fr_file_path}" }
 
+    before do
+      next unless USING_MINIO
+
+      allow_any_instance_of(SignedUrlHelper).to receive(:minio_presigned_url) do |_helper, s3_key, *_args|
+        "#{AWS_S3_ENDPOINT}/#{S3_BUCKET}/#{s3_key}"
+      end
+    end
+
     it "returns an unauthorized response if the user does not provide the correct mobile token" do
       get :stream, params: { token: url_redirect.token, product_file_id: file_1.external_id, format: :json }
       expect(response.code).to eq "401"
@@ -198,15 +206,6 @@ describe Api::Mobile::UrlRedirectsController do
       subtitle_file_fr = create(:subtitle_file, language: "Français", url: subtitle_fr_url, product_file: file_1)
       allow(s3_object).to receive(:content_length).and_return(100, 105)
       allow(s3_object).to receive(:public_url).and_return(subtitle_en_file_path, subtitle_fr_file_path)
-      if USING_MINIO
-        allow(s3_object).to receive(:presigned_url) do |_, options|
-          if options[:response_content_disposition]&.include?("english.srt")
-            "https://example.com/minio/english.srt"
-          else
-            "https://example.com/minio/french.srt"
-          end
-        end
-      end
       travel_to Time.current # Freeze time so we can generate the expected URL(that is based on time)
       subtitle_en_path =
         file_1.signed_download_url_for_s3_key_and_filename(subtitle_file_en.s3_key, subtitle_file_en.s3_filename,


### PR DESCRIPTION
### Problem

The spec `spec/controllers/api/mobile/url_redirects_controller_spec.rb:195` failed locally as per CI error and local error - 

https://github.com/antiwork/gumroad/actions/runs/19107742055/job/54596769004?pr=1773

<img width="1470" height="555" alt="Screenshot 2025-11-09 at 8 54 27 PM" src="https://github.com/user-attachments/assets/72084d2c-d998-4e47-9c30-60e49748ffa1" />

Other specs have single `and_return` chain as underlying code hits their `presigned_url` once the number of times they plan for. In this spec, we call `presigned_url` four times - 

- `subtitle_en_path = file_1.signed_download_url_for_s3_key_and_filename`, while building the expected value.
- `subtitle_fr_path` = …, for the second expected value.
- During the controller action, subtitle_files_for_mobile builds the first subtitle hash.
- The same method builds the second subtitle hash.

There can be ordering issues as well in this spec that should be avoided for english-url and french-url. To keep the spec simple for local, I have added minimal changes to return mocked url as `presigned_url`.

### Fix

Added a `presigned_url` stub tied to MinIO’s payload only for local purposes. This should not affect the main CI with AWS creds.

### After

<img width="2328" height="336" alt="image" src="https://github.com/user-attachments/assets/74063f28-14e4-4fe6-a6cd-2897bd41f614" />


### AI Disclosure

- Cursor used to suggest fix
- Code changes made manually
