### PR TITLE
fix: commission status pill text visibility

### DIFF
--- a/app/javascript/components/Audience/CustomersPage.tsx
+++ b/app/javascript/components/Audience/CustomersPage.tsx
@@ -788,7 +788,11 @@ const CustomerDrawer = ({
           <h2>{customer.product.name}</h2>
         </div>
       </SheetHeader>
-      {commission ? <CommissionStatusPill commission={commission} /> : null}
+      {commission ? (
+        <div>
+          <CommissionStatusPill commission={commission} />
+        </div>
+      ) : null}
       {customer.is_additional_contribution ? (
         <div role="status" className="info">
           <div>


### PR DESCRIPTION
# Problem
Commission status text ("In progress", "Completed", "Cancelled") was not visible in the customer detail panel

### Action Performed
1. Create a commission product
2. Purchase as buyer
3. As seller, navigate to https://gumroad.com/customers
4. Click on the customer row for the commission product
5. Observed a small placeholder shape instead of the "In progress" status text

# Root cause analysis
The `CommissionStatusPill` component was rendered as a direct child of the `Sheet` component, which has `flex flex-col` layout. The `.pill.small` class applies `overflow: hidden; white-space: nowrap; text-overflow: ellipsis`

When combined with:
- Minimal padding on `.pill.small` (only `spacer(1)`)
- The flex column layout constraining the pill's height
- The `overflow: hidden` from `text-singleline`

The text was being hidden, leaving only a small placeholder shape visible

# Solution
Wrapped `CommissionStatusPill` in a `div` container. This breaks the direct `flex-col` relationship with the `Sheet` component, allowing the pill to render its text properly without height constraints

# Before After
### Mobile Light Mode
| Before | After |
|-----------|-----------|
| <img width="308" height="658" alt="Screenshot 2025-12-04 at 22 46 42" src="https://github.com/user-attachments/assets/a4ba1b29-d482-4cf8-a6dd-a9ce27004cad" />    |  <img width="303" height="654" alt="image" src="https://github.com/user-attachments/assets/f925f102-e0b9-45a2-836d-598fba8d3d49" />  |

### Desktop Light Mode
| Before | After |
|-----------|-----------|
|  <img width="1470" height="798" alt="Screenshot 2025-12-04 at 22 45 18" src="https://github.com/user-attachments/assets/3615f70b-c4c5-44bb-872a-0cfd31b4d59a" />  |  <img width="1470" height="798" alt="image" src="https://github.com/user-attachments/assets/b0c3b34a-d92e-47e7-8968-cb9b0f72ef3f" />  |

### Desktop Dark Mode
| Before | After |
|-----------|-----------|
|  <img width="1470" height="796" alt="image" src="https://github.com/user-attachments/assets/39dd56f4-2d9b-4666-9e63-65bc00905736" />  |  <img width="1470" height="790" alt="image" src="https://github.com/user-attachments/assets/94fe80fc-39f1-438a-92ae-4492d5202d0a" />  |

### Mobile Dark Mode
| Before | After |
|-----------|-----------|
| <img width="303" height="652" alt="image" src="https://github.com/user-attachments/assets/46d67411-e974-40c1-8499-60314d4a6609" /> | <img width="305" height="655" alt="image" src="https://github.com/user-attachments/assets/81bd6beb-9317-400b-a9ff-f160b54e4b44" /> |

# AI Disclosure
No AI was used for any part of this contribution.

# Confirmation
I have watched the Gumroad PR reviews live streaming video