### PR TITLE
fix(Flash): Flash message persists across Inertia page navigations

### DIFF
--- a/app/javascript/components/useFlashMessage.ts
+++ b/app/javascript/components/useFlashMessage.ts
@@ -1,0 +1,16 @@
+import { router } from "@inertiajs/react";
+import React from "react";
+
+import { showAlert, type AlertPayload } from "$app/components/server-components/Alert";
+
+export function useFlashMessage(flash?: AlertPayload) {
+  React.useEffect(() => {
+    if (flash?.message) {
+      showAlert(flash.message, flash.status === "danger" ? "error" : flash.status);
+
+      // Clear the flash from the current page's cached props to prevent it from
+      // reappearing when navigating back via browser history
+      router.reload({ only: ['flash'] });
+    }
+  }, [flash]);
+}

--- a/app/javascript/inertia/layout.tsx
+++ b/app/javascript/inertia/layout.tsx
@@ -7,7 +7,8 @@ import { Nav } from "$app/components/client-components/Nav";
 import { CurrentSellerProvider, parseCurrentSeller } from "$app/components/CurrentSeller";
 import LoadingSkeleton from "$app/components/LoadingSkeleton";
 import { type LoggedInUser, LoggedInUserProvider, parseLoggedInUser } from "$app/components/LoggedInUser";
-import Alert, { showAlert, type AlertPayload } from "$app/components/server-components/Alert";
+import Alert, { type AlertPayload } from "$app/components/server-components/Alert";
+import { useFlashMessage } from "$app/components/useFlashMessage";
 import useRouteLoading from "$app/components/useRouteLoading";
 
 type PageProps = {
@@ -33,11 +34,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
   const { title, flash, logged_in_user, current_seller } = usePage<PageProps>().props;
   const isRouteLoading = useRouteLoading();
 
-  React.useEffect(() => {
-    if (flash?.message) {
-      showAlert(flash.message, flash.status === "danger" ? "error" : flash.status);
-    }
-  }, [flash]);
+  useFlashMessage(flash);
 
   return (
     <LoggedInUserProvider value={parseLoggedInUser(logged_in_user)}>
@@ -57,11 +54,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
 export function LoggedInUserLayout({ children }: { children: React.ReactNode }) {
   const { title, flash, logged_in_user, current_seller } = usePage<PageProps>().props;
 
-  React.useEffect(() => {
-    if (flash?.message) {
-      showAlert(flash.message, flash.status === "danger" ? "error" : flash.status);
-    }
-  }, [flash]);
+  useFlashMessage(flash);
 
   return (
     <LoggedInUserProvider value={parseLoggedInUser(logged_in_user)}>

--- a/app/javascript/layouts/Admin.tsx
+++ b/app/javascript/layouts/Admin.tsx
@@ -7,7 +7,8 @@ import AdminNav from "$app/components/Admin/Nav";
 import AdminNewSalesReportPopover from "$app/components/Admin/SalesReports/NewSalesReportPopover";
 import AdminSearchPopover from "$app/components/Admin/SearchPopover";
 import LoadingSkeleton from "$app/components/LoadingSkeleton";
-import Alert, { showAlert, type AlertPayload } from "$app/components/server-components/Alert";
+import Alert, { type AlertPayload } from "$app/components/server-components/Alert";
+import { useFlashMessage } from "$app/components/useFlashMessage";
 import useRouteLoading from "$app/components/useRouteLoading";
 
 type PageProps = {
@@ -19,11 +20,7 @@ const Admin = ({ children }: { children: React.ReactNode }) => {
   const { title, flash } = usePage<PageProps>().props;
   const isRouteLoading = useRouteLoading();
 
-  React.useEffect(() => {
-    if (flash?.message) {
-      showAlert(flash.message, flash.status === "danger" ? "error" : flash.status);
-    }
-  }, [flash]);
+  useFlashMessage(flash);
 
   return (
     <div id="inertia-shell" className="flex h-screen flex-col lg:flex-row">


### PR DESCRIPTION
Issue: #2562 

# Description
Flash messages rendered on Inertia pages persist across subsequent navigations, causing stale banners to reappear even when no new action has occurred.

For example, after successfully publishing/sending an email, the success banner (“Email successfully sent”) continues to show up when navigating to unrelated pages and then returning, despite no new send action being triggered.

## Solution
Clear flash from Inertia's cache after showing it by reloading only the flash prop

---

# Before/After

**Before**

https://github.com/user-attachments/assets/24b67e4d-a43a-4cb1-8ea2-08ecab7b4b75



**After**

https://github.com/user-attachments/assets/73e4fa71-abbb-4610-a68d-41a01f2bc133



---

# Test Results

<!-- Include a screenshot of your test suite passing locally -->

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [ ] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

Was used in a couple of iterations to come up with this fix.

<!-- State whether AI was used and for what purpose, or "No AI was used for any part of this contribution." -->
