### PR TITLE
fix: rename "User Memberships" to "User Collaborations" in admin dashboard

### DIFF
--- a/app/javascript/components/Admin/Users/Memberships.tsx
+++ b/app/javascript/components/Admin/Users/Memberships.tsx
@@ -44,7 +44,7 @@ const Memberships = ({ user: { admin_manageable_user_memberships } }: Membership
       <hr />
       <details>
         <summary>
-          <h3>User memberships</h3>
+          <h3>User Collaborations</h3>
         </summary>
         <div className="stack">
           {admin_manageable_user_memberships.map((membership) => (

--- a/app/views/admin/users/_user_memberships.html.erb
+++ b/app/views/admin/users/_user_memberships.html.erb
@@ -3,7 +3,7 @@
   <hr>
   <details>
     <summary>
-      <h3>User memberships</h3>
+      <h3>User Collaborations</h3>
     </summary>
     <div class="stack">
       <% user_memberships.each do |user_membership| %>

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -46,16 +46,16 @@ describe "Admin::UsersController Scenario", type: :system, js: true do
     end
   end
 
-  describe "user memberships" do
-    context "when the user has no user memberships" do
-      it "doesn't render user memberships" do
+  describe "user collaborations" do
+    context "when the user has no user collaborations" do
+      it "doesn't render user collaborations" do
         visit admin_user_path(user.id)
 
-        expect(page).not_to have_text("User memberships")
+        expect(page).not_to have_text("User Collaborations")
       end
     end
 
-    context "when the user has user memberships" do
+    context "when the user has user collaborations" do
       let(:seller_one) { create(:user, :without_username) }
       let(:seller_two) { create(:user) }
       let(:seller_three) { create(:user) }
@@ -64,10 +64,10 @@ describe "Admin::UsersController Scenario", type: :system, js: true do
       let!(:team_membership_two) { create(:team_membership, user:, seller: seller_two) }
       let!(:team_membership_three) { create(:team_membership, user:, seller: seller_three, deleted_at: 1.hour.ago) }
 
-      it "renders user memberships" do
+      it "renders user collaborations" do
         visit admin_user_path(user.id)
 
-        find_and_click "h3", text: "User memberships"
+        find_and_click "h3", text: "User Collaborations"
         expect(page).to have_text(seller_one.display_name(prefer_email_over_default_username: true))
         expect(page).to have_text(seller_two.display_name(prefer_email_over_default_username: true))
         expect(page).not_to have_text(seller_three.display_name(prefer_email_over_default_username: true))


### PR DESCRIPTION
Closes #2062

## Summary
Renames "User Memberships" to "User Collaborations" in the admin dashboard user profile page. This resolves terminology confusion since "memberships" is used for subscription products in Gumroad, while the section actually displays team collaborations (users who have admin/marketing roles on other sellers' accounts).

### Changes
- Updated label in React component (`Memberships.tsx`) for Inertia rendering
- Updated label in ERB partial (`_user_memberships.html.erb`) for legacy/fallback rendering
- Updated spec descriptions and assertions to match new label

## Video
https://www.loom.com/share/b45614763d03496c8c21199839e8cf9c

## Before / After

| Before | After |
|--------|-------|
| <img width="2990" height="1492" alt="image" src="https://github.com/user-attachments/assets/8871ebba-53dd-4d3d-9865-33055ac1a1e5" /> | <img width="2966" height="1498" alt="image" src="https://github.com/user-attachments/assets/3ccc5650-75d4-4517-ad58-1f0f231cc421" /> |


## Test result (local run)
<img width="1590" height="342" alt="image" src="https://github.com/user-attachments/assets/ddf45e6f-9607-4dc1-9781-eb733b8f8a5c" />


## AI disclosure
- Claude was used to assist with code exploration and implementation

## Live stream disclosure
- Watched the Gumroad live streams