### PR TITLE
feat(admin): Display collaborator and team membership info on admin user page (#2225)

### DIFF
--- a/app/javascript/components/Admin/Users/Memberships.tsx
+++ b/app/javascript/components/Admin/Users/Memberships.tsx
@@ -2,7 +2,7 @@ import { Link } from "@inertiajs/react";
 import React from "react";
 
 import DateTimeWithRelativeTooltip from "$app/components/Admin/DateTimeWithRelativeTooltip";
-import type { User, UserMembership } from "$app/components/Admin/Users/User";
+import type { IncomingCollaboration, User, UserMembership } from "$app/components/Admin/Users/User";
 
 type MembershipsProps = {
   user: User;
@@ -10,6 +10,10 @@ type MembershipsProps = {
 
 type MembershipProps = {
   membership: UserMembership;
+};
+
+type CollaborationProps = {
+  collaboration: IncomingCollaboration;
 };
 
 const Membership = ({ membership }: MembershipProps) => (
@@ -38,21 +42,70 @@ const Membership = ({ membership }: MembershipProps) => (
   </div>
 );
 
-const Memberships = ({ user: { admin_manageable_user_memberships } }: MembershipsProps) =>
-  admin_manageable_user_memberships.length > 0 && (
+const Collaboration = ({ collaboration }: CollaborationProps) => (
+  <div>
+    <div className="flex items-center gap-4">
+      <img
+        src={collaboration.seller.avatar_url}
+        className="user-avatar"
+        alt={collaboration.seller.display_name_or_email}
+      />
+      <div className="grid">
+        <h5>
+          <Link href={Routes.admin_user_url(collaboration.seller.id)}>{collaboration.seller.display_name_or_email}</Link>
+        </h5>
+        <div className="flex gap-2">
+          {collaboration.invitation_accepted ? (
+            <span className="text-green-600">Accepted</span>
+          ) : (
+            <span className="text-yellow-600">Pending</span>
+          )}
+          {collaboration.percent_commission != null && <span>{collaboration.percent_commission}% commission</span>}
+        </div>
+      </div>
+    </div>
+    <div className="space-x-1">
+      <span>added</span>
+      <DateTimeWithRelativeTooltip date={collaboration.created_at} />
+    </div>
+  </div>
+);
+
+const Memberships = ({ user: { admin_manageable_user_memberships, incoming_collaborations } }: MembershipsProps) => {
+  const hasMemberships = admin_manageable_user_memberships.length > 0;
+  const hasCollaborations = incoming_collaborations.length > 0;
+
+  if (!hasMemberships && !hasCollaborations) return null;
+
+  return (
     <>
       <hr />
-      <details>
-        <summary>
-          <h3>User memberships</h3>
-        </summary>
-        <div className="stack">
-          {admin_manageable_user_memberships.map((membership) => (
-            <Membership key={membership.id} membership={membership} />
-          ))}
-        </div>
-      </details>
+      {hasMemberships && (
+        <details>
+          <summary>
+            <h3>Team memberships ({admin_manageable_user_memberships.length})</h3>
+          </summary>
+          <div className="stack">
+            {admin_manageable_user_memberships.map((membership) => (
+              <Membership key={membership.id} membership={membership} />
+            ))}
+          </div>
+        </details>
+      )}
+      {hasCollaborations && (
+        <details>
+          <summary>
+            <h3>Collaborations ({incoming_collaborations.length})</h3>
+          </summary>
+          <div className="stack">
+            {incoming_collaborations.map((collaboration) => (
+              <Collaboration key={collaboration.id} collaboration={collaboration} />
+            ))}
+          </div>
+        </details>
+      )}
     </>
   );
+};
 
 export default Memberships;

--- a/app/javascript/components/Admin/Users/User.tsx
+++ b/app/javascript/components/Admin/Users/User.tsx
@@ -30,6 +30,15 @@ export type UserMembership = {
   created_at: string;
 };
 
+export type IncomingCollaboration = {
+  id: number;
+  invitation_accepted: boolean;
+  percent_commission: number | null;
+  apply_to_all_products: boolean;
+  created_at: string;
+  seller: Seller;
+};
+
 type BlockedObject = {
   blocked_at: string | null;
   created_at: string;
@@ -53,6 +62,7 @@ export type User = {
   verified: boolean | null;
   all_adult_products: boolean;
   admin_manageable_user_memberships: UserMembership[];
+  incoming_collaborations: IncomingCollaboration[];
   alive_user_compliance_info?: ComplianceInfoProps | null;
   compliant?: boolean | null;
   suspended: boolean;

--- a/app/presenters/admin/user_presenter/card.rb
+++ b/app/presenters/admin/user_presenter/card.rb
@@ -62,6 +62,7 @@ class Admin::UserPresenter::Card
 
       # Associations
       admin_manageable_user_memberships: user_memberships,
+      incoming_collaborations: incoming_collaborations,
       alive_user_compliance_info: compliance_info
     }
   end
@@ -86,6 +87,23 @@ class Admin::UserPresenter::Card
             id: membership.seller.id,
             avatar_url: membership.seller.avatar_url,
             display_name_or_email: membership.seller.display_name_or_email
+          }
+        }
+      end
+    end
+
+    def incoming_collaborations
+      user.incoming_collaborators.alive.includes(:seller, :collaborator_invitation).map do |collaborator|
+        {
+          id: collaborator.id,
+          invitation_accepted: collaborator.invitation_accepted?,
+          percent_commission: collaborator.affiliate_percentage,
+          apply_to_all_products: collaborator.apply_to_all_products?,
+          created_at: collaborator.created_at,
+          seller: {
+            id: collaborator.seller.id,
+            avatar_url: collaborator.seller.avatar_url,
+            display_name_or_email: collaborator.seller.display_name_or_email
           }
         }
       end

--- a/spec/presenters/admin/user_presenter/card_spec.rb
+++ b/spec/presenters/admin/user_presenter/card_spec.rb
@@ -147,6 +147,69 @@ describe Admin::UserPresenter::Card do
       end
     end
 
+    describe "incoming collaborations" do
+      context "when user has no incoming collaborations" do
+        it "returns an empty array" do
+          expect(props[:incoming_collaborations]).to eq([])
+        end
+      end
+
+      context "when user has incoming collaborations" do
+        let(:seller) { create(:user) }
+        let!(:collaboration) do
+          create(:collaborator, affiliate_user: user, seller: seller)
+        end
+
+        it "returns an array of collaboration hashes" do
+          collaborations = props[:incoming_collaborations]
+
+          expect(collaborations).to be_an(Array)
+          expect(collaborations.size).to eq(1)
+        end
+
+        it "includes collaboration attributes" do
+          collaboration_data = props[:incoming_collaborations].first
+
+          expect(collaboration_data).to include(
+            id: collaboration.id,
+            invitation_accepted: true,
+            percent_commission: collaboration.affiliate_percentage,
+            apply_to_all_products: collaboration.apply_to_all_products?,
+            created_at: collaboration.created_at
+          )
+        end
+
+        it "includes seller information" do
+          collaboration_data = props[:incoming_collaborations].first
+
+          expect(collaboration_data[:seller]).to eq(
+            id: seller.id,
+            avatar_url: seller.avatar_url,
+            display_name_or_email: seller.display_name_or_email
+          )
+        end
+
+        context "with pending invitation" do
+          let!(:collaboration) do
+            create(:collaborator, :with_pending_invitation, affiliate_user: user, seller: seller)
+          end
+
+          it "returns invitation_accepted as false" do
+            collaboration_data = props[:incoming_collaborations].first
+            expect(collaboration_data[:invitation_accepted]).to be false
+          end
+        end
+
+        context "when collaboration is deleted" do
+          before { collaboration.mark_deleted! }
+
+          it "does not include deleted collaborations" do
+            expect(props[:incoming_collaborations]).to eq([])
+          end
+        end
+      end
+    end
+
     describe "compliance info" do
       context "when user has no compliance info" do
         before do


### PR DESCRIPTION
## Summary

- Display incoming collaborations on admin user page showing which sellers the user collaborates with
- Display team memberships showing which accounts the user has admin/team access to
- Both sections include hyperlinks to the related users' admin pages

Closes #2225 

## Test plan

- [ ] Visit `/admin/users/:id` for a user with collaborations - verify "Collaborations" section appears
- [ ] Visit `/admin/users/:id` for a user with team memberships - verify "Team memberships" section appears
- [ ] Click on seller names - verify they link to the correct admin pages
- [ ] Verify collaboration shows: status (Accepted/Pending), commission %, date added
- [ ] Verify team membership shows: role, invited date
- [ ] Test with user having no collaborations/memberships - sections should not appear

## Screenshots
[Screencast from 2025-12-30 21-21-20.webm](https://github.com/user-attachments/assets/81a6a9dc-e1de-4802-8507-da0674785ce9)



## AI Disclosure
This PR was developed with assistance from Claude Code.