### PR TITLE
Improve error message for invalid state selection

### DIFF
--- a/app/javascript/components/server-components/Settings/PaymentsPage.tsx
+++ b/app/javascript/components/server-components/Settings/PaymentsPage.tsx
@@ -602,7 +602,7 @@ const PaymentsPage = (props: Props) => {
       !complianceInfo.state
     ) {
       markFieldInvalid("state");
-      setErrorMessage({ message: "Please select a valid state." });
+      setErrorMessage({ message: "Please select a valid state or province." });
     }
     if (!complianceInfo.zip_code && complianceInfo.country !== "BW") {
       markFieldInvalid("zip_code");
@@ -676,7 +676,7 @@ const PaymentsPage = (props: Props) => {
         !complianceInfo.business_state
       ) {
         markFieldInvalid("business_state");
-        setErrorMessage({ message: "Please select a valid state." });
+        setErrorMessage({ message: "Please select a valid state or province." });
       }
       if (!complianceInfo.business_zip_code && props.user.country_code !== "BW") {
         markFieldInvalid("business_zip_code");

--- a/spec/requests/settings/payments_spec.rb
+++ b/spec/requests/settings/payments_spec.rb
@@ -338,7 +338,7 @@ describe("Payments Settings Scenario", type: :system, js: true) do
 
       expect do
         click_on("Update settings")
-        expect(page).to have_status(text: "Please select a valid state.")
+        expect(page).to have_status(text: "Please select a valid state or province.")
       end.to_not change { @user.alive_user_compliance_info.reload.state }
 
       select("California", from: "State")
@@ -382,7 +382,7 @@ describe("Payments Settings Scenario", type: :system, js: true) do
 
       expect do
         click_on("Update settings")
-        expect(page).to have_status(text: "Please select a valid state.")
+        expect(page).to have_status(text: "Please select a valid state or province.")
       end.to_not change { @user.alive_user_compliance_info.reload.business_state }
 
       find_field("State", match: :first).select("California")
@@ -1150,7 +1150,7 @@ describe("Payments Settings Scenario", type: :system, js: true) do
         click_on("Update settings")
         expect(page).to_not have_alert(text: "Thanks! You're all set.")
         expect(find_field("State")["aria-invalid"]).to eq "true"
-        expect(page).to have_status(text: "Please select a valid state.")
+        expect(page).to have_status(text: "Please select a valid state or province.")
 
         select("Rio de Janeiro", from: "State")
         click_on("Update settings")


### PR DESCRIPTION
Forgot to change this before merging https://github.com/antiwork/gumroad/pull/1953

As noted in https://github.com/antiwork/gumroad/pull/1951, not all countries call their subdivisions "states"