### PR TITLE
fix(exports): Show email notification when exporting Sales CSV from all time

### DIFF
--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -414,7 +414,7 @@ class PurchasesController < ApplicationController
       send_file tempfile.path
     else
       flash[:warning] = "You will receive an email in your inbox with the data you've requested shortly."
-      redirect_back(fallback_location: customers_path)
+      redirect_to customers_path, status: :see_other
     end
   end
 

--- a/spec/controllers/purchases_controller_spec.rb
+++ b/spec/controllers/purchases_controller_spec.rb
@@ -687,8 +687,7 @@ describe PurchasesController, :vcr do
           stub_const("Exports::PurchaseExportService::SYNCHRONOUS_EXPORT_THRESHOLD", 1)
         end
 
-        it "queues sidekiq job and redirects back" do
-          request.env["HTTP_REFERER"] = "/customers"
+        it "queues sidekiq job and redirects to customers path with flash message" do
           get :export
 
           export = SalesExport.last!
@@ -696,7 +695,8 @@ describe PurchasesController, :vcr do
 
           expect(Exports::Sales::CreateAndEnqueueChunksWorker).to have_enqueued_sidekiq_job(export.id)
           expect(flash[:warning]).to eq("You will receive an email in your inbox with the data you've requested shortly.")
-          expect(response).to redirect_to("/customers")
+          expect(response).to redirect_to(customers_path)
+          expect(response).to have_http_status(:see_other)
         end
 
         context "when running sidekiq jobs" do
@@ -726,7 +726,8 @@ describe PurchasesController, :vcr do
 
             expect(Exports::Sales::CreateAndEnqueueChunksWorker).to have_enqueued_sidekiq_job(export.id)
             expect(flash[:warning]).to eq("You will receive an email in your inbox with the data you've requested shortly.")
-            expect(response).to redirect_to("/customers")
+            expect(response).to redirect_to(customers_path)
+            expect(response).to have_http_status(:see_other)
           end
         end
       end


### PR DESCRIPTION
Fixes #1930

## Problem
When downloading sales data from All Time (or any export with >2000 rows), the flash notification message was not appearing to inform users that they would receive an email with the export data.

## Root Cause
The  method does not work correctly with Inertia.js pages, causing flash messages to not display properly after redirects.

## Solution
Changed  to  in . The  status code (303) is required for Inertia.js to correctly handle redirects after non-GET requests and preserve flash messages.

## Changes
- Updated  to use explicit redirect with  status
- Updated test expectations to match new redirect behavior

## Testing
- Tested locally with 2001+ sales records
- Verified flash message appears after clicking Download for large exports


https://github.com/user-attachments/assets/868ef0ba-c052-4ca0-bf1a-477355c6f2f7

<img width="1072" height="188" alt="image" src="https://github.com/user-attachments/assets/89f1a419-99a6-4c3a-b6d2-a067a6eb84f9" />


## AI Disclosure
This PR was created with assistance from AI (Claude via Cursor).