### PR TITLE
Fix: prevent suspended accounts from being auto-unsuspended via probation

### DIFF
--- a/app/models/concerns/user/low_balance_fraud_check.rb
+++ b/app/models/concerns/user/low_balance_fraud_check.rb
@@ -26,6 +26,8 @@ module User::LowBalanceFraudCheck
     return if unpaid_balance_cents > LOW_BALANCE_THRESHOLD
 
     AdminMailer.low_balance_notify(id, refunded_or_disputed_purchase_id).deliver_later
+    return if suspended? # Don't change risk state for already suspended users
+
     disable_refunds_and_put_on_probation! unless recently_probated_for_low_balance?
   end
 

--- a/spec/models/concerns/user/low_balance_fraud_check_spec.rb
+++ b/spec/models/concerns/user/low_balance_fraud_check_spec.rb
@@ -57,6 +57,22 @@ describe User::LowBalanceFraudCheck do
         allow(@creator).to receive(:unpaid_balance_cents).and_return(-200_00)
       end
 
+      context "when the creator is suspended for fraud" do
+        before do
+          @creator.flag_for_fraud!(author_name: "test_admin")
+          @creator.suspend_for_fraud!(author_name: "test_admin")
+        end
+
+        it "notifies admins but keeps the creator suspended and off probation" do
+          expect do
+            @creator.check_for_low_balance_and_probate(@purchase.id)
+          end.to have_enqueued_mail(AdminMailer, :low_balance_notify).with(@creator.id, @purchase.id)
+
+          expect(@creator.reload.suspended_for_fraud?).to eq(true)
+          expect(@creator.reload.on_probation?).to eq(false)
+        end
+      end
+
       context "when the creator is not on probation" do
         context "when the creator is not recently probated for low balance" do
           it "probates the creator" do


### PR DESCRIPTION
Closes: #2049


## Summary
Prevents suspended (fraud/TOS) accounts from being automatically moved to probation when their balance goes negative due to chargebacks. Previously, the low-balance fraud check would unsuspend these accounts, allowing creators to log in and change bank details.

### Changes
- Added guard in `check_for_low_balance_and_probate` to skip probation for suspended users
- Admin notification still fires so risk team is alerted to negative balance
- Added test coverage for suspended user scenario

### Screen Recording
https://github.com/user-attachments/assets/66365237-5cdf-4e94-a07d-b409cd6a941b


### Before:
```
def check_for_low_balance_and_probate(refunded_or_disputed_purchase_id)
  return if unpaid_balance_cents > LOW_BALANCE_THRESHOLD

  AdminMailer.low_balance_notify(id, refunded_or_disputed_purchase_id).deliver_later
  disable_refunds_and_put_on_probation! unless recently_probated_for_low_balance?
end
```

### After:
```
def check_for_low_balance_and_probate(refunded_or_disputed_purchase_id)
  return if unpaid_balance_cents > LOW_BALANCE_THRESHOLD

  AdminMailer.low_balance_notify(id, refunded_or_disputed_purchase_id).deliver_later
  return if suspended? # Don't change risk state for already suspended users

  disable_refunds_and_put_on_probation! unless recently_probated_for_low_balance?
end
```

## Tests Result:
<img width="1828" height="1100" alt="image" src="https://github.com/user-attachments/assets/9f0d34e9-3e9f-4f9b-b239-4c34eacd3753" />

### AI Disclosure:
- Claude Opus 4.5

### Live Stream Disclosure:
- Watched all live streams