### PR TITLE
feat(payments): auto-remove LowBalanceFraudCheck probation when balance exceeds $100

### DIFF
--- a/app/models/concerns/user/low_balance_fraud_check.rb
+++ b/app/models/concerns/user/low_balance_fraud_check.rb
@@ -3,8 +3,11 @@
 module User::LowBalanceFraudCheck
   extend ActiveSupport::Concern
 
-  LOW_BALANCE_THRESHOLD = -100_00 # USD -100
+  LOW_BALANCE_THRESHOLD = -100_00 # USD -$100 (triggers probation)
   private_constant :LOW_BALANCE_THRESHOLD
+
+  HIGH_BALANCE_THRESHOLD = 100_00 # USD +$100 (removes probation)
+  private_constant :HIGH_BALANCE_THRESHOLD
 
   LOW_BALANCE_PROBATION_WAIT_TIME = 2.months
   private_constant :LOW_BALANCE_PROBATION_WAIT_TIME
@@ -30,12 +33,30 @@ module User::LowBalanceFraudCheck
     disable_refunds_and_put_on_probation! unless recently_probated_for_low_balance? || suspended?
   end
 
+  def check_for_high_balance_and_remove_low_balance_probation
+    return if unpaid_balance_cents <= HIGH_BALANCE_THRESHOLD
+    return if !on_probation?
+
+    probation_comment = most_recent_low_balance_probation_comment
+    return if probation_comment.nil?
+
+    revert_to_previous_risk_state!(probation_comment)
+  end
+
   private
     def disable_refunds_and_put_on_probation!
+      previous_state = user_risk_state
+
       disable_refunds!
 
       content = "Probated (payouts suspended) automatically on #{Time.current.to_fs(:formatted_date_full_month)} because of suspicious refund activity"
       self.put_on_probation(author_name: LOW_BALANCE_FRAUD_CHECK_AUTHOR_NAME, content:)
+
+      probation_comment = comments.with_type_on_probation
+                                  .where(author_name: LOW_BALANCE_FRAUD_CHECK_AUTHOR_NAME)
+                                  .order(created_at: :desc)
+                                  .first
+      probation_comment&.update!(json_data: probation_comment.json_data.merge("previous_risk_state" => previous_state))
     end
 
     def recently_probated_for_low_balance?
@@ -43,5 +64,25 @@ module User::LowBalanceFraudCheck
               .where(author_name: LOW_BALANCE_FRAUD_CHECK_AUTHOR_NAME)
               .where("created_at > ?", LOW_BALANCE_PROBATION_WAIT_TIME.ago)
               .exists?
+    end
+
+    def most_recent_low_balance_probation_comment
+      comments.with_type_on_probation
+              .where(author_name: LOW_BALANCE_FRAUD_CHECK_AUTHOR_NAME)
+              .order(created_at: :desc)
+              .first
+    end
+
+    def revert_to_previous_risk_state!(probation_comment)
+      previous_state = probation_comment.json_data["previous_risk_state"] || "compliant"
+      content = "Probation removed automatically on #{Time.current.to_fs(:formatted_date_full_month)} because balance exceeded $100"
+
+      case previous_state
+      when "not_reviewed"
+        mark_not_reviewed!(author_name: LOW_BALANCE_FRAUD_CHECK_AUTHOR_NAME, content:)
+        enable_refunds!
+      else
+        mark_compliant!(author_name: LOW_BALANCE_FRAUD_CHECK_AUTHOR_NAME, content:)
+      end
     end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -317,7 +317,7 @@ class User < ApplicationRecord
                       :do => :not_verified?
     after_transition any => %i[suspended_for_fraud suspended_for_tos_violation], :do => :invalidate_active_sessions!
     after_transition any => %i[suspended_for_fraud suspended_for_tos_violation], :do => :disable_links_and_tell_chat
-    after_transition any => %i[on_probation compliant flagged_for_tos_violation flagged_for_fraud suspended_for_tos_violation suspended_for_fraud],
+    after_transition any => %i[on_probation compliant not_reviewed flagged_for_tos_violation flagged_for_fraud suspended_for_tos_violation suspended_for_fraud],
                      :do => :add_user_comment
     after_transition any => [:flagged_for_tos_violation], :do => :add_product_comment
 
@@ -356,6 +356,10 @@ class User < ApplicationRecord
 
     event :put_on_probation do
       transition all => :on_probation
+    end
+
+    event :mark_not_reviewed do
+      transition on_probation: :not_reviewed
     end
   end
 

--- a/app/sidekiq/update_seller_refund_eligibility_job.rb
+++ b/app/sidekiq/update_seller_refund_eligibility_job.rb
@@ -13,5 +13,7 @@ class UpdateSellerRefundEligibilityJob
     elsif unpaid_balance_cents < -10000 && !user.refunds_disabled?
       user.disable_refunds!
     end
+
+    user.check_for_high_balance_and_remove_low_balance_probation
   end
 end

--- a/spec/models/concerns/user/low_balance_fraud_check_spec.rb
+++ b/spec/models/concerns/user/low_balance_fraud_check_spec.rb
@@ -5,7 +5,6 @@ require "spec_helper"
 describe User::LowBalanceFraudCheck do
   before do
     @creator = create(:user)
-    @purchase = create(:refunded_purchase, link: create(:product, user: @creator))
   end
 
   describe "#enable_refunds!" do
@@ -39,7 +38,43 @@ describe User::LowBalanceFraudCheck do
     end
   end
 
+  describe "#mark_not_reviewed!" do
+    context "when user is on probation" do
+      before do
+        @creator.put_on_probation(author_name: "admin", content: "test probation")
+      end
+
+      it "transitions from on_probation to not_reviewed" do
+        @creator.mark_not_reviewed!(author_name: "LowBalanceFraudCheck", content: "auto removed")
+
+        expect(@creator.reload.user_risk_state).to eq("not_reviewed")
+      end
+    end
+
+    context "when user is not on probation" do
+      it "raises an error when transitioning from not_reviewed" do
+        expect(@creator.user_risk_state).to eq("not_reviewed")
+
+        expect do
+          @creator.mark_not_reviewed!(author_name: "test", content: "test")
+        end.to raise_error(StateMachines::InvalidTransition)
+      end
+
+      it "raises an error when transitioning from compliant" do
+        @creator.mark_compliant!(author_name: "admin", content: "test")
+
+        expect do
+          @creator.mark_not_reviewed!(author_name: "test", content: "test")
+        end.to raise_error(StateMachines::InvalidTransition)
+      end
+    end
+  end
+
   describe "#check_for_low_balance_and_probate" do
+    before do
+      @purchase = create(:refunded_purchase, link: create(:product, user: @creator))
+    end
+
     context "when the unpaid balance is above threshold" do
       before do
         allow(@creator).to receive(:unpaid_balance_cents).and_return(-40_00)
@@ -140,6 +175,133 @@ describe User::LowBalanceFraudCheck do
             end
           end
         end
+      end
+    end
+  end
+
+  describe "#disable_refunds_and_put_on_probation!" do
+    it "stores the previous risk state in the probation comment" do
+      expect(@creator.user_risk_state).to eq("not_reviewed")
+
+      @creator.send(:disable_refunds_and_put_on_probation!)
+
+      probation_comment = @creator.comments.with_type_on_probation.order(created_at: :desc).first
+      expect(probation_comment.json_data["previous_risk_state"]).to eq("not_reviewed")
+    end
+
+    it "stores compliant state when user was compliant before probation" do
+      @creator.mark_compliant!(author_name: "admin", content: "cleared")
+      expect(@creator.user_risk_state).to eq("compliant")
+
+      @creator.send(:disable_refunds_and_put_on_probation!)
+
+      probation_comment = @creator.comments.with_type_on_probation.order(created_at: :desc).first
+      expect(probation_comment.json_data["previous_risk_state"]).to eq("compliant")
+    end
+  end
+
+  describe "#check_for_high_balance_and_remove_low_balance_probation" do
+    context "when user is on LowBalanceFraudCheck probation" do
+      before do
+        @creator.send(:disable_refunds_and_put_on_probation!)
+        @creator.reload
+      end
+
+      context "when balance exceeds $100" do
+        before do
+          allow(@creator).to receive(:unpaid_balance_cents).and_return(101_00)
+        end
+
+        it "reverts to not_reviewed when previous state was not_reviewed" do
+          @creator.check_for_high_balance_and_remove_low_balance_probation
+
+          expect(@creator.reload.user_risk_state).to eq("not_reviewed")
+          expect(@creator.refunds_disabled?).to eq(false)
+        end
+
+        it "reverts to compliant when previous state was compliant" do
+          probation_comment = @creator.comments.with_type_on_probation.order(created_at: :desc).first
+          probation_comment.update!(json_data: probation_comment.json_data.merge("previous_risk_state" => "compliant"))
+
+          @creator.check_for_high_balance_and_remove_low_balance_probation
+
+          expect(@creator.reload.user_risk_state).to eq("compliant")
+          expect(@creator.refunds_disabled?).to eq(false)
+        end
+
+        it "defaults to compliant for legacy comments without previous_risk_state" do
+          probation_comment = @creator.comments.with_type_on_probation.order(created_at: :desc).first
+          probation_comment.update!(json_data: {})
+
+          @creator.check_for_high_balance_and_remove_low_balance_probation
+
+          expect(@creator.reload.user_risk_state).to eq("compliant")
+          expect(@creator.refunds_disabled?).to eq(false)
+        end
+
+        it "creates a comment explaining the removal" do
+          @creator.check_for_high_balance_and_remove_low_balance_probation
+
+          latest_comment = @creator.reload.comments.order(id: :desc).first
+          expect(latest_comment.content).to eq("Probation removed automatically on #{Time.current.to_fs(:formatted_date_full_month)} because balance exceeded $100")
+        end
+
+        it "enables refunds" do
+          @creator.check_for_high_balance_and_remove_low_balance_probation
+
+          expect(@creator.reload.refunds_disabled?).to eq(false)
+        end
+      end
+
+      context "when balance is exactly $100" do
+        before do
+          allow(@creator).to receive(:unpaid_balance_cents).and_return(100_00)
+        end
+
+        it "does not remove probation" do
+          @creator.check_for_high_balance_and_remove_low_balance_probation
+
+          expect(@creator.reload.on_probation?).to eq(true)
+        end
+      end
+
+      context "when balance is below $100" do
+        before do
+          allow(@creator).to receive(:unpaid_balance_cents).and_return(50_00)
+        end
+
+        it "does not remove probation" do
+          @creator.check_for_high_balance_and_remove_low_balance_probation
+
+          expect(@creator.reload.on_probation?).to eq(true)
+        end
+      end
+    end
+
+    context "when user is manually probated (not by LowBalanceFraudCheck)" do
+      before do
+        @creator.put_on_probation(author_name: "admin", content: "manual probation")
+        allow(@creator).to receive(:unpaid_balance_cents).and_return(101_00)
+      end
+
+      it "does not remove probation" do
+        @creator.check_for_high_balance_and_remove_low_balance_probation
+
+        expect(@creator.reload.on_probation?).to eq(true)
+      end
+    end
+
+    context "when user is not on probation" do
+      before do
+        allow(@creator).to receive(:unpaid_balance_cents).and_return(101_00)
+      end
+
+      it "does nothing" do
+        expect(@creator.on_probation?).to eq(false)
+
+        @creator.check_for_high_balance_and_remove_low_balance_probation
+
+        expect(@creator.reload.user_risk_state).to eq("not_reviewed")
       end
     end
   end

--- a/spec/sidekiq/update_seller_refund_eligibility_job_spec.rb
+++ b/spec/sidekiq/update_seller_refund_eligibility_job_spec.rb
@@ -52,4 +52,43 @@ describe UpdateSellerRefundEligibilityJob do
       expect { perform }.to change { user.reload.refunds_disabled? }.from(false).to(true)
     end
   end
+
+  context "when user is on LowBalanceFraudCheck probation" do
+    before do
+      user.send(:disable_refunds_and_put_on_probation!)
+      user.reload
+    end
+
+    it "removes probation when balance exceeds $100" do
+      allow_any_instance_of(User).to receive(:unpaid_balance_cents).and_return(101_00)
+
+      expect { perform }.to change { user.reload.on_probation? }.from(true).to(false)
+      expect(user.refunds_disabled?).to eq(false)
+    end
+
+    it "does not remove probation when balance is $100 or below" do
+      allow_any_instance_of(User).to receive(:unpaid_balance_cents).and_return(100_00)
+
+      expect { perform }.not_to change { user.reload.on_probation? }
+    end
+
+    it "reverts to original risk state (not_reviewed)" do
+      allow_any_instance_of(User).to receive(:unpaid_balance_cents).and_return(101_00)
+
+      perform
+
+      expect(user.reload.user_risk_state).to eq("not_reviewed")
+    end
+  end
+
+  context "when user is manually probated by admin" do
+    before do
+      user.put_on_probation(author_name: "admin", content: "manual probation")
+      allow_any_instance_of(User).to receive(:unpaid_balance_cents).and_return(101_00)
+    end
+
+    it "does not remove probation even when balance exceeds $100" do
+      expect { perform }.not_to change { user.reload.on_probation? }
+    end
+  end
 end


### PR DESCRIPTION
Issue: #1884

# Description

## Problem

When a user's balance drops below -$100 due to refunds/chargebacks, they are automatically put on probation by `LowBalanceFraudCheck`. However, there was no mechanism to automatically remove this probation when their balance recovered.

Previous 5 PRs were rejected because they incorrectly reverted all users to "compliant" state, but users can be "not_reviewed" before being probated.

## Solution

- Store the user's previous `user_risk_state` in the probation comment's `json_data` when probating
- Add `check_for_high_balance_and_remove_low_balance_probation` method that:
  - Triggers when balance exceeds $100
  - Reverts to the stored previous state (not just "compliant")
  - Only affects LowBalanceFraudCheck probations (not manual admin probations)
- Add `mark_not_reviewed` state machine event for proper state restoration

---

# Before/After

Backend-only change - no UI modifications.

---

# Test Results

<img width="1663" height="457" alt="Screenshot 2026-01-02 at 6 18 48 pm" src="https://github.com/user-attachments/assets/2a7016bf-6f6c-480a-93a1-8e80c2dec1f6" />



---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

AI (Claude Code) was used for:
- Analyzing the codebase and understanding why 5 previous PRs were rejected
- Writing the implementation code (state machine event, concern methods, job integration)
- Writing test cases
- Creating the PR description and self-review comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)