### PR TITLE
Add default discount code support across products and purchases

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -191,7 +191,8 @@ class LinksController < ApplicationController
                                   ChargeProcessor::DEFAULT_CURRENCY_CODE
     @pay_with_card_enabled = @product.user.pay_with_card_enabled?
     presenter = ProductPresenter.new(pundit_user:, product: @product, request:)
-    presenter_props = { recommended_by: params[:recommended_by], discount_code: params[:offer_code] || params[:code], quantity: (params[:quantity] || 1).to_i, layout: params[:layout], seller_custom_domain_url: }
+    discount_code = params[:offer_code] || params[:code] || @product.default_discount_code
+    presenter_props = { recommended_by: params[:recommended_by], discount_code:, quantity: (params[:quantity] || 1).to_i, layout: params[:layout], seller_custom_domain_url: }
     @product_props = params[:embed] || params[:overlay] ? presenter.product_props(**presenter_props) : presenter.product_page_props(**presenter_props)
     @body_class = "iframe" if params[:overlay] || params[:embed]
 
@@ -611,7 +612,7 @@ class LinksController < ApplicationController
                                    :should_include_last_post, :should_show_all_posts, :should_show_sales_count, :duration_in_months,
                                    :free_trial_enabled, :free_trial_duration_amount, :free_trial_duration_unit,
                                    :is_adult, :is_epublication, :product_refund_policy_enabled, :seller_refund_policy_enabled,
-                                   :refund_policy, :taxonomy_id)
+                                   :refund_policy, :taxonomy_id, :default_discount_code)
     end
 
     def paged_params

--- a/app/javascript/components/BundleEdit/ProductPreview.tsx
+++ b/app/javascript/components/BundleEdit/ProductPreview.tsx
@@ -101,6 +101,7 @@ export const ProductPreview = ({ showRefundPolicyModal }: { showRefundPolicyModa
           })),
           public_files: bundle.public_files,
           audio_previews_enabled: bundle.audio_previews_enabled,
+          default_discount_code: null,
         }}
         purchase={null}
         selection={{

--- a/app/javascript/components/Checkout/cartState.ts
+++ b/app/javascript/components/Checkout/cartState.ts
@@ -54,6 +54,7 @@ export type Product = {
   cross_sells: CrossSell[];
   archived: boolean;
   can_gift: boolean;
+  default_discount_code: string | null;
   bundle_products: {
     product_id: string;
     name: string;

--- a/app/javascript/components/Checkout/index.tsx
+++ b/app/javascript/components/Checkout/index.tsx
@@ -140,6 +140,13 @@ export const Checkout = ({
       void applyDiscount(code, true);
       url.searchParams.delete("code");
       window.history.replaceState(window.history.state, "", url.toString());
+    } else {
+      // Apply default discount codes if no URL code is present
+      cart.items.forEach((item) => {
+        if (item.product.default_discount_code) {
+          void applyDiscount(item.product.default_discount_code, false);
+        }
+      });
     }
   });
 

--- a/app/javascript/components/Product/index.tsx
+++ b/app/javascript/components/Product/index.tsx
@@ -138,6 +138,7 @@ export type Product = {
   }[];
   public_files: PublicFile[];
   audio_previews_enabled: boolean;
+  default_discount_code: string | null;
 };
 export type Purchase = {
   id: string;
@@ -253,9 +254,16 @@ export const Product = ({
 
   const notForSaleMessage = getNotForSaleMessage(product);
   const [discountCode, setDiscountCode] = React.useState(initialDiscountCode);
+
+  // Update internal discount state when prop changes
+  React.useEffect(() => {
+    setDiscountCode(initialDiscountCode);
+  }, [initialDiscountCode]);
+
   const selectionAttributes = applySelection(product, discountCode?.valid ? discountCode.discount : null, selection);
   let { basePriceCents } = selectionAttributes;
   const { priceCents, discountedPriceCents, pppDiscounted, isPWYW, maxQuantity } = selectionAttributes;
+
   React.useEffect(() => {
     if (maxQuantity !== null && selection.quantity > maxQuantity)
       setSelection?.({ ...selection, quantity: maxQuantity });

--- a/app/javascript/components/ProductEdit/ProductPreview.tsx
+++ b/app/javascript/components/ProductEdit/ProductPreview.tsx
@@ -1,9 +1,10 @@
 import * as React from "react";
 
+import { computeOfferDiscount } from "$app/data/offer_code";
 import { recurrenceIds } from "$app/utils/recurringPricing";
 
 import { useCurrentSeller } from "$app/components/CurrentSeller";
-import { Product } from "$app/components/Product";
+import { Product, ProductDiscount } from "$app/components/Product";
 import { useProductUrl } from "$app/components/ProductEdit/Layout";
 import { RefundPolicyModalPreview } from "$app/components/ProductEdit/RefundPolicy";
 import { useProductEditContext } from "$app/components/ProductEdit/state";
@@ -24,6 +25,43 @@ export const ProductPreview = ({ showRefundPolicyModal }: { showRefundPolicyModa
   } = useProductEditContext();
 
   const url = useProductUrl();
+  const [discountCode, setDiscountCode] = React.useState<ProductDiscount | null>(null);
+
+  // Fetch discount details when default_discount_code changes
+  React.useEffect(() => {
+    if (!product.default_discount_code) {
+      setDiscountCode(null);
+      return;
+    }
+
+    void (async () => {
+      try {
+        const discount = await computeOfferDiscount({
+          code: product.default_discount_code!,
+          products: {
+            [uniquePermalink]: { permalink: uniquePermalink, quantity: 1 },
+          },
+        });
+
+        if (discount.valid && "products_data" in discount) {
+          const discountData = discount.products_data[uniquePermalink];
+          if (discountData) {
+            setDiscountCode({
+              valid: true as const,
+              code: product.default_discount_code as unknown as string,
+              discount: discountData,
+            });
+          } else {
+            setDiscountCode(null);
+          }
+        } else {
+          setDiscountCode(null);
+        }
+      } catch {
+        setDiscountCode(null);
+      }
+    })();
+  }, [product.default_discount_code, uniquePermalink]);
 
   if (!currentSeller) return null;
 
@@ -137,6 +175,7 @@ export const ProductPreview = ({ showRefundPolicyModal }: { showRefundPolicyModa
     bundle_products: [],
     public_files: product.public_files,
     audio_previews_enabled: product.audio_previews_enabled,
+    default_discount_code: product.default_discount_code ?? null,
   };
 
   return product.native_type === "coffee" ? (
@@ -161,7 +200,7 @@ export const ProductPreview = ({ showRefundPolicyModal }: { showRefundPolicyModa
         twitter_handle: "",
       }}
       purchase={null}
-      discount_code={null}
+      discount_code={discountCode}
       wishlists={[]}
       selection={{
         optionId: null,
@@ -180,6 +219,7 @@ export const ProductPreview = ({ showRefundPolicyModal }: { showRefundPolicyModa
       <Product
         product={serializedProduct}
         purchase={null}
+        discountCode={discountCode}
         selection={{
           quantity: 1,
           optionId: serializedProduct.options[0]?.id ?? null,

--- a/app/javascript/components/ProductEdit/ProductTab/PriceEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/PriceEditor.tsx
@@ -5,6 +5,7 @@ import { CurrencyCode, formatPriceCentsWithoutCurrencySymbol } from "$app/utils/
 import { Details } from "$app/components/Details";
 import { PriceInput } from "$app/components/PriceInput";
 import { InstallmentPlanEditor } from "$app/components/ProductEdit/ProductTab/InstallmentPlanEditor";
+import { Select } from "$app/components/Select";
 import { Toggle } from "$app/components/Toggle";
 
 export const PriceEditor = ({
@@ -21,6 +22,9 @@ export const PriceEditor = ({
   onAllowInstallmentPlanChange,
   onNumberOfInstallmentsChange,
   currencyCodeSelector,
+  defaultDiscountCode,
+  onDefaultDiscountCodeChange,
+  availableOfferCodes = [],
 }: {
   priceCents: number;
   suggestedPriceCents: number | null;
@@ -35,6 +39,9 @@ export const PriceEditor = ({
   onAllowInstallmentPlanChange: (allowed: boolean) => void;
   onNumberOfInstallmentsChange: (numberOfInstallments: number) => void;
   currencyCodeSelector?: { options: CurrencyCode[]; onChange: (currencyCode: CurrencyCode) => void };
+  defaultDiscountCode?: string | null | undefined;
+  onDefaultDiscountCodeChange?: (code: string | null) => void;
+  availableOfferCodes?: Array<{ code: string; name: string | null }>;
 }) => {
   const uid = React.useId();
 
@@ -92,6 +99,53 @@ export const PriceEditor = ({
           onAllowInstallmentPaymentsChange={onAllowInstallmentPlanChange}
           onNumberOfInstallmentsChange={onNumberOfInstallmentsChange}
         />
+      ) : null}
+      {onDefaultDiscountCodeChange ? (
+        <Details
+          className="toggle"
+          open={defaultDiscountCode !== null && defaultDiscountCode !== undefined}
+          summary={
+            <Toggle
+              value={defaultDiscountCode !== null && defaultDiscountCode !== undefined}
+              onChange={(enabled) => {
+                if (!enabled) {
+                  onDefaultDiscountCodeChange(null);
+                } else if (!defaultDiscountCode) {
+                  // When enabling, set to empty string to open the dropdown
+                  onDefaultDiscountCodeChange("");
+                }
+              }}
+            >
+              Apply discount
+            </Toggle>
+          }
+        >
+          <div className="dropdown">
+            <fieldset>
+              <label htmlFor={`${uid}-discount-code`}>Discount code</label>
+              <Select
+                inputId={`${uid}-discount-code`}
+                value={
+                  defaultDiscountCode
+                    ? availableOfferCodes
+                        .map((offer) => ({
+                          id: offer.code,
+                          label: offer.name ? `${offer.name} (${offer.code})` : offer.code,
+                        }))
+                        .find((option) => option.id === defaultDiscountCode) ?? null
+                    : null
+                }
+                onChange={(option) => onDefaultDiscountCodeChange(option && "id" in option ? option.id : null)}
+                placeholder="Begin typing to select a discount code"
+                options={availableOfferCodes.map((offer) => ({
+                  id: offer.code,
+                  label: offer.name ? `${offer.name} (${offer.code})` : offer.code,
+                }))}
+                isClearable
+              />
+            </fieldset>
+          </div>
+        </Details>
       ) : null}
     </fieldset>
   );

--- a/app/javascript/components/ProductEdit/ProductTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/index.tsx
@@ -292,6 +292,9 @@ export const ProductTab = () => {
                           installment_plan: { ...product.installment_plan, number_of_installments: value },
                         })
                       }
+                      defaultDiscountCode={product.default_discount_code}
+                      onDefaultDiscountCodeChange={(code) => updateProduct({ default_discount_code: code })}
+                      availableOfferCodes={product.available_offer_codes || []}
                     />
                     {product.native_type === "commission" ? (
                       <p

--- a/app/javascript/components/ProductEdit/state.ts
+++ b/app/javascript/components/ProductEdit/state.ts
@@ -142,6 +142,8 @@ export type Product = {
   public_files: PublicFileWithStatus[];
   audio_previews_enabled: boolean;
   community_chat_enabled: boolean | null;
+  default_discount_code?: string | null;
+  available_offer_codes?: Array<{ code: string; name: string | null }>;
 } & (
   | { native_type: "call"; variants: Duration[] }
   | { native_type: "membership"; variants: Tier[] }

--- a/app/javascript/components/server-components/ProductEditPage.tsx
+++ b/app/javascript/components/server-components/ProductEditPage.tsx
@@ -77,6 +77,7 @@ type Props = {
   seller_refund_policy_enabled: boolean;
   seller_refund_policy: Pick<RefundPolicy, "title" | "fine_print">;
   cancellation_discounts_enabled: boolean;
+  available_offer_codes: Array<{ code: string; name: string | null }>;
 };
 
 const createContextValue = (props: Props) => ({
@@ -133,7 +134,10 @@ const findUpdatedContent = (product: Product, lastSavedProduct: Product) => {
 };
 
 const ProductEditPage = (props: Props) => {
-  const [product, setProduct] = React.useState(props.product);
+  const [product, setProduct] = React.useState({
+    ...props.product,
+    available_offer_codes: props.available_offer_codes,
+  });
   const [contentUpdates, setContentUpdates] = React.useState<ContentUpdates>(null);
   const [currencyType, setCurrencyType] = React.useState<CurrencyCode>(props.currency_type);
   const lastSavedProductRef = React.useRef<Product>(structuredClone(props.product));

--- a/app/javascript/data/product_edit.ts
+++ b/app/javascript/data/product_edit.ts
@@ -27,12 +27,14 @@ export const saveProduct = async (permalink: string, id: string, product: Produc
   editor.destroy();
   product.files = product.files.filter((file) => fileIds.has(file.id));
 
+  const { available_offer_codes, ...productData } = product;
+
   const response = await request({
     method: "POST",
     accept: "json",
     url: Routes.link_path(permalink),
     data: {
-      ...product,
+      ...productData,
       price_currency_type: currencyType,
       covers: product.covers.map(({ id }) => id),
       variants: product.variants.map(({ newlyAdded, ...variant }) => (newlyAdded ? { ...variant, id: null } : variant)),

--- a/app/javascript/utils/cart.ts
+++ b/app/javascript/utils/cart.ts
@@ -72,6 +72,7 @@ export const PLACEHOLDER_CART_ITEM: CartItem = {
     archived: false,
     bundle_products: [],
     can_gift: true,
+    default_discount_code: null,
   },
   price: 100,
   quantity: 1,

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -71,6 +71,7 @@ class Purchase < ApplicationRecord
   attr_json_data_accessor :perceived_price_cents
   attr_json_data_accessor :recommender_model_name
   attr_json_data_accessor :custom_fee_per_thousand
+  attr_json_data_accessor :used_default_discount_code
 
   alias_attribute :total_transaction_cents_usd, :total_transaction_cents
 

--- a/app/policies/link_policy.rb
+++ b/app/policies/link_policy.rb
@@ -76,6 +76,7 @@ class LinkPolicy < ApplicationPolicy
       :is_adult,
       :discover_fee_per_thousand,
       :taxonomy_id,
+      :default_discount_code,
       :product_refund_policy_enabled,
       :seller_refund_policy_enabled,
       :custom_domain,

--- a/app/presenters/product_presenter.rb
+++ b/app/presenters/product_presenter.rb
@@ -91,6 +91,7 @@ class ProductPresenter
         price_cents: product.price_cents,
         customizable_price: !!product.customizable_price,
         suggested_price_cents: product.suggested_price_cents,
+        default_discount_code: product.default_discount_code,
         **ProductPresenter::InstallmentPlanProps.new(product:).props,
         custom_button_text_option: product.custom_button_text_option.presence,
         custom_summary: product.custom_summary,
@@ -237,6 +238,7 @@ class ProductPresenter
         fine_print: product.user.refund_policy.fine_print,
       },
       cancellation_discounts_enabled: Feature.active?(:cancellation_discounts, product.user),
+      available_offer_codes: product.product_and_universal_offer_codes.map { |code| { code: code.code, name: code.name } },
     }
   end
 

--- a/app/presenters/product_presenter/product_props.rb
+++ b/app/presenters/product_presenter/product_props.rb
@@ -68,6 +68,7 @@ class ProductPresenter::ProductProps
         bundle_products: product.bundle_products.in_order.includes(:product, :variant).alive.map { bundle_product_props(_1, request:, recommended_by:, layout:) },
         public_files: product.alive_public_files.attached.map { PublicFilePresenter.new(public_file: _1).props },
         audio_previews_enabled: Feature.active?(:audio_previews, product.user),
+        default_discount_code: product.default_discount_code,
       },
       discount_code: discount_code_props(discount_code, quantity),
       purchase: purchase_props(product.purchase_info_for_product_page(pundit_user&.user, request.cookie_jar[:_gumroad_guid])),
@@ -96,7 +97,8 @@ class ProductPresenter::ProductProps
       if offer_code_response[:error_code].present?
         { valid: false, error_code: offer_code_response[:error_code] }
       else
-        { valid: true, code: discount_code, **offer_code_response[:products_data][product.unique_permalink] }
+        discount_data = offer_code_response[:products_data][product.unique_permalink]
+        { valid: true, code: discount_code, discount: discount_data[:discount] }
       end
     end
 

--- a/app/services/purchase/create_service.rb
+++ b/app/services/purchase/create_service.rb
@@ -242,6 +242,7 @@ class Purchase::CreateService < Purchase::BaseService
       purchase.seller = product.user
       purchase.is_gift_sender_purchase = is_gift? unless params_for_purchase.has_key?(:is_gift_receiver_purchase)
       purchase.offer_code = product.find_offer_code(code: purchase.discount_code.downcase.strip) if purchase.discount_code.present?
+      purchase.used_default_discount_code = purchase.discount_code.present? && product.default_discount_code.present? && purchase.discount_code.downcase.strip == product.default_discount_code.downcase.strip
       purchase.business_vat_id = (params_for_purchase[:business_vat_id] && params_for_purchase[:business_vat_id].size > 0 ? params_for_purchase[:business_vat_id] : nil)
       purchase.is_original_subscription_purchase = (product.is_recurring_billing && !params_for_purchase[:is_gift_receiver_purchase]) || purchase.is_installment_payment
       purchase.is_free_trial_purchase = product.free_trial_enabled? && !is_gift?

--- a/db/migrate/20251118000001_add_default_discount_code_to_links.rb
+++ b/db/migrate/20251118000001_add_default_discount_code_to_links.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDefaultDiscountCodeToLinks < ActiveRecord::Migration[7.1]
+  def change
+    add_column :links, :default_discount_code, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_11_10_144032) do
+ActiveRecord::Schema[7.1].define(version: 2025_11_18_000001) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -1121,6 +1121,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_11_10_144032) do
     t.string "native_type", default: "digital", null: false
     t.integer "discover_fee_per_thousand", default: 100, null: false
     t.string "support_email"
+    t.string "default_discount_code"
     t.index ["banned_at"], name: "index_links_on_banned_at"
     t.index ["custom_permalink"], name: "index_links_on_custom_permalink", length: 191
     t.index ["deleted_at"], name: "index_links_on_deleted_at"


### PR DESCRIPTION
- Introduced `default_discount_code` attribute in various models and components.
- Updated logic to apply default discount codes during checkout and product previews.
- Enhanced product editing capabilities to manage default discount codes.
- Added migration to include `default_discount_code` in the links table.

This pull request introduces support for setting and applying a default discount code to products, including full integration with the backend, admin/product editing UI, and the checkout flow. It allows sellers to specify a default discount code for a product, ensures this code is applied automatically in the absence of a user-supplied code, and updates all relevant data structures and UI components to handle this new property.

**Backend and API changes:**

* Added `default_discount_code` as a permitted and editable attribute for products, and ensured it is included in product serialization and strong parameters. [[1]](diffhunk://#diff-1c8ec4c0182d961c15c9e3fbb83f72df30c7809726d4f055e1cb18b857f0f111L614-R615) [[2]](diffhunk://#diff-19e9e810bf4825c5af53afbdfbcf80e2c9dcf8df8207baa71a3710151b01cb5eR79) [[3]](diffhunk://#diff-49f17cf4d075be1cf2602cc5a4fc0b9bc02c6c69a5ca85ac7545e6aeccc488b2R94) [[4]](diffhunk://#diff-12953f0908b1fb916d91033479ead7672532a74b072c577913bb5a311c21a06aR71) [[5]](diffhunk://#diff-49f17cf4d075be1cf2602cc5a4fc0b9bc02c6c69a5ca85ac7545e6aeccc488b2R241)
* Updated the `links_controller` to use the product's `default_discount_code` if no discount code is provided in the URL, and included this in the presenter props.
* Added `used_default_discount_code` as a tracked property on purchases, likely to support analytics or business logic.

**Checkout and discount application:**

* Modified the checkout logic to automatically apply a product's `default_discount_code` if no discount code is present in the URL, ensuring the discount is applied seamlessly for eligible products.
* Refined how discount code data is handled and passed to components, including updating the `discount_code_props` method to provide the correct discount data.

**Product editing and admin UI:**

* Added a UI control in the product price editor tab for selecting a default discount code from available offer codes, with full support for enabling/disabling and clearing the selection. [[1]](diffhunk://#diff-4881a6ba3cf7e4c9c0916325dd6cd87054696ddd8d14ad8751216da927026375R25-R27) [[2]](diffhunk://#diff-4881a6ba3cf7e4c9c0916325dd6cd87054696ddd8d14ad8751216da927026375R42-R44) [[3]](diffhunk://#diff-4881a6ba3cf7e4c9c0916325dd6cd87054696ddd8d14ad8751216da927026375R103-R149) [[4]](diffhunk://#diff-f2866cb2ea0ea066046449bba72553dba38f2fe7ab4f244ff9e8dfc19a3b1185R295-R297)
* Ensured the list of available offer codes is provided to the product edit page and preserved through the product editing state and save operations. [[1]](diffhunk://#diff-3778c60259fbe195594f43e1a950372ac95223dc82018357f062121b830805b9R80) [[2]](diffhunk://#diff-3778c60259fbe195594f43e1a950372ac95223dc82018357f062121b830805b9L136-R140) [[3]](diffhunk://#diff-6326c4832e27140fdb51992c1ebc1eb14c0365ea53abd99ac62c3a0930c31844R145-R146) [[4]](diffhunk://#diff-2dbac21fb9cf23b64aa3b8ddfcfd356f035c5849b9f4239cd617e71235b51c56R30-R37)

**Frontend data model and state updates:**

* Added `default_discount_code` to all relevant product and cart item types in TypeScript, ensuring consistent access throughout the frontend. [[1]](diffhunk://#diff-d7bbe24068bc9708428c01336d6c063735b6b171a362234abc40bd53858aecaaR57) [[2]](diffhunk://#diff-af6541601a8e0790c00b64d1129d899f2c0eff8728aec520e217c42b4dce0823R141) [[3]](diffhunk://#diff-56c4efbd013d63b884d527d01caed57d6b1f04462459deeffd22af9ddf8037edR75) [[4]](diffhunk://#diff-f6bfab61751c8424f5a3b0b79c563d2a3c3558efdf9d406293d541e2e7db6b8dR178)
* Updated product preview and product components to handle and display the default discount code, including fetching and applying discount details as needed. [[1]](diffhunk://#diff-b6ae0709283b315d710fb7c0b0fe0afb62dd71fa5ec56b7501ad49555f789cf5R104) [[2]](diffhunk://#diff-f6bfab61751c8424f5a3b0b79c563d2a3c3558efdf9d406293d541e2e7db6b8dR28-R64) [[3]](diffhunk://#diff-f6bfab61751c8424f5a3b0b79c563d2a3c3558efdf9d406293d541e2e7db6b8dL164-R203) [[4]](diffhunk://#diff-f6bfab61751c8424f5a3b0b79c563d2a3c3558efdf9d406293d541e2e7db6b8dR222) [[5]](diffhunk://#diff-af6541601a8e0790c00b64d1129d899f2c0eff8728aec520e217c42b4dce0823R257-R266)

These changes together provide a seamless experience for sellers to set a default discount code on their products and for buyers to automatically receive the intended discount during purchase, even if they do not manually enter a code.

closes #2053 