### PR TITLE
Fix sparkle in Black friday hero dark mode

### DIFF
--- a/app/javascript/components/server-components/Discover/index.tsx
+++ b/app/javascript/components/server-components/Discover/index.tsx
@@ -105,21 +105,21 @@ const BlackFridayBanner = ({
   currencyCode: CurrencyCode;
 }) => (
   <div className="flex h-full shrink-0 items-center gap-x-4 [&>*]:flex-shrink-0">
-    <span className="mx-2 inline-block text-lg">✦</span>
+    <span className="mx-2 inline-block text-lg text-black">✦</span>
     <span className="flex items-center text-xl font-medium text-black">BLACK FRIDAY IS LIVE</span>
     {stats.active_deals_count > 0 && (
       <>
-        <span className="mx-2 inline-block text-lg">✦</span>
+        <span className="mx-2 inline-block text-lg text-black">✦</span>
         <span className="flex items-center text-xl font-medium text-black">
           <span className="mr-1.5 font-bold">{stats.active_deals_count.toLocaleString()}</span>ACTIVE DEALS
         </span>
       </>
     )}
-    <span className="mx-2 inline-block text-lg">✦</span>
+    <span className="mx-2 inline-block text-lg text-black">✦</span>
     <span className="flex items-center text-xl font-medium text-black">CREATOR-MADE PRODUCTS</span>
     {stats.revenue_cents > 0 && (
       <>
-        <span className="mx-2 inline-block text-lg">✦</span>
+        <span className="mx-2 inline-block text-lg text-black">✦</span>
         <span className="flex items-center text-xl font-medium text-black">
           <span className="mr-1.5 font-bold">
             {formatPriceCentsWithCurrencySymbol(currencyCode, stats.revenue_cents, { symbolFormat: "short" })}
@@ -128,11 +128,11 @@ const BlackFridayBanner = ({
         </span>
       </>
     )}
-    <span className="mx-2 inline-block text-lg">✦</span>
+    <span className="mx-2 inline-block text-lg text-black">✦</span>
     <span className="flex items-center text-xl font-medium text-black">BIG SAVINGS</span>
     {stats.average_discount_percentage > 0 && (
       <>
-        <span className="mx-2 inline-block text-lg">✦</span>
+        <span className="mx-2 inline-block text-lg text-black">✦</span>
         <span className="flex items-center text-xl font-medium text-black">
           <span className="mr-1.5 font-bold">{stats.average_discount_percentage}%</span>AVERAGE DISCOUNT
         </span>


### PR DESCRIPTION
 I noticed the sparkles in the hero section aren’t displaying correctly in dark mode, so I’m pushing this fix. The color is currently white but should be black.
Before
<img width="202" height="54" alt="Screenshot 2025-11-27 at 21 29 55" src="https://github.com/user-attachments/assets/5d9fcaf7-ab10-4359-8358-cd44a1401e50" />
After
<img width="313" height="68" alt="Screenshot 2025-11-27 at 21 30 11" src="https://github.com/user-attachments/assets/91987b07-ef27-47ba-a17d-3af5ef45759e" />
