### PR TITLE
Migrate stack layout to Tailwind in collaborator details sheet

### DIFF
--- a/app/javascript/components/Collaborators/index.tsx
+++ b/app/javascript/components/Collaborators/index.tsx
@@ -23,6 +23,8 @@ import { getIncomingCollaborators } from "$app/data/incoming_collaborators";
 import { assertDefined } from "$app/utils/assert";
 import { asyncVoid } from "$app/utils/promise";
 import { assertResponseError } from "$app/utils/request";
+import { classNames } from "$app/utils/classNames";
+
 
 import { Button } from "$app/components/Button";
 import CollaboratorForm from "$app/components/Collaborators/Form";
@@ -94,21 +96,43 @@ const CollaboratorDetails = ({
         </Alert>
       ) : null}
 
-      <section className="stack">
-        <h3>Email</h3>
-        <div>
-          <span>{selectedCollaborator.email}</span>
-        </div>
+      <section
+  className={classNames(
+    "grid rounded border",
+    "bg-white dark:bg-gray-900",
+    "divide-y divide-gray-200 dark:divide-gray-700"
+  )}
+><div className="flex flex-wrap items-center justify-between gap-4 p-4">
+  <h3 className="font-semibold">Email</h3>
+</div>
+
+<div className="flex flex-wrap items-center gap-4 p-4">
+  <span>{selectedCollaborator.email}</span>
+</div>
+
       </section>
 
-      <section className="stack">
-        <h3>Products</h3>
-        {selectedCollaborator.products.map((product) => (
-          <section key={product.id}>
-            <div>{product.name}</div>
-            <div>{formatAsPercent(product.percent_commission || selectedCollaborator.percent_commission || 0)}</div>
-          </section>
-        ))}
+      <section
+  className={classNames(
+    "grid rounded border mt-4",
+    "bg-white dark:bg-gray-900",
+    "divide-y divide-gray-200 dark:divide-gray-700"
+  )}
+>
+        <div className="flex flex-wrap items-center justify-between gap-4 p-4">
+  <h3 className="font-semibold">Products</h3>
+</div>
+
+{selectedCollaborator.products.map((product) => (
+  <div
+    key={product.id}
+    className="flex flex-wrap items-center justify-between gap-4 p-4"
+  >
+    <div>{product.name}</div>
+    <div>{formatAsPercent(product.percent_commission || selectedCollaborator.percent_commission || 0)}</div>
+  </div>
+))}
+
       </section>
 
       <section className="mt-auto flex gap-4">


### PR DESCRIPTION
### What changed
Replaced usage of the `.stack` layout in the Collaborator details sheet with equivalent Tailwind utility classes.

### Why
- Aligns this component with the ongoing Tailwind migration
- Reduces reliance on legacy SCSS
- Keeps layout and behavior unchanged

### Screenshots

#### Desktop – Light
<img width="1470" height="956" alt="Screenshot 2025-12-30 at 1 08 22 AM" src="https://github.com/user-attachments/assets/b4ccb714-f487-4f7a-8cc9-fd0e02915133" />


#### Desktop – Dark
<img width="1470" height="956" alt="Screenshot 2025-12-30 at 1 08 33 AM" src="https://github.com/user-attachments/assets/648fa45d-4bee-44c9-85ab-0f3c4bf6eb25" />

#### Mobile – Light
<img width="1470" height="956" alt="Screenshot 2025-12-30 at 1 08 57 AM" src="https://github.com/user-attachments/assets/e5140f0c-185e-4412-8f67-a5397f6049b7" />


#### Mobile – Dark
<img width="1470" height="956" alt="Screenshot 2025-12-30 at 1 08 50 AM" src="https://github.com/user-attachments/assets/b7e3f75c-42cd-414b-bca3-db13b9da46cc" />


Related to #1055

