### PR TITLE
Fix: Audience export timeout for large lists (#2092)

### DIFF
--- a/app/models/audience_export.rb
+++ b/app/models/audience_export.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AudienceExport < ApplicationRecord
+  belongs_to :user
+  belongs_to :recipient, class_name: "User"
+  has_many :chunks, class_name: "AudienceExportChunk", foreign_key: :export_id, dependent: :delete_all
+  serialize :audience_options, type: Hash, coder: YAML
+  validates_presence_of :audience_options
+end

--- a/app/models/audience_export_chunk.rb
+++ b/app/models/audience_export_chunk.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AudienceExportChunk < ApplicationRecord
+  belongs_to :export, class_name: "AudienceExport"
+  serialize :audience_member_ids, type: Array, coder: YAML
+  serialize :audience_members_data, type: Array, coder: YAML
+end

--- a/app/services/exports/audience_export_service.rb
+++ b/app/services/exports/audience_export_service.rb
@@ -4,6 +4,7 @@ require "csv"
 
 class Exports::AudienceExportService
   FIELDS = ["Subscriber Email", "Subscribed Time"].freeze
+  SYNCHRONOUS_EXPORT_THRESHOLD = 5_000
 
   def initialize(user, options = {})
     @user = user
@@ -20,16 +21,7 @@ class Exports::AudienceExportService
     @tempfile = Tempfile.new(["Subscribers", ".csv"], encoding: "UTF-8")
 
     CSV.open(@tempfile, "wb", headers: FIELDS, write_headers: true) do |csv|
-      query = @user.audience_members.select(:id, :email, :min_created_at)
-
-      conditions = []
-      conditions << "follower = true" if @options[:followers]
-      conditions << "customer = true" if @options[:customers]
-      conditions << "affiliate = true" if @options[:affiliates]
-
-      query = query.where(conditions.join(" OR "))
-
-      query.order(:min_created_at).find_each do |member|
+      query.select(:id, :email, :min_created_at).find_each do |member|
         csv << [member.email, member.min_created_at]
       end
     end
@@ -37,6 +29,33 @@ class Exports::AudienceExportService
     @tempfile.rewind
 
     self
+  end
+
+  def query
+    query = @user.audience_members
+
+    conditions = []
+    conditions << "follower = true" if @options[:followers]
+    conditions << "customer = true" if @options[:customers]
+    conditions << "affiliate = true" if @options[:affiliates]
+
+    query.where(conditions.join(" OR ")).order(:min_created_at)
+  end
+
+  def self.export(seller_id, recipient_id, audience_options = {})
+    seller = User.find(seller_id)
+    recipient = recipient_id ? User.find(recipient_id) : seller
+
+    service = new(seller, audience_options)
+    count = service.query.count
+
+    if count > SYNCHRONOUS_EXPORT_THRESHOLD
+      export = AudienceExport.create!(user: seller, recipient: recipient, audience_options: audience_options)
+      Exports::Audience::CreateAndEnqueueChunksWorker.perform_async(export.id)
+      nil
+    else
+      service.perform
+    end
   end
 
   private

--- a/app/sidekiq/exports/audience/compile_chunks_worker.rb
+++ b/app/sidekiq/exports/audience/compile_chunks_worker.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class Exports::Audience::CompileChunksWorker
+  include Sidekiq::Job
+  sidekiq_options retry: 5, queue: :low, lock: :until_executed
+
+  def perform(export_id)
+    @export = AudienceExport.find(export_id)
+
+    service = Exports::AudienceExportService.new(@export.user, @export.audience_options)
+    filename = service.filename
+
+    tempfile = generate_compiled_tempfile(service.class::FIELDS)
+
+    ContactingCreatorMailer.subscribers_data(
+      recipient: @export.recipient,
+      tempfile: tempfile,
+      filename: filename
+    ).deliver_now
+
+    @export.chunks.in_batches(of: 1).delete_all
+    @export.destroy!
+  end
+
+  private
+    def generate_compiled_tempfile(fields)
+      tempfile = Tempfile.new(["Subscribers", ".csv"], encoding: "UTF-8")
+
+      CSV.open(tempfile, "wb", headers: fields, write_headers: true) do |csv|
+        # Use find_each to avoid loading all chunks into memory
+        @export.chunks.select(:id, :audience_members_data).find_each(batch_size: 1) do |chunk|
+          chunk.audience_members_data.each do |row|
+            csv << row
+          end
+        end
+      end
+
+      tempfile.rewind
+      tempfile
+    end
+end

--- a/app/sidekiq/exports/audience/create_and_enqueue_chunks_worker.rb
+++ b/app/sidekiq/exports/audience/create_and_enqueue_chunks_worker.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class Exports::Audience::CreateAndEnqueueChunksWorker
+  include Sidekiq::Job
+  sidekiq_options retry: 5, queue: :low
+
+  MAX_MEMBERS_PER_CHUNK = 1_000
+
+  def perform(export_id)
+    @export = AudienceExport.find(export_id)
+    create_chunks
+    enqueue_chunks
+  end
+
+  private
+    def create_chunks
+      @export.chunks.in_batches(of: 1).delete_all
+
+      service = Exports::AudienceExportService.new(@export.user, @export.audience_options)
+      # Ensure we select only ID for chunking
+      query = service.query.select(:id)
+
+      query.find_in_batches(batch_size: MAX_MEMBERS_PER_CHUNK) do |batch|
+        @export.chunks.create!(audience_member_ids: batch.map(&:id))
+      end
+    end
+
+    def enqueue_chunks
+      Exports::Audience::ProcessChunkWorker.perform_bulk(@export.chunks.ids.map { |id| [id] })
+    end
+end

--- a/app/sidekiq/exports/audience/process_chunk_worker.rb
+++ b/app/sidekiq/exports/audience/process_chunk_worker.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class Exports::Audience::ProcessChunkWorker
+  include Sidekiq::Job
+  sidekiq_options retry: 5, queue: :low, lock: :until_executed
+
+  def perform(chunk_id)
+    @chunk = AudienceExportChunk.find(chunk_id)
+    @export = @chunk.export
+
+    process_chunk
+    return if chunks_left_to_process?
+
+    Exports::Audience::CompileChunksWorker.perform_async(@export.id)
+  end
+
+  private
+    def process_chunk
+      # Fetch members using the IDs stored in the chunk
+      members = @export.user.audience_members.where(id: @chunk.audience_member_ids).select(:id, :email, :min_created_at)
+
+      data = members.map do |member|
+        [member.email, member.min_created_at]
+      end
+
+      @chunk.update!(
+        audience_members_data: data,
+        processed: true
+      )
+    end
+
+    def chunks_left_to_process?
+      @export.chunks.where(processed: false).exists?
+    end
+end

--- a/app/sidekiq/exports/audience_export_worker.rb
+++ b/app/sidekiq/exports/audience_export_worker.rb
@@ -5,15 +5,15 @@ class Exports::AudienceExportWorker
   sidekiq_options retry: 5, queue: :low, lock: :until_executed
 
   def perform(seller_id, recipient_id, audience_options = {})
-    seller, recipient = User.find(seller_id, recipient_id)
-    recipient ||= seller
+    result = Exports::AudienceExportService.export(seller_id, recipient_id, audience_options)
 
-    result = Exports::AudienceExportService.new(seller, audience_options).perform
-
-    ContactingCreatorMailer.subscribers_data(
-      recipient:,
-      tempfile: result.tempfile,
-      filename: result.filename,
-    ).deliver_now
+    if result
+      recipient = recipient_id ? User.find(recipient_id) : User.find(seller_id)
+      ContactingCreatorMailer.subscribers_data(
+        recipient:,
+        tempfile: result.tempfile,
+        filename: result.filename,
+      ).deliver_now
+    end
   end
 end

--- a/db/migrate/20251230035000_create_audience_exports_and_chunks.rb
+++ b/db/migrate/20251230035000_create_audience_exports_and_chunks.rb
@@ -1,0 +1,19 @@
+class CreateAudienceExportsAndChunks < ActiveRecord::Migration[6.1]
+  def change
+    create_table :audience_exports do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :recipient, null: false, foreign_key: { to_table: :users }
+      t.text :audience_options
+      t.timestamps
+    end
+
+    create_table :audience_export_chunks do |t|
+      t.references :export, null: false, foreign_key: { to_table: :audience_exports }
+      t.text :audience_member_ids
+      t.text :audience_members_data
+      t.boolean :processed, default: false, null: false
+      t.integer :revision, default: 0, null: false
+      t.timestamps
+    end
+  end
+end


### PR DESCRIPTION
This PR resolves #2092 by implementing a chunked export system for audience data, mirroring the existing sales export architecture.

### Changes:
- **Migration**: Added  and  tables.
- **Models**: Created corresponding Active Record models.
- **Workers**: Added , , and  to handle background processing.
- **Service**: Refactored  to automatically switch to async chunked processing for lists larger than 5,000 members.

Test plan:
- Confirmed synchronous export works for small lists.
- Verified background jobs assume control for large exports (> 5000).