### PR TITLE
fix: Show flash notification when exporting all time sales

### DIFF
--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -413,8 +413,16 @@ class PurchasesController < ApplicationController
     if tempfile
       send_file tempfile.path
     else
-      flash[:warning] = "You will receive an email in your inbox with the data you've requested shortly."
-      redirect_back(fallback_location: customers_path)
+      respond_to do |format|
+        format.html do
+          flash[:warning] = "You will receive an email in your inbox with the data you've requested shortly."
+          redirect_to customers_path, status: :see_other
+        end
+        format.any do
+          flash[:warning] = "You will receive an email in your inbox with the data you've requested shortly."
+          redirect_to customers_path, status: :see_other
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #1930

## Summary
This PR fixes the issue where the email notification message was not appearing when exporting Sales CSV from All Time.

## Changes
- Replaced redirect_back with explicit redirect_to in PurchasesController#export
- Used respond_to block to handle different format requests
- Added :see_other status for proper HTTP redirect with Inertia

## Root Cause
The original redirect_back does not work correctly with Inertia pages, causing flash messages to not display.