### PR TITLE
fix: update magic link instruction text

### DIFF
--- a/app/javascript/components/server-components/SubscriptionManagerMagicLink.tsx
+++ b/app/javascript/components/server-components/SubscriptionManagerMagicLink.tsx
@@ -83,10 +83,10 @@ const SubscriptionManagerMagicLink = ({
                     <button className="underline" onClick={() => setHasSentEmail(false)}>
                       Click here to choose another email
                     </button>{" "}
-                    or try resending the link below.
+                    or try resending the link above.
                   </>
                 ) : (
-                  "Can't see the email? Please check your spam folder or try resending the link below."
+                  "Can't see the email? Please check your spam folder or try resending the link above."
                 )}
               </p>
             </>


### PR DESCRIPTION
# Problem
The instruction text said “... resending the link below,” but the "Resend magic link" button appears above the text

### Action Performed
1. Purchase a membership
2. Log out and open the “Subscription settings” link from the receipt
3. Click "Send magic link" button

# Root cause analysis
The text always says “... resending the link below”, but the "Resend magic link" button is actually rendered above the text
https://github.com/antiwork/gumroad/blob/480ff8b3458e1cbf52223176e273539c1eb539cb/app/javascript/components/server-components/SubscriptionManagerMagicLink.tsx#L74-L92

# Solution
Updated the texts to say “... resending the link above” to match the actual button placement

# Before After
### Desktop Dark Mode
| Before | After |
|-----------|-----------|
|  <img width="1470" height="796" alt="image" src="https://github.com/user-attachments/assets/820def3b-1750-4594-ae24-76f4a1764c81" />  |  <img width="1470" height="792" alt="image" src="https://github.com/user-attachments/assets/de8ddbff-e200-4b47-9fe6-d55fc7950bf3" />  |

### Desktop Light Mode
| Before | After |
|-----------|-----------|
|  <img width="1470" height="793" alt="image" src="https://github.com/user-attachments/assets/0c84ba88-9a10-4897-b66d-74b41b849143" />  |  <img width="1470" height="796" alt="image" src="https://github.com/user-attachments/assets/f7e7aec6-187f-446e-9d32-08b65a7d67e9" />  |

### Mobile Dark Mode
| Before | After |
|-----------|-----------|
|  <img width="312" height="659" alt="image" src="https://github.com/user-attachments/assets/fe9c4ecb-5a90-4b77-b25c-8690edcea748" />  | <img width="311" height="661" alt="image" src="https://github.com/user-attachments/assets/d729a825-d307-4c16-932e-03e1128ea79e" /> |

### Mobile Light Mode
| Before | After |
|-----------|-----------|
|  <img width="311" height="662" alt="image" src="https://github.com/user-attachments/assets/4f921060-240f-4d14-aa7f-8e31213d121e" />  |  <img width="305" height="657" alt="image" src="https://github.com/user-attachments/assets/9e288795-a1b0-4e69-bacb-e2991147d2ad" />  |

# AI Disclosure
No AI was used for any part of this contribution.

# Confirmation
I have watched the Gumroad PR reviews live streaming video