### PR TITLE
fix: Desktop Analytics view is missing sales due to Daylight saving time issue

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -809,10 +809,9 @@ class User < ApplicationRecord
   # Returns the user's UTC offset, formatted (e.g. "-08:00")
   # Useful to resolve inconsistencies between Rails, Elasticsearch and MySQL which may all have
   # different TZ databases: https://github.com/gumroad/web/pull/25208
-  # Note that it doesn't acknowledge DST by nature: it is just the difference between the timezone's
   # Standard time and UTC, so the returned value does not change depending on when the method is called.
   def timezone_formatted_offset
-    ActiveSupport::TimeZone.new(timezone_id).formatted_offset
+    Time.now.in_time_zone(timezone).formatted_offset
   end
 
   def supports_card?(card)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2580,6 +2580,34 @@ describe User, :vcr do
       expect(build(:user, timezone: "Pacific Time (US & Canada)").timezone_formatted_offset).to eq("-08:00")
       expect(build(:user, timezone: "London").timezone_formatted_offset).to eq("+00:00")
     end
+
+    it "returns DST-aware offset for Pacific Time" do
+      user = build(:user, timezone: "Pacific Time (US & Canada)")
+
+      # During Standard Time (winter) - PST is UTC-8
+      travel_to Time.utc(2025, 1, 15, 12, 0, 0) do
+        expect(user.timezone_formatted_offset).to eq("-08:00")
+      end
+
+      # During Daylight Saving Time (summer) - PDT is UTC-7
+      travel_to Time.utc(2025, 7, 15, 12, 0, 0) do
+        expect(user.timezone_formatted_offset).to eq("-07:00")
+      end
+    end
+
+    it "returns DST-aware offset for London" do
+      user = build(:user, timezone: "London")
+
+      # During Standard Time (winter) - GMT is UTC+0
+      travel_to Time.utc(2025, 1, 15, 12, 0, 0) do
+        expect(user.timezone_formatted_offset).to eq("+00:00")
+      end
+
+      # During British Summer Time (summer) - BST is UTC+1
+      travel_to Time.utc(2025, 7, 15, 12, 0, 0) do
+        expect(user.timezone_formatted_offset).to eq("+01:00")
+      end
+    end
   end
 
   describe "#supports_card?" do


### PR DESCRIPTION
fixes: #1811

## Root Cause:
- The Analytics view uses timezone_formatted_offset which always returns the Standard Time offset and ignores Daylight Saving Time, while other parts of the app (like the Sales page and Home tab) use DST-aware timezone handling.

- `timezone_formatted_offset` used `ActiveSupport::TimeZone.new(timezone_id).formatted_offset` which always returns the Standard Time offset, ignoring DST. 

```rb
# timezone_formatted_offset used ActiveSupport::TimeZone.new(timezone_id).formatted_offset which always returns the Standard Time offset, ignoring DST.
  def timezone_formatted_offset
    ActiveSupport::TimeZone.new(timezone_id).formatted_offset
end
```
- and `CreatorAnalytics::Sales` [uses this method](https://github.com/antiwork/gumroad/blob/2ef9e60b830fb67508764304bf584b524236b80a/app/services/creator_analytics/sales.rb#L15) for Elasticsearch queries. 
- due to which sometimes Sales page shows sales that don't appear on the Analytics view


## Solution:
now we use `Time.now.in_time_zone(timezone).formatted_offset` which correctly accounts for Daylight Saving Time.
- also this method (`Time.now.in_time_zone(timezone).formatted_offset` ) is commonly used across codebase

```rb
def timezone_formatted_offset
# This converts the current time to the user's timezone, then gets the offset. 
# Since the Time object knows the actual date, it correctly applies DST rules.
     Time.now.in_time_zone(@user.timezone).formatted_offset
end
```

---

## Test Result - Before Fix: (local run):

<img width="1103" height="316" alt="Screenshot 2025-12-10 at 11 55 54 AM" src="https://github.com/user-attachments/assets/a8c8d538-77ed-4b8b-b110-d50c90659c70" />

## Test Result - After Fix: (local run):

<img width="811" height="223" alt="Screenshot 2025-12-10 at 11 58 42 AM" src="https://github.com/user-attachments/assets/bd1329ef-c0cd-49ae-ac62-73c18c402fcb" />

### AI Disclosure:
- used cursor with sonnet-4.5 to generate test case, and understand how DST works

### Live Stream Disclosure:
- watched all 4 live streams. 