### PR TITLE
Fix flash message not appearing for email CSV exports

### DIFF
--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -414,7 +414,7 @@ class PurchasesController < ApplicationController
       send_file tempfile.path
     else
       flash[:warning] = "You will receive an email in your inbox with the data you've requested shortly."
-      redirect_back(fallback_location: customers_path)
+      redirect_back(fallback_location: customers_path, format: :html)
     end
   end
 


### PR DESCRIPTION
## What

Fixes the flash message not appearing when large exports are processed via email.

## Why

When clicking "Download" for All Time exports, the backend queues the export to be emailed but users see no notification. The flash message was being set but not displayed.

## Root Cause

The export form submits with `format: csv`, but when the export is too large and needs to be emailed, the controller calls:

```ruby
flash[:warning] = "You will receive an email..."
redirect_back(fallback_location: customers_path)
```

The redirect inherits the CSV format from the request, so the browser doesn't render an HTML page where the flash can be displayed.

## The Fix

```diff
- redirect_back(fallback_location: customers_path)
+ redirect_back(fallback_location: customers_path, format: :html)
```

Adding `format: :html` forces the redirect to return an HTML page, allowing the flash message to render properly via the `Alert` React component.

## Testing

- Large export (All Time) now shows: "You will receive an email in your inbox with the data you've requested shortly."
- Small exports still download immediately as before

## AI Disclosure
This PR was developed with AI assistance:
- **Planning & Review**: Claude Opus 4.5
- **Implementation**: GLM 4.7

Fixes #1930