### PR TITLE
  fix: admin navigation menu not closing on mobile after navigation

### DIFF
--- a/app/javascript/components/Admin/Nav/index.tsx
+++ b/app/javascript/components/Admin/Nav/index.tsx
@@ -1,11 +1,23 @@
-import { Link, usePage } from "@inertiajs/react";
+import { Link, router, usePage } from "@inertiajs/react";
 import * as React from "react";
 
 import AdminNavFooter from "$app/components/Admin/Nav/Footer";
 import { useAppDomain } from "$app/components/DomainSettings";
-import { Nav as NavFramework, NavLink, InertiaNavLink, NavSection } from "$app/components/Nav";
+import { Nav as NavFramework, NavLink, InertiaNavLink, NavSection, useNav } from "$app/components/Nav";
 
 type PageProps = { title: string };
+
+const CloseOnNavigate = () => {
+  const nav = useNav();
+  const close = nav?.close;
+
+  React.useEffect(() => {
+    if (!close) return;
+    return router.on("navigate", close);
+  }, [close]);
+
+  return null;
+};
 
 const Nav = () => {
   const { title } = usePage<PageProps>().props;
@@ -13,6 +25,7 @@ const Nav = () => {
 
   return (
     <NavFramework title={title} footer={<AdminNavFooter />}>
+      <CloseOnNavigate />
       <NavSection>
         <InertiaNavLink
           text="Suspend users"

--- a/spec/requests/admin_nav_mobile_spec.rb
+++ b/spec/requests/admin_nav_mobile_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe("Admin - Nav - Mobile", :js, :mobile_view, type: :system) do
+  let(:admin) { create(:admin_user) }
+
+  before do
+    login_as admin
+  end
+
+  it "auto closes the menu when navigating to a different page" do
+    visit admin_suspend_users_path
+
+    click_on "Toggle navigation"
+    expect(page).to have_link("Suspend users")
+    expect(page).to have_link("Block emails")
+
+    click_on "Block emails"
+    expect(page).to_not have_link("Suspend users")
+    expect(page).to_not have_link("Block emails")
+  end
+end


### PR DESCRIPTION

## What PR Does?
- Fixes issue where the admin navigation menu remains open on mobile after clicking a link
- add test coverage for the changes

## Before:

https://github.com/user-attachments/assets/edd192ad-2eb7-4315-9855-a79427fab17e

## After:

https://github.com/user-attachments/assets/88a54775-cdc9-451f-b8df-b9d3074d1ba7

## Test Result (local run): 
<img width="693" height="153" alt="Screenshot 2025-11-23 at 4 19 51 PM" src="https://github.com/user-attachments/assets/0c04d46c-9fac-4d0b-8406-0e2d532a062b" />


### AI Disclosure:
- used claude code sonnet 4.5 to add test

### Live Stream Disclosure:
- watched all 4 live streams