### PR TITLE
Fix: offer_code validation error on Admin Purchases page

### DIFF
--- a/app/javascript/components/Admin/Purchases/index.tsx
+++ b/app/javascript/components/Admin/Purchases/index.tsx
@@ -357,9 +357,11 @@ const Info = ({ purchase }: { purchase: Purchase }) => (
 
       {purchase.offer_code && !purchase.gift?.is_sender_purchase ? (
         <>
-          <dt>Discount code</dt>
+          <dt>{purchase.offer_code.code ? "Discount code" : "Discount"}</dt>
           <dd>
-            {purchase.offer_code.code} for {purchase.offer_code.displayed_amount_off} off
+            {purchase.offer_code.code
+              ? `${purchase.offer_code.code} for ${purchase.offer_code.displayed_amount_off} off`
+              : `${purchase.offer_code.displayed_amount_off} off`}
           </dd>
         </>
       ) : null}


### PR DESCRIPTION
ref: #1984 

### Root Cause:
- The OfferCode model allows the code field to be `nil`, 
- This caused it to return { code: nil, displayed_amount_off: "..." } instead of nil for these cases, which failed the TypeScript type validation expecting { code: string; displayed_amount_off: string } | null.

### Before:
```tsx
 offer_code: { code: string; displayed_amount_off: string } | null;
```

### After:
```tsx
  offer_code: { code: string | null; displayed_amount_off: string } | null;
```


### AI Disclosure:
- used cursor with sonnet-4.5 to navigate and understand code

### Live Stream Disclosure:
- watched all live streams