### PR TITLE
feat: Display on admin page if user is a collaborator or admin for another page

### DIFF
--- a/app/javascript/components/Admin/Users/Collaborations.tsx
+++ b/app/javascript/components/Admin/Users/Collaborations.tsx
@@ -1,0 +1,57 @@
+import { Link } from "@inertiajs/react";
+import React from "react";
+
+import DateTimeWithRelativeTooltip from "$app/components/Admin/DateTimeWithRelativeTooltip";
+import type { Collaboration, User } from "$app/components/Admin/Users/User";
+
+type CollaborationsProps = {
+  user: User;
+};
+
+type CollaborationItemProps = {
+  collaboration: Collaboration;
+};
+
+const CollaborationItem = ({ collaboration }: CollaborationItemProps) => (
+  <div>
+    <div className="flex items-center gap-4">
+      <img
+        src={collaboration.seller.avatar_url}
+        className="user-avatar"
+        alt={collaboration.seller.display_name_or_email}
+      />
+      <div className="grid">
+        <h5>
+          <Link href={Routes.admin_user_url(collaboration.seller.id)}>
+            {collaboration.seller.display_name_or_email}
+          </Link>
+        </h5>
+        <div>{collaboration.percent_commission}% commission</div>
+      </div>
+    </div>
+
+    <div className="space-x-1">
+      <span>since</span>
+      <DateTimeWithRelativeTooltip date={collaboration.created_at} />
+    </div>
+  </div>
+);
+
+const Collaborations = ({ user: { collaborations } }: CollaborationsProps) =>
+  collaborations.length > 0 && (
+    <>
+      <hr />
+      <details>
+        <summary>
+          <h3>Collaborations</h3>
+        </summary>
+        <div className="stack">
+          {collaborations.map((collaboration) => (
+            <CollaborationItem key={collaboration.id} collaboration={collaboration} />
+          ))}
+        </div>
+      </details>
+    </>
+  );
+
+export default Collaborations;

--- a/app/javascript/components/Admin/Users/User.tsx
+++ b/app/javascript/components/Admin/Users/User.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import AdminUserActions from "$app/components/Admin/Users/Actions";
 import AdminUserAddCredit from "$app/components/Admin/Users/AddCredit";
 import AdminUserChangeEmail from "$app/components/Admin/Users/ChangeEmail";
+import AdminUserCollaborations from "$app/components/Admin/Users/Collaborations";
 import AdminUserComments from "$app/components/Admin/Users/Comments";
 import AdminUserComplianceInfo, { type ComplianceInfoProps } from "$app/components/Admin/Users/ComplianceInfo";
 import AdminUserCustomFee from "$app/components/Admin/Users/CustomFee";
@@ -30,6 +31,13 @@ export type UserMembership = {
   created_at: string;
 };
 
+export type Collaboration = {
+  id: number;
+  seller: Seller;
+  percent_commission: number;
+  created_at: string;
+};
+
 type BlockedObject = {
   blocked_at: string | null;
   created_at: string;
@@ -53,6 +61,7 @@ export type User = {
   verified: boolean | null;
   all_adult_products: boolean;
   admin_manageable_user_memberships: UserMembership[];
+  collaborations: Collaboration[];
   alive_user_compliance_info?: ComplianceInfoProps | null;
   compliant?: boolean | null;
   suspended: boolean;
@@ -86,6 +95,7 @@ const UserCard = ({ user, isAffiliateUser = false }: Props) => {
 
       <AdminUserActions user={user} />
       <AdminUserMemberships user={user} />
+      <AdminUserCollaborations user={user} />
       <AdminUserPermissionRisk user={user} />
       <AdminUserComplianceInfo user={user} />
       <hr />

--- a/app/presenters/admin/user_presenter/card.rb
+++ b/app/presenters/admin/user_presenter/card.rb
@@ -62,7 +62,8 @@ class Admin::UserPresenter::Card
 
       # Associations
       admin_manageable_user_memberships: user_memberships,
-      alive_user_compliance_info: compliance_info
+      alive_user_compliance_info: compliance_info,
+      collaborations: collaborations
     }
   end
 
@@ -119,5 +120,20 @@ class Admin::UserPresenter::Card
         has_individual_tax_id: info.has_individual_tax_id,
         has_business_tax_id: info.has_business_tax_id
       }
+    end
+
+    def collaborations
+      user.accepted_alive_collaborations.includes(:seller).map do |collaboration|
+        {
+          id: collaboration.id,
+          percent_commission: collaboration.affiliate_percentage,
+          created_at: collaboration.created_at,
+          seller: {
+            id: collaboration.seller.id,
+            avatar_url: collaboration.seller.avatar_url,
+            display_name_or_email: collaboration.seller.display_name_or_email
+          }
+        }
+      end
     end
 end

--- a/spec/presenters/admin/user_presenter/card_spec.rb
+++ b/spec/presenters/admin/user_presenter/card_spec.rb
@@ -147,6 +147,72 @@ describe Admin::UserPresenter::Card do
       end
     end
 
+    describe "collaborations" do
+      context "when user has no collaborations" do
+        it "returns an empty array" do
+          expect(props[:collaborations]).to eq([])
+        end
+      end
+
+      context "when user has accepted collaborations" do
+        let(:seller) { create(:user) }
+        let!(:collaboration) do
+          create(:collaborator, affiliate_user: user, seller:, affiliate_basis_points: 20_00)
+        end
+
+        it "returns an array of collaboration hashes" do
+          collaborations = props[:collaborations]
+
+          expect(collaborations).to be_an(Array)
+          expect(collaborations.size).to eq(1)
+        end
+
+        it "includes collaboration attributes" do
+          collaboration_data = props[:collaborations].first
+
+          expect(collaboration_data).to include(
+            id: collaboration.id,
+            percent_commission: 20,
+            created_at: collaboration.created_at
+          )
+        end
+
+        it "includes seller information" do
+          collaboration_data = props[:collaborations].first
+
+          expect(collaboration_data[:seller]).to eq(
+            id: seller.id,
+            avatar_url: seller.avatar_url,
+            display_name_or_email: seller.display_name_or_email
+          )
+        end
+      end
+
+      context "when user has pending collaboration invitations" do
+        let(:seller) { create(:user) }
+        let!(:collaboration) do
+          create(:collaborator, :with_pending_invitation, affiliate_user: user, seller:)
+        end
+
+        it "does not include pending collaborations" do
+          expect(props[:collaborations]).to eq([])
+        end
+      end
+
+      context "when user has deleted collaborations" do
+        let(:seller) { create(:user) }
+        let!(:collaboration) do
+          collaborator = create(:collaborator, affiliate_user: user, seller:)
+          collaborator.mark_deleted!
+          collaborator
+        end
+
+        it "does not include deleted collaborations" do
+          expect(props[:collaborations]).to eq([])
+        end
+      end
+    end
+
     describe "compliance info" do
       context "when user has no compliance info" do
         before do


### PR DESCRIPTION
fixes #2225 


<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

</td>
<td>
<img width="1901" height="1013" alt="Screenshot 2025-12-30 at 7 05 21 AM" src="https://github.com/user-attachments/assets/c3bd0520-c657-4cfa-8747-fa5bba60fb06" />



</td>
</tr>
</table>


### Tests

<img width="1141" height="409" alt="Screenshot 2025-12-30 at 7 04 29 AM" src="https://github.com/user-attachments/assets/97244dfe-61f4-41a5-8b1c-d9c32d99977f" />


### AI disclosure
Used Claude Opus 4.5 via Opencode for initial drafting

### Confirmation
I have watched all Antiwork Livestreams