### PR TITLE
Rename 'User Memberships' to 'User Collaborations' in admin dashboard

### DIFF
--- a/app/javascript/components/Admin/Users/Memberships.tsx
+++ b/app/javascript/components/Admin/Users/Memberships.tsx
@@ -44,7 +44,7 @@ const Memberships = ({ user: { admin_manageable_user_memberships } }: Membership
       <hr />
       <details>
         <summary>
-          <h3>User memberships</h3>
+          <h3>User collaborations</h3>
         </summary>
         <div className="stack">
           {admin_manageable_user_memberships.map((membership) => (

--- a/app/views/admin/users/_user_memberships.html.erb
+++ b/app/views/admin/users/_user_memberships.html.erb
@@ -3,7 +3,7 @@
   <hr>
   <details>
     <summary>
-      <h3>User memberships</h3>
+      <h3>User collaborations</h3>
     </summary>
     <div class="stack">
       <% user_memberships.each do |user_membership| %>

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -46,16 +46,16 @@ describe "Admin::UsersController Scenario", type: :system, js: true do
     end
   end
 
-  describe "user memberships" do
-    context "when the user has no user memberships" do
-      it "doesn't render user memberships" do
+  describe "user collaborations" do
+    context "when the user has no user collaborations" do
+      it "doesn't render user collaborations" do
         visit admin_user_path(user.id)
 
-        expect(page).not_to have_text("User memberships")
+        expect(page).not_to have_text("User collaborations")
       end
     end
 
-    context "when the user has user memberships" do
+    context "when the user has user collaborations" do
       let(:seller_one) { create(:user, :without_username) }
       let(:seller_two) { create(:user) }
       let(:seller_three) { create(:user) }
@@ -64,10 +64,10 @@ describe "Admin::UsersController Scenario", type: :system, js: true do
       let!(:team_membership_two) { create(:team_membership, user:, seller: seller_two) }
       let!(:team_membership_three) { create(:team_membership, user:, seller: seller_three, deleted_at: 1.hour.ago) }
 
-      it "renders user memberships" do
+      it "renders user collaborations" do
         visit admin_user_path(user.id)
 
-        find_and_click "h3", text: "User memberships"
+        find_and_click "h3", text: "User collaborations"
         expect(page).to have_text(seller_one.display_name(prefer_email_over_default_username: true))
         expect(page).to have_text(seller_two.display_name(prefer_email_over_default_username: true))
         expect(page).not_to have_text(seller_three.display_name(prefer_email_over_default_username: true))


### PR DESCRIPTION
@schrodingrsbrat @ershad this fixes #2062

Renames “User Memberships” to “User Collaborations” across the admin dashboard to avoid confusion with subscription memberships.

Changes
	•	Updated admin user UI headings (React + Rails views)
	•	Updated system specs to reflect the new admin-facing copy
	•	Left internal domain language and data structures unchanged

Note: This is a UI-only terminology change. No functional, data, or permission logic was modified.

Internal presenter props and models continue to use user_memberships intentionally; only admin-visible copy was updated.

AI Disclosure:
Used GPT 5.2 to help with understanding the code base and help with code.

Please let me know if any changes are required, thank you!