### PR TITLE
The issue was caused by a default limit in the product search logic .

### DIFF
--- a/app/modules/product/searchable.rb
+++ b/app/modules/product/searchable.rb
@@ -5,7 +5,7 @@ module Product::Searchable
 
   # we want to show 9 tags, but this is used as an array indexing which starts at 0
   MAX_NUMBER_OF_TAGS = 8
-  RECOMMENDED_PRODUCTS_PER_PAGE = 9
+  RECOMMENDED_PRODUCTS_PER_PAGE = 12
   MAX_NUMBER_OF_FILETYPES = 8
   MAX_OFFER_CODES_IN_INDEX = 300
 


### PR DESCRIPTION
Issue: #2476 

# Description
The issue was caused by a default limit in the product search logic. The constant RECOMMENDED_PRODUCTS_PER_PAGE was set to 9 in 
app/modules/product/searchable.rb
.
## Problem
Truncation: This limit prevented the 10th product from being fetched and displayed, even when you explicitly selected 10 products for a section.
Grid Misalignment: On a desktop grid with 4 products per row, displaying 9 products leaves an incomplete row (2 full rows + 1 orphan product), which looks awkward compared to a clean grid.

## Solution
 have updated RECOMMENDED_PRODUCTS_PER_PAGE from 9 to 12 in 
app/modules/product/searchable.rb
.

Verification
Count Accuracy: The sections will now fetch up to 12 products. This covers your requirement to show 10 products without truncation.
Grid Alignment: 12 is divisible by both 3 and 4. On your 4-column desktop grid, this will result in 3 full rows, ensuring a symmetrical and polished look.
Safety: I verified that the 
DiscoverController
 (which handles the Discover page) explicitly sets its own limit (8 products), so this change is targeted purely at the general product/profile page sections where the default limit applies. The related test spec
(spec/controllers/discover_controller_spec.rb)dynamically references the constant, so it remains valid.


---
# AI Disclosure

I used the replace_file_content tool to modify the source code directly


