### PR TITLE
fix: duplicate anchor usage causing button layout issue on mobile

### DIFF
--- a/app/javascript/components/NewProductPage.tsx
+++ b/app/javascript/components/NewProductPage.tsx
@@ -1,4 +1,3 @@
-import { Link } from "@inertiajs/react";
 import cx from "classnames";
 import hands from "images/illustrations/hands.png";
 import * as React from "react";
@@ -222,12 +221,10 @@ const NewProductPage = ({
         title={show_orientation_text ? "Publish your first product" : "What are you creating?"}
         actions={
           <>
-            <Link href={Routes.products_path()} className="no-underline">
-              <NavigationButton>
-                <Icon name="x-square" />
-                <span>Cancel</span>
-              </NavigationButton>
-            </Link>
+            <NavigationButton href={Routes.products_path()}>
+              <Icon name="x-square" />
+              <span>Cancel</span>
+            </NavigationButton>
             {ai_generation_enabled ? (
               <Popover
                 open={aiPopoverOpen}


### PR DESCRIPTION
# Problem
The Cancel button used two different anchor wrappers (`<Link>` and `<NavigationButton href>`), which resulted in duplicated `<a>` tags

<img width="356" height="101" alt="image" src="https://github.com/user-attachments/assets/2f4b6a31-5188-483b-a992-b8a06c6be9b7" />

On mobile, this caused an issue where the Cancel button failed to fill the remaining horizontal space

| https://gumroad.com/products/new | Compared to https://gumroad.com/collaborators/new |
|-----------|-----------|
|  <img width="351" height="257" alt="image" src="https://github.com/user-attachments/assets/b2631fda-9b3d-4f46-968f-e49c149b57f7" />  |  <img width="355" height="231" alt="image" src="https://github.com/user-attachments/assets/0ad42d2a-cbe3-4482-b500-029d14cac76a" />  |

### Action Performed
1. Go to new product page https://gumroad.com/products/new on mobile
2. Observe that the cancel button does not fill the empty space

# Root cause analysis
Related PR https://github.com/antiwork/gumroad/pull/1627

Using both `<Link>` and `<NavigationButton href>` produced two anchor elements, creating invalid nesting and breaking mobile flexbox layout
https://github.com/antiwork/gumroad/blob/6de92e0655ec8d152a6864892c56b3d38698d68d/app/javascript/components/NewProductPage.tsx#L225-L230

# Solution
Remove the extra `<Link>` wrapper and just use `NavigationButton`

# Before After
### Mobile Dark Mode
| Before | After |
|-----------|-----------|
| <img width="337" height="785" alt="image" src="https://github.com/user-attachments/assets/eed7251a-97a8-4c36-81df-1a95fd999a40" /> | <img width="341" height="789" alt="image" src="https://github.com/user-attachments/assets/39d9edf4-61e7-4098-9fc6-0864b48bc4b8" /> |

### Mobile Light Mode
| Before | After |
|-----------|-----------|
|  <img width="336" height="785" alt="image" src="https://github.com/user-attachments/assets/48506a95-904f-49ff-9f37-ef0302fb75b1" />  |  <img width="334" height="785" alt="image" src="https://github.com/user-attachments/assets/57f63e3b-b20e-4dc2-8128-922eee3bb2f2" />  |

### Desktop Dark Mode (No changes)
| Before | After |
|-----------|-----------|
|  <img width="1469" height="793" alt="image" src="https://github.com/user-attachments/assets/3a77deba-9b7c-4d48-bc06-83043c70beff" />  |  <img width="1470" height="789" alt="image" src="https://github.com/user-attachments/assets/a8976227-edcc-4168-83cd-d02e0f3fb8f3" />  |

### Desktop Light Mode (No changes)
| Before | After |
|-----------|-----------|
|  <img width="1470" height="790" alt="image" src="https://github.com/user-attachments/assets/59a53474-55ae-43b2-85f2-9e6050bc6c05" />  |  <img width="1470" height="793" alt="image" src="https://github.com/user-attachments/assets/12814164-923a-462a-88ae-dc4ba2d2b4b5" />  |

# AI Disclosure
No AI was used for any part of this contribution.

# Confirmation
I have watched the Gumroad PR reviews live streaming video