### PR TITLE
fix mismatch layout alignment for `Impersonate` button 

### DIFF
--- a/app/javascript/components/Profile/Layout.tsx
+++ b/app/javascript/components/Profile/Layout.tsx
@@ -46,7 +46,6 @@ export const Layout = ({ creatorProfile, hideFollowForm, children }: LayoutProps
                 href={Routes.admin_impersonate_url({
                   user_identifier: creatorProfile.external_id,
                 })}
-                className="absolute left-3"
                 color="filled"
               >
                 Impersonate


### PR DESCRIPTION
## Screenshots

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img width="1905" height="1041" alt="Screenshot 2025-12-18 at 11 16 32 AM" src="https://github.com/user-attachments/assets/2ea96ae6-6132-4e93-b0e7-61b34ea9e285" />


</td>
<td>

<img width="1898" height="1042" alt="Screenshot 2025-12-18 at 11 23 07 AM" src="https://github.com/user-attachments/assets/d175ec12-c1fa-4a2a-96ac-45195f4d149c" />


</td>
</tr>
</table>

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img width="391" height="866" alt="Screenshot 2025-12-18 at 11 17 24 AM" src="https://github.com/user-attachments/assets/29171762-e4b8-400b-8aef-72b361625103" />




</td>
<td>


<img width="390" height="863" alt="Screenshot 2025-12-18 at 11 23 23 AM" src="https://github.com/user-attachments/assets/574ed40a-0cf8-4def-bb00-59a47a8999f1" />



</td>
</tr> 
</table>

**No change when user is not admin**


<img width="1895" height="1041" alt="Screenshot 2025-12-18 at 11 24 28 AM" src="https://github.com/user-attachments/assets/a9050c45-af4e-45b7-a6ec-ab9a13a9c440" />



 
<img width="390" height="864" alt="Screenshot 2025-12-18 at 11 24 40 AM" src="https://github.com/user-attachments/assets/c57d4831-b60c-4492-93fe-ecef94bb82fe" />







### AI disclosure
No AI was used

### Confirmation
I have watched all Antiwork Livestreams