### PR TITLE
fix(ui): inconsistent button styles in Embed media modal

### DIFF
--- a/app/javascript/components/ProductEdit/ContentTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/index.tsx
@@ -618,7 +618,7 @@ const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: string | 
                           }}
                         />
                         <Icon name="upload-fill" />
-                          <h4>Upload</h4>
+                        <h4>Upload</h4>
                       </label>
                     </Tab>
                   </Tabs>


### PR DESCRIPTION
Fix #2082 
## Summary
The “Embed media” modal displays misaligned action buttons — the Upload button overlaps its border, and the Embed link button uses a different UI style. The UI has been updated to match both buttons and ensure a consistent design. Previously, these differences resulted in uneven spacing and broke the visual balance of the button group.


## Desktop

## Before

<img width="1507" height="730" alt="Screenshot 2025-11-19 at 4 28 32 PM" src="https://github.com/user-attachments/assets/061c463d-b1e0-4f39-9745-963535841d32" /> 

##

<img src="https://github.com/user-attachments/assets/b6095275-4a1f-4896-ab5c-52e9d5f59838" />

## After

<img width="1509" height="733" alt="Screenshot 2025-11-19 at 4 15 50 PM" src="https://github.com/user-attachments/assets/35720cdf-75c8-41ae-8537-d403973f59a6" />

##

<img src="https://github.com/user-attachments/assets/74b4f8d6-3c61-40f5-91f4-d5052d1a0860" />

## Mobile
| Before | After |
|--------|--------|
| <img src="https://github.com/user-attachments/assets/6fb82989-e1e7-409e-bc81-2f5fb60189c2" width="450" /> | <img src="https://github.com/user-attachments/assets/8b5f830c-e18a-41b3-ab85-39a8df1d8139" width="450" /> |

| Before | After |
|--------|--------|
| <img src="https://github.com/user-attachments/assets/59dbd494-8a91-4374-a186-064bf547b5c2" width="450" /> | <img src="https://github.com/user-attachments/assets/08f95ba6-e23f-498b-82b0-62e96743e401" width="450" /> |


## AI Usage
No AI was used to generate any of this code.

## Confirmation
I have watched the Gumroad PR reviews live streaming video.

## Self-Review
I have self-reviewed all the code that I have written.
