### PR TITLE
fix: handle null selected_year on tax center

### DIFF
--- a/app/javascript/pages/TaxCenter/Index.tsx
+++ b/app/javascript/pages/TaxCenter/Index.tsx
@@ -88,7 +88,7 @@ const TaxCenterIndex = () => {
   const { documents, available_years, selected_year } = cast<{
     documents: TaxDocument[];
     available_years: number[];
-    selected_year: number;
+    selected_year: number | null;
   }>(usePage().props);
   const loggedInUser = useLoggedInUser();
   const [isLoading, setIsLoading] = React.useState(false);
@@ -141,7 +141,7 @@ const TaxCenterIndex = () => {
       <section className="p-4 md:p-8">
         <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <h2>Tax documents</h2>
-          {available_years.length > 0 && (
+          {selected_year ? (
             <div className="flex items-center gap-3">
               <select
                 aria-label="Tax year"
@@ -156,7 +156,7 @@ const TaxCenterIndex = () => {
                 ))}
               </select>
             </div>
-          )}
+          ) : null}
         </div>
 
         {documents.length > 0 ? (

--- a/spec/presenters/tax_center_presenter_spec.rb
+++ b/spec/presenters/tax_center_presenter_spec.rb
@@ -22,6 +22,19 @@ describe TaxCenterPresenter do
       end
     end
 
+    context "when seller was created in the current year" do
+      let(:seller) { create(:user, created_at: Time.current) }
+      let(:presenter) { described_class.new(seller:, year: Time.current.year) }
+
+      it "returns empty available years and nil selected year" do
+        result = presenter.props
+
+        expect(result[:available_years]).to eq([])
+        expect(result[:selected_year]).to be_nil
+        expect(result[:documents]).to eq([])
+      end
+    end
+
     context "when seller has a tax form for the year" do
       let!(:tax_form) { create(:user_tax_form, user: seller, tax_year: 2023, tax_form_type: "us_1099_k") }
       let!(:product) { create(:product, user: seller, price_cents: 1000) }


### PR DESCRIPTION
# Problem
Payouts > Taxes page was blank and showed a JavaScript error: "Expected root.selected_year to be a number, got null". Users created in the current year could not access their tax information because the system had no available tax years to display

### Action Performed
1. Navigate to https://gumroad.com/payouts/taxes as a user registered this year

# Root cause analysis
The `available_years` method returns an empty array when a seller was created in the current year. 
https://github.com/antiwork/gumroad/blob/74e6bc9a7c7b57a71089b617b53c8e82b70fb337/app/presenters/tax_center_presenter.rb#L77-L82

The `selected_year` becomes null because the `available_years` empty
https://github.com/antiwork/gumroad/blob/74e6bc9a7c7b57a71089b617b53c8e82b70fb337/app/presenters/tax_center_presenter.rb#L8

The frontend not handling the null case
https://github.com/antiwork/gumroad/blob/74e6bc9a7c7b57a71089b617b53c8e82b70fb337/app/javascript/pages/TaxCenter/Index.tsx#L91

# Before After
## Before

<img width="1470" height="795" alt="image" src="https://github.com/user-attachments/assets/6e3b22d0-eb15-45a4-90b4-23b8cdc294a3" />

## After

<img width="1470" height="798" alt="image" src="https://github.com/user-attachments/assets/61abdb33-1bf9-4e37-a8d8-6d0bb791282e" />