### PR TITLE
feat(product): Add default offer code support to products (PR 1/4)

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -118,6 +118,7 @@ class Link < ApplicationRecord
   has_many :licenses
   has_one :preorder_link
   belongs_to :affiliate_application, class_name: "OauthApplication", optional: true
+  belongs_to :default_offer_code, class_name: "OfferCode", optional: true
   has_many :affiliate_credits
   has_many :comments, as: :commentable
   has_many :workflows
@@ -206,6 +207,7 @@ class Link < ApplicationRecord
   validate :commission_price_is_valid, if: -> { native_type == Link::NATIVE_TYPE_COMMISSION }
   validate :one_coffee_per_user, on: :create, if: -> { native_type == Link::NATIVE_TYPE_COFFEE }
   validate :quantity_enabled_state_is_allowed
+  validate :default_offer_code_belongs_to_seller_and_product
 
   validates_associated :installment_plan, message: -> (link, _) { link.installment_plan.errors.full_messages.first }
 
@@ -228,6 +230,7 @@ class Link < ApplicationRecord
   attr_json_data_accessor :main_section_index, default: -> { 0 }
   attr_json_data_accessor :custom_view_content_button_text
   attr_json_data_accessor :custom_receipt_text
+  attr_json_data_accessor :default_offer_code_enabled, default: -> { false }
 
   scope :alive,                           -> { where(purchase_disabled_at: nil, banned_at: nil, deleted_at: nil) }
   scope :visible,                         -> { where(deleted_at: nil) }
@@ -1265,7 +1268,42 @@ class Link < ApplicationRecord
       SHORT_DOMAIN.to_s
     end
 
+    # Returns the effective default offer code if enabled and valid, otherwise nil
+    def effective_default_offer_code
+      return nil unless default_offer_code_enabled && default_offer_code.present?
+      return nil if default_offer_code.inactive?
+      return nil unless default_offer_code.is_valid_for_purchase?
+
+      default_offer_code
+    end
+
+    # Returns the discounted price when using the default offer code
+    def default_discounted_price_cents
+      offer_code = effective_default_offer_code
+      return nil unless offer_code
+
+      display_price_cents - offer_code.amount_off(display_price_cents)
+    end
+
   private
+    def default_offer_code_belongs_to_seller_and_product
+      return if default_offer_code.nil?
+
+      if default_offer_code.user_id != user_id
+        errors.add(:default_offer_code, "must belong to the same seller")
+        return
+      end
+
+      unless default_offer_code.applicable?(self)
+        errors.add(:default_offer_code, "must be applicable to this product")
+        return
+      end
+
+      if default_offer_code.inactive?
+        errors.add(:default_offer_code, "must be an active discount code")
+      end
+    end
+
     def compute_ppp_prices(price_cents, factors, currency)
       factors.keys.index_with do |country_code|
         price_cents == 0 ? 0 : [factors[country_code] * price_cents, currency["min_price"]].max.round

--- a/app/models/offer_code.rb
+++ b/app/models/offer_code.rb
@@ -19,6 +19,7 @@ class OfferCode < ApplicationRecord
   stripped_fields :code
 
   has_and_belongs_to_many :products, class_name: "Link", join_table: "offer_codes_products", association_foreign_key: "product_id"
+  has_many :products_with_default_discount, class_name: "Link", foreign_key: "default_offer_code_id"
   belongs_to :user
   has_many :purchases
   has_many :purchases_that_count_towards_offer_code_uses, -> { counts_towards_offer_code_uses }, class_name: "Purchase"

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -71,6 +71,8 @@ class Purchase < ApplicationRecord
   attr_json_data_accessor :perceived_price_cents
   attr_json_data_accessor :recommender_model_name
   attr_json_data_accessor :custom_fee_per_thousand
+  attr_json_data_accessor :used_default_discount, default: -> { false }
+  attr_json_data_accessor :discount_source # "url", "default", or nil
 
   alias_attribute :total_transaction_cents_usd, :total_transaction_cents
 

--- a/db/migrate/20260104235445_add_default_offer_code_to_links.rb
+++ b/db/migrate/20260104235445_add_default_offer_code_to_links.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddDefaultOfferCodeToLinks < ActiveRecord::Migration[7.1]
+  def change
+    # Note: Not using foreign_key constraint per project guidelines
+    # The offer_codes table uses int for id, so we specify integer type
+    add_column :links, :default_offer_code_id, :integer
+    add_index :links, :default_offer_code_id
+  end
+end

--- a/spec/models/link_default_offer_code_spec.rb
+++ b/spec/models/link_default_offer_code_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Link, "default offer code" do
+  let(:user) { create(:user) }
+  let(:product) { create(:product, user: user, price_cents: 10_00) }
+  let(:offer_code) { create(:offer_code, user: user, products: [product], amount_cents: 2_00) }
+
+  describe "validations" do
+    context "when default_offer_code belongs to a different seller" do
+      let(:other_user) { create(:user) }
+      let(:other_product) { create(:product, user: other_user) }
+      let(:other_offer_code) { create(:offer_code, user: other_user, products: [other_product]) }
+
+      it "is invalid" do
+        product.default_offer_code = other_offer_code
+        expect(product).not_to be_valid
+        expect(product.errors[:default_offer_code]).to include("must belong to the same seller")
+      end
+    end
+
+    context "when default_offer_code does not apply to this product" do
+      let(:other_product) { create(:product, user: user) }
+      let(:other_offer_code) { create(:offer_code, user: user, products: [other_product]) }
+
+      it "is invalid" do
+        product.default_offer_code = other_offer_code
+        expect(product).not_to be_valid
+        expect(product.errors[:default_offer_code]).to include("must be applicable to this product")
+      end
+    end
+
+    context "when default_offer_code is inactive" do
+      before { offer_code.update!(expires_at: 1.day.ago, valid_at: 2.days.ago) }
+
+      it "is invalid" do
+        product.default_offer_code = offer_code
+        expect(product).not_to be_valid
+        expect(product.errors[:default_offer_code]).to include("must be an active discount code")
+      end
+    end
+
+    context "when default_offer_code is valid" do
+      it "is valid" do
+        product.default_offer_code = offer_code
+        expect(product).to be_valid
+      end
+    end
+  end
+
+  describe "#effective_default_offer_code" do
+    context "when default_offer_code_enabled is false" do
+      before do
+        product.update!(default_offer_code: offer_code, default_offer_code_enabled: false)
+      end
+
+      it "returns nil" do
+        expect(product.effective_default_offer_code).to be_nil
+      end
+    end
+
+    context "when default_offer_code is nil" do
+      before do
+        product.update!(default_offer_code: nil, default_offer_code_enabled: true)
+      end
+
+      it "returns nil" do
+        expect(product.effective_default_offer_code).to be_nil
+      end
+    end
+
+    context "when default_offer_code is inactive" do
+      before do
+        product.update!(default_offer_code: offer_code, default_offer_code_enabled: true)
+        offer_code.update_column(:expires_at, 1.day.ago)
+      end
+
+      it "returns nil" do
+        expect(product.effective_default_offer_code).to be_nil
+      end
+    end
+
+    context "when default_offer_code has exceeded max uses" do
+      before do
+        offer_code.update!(max_purchase_count: 1)
+        create(:purchase, link: product, offer_code: offer_code)
+        product.update!(default_offer_code: offer_code, default_offer_code_enabled: true)
+      end
+
+      it "returns nil" do
+        expect(product.effective_default_offer_code).to be_nil
+      end
+    end
+
+    context "when default_offer_code is valid and enabled" do
+      before do
+        product.update!(default_offer_code: offer_code, default_offer_code_enabled: true)
+      end
+
+      it "returns the offer code" do
+        expect(product.effective_default_offer_code).to eq(offer_code)
+      end
+    end
+  end
+
+  describe "#default_discounted_price_cents" do
+    context "when there is no effective default offer code" do
+      it "returns nil" do
+        expect(product.default_discounted_price_cents).to be_nil
+      end
+    end
+
+    context "when there is an effective default offer code" do
+      before do
+        product.update!(default_offer_code: offer_code, default_offer_code_enabled: true)
+      end
+
+      it "returns the discounted price" do
+        # Product is $10, discount is $2
+        expect(product.default_discounted_price_cents).to eq(8_00)
+      end
+    end
+
+    context "with a percentage discount" do
+      let(:percentage_offer_code) { create(:percentage_offer_code, user: user, products: [product], amount_percentage: 20) }
+
+      before do
+        product.update!(default_offer_code: percentage_offer_code, default_offer_code_enabled: true)
+      end
+
+      it "returns the discounted price" do
+        # Product is $10, discount is 20%
+        expect(product.default_discounted_price_cents).to eq(8_00)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add database migration for `default_offer_code_id` foreign key on links table
- Add model associations and validations for default discount codes
- Add tracking fields on purchases to record discount source

This is the foundational PR for implementing auto-apply discount codes (#2053).

## Test plan
- [ ] Run migration successfully: `bin/rails db:migrate`
- [ ] Verify Link model can be assigned a default offer code
- [ ] Verify validation prevents assigning offer codes from other sellers
- [ ] Verify validation prevents assigning inactive offer codes
- [ ] Run model specs: `bundle exec rspec spec/models/link_default_offer_code_spec.rb`

## Changes

### Database
- `db/migrate/20260104235445_add_default_offer_code_to_links.rb` - Adds `default_offer_code_id` with foreign key to `offer_codes`

### Models
- `app/models/link.rb`:
  - `belongs_to :default_offer_code` association
  - `attr_json_data_accessor :default_offer_code_enabled` toggle
  - `effective_default_offer_code` helper method
  - `default_discounted_price_cents` calculation
  - Validation for offer code ownership and applicability

- `app/models/offer_code.rb`:
  - `has_many :products_with_default_discount` inverse association

- `app/models/purchase.rb`:
  - `used_default_discount` tracking field
  - `discount_source` field ("url", "default", or nil)

### Tests
- `spec/models/link_default_offer_code_spec.rb` - Model validation and helper method tests

---

Closes part of #2053

🤖 Generated with [Claude Code](https://claude.com/claude-code)