### PR TITLE
Fix #2092: Prevent timeout on large audience CSV exports

### DIFF
--- a/app/models/audience_export.rb
+++ b/app/models/audience_export.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AudienceExport < ApplicationRecord
+  belongs_to :recipient, class_name: "User"
+  # We use :delete_all instead of :destroy to prevent needlessly loading
+  # a lot of data in memory (column `members_data`)
+  has_many :chunks, class_name: "AudienceExportChunk", foreign_key: :export_id, dependent: :delete_all
+  serialize :audience_options, type: Hash, coder: YAML
+  validates_presence_of :audience_options
+end

--- a/app/models/audience_export_chunk.rb
+++ b/app/models/audience_export_chunk.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AudienceExportChunk < ApplicationRecord
+  belongs_to :export, class_name: "AudienceExport"
+  serialize :member_ids, type: Array, coder: YAML
+  serialize :members_data, type: Array, coder: YAML
+end

--- a/app/services/exports/audience_export_service.rb
+++ b/app/services/exports/audience_export_service.rb
@@ -4,6 +4,9 @@ require "csv"
 
 class Exports::AudienceExportService
   FIELDS = ["Subscriber Email", "Subscribed Time"].freeze
+  # Threshold for switching to chunked processing
+  # Exports with more members than this will be processed asynchronously in chunks
+  SYNCHRONOUS_EXPORT_THRESHOLD = 2_000
 
   def initialize(user, options = {})
     @user = user
@@ -37,6 +40,29 @@ class Exports::AudienceExportService
     @tempfile.rewind
 
     self
+  end
+
+  def self.export(user:, recipient:, audience_options: {})
+    query = user.audience_members
+
+    conditions = []
+    conditions << "follower = true" if audience_options[:followers]
+    conditions << "customer = true" if audience_options[:customers]
+    conditions << "affiliate = true" if audience_options[:affiliates]
+
+    query = query.where(conditions.join(" OR ")) if conditions.any?
+    count = query.count
+
+    if count <= SYNCHRONOUS_EXPORT_THRESHOLD
+      new(user, audience_options).perform
+    else
+      export = AudienceExport.create!(
+        recipient: recipient,
+        audience_options: audience_options
+      )
+      Exports::Audience::CreateAndEnqueueChunksWorker.perform_async(export.id)
+      false
+    end
   end
 
   private

--- a/app/sidekiq/exports/audience/compile_chunks_worker.rb
+++ b/app/sidekiq/exports/audience/compile_chunks_worker.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "csv"
+
+class Exports::Audience::CompileChunksWorker
+  include Sidekiq::Job
+  sidekiq_options retry: 5, queue: :low
+
+  FIELDS = ["Subscriber Email", "Subscribed Time"].freeze
+
+  def perform(export_id)
+    export = AudienceExport.find(export_id)
+    recipient = export.recipient
+    seller = recipient.seller || recipient
+
+    timestamp = Time.current.to_fs(:db).gsub(/ |:/, "-")
+    filename = "Subscribers-#{seller.username}_#{timestamp}.csv"
+
+    tempfile = Tempfile.new(["Subscribers", ".csv"], encoding: "UTF-8")
+
+    begin
+      CSV.open(tempfile, "wb", headers: FIELDS, write_headers: true) do |csv|
+        export.chunks.order(:id).find_each do |chunk|
+          chunk.members_data.each do |row|
+            csv << row
+          end
+        end
+      end
+
+      tempfile.rewind
+
+      ContactingCreatorMailer.subscribers_data(
+        recipient: recipient,
+        tempfile: tempfile,
+        filename: filename
+      ).deliver_now
+
+    ensure
+      tempfile.close
+      tempfile.unlink
+
+      export.destroy
+    end
+  end
+end

--- a/app/sidekiq/exports/audience/create_and_enqueue_chunks_worker.rb
+++ b/app/sidekiq/exports/audience/create_and_enqueue_chunks_worker.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class Exports::Audience::CreateAndEnqueueChunksWorker
+  include Sidekiq::Job
+  sidekiq_options retry: 5, queue: :low
+
+  MAX_MEMBERS_PER_CHUNK = 1_000
+
+  def perform(export_id)
+    @export = AudienceExport.find(export_id)
+    create_chunks
+    enqueue_chunks
+  end
+
+  private
+    def create_chunks
+      @export.chunks.in_batches(of: 1).delete_all
+
+      seller = @export.recipient.seller || @export.recipient
+      options = @export.audience_options
+      query = seller.audience_members.select(:id, :email, :min_created_at)
+
+      conditions = []
+      conditions << "follower = true" if options[:followers]
+      conditions << "customer = true" if options[:customers]
+      conditions << "affiliate = true" if options[:affiliates]
+
+      query = query.where(conditions.join(" OR ")) if conditions.any?
+      query = query.order(:min_created_at)
+
+      query.in_batches(of: MAX_MEMBERS_PER_CHUNK) do |batch|
+        member_ids = batch.pluck(:id)
+        @export.chunks.create!(member_ids: member_ids)
+      end
+    end
+
+    def enqueue_chunks
+      Exports::Audience::ProcessChunkWorker.perform_bulk(@export.chunks.ids.map { |id| [id] })
+    end
+end

--- a/app/sidekiq/exports/audience/process_chunk_worker.rb
+++ b/app/sidekiq/exports/audience/process_chunk_worker.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class Exports::Audience::ProcessChunkWorker
+  include Sidekiq::Job
+  sidekiq_options retry: 5, queue: :low
+
+  def perform(chunk_id)
+    chunk = AudienceExportChunk.find(chunk_id)
+    return if chunk.processed?
+
+    members = AudienceMember.where(id: chunk.member_ids)
+                            .select(:id, :email, :min_created_at)
+                            .order(:min_created_at)
+    members_data = members.map do |member|
+      [member.email, member.min_created_at]
+    end
+
+    chunk.update!(
+      members_data: members_data,
+      processed: true
+    )
+
+    export = chunk.export
+    if export.chunks.where(processed: false).count.zero?
+      Exports::Audience::CompileChunksWorker.perform_async(export.id)
+    end
+  end
+end

--- a/app/sidekiq/exports/audience_export_worker.rb
+++ b/app/sidekiq/exports/audience_export_worker.rb
@@ -8,10 +8,15 @@ class Exports::AudienceExportWorker
     seller, recipient = User.find(seller_id, recipient_id)
     recipient ||= seller
 
-    result = Exports::AudienceExportService.new(seller, audience_options).perform
+    result = Exports::AudienceExportService.export(
+      user: seller,
+      recipient: recipient,
+      audience_options: audience_options
+    )
+    return unless result
 
     ContactingCreatorMailer.subscribers_data(
-      recipient:,
+      recipient: recipient,
       tempfile: result.tempfile,
       filename: result.filename,
     ).deliver_now

--- a/db/migrate/20251210131842_create_audience_exports.rb
+++ b/db/migrate/20251210131842_create_audience_exports.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreateAudienceExports < ActiveRecord::Migration[7.0]
+  def change
+    create_table :audience_exports do |t|
+      t.bigint :recipient_id, null: false, index: true
+      t.text :audience_options
+      t.timestamps
+    end
+
+    create_table :audience_export_chunks do |t|
+      t.bigint :export_id, null: false, index: true
+      t.longtext :member_ids
+      t.longtext :members_data
+      t.boolean :processed, default: false, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_11_24_133549) do
+ActiveRecord::Schema[7.1].define(version: 2025_12_10_131842) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -144,6 +144,24 @@ ActiveRecord::Schema[7.1].define(version: 2025_11_24_133549) do
     t.string "unsplash_url"
     t.index ["deleted_at"], name: "index_asset_previews_on_deleted_at"
     t.index ["link_id"], name: "index_asset_previews_on_link_id"
+  end
+
+  create_table "audience_export_chunks", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "export_id", null: false
+    t.text "member_ids", size: :long
+    t.text "members_data", size: :long
+    t.boolean "processed", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["export_id"], name: "index_audience_export_chunks_on_export_id"
+  end
+
+  create_table "audience_exports", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "recipient_id", null: false
+    t.text "audience_options"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["recipient_id"], name: "index_audience_exports_on_recipient_id"
   end
 
   create_table "audience_members", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|

--- a/spec/factories/audience_exports.rb
+++ b/spec/factories/audience_exports.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :audience_export do
+    association :recipient, factory: :user
+    audience_options { { followers: true } }
+  end
+
+  factory :audience_export_chunk do
+    association :export, factory: :audience_export
+    member_ids { [] }
+    members_data { [] }
+    processed { false }
+  end
+end

--- a/spec/models/audience_export_chunk_spec.rb
+++ b/spec/models/audience_export_chunk_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe AudienceExportChunk do
+  it "belongs to export" do
+    export = create(:audience_export)
+    chunk = create(:audience_export_chunk, export:)
+    expect(chunk.export).to eq(export)
+  end
+
+  it "serializes member_ids as array" do
+    chunk = create(:audience_export_chunk, member_ids: [1, 2, 3])
+    chunk.reload
+    expect(chunk.member_ids).to eq([1, 2, 3])
+  end
+
+  it "serializes members_data as array" do
+    data = [["test@example.com", Time.current.to_s]]
+    chunk = create(:audience_export_chunk, members_data: data)
+    chunk.reload
+    expect(chunk.members_data).to be_an(Array)
+    expect(chunk.members_data.first).to eq(["test@example.com", Time.current.to_s])
+  end
+end

--- a/spec/models/audience_export_spec.rb
+++ b/spec/models/audience_export_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe AudienceExport do
+  describe "#destroy" do
+    it "deletes chunks" do
+      export = create(:audience_export)
+      create(:audience_export_chunk, export:)
+      expect(AudienceExportChunk.count).to eq(1)
+      export.destroy!
+      expect(AudienceExportChunk.count).to eq(0)
+    end
+  end
+
+  describe "validations" do
+    it "requires audience_options" do
+      export = build(:audience_export, audience_options: nil)
+      expect(export).not_to be_valid
+      expect(export.errors[:audience_options]).to be_present
+    end
+  end
+end

--- a/spec/services/exports/audience_export_service_spec.rb
+++ b/spec/services/exports/audience_export_service_spec.rb
@@ -104,4 +104,73 @@ describe Exports::AudienceExportService do
       end
     end
   end
+
+  describe ".export" do
+    let!(:user) { create(:user) }
+    let(:recipient) { user }
+
+    context "when audience size is below threshold" do
+      let!(:followers) { create_list(:active_follower, 10, user: user) }
+      let(:options) { { followers: true } }
+
+      it "processes synchronously and returns result" do
+        result = described_class.export(
+          user: user,
+          recipient: recipient,
+          audience_options: options
+        )
+
+        expect(result).not_to eq(false)
+        expect(result).to respond_to(:tempfile)
+        expect(result).to respond_to(:filename)
+      end
+
+      it "does not create AudienceExport record" do
+        expect {
+          described_class.export(
+            user: user,
+            recipient: recipient,
+            audience_options: options
+          )
+        }.not_to change(AudienceExport, :count)
+      end
+    end
+
+    context "when audience size is above threshold" do
+      let!(:followers) { create_list(:active_follower, 2001, user: user) }
+      let(:options) { { followers: true } }
+
+      it "creates AudienceExport record" do
+        expect {
+          described_class.export(
+            user: user,
+            recipient: recipient,
+            audience_options: options
+          )
+        }.to change(AudienceExport, :count).by(1)
+      end
+
+      it "enqueues CreateAndEnqueueChunksWorker" do
+        expect(Exports::Audience::CreateAndEnqueueChunksWorker).to receive(:perform_async)
+
+        described_class.export(
+          user: user,
+          recipient: recipient,
+          audience_options: options
+        )
+      end
+
+      it "returns false to indicate async processing" do
+        allow(Exports::Audience::CreateAndEnqueueChunksWorker).to receive(:perform_async)
+
+        result = described_class.export(
+          user: user,
+          recipient: recipient,
+          audience_options: options
+        )
+
+        expect(result).to eq(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes: #2092 
## What
Fixed timeout issue when exporting large follower/subscriber lists by implementing chunked processing.

## Why
Users with >2,000 followers/subscribers couldn't export their data because the Sidekiq job would timeout trying to process everything in one go. The job would fail silently and users never received their CSV.

## How
Implemented chunked processing pattern (similar to Sales exports):

1. **Threshold check**: Exports ≤2,000 members process synchronously (fast path)
2. **Chunked processing**: Exports >2,000 split into chunks of 1,000 members each
3. **Parallel processing**: Each chunk processes independently (no timeout risk)
4. **Compilation**: All chunks combine into final CSV and email to user

### Architecture
Small (≤2000) → Process immediately → Email Large (>2000) → Split → Process chunks in parallel → Combine → Email

## AI Disclosure
Model: Claude 4.5 Sonnet 
Code was manually reviewed and modified by me
## Livestream Viewing Confirmation
Have watched both the live streams end-to-end
Followed all the guidelines asked in them
## Screenshot
<img width="593" height="258" alt="Screenshot 2025-12-10 at 8 15 15 PM" src="https://github.com/user-attachments/assets/8d15c0d0-f9a2-47ab-ae2d-5d5f29dcc2e5" />

