### PR TITLE
fix: Unpublish products when archiving (Closes #2373)

### DIFF
--- a/app/controllers/products/archived_controller.rb
+++ b/app/controllers/products/archived_controller.rb
@@ -71,7 +71,9 @@ class Products::ArchivedController < Sellers::BaseController
   def create
     authorize [:products, :archived, @product]
 
-    @product.update!(archived: true)
+    # When archiving, also unpublish the product to ensure it's no longer
+    # publicly accessible or indexed by search engines (fixes #2373)
+    @product.update!(archived: true, purchase_disabled_at: @product.purchase_disabled_at || Time.current)
     render json: { success: true }
   end
 

--- a/spec/controllers/products/archived_controller_spec.rb
+++ b/spec/controllers/products/archived_controller_spec.rb
@@ -197,6 +197,25 @@ describe Products::ArchivedController, inertia: true do
       expect(response.parsed_body).to eq({ "success" => true })
       expect(membership.reload.archived?).to be(true)
     end
+
+    it "unpublishes the product when archiving" do
+      published_product = create(:product, user: seller, purchase_disabled_at: nil)
+
+      post :create, params: { id: published_product.unique_permalink }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(published_product.reload.purchase_disabled_at).to be_present
+    end
+
+    it "does not change purchase_disabled_at if already unpublished" do
+      unpublished_at = 1.day.ago
+      unpublished_product = create(:product, user: seller, purchase_disabled_at: unpublished_at)
+
+      post :create, params: { id: unpublished_product.unique_permalink }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(unpublished_product.reload.purchase_disabled_at).to be_within(1.second).of(unpublished_at)
+    end
   end
 
   describe "DELETE destroy" do


### PR DESCRIPTION
## Summary

When a product is archived, it should no longer be publicly accessible or discoverable. This PR ensures that archiving a product also unpublishes it by setting `purchase_disabled_at`.

## Changes

- Modified `Products::ArchivedController#create` to set `purchase_disabled_at` when archiving a product
- Added tests to verify the unpublishing behavior
- Preserves the original `purchase_disabled_at` timestamp if the product was already unpublished

## Fixes

Closes #2373

/claim #2373