### PR TITLE
feat: Add Order ID search field to admin purchase search

### DIFF
--- a/app/controllers/admin/search/purchases_controller.rb
+++ b/app/controllers/admin/search/purchases_controller.rb
@@ -7,7 +7,7 @@ class Admin::Search::PurchasesController < Admin::BaseController
   def index
     @title = "Purchase results"
 
-    search_params = params.permit(:transaction_date, :last_4, :card_type, :price, :expiry_date, :purchase_status).to_hash.symbolize_keys
+    search_params = params.permit(:transaction_date, :last_4, :card_type, :price, :expiry_date, :purchase_status, :order_id).to_hash.symbolize_keys
 
     if search_params[:transaction_date].present?
       begin

--- a/app/controllers/api/internal/helper/purchases_controller.rb
+++ b/app/controllers/api/internal/helper/purchases_controller.rb
@@ -178,7 +178,7 @@ class Api::Internal::Helper::PurchasesController < Api::Internal::Helper::BaseCo
 
   SEARCH_PURCHASE_OPENAPI = {
     summary: "Search purchase",
-    description: "Search purchase by email, seller, license key, or card details. At least one of the parameters is required.",
+    description: "Search purchase by order ID, email, seller, license key, or card details. At least one of the parameters is required. Order ID is the most efficient search method when available.",
     requestBody: {
       required: true,
       content: {
@@ -186,6 +186,7 @@ class Api::Internal::Helper::PurchasesController < Api::Internal::Helper::BaseCo
           schema: {
             type: "object",
             properties: {
+              order_id: { type: "string", description: "Order ID (also known as purchase ID or external ID) - the unique identifier shown to customers on receipts" },
               email: { type: "string", description: "Email address of the customer/buyer" },
               creator_email: { type: "string", description: "Email address of the creator/seller" },
               license_key: { type: "string", description: "Product license key (4 groups of alphanumeric characters separated by dashes)" },
@@ -259,6 +260,7 @@ class Api::Internal::Helper::PurchasesController < Api::Internal::Helper::BaseCo
   }.freeze
   def search
     search_params = {
+      order_id: params[:order_id],
       query: params[:email],
       creator_email: params[:creator_email],
       license_key: params[:license_key],

--- a/app/javascript/components/Admin/SearchPopover.tsx
+++ b/app/javascript/components/Admin/SearchPopover.tsx
@@ -42,6 +42,7 @@ const SearchPopover = () => {
     user_query: initialQueries.user_query,
     purchase_query: initialQueries.purchase_query,
     affiliate_query: initialQueries.affiliate_query,
+    order_id: searchParams.get("order_id") || "",
     product_title_query: searchParams.get("product_title_query") || "",
     purchase_status: searchParams.get("purchase_status") || "",
     card_type: searchParams.get("card_type") || "",
@@ -52,7 +53,7 @@ const SearchPopover = () => {
   });
 
   const resetOtherQueryFields = (activeField?: keyof typeof data | null) => {
-    const queryFields = ["user_query", "purchase_query", "affiliate_query"] as const;
+    const queryFields = ["user_query", "purchase_query", "affiliate_query", "order_id"] as const;
     const cardFields = ["card_type", "transaction_date", "last_4", "expiry_date", "price"] as const;
 
     if (activeField === null) {
@@ -60,7 +61,7 @@ const SearchPopover = () => {
       return;
     }
 
-    if (activeField && ["user_query", "purchase_query", "affiliate_query"].includes(activeField)) {
+    if (activeField && ["user_query", "purchase_query", "affiliate_query", "order_id"].includes(activeField)) {
       cardFields.forEach((field) => setData(field, ""));
       queryFields.forEach((field) => {
         if (field !== activeField) setData(field, "");
@@ -68,12 +69,10 @@ const SearchPopover = () => {
     }
   };
 
-  const submit = (endpoint: string, queryParam?: keyof typeof data | null) => {
-    const queryData = { query: queryParam ? String(data[queryParam]) : "" };
+  const submit = (endpoint: string, queryParam?: keyof typeof data | null, paramName = "query") => {
+    const queryValue: string = queryParam ? String(data[queryParam]) : "";
     const url = new URL(endpoint, window.location.origin);
-    Object.entries(queryData).forEach(([key, value]) => {
-      url.searchParams.set(key, value);
-    });
+    url.searchParams.set(paramName, queryValue);
 
     get(url.toString(), {
       onBefore: () => resetOtherQueryFields(queryParam),
@@ -145,6 +144,28 @@ const SearchPopover = () => {
               type="text"
               value={data.affiliate_query}
               onChange={(e) => setData("affiliate_query", e.target.value)}
+            />
+          </div>
+          <Button color="primary" type="submit">
+            <Icon name="solid-search" />
+          </Button>
+        </form>
+
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            submit(Routes.admin_search_purchases_path(), "order_id", "order_id");
+          }}
+          className="flex gap-2"
+        >
+          <div className="input">
+            <Icon name="outline-shopping-bag" />
+            <input
+              name="order_id"
+              placeholder="Search by Order ID"
+              type="text"
+              value={data.order_id}
+              onChange={(e) => setData("order_id", e.target.value)}
             />
           </div>
           <Button color="primary" type="submit">

--- a/app/javascript/components/server-components/Admin/SearchPopover.tsx
+++ b/app/javascript/components/server-components/Admin/SearchPopover.tsx
@@ -73,6 +73,20 @@ export const SearchPopover = ({ card_types }: Props) => {
             <Icon name="solid-search" />
           </Button>
         </form>
+        <form action={Routes.admin_search_purchases_path()} method="get" className="input-with-button">
+          <div className="input">
+            <Icon name="outline-shopping-bag" />
+            <input
+              name="order_id"
+              placeholder="Search by Order ID"
+              type="text"
+              defaultValue={searchParams.get("order_id") || ""}
+            />
+          </div>
+          <Button color="primary" type="submit">
+            <Icon name="solid-search" />
+          </Button>
+        </form>
         <Separator>or search by card</Separator>
         <form action={Routes.admin_search_purchases_path()} method="get" style={{ display: "contents" }}>
           <select name="card_type" defaultValue={searchParams.get("card_type") || ""}>

--- a/app/services/admin_search_service.rb
+++ b/app/services/admin_search_service.rb
@@ -3,8 +3,15 @@
 class AdminSearchService
   class InvalidDateError < StandardError; end
 
-  def search_purchases(query: nil, product_title_query: nil, purchase_status: nil, creator_email: nil, license_key: nil, transaction_date: nil, last_4: nil, card_type: nil, price: nil, expiry_date: nil, limit: nil)
+  def search_purchases(query: nil, order_id: nil, product_title_query: nil, purchase_status: nil, creator_email: nil, license_key: nil, transaction_date: nil, last_4: nil, card_type: nil, price: nil, expiry_date: nil, limit: nil)
     purchases = Purchase.order(created_at: :desc)
+
+    if order_id.present?
+      purchase_id = Purchase.from_external_id(order_id.strip)
+      purchase_id ||= ObfuscateIds.decrypt_numeric(order_id.strip.to_i)
+      return purchases.where(id: purchase_id).limit(limit) if purchase_id
+      return Purchase.none
+    end
 
     if query.present?
       unions = [

--- a/spec/controllers/admin/search/purchases_controller_spec.rb
+++ b/spec/controllers/admin/search/purchases_controller_spec.rb
@@ -140,5 +140,22 @@ describe Admin::Search::PurchasesController, type: :controller, inertia: true do
         end
       end
     end
+
+    describe "order_id" do
+      it "redirects to purchase page when searching by order_id" do
+        purchase = create(:purchase)
+
+        get :index, params: { order_id: purchase.external_id }
+        expect(response).to redirect_to admin_purchase_path(purchase.external_id)
+      end
+
+      it "passes order_id to AdminSearchService" do
+        purchase = create(:purchase)
+
+        expect_any_instance_of(AdminSearchService).to receive(:search_purchases).with(query: nil, product_title_query: nil, order_id: purchase.external_id).and_call_original
+
+        get :index, params: { order_id: purchase.external_id }
+      end
+    end
   end
 end

--- a/spec/controllers/api/internal/helper/purchases_controller_spec.rb
+++ b/spec/controllers/api/internal/helper/purchases_controller_spec.rb
@@ -371,6 +371,46 @@ describe Api::Internal::Helper::PurchasesController, :vcr do
         expect(response.parsed_body).to eq({ success: true, message: "Purchase found", purchase: purchase_json }.as_json)
       end
     end
+
+    context "when searching by order_id" do
+      it "returns purchase data when searching by order_id (external_id)" do
+        purchase = create(:purchase)
+        purchase_json = purchase.slice(:email, :link_name, :price_cents, :purchase_state, :created_at)
+        purchase_json[:id] = purchase.external_id_numeric
+        purchase_json[:seller_email] = purchase.seller_email
+        purchase_json[:receipt_url] = receipt_purchase_url(purchase.external_id, host: UrlService.domain_with_protocol, email: purchase.email)
+        purchase_json[:refund_status] = nil
+
+        params = { order_id: purchase.external_id, timestamp: Time.now.to_i }
+        post :search, params: params
+
+        expect(response).to have_http_status(:success)
+        expect(response.parsed_body).to eq({ success: true, message: "Purchase found", purchase: purchase_json }.as_json)
+      end
+
+      it "returns purchase data when searching by order_id (external_id_numeric)" do
+        purchase = create(:purchase)
+        purchase_json = purchase.slice(:email, :link_name, :price_cents, :purchase_state, :created_at)
+        purchase_json[:id] = purchase.external_id_numeric
+        purchase_json[:seller_email] = purchase.seller_email
+        purchase_json[:receipt_url] = receipt_purchase_url(purchase.external_id, host: UrlService.domain_with_protocol, email: purchase.email)
+        purchase_json[:refund_status] = nil
+
+        params = { order_id: purchase.external_id_numeric.to_s, timestamp: Time.now.to_i }
+        post :search, params: params
+
+        expect(response).to have_http_status(:success)
+        expect(response.parsed_body).to eq({ success: true, message: "Purchase found", purchase: purchase_json }.as_json)
+      end
+
+      it "returns not found when order_id is invalid" do
+        params = { order_id: "invalid_order_id", timestamp: Time.now.to_i }
+        post :search, params: params
+
+        expect(response).to have_http_status(:not_found)
+        expect(response.parsed_body).to eq({ success: false, message: "Purchase not found" }.as_json)
+      end
+    end
   end
 
   describe "POST auto_refund_purchase" do

--- a/spec/services/admin_search_service_spec.rb
+++ b/spec/services/admin_search_service_spec.rb
@@ -38,6 +38,41 @@ describe AdminSearchService do
       expect(purchases).not_to include(other_purchase)
     end
 
+    describe "searching by order_id" do
+      it "returns purchase when searching by order_id (external_id)" do
+        purchase = create(:purchase)
+        other_purchase = create(:purchase)
+
+        purchases = AdminSearchService.new.search_purchases(order_id: purchase.external_id)
+        expect(purchases).to eq([purchase])
+        expect(purchases).not_to include(other_purchase)
+      end
+
+      it "returns purchase when searching by order_id (external_id_numeric)" do
+        purchase = create(:purchase)
+        other_purchase = create(:purchase)
+
+        purchases = AdminSearchService.new.search_purchases(order_id: purchase.external_id_numeric.to_s)
+        expect(purchases).to eq([purchase])
+        expect(purchases).not_to include(other_purchase)
+      end
+
+      it "returns no purchases when order_id is invalid" do
+        create(:purchase)
+        purchases = AdminSearchService.new.search_purchases(order_id: "invalid_order_id")
+        expect(purchases).to be_empty
+      end
+
+      it "prioritizes order_id over other search parameters" do
+        purchase = create(:purchase, email: "user@example.com")
+        other_purchase = create(:purchase, email: "user@example.com")
+
+        purchases = AdminSearchService.new.search_purchases(order_id: purchase.external_id, query: "user@example.com")
+        expect(purchases).to eq([purchase])
+        expect(purchases).not_to include(other_purchase)
+      end
+    end
+
     it "returns purchases when searching by email with empty card parameters" do
       email = "user@example.com"
       purchase = create(:purchase, email:)


### PR DESCRIPTION
# Fixes #2480
## What
When customers contact support, they often have their Order ID handy but can't remember which email they used at checkout. This adds a dedicated Order ID search field so support can quickly find purchases without having to guess at emails or search by card details.

## Changes
- Added an `order_id` parameter to the backend search service that looks up purchases directly by their external ID
- Updated the admin search popover UI to include a new Order ID input field (with a shopping bag icon 🛒)
- Wired up the Helper API so support tools can also search by Order ID

The new field shows up right in the search popover, between the affiliates search and the card search section.

## UI 

https://github.com/user-attachments/assets/95097b0d-a71b-429e-b1b2-e179e87ad324


## Tests
All the new order_id search tests pass:

## AI disclousure 
Used Claude Sonnet 4.5 via Cursor for tests and implementing 

## Notes

I have watched all Antiwork Livestreams 
