### PR TITLE
fix: prevent Iffy from overriding admin suspensions

### DIFF
--- a/app/modules/user/risk.rb
+++ b/app/modules/user/risk.rb
@@ -161,8 +161,8 @@ module User::Risk
 
     last_suspension_comment = comments
       .where(comment_type: Comment::COMMENT_TYPE_SUSPENDED)
-      .order(created_at: :desc)
-      .first
+      .order(:created_at)
+      .last
 
     last_suspension_comment&.author_id.present?
   end

--- a/app/sidekiq/iffy/event_job.rb
+++ b/app/sidekiq/iffy/event_job.rb
@@ -18,17 +18,12 @@ class Iffy::EventJob
     return unless event.in?(EVENTS)
 
     case event
-    when "user.banned", "user.suspended", "user.compliant"
-      return if user_suspended_by_admin?(id)
-
-      case event
-      when "user.banned"
-        Iffy::User::BanService.new(id).perform
-      when "user.suspended"
-        Iffy::User::SuspendService.new(id).perform
-      when "user.compliant"
-        Iffy::User::MarkCompliantService.new(id).perform
-      end
+    when "user.banned"
+      Iffy::User::BanService.new(id).perform
+    when "user.suspended"
+      Iffy::User::SuspendService.new(id).perform
+    when "user.compliant"
+      Iffy::User::MarkCompliantService.new(id).perform unless user_suspended_by_admin?(id)
     when "record.flagged"
       if entity == "Product" && !user_protected?(user)
         Iffy::Product::FlagService.new(id).perform

--- a/spec/sidekiq/iffy/event_job_spec.rb
+++ b/spec/sidekiq/iffy/event_job_spec.rb
@@ -79,16 +79,6 @@ describe Iffy::EventJob do
         user.suspend_for_tos_violation!(author_id: admin_user.id, bulk: true)
       end
 
-      it "does not call BanService for admin-suspended users" do
-        expect(Iffy::User::BanService).not_to receive(:new)
-        described_class.new.perform("user.banned", user.external_id, entity)
-      end
-
-      it "does not call SuspendService for admin-suspended users" do
-        expect(Iffy::User::SuspendService).not_to receive(:new)
-        described_class.new.perform("user.suspended", user.external_id, entity)
-      end
-
       it "does not call MarkCompliantService for admin-suspended users" do
         expect(Iffy::User::MarkCompliantService).not_to receive(:new)
         described_class.new.perform("user.compliant", user.external_id, entity)


### PR DESCRIPTION
Issue: https://github.com/antiwork/gumroad/issues/2538

# Description

Prevent Iffy from overriding admin suspensions by detecting admin suspensions and skipping Iffy event processing for compliant state transitions.

## Problem

Iffy was able to override suspensions made by admin team members by marking them as compliant

## Solution

Implemented a check to prevent Iffy from processing `user.compliant` events for users who have been suspended by an admin

# Test Results
### Before
<img width="604" height="136" alt="image" src="https://github.com/user-attachments/assets/4b5ac60a-50d9-4eb4-99d7-f4a1ecdafd8e" />

### After
<img width="475" height="65" alt="image" src="https://github.com/user-attachments/assets/55da98ee-cd59-4de4-b9e4-8fefab7d62c5" />

bundle exec rspec spec/sidekiq/iffy/event_job_spec.rb

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

Claude Sonnet 4.5 to help with the tests


