### PR TITLE
Fix scroll issue for upsell on Modal

### DIFF
--- a/app/javascript/components/Modal.tsx
+++ b/app/javascript/components/Modal.tsx
@@ -29,7 +29,7 @@ export const Modal = ({
       <Dialog.Content
         aria-modal={modal}
         className={classNames(
-          "bg-filled fixed top-[50%] left-[50%] z-31 flex max-w-175 min-w-80 translate-[-50%] flex-col gap-4 rounded border border-border p-8 shadow-lg dark:shadow-none",
+          "bg-filled fixed top-[50%] left-[50%] z-31 flex max-h-[85vh] max-w-175 min-w-80 translate-[-50%] flex-col gap-4 overflow-y-auto rounded border border-border p-8 shadow-lg dark:shadow-none",
           className,
         )}
         onOpenAutoFocus={(e) => {


### PR DESCRIPTION
Fixes #2118 

Fixes issue of the Add to Cart button being out of view due to overflow, not ideal for upsell as described in the original issue. 

Added stying to standardise max height of modal and enabling overflow-y scrolling.


Before fix:



After fix:

https://github.com/user-attachments/assets/f6a22798-149e-45ad-83a0-22f416581e22


