### PR TITLE
Fix(test): adds dummy `PAYPAL_MERCHANT_EMAIL` to `.env.test`

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -25,6 +25,7 @@ OBFUSCATE_IDS_CIPHER_KEY=test-cipher-key
 IFFY_TOKEN=test-iffy-token
 IFFY_WEBHOOK_SECRET=test-iffy-webhook-secret
 PAYPAL_PARTNER_MERCHANT_ID=TESTPAYPALID
+PAYPAL_MERCHANT_EMAIL=test-paypal-merchant-email
 HELPER_WIDGET_SECRET=test-helper-secret
 HELPER_TOOLS_TOKEN=test-helper-tools-token
 GRMC_WEBHOOK_SECRET=test-grmc-webhook-secret


### PR DESCRIPTION
Issue: #959 

## Problem

### CI Log: 

<img width="1114" height="174" alt="Screenshot 2026-01-02 at 2 17 45 PM" src="https://github.com/user-attachments/assets/2006cc21-df37-41e2-8ae5-a9b4ca284870" />

### VCR configuration: 
```rb
config.filter_sensitive_data("<PAYPAL_MERCHANT_EMAIL>") { GlobalConfig.get("PAYPAL_MERCHANT_EMAIL") }
```

When GlobalConfig.get("PAYPAL_MERCHANT_EMAIL") returns nil, VCR's filter_sensitive_data cannot properly handle the placeholder during playback. The raw <PAYPAL_MERCHANT_EMAIL> text stays in the XML response.
and tests fails with : 
```text
Missing end tag for 'PAYPAL_MERCHANT_EMAIL' (got 'Business')
```

<img width="924" height="446" alt="Screenshot 2026-01-02 at 2 16 14 PM" src="https://github.com/user-attachments/assets/633730ee-7b73-4470-910b-cb2f714f6af9" />


## Solution:
- added `PAYPAL_MERCHANT_EMAIL=test-paypal-merchant-email` in .env.test
- This gives VCR's filter_sensitive_data a non-nil value, so the <PAYPAL_MERCHANT_EMAIL> placeholder in cassettes gets replaced with test-paypal-merchant-email during playback, producing valid XML


---

# Test Results

# Before:
### CI:
<img width="2038" height="559" alt="Screenshot 2026-01-02 at 1 21 07 PM" src="https://github.com/user-attachments/assets/ee2f0305-4413-4269-a0e1-baed0c7ee607" />

### Local: 
<img width="1278" height="566" alt="Screenshot 2026-01-02 at 1 57 10 PM" src="https://github.com/user-attachments/assets/ceb2080c-d7cf-43c5-b662-743124fafd33" />

# After:
### Local: 
<img width="1276" height="419" alt="Screenshot 2026-01-02 at 1 55 56 PM" src="https://github.com/user-attachments/assets/d91c6249-545d-4719-80d1-f9f3f8ebcfcf" />

---


# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure
- use cursor with claude sonnet-4.5 for debugging purpose