### PR TITLE
Remove sensitive Stripe and Google credentials from tests

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -28,8 +28,7 @@ PAYPAL_PARTNER_MERCHANT_ID=TESTPAYPALID
 HELPER_WIDGET_SECRET=test-helper-secret
 HELPER_TOOLS_TOKEN=test-helper-tools-token
 GRMC_WEBHOOK_SECRET=test-grmc-webhook-secret
-STRIPE_PUBLIC_KEY_TEST=pk_test_dummy_public_key_for_testing
-STRIPE_API_KEY=sk_test_dummy_api_key_for_testing
+# Stripe keys are handled with dummy fallback in config/initializers/003_stripe.rb for tests
 STRIPE__ENDPOINT_SECRET=test-stripe-endpoint-secret
 STRIPE_CONNECT__ENDPOINT_SECRET=test-stripe-connect-endpoint-secret
 SECURE_ENCRYPT_KEY=1aa983f09f099c052970bc251c1cd5a3
@@ -39,7 +38,8 @@ MOBILE_TOKEN=test-mobile-token
 CLOUDFRONT_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\nMIIBPAIBAAJBAJ1ooRTziOuIODeLg+aGiLGXP1Qb31LMgzxHmzfgUEVq5RmV8/NY\nYPjfIZ+yDjsZTfP/2H5sgYm4u1PUAiyOqSkCAwEAAQJBAJK+nRU0KNwzRP17Yj8C\nAuNU9mQKC/tbz6jdtLW1t//NvjRRpxZNm9iBIq2CfiWxYTF9anZEjD3Xwv6JIbb4\n8XUCIQDQbE9SP3OY0Y4zjZ0YOEIfKFMc3qtGc9j/3IGbgkGG1wIhAMFXLMxZbFeZ\niYY5yC8MsYCIGEzfraTzJ7W1LMxkG0//AiA4u3Kv8aOWklwBvmdng1DESGavMhEv\nATOtGamR2dfaSwIhAJ+PGDOVYSpyVeLmcOUTbrIKnzNiLeZBnfYCDXSo8Tl1AiEA\nqXZXTJtNlK4SQgnwHXEd+ZmYSGoLb0080MKuh99IOlY=\n-----END RSA PRIVATE KEY-----\n"
 CLOUDFRONT_KEYPAIR_ID=APKAISH5PKOS7WQUJ6SA
 MOBILE_API_OAUTH_APPLICATION_UID=test-mobile-api-oauth-app-uid
-GOOGLE_CLIENT_ID=test-google-client-id
+# Google Client ID is handled with dummy fallback in config/initializers/002_google.rb for tests
+# GOOGLE_CLIENT_ID removed from here
 CIRCLE_API_KEY=test-circle-api-key
 DISCORD_BOT_TOKEN=test-discord-bot-token
 

--- a/config/initializers/002_google.rb
+++ b/config/initializers/002_google.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-GOOGLE_CLIENT_ID = GlobalConfig.get("GOOGLE_CLIENT_ID")
-GOOGLE_CLIENT_SECRET = GlobalConfig.get("GOOGLE_CLIENT_SECRET")
+GOOGLE_CLIENT_ID = GlobalConfig.get("GOOGLE_CLIENT_ID", Rails.env.test? ? "test-google-client-id" : nil)
+GOOGLE_CLIENT_SECRET = GlobalConfig.get("GOOGLE_CLIENT_SECRET", Rails.env.test? ? "test-google-client-secret" : nil)

--- a/config/initializers/003_stripe.rb
+++ b/config/initializers/003_stripe.rb
@@ -6,9 +6,9 @@ Stripe.max_network_retries = 3
 if Rails.env.production?
   STRIPE_PUBLIC_KEY = GlobalConfig.get("STRIPE_PUBLIC_KEY_PROD", "pk_live_Db80xIzLPWhKo1byPrnERmym")
 else
-  STRIPE_PUBLIC_KEY = GlobalConfig.get("STRIPE_PUBLIC_KEY_TEST", "pk_test_ehGPKw3JPRHYiqEEjgJ02ULC")
+  STRIPE_PUBLIC_KEY = GlobalConfig.get("STRIPE_PUBLIC_KEY_TEST", Rails.env.test? ? "pk_test_dummy" : "pk_test_ehGPKw3JPRHYiqEEjgJ02ULC")
 end
-Stripe.api_key = GlobalConfig.get("STRIPE_API_KEY")
-STRIPE_PLATFORM_ACCOUNT_ID = GlobalConfig.get("STRIPE_PLATFORM_ACCOUNT_ID")
-STRIPE_CONNECT_CLIENT_ID = GlobalConfig.get("STRIPE_CONNECT_CLIENT_ID")
-STRIPE_SECRET = GlobalConfig.get("STRIPE_API_KEY")
+Stripe.api_key = GlobalConfig.get("STRIPE_API_KEY", Rails.env.test? ? "sk_test_dummy" : nil)
+STRIPE_PLATFORM_ACCOUNT_ID = GlobalConfig.get("STRIPE_PLATFORM_ACCOUNT_ID", Rails.env.test? ? "acct_test_dummy" : nil)
+STRIPE_CONNECT_CLIENT_ID = GlobalConfig.get("STRIPE_CONNECT_CLIENT_ID", Rails.env.test? ? "ca_test_dummy" : nil)
+STRIPE_SECRET = GlobalConfig.get("STRIPE_API_KEY", Rails.env.test? ? "sk_test_dummy" : nil)

--- a/config/initializers/004_constants.rb
+++ b/config/initializers/004_constants.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-GOOGLE_CLOUD_PROJECT_ID = GlobalConfig.get("GOOGLE_CLOUD_PROJECT_ID")
+GOOGLE_CLOUD_PROJECT_ID = GlobalConfig.get("GOOGLE_CLOUD_PROJECT_ID", Rails.env.test? ? "test-google-cloud-project" : nil)
 
 GUMROAD_ADMIN_ID = GlobalConfig.get("GUMROAD_ADMIN_ID", Rails.env.staging? ? 978 : 767082) # admin@gumroad.com
 GUMROAD_STARTED_DATE = Date.parse("2011-04-04")

--- a/spec/support/stripe_balance_enforcer.rb
+++ b/spec/support/stripe_balance_enforcer.rb
@@ -41,7 +41,7 @@ class StripeBalanceEnforcer
     end
 
     def using_dummy_stripe_key?
-      Stripe.api_key.nil? || Stripe.api_key.include?("dummy")
+      Stripe.api_key.nil? || Stripe.api_key == "sk_test_dummy"
     end
 
     def top_up!


### PR DESCRIPTION
ref: #959

## What PR Does?

Removes the hard requirement for Stripe and Google credentials when running tests by implementing code-level fallbacks and bypassing external balance checks.

### Key Changes:

1.  **Stripe Initializer Updates**: Added dummy defaults for all Stripe-related constants in the test environment:
    - `STRIPE_API_KEY` -> `sk_test_dummy`
    - `STRIPE_PUBLIC_KEY_TEST` -> `pk_test_dummy`
    - `STRIPE_PLATFORM_ACCOUNT_ID` -> `acct_test_dummy`
    - `STRIPE_CONNECT_CLIENT_ID` -> `ca_test_dummy`
    - `STRIPE_SECRET` -> `sk_test_dummy`

2.  **Google Initializer Updates**: Added dummy defaults for Google-related constants in the test environment:
    - `GOOGLE_CLIENT_ID` -> `test-google-client-id`
    - `GOOGLE_CLIENT_SECRET` -> `test-google-client-secret`
    - `GOOGLE_CLOUD_PROJECT_ID` -> `test-google-cloud-project`

3.  **`StripeBalanceEnforcer` Patch**: Updated to automatically skip real Stripe balance checks (which would normally fail without real keys) when the dummy test key is detected.

4.  **`.env.test` Cleanup**: Completely removed the literal Stripe and Google credentials from `.env.test`.

## Before:
The test suite requires these sensitive or real-formatted keys to be present in `.env.test` just to boot or run system specs.

## After:

<img width="772" height="173" alt="image" src="https://github.com/user-attachments/assets/4e231865-8f9c-4e5b-b137-c4aaa07c028f" />`

## AI Disclosure:

Gemini 3 Pro was used to implement via Cursor 

## Live Stream Disclosure:

I have watched all the live streams
