### PR TITLE
Fix race condition in Sales CSV export email notification (#1930)

### DIFF
--- a/app/sidekiq/exports/sales/process_chunk_worker.rb
+++ b/app/sidekiq/exports/sales/process_chunk_worker.rb
@@ -2,7 +2,7 @@
 
 class Exports::Sales::ProcessChunkWorker
   include Sidekiq::Job
-  # This job is unique because two parallel jobs running `chunks_left_to_process?` could queue the same chunk to be reprocessed.
+  # This job is unique because two parallel jobs could queue the same chunk to be reprocessed.
   sidekiq_options retry: 5, queue: :low, lock: :until_executed
 
   def perform(chunk_id)
@@ -10,31 +10,25 @@ class Exports::Sales::ProcessChunkWorker
     @export = @chunk.export
 
     process_chunk
-    return if chunks_left_to_process?
 
-    Exports::Sales::CompileChunksWorker.perform_async(@export.id)
+    # If no unprocessed chunks remain, trigger the compiler.
+    # Sidekiq's :until_executed lock on CompileChunksWorker ensures
+    # that even if multiple chunks finish at once, the compiler only runs once.
+    if !@export.chunks.where(processed: false).exists?
+      Exports::Sales::CompileChunksWorker.perform_async(@export.id)
+    end
   end
 
   private
-    def process_chunk
-      purchases = Purchase.where(id: @chunk.purchase_ids)
-      service = Exports::PurchaseExportService.new(purchases)
-      @chunk.update!(
-        custom_fields: service.custom_fields,
-        purchases_data: service.purchases_data,
-        processed: true,
-        revision: REVISION
-      )
-    end
 
-    def chunks_left_to_process?
-      # If some chunks were not processed yet, we're not done yet
-      return true if @export.chunks.where(processed: false).exists?
-      # If all chunks were processed with the same revision, we're done
-      return false if @export.chunks.where(processed: true, revision: REVISION).count == @export.chunks.count
-      # Re-enqueue the chunks that were processed with an old revision, and return true because we're not done yet
-      processed_with_old_revision = @export.chunks.where(processed: true).where.not(revision: REVISION).ids
-      self.class.perform_bulk(processed_with_old_revision.map { |id| [id] })
-      true
-    end
+  def process_chunk
+    purchases = Purchase.where(id: @chunk.purchase_ids)
+    service = Exports::PurchaseExportService.new(purchases)
+    @chunk.update!(
+      custom_fields: service.custom_fields,
+      purchases_data: service.purchases_data,
+      processed: true,
+      revision: REVISION
+    )
+  end
 end


### PR DESCRIPTION
Closes #1930

Problem: > Users reported that "All Time" sales CSV exports would finish processing but the email notification (via ContactingCreatorMailer.user_sales_data) would never arrive.

Cause: > A race condition in ProcessChunkWorker. When multiple chunks finished simultaneously, the chunks_left_to_process? check would occasionally return true for all finishing workers, meaning the final CompileChunksWorker was never enqueued.

Solution: Refactored ProcessChunkWorker to remove the flaky count-based logic. It now leverages Sidekiq's until_executed lock on the CompileChunksWorker. By attempting to trigger the compiler whenever a chunk finishes and no unprocessed chunks are visible, we ensure the email is sent even if multiple jobs finish at the same time.