### PR TITLE
fix(profile): Display all selected products in profile sections

### DIFF
--- a/app/presenters/profile_sections_presenter.rb
+++ b/app/presenters/profile_sections_presenter.rb
@@ -127,6 +127,7 @@ class ProfileSectionsPresenter
             section:,
             is_alive_on_profile: true,
             user_id: seller.id,
+            size: section.shown_products.length,
           }
         )
       )

--- a/spec/presenters/profile_sections_presenter_spec.rb
+++ b/spec/presenters/profile_sections_presenter_spec.rb
@@ -147,4 +147,20 @@ describe ProfileSectionsPresenter do
       subject.props(request:, pundit_user:, seller_custom_domain_url: nil)
     end
   end
+
+  describe "#section_search_results" do
+    context "when section has more than 9 products" do
+      it "returns all selected products" do
+        many_products = create_list(:product, 10, user: seller)
+        section_with_many_products = create(:seller_profile_products_section, seller:, shown_products: many_products.map(&:id))
+        Link.import(force: true, refresh: true)
+
+        presenter = described_class.new(seller:, query: seller.seller_profile_sections.where(id: section_with_many_products.id))
+        cached_sections = presenter.cached_sections
+
+        expect(cached_sections.first[:search_results][:total]).to eq(10)
+        expect(cached_sections.first[:search_results][:products].length).to eq(10)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description
Fixes issue #2476 where profile product sections displayed only 9 products even when more were selected.

The root cause was that `section_search_results` did not pass a `size` parameter, causing Elasticsearch to fall back to `RECOMMENDED_PRODUCTS_PER_PAGE = 9` instead of returning all `shown_products`.

## Changes
- Added `size: section.shown_products.length` parameter to `section_search_results` method in `ProfileSectionsPresenter` to ensure all selected products are returned
- Added a test to verify all products are returned when a section has 10+ products

The fix ensures that when a profile section has `shown_products` selected, the Elasticsearch query uses the actual count of selected products rather than the default limit of 9. This allows sections with 10, 11, or any number of products to display all of them correctly.

## Testing
All tests pass locally (5 examples, 0 failures). Manually verified that sections with 10+ products now render correctly on product pages. Test case added to prevent regression.
![tests_passed](https://github.com/user-attachments/assets/07d5c981-64ec-4695-91de-c75ab5e526cc)

## Videos
**Before** - The video shows that when 10 products were present only 9 were visible, and also shows manually adding one product, making the total 11, but still 9 were visible

https://github.com/user-attachments/assets/eba7e6d7-5e52-4bb7-8e1f-ef31000d5bf9

https://github.com/user-attachments/assets/e2413433-1a8d-4ee5-89be-862b272f385b

**After** - The video shows that now all the products that are added are visible they don't get stuck at 9

https://github.com/user-attachments/assets/af664072-024c-4e1d-aa31-000acf74a68c

https://github.com/user-attachments/assets/c42d1dc3-1602-4b06-8f16-f615e1061893

## Screenshots

### Desktop
| Before | After |
|--------|-------|
| <img width="1271" height="719" alt="Desktop before - 9 products" src="https://github.com/user-attachments/assets/3d7aa8c7-da9e-410c-8629-56e628471334" /> | <img width="1280" height="747" alt="Desktop after - 10+ products" src="https://github.com/user-attachments/assets/92f84132-bb3f-4304-a8f6-0c0bf1e4995d" /> |

### Mobile
| Before | After |
|--------|-------|
| <img width="292" height="617" alt="Mobile before - 9 products" src="https://github.com/user-attachments/assets/cb07a594-13fc-4fd8-a779-a28330f6e3d8" /> | <img width="290" height="618" alt="Mobile after - 10+ products" src="https://github.com/user-attachments/assets/07a5dc8e-5894-4b52-9ce6-1b2ae04b1de2" /> |
| <img width="289" height="595" alt="Mobile before - 9 products" src="https://github.com/user-attachments/assets/6407d4c9-a27a-41c1-8ab4-cffc78015291" /> | <img width="288" height="590" alt="Mobile after - 10+ products" src="https://github.com/user-attachments/assets/11b54bd4-38e6-4115-9351-edbe6ca817fc" /> |

## Self-Review
- Verified the fix ensures `size` parameter matches the number of selected products
- Confirmed the change follows existing code patterns in the file
- Test covers the specific bug scenario (10+ products)
- No breaking changes introduced
- Code follows existing style (no comments, proper formatting)

## AI Disclosure
Used Cursor AI for code analysis and finding related tests.

Fixes #2476