### PR TITLE
Support the same new ticket URL for anonymous and logged-in users

### DIFF
--- a/app/javascript/components/server-components/support/Header.tsx
+++ b/app/javascript/components/server-components/support/Header.tsx
@@ -22,20 +22,22 @@ export function SupportHeader({
   recaptchaSiteKey?: string | null;
 }) {
   const { pathname, searchParams } = new URL(useOriginalLocation());
-  const isHelpArticle =
-    pathname.startsWith(Routes.help_center_root_path()) && pathname !== Routes.help_center_root_path();
-  const isAnonymousUserOnHelpCenter = !hasHelperSession && pathname === Routes.help_center_root_path();
+  const isHelpCenterHome = pathname === Routes.help_center_root_path();
+  const isHelpArticle = pathname.startsWith(Routes.help_center_root_path()) && !isHelpCenterHome;
+  const isAnonymousUserOnHelpCenter = !hasHelperSession && isHelpCenterHome;
 
   const [isUnauthenticatedNewTicketOpen, setIsUnauthenticatedNewTicketOpen] = React.useState(
     isAnonymousUserOnHelpCenter && !!searchParams.get("new_ticket"),
   );
 
   React.useEffect(() => {
-    if (isAnonymousUserOnHelpCenter) {
-      const url = new URL(location.href);
-      if (!isUnauthenticatedNewTicketOpen && url.searchParams.get("new_ticket")) {
+    const url = new URL(location.href);
+    if (url.searchParams.get("new_ticket")) {
+      if (isAnonymousUserOnHelpCenter && !isUnauthenticatedNewTicketOpen) {
         url.searchParams.delete("new_ticket");
         history.replaceState(null, "", url.toString());
+      } else if (hasHelperSession && isHelpCenterHome) {
+        onOpenNewTicket();
       }
     }
   }, [isUnauthenticatedNewTicketOpen, isAnonymousUserOnHelpCenter]);

--- a/spec/requests/help_center_spec.rb
+++ b/spec/requests/help_center_spec.rb
@@ -48,6 +48,15 @@ describe "Help Center", type: :system, js: true do
       expect(page).to have_field("Tell us about your issue or question...")
     end
 
+    it "opens the new ticket modal when the new ticket parameter is present" do
+      visit "/help?new_ticket=true"
+      within_modal "How can we help you today?" do
+        expect(page).to have_field("Your email address")
+        expect(page).to have_field("Subject")
+        expect(page).to have_field("Tell us about your issue or question...")
+      end
+    end
+
     it "successfully submits a support ticket form" do
       visit "/help"
 
@@ -73,6 +82,15 @@ describe "Help Center", type: :system, js: true do
 
       expect(page).to have_button("New ticket")
       expect(page).to have_link("Report a bug", href: "https://github.com/antiwork/gumroad/issues/new")
+    end
+
+    it "opens the new ticket modal when the new ticket parameter is present" do
+      visit "/help?new_ticket=true"
+      within_modal "How can we help you today?" do
+        expect(page).not_to have_field("Your email address")
+        expect(page).to have_field("Subject")
+        expect(page).to have_field("Tell us about your issue or question...")
+      end
     end
   end
 end


### PR DESCRIPTION
## What

Updates the help center so that `/help?new_ticket=true` works for both anonymous and logged in users - for anonymous it opens the ticket form, and when logged in it redirects to the tickets page with the form open.

### Authenticated

https://github.com/user-attachments/assets/11247296-f036-4b89-8e37-57f6744cb860

### Unauthenticated

https://github.com/user-attachments/assets/7946235e-c011-4733-8fe1-b30e7c112f59

## Why

Currently when we redirect people from other channels (e.g. GitHub issues) to our support system, we can't give people a consistent URL to open the modal. This will make it easier for us to tell people how to open tickets.