### PR TITLE
Replace BGN with EUR for Bulgaria

### DIFF
--- a/app/business/payments/currency.rb
+++ b/app/business/payments/currency.rb
@@ -11,7 +11,6 @@ module Currency
   # These cannot be used as account's default currency or to set product prices.
   # Currency conversion helpers do not support for these currencies.
   THB = "thb"
-  BGN = "bgn"
   BAM = "bam"
   BDT = "bdt"
   BTN = "btn"

--- a/app/models/bulgaria_bank_account.rb
+++ b/app/models/bulgaria_bank_account.rb
@@ -14,7 +14,7 @@ class BulgariaBankAccount < BankAccount
   end
 
   def currency
-    Currency::BGN
+    Currency::EUR
   end
 
   def account_number_visual

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -120,6 +120,7 @@ class Country
       Currency::GBP
     when Compliance::Countries::AUT.alpha2,
         Compliance::Countries::BEL.alpha2,
+        Compliance::Countries::BGR.alpha2,
         Compliance::Countries::HRV.alpha2,
         Compliance::Countries::CYP.alpha2,
         Compliance::Countries::EST.alpha2,
@@ -163,7 +164,7 @@ class Country
     when Compliance::Countries::THA.alpha2
       Currency::THB
     when Compliance::Countries::BGR.alpha2
-      Currency::BGN
+      Currency::EUR
     when Compliance::Countries::DNK.alpha2
       Currency::DKK
     when Compliance::Countries::HUN.alpha2

--- a/app/views/help_center/articles/contents/_13-getting-paid.html.erb
+++ b/app/views/help_center/articles/contents/_13-getting-paid.html.erb
@@ -88,7 +88,7 @@
           <td>Brunei</td>
           <td>BND</td>
           <td>Bulgaria</td>
-          <td>BGN</td>
+          <td>EUR</td>
         </tr>
         <tr>
           <td>Cambodia</td>

--- a/spec/models/bulgaria_bank_account_spec.rb
+++ b/spec/models/bulgaria_bank_account_spec.rb
@@ -16,8 +16,8 @@ describe BulgariaBankAccount do
   end
 
   describe "#currency" do
-    it "returns bgn" do
-      expect(create(:bulgaria_bank_account).currency).to eq("bgn")
+    it "returns eur" do
+      expect(create(:bulgaria_bank_account).currency).to eq("eur")
     end
   end
 

--- a/spec/models/country_spec.rb
+++ b/spec/models/country_spec.rb
@@ -292,6 +292,7 @@ describe Country do
       expect(Country.new("GB").default_currency).to eq Currency::GBP
       expect(Country.new("AU").default_currency).to eq Currency::AUD
       expect(Country.new("FR").default_currency).to eq Currency::EUR
+      expect(Country.new("BG").default_currency).to eq Currency::EUR
       expect(Country.new("TH").default_currency).to eq nil
       expect(Country.new("KR").default_currency).to eq nil
       expect(Country.new("AE").default_currency).to eq nil
@@ -387,6 +388,7 @@ describe Country do
       expect(Country.new("GB").payout_currency).to eq Currency::GBP
       expect(Country.new("AU").payout_currency).to eq Currency::AUD
       expect(Country.new("FR").payout_currency).to eq Currency::EUR
+      expect(Country.new("BG").payout_currency).to eq Currency::EUR
       expect(Country.new("TH").payout_currency).to eq Currency::THB
       expect(Country.new("KR").payout_currency).to eq Currency::KRW
       expect(Country.new("AE").payout_currency).to eq Currency::AED

--- a/spec/requests/settings/payments_spec.rb
+++ b/spec/requests/settings/payments_spec.rb
@@ -1530,7 +1530,7 @@ describe("Payments Settings Scenario", type: :system, js: true) do
         fill_in("Confirm IBAN", with: "BG80BNBG96611020345678")
 
         expect(page).to have_content("Must exactly match the name on your bank account")
-        expect(page).to have_content("Payouts will be made in BGN.")
+        expect(page).to have_content("Payouts will be made in EUR.")
 
         click_on("Update settings")
 


### PR DESCRIPTION
- Replace Bulgaria default/payout currency BGN -> EUR
- Update Bulgaria bank account currency and help center table
- Update related specs