### PR TITLE
fix: payment method button responsive layout on mobile

### DIFF
--- a/app/javascript/components/Checkout/PaymentForm.tsx
+++ b/app/javascript/components/Checkout/PaymentForm.tsx
@@ -422,6 +422,7 @@ const PaymentMethodRadio = ({
         if (paymentMethod !== state.paymentMethod) dispatch({ type: "set-value", paymentMethod });
       }}
       disabled={!selected && isProcessing(state)}
+      className="px-1"
     >
       {children}
     </Tab>
@@ -1224,7 +1225,7 @@ export const PaymentForm = ({
             <div className="flex flex-col gap-4">
               <h4>Pay with</h4>
               {state.availablePaymentMethods.length > 1 ? (
-                <Tabs variant="buttons" className="grid-flow-col">
+                <Tabs variant="buttons" className="auto-cols-fr grid-flow-col">
                   {state.availablePaymentMethods.map((method) => (
                     <React.Fragment key={method.type}>{method.button}</React.Fragment>
                   ))}


### PR DESCRIPTION
# Problem
Payment method buttons (Card, PayPal, Google Pay) overflow and cropped on mobile

### Action Performed
1. Open the checkout page on mobile https://gumroad.com/checkout
2. Scroll down to the payment section
3. Observe the Google Pay button

# Root cause analysis
The `Tabs` component was using fixed grid layout classes (`auto-cols-max grid-flow-col`) for all screen sizes. This prevented buttons from wrapping on mobile viewports when multiple payment methods were available
https://github.com/antiwork/gumroad/blob/e0429f865a2627dc083f314fa93aed5af063130c/app/javascript/components/Checkout/PaymentForm.tsx#L1221


Seems related to https://github.com/antiwork/gumroad/issues/1962

But before that PR, this section was already broken, like this:

<img width="309" height="661" alt="Screenshot 2025-12-05 at 16 57 48" src="https://github.com/user-attachments/assets/03983d32-2cd2-4add-89d0-f2a1389a6ba8" />

# Solution
Stack the payment option icon and text vertically

# Before After
## 3 Payment Options

### Mobile Dark Mode
| Before | After |
|-----------|-----------|
| <img width="309" height="657" alt="Screenshot 2025-12-05 at 16 40 43" src="https://github.com/user-attachments/assets/bf85b7bd-1b61-4862-b155-3e7eb8ca47a6" /> |  <img width="306" height="656" alt="image" src="https://github.com/user-attachments/assets/6ae20c9a-7b35-4603-a3f0-ae403994dc5a" />  |

### Mobile Light Mode
| Before | After |
|-----------|-----------|
|  <img width="304" height="655" alt="Screenshot 2025-12-05 at 16 41 14" src="https://github.com/user-attachments/assets/29aea4e2-ee68-477e-aede-4cd2461909a1" />  |  <img width="306" height="655" alt="image" src="https://github.com/user-attachments/assets/88b0cd63-3c0a-4393-84d0-2491e7fefdd8" />  |


### Desktop Dark Mode
| Before | After |
|-----------|-----------|
|  <img width="1470" height="794" alt="Screenshot 2025-12-05 at 16 40 54" src="https://github.com/user-attachments/assets/baa7d2a4-ab29-4d63-9f27-99db40c2598f" />  |  <img width="1470" height="797" alt="image" src="https://github.com/user-attachments/assets/bcfec154-5bf3-4f9b-9402-c4815ce6b83d" />  |

### Desktop Light Mode
| Before | After |
|-----------|-----------|
|  <img width="1470" height="795" alt="Screenshot 2025-12-05 at 16 41 05" src="https://github.com/user-attachments/assets/1f5e6338-6fe6-4629-82f4-31ad0a95d296" />  |  <img width="1470" height="792" alt="image" src="https://github.com/user-attachments/assets/0b8cccf4-a471-4370-b974-d15f7650398e" />  |

## 2 Payment Options
### After
<img width="301" height="654" alt="image" src="https://github.com/user-attachments/assets/9ed15b91-625c-4b1f-a784-74460ca92ba5" />
<img width="303" height="655" alt="image" src="https://github.com/user-attachments/assets/cce1a2ce-0456-4914-9416-f5e95ad93b71" />
<img width="1470" height="795" alt="image" src="https://github.com/user-attachments/assets/629e2087-754d-4476-be94-4b2eb5f0e5ab" />
<img width="1470" height="794" alt="image" src="https://github.com/user-attachments/assets/c62ace13-ac15-4e96-b473-83826f45409d" />

## Narrow phone, e.g. Galaxy Fold
<img width="282" height="151" alt="Screenshot 2025-12-05 at 19 51 38" src="https://github.com/user-attachments/assets/c3714f45-13ee-4077-9ce6-d5357db116d5" />

# AI Disclosure
No AI was used for any part of this contribution.

# Confirmation
I have watched the Gumroad PR reviews live streaming video