### PR TITLE
refactor(merchant accounts): use external_id instead of id

### DIFF
--- a/app/controllers/admin/merchant_accounts_controller.rb
+++ b/app/controllers/admin/merchant_accounts_controller.rb
@@ -2,8 +2,12 @@
 
 class Admin::MerchantAccountsController < Admin::BaseController
   def show
-    @merchant_account = MerchantAccount.find_by(id: params[:id]) || MerchantAccount.find_by(charge_processor_merchant_id: params[:id]) || e404
-    @title = "Merchant Account #{@merchant_account.id}"
+    if !MerchantAccount.external_id?(params[:external_id]) && merchant_account = MerchantAccount.find_by(id: params[:external_id])
+      return redirect_to admin_merchant_account_path(merchant_account.external_id)
+    end
+
+    @merchant_account = MerchantAccount.find_by_external_id(params[:external_id]) || MerchantAccount.find_by(charge_processor_merchant_id: params[:external_id]) || e404
+    @title = "Merchant Account #{@merchant_account.external_id}"
     render inertia: "Admin/MerchantAccounts/Show", props: { merchant_account: Admin::MerchantAccountPresenter.new(merchant_account: @merchant_account).props }
   end
 end

--- a/app/controllers/admin/users/merchant_accounts_controller.rb
+++ b/app/controllers/admin/users/merchant_accounts_controller.rb
@@ -5,7 +5,7 @@ class Admin::Users::MerchantAccountsController < Admin::Users::BaseController
 
   def index
     render json: {
-      merchant_accounts: @user.merchant_accounts.as_json(only: %i[id charge_processor_id], methods: %i[alive charge_processor_alive]),
+      merchant_accounts: @user.merchant_accounts.as_json(only: %i[charge_processor_id], methods: %i[external_id alive charge_processor_alive]),
       has_stripe_account: @user.merchant_accounts.alive.charge_processor_alive.stripe.any?
     }
   end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -74,8 +74,8 @@ class Admin::UsersController < Admin::BaseController
                                                                    from_admin: true)
     render json: {
       success: true,
-      message: "Merchant Account created, ID: #{merchant_account.id} Stripe Account ID: #{merchant_account.charge_processor_merchant_id}",
-      merchant_account_id: merchant_account.id,
+      message: "Merchant Account created, External ID: #{merchant_account.external_id} Stripe Account ID: #{merchant_account.charge_processor_merchant_id}",
+      merchant_account_external_id: merchant_account.external_id,
       charge_processor_merchant_id: merchant_account.charge_processor_merchant_id
     }
   rescue MerchantRegistrationUserAlreadyHasAccountError

--- a/app/javascript/components/Admin/Purchases/index.tsx
+++ b/app/javascript/components/Admin/Purchases/index.tsx
@@ -35,7 +35,7 @@ export type Purchase = PurchaseStatesInfo & {
     email: string;
   };
   merchant_account: {
-    id: number;
+    external_id: string;
     charge_processor_id: string;
     holder_of_funds: string;
   } | null;
@@ -173,8 +173,8 @@ const Info = ({ purchase }: { purchase: Purchase }) => (
         <>
           <dt>Merchant account</dt>
           <dd>
-            <Link href={Routes.admin_merchant_account_path(purchase.merchant_account.id)}>
-              {purchase.merchant_account.id} – {purchase.merchant_account.charge_processor_id}
+            <Link href={Routes.admin_merchant_account_path(purchase.merchant_account.external_id)}>
+              {purchase.merchant_account.external_id} – {purchase.merchant_account.charge_processor_id}
             </Link>
           </dd>
           <dt>Funds held by</dt>

--- a/app/javascript/components/Admin/Users/MerchantAccounts.tsx
+++ b/app/javascript/components/Admin/Users/MerchantAccounts.tsx
@@ -20,16 +20,16 @@ type AdminUserMerchantAccountsData = {
 };
 
 export type MerchantAccountProps = {
-  id: number;
+  external_id: string;
   charge_processor_id: string;
   alive: boolean;
   charge_processor_alive: boolean;
 };
 
-const MerchantAccount = ({ id, charge_processor_id, alive, charge_processor_alive }: MerchantAccountProps) => (
+const MerchantAccount = ({ external_id, charge_processor_id, alive, charge_processor_alive }: MerchantAccountProps) => (
   <li>
-    <Link href={Routes.admin_merchant_account_path(id)}>
-      {id} - {charge_processor_id}
+    <Link href={Routes.admin_merchant_account_path(external_id)}>
+      {external_id} - {charge_processor_id}
     </Link>{" "}
     <BooleanIcon value={alive ? charge_processor_alive : false} />
   </li>
@@ -65,7 +65,7 @@ const AdminUserMerchantAccounts = ({ user }: AdminUserMerchantAccountsProps) => 
       {data?.merchant_accounts && data.merchant_accounts.length > 0 ? (
         <ul className="inline">
           {data.merchant_accounts.map((merchant_account: MerchantAccountProps) => (
-            <MerchantAccount key={merchant_account.id} {...merchant_account} />
+            <MerchantAccount key={merchant_account.external_id} {...merchant_account} />
           ))}
         </ul>
       ) : (

--- a/app/javascript/pages/Admin/MerchantAccounts/Show.tsx
+++ b/app/javascript/pages/Admin/MerchantAccounts/Show.tsx
@@ -7,7 +7,6 @@ import DateTimeWithRelativeTooltip from "$app/components/Admin/DateTimeWithRelat
 import { BooleanIcon, NoIcon } from "$app/components/Admin/Icons";
 
 export type AdminMerchantAccountProps = {
-  id: number;
   charge_processor_id: string;
   charge_processor_merchant_id: string | null;
   created_at: string;
@@ -32,16 +31,13 @@ const AdminMerchantAccountsShow = () => {
   return (
     <div className="override grid gap-4 rounded border border-border bg-background p-4">
       <div>
-        <h2>Merchant Account {merchant_account.id}</h2>
+        <h2>Merchant Account {merchant_account.external_id}</h2>
         <DateTimeWithRelativeTooltip date={merchant_account.created_at} utc />
       </div>
 
       <hr />
       <div>
         <dl>
-          <dt>ID</dt>
-          <dd>{merchant_account.id}</dd>
-
           <dt>External ID</dt>
           <dd>{merchant_account.external_id}</dd>
 

--- a/app/presenters/admin/merchant_account_presenter.rb
+++ b/app/presenters/admin/merchant_account_presenter.rb
@@ -9,7 +9,6 @@ class Admin::MerchantAccountPresenter
 
   def props
     {
-      id: merchant_account.id,
       charge_processor_id: merchant_account.charge_processor_id,
       charge_processor_merchant_id: merchant_account.charge_processor_merchant_id,
       created_at: merchant_account.created_at,

--- a/app/presenters/admin/purchase_presenter.rb
+++ b/app/presenters/admin/purchase_presenter.rb
@@ -48,7 +48,7 @@ class Admin::PurchasePresenter
                        deleted_at: purchase.deleted_at,
                        external_id: purchase.external_id,
                        merchant_account: purchase.merchant_account.present? ? {
-                         id: purchase.merchant_account.id,
+                         external_id: purchase.merchant_account.external_id,
                          charge_processor_id: purchase.merchant_account.charge_processor_id&.capitalize,
                          holder_of_funds: purchase.merchant_account.holder_of_funds.capitalize,
                        } : nil,

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -128,7 +128,7 @@ namespace :admin do
 
   resources :sales_reports, only: [:index, :create]
 
-  resources :merchant_accounts, only: [:show] do
+  resources :merchant_accounts, only: [:show], param: :external_id do
     member do
       get :live_attributes
     end

--- a/spec/controllers/admin/merchant_accounts_controller_spec.rb
+++ b/spec/controllers/admin/merchant_accounts_controller_spec.rb
@@ -16,10 +16,26 @@ describe Admin::MerchantAccountsController, type: :controller, inertia: true do
   end
 
   describe "GET show" do
-    let(:merchant_account) { MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id) }
+    let(:merchant_account) { create(:merchant_account) }
 
-    it "renders the page successfully" do
-      get :show, params: { id: merchant_account }
+    before do
+      allow(Stripe::Account).to receive(:retrieve).and_return(double(:account, charges_enabled: true, payouts_enabled: true, requirements: double(:requirements, disabled_reason: nil, as_json: {})))
+    end
+
+    it "redirects numeric ID to external_id" do
+      get :show, params: { external_id: merchant_account.id }
+      expect(response).to redirect_to admin_merchant_account_path(merchant_account.external_id)
+    end
+
+    it "renders the page successfully with external_id" do
+      get :show, params: { external_id: merchant_account.external_id }
+
+      expect(response).to be_successful
+      expect(inertia.component).to eq("Admin/MerchantAccounts/Show")
+    end
+
+    it "renders the page successfully with charge_processor_merchant_id" do
+      get :show, params: { external_id: merchant_account.charge_processor_merchant_id }
 
       expect(response).to be_successful
       expect(inertia.component).to eq("Admin/MerchantAccounts/Show")

--- a/spec/controllers/admin/users/merchant_accounts_controller_spec.rb
+++ b/spec/controllers/admin/users/merchant_accounts_controller_spec.rb
@@ -35,7 +35,7 @@ describe Admin::Users::MerchantAccountsController do
         expect(response.parsed_body["merchant_accounts"].length).to eq(2)
 
         merchant_account = response.parsed_body["merchant_accounts"].first
-        expect(merchant_account.keys).to match_array(%w[id charge_processor_id alive charge_processor_alive])
+        expect(merchant_account.keys).to match_array(%w[charge_processor_id external_id alive charge_processor_alive])
       end
 
       it "returns true for has_stripe_account" do

--- a/spec/presenters/admin/merchant_account_presenter_spec.rb
+++ b/spec/presenters/admin/merchant_account_presenter_spec.rb
@@ -18,7 +18,6 @@ describe Admin::MerchantAccountPresenter do
       describe "fields" do
         it "returns the correct field values" do
           expect(props).to match(
-            id: merchant_account.id,
             charge_processor_id: merchant_account.charge_processor_id,
             charge_processor_merchant_id: merchant_account.charge_processor_merchant_id,
             created_at: merchant_account.created_at,

--- a/spec/presenters/admin/purchase_presenter_spec.rb
+++ b/spec/presenters/admin/purchase_presenter_spec.rb
@@ -44,7 +44,7 @@ describe Admin::PurchasePresenter do
               search_url: ChargeProcessor.transaction_url_for_admin(purchase.charge_processor_id, purchase.stripe_transaction_id, purchase.charged_using_gumroad_merchant_account?),
             },
             merchant_account: {
-              id: purchase.merchant_account.id,
+              external_id: purchase.merchant_account.external_id,
               charge_processor_id: purchase.merchant_account.charge_processor_id.capitalize,
               holder_of_funds: purchase.merchant_account.holder_of_funds.capitalize,
             },


### PR DESCRIPTION
Part of https://github.com/antiwork/gumroad/issues/2070

# Summary
Migrated **merchant accounts** admin routes to use external_id instead of numeric database IDs for better security, consistency, and public shareability.

# After

### Redirect id to external id

https://github.com/user-attachments/assets/a4a1a87e-bbed-436d-a48d-5da7fa40b2b0

### Open merchant account detail page from user page

https://github.com/user-attachments/assets/1f5e396a-bc3f-4432-bef0-d5ed429426cb

### Create Stripe merchant account

https://github.com/user-attachments/assets/c570d75e-80b2-4d2a-96eb-c972006fc62b

### No unintended redirection for external id start with number

https://github.com/user-attachments/assets/a356cc11-2d01-4513-b630-759c071cb01b


