### PR TITLE
Inertia Migration: Audience Page

### DIFF
--- a/app/controllers/audience_controller.rb
+++ b/app/controllers/audience_controller.rb
@@ -1,16 +1,35 @@
 # frozen_string_literal: true
 
 class AudienceController < Sellers::BaseController
-  before_action :set_body_id_as_app
-  before_action :set_time_range, only: %i[data_by_date]
+  before_action :set_time_range, only: :index
 
   after_action :set_dashboard_preference_to_audience, only: :index
   before_action :check_payment_details, only: :index
 
+  layout "inertia", only: :index
+
   def index
     authorize :audience
 
-    @total_follower_count = current_seller.audience_members.where(follower: true).count
+    total_follower_count = current_seller.audience_members.where(follower: true).count
+
+    if @date_range_error
+      flash[:alert] = "Please select a valid date range"
+    end
+
+    render inertia: "Analytics/Audience/Index", props: {
+      total_follower_count:,
+      audience_data: InertiaRails.defer do
+        if total_follower_count.zero? || @date_range_error
+          nil
+        else
+          CreatorAnalytics::Following.new(current_seller).by_date(
+            start_date: @start_date.to_date,
+            end_date: @end_date.to_date
+          )
+        end
+      end
+    }
   end
 
   def export
@@ -25,29 +44,23 @@ class AudienceController < Sellers::BaseController
     head :ok
   end
 
-  def data_by_date
-    authorize :audience, :index?
-
-    data = CreatorAnalytics::Following.new(current_seller).by_date(start_date: @start_date.to_date, end_date: @end_date.to_date)
-
-    render json: data
-  end
-
   protected
     def set_time_range
       begin
-        end_time = DateTime.parse(params[:end_time])
-        start_date = DateTime.parse(params[:start_time])
+        end_date = DateTime.parse(params[:to])
+        start_date = DateTime.parse(params[:from])
+        if end_date < start_date
+          @date_range_error = true
+        end
       rescue StandardError
-        end_time = DateTime.current
-        start_date = end_time.ago(29.days)
+        end_date = DateTime.current
+        start_date = end_date.ago(29.days)
       end
       @start_date = start_date
-      @end_date = end_time
-      @timezone_offset = end_time.zone
+      @end_date = end_date
     end
 
     def set_title
-      @title = "Analytics"
+      @title = "Audience"
     end
 end

--- a/app/javascript/components/Analytics/useAnalyticsDateRange.tsx
+++ b/app/javascript/components/Analytics/useAnalyticsDateRange.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 
 import { useOriginalLocation } from "$app/components/useOriginalLocation";
 
-export const useAnalyticsDateRange = () => {
+export const useAnalyticsDateRange = ({ onDateChange }: { onDateChange?: (from: Date, to: Date) => void } = {}) => {
   const location = useOriginalLocation();
   const url = new URL(location);
 
@@ -19,11 +19,16 @@ export const useAnalyticsDateRange = () => {
     const value = tryParseDateParam("to") ?? new Date();
     return value < from ? from : value;
   });
+  const isInitialMount = React.useRef(true);
 
   React.useEffect(() => {
     url.searchParams.set("from", lightFormat(from, "yyyy-MM-dd"));
     url.searchParams.set("to", lightFormat(to, "yyyy-MM-dd"));
     history.pushState(null, "", url);
+    if (!isInitialMount.current) {
+      onDateChange?.(from, to);
+    }
+    isInitialMount.current = false;
   }, [from.getTime(), to.getTime()]);
 
   return { from, to, setFrom, setTo };

--- a/app/javascript/data/audience.ts
+++ b/app/javascript/data/audience.ts
@@ -1,5 +1,3 @@
-import { cast } from "ts-safe-cast";
-
 import { request, ResponseError } from "$app/utils/request";
 
 export type AudienceDataByDate = {
@@ -15,17 +13,9 @@ export type AudienceDataByDate = {
   new_followers: number;
 };
 
-export const fetchAudienceDataByDate = ({ startTime, endTime }: { startTime: string; endTime: string }) => {
-  const abort = new AbortController();
-  const response = request({
-    method: "GET",
-    accept: "json",
-    url: Routes.audience_data_by_date_path(startTime, endTime),
-    abortSignal: abort.signal,
-  })
-    .then((response) => response.json())
-    .then((json) => cast<AudienceDataByDate>(json));
-  return { response, abort };
+export type AudienceIndexPageProps = {
+  total_follower_count: number;
+  audience_data: AudienceDataByDate | null;
 };
 
 export const sendSubscribersReport = async ({

--- a/app/javascript/packs/audience.js
+++ b/app/javascript/packs/audience.js
@@ -1,9 +1,0 @@
-import ReactOnRails from "react-on-rails";
-
-import BasePage from "$app/utils/base_page";
-
-import AudiencePage from "$app/components/server-components/AudiencePage";
-
-BasePage.initialize();
-
-ReactOnRails.default.register({ AudiencePage });

--- a/app/javascript/pages/Analytics/Audience/Index.tsx
+++ b/app/javascript/pages/Analytics/Audience/Index.tsx
@@ -1,10 +1,8 @@
-import { lightFormat } from "date-fns";
+import { Deferred, router, usePage } from "@inertiajs/react";
 import * as React from "react";
-import { createCast } from "ts-safe-cast";
+import { cast } from "ts-safe-cast";
 
-import { AudienceDataByDate, fetchAudienceDataByDate } from "$app/data/audience";
-import { AbortError } from "$app/utils/request";
-import { register } from "$app/utils/serverComponentUtil";
+import { AudienceIndexPageProps } from "$app/data/audience";
 
 import { AnalyticsLayout } from "$app/components/Analytics/AnalyticsLayout";
 import { useAnalyticsDateRange } from "$app/components/Analytics/useAnalyticsDateRange";
@@ -16,39 +14,20 @@ import { ExportSubscribersPopover } from "$app/components/Followers/ExportSubscr
 import { Icon } from "$app/components/Icons";
 import { LoadingSpinner } from "$app/components/LoadingSpinner";
 import { Popover } from "$app/components/Popover";
-import { showAlert } from "$app/components/server-components/Alert";
 import Placeholder from "$app/components/ui/Placeholder";
 import { WithTooltip } from "$app/components/WithTooltip";
 
 import placeholder from "$assets/images/placeholders/audience.png";
 
-const AudiencePage = ({ total_follower_count }: { total_follower_count: number }) => {
-  const dateRange = useAnalyticsDateRange();
-  const [data, setData] = React.useState<AudienceDataByDate | null>(null);
-  const startTime = lightFormat(dateRange.from, "yyyy-MM-dd");
-  const endTime = lightFormat(dateRange.to, "yyyy-MM-dd");
-
+export default function Audience() {
+  const { total_follower_count, audience_data } = cast<AudienceIndexPageProps>(usePage().props);
+  const onlyProps = ["audience_data", "flash"];
+  const dateRange = useAnalyticsDateRange({
+    onDateChange: () => {
+      router.reload({ only: onlyProps });
+    },
+  });
   const hasContent = total_follower_count > 0;
-
-  const activeRequest = React.useRef<AbortController | null>(null);
-  React.useEffect(() => {
-    const loadData = async () => {
-      if (!hasContent) return;
-
-      try {
-        if (activeRequest.current) activeRequest.current.abort();
-        setData(null);
-        const request = fetchAudienceDataByDate({ startTime, endTime });
-        activeRequest.current = request.abort;
-        setData(await request.response);
-        activeRequest.current = null;
-      } catch (e) {
-        if (e instanceof AbortError) return;
-        showAlert("Sorry, something went wrong. Please try again.", "error");
-      }
-    };
-    void loadData();
-  }, [startTime, endTime]);
 
   return (
     <AnalyticsLayout
@@ -75,15 +54,21 @@ const AudiencePage = ({ total_follower_count }: { total_follower_count: number }
     >
       {hasContent ? (
         <div className="space-y-8 p-4 md:p-8">
-          <AudienceQuickStats totalFollowers={total_follower_count} newFollowers={data?.new_followers ?? null} />
-          {data ? (
-            <AudienceChart data={data} />
-          ) : (
-            <div className="input">
-              <LoadingSpinner />
-              Loading charts...
-            </div>
-          )}
+          <AudienceQuickStats
+            totalFollowers={total_follower_count}
+            newFollowers={audience_data?.new_followers ?? null}
+          />
+          <Deferred
+            data={onlyProps}
+            fallback={
+              <div className="input">
+                <LoadingSpinner />
+                Loading charts...
+              </div>
+            }
+          >
+            {audience_data ? <AudienceChart data={audience_data} /> : null}
+          </Deferred>
         </div>
       ) : (
         <div className="p-4 md:p-8">
@@ -104,6 +89,4 @@ const AudiencePage = ({ total_follower_count }: { total_follower_count: number }
       )}
     </AnalyticsLayout>
   );
-};
-
-export default register({ component: AudiencePage, propParser: createCast() });
+}

--- a/app/javascript/ssr.ts
+++ b/app/javascript/ssr.ts
@@ -26,7 +26,6 @@ import AdminUserStats from "$app/components/server-components/Admin/UserStats";
 import AffiliateRequestPage from "$app/components/server-components/AffiliateRequestPage";
 import AffiliatesPage from "$app/components/server-components/AffiliatesPage";
 import Alert from "$app/components/server-components/Alert";
-import AudiencePage from "$app/components/server-components/AudiencePage";
 import BundleEditPage from "$app/components/server-components/BundleEditPage";
 import CheckoutPage from "$app/components/server-components/CheckoutPage";
 import CommunitiesPage from "$app/components/server-components/CommunitiesPage";
@@ -103,7 +102,6 @@ ReactOnRails.register({
   AdminAddCreditForm,
   HelpCenterArticlesIndexPage,
   SupportHeader,
-  AudiencePage,
   BundleEditPage,
   CheckoutPage,
   CodeSnippet,

--- a/spec/controllers/audience_controller_spec.rb
+++ b/spec/controllers/audience_controller_spec.rb
@@ -2,8 +2,9 @@
 
 require "spec_helper"
 require "shared_examples/authorize_called"
+require "inertia_rails/rspec"
 
-describe AudienceController do
+describe AudienceController, inertia: true do
   let(:seller) { create(:named_seller) }
 
   include_context "with user signed in as admin for seller"
@@ -13,16 +14,88 @@ describe AudienceController do
       let(:record) { :audience }
     end
 
-    it "sets follower count correctly if there are no followers" do
+    it "renders with Inertia when there are no followers" do
       get :index
-      expect(assigns(:total_follower_count)).to eq 0
+
+      expect(response).to be_successful
+      expect(inertia).to render_component("Analytics/Audience/Index")
+      expect(inertia.props[:total_follower_count]).to eq 0
     end
 
-    it "sets follower count correctly if there are followers" do
+    it "renders with Inertia and correct props when there are followers" do
       @follower = create(:active_follower, user: seller)
 
       get :index
-      expect(assigns(:total_follower_count)).to eq 1
+
+      expect(response).to be_successful
+      expect(inertia).to render_component("Analytics/Audience/Index")
+      expect(inertia.props[:total_follower_count]).to eq 1
+      expect(inertia.props[:audience_data]).to be_nil
+    end
+
+    context "when testing deferred audience_data prop", :sidekiq_inline, :elasticsearch_wait_for_refresh do
+      before do
+        seller.update!(timezone: "UTC")
+
+        request.headers["X-Inertia"] = "true"
+        request.headers["X-Inertia-Partial-Component"] = "Analytics/Audience/Index"
+        request.headers["X-Inertia-Partial-Data"] = "audience_data,flash"
+      end
+
+      it "returns nil when there are no followers" do
+        get :index, params: { from: Time.utc(2021, 1, 1), to: Time.utc(2021, 1, 3) }
+
+        expect(response).to be_successful
+        expect(inertia).to render_component("Analytics/Audience/Index")
+        expect(inertia.props["audience_data"]).to be_nil
+      end
+
+      context "with followers" do
+        before do
+          travel_to Time.utc(2021, 1, 3) do
+            create(:active_follower, user: seller).confirm!
+            follower = create(:active_follower, user: seller)
+            follower.confirm!
+            follower.mark_deleted!
+          end
+        end
+
+        it "returns nil when end date is before start date" do
+          get :index, params: { from: Time.utc(2021, 1, 2), to: Time.utc(2021, 1, 1) }
+
+          puts "flash: #{inertia.props}"
+
+          expect(response).to be_successful
+          expect(inertia).to render_component("Analytics/Audience/Index")
+          expect(inertia.props["flash"]["message"]).to eq("Please select a valid date range")
+          expect(inertia.props["flash"]["status"]).to eq("danger")
+          expect(inertia.props["audience_data"]).to be_nil
+        end
+
+        it "returns expected data for the given date range" do
+          get :index, params: { from: Time.utc(2021, 1, 1), to: Time.utc(2021, 1, 3) }
+
+          expect(response).to be_successful
+          expect(inertia.props["audience_data"]).to eq({
+                                                         "dates" => ["Friday, January 1st", "Saturday, January 2nd", "Sunday, January 3rd"],
+                                                         "start_date" => "Jan  1, 2021",
+                                                         "end_date" => "Jan  3, 2021",
+                                                         "by_date" => {
+                                                           "new_followers" => [0, 0, 2],
+                                                           "followers_removed" => [0, 0, 1],
+                                                           "totals" => [0, 0, 1]
+                                                         },
+                                                         "first_follower_date" => "Jan  3, 2021",
+                                                         "new_followers" => 1
+                                                       })
+        end
+        it "works for someone in the GMT-1200 TZ" do
+          mask = "%a %b %d %Y %H:%M:%S GMT-1200 (Changement de date)"
+
+          get :index, params: { start_time: 2.days.ago.strftime(mask), end_time: 1.day.ago.strftime(mask) }
+          expect(response.status).to be(200)
+        end
+      end
     end
 
     it "sets the last viewed dashboard cookie" do
@@ -61,49 +134,6 @@ describe AudienceController do
 
         expect(response).to have_http_status(:ok)
       end
-    end
-  end
-
-  describe "GET data_by_date" do
-    before do
-      seller.update!(timezone: "UTC")
-
-      travel_to Time.utc(2021, 1, 3) do
-        create(:active_follower, user: seller).confirm!
-        follower = create(:active_follower, user: seller)
-        follower.confirm!
-        follower.mark_deleted!
-      end
-    end
-
-    it_behaves_like "authorize called for action", :get, :data_by_date do
-      let(:record) { :audience }
-      let(:policy_method) { :index? }
-      let(:request_params) { { start_time: Time.utc(2021, 1, 1), end_time: Time.utc(2021, 1, 3) } }
-    end
-
-    it "returns expected data", :sidekiq_inline, :elasticsearch_wait_for_refresh do
-      expect_any_instance_of(CreatorAnalytics::Following).to receive(:by_date).with(start_date: Date.new(2021, 1, 1), end_date: Date.new(2021, 1, 3)).and_call_original
-      get :data_by_date, params: { start_time: Time.utc(2021, 1, 1), end_time: Time.utc(2021, 1, 3) }
-
-      expect(response.parsed_body).to eq(
-        "dates" => ["Friday, January 1st", "Saturday, January 2nd", "Sunday, January 3rd"],
-        "start_date" => "Jan  1, 2021",
-        "end_date" => "Jan  3, 2021",
-        "by_date" => {
-          "new_followers" => [0, 0, 2],
-          "followers_removed" => [0, 0, 1],
-          "totals" => [0, 0, 1]
-        },
-        "first_follower_date" => "Jan  3, 2021",
-        "new_followers" => 1
-      )
-    end
-
-    it "works for someone in the GMT-1200 TZ" do
-      mask = "%a %b %d %Y %H:%M:%S GMT-1200 (Changement de date)"
-      get(:data_by_date, params: { start_time: 2.days.ago.strftime(mask), end_time: 1.day.ago.strftime(mask) })
-      expect(response.status).to be(200)
     end
   end
 end

--- a/spec/controllers/audience_controller_spec.rb
+++ b/spec/controllers/audience_controller_spec.rb
@@ -63,8 +63,6 @@ describe AudienceController, inertia: true do
         it "returns nil when end date is before start date" do
           get :index, params: { from: Time.utc(2021, 1, 2), to: Time.utc(2021, 1, 1) }
 
-          puts "flash: #{inertia.props}"
-
           expect(response).to be_successful
           expect(inertia).to render_component("Analytics/Audience/Index")
           expect(inertia.props["flash"]["message"]).to eq("Please select a valid date range")


### PR DESCRIPTION
# Part of #856 
- Related PR #2496 (Sliced out code related to Audience page from this PR after verifying end-to-end inertia migration for Analytics Pages)

This PR migrates `/dashboard/audience` page to inertia. 

## Code Changes
- Using props as source of truth for audience chart data in frontend
- Greatly simplified frontend using Inertia.defer + `Deferred` component to load audience chart data with a fallback. This removes the need of managing our own loader.
- Subsequent data request on date change are handled by passing a callback to `useAnalyticsDateRange` hook which reloads the page using inertia

### Demos

1. `Deferred` component handles loading audience data on first load

https://github.com/user-attachments/assets/4916660e-04f0-42c5-bbec-f6ad740b8800

2. Flash error to handle invalid date range (end_date < start_date)

https://github.com/user-attachments/assets/e2077d32-da7c-48d9-b2c8-a62c67765166


### Specs Passing

<img width="850" height="148" alt="specs-passing" src="https://github.com/user-attachments/assets/a495619c-2bd6-482a-9b00-67d6fba49a65" />

## AI Disclosure
- Cursor auto mode for edits, migrating specs, checking docs and debugging 

### Live Stream Disclosure 
Have watched all the live streams