### PR TITLE
Fix email notification not appearing for All Time CSV exports

### DIFF
--- a/app/javascript/components/Audience/CustomersPage.tsx
+++ b/app/javascript/components/Audience/CustomersPage.tsx
@@ -432,7 +432,7 @@ const CustomersPage = ({
                 >
                   Download
                 </NavigationButton>
-                {count > 2000 && (
+                {(count > 2000 || lightFormat(from, "yyyy-MM-dd") === "2012-10-13") && (
                   <div className="mt-2 text-sm text-gray-600">
                     Exports over 2,000 rows will be processed in the background and emailed to you.
                   </div>


### PR DESCRIPTION
## Summary

Fixes #1930

### The Problem
When downloading sales data for "All Time", no notice appears informing users that the export will be processed in the background and emailed to them. Users may be confused when they click "Download" and nothing seems to happen immediately.

### Root Cause
The email notification message only showed when `count > 2000`:

```typescript
{count > 2000 && (
  <div className="mt-2 text-sm text-gray-600">
    Exports over 2,000 rows will be processed in the background and emailed to you.
  </div>
)}
```

The `count` variable reflects the currently filtered table data. When "All Time" is selected in the DateRangePicker, the filter changes but the count may still be based on paginated data - not reflecting the true total that will be exported.

### The Fix
Added a check for "All Time" selection by detecting when the `from` date equals Gumroad's founding date (2012-10-13):

```typescript
{(count > 2000 || lightFormat(from, "yyyy-MM-dd") === "2012-10-13") && (
  <div className="mt-2 text-sm text-gray-600">
    Exports over 2,000 rows will be processed in the background and emailed to you.
  </div>
)}
```

### Why "2012-10-13"?
The DateRangePicker uses `2012-10-13` (Gumroad's founding date) as the start date when "All Time" is selected. This is a reliable indicator that the user wants ALL historical data.

## Before & After

| Date Range | Before | After |
|------------|--------|-------|
| All Time | ❌ No notification | ✅ Shows email notification |
| Custom dates (< 2000 rows) | ❌ No notification | ❌ No notification |
| Custom dates (> 2000 rows) | ✅ Shows notification | ✅ Shows notification |

## Testing

- [x] "All Time" selection shows email notification
- [x] Custom date range with < 2000 rows doesn't show notification
- [x] Custom date range with > 2000 rows still shows notification
- [x] Matches backend behavior in `purchases_controller.rb`

## AI Disclosure

This PR was developed with AI assistance:
- **Opus 4.5** for planning and code review
- **GLM 4.7** for code execution
- **GitHub PR review** for quality assurance

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] My changes follow the existing code style
- [x] This change is backwards compatible