### PR TITLE
chore: Remove unused code for service charges search functionality

### DIFF
--- a/app/services/admin_search_service.rb
+++ b/app/services/admin_search_service.rb
@@ -80,43 +80,6 @@ class AdminSearchService
     purchases.limit(limit)
   end
 
-  def search_service_charges(query: nil, creator_email: nil, transaction_date: nil, last_4: nil, card_type: nil, price: nil, expiry_date: nil, limit: nil)
-    service_charges = ServiceCharge.order(created_at: :desc)
-
-    if query.present?
-      service_charges = service_charges.joins(:user).where(users: { email: query })
-    end
-
-    if creator_email.present?
-      user = User.find_by(email: creator_email)
-      return ServiceCharge.none unless user
-      service_charges = service_charges.where(user_id: user.id)
-    end
-
-    if [transaction_date, last_4, card_type, price, expiry_date].any?
-      service_charges = service_charges.where.not(charge_processor_fingerprint: nil)
-
-      if transaction_date.present?
-        formatted_date = parse_date!(transaction_date)
-        start_date = (formatted_date - 1.days).beginning_of_day.to_fs(:db)
-        end_date = (formatted_date + 1.days).end_of_day.to_fs(:db)
-        service_charges = service_charges.where("created_at between ? and ?", start_date, end_date)
-      end
-
-      service_charges = service_charges.where(card_type:) if card_type.present?
-      service_charges = service_charges.where(card_visual_sql_finder(last_4)) if last_4.present?
-      service_charges = service_charges.where("charge_cents between ? and ?", (price.to_d * 75).to_i, (price.to_d * 125).to_i) if price.present?
-
-      if expiry_date.present?
-        expiry_month, expiry_year = CreditCardUtility.extract_month_and_year(expiry_date)
-        service_charges = service_charges.where(card_expiry_year: "20#{expiry_year}") if expiry_year.present?
-        service_charges = service_charges.where(card_expiry_month: expiry_month) if expiry_month.present?
-      end
-    end
-
-    service_charges.limit(limit)
-  end
-
   private
     def parse_date!(transaction_date)
       Date.strptime(transaction_date, "%Y-%m-%d").in_time_zone

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -38,7 +38,6 @@ namespace :admin do
       end
       resources :guids, only: [:index]
     end
-    resources :service_charges, only: :index
     member do
       post :add_credit
       post :mass_transfer_purchases


### PR DESCRIPTION
  ## What PR does? 
  - Remove `AdminSearchService#search_service_charges` method (never called) -   This appears to be incomplete cleanup from a removed feature.

  ## Verification
  Confirmed via codebase search:
  - No calls to `search_service_charges`
  - No `ServiceChargesController` in admin namespace
  - No tests for this functionality
  - No views or frontend references
  
<img width="688" height="261" alt="Screenshot 2025-12-13 at 2 20 16 PM" src="https://github.com/user-attachments/assets/9580f18e-2df6-48d2-8d6d-45b625cf8f98" />

<img width="263" height="194" alt="Screenshot 2025-12-13 at 2 28 07 PM" src="https://github.com/user-attachments/assets/940fddf9-2fa4-4674-be79-00796f20a458" />

### AI Disclosure:
- used claude-code-4.5 to make sure it's safe to remove and not used anywhere. 

### Live Stream Disclosure:
- watched all 4 live streams. 
