### PR TITLE
fix: Disable turning off PWYW setting for dollor 0 products

### DIFF
--- a/app/javascript/components/ProductEdit/ProductTab/PriceEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/PriceEditor.tsx
@@ -45,7 +45,13 @@ export const PriceEditor = ({
         id={`${uid}-price-cents`}
         currencyCode={currencyType}
         cents={priceCents}
-        onChange={(newAmount) => setPriceCents(newAmount ?? 0)}
+        onChange={(newAmount) => { 
+          const amount = newAmount ?? 0;
+          setPriceCents(amount);
+          if (amount === 0) {
+            setIsPWYW(true);
+          }
+        }}
         currencyCodeSelector={currencyCodeSelector}
       />
       <Details


### PR DESCRIPTION
# Description

Closes #2043

**Summary:**
This PR disables the ability to toggle off "Pay What You Want" (PWYW) when a product's price is set to $0. It also adds explanatory text ("Free products must allow customers to pay what they want") to the settings dropdown to clarify this behavior to the user.

**AI Disclosure:**
I used the Gemini 2.5 Pro for assisting in setting up gumroad locally on the system [ wsl ] and helping me debugging things..

# Testing
ran this command : bundle exec rspec spec/requests/products/edit/pwyw_spec.rb (as i did changes for the pwyw)
test this file and its successfully passed without any errors

**Test Suite Screenshot:**
<img width="1919" height="1014" alt="Screenshot 2025-11-18 011729" src="https://github.com/user-attachments/assets/4fc54758-0720-4fe0-8f0e-8f5ade77a03d" />


# Visuals
** Before **

https://github.com/user-attachments/assets/d0f92c3c-ffd4-44aa-8889-8ab214a4fe78


**After**


https://github.com/user-attachments/assets/7cdb71b0-68ef-405e-8e73-154a98e98383

