### PR TITLE
Fixed Product page count

### DIFF
--- a/app/controllers/discover_controller.rb
+++ b/app/controllers/discover_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class DiscoverController < ApplicationController
-  RECOMMENDED_PRODUCTS_COUNT = 8
+  RECOMMENDED_PRODUCTS_COUNT = 10
   INITIAL_PRODUCTS_COUNT = 36
 
   include ActionView::Helpers::NumberHelper, RecommendationType, CreateDiscoverSearch,

--- a/app/javascript/components/server-components/Discover/index.tsx
+++ b/app/javascript/components/server-components/Discover/index.tsx
@@ -143,7 +143,7 @@ const BlackFridayBanner = ({
 
 // Featured products and search results overlap when there are no filters, so we skip over the featured products in the search request
 // See DiscoverController::RECOMMENDED_PRODUCTS_COUNT
-const recommendedProductsCount = 8;
+const recommendedProductsCount = 10;
 const addInitialOffset = (params: SearchRequest) =>
   Object.entries(params).every(([key, value]) => !value || ["taxonomy", "curated_product_ids"].includes(key))
     ? { ...params, from: recommendedProductsCount + 1 }


### PR DESCRIPTION
# Issue: #2476

# Description

## Problem
The "Featured products" section on the Discover page is displaying only 9 products instead of the intended 10 products. This occurs because the backend `RECOMMENDED_PRODUCTS_COUNT` constant is set to 8, but the UI grid layout is designed to display 10 products (2 rows × 5 columns).

The mismatch causes:
1. Only 8 products to be fetched for the featured/recommended section
2. The 9th visible product is bleeding in from the search results below
3. The 10th grid position remains empty

## Solution
Updated the `RECOMMENDED_PRODUCTS_COUNT` constant from 8 to 10 in both:
- **Backend**: `DiscoverController::RECOMMENDED_PRODUCTS_COUNT`
- **Frontend**: `recommendedProductsCount` constant in the Discover component

This ensures:
- 10 products are fetched for the featured section
- All 10 grid positions are filled
- Search results are properly offset by 11 (10 + 1) to prevent duplicates

---

# Before/After

## Before
- Featured products section shows 9 products (8 from recommended + 1 bleeding from search results)
- 10th grid position empty
- Inconsistent across all product pages

## After
- Featured products section displays full 10 products
- All grid positions filled correctly
- Proper separation between featured and search result sections

<!-- Screenshots would go here showing the filled 10-product grid -->

---

# Test Results

<!-- Screenshot of test suite passing locally -->

---

# Checklist
- [ ] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [ ] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [ ] I have performed a self-review and left review comments on my PR
- [ ] I have added/updated tests for my changes

---

# AI Disclosure
AI (Claude) was used to analyze the codebase, identify the root cause by examining both frontend and backend code, and draft this PR description. The actual code changes were determined through this analysis.