### PR TITLE
fix access admin product file link

### DIFF
--- a/app/javascript/components/Admin/Products/Header.tsx
+++ b/app/javascript/components/Admin/Products/Header.tsx
@@ -70,7 +70,7 @@ const AdminUsersProductsHeader = ({ product, isCurrentUrl }: Props) => (
       {product.alive_product_files.map((file) => (
         <a
           key={file.external_id}
-          href={Routes.admin_access_product_file_admin_product_path(product.id, file.external_id)}
+          href={Routes.admin_access_product_file_admin_product_path(product.unique_permalink, file.external_id)}
           className="button small"
           target="_blank"
           rel="noreferrer noopener"


### PR DESCRIPTION
This PR fixes https://github.com/antiwork/gumroad/issues/2008
- Fixes the access product file link by passing the product's unique permalink instead of the ID to the url helper, like it was in the old Admin UI, in which the download feature still works.

### AI Disclosure

No AI was used

---

Will merge this fix when the CI is green.