### PR TITLE
feat: Add auto-apply default discount code to products

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -340,6 +340,7 @@ class LinksController < ApplicationController
           :products,
           :description,
           :cancellation_discount,
+          :default_offer_code_id,
           :custom_button_text_option,
           :custom_summary,
           :custom_attributes,
@@ -383,6 +384,14 @@ class LinksController < ApplicationController
             Product::SaveCancellationDiscountService.new(@product, product_permitted_params[:cancellation_discount]).perform
           rescue ActiveRecord::RecordInvalid => e
             return render json: { error_message: e.record.errors.full_messages.first }, status: :unprocessable_entity
+          end
+        end
+
+        if product_permitted_params.key?(:default_offer_code_id)
+          begin
+            Product::SaveDefaultOfferCodeService.new(@product, product_permitted_params[:default_offer_code_id]).perform
+          rescue ActiveRecord::RecordNotFound, ArgumentError => e
+            return render json: { error_message: e.message }, status: :unprocessable_entity
           end
         end
 

--- a/app/javascript/components/Product/Card.tsx
+++ b/app/javascript/components/Product/Card.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { CardProduct, Ratings } from "$app/parsers/product";
+import { CardProduct, DiscountBadge, Ratings } from "$app/parsers/product";
 import { classNames } from "$app/utils/classNames";
 import { formatOrderOfMagnitude } from "$app/utils/formatOrderOfMagnitude";
 
@@ -48,6 +48,7 @@ export const Card = ({
           url={product.url}
           currencyCode={product.currency_code}
           price={product.price_cents}
+          oldPrice={product.original_price_cents ?? undefined}
           isPayWhatYouWant={product.is_pay_what_you_want}
           isSalesLimited={product.is_sales_limited}
           recurrence={
@@ -55,6 +56,7 @@ export const Card = ({
           }
           creatorName={product.seller?.name}
         />
+        {product.discount_badge ? <DiscountBadgeDisplay badge={product.discount_badge} /> : null}
       </div>
       {footerAction}
     </ProductCardFooter>
@@ -98,6 +100,7 @@ export const HorizontalCard = ({ product, big, eager }: { product: CardProduct; 
             url={product.url}
             currencyCode={product.currency_code}
             price={product.price_cents}
+            oldPrice={product.original_price_cents ?? undefined}
             isPayWhatYouWant={product.is_pay_what_you_want}
             isSalesLimited={product.is_sales_limited}
             recurrence={
@@ -107,6 +110,7 @@ export const HorizontalCard = ({ product, big, eager }: { product: CardProduct; 
             }
             creatorName={product.seller?.name}
           />
+          {product.discount_badge ? <DiscountBadgeDisplay badge={product.discount_badge} /> : null}
         </div>
         {product.ratings?.count ? (
           <div className="p-4 lg:p-0">
@@ -127,3 +131,14 @@ const Rating = ({ ratings, style }: { ratings: Ratings; style?: React.CSSPropert
     </span>
   </div>
 );
+
+const DiscountBadgeDisplay = ({ badge }: { badge: DiscountBadge }) => {
+  const discountText = badge.percent_off ? `${badge.percent_off}% off` : "Discount";
+
+  return (
+    <div className="mt-1 text-sm text-green-600">
+      <Icon name="outline-check-circle" className="mr-1 inline-block h-4 w-4" />
+      {discountText} will be applied at checkout (Code {badge.code})
+    </div>
+  );
+};

--- a/app/javascript/components/ProductEdit/ProductTab/DefaultDiscountSelector.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/DefaultDiscountSelector.tsx
@@ -1,0 +1,68 @@
+import * as React from "react";
+
+import { useProductEditContext } from "$app/components/ProductEdit/state";
+import { Select, Option } from "$app/components/Select";
+import { ToggleSettingRow } from "$app/components/SettingRow";
+
+export const DefaultDiscountSelector = () => {
+  const { product, updateProduct } = useProductEditContext();
+  const defaultOfferCode = product.default_offer_code;
+  const availableOfferCodes = product.available_offer_codes ?? [];
+
+  const [isEnabled, setIsEnabled] = React.useState(!!defaultOfferCode);
+  const [selectedId, setSelectedId] = React.useState<string | null>(defaultOfferCode?.id ?? null);
+
+  React.useEffect(() => {
+    if (!isEnabled) {
+      updateProduct({ default_offer_code: null });
+      return;
+    }
+
+    if (!selectedId) {
+      return;
+    }
+
+    const selected = availableOfferCodes.find((oc) => oc.id === selectedId);
+    if (selected) {
+      updateProduct({
+        default_offer_code: {
+          id: selected.id,
+          code: selected.label.split(" ")[0] ?? "",
+        },
+      });
+    }
+  }, [isEnabled, selectedId, updateProduct, availableOfferCodes]);
+
+  // Don't render if there are no available discount codes
+  if (availableOfferCodes.length === 0) {
+    return null;
+  }
+
+  const options: Option[] = availableOfferCodes.map((oc) => ({
+    id: oc.id,
+    label: oc.label,
+  }));
+
+  const selectedOption = selectedId ? options.find((opt) => opt.id === selectedId) ?? null : null;
+
+  return (
+    <ToggleSettingRow
+      value={isEnabled}
+      onChange={setIsEnabled}
+      label="Apply discount"
+      dropdown={
+        <fieldset>
+          <label htmlFor="default-discount">Discount code</label>
+          <Select
+            inputId="default-discount"
+            options={options}
+            value={selectedOption}
+            onChange={(opt) => setSelectedId(opt?.id ?? null)}
+            placeholder="Begin typing to select a discount code"
+            isClearable
+          />
+        </fieldset>
+      }
+    />
+  );
+};

--- a/app/javascript/components/ProductEdit/ProductTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/index.tsx
@@ -15,6 +15,7 @@ import { AvailabilityEditor } from "$app/components/ProductEdit/ProductTab/Avail
 import { BundleConversionNotice } from "$app/components/ProductEdit/ProductTab/BundleConversionNotice";
 import { CallLimitationsEditor } from "$app/components/ProductEdit/ProductTab/CallLimitationsEditor";
 import { CancellationDiscountSelector } from "$app/components/ProductEdit/ProductTab/CancellationDiscountSelector";
+import { DefaultDiscountSelector } from "$app/components/ProductEdit/ProductTab/DefaultDiscountSelector";
 import { CircleIntegrationEditor } from "$app/components/ProductEdit/ProductTab/CircleIntegrationEditor";
 import { CoverEditor } from "$app/components/ProductEdit/ProductTab/CoverEditor";
 import { CustomButtonTextOptionInput } from "$app/components/ProductEdit/ProductTab/CustomButtonTextOptionInput";
@@ -307,6 +308,7 @@ export const ProductTab = () => {
                         Commission products use a 50% deposit upfront, 50% upon completion payment split.
                       </p>
                     ) : null}
+                    <DefaultDiscountSelector />
                   </section>
                   {product.native_type === "call" ? (
                     <>

--- a/app/javascript/components/ProductEdit/state.ts
+++ b/app/javascript/components/ProductEdit/state.ts
@@ -81,6 +81,16 @@ export type CancellationDiscount = {
   duration_in_billing_cycles: number | null;
 };
 
+export type DefaultOfferCode = {
+  id: string;
+  code: string;
+};
+
+export type AvailableOfferCode = {
+  id: string;
+  label: string;
+};
+
 export type InstallmentPlan = {
   number_of_installments: number;
 };
@@ -139,6 +149,8 @@ export type Product = {
   call_limitation_info: CallLimitationInfo | null;
   require_shipping: boolean;
   cancellation_discount: CancellationDiscount | null;
+  default_offer_code: DefaultOfferCode | null;
+  available_offer_codes: AvailableOfferCode[];
   public_files: PublicFileWithStatus[];
   audio_previews_enabled: boolean;
   community_chat_enabled: boolean | null;

--- a/app/javascript/parsers/product.ts
+++ b/app/javascript/parsers/product.ts
@@ -33,6 +33,13 @@ export type Ratings = { count: number; average: number };
 
 export type RatingsWithPercentages = Ratings & { percentages: Tuple<number, 5> };
 
+export type DiscountBadge = {
+  code: string;
+  percent_off: number | null;
+  amount_off_cents: number | null;
+  is_default: boolean;
+};
+
 export type CardProduct = {
   id: string;
   permalink: string;
@@ -40,6 +47,7 @@ export type CardProduct = {
   seller: { id: string; name: string; profile_url: string; avatar_url: string | null } | null;
   ratings: Ratings | null;
   price_cents: number;
+  original_price_cents?: number | null;
   currency_code: CurrencyCode;
   thumbnail_url: string | null;
   native_type: ProductNativeType;
@@ -50,6 +58,7 @@ export type CardProduct = {
   duration_in_months: number | null;
   recurrence: RecurrenceId | null;
   description?: string;
+  discount_badge?: DiscountBadge | null;
 };
 
 export type AnalyticsData = {

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -113,6 +113,7 @@ class Link < ApplicationRecord
   has_many :installments
   has_many :subscriptions
   has_and_belongs_to_many :offer_codes, join_table: "offer_codes_products", foreign_key: "product_id"
+  belongs_to :default_offer_code, class_name: "OfferCode", optional: true
   has_many :transcoded_videos
   has_many :imported_customers
   has_many :licenses
@@ -205,6 +206,7 @@ class Link < ApplicationRecord
   validate :commission_price_is_valid, if: -> { native_type == Link::NATIVE_TYPE_COMMISSION }
   validate :one_coffee_per_user, on: :create, if: -> { native_type == Link::NATIVE_TYPE_COFFEE }
   validate :quantity_enabled_state_is_allowed
+  validate :default_offer_code_validity
 
   validates_associated :installment_plan, message: -> (link, _) { link.installment_plan.errors.full_messages.first }
 
@@ -1129,6 +1131,15 @@ class Link < ApplicationRecord
     offer_codes.is_cancellation_discount.alive.first
   end
 
+  # Returns the effective default offer code for auto-apply discount feature.
+  # Returns nil if no default is set, or if the default code is invalid/expired/inapplicable.
+  def effective_default_offer_code
+    return nil unless default_offer_code&.alive?
+    return nil if default_offer_code.inactive?
+    return nil unless default_offer_code.applicable?(self)
+    default_offer_code
+  end
+
   def toggle_community_chat!(enable)
     if enable
       return if community_chat_enabled?
@@ -1312,6 +1323,15 @@ class Link < ApplicationRecord
     def quantity_enabled_state_is_allowed
       if quantity_enabled && !can_enable_quantity?
         errors.add(:base, "Customers cannot be allowed to choose a quantity for this product.")
+      end
+    end
+
+    def default_offer_code_validity
+      return if default_offer_code_id.blank?
+
+      offer_code = OfferCode.find_by(id: default_offer_code_id)
+      if offer_code.blank? || !offer_code.alive? || !offer_code.applicable?(self)
+        errors.add(:default_offer_code, "is invalid or not applicable to this product")
       end
     end
 

--- a/app/models/offer_code.rb
+++ b/app/models/offer_code.rb
@@ -38,6 +38,7 @@ class OfferCode < ApplicationRecord
 
   after_save :invalidate_product_cache
   after_save :reindex_associated_products
+  after_save :clear_as_default_if_deleted, if: -> { saved_change_to_deleted_at? && deleted? }
   before_destroy :capture_associated_product_ids
   after_destroy :reindex_captured_products
 
@@ -300,5 +301,9 @@ class OfferCode < ApplicationRecord
 
     def reindex_captured_products
       reindex_associated_products(products_to_reindex: Link.where(id: @product_ids_to_reindex)) if @product_ids_to_reindex.present?
+    end
+
+    def clear_as_default_if_deleted
+      Link.where(default_offer_code_id: id).update_all(default_offer_code_id: nil)
     end
 end

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -71,6 +71,7 @@ class Purchase < ApplicationRecord
   attr_json_data_accessor :perceived_price_cents
   attr_json_data_accessor :recommender_model_name
   attr_json_data_accessor :custom_fee_per_thousand
+  attr_json_data_accessor :was_default_discount, default: -> { false }
 
   alias_attribute :total_transaction_cents_usd, :total_transaction_cents
 

--- a/app/policies/link_policy.rb
+++ b/app/policies/link_policy.rb
@@ -146,6 +146,7 @@ class LinkPolicy < ApplicationPolicy
         { discount: [:type, :cents, :percents] },
         :duration_in_billing_cycles
       ],
+      :default_offer_code_id,
       installment_plan: [
         :number_of_installments,
       ]

--- a/app/presenters/product_presenter.rb
+++ b/app/presenters/product_presenter.rb
@@ -192,6 +192,16 @@ class ProductPresenter
             { type: "percent", percents: cancellation_discount.amount_percentage },
           duration_in_billing_cycles: cancellation_discount.duration_in_billing_cycles,
         } : nil,
+        default_offer_code: product.default_offer_code.present? ? {
+          id: product.default_offer_code.external_id,
+          code: product.default_offer_code.code,
+        } : nil,
+        available_offer_codes: product.product_and_universal_offer_codes.reject(&:is_cancellation_discount?).map do |oc|
+          {
+            id: oc.external_id,
+            label: "#{oc.code} (#{oc.displayed_amount_off(product.price_currency_type, with_symbol: true)} off)",
+          }
+        end,
         public_files: product.alive_public_files.attached.map { PublicFilePresenter.new(public_file: _1).props },
         audio_previews_enabled: Feature.active?(:audio_previews, product.user),
         community_chat_enabled: Feature.active?(:communities, product.user) ? product.community_chat_enabled? : nil,

--- a/app/presenters/product_presenter/card.rb
+++ b/app/presenters/product_presenter/card.rb
@@ -21,6 +21,23 @@ class ProductPresenter::Card
 
   def for_web(request: nil, recommended_by: nil, recommender_model_name: nil, target: nil, show_seller: true, affiliate_id: nil, query: nil, offer_code: nil, compute_description: true)
     default_recurrence = product.default_price_recurrence
+    original_price_cents = product.display_price_cents(for_default_duration: true)
+
+    # Determine effective offer code: URL code takes priority over default
+    effective_offer_code = if offer_code.present?
+      product.find_offer_code(code: offer_code)
+    else
+      product.effective_default_offer_code
+    end
+    is_default_discount = offer_code.blank? && effective_offer_code.present?
+
+    # Calculate discounted price if offer code is valid
+    discounted_price_cents = if effective_offer_code
+      original_price_cents - effective_offer_code.amount_off(original_price_cents)
+    else
+      original_price_cents
+    end
+
     props = {
       id: product.external_id,
       permalink: product.unique_permalink,
@@ -34,13 +51,24 @@ class ProductPresenter::Card
       native_type: product.native_type,
       quantity_remaining: product.remaining_for_sale_count,
       is_sales_limited: product.max_purchase_count?,
-      price_cents: product.display_price_cents(for_default_duration: true),
+      price_cents: discounted_price_cents,
+      original_price_cents: effective_offer_code ? original_price_cents : nil,
       currency_code: product.price_currency_type.downcase,
       is_pay_what_you_want: product.has_customizable_price_option?,
       url: url_for_product_page(product, request:, recommended_by:, recommender_model_name:, layout: target, affiliate_id:, query:, offer_code:),
       duration_in_months: product.duration_in_months,
       recurrence: default_recurrence&.recurrence,
     }
+
+    # Add discount badge info if an offer code is applied
+    if effective_offer_code
+      props[:discount_badge] = {
+        code: effective_offer_code.code,
+        percent_off: effective_offer_code.is_percent? ? effective_offer_code.amount_percentage : nil,
+        amount_off_cents: effective_offer_code.is_cents? ? effective_offer_code.amount_cents : nil,
+        is_default: is_default_discount,
+      }
+    end
 
     if compute_description
       props[:description] = product.plaintext_description.truncate(100)

--- a/app/presenters/product_presenter/product_props.rb
+++ b/app/presenters/product_presenter/product_props.rb
@@ -81,14 +81,18 @@ class ProductPresenter::ProductProps
     attr_reader :product, :seller
 
     def discount_code_props(discount_code, quantity)
-      return if discount_code.blank?
+      # Use default offer code if no URL discount code is provided
+      effective_discount_code = discount_code.presence || product.effective_default_offer_code&.code
+      is_default_discount = discount_code.blank? && effective_discount_code.present?
+
+      return if effective_discount_code.blank?
 
       offer_code_response = OfferCodeDiscountComputingService.new(
-        discount_code,
+        effective_discount_code,
         {
           product.unique_permalink => {
             permalink: product.unique_permalink,
-            quantity: [quantity, product.find_offer_code(code: discount_code)&.minimum_quantity || 0].max
+            quantity: [quantity, product.find_offer_code(code: effective_discount_code)&.minimum_quantity || 0].max
           }
         }
       ).process
@@ -96,7 +100,7 @@ class ProductPresenter::ProductProps
       if offer_code_response[:error_code].present?
         { valid: false, error_code: offer_code_response[:error_code] }
       else
-        { valid: true, code: discount_code, **offer_code_response[:products_data][product.unique_permalink] }
+        { valid: true, code: effective_discount_code, is_default_discount:, **offer_code_response[:products_data][product.unique_permalink] }
       end
     end
 

--- a/app/services/product/save_default_offer_code_service.rb
+++ b/app/services/product/save_default_offer_code_service.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class Product::SaveDefaultOfferCodeService
+  attr_reader :product, :offer_code_id
+
+  def initialize(product, offer_code_id)
+    @product = product
+    @offer_code_id = offer_code_id
+  end
+
+  def perform
+    if offer_code_id.blank?
+      product.update!(default_offer_code_id: nil)
+      return
+    end
+
+    offer_code = product.find_offer_code_by_external_id(offer_code_id)
+
+    raise ActiveRecord::RecordNotFound, "Offer code not found" unless offer_code&.alive?
+    raise ArgumentError, "Offer code is not applicable to this product" unless offer_code.applicable?(product)
+
+    product.update!(default_offer_code_id: offer_code.id)
+  end
+end

--- a/app/services/purchase/create_service.rb
+++ b/app/services/purchase/create_service.rb
@@ -241,7 +241,17 @@ class Purchase::CreateService < Purchase::BaseService
       purchase.save_card = !!params_for_purchase[:save_card] || (product.is_recurring_billing && !is_gift?) || purchase.is_preorder_authorization || purchase.is_installment_payment
       purchase.seller = product.user
       purchase.is_gift_sender_purchase = is_gift? unless params_for_purchase.has_key?(:is_gift_receiver_purchase)
-      purchase.offer_code = product.find_offer_code(code: purchase.discount_code.downcase.strip) if purchase.discount_code.present?
+      # Handle offer code - URL/user-provided code takes priority, otherwise use default
+      if purchase.discount_code.present?
+        purchase.offer_code = product.find_offer_code(code: purchase.discount_code.downcase.strip)
+        # Track if this was the default discount code
+        purchase.was_default_discount = (purchase.offer_code == product.effective_default_offer_code)
+      elsif product.effective_default_offer_code.present?
+        # Auto-apply the default discount code
+        purchase.offer_code = product.effective_default_offer_code
+        purchase.discount_code = product.effective_default_offer_code.code
+        purchase.was_default_discount = true
+      end
       purchase.business_vat_id = (params_for_purchase[:business_vat_id] && params_for_purchase[:business_vat_id].size > 0 ? params_for_purchase[:business_vat_id] : nil)
       purchase.is_original_subscription_purchase = (product.is_recurring_billing && !params_for_purchase[:is_gift_receiver_purchase]) || purchase.is_installment_payment
       purchase.is_free_trial_purchase = product.free_trial_enabled? && !is_gift?

--- a/db/migrate/20251228164616_add_default_offer_code_to_links.rb
+++ b/db/migrate/20251228164616_add_default_offer_code_to_links.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDefaultOfferCodeToLinks < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :links, :default_offer_code, foreign_key: { to_table: :offer_codes }, null: true
+  end
+end

--- a/spec/models/link_default_offer_code_spec.rb
+++ b/spec/models/link_default_offer_code_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+RSpec.describe Link, "default offer code" do
+  let(:user) { create(:user) }
+  let(:product) { create(:product, user:) }
+
+  describe "#effective_default_offer_code" do
+    context "when no default offer code is set" do
+      it "returns nil" do
+        expect(product.effective_default_offer_code).to be_nil
+      end
+    end
+
+    context "when a valid default offer code is set" do
+      let(:offer_code) { create(:percentage_offer_code, user:, products: [product], amount_percentage: 20) }
+
+      before do
+        product.update!(default_offer_code: offer_code)
+      end
+
+      it "returns the offer code" do
+        expect(product.effective_default_offer_code).to eq(offer_code)
+      end
+    end
+
+    context "when the default offer code is deleted" do
+      let(:offer_code) { create(:percentage_offer_code, user:, products: [product], amount_percentage: 20) }
+
+      before do
+        product.update!(default_offer_code: offer_code)
+        offer_code.mark_deleted!
+      end
+
+      it "returns nil" do
+        expect(product.effective_default_offer_code).to be_nil
+      end
+    end
+
+    context "when the default offer code is expired" do
+      let(:offer_code) do
+        create(:percentage_offer_code, user:, products: [product], amount_percentage: 20,
+                                       valid_at: 2.days.ago, expires_at: 1.day.ago)
+      end
+
+      before do
+        product.update!(default_offer_code: offer_code)
+      end
+
+      it "returns nil" do
+        expect(product.effective_default_offer_code).to be_nil
+      end
+    end
+
+    context "when the default offer code is not yet active" do
+      let(:offer_code) do
+        create(:percentage_offer_code, user:, products: [product], amount_percentage: 20,
+                                       valid_at: 1.day.from_now, expires_at: 2.days.from_now)
+      end
+
+      before do
+        product.update!(default_offer_code: offer_code)
+      end
+
+      it "returns nil" do
+        expect(product.effective_default_offer_code).to be_nil
+      end
+    end
+  end
+
+  describe "validation" do
+    context "when default offer code is invalid" do
+      it "adds an error when the offer code does not exist" do
+        product.default_offer_code_id = 999_999_999
+        expect(product).not_to be_valid
+        expect(product.errors[:default_offer_code]).to include("is invalid or not applicable to this product")
+      end
+
+      it "adds an error when the offer code is not applicable to the product" do
+        other_product = create(:product, user:)
+        other_offer_code = create(:percentage_offer_code, user:, products: [other_product])
+
+        product.default_offer_code = other_offer_code
+        expect(product).not_to be_valid
+        expect(product.errors[:default_offer_code]).to include("is invalid or not applicable to this product")
+      end
+    end
+
+    context "when default offer code is valid" do
+      let(:offer_code) { create(:percentage_offer_code, user:, products: [product], amount_percentage: 20) }
+
+      it "is valid" do
+        product.default_offer_code = offer_code
+        expect(product).to be_valid
+      end
+    end
+  end
+end
+
+RSpec.describe OfferCode, "clear_as_default_if_deleted" do
+  let(:user) { create(:user) }
+  let(:product) { create(:product, user:) }
+  let(:offer_code) { create(:percentage_offer_code, user:, products: [product], amount_percentage: 20) }
+
+  before do
+    product.update!(default_offer_code: offer_code)
+  end
+
+  it "clears default_offer_code_id when offer code is deleted" do
+    expect(product.default_offer_code_id).to eq(offer_code.id)
+
+    offer_code.mark_deleted!
+
+    product.reload
+    expect(product.default_offer_code_id).to be_nil
+  end
+end

--- a/spec/services/product/save_default_offer_code_service_spec.rb
+++ b/spec/services/product/save_default_offer_code_service_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+RSpec.describe Product::SaveDefaultOfferCodeService do
+  let(:user) { create(:user) }
+  let(:product) { create(:product, user:) }
+  let(:offer_code) { create(:percentage_offer_code, user:, products: [product], amount_percentage: 20) }
+  let(:service) { described_class.new(product, offer_code_id) }
+
+  describe "#perform" do
+    context "when a valid offer code id is provided" do
+      let(:offer_code_id) { offer_code.external_id }
+
+      it "sets the default_offer_code_id on the product" do
+        service.perform
+
+        product.reload
+        expect(product.default_offer_code_id).to eq(offer_code.id)
+        expect(product.default_offer_code).to eq(offer_code)
+      end
+    end
+
+    context "when a nil offer code id is provided" do
+      let(:offer_code_id) { nil }
+
+      before do
+        product.update!(default_offer_code: offer_code)
+      end
+
+      it "clears the default_offer_code_id on the product" do
+        service.perform
+
+        product.reload
+        expect(product.default_offer_code_id).to be_nil
+        expect(product.default_offer_code).to be_nil
+      end
+    end
+
+    context "when an empty string offer code id is provided" do
+      let(:offer_code_id) { "" }
+
+      before do
+        product.update!(default_offer_code: offer_code)
+      end
+
+      it "clears the default_offer_code_id on the product" do
+        service.perform
+
+        product.reload
+        expect(product.default_offer_code_id).to be_nil
+      end
+    end
+
+    context "when offer code does not exist" do
+      let(:offer_code_id) { "nonexistent_id" }
+
+      it "raises ActiveRecord::RecordNotFound" do
+        expect { service.perform }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "when offer code is deleted" do
+      let(:offer_code_id) { offer_code.external_id }
+
+      before do
+        offer_code.mark_deleted!
+      end
+
+      it "raises ActiveRecord::RecordNotFound" do
+        expect { service.perform }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "when offer code is not applicable to the product" do
+      let(:other_product) { create(:product, user:) }
+      let(:other_offer_code) { create(:percentage_offer_code, user:, products: [other_product]) }
+      let(:offer_code_id) { other_offer_code.external_id }
+
+      it "raises ArgumentError" do
+        expect { service.perform }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "with a universal offer code" do
+      let(:universal_offer_code) { create(:percentage_offer_code, user:, universal: true, amount_percentage: 15) }
+      let(:offer_code_id) { universal_offer_code.external_id }
+
+      it "sets the default_offer_code_id on the product" do
+        service.perform
+
+        product.reload
+        expect(product.default_offer_code_id).to eq(universal_offer_code.id)
+        expect(product.default_offer_code).to eq(universal_offer_code)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Implements GitHub Issue #2053:
- Add default_offer_code_id to products (links table)
- Add "Apply discount" toggle in product Pricing section
- Show discounted pricing on product cards and pages
- URL discount codes take priority over default
- Track purchases using default discount via was_default_discount

Closes #2053

## Changes
- **Migration**: adds `default_offer_code_id` to links table
- **Models**: Link (association, validation, helper), OfferCode (cleanup callback), Purchase (tracking accessor)
- **Service**: `Product::SaveDefaultOfferCodeService` for saving/clearing default offer code
- **Controller**: LinksController updated to handle the new param
- **Presenters**: ProductPresenter, Card presenter updated for discount display
- **Frontend**: DefaultDiscountSelector component, Card component updates, TypeScript types
- **Tests**: Model specs, service specs

## Test Plan
- [ ] Create product with discount codes
- [ ] Enable "Apply discount" toggle, select code
- [ ] Verify product page shows strikethrough + discounted price
- [ ] Verify product cards show discounted price + badge
- [ ] Test URL code (`?code=XXX`) override works
- [ ] Complete purchase, verify `was_default_discount` tracking