### PR TITLE
Minio Spec Fix: url_redirect_presenter_spec.rb:8 for local setup

### DIFF
--- a/spec/presenters/url_redirect_presenter_spec.rb
+++ b/spec/presenters/url_redirect_presenter_spec.rb
@@ -6,7 +6,13 @@ describe UrlRedirectPresenter do
   include Rails.application.routes.url_helpers
   describe "#download_attributes" do
     it "returns all necessary attributes for the download page" do
-      allow(Aws::S3::Resource).to receive(:new).and_return(double(bucket: double(object: double(content_length: 1, public_url: "#{AWS_S3_ENDPOINT}/#{S3_BUCKET}/attachments/4768692737035/bb69798a4a694e19a0976390a7e40e6b/original/chapter1.srt"))))
+      public_url = "#{AWS_S3_ENDPOINT}/#{S3_BUCKET}/attachments/4768692737035/bb69798a4a694e19a0976390a7e40e6b/original/chapter1.srt"
+      s3_object = double(
+        content_length: 1,
+        public_url: public_url
+      )
+      allow(s3_object).to receive(:presigned_url).and_return(public_url) if USING_MINIO
+      allow(Aws::S3::Resource).to receive(:new).and_return(double(bucket: double(object: s3_object)))
 
       product = create(:product)
       folder = create(:product_folder, link: product, name: "Folder")


### PR DESCRIPTION
Ref: https://github.com/antiwork/gumroad/pull/1773

Spec failure on CI: https://github.com/antiwork/gumroad/actions/runs/19107742055/job/54596769026?pr=1773

### Why?

Locally we run with `USING_MINIO` so `SignedUrlHelper` calls `presigned_url` on s3 object it receives. Currectly the spec only exposed `content_length` and `public_url` so when helper tried to call `presigned_url`, double raised error.

### Fix

Pass in the public url defined is spec as the `presigned_url` as well conditionally with `if USING_MINIO`.

This follows pattern as per `purchases_controller_spec.rb:1599` -

```rb
      before :each do
        @s3_obj_public_url = "#{AWS_S3_ENDPOINT}/#{S3_BUCKET}/attachment/manual.pdf"

        s3_obj_double = double
        allow(s3_obj_double).to receive(:presigned_url).and_return(@s3_obj_public_url) # => THIS

        ...
        end
      end
``` 

The spec just verifies `UrlRedirectPresenter#download_attributes` building right hash and failed mainly due to `presigned_url` missing.

With the `presigned_url` stubbed, it fixes the failure.

### After

<img width="1032" height="169" alt="Screenshot 2025-11-10 at 11 48 10 PM" src="https://github.com/user-attachments/assets/528e1bdb-c6c3-4360-9d87-319d9e86740d" />


### AI Disclosure

- Cursor used to find root cause in auto mode
- Code changes made and verified manually

### LiveStream Disclosure
- All antiwork PR livestreams viewed