### PR TITLE
Enable PayPal payouts for creators in Egypt

### DIFF
--- a/app/modules/user/feature_status.rb
+++ b/app/modules/user/feature_status.rb
@@ -24,6 +24,14 @@ class User
         !active_preorders?(charge_processor_id: PaypalChargeProcessor.charge_processor_id)
     end
 
+    def can_setup_bank_payouts?
+      active_bank_account.present? || native_payouts_supported? || signed_up_from_united_arab_emirates?
+    end
+
+    def can_setup_paypal_payouts?
+      payment_address.present? || !native_payouts_supported? || signed_up_from_united_arab_emirates? || signed_up_from_egypt?
+    end
+
     def charge_paypal_payout_fee?
       Feature.active?(:paypal_payout_fee, self) &&
         !paypal_payout_fee_waived? &&

--- a/app/presenters/settings_presenter.rb
+++ b/app/presenters/settings_presenter.rb
@@ -329,8 +329,8 @@ class SettingsPresenter
       bank_account = seller.active_bank_account
 
       {
-        show_bank_account: bank_account.present? || seller.native_payouts_supported? || seller.signed_up_from_united_arab_emirates?,
-        show_paypal: seller.payment_address.present? || !seller.native_payouts_supported? || seller.signed_up_from_united_arab_emirates?,
+        show_bank_account: seller.can_setup_bank_payouts?,
+        show_paypal: seller.can_setup_paypal_payouts?,
         card_data_handling_mode: CardDataHandlingMode.get_card_data_handling_mode(seller),
         is_a_card: bank_account.is_a?(CardBankAccount),
         card: bank_account.is_a?(CardBankAccount) ? {

--- a/app/services/update_payout_method.rb
+++ b/app/services/update_payout_method.rb
@@ -194,7 +194,7 @@ class UpdatePayoutMethod
     end
 
     def paypal_payouts_supported?
-      !user.native_payouts_supported? || switching_to_uae_individual_account?
+      user.can_setup_paypal_payouts? || switching_to_uae_individual_account?
     end
 
     def switching_to_uae_individual_account?

--- a/spec/controllers/settings/payments_controller_spec.rb
+++ b/spec/controllers/settings/payments_controller_spec.rb
@@ -998,6 +998,8 @@ describe Settings::PaymentsController, :vcr do
       end
 
       it "fails if bank payouts are supported in seller's country" do
+        user.update!(payment_address: "")
+
         put :update, xhr: true, params: { payment_address: "sebastian@example.com" }
 
         expect(response.parsed_body["success"]).to be(false)

--- a/spec/presenters/settings_presenter_spec.rb
+++ b/spec/presenters/settings_presenter_spec.rb
@@ -846,6 +846,13 @@ describe SettingsPresenter do
         seller.update!(payment_address: "")
         expect(presenter.payments_props[:bank_account_details][:show_paypal]).to eq(false)
       end
+
+      it "returns true for show_paypal if user country is Egypt" do
+        create(:user_compliance_info, user: seller, country: "Egypt")
+        seller.update!(payment_address: nil)
+
+        expect(presenter.payments_props[:bank_account_details][:show_paypal]).to eq(true)
+      end
     end
 
     context "when seller's payouts are paused" do

--- a/spec/requests/settings/payments_spec.rb
+++ b/spec/requests/settings/payments_spec.rb
@@ -2832,6 +2832,8 @@ describe("Payments Settings Scenario", type: :system, js: true) do
       it "allows to enter bank account details" do
         visit settings_payments_path
 
+        choose "Bank Account"
+
         fill_in("First name", with: "barnabas")
         fill_in("Last name", with: "barnabastein")
         fill_in("Address", with: "address_full_match")
@@ -2864,6 +2866,41 @@ describe("Payments Settings Scenario", type: :system, js: true) do
         expect(compliance_info.phone).to eq("+209876543210")
         expect(compliance_info.birthday).to eq(Date.new(1980, 1, 1))
         expect(@user.reload.active_bank_account.send(:account_number_decrypted)).to eq("EG800002000156789012345180002")
+      end
+
+      it "allows to enter PayPal details" do
+        visit settings_payments_path
+
+        choose "PayPal"
+
+        fill_in("First name", with: "barnabas")
+        fill_in("Last name", with: "barnabastein")
+        fill_in("Address", with: "address_full_match")
+        fill_in("City", with: "barnabasville")
+        fill_in("Phone number", with: "9876543210")
+        fill_in("Postal code", with: "10110")
+
+        select("1", from: "Day")
+        select("January", from: "Month")
+        select("1980", from: "Year")
+
+        expect(page).to have_status(text: "PayPal payouts are subject to a 2% processing fee.")
+        fill_in("PayPal Email", with: "egycr@example.com")
+
+        click_on("Update settings")
+
+        expect(page).to have_content("Thanks! You're all set.")
+        compliance_info = @user.alive_user_compliance_info
+        expect(compliance_info.first_name).to eq("barnabas")
+        expect(compliance_info.last_name).to eq("barnabastein")
+        expect(compliance_info.street_address).to eq("address_full_match")
+        expect(compliance_info.city).to eq("barnabasville")
+        expect(compliance_info.zip_code).to eq("10110")
+        expect(compliance_info.country).to eq("Egypt")
+        expect(compliance_info.phone).to eq("+209876543210")
+        expect(compliance_info.birthday).to eq(Date.new(1980, 1, 1))
+        expect(@user.reload.payment_address).to eq("egycr@example.com")
+        expect(@user.active_bank_account).to be nil
       end
     end
 


### PR DESCRIPTION
### What

Enable PayPal payouts for creators in Egypt

### Why

- Fixes #2164 
- Creators in Egypt are having issues receiving bank payouts via Stripe. Allow them to select PayPal as payout method.