### PR TITLE
fix: Add underline styling to team member removal undo button

### DIFF
--- a/app/javascript/components/server-components/Settings/TeamPage.tsx
+++ b/app/javascript/components/server-components/Settings/TeamPage.tsx
@@ -271,7 +271,7 @@ const TeamMembersSection = ({
             {deletedMember.name !== "" ? deletedMember.name : deletedMember.email} was removed from team members
           </div>
           <button
-            className="close"
+            className="close underline"
             type="button"
             onClick={asyncVoid(async () => {
               try {


### PR DESCRIPTION
# Problem
The "Undo" button that appears after removing a team member lacks visual styling, making it unclear to users that it's clickable

### Action Performed
1. Go to Settings > Team
2. Remove a team member
3. Observe the "Undo" text in the success alert

### Actual Result
The undo text appears in normal text style

### Expected Result
The undo button should be visually styled with underline to indicate it's clickable

# Root cause analysis
Seems like we missed updating it in [this PR](https://github.com/antiwork/gumroad/pull/1767)

# Solution
Added the `underline` Tailwind class like we did here:
https://github.com/antiwork/gumroad/blob/301e40dacaa851c01a27262cade1de4b836ce8f0/app/javascript/components/ProductEdit/ShareTab/index.tsx#L139-L140

# Before After
### Desktop Dark Mode
| Before | After |
|-----------|-----------|
|  <img width="1470" height="794" alt="image" src="https://github.com/user-attachments/assets/254892fa-7524-483f-969f-4c994f5cf4f9" />  |  <img width="1470" height="800" alt="image" src="https://github.com/user-attachments/assets/bb2c8842-490d-457d-a268-66000fcddee6" />  |

### Desktop Light Mode
| Before | After |
|-----------|-----------|
|  <img width="1470" height="794" alt="image" src="https://github.com/user-attachments/assets/b71d5f9e-f905-4007-8ec4-ca29bf44b1de" />  |  <img width="1470" height="796" alt="image" src="https://github.com/user-attachments/assets/3107fec3-fa3f-4de9-8fd8-eecd9699d149" />  |

### Mobile Dark Mode
| Before | After |
|-----------|-----------|
| <img width="310" height="662" alt="image" src="https://github.com/user-attachments/assets/f3df5f98-6995-4cf5-9d96-bd3854fcca0b" /> | <img width="309" height="657" alt="image" src="https://github.com/user-attachments/assets/5ec2d0be-51ff-463e-aeb8-66301e3e1405" /> |

### Mobile Light Mode
| Before | After |
|-----------|-----------|
|  <img width="311" height="660" alt="image" src="https://github.com/user-attachments/assets/ca7c4ba8-3152-4250-8205-570f4695679c" />  |  <img width="309" height="660" alt="image" src="https://github.com/user-attachments/assets/a0708c77-0a63-4cb3-a0be-7b633da286c8" />  |

# AI Disclosure
No AI was used for any part of this contribution.

# Confirmation
I have watched the Gumroad PR reviews live streaming video