### PR TITLE
feat(risk): auto-remove LowBalanceFraudCheck probation when balance exceeds $100

### DIFF
--- a/app/models/concerns/user/low_balance_fraud_check.rb
+++ b/app/models/concerns/user/low_balance_fraud_check.rb
@@ -3,8 +3,11 @@
 module User::LowBalanceFraudCheck
   extend ActiveSupport::Concern
 
-  LOW_BALANCE_THRESHOLD = -100_00 # USD -100
+  LOW_BALANCE_THRESHOLD = -100_00 # USD -$100 (triggers probation)
   private_constant :LOW_BALANCE_THRESHOLD
+
+  HIGH_BALANCE_THRESHOLD = 100_00 # USD +$100 (removes probation)
+  private_constant :HIGH_BALANCE_THRESHOLD
 
   LOW_BALANCE_PROBATION_WAIT_TIME = 2.months
   private_constant :LOW_BALANCE_PROBATION_WAIT_TIME
@@ -30,6 +33,14 @@ module User::LowBalanceFraudCheck
     disable_refunds_and_put_on_probation! unless recently_probated_for_low_balance? || suspended?
   end
 
+  def check_for_high_balance_and_remove_low_balance_probation!
+    return if unpaid_balance_cents <= HIGH_BALANCE_THRESHOLD
+    return if !on_probation?
+    return if !should_auto_remove_probation?
+
+    revert_to_previous_risk_state!
+  end
+
   private
     def disable_refunds_and_put_on_probation!
       disable_refunds!
@@ -43,5 +54,53 @@ module User::LowBalanceFraudCheck
               .where(author_name: LOW_BALANCE_FRAUD_CHECK_AUTHOR_NAME)
               .where("created_at > ?", LOW_BALANCE_PROBATION_WAIT_TIME.ago)
               .exists?
+    end
+
+    def should_auto_remove_probation?
+      low_balance_probation_comment = most_recent_low_balance_probation_comment
+      return false if low_balance_probation_comment.nil?
+
+      !has_newer_risk_state_transition?(low_balance_probation_comment)
+    end
+
+    def most_recent_low_balance_probation_comment
+      comments.with_type_on_probation
+              .where(author_name: LOW_BALANCE_FRAUD_CHECK_AUTHOR_NAME)
+              .order(created_at: :desc)
+              .first
+    end
+
+    def has_newer_risk_state_transition?(probation_comment)
+      comments.where(comment_type: Comment::RISK_STATE_COMMENT_TYPES)
+              .where("id > ?", probation_comment.id)
+              .exists?
+    end
+
+    def revert_to_previous_risk_state!
+      previous_state = previous_risk_state_from_paper_trail
+      return if previous_state.in?(%w[flagged_for_fraud flagged_for_tos_violation])
+
+      content = "Probation removed automatically on #{Time.current.to_fs(:formatted_date_full_month)} because balance exceeded $100"
+
+      case previous_state
+      when "not_reviewed"
+        mark_not_reviewed!(author_name: LOW_BALANCE_FRAUD_CHECK_AUTHOR_NAME, content:)
+        enable_refunds!
+      else
+        mark_compliant!(author_name: LOW_BALANCE_FRAUD_CHECK_AUTHOR_NAME, content:)
+      end
+    end
+
+    def previous_risk_state_from_paper_trail
+      probation_version = versions.where("object_changes LIKE ?", "%user_risk_state%")
+                                  .where("object_changes LIKE ?", "%on_probation%")
+                                  .order(created_at: :desc)
+                                  .first
+      return "compliant" if probation_version.nil?
+
+      changeset = probation_version.changeset
+      return "compliant" if changeset.nil? || !changeset.key?("user_risk_state")
+
+      changeset["user_risk_state"].first || "compliant"
     end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -317,7 +317,7 @@ class User < ApplicationRecord
                       :do => :not_verified?
     after_transition any => %i[suspended_for_fraud suspended_for_tos_violation], :do => :invalidate_active_sessions!
     after_transition any => %i[suspended_for_fraud suspended_for_tos_violation], :do => :disable_links_and_tell_chat
-    after_transition any => %i[on_probation compliant flagged_for_tos_violation flagged_for_fraud suspended_for_tos_violation suspended_for_fraud],
+    after_transition any => %i[on_probation compliant not_reviewed flagged_for_tos_violation flagged_for_fraud suspended_for_tos_violation suspended_for_fraud],
                      :do => :add_user_comment
     after_transition any => [:flagged_for_tos_violation], :do => :add_product_comment
 
@@ -356,6 +356,10 @@ class User < ApplicationRecord
 
     event :put_on_probation do
       transition all => :on_probation
+    end
+
+    event :mark_not_reviewed do
+      transition on_probation: :not_reviewed
     end
   end
 

--- a/app/modules/user/risk.rb
+++ b/app/modules/user/risk.rb
@@ -176,6 +176,8 @@ module User::Risk
     content = case transition.to_name
               when :compliant
                 "Marked compliant by #{author_name} on #{date}"
+              when :not_reviewed
+                "Marked not reviewed by #{author_name} on #{date}"
               when :on_probation
                 "Probated (payouts suspended) by #{author_name} on #{date}"
               when :flagged_for_tos_violation
@@ -192,7 +194,7 @@ module User::Risk
                 transition.to_name.to_s.humanize
     end
     comment_type = case transition.to_name
-                   when :compliant
+                   when :compliant, :not_reviewed
                      Comment::COMMENT_TYPE_COMPLIANT
                    when :on_probation
                      Comment::COMMENT_TYPE_ON_PROBATION

--- a/app/sidekiq/update_seller_refund_eligibility_job.rb
+++ b/app/sidekiq/update_seller_refund_eligibility_job.rb
@@ -13,5 +13,7 @@ class UpdateSellerRefundEligibilityJob
     elsif unpaid_balance_cents < -10000 && !user.refunds_disabled?
       user.disable_refunds!
     end
+
+    user.check_for_high_balance_and_remove_low_balance_probation!
   end
 end

--- a/spec/models/concerns/user/low_balance_fraud_check_spec.rb
+++ b/spec/models/concerns/user/low_balance_fraud_check_spec.rb
@@ -39,6 +39,46 @@ describe User::LowBalanceFraudCheck do
     end
   end
 
+  describe "#mark_not_reviewed!" do
+    context "when user is on probation" do
+      before do
+        @creator.put_on_probation(author_name: "admin", content: "test probation")
+      end
+
+      it "transitions from on_probation to not_reviewed" do
+        @creator.mark_not_reviewed!(author_name: "LowBalanceFraudCheck", content: "auto removed")
+
+        expect(@creator.reload.user_risk_state).to eq("not_reviewed")
+      end
+
+      it "creates a comment with compliant comment_type" do
+        @creator.mark_not_reviewed!(author_name: "LowBalanceFraudCheck", content: "auto removed")
+
+        comment = @creator.comments.order(id: :desc).first
+        expect(comment.comment_type).to eq(Comment::COMMENT_TYPE_COMPLIANT)
+        expect(comment.content).to eq("auto removed")
+      end
+    end
+
+    context "when user is not on probation" do
+      it "raises an error when transitioning from not_reviewed" do
+        expect(@creator.user_risk_state).to eq("not_reviewed")
+
+        expect do
+          @creator.mark_not_reviewed!(author_name: "test", content: "test")
+        end.to raise_error(StateMachines::InvalidTransition)
+      end
+
+      it "raises an error when transitioning from compliant" do
+        @creator.mark_compliant!(author_name: "admin", content: "test")
+
+        expect do
+          @creator.mark_not_reviewed!(author_name: "test", content: "test")
+        end.to raise_error(StateMachines::InvalidTransition)
+      end
+    end
+  end
+
   describe "#check_for_low_balance_and_probate" do
     context "when the unpaid balance is above threshold" do
       before do
@@ -141,6 +181,184 @@ describe User::LowBalanceFraudCheck do
           end
         end
       end
+    end
+  end
+
+  describe "#check_for_high_balance_and_remove_low_balance_probation!", versioning: true do
+    context "when user is on LowBalanceFraudCheck probation" do
+      before do
+        @creator.send(:disable_refunds_and_put_on_probation!)
+        @creator.reload
+      end
+
+      context "when balance exceeds $100" do
+        before do
+          allow(@creator).to receive(:unpaid_balance_cents).and_return(101_00)
+        end
+
+        it "reverts to not_reviewed when previous state was not_reviewed" do
+          @creator.check_for_high_balance_and_remove_low_balance_probation!
+
+          expect(@creator.reload.user_risk_state).to eq("not_reviewed")
+          expect(@creator.refunds_disabled?).to eq(false)
+        end
+
+        it "reverts to compliant when previous state was compliant" do
+          # Start fresh to get a clean version history
+          creator = create(:user)
+          creator.mark_compliant!(author_name: "admin", content: "cleared")
+          creator.send(:disable_refunds_and_put_on_probation!)
+          creator.reload
+          allow(creator).to receive(:unpaid_balance_cents).and_return(101_00)
+
+          creator.check_for_high_balance_and_remove_low_balance_probation!
+
+          expect(creator.reload.user_risk_state).to eq("compliant")
+          expect(creator.refunds_disabled?).to eq(false)
+        end
+
+        it "creates a comment explaining the removal" do
+          @creator.check_for_high_balance_and_remove_low_balance_probation!
+
+          latest_comment = @creator.reload.comments.order(id: :desc).first
+          expect(latest_comment.content).to eq("Probation removed automatically on #{Time.current.to_fs(:formatted_date_full_month)} because balance exceeded $100")
+        end
+
+        it "enables refunds" do
+          @creator.check_for_high_balance_and_remove_low_balance_probation!
+
+          expect(@creator.reload.refunds_disabled?).to eq(false)
+        end
+      end
+
+      context "when balance is exactly $100" do
+        before do
+          allow(@creator).to receive(:unpaid_balance_cents).and_return(100_00)
+        end
+
+        it "does not remove probation" do
+          @creator.check_for_high_balance_and_remove_low_balance_probation!
+
+          expect(@creator.reload.on_probation?).to eq(true)
+        end
+      end
+
+      context "when balance is below $100" do
+        before do
+          allow(@creator).to receive(:unpaid_balance_cents).and_return(50_00)
+        end
+
+        it "does not remove probation" do
+          @creator.check_for_high_balance_and_remove_low_balance_probation!
+
+          expect(@creator.reload.on_probation?).to eq(true)
+        end
+      end
+    end
+
+    context "when user is manually probated by admin" do
+      before do
+        @creator.put_on_probation(author_name: "admin", content: "manual probation")
+        allow(@creator).to receive(:unpaid_balance_cents).and_return(101_00)
+      end
+
+      it "does not remove probation" do
+        @creator.check_for_high_balance_and_remove_low_balance_probation!
+
+        expect(@creator.reload.on_probation?).to eq(true)
+      end
+    end
+
+    context "when user was flagged_for_fraud before probation" do
+      before do
+        @creator.flag_for_fraud!(author_name: "admin", content: "fraud investigation")
+        @creator.send(:disable_refunds_and_put_on_probation!)
+        @creator.reload
+        allow(@creator).to receive(:unpaid_balance_cents).and_return(101_00)
+      end
+
+      it "does not remove probation because admin flagged them" do
+        @creator.check_for_high_balance_and_remove_low_balance_probation!
+
+        expect(@creator.reload.on_probation?).to eq(true)
+      end
+    end
+
+    context "when user was flagged_for_tos_violation before probation" do
+      before do
+        product = create(:product, user: @creator)
+        @creator.flag_for_tos_violation!(author_name: "admin", content: "tos investigation", product_id: product.id)
+        @creator.send(:disable_refunds_and_put_on_probation!)
+        @creator.reload
+        allow(@creator).to receive(:unpaid_balance_cents).and_return(101_00)
+      end
+
+      it "does not remove probation because admin flagged them" do
+        @creator.check_for_high_balance_and_remove_low_balance_probation!
+
+        expect(@creator.reload.on_probation?).to eq(true)
+      end
+    end
+
+    context "when user has a newer state transition after LowBalanceFraudCheck probation" do
+      before do
+        @creator.send(:disable_refunds_and_put_on_probation!)
+        # Admin reviews and clears the user
+        @creator.mark_compliant!(author_name: "admin", content: "reviewed and cleared")
+        # Then admin probates again for a different reason
+        @creator.put_on_probation(author_name: "admin", content: "probated again manually")
+        allow(@creator).to receive(:unpaid_balance_cents).and_return(101_00)
+      end
+
+      it "does not remove probation because admin took action after the auto-probation" do
+        @creator.check_for_high_balance_and_remove_low_balance_probation!
+
+        expect(@creator.reload.on_probation?).to eq(true)
+      end
+    end
+
+    context "when user is not on probation" do
+      before do
+        allow(@creator).to receive(:unpaid_balance_cents).and_return(101_00)
+      end
+
+      it "does nothing" do
+        expect(@creator.on_probation?).to eq(false)
+
+        @creator.check_for_high_balance_and_remove_low_balance_probation!
+
+        expect(@creator.reload.user_risk_state).to eq("not_reviewed")
+      end
+    end
+  end
+
+  describe "#previous_risk_state_from_paper_trail", versioning: true do
+    it "returns the previous state before probation from PaperTrail" do
+      creator = create(:user)
+      expect(creator.user_risk_state).to eq("not_reviewed")
+      creator.send(:disable_refunds_and_put_on_probation!)
+
+      previous_state = creator.send(:previous_risk_state_from_paper_trail)
+
+      expect(previous_state).to eq("not_reviewed")
+    end
+
+    it "returns compliant when user was compliant before probation" do
+      creator = create(:user)
+      creator.mark_compliant!(author_name: "admin", content: "cleared")
+      creator.send(:disable_refunds_and_put_on_probation!)
+
+      previous_state = creator.send(:previous_risk_state_from_paper_trail)
+
+      expect(previous_state).to eq("compliant")
+    end
+
+    it "returns compliant when no probation version is found" do
+      creator = create(:user)
+
+      previous_state = creator.send(:previous_risk_state_from_paper_trail)
+
+      expect(previous_state).to eq("compliant")
     end
   end
 end

--- a/spec/sidekiq/update_seller_refund_eligibility_job_spec.rb
+++ b/spec/sidekiq/update_seller_refund_eligibility_job_spec.rb
@@ -52,4 +52,43 @@ describe UpdateSellerRefundEligibilityJob do
       expect { perform }.to change { user.reload.refunds_disabled? }.from(false).to(true)
     end
   end
+
+  context "when user is on LowBalanceFraudCheck probation", versioning: true do
+    before do
+      user.send(:disable_refunds_and_put_on_probation!)
+      user.reload
+    end
+
+    it "removes probation when balance exceeds $100" do
+      allow_any_instance_of(User).to receive(:unpaid_balance_cents).and_return(101_00)
+
+      expect { perform }.to change { user.reload.on_probation? }.from(true).to(false)
+      expect(user.refunds_disabled?).to eq(false)
+    end
+
+    it "does not remove probation when balance is $100 or below" do
+      allow_any_instance_of(User).to receive(:unpaid_balance_cents).and_return(100_00)
+
+      expect { perform }.not_to change { user.reload.on_probation? }
+    end
+
+    it "reverts to original risk state (not_reviewed)" do
+      allow_any_instance_of(User).to receive(:unpaid_balance_cents).and_return(101_00)
+
+      perform
+
+      expect(user.reload.user_risk_state).to eq("not_reviewed")
+    end
+  end
+
+  context "when user is manually probated by admin" do
+    before do
+      user.put_on_probation(author_name: "admin", content: "manual probation")
+      allow_any_instance_of(User).to receive(:unpaid_balance_cents).and_return(101_00)
+    end
+
+    it "does not remove probation even when balance exceeds $100" do
+      expect { perform }.not_to change { user.reload.on_probation? }
+    end
+  end
 end


### PR DESCRIPTION
Issue: #1884

# Description
## Problem
When sellers are automatically put on probation by LowBalanceFraudCheck due to suspicious refund activity, there's no automatic way to remove that probation when their balance recovers. This requires manual admin intervention even though the original trigger condition is no longer met.

## Solution
Automatically remove LowBalanceFraudCheck probation when the seller's unpaid balance exceeds $100, restoring them to their previous risk state using PaperTrail version history.

Key implementation details:
- Uses PaperTrail to retrieve the previous risk state before probation was applied
- Only auto-removes probation if the most recent probation was applied by LowBalanceFraudCheck (not manually by an admin)
- Guards against removing probation if an admin took any action after the auto-probation
- Skips auto-removal if previous state was `flagged_for_fraud` or `flagged_for_tos_violation` (admin should review these cases)
- Restores to `not_reviewed` or `compliant` based on PaperTrail history
- Adds `mark_not_reviewed!` state machine event for `on_probation → not_reviewed` transitions

---
# Before/After
Backend-only change

---
# Test Results
```
Finished in 6.13 seconds
33 examples, 0 failures
```

---
# Checklist
- [x] I have read the contributing guidelines
- [x] I have watched Gumroad PR review livestreams
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---
# AI Disclosure
AI (Claude Code) was used for:
- Implementing the feature based on PR #2618 feedback from EmCousin
- Writing comprehensive tests for all scenarios
- Adding PaperTrail integration for state history lookup
- Identifying and fixing edge case where flagged states couldn't be restored due to state machine constraints