### PR TITLE
[Fixed #865] Dev docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,13 @@ ci_scripts/
 docker/tmp/
 .env
 .env.*.local
+node_modules/
+public/packs/
+public/packs-test/
+public/assets/
+coverage/
+.sass-cache/
+*.swp
+*.swo
+*~
+.cache/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build_base build_base_test build build_nginx build_branch_app_nginx build_test build_staging build_production clean clean_local pull stop
+.PHONY: build_base build_base_test build build_nginx build_branch_app_nginx build_test build_staging build_production clean clean_local pull stop dev dev-build dev-down dev-logs dev-shell dev-clean-certs
 
 NEW_BASE_REPO ?= $(ECR_REGISTRY)/gumroad/web_base
 NEW_WEB_REPO ?= $(ECR_REGISTRY)/gumroad/web
@@ -18,6 +18,7 @@ AWS_CLI_DOCKER_IMAGE ?= garland/aws-cli-docker
 PUSH_ASSETS ?= false
 LOCAL_DETACHED ?= false
 LOCAL_DOCKER_COMPOSE_CONFIG = docker-compose-local.yml
+DEV_DOCKER_COMPOSE_CONFIG = docker-compose.dev.yml
 
 build_base:
 	: $${BUNDLE_GEMS__CONTRIBSYS__COM?"Need to set BUNDLE_GEMS__CONTRIBSYS__COM for sidekiq-pro"}
@@ -204,7 +205,29 @@ stop_local:
 	COMPOSE_PROJECT_NAME=$(COMPOSE_PROJECT_NAME) \
 		$(DOCKER_COMPOSE_CMD) -f docker/$(LOCAL_DOCKER_COMPOSE_CONFIG) down
 
+dev:
+	COMPOSE_PROJECT_NAME=$(COMPOSE_PROJECT_NAME) \
+		$(DOCKER_COMPOSE_CMD) -f docker/$(DEV_DOCKER_COMPOSE_CONFIG) up
 
+dev-build:
+	COMPOSE_PROJECT_NAME=$(COMPOSE_PROJECT_NAME) \
+		$(DOCKER_COMPOSE_CMD) -f docker/$(DEV_DOCKER_COMPOSE_CONFIG) build
+
+dev-down:
+	COMPOSE_PROJECT_NAME=$(COMPOSE_PROJECT_NAME) \
+		$(DOCKER_COMPOSE_CMD) -f docker/$(DEV_DOCKER_COMPOSE_CONFIG) down
+
+dev-logs:
+	COMPOSE_PROJECT_NAME=$(COMPOSE_PROJECT_NAME) \
+		$(DOCKER_COMPOSE_CMD) -f docker/$(DEV_DOCKER_COMPOSE_CONFIG) logs -f
+
+dev-shell:
+	COMPOSE_PROJECT_NAME=$(COMPOSE_PROJECT_NAME) \
+		$(DOCKER_COMPOSE_CMD) -f docker/$(DEV_DOCKER_COMPOSE_CONFIG) exec web bash
+
+dev-clean-certs:
+	rm -f docker/local-nginx/certs/*.crt docker/local-nginx/certs/*.key
+	@echo "Certificates removed. They will be regenerated on next 'make dev'"
 
 stop:
 	COMPOSE_PROJECT_NAME=$(COMPOSE_PROJECT_NAME) \

--- a/README.md
+++ b/README.md
@@ -34,21 +34,9 @@
 
 > 💡 If you're on Windows, follow our [Windows setup guide](docs/development/windows.md) instead.
 
-Before you begin, ensure you have the following installed:
-
-#### Ruby
-
-- https://www.ruby-lang.org/en/documentation/installation/
-- Install the version listed in [the .ruby-version file](./.ruby-version)
-
-#### Node.js
-
-- https://nodejs.org/en/download
-- Install the version listed in [the .node-version file](./.node-version)
+The only requirement is **Docker**. All dependencies (Ruby, Node.js, MySQL, Redis, etc.) run inside Docker containers.
 
 #### Docker
-
-We use Docker to setup the services for development environment.
 
 - For MacOS: Download the Docker app from the [Docker website](https://www.docker.com/products/docker-desktop)
 - For Linux:
@@ -58,104 +46,7 @@ sudo wget -qO- https://get.docker.com/ | sh
 sudo usermod -aG docker $(whoami)
 ```
 
-#### MySQL & Percona Toolkit
-
-Install a local version of MySQL 8.0.x to match the version running in production.
-
-The local version of MySQL is a dependency of the Ruby `mysql2` gem. You do not need to start an instance of the MySQL service locally. The app will connect to a MySQL instance running in the Docker container.
-
-- For MacOS:
-
-```bash
-brew install mysql@8.0 percona-toolkit
-brew link --force mysql@8.0
-
-# to use Homebrew's `openssl`:
-brew install openssl
-bundle config --global build.mysql2 --with-opt-dir="$(brew --prefix openssl)"
-
-# ensure MySQL is not running as a service
-brew services stop mysql@8.0
-```
-
-- For Linux:
-  - MySQL:
-    - https://dev.mysql.com/doc/refman/8.0/en/linux-installation.html
-    - `apt install libmysqlclient-dev`
-  - Percona Toolkit: https://www.percona.com/doc/percona-toolkit/LATEST/installation.html
-
-#### Image Processing Libraries
-
-##### ImageMagick
-
-We use `imagemagick` for preview editing.
-
-- For MacOS: `brew install imagemagick`
-- For Linux: `sudo apt-get install imagemagick`
-
-##### libvips
-
-For newer image formats we use `libvips` for image processing with ActiveStorage.
-
-- For MacOS: `brew install libvips`
-- For Linux: `sudo apt-get install libvips-dev`
-
-#### FFmpeg
-
-We use `ffprobe` that comes with `FFmpeg` package to fetch metadata from video files.
-
-- For MacOS: `brew install ffmpeg`
-- For Linux: `sudo apt-get install ffmpeg`
-
-#### PDFtk
-
-We use [pdftk](https://www.pdflabs.com/tools/pdftk-server/) to stamp PDF files with the Gumroad logo and the buyers' emails.
-
-- For MacOS: Download from [here](https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/pdftk_server-2.02-mac_osx-10.11-setup.pkg)
-  - **Note:** pdftk may be blocked by Apple's firewall. If this happens, go to Settings > Privacy & Security and click "Open Anyways" to allow the installation.
-- For Linux: `sudo apt-get install pdftk`
-
-#### wkhtmltopdf
-
-While generating invoices, to convert HTML to PDF, PDFKit expects [wkhtmltopdf](https://wkhtmltopdf.org/) to be installed on your system. [Download](https://wkhtmltopdf.org/downloads.html) and install the version 0.12.6 for your platform.
-
-- **Note** similar to pdftk, this may also be blocked by Apple's firewall on MacOS. Follow a similar process as above.
-
-### Installation
-
-#### Bundler and gems
-
-We use Bundler to install Ruby gems.
-
-```shell
-gem install bundler
-```
-
-Install gems:
-
-```shell
-bundle install
-```
-
-Also make sure to install `dotenv` as it is required for some console commands:
-
-```shell
-gem install dotenv
-```
-
-#### npm and Node.js dependencies
-
-Make sure the correct version of `npm` is enabled:
-
-```shell
-corepack enable
-```
-
-Install dependencies:
-
-```shell
-npm install
-```
+If you are on Linux, or installed Docker via a package manager on a mac, you may need to manually give docker superuser access to open ports 80 and 443. To do that, use `sudo` with the commands below.
 
 ### Configuration
 
@@ -163,56 +54,69 @@ npm install
 
 App can be booted without any custom credentials. But if you would like to use services that require custom credentials (e.g. S3, Stripe, Resend, etc.), you can copy the `.env.example` file to `.env` and fill in the values.
 
-#### Local SSL Certificates
+#### SSL Certificates
 
-1. Install mkcert on macOS:
+SSL certificates are **automatically generated** inside Docker containers when you first run the development environment. The certificates are self-signed, which means:
 
-```shell
-brew install mkcert
+- Browsers will show a security warning when you first visit `https://gumroad.dev`
+- This is normal and expected for development environments
+- To proceed, click "Advanced" → "Proceed to gumroad.dev" (or similar option in your browser)
+- You may need to accept the certificate once per browser
+
+If you need to regenerate certificates, run:
+
+```bash
+make dev-clean-certs
 ```
 
-For other operating systems, see [mkcert installation instructions](https://github.com/FiloSottile/mkcert?tab=readme-ov-file#installation).
-
-2. Generate certificates by running:
-
-```shell
-bin/generate_ssl_certificates
-```
+Then restart the development environment.
 
 ### Running Locally
 
-#### Start Docker services
+#### First-time setup
 
-If you installed Docker Desktop (on a Mac or Windows machine), you can run the following command to start the Docker services:
+Build the development Docker images:
 
-```shell
-make local
+```bash
+make dev-build
 ```
 
-If you are on Linux, or installed Docker via a package manager on a mac, you may have to manually give docker superuser access to open ports 80 and 443. To do that, use `sudo make local` instead.
+This may take several minutes the first time as it downloads base images and installs dependencies.
 
-This command will not terminate. You run this in one tab and start the application in another tab.
-If you want to run Docker services in the background, use `LOCAL_DETACHED=true make local` instead.
+#### Start the development environment
 
-#### Set up the database
+Start all services (Rails, webpack, Sidekiq, AnyCable, databases, etc.):
 
-```shell
-bin/rails db:prepare
+```bash
+make dev
 ```
 
-For Linux (Debian / Ubuntu) you might need the following:
+This command will:
 
-- `apt install libxslt-dev libxml2-dev`
-
-#### Start the application
-
-```shell
-bin/dev
-```
-
-This starts the Rails server, the JavaScript build system, and a Sidekiq worker.
+- Automatically generate SSL certificates (if they don't exist)
+- Start all required services (MySQL, Redis, MongoDB, Elasticsearch, MinIO, etc.)
+- Start the Rails server, webpack dev server, Sidekiq, and AnyCable
+- Set up the database automatically
+- Run in the foreground (press Ctrl+C to stop)
 
 You can now access the application at `https://gumroad.dev`.
+
+#### Running in the background
+
+To run services in the background:
+
+```bash
+make dev-build
+docker compose -f docker/docker-compose.dev.yml up -d
+```
+
+To stop services:
+
+```bash
+make dev-down
+```
+
+For more information, see [Docker Development Guide](docs/development/docker.md).
 
 ## Development
 
@@ -244,14 +148,36 @@ INITIALIZE_RPUSH_APPS=true bundle exec rpush start -e development -f
 #### Rails console:
 
 ```shell
-bin/rails c
+make dev-shell
+# Then inside the container:
+bundle exec rails c
+```
+
+Or using docker compose directly:
+
+```shell
+docker compose -f docker/docker-compose.dev.yml exec web bundle exec rails c
 ```
 
 #### Rake tasks:
 
 ```shell
-bin/rake task_name
+docker compose -f docker/docker-compose.dev.yml exec web bundle exec rake task_name
 ```
+
+#### View logs:
+
+```shell
+make dev-logs
+```
+
+#### Access container shell:
+
+```shell
+make dev-shell
+```
+
+Read more about [dev docker](docs/development/docker.md).
 
 ### Linting
 

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,0 +1,73 @@
+# Development Dockerfile
+# Based on docker/base/Dockerfile but optimized for development
+
+ARG WEB_BASE_DOCKERFILE_FROM
+FROM ${WEB_BASE_DOCKERFILE_FROM}
+
+ENV BUNDLE_PATH=/bundle_path \
+  APP_DIR=/app
+
+# Use unicode
+ENV LANG=C.UTF-8
+
+# Setup app user, directories
+RUN useradd -ms /bin/bash app \
+  && mkdir -p $APP_DIR \
+  && mkdir -p $BUNDLE_PATH \
+  && mkdir -p $APP_DIR/log \
+  && mkdir -p $APP_DIR/tmp \
+  && mkdir -p /docker/dev \
+  && mkdir -p /certs
+
+# Copy certificate generation script
+COPY docker/dev/generate_certificates.sh /docker/dev/generate_certificates.sh
+RUN chmod +x /docker/dev/generate_certificates.sh
+
+# Install dependencies: netcat, git, gosu, imagemagick, Node.js, and build tools
+ARG GOSU_VERSION=1.10
+RUN apt-get update -y -qq \
+  && apt-get install -yq --no-install-recommends \
+  build-essential \
+  netcat-openbsd \
+  git \
+  imagemagick \
+  ca-certificates \
+  curl \
+  gnupg \
+  ruby-dev \
+  && curl -fsSL -o /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64" \
+  && chmod +x /usr/local/bin/gosu \
+  && mkdir -p /etc/apt/keyrings \
+  && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --batch --yes --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+  && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+  && apt-get update \
+  && apt-get install -y nodejs \
+  && corepack enable \
+  && apt-get clean autoclean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Copy Gemfile and install ALL gems (including dev/test)
+COPY Gemfile* .ruby-version $APP_DIR/
+ARG BUNDLE_GEMS__CONTRIBSYS__COM
+RUN cd $APP_DIR \
+  && gem install bundler:$(awk '/BUNDLED\ WITH/{getline; print}' Gemfile.lock | tr -d " ") \
+  && BUNDLE_GEMS__CONTRIBSYS__COM=${BUNDLE_GEMS__CONTRIBSYS__COM} bundle install
+
+# Set permissions
+RUN chmod -R 755 $BUNDLE_PATH \
+  && chmod -R 755 $APP_DIR \
+  && chmod -R 770 $APP_DIR/tmp \
+  && chmod -R 770 $APP_DIR/log \
+  && chown -R app:app $APP_DIR \
+  && chown -R root:app $BUNDLE_PATH
+
+# Update ImageMagick configuration (same as production)
+RUN sed -r 's/(name="memory" value=")[^"]+"/\11GiB"/' -i /etc/ImageMagick-6/policy.xml \
+  && sed -r 's/(name="disk" value=")[^"]+"/\18GiB"/' -i /etc/ImageMagick-6/policy.xml \
+  && sed -r 's/(name="width" value=")[^"]+"/\150KP"/' -i /etc/ImageMagick-6/policy.xml \
+  && sed -r 's/(name="height" value=")[^"]+"/\150KP"/' -i /etc/ImageMagick-6/policy.xml
+
+WORKDIR $APP_DIR
+
+# Default entrypoint (can be overridden in docker-compose)
+ENTRYPOINT ["/usr/local/bin/gosu", "app"]

--- a/docker/dev/entrypoint.sh
+++ b/docker/dev/entrypoint.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+
+# Generate SSL certificates if needed
+if [ "$GENERATE_CERTIFICATES" = "true" ]; then
+  echo "Checking SSL certificates..."
+  if [ ! -f "/certs/gumroad_dev.crt" ] || [ ! -f "/certs/gumroad_dev.key" ]; then
+    echo "Generating self-signed SSL certificates..."
+    /docker/dev/generate_certificates.sh
+  else
+    echo "SSL certificates already exist, skipping generation"
+  fi
+fi
+
+# Wait for database if needed
+if [ -n "$DATABASE_HOST" ]; then
+  echo "Waiting for database at $DATABASE_HOST:3306..."
+  until nc -z "$DATABASE_HOST" 3306 2>/dev/null; do
+    echo "Database not ready, waiting..."
+    sleep 1
+  done
+  echo "Database is ready"
+fi
+
+# Run database setup if needed
+if [ "$RUN_DB_SETUP" = "true" ]; then
+  echo "Setting up database..."
+  bundle exec rails db:prepare
+fi
+
+# Execute main command
+exec "$@"
+

--- a/docker/dev/generate_certificates.sh
+++ b/docker/dev/generate_certificates.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+set -e
+
+CERT_DIR="/certs"
+
+generate_cert() {
+  local domain=$1
+  local cert_file="${CERT_DIR}/${domain//\*/wildcard}_dev.crt"
+  local key_file="${CERT_DIR}/${domain//\*/wildcard}_dev.key"
+
+  # Skip if certificate already exists
+  if [ -f "$cert_file" ] && [ -f "$key_file" ]; then
+    echo "Certificate for $domain already exists, skipping..."
+    return 0
+  fi
+
+  echo "Generating self-signed certificate for $domain..."
+
+  # Generate private key
+  openssl genrsa -out "$key_file" 2048
+
+  # Create openssl config for SAN
+  local san_config="/tmp/san_${domain//\*/wildcard}.conf"
+  cat > "$san_config" <<EOF
+[req]
+distinguished_name = req_distinguished_name
+req_extensions = v3_req
+prompt = no
+
+[req_distinguished_name]
+CN = $domain
+O = Gumroad Development
+C = US
+
+[v3_req]
+keyUsage = keyEncipherment, dataEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = $domain
+EOF
+
+  # Add additional DNS entries for wildcard domains
+  if [[ "$domain" == *"*"* ]]; then
+    echo "DNS.2 = gumroad.dev" >> "$san_config"
+    echo "DNS.3 = helperai.dev" >> "$san_config"
+    echo "DNS.4 = *.gumroad.dev" >> "$san_config"
+    echo "DNS.5 = *.helperai.dev" >> "$san_config"
+  fi
+
+  # Generate certificate signing request and self-signed certificate
+  openssl req -new -key "$key_file" -out /tmp/cert.csr -config "$san_config"
+
+  # Generate self-signed certificate (valid for 1 year)
+  openssl x509 -req -days 365 -in /tmp/cert.csr -signkey "$key_file" -out "$cert_file" \
+    -extensions v3_req -extfile "$san_config"
+
+  rm -f /tmp/cert.csr "$san_config"
+  chmod 644 "$cert_file"
+  chmod 600 "$key_file"
+  echo "Certificate for $domain generated successfully"
+}
+
+# Create cert directory if it doesn't exist
+mkdir -p "$CERT_DIR"
+
+# Generate certificates for gumroad.dev domains
+generate_cert "gumroad.dev"
+generate_cert "*.gumroad.dev"
+
+# Generate certificates for helperai.dev domains
+generate_cert "helperai.dev"
+generate_cert "*.helperai.dev"
+
+# Create symlinks for nginx (gumroad_dev.crt/key)
+if [ ! -f "${CERT_DIR}/gumroad_dev.crt" ]; then
+  ln -sf "${CERT_DIR}/gumroad.dev_dev.crt" "${CERT_DIR}/gumroad_dev.crt"
+  ln -sf "${CERT_DIR}/gumroad.dev_dev.key" "${CERT_DIR}/gumroad_dev.key"
+fi
+
+if [ ! -f "${CERT_DIR}/helperai_dev.crt" ]; then
+  ln -sf "${CERT_DIR}/helperai.dev_dev.crt" "${CERT_DIR}/helperai_dev.crt"
+  ln -sf "${CERT_DIR}/helperai.dev_dev.key" "${CERT_DIR}/helperai_dev.key"
+fi
+
+echo "All certificates generated successfully in $CERT_DIR"
+

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,0 +1,339 @@
+# Development Docker Compose Configuration
+# All services run in Docker for consistent development environment
+
+x-app-build: &app-build
+  build:
+    context: ..
+    dockerfile: docker/dev/Dockerfile
+    args:
+      WEB_BASE_DOCKERFILE_FROM: ${WEB_BASE_DOCKERFILE_FROM:-ruby:3.4.3-slim-bullseye}
+      BUNDLE_GEMS__CONTRIBSYS__COM: ${BUNDLE_GEMS__CONTRIBSYS__COM:-}
+  environment:
+    DATABASE_HOST: db
+    DATABASE_NAME: gumroad_development
+    DATABASE_PORT: 3306
+    DATABASE_USERNAME: gumroad_development
+    DATABASE_PASSWORD: gumroad_development
+    PUMA_WORKING_DIRECTORY: /app
+    REDIS_HOST: redis:6379/0
+    SIDEKIQ_REDIS_HOST: redis:6379/1
+    RPUSH_REDIS_HOST: redis:6379/2
+    RACK_ATTACK_REDIS_HOST: redis:6379/3
+    RAILS_ENV: development
+    RACK_ENV: development
+    NODE_ENV: development
+    MONGO_DATABASE_URL: mongo:27017
+    MONGO_SECONDARY_DATABASE_URL: mongo:27017
+    MONGO_DATABASE_NAME: gumroad_log_development
+    MONGO_DATABASE_USERNAME: username
+    MONGO_DATABASE_PASSWORD: password
+    MONGO_REPLICA_SET: empty_replica_set
+    ELASTICSEARCH_HOST: http://elasticsearch:9200
+    MEMCACHE_SERVERS: memcached
+    IN_DOCKER: "true"
+
+services:
+  cert-generator:
+    <<: *app-build
+    volumes:
+      - ./local-nginx/certs:/certs
+    command: /docker/dev/generate_certificates.sh
+    restart: "no"
+    networks:
+      - default
+
+  db:
+    image: mysql:8.0.32
+    volumes:
+      - mysql_data:/var/lib/mysql
+    ports:
+      - "3306:3306"
+    environment:
+      - MYSQL_ROOT_PASSWORD=password
+    command:
+      - "mysqld"
+      - "--default-authentication-plugin=mysql_native_password"
+      - "--collation-server=utf8mb4_unicode_ci"
+      - "--character-set-server=utf8mb4"
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    networks:
+      - default
+
+  redis:
+    image: redis:7.0.7
+    command: ["redis-server", "--appendonly", "yes"]
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    networks:
+      - default
+
+  mongo:
+    image: mongo:3.6.16
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo_data:/data/db
+    command: "mongod --smallfiles"
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    networks:
+      - default
+
+  elasticsearch:
+    image: elasticsearch:7.9.3
+    ports:
+      - "9200:9200"
+    environment:
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - "discovery.type=single-node"
+    volumes:
+      - elasticsearch7data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:9200/_cluster/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks:
+      - default
+
+  minio:
+    image: minio/minio
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - minio_data:/data
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    command: server /data --console-address ":9001"
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+      start_period: 30s
+    networks:
+      - default
+
+  createbuckets:
+    image: minio/mc
+    depends_on:
+      minio:
+        condition: service_healthy
+      cert-generator:
+        condition: service_completed_successfully
+    entrypoint: >
+      /bin/sh -c " /usr/bin/mc alias set myminio http://minio:9000 minioadmin minioadmin; for bucket in gumroad-dev gumroad-specs gumroad-invoices gumroad-dev-public-storage; do
+        if ! /usr/bin/mc ls myminio/$$bucket > /dev/null 2>&1; then
+          echo \"Bucket $$bucket does not exist. Creating...\";
+          /usr/bin/mc mb myminio/$$bucket;
+          echo \"Setting public read policy for $$bucket\";
+          /usr/bin/mc anonymous set public myminio/$$bucket;
+        else
+          echo \"Bucket $$bucket already exists.\";
+        fi;
+        echo \"Enabling versioning for $$bucket\";
+        /usr/bin/mc version enable myminio/$$bucket;
+      done; exit 0; "
+    networks:
+      - default
+
+  copyfixturefiles:
+    image: minio/mc
+    depends_on:
+      createbuckets:
+        condition: service_completed_successfully
+    volumes:
+      - ../spec/support/fixtures:/fixtures:ro
+      - ./fixture-files-private.txt:/fixture-files-private.txt:ro
+      - ./fixture-files-public.txt:/fixture-files-public.txt:ro
+    entrypoint: >
+      /bin/sh -c " /usr/bin/mc alias set myminio http://minio:9000 minioadmin minioadmin > /dev/null 2>&1; echo \"Copying private fixture files to MinIO bucket...\"; while IFS= read -r file || [ -n \"$$file\" ]; do
+        [ -z \"$$file\" ] && continue;
+        if [ -f \"/fixtures/$$file\" ]; then
+          echo \"Copying '$$file' to gumroad-specs/specs/ (private)\";
+          /usr/bin/mc cp \"/fixtures/$$file\" \"myminio/gumroad-specs/specs/$$file\" > /dev/null 2>&1;
+        else
+          echo \"Error: '$$file' not found in fixtures directory\";
+          exit 1;
+        fi;
+      done < /fixture-files-private.txt; echo \"Copying public fixture files to MinIO bucket...\"; while IFS= read -r file || [ -n \"$$file\" ]; do
+        [ -z \"$$file\" ] && continue;
+        if [ -f \"/fixtures/$$file\" ]; then
+          echo \"Copying '$$file' to gumroad-specs/specs/ (public)\";
+          /usr/bin/mc cp \"/fixtures/$$file\" \"myminio/gumroad-specs/specs/$$file\" > /dev/null 2>&1;
+          echo \"Setting public-read ACL for '$$file'\";
+          /usr/bin/mc anonymous set download \"myminio/gumroad-specs/specs/$$file\" > /dev/null 2>&1;
+        else
+          echo \"Error: '$$file' not found in fixtures directory\";
+          exit 1;
+        fi;
+      done < /fixture-files-public.txt; echo \"Fixture files copied successfully\"; exit 0; "
+    networks:
+      - default
+
+  web:
+    <<: *app-build
+    volumes:
+      - ../:/app
+      - ./local-nginx/certs:/certs:ro
+    ports:
+      - "3000:3000"
+    environment:
+      GENERATE_CERTIFICATES: "false"
+      RUN_DB_SETUP: "true"
+    entrypoint: ["/docker/dev/entrypoint.sh"]
+    command: bundle exec rails server -b 0.0.0.0 -p 3000
+    depends_on:
+      cert-generator:
+        condition: service_completed_successfully
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:3000/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    networks:
+      - default
+
+  webpack:
+    <<: *app-build
+    volumes:
+      - ../:/app
+      - ./local-nginx/certs:/certs:ro
+    ports:
+      - "3035:3035"
+    environment:
+      GENERATE_CERTIFICATES: "false"
+    depends_on:
+      cert-generator:
+        condition: service_completed_successfully
+      web:
+        condition: service_started
+    command: sh -c "npm run setup && ./bin/shakapacker-dev-server"
+    networks:
+      - default
+
+  webpack-ssr:
+    <<: *app-build
+    volumes:
+      - ../:/app
+    environment:
+      GENERATE_CERTIFICATES: "false"
+    depends_on:
+      web:
+        condition: service_started
+    command: WEBPACK_SSR=true ./bin/shakapacker --watch
+    networks:
+      - default
+
+  sidekiq:
+    <<: *app-build
+    volumes:
+      - ../:/app
+    environment:
+      GENERATE_CERTIFICATES: "false"
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    command: RAILS_MAX_THREADS=5 USE_DB_WORKER_REPLICAS=true bundle exec sidekiq -q critical -q default -q low -q mongo
+    networks:
+      - default
+
+  anycable_rpc:
+    <<: *app-build
+    volumes:
+      - ../:/app
+    ports:
+      - "50051:50051"
+    environment:
+      GENERATE_CERTIFICATES: "false"
+      ANYCABLE_SECRET: anycable-local-secret
+      ANYCABLE_RPC_HOST: 0.0.0.0:50051
+    depends_on:
+      redis:
+        condition: service_healthy
+    command: bundle exec anycable
+    networks:
+      - default
+
+  anycable_ws:
+    <<: *app-build
+    volumes:
+      - ../:/app
+    ports:
+      - "8080:8080"
+    environment:
+      GENERATE_CERTIFICATES: "false"
+      ANYCABLE_HOST: cable.gumroad.dev
+      ANYCABLE_PORT: "8080"
+      ANYCABLE_RPC_HOST: anycable_rpc:50051
+      ANYCABLE_SECRET: anycable-local-secret
+      ANYCABLE_BROADCAST_ADAPTER: http,redisx
+      ANYCABLE_PUBSUB: redis
+      ANYCABLE_BROKER: memory
+      ANYCABLE_METRICS_PORT: "8080"
+      ANYCABLE_LOG_LEVEL: debug
+      ANYCABLE_DEBUG: "true"
+    depends_on:
+      anycable_rpc:
+        condition: service_started
+      redis:
+        condition: service_healthy
+    command: bin/anycable-go
+    networks:
+      - default
+
+  nginx:
+    image: nginx:1.23.3
+    volumes:
+      - ./local-nginx/gumroad_dev.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./local-nginx/helperai_dev.conf:/etc/nginx/conf.d/helperai_dev.conf:ro
+      - ./local-nginx/certs:/etc/ssl/certs:ro
+    ports:
+      - "80:80"
+      - "8081:8081"
+      - "443:443"
+    depends_on:
+      cert-generator:
+        condition: service_completed_successfully
+      web:
+        condition: service_started
+      anycable_ws:
+        condition: service_started
+    labels:
+      com.antiwork.helper.proxy: "true"
+    networks:
+      - default
+
+volumes:
+  elasticsearch7data:
+  mysql_data:
+  redis_data:
+  mongo_data:
+  minio_data:
+
+networks:
+  default:
+    name: ${COMPOSE_PROJECT_NAME:-web}_default

--- a/docker/local-nginx/gumroad_dev.conf
+++ b/docker/local-nginx/gumroad_dev.conf
@@ -1,5 +1,5 @@
 upstream app {
-  server host.docker.internal:3000;
+  server web:3000;
 }
 
 upstream next_app {
@@ -7,7 +7,7 @@ upstream next_app {
 }
 
 upstream anycable_ws {
-  server host.docker.internal:8080;
+  server anycable_ws:8080;
 }
 
 upstream minio {

--- a/docs/development/docker.md
+++ b/docs/development/docker.md
@@ -1,0 +1,339 @@
+# Docker Development Guide
+
+This guide covers the unified Docker development setup for Gumroad. All services run in Docker containers, providing a consistent development environment with zero local dependencies beyond Docker itself.
+
+## Overview
+
+The development environment consists of:
+
+- **Application services**: Rails server, webpack dev server, Sidekiq, AnyCable (RPC and WebSocket)
+- **Data services**: MySQL, Redis, MongoDB, Elasticsearch
+- **Storage**: MinIO (S3-compatible object storage)
+- **Proxy**: Nginx (reverse proxy with SSL termination)
+
+All services are defined in `docker/docker-compose.dev.yml` and can be managed with simple `make` commands.
+
+## Quick Start
+
+1. **Build development images** (first time only):
+
+   ```bash
+   make dev-build
+   ```
+
+2. **Start all services**:
+
+   ```bash
+   make dev
+   ```
+
+3. **Access the application**:
+   - Open `https://gumroad.dev` in your browser
+   - Accept the self-signed certificate warning (see [SSL Certificates](#ssl-certificates) below)
+
+That's it! The database is automatically set up, and all services are ready to use.
+
+## SSL Certificates
+
+### Automatic Generation
+
+SSL certificates are automatically generated inside Docker containers when you first run `make dev`. The certificates are:
+
+- **Self-signed** (not from a trusted Certificate Authority)
+- **Generated using openssl** (no external tools needed)
+- **Valid for 1 year**
+- **Stored in** `docker/local-nginx/certs/`
+
+### Browser Security Warnings
+
+Since the certificates are self-signed, browsers will show a security warning. This is **normal and expected** for development environments.
+
+**To proceed:**
+
+1. Click "Advanced" or "Show Details"
+2. Click "Proceed to gumroad.dev" (or similar option)
+3. The browser will remember your choice for future visits
+
+**Common browser messages:**
+
+- Chrome/Edge: "Your connection is not private" → "Advanced" → "Proceed to gumroad.dev (unsafe)"
+- Firefox: "Warning: Potential Security Risk Ahead" → "Advanced" → "Accept the Risk and Continue"
+- Safari: "This connection is not private" → "Show Details" → "visit this website"
+
+### Regenerating Certificates
+
+If you need to regenerate certificates:
+
+```bash
+make dev-clean-certs
+make dev
+```
+
+## Common Commands
+
+### Starting and Stopping
+
+```bash
+# Start all services (foreground)
+make dev
+
+# Start all services (background)
+make dev-build
+docker compose -f docker/docker-compose.dev.yml up -d
+
+# Stop all services
+make dev-down
+
+# View logs (all services)
+make dev-logs
+
+# View logs (specific service)
+docker compose -f docker/docker-compose.dev.yml logs -f web
+docker compose -f docker/docker-compose.dev.yml logs -f webpack
+```
+
+### Accessing Services
+
+```bash
+# Open a shell in the web container
+make dev-shell
+
+# Run Rails console
+docker compose -f docker/docker-compose.dev.yml exec web bundle exec rails c
+
+# Run Rake tasks
+docker compose -f docker/docker-compose.dev.yml exec web bundle exec rake task_name
+
+# Run database migrations
+docker compose -f docker/docker-compose.dev.yml exec web bundle exec rails db:migrate
+```
+
+### Rebuilding Images
+
+```bash
+# Rebuild all development images
+make dev-build
+
+# Rebuild a specific service
+docker compose -f docker/docker-compose.dev.yml build web
+```
+
+## Service Details
+
+### Application Services
+
+- **web**: Rails server on port 3000
+- **webpack**: Webpack dev server on port 3035 (HTTPS)
+- **webpack-ssr**: Webpack SSR watcher
+- **sidekiq**: Background job processor
+- **anycable_rpc**: AnyCable RPC server on port 50051
+- **anycable_ws**: AnyCable WebSocket server on port 8080
+
+### Data Services
+
+- **db**: MySQL 8.0.32 on port 3306
+- **redis**: Redis 7.0.7 on port 6379
+- **mongo**: MongoDB 3.6.16 on port 27017
+- **elasticsearch**: Elasticsearch 7.9.3 on port 9200
+
+### Storage
+
+- **minio**: MinIO S3-compatible storage
+  - API: `http://localhost:9000`
+  - Console: `http://localhost:9001` (minioadmin/minioadmin)
+
+### Proxy
+
+- **nginx**: Reverse proxy
+  - HTTP: `http://localhost:80` (redirects to HTTPS)
+  - HTTPS: `https://localhost:443`
+  - AnyCable: `https://localhost:8081`
+
+## Volume Mounts
+
+Code is mounted as volumes for hot reloading:
+
+- **Application code**: `/app` (mounted from repository root)
+- **SSL certificates**: `/certs` (mounted from `docker/local-nginx/certs/`)
+
+Changes to your code are immediately reflected in the containers without rebuilding.
+
+## Environment Variables
+
+Development environment variables are set in `docker/docker-compose.dev.yml`. Key variables:
+
+- `RAILS_ENV=development`
+- `DATABASE_HOST=db`
+- `REDIS_HOST=redis:6379/0`
+- `ELASTICSEARCH_HOST=http://elasticsearch:9200`
+
+To override or add variables, create a `.env` file in the repository root or use Docker Compose environment files.
+
+## Troubleshooting
+
+### Services won't start
+
+**Check if ports are already in use:**
+
+```bash
+# Check for processes using ports
+lsof -i :3000
+lsof -i :3306
+lsof -i :6379
+```
+
+**Check Docker logs:**
+
+```bash
+make dev-logs
+```
+
+### Database connection errors
+
+**Wait for database to be ready:**
+The entrypoint script automatically waits for the database, but if you see connection errors:
+
+```bash
+# Check database health
+docker compose -f docker/docker-compose.dev.yml ps db
+
+# View database logs
+docker compose -f docker/docker-compose.dev.yml logs db
+```
+
+### SSL certificate issues
+
+**Certificates not generating:**
+
+```bash
+# Check certificate directory permissions
+ls -la docker/local-nginx/certs/
+
+# Regenerate certificates
+make dev-clean-certs
+make dev
+```
+
+**Browser still shows errors after accepting:**
+
+- Clear browser cache and cookies for `gumroad.dev`
+- Try an incognito/private window
+- Check that certificates exist: `ls docker/local-nginx/certs/`
+
+### Code changes not reflecting
+
+**Check volume mounts:**
+
+```bash
+# Verify code is mounted
+docker compose -f docker/docker-compose.dev.yml exec web ls -la /app
+```
+
+**Restart the service:**
+
+```bash
+docker compose -f docker/docker-compose.dev.yml restart web
+```
+
+### Performance issues
+
+**Docker Desktop resource limits:**
+
+- Increase CPU and memory allocation in Docker Desktop settings
+- Recommended: 4+ CPU cores, 8GB+ RAM
+
+**Volume mount performance (macOS):**
+
+- Use Docker Desktop's file sharing settings
+- Consider using `:cached` or `:delegated` mount options (advanced)
+
+### Container won't start
+
+**Check container logs:**
+
+```bash
+docker compose -f docker/docker-compose.dev.yml logs web
+```
+
+**Rebuild the image:**
+
+```bash
+make dev-build
+```
+
+**Clean up and start fresh:**
+
+```bash
+make dev-down
+docker compose -f docker/docker-compose.dev.yml build --no-cache web
+make dev
+```
+
+## Advanced Usage
+
+### Running specific services
+
+```bash
+# Start only database services
+docker compose -f docker/docker-compose.dev.yml up db redis mongo
+
+# Start only application services
+docker compose -f docker/docker-compose.dev.yml up web webpack sidekiq
+```
+
+### Accessing service logs
+
+```bash
+# All services
+make dev-logs
+
+# Specific service
+docker compose -f docker/docker-compose.dev.yml logs -f web
+docker compose -f docker/docker-compose.dev.yml logs -f webpack
+docker compose -f docker/docker-compose.dev.yml logs -f sidekiq
+```
+
+### Database access
+
+```bash
+# MySQL client
+docker compose -f docker/docker-compose.dev.yml exec db mysql -uroot -ppassword
+
+# Redis client
+docker compose -f docker/docker-compose.dev.yml exec redis redis-cli
+
+# MongoDB shell
+docker compose -f docker/docker-compose.dev.yml exec mongo mongosh
+```
+
+### Running tests
+
+Tests can be run inside the Docker container:
+
+```bash
+# Run all tests
+docker compose -f docker/docker-compose.dev.yml exec web bundle exec rspec
+
+# Run specific test file
+docker compose -f docker/docker-compose.dev.yml exec web bundle exec rspec spec/models/user_spec.rb
+```
+
+## File Structure
+
+```
+docker/
+├── dev/
+│   ├── Dockerfile              # Development Docker image
+│   ├── entrypoint.sh          # Container entrypoint script
+│   └── generate_certificates.sh # SSL certificate generation
+├── docker-compose.dev.yml     # Development compose configuration
+└── local-nginx/
+    ├── gumroad_dev.conf       # Nginx configuration
+    └── certs/                 # SSL certificates (auto-generated)
+```
+
+## Additional Resources
+
+- [Docker Compose Documentation](https://docs.docker.com/compose/)
+- [Docker Desktop Documentation](https://docs.docker.com/desktop/)
+- [Main README](../README.md) for general project information


### PR DESCRIPTION
# Unified Docker Development Setup

## Summary

This PR consolidates the mixed local/Docker development setup into a unified Docker Compose configuration where all services run in Docker containers. This eliminates the need for local Ruby, Node.js, and other system dependencies, making onboarding significantly easier for new developers.

## AI Disclosure
AI tool sonet 4.5 was used for ssl generation script to move inside container and documentation.

## Self-Review

- [x] All services properly configured in docker-compose.dev.yml
- [x] SSL certificates automatically generated in Docker (self-signed)
- [x] Environment variables moved to docker-compose for easier management
- [x] Documentation updated (README.md and new docker.md guide)
- [x] Makefile targets added for common operations
- [x] Nginx configuration updated to use Docker service names
- [x] Build context and volume paths verified

## Changes

### New Files

- `docker/dev/Dockerfile` - Development-optimized Docker image
- `docker/dev/entrypoint.sh` - Container entrypoint with database setup and certificate generation
- `docker/dev/generate_certificates.sh` - Script to generate self-signed SSL certificates
- `docker/docker-compose.dev.yml` - Unified Docker Compose configuration for development
- `docs/development/docker.md` - Comprehensive Docker development guide

### Modified Files

- `README.md` - Simplified prerequisites (only Docker required), updated setup instructions
- `Makefile` - Added `dev`, `dev-build`, `dev-down`, `dev-logs`, `dev-shell`, `dev-clean-certs` targets
- `docker/local-nginx/gumroad_dev.conf` - Updated to proxy to Docker service names instead of `host.docker.internal`
- `.dockerignore` - Optimized to exclude unnecessary files for faster builds

### For Existing Developers

The old setup (`make local` + `bin/dev`) continues to work. To migrate to the new setup:

1. Build the development images:
   ```bash
   make dev-build
   ```

2. Start all services:
   ```bash
   make dev
   ```

3. Access the application at `https://gumroad.dev` (accept the browser security warning for self-signed certificate)

## Known Limitations

- Self-signed SSL certificates will trigger browser security warnings (expected and acceptable for development)
- Volume mounts may have slight performance impact on macOS (mitigated by Docker Desktop optimizations)
- All services in Docker may use more system resources than the previous mixed setup

## Documentation

- Updated `README.md` with simplified setup instructions
- Created `docs/development/docker.md` with detailed guide, troubleshooting, and best practices