### PR TITLE
fix: backfill missing EndSubscriptionWorker jobs for fixed-length subscriptions

### DIFF
--- a/app/services/onetime/fix_missing_subscription_end_jobs.rb
+++ b/app/services/onetime/fix_missing_subscription_end_jobs.rb
@@ -17,7 +17,7 @@ module Onetime
 
       Subscription.where.not(charge_occurrence_count: nil)
                   .where(ended_at: nil)
-                  .find_each(batch_size: 100) do |subscription|
+                  .find_each do |subscription|
         next unless subscription.charges_completed?
 
         begin


### PR DESCRIPTION
Issue: https://github.com/antiwork/gumroad-private/issues/46

# Description

Some fixed-length membership subscriptions are not ending automatically. Subscriptions that should have ended are missing their scheduled `EndSubscriptionWorker` jobs

## Solution

Created a one-time script to identify and fix affected subscriptions.

# Usage:
```bash
# Preview changes
Onetime::FixMissingSubscriptionEndJobs.perform
# Execute fixes
Onetime::FixMissingSubscriptionEndJobs.perform(dry_run: false)
```

# Tests
I tested the rake task by creating three yearly subscriptions for a product that should automatically end after 12 months:

- Subscription 1 was created on January 6, 2026 and already has an EndSubscriptionWorker correctly scheduled in Sidekiq.
- Subscription 2 was created on January 6, 2026 but does not have an EndSubscriptionWorker scheduled in Sidekiq (the worker was intentionally deleted).
- Subscription 3 was created on December 6, 2023 and remains active, even though it should have ended after the 12-month period

## Before

### Only one `EndSubscriptionWorker` exist, scheduled for Subscription 1
<img width="1470" height="526" alt="image" src="https://github.com/user-attachments/assets/0d1b67f8-c4fe-4eb3-8f14-268e7c4bddf9" />

### Subscription 3 was still active even though it should have ended on December 6, 2024
<img width="1470" height="797" alt="image" src="https://github.com/user-attachments/assets/7e6d4aca-bdc1-4d66-825d-bd4653af47d6" />

## Script execute

### Dry run
<img width="880" height="743" alt="image" src="https://github.com/user-attachments/assets/9754ea9d-4559-4bb0-a770-43bfc3cc1a4a" />

### Live Run
<img width="1425" height="746" alt="Screenshot 2026-01-12 at 17 13 37" src="https://github.com/user-attachments/assets/f5a0d767-19c3-4a0a-90a3-a2cef0f65bd2" />
<img width="1430" height="188" alt="Screenshot 2026-01-12 at 17 13 51" src="https://github.com/user-attachments/assets/7aa8ab7d-dbc3-421d-8089-2b186b431759" />

## After
### A new `EndSubscriptionWorker` was successfully added for Subscription 2
<img width="1470" height="563" alt="image" src="https://github.com/user-attachments/assets/f2094109-59b5-4d30-bceb-3f02e266d0fd" />

### Subscription 3 updated to ended at December 6, 2024
<img width="1470" height="805" alt="image" src="https://github.com/user-attachments/assets/4c482554-103e-4b2e-a36c-6171693ce515" />
