### PR TITLE
Hide reCAPTCHA badge on the new ticket form

### DIFF
--- a/app/javascript/components/support/UnauthenticatedNewTicketModal.tsx
+++ b/app/javascript/components/support/UnauthenticatedNewTicketModal.tsx
@@ -115,6 +115,7 @@ export function UnauthenticatedNewTicketModal({
           />
         </div>
         {recaptchaContainer}
+        {/* We hide the reCAPTCHA badge to avoid it overlapping the modal content and show this standard disclaimer instead (see https://developers.google.com/recaptcha/docs/faq#id-like-to-hide-the-recaptcha-badge.-what-is-allowed) */}
         <p className="text-sm text-muted">
           This site is protected by reCAPTCHA and the Google{" "}
           <a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
Noticed this visual bug when fixing #2104.

The reCAPTCHA badge overlays the submit button and looks bad on the new ticket form (it's position:fixed but anchored to the modal instead of the page due to the transform), so this hides it and adds a disclaimer according to the [reCAPTCHA FAQ](https://developers.google.com/recaptcha/docs/faq#id-like-to-hide-the-recaptcha-badge.-what-is-allowed)

### Before

<img width="837" height="617" alt="Screenshot 2025-11-28 at 16 09 44" src="https://github.com/user-attachments/assets/39815e13-2553-41d2-8765-6d1814cdece4" />

### After

<img width="882" height="635" alt="Screenshot 2025-11-28 at 16 04 41" src="https://github.com/user-attachments/assets/76c63d0d-5f55-475f-afba-3246bef56828" />

## AI Disclosure

Pasted the FAQ into Sonnet 4.5 for the initial implementation; reviewed and edited by me.