### PR TITLE
convert email routes to inertia

### DIFF
--- a/app/controllers/emails_controller.rb
+++ b/app/controllers/emails_controller.rb
@@ -1,21 +1,45 @@
 # frozen_string_literal: true
 
 class EmailsController < Sellers::BaseController
-  before_action :set_body_id_as_app
+  # TODO: Remove set_body_id_as_app once all email pages are migrated to Inertia
+  before_action :set_body_id_as_app, only: %i[index]
+  before_action :set_inertia_layout, only: %i[published scheduled]
 
   def index
     authorize Installment
 
     create_user_event("emails_view")
 
+    # TODO: Remove this redirect logic once all email pages are migrated to Inertia
+    # For now, /emails/drafts, /emails/new, /emails/:id/edit are still handled by react-router
     if request.path == emails_path
       default_tab = Installment.alive.not_workflow_installment.scheduled.where(seller: current_seller).exists? ? "scheduled" : "published"
       redirect_to "#{emails_path}/#{default_tab}", status: :moved_permanently
     end
   end
 
+  def published
+    authorize Installment, :index?
+    create_user_event("emails_view")
+
+    presenter = PaginatedInstallmentsPresenter.new(seller: current_seller, type: Installment::PUBLISHED, page: 1)
+    render inertia: "Emails/Published", props: presenter.props
+  end
+
+  def scheduled
+    authorize Installment, :index?
+    create_user_event("emails_view")
+
+    presenter = PaginatedInstallmentsPresenter.new(seller: current_seller, type: Installment::SCHEDULED, page: 1)
+    render inertia: "Emails/Scheduled", props: presenter.props
+  end
+
   private
     def set_title
       @title = "Emails"
+    end
+
+    def set_inertia_layout
+      self.class.layout "inertia"
     end
 end

--- a/app/javascript/components/EmailsPage/Layout.tsx
+++ b/app/javascript/components/EmailsPage/Layout.tsx
@@ -1,0 +1,74 @@
+import { Link } from "@inertiajs/react";
+import React from "react";
+
+import { PageHeader } from "$app/components/ui/PageHeader";
+import { Tab, Tabs } from "$app/components/ui/Tabs";
+
+// TODO: Add "drafts" tab back once Drafts page is migrated to Inertia
+const TABS = ["published", "scheduled", "subscribers"] as const;
+export type EmailTab = (typeof TABS)[number];
+
+// Path helpers using Rails routes
+export const emailTabPath = (tab: (typeof TABS)[number]) => {
+  switch (tab) {
+    case "published":
+      return Routes.published_emails_path();
+    case "scheduled":
+      return Routes.scheduled_emails_path();
+    case "subscribers":
+      return Routes.followers_path();
+  }
+};
+
+type LayoutProps = {
+  selectedTab: EmailTab;
+  children: React.ReactNode;
+  hideNewButton?: boolean;
+};
+
+export const EmailsLayout = ({ selectedTab, children, hideNewButton }: LayoutProps) => {
+  return (
+    <div>
+      <PageHeader title="Emails" actions={!hideNewButton && <NewEmailButton />}>
+        <Tabs>
+          <Tab asChild isSelected={selectedTab === "published"}>
+            <Link href={Routes.published_emails_path()}>Published</Link>
+          </Tab>
+          <Tab asChild isSelected={selectedTab === "scheduled"}>
+            <Link href={Routes.scheduled_emails_path()}>Scheduled</Link>
+          </Tab>
+          {/* TODO: Add Drafts tab back once Drafts page is migrated to Inertia */}
+          <Tab href={Routes.followers_path()} isSelected={false}>
+            Subscribers
+          </Tab>
+        </Tabs>
+      </PageHeader>
+      {children}
+    </div>
+  );
+};
+
+// Path helpers for server-components (react-router pages)
+// TODO: Remove these once all email pages are migrated to Inertia
+export const newEmailPath = "/emails/new";
+export const editEmailPath = (id: string) => `/emails/${id}/edit`;
+
+// TODO: Update to use Inertia Link once New email page is migrated
+export const NewEmailButton = ({ copyFrom }: { copyFrom?: string } = {}) => {
+  const href = copyFrom ? `/emails/new?copy_from=${copyFrom}` : "/emails/new";
+
+  return (
+    <a className={copyFrom ? "button" : "button accent"} href={href}>
+      {copyFrom ? "Duplicate" : "New email"}
+    </a>
+  );
+};
+
+// TODO: Update to use Inertia Link once Edit email page is migrated
+export const EditEmailButton = ({ id }: { id: string }) => {
+  return (
+    <a className="button" href={`/emails/${id}/edit`}>
+      Edit
+    </a>
+  );
+};

--- a/app/javascript/components/client-components/Nav/index.tsx
+++ b/app/javascript/components/client-components/Nav/index.tsx
@@ -123,7 +123,7 @@ export const Nav = (props: Props) => {
           href={Routes.checkout_discounts_url(routeParams)}
           additionalPatterns={[Routes.checkout_form_url(routeParams), Routes.checkout_upsells_url(routeParams)]}
         />
-        <NavLink
+        <ClientNavLink
           text="Emails"
           icon="envelope-fill"
           href={Routes.emails_url(routeParams)}

--- a/app/javascript/pages/Emails/Published.tsx
+++ b/app/javascript/pages/Emails/Published.tsx
@@ -1,0 +1,346 @@
+import { usePage } from "@inertiajs/react";
+import React from "react";
+import { cast } from "ts-safe-cast";
+
+import {
+  deleteInstallment,
+  getPublishedInstallments,
+  Pagination,
+  PublishedInstallment,
+  previewInstallment,
+  SavedInstallment,
+} from "$app/data/installments";
+import { assertDefined } from "$app/utils/assert";
+import { classNames } from "$app/utils/classNames";
+import { formatStatNumber } from "$app/utils/formatStatNumber";
+import { asyncVoid } from "$app/utils/promise";
+import { AbortError, assertResponseError } from "$app/utils/request";
+
+import { Button, NavigationButton } from "$app/components/Button";
+import { useCurrentSeller } from "$app/components/CurrentSeller";
+import { EditEmailButton, EmailsLayout, NewEmailButton } from "$app/components/EmailsPage/Layout";
+import { Icon } from "$app/components/Icons";
+import { Modal } from "$app/components/Modal";
+import { showAlert } from "$app/components/server-components/Alert";
+import { Sheet, SheetHeader } from "$app/components/ui/Sheet";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "$app/components/ui/Table";
+import Placeholder from "$app/components/ui/Placeholder";
+import { useUserAgentInfo } from "$app/components/UserAgent";
+import { WithTooltip } from "$app/components/WithTooltip";
+
+import publishedPlaceholder from "$assets/images/placeholders/published_posts.png";
+
+type PageProps = {
+  installments: PublishedInstallment[];
+  pagination: Pagination;
+};
+
+export default function EmailsPublished() {
+  const { installments: initialInstallments, pagination: initialPagination } = cast<PageProps>(usePage().props);
+  const [installments, setInstallments] = React.useState<PublishedInstallment[]>(initialInstallments);
+  const [pagination, setPagination] = React.useState<Pagination>(initialPagination);
+  const currentSeller = assertDefined(useCurrentSeller(), "currentSeller is required");
+  const [selectedInstallmentId, setSelectedInstallmentId] = React.useState<string | null>(null);
+  const [deletingInstallment, setDeletingInstallment] = React.useState<{
+    id: string;
+    name: string;
+    state: "delete-confirmation" | "deleting";
+  } | null>(null);
+  const [isLoading, setIsLoading] = React.useState(false);
+  const selectedInstallment = selectedInstallmentId
+    ? (installments.find((i) => i.external_id === selectedInstallmentId) ?? null)
+    : null;
+
+  const activeFetchRequest = React.useRef<{ cancel: () => void } | null>(null);
+
+  const fetchInstallments = async ({ reset }: { reset: boolean }) => {
+    const nextPage = reset ? 1 : pagination.next;
+    if (!nextPage) return;
+    setIsLoading(true);
+    try {
+      activeFetchRequest.current?.cancel();
+      const request = getPublishedInstallments({ page: nextPage, query: "" });
+      activeFetchRequest.current = request;
+      const response = await request.response;
+      setInstallments(reset ? response.installments : [...installments, ...response.installments]);
+      setPagination(response.pagination);
+      activeFetchRequest.current = null;
+      setIsLoading(false);
+    } catch (e) {
+      if (e instanceof AbortError) return;
+      activeFetchRequest.current = null;
+      setIsLoading(false);
+      assertResponseError(e);
+      showAlert("Sorry, something went wrong. Please try again.", "error");
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deletingInstallment) return;
+    try {
+      setDeletingInstallment({ ...deletingInstallment, state: "deleting" });
+      await deleteInstallment(deletingInstallment.id);
+      setInstallments(installments.filter((installment) => installment.external_id !== deletingInstallment.id));
+      setDeletingInstallment(null);
+      showAlert("Email deleted!", "success");
+    } catch (e) {
+      assertResponseError(e);
+      showAlert("Sorry, something went wrong. Please try again.", "error");
+    }
+  };
+
+  const userAgentInfo = useUserAgentInfo();
+
+  return (
+    <EmailsLayout selectedTab="published">
+      <div className="space-y-4 p-4 md:p-8">
+        {installments.length > 0 ? (
+          <>
+            <Table
+              aria-live="polite"
+              className={classNames(isLoading && "pointer-events-none opacity-50")}
+              aria-label="Published"
+            >
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Subject</TableHead>
+                  <TableHead>Date</TableHead>
+                  <TableHead>Emailed</TableHead>
+                  <TableHead>Opened</TableHead>
+                  <TableHead>Clicks</TableHead>
+                  <TableHead>
+                    Views{" "}
+                    <WithTooltip
+                      position="top"
+                      tip="Views only apply to emails published on your profile."
+                      className="whitespace-normal"
+                    >
+                      <Icon name="info-circle" />
+                    </WithTooltip>
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {installments.map((installment) => (
+                  <TableRow
+                    key={installment.external_id}
+                    selected={installment.external_id === selectedInstallmentId}
+                    onClick={() => setSelectedInstallmentId(installment.external_id)}
+                  >
+                    <TableCell>{installment.name}</TableCell>
+                    <TableCell className="whitespace-nowrap">
+                      {new Date(installment.published_at).toLocaleDateString(userAgentInfo.locale, {
+                        day: "numeric",
+                        month: "short",
+                        year: "numeric",
+                        timeZone: currentSeller.timeZone.name,
+                      })}
+                    </TableCell>
+                    <TableCell className="whitespace-nowrap">
+                      {installment.send_emails ? formatStatNumber({ value: installment.sent_count }) : "n/a"}
+                    </TableCell>
+                    <TableCell className="whitespace-nowrap">
+                      {installment.send_emails
+                        ? formatStatNumber({ value: installment.open_rate, suffix: "%" })
+                        : "n/a"}
+                    </TableCell>
+                    <TableCell className="whitespace-nowrap">
+                      {installment.clicked_urls.length > 0 ? (
+                        <WithTooltip
+                          tooltipProps={{ className: "w-[20rem] p-0" }}
+                          tip={
+                            <Table>
+                              <TableBody>
+                                {installment.clicked_urls.map(({ url, count }) => (
+                                  <TableRow key={`${installment.external_id}-${url}`} className="bg-transparent">
+                                    <TableHead scope="row" className="max-w-56 whitespace-break-spaces">
+                                      {url}
+                                    </TableHead>
+                                    <TableCell>{formatStatNumber({ value: count })}</TableCell>
+                                  </TableRow>
+                                ))}
+                              </TableBody>
+                            </Table>
+                          }
+                        >
+                          {formatStatNumber({ value: installment.click_count })}
+                        </WithTooltip>
+                      ) : (
+                        formatStatNumber({ value: installment.click_count })
+                      )}
+                    </TableCell>
+                    <TableCell className="whitespace-nowrap">
+                      {formatStatNumber({
+                        value: installment.view_count,
+                        placeholder: "n/a",
+                      })}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+            {pagination.next ? (
+              <Button color="primary" disabled={isLoading} onClick={() => void fetchInstallments({ reset: false })}>
+                Load more
+              </Button>
+            ) : null}
+            {selectedInstallment ? (
+              <Sheet open onOpenChange={() => setSelectedInstallmentId(null)}>
+                <SheetHeader>{selectedInstallment.name}</SheetHeader>
+                <div className="stack">
+                  <div>
+                    <h5>Sent</h5>
+                    {new Date(selectedInstallment.published_at).toLocaleString(userAgentInfo.locale, {
+                      timeZone: currentSeller.timeZone.name,
+                    })}
+                  </div>
+                  <div>
+                    <h5>Emailed</h5>
+                    {selectedInstallment.send_emails
+                      ? formatStatNumber({ value: selectedInstallment.sent_count })
+                      : "n/a"}
+                  </div>
+                  <div>
+                    <h5>Opened</h5>
+                    {selectedInstallment.send_emails
+                      ? selectedInstallment.open_rate !== null
+                        ? `${formatStatNumber({ value: selectedInstallment.open_count })} (${formatStatNumber({ value: selectedInstallment.open_rate, suffix: "%" })})`
+                        : formatStatNumber({ value: selectedInstallment.open_rate })
+                      : "n/a"}
+                  </div>
+                  <div>
+                    <h5>Clicks</h5>
+                    {selectedInstallment.send_emails
+                      ? selectedInstallment.click_rate !== null
+                        ? `${formatStatNumber({ value: selectedInstallment.click_count })} (${formatStatNumber({ value: selectedInstallment.click_rate, suffix: "%" })})`
+                        : formatStatNumber({ value: selectedInstallment.click_rate })
+                      : "n/a"}
+                  </div>
+                  <div>
+                    <h5>Views</h5>
+                    {formatStatNumber({
+                      value: selectedInstallment.view_count,
+                      placeholder: "n/a",
+                    })}
+                  </div>
+                </div>
+                <div className="grid grid-flow-col gap-4">
+                  {selectedInstallment.send_emails ? <ViewEmailButton installment={selectedInstallment} /> : null}
+                  {selectedInstallment.shown_on_profile ? (
+                    <NavigationButton href={selectedInstallment.full_url} target="_blank" rel="noopener noreferrer">
+                      <Icon name="file-earmark-medical-fill"></Icon>
+                      View post
+                    </NavigationButton>
+                  ) : null}
+                </div>
+                <div className="grid grid-flow-col gap-4">
+                  <NewEmailButton copyFrom={selectedInstallment.external_id} />
+                  <EditEmailButton id={selectedInstallment.external_id} />
+                  <Button
+                    color="danger"
+                    onClick={() =>
+                      setDeletingInstallment({
+                        id: selectedInstallment.external_id,
+                        name: selectedInstallment.name,
+                        state: "delete-confirmation",
+                      })
+                    }
+                  >
+                    Delete
+                  </Button>
+                </div>
+              </Sheet>
+            ) : null}
+            {deletingInstallment ? (
+              <Modal
+                open
+                allowClose={deletingInstallment.state === "delete-confirmation"}
+                onClose={() => setDeletingInstallment(null)}
+                title="Delete email?"
+                footer={
+                  <>
+                    <Button
+                      disabled={deletingInstallment.state === "deleting"}
+                      onClick={() => setDeletingInstallment(null)}
+                    >
+                      Cancel
+                    </Button>
+                    {deletingInstallment.state === "deleting" ? (
+                      <Button color="danger" disabled>
+                        Deleting...
+                      </Button>
+                    ) : (
+                      <Button color="danger" onClick={() => void handleDelete()}>
+                        Delete email
+                      </Button>
+                    )}
+                  </>
+                }
+              >
+                <h4>
+                  Are you sure you want to delete the email "{deletingInstallment.name}"? Customers who had access will
+                  no longer be able to see it. This action cannot be undone.
+                </h4>
+              </Modal>
+            ) : null}
+          </>
+        ) : (
+          <EmptyStatePlaceholder
+            title="Connect with your customers."
+            description="Post new updates, send email broadcasts, and use powerful automated workflows to connect and grow your audience."
+            placeholderImage={publishedPlaceholder}
+          />
+        )}
+      </div>
+    </EmailsLayout>
+  );
+}
+
+const ViewEmailButton = (props: { installment: SavedInstallment }) => {
+  const [sendingPreviewEmail, setSendingPreviewEmail] = React.useState(false);
+
+  return (
+    <Button
+      disabled={sendingPreviewEmail}
+      onClick={asyncVoid(async () => {
+        setSendingPreviewEmail(true);
+        try {
+          await previewInstallment(props.installment.external_id);
+          showAlert("A preview has been sent to your email.", "success");
+        } catch (error) {
+          assertResponseError(error);
+          showAlert(error.message, "error");
+        } finally {
+          setSendingPreviewEmail(false);
+        }
+      })}
+    >
+      <Icon name="envelope-fill"></Icon>
+      {sendingPreviewEmail ? "Sending..." : "View email"}
+    </Button>
+  );
+};
+
+const EmptyStatePlaceholder = ({
+  title,
+  description,
+  placeholderImage,
+}: {
+  title: string;
+  description: string;
+  placeholderImage: string;
+}) => (
+  <Placeholder>
+    <figure>
+      <img src={placeholderImage} />
+    </figure>
+    <h2>{title}</h2>
+    <p>{description}</p>
+    <NewEmailButton />
+    <p>
+      <a href="/help/article/169-how-to-send-an-update" target="_blank" rel="noreferrer">
+        Learn more about emails
+      </a>
+    </p>
+  </Placeholder>
+);

--- a/app/javascript/pages/Emails/Scheduled.tsx
+++ b/app/javascript/pages/Emails/Scheduled.tsx
@@ -1,0 +1,329 @@
+import { usePage } from "@inertiajs/react";
+import React from "react";
+import { cast } from "ts-safe-cast";
+
+import {
+  deleteInstallment,
+  getAudienceCount,
+  getScheduledInstallments,
+  Pagination,
+  ScheduledInstallment,
+  previewInstallment,
+  SavedInstallment,
+} from "$app/data/installments";
+import { assertDefined } from "$app/utils/assert";
+import { classNames } from "$app/utils/classNames";
+import { asyncVoid } from "$app/utils/promise";
+import { AbortError, assertResponseError } from "$app/utils/request";
+import { formatStatNumber } from "$app/utils/formatStatNumber";
+
+import { Button, NavigationButton } from "$app/components/Button";
+import { useCurrentSeller } from "$app/components/CurrentSeller";
+import { EditEmailButton, EmailsLayout, NewEmailButton } from "$app/components/EmailsPage/Layout";
+import { Icon } from "$app/components/Icons";
+import { Modal } from "$app/components/Modal";
+import { showAlert } from "$app/components/server-components/Alert";
+import { Sheet, SheetHeader } from "$app/components/ui/Sheet";
+import { Table, TableBody, TableCaption, TableCell, TableHead, TableHeader, TableRow } from "$app/components/ui/Table";
+import Placeholder from "$app/components/ui/Placeholder";
+import { useUserAgentInfo } from "$app/components/UserAgent";
+
+import scheduledPlaceholder from "$assets/images/placeholders/scheduled_posts.png";
+
+type AudienceCounts = Map<string, number | "loading" | "failed">;
+
+const audienceCountValue = (audienceCounts: AudienceCounts, installmentId: string) => {
+  const count = audienceCounts.get(installmentId);
+  return count === undefined || count === "loading"
+    ? null
+    : count === "failed"
+      ? "--"
+      : formatStatNumber({ value: count });
+};
+
+type PageProps = {
+  installments: ScheduledInstallment[];
+  pagination: Pagination;
+};
+
+export default function EmailsScheduled() {
+  const { installments: initialInstallments, pagination: initialPagination } = cast<PageProps>(usePage().props);
+  const [installments, setInstallments] = React.useState<ScheduledInstallment[]>(initialInstallments);
+  const [pagination, setPagination] = React.useState<Pagination>(initialPagination);
+  const currentSeller = assertDefined(useCurrentSeller(), "currentSeller is required");
+  const userAgentInfo = useUserAgentInfo();
+  const installmentsByDate = React.useMemo(
+    () =>
+      installments.reduce<Record<string, ScheduledInstallment[]>>((acc, installment) => {
+        const date = new Date(installment.to_be_published_at).toLocaleDateString(userAgentInfo.locale, {
+          month: "short",
+          day: "numeric",
+          year: "numeric",
+          timeZone: currentSeller.timeZone.name,
+        });
+        if (!acc[date]) acc[date] = [];
+        acc[date].push(installment);
+        return acc;
+      }, {}),
+    [installments, userAgentInfo.locale, currentSeller.timeZone.name],
+  );
+  const [audienceCounts, setAudienceCounts] = React.useState<AudienceCounts>(new Map());
+  React.useEffect(() => {
+    installments.forEach(
+      asyncVoid(async ({ external_id }) => {
+        if (audienceCounts.has(external_id)) return;
+        setAudienceCounts((prev) => new Map(prev).set(external_id, "loading"));
+        try {
+          const { count } = await getAudienceCount(external_id);
+          setAudienceCounts((prev) => new Map(prev).set(external_id, count));
+        } catch (e) {
+          assertResponseError(e);
+          setAudienceCounts((prev) => new Map(prev).set(external_id, "failed"));
+        }
+      }),
+    );
+  }, [installments]);
+  const [selectedInstallmentId, setSelectedInstallmentId] = React.useState<string | null>(null);
+  const selectedInstallment = selectedInstallmentId
+    ? (installments.find((i) => i.external_id === selectedInstallmentId) ?? null)
+    : null;
+  const [deletingInstallment, setDeletingInstallment] = React.useState<{
+    id: string;
+    name: string;
+    state: "delete-confirmation" | "deleting";
+  } | null>(null);
+  const [isLoading, setIsLoading] = React.useState(false);
+
+  const activeFetchRequest = React.useRef<{ cancel: () => void } | null>(null);
+
+  const fetchInstallments = async (reset = false) => {
+    const nextPage = reset ? 1 : pagination.next;
+    if (!nextPage) return;
+    setIsLoading(true);
+    try {
+      activeFetchRequest.current?.cancel();
+      const request = getScheduledInstallments({ page: nextPage, query: "" });
+      activeFetchRequest.current = request;
+      const response = await request.response;
+      setInstallments(reset ? response.installments : [...installments, ...response.installments]);
+      setPagination(response.pagination);
+      activeFetchRequest.current = null;
+      setIsLoading(false);
+    } catch (e) {
+      if (e instanceof AbortError) return;
+      activeFetchRequest.current = null;
+      setIsLoading(false);
+      assertResponseError(e);
+      showAlert("Sorry, something went wrong. Please try again.", "error");
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deletingInstallment) return;
+    try {
+      setDeletingInstallment({ ...deletingInstallment, state: "deleting" });
+      await deleteInstallment(deletingInstallment.id);
+      setInstallments(installments.filter((installment) => installment.external_id !== deletingInstallment.id));
+      setDeletingInstallment(null);
+      showAlert("Email deleted!", "success");
+    } catch (e) {
+      assertResponseError(e);
+      showAlert("Sorry, something went wrong. Please try again.", "error");
+    }
+  };
+
+  return (
+    <EmailsLayout selectedTab="scheduled">
+      <div className="space-y-4 p-4 md:p-8">
+        {installments.length > 0 ? (
+          <>
+            {Object.keys(installmentsByDate).map((date) => (
+              <Table
+                key={date}
+                aria-live="polite"
+                className={classNames("mb-16", isLoading && "pointer-events-none opacity-50")}
+              >
+                <TableCaption>Scheduled for {date}</TableCaption>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Subject</TableHead>
+                    <TableHead>Sent to</TableHead>
+                    <TableHead>Audience</TableHead>
+                    <TableHead>Delivery Time</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {installmentsByDate[date]?.map((installment) => (
+                    <TableRow
+                      key={installment.external_id}
+                      aria-selected={installment.external_id === selectedInstallmentId}
+                      onClick={() => setSelectedInstallmentId(installment.external_id)}
+                    >
+                      <TableCell>{installment.name}</TableCell>
+                      <TableCell>{installment.recipient_description}</TableCell>
+                      <TableCell
+                        aria-busy={audienceCountValue(audienceCounts, installment.external_id) === null}
+                        className="whitespace-nowrap"
+                      >
+                        {audienceCountValue(audienceCounts, installment.external_id)}
+                      </TableCell>
+                      <TableCell className="whitespace-nowrap">
+                        {new Date(installment.to_be_published_at).toLocaleTimeString(userAgentInfo.locale, {
+                          hour: "numeric",
+                          minute: "numeric",
+                          timeZone: currentSeller.timeZone.name,
+                        })}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            ))}
+            {pagination.next ? (
+              <Button color="primary" disabled={isLoading} onClick={() => void fetchInstallments()}>
+                Load more
+              </Button>
+            ) : null}
+            {selectedInstallment ? (
+              <Sheet open onOpenChange={() => setSelectedInstallmentId(null)}>
+                <SheetHeader>{selectedInstallment.name}</SheetHeader>
+                <div className="stack">
+                  <div>
+                    <h5>Sent to</h5>
+                    {selectedInstallment.recipient_description}
+                  </div>
+                  <div>
+                    <h5>Audience</h5>
+                    {audienceCountValue(audienceCounts, selectedInstallment.external_id)}
+                  </div>
+                  <div>
+                    <h5>Delivery Time</h5>
+                    {new Date(selectedInstallment.to_be_published_at).toLocaleString(userAgentInfo.locale, {
+                      month: "short",
+                      day: "numeric",
+                      year: "numeric",
+                      hour: "numeric",
+                      minute: "numeric",
+                      timeZone: currentSeller.timeZone.name,
+                    })}
+                  </div>
+                </div>
+                <div className="grid grid-flow-col gap-4">
+                  {selectedInstallment.send_emails ? <ViewEmailButton installment={selectedInstallment} /> : null}
+                  {selectedInstallment.shown_on_profile ? (
+                    <NavigationButton href={selectedInstallment.full_url} target="_blank" rel="noopener noreferrer">
+                      <Icon name="file-earmark-medical-fill"></Icon>
+                      View post
+                    </NavigationButton>
+                  ) : null}
+                </div>
+                <div className="grid grid-flow-col gap-4">
+                  <NewEmailButton copyFrom={selectedInstallment.external_id} />
+                  <EditEmailButton id={selectedInstallment.external_id} />
+                  <Button
+                    color="danger"
+                    onClick={() =>
+                      setDeletingInstallment({
+                        id: selectedInstallment.external_id,
+                        name: selectedInstallment.name,
+                        state: "delete-confirmation",
+                      })
+                    }
+                  >
+                    Delete
+                  </Button>
+                </div>
+              </Sheet>
+            ) : null}
+            {deletingInstallment ? (
+              <Modal
+                open
+                allowClose={deletingInstallment.state === "delete-confirmation"}
+                onClose={() => setDeletingInstallment(null)}
+                title="Delete email?"
+                footer={
+                  <>
+                    <Button
+                      disabled={deletingInstallment.state === "deleting"}
+                      onClick={() => setDeletingInstallment(null)}
+                    >
+                      Cancel
+                    </Button>
+                    {deletingInstallment.state === "deleting" ? (
+                      <Button color="danger" disabled>
+                        Deleting...
+                      </Button>
+                    ) : (
+                      <Button color="danger" onClick={() => void handleDelete()}>
+                        Delete email
+                      </Button>
+                    )}
+                  </>
+                }
+              >
+                <h4>
+                  Are you sure you want to delete the email "{deletingInstallment.name}"? This action cannot be undone.
+                </h4>
+              </Modal>
+            ) : null}
+          </>
+        ) : (
+          <EmptyStatePlaceholder
+            title="Set it and forget it."
+            description="Schedule an email to be sent exactly when you want."
+            placeholderImage={scheduledPlaceholder}
+          />
+        )}
+      </div>
+    </EmailsLayout>
+  );
+}
+
+const ViewEmailButton = (props: { installment: SavedInstallment }) => {
+  const [sendingPreviewEmail, setSendingPreviewEmail] = React.useState(false);
+
+  return (
+    <Button
+      disabled={sendingPreviewEmail}
+      onClick={asyncVoid(async () => {
+        setSendingPreviewEmail(true);
+        try {
+          await previewInstallment(props.installment.external_id);
+          showAlert("A preview has been sent to your email.", "success");
+        } catch (error) {
+          assertResponseError(error);
+          showAlert(error.message, "error");
+        } finally {
+          setSendingPreviewEmail(false);
+        }
+      })}
+    >
+      <Icon name="envelope-fill"></Icon>
+      {sendingPreviewEmail ? "Sending..." : "View email"}
+    </Button>
+  );
+};
+
+const EmptyStatePlaceholder = ({
+  title,
+  description,
+  placeholderImage,
+}: {
+  title: string;
+  description: string;
+  placeholderImage: string;
+}) => (
+  <Placeholder>
+    <figure>
+      <img src={placeholderImage} />
+    </figure>
+    <h2>{title}</h2>
+    <p>{description}</p>
+    <NewEmailButton />
+    <p>
+      <a href="/help/article/169-how-to-send-an-update" target="_blank" rel="noreferrer">
+        Learn more about emails
+      </a>
+    </p>
+  </Placeholder>
+);

--- a/app/javascript/pages/Followers/Index.tsx
+++ b/app/javascript/pages/Followers/Index.tsx
@@ -39,19 +39,15 @@ const Layout = ({
     <div>
       <PageHeader title={title} actions={actions}>
         <Tabs>
-          <Tab href={`${Routes.emails_path()}/published`} isSelected={false}>
+          <Tab href={Routes.published_emails_path()} isSelected={false}>
             Published
           </Tab>
           {loggedInUser?.policies.installment.create ? (
-            <>
-              <Tab href={`${Routes.emails_path()}/scheduled`} isSelected={false}>
-                Scheduled
-              </Tab>
-              <Tab href={`${Routes.emails_path()}/drafts`} isSelected={false}>
-                Drafts
-              </Tab>
-            </>
+            <Tab href={Routes.scheduled_emails_path()} isSelected={false}>
+              Scheduled
+            </Tab>
           ) : null}
+          {/* TODO: Add Drafts tab back once Drafts page is migrated to Inertia */}
           <Tab href={Routes.followers_path()} isSelected>
             Subscribers
           </Tab>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -397,6 +397,7 @@ Rails.application.routes.draw do
     get "/collaborators/*other", to: "collaborators#index"
 
     get "/affiliates/*other", to: "affiliates#index" # route handled by react-router
+    # TODO: Remove this catch-all once drafts, new, edit email pages are migrated to Inertia
     get "/emails/*other", to: "emails#index" # route handled by react-router
     get "/dashboard/utm_links/*other", to: "utm_links#index" # route handled by react-router
     get "/communities/*other", to: "communities#index" # route handled by react-router
@@ -801,7 +802,13 @@ Rails.application.routes.draw do
     get "/communities(/:seller_id/:community_id)", to: "communities#index", as: :community
 
     # emails
-    get "/emails", to: "emails#index", as: :emails
+    # TODO: Add :drafts, :new, :edit routes once those pages are migrated to Inertia
+    resources :emails, only: [:index] do
+      collection do
+        get :published
+        get :scheduled
+      end
+    end
     get "/posts", to: redirect("/emails")
 
     # workflows


### PR DESCRIPTION
Part of #856 

This PR Migrate following routes to inertia : 
- Published emails page (/emails/published)
- Scheduled emails page (/emails/scheduled)

## AI disclosure
Used Claude Opus 4.5 via Opencode for initial drafting

## Confirmation
I have watched all Antiwork Livestreams