### PR TITLE
fix: always show email notice for CSV exports

### DIFF
--- a/app/javascript/components/Audience/CustomersPage.tsx
+++ b/app/javascript/components/Audience/CustomersPage.tsx
@@ -430,11 +430,9 @@ const CustomersPage = ({
                 >
                   Download
                 </NavigationButton>
-                {count > 2000 && (
-                  <div className="mt-2 text-sm text-gray-600">
-                    Exports over 2,000 rows will be processed in the background and emailed to you.
-                  </div>
-                )}
+                <div className="text-muted">
+                  Exports over 2,000 rows will be processed in the background and emailed to you.
+                </div>
               </div>
             </Popover>
           </>


### PR DESCRIPTION
Fixes #1930 

## Issue
The email is only sent when the actual export count exceeds 2,000 rows. However, the notice informing users that "exports exceeding 2,000 rows will be emailed" was not displayed when the “All Time” option was selected. This occurred because the notice was only shown when the page’s filtered customer count exceeded 2,000, but that number does not accurately represent the actual export size.

## Root Cause
The frontend cannot determine the true export row count without making an additional API request. The export date range is independent of the page’s customer filters, so relying on the filtered count was inaccurate.

## Fix
Display the notice consistently: “Exports exceeding 2,000 rows will be emailed.”
This ensures clarity and eliminates the need for additional logic or API calls on the frontend.

## Change
The Sales CSV export dialog will always display the notice, regardless of filtered counts or selected date ranges.

## Before

<img width="1512" height="814" alt="Screenshot 2025-12-10 at 10 18 23 PM" src="https://github.com/user-attachments/assets/03a2ae47-6d88-46e1-832d-e5a8b657c3be" />


## After

<img width="1511" height="814" alt="Screenshot 2025-12-10 at 10 16 51 PM" src="https://github.com/user-attachments/assets/3f344b5f-9bab-40a1-8ed2-d272dd728167" />


## AI Usage
No AI was used to generate any of this code.

## Confirmation
I have watched the Gumroad PR reviews live streaming video.

## Self-Review
I have self-reviewed all the code that I have written.