### PR TITLE
Fix: make navigation links sidebar sticky in api page

### DIFF
--- a/app/views/public/api/shared/_navigation.html.erb
+++ b/app/views/public/api/shared/_navigation.html.erb
@@ -1,4 +1,4 @@
-<div role="navigation" aria-label="API Reference" class="lg:sticky lg:top-8 lg:max-h-[calc(100vh-4rem)] lg:overflow-auto">
+<div role="navigation" aria-label="API Reference" class="lg:sticky lg:top-8 lg:max-h-[calc(100vh-4rem)] lg:h-full lg:overflow-auto">
   <menu>
     <li>
       <%= link_to("Introduction", api_path(anchor: "api-intro")) %>


### PR DESCRIPTION
### Problem:
- sidebar to navigate between sections in api page is not sticky, which makes it harder to navigate as we've to scroll till top to navigate between sections. 

## Before:
### desktop:
https://github.com/user-attachments/assets/12a1d456-1622-4125-b15d-d3b811b95ec1

### mobile:
https://github.com/user-attachments/assets/5663d5a6-fe17-403b-9fe3-08e10630a41f


## After:
### desktop:
https://github.com/user-attachments/assets/c05d3fb5-f201-495a-a73b-6aedfc8e01c3

### mobile: (same as before for mobile)
https://github.com/user-attachments/assets/a1dd4a52-5520-4210-8987-28b5b6ecdf88




### AI Disclosure:
- watched all live streams

### Live Stream Disclosure:
- watched all live streams