### PR TITLE
Fix export timeout for large audience CSV exports

### DIFF
--- a/app/sidekiq/exports/audience_export_worker.rb
+++ b/app/sidekiq/exports/audience_export_worker.rb
@@ -7,8 +7,11 @@ class Exports::AudienceExportWorker
   def perform(seller_id, recipient_id, audience_options = {})
     seller, recipient = User.find(seller_id, recipient_id)
     recipient ||= seller
+    result = nil
 
-    result = Exports::AudienceExportService.new(seller, audience_options).perform
+    WithMaxExecutionTime.timeout_queries(seconds: 1.hour) do
+      result = Exports::AudienceExportService.new(seller, audience_options).perform
+    end
 
     ContactingCreatorMailer.subscribers_data(
       recipient:,

--- a/spec/sidekiq/exports/audience_export_worker_spec.rb
+++ b/spec/sidekiq/exports/audience_export_worker_spec.rb
@@ -25,5 +25,10 @@ describe Exports::AudienceExportWorker do
       mail = ActionMailer::Base.deliveries.last
       expect(mail.to).to eq([recipient.email])
     end
+
+    it "uses extended query timeout for large exports" do
+      expect(WithMaxExecutionTime).to receive(:timeout_queries).with(seconds: 1.hour).and_call_original
+      described_class.new.perform(seller.id, seller.id, audience_options)
+    end
   end
 end


### PR DESCRIPTION
Fixes #2092
## Summary
Wraps the audience export in `WithMaxExecutionTime.timeout_queries(seconds: 1.hour)` to prevent timeout when exporting large lists of followers/subscribers.
## Problem
Users with large audiences were not receiving their CSV export emails because the MySQL query was exceeding the default 5-minute `max_execution_time` configured in `database.yml`.
## Solution
- Added `WithMaxExecutionTime` wrapper to extend the query timeout to 1 hour
- Kept the mailer outside the timeout block to avoid misleading `QueryTimeoutError` on email delivery issues
This follows the same pattern used by:
- `AnnualPayoutExportWorker` (1 hour)
- `AnnualTaxSummaryExportWorker` (4 hours)
## Tests
<img width="595" height="196" alt="Screenshot 2025-12-29 at 1 20 01 PM" src="https://github.com/user-attachments/assets/e6829e5d-0d69-4e6e-9024-1eba1202187d" />

## AI Disclosure
Used Claude Opus 4.5(Cursor) to investigate and implement this fix.
## Self-Review
I have reviewed all the code changes

## Confirmation
I have watched the Gumroad PR reviews live streaming video.