### PR TITLE
  fix: Prevent automatic probation from unsuspending fraud accounts

### DIFF
--- a/app/models/concerns/user/low_balance_fraud_check.rb
+++ b/app/models/concerns/user/low_balance_fraud_check.rb
@@ -26,7 +26,8 @@ module User::LowBalanceFraudCheck
     return if unpaid_balance_cents > LOW_BALANCE_THRESHOLD
 
     AdminMailer.low_balance_notify(id, refunded_or_disputed_purchase_id).deliver_later
-    disable_refunds_and_put_on_probation! unless recently_probated_for_low_balance?
+
+    disable_refunds_and_put_on_probation! unless recently_probated_for_low_balance? || suspended?
   end
 
   private


### PR DESCRIPTION
fixes #2049 

### Problem:
- Admin suspends user for fraud → user_risk_state = 'suspended_for_fraud'
- Chargebacks occur → balance drops below -$100
- LowBalanceFraudCheckWorker triggers automatic probation
- System transitions: suspended_for_fraud → on_probation 
- Fraudster can now login and change payment details

**This should not happen if user is already suspended, then user should stay suspended**


### Root Cause:
- The low balance fraud check system (app/models/concerns/user/low_balance_fraud_check.rb) automatically probates users with negative balances without checking if they're already suspended (more restrictive state)

### Solution:
```rb
    # Don't unsuspend users with automated probation
    disable_refunds_and_put_on_probation! unless recently_probated_for_low_balance? || suspended?
```

### Tests Result: (local run)
<img width="2266" height="473" alt="Screenshot 2025-12-10 at 8 30 08 AM" src="https://github.com/user-attachments/assets/92b2c1c9-3391-4af7-86fe-ae27abe4fcd1" />

### AI Disclosure:
- used claude-sonnet-4.5 to understand codebase

### Live Stream Disclosure:
- watched all 4 live streams
