### PR TITLE
fix: make payout info and merchant accounts responsive on mobile

### DIFF
--- a/app/javascript/components/Admin/Users/PayoutInfo/PausePayoutsForm.tsx
+++ b/app/javascript/components/Admin/Users/PayoutInfo/PausePayoutsForm.tsx
@@ -21,7 +21,7 @@ const AdminPausePayoutsForm = ({ user_id, onSuccess }: { user_id: number; onSucc
     >
       {(isLoading) => (
         <fieldset>
-          <div className="flex items-end gap-2">
+          <div className="flex flex-col gap-2 md:flex-row md:items-end">
             <textarea
               name="pause_payouts[reason]"
               rows={2}

--- a/app/javascript/components/Admin/Users/User.tsx
+++ b/app/javascript/components/Admin/Users/User.tsx
@@ -91,6 +91,7 @@ const UserCard = ({ user, isAffiliateUser = false }: Props) => {
       <hr />
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
         <AdminUserPayoutInfo user={user} />
+        <hr className="block md:hidden" />
         <AdminUserMerchantAccounts user={user} />
       </div>
       <AdminUserEmailChanges user={user} />


### PR DESCRIPTION
# Problem
Mobile responsive issue on Payout Info and Merchant Account sections. The text input for the pause payout reason is too narrow, making it difficult to use on smaller screens.

Noticed this issue when testing PR https://github.com/antiwork/gumroad/pull/2375

### Action Performed
Go to https://gumroad.com/admin/users/1 on mobile

# Before After
## Before
<img width="348" height="687" alt="Screenshot 2025-12-18 at 14 09 53" src="https://github.com/user-attachments/assets/c06ca4ff-d8a8-498e-83b3-0be06f53e55d" />
<img width="1470" height="796" alt="Screenshot 2025-12-18 at 14 09 40" src="https://github.com/user-attachments/assets/42a48c1e-f500-4fab-8cad-7dec0b206f52" />


## After
<img width="341" height="689" alt="Screenshot 2025-12-18 at 14 09 07" src="https://github.com/user-attachments/assets/c2efbd35-89f6-4dff-99e7-5f6df8c6bdb6" />
<img width="1470" height="800" alt="Screenshot 2025-12-18 at 14 09 17" src="https://github.com/user-attachments/assets/91a74123-9b23-4974-8ae7-f1b39cc848ee" />


