### PR TITLE
Add "Report a bug" button in Help Center

### DIFF
--- a/app/javascript/components/server-components/support/Header.tsx
+++ b/app/javascript/components/server-components/support/Header.tsx
@@ -4,7 +4,7 @@ import { createCast } from "ts-safe-cast";
 
 import { register } from "$app/utils/serverComponentUtil";
 
-import { Button } from "$app/components/Button";
+import { Button, NavigationButton } from "$app/components/Button";
 import { Icon } from "$app/components/Icons";
 import { UnauthenticatedNewTicketModal } from "$app/components/support/UnauthenticatedNewTicketModal";
 import { UnreadTicketsBadge } from "$app/components/support/UnreadTicketsBadge";
@@ -50,13 +50,53 @@ export function SupportHeader({
               <Icon name="solid-search" />
             </a>
           ) : isAnonymousUserOnHelpCenter ? (
-            <Button color="accent" onClick={() => setIsUnauthenticatedNewTicketOpen(true)}>
-              Contact support
-            </Button>
+            <>
+              <NavigationButton
+                color="accent"
+                outline
+                href="https://github.com/antiwork/gumroad/issues/new"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-2"
+              >
+                <svg width="16" height="16" viewBox="0 0 98 96" xmlns="http://www.w3.org/2000/svg" className="fill-current">
+                  <path
+                    fillRule="evenodd"
+                    clipRule="evenodd"
+                    d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z"
+                    fill="currentColor"
+                  />
+                </svg>
+                Report a bug
+              </NavigationButton>
+              <Button color="accent" onClick={() => setIsUnauthenticatedNewTicketOpen(true)}>
+                Contact support
+              </Button>
+            </>
           ) : hasHelperSession ? (
-            <Button color="accent" onClick={onOpenNewTicket}>
-              New ticket
-            </Button>
+            <>
+              <NavigationButton
+                color="accent"
+                outline
+                href="https://github.com/antiwork/gumroad/issues/new"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-2"
+              >
+                <svg width="16" height="16" viewBox="0 0 98 96" xmlns="http://www.w3.org/2000/svg" className="fill-current">
+                  <path
+                    fillRule="evenodd"
+                    clipRule="evenodd"
+                    d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z"
+                    fill="currentColor"
+                  />
+                </svg>
+                Report a bug
+              </NavigationButton>
+              <Button color="accent" onClick={onOpenNewTicket}>
+                New ticket
+              </Button>
+            </>
           ) : null
         }
       >

--- a/spec/requests/help_center_spec.rb
+++ b/spec/requests/help_center_spec.rb
@@ -38,6 +38,7 @@ describe "Help Center", type: :system, js: true do
       visit "/help"
 
       expect(page).to have_button("Contact support")
+      expect(page).to have_link("Report a bug", href: "https://github.com/antiwork/gumroad/issues/new")
 
       click_on "Contact support"
 
@@ -59,6 +60,19 @@ describe "Help Center", type: :system, js: true do
       click_on "Send message"
       expect(page).to have_content("Your support ticket has been created successfully!")
       expect(page).not_to have_content("How can we help you today?")
+    end
+  end
+
+  describe "the user is authenticated with Helper session" do
+    before do
+      sign_in seller
+    end
+
+    it "shows the new ticket button and report a bug link" do
+      visit "/help"
+
+      expect(page).to have_button("New ticket")
+      expect(page).to have_link("Report a bug", href: "https://github.com/antiwork/gumroad/issues/new")
     end
   end
 end


### PR DESCRIPTION
Adds "Report a bug" button in Help Center that links to GitHub issue creation.

Closes #1996 

## Changes

- Added a "Report a bug" button to the Help Center header that links to [GitHub's issue creation page](https://github.com/antiwork/gumroad/issues/new)
- Added a GitHub icon to the "Report a bug" button for better visual recognition
- "Report a bug" appears on the left and "New ticket" (or "Contact support" for anonymous users) appears on the right
- Updated tests to verify the new button appears correctly for both logged-in and anonymous users

## Screenshots

**Before - Desktop**
<img width="3742" height="2396" src="https://github.com/user-attachments/assets/d216310f-7ba1-4ffd-9063-57b427f61ed4" />

**After - Desktop**
<img width="3742" height="2396" src="https://github.com/user-attachments/assets/85d9b5d2-e1fb-4cdb-9eaf-fe5f4fbbc119" />

**After - Desktop (light mode)**
<img width="3742" height="2396" src="https://github.com/user-attachments/assets/e2dd6abf-2404-45f2-849f-b1bff2fe355a" />

**Before - Mobile**
<img width="380" src="https://github.com/user-attachments/assets/4737aedd-5fd8-46c9-93fc-fd5b23a50fe5" />

**After - Mobile**
<img width="380" src="https://github.com/user-attachments/assets/39283058-70b2-4597-9bce-7bf992586fa0" />

**After - Mobile (light mode)**
<img width="380" src="https://github.com/user-attachments/assets/38e00946-6cc9-4d1a-b156-eee865da4b99" />

**Tests passing**
<img width="380" src="https://github.com/user-attachments/assets/f897eabc-9dc6-49a6-87fd-ab1571eeb1a0" />

## AI Disclosure
**Model:** Claude 4.5 Sonnet.
**Used for:** Unit tests. 
**Code review:** All changes manually reviewed and adjusted.