### PR TITLE
fix: keep recaptcha_key on SubscriptionManager optional for development mode

### DIFF
--- a/app/javascript/components/server-components/SubscriptionManager.tsx
+++ b/app/javascript/components/server-components/SubscriptionManager.tsx
@@ -92,7 +92,7 @@ type Props = {
   us_states: string[];
   ca_provinces: string[];
   used_card: SavedCreditCard | null;
-  recaptcha_key: string;
+  recaptcha_key: string | null;
   paypal_client_id: string;
 };
 


### PR DESCRIPTION
### what PR does?
- make recaptcha_key on [SubscriptionManager.tsx‎](https://github.com/antiwork/gumroad/pull/2130/files#diff-51d9336596ca654650c9841653c6b60a8861248f4fcf012a8c55cfe549a2cfa0) optional for development mode
related PR: #1198

## Before:  

https://github.com/user-attachments/assets/ea3e93f3-3416-43ff-9e87-01e7d0f20c3d



## After: 

https://github.com/user-attachments/assets/7ac07707-200e-4771-8783-6bf453adcef9

### AI Disclosure:
- no AI used

### live stream disclosure:
- watched all live streams


