### PR TITLE
Minio Spec Fix: url_redirect_spec.rb

### DIFF
--- a/spec/models/url_redirect_spec.rb
+++ b/spec/models/url_redirect_spec.rb
@@ -240,7 +240,10 @@ describe UrlRedirect do
 
     it "creates the right signed url for a file" do
       signed_s3_url = @url_redirect.signed_location_for_file(@product.product_files.first)
-      expect(signed_s3_url).to match(/verify=/)
+
+      if not USING_MINIO
+        expect(signed_s3_url).to match(/verify=/)
+      end
       expect(signed_s3_url).to match(/episode1/)
       expect(signed_s3_url).to_not match(/episode2/)
       expect(signed_s3_url).to_not match(/manual/)
@@ -252,7 +255,9 @@ describe UrlRedirect do
       url = "#{AWS_S3_ENDPOINT}/#{S3_BUCKET}/attachments/43a5363194e74e9ee75b6203eaea6705/original/stamped_manual.pdf"
       @url_redirect.stamped_pdfs.create!(product_file: pdf_product_file, url:)
       signed_s3_url = @url_redirect.signed_location_for_file(pdf_product_file)
-      expect(signed_s3_url).to match(/verify=/)
+      if not USING_MINIO
+        expect(signed_s3_url).to match(/verify=/)
+      end
       expect(signed_s3_url).to match(/stamped_manual/)
     end
   end


### PR DESCRIPTION
Ref: https://github.com/antiwork/gumroad/pull/1773

Spec failing: https://github.com/antiwork/gumroad/actions/runs/19107742055/job/54596769020?pr=1773

### Why?

The spec fails in local using minio as the method `signed_download_url_for_s3_key_and_filename` with `USING_MINIO` returns plain s3/minio presigned url without cloudflare **verify** token.

```rb
if USING_MINIO
      return minio_presigned_url(s3_key, s3_filename, is_video, expires_in)
    end
```

Since the URL is returned without making `is_cloudflare_cacheable?` check and does not append url via `url + "&verify=#{token}"`, it makes sense to rather not check this **verify** for minio urls for local working.

### After

<img width="827" height="163" alt="Screenshot 2025-11-10 at 10 16 39 PM" src="https://github.com/user-attachments/assets/6cc7125e-38d1-4c21-9038-7347bc856c9d" />

<img width="760" height="167" alt="Screenshot 2025-11-10 at 10 16 45 PM" src="https://github.com/user-attachments/assets/c39478b5-257a-4f22-baa6-31175037fd71" />

This is what minio url for file uploaded locally looks like: "http://localhost:9000/gumroad-specs/attachments/43a5363194e74e9ee75b6203eaea6705/original/episode1.mp4?response-content-disposition=attachment%3B%20filename%3D%22episode1.mp4%22&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=minioadmin%2F20251110%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20251110T163438Z&X-Amz-Expires=43200&X-Amz-SignedHeaders=host&X-Amz-Signature=f78baba514965feedd4d2ebdcea93db21d070b54be1a2f61e9d44a8f6ebbb86f"

### AI Disclosure

- No AI tools used

### LiveStream Disclosure

- All antiwork PR streams viewed
