### PR TITLE
fix: Reassign Purchases sends receipts and links to Library

### DIFF
--- a/app/controllers/api/internal/helper/purchases_controller.rb
+++ b/app/controllers/api/internal/helper/purchases_controller.rb
@@ -502,6 +502,7 @@ class Api::Internal::Helper::PurchasesController < Api::Internal::Helper::BaseCo
     target_user = User.find_by(email: to_email)
 
     count = 0
+    reassigned_purchases = []
     purchases.each do |purchase|
       purchase.email = to_email
 
@@ -510,7 +511,8 @@ class Api::Internal::Helper::PurchasesController < Api::Internal::Helper::BaseCo
         count += 1 if purchase.original_purchase.saved_changes?
       end
 
-      if target_user && purchase.purchaser_id.present?
+      # Always link purchase to the target user's library if they exist
+      if target_user
         purchase.purchaser_id = target_user.id
       else
         purchase.purchaser_id = nil
@@ -526,8 +528,14 @@ class Api::Internal::Helper::PurchasesController < Api::Internal::Helper::BaseCo
         end
       end
 
-      count += 1 if purchase.save
+      if purchase.save
+        count += 1
+        reassigned_purchases << purchase
+      end
     end
+
+    # Send receipts to the new email so they have access to their purchases
+    reassigned_purchases.each(&:resend_receipt)
 
     render json: {
       success: true,

--- a/spec/controllers/api/internal/helper/purchases_controller_spec.rb
+++ b/spec/controllers/api/internal/helper/purchases_controller_spec.rb
@@ -44,7 +44,7 @@ describe Api::Internal::Helper::PurchasesController, :vcr do
 
         purchase3.reload
         expect(purchase3.email).to eq(to_email)
-        expect(purchase3.purchaser_id).to be_nil
+        expect(purchase3.purchaser_id).to eq(target_user.id)
 
         subscription_purchase.reload
         expect(subscription_purchase.email).to eq(to_email)
@@ -152,6 +152,29 @@ describe Api::Internal::Helper::PurchasesController, :vcr do
         expect(response).to have_http_status(:not_found)
         expect(response.parsed_body["success"]).to eq(false)
         expect(response.parsed_body["message"]).to eq("No purchases found for email: no-purchases@example.com")
+      end
+    end
+
+    context "when reassigning purchases" do
+      it "sends receipts to the new email after reassignment" do
+        post :reassign_purchases, params: { from: from_email, to: to_email }
+
+        expect(response).to have_http_status(:success)
+        # Check that receipts are sent for all reassigned purchases
+        expect(SendPurchaseReceiptJob).to have_enqueued_sidekiq_job(purchase1.id).on("critical")
+        expect(SendPurchaseReceiptJob).to have_enqueued_sidekiq_job(purchase2.id).on("critical")
+        expect(SendPurchaseReceiptJob).to have_enqueued_sidekiq_job(purchase3.id).on("critical")
+      end
+
+      it "links purchases to target user library even when purchaser_id was nil" do
+        # Create a purchase with no purchaser
+        orphan_purchase = create(:purchase, email: from_email, purchaser: nil)
+
+        post :reassign_purchases, params: { from: from_email, to: to_email }
+
+        expect(response).to have_http_status(:success)
+        orphan_purchase.reload
+        expect(orphan_purchase.purchaser_id).to eq(target_user.id)
       end
     end
   end


### PR DESCRIPTION
Fixes #2184