### PR TITLE
fix: Replace BGN with EUR for Bulgaria payouts

### DIFF
--- a/app/models/bulgaria_bank_account.rb
+++ b/app/models/bulgaria_bank_account.rb
@@ -14,7 +14,7 @@ class BulgariaBankAccount < BankAccount
   end
 
   def currency
-    Currency::BGN
+    Currency::EUR
   end
 
   def account_number_visual

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -163,7 +163,7 @@ class Country
     when Compliance::Countries::THA.alpha2
       Currency::THB
     when Compliance::Countries::BGR.alpha2
-      Currency::BGN
+      Currency::EUR
     when Compliance::Countries::DNK.alpha2
       Currency::DKK
     when Compliance::Countries::HUN.alpha2

--- a/app/views/help_center/articles/contents/_13-getting-paid.html.erb
+++ b/app/views/help_center/articles/contents/_13-getting-paid.html.erb
@@ -88,7 +88,7 @@
           <td>Brunei</td>
           <td>BND</td>
           <td>Bulgaria</td>
-          <td>BGN</td>
+          <td>EUR</td>
         </tr>
         <tr>
           <td>Cambodia</td>

--- a/spec/models/bulgaria_bank_account_spec.rb
+++ b/spec/models/bulgaria_bank_account_spec.rb
@@ -16,8 +16,8 @@ describe BulgariaBankAccount do
   end
 
   describe "#currency" do
-    it "returns bgn" do
-      expect(create(:bulgaria_bank_account).currency).to eq("bgn")
+    it "returns eur" do
+      expect(create(:bulgaria_bank_account).currency).to eq("eur")
     end
   end
 

--- a/spec/requests/settings/payments_spec.rb
+++ b/spec/requests/settings/payments_spec.rb
@@ -1530,7 +1530,7 @@ describe("Payments Settings Scenario", type: :system, js: true) do
         fill_in("Confirm IBAN", with: "BG80BNBG96611020345678")
 
         expect(page).to have_content("Must exactly match the name on your bank account")
-        expect(page).to have_content("Payouts will be made in BGN.")
+        expect(page).to have_content("Payouts will be made in EUR.")
 
         click_on("Update settings")
 


### PR DESCRIPTION
Stripe has discontinued support for Bulgarian Lev (BGN), so Bulgarian merchants need to transition to EUR for payouts.

- Update Country#payout_currency to return EUR for Bulgaria
- Update BulgariaBankAccount#currency to return EUR
- Update help center article to show EUR for Bulgaria
- Update corresponding tests to expect EUR

Fixes #2435