### PR TITLE
Minio dev spec fix: file_embeds_spec.rb

### DIFF
--- a/spec/requests/products/edit/file_embeds_spec.rb
+++ b/spec/requests/products/edit/file_embeds_spec.rb
@@ -122,7 +122,12 @@ describe("File embeds in product content editor", type: :system, js: true) do
   end
 
   it "allows users to upload subtitles with special characters in filenames" do
-    allow(Aws::S3::Resource).to receive(:new).and_return(double(bucket: double(object: double(content_length: 1024, public_url: Addressable::URI.encode("#{AWS_S3_ENDPOINT}/#{S3_BUCKET}/attachment/0000063137454006b85553304efaffb7/original/[]&+.mp4")))))
+    s3_object = double(
+      content_length: 1024,
+      public_url: Addressable::URI.encode("#{AWS_S3_ENDPOINT}/#{S3_BUCKET}/attachment/0000063137454006b85553304efaffb7/original/[]&+.mp4")
+    )
+    allow(s3_object).to receive(:presigned_url).and_return(s3_object.public_url) if USING_MINIO
+    allow(Aws::S3::Resource).to receive(:new).and_return(double(bucket: double(object: s3_object)))
 
     product_file = create(:product_file, url: "#{AWS_S3_ENDPOINT}/#{S3_BUCKET}/attachment/0000063137454006b85553304efaffb7/original/[]&+.mp4")
     @product.product_files << product_file
@@ -147,7 +152,12 @@ describe("File embeds in product content editor", type: :system, js: true) do
 
   describe "with video" do
     before do
-      allow(Aws::S3::Resource).to receive(:new).and_return(double(bucket: double(object: double(content_length: 1024, public_url: Addressable::URI.encode("#{AWS_S3_ENDPOINT}/#{S3_BUCKET}/attachment/1111163137454006b85553304efaffb7/original/[]&+.mp4")))))
+      s3_object = double(
+        content_length: 1024,
+        public_url: Addressable::URI.encode("#{AWS_S3_ENDPOINT}/#{S3_BUCKET}/attachment/1111163137454006b85553304efaffb7/original/[]&+.mp4")
+      )
+      allow(s3_object).to receive(:presigned_url).and_return(s3_object.public_url) if USING_MINIO
+      allow(Aws::S3::Resource).to receive(:new).and_return(double(bucket: double(object: s3_object)))
 
       product_file = create(:product_file, url: "#{AWS_S3_ENDPOINT}/#{S3_BUCKET}/attachment/0000063137454006b85553304efaffb7/original/[]&+.mp4")
       @product.product_files << product_file
@@ -212,6 +222,7 @@ describe("File embeds in product content editor", type: :system, js: true) do
         allow(bucket_double).to receive(:object).times.and_return(@s3_object_double)
         allow(@s3_object_double).to receive(:content_length).times.and_return(1)
         allow(@s3_object_double).to receive(:public_url).times.and_return(video_uri)
+        allow(@s3_object_double).to receive(:presigned_url).and_return(pdf_uri) if USING_MINIO
 
         visit edit_link_path(@product.unique_permalink) + "/content"
         within find_embed(name: "chapter2") do


### PR DESCRIPTION
Issue: https://github.com/antiwork/gumroad/pull/1773

Previous PR: https://github.com/antiwork/gumroad/pull/1966 

### What's changed?

This PR implemented alternative solution to my previous PR 1966 as mentioned above which now uses the same `public_url` as the `presigned_url` if using minio.

The pattern is picked up from `spec/controllers/purchase_controller_spec.rb` - 

```rb
      before :each do
        @s3_obj_public_url = "#{AWS_S3_ENDPOINT}/#{S3_BUCKET}/attachment/manual.pdf"

        s3_obj_double = double
        allow(s3_obj_double).to receive(:presigned_url).and_return(@s3_obj_public_url)
```

What it simply does it, it uses the same public url as the presigned url **only for local purposes**. This is so we make the failing specs work without altering the specs running on main CI.

#### How is it different from previous PR?

The previous approach created a url in format - `#{AWS_S3_ENDPOINT}/#{S3_BUCKET}/#{s3_key}` and used `allow_any_instance_of` which is generally discouraged and is bit of anti-pattern in the specs.

This PR might keep testing behaviour closer to production. 

### Before

Failing Specs:

https://github.com/antiwork/gumroad/actions/runs/19107742055/job/54596769458?pr=1773
https://github.com/antiwork/gumroad/actions/runs/19107742055/job/54596769346?pr=1773
https://github.com/antiwork/gumroad/actions/runs/19107742055/job/54596769483?pr=1773
https://github.com/antiwork/gumroad/actions/runs/19107742055/job/54596769339?pr=1773

### After

All the failing specs are passing here - 


<img width="1470" height="189" alt="Screenshot 2025-11-11 at 12 01 50 AM" src="https://github.com/user-attachments/assets/b33a6938-658e-4474-8925-bdbee1549464" />

<img width="1160" height="160" alt="Screenshot 2025-11-11 at 12 02 16 AM" src="https://github.com/user-attachments/assets/b8419f47-45d0-4fed-a427-4b1ca8c8b8a4" />

<img width="1470" height="189" alt="Screenshot 2025-11-11 at 12 02 41 AM" src="https://github.com/user-attachments/assets/4a6ef1e0-158e-41ce-9835-378d80dd358d" />

<img width="1470" height="163" alt="Screenshot 2025-11-11 at 12 03 36 AM" src="https://github.com/user-attachments/assets/cf8a9500-d0c1-4c0e-86a3-ab0507660fd4" />


### AI Disclosure

- Cursor used to recommend changed
- Code changed made and verified manually

### LiveStream Disclosure

- I have viewed all antiwork PRs
