### PR TITLE
feat: Add auto-apply discount code for products

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -360,7 +360,8 @@ class LinksController < ApplicationController
           :shipping_destinations,
           :call_limitation_info,
           :installment_plan,
-          :community_chat_enabled
+          :community_chat_enabled,
+          :default_offer_code_id
         ))
         @product.description = SaveContentUpsellsService.new(seller: @product.user, content: product_permitted_params[:description], old_content: @product.description_was).from_html
         @product.skus_enabled = false
@@ -377,6 +378,16 @@ class LinksController < ApplicationController
         end
         @product.show_in_sections!(product_permitted_params[:section_ids] || [])
         @product.save_shipping_destinations!(product_permitted_params[:shipping_destinations] || []) if @product.is_physical
+
+        # Handle default offer code (auto-apply discount)
+        if product_permitted_params.key?(:default_offer_code_id)
+          if product_permitted_params[:default_offer_code_id].present?
+            offer_code = @product.find_offer_code_by_external_id(product_permitted_params[:default_offer_code_id])
+            @product.default_offer_code = offer_code
+          else
+            @product.default_offer_code = nil
+          end
+        end
 
         if Feature.active?(:cancellation_discounts, @product.user) && (product_permitted_params[:cancellation_discount].present? || @product.cancellation_discount_offer_code.present?)
           begin

--- a/app/javascript/components/ProductEdit/ProductTab/DefaultDiscountSelector.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/DefaultDiscountSelector.tsx
@@ -1,0 +1,103 @@
+import * as React from "react";
+
+import { formatPriceCentsWithCurrencySymbol } from "$app/utils/currency";
+
+import { useProductEditContext, AvailableOfferCode } from "$app/components/ProductEdit/state";
+import { TypeSafeOptionSelect } from "$app/components/TypeSafeOptionSelect";
+
+const formatDiscount = (offerCode: AvailableOfferCode) => {
+  if (offerCode.discount.type === "percent") {
+    return `${offerCode.discount.value}% off`;
+  }
+  return `${formatPriceCentsWithCurrencySymbol(offerCode.currency_type, offerCode.discount.value, { symbolFormat: "short" })} off`;
+};
+
+export const DefaultDiscountSelector = () => {
+  const { product, updateProduct, availableOfferCodes, currencyType } = useProductEditContext();
+  const uid = React.useId();
+
+  const hasOfferCodes = availableOfferCodes.length > 0;
+  const isEnabled = product.default_offer_code_id !== null;
+
+  const selectedOfferCode = availableOfferCodes.find((code) => code.id === product.default_offer_code_id);
+
+  const handleToggle = (enabled: boolean) => {
+    if (enabled && availableOfferCodes.length > 0) {
+      // Select the first available offer code
+      updateProduct({ default_offer_code_id: availableOfferCodes[0]?.id ?? null });
+    } else {
+      updateProduct({ default_offer_code_id: null });
+    }
+  };
+
+  const handleOfferCodeChange = (offerCodeId: string) => {
+    updateProduct({ default_offer_code_id: offerCodeId });
+  };
+
+  if (!hasOfferCodes) {
+    return (
+      <fieldset>
+        <legend>
+          <label>Auto-apply discount</label>
+        </legend>
+        <p className="text-secondary text-sm">
+          No discount codes available.{" "}
+          <a href="/checkout/discounts" target="_blank" rel="noreferrer">
+            Create a discount code
+          </a>{" "}
+          to automatically apply it to this product.
+        </p>
+      </fieldset>
+    );
+  }
+
+  return (
+    <fieldset>
+      <legend>
+        <label htmlFor={`${uid}-toggle`}>Auto-apply discount</label>
+      </legend>
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-2">
+          <label className="flex items-center gap-2">
+            <input
+              type="radio"
+              name={`${uid}-discount-mode`}
+              checked={!isEnabled}
+              onChange={() => handleToggle(false)}
+            />
+            <span>No discount</span>
+          </label>
+          <label className="flex items-center gap-2">
+            <input
+              type="radio"
+              name={`${uid}-discount-mode`}
+              checked={isEnabled}
+              onChange={() => handleToggle(true)}
+            />
+            <span>Apply discount code</span>
+          </label>
+        </div>
+
+        {isEnabled ? (
+          <div className="ml-6">
+            <TypeSafeOptionSelect
+              id={`${uid}-offer-code`}
+              value={product.default_offer_code_id ?? ""}
+              onChange={handleOfferCodeChange}
+              options={availableOfferCodes.map((offerCode) => ({
+                id: offerCode.id,
+                label: `${offerCode.code.toUpperCase()}${offerCode.name ? ` - ${offerCode.name}` : ""} (${formatDiscount(offerCode)})`,
+              }))}
+            />
+            {selectedOfferCode ? (
+              <p className="text-secondary mt-2 text-sm">
+                This discount will be automatically applied when customers view this product.
+              </p>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    </fieldset>
+  );
+};
+

--- a/app/javascript/components/ProductEdit/ProductTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/index.tsx
@@ -20,6 +20,7 @@ import { CoverEditor } from "$app/components/ProductEdit/ProductTab/CoverEditor"
 import { CustomButtonTextOptionInput } from "$app/components/ProductEdit/ProductTab/CustomButtonTextOptionInput";
 import { CustomPermalinkInput } from "$app/components/ProductEdit/ProductTab/CustomPermalinkInput";
 import { CustomSummaryInput } from "$app/components/ProductEdit/ProductTab/CustomSummaryInput";
+import { DefaultDiscountSelector } from "$app/components/ProductEdit/ProductTab/DefaultDiscountSelector";
 import { DescriptionEditor, useImageUpload } from "$app/components/ProductEdit/ProductTab/DescriptionEditor";
 import { DiscordIntegrationEditor } from "$app/components/ProductEdit/ProductTab/DiscordIntegrationEditor";
 import { DurationEditor } from "$app/components/ProductEdit/ProductTab/DurationEditor";
@@ -307,6 +308,7 @@ export const ProductTab = () => {
                         Commission products use a 50% deposit upfront, 50% upon completion payment split.
                       </p>
                     ) : null}
+                    <DefaultDiscountSelector />
                   </section>
                   {product.native_type === "call" ? (
                     <>

--- a/app/javascript/components/ProductEdit/state.ts
+++ b/app/javascript/components/ProductEdit/state.ts
@@ -81,6 +81,14 @@ export type CancellationDiscount = {
   duration_in_billing_cycles: number | null;
 };
 
+export type AvailableOfferCode = {
+  id: string;
+  code: string;
+  name: string | null;
+  discount: { type: "percent"; value: number } | { type: "cents"; value: number };
+  currency_type: string;
+};
+
 export type InstallmentPlan = {
   number_of_installments: number;
 };
@@ -142,6 +150,7 @@ export type Product = {
   public_files: PublicFileWithStatus[];
   audio_previews_enabled: boolean;
   community_chat_enabled: boolean | null;
+  default_offer_code_id: string | null;
 } & (
   | { native_type: "call"; variants: Duration[] }
   | { native_type: "membership"; variants: Tier[] }
@@ -190,6 +199,7 @@ export const ProductEditContext = React.createContext<{
   contentUpdates: ContentUpdates;
   setContentUpdates: React.Dispatch<React.SetStateAction<ContentUpdates>>;
   filesById: Map<string, FileEntry>;
+  availableOfferCodes: AvailableOfferCode[];
 } | null>(null);
 export const useProductEditContext = () => assertDefined(React.useContext(ProductEditContext));
 

--- a/app/javascript/components/server-components/ProductEditPage.tsx
+++ b/app/javascript/components/server-components/ProductEditPage.tsx
@@ -29,6 +29,7 @@ import {
   ExistingFileEntry,
   ShippingCountry,
   ContentUpdates,
+  AvailableOfferCode,
 } from "$app/components/ProductEdit/state";
 import { ImageUploadSettingsContext } from "$app/components/RichTextEditor";
 import { showAlert } from "$app/components/server-components/Alert";
@@ -78,6 +79,7 @@ type Props = {
   seller_refund_policy_enabled: boolean;
   seller_refund_policy: Pick<RefundPolicy, "title" | "fine_print">;
   cancellation_discounts_enabled: boolean;
+  available_offer_codes: AvailableOfferCode[];
 };
 
 const createContextValue = (props: Props) => ({
@@ -114,6 +116,7 @@ const createContextValue = (props: Props) => ({
   contentUpdates: null,
   setContentUpdates: () => {},
   filesById: new Map(props.product.files.map((file) => [file.id, { ...file, url: getDownloadUrl(props.id, file) }])),
+  availableOfferCodes: props.available_offer_codes,
 });
 
 const pagesHaveSameContent = (pages1: Page[], pages2: Page[]): boolean => isEqual(pages1, pages2);

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -113,6 +113,7 @@ class Link < ApplicationRecord
   has_many :installments
   has_many :subscriptions
   has_and_belongs_to_many :offer_codes, join_table: "offer_codes_products", foreign_key: "product_id"
+  belongs_to :default_offer_code, class_name: "OfferCode", optional: true
   has_many :transcoded_videos
   has_many :imported_customers
   has_many :licenses
@@ -205,6 +206,7 @@ class Link < ApplicationRecord
   validate :commission_price_is_valid, if: -> { native_type == Link::NATIVE_TYPE_COMMISSION }
   validate :one_coffee_per_user, on: :create, if: -> { native_type == Link::NATIVE_TYPE_COFFEE }
   validate :quantity_enabled_state_is_allowed
+  validate :default_offer_code_is_applicable
 
   validates_associated :installment_plan, message: -> (link, _) { link.installment_plan.errors.full_messages.first }
 
@@ -808,6 +810,27 @@ class Link < ApplicationRecord
       user.offer_codes.universal_with_matching_currency(price_currency_type).alive.find_by_code(code)
   end
 
+  # Returns the effective offer code for this product.
+  # If an explicit code is provided, it takes priority.
+  # Otherwise, returns the default offer code if set and valid.
+  def effective_offer_code(explicit_code: nil)
+    if explicit_code.present?
+      find_offer_code(code: explicit_code)
+    elsif default_offer_code.present? && !default_offer_code.deleted? && !default_offer_code.inactive?
+      default_offer_code
+    end
+  end
+
+  # Returns the discounted price cents when the default offer code is applied.
+  # Returns nil if no default offer code is set or if it's invalid.
+  def discounted_price_cents_with_default_offer_code
+    return nil unless default_offer_code.present? && !default_offer_code.deleted? && !default_offer_code.inactive?
+
+    base_price = display_price_cents(for_default_duration: true)
+    discount_amount = default_offer_code.amount_off(base_price)
+    [base_price - discount_amount, 0].max
+  end
+
   def find_offer_code_by_external_id(external_id)
     offer_codes.alive.find_by_external_id(external_id) ||
       user.offer_codes.universal_with_matching_currency(price_currency_type).alive.find_by_external_id(external_id)
@@ -1312,6 +1335,25 @@ class Link < ApplicationRecord
     def quantity_enabled_state_is_allowed
       if quantity_enabled && !can_enable_quantity?
         errors.add(:base, "Customers cannot be allowed to choose a quantity for this product.")
+      end
+    end
+
+    def default_offer_code_is_applicable
+      return if default_offer_code.blank?
+      return if default_offer_code.deleted?
+
+      unless default_offer_code.applicable?(self)
+        errors.add(:base, "The selected discount code is not applicable to this product.")
+        return
+      end
+
+      unless default_offer_code.is_currency_valid?(self)
+        errors.add(:base, "The selected discount code currency does not match this product's currency.")
+        return
+      end
+
+      unless default_offer_code.is_amount_valid?(self)
+        errors.add(:base, "The selected discount code would result in an invalid price for this product.")
       end
     end
 

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -71,6 +71,7 @@ class Purchase < ApplicationRecord
   attr_json_data_accessor :perceived_price_cents
   attr_json_data_accessor :recommender_model_name
   attr_json_data_accessor :custom_fee_per_thousand
+  attr_json_data_accessor :was_default_offer_code_applied
 
   alias_attribute :total_transaction_cents_usd, :total_transaction_cents
 
@@ -1664,6 +1665,11 @@ class Purchase < ApplicationRecord
       self.build_purchase_offer_code_discount(offer_code:, offer_code_amount: offer_code.amount, offer_code_is_percent: offer_code.is_percent?,
                                               pre_discount_minimum_price_cents: minimum_paid_price_cents_per_unit_before_discount,
                                               duration_in_months: link.is_tiered_membership? ? offer_code.duration_in_months : nil)
+
+      # Track if this purchase used the product's default auto-applied offer code
+      if link.default_offer_code_id.present? && offer_code.id == link.default_offer_code_id
+        self.was_default_offer_code_applied = true
+      end
     end
 
     self.build_purchasing_power_parity_info(factor: purchasing_power_parity_factor) if is_purchasing_power_parity_discounted? && purchasing_power_parity_factor < 1

--- a/app/policies/link_policy.rb
+++ b/app/policies/link_policy.rb
@@ -91,6 +91,7 @@ class LinkPolicy < ApplicationPolicy
       :require_shipping,
       :is_multiseat_license,
       :community_chat_enabled,
+      :default_offer_code_id,
       refund_policy: [
         :max_refund_period_in_days,
         :title,

--- a/app/presenters/product_presenter.rb
+++ b/app/presenters/product_presenter.rb
@@ -195,6 +195,7 @@ class ProductPresenter
         public_files: product.alive_public_files.attached.map { PublicFilePresenter.new(public_file: _1).props },
         audio_previews_enabled: Feature.active?(:audio_previews, product.user),
         community_chat_enabled: Feature.active?(:communities, product.user) ? product.community_chat_enabled? : nil,
+        default_offer_code_id: product.default_offer_code&.external_id,
       },
       id: product.external_id,
       unique_permalink: product.unique_permalink,
@@ -237,6 +238,7 @@ class ProductPresenter
         fine_print: product.user.refund_policy.fine_print,
       },
       cancellation_discounts_enabled: Feature.active?(:cancellation_discounts, product.user),
+      available_offer_codes: available_offer_codes_for_product,
     }
   end
 
@@ -298,6 +300,20 @@ class ProductPresenter
         {
           success: false,
           message: "Domain verification failed. Please make sure you have correctly configured the DNS record for #{domain}.",
+        }
+      end
+    end
+
+    def available_offer_codes_for_product
+      product.product_and_universal_offer_codes.reject(&:inactive?).map do |offer_code|
+        {
+          id: offer_code.external_id,
+          code: offer_code.code,
+          name: offer_code.name,
+          discount: offer_code.is_percent? ?
+            { type: "percent", value: offer_code.amount_percentage } :
+            { type: "cents", value: offer_code.amount_cents },
+          currency_type: offer_code.currency_type || product.price_currency_type,
         }
       end
     end

--- a/app/presenters/product_presenter/card.rb
+++ b/app/presenters/product_presenter/card.rb
@@ -5,7 +5,7 @@ class ProductPresenter::Card
   include ProductsHelper
 
   ASSOCIATIONS = [
-    :alive_prices, :product_review_stat, :tiers, :variant_categories_alive,
+    :alive_prices, :product_review_stat, :tiers, :variant_categories_alive, :default_offer_code,
     {
       user: [:avatar_attachment, :avatar_blob],
       thumbnail_alive: { file_attachment: { blob: { variant_records: { image_attachment: :blob } } } },
@@ -21,6 +21,19 @@ class ProductPresenter::Card
 
   def for_web(request: nil, recommended_by: nil, recommender_model_name: nil, target: nil, show_seller: true, affiliate_id: nil, query: nil, offer_code: nil, compute_description: true)
     default_recurrence = product.default_price_recurrence
+    original_price_cents = product.display_price_cents(for_default_duration: true)
+
+    # Determine the effective offer code: explicit offer_code param or product's default
+    effective_code = product.effective_offer_code(explicit_code: offer_code)
+    effective_offer_code_string = effective_code&.code || offer_code
+
+    # Calculate discounted price if an offer code applies
+    discounted_price_cents = nil
+    if effective_code.present?
+      discount_amount = effective_code.amount_off(original_price_cents)
+      discounted_price_cents = [original_price_cents - discount_amount, 0].max
+    end
+
     props = {
       id: product.external_id,
       permalink: product.unique_permalink,
@@ -34,13 +47,18 @@ class ProductPresenter::Card
       native_type: product.native_type,
       quantity_remaining: product.remaining_for_sale_count,
       is_sales_limited: product.max_purchase_count?,
-      price_cents: product.display_price_cents(for_default_duration: true),
+      price_cents: discounted_price_cents || original_price_cents,
       currency_code: product.price_currency_type.downcase,
       is_pay_what_you_want: product.has_customizable_price_option?,
-      url: url_for_product_page(product, request:, recommended_by:, recommender_model_name:, layout: target, affiliate_id:, query:, offer_code:),
+      url: url_for_product_page(product, request:, recommended_by:, recommender_model_name:, layout: target, affiliate_id:, query:, offer_code: effective_offer_code_string),
       duration_in_months: product.duration_in_months,
       recurrence: default_recurrence&.recurrence,
     }
+
+    # Include original price if discounted, so UI can show strikethrough
+    if discounted_price_cents.present? && discounted_price_cents < original_price_cents
+      props[:original_price_cents] = original_price_cents
+    end
 
     if compute_description
       props[:description] = product.plaintext_description.truncate(100)

--- a/app/presenters/product_presenter/product_props.rb
+++ b/app/presenters/product_presenter/product_props.rb
@@ -13,6 +13,9 @@ class ProductPresenter::ProductProps
   end
 
   def props(seller_custom_domain_url:, request:, pundit_user:, recommended_by: nil, discount_code: nil, quantity: 1, layout: nil)
+    # Use explicit discount_code if provided, otherwise fall back to product's default
+    effective_code = effective_discount_code(discount_code)
+
     {
       product: {
         id: product.external_id,
@@ -69,7 +72,7 @@ class ProductPresenter::ProductProps
         public_files: product.alive_public_files.attached.map { PublicFilePresenter.new(public_file: _1).props },
         audio_previews_enabled: Feature.active?(:audio_previews, product.user),
       },
-      discount_code: discount_code_props(discount_code, quantity),
+      discount_code: discount_code_props(effective_code, quantity),
       purchase: purchase_props(product.purchase_info_for_product_page(pundit_user&.user, request.cookie_jar[:_gumroad_guid])),
       wishlists: pundit_user&.seller.present? ? (
         pundit_user.seller.wishlists.alive.includes(:alive_wishlist_products).map { |wishlist| WishlistPresenter.new(wishlist:).listing_props(product:) }
@@ -79,6 +82,16 @@ class ProductPresenter::ProductProps
 
   private
     attr_reader :product, :seller
+
+    # Returns the effective discount code string, prioritizing explicit code over product's default
+    def effective_discount_code(explicit_code)
+      return explicit_code if explicit_code.present?
+
+      default_offer_code = product.default_offer_code
+      return nil unless default_offer_code.present? && !default_offer_code.deleted? && !default_offer_code.inactive?
+
+      default_offer_code.code
+    end
 
     def discount_code_props(discount_code, quantity)
       return if discount_code.blank?

--- a/db/migrate/20251229000000_add_default_offer_code_to_links.rb
+++ b/db/migrate/20251229000000_add_default_offer_code_to_links.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddDefaultOfferCodeToLinks < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :links, :default_offer_code, foreign_key: { to_table: :offer_codes }, index: true
+  end
+end
+

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -895,6 +895,44 @@ describe LinksController, :vcr, inertia: true do
         expect(@product.reload.should_show_sales_count).to be(false)
       end
 
+      describe "default_offer_code_id" do
+        let(:offer_code) { create(:offer_code, products: [@product], amount_cents: 200) }
+
+        it "sets the default offer code when provided" do
+          post :update, params: @params.merge(default_offer_code_id: offer_code.external_id), format: :json
+
+          expect(response).to have_http_status(:no_content)
+          expect(@product.reload.default_offer_code).to eq(offer_code)
+        end
+
+        it "clears the default offer code when set to empty string" do
+          @product.update!(default_offer_code: offer_code)
+
+          post :update, params: @params.merge(default_offer_code_id: ""), format: :json
+
+          expect(response).to have_http_status(:no_content)
+          expect(@product.reload.default_offer_code).to be_nil
+        end
+
+        it "clears the default offer code when set to nil" do
+          @product.update!(default_offer_code: offer_code)
+
+          post :update, params: @params.merge(default_offer_code_id: nil), format: :json
+
+          expect(response).to have_http_status(:no_content)
+          expect(@product.reload.default_offer_code).to be_nil
+        end
+
+        it "does not change the default offer code when not provided" do
+          @product.update!(default_offer_code: offer_code)
+
+          post :update, params: @params, format: :json
+
+          expect(response).to have_http_status(:no_content)
+          expect(@product.reload.default_offer_code).to eq(offer_code)
+        end
+      end
+
       describe "adding variants" do
         describe "variants" do
           it "adds variants to the product" do

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -4799,4 +4799,128 @@ describe Link, :vcr do
       end
     end
   end
+
+  describe "#default_offer_code" do
+    let(:product) { create(:product) }
+    let(:offer_code) { create(:offer_code, products: [product]) }
+
+    it "can be associated with an offer code" do
+      product.default_offer_code = offer_code
+      product.save!
+      expect(product.reload.default_offer_code).to eq(offer_code)
+    end
+
+    it "can be set to nil" do
+      product.update!(default_offer_code: offer_code)
+      product.update!(default_offer_code: nil)
+      expect(product.reload.default_offer_code).to be_nil
+    end
+
+    describe "validation" do
+      it "is valid when the offer code is applicable to the product" do
+        product.default_offer_code = offer_code
+        expect(product).to be_valid
+      end
+
+      it "is invalid when the offer code is not applicable to the product" do
+        other_product = create(:product)
+        other_offer_code = create(:offer_code, products: [other_product])
+        product.default_offer_code = other_offer_code
+        expect(product).not_to be_valid
+        expect(product.errors[:base]).to include("The selected discount code is not applicable to this product.")
+      end
+
+      it "is invalid when the offer code currency doesn't match the product" do
+        gbp_offer_code = create(:offer_code, products: [product], currency_type: "gbp", amount_cents: 100)
+        product.default_offer_code = gbp_offer_code
+        expect(product).not_to be_valid
+        expect(product.errors[:base]).to include("The selected discount code currency does not match this product's currency.")
+      end
+
+      it "is invalid when the offer code amount exceeds the product price" do
+        expensive_offer_code = create(:offer_code, products: [product], amount_cents: product.price_cents + 100)
+        product.default_offer_code = expensive_offer_code
+        expect(product).not_to be_valid
+        expect(product.errors[:base]).to include("The selected discount code would result in an invalid price for this product.")
+      end
+
+      it "allows a deleted offer code to be set (but it won't be applied)" do
+        offer_code.mark_deleted!
+        product.default_offer_code = offer_code
+        expect(product).to be_valid
+      end
+    end
+  end
+
+  describe "#effective_offer_code" do
+    let(:product) { create(:product) }
+    let(:offer_code) { create(:offer_code, products: [product]) }
+    let(:other_offer_code) { create(:offer_code, products: [product], code: "OTHER") }
+
+    it "returns the explicit offer code when provided" do
+      product.update!(default_offer_code: offer_code)
+      result = product.effective_offer_code(explicit_code: other_offer_code.code)
+      expect(result).to eq(other_offer_code)
+    end
+
+    it "returns the default offer code when no explicit code is provided" do
+      product.update!(default_offer_code: offer_code)
+      result = product.effective_offer_code
+      expect(result).to eq(offer_code)
+    end
+
+    it "returns nil when no default offer code is set and no explicit code is provided" do
+      result = product.effective_offer_code
+      expect(result).to be_nil
+    end
+
+    it "returns nil when the default offer code is deleted" do
+      product.update!(default_offer_code: offer_code)
+      offer_code.mark_deleted!
+      result = product.effective_offer_code
+      expect(result).to be_nil
+    end
+
+    it "returns nil when the default offer code is inactive" do
+      product.update!(default_offer_code: offer_code)
+      offer_code.update!(expires_at: 1.day.ago)
+      result = product.effective_offer_code
+      expect(result).to be_nil
+    end
+  end
+
+  describe "#discounted_price_cents_with_default_offer_code" do
+    let(:product) { create(:product, price_cents: 1000) }
+    let(:offer_code) { create(:offer_code, products: [product], amount_cents: 200) }
+
+    it "returns nil when no default offer code is set" do
+      expect(product.discounted_price_cents_with_default_offer_code).to be_nil
+    end
+
+    it "returns the discounted price when a default offer code is set" do
+      product.update!(default_offer_code: offer_code)
+      expect(product.discounted_price_cents_with_default_offer_code).to eq(800)
+    end
+
+    it "returns nil when the default offer code is deleted" do
+      product.update!(default_offer_code: offer_code)
+      offer_code.mark_deleted!
+      expect(product.discounted_price_cents_with_default_offer_code).to be_nil
+    end
+
+    it "returns nil when the default offer code is inactive" do
+      product.update!(default_offer_code: offer_code)
+      offer_code.update!(expires_at: 1.day.ago)
+      expect(product.discounted_price_cents_with_default_offer_code).to be_nil
+    end
+
+    context "with percentage discount" do
+      let(:percent_offer_code) { create(:offer_code, products: [product], amount_percentage: 25) }
+
+      it "returns the correct discounted price" do
+        product.update!(default_offer_code: percent_offer_code)
+        expect(product.discounted_price_cents_with_default_offer_code).to eq(750)
+      end
+    end
+  end
 end

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -6527,4 +6527,35 @@ describe Purchase, :vcr do
       end
     end
   end
+
+  describe "#was_default_offer_code_applied" do
+    let(:product) { create(:product, price_cents: 1000) }
+    let(:offer_code) { create(:offer_code, products: [product], amount_cents: 200) }
+
+    before do
+      product.update!(default_offer_code: offer_code)
+    end
+
+    it "tracks when a purchase uses the product's default offer code" do
+      purchase = build(:purchase, link: product, offer_code: offer_code)
+      purchase.send(:set_price_and_rate)
+
+      expect(purchase.was_default_offer_code_applied).to be true
+    end
+
+    it "does not set the flag when using a different offer code" do
+      other_offer_code = create(:offer_code, products: [product], code: "OTHER", amount_cents: 100)
+      purchase = build(:purchase, link: product, offer_code: other_offer_code)
+      purchase.send(:set_price_and_rate)
+
+      expect(purchase.was_default_offer_code_applied).to be_nil
+    end
+
+    it "does not set the flag when no offer code is used" do
+      purchase = build(:purchase, link: product, offer_code: nil)
+      purchase.send(:set_price_and_rate)
+
+      expect(purchase.was_default_offer_code_applied).to be_nil
+    end
+  end
 end

--- a/spec/presenters/product_presenter/card_spec.rb
+++ b/spec/presenters/product_presenter/card_spec.rb
@@ -115,4 +115,82 @@ describe ProductPresenter::Card do
       )
     end
   end
+
+  describe "default_offer_code in for_web" do
+    let(:offer_code) { create(:offer_code, products: [product], amount_cents: 200) }
+
+    context "when product has a default offer code" do
+      before do
+        product.update!(default_offer_code: offer_code)
+      end
+
+      it "includes the discounted price" do
+        data = described_class.new(product:).for_web
+
+        expect(data[:price_cents]).to eq(product.price_cents - 200)
+        expect(data[:original_price_cents]).to eq(product.price_cents)
+      end
+
+      it "includes the offer code in the URL" do
+        data = described_class.new(product:).for_web
+
+        expect(data[:url]).to include("code=#{offer_code.code}")
+      end
+    end
+
+    context "when explicit offer_code param is provided" do
+      let(:other_offer_code) { create(:offer_code, products: [product], code: "OTHER", amount_cents: 100) }
+
+      before do
+        product.update!(default_offer_code: offer_code)
+      end
+
+      it "uses the explicit offer code over the default" do
+        data = described_class.new(product:).for_web(offer_code: other_offer_code.code)
+
+        expect(data[:price_cents]).to eq(product.price_cents - 100)
+        expect(data[:original_price_cents]).to eq(product.price_cents)
+        expect(data[:url]).to include("code=#{other_offer_code.code}")
+      end
+    end
+
+    context "when product has no default offer code" do
+      it "does not include original_price_cents" do
+        data = described_class.new(product:).for_web
+
+        expect(data).not_to have_key(:original_price_cents)
+        expect(data[:price_cents]).to eq(product.price_cents)
+      end
+    end
+
+    context "when default offer code is expired" do
+      before do
+        product.update!(default_offer_code: offer_code)
+        offer_code.update!(expires_at: 1.day.ago)
+      end
+
+      it "does not apply the discount" do
+        data = described_class.new(product:).for_web
+
+        expect(data).not_to have_key(:original_price_cents)
+        expect(data[:price_cents]).to eq(product.price_cents)
+      end
+    end
+
+    context "with percentage discount" do
+      let(:percent_offer_code) { create(:offer_code, products: [product], amount_percentage: 25) }
+
+      before do
+        product.update!(default_offer_code: percent_offer_code)
+      end
+
+      it "calculates the correct discounted price" do
+        data = described_class.new(product:).for_web
+
+        expected_discount = (product.price_cents * 0.25).to_i
+        expect(data[:price_cents]).to eq(product.price_cents - expected_discount)
+        expect(data[:original_price_cents]).to eq(product.price_cents)
+      end
+    end
+  end
 end

--- a/spec/presenters/product_presenter/product_props_spec.rb
+++ b/spec/presenters/product_presenter/product_props_spec.rb
@@ -565,5 +565,55 @@ describe ProductPresenter::ProductProps do
         expect(props[:audio_previews_enabled]).to be(true)
       end
     end
+
+    context "with default offer code" do
+      let(:product) { create(:product, price_cents: 1000) }
+      let(:offer_code) { create(:offer_code, products: [product], amount_cents: 200) }
+
+      before do
+        product.update!(default_offer_code: offer_code)
+      end
+
+      it "uses the default offer code when no discount_code param is provided" do
+        props = described_class.new(product:).props(seller_custom_domain_url: nil, request:, pundit_user: nil)
+
+        expect(props[:discount_code]).to include(
+          valid: true,
+          code: offer_code.code
+        )
+      end
+
+      it "uses the explicit discount_code param over the default offer code" do
+        other_offer_code = create(:offer_code, products: [product], code: "OTHER", amount_cents: 100)
+
+        props = described_class.new(product:).props(
+          seller_custom_domain_url: nil,
+          request:,
+          pundit_user: nil,
+          discount_code: other_offer_code.code
+        )
+
+        expect(props[:discount_code]).to include(
+          valid: true,
+          code: other_offer_code.code
+        )
+      end
+
+      it "does not apply the default offer code if it is expired" do
+        offer_code.update!(expires_at: 1.day.ago)
+
+        props = described_class.new(product:).props(seller_custom_domain_url: nil, request:, pundit_user: nil)
+
+        expect(props[:discount_code]).to be_nil
+      end
+
+      it "does not apply the default offer code if it is deleted" do
+        offer_code.mark_deleted!
+
+        props = described_class.new(product:).props(seller_custom_domain_url: nil, request:, pundit_user: nil)
+
+        expect(props[:discount_code]).to be_nil
+      end
+    end
   end
 end

--- a/spec/presenters/product_presenter_spec.rb
+++ b/spec/presenters/product_presenter_spec.rb
@@ -999,4 +999,44 @@ describe ProductPresenter do
       expect(presenter.existing_files).to eq(product_files)
     end
   end
+
+  describe "default_offer_code in edit_props" do
+    let(:seller) { create(:user) }
+    let(:product) { create(:product, user: seller) }
+    let(:offer_code) { create(:offer_code, products: [product], amount_cents: 200) }
+    let(:presenter) { described_class.new(product: product) }
+
+    it "includes default_offer_code_id when set" do
+      product.update!(default_offer_code: offer_code)
+      props = presenter.edit_props
+
+      expect(props[:product][:default_offer_code_id]).to eq(offer_code.external_id)
+    end
+
+    it "returns nil for default_offer_code_id when not set" do
+      props = presenter.edit_props
+
+      expect(props[:product][:default_offer_code_id]).to be_nil
+    end
+
+    it "includes available_offer_codes for the product" do
+      offer_code # create the offer code
+      props = presenter.edit_props
+
+      expect(props[:available_offer_codes]).to include(
+        hash_including(
+          id: offer_code.external_id,
+          code: offer_code.code,
+          discount: { type: "cents", value: 200 }
+        )
+      )
+    end
+
+    it "excludes inactive offer codes from available_offer_codes" do
+      offer_code.update!(expires_at: 1.day.ago)
+      props = presenter.edit_props
+
+      expect(props[:available_offer_codes]).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Implements the ability for sellers to set a default/auto-applied discount code on a product, as requested in #2053. When set, the discounted price is automatically shown everywhere and purchases using it are tracked for analytics.

## Changes

### Backend
- **Migration**: Add `default_offer_code_id` foreign key to `links` table
- **Link model**: Add `belongs_to :default_offer_code` association with validation to ensure the code is applicable, has matching currency, and valid amount
- **Link model**: Add `effective_offer_code(explicit_code:)` method - returns URL code if provided, otherwise the default
- **Link model**: Add `discounted_price_cents_with_default_offer_code` method for calculating discounted prices
- **Purchase model**: Track `was_default_offer_code_applied` for analytics

### Presenters
- **ProductPresenter::Card**: Include discounted prices and `original_price_cents` for strikethrough display
- **ProductPresenter::ProductProps**: Use default offer code as fallback when no explicit code is provided
- **ProductPresenter**: Add `available_offer_codes` and `default_offer_code_id` to edit_props

### Frontend
- **DefaultDiscountSelector component**: Radio buttons (No discount / Apply discount code) with dropdown to select from available offer codes
- **ProductTab**: Integrated the selector in the Pricing section

## How it works

1. Seller goes to product edit page → Pricing section
2. Selects "Apply discount code" and chooses from available offer codes
3. The selected discount is automatically applied when customers view the product
4. URL-provided discount codes still take priority over the default
5. Purchases using the default code are tracked with `was_default_offer_code_applied` flag

## Testing

Added comprehensive tests for:
- Link model (association, validation, helper methods)
- Purchase model (tracking flag)
- ProductPresenter::Card (discounted prices)
- ProductPresenter::ProductProps (fallback logic)
- ProductPresenter (edit_props)
- LinksController (update action)

Closes #2053