### PR TITLE
Allow restarting membership when product has required custom fields

### DIFF
--- a/app/javascript/components/server-components/SubscriptionManager.tsx
+++ b/app/javascript/components/server-components/SubscriptionManager.tsx
@@ -194,7 +194,7 @@ const SubscriptionManager = ({
     price: Math.round(amountDueToday / product.exchange_rate),
     payInInstallments: subscription.is_installment_plan,
     requireShipping: product.require_shipping,
-    customFields: product.custom_fields,
+    customFields: [], // Custom fields were already collected during original purchase
     bundleProductCustomFields: [],
     supportsPaypal: product.supports_paypal,
     testPurchase: subscription.is_test,


### PR DESCRIPTION
Related to: #1971

Skip custom field validation on the subscription management page by passing an empty array

