### PR TITLE
Add Heroku and Railway deployment guides 

### DIFF
--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -19,6 +19,11 @@
 
 Deployments are automated. When Buildkite builds the `main` branch, it will automatically deploy it to production. The rest of this section explains how deployments can be performed outside of this automated process.
 
+## Platform-specific guides
+
+- [Deploying on Heroku](deploying_heroku.md)
+- [Deploying on Railway](deploying_railway.md)
+
 ### Prerequisites
 
 Before deploying, make sure you have the `nomad/.env` environment variables file with [these credentials](https://antiwork.1password.com/vaults/xecpqop3ylrsq6zz53klqaaoxq/allitems/qyenwnmcuidk6gzvppa4weagmm).

--- a/docs/deploying_heroku.md
+++ b/docs/deploying_heroku.md
@@ -1,0 +1,127 @@
+# Deploying to Heroku
+
+Heroku is a Platform as a Service (PaaS) that allows you to deploy and run applications without managing infrastructure. This guide explains how to deploy a self-hosted Gumroad instance on Heroku.
+
+## Prerequisites
+
+Before you begin, ensure you have:
+
+- A Heroku account
+- The [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli) installed
+- `git` installed locally
+- A fork of the Gumroad repository
+
+## Step 1: Create a Heroku App
+
+From the root of the Gumroad project, create a new Heroku application:
+
+```bash
+heroku create my-gumroad-app
+```
+
+Replace `my-gumroad-app` with a unique name.
+
+## Step 2: Configure Buildpacks
+
+Gumroad requires both Node.js (for asset compilation) and Ruby. Ensure the buildpacks are configured in the correct order:
+
+```bash
+heroku buildpacks:set heroku/nodejs
+heroku buildpacks:add heroku/ruby
+```
+
+You can verify the order with:
+
+```bash
+heroku buildpacks
+```
+
+## Step 3: Provision Add-ons
+
+Gumroad requires a relational database and Redis.
+
+### PostgreSQL
+
+```bash
+heroku addons:create heroku-postgresql
+```
+
+### Redis
+
+```bash
+heroku addons:create heroku-redis
+```
+
+Heroku will automatically inject the appropriate `DATABASE_URL` and `REDIS_URL` environment variables.
+
+## Step 4: Configure Environment Variables
+
+Set the required environment variables. At minimum, you will need:
+
+```bash
+heroku config:set RAILS_ENV=production
+heroku config:set RAILS_MASTER_KEY=<your-rails-master-key>
+```
+
+The `RAILS_MASTER_KEY` value should match the contents of your local `config/master.key`.
+
+Additional environment variables may be required depending on your setup, such as AWS credentials, Stripe API keys, and email provider configuration. Refer to `.env.example` for a complete list.
+
+## Step 5: Deploy
+
+Push your code to Heroku:
+
+```bash
+git push heroku main
+```
+
+If your default branch is not `main`, push the appropriate branch instead.
+
+## Step 6: Database Setup
+
+Once the deployment finishes, run the database migrations:
+
+```bash
+heroku run bundle exec rails db:migrate
+```
+
+## Step 7: Enable Background Workers
+
+Gumroad uses Sidekiq for background job processing. Enable a worker dyno:
+
+```bash
+heroku ps:scale worker=1
+```
+
+You may scale this up later based on workload.
+
+## Step 8: Verify Deployment
+
+Open your application in the browser:
+
+```bash
+heroku open
+```
+
+If the application boots successfully, the deployment is complete.
+
+## Troubleshooting
+
+If something goes wrong, check the logs:
+
+```bash
+heroku logs --tail
+```
+
+Common issues include:
+
+- Missing or incorrect `RAILS_MASTER_KEY`
+- Asset compilation failures due to missing Node/Yarn
+- Redis not provisioned or misconfigured
+- Sidekiq not running (worker dyno not scaled)
+
+## Notes
+
+- Heroku dynos use an ephemeral filesystem. Do not rely on local disk storage.
+- Ensure all file uploads are configured to use external storage (for example, Amazon S3).
+- Production performance may require tuning dyno sizes and worker counts.

--- a/docs/deploying_railway.md
+++ b/docs/deploying_railway.md
@@ -1,0 +1,140 @@
+# Deploying to Railway
+
+Railway is a modern infrastructure platform that makes it easy to deploy and run applications in the cloud. This guide explains how to deploy a self-hosted Gumroad instance on Railway.
+
+## Prerequisites
+
+Before you begin, ensure you have:
+
+- A Railway account
+- The [Railway CLI](https://docs.railway.app/guides/cli) installed (optional — the web dashboard can also be used)
+- `git` installed locally
+- A fork of the Gumroad repository
+
+---
+
+## Step 1: Create a New Railway Project
+
+1. Sign in to the Railway dashboard.
+2. Click **New Project**.
+3. Choose **Deploy from GitHub Repo**.
+4. Select your Gumroad fork and the branch you want to deploy.
+
+Railway will automatically detect the Rails application and begin the initial build.
+
+---
+
+## Step 2: Add Required Services
+
+Gumroad requires both a relational database and Redis.
+
+### PostgreSQL
+
+From the Railway project dashboard:
+
+1. Click **Add Service**
+2. Select **PostgreSQL**
+
+Railway will automatically provide a `DATABASE_URL` environment variable.
+
+### Redis
+
+1. Click **Add Service**
+2. Select **Redis**
+
+Railway will automatically provide a `REDIS_URL` environment variable.
+
+---
+
+## Step 3: Configure Environment Variables
+
+In the Railway dashboard, open your application service and configure the required environment variables.
+
+At minimum, you will need:
+
+- `RAILS_ENV=production`
+- `RAILS_MASTER_KEY=<your-rails-master-key>`
+
+The `RAILS_MASTER_KEY` value should match the contents of your local `config/master.key`.
+
+Additional environment variables may be required depending on your setup, such as:
+
+- AWS credentials (for file uploads)
+- Stripe API keys
+- Email provider configuration
+
+Refer to `.env.example` for a complete list of configuration options.
+
+---
+
+## Step 4: Configure the Start Command
+
+Railway automatically detects Rails applications, but you should ensure the correct start command is configured:
+
+```bash
+bundle exec rails server -b 0.0.0.0 -p $PORT
+```
+
+This can be set in the **Start Command** field of the service settings.
+
+---
+
+## Step 5: Run Database Migrations
+
+After the first successful deployment, run database migrations.
+
+Using the Railway CLI:
+
+```bash
+railway run bundle exec rails db:migrate
+```
+
+Or via the Railway dashboard terminal.
+
+---
+
+## Step 6: Enable Background Workers
+
+Gumroad uses Sidekiq for background job processing. Create a separate service for workers:
+
+1. Duplicate the main application service.
+2. Set the start command to:
+
+```bash
+bundle exec sidekiq
+```
+
+3. Ensure the worker service has access to the same environment variables and Redis instance.
+
+You can scale workers based on workload requirements.
+
+---
+
+## Step 7: Verify Deployment
+
+Once the deployment completes, open the generated Railway domain from the dashboard and verify that the application loads successfully.
+
+---
+
+## Troubleshooting
+
+To inspect logs, use the Railway dashboard or CLI:
+
+```bash
+railway logs
+```
+
+Common issues include:
+
+- Missing or incorrect `RAILS_MASTER_KEY`
+- Database migrations not run
+- Redis service not connected
+- Sidekiq not running or misconfigured
+
+---
+
+## Notes
+
+- Railway provides ephemeral filesystems. Do not rely on local disk storage.
+- Ensure all file uploads are configured to use external storage (for example, Amazon S3).
+- Production performance may require tuning service resources and worker counts.


### PR DESCRIPTION
This PR adds platform-specific deployment documentation for Gumroad.

- Adds detailed guides for deploying on Heroku and Railway
- Links them from the existing deployment documentation

Closes #2251

AI disclosure: GPT-5.2 was used to help draft this documentation.