### PR TITLE
Sanitize CSV exports to prevent formula injection attacks

### DIFF
--- a/app/business/payments/reports/stripe_currency_balances_report.rb
+++ b/app/business/payments/reports/stripe_currency_balances_report.rb
@@ -15,7 +15,7 @@ module StripeCurrencyBalancesReport
       currency_balances[balance["currency"]] += balance["amount"] if currency_balances[balance["currency"]].abs != balance["amount"].abs
     end
 
-    CSV.generate do |csv|
+    CsvSafe.generate do |csv|
       csv << %w(Currency Balance)
       currency_balances.each do |currency, balance|
         csv << [currency, is_currency_type_single_unit?(currency) ? balance : (balance / 100.0).round(2)]

--- a/app/mailers/accounting_mailer.rb
+++ b/app/mailers/accounting_mailer.rb
@@ -73,7 +73,7 @@ class AccountingMailer < ApplicationMailer
       stripe: { held_by_gumroad: { active: 0, suspended: 0 }, held_by_stripe: { active: 0, suspended: 0 } },
       paypal: { active: 0, suspended: 0 }
     }
-    balances_csv = CSV.generate do |csv|
+    balances_csv = CsvSafe.generate do |csv|
       csv << ["user id", "paypal balance (in dollars)", "stripe balance (in dollars)", "is_suspended", "user_risk_state", "tos_violation_reason"]
       User.holding_non_zero_balance.each do |user|
         stat_key = user.suspended? ? :suspended : :active

--- a/app/services/admin_funds_csv_report_service.rb
+++ b/app/services/admin_funds_csv_report_service.rb
@@ -8,7 +8,7 @@ class AdminFundsCsvReportService
   end
 
   def generate
-    CSV.generate do |csv|
+    CsvSafe.generate do |csv|
       report.each do |(type, data)|
         data.each do |payment_method|
           transaction_type_key = type == "Purchases" ? "Sales" : "Charges"

--- a/app/services/clean_us_zip_code_database_file.rb
+++ b/app/services/clean_us_zip_code_database_file.rb
@@ -21,7 +21,7 @@ class CleanUsZipCodeDatabaseFile
     File.delete(destination_file_path) if File.exist?(destination_file_path)
     rows = CSV.parse(File.read(source_file_path)).map! { |row| [row[0], row[6]] }
 
-    CSV.open(destination_file_path, "w") do |csv|
+    CsvSafe.open(destination_file_path, "w") do |csv|
       rows.each do |row|
         csv << row
       end

--- a/app/services/exports/affiliate_export_service.rb
+++ b/app/services/exports/affiliate_export_service.rb
@@ -20,7 +20,7 @@ class Exports::AffiliateExportService
   def perform
     @tempfile = Tempfile.new(["Affiliates", ".csv"], "tmp", encoding: "UTF-8")
 
-    CSV.open(@tempfile, "wb") do |csv|
+    CsvSafe.open(@tempfile, "wb") do |csv|
       csv << AFFILIATE_FIELDS
       @seller.direct_affiliates.alive.includes(:affiliate_user, :products).find_each do |affiliate|
         csv << affiliate_row(affiliate)

--- a/app/services/exports/audience_export_service.rb
+++ b/app/services/exports/audience_export_service.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "csv"
-
 class Exports::AudienceExportService
   FIELDS = ["Subscriber Email", "Subscribed Time"].freeze
 
@@ -19,7 +17,7 @@ class Exports::AudienceExportService
   def perform
     @tempfile = Tempfile.new(["Subscribers", ".csv"], encoding: "UTF-8")
 
-    CSV.open(@tempfile, "wb", headers: FIELDS, write_headers: true) do |csv|
+    CsvSafe.open(@tempfile, "wb", headers: FIELDS, write_headers: true) do |csv|
       query = @user.audience_members.select(:id, :email, :min_created_at)
 
       conditions = []

--- a/app/services/exports/payouts/annual.rb
+++ b/app/services/exports/payouts/annual.rb
@@ -21,7 +21,7 @@ class Exports::Payouts::Annual < Exports::Payouts::Csv
 
     tempfile = Tempfile.open(File.join(Rails.root, "tmp", "#{@user.id}_#{@year}_annual.csv"),
                              encoding: "UTF-8")
-    CSV.open(tempfile, "wb") do |csv|
+    CsvSafe.open(tempfile, "wb") do |csv|
       csv << HEADERS
       payments_scope.find_each do |payment|
         @payment_id = payment.id

--- a/app/services/exports/payouts/csv.rb
+++ b/app/services/exports/payouts/csv.rb
@@ -11,7 +11,7 @@ class Exports::Payouts::Csv < Exports::Payouts::Base
 
   def perform
     data = payout_data
-    CSV.generate do |csv|
+    CsvSafe.generate do |csv|
       csv << HEADERS
       data.each do |row|
         csv << row

--- a/app/services/exports/purchase_export_service.rb
+++ b/app/services/exports/purchase_export_service.rb
@@ -66,7 +66,7 @@ class Exports::PurchaseExportService
     tempfile = Tempfile.new(["Sales", ".csv"], "tmp", encoding: "UTF-8")
     totals = Hash.new(0)
 
-    CSV.open(tempfile, "wb") do |csv|
+    CsvSafe.open(tempfile, "wb") do |csv|
       csv << fields
       purchases_data_enumerator.each do |(purchase_fields_data, custom_fields_data)|
         row = Array.new(fields.size)

--- a/app/services/exports/tax_summary/annual.rb
+++ b/app/services/exports/tax_summary/annual.rb
@@ -10,7 +10,7 @@ class Exports::TaxSummary::Annual
   def perform
     tempfile = Tempfile.new(File.join(Rails.root, "tmp", tempfile_name),
                             encoding: "UTF-8")
-    CSV.open(tempfile, "wb") do |csv|
+    CsvSafe.open(tempfile, "wb") do |csv|
       headers_added = false
       User.alive.find_each(start: @start, finish: @finish) do |user|
         if user.eligible_for_1099?(@year)

--- a/app/services/exports/tax_summary/payable.rb
+++ b/app/services/exports/tax_summary/payable.rb
@@ -13,7 +13,7 @@ class Exports::TaxSummary::Payable < Exports::TaxSummary::Base
     data = payouts_summary
     return nil unless data && data[:total_transaction_cents] > 0
     if as_csv
-      CSV.generate do |csv|
+      CsvSafe.generate do |csv|
         csv << payable_headers
 
         row = build_payable_summary(data)

--- a/app/sidekiq/reports/generate_ytd_sales_report_job.rb
+++ b/app/sidekiq/reports/generate_ytd_sales_report_job.rb
@@ -62,7 +62,7 @@ module Reports
       results = Purchase.search(es_query)
       aggregations = results.aggregations
 
-      csv_string = CSV.generate do |csv|
+      csv_string = CsvSafe.generate do |csv|
         csv << ["Country", "State", "Net Sales (USD)"]
 
         if aggregations && aggregations["sales_by_country"] && aggregations["sales_by_country"]["buckets"]

--- a/lib/mailer_previews/contacting_creator_mailer_preview.rb
+++ b/lib/mailer_previews/contacting_creator_mailer_preview.rb
@@ -219,7 +219,7 @@ class ContactingCreatorMailerPreview < ActionMailer::Preview
   private
     def sample_csv_file
       tempfile = Tempfile.new
-      CSV.open(tempfile, "wb") { |csv| 100.times { csv << ["Some", "CSV", "Data"] } }
+      CsvSafe.open(tempfile, "wb") { |csv| 100.times { csv << ["Some", "CSV", "Data"] } }
       tempfile.rewind
       tempfile
     end

--- a/lib/utilities/csv_safe.rb
+++ b/lib/utilities/csv_safe.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "csv"
+
+# Custom CSV sanitization to prevent formula injection
+# Based on csv-safe gem but modified to preserve numeric strings with + or -
+# Original: https://github.com/zvory/csv-safe/blob/master/lib/csv-safe.rb
+class CsvSafe < CSV
+  FORMULA_PREFIXES = ["=", "@", "|", "%", "\r", "\t"].freeze
+  NUMERIC_PATTERN = /\A\d+\.?\d*\z/
+
+  def <<(row)
+    super(sanitize_row(row))
+  end
+  alias_method :add_row, :<<
+  alias_method :puts, :<<
+
+  private
+    def sanitize_row(row)
+      case row
+      when CSV::Row then row.fields.map { |field| sanitize_field(field) }
+      when Hash then headers.map { |header| sanitize_field(row[header]) }
+      else row.map { |field| sanitize_field(field) }
+      end
+    end
+
+    def sanitize_field(field)
+      return field if field.nil? || field.is_a?(Numeric)
+
+      str = field.to_s
+      needs_sanitization?(str) ? "'#{str}" : field
+    end
+
+    def needs_sanitization?(str)
+      return false if str.empty?
+
+      first_char = str[0]
+
+      if first_char == "+" || first_char == "-"
+        rest = str[1..]
+        return false if rest&.match?(NUMERIC_PATTERN)
+      end
+
+      FORMULA_PREFIXES.include?(first_char) || first_char == "+" || first_char == "-"
+    end
+end

--- a/spec/lib/utilities/csv_safe_spec.rb
+++ b/spec/lib/utilities/csv_safe_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe CsvSafe do
+  describe "CSV injection protection with numeric preservation" do
+    it "preserves positive numeric strings" do
+      csv = CsvSafe.generate { |csv| csv << ["+100", "+123.45", "+999"] }
+      expect(csv).to eq("+100,+123.45,+999\n")
+    end
+
+    it "preserves negative numeric strings" do
+      csv = CsvSafe.generate { |csv| csv << ["-100", "-123.45", "-999"] }
+      expect(csv).to eq("-100,-123.45,-999\n")
+    end
+
+    it "preserves mixed numeric values" do
+      csv = CsvSafe.generate { |csv| csv << ["-100", "+200", "300", "-1.5", "+2.75"] }
+      expect(csv).to eq("-100,+200,300,-1.5,+2.75\n")
+    end
+
+    it "sanitizes formula injection with equals" do
+      csv = CsvSafe.generate { |csv| csv << ["=1+1", "=SUM(A1:A10)", "=cmd|' /C calc'!A0"] }
+      expect(csv).to eq("'=1+1,'=SUM(A1:A10),'=cmd|' /C calc'!A0\n")
+    end
+
+    it "sanitizes non-numeric strings starting with plus" do
+      csv = CsvSafe.generate { |csv| csv << ["+abc", "+1+1", "+test"] }
+      expect(csv).to eq("'+abc,'+1+1,'+test\n")
+    end
+
+    it "sanitizes non-numeric strings starting with minus" do
+      csv = CsvSafe.generate { |csv| csv << ["-abc", "-1+1", "-test"] }
+      expect(csv).to eq("'-abc,'-1+1,'-test\n")
+    end
+
+    it "sanitizes at-sign formulas" do
+      csv = CsvSafe.generate { |csv| csv << ["@SUM(1+1)", "@A1"] }
+      expect(csv).to eq("'@SUM(1+1),'@A1\n")
+    end
+
+    it "sanitizes tab and carriage return prefixes" do
+      csv = CsvSafe.generate { |csv| csv << ["\t=1+1", "\r=1+1"] }
+      expect(csv).to eq("'\t=1+1,\"'\r=1+1\"\n")
+    end
+
+    it "sanitizes pipe and percent prefixes" do
+      csv = CsvSafe.generate { |csv| csv << ["|test", "%test"] }
+      expect(csv).to eq("'|test,'%test\n")
+    end
+
+    it "preserves normal text without dangerous prefixes" do
+      csv = CsvSafe.generate { |csv| csv << ["hello", "world", "123", "test@example.com"] }
+      expect(csv).to eq("hello,world,123,test@example.com\n")
+    end
+
+    it "handles nil and empty values" do
+      csv = CsvSafe.generate { |csv| csv << [nil, "", "test"] }
+      expect(csv).to eq(",\"\",test\n")
+    end
+
+    it "preserves actual Numeric types" do
+      csv = CsvSafe.generate { |csv| csv << [100, -200, 3.14, -5.67] }
+      expect(csv).to eq("100,-200,3.14,-5.67\n")
+    end
+
+    it "handles edge cases with decimals" do
+      csv = CsvSafe.generate { |csv| csv << ["+0.5", "-0.5", "+.5", "-.5"] }
+      expect(csv).to eq("+0.5,-0.5,'+.5,'-.5\n")
+    end
+
+    it "sanitizes HYPERLINK attacks" do
+      csv = CsvSafe.generate { |csv| csv << ['=HYPERLINK("http://attacker.invalid","click")'] }
+      expect(csv).to eq("\"'=HYPERLINK(\"\"http://attacker.invalid\"\",\"\"click\"\")\"\n")
+    end
+
+    it "sanitizes DDE attacks" do
+      csv = CsvSafe.generate { |csv| csv << ["=cmd|' /C calc'!A0", "=10+20+cmd|' /C calc'!A0"] }
+      expect(csv).to eq("'=cmd|' /C calc'!A0,'=10+20+cmd|' /C calc'!A0\n")
+    end
+
+    it "handles mixed safe and dangerous values in same row" do
+      csv = CsvSafe.generate do |csv|
+        csv << ["normal", "+100", "-200", "=1+1", "@SUM()", "+abc", "test"]
+      end
+      expect(csv).to eq("normal,+100,-200,'=1+1,'@SUM(),'+abc,test\n")
+    end
+  end
+
+  describe "CsvSafe.open" do
+    it "sanitizes values when writing to file" do
+      tempfile = Tempfile.new(["test", ".csv"])
+
+      CsvSafe.open(tempfile.path, "w") do |csv|
+        csv << ["+100", "-200", "=1+1", "normal"]
+      end
+
+      content = File.read(tempfile.path)
+      expect(content).to eq("+100,-200,'=1+1,normal\n")
+
+      tempfile.close
+      tempfile.unlink
+    end
+  end
+end


### PR DESCRIPTION
This PR is an upstream of https://github.com/antiwork/gumroad-private/pull/35

# Summary

This PR fixes a critical CSV injection vulnerability by introducing a custom CsvSafe implementation and applying it to all CSV exports across the application.

The change protects against formula injection attacks where user-controlled values starting with =, +, -, @, %, |, carriage return, or tab could be interpreted as executable formulas when opened in spreadsheet tools like Excel or Google Sheets.

