### PR TITLE
fix: Flash message persists across Inertia page navigations

### DIFF
--- a/app/controllers/concerns/inertia_rendering.rb
+++ b/app/controllers/concerns/inertia_rendering.rb
@@ -8,7 +8,6 @@ module InertiaRendering
     inertia_share do
       RenderingExtension.custom_context(view_context).merge(
         authenticity_token: form_authenticity_token,
-        flash: inertia_flash_props,
         title: @title
       )
     end
@@ -17,11 +16,4 @@ module InertiaRendering
       { current_user: current_user_props(current_user, impersonated_user) }
     end
   end
-
-  private
-    def inertia_flash_props
-      return if (flash_message = flash[:alert] || flash[:warning] || flash[:notice]).blank?
-
-      { message: flash_message, status: flash[:alert] ? "danger" : flash[:warning] ? "warning" : "success" }
-    end
 end

--- a/app/javascript/components/WarningFlashMessage.tsx
+++ b/app/javascript/components/WarningFlashMessage.tsx
@@ -1,18 +1,15 @@
 import { usePage } from "@inertiajs/react";
 import * as React from "react";
 
-import { type AlertPayload } from "$app/components/server-components/Alert";
+import { flashToAlert } from "$app/components/server-components/Alert";
 import { Alert } from "$app/components/ui/Alert";
 
-type PageProps = {
-  flash?: AlertPayload;
-};
-
 export const WarningFlash: React.FC = () => {
-  const { flash } = usePage<PageProps>().props;
+  const { flash } = usePage();
+  const flashAlert = flashToAlert(flash);
 
-  if (flash?.status === "warning" && flash.message) {
-    return <Alert variant="danger">{flash.message}</Alert>;
+  if (flashAlert?.status === "warning" && flashAlert.message) {
+    return <Alert variant="danger">{flashAlert.message}</Alert>;
   }
 
   return null;

--- a/app/javascript/components/server-components/Alert.tsx
+++ b/app/javascript/components/server-components/Alert.tsx
@@ -11,6 +11,45 @@ const ALERT_KEY = "alert";
 
 export type AlertPayload = { message: string; status: "success" | "danger" | "info" | "warning"; html?: boolean };
 
+type FlashData = Record<string, unknown>;
+
+const flashStatus = (flash: FlashData) => {
+  if (typeof flash.alert === "string") return "danger";
+  if (typeof flash.warning === "string") return "warning";
+  if (typeof flash.notice === "string") return "success";
+  return null;
+};
+
+const flashMessage = (flash: FlashData) =>
+  (typeof flash.alert === "string" && flash.alert) ||
+  (typeof flash.warning === "string" && flash.warning) ||
+  (typeof flash.notice === "string" && flash.notice) ||
+  null;
+
+export const flashToAlert = (flash?: FlashData | null): AlertPayload | null => {
+  if (!flash || typeof flash !== "object") return null;
+
+  if (
+    typeof flash.message === "string" &&
+    (flash.status === "success" || flash.status === "danger" || flash.status === "info" || flash.status === "warning")
+  ) {
+    const payload: AlertPayload = {
+      message: flash.message,
+      status: flash.status,
+    };
+    if (typeof flash.html === "boolean") {
+      payload.html = flash.html;
+    }
+    return payload;
+  }
+
+  const status = flashStatus(flash);
+  const message = flashMessage(flash);
+  if (!status || !message) return null;
+
+  return { message, status };
+};
+
 const ToastAlert = ({ initial }: { initial: AlertPayload | null }) => {
   const [alert, setAlert] = React.useState<AlertPayload | null>(initial);
   const [isVisible, setIsVisible] = React.useState(!!initial);

--- a/app/javascript/inertia/admin_app_wrapper.tsx
+++ b/app/javascript/inertia/admin_app_wrapper.tsx
@@ -6,7 +6,6 @@ import { LoggedInUser, Seller, CurrentUser } from "$app/types/user";
 import { DesignContextProvider, DesignSettings } from "$app/components/DesignSettings";
 import { DomainSettingsProvider } from "$app/components/DomainSettings";
 import { LoggedInUserProvider, parseLoggedInUser } from "$app/components/LoggedInUser";
-import { type AlertPayload } from "$app/components/server-components/Alert";
 import { SSRLocationProvider } from "$app/components/useOriginalLocation";
 import { UserAgentProvider } from "$app/components/UserAgent";
 
@@ -28,7 +27,6 @@ export type GlobalProps = {
   title: string;
   current_user: CurrentUser;
   card_types: CardType[];
-  flash: AlertPayload | null;
 };
 
 const AdminAppWrapper = ({ children, global }: { children: React.ReactNode; global: GlobalProps }) => (

--- a/app/javascript/inertia/layout.tsx
+++ b/app/javascript/inertia/layout.tsx
@@ -7,12 +7,11 @@ import { Nav } from "$app/components/client-components/Nav";
 import { CurrentSellerProvider, parseCurrentSeller } from "$app/components/CurrentSeller";
 import LoadingSkeleton from "$app/components/LoadingSkeleton";
 import { type LoggedInUser, LoggedInUserProvider, parseLoggedInUser } from "$app/components/LoggedInUser";
-import Alert, { showAlert, type AlertPayload } from "$app/components/server-components/Alert";
+import Alert, { flashToAlert, showAlert } from "$app/components/server-components/Alert";
 import useRouteLoading from "$app/components/useRouteLoading";
 
 type PageProps = {
   title: string;
-  flash?: AlertPayload;
   logged_in_user: LoggedInUser;
   current_seller: {
     id: number;
@@ -30,12 +29,15 @@ type PageProps = {
 };
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  const { title, flash, logged_in_user, current_seller } = usePage<PageProps>().props;
+  const { props, flash } = usePage<PageProps>();
+  const { title, logged_in_user, current_seller } = props;
+  const flashAlert = flashToAlert(flash);
   const isRouteLoading = useRouteLoading();
 
   React.useEffect(() => {
-    if (flash?.message) {
-      showAlert(flash.message, flash.status === "danger" ? "error" : flash.status);
+    if (flashAlert?.message) {
+      const options = flashAlert.html !== undefined ? { html: flashAlert.html } : undefined;
+      showAlert(flashAlert.message, flashAlert.status === "danger" ? "error" : flashAlert.status, options);
     }
   }, [flash]);
 
@@ -43,7 +45,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
     <LoggedInUserProvider value={parseLoggedInUser(logged_in_user)}>
       <CurrentSellerProvider value={parseCurrentSeller(current_seller)}>
         <Head title={title} />
-        <Alert initial={flash ?? null} />
+        <Alert initial={flashAlert} />
         <div id="inertia-shell" className="flex h-screen flex-col lg:flex-row">
           <Nav title="Dashboard" />
           {isRouteLoading ? <LoadingSkeleton /> : null}
@@ -55,11 +57,14 @@ export default function Layout({ children }: { children: React.ReactNode }) {
 }
 
 export function LoggedInUserLayout({ children }: { children: React.ReactNode }) {
-  const { title, flash, logged_in_user, current_seller } = usePage<PageProps>().props;
+  const { props, flash } = usePage<PageProps>();
+  const { title, logged_in_user, current_seller } = props;
+  const flashAlert = flashToAlert(flash);
 
   React.useEffect(() => {
-    if (flash?.message) {
-      showAlert(flash.message, flash.status === "danger" ? "error" : flash.status);
+    if (flashAlert?.message) {
+      const options = flashAlert.html !== undefined ? { html: flashAlert.html } : undefined;
+      showAlert(flashAlert.message, flashAlert.status === "danger" ? "error" : flashAlert.status, options);
     }
   }, [flash]);
 
@@ -67,7 +72,7 @@ export function LoggedInUserLayout({ children }: { children: React.ReactNode }) 
     <LoggedInUserProvider value={parseLoggedInUser(logged_in_user)}>
       <CurrentSellerProvider value={parseCurrentSeller(current_seller)}>
         <Head title={title} />
-        <Alert initial={flash ?? null} />
+        <Alert initial={flashAlert} />
         {children}
       </CurrentSellerProvider>
     </LoggedInUserProvider>

--- a/app/javascript/layouts/Admin.tsx
+++ b/app/javascript/layouts/Admin.tsx
@@ -7,28 +7,30 @@ import AdminNav from "$app/components/Admin/Nav";
 import AdminNewSalesReportPopover from "$app/components/Admin/SalesReports/NewSalesReportPopover";
 import AdminSearchPopover from "$app/components/Admin/SearchPopover";
 import LoadingSkeleton from "$app/components/LoadingSkeleton";
-import Alert, { showAlert, type AlertPayload } from "$app/components/server-components/Alert";
+import Alert, { flashToAlert, showAlert } from "$app/components/server-components/Alert";
 import useRouteLoading from "$app/components/useRouteLoading";
 
 type PageProps = {
   title: string;
-  flash?: AlertPayload;
 };
 
 const Admin = ({ children }: { children: React.ReactNode }) => {
-  const { title, flash } = usePage<PageProps>().props;
+  const { props, flash } = usePage<PageProps>();
+  const { title } = props;
+  const flashAlert = flashToAlert(flash);
   const isRouteLoading = useRouteLoading();
 
   React.useEffect(() => {
-    if (flash?.message) {
-      showAlert(flash.message, flash.status === "danger" ? "error" : flash.status);
+    if (flashAlert?.message) {
+      const options = flashAlert.html !== undefined ? { html: flashAlert.html } : undefined;
+      showAlert(flashAlert.message, flashAlert.status === "danger" ? "error" : flashAlert.status, options);
     }
   }, [flash]);
 
   return (
     <div id="inertia-shell" className="flex h-screen flex-col lg:flex-row">
       <Head title={title} />
-      <Alert initial={null} />
+      <Alert initial={flashAlert} />
       <AdminNav />
       <main className="flex h-screen flex-1 flex-col overflow-y-auto">
         <header className="flex items-center justify-between border-b border-border p-4 md:p-8">

--- a/config/initializers/inertia_rails.rb
+++ b/config/initializers/inertia_rails.rb
@@ -3,3 +3,20 @@
 InertiaRails.configure do |config|
   config.deep_merge_shared_data = true
 end
+
+module InertiaRails
+  class Renderer
+    unless method_defined?(:page_without_flash)
+      alias_method :page_without_flash, :page
+    end
+
+    def page
+      page = page_without_flash
+      return page if page.key?(:flash)
+
+      flash_data = @controller.flash.to_hash.symbolize_keys.slice(:notice, :alert, :warning).compact_blank
+      page[:flash] = flash_data if flash_data.present?
+      page
+    end
+  end
+end

--- a/spec/controllers/workflows_controller_spec.rb
+++ b/spec/controllers/workflows_controller_spec.rb
@@ -24,6 +24,18 @@ describe WorkflowsController, type: :controller, inertia: true do
       expect(inertia.component).to eq("Workflows/Index")
       expect(inertia.props[:workflows]).to be_an(Array)
     end
+
+    it "exposes flash in the Inertia page data without including it in props" do
+      request.session["flash"] = ActionDispatch::Flash::FlashHash.new
+      request.session["flash"]["notice"] = "Changes saved!"
+      request.headers["X-Inertia"] = "true"
+
+      get :index
+
+      page = JSON.parse(response.body)
+      expect(page["flash"]).to eq({ "notice" => "Changes saved!" })
+      expect(page["props"]).not_to have_key("flash")
+    end
   end
 
   describe "GET new" do


### PR DESCRIPTION
Issue: #2562

# Description

<!-- Briefly describe the problem and your solution -->

## Problem
Flash messages rendered on Inertia pages persist across subsequent navigations, causing stale banners to reappear even when no new action has occurred.

For example, after successfully publishing/sending an email, the success banner (“Email successfully sent”) continues to show up when navigating to unrelated pages and then returning, despite no new send action being triggered.
(this has been copied directly from the issue)

I found this issue to be reproducible and sitewide. The other proposed fixes I reviewed were incomplete or introduced new issues.
## Solution
My solution is fairly simple: stop shoving flash into shared props (which Inertia stores in history) and instead rely on top-level `page.flash`, which Inertia explicitly clears from history during navigation. The client reads `page.flash` and turns it into a toast.

While validating the fix, I hit a follow-up regression: identical toasts no longer reappeared on repeated actions (e.g. submitting the same invalid password twice on the same page). This matched neither production nor expected behavior. The fix there was to trigger the toast effect on each new Inertia response by keying the effect on the `flash` object itself (not just its message/status), so identical messages still surface every time the server responds with flash.

Possible edges I noticed that may need review:
- Only `notice`, `alert`, and `warning` are forwarded into `page.flash` for Inertia responses. Non-Inertia flows still use Rails’ regular flash rendering.
- Flash-only partial reloads should still work, but if the server returns an identical flash payload, it relies on the Inertia response object changing (which should happen per response).
---

# Before/After

<!-- For UI/CSS changes, include screenshots or videos showing both states -->
<!-- Include: Desktop (light + dark) and Mobile (light + dark) -->

Desktop Before

https://github.com/user-attachments/assets/ff44c1b8-5271-4f86-84ea-c0f6c0ac4e6f

https://github.com/user-attachments/assets/7e91a828-5268-4509-80ea-c613b5835b69

Mobile Before


https://github.com/user-attachments/assets/e611669a-f82b-42b2-9023-c62dafd2bc7a


https://github.com/user-attachments/assets/74fe89cb-7adf-4849-9a6c-6b7f86e836eb


Desktop After


https://github.com/user-attachments/assets/6d0cbe08-364f-47e4-abb5-b295944ea0ef


https://github.com/user-attachments/assets/eded722e-8e04-42bc-ae78-2bae0f79bbc8

Mobile After


https://github.com/user-attachments/assets/af154a52-1701-4e08-9c82-9b81daf0976f


https://github.com/user-attachments/assets/516a7f20-1305-48b0-aa93-0cfe03004e2f



---

# Test Results

<!-- Include a screenshot of your test suite passing locally -->
<img width="880" height="713" alt="Screenshot 2026-01-01 at 6 02 55 PM" src="https://github.com/user-attachments/assets/8f1b44d1-843f-479c-9f39-d1e4363360be" />

Ran locally (macOS, Spring disabled):
- `DISABLE_SPRING=1 bin/rspec spec/controllers/workflows_controller_spec.rb` (pass)
- `DISABLE_SPRING=1 bin/rspec spec/requests/emails/create_spec.rb` (fail: Stripe balance/VCR and purchase creation failures due to card charge validation)

Test coverage note:
- Added a controller spec to assert Inertia `page.flash` is populated and `props[:flash]` is absent for a flash response.
- The back/forward history behavior is currently verified manually (hard to simulate reliably in request specs).

---

# Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

<!-- State whether AI was used and for what purpose, or "No AI was used for any part of this contribution." -->
Codex 5.2 was used to aggregate docs related to the issue, surmise possible fixes, test the fix that made the most sense, and test edges and regressions. Throughout the process, I reviewed code changes manually, and ensured that the AI did not create complications or unnecessary changes. I cross checked the fix with Claude Opus 4.5, and the results were consistent.

# Self Review
  - Verified flash no longer persists in history; back/forward doesn’t re‑show stale toasts.
  - Confirmed identical toasts still appear on repeated actions.
  - Added controller spec for Inertia page.flash vs props.flash.
  - Manually tested and envisioned other edges, found no complications other than the one noted and fixed.
  
  
This is my first PR on the gumroad repo, if I missed any requirements for contributions please let me know.

