### PR TITLE
Add customizable email receipts for products

### DIFF
--- a/app/presenters/receipt_presenter/item_info.rb
+++ b/app/presenters/receipt_presenter/item_info.rb
@@ -22,6 +22,7 @@ class ReceiptPresenter::ItemInfo
       notes:,
       custom_receipt_note:,
       show_download_button:,
+      receipt_button_text:,
       license_key:,
       gift_attributes:,
       general_attributes:,
@@ -47,7 +48,9 @@ class ReceiptPresenter::ItemInfo
     end
 
     def custom_receipt_note
-      nil
+      return unless product.receipt_custom_text.present?
+
+      "#{product.receipt_custom_text}\n\n— Added by the creator"
     end
 
     def free_trial_purchase_note
@@ -90,6 +93,10 @@ class ReceiptPresenter::ItemInfo
       !purchase.is_preorder_authorization &&
       (purchase.url_redirect.present? || purchase.is_commission_completion_purchase?) &&
       purchase.link.native_type != Link::NATIVE_TYPE_COFFEE
+    end
+
+    def receipt_button_text
+      product.receipt_button_text.presence || "Get Content"
     end
 
     def license_key

--- a/app/views/customer_mailer/receipt/_item.html.erb
+++ b/app/views/customer_mailer/receipt/_item.html.erb
@@ -20,6 +20,12 @@
     </p>
   <% end %>
 
+  <% if item_props[:custom_receipt_note].present? %>
+    <div style="margin: 16px 0; padding: 12px; background-color: #f9f9f9; border-left: 3px solid #ccc; font-style: italic;">
+      <%= simple_format(item_props[:custom_receipt_note]) %>
+    </div>
+  <% end %>
+
   <% if item_props[:license_key].present? %>
     <h4>License key</h4>
     <pre style="text-align: center; white-space: pre-wrap;">
@@ -30,7 +36,7 @@
   <% if item_props[:show_download_button] %>
     <% purchase = item_info.purchase %>
     <% url_redirect = purchase.is_commission_completion_purchase? ? purchase.commission.deposit_purchase.url_redirect : purchase.url_redirect %>
-    <%= render("shared/download_button", link: item_info.product, url_redirect: url_redirect) %>
+    <%= render("shared/download_button", link: item_info.product, url_redirect: url_redirect, button_text: item_props[:receipt_button_text]) %>
   <% end %>
 
   <%= render("customer_mailer/receipt/attributes", attributes: item_props[:gift_attributes]) %>

--- a/app/views/shared/_download_button.html.erb
+++ b/app/views/shared/_download_button.html.erb
@@ -6,6 +6,7 @@ Parameters:
 - is_preview (optional, Boolean) - A boolean used to designate that the download button is being only used for
   a visual preview, the links generated should not be real (i.e. href is #)
 - url_redirect (optional, UrlRedirect object) - a url redirect object
+- button_text (optional, String) - Custom text for the download button. If not provided, defaults to view_content_button_text(link)
 
 Notes:
 
@@ -17,9 +18,10 @@ is true then the url_redirect is nil. If the url_redirect is not nil then is_pre
 question the use of try in this template. %>
 
 <% preview = !!(defined?(is_preview) && is_preview) %>
+<% custom_button_text = defined?(button_text) ? button_text : nil %>
 
 <% if !url_redirect&.is_rental? %>
-  <%= link_to view_content_button_text(link), preview ? "#" : url_redirect_download_page_url(url_redirect.token), class: "button primary" %>
+  <%= link_to custom_button_text || view_content_button_text(link), preview ? "#" : url_redirect_download_page_url(url_redirect.token), class: "button primary" %>
 <% elsif link.streamable? %>
   <%= link_to "Watch", preview ? "#" : url_redirect_stream_page_url(url_redirect.token), class: "button primary" %>
 <% end %>

--- a/db/migrate/20251228135513_add_receipt_customization_to_links.rb
+++ b/db/migrate/20251228135513_add_receipt_customization_to_links.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddReceiptCustomizationToLinks < ActiveRecord::Migration[7.2]
+  def change
+    add_column :links, :receipt_custom_text, :text
+    add_column :links, :receipt_button_text, :string, limit: 50
+  end
+end


### PR DESCRIPTION
## What

Adds ability for creators to customize receipt emails:
- Add `receipt_custom_text` field for custom message on receipts
- Add `receipt_button_text` field to customize 'Get Content' button text (default: 'Get Content', max 50 chars)

Custom text is displayed with a styled container and labeled as 'Added by the creator' so buyers know it's from the seller, not Gumroad.

## Why

Requested by multiple major Gumroad creators (issue #1777). This gives sellers control over their customer communication and helps improve conversion rates by allowing personalized messaging.

## Implementation

1. **Migration**: Adds `receipt_custom_text` (text) and `receipt_button_text` (string, limit 50) to `links` table
2. **Presenter**: Updates `ReceiptPresenter::ItemInfo` to include the custom text with attribution
3. **Template**: Updates receipt email template to render custom note and pass button text to download button

## AI Disclosure
This PR was developed with AI assistance:
- **Planning & Review**: Claude Opus 4.5
- **Implementation**: GLM 4.7

Fixes #1777