### PR TITLE
Revert "(fix) Product content edit: only fetch Dropbox files when pending files exist"

### DIFF
--- a/app/javascript/components/ProductEdit/ContentTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/index.tsx
@@ -412,20 +412,13 @@ const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: string | 
     }
     window.Dropbox.choose({ linkType: "direct", multiselect: true, success: (files) => void uploadFiles(files) });
   };
-
-  const hasPendingDropboxFiles = React.useMemo(
-    () => product.files.some((f) => f.status.type === "dropbox" && f.status.uploadState === "in_progress"),
-    [product.files],
-  );
   React.useEffect(() => {
-    if (!hasPendingDropboxFiles) return;
-
     const interval = setInterval(
       () => void fetchDropboxFiles(uniquePermalink).then(({ dropbox_files }) => addDropboxFiles(dropbox_files)),
       10000,
     );
     return () => clearInterval(interval);
-  }, [hasPendingDropboxFiles, uniquePermalink]);
+  }, [editor]);
 
   const [showUpsellModal, setShowUpsellModal] = React.useState(false);
   const [showReviewModal, setShowReviewModal] = React.useState(false);

--- a/app/javascript/components/ProductEdit/state.ts
+++ b/app/javascript/components/ProductEdit/state.ts
@@ -1,6 +1,5 @@
 import * as React from "react";
 
-import { ResponseDropboxFile } from "$app/data/dropbox_upload";
 import { OtherRefundPolicy } from "$app/data/products/other_refund_policies";
 import { Thumbnail } from "$app/data/thumbnails";
 import {
@@ -204,7 +203,7 @@ type UploadProgress = { percent: number; bitrate: number };
 type FileStatus =
   | { type: "saved" }
   | { type: "existing" }
-  | { type: "dropbox"; externalId: string; uploadState: ResponseDropboxFile["state"] }
+  | { type: "dropbox"; externalId: string; uploadState: string }
   | {
       type: "unsaved";
       uploadStatus: { type: "uploaded" } | { type: "uploading"; progress: UploadProgress };


### PR DESCRIPTION
Reverts antiwork/gumroad#2348

@brentguf Not sure why, but this PR caused several product edit tests to start failing consistently on CI (despite passing locally). The performance bump is probably not huge tbh, but you'd be very welcome to look into it and reopen if you find a fix!