### PR TITLE
fix: follow wishlist from the discover page

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -845,7 +845,7 @@ Rails.application.routes.draw do
     end
     resources :wishlists, only: [:index, :create, :update, :destroy] do
       resources :products, only: [:create], controller: "wishlists/products"
-      resource :followers, only: [:destroy], controller: "wishlists/followers" do
+      resource :followers, only: [:create, :destroy], controller: "wishlists/followers" do
         get :unsubscribe
       end
     end


### PR DESCRIPTION
# Description

## Problem

Users could not follow a wishlist from the Discover page because the followers route did not support a POST request under `GumroadDomainConstraint`. This caused the action to fail with:

`No route matches [POST] "/wishlists/_w5Cs2L-I6DhfvBIR1Mp8w==/followers"`

## Solution
Updated the wishlist followers route to support both `create` and `destroy` actions under `GumroadDomainConstraint`

# Before/After

### Before


https://github.com/user-attachments/assets/ebf09bbb-f9a0-4f84-830b-7b687b753204



### After


https://github.com/user-attachments/assets/978efa74-bbae-4275-89ff-8f2414aa234d


---
