### PR TITLE
Fix: offer_code validation error on Admin Purchases page

### DIFF
--- a/spec/requests/admin/pages_spec.rb
+++ b/spec/requests/admin/pages_spec.rb
@@ -38,40 +38,6 @@ describe "Admin Pages Scenario", type: :system, js: true do
 
       expect(page).to have_text("A$6.49 for Tim Tam")
     end
-
-    it "displays discount code when offer_code has a code" do
-      product = create(:product, price_cents: 1000)
-      offer_code = create(:percentage_offer_code, products: [product], amount_percentage: 20, code: "SAVE20")
-      purchase = create(:purchase, link: product)
-      offer_code.purchases << purchase
-
-      visit admin_purchase_path(purchase)
-
-      expect(page).to have_text("Discount code")
-      expect(page).to have_text("SAVE20 for 20% off")
-    end
-
-    it "displays discount without code when offer_code.code is nil" do
-      seller = create(:user)
-      product = create(:product, user: seller, price_cents: 1000)
-      upsell_offer_code = OfferCode.new(
-        user: seller,
-        code: nil,
-        amount_percentage: 15,
-        universal: false
-      )
-      upsell_offer_code.products << product
-      upsell_offer_code.save!(validate: false)
-      create(:upsell, seller: seller, product: product, cross_sell: true, offer_code: upsell_offer_code)
-      purchase = create(:purchase, link: product)
-      upsell_offer_code.purchases << purchase
-
-      visit admin_purchase_path(purchase)
-
-      expect(page).not_to have_text("Discount code")
-      expect(page).to have_text("Discount")
-      expect(page).to have_text("15% off")
-    end
   end
 
   describe "Search" do

--- a/spec/requests/admin/purchases_spec.rb
+++ b/spec/requests/admin/purchases_spec.rb
@@ -113,4 +113,40 @@ describe "Admin::PurchasesController Scenario", type: :system, js: true do
       expect(giftee_purchase.reload.email).to eq(new_giftee_email)
     end
   end
+
+  describe "discount display" do
+    it "displays discount code when offer_code has a code" do
+      product = create(:product, price_cents: 1000)
+      offer_code = create(:percentage_offer_code, products: [product], amount_percentage: 20, code: "SAVE20")
+      purchase = create(:purchase, link: product)
+      offer_code.purchases << purchase
+
+      visit admin_purchase_path(purchase)
+
+      expect(page).to have_text("Discount code")
+      expect(page).to have_text("SAVE20 for 20% off")
+    end
+
+    it "displays discount without code when offer_code.code is nil" do
+      seller = create(:user)
+      product = create(:product, user: seller, price_cents: 1000)
+      upsell_offer_code = OfferCode.new(
+        user: seller,
+        code: nil,
+        amount_percentage: 15,
+        universal: false
+      )
+      upsell_offer_code.products << product
+      upsell_offer_code.save!(validate: false)
+      create(:upsell, seller: seller, product: product, cross_sell: true, offer_code: upsell_offer_code)
+      purchase = create(:purchase, link: product)
+      upsell_offer_code.purchases << purchase
+
+      visit admin_purchase_path(purchase)
+
+      expect(page).not_to have_text("Discount code")
+      expect(page).to have_text("Discount")
+      expect(page).to have_text("15% off")
+    end
+  end
 end


### PR DESCRIPTION
ref: #1984 

### Root Cause:
- The OfferCode model allows the code field to be `nil`, 
- This caused it to return { code: nil, displayed_amount_off: "..." } instead of nil for these cases, which failed the TypeScript type validation expecting { code: string; displayed_amount_off: string } | null.

### Before:
```tsx
 offer_code: { code: string; displayed_amount_off: string } | null;
```

### After:
```tsx
  offer_code: { code: string | null; displayed_amount_off: string } | null;
```
### eg. when offer_code.code is null
<img width="739" height="341" alt="Screenshot 2025-12-03 at 3 30 40 PM" src="https://github.com/user-attachments/assets/820f2b2f-cba5-42d8-b213-33a1533c0ae7" />

### eg. when offer_code.code is not null
<img width="796" height="339" alt="Screenshot 2025-12-03 at 3 31 23 PM" src="https://github.com/user-attachments/assets/02e81b49-1fe6-41e3-bb76-306b4ef96c55" />


## Tests Result:
<img width="723" height="221" alt="Screenshot 2025-12-03 at 3 12 32 PM" src="https://github.com/user-attachments/assets/742b43b0-5a29-4f14-841f-a0f1177c0352" />



### AI Disclosure:
- used cursor with sonnet-4.5 to navigate and understand code, and add test case. 

### Live Stream Disclosure:
- watched all live streams