### PR TITLE
Rename 'User Memberships' to 'User Collaborations' in Admin Dashboard

### DIFF
--- a/app/javascript/components/Admin/Users/Memberships.tsx
+++ b/app/javascript/components/Admin/Users/Memberships.tsx
@@ -44,7 +44,7 @@ const Memberships = ({ user: { admin_manageable_user_memberships } }: Membership
       <hr />
       <details>
         <summary>
-          <h3>User memberships</h3>
+          <h3>User Collaborations</h3>
         </summary>
         <div className="stack">
           {admin_manageable_user_memberships.map((membership) => (

--- a/app/views/admin/users/_user_memberships.html.erb
+++ b/app/views/admin/users/_user_memberships.html.erb
@@ -3,7 +3,7 @@
   <hr>
   <details>
     <summary>
-      <h3>User memberships</h3>
+      <h3>User Collaborations</h3>
     </summary>
     <div class="stack">
       <% user_memberships.each do |user_membership| %>

--- a/spec/presenters/admin/user_presenter/card_spec.rb
+++ b/spec/presenters/admin/user_presenter/card_spec.rb
@@ -103,7 +103,7 @@ describe Admin::UserPresenter::Card do
       end
     end
 
-    describe "user memberships" do
+    describe "user collaborations" do
       context "when user has no memberships" do
         it "returns an empty array" do
           expect(props[:admin_manageable_user_memberships]).to eq([])

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -46,16 +46,16 @@ describe "Admin::UsersController Scenario", type: :system, js: true do
     end
   end
 
-  describe "user memberships" do
-    context "when the user has no user memberships" do
-      it "doesn't render user memberships" do
+  describe "user collaborations" do
+    context "when the user has no user collaborations" do
+      it "doesn't render user collaborations" do
         visit admin_user_path(user.id)
 
-        expect(page).not_to have_text("User memberships")
+        expect(page).not_to have_text("User Collaborations")
       end
     end
 
-    context "when the user has user memberships" do
+    context "when the user has user collaborations" do
       let(:seller_one) { create(:user, :without_username) }
       let(:seller_two) { create(:user) }
       let(:seller_three) { create(:user) }
@@ -64,10 +64,10 @@ describe "Admin::UsersController Scenario", type: :system, js: true do
       let!(:team_membership_two) { create(:team_membership, user:, seller: seller_two) }
       let!(:team_membership_three) { create(:team_membership, user:, seller: seller_three, deleted_at: 1.hour.ago) }
 
-      it "renders user memberships" do
+      it "renders user collaborations" do
         visit admin_user_path(user.id)
 
-        find_and_click "h3", text: "User memberships"
+        find_and_click "h3", text: "User Collaborations"
         expect(page).to have_text(seller_one.display_name(prefer_email_over_default_username: true))
         expect(page).to have_text(seller_two.display_name(prefer_email_over_default_username: true))
         expect(page).not_to have_text(seller_three.display_name(prefer_email_over_default_username: true))


### PR DESCRIPTION
## Summary

Fixes #2062

### The Problem
Currently, when a user is a collaborator/affiliate for someone else, their collaborations are displayed under "User Memberships" in the admin dashboard. This terminology is confusing because "memberships" is the term Gumroad uses for **subscription products** (e.g., recurring memberships that customers purchase).

### The Solution
This PR renames the display text from "User Memberships" to "User Collaborations" throughout the admin dashboard, providing clearer terminology that accurately reflects the functionality (collaborations/affiliates vs subscription memberships).

## Changes Made

| File | Change |
|------|--------|
| `app/javascript/components/Admin/Users/Memberships.tsx` | Updated `<h3>` heading from "User memberships" to "User Collaborations" |
| `app/views/admin/users/_user_memberships.html.erb` | Updated `<h3>` heading from "User memberships" to "User Collaborations" |
| `spec/requests/admin/users_spec.rb` | Updated test descriptions and assertions to match new terminology |
| `spec/presenters/admin/user_presenter/card_spec.rb` | Updated test description to match new terminology |

## Screenshots

N/A - This is a text-only change. The section will now display as:

```
▼ User Collaborations
  [collaborator avatar] Collaborator Name
                        Role: admin
                        invited Dec 15, 2025
```

## Testing

- [x] All existing tests updated to reflect new terminology
- [x] No breaking changes to functionality
- [x] Only display text modified - no variable names or code logic changed

## AI Disclosure

This PR was developed with AI assistance:
- **Opus 4.5** for planning and code review
- **GLM 4.7** for code execution
- **GitHub PR review** for quality assurance

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] My changes follow the existing code style
- [x] I have updated tests where applicable
- [x] This change is backwards compatible