### PR TITLE
Automatically unpublish products when archiving

### DIFF
--- a/app/controllers/products/archived_controller.rb
+++ b/app/controllers/products/archived_controller.rb
@@ -71,7 +71,10 @@ class Products::ArchivedController < Sellers::BaseController
   def create
     authorize [:products, :archived, @product]
 
-    @product.update!(archived: true)
+    @product.transaction do
+      @product.update!(archived: true)
+      @product.unpublish! if @product.published?
+    end
     render json: { success: true }
   end
 

--- a/spec/requests/products/index_spec.rb
+++ b/spec/requests/products/index_spec.rb
@@ -680,5 +680,34 @@ describe "Products Page Scenario", type: :system, js: true do
 
       expect(page).to have_content(product.name)
     end
+
+    context "when archiving a published product" do
+      it "automatically unpublishes the product" do
+        product = create(:product, user: seller, draft: false, purchase_disabled_at: nil)
+        expect(product.published?).to be(true)
+
+        visit(products_path)
+        expect(page).to have_content(product.name)
+
+        within find_product_row product do
+          select_disclosure "Open product action menu" do
+            click_on "Archive"
+          end
+        end
+        wait_for_ajax
+
+        product.reload
+        expect(product.archived?).to be(true)
+        expect(product.published?).to be(false)
+        expect(product.purchase_disabled_at).to be_present
+
+        # Product should not appear in main products list
+        expect(page).not_to have_content(product.name)
+
+        # Product should appear in archived tab
+        find(:tab_button, "Archived").click
+        expect(page).to have_content(product.name)
+      end
+    end
   end
 end


### PR DESCRIPTION
# Automatically unpublish products when archiving

## Summary

This PR ensures that when a product is archived, it is automatically unpublished if it's currently published. This prevents archived products from remaining publicly available for purchase.

## Implementation Details

1. The product is marked as archived (`archived: true`)
2. If the product is currently published, it is automatically unpublished by calling `unpublish!`
3. Both operations are wrapped in a database transaction to ensure consistency

### Before

https://github.com/user-attachments/assets/e81ef14d-e0f7-4f7f-bbc4-1995e1697d91


### After

https://github.com/user-attachments/assets/5eb829b0-df23-44f0-860e-f1a58f8ed676


## Related
Fixed #2373 