### PR TITLE
Fix: Apply variant filters to product installments in `missed_for_purchase` scope

### DIFF
--- a/app/models/installment.rb
+++ b/app/models/installment.rb
@@ -130,7 +130,9 @@ class Installment < ApplicationRecord
   }
 
   scope :missed_for_purchase, -> (purchase) {
-    product_installment_ids = purchase.link.installments.where(seller_id: purchase.seller_id).alive.published.pluck(:id)
+    product_installment_ids = purchase.link.installments.where(seller_id: purchase.seller_id).alive.published.filter_map do |post|
+      post.id if post.purchase_passes_filters(purchase)
+    end
     seller_installment_ids = purchase.seller.installments.alive.published.filter_map do |post|
       post.id if post.purchase_passes_filters(purchase)
     end


### PR DESCRIPTION
Issue: https://github.com/antiwork/gumroad-private/issues/43#issuecomment-3707613482

# Description

## Problem

The "Send missed posts" section on the `/customers` page is incorrectly showing workflow emails for customers who purchased a different product version than the workflow was configured for. This happens because the `Installment.missed_for_purchase` scope applies audience filters (including variant filters) to seller-level installments but not to product-level installments.

Example scenario:
- Seller creates a workflow for "The Basic Journal" version
- Customer purchases "The Power Journal" variant
- UI on `/customers` page incorrectly shows the Basic Journal workflow email in "Send missed posts" section in the sale details drawer
- This could mislead sellers into manually sending emails to the wrong audience

## Solution

Updates `Installment.missed_for_purchase` scope to apply `purchase_passes_filters` when fetching product installments to ensure variant filters are respected.