### PR TITLE
feat: Add feature flag to disable signup via Stripe

### DIFF
--- a/app/controllers/user/omniauth_callbacks_controller.rb
+++ b/app/controllers/user/omniauth_callbacks_controller.rb
@@ -92,7 +92,14 @@ class User::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     end
 
     if logged_in_user.blank?
-      user = User.find_or_create_for_stripe_connect_account(auth)
+      result = User.find_or_create_for_stripe_connect_account(auth)
+
+      if result == User::StripeConnect::SIGNUP_DISABLED
+        flash[:alert] = "Signup via Stripe is disabled."
+        return safe_redirect_to referer
+      end
+
+      user = result
 
       if user.nil?
         flash[:alert] = "An account already exists with this email."

--- a/app/models/concerns/user/stripe_connect.rb
+++ b/app/models/concerns/user/stripe_connect.rb
@@ -3,6 +3,8 @@
 module User::StripeConnect
   extend ActiveSupport::Concern
 
+  SIGNUP_DISABLED = :signup_disabled
+
   class_methods do
     def find_or_create_for_stripe_connect_account(data)
       return nil if data.blank?
@@ -10,25 +12,29 @@ module User::StripeConnect
       user = MerchantAccount.where(charge_processor_merchant_id: data["uid"]).alive
                  .find { |ma| ma.is_a_stripe_connect_account? }&.user
 
-      if user.nil?
-        ActiveRecord::Base.transaction do
-          user = User.new
-          user.provider = :stripe_connect
-          email = data["info"]["email"]
-          user.email = email if EmailFormatValidator.valid?(email)
-          user.name = data["info"]["name"]
-          user.password = Devise.friendly_token[0, 20]
-          user.skip_confirmation!
-          user.save!
-          user.user_compliance_infos.build.tap do |new_user_compliance_info|
-            new_user_compliance_info.country = Compliance::Countries.mapping[data["extra"]["extra_info"]["country"]]
-            new_user_compliance_info.json_data = {}
-            new_user_compliance_info.save!
-          end
-          if user.email.present?
-            Purchase.where(email: user.email, purchaser_id: nil).each do |past_purchase|
-              past_purchase.attach_to_user_and_card(user, nil, nil)
-            end
+      # If user exists, return them (allow login)
+      return user if user.present?
+
+      # If no existing user and signup is disabled, return special value
+      return SIGNUP_DISABLED if Feature.active?(:disable_user_signup_via_stripe)
+
+      ActiveRecord::Base.transaction do
+        user = User.new
+        user.provider = :stripe_connect
+        email = data["info"]["email"]
+        user.email = email if EmailFormatValidator.valid?(email)
+        user.name = data["info"]["name"]
+        user.password = Devise.friendly_token[0, 20]
+        user.skip_confirmation!
+        user.save!
+        user.user_compliance_infos.build.tap do |new_user_compliance_info|
+          new_user_compliance_info.country = Compliance::Countries.mapping[data["extra"]["extra_info"]["country"]]
+          new_user_compliance_info.json_data = {}
+          new_user_compliance_info.save!
+        end
+        if user.email.present?
+          Purchase.where(email: user.email, purchaser_id: nil).each do |past_purchase|
+            past_purchase.attach_to_user_and_card(user, nil, nil)
           end
         end
       end

--- a/spec/controllers/user/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/user/omniauth_callbacks_controller_spec.rb
@@ -129,6 +129,30 @@ describe User::OmniauthCallbacksController do
       end
     end
 
+    context "when signup via Stripe is disabled" do
+      before do
+        Feature.activate(:disable_user_signup_via_stripe)
+        request.env["omniauth.params"] = { "referer" => signup_path }
+      end
+
+      it "does not create a new user and shows error message" do
+        expect { post :stripe_connect }.not_to change { User.count }
+
+        expect(flash[:alert]).to eq "Signup via Stripe is disabled."
+        expect(response).to redirect_to signup_url
+      end
+
+      it "allows existing users to log in" do
+        creator = create(:user)
+        create(:merchant_account_stripe_connect, user: creator, charge_processor_merchant_id: stripe_uid)
+
+        post :stripe_connect
+
+        expect(flash[:alert]).to be_nil
+        expect(response).to redirect_to safe_redirect_path(two_factor_authentication_path(next: oauth_completions_stripe_path))
+      end
+    end
+
     context "when referer is signup" do
       let(:referer) { "signup" }
       before { request.env["omniauth.params"] = { "referer" => signup_path } }

--- a/spec/models/concerns/user/stripe_connect_spec.rb
+++ b/spec/models/concerns/user/stripe_connect_spec.rb
@@ -68,6 +68,27 @@ describe User::StripeConnect do
       expect(purchase1.reload.purchaser_id).to eq(user.id)
       expect(purchase2.reload.purchaser_id).to eq(user.id)
     end
+
+    context "when signup via Stripe is disabled" do
+      before do
+        Feature.activate(:disable_user_signup_via_stripe)
+      end
+
+      it "returns SIGNUP_DISABLED when no existing user is found" do
+        expect do
+          expect do
+            expect(User.find_or_create_for_stripe_connect_account(@data)).to eq(User::StripeConnect::SIGNUP_DISABLED)
+          end.not_to change { User.count }
+        end.not_to change { UserComplianceInfo.count }
+      end
+
+      it "returns the existing user if one exists" do
+        creator = create(:user)
+        create(:merchant_account_stripe_connect, user: creator, charge_processor_merchant_id: @data["uid"])
+
+        expect(User.find_or_create_for_stripe_connect_account(@data)).to eq(creator)
+      end
+    end
   end
 
   describe "#has_brazilian_stripe_connect_account?" do


### PR DESCRIPTION
Add a `:disable_user_signup_via_stripe` feature flag that blocks new user registration through Stripe Connect OAuth while allowing existing users to continue logging in normally.

When the flag is enabled:
- New users attempting to sign up via Stripe are shown an error message
- Existing users with a linked Stripe Connect account can still log in

Fixes #2450 