### PR TITLE
fix: error handling for admin update email action

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -46,6 +46,8 @@ class Admin::UsersController < Admin::BaseController
     @user.email = params[:update_email][:email_address]
     @user.save!
     render json: { success: true }
+  rescue ActiveRecord::RecordInvalid => e
+    render json: { message: e.message }, status: :unprocessable_entity
   end
 
   def reset_password


### PR DESCRIPTION
# Problem
When changing a user's email in the admin panel (/admin/users/:id), if the email already exists for another user, no error message is displayed in the UI

Noticed this issue when testing PR https://github.com/antiwork/gumroad/pull/2375

### Action Performed
1. Navigate to /admin/users/:id
2. Expand "Change email" section
3. Enter an email that already exists for another user
4. Click "Update email"

# Root cause analysis
The `update_email` action uses `user.save!` which raises ActiveRecord::RecordInvalid when validation fails, and there was no rescue block to catch the exception and return a proper JSON error response

https://github.com/antiwork/gumroad/blob/a84031823f021a8a0aca5844d65b403a6e2eea44/app/controllers/admin/users_controller.rb#L43-L49
# Before After
## Before (No error alert)

https://github.com/user-attachments/assets/3e7eb30e-d52b-40bd-baa4-b29f0aff2674

## After

https://github.com/user-attachments/assets/faaae4a2-4156-4686-85f2-7e2600a76d6e

