### PR TITLE
Fix: blog footer not reaching bottom of viewport

### DIFF
--- a/app/views/layouts/gumroad_blog.html.erb
+++ b/app/views/layouts/gumroad_blog.html.erb
@@ -14,9 +14,9 @@
 <% end %>
 
 <% content_for :content do %>
-  <div class="block bg-white text-black font-['ABC_Favorit'] text-base font-normal leading-relaxed tracking-tight">
+  <div class="flex-1 flex flex-col bg-white text-black font-['ABC_Favorit'] text-base font-normal leading-relaxed tracking-tight">
     <%= render "home/shared/nav" %>
-    <div class="overflow-hidden">
+    <div class="flex-1 overflow-hidden">
       <%= yield %>
     </div>
   </div>


### PR DESCRIPTION
### Issue: 
- footer not touching the bottom of the viewport on blog pages with minimal content
- eg. https://gumroad.com/blog/p/send-missed-updates-to-customers-351c9f17-5275-4ff0-b663-9685958927c9

### What PR Does?
- Ensure footer always touches the bottom of the page regardless of content length

## Before
<img width="2555" height="1371" alt="Screenshot 2025-12-19 at 11 01 41 AM" src="https://github.com/user-attachments/assets/01e4d9d9-3de0-443e-acff-ef6b41cd829e" />

## After:
<img width="2560" height="1365" alt="Screenshot 2025-12-19 at 11 00 02 AM" src="https://github.com/user-attachments/assets/5c9dbcd0-8e8e-4a74-b943-bde66f9a29f9" />


### AI Disclosure:
- no AI used

### Live stream Disclosure:
- watched all live streams