### PR TITLE
fix: handle fileEmbed nodes with null id/uid

### DIFF
--- a/app/javascript/components/ProductEdit/ContentTab/FileEmbed.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/FileEmbed.tsx
@@ -53,6 +53,8 @@ export const getDraggedFileEmbed = (editor: Editor) => {
 };
 
 const FileEmbedNodeView = ({ node, editor, getPos, updateAttributes }: NodeViewProps) => {
+  if (!node.attrs.id) return;
+
   const { id, updateProduct, filesById } = useProductEditContext();
   const uid = React.useId();
   const ref = React.useRef<HTMLDivElement>(null);


### PR DESCRIPTION
Issue: https://github.com/antiwork/gumroad/issues/2619

# Description

This is a quick fix for the issue, to handle null id/uid.

We will still need to identify the exact reproduction steps that allow null id and uid to be persisted, then fix the root cause

## Problem
Product ID `XqmlbQubOBcBGRD3sb3toQ==` contain `fileEmbed` nodes in their `rich_content` with null `id` and `uid` values, causing rendering errors on the product edit page
<img width="591" height="400" alt="Image" src="https://github.com/user-attachments/assets/67ded112-dce4-411b-8d98-4809d59d856e" />

## Solution

Add an early return in `FileEmbedNodeView` component to handle `fileEmbed` nodes with null `id` values

---

# Before/After

I manually add `fileEmbed` nodes with null `id` and `uid` values using rails console for test:


## Before
<img width="1470" height="796" alt="image" src="https://github.com/user-attachments/assets/87e51e43-566e-4e36-bfb8-c6fc21297129" />

## After
<img width="1470" height="797" alt="image" src="https://github.com/user-attachments/assets/af52bd00-4b64-4b64-82b9-79d4b2875195" />


---

# AI Disclosure

No AI was used for any part of this contribution.
