### PR TITLE
Add PayPal dispute evidence submission

### DIFF
--- a/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
+++ b/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
@@ -577,6 +577,195 @@ class PaypalChargeProcessor
     HolderOfFunds::GUMROAD
   end
 
+  def fight_chargeback(paypal_capture_id, dispute_evidence, merchant_account: nil)
+    dispute = dispute_evidence.dispute
+    paypal_dispute_id = dispute.charge_processor_dispute_id
+
+    return if paypal_dispute_id.blank?
+
+    paypal_rest_api = PaypalRestApi.new
+    evidences = build_paypal_evidences(dispute_evidence, dispute)
+
+    api_response = paypal_rest_api.provide_evidence(
+      dispute_id: paypal_dispute_id,
+      evidences: evidences
+    )
+
+    PaypalChargeProcessor.log_paypal_api_response("Provide Dispute Evidence", paypal_dispute_id, api_response)
+
+    unless paypal_rest_api.successful_response?(api_response)
+      error_message = PaypalChargeProcessor.build_error_message(
+        "Failed to submit dispute evidence for #{paypal_dispute_id}",
+        api_response.result&.message || api_response.result.to_s
+      )
+      raise ChargeProcessorInvalidRequestError, error_message
+    end
+
+    api_response
+  end
+
+  EVIDENCE_TYPE_MAPPING = {
+    Dispute::REASON_PRODUCT_NOT_RECEIVED => "PROOF_OF_FULFILLMENT",
+    Dispute::REASON_PRODUCT_UNACCEPTABLE => "PROOF_OF_FULFILLMENT",
+    Dispute::REASON_CREDIT_NOT_PROCESSED => "PROOF_OF_REFUND",
+    Dispute::REASON_SUBSCRIPTION_CANCELED => "PROOF_OF_FULFILLMENT",
+    Dispute::REASON_DUPLICATE => "OTHER",
+    Dispute::REASON_FRAUDULENT => "OTHER",
+    Dispute::REASON_UNRECOGNIZED => "OTHER",
+    Dispute::REASON_GENERAL => "OTHER"
+  }.freeze
+
+  PAYPAL_CARRIER_MAPPING = {
+    "ups" => "UPS",
+    "usps" => "USPS",
+    "fedex" => "FEDEX",
+    "dhl" => "DHL",
+    "dhl_express" => "DHL",
+    "royal_mail" => "ROYAL_MAIL",
+    "canada_post" => "CANADA_POST",
+    "australia_post" => "AUSTRALIA_POST"
+  }.freeze
+
+  def build_paypal_evidences(dispute_evidence, dispute)
+    evidences = []
+
+    primary_evidence = build_primary_evidence(dispute_evidence, dispute)
+    evidences << primary_evidence if primary_evidence
+
+    supporting_notes = build_comprehensive_notes(dispute_evidence)
+    if supporting_notes.present?
+      evidences << { evidence_type: "OTHER", notes: supporting_notes.truncate(2000) }
+    end
+
+    evidences
+  end
+
+  def build_primary_evidence(dispute_evidence, dispute)
+    evidence_type = EVIDENCE_TYPE_MAPPING[dispute.reason] || "OTHER"
+
+    case evidence_type
+    when "PROOF_OF_FULFILLMENT"
+      build_fulfillment_evidence(dispute_evidence)
+    when "PROOF_OF_REFUND"
+      build_refund_evidence(dispute_evidence)
+    else
+      build_general_evidence(dispute_evidence)
+    end
+  end
+
+  def build_fulfillment_evidence(dispute_evidence)
+    evidence = { evidence_type: "PROOF_OF_FULFILLMENT" }
+
+    if dispute_evidence.shipping_tracking_number.present?
+      carrier = normalize_carrier_name(dispute_evidence.shipping_carrier)
+      evidence[:evidence_info] = {
+        tracking_info: [{
+          carrier_name: carrier,
+          carrier_name_other: carrier == "OTHER" ? dispute_evidence.shipping_carrier : nil,
+          tracking_number: dispute_evidence.shipping_tracking_number
+        }.compact]
+      }
+    end
+
+    if dispute_evidence.access_activity_log.present?
+      evidence[:notes] = "Digital product delivery confirmed. #{dispute_evidence.access_activity_log}".truncate(2000)
+    elsif dispute_evidence.product_description.present?
+      evidence[:notes] = "Product/service delivered: #{dispute_evidence.product_description}".truncate(2000)
+    end
+
+    evidence
+  end
+
+  def build_refund_evidence(dispute_evidence)
+    {
+      evidence_type: "PROOF_OF_REFUND",
+      notes: [
+        dispute_evidence.refund_refusal_explanation,
+        "Refund policy: #{dispute_evidence.refund_policy_disclosure}"
+      ].compact.join("\n\n").truncate(2000)
+    }
+  end
+
+  def build_general_evidence(dispute_evidence)
+    notes = [
+      dispute_evidence.reason_for_winning,
+      dispute_evidence.uncategorized_text
+    ].compact.join("\n\n")
+
+    {
+      evidence_type: "OTHER",
+      notes: notes.truncate(2000)
+    }
+  end
+
+  def normalize_carrier_name(carrier)
+    return "OTHER" if carrier.blank?
+
+    normalized = PAYPAL_CARRIER_MAPPING[carrier.to_s.downcase.strip]
+    normalized || "OTHER"
+  end
+
+  def build_comprehensive_notes(dispute_evidence)
+    sections = []
+
+    if dispute_evidence.customer_name.present? || dispute_evidence.customer_email.present?
+      sections << "CUSTOMER INFORMATION:"
+      sections << "Name: #{dispute_evidence.customer_name}" if dispute_evidence.customer_name.present?
+      sections << "Email: #{dispute_evidence.customer_email}" if dispute_evidence.customer_email.present?
+      sections << "Purchase IP: #{dispute_evidence.customer_purchase_ip}" if dispute_evidence.customer_purchase_ip.present?
+    end
+
+    if dispute_evidence.product_description.present?
+      sections << "\nPRODUCT/SERVICE:"
+      sections << dispute_evidence.product_description
+    end
+
+    if dispute_evidence.billing_address.present?
+      sections << "\nBILLING ADDRESS:"
+      sections << dispute_evidence.billing_address
+    end
+
+    if dispute_evidence.shipping_address.present? || dispute_evidence.shipping_tracking_number.present?
+      sections << "\nSHIPPING INFORMATION:"
+      sections << "Address: #{dispute_evidence.shipping_address}" if dispute_evidence.shipping_address.present?
+      sections << "Carrier: #{dispute_evidence.shipping_carrier}" if dispute_evidence.shipping_carrier.present?
+      sections << "Tracking: #{dispute_evidence.shipping_tracking_number}" if dispute_evidence.shipping_tracking_number.present?
+      sections << "Shipped: #{dispute_evidence.shipped_at}" if dispute_evidence.shipped_at.present?
+    end
+
+    if dispute_evidence.access_activity_log.present?
+      sections << "\nACCESS ACTIVITY LOG:"
+      sections << dispute_evidence.access_activity_log
+    end
+
+    if dispute_evidence.refund_policy_disclosure.present?
+      sections << "\nREFUND POLICY DISCLOSURE:"
+      sections << dispute_evidence.refund_policy_disclosure
+    end
+
+    if dispute_evidence.cancellation_policy_disclosure.present?
+      sections << "\nCANCELLATION POLICY DISCLOSURE:"
+      sections << dispute_evidence.cancellation_policy_disclosure
+    end
+
+    if dispute_evidence.reason_for_winning.present?
+      sections << "\nMERCHANT STATEMENT:"
+      sections << dispute_evidence.reason_for_winning
+    end
+
+    if dispute_evidence.cancellation_rebuttal.present?
+      sections << "\nCANCELLATION REBUTTAL:"
+      sections << dispute_evidence.cancellation_rebuttal
+    end
+
+    if dispute_evidence.refund_refusal_explanation.present?
+      sections << "\nREFUND REFUSAL EXPLANATION:"
+      sections << dispute_evidence.refund_refusal_explanation
+    end
+
+    sections.join("\n")
+  end
+
   def transaction_url(charge_id)
     sub_domain = Rails.env.production? ? "history" : "sandbox"
     "https://#{sub_domain}.paypal.com/us/cgi-bin/webscr?cmd=_history-details-from-hub&id=#{charge_id}"

--- a/app/business/payments/charging/implementations/paypal/paypal_rest_api.rb
+++ b/app/business/payments/charging/implementations/paypal/paypal_rest_api.rb
@@ -127,7 +127,23 @@ class PaypalRestApi
     (200...300).include?(api_response.status_code)
   end
 
+  # Dispute Management API Methods
+  # https://developer.paypal.com/docs/api/customer-disputes/v1/
+
+  def get_dispute(dispute_id:)
+    @request = new_request(path: "/v1/customer/disputes/#{dispute_id}", verb: "GET")
+    execute_request
+  end
+
+  def provide_evidence(dispute_id:, evidences:)
+    @request = new_request(path: "/v1/customer/disputes/#{dispute_id}/provide-evidence", verb: "POST")
+    @request.headers["PayPal-Request-Id"] = "provide-evidence-#{dispute_id}-#{timestamp}"
+    @request.body = { evidences: evidences }
+    execute_request
+  end
+
   private
+
     def purchase_unit(purchase_unit_info)
       currency = purchase_unit_info[:currency]
 

--- a/app/models/concerns/charge/disputable.rb
+++ b/app/models/concerns/charge/disputable.rb
@@ -225,9 +225,16 @@ module Charge::Disputable
   end
 
   def eligible_for_dispute_evidence?
-    return false unless charge_processor == StripeChargeProcessor.charge_processor_id
-    return false if merchant_account&.is_a_stripe_connect_account?
-    true
+    # Stripe disputes are eligible unless on Connect accounts
+    if charge_processor == StripeChargeProcessor.charge_processor_id
+      return false if merchant_account&.is_a_stripe_connect_account?
+      return true
+    end
+
+    # PayPal disputes are now eligible for automatic evidence submission
+    return true if charge_processor == PaypalChargeProcessor.charge_processor_id
+
+    false
   end
 
   def fight_chargeback

--- a/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
@@ -1532,4 +1532,219 @@ describe PaypalChargeProcessor, :vcr do
       expect(PaypalChargeProcessor.formatted_amount_for_paypal(1644, "jpy").class).to eq(Integer)
     end
   end
+
+  describe "#fight_chargeback" do
+    let(:processor) { described_class.new }
+    let(:purchase) { create(:purchase) }
+    let(:dispute) do
+      create(:dispute,
+        purchase: purchase,
+        charge_processor_dispute_id: "PP-D-12345",
+        reason: Dispute::REASON_PRODUCT_NOT_RECEIVED
+      )
+    end
+    let(:dispute_evidence) do
+      create(:dispute_evidence,
+        dispute: dispute,
+        customer_name: "John Doe",
+        customer_email: "john@example.com",
+        customer_purchase_ip: "192.168.1.1",
+        product_description: "Digital Product - Online Course",
+        billing_address: "123 Main St, City, State 12345",
+        shipping_address: "456 Oak Ave, Town, State 67890",
+        shipping_carrier: "ups",
+        shipping_tracking_number: "1Z999AA10123456784",
+        refund_policy_disclosure: "30-day refund policy displayed at checkout",
+        reason_for_winning: "Customer accessed the product 15 times after purchase"
+      )
+    end
+    let(:paypal_rest_api) { instance_double(PaypalRestApi) }
+
+    before do
+      allow(PaypalRestApi).to receive(:new).and_return(paypal_rest_api)
+    end
+
+    context "when dispute has no charge_processor_dispute_id" do
+      before do
+        dispute.update!(charge_processor_dispute_id: nil)
+      end
+
+      it "returns early without submitting evidence" do
+        expect(paypal_rest_api).not_to receive(:provide_evidence)
+        processor.fight_chargeback("capture_123", dispute_evidence)
+      end
+    end
+
+    context "when evidence submission succeeds" do
+      let(:success_response) do
+        OpenStruct.new(
+          status_code: 200,
+          result: OpenStruct.new(links: []),
+          headers: {}
+        )
+      end
+
+      before do
+        allow(paypal_rest_api).to receive(:successful_response?).and_return(true)
+        allow(paypal_rest_api).to receive(:provide_evidence).and_return(success_response)
+      end
+
+      it "submits evidence to PayPal" do
+        expect(paypal_rest_api).to receive(:provide_evidence).with(
+          dispute_id: "PP-D-12345",
+          evidences: array_including(
+            hash_including(evidence_type: "PROOF_OF_FULFILLMENT")
+          )
+        )
+
+        processor.fight_chargeback("capture_123", dispute_evidence)
+      end
+
+      it "returns the API response" do
+        result = processor.fight_chargeback("capture_123", dispute_evidence)
+        expect(result).to eq(success_response)
+      end
+    end
+
+    context "when evidence submission fails" do
+      let(:error_response) do
+        OpenStruct.new(
+          status_code: 400,
+          result: OpenStruct.new(message: "Invalid evidence format"),
+          headers: {}
+        )
+      end
+
+      before do
+        allow(paypal_rest_api).to receive(:successful_response?).and_return(false)
+        allow(paypal_rest_api).to receive(:provide_evidence).and_return(error_response)
+      end
+
+      it "raises ChargeProcessorInvalidRequestError" do
+        expect {
+          processor.fight_chargeback("capture_123", dispute_evidence)
+        }.to raise_error(ChargeProcessorInvalidRequestError)
+      end
+    end
+
+  end
+
+  describe "#build_paypal_evidences" do
+    let(:processor) { described_class.new }
+    let(:purchase) { create(:purchase) }
+
+    context "for PRODUCT_NOT_RECEIVED disputes" do
+      let(:dispute) do
+        build(:dispute, purchase: purchase, reason: Dispute::REASON_PRODUCT_NOT_RECEIVED)
+      end
+      let(:dispute_evidence) do
+        build(:dispute_evidence,
+          dispute: dispute,
+          shipping_carrier: "fedex",
+          shipping_tracking_number: "123456789"
+        )
+      end
+
+      it "builds PROOF_OF_FULFILLMENT evidence with tracking info" do
+        evidences = processor.send(:build_paypal_evidences, dispute_evidence, dispute)
+        primary = evidences.first
+
+        expect(primary[:evidence_type]).to eq("PROOF_OF_FULFILLMENT")
+        expect(primary[:evidence_info][:tracking_info].first[:carrier_name]).to eq("FEDEX")
+        expect(primary[:evidence_info][:tracking_info].first[:tracking_number]).to eq("123456789")
+      end
+    end
+
+    context "for CREDIT_NOT_PROCESSED disputes" do
+      let(:dispute) do
+        build(:dispute, purchase: purchase, reason: Dispute::REASON_CREDIT_NOT_PROCESSED)
+      end
+      let(:dispute_evidence) do
+        build(:dispute_evidence,
+          dispute: dispute,
+          refund_refusal_explanation: "Refund was already processed",
+          refund_policy_disclosure: "30-day policy"
+        )
+      end
+
+      it "builds PROOF_OF_REFUND evidence" do
+        evidences = processor.send(:build_paypal_evidences, dispute_evidence, dispute)
+        primary = evidences.first
+
+        expect(primary[:evidence_type]).to eq("PROOF_OF_REFUND")
+        expect(primary[:notes]).to include("Refund was already processed")
+      end
+    end
+
+    context "for FRAUDULENT disputes" do
+      let(:dispute) do
+        build(:dispute, purchase: purchase, reason: Dispute::REASON_FRAUDULENT)
+      end
+      let(:dispute_evidence) do
+        build(:dispute_evidence,
+          dispute: dispute,
+          reason_for_winning: "Customer verified purchase via email"
+        )
+      end
+
+      it "builds OTHER evidence type" do
+        evidences = processor.send(:build_paypal_evidences, dispute_evidence, dispute)
+        primary = evidences.first
+
+        expect(primary[:evidence_type]).to eq("OTHER")
+        expect(primary[:notes]).to include("Customer verified purchase via email")
+      end
+    end
+  end
+
+  describe "#normalize_carrier_name" do
+    let(:processor) { described_class.new }
+
+    it "normalizes known carriers to PayPal format" do
+      expect(processor.send(:normalize_carrier_name, "ups")).to eq("UPS")
+      expect(processor.send(:normalize_carrier_name, "fedex")).to eq("FEDEX")
+      expect(processor.send(:normalize_carrier_name, "usps")).to eq("USPS")
+      expect(processor.send(:normalize_carrier_name, "dhl")).to eq("DHL")
+      expect(processor.send(:normalize_carrier_name, "dhl_express")).to eq("DHL")
+    end
+
+    it "returns OTHER for unknown carriers" do
+      expect(processor.send(:normalize_carrier_name, "random_carrier")).to eq("OTHER")
+      expect(processor.send(:normalize_carrier_name, nil)).to eq("OTHER")
+      expect(processor.send(:normalize_carrier_name, "")).to eq("OTHER")
+    end
+  end
+
+  describe "#build_comprehensive_notes" do
+    let(:processor) { described_class.new }
+    let(:dispute_evidence) do
+      build(:dispute_evidence,
+        customer_name: "John Doe",
+        customer_email: "john@example.com",
+        customer_purchase_ip: "192.168.1.1",
+        product_description: "Online Course",
+        billing_address: "123 Main St",
+        shipping_address: "456 Oak Ave",
+        shipping_carrier: "ups",
+        shipping_tracking_number: "1Z123",
+        access_activity_log: "Accessed 15 times",
+        refund_policy_disclosure: "30-day policy",
+        reason_for_winning: "Customer used the product"
+      )
+    end
+
+    it "builds comprehensive notes with all sections" do
+      notes = processor.send(:build_comprehensive_notes, dispute_evidence)
+
+      expect(notes).to include("CUSTOMER INFORMATION:")
+      expect(notes).to include("John Doe")
+      expect(notes).to include("john@example.com")
+      expect(notes).to include("PRODUCT/SERVICE:")
+      expect(notes).to include("Online Course")
+      expect(notes).to include("SHIPPING INFORMATION:")
+      expect(notes).to include("1Z123")
+      expect(notes).to include("ACCESS ACTIVITY LOG:")
+      expect(notes).to include("MERCHANT STATEMENT:")
+    end
+  end
 end

--- a/spec/business/payments/charging/implementations/paypal/paypal_rest_api_spec.rb
+++ b/spec/business/payments/charging/implementations/paypal/paypal_rest_api_spec.rb
@@ -396,4 +396,51 @@ describe PaypalRestApi, :vcr do
       end
     end
   end
+
+  describe "#get_dispute" do
+    let(:api_object) { described_class.new }
+    let(:dispute_id) { "PP-D-12345" }
+
+    it "makes a GET request to the disputes endpoint" do
+      expect(api_object).to receive(:execute_request)
+      expect(api_object).to receive(:new_request).with(
+        path: "/v1/customer/disputes/#{dispute_id}",
+        verb: "GET"
+      ).and_call_original
+
+      api_object.get_dispute(dispute_id: dispute_id)
+    end
+  end
+
+  describe "#provide_evidence" do
+    let(:api_object) { described_class.new }
+    let(:dispute_id) { "PP-D-12345" }
+    let(:evidences) do
+      [{ evidence_type: "PROOF_OF_FULFILLMENT", notes: "Package delivered" }]
+    end
+
+    it "makes a POST request to provide-evidence endpoint" do
+      expect(api_object).to receive(:execute_request)
+
+      api_object.provide_evidence(dispute_id: dispute_id, evidences: evidences)
+    end
+
+    it "includes evidences in the request body" do
+      allow(api_object).to receive(:execute_request)
+
+      api_object.provide_evidence(dispute_id: dispute_id, evidences: evidences)
+
+      request = api_object.instance_variable_get(:@request)
+      expect(request.body).to eq({ evidences: evidences })
+    end
+
+    it "sets the correct path" do
+      allow(api_object).to receive(:execute_request)
+
+      api_object.provide_evidence(dispute_id: dispute_id, evidences: evidences)
+
+      request = api_object.instance_variable_get(:@request)
+      expect(request.path).to eq("/v1/customer/disputes/#{dispute_id}/provide-evidence")
+    end
+  end
 end

--- a/spec/models/concerns/charge/disputable_spec.rb
+++ b/spec/models/concerns/charge/disputable_spec.rb
@@ -1137,8 +1137,8 @@ describe Charge::Disputable, :vcr do
     context "when processor is PayPal" do
       before { purchase.update!(charge_processor_id: PaypalChargeProcessor.charge_processor_id) }
 
-      it "returns false" do
-        expect(purchase.eligible_for_dispute_evidence?).to be(false)
+      it "returns true for PayPal disputes (automatic evidence submission now supported)" do
+        expect(purchase.eligible_for_dispute_evidence?).to be(true)
       end
     end
 


### PR DESCRIPTION
Closes #876

## Summary
Enables automatic dispute evidence submission for PayPal transactions, matching the existing Stripe functionality.

## Changes
- `PaypalChargeProcessor#fight_chargeback` - submits evidence to PayPal API
- `PaypalRestApi#provide_evidence` - calls PayPal Disputes API v1
- `eligible_for_dispute_evidence?` - now returns true for PayPal

## Implementation

**Evidence Type Mapping** - Maps dispute reasons to appropriate PayPal evidence types:
| Dispute Reason | Evidence Type |
|----------------|---------------|
| product_not_received | PROOF_OF_FULFILLMENT |
| product_unacceptable | PROOF_OF_FULFILLMENT |
| credit_not_processed | PROOF_OF_REFUND |
| subscription_canceled | PROOF_OF_FULFILLMENT |
| fraudulent/general | OTHER |

**Key Details:**
- Notes truncated to 2000 chars (PayPal's documented limit)
- Carrier names normalized to PayPal format (UPS, FEDEX, USPS, DHL, etc.)
- Builds comprehensive notes from all DisputeEvidence fields

## Testing
- API connectivity verified with PayPal sandbox credentials
- Endpoint format confirmed against PayPal documentation
- Syntax validated with Ruby 3.4.3
- All model field references verified against schema
- RSpec coverage for fight_chargeback, build_paypal_evidences, normalize_carrier_name

## Files Changed
- `app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb`
- `app/business/payments/charging/implementations/paypal/paypal_rest_api.rb`
- `app/models/concerns/charge/disputable.rb`
- `spec/` - corresponding test files

AI Disclosure: Claude assisted with implementation