### PR TITLE
Fix table hover state

### DIFF
--- a/app/javascript/components/ui/Table.tsx
+++ b/app/javascript/components/ui/Table.tsx
@@ -98,7 +98,8 @@ export const TableRow = ({
       className={classNames(
         "block rounded-sm border border-border lg:table-row",
         rowGroup === "body" && "bg-background",
-        selected && "cursor-pointer bg-active-bg",
+        selected != null && "cursor-pointer hover:bg-active-bg",
+        selected && "bg-active-bg",
         className,
       )}
       {...props}


### PR DESCRIPTION
Fixes a regression from #1989 which removed the hover background and pointer cursor from selectable table rows.