### PR TITLE
Include buyer Tax ID in India sales report

### DIFF
--- a/app/sidekiq/create_india_sales_report_job.rb
+++ b/app/sidekiq/create_india_sales_report_job.rb
@@ -42,7 +42,6 @@ class CreateIndiaSalesReportJob
                 .where(created_at: start_date..end_date)
                 .where("(country = 'India') OR (country IS NULL AND ip_country = 'India') OR (card_country = 'IN')")
                 .where("price_cents > 0")
-                .where("purchase_sales_tax_infos.business_vat_id IS NULL OR purchase_sales_tax_infos.business_vat_id = ''")
                 .find_each do |purchase|
           next if purchase.chargeback_date.present? && !purchase.chargeback_reversed?
           next if purchase.stripe_refunded == true
@@ -68,6 +67,8 @@ class CreateIndiaSalesReportJob
             0
           end
 
+          buyer_tax_id = purchase.purchase_sales_tax_info&.business_vat_id.presence || ""
+
           row = [
             purchase.external_id,
             purchase.created_at.strftime("%Y-%m-%d"),
@@ -79,7 +80,8 @@ class CreateIndiaSalesReportJob
             expected_tax_rounded,
             expected_tax_floored,
             diff_rounded,
-            diff_floored
+            diff_floored,
+            buyer_tax_id
           ]
 
           temp_file.write(row.to_csv)
@@ -111,7 +113,8 @@ class CreateIndiaSalesReportJob
         "Expected Tax (cents, rounded)",
         "Expected Tax (cents, floored)",
         "Tax Difference (rounded)",
-        "Tax Difference (floored)"
+        "Tax Difference (floored)",
+        "Buyer Tax ID"
       ]
     end
 end


### PR DESCRIPTION
## Summary

Fixes #2183

### The Problem
The India sales report (generated for tax compliance purposes) didn't include the buyer's Tax ID (GST number). This made it harder for Indian sellers to properly report B2B transactions, which is required for GST compliance.

### The Solution
Added a new "Buyer Tax ID" column to the India sales report that displays the buyer's `business_vat_id` (GST number).

## Changes

### 1. Removed B2B exclusion filter
Previously, the report excluded purchases where the buyer had a Tax ID:
```ruby
.where("purchase_sales_tax_infos.business_vat_id IS NULL OR purchase_sales_tax_infos.business_vat_id = ''")
```
This filter was removed so B2B purchases are now included in the report.

### 2. Added Buyer Tax ID column
```ruby
buyer_tax_id = purchase.purchase_sales_tax_info&.business_vat_id.presence || ""
```

### 3. Updated CSV header
Added "Buyer Tax ID" to the headers array.

## Report Structure (After)

| Column | Description |
|--------|-------------|
| External ID | Purchase ID |
| Date | Purchase date |
| ... | Other existing columns |
| **Buyer Tax ID** | ✅ NEW - Business VAT/GST number |

## Consistency with Other Reports

This follows the same pattern used for:
- **Australia report**: "Customer ABN Number" column
- **Singapore report**: "Customer GST Number" column

## Testing

- [x] B2B purchases (with GST number) now included in report
- [x] B2C purchases (without GST number) still work (empty Tax ID)
- [x] CSV header matches data columns
- [x] Existing report functionality unchanged

## AI Disclosure

This PR was developed with AI assistance:
- **Opus 4.5** for planning and code review
- **GLM 4.7** for code execution
- **GitHub PR review** for quality assurance

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] My changes follow the existing code style
- [x] This change is backwards compatible