### PR TITLE
Disable new Stripe signups via Feature Flag

### DIFF
--- a/app/controllers/user/omniauth_callbacks_controller.rb
+++ b/app/controllers/user/omniauth_callbacks_controller.rb
@@ -91,8 +91,17 @@ class User::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       return safe_redirect_to referer
     end
 
-    if logged_in_user.blank?
+   if logged_in_user.blank?
+      # 1. Let the existing (hidden) method do its thing
       user = User.find_or_create_for_stripe_connect_account(auth)
+
+      # 2. Check if the user was JUST created (is a new signup)
+      # .previously_new_record? is a built-in Rails tool for exactly this.
+      if user&.previously_new_record? && FeatureConfig.enabled?(:disable_stripe_signup)
+        user.destroy # Clean up the newly created record
+        flash[:alert] = "New signups via Stripe are currently disabled. Please sign up with an email address."
+        return safe_redirect_to signup_path
+      end
 
       if user.nil?
         flash[:alert] = "An account already exists with this email."


### PR DESCRIPTION
Closes #2450

This PR adds a check to the Stripe Omniauth callback to prevent new user creation when the :disable_stripe_signup feature flag is enabled.

Technical Details:

Intercepts the flow after User.find_or_create_for_stripe_connect_account.

Uses previously_new_record? to detect if a new account was created.

Destroys the new record and redirects with a flash message if the flag is active.

Existing users can still log in normally.

AI Disclosure: I used Gemini to help navigate the codebase and structure the logic for this PR.