### PR TITLE
Fix mobile dashboard table labels showing incorrect data in sections

### DIFF
--- a/app/javascript/components/DashboardPage.tsx
+++ b/app/javascript/components/DashboardPage.tsx
@@ -258,23 +258,29 @@ const ProductsTable = ({ sales }: TableProps) => {
         {items.map(({ id, name, thumbnail, today, last_7, last_30, sales, visits, revenue }) => (
           <TableRow key={id}>
             <ProductIconCell href={Routes.edit_link_url({ id }, { host: appDomain })} thumbnail={thumbnail} />
-            <TableCell>
+            <TableCell label="Products">
               <a href={Routes.edit_link_url({ id }, { host: appDomain })} className="line-clamp-2" title={name}>
                 {name}
               </a>
             </TableCell>
-            <TableCell title={sales.toLocaleString(locale)} className="whitespace-nowrap">
+            <TableCell label="Sales" title={sales.toLocaleString(locale)} className="whitespace-nowrap">
               {sales.toLocaleString(locale, { notation: "compact" })}
             </TableCell>
-            <TableCell title={formatPrice(revenue)} className="whitespace-nowrap">
+            <TableCell label="Revenue" title={formatPrice(revenue)} className="whitespace-nowrap">
               {formatPrice(revenue)}
             </TableCell>
-            <TableCell title={visits.toLocaleString(locale)} className="whitespace-nowrap">
+            <TableCell label="Visits" title={visits.toLocaleString(locale)} className="whitespace-nowrap">
               {visits.toLocaleString(locale, { notation: "compact" })}
             </TableCell>
-            <TableCell className="whitespace-nowrap">{formatPrice(today)}</TableCell>
-            <TableCell className="whitespace-nowrap">{formatPrice(last_7)}</TableCell>
-            <TableCell className="whitespace-nowrap">{formatPrice(last_30)}</TableCell>
+            <TableCell label="Today" className="whitespace-nowrap">
+              {formatPrice(today)}
+            </TableCell>
+            <TableCell label="Last 7 days" className="whitespace-nowrap">
+              {formatPrice(last_7)}
+            </TableCell>
+            <TableCell label="Last 30 days" className="whitespace-nowrap">
+              {formatPrice(last_30)}
+            </TableCell>
           </TableRow>
         ))}
       </TableBody>

--- a/spec/requests/dashboard_mobile_table_spec.rb
+++ b/spec/requests/dashboard_mobile_table_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Dashboard - Mobile Table Labels", type: :system, js: true, mobile_view: true do
+  let(:seller) { create(:named_seller) }
+  let(:product) { create(:product, user: seller, name: "Test eBook", price_cents: 1000) }
+
+  before do
+    login_as(seller)
+
+    # Create sales data for the product
+    3.times do
+      create(:purchase, link: product, created_at: Time.current)
+    end
+
+    # Mock analytics data to ensure predictable test values
+    allow_any_instance_of(CreatorAnalytics::CachingProxy).to receive(:sales_by_product_id).and_return(
+      product.id => {
+        sales: 26,
+        revenue_cents: 229_698,
+        visits: 150,
+        today_cents: 0,
+        last_7_cents: 5000,
+        last_30_cents: 20_000
+      }
+    )
+  end
+
+  it "shows Sales as a number in the best selling table" do
+    visit(dashboard_path)
+
+    expect(page).to have_text("Best selling")
+
+    # Sales should display a number (26), not a dollar amount
+    # Find the cell containing "Sales" label and verify it shows a number
+    sales_cells = page.all("td", text: /Sales/i)
+    within(sales_cells.first) do
+      expect(page).to have_text("Sales")
+      expect(page).to have_text("26")
+      # Ensure it's not showing a dollar sign (which would indicate misalignment)
+      expect(page.text.gsub("Sales", "").strip).not_to match(/^\$/)
+    end
+  end
+
+  it "shows Revenue as a dollar amount in the best selling table" do
+    visit(dashboard_path)
+
+    expect(page).to have_text("Best selling")
+
+    # Revenue should display a dollar amount ($2,296.98)
+    revenue_cells = page.all("td", text: /Revenue/i)
+    within(revenue_cells.first) do
+      expect(page).to have_text("Revenue")
+      expect(page).to have_text("$2,296", normalize_ws: true)
+    end
+  end
+
+  it "shows Visits as a number in the best selling table" do
+    visit(dashboard_path)
+
+    expect(page).to have_text("Best selling")
+
+    # Visits should display a number (150), not a dollar amount
+    visits_cells = page.all("td", text: /Visits/i)
+    within(visits_cells.first) do
+      expect(page).to have_text("Visits")
+      expect(page).to have_text("150")
+      # Ensure it's not showing a dollar sign (which would indicate misalignment)
+      expect(page.text.gsub("Visits", "").strip).not_to match(/^\$/)
+    end
+  end
+
+  it "shows Today, Last 7 days, and Last 30 days as dollar amounts in the best selling table" do
+    visit(dashboard_path)
+
+    expect(page).to have_text("Best selling")
+
+    # Today should show dollar amount
+    today_cells = page.all("td", text: /Today/i)
+    within(today_cells.first) do
+      expect(page).to have_text("Today")
+      expect(page).to have_text("$0", normalize_ws: true)
+    end
+
+    # Last 7 days should show dollar amount
+    last_7_cells = page.all("td", text: /Last 7 days/i)
+    within(last_7_cells.first) do
+      expect(page).to have_text("Last 7 days")
+      expect(page).to have_text("$50", normalize_ws: true)
+    end
+
+    # Last 30 days should show dollar amount
+    last_30_cells = page.all("td", text: /Last 30 days/i)
+    within(last_30_cells.first) do
+      expect(page).to have_text("Last 30 days")
+      expect(page).to have_text("$200", normalize_ws: true)
+    end
+  end
+end


### PR DESCRIPTION

## What PR Does?
- Added explicit `label` props to all `TableCell` components in the dashboard table (lines 261-277). The `TableCell` component accepts an optional `label` prop that overrides the auto-extracted header labels.

# Before:
<img width="428" height="936" alt="Screenshot 2025-12-19 at 6 26 08 AM" src="https://github.com/user-attachments/assets/c79cba90-a308-45b3-bdb9-ee65c573cf2b" />

# After:
<img width="438" height="936" alt="Screenshot 2025-12-19 at 6 27 05 AM" src="https://github.com/user-attachments/assets/7aeed9ab-9804-47b4-873a-de12ae7ae89f" />


### AI DIsclosure:
- no AI used

### Live Stream Disclosuere:
- watched all live streams