### PR TITLE
Add VAT ID update endpoint for recurring subscriptions

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -8,7 +8,7 @@ class SubscriptionsController < ApplicationController
   before_action :fetch_subscription, only: %i[unsubscribe_by_seller unsubscribe_by_user magic_link send_magic_link]
   before_action :hide_layouts, only: [:manage, :magic_link, :send_magic_link]
   before_action :set_noindex_header, only: [:manage]
-  before_action :check_can_manage, only: [:manage, :unsubscribe_by_user]
+  before_action :check_can_manage, only: [:manage, :unsubscribe_by_user, :update_vat_id]
 
   SUBSCRIPTION_COOKIE_EXPIRY = 1.week
 
@@ -54,6 +54,46 @@ class SubscriptionsController < ApplicationController
     head :no_content
   end
 
+  def update_vat_id
+    vat_id = params[:vat_id].to_s.strip
+    original_purchase = @subscription.original_purchase
+    e404 if original_purchase.nil?
+
+    if vat_id.blank?
+      render json: { success: false, error: "VAT ID cannot be blank" }, status: :bad_request
+      return
+    end
+
+    # Determine which validation service to use based on the original purchase's country
+    sales_tax_info = original_purchase.purchase_sales_tax_info
+    country_code = sales_tax_info&.country_code
+
+    if country_code.blank?
+      render json: { success: false, error: "Unable to determine country for VAT validation" }, status: :bad_request
+      return
+    end
+
+    # Validate the VAT ID using the appropriate validation service
+    is_valid = validate_vat_id(vat_id, country_code, sales_tax_info&.state_code)
+
+    unless is_valid
+      render json: { success: false, error: "Invalid VAT ID" }, status: :unprocessable_entity
+      return
+    end
+
+    # Create purchase_sales_tax_info if it doesn't exist
+    if sales_tax_info.nil?
+      sales_tax_info = original_purchase.create_purchase_sales_tax_info!
+    end
+
+    # Update the VAT ID
+    sales_tax_info.update!(business_vat_id: vat_id)
+
+    render json: { success: true }
+  rescue ActiveRecord::RecordInvalid => e
+    render json: { success: false, error: e.message }, status: :unprocessable_entity
+  end
+
   private
     def check_can_manage
       (@subscription = Subscription.find_by_external_id(params[:id])) || e404
@@ -92,5 +132,32 @@ class SubscriptionsController < ApplicationController
     def fetch_subscription
       @subscription = Subscription.find_by_external_id(params[:id] || params[:subscription_id])
       render json: { success: false } if @subscription.nil?
+    end
+
+    def validate_vat_id(vat_id, country_code, state_code)
+      if Compliance::Countries::AUS.alpha2 == country_code
+        AbnValidationService.new(vat_id).process
+      elsif Compliance::Countries::SGP.alpha2 == country_code
+        GstValidationService.new(vat_id).process
+      elsif Compliance::Countries::CAN.alpha2 == country_code && state_code == QUEBEC
+        QstValidationService.new(vat_id).process
+      elsif Compliance::Countries::NOR.alpha2 == country_code
+        MvaValidationService.new(vat_id).process
+      elsif Compliance::Countries::BHR.alpha2 == country_code
+        TrnValidationService.new(vat_id).process
+      elsif Compliance::Countries::KEN.alpha2 == country_code
+        KraPinValidationService.new(vat_id).process
+      elsif Compliance::Countries::OMN.alpha2 == country_code
+        OmanVatNumberValidationService.new(vat_id).process
+      elsif Compliance::Countries::NGA.alpha2 == country_code
+        FirsTinValidationService.new(vat_id).process
+      elsif Compliance::Countries::TZA.alpha2 == country_code
+        TraTinValidationService.new(vat_id).process
+      elsif Compliance::Countries::COUNTRIES_THAT_COLLECT_TAX_ON_ALL_PRODUCTS.include?(country_code) ||
+            Compliance::Countries::COUNTRIES_THAT_COLLECT_TAX_ON_DIGITAL_PRODUCTS_WITH_TAX_ID_PRO_VALIDATION.include?(country_code)
+        TaxIdValidationService.new(vat_id, country_code).process
+      else
+        VatValidationService.new(vat_id).process
+      end
     end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -791,6 +791,7 @@ Rails.application.routes.draw do
         post :unsubscribe_by_user
         post :unsubscribe_by_seller
         put :update, to: "purchases#update_subscription"
+        put :update_vat_id
       end
     end
 


### PR DESCRIPTION
## What

Adds a new endpoint `PUT /subscriptions/:id/update_vat_id` that allows subscription customers to add or update their VAT ID for future charges.

When a valid VAT ID is stored, future subscription charges automatically skip VAT (existing logic in `get_vat_id_from_original_purchase` and `SalesTaxCalculator`).

## Why

Currently customers need to create VAT refunds for every recurring charge manually. This saves time for customers and support staff by allowing VAT exemption to be applied automatically going forward.

## Implementation

1. **New Controller Action**: `update_vat_id` in `SubscriptionsController`
   - Validates VAT ID using appropriate service based on country
   - Updates `original_purchase.purchase_sales_tax_info.business_vat_id`
   - Protected by `check_can_manage` (same auth as subscription management page)

2. **Country-Specific Validation**: Supports EU VAT, Australian ABN, Singapore GST, Norway MVA, Canada QST (Quebec), Kenya KRA PIN, and other tax IDs

3. **Route**: Added PUT route at `/subscriptions/:id/update_vat_id`

## How It Works

1. Customer accesses subscription management page
2. Customer submits their VAT ID via the new endpoint
3. VAT ID is validated and stored on the original purchase
4. Future charges use `get_vat_id_from_original_purchase` to copy the VAT ID
5. `SalesTaxCalculator` returns zero tax when VAT ID is valid

## AI Disclosure
This PR was developed with AI assistance:
- **Planning & Review**: Claude Opus 4.5
- **Implementation**: GLM 4.7

Fixes #721