### PR TITLE
Replace BGN with EUR for Bulgaria payouts

### DIFF
--- a/app/business/payments/currency.rb
+++ b/app/business/payments/currency.rb
@@ -11,7 +11,6 @@ module Currency
   # These cannot be used as account's default currency or to set product prices.
   # Currency conversion helpers do not support for these currencies.
   THB = "thb"
-  BGN = "bgn"
   BAM = "bam"
   BDT = "bdt"
   BTN = "btn"

--- a/app/models/bulgaria_bank_account.rb
+++ b/app/models/bulgaria_bank_account.rb
@@ -14,7 +14,7 @@ class BulgariaBankAccount < BankAccount
   end
 
   def currency
-    Currency::BGN
+    Currency::EUR
   end
 
   def account_number_visual

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -163,7 +163,7 @@ class Country
     when Compliance::Countries::THA.alpha2
       Currency::THB
     when Compliance::Countries::BGR.alpha2
-      Currency::BGN
+      Currency::EUR
     when Compliance::Countries::DNK.alpha2
       Currency::DKK
     when Compliance::Countries::HUN.alpha2

--- a/app/views/help_center/articles/contents/_13-getting-paid.html.erb
+++ b/app/views/help_center/articles/contents/_13-getting-paid.html.erb
@@ -88,7 +88,7 @@
           <td>Brunei</td>
           <td>BND</td>
           <td>Bulgaria</td>
-          <td>BGN</td>
+          <td>EUR</td>
         </tr>
         <tr>
           <td>Cambodia</td>

--- a/spec/models/bulgaria_bank_account_spec.rb
+++ b/spec/models/bulgaria_bank_account_spec.rb
@@ -16,8 +16,8 @@ describe BulgariaBankAccount do
   end
 
   describe "#currency" do
-    it "returns bgn" do
-      expect(create(:bulgaria_bank_account).currency).to eq("bgn")
+    it "returns eur" do
+      expect(create(:bulgaria_bank_account).currency).to eq("eur")
     end
   end
 

--- a/spec/models/country_spec.rb
+++ b/spec/models/country_spec.rb
@@ -7,6 +7,7 @@ describe Country do
       expect(Country.new("GB").supports_stripe_cross_border_payouts?).to be false
       expect(Country.new("AU").supports_stripe_cross_border_payouts?).to be false
       expect(Country.new("FR").supports_stripe_cross_border_payouts?).to be false
+      expect(Country.new("BG").supports_stripe_cross_border_payouts?).to be false
       expect(Country.new("TH").supports_stripe_cross_border_payouts?).to be true
       expect(Country.new("KR").supports_stripe_cross_border_payouts?).to be true
       expect(Country.new("AE").supports_stripe_cross_border_payouts?).to be false
@@ -188,6 +189,7 @@ describe Country do
       expect(Country.new("MO").can_accept_stripe_charges?).to be false
       expect(Country.new("BJ").can_accept_stripe_charges?).to be false
       expect(Country.new("CI").can_accept_stripe_charges?).to be false
+      expect(Country.new("BG").can_accept_stripe_charges?).to be true
     end
   end
 
@@ -283,6 +285,7 @@ describe Country do
       expect(Country.new("MO").stripe_capabilities).to eq StripeMerchantAccountManager::CROSS_BORDER_PAYOUTS_ONLY_CAPABILITIES
       expect(Country.new("BJ").stripe_capabilities).to eq StripeMerchantAccountManager::CROSS_BORDER_PAYOUTS_ONLY_CAPABILITIES
       expect(Country.new("CI").stripe_capabilities).to eq StripeMerchantAccountManager::CROSS_BORDER_PAYOUTS_ONLY_CAPABILITIES
+      expect(Country.new("BG").stripe_capabilities).to eq StripeMerchantAccountManager::REQUESTED_CAPABILITIES
     end
   end
 
@@ -292,6 +295,7 @@ describe Country do
       expect(Country.new("GB").default_currency).to eq Currency::GBP
       expect(Country.new("AU").default_currency).to eq Currency::AUD
       expect(Country.new("FR").default_currency).to eq Currency::EUR
+      expect(Country.new("BG").default_currency).to eq Currency::EUR
       expect(Country.new("TH").default_currency).to eq nil
       expect(Country.new("KR").default_currency).to eq nil
       expect(Country.new("AE").default_currency).to eq nil
@@ -473,6 +477,7 @@ describe Country do
       expect(Country.new("MO").payout_currency).to eq Currency::MOP
       expect(Country.new("BJ").payout_currency).to eq Currency::XOF
       expect(Country.new("CI").payout_currency).to eq Currency::XOF
+      expect(Country.new("BG").payout_currency).to eq Currency::EUR
     end
   end
 

--- a/spec/requests/settings/payments_spec.rb
+++ b/spec/requests/settings/payments_spec.rb
@@ -1530,7 +1530,7 @@ describe("Payments Settings Scenario", type: :system, js: true) do
         fill_in("Confirm IBAN", with: "BG80BNBG96611020345678")
 
         expect(page).to have_content("Must exactly match the name on your bank account")
-        expect(page).to have_content("Payouts will be made in BGN.")
+        expect(page).to have_content("Payouts will be made in EUR.")
 
         click_on("Update settings")
 


### PR DESCRIPTION
Stripe no longer supports BGN.

This PR updates Bulgaria to use EUR across:
- Payout currency logic
- Bank account handling
- Country defaults
- User-facing documentation

All changes are limited to Bulgaria and do not affect other countries.

Closes #2435