### PR TITLE
Feat: Send Slack Notifications via Email

### DIFF
--- a/app/mailers/slack_notification_mailer.rb
+++ b/app/mailers/slack_notification_mailer.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class SlackNotificationMailer < ApplicationMailer
+  def notification
+    @room_name = params[:room_name].to_s
+    @slack_channel = params[:slack_channel]
+    @sender = params[:sender]
+    @message_text = params[:message_text]
+    @attachments = Array(params[:attachments])
+    notifications_email = params[:notifications_email]
+
+    return unless notifications_email.present?
+
+    mail(
+      to: notifications_email,
+      from: ApplicationMailer::NOREPLY_EMAIL,
+      subject: formatted_subject
+    )
+  end
+
+  private
+    def formatted_subject
+      readable_room = @room_name.titleize
+      base_subject = Array(@message_text).flatten.compact.join(" ").squish
+      suffix = base_subject.presence || "Slack notification"
+      "[Gumroad Notifications][#{readable_room}] #{suffix}"
+    end
+end

--- a/app/sidekiq/slack_message_worker.rb
+++ b/app/sidekiq/slack_message_worker.rb
@@ -27,6 +27,22 @@ class SlackMessageWorker
     chat_room = CHAT_ROOMS[room_name.to_sym][:slack]
     return if chat_room.nil?
 
+    attachments = Array(options["attachments"] || options[:attachments])
+    notifications_email = GlobalConfig.get("NOTIFICATIONS_EMAIL_ADDRESS")
+
+    if notifications_email.present?
+      SlackNotificationMailer.with(
+        room_name:,
+        sender:,
+        message_text:,
+        attachments:,
+        slack_channel: chat_room[:channel],
+        notifications_email:
+      ).notification.deliver_now
+    end
+
+    return if Feature.active?(:skip_slack_notifications)
+
     hex_color = Color::CSS[color].html
 
     Timeout.timeout(SLACK_MESSAGE_SEND_TIMEOUT) do
@@ -35,12 +51,11 @@ class SlackMessageWorker
                  username: sender
       end
 
-      extra_attachments = (options["attachments"].nil? ? [] : options["attachments"])
       client.ping("", attachments: [{
         fallback: message_text,
         color: hex_color,
         text: message_text
-      }] + extra_attachments)
+      }] + attachments)
     end
   rescue StandardError, Timeout::Error => e
     unless e.message.include? "rate_limited"

--- a/app/views/slack_notification_mailer/notification.html.erb
+++ b/app/views/slack_notification_mailer/notification.html.erb
@@ -1,0 +1,18 @@
+<p>
+  Slack notification from <strong><%= @room_name.titleize %></strong> (<code>#<%= @slack_channel %></code>) sent by <strong><%= @sender %></strong>.
+</p>
+
+<p><strong>Message:</strong></p>
+<pre><%= @message_text %></pre>
+
+<% if @attachments.present? %>
+  <p><strong>Attachments:</strong></p>
+  <ul>
+    <% @attachments.each do |attachment| %>
+      <li>
+        <pre><%= attachment %></pre>
+      </li>
+    <% end %>
+  </ul>
+<% end %>
+


### PR DESCRIPTION
Fixes: https://github.com/antiwork/gumroad/issues/2011

### Feature

Added `SlackNotificationMailer` which utilises same fields as slack notification worker using earlier to send a copy of slack notifications as emails as well.

Added flag `skip_slack_notifications` to be set which when `true` will not send slack notifications and only mails.

Utilised `NOREPLY_EMAIL` and `NOTIFICATIONS_EMAIL_ADDRESS` as required in the issue for sender and receiver email addresses.

Created file `notification.html.erb` to have HTML body for slack notification email.

**Note** - Specs not added as `SlackMessageWorker` specs can be used to verify validation itself. The report generation specs can be run with flipper feature set true. 
Let me know is specs like below should be added for this slack notification mailer - 

```rb
# frozen_string_literal: true

require "spec_helper"

RSpec.describe SlackNotificationMailer, type: :mailer do
  describe "#notification" do
    let(:room_name) { :payments }
    let(:sender) { "VAT Reporting" }
    let(:message_text) { "Quarterly report is ready" }
    let(:attachments) { [{ title: "Report URL", text: "https://example.com" }] }
    let(:slack_channel) { "accounting" }
    let(:notifications_email) { "alerts@gumroad.com" }

    subject(:mail) do
      described_class.with(
        room_name:,
        sender:,
        message_text:,
        attachments:,
        slack_channel:,
        notifications_email:
      ).notification.deliver_now
    end

    it "sends to the configured notifications email" do
      expect(mail.to).to contain_exactly(notifications_email)
    end

    it "uses the noreply address as the from header" do
      expect(mail.from).to contain_exactly(ApplicationMailer::NOREPLY_EMAIL)
    end

    it "prefixes the subject with the expected format" do
      expect(mail.subject).to eq("[Gumroad Notifications][Payments] #{message_text}")
    end

    it "renders the message text in the body" do
      expect(mail.body.encoded).to include(message_text)
    end

    it "lists attachment metadata in the body" do
      expect(mail.body.encoded).to include(attachments.first.to_s)
    end
  end
end
```

#### Enable and Disable Flipper

```bash
# bin/rails c
Feature.activate(:skip_slack_notifications)
Feature.deactivate(:skip_slack_notifications)
```

### AI Disclosure

- Cursor auto mode used to suggest changes
- Code was then verified and modified manually for desired functionality

### LiveStream Disclosure

- I have viewed all antiwork PR livestreams