### PR TITLE
Fix flash message persistence across Inertia navigations

### DIFF
--- a/app/controllers/concerns/inertia_rendering.rb
+++ b/app/controllers/concerns/inertia_rendering.rb
@@ -8,7 +8,6 @@ module InertiaRendering
     inertia_share do
       RenderingExtension.custom_context(view_context).merge(
         authenticity_token: form_authenticity_token,
-        flash: inertia_flash_props,
         title: @title
       )
     end
@@ -17,11 +16,4 @@ module InertiaRendering
       { current_user: current_user_props(current_user, impersonated_user) }
     end
   end
-
-  private
-    def inertia_flash_props
-      return if (flash_message = flash[:alert] || flash[:warning] || flash[:notice]).blank?
-
-      { message: flash_message, status: flash[:alert] ? "danger" : flash[:warning] ? "warning" : "success" }
-    end
 end

--- a/app/javascript/components/WarningFlashMessage.tsx
+++ b/app/javascript/components/WarningFlashMessage.tsx
@@ -1,18 +1,19 @@
 import { usePage } from "@inertiajs/react";
 import * as React from "react";
 
-import { type AlertPayload } from "$app/components/server-components/Alert";
 import { Alert } from "$app/components/ui/Alert";
 
-type PageProps = {
-  flash?: AlertPayload;
+type FlashData = {
+  warning?: string;
 };
 
 export const WarningFlash: React.FC = () => {
-  const { flash } = usePage<PageProps>().props;
+  const page = usePage();
+  // Access flash from page.flash (not page.props.flash) - this data does NOT persist in history state
+  const flash = (page as unknown as { flash: FlashData }).flash;
 
-  if (flash?.status === "warning" && flash.message) {
-    return <Alert variant="danger">{flash.message}</Alert>;
+  if (flash?.warning) {
+    return <Alert variant="danger">{flash.warning}</Alert>;
   }
 
   return null;

--- a/app/javascript/inertia/layout.tsx
+++ b/app/javascript/inertia/layout.tsx
@@ -10,9 +10,14 @@ import { type LoggedInUser, LoggedInUserProvider, parseLoggedInUser } from "$app
 import Alert, { showAlert, type AlertPayload } from "$app/components/server-components/Alert";
 import useRouteLoading from "$app/components/useRouteLoading";
 
+type FlashData = {
+  notice?: string;
+  alert?: string;
+  warning?: string;
+};
+
 type PageProps = {
   title: string;
-  flash?: AlertPayload;
   logged_in_user: LoggedInUser;
   current_seller: {
     id: number;
@@ -29,21 +34,35 @@ type PageProps = {
   };
 };
 
+// Convert Inertia flash data to AlertPayload format
+const flashToAlertPayload = (flash: FlashData): AlertPayload | null => {
+  if (flash.alert) return { message: flash.alert, status: "danger" };
+  if (flash.warning) return { message: flash.warning, status: "warning" };
+  if (flash.notice) return { message: flash.notice, status: "success" };
+  return null;
+};
+
 export default function Layout({ children }: { children: React.ReactNode }) {
-  const { title, flash, logged_in_user, current_seller } = usePage<PageProps>().props;
+  const page = usePage<PageProps>();
+  const { title, logged_in_user, current_seller } = page.props;
+  // Access flash from page.flash (not page.props.flash) - this data does NOT persist in history state
+  const flash = (page as unknown as { flash: FlashData }).flash;
   const isRouteLoading = useRouteLoading();
 
   React.useEffect(() => {
-    if (flash?.message) {
-      showAlert(flash.message, flash.status === "danger" ? "error" : flash.status);
+    const alertPayload = flashToAlertPayload(flash || {});
+    if (alertPayload) {
+      showAlert(alertPayload.message, alertPayload.status === "danger" ? "error" : alertPayload.status);
     }
   }, [flash]);
+
+  const initialAlert = flashToAlertPayload(flash || {});
 
   return (
     <LoggedInUserProvider value={parseLoggedInUser(logged_in_user)}>
       <CurrentSellerProvider value={parseCurrentSeller(current_seller)}>
         <Head title={title} />
-        <Alert initial={flash ?? null} />
+        <Alert initial={initialAlert} />
         <div id="inertia-shell" className="flex h-screen flex-col lg:flex-row">
           <Nav title="Dashboard" />
           {isRouteLoading ? <LoadingSkeleton /> : null}
@@ -55,19 +74,25 @@ export default function Layout({ children }: { children: React.ReactNode }) {
 }
 
 export function LoggedInUserLayout({ children }: { children: React.ReactNode }) {
-  const { title, flash, logged_in_user, current_seller } = usePage<PageProps>().props;
+  const page = usePage<PageProps>();
+  const { title, logged_in_user, current_seller } = page.props;
+  // Access flash from page.flash (not page.props.flash) - this data does NOT persist in history state
+  const flash = (page as unknown as { flash: FlashData }).flash;
 
   React.useEffect(() => {
-    if (flash?.message) {
-      showAlert(flash.message, flash.status === "danger" ? "error" : flash.status);
+    const alertPayload = flashToAlertPayload(flash || {});
+    if (alertPayload) {
+      showAlert(alertPayload.message, alertPayload.status === "danger" ? "error" : alertPayload.status);
     }
   }, [flash]);
+
+  const initialAlert = flashToAlertPayload(flash || {});
 
   return (
     <LoggedInUserProvider value={parseLoggedInUser(logged_in_user)}>
       <CurrentSellerProvider value={parseCurrentSeller(current_seller)}>
         <Head title={title} />
-        <Alert initial={flash ?? null} />
+        <Alert initial={initialAlert} />
         {children}
       </CurrentSellerProvider>
     </LoggedInUserProvider>

--- a/app/javascript/layouts/Admin.tsx
+++ b/app/javascript/layouts/Admin.tsx
@@ -10,25 +10,44 @@ import LoadingSkeleton from "$app/components/LoadingSkeleton";
 import Alert, { showAlert, type AlertPayload } from "$app/components/server-components/Alert";
 import useRouteLoading from "$app/components/useRouteLoading";
 
+type FlashData = {
+  notice?: string;
+  alert?: string;
+  warning?: string;
+};
+
 type PageProps = {
   title: string;
-  flash?: AlertPayload;
+};
+
+// Convert Inertia flash data to AlertPayload format
+const flashToAlertPayload = (flash: FlashData): AlertPayload | null => {
+  if (flash.alert) return { message: flash.alert, status: "danger" };
+  if (flash.warning) return { message: flash.warning, status: "warning" };
+  if (flash.notice) return { message: flash.notice, status: "success" };
+  return null;
 };
 
 const Admin = ({ children }: { children: React.ReactNode }) => {
-  const { title, flash } = usePage<PageProps>().props;
+  const page = usePage<PageProps>();
+  const { title } = page.props;
+  // Access flash from page.flash (not page.props.flash) - this data does NOT persist in history state
+  const flash = (page as unknown as { flash: FlashData }).flash;
   const isRouteLoading = useRouteLoading();
 
   React.useEffect(() => {
-    if (flash?.message) {
-      showAlert(flash.message, flash.status === "danger" ? "error" : flash.status);
+    const alertPayload = flashToAlertPayload(flash || {});
+    if (alertPayload) {
+      showAlert(alertPayload.message, alertPayload.status === "danger" ? "error" : alertPayload.status);
     }
   }, [flash]);
+
+  const initialAlert = flashToAlertPayload(flash || {});
 
   return (
     <div id="inertia-shell" className="flex h-screen flex-col lg:flex-row">
       <Head title={title} />
-      <Alert initial={null} />
+      <Alert initial={initialAlert} />
       <AdminNav />
       <main className="flex h-screen flex-1 flex-col overflow-y-auto">
         <header className="flex items-center justify-between border-b border-border p-4 md:p-8">

--- a/config/initializers/inertia_rails.rb
+++ b/config/initializers/inertia_rails.rb
@@ -2,4 +2,7 @@
 
 InertiaRails.configure do |config|
   config.deep_merge_shared_data = true
+  # Expose these Rails flash keys to the frontend via page.flash
+  # Flash data accessed this way does NOT persist in browser history state
+  config.flash_keys = %i[notice alert warning]
 end


### PR DESCRIPTION
Closes #2562

## Summary

Flash messages were persisting across Inertia page navigations because they were being passed as regular shared props (which get stored in browser history state).

**The fix:** Use Inertia's native flash mechanism via `page.flash` instead of `page.props.flash`. Data in `page.flash` is specifically designed to NOT persist in history state.

## Changes

**Backend:**
- Add `config.flash_keys = %i[notice alert warning]` to expose Rails flash via Inertia's native mechanism
- Remove manual `flash: inertia_flash_props` from `inertia_share`

**Frontend:**
- Update `layout.tsx`, `Admin.tsx`, `WarningFlashMessage.tsx` to read from `page.flash`
- Convert flash format (`notice`/`alert`/`warning`) to existing `AlertPayload` format

## Why this works

Per [Inertia docs](https://inertia-rails.dev/guide/flash-data):
> "Unlike regular props, flash data isn't persisted in history state"

---

## AI Disclosure

Model: Claude Opus 4.5 via Claude Code
Used for:
- Understanding Inertia's flash data mechanism from docs
- Identifying the root cause (flash passed as regular props)
- Implementing the fix across backend and frontend files

All code was reviewed and tested by me before inclusion.

---

I have watched the PR live streaming videos.