### PR TITLE
Enhance Stripe signup flow with feature flag support

### DIFF
--- a/app/javascript/components/Authentication/SocialAuth.tsx
+++ b/app/javascript/components/Authentication/SocialAuth.tsx
@@ -1,10 +1,14 @@
 import * as React from "react";
 
+import { useFeatureFlags } from "$app/components/FeatureFlags";
 import { SocialAuthButton } from "$app/components/SocialAuthButton";
 import { useOriginalLocation } from "$app/components/useOriginalLocation";
 
-export const SocialAuth = () => {
+export const SocialAuth = ({ isSignup = false }: { isSignup?: boolean }) => {
   const next = new URL(useOriginalLocation()).searchParams.get("next");
+  const featureFlags = useFeatureFlags();
+  const showStripe = isSignup ? featureFlags.stripe_signup_enabled : true;
+
   return (
     <section className="flex flex-col gap-4">
       <SocialAuthButton provider="facebook" href={Routes.user_facebook_omniauth_authorize_path({ referer: next })}>
@@ -22,9 +26,14 @@ export const SocialAuth = () => {
       >
         X
       </SocialAuthButton>
-      <SocialAuthButton provider="stripe" href={Routes.user_stripe_connect_omniauth_authorize_path({ referer: next })}>
-        Stripe
-      </SocialAuthButton>
+      {showStripe ? (
+        <SocialAuthButton
+          provider="stripe"
+          href={Routes.user_stripe_connect_omniauth_authorize_path({ referer: next })}
+        >
+          Stripe
+        </SocialAuthButton>
+      ) : null}
     </section>
   );
 };

--- a/app/javascript/components/FeatureFlags.tsx
+++ b/app/javascript/components/FeatureFlags.tsx
@@ -2,10 +2,12 @@ import * as React from "react";
 
 type FeatureFlags = {
   require_email_typo_acknowledgment: boolean;
+  stripe_signup_enabled: boolean;
 };
 
 const FeatureFlagsContext = React.createContext<FeatureFlags>({
   require_email_typo_acknowledgment: false,
+  stripe_signup_enabled: true,
 });
 
 export const FeatureFlagsProvider = FeatureFlagsContext.Provider;

--- a/app/javascript/components/server-components/SignupPage.tsx
+++ b/app/javascript/components/server-components/SignupPage.tsx
@@ -78,7 +78,7 @@ export const SignupPage = ({
       headerActions={<a href={Routes.login_path({ next })}>Log in</a>}
     >
       <form onSubmit={(e) => void handleSubmit(e)}>
-        <SocialAuth />
+        <SocialAuth isSignup />
         <Separator>
           <span>or</span>
         </Separator>

--- a/app/javascript/utils/serverComponentUtil.tsx
+++ b/app/javascript/utils/serverComponentUtil.tsx
@@ -34,6 +34,7 @@ export type GlobalProps = {
   locale: string;
   feature_flags: {
     require_email_typo_acknowledgment: boolean;
+    stripe_signup_enabled: boolean;
   };
 };
 

--- a/config/initializers/react_on_rails.rb
+++ b/config/initializers/react_on_rails.rb
@@ -28,6 +28,7 @@ module RenderingExtension
       locale: view_context.controller.http_accept_language.user_preferred_languages[0] || "en-US",
       feature_flags: {
         require_email_typo_acknowledgment: Feature.active?(:require_email_typo_acknowledgment),
+        stripe_signup_enabled: Feature.active?(:stripe_signup_enabled),
       }
     }
   end

--- a/spec/support/fixtures/vcr_cassettes/User_OmniauthCallbacksController/_stripe_connect/when_stripe_signup_enabled_feature_flag_is_disabled/when_referer_is_login/allows_existing_user_to_log_in_by_email.yml
+++ b/spec/support/fixtures/vcr_cassettes/User_OmniauthCallbacksController/_stripe_connect/when_stripe_signup_enabled_feature_flag_is_disabled/when_referer_is_login/allows_existing_user_to_log_in_by_email.yml
@@ -1,0 +1,329 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://api.stripe.com/v1/accounts/acct_1SOb0DEwFhlcVS6d
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Stripe/v1 RubyBindings/12.5.0
+        Authorization:
+          - Bearer <STRIPE_API_KEY>
+        Content-Type:
+          - application/x-www-form-urlencoded
+        X-Stripe-Client-Telemetry:
+          - '{"last_request_metrics":{"request_id":"req_BtqFlQwVzGrX1s","request_duration_ms":686}}'
+        Stripe-Version:
+          - "2023-10-16"
+        X-Stripe-Client-User-Agent:
+          - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
+            version 6.14.0-33-generic (buildd@lcy02-amd64-026) (x86_64-linux-gnu-gcc-13
+            (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0, GNU ld (GNU Binutils for Ubuntu) 2.42)
+            #33~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC Fri Sep 19 17:02:30 UTC 2","hostname":"hsc-desk"}'
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Server:
+          - nginx
+        Date:
+          - Sat, 01 Nov 2025 19:00:41 GMT
+        Content-Type:
+          - application/json
+        Content-Length:
+          - "6699"
+        Connection:
+          - keep-alive
+        Access-Control-Allow-Credentials:
+          - "true"
+        Access-Control-Allow-Methods:
+          - GET, HEAD, PUT, PATCH, POST, DELETE
+        Access-Control-Allow-Origin:
+          - "*"
+        Access-Control-Expose-Headers:
+          - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+            X-Stripe-Privileged-Session-Required
+        Access-Control-Max-Age:
+          - "300"
+        Cache-Control:
+          - no-cache, no-store
+        Content-Security-Policy:
+          - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+            img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+            style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+            https://q.stripe.com/csp-violation?q=XM2gL-jSTEX7Joh2OEplMLD9hts4M7lzv_RRu_kpwLuL2h_s6khJQtJA1x0da5j61LAgwQuksHUJGgUC
+        Request-Id:
+          - req_Bc84qj5LSz8rkz
+        Stripe-Account:
+          - acct_1SOb0DEwFhlcVS6d
+        Stripe-Version:
+          - "2023-10-16"
+        Vary:
+          - Origin
+        X-Stripe-Priority-Routing-Enabled:
+          - "true"
+        X-Stripe-Routing-Context-Priority-Tier:
+          - api-testmode
+        X-Wc:
+          - ABGHIJ
+        Strict-Transport-Security:
+          - max-age=63072000; includeSubDomains; preload
+      body:
+        encoding: UTF-8
+        string: |-
+          {
+            "id": "acct_1SOb0DEwFhlcVS6d",
+            "object": "account",
+            "business_profile": {
+              "annual_revenue": null,
+              "estimated_worker_count": null,
+              "mcc": null,
+              "minority_owned_business_designation": null,
+              "name": null,
+              "product_description": null,
+              "support_address": null,
+              "support_email": null,
+              "support_phone": null,
+              "support_url": null,
+              "url": null
+            },
+            "business_type": "individual",
+            "capabilities": {
+              "acss_debit_payments": "inactive",
+              "affirm_payments": "inactive",
+              "afterpay_clearpay_payments": "inactive",
+              "amazon_pay_payments": "inactive",
+              "bancontact_payments": "inactive",
+              "card_payments": "inactive",
+              "cartes_bancaires_payments": "inactive",
+              "cashapp_payments": "inactive",
+              "eps_payments": "inactive",
+              "giropay_payments": "inactive",
+              "ideal_payments": "inactive",
+              "kakao_pay_payments": "inactive",
+              "klarna_payments": "inactive",
+              "kr_card_payments": "inactive",
+              "link_payments": "inactive",
+              "mb_way_payments": "inactive",
+              "multibanco_payments": "inactive",
+              "naver_pay_payments": "inactive",
+              "p24_payments": "inactive",
+              "payco_payments": "inactive",
+              "pix_payments": "inactive",
+              "samsung_pay_payments": "inactive",
+              "sepa_bank_transfer_payments": "inactive",
+              "sepa_debit_payments": "inactive",
+              "sofort_payments": "inactive",
+              "tax_reporting_us_1099_k": "active",
+              "tax_reporting_us_1099_misc": "active",
+              "transfers": "inactive",
+              "us_bank_account_ach_payments": "inactive",
+              "us_bank_transfer_payments": "inactive",
+              "zip_payments": "inactive"
+            },
+            "charges_enabled": false,
+            "company": {
+              "address": {
+                "city": null,
+                "country": "US",
+                "line1": null,
+                "line2": null,
+                "postal_code": null,
+                "state": null
+              },
+              "directors_provided": true,
+              "executives_provided": true,
+              "name": null,
+              "owners_provided": true,
+              "tax_id_provided": false,
+              "verification": {
+                "document": {
+                  "back": null,
+                  "details": null,
+                  "details_code": null,
+                  "front": null
+                }
+              }
+            },
+            "controller": {
+              "fees": {
+                "payer": "account"
+              },
+              "is_controller": true,
+              "losses": {
+                "payments": "stripe"
+              },
+              "requirement_collection": "stripe",
+              "stripe_dashboard": {
+                "type": "full"
+              },
+              "type": "application"
+            },
+            "country": "US",
+            "created": 1761988902,
+            "default_currency": "usd",
+            "details_submitted": false,
+            "email": null,
+            "external_accounts": {
+              "object": "list",
+              "data": [],
+              "has_more": false,
+              "total_count": 0,
+              "url": "/v1/accounts/acct_1SOb0DEwFhlcVS6d/external_accounts"
+            },
+            "future_requirements": {
+              "alternatives": [],
+              "current_deadline": null,
+              "currently_due": [],
+              "disabled_reason": null,
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "metadata": {},
+            "payouts_enabled": false,
+            "requirements": {
+              "alternatives": [],
+              "current_deadline": 1763208247,
+              "currently_due": [
+                "business_profile.mcc",
+                "business_profile.product_description",
+                "business_profile.support_email",
+                "business_profile.support_phone",
+                "business_profile.url",
+                "external_account",
+                "individual.address.city",
+                "individual.address.line1",
+                "individual.address.postal_code",
+                "individual.address.state",
+                "individual.dob.day",
+                "individual.dob.month",
+                "individual.dob.year",
+                "individual.email",
+                "individual.first_name",
+                "individual.last_name",
+                "individual.phone",
+                "individual.ssn_last_4",
+                "individual.verification.proof_of_liveness",
+                "settings.payments.statement_descriptor",
+                "tos_acceptance.date",
+                "tos_acceptance.ip"
+              ],
+              "disabled_reason": "requirements.past_due",
+              "errors": [],
+              "eventually_due": [
+                "business_profile.mcc",
+                "business_profile.product_description",
+                "business_profile.support_email",
+                "business_profile.support_phone",
+                "business_profile.url",
+                "external_account",
+                "individual.address.city",
+                "individual.address.line1",
+                "individual.address.postal_code",
+                "individual.address.state",
+                "individual.dob.day",
+                "individual.dob.month",
+                "individual.dob.year",
+                "individual.email",
+                "individual.first_name",
+                "individual.last_name",
+                "individual.phone",
+                "individual.ssn_last_4",
+                "individual.verification.proof_of_liveness",
+                "settings.payments.statement_descriptor",
+                "tos_acceptance.date",
+                "tos_acceptance.ip"
+              ],
+              "past_due": [
+                "business_profile.mcc",
+                "business_profile.product_description",
+                "business_profile.support_email",
+                "business_profile.support_phone",
+                "business_profile.url",
+                "external_account",
+                "individual.address.city",
+                "individual.address.line1",
+                "individual.address.postal_code",
+                "individual.address.state",
+                "individual.dob.day",
+                "individual.dob.month",
+                "individual.dob.year",
+                "individual.email",
+                "individual.first_name",
+                "individual.last_name",
+                "individual.phone",
+                "individual.ssn_last_4",
+                "individual.verification.proof_of_liveness",
+                "settings.payments.statement_descriptor",
+                "tos_acceptance.date",
+                "tos_acceptance.ip"
+              ],
+              "pending_verification": []
+            },
+            "settings": {
+              "bacs_debit_payments": {
+                "display_name": null,
+                "service_user_number": null
+              },
+              "branding": {
+                "icon": null,
+                "logo": null,
+                "primary_color": null,
+                "secondary_color": null
+              },
+              "card_issuing": {
+                "tos_acceptance": {
+                  "date": null,
+                  "ip": null
+                }
+              },
+              "card_payments": {
+                "decline_on": {
+                  "avs_failure": false,
+                  "cvc_failure": false
+                },
+                "statement_descriptor_prefix": null,
+                "statement_descriptor_prefix_kana": null,
+                "statement_descriptor_prefix_kanji": null
+              },
+              "dashboard": {
+                "display_name": null,
+                "timezone": "Etc/UTC"
+              },
+              "invoices": {
+                "default_account_tax_ids": null,
+                "hosted_payment_method_save": "offer"
+              },
+              "payments": {
+                "statement_descriptor": null,
+                "statement_descriptor_kana": null,
+                "statement_descriptor_kanji": null
+              },
+              "payouts": {
+                "debit_negative_balances": true,
+                "schedule": {
+                  "delay_days": 2,
+                  "interval": "daily"
+                },
+                "statement_descriptor": null
+              },
+              "sepa_debit_payments": {}
+            },
+            "tos_acceptance": {
+              "date": null,
+              "ip": null,
+              "user_agent": null
+            },
+            "type": "standard"
+          }
+    recorded_at: Sat, 01 Nov 2025 19:00:41 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/User_OmniauthCallbacksController/_stripe_connect/when_stripe_signup_enabled_feature_flag_is_disabled/when_referer_is_login/shows_error_message_when_no_existing_user_is_found.yml
+++ b/spec/support/fixtures/vcr_cassettes/User_OmniauthCallbacksController/_stripe_connect/when_stripe_signup_enabled_feature_flag_is_disabled/when_referer_is_login/shows_error_message_when_no_existing_user_is_found.yml
@@ -1,0 +1,328 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://api.stripe.com/v1/accounts/acct_1SOb0DEwFhlcVS6d
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Stripe/v1 RubyBindings/12.5.0
+        Authorization:
+          - Bearer <STRIPE_API_KEY>
+        Content-Type:
+          - application/x-www-form-urlencoded
+        X-Stripe-Client-Telemetry:
+          - '{"last_request_metrics":{"request_id":"req_Cidq61Y4CxvH8E","request_duration_ms":3}}'
+        Stripe-Version:
+          - "2023-10-16"
+        X-Stripe-Client-User-Agent:
+          - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"x86_64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+            Vishals-MacBook-Pro-2.local 25.2.0 Darwin Kernel Version 25.2.0: Tue Nov 18
+            21:09:41 PST 2025; root:xnu-12377.61.12~1/RELEASE_ARM64_T6031 x86_64","hostname":"Vishals-MacBook-Pro-2.local"}'
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Server:
+          - nginx
+        Date:
+          - Sat, 01 Nov 2025 19:00:41 GMT
+        Content-Type:
+          - application/json
+        Content-Length:
+          - "6699"
+        Connection:
+          - keep-alive
+        Access-Control-Allow-Credentials:
+          - "true"
+        Access-Control-Allow-Methods:
+          - GET, HEAD, PUT, PATCH, POST, DELETE
+        Access-Control-Allow-Origin:
+          - "*"
+        Access-Control-Expose-Headers:
+          - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+            X-Stripe-Privileged-Session-Required
+        Access-Control-Max-Age:
+          - "300"
+        Cache-Control:
+          - no-cache, no-store
+        Content-Security-Policy:
+          - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+            img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+            style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+            https://q.stripe.com/csp-violation?q=XM2gL-jSTEX7Joh2OEplMLD9hts4M7lzv_RRu_kpwLuL2h_s6khJQtJA1x0da5j61LAgwQuksHUJGgUC
+        Request-Id:
+          - req_Bc84qj5LSz8rkz
+        Stripe-Account:
+          - acct_1SOb0DEwFhlcVS6d
+        Stripe-Version:
+          - "2023-10-16"
+        Vary:
+          - Origin
+        X-Stripe-Priority-Routing-Enabled:
+          - "true"
+        X-Stripe-Routing-Context-Priority-Tier:
+          - api-testmode
+        X-Wc:
+          - ABGHIJ
+        Strict-Transport-Security:
+          - max-age=63072000; includeSubDomains; preload
+      body:
+        encoding: UTF-8
+        string: |-
+          {
+            "id": "acct_1SOb0DEwFhlcVS6d",
+            "object": "account",
+            "business_profile": {
+              "annual_revenue": null,
+              "estimated_worker_count": null,
+              "mcc": null,
+              "minority_owned_business_designation": null,
+              "name": null,
+              "product_description": null,
+              "support_address": null,
+              "support_email": null,
+              "support_phone": null,
+              "support_url": null,
+              "url": null
+            },
+            "business_type": "individual",
+            "capabilities": {
+              "acss_debit_payments": "inactive",
+              "affirm_payments": "inactive",
+              "afterpay_clearpay_payments": "inactive",
+              "amazon_pay_payments": "inactive",
+              "bancontact_payments": "inactive",
+              "card_payments": "inactive",
+              "cartes_bancaires_payments": "inactive",
+              "cashapp_payments": "inactive",
+              "eps_payments": "inactive",
+              "giropay_payments": "inactive",
+              "ideal_payments": "inactive",
+              "kakao_pay_payments": "inactive",
+              "klarna_payments": "inactive",
+              "kr_card_payments": "inactive",
+              "link_payments": "inactive",
+              "mb_way_payments": "inactive",
+              "multibanco_payments": "inactive",
+              "naver_pay_payments": "inactive",
+              "p24_payments": "inactive",
+              "payco_payments": "inactive",
+              "pix_payments": "inactive",
+              "samsung_pay_payments": "inactive",
+              "sepa_bank_transfer_payments": "inactive",
+              "sepa_debit_payments": "inactive",
+              "sofort_payments": "inactive",
+              "tax_reporting_us_1099_k": "active",
+              "tax_reporting_us_1099_misc": "active",
+              "transfers": "inactive",
+              "us_bank_account_ach_payments": "inactive",
+              "us_bank_transfer_payments": "inactive",
+              "zip_payments": "inactive"
+            },
+            "charges_enabled": false,
+            "company": {
+              "address": {
+                "city": null,
+                "country": "US",
+                "line1": null,
+                "line2": null,
+                "postal_code": null,
+                "state": null
+              },
+              "directors_provided": true,
+              "executives_provided": true,
+              "name": null,
+              "owners_provided": true,
+              "tax_id_provided": false,
+              "verification": {
+                "document": {
+                  "back": null,
+                  "details": null,
+                  "details_code": null,
+                  "front": null
+                }
+              }
+            },
+            "controller": {
+              "fees": {
+                "payer": "account"
+              },
+              "is_controller": true,
+              "losses": {
+                "payments": "stripe"
+              },
+              "requirement_collection": "stripe",
+              "stripe_dashboard": {
+                "type": "full"
+              },
+              "type": "application"
+            },
+            "country": "US",
+            "created": 1761988902,
+            "default_currency": "usd",
+            "details_submitted": false,
+            "email": null,
+            "external_accounts": {
+              "object": "list",
+              "data": [],
+              "has_more": false,
+              "total_count": 0,
+              "url": "/v1/accounts/acct_1SOb0DEwFhlcVS6d/external_accounts"
+            },
+            "future_requirements": {
+              "alternatives": [],
+              "current_deadline": null,
+              "currently_due": [],
+              "disabled_reason": null,
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "metadata": {},
+            "payouts_enabled": false,
+            "requirements": {
+              "alternatives": [],
+              "current_deadline": 1763208247,
+              "currently_due": [
+                "business_profile.mcc",
+                "business_profile.product_description",
+                "business_profile.support_email",
+                "business_profile.support_phone",
+                "business_profile.url",
+                "external_account",
+                "individual.address.city",
+                "individual.address.line1",
+                "individual.address.postal_code",
+                "individual.address.state",
+                "individual.dob.day",
+                "individual.dob.month",
+                "individual.dob.year",
+                "individual.email",
+                "individual.first_name",
+                "individual.last_name",
+                "individual.phone",
+                "individual.ssn_last_4",
+                "individual.verification.proof_of_liveness",
+                "settings.payments.statement_descriptor",
+                "tos_acceptance.date",
+                "tos_acceptance.ip"
+              ],
+              "disabled_reason": "requirements.past_due",
+              "errors": [],
+              "eventually_due": [
+                "business_profile.mcc",
+                "business_profile.product_description",
+                "business_profile.support_email",
+                "business_profile.support_phone",
+                "business_profile.url",
+                "external_account",
+                "individual.address.city",
+                "individual.address.line1",
+                "individual.address.postal_code",
+                "individual.address.state",
+                "individual.dob.day",
+                "individual.dob.month",
+                "individual.dob.year",
+                "individual.email",
+                "individual.first_name",
+                "individual.last_name",
+                "individual.phone",
+                "individual.ssn_last_4",
+                "individual.verification.proof_of_liveness",
+                "settings.payments.statement_descriptor",
+                "tos_acceptance.date",
+                "tos_acceptance.ip"
+              ],
+              "past_due": [
+                "business_profile.mcc",
+                "business_profile.product_description",
+                "business_profile.support_email",
+                "business_profile.support_phone",
+                "business_profile.url",
+                "external_account",
+                "individual.address.city",
+                "individual.address.line1",
+                "individual.address.postal_code",
+                "individual.address.state",
+                "individual.dob.day",
+                "individual.dob.month",
+                "individual.dob.year",
+                "individual.email",
+                "individual.first_name",
+                "individual.last_name",
+                "individual.phone",
+                "individual.ssn_last_4",
+                "individual.verification.proof_of_liveness",
+                "settings.payments.statement_descriptor",
+                "tos_acceptance.date",
+                "tos_acceptance.ip"
+              ],
+              "pending_verification": []
+            },
+            "settings": {
+              "bacs_debit_payments": {
+                "display_name": null,
+                "service_user_number": null
+              },
+              "branding": {
+                "icon": null,
+                "logo": null,
+                "primary_color": null,
+                "secondary_color": null
+              },
+              "card_issuing": {
+                "tos_acceptance": {
+                  "date": null,
+                  "ip": null
+                }
+              },
+              "card_payments": {
+                "decline_on": {
+                  "avs_failure": false,
+                  "cvc_failure": false
+                },
+                "statement_descriptor_prefix": null,
+                "statement_descriptor_prefix_kana": null,
+                "statement_descriptor_prefix_kanji": null
+              },
+              "dashboard": {
+                "display_name": null,
+                "timezone": "Etc/UTC"
+              },
+              "invoices": {
+                "default_account_tax_ids": null,
+                "hosted_payment_method_save": "offer"
+              },
+              "payments": {
+                "statement_descriptor": null,
+                "statement_descriptor_kana": null,
+                "statement_descriptor_kanji": null
+              },
+              "payouts": {
+                "debit_negative_balances": true,
+                "schedule": {
+                  "delay_days": 2,
+                  "interval": "daily"
+                },
+                "statement_descriptor": null
+              },
+              "sepa_debit_payments": {}
+            },
+            "tos_acceptance": {
+              "date": null,
+              "ip": null,
+              "user_agent": null
+            },
+            "type": "standard"
+          }
+    recorded_at: Sat, 01 Nov 2025 19:00:41 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/User_OmniauthCallbacksController/_stripe_connect/when_stripe_signup_enabled_feature_flag_is_disabled/when_referer_is_signup/allows_existing_user_to_log_in_by_email.yml
+++ b/spec/support/fixtures/vcr_cassettes/User_OmniauthCallbacksController/_stripe_connect/when_stripe_signup_enabled_feature_flag_is_disabled/when_referer_is_signup/allows_existing_user_to_log_in_by_email.yml
@@ -1,0 +1,328 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://api.stripe.com/v1/accounts/acct_1SOb0DEwFhlcVS6d
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Stripe/v1 RubyBindings/12.5.0
+        Authorization:
+          - Bearer <STRIPE_API_KEY>
+        Content-Type:
+          - application/x-www-form-urlencoded
+        X-Stripe-Client-Telemetry:
+          - '{"last_request_metrics":{"request_id":"req_Cidq61Y4CxvH8E","request_duration_ms":3}}'
+        Stripe-Version:
+          - "2023-10-16"
+        X-Stripe-Client-User-Agent:
+          - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"x86_64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+            Vishals-MacBook-Pro-2.local 25.2.0 Darwin Kernel Version 25.2.0: Tue Nov 18
+            21:09:41 PST 2025; root:xnu-12377.61.12~1/RELEASE_ARM64_T6031 x86_64","hostname":"Vishals-MacBook-Pro-2.local"}'
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Server:
+          - nginx
+        Date:
+          - Sat, 01 Nov 2025 19:00:47 GMT
+        Content-Type:
+          - application/json
+        Content-Length:
+          - "6699"
+        Connection:
+          - keep-alive
+        Access-Control-Allow-Credentials:
+          - "true"
+        Access-Control-Allow-Methods:
+          - GET, HEAD, PUT, PATCH, POST, DELETE
+        Access-Control-Allow-Origin:
+          - "*"
+        Access-Control-Expose-Headers:
+          - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+            X-Stripe-Privileged-Session-Required
+        Access-Control-Max-Age:
+          - "300"
+        Cache-Control:
+          - no-cache, no-store
+        Content-Security-Policy:
+          - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+            img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+            style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+            https://q.stripe.com/csp-violation?q=XM2gL-jSTEX7Joh2OEplMLD9hts4M7lzv_RRu_kpwLuL2h_s6khJQtJA1x0da5j61LAgwQuksHUJGgUC
+        Request-Id:
+          - req_FWKLmX7uoWkTaa
+        Stripe-Account:
+          - acct_1SOb0DEwFhlcVS6d
+        Stripe-Version:
+          - "2023-10-16"
+        Vary:
+          - Origin
+        X-Stripe-Priority-Routing-Enabled:
+          - "true"
+        X-Stripe-Routing-Context-Priority-Tier:
+          - api-testmode
+        X-Wc:
+          - ABGHIJ
+        Strict-Transport-Security:
+          - max-age=63072000; includeSubDomains; preload
+      body:
+        encoding: UTF-8
+        string: |-
+          {
+            "id": "acct_1SOb0DEwFhlcVS6d",
+            "object": "account",
+            "business_profile": {
+              "annual_revenue": null,
+              "estimated_worker_count": null,
+              "mcc": null,
+              "minority_owned_business_designation": null,
+              "name": null,
+              "product_description": null,
+              "support_address": null,
+              "support_email": null,
+              "support_phone": null,
+              "support_url": null,
+              "url": null
+            },
+            "business_type": "individual",
+            "capabilities": {
+              "acss_debit_payments": "inactive",
+              "affirm_payments": "inactive",
+              "afterpay_clearpay_payments": "inactive",
+              "amazon_pay_payments": "inactive",
+              "bancontact_payments": "inactive",
+              "card_payments": "inactive",
+              "cartes_bancaires_payments": "inactive",
+              "cashapp_payments": "inactive",
+              "eps_payments": "inactive",
+              "giropay_payments": "inactive",
+              "ideal_payments": "inactive",
+              "kakao_pay_payments": "inactive",
+              "klarna_payments": "inactive",
+              "kr_card_payments": "inactive",
+              "link_payments": "inactive",
+              "mb_way_payments": "inactive",
+              "multibanco_payments": "inactive",
+              "naver_pay_payments": "inactive",
+              "p24_payments": "inactive",
+              "payco_payments": "inactive",
+              "pix_payments": "inactive",
+              "samsung_pay_payments": "inactive",
+              "sepa_bank_transfer_payments": "inactive",
+              "sepa_debit_payments": "inactive",
+              "sofort_payments": "inactive",
+              "tax_reporting_us_1099_k": "active",
+              "tax_reporting_us_1099_misc": "active",
+              "transfers": "inactive",
+              "us_bank_account_ach_payments": "inactive",
+              "us_bank_transfer_payments": "inactive",
+              "zip_payments": "inactive"
+            },
+            "charges_enabled": false,
+            "company": {
+              "address": {
+                "city": null,
+                "country": "US",
+                "line1": null,
+                "line2": null,
+                "postal_code": null,
+                "state": null
+              },
+              "directors_provided": true,
+              "executives_provided": true,
+              "name": null,
+              "owners_provided": true,
+              "tax_id_provided": false,
+              "verification": {
+                "document": {
+                  "back": null,
+                  "details": null,
+                  "details_code": null,
+                  "front": null
+                }
+              }
+            },
+            "controller": {
+              "fees": {
+                "payer": "account"
+              },
+              "is_controller": true,
+              "losses": {
+                "payments": "stripe"
+              },
+              "requirement_collection": "stripe",
+              "stripe_dashboard": {
+                "type": "full"
+              },
+              "type": "application"
+            },
+            "country": "US",
+            "created": 1761988902,
+            "default_currency": "usd",
+            "details_submitted": false,
+            "email": null,
+            "external_accounts": {
+              "object": "list",
+              "data": [],
+              "has_more": false,
+              "total_count": 0,
+              "url": "/v1/accounts/acct_1SOb0DEwFhlcVS6d/external_accounts"
+            },
+            "future_requirements": {
+              "alternatives": [],
+              "current_deadline": null,
+              "currently_due": [],
+              "disabled_reason": null,
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "metadata": {},
+            "payouts_enabled": false,
+            "requirements": {
+              "alternatives": [],
+              "current_deadline": 1763208247,
+              "currently_due": [
+                "business_profile.mcc",
+                "business_profile.product_description",
+                "business_profile.support_email",
+                "business_profile.support_phone",
+                "business_profile.url",
+                "external_account",
+                "individual.address.city",
+                "individual.address.line1",
+                "individual.address.postal_code",
+                "individual.address.state",
+                "individual.dob.day",
+                "individual.dob.month",
+                "individual.dob.year",
+                "individual.email",
+                "individual.first_name",
+                "individual.last_name",
+                "individual.phone",
+                "individual.ssn_last_4",
+                "individual.verification.proof_of_liveness",
+                "settings.payments.statement_descriptor",
+                "tos_acceptance.date",
+                "tos_acceptance.ip"
+              ],
+              "disabled_reason": "requirements.past_due",
+              "errors": [],
+              "eventually_due": [
+                "business_profile.mcc",
+                "business_profile.product_description",
+                "business_profile.support_email",
+                "business_profile.support_phone",
+                "business_profile.url",
+                "external_account",
+                "individual.address.city",
+                "individual.address.line1",
+                "individual.address.postal_code",
+                "individual.address.state",
+                "individual.dob.day",
+                "individual.dob.month",
+                "individual.dob.year",
+                "individual.email",
+                "individual.first_name",
+                "individual.last_name",
+                "individual.phone",
+                "individual.ssn_last_4",
+                "individual.verification.proof_of_liveness",
+                "settings.payments.statement_descriptor",
+                "tos_acceptance.date",
+                "tos_acceptance.ip"
+              ],
+              "past_due": [
+                "business_profile.mcc",
+                "business_profile.product_description",
+                "business_profile.support_email",
+                "business_profile.support_phone",
+                "business_profile.url",
+                "external_account",
+                "individual.address.city",
+                "individual.address.line1",
+                "individual.address.postal_code",
+                "individual.address.state",
+                "individual.dob.day",
+                "individual.dob.month",
+                "individual.dob.year",
+                "individual.email",
+                "individual.first_name",
+                "individual.last_name",
+                "individual.phone",
+                "individual.ssn_last_4",
+                "individual.verification.proof_of_liveness",
+                "settings.payments.statement_descriptor",
+                "tos_acceptance.date",
+                "tos_acceptance.ip"
+              ],
+              "pending_verification": []
+            },
+            "settings": {
+              "bacs_debit_payments": {
+                "display_name": null,
+                "service_user_number": null
+              },
+              "branding": {
+                "icon": null,
+                "logo": null,
+                "primary_color": null,
+                "secondary_color": null
+              },
+              "card_issuing": {
+                "tos_acceptance": {
+                  "date": null,
+                  "ip": null
+                }
+              },
+              "card_payments": {
+                "decline_on": {
+                  "avs_failure": false,
+                  "cvc_failure": false
+                },
+                "statement_descriptor_prefix": null,
+                "statement_descriptor_prefix_kana": null,
+                "statement_descriptor_prefix_kanji": null
+              },
+              "dashboard": {
+                "display_name": null,
+                "timezone": "Etc/UTC"
+              },
+              "invoices": {
+                "default_account_tax_ids": null,
+                "hosted_payment_method_save": "offer"
+              },
+              "payments": {
+                "statement_descriptor": null,
+                "statement_descriptor_kana": null,
+                "statement_descriptor_kanji": null
+              },
+              "payouts": {
+                "debit_negative_balances": true,
+                "schedule": {
+                  "delay_days": 2,
+                  "interval": "daily"
+                },
+                "statement_descriptor": null
+              },
+              "sepa_debit_payments": {}
+            },
+            "tos_acceptance": {
+              "date": null,
+              "ip": null,
+              "user_agent": null
+            },
+            "type": "standard"
+          }
+    recorded_at: Sat, 01 Nov 2025 19:00:47 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/User_OmniauthCallbacksController/_stripe_connect/when_stripe_signup_enabled_feature_flag_is_disabled/when_referer_is_signup/allows_existing_user_to_log_in_by_merchant_account.yml
+++ b/spec/support/fixtures/vcr_cassettes/User_OmniauthCallbacksController/_stripe_connect/when_stripe_signup_enabled_feature_flag_is_disabled/when_referer_is_signup/allows_existing_user_to_log_in_by_merchant_account.yml
@@ -1,0 +1,328 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://api.stripe.com/v1/accounts/acct_1SOb0DEwFhlcVS6d
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Stripe/v1 RubyBindings/12.5.0
+        Authorization:
+          - Bearer <STRIPE_API_KEY>
+        Content-Type:
+          - application/x-www-form-urlencoded
+        X-Stripe-Client-Telemetry:
+          - '{"last_request_metrics":{"request_id":"req_Cidq61Y4CxvH8E","request_duration_ms":3}}'
+        Stripe-Version:
+          - "2023-10-16"
+        X-Stripe-Client-User-Agent:
+          - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"x86_64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+            Vishals-MacBook-Pro-2.local 25.2.0 Darwin Kernel Version 25.2.0: Tue Nov 18
+            21:09:41 PST 2025; root:xnu-12377.61.12~1/RELEASE_ARM64_T6031 x86_64","hostname":"Vishals-MacBook-Pro-2.local"}'
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Server:
+          - nginx
+        Date:
+          - Sat, 01 Nov 2025 19:00:41 GMT
+        Content-Type:
+          - application/json
+        Content-Length:
+          - "6699"
+        Connection:
+          - keep-alive
+        Access-Control-Allow-Credentials:
+          - "true"
+        Access-Control-Allow-Methods:
+          - GET, HEAD, PUT, PATCH, POST, DELETE
+        Access-Control-Allow-Origin:
+          - "*"
+        Access-Control-Expose-Headers:
+          - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+            X-Stripe-Privileged-Session-Required
+        Access-Control-Max-Age:
+          - "300"
+        Cache-Control:
+          - no-cache, no-store
+        Content-Security-Policy:
+          - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+            img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+            style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+            https://q.stripe.com/csp-violation?q=XM2gL-jSTEX7Joh2OEplMLD9hts4M7lzv_RRu_kpwLuL2h_s6khJQtJA1x0da5j61LAgwQuksHUJGgUC
+        Request-Id:
+          - req_Bc84qj5LSz8rkz
+        Stripe-Account:
+          - acct_1SOb0DEwFhlcVS6d
+        Stripe-Version:
+          - "2023-10-16"
+        Vary:
+          - Origin
+        X-Stripe-Priority-Routing-Enabled:
+          - "true"
+        X-Stripe-Routing-Context-Priority-Tier:
+          - api-testmode
+        X-Wc:
+          - ABGHIJ
+        Strict-Transport-Security:
+          - max-age=63072000; includeSubDomains; preload
+      body:
+        encoding: UTF-8
+        string: |-
+          {
+            "id": "acct_1SOb0DEwFhlcVS6d",
+            "object": "account",
+            "business_profile": {
+              "annual_revenue": null,
+              "estimated_worker_count": null,
+              "mcc": null,
+              "minority_owned_business_designation": null,
+              "name": null,
+              "product_description": null,
+              "support_address": null,
+              "support_email": null,
+              "support_phone": null,
+              "support_url": null,
+              "url": null
+            },
+            "business_type": "individual",
+            "capabilities": {
+              "acss_debit_payments": "inactive",
+              "affirm_payments": "inactive",
+              "afterpay_clearpay_payments": "inactive",
+              "amazon_pay_payments": "inactive",
+              "bancontact_payments": "inactive",
+              "card_payments": "inactive",
+              "cartes_bancaires_payments": "inactive",
+              "cashapp_payments": "inactive",
+              "eps_payments": "inactive",
+              "giropay_payments": "inactive",
+              "ideal_payments": "inactive",
+              "kakao_pay_payments": "inactive",
+              "klarna_payments": "inactive",
+              "kr_card_payments": "inactive",
+              "link_payments": "inactive",
+              "mb_way_payments": "inactive",
+              "multibanco_payments": "inactive",
+              "naver_pay_payments": "inactive",
+              "p24_payments": "inactive",
+              "payco_payments": "inactive",
+              "pix_payments": "inactive",
+              "samsung_pay_payments": "inactive",
+              "sepa_bank_transfer_payments": "inactive",
+              "sepa_debit_payments": "inactive",
+              "sofort_payments": "inactive",
+              "tax_reporting_us_1099_k": "active",
+              "tax_reporting_us_1099_misc": "active",
+              "transfers": "inactive",
+              "us_bank_account_ach_payments": "inactive",
+              "us_bank_transfer_payments": "inactive",
+              "zip_payments": "inactive"
+            },
+            "charges_enabled": false,
+            "company": {
+              "address": {
+                "city": null,
+                "country": "US",
+                "line1": null,
+                "line2": null,
+                "postal_code": null,
+                "state": null
+              },
+              "directors_provided": true,
+              "executives_provided": true,
+              "name": null,
+              "owners_provided": true,
+              "tax_id_provided": false,
+              "verification": {
+                "document": {
+                  "back": null,
+                  "details": null,
+                  "details_code": null,
+                  "front": null
+                }
+              }
+            },
+            "controller": {
+              "fees": {
+                "payer": "account"
+              },
+              "is_controller": true,
+              "losses": {
+                "payments": "stripe"
+              },
+              "requirement_collection": "stripe",
+              "stripe_dashboard": {
+                "type": "full"
+              },
+              "type": "application"
+            },
+            "country": "US",
+            "created": 1761988902,
+            "default_currency": "usd",
+            "details_submitted": false,
+            "email": null,
+            "external_accounts": {
+              "object": "list",
+              "data": [],
+              "has_more": false,
+              "total_count": 0,
+              "url": "/v1/accounts/acct_1SOb0DEwFhlcVS6d/external_accounts"
+            },
+            "future_requirements": {
+              "alternatives": [],
+              "current_deadline": null,
+              "currently_due": [],
+              "disabled_reason": null,
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "metadata": {},
+            "payouts_enabled": false,
+            "requirements": {
+              "alternatives": [],
+              "current_deadline": 1763208247,
+              "currently_due": [
+                "business_profile.mcc",
+                "business_profile.product_description",
+                "business_profile.support_email",
+                "business_profile.support_phone",
+                "business_profile.url",
+                "external_account",
+                "individual.address.city",
+                "individual.address.line1",
+                "individual.address.postal_code",
+                "individual.address.state",
+                "individual.dob.day",
+                "individual.dob.month",
+                "individual.dob.year",
+                "individual.email",
+                "individual.first_name",
+                "individual.last_name",
+                "individual.phone",
+                "individual.ssn_last_4",
+                "individual.verification.proof_of_liveness",
+                "settings.payments.statement_descriptor",
+                "tos_acceptance.date",
+                "tos_acceptance.ip"
+              ],
+              "disabled_reason": "requirements.past_due",
+              "errors": [],
+              "eventually_due": [
+                "business_profile.mcc",
+                "business_profile.product_description",
+                "business_profile.support_email",
+                "business_profile.support_phone",
+                "business_profile.url",
+                "external_account",
+                "individual.address.city",
+                "individual.address.line1",
+                "individual.address.postal_code",
+                "individual.address.state",
+                "individual.dob.day",
+                "individual.dob.month",
+                "individual.dob.year",
+                "individual.email",
+                "individual.first_name",
+                "individual.last_name",
+                "individual.phone",
+                "individual.ssn_last_4",
+                "individual.verification.proof_of_liveness",
+                "settings.payments.statement_descriptor",
+                "tos_acceptance.date",
+                "tos_acceptance.ip"
+              ],
+              "past_due": [
+                "business_profile.mcc",
+                "business_profile.product_description",
+                "business_profile.support_email",
+                "business_profile.support_phone",
+                "business_profile.url",
+                "external_account",
+                "individual.address.city",
+                "individual.address.line1",
+                "individual.address.postal_code",
+                "individual.address.state",
+                "individual.dob.day",
+                "individual.dob.month",
+                "individual.dob.year",
+                "individual.email",
+                "individual.first_name",
+                "individual.last_name",
+                "individual.phone",
+                "individual.ssn_last_4",
+                "individual.verification.proof_of_liveness",
+                "settings.payments.statement_descriptor",
+                "tos_acceptance.date",
+                "tos_acceptance.ip"
+              ],
+              "pending_verification": []
+            },
+            "settings": {
+              "bacs_debit_payments": {
+                "display_name": null,
+                "service_user_number": null
+              },
+              "branding": {
+                "icon": null,
+                "logo": null,
+                "primary_color": null,
+                "secondary_color": null
+              },
+              "card_issuing": {
+                "tos_acceptance": {
+                  "date": null,
+                  "ip": null
+                }
+              },
+              "card_payments": {
+                "decline_on": {
+                  "avs_failure": false,
+                  "cvc_failure": false
+                },
+                "statement_descriptor_prefix": null,
+                "statement_descriptor_prefix_kana": null,
+                "statement_descriptor_prefix_kanji": null
+              },
+              "dashboard": {
+                "display_name": null,
+                "timezone": "Etc/UTC"
+              },
+              "invoices": {
+                "default_account_tax_ids": null,
+                "hosted_payment_method_save": "offer"
+              },
+              "payments": {
+                "statement_descriptor": null,
+                "statement_descriptor_kana": null,
+                "statement_descriptor_kanji": null
+              },
+              "payouts": {
+                "debit_negative_balances": true,
+                "schedule": {
+                  "delay_days": 2,
+                  "interval": "daily"
+                },
+                "statement_descriptor": null
+              },
+              "sepa_debit_payments": {}
+            },
+            "tos_acceptance": {
+              "date": null,
+              "ip": null,
+              "user_agent": null
+            },
+            "type": "standard"
+          }
+    recorded_at: Sat, 01 Nov 2025 19:00:41 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/User_OmniauthCallbacksController/_stripe_connect/when_stripe_signup_enabled_feature_flag_is_disabled/when_referer_is_signup/does_not_create_a_new_user_account.yml
+++ b/spec/support/fixtures/vcr_cassettes/User_OmniauthCallbacksController/_stripe_connect/when_stripe_signup_enabled_feature_flag_is_disabled/when_referer_is_signup/does_not_create_a_new_user_account.yml
@@ -1,0 +1,328 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://api.stripe.com/v1/accounts/acct_1SOb0DEwFhlcVS6d
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Stripe/v1 RubyBindings/12.5.0
+        Authorization:
+          - Bearer <STRIPE_API_KEY>
+        Content-Type:
+          - application/x-www-form-urlencoded
+        X-Stripe-Client-Telemetry:
+          - '{"last_request_metrics":{"request_id":"req_Cidq61Y4CxvH8E","request_duration_ms":3}}'
+        Stripe-Version:
+          - "2023-10-16"
+        X-Stripe-Client-User-Agent:
+          - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"x86_64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+            Vishals-MacBook-Pro-2.local 25.2.0 Darwin Kernel Version 25.2.0: Tue Nov 18
+            21:09:41 PST 2025; root:xnu-12377.61.12~1/RELEASE_ARM64_T6031 x86_64","hostname":"Vishals-MacBook-Pro-2.local"}'
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Server:
+          - nginx
+        Date:
+          - Sat, 01 Nov 2025 19:00:47 GMT
+        Content-Type:
+          - application/json
+        Content-Length:
+          - "6699"
+        Connection:
+          - keep-alive
+        Access-Control-Allow-Credentials:
+          - "true"
+        Access-Control-Allow-Methods:
+          - GET, HEAD, PUT, PATCH, POST, DELETE
+        Access-Control-Allow-Origin:
+          - "*"
+        Access-Control-Expose-Headers:
+          - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+            X-Stripe-Privileged-Session-Required
+        Access-Control-Max-Age:
+          - "300"
+        Cache-Control:
+          - no-cache, no-store
+        Content-Security-Policy:
+          - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+            img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+            style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+            https://q.stripe.com/csp-violation?q=XM2gL-jSTEX7Joh2OEplMLD9hts4M7lzv_RRu_kpwLuL2h_s6khJQtJA1x0da5j61LAgwQuksHUJGgUC
+        Request-Id:
+          - req_FWKLmX7uoWkTaa
+        Stripe-Account:
+          - acct_1SOb0DEwFhlcVS6d
+        Stripe-Version:
+          - "2023-10-16"
+        Vary:
+          - Origin
+        X-Stripe-Priority-Routing-Enabled:
+          - "true"
+        X-Stripe-Routing-Context-Priority-Tier:
+          - api-testmode
+        X-Wc:
+          - ABGHIJ
+        Strict-Transport-Security:
+          - max-age=63072000; includeSubDomains; preload
+      body:
+        encoding: UTF-8
+        string: |-
+          {
+            "id": "acct_1SOb0DEwFhlcVS6d",
+            "object": "account",
+            "business_profile": {
+              "annual_revenue": null,
+              "estimated_worker_count": null,
+              "mcc": null,
+              "minority_owned_business_designation": null,
+              "name": null,
+              "product_description": null,
+              "support_address": null,
+              "support_email": null,
+              "support_phone": null,
+              "support_url": null,
+              "url": null
+            },
+            "business_type": "individual",
+            "capabilities": {
+              "acss_debit_payments": "inactive",
+              "affirm_payments": "inactive",
+              "afterpay_clearpay_payments": "inactive",
+              "amazon_pay_payments": "inactive",
+              "bancontact_payments": "inactive",
+              "card_payments": "inactive",
+              "cartes_bancaires_payments": "inactive",
+              "cashapp_payments": "inactive",
+              "eps_payments": "inactive",
+              "giropay_payments": "inactive",
+              "ideal_payments": "inactive",
+              "kakao_pay_payments": "inactive",
+              "klarna_payments": "inactive",
+              "kr_card_payments": "inactive",
+              "link_payments": "inactive",
+              "mb_way_payments": "inactive",
+              "multibanco_payments": "inactive",
+              "naver_pay_payments": "inactive",
+              "p24_payments": "inactive",
+              "payco_payments": "inactive",
+              "pix_payments": "inactive",
+              "samsung_pay_payments": "inactive",
+              "sepa_bank_transfer_payments": "inactive",
+              "sepa_debit_payments": "inactive",
+              "sofort_payments": "inactive",
+              "tax_reporting_us_1099_k": "active",
+              "tax_reporting_us_1099_misc": "active",
+              "transfers": "inactive",
+              "us_bank_account_ach_payments": "inactive",
+              "us_bank_transfer_payments": "inactive",
+              "zip_payments": "inactive"
+            },
+            "charges_enabled": false,
+            "company": {
+              "address": {
+                "city": null,
+                "country": "US",
+                "line1": null,
+                "line2": null,
+                "postal_code": null,
+                "state": null
+              },
+              "directors_provided": true,
+              "executives_provided": true,
+              "name": null,
+              "owners_provided": true,
+              "tax_id_provided": false,
+              "verification": {
+                "document": {
+                  "back": null,
+                  "details": null,
+                  "details_code": null,
+                  "front": null
+                }
+              }
+            },
+            "controller": {
+              "fees": {
+                "payer": "account"
+              },
+              "is_controller": true,
+              "losses": {
+                "payments": "stripe"
+              },
+              "requirement_collection": "stripe",
+              "stripe_dashboard": {
+                "type": "full"
+              },
+              "type": "application"
+            },
+            "country": "US",
+            "created": 1761988902,
+            "default_currency": "usd",
+            "details_submitted": false,
+            "email": null,
+            "external_accounts": {
+              "object": "list",
+              "data": [],
+              "has_more": false,
+              "total_count": 0,
+              "url": "/v1/accounts/acct_1SOb0DEwFhlcVS6d/external_accounts"
+            },
+            "future_requirements": {
+              "alternatives": [],
+              "current_deadline": null,
+              "currently_due": [],
+              "disabled_reason": null,
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "metadata": {},
+            "payouts_enabled": false,
+            "requirements": {
+              "alternatives": [],
+              "current_deadline": 1763208247,
+              "currently_due": [
+                "business_profile.mcc",
+                "business_profile.product_description",
+                "business_profile.support_email",
+                "business_profile.support_phone",
+                "business_profile.url",
+                "external_account",
+                "individual.address.city",
+                "individual.address.line1",
+                "individual.address.postal_code",
+                "individual.address.state",
+                "individual.dob.day",
+                "individual.dob.month",
+                "individual.dob.year",
+                "individual.email",
+                "individual.first_name",
+                "individual.last_name",
+                "individual.phone",
+                "individual.ssn_last_4",
+                "individual.verification.proof_of_liveness",
+                "settings.payments.statement_descriptor",
+                "tos_acceptance.date",
+                "tos_acceptance.ip"
+              ],
+              "disabled_reason": "requirements.past_due",
+              "errors": [],
+              "eventually_due": [
+                "business_profile.mcc",
+                "business_profile.product_description",
+                "business_profile.support_email",
+                "business_profile.support_phone",
+                "business_profile.url",
+                "external_account",
+                "individual.address.city",
+                "individual.address.line1",
+                "individual.address.postal_code",
+                "individual.address.state",
+                "individual.dob.day",
+                "individual.dob.month",
+                "individual.dob.year",
+                "individual.email",
+                "individual.first_name",
+                "individual.last_name",
+                "individual.phone",
+                "individual.ssn_last_4",
+                "individual.verification.proof_of_liveness",
+                "settings.payments.statement_descriptor",
+                "tos_acceptance.date",
+                "tos_acceptance.ip"
+              ],
+              "past_due": [
+                "business_profile.mcc",
+                "business_profile.product_description",
+                "business_profile.support_email",
+                "business_profile.support_phone",
+                "business_profile.url",
+                "external_account",
+                "individual.address.city",
+                "individual.address.line1",
+                "individual.address.postal_code",
+                "individual.address.state",
+                "individual.dob.day",
+                "individual.dob.month",
+                "individual.dob.year",
+                "individual.email",
+                "individual.first_name",
+                "individual.last_name",
+                "individual.phone",
+                "individual.ssn_last_4",
+                "individual.verification.proof_of_liveness",
+                "settings.payments.statement_descriptor",
+                "tos_acceptance.date",
+                "tos_acceptance.ip"
+              ],
+              "pending_verification": []
+            },
+            "settings": {
+              "bacs_debit_payments": {
+                "display_name": null,
+                "service_user_number": null
+              },
+              "branding": {
+                "icon": null,
+                "logo": null,
+                "primary_color": null,
+                "secondary_color": null
+              },
+              "card_issuing": {
+                "tos_acceptance": {
+                  "date": null,
+                  "ip": null
+                }
+              },
+              "card_payments": {
+                "decline_on": {
+                  "avs_failure": false,
+                  "cvc_failure": false
+                },
+                "statement_descriptor_prefix": null,
+                "statement_descriptor_prefix_kana": null,
+                "statement_descriptor_prefix_kanji": null
+              },
+              "dashboard": {
+                "display_name": null,
+                "timezone": "Etc/UTC"
+              },
+              "invoices": {
+                "default_account_tax_ids": null,
+                "hosted_payment_method_save": "offer"
+              },
+              "payments": {
+                "statement_descriptor": null,
+                "statement_descriptor_kana": null,
+                "statement_descriptor_kanji": null
+              },
+              "payouts": {
+                "debit_negative_balances": true,
+                "schedule": {
+                  "delay_days": 2,
+                  "interval": "daily"
+                },
+                "statement_descriptor": null
+              },
+              "sepa_debit_payments": {}
+            },
+            "tos_acceptance": {
+              "date": null,
+              "ip": null,
+              "user_agent": null
+            },
+            "type": "standard"
+          }
+    recorded_at: Sat, 01 Nov 2025 19:00:47 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
Fixed #2450 

This change improves the flexibility of the signup process and enhances user experience by providing clear messaging based on the current feature state.

- Updated `User::OmniauthCallbacksController` to conditionally allow signup via Stripe based on the `stripe_signup_enabled` feature flag.
- Modified `find_or_create_for_stripe_connect_account` method to accept an `allow_signup` parameter, controlling user creation based on the feature flag.
- Adjusted flash messages to provide user feedback depending on the feature flag status.
- Updated `SocialAuth` component to show or hide the Stripe button based on the feature flag.
- Added tests to ensure correct behavior when the feature flag is disabled, including user login and error messaging.

### Screenshots

### Login

<img width="1728" height="1049" alt="Screenshot 2025-12-24 at 1 24 52 PM" src="https://github.com/user-attachments/assets/9e08264a-cee6-4768-812c-47be69afa02a" />

### Sign up


<img width="1683" height="1040" alt="Screenshot 2025-12-24 at 1 25 01 PM" src="https://github.com/user-attachments/assets/9575e4b7-754f-419a-8622-279b83b987f2" />


## AI disclosure

Used Cursor Sonet 4.5 
  1. Code discovery 
  2. Flash Message
  3. Spec improvements
