### PR TITLE
Fix Reassign Purchases to send receipt to new email

### DIFF
--- a/app/controllers/api/internal/helper/purchases_controller.rb
+++ b/app/controllers/api/internal/helper/purchases_controller.rb
@@ -426,7 +426,7 @@ class Api::Internal::Helper::PurchasesController < Api::Internal::Helper::BaseCo
 
   REASSIGN_PURCHASES_OPENAPI = {
     summary: "Reassign purchases",
-    description: "Update the email on all purchases belonging to the 'from' email address to the 'to' email address",
+    description: "Update the email on all purchases belonging to the 'from' email address to the 'to' email address. A receipt will also be sent to the new email address.",
     requestBody: {
       required: true,
       content: {
@@ -507,7 +507,10 @@ class Api::Internal::Helper::PurchasesController < Api::Internal::Helper::BaseCo
 
       if purchase.subscription.present? && !purchase.is_original_subscription_purchase? && !purchases.include?(purchase.original_purchase)
         purchase.original_purchase.update(email: to_email)
-        count += 1 if purchase.original_purchase.saved_changes?
+        if purchase.original_purchase.saved_changes?
+          purchase.original_purchase.resend_receipt
+          count += 1
+        end
       end
 
       if target_user && purchase.purchaser_id.present?
@@ -527,6 +530,9 @@ class Api::Internal::Helper::PurchasesController < Api::Internal::Helper::BaseCo
       end
 
       count += 1 if purchase.save
+
+      # Send receipt to new email after successful reassignment
+      purchase.resend_receipt if purchase.saved_changes?
     end
 
     render json: {


### PR DESCRIPTION
## Summary

Fixes #2479

### The Problem
The "Reassign Purchases" tool in Helper was only updating the email address on purchases in the database, but was **not**:
1. ❌ Sending a receipt to the new email address
2. ❌ Properly notifying the customer about their purchase access

This meant support agents had to manually use "Resend Receipt" as a follow-up step after every reassignment - adding extra work and room for error.

### The Solution
Added automatic receipt sending after successful purchase reassignment.

```ruby
count += 1 if purchase.save

# Send receipt to new email after successful reassignment
purchase.resend_receipt if purchase.saved_changes?
```

## Technical Details

| Aspect | Before | After |
|--------|--------|-------|
| Database email update | ✅ | ✅ |
| Receipt to new email | ❌ | ✅ |
| Library access at new email | ❌ (email not notified) | ✅ (via receipt link) |

### Why `saved_changes?` Check?
The `saved_changes?` check ensures:
- Receipts are only sent when the purchase was **actually modified**
- Avoids duplicate receipts for no-op cases (e.g., reassigning to same email)
- Prevents spam if tool is called multiple times

### OpenAPI Documentation Update
Updated the tool description to inform Helper that receipts will be sent:
```diff
-description: "Update the email on all purchases..."
+description: "Update the email on all purchases... A receipt will also be sent to the new email address."
```

## User Experience

When support uses "Reassign Purchases" to fix a customer's email:

**Before:**
1. Helper updates email in database
2. Support must separately use "Resend Receipt"
3. Customer finally gets email with library access link

**After:**
1. Helper updates email in database + auto-sends receipt
2. Customer immediately gets email with library access link
3. ✨ Single step, immediate resolution

## Files Changed

- `app/controllers/api/internal/helper/purchases_controller.rb`
  - Added `purchase.resend_receipt if purchase.saved_changes?` after save
  - Updated OpenAPI description for clarity

## Testing

- [x] Receipt is sent to new email after reassignment
- [x] Receipt is NOT sent if no changes were made (idempotent)
- [x] Existing reassignment functionality unchanged
- [x] OpenAPI documentation reflects new behavior

## AI Disclosure

This PR was developed with AI assistance:
- **Opus 4.5** for planning and code review
- **GLM 4.7** for code execution
- **GitHub PR review** for quality assurance

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] My changes follow the existing code style
- [x] This change is backwards compatible
- [x] Documentation updated (OpenAPI)