### PR TITLE
Fix impersonate button on admin user show page

### DIFF
--- a/app/javascript/components/Admin/Users/Actions/ImpersonateAction.tsx
+++ b/app/javascript/components/Admin/Users/Actions/ImpersonateAction.tsx
@@ -7,7 +7,7 @@ type ImpersonateActionProps = {
   user: User;
 };
 
-const ImpersonateAction = ({ user: { impersonatable, id: user_identifier } }: ImpersonateActionProps) =>
+const ImpersonateAction = ({ user: { impersonatable, username: user_identifier } }: ImpersonateActionProps) =>
   impersonatable ? (
     <a href={Routes.admin_impersonate_url({ user_identifier })} className="button small">
       Become


### PR DESCRIPTION
The [`find_user`](https://github.com/antiwork/gumroad/blob/822a5a61371afcfb45b0125ed16fe070fb2073ba/app/controllers/admin/base_controller.rb#L103) method used by the impersonate action doesn't support ID as an identifier, so updated to impersonate by `username`.