### PR TITLE
Implement automatic PayPal dispute evidence submission

### DIFF
--- a/app/business/payments/charging/charge_processor.rb
+++ b/app/business/payments/charging/charge_processor.rb
@@ -196,8 +196,17 @@ module ChargeProcessor
   end
 
   # Public: Fights a chargeback by supplying evidence.
-  def self.fight_chargeback(charge_processor_id, charge_id, dispute_evidence)
-    get_charge_processor(charge_processor_id).fight_chargeback(charge_id, dispute_evidence)
+  def self.fight_chargeback(charge_processor_id, charge_id, dispute_evidence, merchant_account: nil, dispute_id: nil)
+    charge_processor = get_charge_processor(charge_processor_id)
+
+    if charge_processor_id == PaypalChargeProcessor.charge_processor_id
+      paypal_dispute_id = dispute_id.presence
+      raise ChargeProcessorInvalidRequestError, "PayPal dispute id is required" if paypal_dispute_id.blank?
+
+      charge_processor.fight_chargeback(paypal_dispute_id, dispute_evidence, merchant_account: merchant_account)
+    else
+      charge_processor.fight_chargeback(charge_id, dispute_evidence, merchant_account: merchant_account)
+    end
   end
 
   # Public: Returns where the funds are held for this merchant account.

--- a/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
+++ b/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
@@ -609,6 +609,26 @@ class PaypalChargeProcessor
     Rails.logger.info("#{api_label} (#{resource_id}) body => #{api_response.inspect}")
   end
 
+  def fight_chargeback(paypal_dispute_id, dispute_evidence, merchant_account: nil)
+    raise ChargeProcessorInvalidRequestError, "PayPal dispute id is required" if paypal_dispute_id.blank?
+    if merchant_account&.charge_processor_merchant_id.blank?
+      raise ChargeProcessorInvalidRequestError, "PayPal merchant account is required"
+    end
+
+    evidence_payload = build_paypal_evidence(dispute_evidence)
+    api_response = PaypalRestApi.new.provide_dispute_evidence(
+      dispute_id: paypal_dispute_id,
+      evidence: evidence_payload,
+      merchant_account:
+    )
+
+    if api_response.status_code.in?(400...500)
+      raise ChargeProcessorInvalidRequestError, api_response.result.to_json
+    elsif !PaypalRestApi.new.successful_response?(api_response)
+      raise ChargeProcessorError, "Failed to submit PayPal dispute evidence: #{api_response.result.inspect}"
+    end
+  end
+
   private
     def paypal_api
       PaypalChargeProcessor.paypal_api
@@ -732,5 +752,131 @@ class PaypalChargeProcessor
 
     def self.sanitize_for_paypal(string, max_length)
       string.gsub(PAYPAL_VALID_CHARACTERS_REGEX, "").to_s.strip[0...max_length]
+    end
+
+    def build_paypal_evidence(dispute_evidence)
+      evidence = {
+        evidence_type: evidence_type_for(dispute_evidence)
+      }
+
+      notes = build_evidence_notes(dispute_evidence)
+      evidence[:notes] = notes if notes.present?
+
+      evidence_info = build_evidence_info(dispute_evidence)
+      evidence[:evidence_info] = evidence_info if evidence_info.present?
+
+      { evidences: [evidence] }
+    end
+
+    def build_evidence_info(dispute_evidence)
+      tracking_info = build_tracking_info(dispute_evidence)
+      return nil if tracking_info.blank?
+
+      { tracking_info: [tracking_info] }
+    end
+
+    def evidence_type_for(dispute_evidence)
+      return "PROOF_OF_FULFILLMENT" if dispute_evidence.shipping_tracking_number.present?
+
+      "ITEM_DESCRIPTION"
+    end
+
+    def build_evidence_notes(dispute_evidence)
+      notes_parts = []
+
+      if dispute_evidence.reason_for_winning.present?
+        notes_parts << "Reason for winning:\n#{dispute_evidence.reason_for_winning}"
+      end
+
+      if dispute_evidence.customer_name.present? || dispute_evidence.customer_email.present?
+        customer_info = "Customer information:\n"
+        customer_info += "Name: #{dispute_evidence.customer_name}\n" if dispute_evidence.customer_name.present?
+        customer_info += "Email: #{dispute_evidence.customer_email}\n" if dispute_evidence.customer_email.present?
+        customer_info += "IP: #{dispute_evidence.customer_purchase_ip}" if dispute_evidence.customer_purchase_ip.present?
+        notes_parts << customer_info
+      end
+
+      if dispute_evidence.product_description.present?
+        notes_parts << "Product: #{dispute_evidence.product_description}"
+      end
+
+      if dispute_evidence.purchased_at.present?
+        notes_parts << "Purchase date: #{dispute_evidence.purchased_at.to_fs(:formatted_date_full_month)}"
+      end
+
+      if dispute_evidence.access_activity_log.present?
+        notes_parts << "Access activity:\n#{dispute_evidence.access_activity_log}"
+      end
+
+      if dispute_evidence.refund_policy_disclosure.present?
+        notes_parts << "Refund policy:\n#{dispute_evidence.refund_policy_disclosure}"
+      end
+
+      if dispute_evidence.cancellation_policy_disclosure.present?
+        notes_parts << "Cancellation policy:\n#{dispute_evidence.cancellation_policy_disclosure}"
+      end
+
+      if dispute_evidence.refund_refusal_explanation.present?
+        notes_parts << "Refund refusal explanation:\n#{dispute_evidence.refund_refusal_explanation}"
+      end
+
+      if dispute_evidence.cancellation_rebuttal.present?
+        notes_parts << "Cancellation rebuttal:\n#{dispute_evidence.cancellation_rebuttal}"
+      end
+
+      if dispute_evidence.uncategorized_text.present?
+        notes_parts << dispute_evidence.uncategorized_text
+      end
+
+      notes = notes_parts.join("\n\n")
+      notes.present? ? notes[0...2000] : nil
+    end
+
+    def build_tracking_info(dispute_evidence)
+      return nil if dispute_evidence.shipping_tracking_number.blank?
+
+      tracking = { tracking_number: dispute_evidence.shipping_tracking_number }
+
+      carrier = dispute_evidence.shipping_carrier.to_s.strip
+      carrier_name = normalize_carrier_name(carrier)
+      tracking[:carrier_name] = carrier_name
+      if carrier_name == "OTHER"
+        tracking[:carrier_name_other] = carrier.presence || "Unknown"
+      end
+
+      tracking_url = tracking_url_for(carrier, dispute_evidence.shipping_tracking_number)
+      tracking[:tracking_url] = tracking_url if tracking_url.present?
+
+      tracking
+    end
+
+    def normalize_carrier_name(carrier)
+      carrier_mapping = {
+        "USPS" => "USPS",
+        "UPS" => "UPS",
+        "FEDEX" => "FEDEX",
+        "DHL" => "DHL",
+        "DHL GLOBAL MAIL" => "DHL",
+        "AIRBORNE" => "AIRBORNE_EXPRESS",
+        "AIRSURE" => "AIRSURE",
+        "ROYAL MAIL" => "ROYAL_MAIL",
+        "PARCELFORCE" => "PARCELFORCE",
+        "SWIFT AIR" => "SWIFTAIR",
+        "SWIFTAIR" => "SWIFTAIR"
+      }
+
+      carrier_upcase = carrier.to_s.upcase
+      carrier_mapping.each do |key, value|
+        return value if carrier_upcase.include?(key)
+      end
+
+      "OTHER"
+    end
+
+    def tracking_url_for(carrier, tracking_number)
+      return nil if carrier.blank? || tracking_number.blank?
+
+      base_url = Shipment::CARRIER_TRACKING_URL_MAPPING[carrier]
+      base_url ? "#{base_url}#{tracking_number}" : nil
     end
 end

--- a/app/business/payments/charging/implementations/paypal/paypal_rest_api.rb
+++ b/app/business/payments/charging/implementations/paypal/paypal_rest_api.rb
@@ -123,6 +123,16 @@ class PaypalRestApi
     execute_request
   end
 
+  def provide_dispute_evidence(dispute_id:, evidence:, merchant_account:)
+    paypal_account_id = merchant_account&.charge_processor_merchant_id
+
+    @request = new_request(path: "/v1/customer/disputes/#{dispute_id}/provide-evidence", verb: "POST")
+    @request.headers["PayPal-Request-Id"] = "dispute-evidence-#{dispute_id}-#{timestamp}"
+    @request.headers["Paypal-Auth-Assertion"] = paypal_auth_assertion_header(paypal_account_id)
+    @request.body = evidence
+    execute_request
+  end
+
   def successful_response?(api_response)
     (200...300).include?(api_response.status_code)
   end

--- a/app/models/concerns/charge/disputable.rb
+++ b/app/models/concerns/charge/disputable.rb
@@ -225,14 +225,31 @@ module Charge::Disputable
   end
 
   def eligible_for_dispute_evidence?
-    return false unless charge_processor == StripeChargeProcessor.charge_processor_id
-    return false if merchant_account&.is_a_stripe_connect_account?
-    true
+    if charge_processor == StripeChargeProcessor.charge_processor_id
+      return false if merchant_account&.is_a_stripe_connect_account?
+      return true
+    end
+
+    if charge_processor == PaypalChargeProcessor.charge_processor_id
+      return true
+    end
+
+    false
   end
 
   def fight_chargeback
     dispute_evidence = dispute.dispute_evidence
+    merchant_account_for_dispute = merchant_account || purchase_for_dispute_evidence&.merchant_account
+    dispute_id = if charge_processor == PaypalChargeProcessor.charge_processor_id
+      dispute.charge_processor_dispute_id
+    end
 
-    ChargeProcessor.fight_chargeback(charge_processor, charge_processor_transaction_id, dispute_evidence)
+    ChargeProcessor.fight_chargeback(
+      charge_processor,
+      charge_processor_transaction_id,
+      dispute_evidence,
+      merchant_account: merchant_account_for_dispute,
+      dispute_id:
+    )
   end
 end

--- a/app/services/dispute_evidence/create_from_dispute_service.rb
+++ b/app/services/dispute_evidence/create_from_dispute_service.rb
@@ -87,12 +87,22 @@ class DisputeEvidence::CreateFromDisputeService
     end
 
     def generate_refund_policy_disclosure(purchase, events)
-      return if events.none?
+      return if purchase.purchase_refund_policy.blank?
 
-      "The refund policy modal has been viewed by the customer #{events.count} #{"time".pluralize(events.count)}" \
-      " before the purchase was made at #{purchase.created_at}.\n" \
-      "Timestamp information of the #{"view".pluralize(events.count)}: #{events.map(&:created_at).join(", ")}\n\n" \
-      "Internal browser GUID for reference: #{purchase.browser_guid}"
+      parts = []
+
+      if events.any?
+        parts << "The refund policy modal has been viewed by the customer #{events.count} #{"time".pluralize(events.count)}" \
+          " before the purchase was made at #{purchase.created_at}.\n" \
+          "Timestamp information of the #{"view".pluralize(events.count)}: #{events.map(&:created_at).join(", ")}\n\n" \
+          "Internal browser GUID for reference: #{purchase.browser_guid}"
+      end
+
+      if purchase.purchase_refund_policy.fine_print.present?
+        parts << purchase.purchase_refund_policy.fine_print
+      end
+
+      parts.join("\n\n").presence
     end
 
     def attach_refund_policy_image(dispute_evidence, purchase, open_fine_print_modal:)

--- a/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
@@ -47,7 +47,7 @@ describe PaypalChargeProcessor, :vcr do
 
     describe "payment event" do
       before do
-        @purchase = create(:purchase_with_balance, id: 1001)
+        @purchase = create(:purchase_with_balance)
         allow_any_instance_of(Purchase).to receive(:fight_chargeback).and_return(true)
         allow_any_instance_of(Purchase).to receive(:secure_external_id).and_return("sample-secure-id")
         allow(Purchase).to receive(:find_by_external_id).and_return(@purchase)
@@ -262,8 +262,12 @@ describe PaypalChargeProcessor, :vcr do
   describe ".handle_order_events" do
     context "when event type is CUSTOMER.DISPUTE.CREATED" do
       it "sets chargeback details on purchase" do
+        sample_image = File.read(Rails.root.join("spec", "support", "fixtures", "test-small.jpg"))
+        allow(DisputeEvidence::GenerateReceiptImageService).to receive(:perform).and_return(sample_image)
+        allow(DisputeEvidence::GenerateRefundPolicyImageService).to receive(:perform).and_return(sample_image)
+
         event_info = { "id" => "WH-3TW20315YE525782H-3BD552601T418134F", "event_version" => "1.0", "create_time" => "2017-10-10T14:09:01.129Z", "resource_type" => "dispute", "event_type" => "CUSTOMER.DISPUTE.CREATED", "summary" => "A new dispute opened with Case # PP-D-4805PP-D-4805", "resource" => { "dispute_id" => "PP-D-4805", "create_time" => "2017-10-10T14:07:23.000Z", "update_time" => "2017-10-10T14:08:06.000Z", "disputed_transactions" => [{ "seller_transaction_id" => "6Y199803HH2987814", "seller" => { "name" => "facilitator account's Test Store" }, "items" => [{ "item_id" => "uF" }], "seller_protection_eligible" => true }], "reason" => "CREDIT_NOT_PROCESSED", "status" => "UNDER_REVIEW", "dispute_amount" => { "currency_code" => "[FILTERED]", "value" => "6.43" }, "offer" => { "buyer_requested_amount" => { "currency_code" => "[FILTERED]", "value" => "6.43" } }, "links" => [{ "href" => "https://api.sandbox.paypal.com/v1/customer/disputes/PP-D-4805", "rel" => "self", "method" => "GET" }] }, "links" => [{ "href" => "https://api.sandbox.paypal.com/v1/notifications/webhooks-events/WH-3TW20315YE525782H-3BD552601T418134F", "rel" => "self", "method" => "GET" }, { "href" => "https://api.sandbox.paypal.com/v1/notifications/webhooks-events/WH-3TW20315YE525782H-3BD552601T418134F/resend", "rel" => "resend", "method" => "POST" }], "foreign_webhook" => { "id" => "WH-3TW20315YE525782H-3BD552601T418134F", "event_version" => "1.0", "create_time" => "2017-10-10T14:09:01.129Z", "resource_type" => "dispute", "event_type" => "CUSTOMER.DISPUTE.CREATED", "summary" => "A new dispute opened with Case # PP-D-4805PP-D-4805", "resource" => { "dispute_id" => "PP-D-4805", "create_time" => "2017-10-10T14:07:23.000Z", "update_time" => "2017-10-10T14:08:06.000Z", "disputed_transactions" => [{ "seller_transaction_id" => "6Y199803HH2987814", "seller" => { "name" => "facilitator account's Test Store" }, "items" => [{ "item_id" => "uF" }], "seller_protection_eligible" => true }], "reason" => "CREDIT_NOT_PROCESSED", "status" => "UNDER_REVIEW", "dispute_amount" => { "currency_code" => "[FILTERED]", "value" => "6.43" }, "offer" => { "buyer_requested_amount" => { "currency_code" => "[FILTERED]", "value" => "6.43" } }, "links" => [{ "href" => "https://api.sandbox.paypal.com/v1/customer/disputes/PP-D-4805", "rel" => "self", "method" => "GET" }] }, "links" => [{ "href" => "https://api.sandbox.paypal.com/v1/notifications/webhooks-events/WH-3TW20315YE525782H-3BD552601T418134F", "rel" => "self", "method" => "GET" }, { "href" => "https://api.sandbox.paypal.com/v1/notifications/webhooks-events/WH-3TW20315YE525782H-3BD552601T418134F/resend", "rel" => "resend", "method" => "POST" }] } }
-        purchase = create(:purchase_with_balance, id: 1001, stripe_transaction_id: "6Y199803HH2987814")
+        purchase = create(:purchase_with_balance, stripe_transaction_id: "6Y199803HH2987814")
         allow_any_instance_of(Purchase).to receive(:fight_chargeback).and_return(true)
 
         expect(purchase.chargeback_date).to be(nil)
@@ -278,7 +282,7 @@ describe PaypalChargeProcessor, :vcr do
 
       it "raises `ChargeProcessorError` on error" do
         event_info = { "event_type" => "CUSTOMER.DISPUTE.CREATED" }
-        create(:purchase_with_balance, id: 1001, stripe_transaction_id: "6Y199803HH2987814")
+        create(:purchase_with_balance, stripe_transaction_id: "6Y199803HH2987814")
 
         expect do
           described_class.handle_order_events(event_info)
@@ -1530,6 +1534,165 @@ describe PaypalChargeProcessor, :vcr do
       expect(PaypalChargeProcessor.formatted_amount_for_paypal(1644, "huf").class).to eq(Integer)
       expect(PaypalChargeProcessor.formatted_amount_for_paypal(1644, "jpy")).to eq(1644) # unit to subunit is 1
       expect(PaypalChargeProcessor.formatted_amount_for_paypal(1644, "jpy").class).to eq(Integer)
+    end
+  end
+
+  describe "#fight_chargeback" do
+    let(:merchant_account) { create(:merchant_account_paypal) }
+    let(:dispute_id) { "PP-D-12345" }
+
+    let(:disputed_purchase) do
+      create(
+        :disputed_purchase,
+        full_name: "John Doe",
+        email: "buyer@example.com",
+        ip_address: "192.168.1.1",
+        street_address: "123 Example St",
+        city: "San Francisco",
+        state: "CA",
+        zip_code: "94105",
+        country: "United States",
+        link: create(:physical_product)
+      )
+    end
+
+    let!(:shipment) do
+      create(
+        :shipment,
+        carrier: "UPS",
+        tracking_number: "1Z999AA10123456784",
+        purchase: disputed_purchase,
+        ship_state: "shipped",
+        shipped_at: DateTime.parse("2023-02-10 14:55:32")
+      )
+    end
+
+    let(:sample_image) { File.read(Rails.root.join("spec", "support", "fixtures", "test-small.jpg")) }
+
+    before do
+      dispute = create(:dispute_formalized, purchase: disputed_purchase)
+      disputed_purchase.create_purchase_refund_policy!(
+        title: ProductRefundPolicy::ALLOWED_REFUND_PERIODS_IN_DAYS[30],
+        max_refund_period_in_days: 30,
+        fine_print: "All sales are final after 30 days."
+      )
+
+      allow(DisputeEvidence::GenerateReceiptImageService).to receive(:perform).with(disputed_purchase).and_return(sample_image)
+      allow(DisputeEvidence::GenerateRefundPolicyImageService).to receive(:perform).and_return(sample_image)
+
+      DisputeEvidence.create_from_dispute!(dispute)
+    end
+
+    it "calls provide_dispute_evidence on PaypalRestApi with formatted evidence" do
+      dispute_evidence = disputed_purchase.dispute.dispute_evidence
+
+      expect_any_instance_of(PaypalRestApi).to receive(:provide_dispute_evidence).with(
+        dispute_id:,
+        evidence: hash_including(:evidences),
+        merchant_account:
+      ).and_return(OpenStruct.new(status_code: 200))
+
+      subject.fight_chargeback(dispute_id, dispute_evidence, merchant_account:)
+    end
+
+    it "includes tracking information in evidence when tracking number is present" do
+      dispute_evidence = disputed_purchase.dispute.dispute_evidence
+      allow_any_instance_of(PaypalRestApi).to receive(:provide_dispute_evidence) do |_instance, **kwargs|
+        evidences = kwargs[:evidence][:evidences]
+        expect(evidences).to be_an(Array)
+        expect(evidences.first[:evidence_type]).to eq("PROOF_OF_FULFILLMENT")
+        tracking_info = evidences.first[:evidence_info][:tracking_info].first
+        expect(tracking_info[:tracking_number]).to eq("1Z999AA10123456784")
+        expect(tracking_info[:carrier_name]).to eq("UPS")
+        OpenStruct.new(status_code: 200)
+      end
+
+      subject.fight_chargeback(dispute_id, dispute_evidence, merchant_account:)
+    end
+
+    it "includes detailed notes with customer information and policies" do
+      dispute_evidence = disputed_purchase.dispute.dispute_evidence
+      dispute_evidence.update!(reason_for_winning: "Customer received the product")
+
+      allow_any_instance_of(PaypalRestApi).to receive(:provide_dispute_evidence) do |_instance, **kwargs|
+        notes = kwargs[:evidence][:evidences].first[:notes]
+        expect(notes).to include("Customer received the product")
+        expect(notes).to include("buyer@example.com")
+        expect(notes).to include("All sales are final after 30 days")
+        OpenStruct.new(status_code: 200)
+      end
+
+      subject.fight_chargeback(dispute_id, dispute_evidence, merchant_account:)
+    end
+
+    it "truncates notes to 2000 characters maximum" do
+      dispute_evidence = disputed_purchase.dispute.dispute_evidence
+      long_text = "a" * 15000
+      dispute_evidence.update!(uncategorized_text: long_text)
+
+      allow_any_instance_of(PaypalRestApi).to receive(:provide_dispute_evidence) do |_instance, **kwargs|
+        expect(kwargs[:evidence][:evidences].first[:notes].length).to be <= 2000
+        OpenStruct.new(status_code: 200)
+      end
+
+      subject.fight_chargeback(dispute_id, dispute_evidence, merchant_account:)
+    end
+
+    it "raises ChargeProcessorInvalidRequestError when API returns 400-499 status" do
+      dispute_evidence = disputed_purchase.dispute.dispute_evidence
+      error_response = OpenStruct.new(
+        status_code: 400,
+        result: { error: "Invalid dispute ID" }
+      )
+
+      allow_any_instance_of(PaypalRestApi).to receive(:provide_dispute_evidence).and_return(error_response)
+
+      expect do
+        subject.fight_chargeback(dispute_id, dispute_evidence, merchant_account:)
+      end.to raise_error(ChargeProcessorInvalidRequestError)
+    end
+
+    it "raises ChargeProcessorError when API returns 500+ status" do
+      dispute_evidence = disputed_purchase.dispute.dispute_evidence
+      error_response = OpenStruct.new(
+        status_code: 500,
+        result: { error: "Internal server error" }
+      )
+
+      allow_any_instance_of(PaypalRestApi).to receive(:provide_dispute_evidence).and_return(error_response)
+
+      expect do
+        subject.fight_chargeback(dispute_id, dispute_evidence, merchant_account:)
+      end.to raise_error(ChargeProcessorError)
+    end
+
+    it "handles disputes without shipping information" do
+      dispute_evidence = disputed_purchase.dispute.dispute_evidence
+      shipment.destroy
+      dispute_evidence.update!(shipping_tracking_number: nil, shipping_carrier: nil, shipping_address: nil)
+
+      allow_any_instance_of(PaypalRestApi).to receive(:provide_dispute_evidence) do |_instance, **kwargs|
+        evidence = kwargs[:evidence][:evidences].first
+        expect(evidence[:evidence_type]).to eq("ITEM_DESCRIPTION")
+        expect(evidence[:evidence_info]).to be_nil
+        OpenStruct.new(status_code: 200)
+      end
+
+      subject.fight_chargeback(dispute_id, dispute_evidence, merchant_account:)
+    end
+
+    it "normalizes carrier names to PayPal format" do
+      dispute_evidence = disputed_purchase.dispute.dispute_evidence
+      shipment.update!(carrier: "FedEx Express")
+      dispute_evidence.update!(shipping_carrier: "FedEx Express")
+
+      allow_any_instance_of(PaypalRestApi).to receive(:provide_dispute_evidence) do |_instance, **kwargs|
+        tracking_info = kwargs[:evidence][:evidences].first[:evidence_info][:tracking_info].first
+        expect(tracking_info[:carrier_name]).to eq("FEDEX")
+        OpenStruct.new(status_code: 200)
+      end
+
+      subject.fight_chargeback(dispute_id, dispute_evidence, merchant_account:)
     end
   end
 end

--- a/spec/models/concerns/charge/disputable_spec.rb
+++ b/spec/models/concerns/charge/disputable_spec.rb
@@ -577,6 +577,13 @@ describe Charge::Disputable, :vcr do
           let(:link) { @l }
           let(:affiliate_user) { create(:affiliate_user) }
           let(:direct_affiliate) { create(:direct_affiliate, affiliate_user:, seller: user, affiliate_basis_points: 2000, products: [link]) }
+
+          before do
+            sample_image = File.read(Rails.root.join("spec", "support", "fixtures", "test-small.jpg"))
+            allow(DisputeEvidence::GenerateReceiptImageService).to receive(:perform).and_return(sample_image)
+            allow(DisputeEvidence::GenerateRefundPolicyImageService).to receive(:perform).and_return(sample_image)
+          end
+
           let(:purchase) do
             issued_amount = FlowOfFunds::Amount.new(currency: Currency::USD, cents: 100)
             settled_amount = FlowOfFunds::Amount.new(currency: Currency::CAD, cents: 110)
@@ -1067,6 +1074,9 @@ describe Charge::Disputable, :vcr do
       let!(:purchase) { create(:purchase, link: create(:product, :bundle), stripe_transaction_id: "ch_12345") }
 
       before do
+        sample_image = File.read(Rails.root.join("spec", "support", "fixtures", "test-small.jpg"))
+        allow(DisputeEvidence::GenerateReceiptImageService).to receive(:perform).and_return(sample_image)
+        allow(DisputeEvidence::GenerateRefundPolicyImageService).to receive(:perform).and_return(sample_image)
         purchase.create_artifacts_and_send_receipt!
       end
 
@@ -1096,10 +1106,12 @@ describe Charge::Disputable, :vcr do
                                                           url_redirect: create(:url_redirect)) end
     let!(:shipment) do create(:shipment, carrier: "UPS", tracking_number: "123456", purchase: disputed_purchase,
                                          ship_state: "shipped", shipped_at: DateTime.parse("2023-02-10 14:55:32")) end
+    let(:sample_image) { File.read(Rails.root.join("spec", "support", "fixtures", "test-small.jpg")) }
 
     before do
       create_list(:purchase, 2, email: disputed_purchase.email)
       create(:dispute_formalized, purchase: disputed_purchase)
+      allow(DisputeEvidence::GenerateReceiptImageService).to receive(:perform).with(disputed_purchase).and_return(sample_image)
     end
 
     context "when purchase is not eligible" do
@@ -1137,8 +1149,8 @@ describe Charge::Disputable, :vcr do
     context "when processor is PayPal" do
       before { purchase.update!(charge_processor_id: PaypalChargeProcessor.charge_processor_id) }
 
-      it "returns false" do
-        expect(purchase.eligible_for_dispute_evidence?).to be(false)
+      it "returns true" do
+        expect(purchase.eligible_for_dispute_evidence?).to be(true)
       end
     end
 
@@ -1188,7 +1200,7 @@ describe Charge::Disputable, :vcr do
       allow(DisputeEvidence::GenerateReceiptImageService).to receive(:perform).with(disputed_purchase).and_return(sample_image)
       disputed_purchase.create_dispute_evidence_if_needed!
 
-      expect(ChargeProcessor).to receive(:fight_chargeback) do |charge_processor_id, stripe_transaction_id, dispute_evidence|
+      expect(ChargeProcessor).to receive(:fight_chargeback) do |charge_processor_id, stripe_transaction_id, dispute_evidence, merchant_account:, dispute_id:|
         expect(charge_processor_id).to eq disputed_purchase.charge_processor_id
         expect(stripe_transaction_id).to eq disputed_purchase.stripe_transaction_id
         expect(dispute_evidence.customer_purchase_ip).to eq disputed_purchase.ip_address
@@ -1201,14 +1213,52 @@ describe Charge::Disputable, :vcr do
         expect(dispute_evidence.shipping_carrier).to eq "UPS"
         expect(dispute_evidence.shipped_at).to eq shipment.shipped_at
         expect(dispute_evidence.shipping_tracking_number).to eq shipment.tracking_number
+        expect(merchant_account).to eq disputed_purchase.merchant_account
+        expect(dispute_id).to be_nil
       end
 
       disputed_purchase.fight_chargeback
+    end
+
+    context "when processor is PayPal" do
+      let(:paypal_merchant_account) { create(:merchant_account_paypal) }
+      let(:paypal_purchase) do
+        create(:purchase,
+               charge_processor_id: PaypalChargeProcessor.charge_processor_id,
+               stripe_transaction_id: "pp_12345",
+               merchant_account: paypal_merchant_account,
+               chargeback_date: Time.current)
+      end
+
+      before do
+        create(:dispute_formalized, purchase: paypal_purchase, charge_processor_dispute_id: "PP-D-123")
+        sample_image = File.read(Rails.root.join("spec", "support", "fixtures", "test-small.jpg"))
+        allow(DisputeEvidence::GenerateReceiptImageService).to receive(:perform).with(paypal_purchase).and_return(sample_image)
+        allow(DisputeEvidence::GenerateRefundPolicyImageService).to receive(:perform).and_return(sample_image)
+        allow(DisputeEvidence::GenerateUncategorizedTextService).to receive(:perform).with(paypal_purchase).and_return("Sample uncategorized text")
+        paypal_purchase.create_dispute_evidence_if_needed!
+      end
+
+      it "passes the PayPal dispute id and merchant account" do
+        expect(ChargeProcessor).to receive(:fight_chargeback) do |charge_processor_id, charge_id, dispute_evidence, merchant_account:, dispute_id:|
+          expect(charge_processor_id).to eq "paypal"
+          expect(charge_id).to eq "pp_12345"
+          expect(dispute_id).to eq "PP-D-123"
+          expect(merchant_account).to eq paypal_merchant_account
+          expect(dispute_evidence).to be_a(DisputeEvidence)
+        end
+
+        paypal_purchase.fight_chargeback
+      end
     end
   end
 
   describe "fighting chargeback during dispute formalized" do
     it "fights chargeback via stripe" do
+      sample_image = File.read(Rails.root.join("spec", "support", "fixtures", "test-small.jpg"))
+      allow(DisputeEvidence::GenerateReceiptImageService).to receive(:perform).and_return(sample_image)
+      allow(DisputeEvidence::GenerateRefundPolicyImageService).to receive(:perform).and_return(sample_image)
+
       user = create(:user, unpaid_balance_cents: 200)
       link = create(:product, user:)
       purchase = create(:purchase, link:, seller: user, stripe_transaction_id: "ch_zitkxbhds3zqlt", price_cents: 100,

--- a/spec/services/dispute_evidence/create_from_dispute_service_spec.rb
+++ b/spec/services/dispute_evidence/create_from_dispute_service_spec.rb
@@ -262,9 +262,10 @@ describe DisputeEvidence::CreateFromDisputeService, :vcr, :versioning do
         dispute_evidence = DisputeEvidence.create_from_dispute!(disputed_purchase.dispute)
 
         expect(dispute_evidence.refund_policy_disclosure).to eq(
-        "The refund policy modal has been viewed by the customer 1 time before the purchase was made at #{disputed_purchase.created_at}.\n" \
-        "Timestamp information of the view: #{event.created_at}\n\n" \
-        "Internal browser GUID for reference: #{disputed_purchase.browser_guid}"
+          "The refund policy modal has been viewed by the customer 1 time before the purchase was made at #{disputed_purchase.created_at}.\n" \
+          "Timestamp information of the view: #{event.created_at}\n\n" \
+          "Internal browser GUID for reference: #{disputed_purchase.browser_guid}\n\n" \
+          "This is the fine print."
         )
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -114,6 +114,17 @@ def prepare_mysql
   ActiveRecord::Base.connection.execute("SET SESSION information_schema_stats_expiry = 0")
 end
 
+def ensure_gumroad_merchant_accounts
+  ChargeProcessor.charge_processor_ids.each do |charge_processor_id|
+    account = MerchantAccount.find_or_initialize_by(user_id: nil, charge_processor_id: charge_processor_id)
+    next if account.persisted?
+
+    account.charge_processor_merchant_id = "gumroad-#{charge_processor_id}"
+    account.charge_processor_alive_at = Time.current
+    account.save!
+  end
+end
+
 RSpec.configure do |config|
   config.include Capybara::DSL
   config.include ErrorResponses
@@ -145,6 +156,7 @@ RSpec.configure do |config|
       Thread.new { prepare_mysql },
       Thread.new { ElasticsearchSetup.prepare_test_environment }
     ].each(&:join)
+    ensure_gumroad_merchant_accounts
   end
 
   # Stub SsrfFilter globally to allow localhost/minio in tests

--- a/spec/support/fixtures/vcr_cassettes/Charge_Disputable/_fight_chargeback/when_processor_is_PayPal/passes_the_PayPal_dispute_id_and_merchant_account.yml
+++ b/spec/support/fixtures/vcr_cassettes/Charge_Disputable/_fight_chargeback/when_processor_is_PayPal/passes_the_PayPal_dispute_id_and_merchant_account.yml
@@ -1,0 +1,139 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_createDispute
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_ZgqEquo1BRw9Qp","request_duration_ms":9}}'
+      Idempotency-Key:
+      - cfc6363b-9c67-4fb0-9bed-e79088c8c470
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
+        version 6.6.87.2-microsoft-standard-WSL2 (root@439a258ad544) (gcc (GCC) 11.2.0,
+        GNU ld (GNU Binutils) 2.37) #1 SMP PREEMPT_DYNAMIC Thu Jun  5 18:30:46 UTC
+        2025","hostname":"LAPTOP-IC725UQU"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 04 Jan 2026 02:15:28 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1082'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=eJr4W8MMJPs4jrerlch9n9Y5JEsvGwGhOwpopaQCJzTg5EOQHBfougwNbRZ4d-RdgOefzxv_tLq05STA
+      Idempotency-Key:
+      - cfc6363b-9c67-4fb0-9bed-e79088c8c470
+      Original-Request:
+      - req_4msLkKihwLn2Xp
+      Request-Id:
+      - req_4msLkKihwLn2Xp
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - ABGHIJ
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1SlgqpIBOqvOFDrfJo0UUUb0",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 1,
+            "exp_year": 2027,
+            "fingerprint": "xhj6XkBnqmm1SCzj",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "0259",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1767492927,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "type": "card"
+        }
+  recorded_at: Sun, 04 Jan 2026 02:15:24 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/PaypalChargeProcessor/_fight_chargeback/calls_provide_dispute_evidence_on_PaypalRestApi_with_formatted_evidence.yml
+++ b/spec/support/fixtures/vcr_cassettes/PaypalChargeProcessor/_fight_chargeback/calls_provide_dispute_evidence_on_PaypalRestApi_with_formatted_evidence.yml
@@ -1,0 +1,137 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_createDispute
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Idempotency-Key:
+      - 1334d406-14b6-4876-95e7-e1fbb35ba507
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
+        version 6.6.87.2-microsoft-standard-WSL2 (root@439a258ad544) (gcc (GCC) 11.2.0,
+        GNU ld (GNU Binutils) 2.37) #1 SMP PREEMPT_DYNAMIC Thu Jun  5 18:30:46 UTC
+        2025","hostname":"LAPTOP-IC725UQU"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 04 Jan 2026 00:08:43 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1082'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=kFP14_UGifTd6ZTO3Ti6p6ywqyLe5eKXzlzUMfuL2gfdtJeDz4MobjATWN_fdYV6bd73zri9NHAUT4xV
+      Idempotency-Key:
+      - 1334d406-14b6-4876-95e7-e1fbb35ba507
+      Original-Request:
+      - req_4Ky6nrsjuwTiP6
+      Request-Id:
+      - req_4Ky6nrsjuwTiP6
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - ABGHIJ
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1SlesBIBOqvOFDrfl38WPyn7",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 1,
+            "exp_year": 2027,
+            "fingerprint": "xhj6XkBnqmm1SCzj",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "0259",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1767485323,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "type": "card"
+        }
+  recorded_at: Sun, 04 Jan 2026 00:08:40 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/PaypalChargeProcessor/_fight_chargeback/handles_disputes_without_shipping_information.yml
+++ b/spec/support/fixtures/vcr_cassettes/PaypalChargeProcessor/_fight_chargeback/handles_disputes_without_shipping_information.yml
@@ -1,0 +1,139 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_createDispute
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_bboqKkkoSiI9kT","request_duration_ms":343}}'
+      Idempotency-Key:
+      - 9d59ae90-c180-4231-8265-2fbab71d3860
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
+        version 6.6.87.2-microsoft-standard-WSL2 (root@439a258ad544) (gcc (GCC) 11.2.0,
+        GNU ld (GNU Binutils) 2.37) #1 SMP PREEMPT_DYNAMIC Thu Jun  5 18:30:46 UTC
+        2025","hostname":"LAPTOP-IC725UQU"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 04 Jan 2026 00:08:48 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1082'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=z1e7101u7v8S5nLyLubDfb97Tq9i8gFcVtIwKqBdz4aSyv9CZtAMJRABQ4ekSnI5_sQUb6IpzwMOEWZI
+      Idempotency-Key:
+      - 9d59ae90-c180-4231-8265-2fbab71d3860
+      Original-Request:
+      - req_3H3hVghpVbOmMp
+      Request-Id:
+      - req_3H3hVghpVbOmMp
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - ABGHIJ
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1SlesGIBOqvOFDrf8juWyZYO",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 1,
+            "exp_year": 2027,
+            "fingerprint": "xhj6XkBnqmm1SCzj",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "0259",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1767485328,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "type": "card"
+        }
+  recorded_at: Sun, 04 Jan 2026 00:08:44 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/PaypalChargeProcessor/_fight_chargeback/includes_detailed_notes_with_customer_information_and_policies.yml
+++ b/spec/support/fixtures/vcr_cassettes/PaypalChargeProcessor/_fight_chargeback/includes_detailed_notes_with_customer_information_and_policies.yml
@@ -1,0 +1,139 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_createDispute
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_1YMOJgZTJxTKwm","request_duration_ms":526}}'
+      Idempotency-Key:
+      - 8f80099b-910d-4213-a8ca-e9decd4f5f16
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
+        version 6.6.87.2-microsoft-standard-WSL2 (root@439a258ad544) (gcc (GCC) 11.2.0,
+        GNU ld (GNU Binutils) 2.37) #1 SMP PREEMPT_DYNAMIC Thu Jun  5 18:30:46 UTC
+        2025","hostname":"LAPTOP-IC725UQU"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 04 Jan 2026 00:08:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1082'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=z1e7101u7v8S5nLyLubDfb97Tq9i8gFcVtIwKqBdz4aSyv9CZtAMJRABQ4ekSnI5_sQUb6IpzwMOEWZI
+      Idempotency-Key:
+      - 8f80099b-910d-4213-a8ca-e9decd4f5f16
+      Original-Request:
+      - req_evDZw5gBKYjDYy
+      Request-Id:
+      - req_evDZw5gBKYjDYy
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - ABGHIJ
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1SlesDIBOqvOFDrf4ngtJ5vC",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 1,
+            "exp_year": 2027,
+            "fingerprint": "xhj6XkBnqmm1SCzj",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "0259",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1767485325,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "type": "card"
+        }
+  recorded_at: Sun, 04 Jan 2026 00:08:41 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/PaypalChargeProcessor/_fight_chargeback/includes_tracking_information_in_evidence_when_tracking_number_is_present.yml
+++ b/spec/support/fixtures/vcr_cassettes/PaypalChargeProcessor/_fight_chargeback/includes_tracking_information_in_evidence_when_tracking_number_is_present.yml
@@ -1,0 +1,139 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_createDispute
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_4Ky6nrsjuwTiP6","request_duration_ms":500}}'
+      Idempotency-Key:
+      - 4e2c2738-1738-4d89-b9ef-2a783dc4caa6
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
+        version 6.6.87.2-microsoft-standard-WSL2 (root@439a258ad544) (gcc (GCC) 11.2.0,
+        GNU ld (GNU Binutils) 2.37) #1 SMP PREEMPT_DYNAMIC Thu Jun  5 18:30:46 UTC
+        2025","hostname":"LAPTOP-IC725UQU"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 04 Jan 2026 00:08:44 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1082'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=z1e7101u7v8S5nLyLubDfb97Tq9i8gFcVtIwKqBdz4aSyv9CZtAMJRABQ4ekSnI5_sQUb6IpzwMOEWZI
+      Idempotency-Key:
+      - 4e2c2738-1738-4d89-b9ef-2a783dc4caa6
+      Original-Request:
+      - req_1YMOJgZTJxTKwm
+      Request-Id:
+      - req_1YMOJgZTJxTKwm
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - ABGHIJ
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1SlesCIBOqvOFDrfpP810GIb",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 1,
+            "exp_year": 2027,
+            "fingerprint": "xhj6XkBnqmm1SCzj",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "0259",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1767485324,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "type": "card"
+        }
+  recorded_at: Sun, 04 Jan 2026 00:08:41 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/PaypalChargeProcessor/_fight_chargeback/normalizes_carrier_names_to_PayPal_format.yml
+++ b/spec/support/fixtures/vcr_cassettes/PaypalChargeProcessor/_fight_chargeback/normalizes_carrier_names_to_PayPal_format.yml
@@ -1,0 +1,139 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_createDispute
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_3H3hVghpVbOmMp","request_duration_ms":276}}'
+      Idempotency-Key:
+      - 66ff3747-a81d-4169-9fa9-436aabb40630
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
+        version 6.6.87.2-microsoft-standard-WSL2 (root@439a258ad544) (gcc (GCC) 11.2.0,
+        GNU ld (GNU Binutils) 2.37) #1 SMP PREEMPT_DYNAMIC Thu Jun  5 18:30:46 UTC
+        2025","hostname":"LAPTOP-IC725UQU"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 04 Jan 2026 00:08:49 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1082'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=z1e7101u7v8S5nLyLubDfb97Tq9i8gFcVtIwKqBdz4aSyv9CZtAMJRABQ4ekSnI5_sQUb6IpzwMOEWZI
+      Idempotency-Key:
+      - 66ff3747-a81d-4169-9fa9-436aabb40630
+      Original-Request:
+      - req_mbWBBttRggvz9v
+      Request-Id:
+      - req_mbWBBttRggvz9v
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - ABGHIJ
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1SlesHIBOqvOFDrfwbu1iQVh",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 1,
+            "exp_year": 2027,
+            "fingerprint": "xhj6XkBnqmm1SCzj",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "0259",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1767485329,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "type": "card"
+        }
+  recorded_at: Sun, 04 Jan 2026 00:08:45 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/PaypalChargeProcessor/_fight_chargeback/raises_ChargeProcessorError_when_API_returns_500_status.yml
+++ b/spec/support/fixtures/vcr_cassettes/PaypalChargeProcessor/_fight_chargeback/raises_ChargeProcessorError_when_API_returns_500_status.yml
@@ -1,0 +1,139 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_createDispute
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_ScieebN2Hvo9hl","request_duration_ms":263}}'
+      Idempotency-Key:
+      - 61d0442e-2f34-463a-acd6-8bcdfd07994a
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
+        version 6.6.87.2-microsoft-standard-WSL2 (root@439a258ad544) (gcc (GCC) 11.2.0,
+        GNU ld (GNU Binutils) 2.37) #1 SMP PREEMPT_DYNAMIC Thu Jun  5 18:30:46 UTC
+        2025","hostname":"LAPTOP-IC725UQU"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 04 Jan 2026 00:08:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1082'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=z1e7101u7v8S5nLyLubDfb97Tq9i8gFcVtIwKqBdz4aSyv9CZtAMJRABQ4ekSnI5_sQUb6IpzwMOEWZI
+      Idempotency-Key:
+      - 61d0442e-2f34-463a-acd6-8bcdfd07994a
+      Original-Request:
+      - req_bboqKkkoSiI9kT
+      Request-Id:
+      - req_bboqKkkoSiI9kT
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - ABGHIJ
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1SlesFIBOqvOFDrfbChvyAOi",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 1,
+            "exp_year": 2027,
+            "fingerprint": "xhj6XkBnqmm1SCzj",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "0259",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1767485327,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "type": "card"
+        }
+  recorded_at: Sun, 04 Jan 2026 00:08:43 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/PaypalChargeProcessor/_fight_chargeback/raises_ChargeProcessorInvalidRequestError_when_API_returns_400-499_status.yml
+++ b/spec/support/fixtures/vcr_cassettes/PaypalChargeProcessor/_fight_chargeback/raises_ChargeProcessorInvalidRequestError_when_API_returns_400-499_status.yml
@@ -1,0 +1,139 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_createDispute
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_uZkqg1MjfBCk3m","request_duration_ms":325}}'
+      Idempotency-Key:
+      - 9bb3f5a3-88cd-40b2-a1af-38456963c18a
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
+        version 6.6.87.2-microsoft-standard-WSL2 (root@439a258ad544) (gcc (GCC) 11.2.0,
+        GNU ld (GNU Binutils) 2.37) #1 SMP PREEMPT_DYNAMIC Thu Jun  5 18:30:46 UTC
+        2025","hostname":"LAPTOP-IC725UQU"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 04 Jan 2026 00:08:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1082'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=z1e7101u7v8S5nLyLubDfb97Tq9i8gFcVtIwKqBdz4aSyv9CZtAMJRABQ4ekSnI5_sQUb6IpzwMOEWZI
+      Idempotency-Key:
+      - 9bb3f5a3-88cd-40b2-a1af-38456963c18a
+      Original-Request:
+      - req_ScieebN2Hvo9hl
+      Request-Id:
+      - req_ScieebN2Hvo9hl
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - ABGHIJ
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1SlesEIBOqvOFDrfKc4Qf4NK",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 1,
+            "exp_year": 2027,
+            "fingerprint": "xhj6XkBnqmm1SCzj",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "0259",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1767485326,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "type": "card"
+        }
+  recorded_at: Sun, 04 Jan 2026 00:08:43 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/PaypalChargeProcessor/_fight_chargeback/truncates_notes_to_10000_characters_maximum.yml
+++ b/spec/support/fixtures/vcr_cassettes/PaypalChargeProcessor/_fight_chargeback/truncates_notes_to_10000_characters_maximum.yml
@@ -1,0 +1,139 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_createDispute
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_evDZw5gBKYjDYy","request_duration_ms":419}}'
+      Idempotency-Key:
+      - c4eab2c9-23c4-4527-80ef-349199c45aea
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
+        version 6.6.87.2-microsoft-standard-WSL2 (root@439a258ad544) (gcc (GCC) 11.2.0,
+        GNU ld (GNU Binutils) 2.37) #1 SMP PREEMPT_DYNAMIC Thu Jun  5 18:30:46 UTC
+        2025","hostname":"LAPTOP-IC725UQU"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 04 Jan 2026 00:08:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1082'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=z1e7101u7v8S5nLyLubDfb97Tq9i8gFcVtIwKqBdz4aSyv9CZtAMJRABQ4ekSnI5_sQUb6IpzwMOEWZI
+      Idempotency-Key:
+      - c4eab2c9-23c4-4527-80ef-349199c45aea
+      Original-Request:
+      - req_uZkqg1MjfBCk3m
+      Request-Id:
+      - req_uZkqg1MjfBCk3m
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - ABGHIJ
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1SlesEIBOqvOFDrfLvDLCMQN",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 1,
+            "exp_year": 2027,
+            "fingerprint": "xhj6XkBnqmm1SCzj",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "0259",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1767485326,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "type": "card"
+        }
+  recorded_at: Sun, 04 Jan 2026 00:08:42 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/PaypalChargeProcessor/_fight_chargeback/truncates_notes_to_2000_characters_maximum.yml
+++ b/spec/support/fixtures/vcr_cassettes/PaypalChargeProcessor/_fight_chargeback/truncates_notes_to_2000_characters_maximum.yml
@@ -1,0 +1,139 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_createDispute
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_evDZw5gBKYjDYy","request_duration_ms":8}}'
+      Idempotency-Key:
+      - 613eed45-d465-4aa8-96f3-42ced7f6e68c
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
+        version 6.6.87.2-microsoft-standard-WSL2 (root@439a258ad544) (gcc (GCC) 11.2.0,
+        GNU ld (GNU Binutils) 2.37) #1 SMP PREEMPT_DYNAMIC Thu Jun  5 18:30:46 UTC
+        2025","hostname":"LAPTOP-IC725UQU"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 04 Jan 2026 01:14:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1082'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=q91HqbOjfMkQTUwWBkTJiqxMzusq_YBSq6OJTJYTkhpQg6qweG0nij8qKjL47TdMPCeKmCoqL-gFe2pV
+      Idempotency-Key:
+      - 613eed45-d465-4aa8-96f3-42ced7f6e68c
+      Original-Request:
+      - req_jvKjtzIU3bqOWP
+      Request-Id:
+      - req_jvKjtzIU3bqOWP
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - ABGHIJ
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1Slfu5IBOqvOFDrf8SslDuzH",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 1,
+            "exp_year": 2027,
+            "fingerprint": "xhj6XkBnqmm1SCzj",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "0259",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1767489285,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "type": "card"
+        }
+  recorded_at: Sun, 04 Jan 2026 01:14:42 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
Issue: #876

# Description

## Problem

Currently, Gumroad automatically handles dispute evidence submission for Stripe disputes, but PayPal disputes require manual intervention. When a PayPal dispute is created via webhook, the dispute is recorded and `DisputeEvidence` is generated, but no evidence is submitted to PayPal because `eligible_for_dispute_evidence?` explicitly blocks PayPal disputes.

## Solution

Extended the dispute evidence system to support PayPal disputes, matching the existing Stripe functionality. When a PayPal dispute is created via webhook, the system now automatically gathers and submits evidence using the PayPal Disputes API.

**Key changes:**
- Modified `ChargeProcessor.fight_chargeback` to accept PayPal-specific parameters (`merchant_account`, `dispute_id`)
- Implemented `PaypalChargeProcessor#fight_chargeback` with evidence payload builder following PayPal API specifications
- Added `PaypalRestApi#provide_dispute_evidence` endpoint with proper auth assertion headers
- Updated `eligible_for_dispute_evidence?` to return true for PayPal charge processor
- Enhanced dispute evidence creation to include refund policy fine print in `refund_policy_disclosure`
- Evidence notes formatted according to PayPal API spec (2000 character limit)
- Proper error handling for 4xx (invalid request) vs 5xx (server error) responses

**Evidence mapping:**
- Physical products with tracking: Uses `PROOF_OF_FULFILLMENT` evidence type with tracking info
- Digital products or no tracking: Uses `ITEM_DESCRIPTION` evidence type
- All customer details, product info, policies compiled into notes field (max 2000 chars)
- Carrier names normalized to PayPal format with fallback to "OTHER"

---

# Test Results

All tests passing: **209 examples, 0 failures**

See test screenshots in comments below.

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

AI (Claude Code) was used to assist with implementation, testing, and documentation of this feature.