### PR TITLE
feat(dev): add Docker image for app

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -1,0 +1,90 @@
+# syntax=docker/dockerfile:1
+ARG RUBY_VERSION=3.4.3
+FROM ruby:${RUBY_VERSION}-slim-bullseye
+
+ENV APP_DIR=/workspace \
+    BUNDLE_PATH=/bundle_path \
+    GEM_HOME=/bundle_path \
+    BUNDLE_BIN=/bundle_path/bin \
+    PATH=/bundle_path/bin:/usr/local/bundle/bin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Packages
+RUN apt-get update -y -qq \
+    && apt-get install -y --no-install-recommends \
+      build-essential \
+      ca-certificates \
+      curl \
+      ffmpeg \
+      fonts-dejavu \
+      fonts-takao \
+      fonts-wqy-microhei \
+      fonts-wqy-zenhei \
+      gnupg \
+      imagemagick \
+      jq \
+      less \
+      libcurl4-openssl-dev \
+      liblzma-dev \
+      default-libmysqlclient-dev \
+      libnss3-tools \
+      libssl-dev \
+      libtag1-dev \
+      libvips-dev \
+      libxml2-dev \
+      libxslt1-dev \
+      libyaml-dev \
+      default-mysql-client \
+      pdftk \
+      percona-toolkit \
+      pkg-config \
+      python3 \
+      sudo \
+      unzip \
+      vim \
+      wget \
+      zlib1g-dev \
+      git \
+    \
+    # Mkcert
+    && export MKCERT_VERSION=1.4.4 \
+    && wget -qO /usr/local/bin/mkcert "https://github.com/FiloSottile/mkcert/releases/download/v${MKCERT_VERSION}/mkcert-v${MKCERT_VERSION}-linux-amd64" \
+    && chmod +x /usr/local/bin/mkcert \
+    \
+    # Node v20
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && corepack enable \
+    && npm install -g npm@10.8.2 \
+    \
+    # Update ImageMagick configuration
+    && sed -r 's/(name="memory" value=")[^"]+"/\11GiB"/' -i /etc/ImageMagick-6/policy.xml \
+    && sed -r 's/(name="disk" value=")[^"]+"/\18GiB"/' -i /etc/ImageMagick-6/policy.xml \
+    && sed -r 's/(name="width" value=")[^"]+"/\150KP"/' -i /etc/ImageMagick-6/policy.xml \
+    && sed -r 's/(name="height" value=")[^"]+"/\150KP"/' -i /etc/ImageMagick-6/policy.xml \
+    \
+    # Cleanup
+    && apt-get clean autoclean \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+WORKDIR ${APP_DIR}
+
+# Bundler
+COPY Gemfile Gemfile.lock .ruby-version ${APP_DIR}/
+RUN gem install bundler:$(awk '/BUNDLED WITH/{getline; print}' Gemfile.lock | tr -d " ") \
+    && bundle config set path "${BUNDLE_PATH}" \
+    && bundle install --retry 3 --without production test \
+    && gem install foreman \
+    && rm -rf /usr/local/bundle/cache/*.gem \
+    && rm -rf ~/.bundle/cache
+
+# Node dependencies
+COPY package*.json ${APP_DIR}/
+RUN npm install
+
+COPY docker/app/entrypoint.sh /usr/local/bin/docker-entrypoint
+RUN chmod +x /usr/local/bin/docker-entrypoint
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint"]

--- a/docker/app/entrypoint.sh
+++ b/docker/app/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "${APP_DIR}"
+
+mkdir -p tmp/pids
+rm -f tmp/pids/server.pid
+
+bin/rails db:prepare
+bin/rails runner 'DevTools.delete_all_indices_and_reindex_all' || echo "Warning: reindex failed, continuing..."
+
+exec bin/dev


### PR DESCRIPTION
## Part of the submission: https://github.com/antiwork/gumroad/pull/1690
**Issue:** https://github.com/antiwork/gumroad/issues/865 – Add all-in-one Docker setup  
Remake of PR https://github.com/antiwork/gumroad/pull/1908 with a better description.

## Problem

The project didn’t have a dedicated `Dockerfile` for the Gumroad app.  
This file is needed to support a full **Docker Compose all-in-one environment** so all services can run together for local development.

## Solution

A new `Dockerfile` has been added to build the Gumroad app image.  
It installs all system dependencies, Ruby gems, and npm packages so the environment is consistent across setups.

The entrypoint handles the usual boot tasks: database setup, Elasticsearch reindexing, and then launches `bin/dev`.

## Result

A short demo video shows the workflow:

- Terminal 1: run `make local` to start the existing Docker Compose stack (databases, Redis, etc.).
- Terminal 2: build the app image using  
  `docker build -f docker/app/Dockerfile -t gumroad-app .`  
  then start it with:  
  `docker run --network host -v "$(pwd):/workspace" -v /workspace/node_modules gumroad-app`
- Open `https://gumroad.dev` to confirm the app is running.

*The build step is sped up in the demo video.*

https://github.com/user-attachments/assets/fc0600e8-49db-4ddf-a444-3452142d8c4c

### Note
No AI was used in writing this code.