### PR TITLE
Add local currency minimum payout requirements to Getting Paid help article

### DIFF
--- a/app/views/help_center/articles/contents/_13-getting-paid.html.erb
+++ b/app/views/help_center/articles/contents/_13-getting-paid.html.erb
@@ -38,27 +38,27 @@
       <tbody>
         <tr>
           <td>Albania</td>
-          <td>ALL</td>
+          <td>ALL (min 3,000)</td>
           <td>Algeria</td>
           <td>DZD</td>
         </tr>
         <tr>
           <td>Angola</td>
-          <td>AOA</td>
+          <td>AOA (min 23,000)</td>
           <td>Antigua and Barbuda</td>
           <td>XCD</td>
         </tr>
         <tr>
           <td>Argentina</td>
-          <td>ARS</td>
+          <td>ARS (min 4,600)</td>
           <td>Armenia</td>
-          <td>AMD</td>
+          <td>AMD (min 12,100)</td>
         </tr>
         <tr>
           <td>Australia</td>
           <td>AUD</td>
           <td>Azerbaijan</td>
-          <td>AZN</td>
+          <td>AZN (min 50)</td>
         </tr>
         <tr>
           <td>Bahamas</td>
@@ -74,13 +74,13 @@
         </tr>
         <tr>
           <td>Bhutan</td>
-          <td>BTN</td>
+          <td>BTN (min 2,500)</td>
           <td>Bolivia</td>
-          <td>BOB</td>
+          <td>BOB (min 200)</td>
         </tr>
         <tr>
           <td>Bosnia and Herzegovina</td>
-          <td>BAM</td>
+          <td>BAM (min 50)</td>
           <td>Botswana</td>
           <td>BWP</td>
         </tr>
@@ -92,15 +92,15 @@
         </tr>
         <tr>
           <td>Cambodia</td>
-          <td>KHR</td>
+          <td>KHR (min 123,000)</td>
           <td>Canada</td>
           <td>CAD</td>
         </tr>
         <tr>
           <td>Chile</td>
-          <td>CLP</td>
+          <td>CLP (min 23,000)</td>
           <td>Colombia</td>
-          <td>COP</td>
+          <td>COP (min 140,000)</td>
         </tr>
         <tr>
           <td>Costa Rica</td>
@@ -124,7 +124,7 @@
           <td>Egypt</td>
           <td>EGP</td>
           <td>El Salvador</td>
-          <td>USD</td>
+          <td>USD (min 30)</td>
         </tr>
         <tr>
           <td>Ethiopia</td>
@@ -146,7 +146,7 @@
         </tr>
         <tr>
           <td>Guyana</td>
-          <td>GYD</td>
+          <td>GYD (min 6,300)</td>
           <td>Hong Kong</td>
           <td>HKD</td>
         </tr>
@@ -182,13 +182,13 @@
         </tr>
         <tr>
           <td>Korea</td>
-          <td>KRW</td>
+          <td>KRW (min 40,000)</td>
           <td>Kuwait</td>
           <td>KWD</td>
         </tr>
         <tr>
           <td>Laos</td>
-          <td>LAK</td>
+          <td>LAK (min 516,000)</td>
           <td>Liechtenstein</td>
           <td>CHF</td>
         </tr>
@@ -196,11 +196,11 @@
           <td>Macao</td>
           <td>MOP</td>
           <td>Madagascar</td>
-          <td>MGA</td>
+          <td>MGA (min 132,300)</td>
         </tr>
         <tr>
           <td>Malaysia</td>
-          <td>MYR</td>
+          <td>MYR (min 133)</td>
           <td>Mauritius</td>
           <td>MUR</td>
         </tr>
@@ -208,23 +208,23 @@
           <td>Mexico</td>
           <td>MXN</td>
           <td>Moldova</td>
-          <td>MDL</td>
+          <td>MDL (min 500)</td>
         </tr>
         <tr>
           <td>Monaco</td>
           <td>EUR</td>
           <td>Mongolia</td>
-          <td>MNT</td>
+          <td>MNT (min 105,000)</td>
         </tr>
         <tr>
           <td>Morocco</td>
           <td>MAD</td>
           <td>Mozambique</td>
-          <td>MZN</td>
+          <td>MZN (min 1,700)</td>
         </tr>
         <tr>
           <td>Namibia</td>
-          <td>NAD</td>
+          <td>NAD (min 550)</td>
           <td>New Zealand</td>
           <td>NZD</td>
         </tr>
@@ -236,7 +236,7 @@
         </tr>
         <tr>
           <td>North Macedonia</td>
-          <td>MKD</td>
+          <td>MKD (min 1,500)</td>
           <td>Norway</td>
           <td>NOK</td>
         </tr>
@@ -248,9 +248,9 @@
         </tr>
         <tr>
           <td>Panama</td>
-          <td>USD</td>
+          <td>USD (min 50)</td>
           <td>Paraguay</td>
-          <td>PYG</td>
+          <td>PYG (min 210,000)</td>
         </tr>
         <tr>
           <td>Peru</td>
@@ -284,7 +284,7 @@
         </tr>
         <tr>
           <td>Serbia</td>
-          <td>RSD</td>
+          <td>RSD (min 3,000)</td>
           <td>Singapore</td>
           <td>SGD</td>
         </tr>
@@ -304,13 +304,13 @@
           <td>Switzerland</td>
           <td>CHF</td>
           <td>Taiwan</td>
-          <td>TWD</td>
+          <td>TWD (min 800)</td>
         </tr>
         <tr>
           <td>Tanzania</td>
           <td>TZS</td>
           <td>Thailand</td>
-          <td>THB</td>
+          <td>THB (min 600)</td>
         </tr>
         <tr>
           <td>Trinidad and Tobago</td>
@@ -332,7 +332,7 @@
         </tr>
         <tr>
           <td>Uzbekistan</td>
-          <td>UZS</td>
+          <td>UZS (min 343,000)</td>
           <td>Vietnam</td>
           <td>VND</td>
         </tr>
@@ -345,6 +345,7 @@
       </tbody>
     </table>
   </div>
+  <p><b>Note:</b> Countries showing "(min X)" have a higher minimum payout threshold than the standard $10 USD requirement.</p>
   <p>We can only pay out to a local bank account and in your local currency. We cannot pay you out in USD if it is not listed above as your country's payout currency. All currency conversions happen based on the exchange rates at the time of sale, not at the time of the payout. These are typically mid-market rates that you can estimate <a href="https://dashboard.stripe.com/currency_conversion">here</a>.</p>
   <p>For prompt payouts, please ensure that you have the following for your country of residence: </p>
   <ul>
@@ -369,7 +370,7 @@
   <p>If you don't have your Social Security card, or if you believe you've entered the correct information but still receive an error, please contact the Social Security Administration. You can request a copy of your card or update your name here: https://www.ssa.gov/ssnumber/ </p>
   <h3 id="schedule">Payout schedule</h3>
   <div class="callout-red">
-    <p><b>⚠️ You need a minimum balance of $10 USD to receive a payout.</b> Some countries have higher minimums (e.g., Thailand: 600 THB, Korea: 40,000 KRW).</p>
+  <p><b>⚠️ You need a minimum balance of $10 USD to receive a payout.</b> Some countries have higher local currency minimums—see the "(min X)" values in the <a href="#bank-account">table above</a>.</p>
   </div>
   <p>You can choose to get paid daily, weekly, monthly, or quarterly, and set your own payout threshold. Daily payouts are only available for US users with eligible bank accounts and at least 4 prior payouts. You can also pause and resume payouts anytime.</p>
   <p>Payouts include sales made through the previous Friday (UTC). All sales have a minimum 7-day holding period in your Gumroad balance before they become eligible for payout.</p>


### PR DESCRIPTION
Updates the "Getting Paid" help center article to display country-specific minimum payout thresholds directly in the bank payouts table.

## Changes
- Added "(min X)" notation to the Payout Currency column for 28 countries that have minimum requirements higher than the standard $10 USD threshold
- Added explanatory note after the table clarifying what the "(min X)" values mean
- Updated the callout in the Payout Schedule section to reference the table instead of listing examples

## Why
Previously, users had to either contact support or discover minimum requirements through trial and error. The data already exists in `Country#min_cross_border_payout_amount_local_cents` but wasn't surfaced in the help documentation.

## Countries updated
Albania, Angola, Argentina, Armenia, Azerbaijan, Bhutan, Bolivia, Bosnia and Herzegovina, Cambodia, Chile, Colombia, El Salvador, Guyana, Korea, Laos, Madagascar, Malaysia, Moldova, Mongolia, Mozambique, Namibia, North Macedonia, Panama, Paraguay, Serbia, Taiwan, Thailand, Uzbekistan