### PR TITLE
Fix: upsell modal image overflowing and hiding product details

### DIFF
--- a/app/javascript/components/server-components/CheckoutPage.tsx
+++ b/app/javascript/components/server-components/CheckoutPage.tsx
@@ -675,7 +675,7 @@ export const CrossSellModal = ({
       <div className="grid gap-4">
         <h4 dangerouslySetInnerHTML={{ __html: crossSell.description }} />
         <ProductCard className="lg:flex-row">
-          <ProductCardFigure className="lg:h-full lg:rounded-l lg:rounded-tr-none lg:border-r lg:border-b-0 lg:[&_img]:w-auto lg:[&_img]:min-w-full">
+          <ProductCardFigure className="lg:w-56 lg:rounded-l lg:rounded-tr-none lg:border-r lg:border-b-0">
             {product.thumbnail_url ? <img src={product.thumbnail_url} /> : null}
           </ProductCardFigure>
           <section className="flex flex-1 flex-col overflow-hidden lg:gap-8 lg:px-6 lg:py-4">


### PR DESCRIPTION
fixes: #2412 

### Problem:
- The `ProductCardFigure` had no width constraint, which caused the image to expand unbounded.
- probably created during #2223 tailwind migration


# Before:
### desktop:
<img width="2555" height="1368" alt="Screenshot 2025-12-20 at 10 34 20 AM" src="https://github.com/user-attachments/assets/daca1274-c166-40c5-8ced-7ba2ff11b9de" />
### mobile:
<img width="421" height="904" alt="Screenshot 2025-12-20 at 10 34 33 AM" src="https://github.com/user-attachments/assets/c6de95ef-0364-45ee-9325-feaee5d4464c" />

# After:
### desktop:
<img width="2560" height="1376" alt="Screenshot 2025-12-20 at 10 29 52 AM" src="https://github.com/user-attachments/assets/ea203493-808a-4ba5-8905-4f092d26cb1f" />
### mobile:
<img width="516" height="941" alt="Screenshot 2025-12-20 at 10 29 37 AM" src="https://github.com/user-attachments/assets/996480aa-c726-427b-9fd8-20aef4845d63" />

### AI Disclosure:
- no AI used

### Live Stream Disclosure:
- watched all live streams