### PR TITLE
fix(emails): prevent cursor reset to beginning while typing in email …

### DIFF
--- a/app/javascript/components/EmailsPage/EmailForm.tsx
+++ b/app/javascript/components/EmailsPage/EmailForm.tsx
@@ -261,6 +261,8 @@ export const EmailForm = ({ context, installment }: EmailFormProps) => {
   const [publishDate, setPublishDate] = React.useState(toISODateString(installment?.published_at));
   React.useEffect(() => setPublishDate(toISODateString(installment?.published_at)), [installment]);
 
+  const [initialMessage] = React.useState(() => parseInitialValue(installment?.message ?? ""));
+
   const form = useForm({
     installment: {
       name: installment?.name ?? "",
@@ -1165,7 +1167,7 @@ export const EmailForm = ({ context, installment }: EmailFormProps) => {
                     className="textarea"
                     ariaLabel="Email message"
                     placeholder="Write a personalized message..."
-                    initialValue={parseInitialValue(form.data.installment.message)}
+                    initialValue={initialMessage}
                     onChange={handleMessageChange}
                     onCreate={setMessageEditor}
                     extensions={[UpsellCard]}


### PR DESCRIPTION
Issue: #2704

# Description

## Problem

When composing a new email, the text cursor continuously resets to the beginning of the line while typing. This makes it difficult to write emails, as text becomes inserted at the wrong position.

The `initialValue` prop passed to `RichTextEditor` was re-computed from `form.data.installment.message` on every render. When the user types, `onChange` updates the form state, triggering a re-render with a new `initialValue`, which causes the editor's `useEffect` to reset the entire editor state (including cursor position).

## Solution

Used `useState` to freeze the initial message value on mount, matching the existing pattern in `TiersEditor.tsx`:

```tsx
const [initialMessage] = React.useState(() => parseInitialValue(installment?.message ?? ""));
```

Then passed `initialMessage` to `RichTextEditor` instead of re-parsing on each render.

---

# Before/After

**Before:** Cursor jumps to position 0 on every keystroke



https://github.com/user-attachments/assets/8053535d-3a80-4863-9514-b06b12f59d26






**After:** Cursor stays at insertion point while typing



https://github.com/user-attachments/assets/77745568-5fe5-474c-8bdf-e70c82c9fff4




---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
---

# AI Disclosure

AI (OpenCode) was used to identify the root cause of the bug.
