### PR TITLE
Migrate wishlists index page

### DIFF
--- a/app/controllers/wishlists_controller.rb
+++ b/app/controllers/wishlists_controller.rb
@@ -7,13 +7,19 @@ class WishlistsController < ApplicationController
   after_action :verify_authorized, except: :show
   before_action :hide_layouts, only: :show
 
+  layout "inertia", only: :index
+
   def index
     authorize Wishlist
 
     respond_to do |format|
       format.html do
         @title = Feature.active?(:follow_wishlists, current_seller) ? "Saved" : "Wishlists"
-        @wishlists_props = WishlistPresenter.library_props(wishlists: current_seller.wishlists.alive)
+        render inertia: "Wishlists/Index", props: {
+          wishlists: WishlistPresenter.library_props(wishlists: current_seller.wishlists.alive),
+          reviews_page_enabled: Feature.active?(:reviews_page, current_seller),
+          following_wishlists_enabled: Feature.active?(:follow_wishlists, current_seller)
+        }
       end
       format.json do
         wishlists = current_seller.wishlists.alive.includes(:products).by_external_ids(params[:ids])

--- a/app/javascript/components/WishlistsPage/index.tsx
+++ b/app/javascript/components/WishlistsPage/index.tsx
@@ -1,0 +1,169 @@
+import * as React from "react";
+
+import { deleteWishlist, updateWishlist } from "$app/data/wishlists";
+import { assertResponseError } from "$app/utils/request";
+
+import { Button } from "$app/components/Button";
+import { Icon } from "$app/components/Icons";
+import { Layout } from "$app/components/Library/Layout";
+import { Modal } from "$app/components/Modal";
+import { showAlert } from "$app/components/server-components/Alert";
+import { Toggle } from "$app/components/Toggle";
+import Placeholder from "$app/components/ui/Placeholder";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "$app/components/ui/Table";
+import { WithTooltip } from "$app/components/WithTooltip";
+
+import placeholder from "$assets/images/placeholders/wishlists.png";
+
+type Wishlist = {
+  id: string;
+  name: string;
+  url: string;
+  product_count: number;
+  discover_opted_out: boolean;
+};
+
+const WishlistsPage = ({
+  wishlists: preloadedWishlists,
+  reviews_page_enabled,
+  following_wishlists_enabled,
+}: {
+  wishlists: Wishlist[];
+  reviews_page_enabled: boolean;
+  following_wishlists_enabled: boolean;
+}) => {
+  const [wishlists, setWishlists] = React.useState<Wishlist[]>(preloadedWishlists);
+  const [deletingWishlist, setConfirmingDeleteWishlist] = React.useState<Wishlist | null>(null);
+  const [isDeleting, setIsDeleting] = React.useState(false);
+
+  const destroy = async (id: string) => {
+    setIsDeleting(true);
+
+    try {
+      await deleteWishlist({ wishlistId: id });
+      setWishlists(wishlists.filter((wishlist) => wishlist.id !== id));
+      setConfirmingDeleteWishlist(null);
+      showAlert("Wishlist deleted!", "success");
+    } catch (e) {
+      assertResponseError(e);
+      showAlert("Sorry, something went wrong. Please try again.", "error");
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const updateDiscoverOptOut = async (id: string, optOut: boolean) => {
+    try {
+      setWishlists(
+        wishlists.map((wishlist) => (wishlist.id === id ? { ...wishlist, discover_opted_out: optOut } : wishlist)),
+      );
+      await updateWishlist({ id, discover_opted_out: optOut });
+      showAlert(optOut ? "Opted out of Gumroad Discover." : "Wishlist is now discoverable!", "success");
+    } catch (e) {
+      assertResponseError(e);
+      showAlert("Sorry, something went wrong. Please try again.", "error");
+    }
+  };
+
+  return (
+    <Layout
+      selectedTab="wishlists"
+      reviewsPageEnabled={reviews_page_enabled}
+      followingWishlistsEnabled={following_wishlists_enabled}
+    >
+      <section className="space-y-4 p-4 md:p-8">
+        {wishlists.length > 0 ? (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Wishlist</TableHead>
+                <TableHead>Products</TableHead>
+                <TableHead>
+                  Discoverable&nbsp;
+                  <WithTooltip
+                    tip={
+                      <span className="font-normal" style={{ textWrap: "initial" }}>
+                        May be recommended on Gumroad Discover. You will receive an affiliate commission for any sales.
+                      </span>
+                    }
+                    position="top"
+                  >
+                    <Icon name="info-circle" />
+                  </WithTooltip>
+                </TableHead>
+                <TableHead />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {wishlists.map((wishlist) => (
+                <TableRow key={wishlist.id}>
+                  <TableCell>
+                    <a href={wishlist.url} target="_blank" rel="noreferrer" style={{ textDecoration: "none" }}>
+                      <h4>{wishlist.name}</h4>
+                    </a>
+                    <a href={wishlist.url} target="_blank" rel="noreferrer">
+                      <small>{wishlist.url}</small>
+                    </a>
+                  </TableCell>
+                  <TableCell>{wishlist.product_count}</TableCell>
+                  <TableCell>
+                    <Toggle
+                      value={!wishlist.discover_opted_out}
+                      onChange={(checked) => void updateDiscoverOptOut(wishlist.id, !checked)}
+                      ariaLabel="Discoverable"
+                    />
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex flex-wrap gap-3 lg:justify-end">
+                      <Button
+                        color="danger"
+                        outline
+                        aria-label="Delete wishlist"
+                        onClick={() => setConfirmingDeleteWishlist(wishlist)}
+                      >
+                        <Icon name="trash2" />
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        ) : (
+          <Placeholder>
+            <figure>
+              <img src={placeholder} />
+            </figure>
+            <h2>Save products you are wishing for</h2>
+            Bookmark and organize your desired products with ease
+            <a href="/help/article/343-wishlists" target="_blank" rel="noreferrer">
+              Learn more about wishlists
+            </a>
+          </Placeholder>
+        )}
+
+        {deletingWishlist ? (
+          <Modal
+            open
+            onClose={() => setConfirmingDeleteWishlist(null)}
+            title="Delete wishlist?"
+            footer={
+              <>
+                <Button onClick={() => setConfirmingDeleteWishlist(null)}>No, cancel</Button>
+                <Button color="danger" disabled={isDeleting} onClick={() => void destroy(deletingWishlist.id)}>
+                  {isDeleting ? "Deleting..." : "Yes, delete"}
+                </Button>
+              </>
+            }
+          >
+            <h4>
+              Are you sure you want to delete the wishlist "{deletingWishlist.name}"? This action cannot be undone.
+            </h4>
+          </Modal>
+        ) : null}
+      </section>
+    </Layout>
+  );
+};
+
+export default WishlistsPage;

--- a/app/javascript/packs/wishlists.ts
+++ b/app/javascript/packs/wishlists.ts
@@ -6,13 +6,11 @@ import DiscoverWishlistPage from "$app/components/server-components/Discover/Wis
 import ProfileWishlistPage from "$app/components/server-components/Profile/WishlistPage";
 import WishlistPage from "$app/components/server-components/WishlistPage";
 import WishlistsFollowingPage from "$app/components/server-components/WishlistsFollowingPage";
-import WishlistsPage from "$app/components/server-components/WishlistsPage";
 
 BasePage.initialize();
 ReactOnRails.register({
   WishlistPage,
   WishlistsFollowingPage,
-  WishlistsPage,
   ProfileWishlistPage,
   DiscoverWishlistPage,
 });

--- a/app/javascript/pages/Wishlists/Index.tsx
+++ b/app/javascript/pages/Wishlists/Index.tsx
@@ -1,0 +1,22 @@
+import { usePage } from "@inertiajs/react";
+import React from "react";
+import { cast } from "ts-safe-cast";
+
+import WishlistsPage from "$app/components/WishlistsPage";
+
+type Props = {
+  wishlists: {
+    id: string;
+    name: string;
+    url: string;
+    product_count: number;
+    discover_opted_out: boolean;
+  }[];
+  reviews_page_enabled: boolean;
+  following_wishlists_enabled: boolean;
+};
+
+export default function WishlistsIndex() {
+  const props = cast<Props>(usePage().props);
+  return <WishlistsPage {...props} />;
+}

--- a/app/javascript/ssr.ts
+++ b/app/javascript/ssr.ts
@@ -89,7 +89,6 @@ import UtmLinksPage from "$app/components/server-components/UtmLinksPage";
 import VideoStreamPlayer from "$app/components/server-components/VideoStreamPlayer";
 import WishlistPage from "$app/components/server-components/WishlistPage";
 import WishlistsFollowingPage from "$app/components/server-components/WishlistsFollowingPage";
-import WishlistsPage from "$app/components/server-components/WishlistsPage";
 import CodeSnippet from "$app/components/ui/CodeSnippet";
 
 ReactOnRails.register({
@@ -179,6 +178,5 @@ ReactOnRails.register({
   VideoStreamPlayer,
   WishlistPage,
   WishlistsFollowingPage,
-  WishlistsPage,
   UtmLinksPage,
 });

--- a/app/views/wishlists/index.html.erb
+++ b/app/views/wishlists/index.html.erb
@@ -1,3 +1,0 @@
-<%= load_pack("wishlists") %>
-
-<%= react_component "WishlistsPage", props: { wishlists: @wishlists_props, reviews_page_enabled: Feature.active?(:reviews_page, current_seller), following_wishlists_enabled: Feature.active?(:follow_wishlists, current_seller) }, prerender: true %>

--- a/spec/controllers/wishlists_controller_spec.rb
+++ b/spec/controllers/wishlists_controller_spec.rb
@@ -2,9 +2,9 @@
 
 require "spec_helper"
 require "shared_examples/authorize_called"
+require "inertia_rails/rspec"
 
-describe WishlistsController do
-  render_views
+describe WishlistsController, type: :controller, inertia: true do
 
   let(:user) { create(:user) }
   let(:wishlist) { create(:wishlist, user:) }
@@ -20,7 +20,7 @@ describe WishlistsController do
     end
 
     context "when html is requested" do
-      it "renders non-deleted wishlists for the current seller" do
+      it "renders via Inertia with correct props" do
         wishlist.mark_deleted!
         alive_wishlist = create(:wishlist, user:)
         create(:wishlist)
@@ -28,7 +28,8 @@ describe WishlistsController do
         get :index
 
         expect(response).to be_successful
-        expect(assigns(:wishlists_props)).to contain_exactly(a_hash_including(id: alive_wishlist.external_id))
+        expect(inertia.component).to eq("Wishlists/Index")
+        expect(inertia.props[:wishlists]).to contain_exactly(a_hash_including(id: alive_wishlist.external_id))
       end
     end
 


### PR DESCRIPTION
Migrate Wishlists page to Inertia SPA
Part of #856 

# Problem
The Wishlists page (`/wishlists`) currently uses ReactOnRails, which results in a full page reload when navigating to it. This provides a disjointed experience compared to other dashboard pages that are already SPA-enabled (e.g., dashboard, products).

# Solution
Migrate the Wishlists page to use Inertia.js, aligning it with the rest of the SPA architecture. This involves:
- Updating `WishlistsController` to render via Inertia
- Creating a new Inertia page wrapper
- Moving the `WishlistsPage` component from `server-components` to standard `components`
- Removing ReactOnRails registrations and old templates


# Screenshots:

## BEFORE
<img width="3388" height="2044" alt="image" src="https://github.com/user-attachments/assets/231f7bde-6bc3-499b-bb0a-922eb87be5fc" />

mobile
<img width="1704" height="1030" alt="image" src="https://github.com/user-attachments/assets/5c55d1b3-73f4-49e2-8e2e-4ca2c1be799a" />

## AFTER 

<img width="3388" height="2044" alt="image" src="https://github.com/user-attachments/assets/d44bf577-6062-46b5-a52b-da26e0fc98b8" />

MOBILE

<img width="1708" height="1036" alt="image" src="https://github.com/user-attachments/assets/c0441bc3-e99e-4de2-a99e-71016f2cc8c4" />

# Tests
`bundle exec rspec spec/controllers/wishlists_controller_spec.rb`

<img width="632" height="387" alt="image" src="https://github.com/user-attachments/assets/cae5d29d-91f2-48a0-b12f-015ad7e66332" />

12 examples, 0 failures

# AI Disclosure
- Model: Gemini 3.0 
- Used for implementation of Inertia migration code and test updates.
- All code was reviewed and verified manually.

# Confirmation
I have watched the Antiwork PR reviews live streaming video.
