### PR TITLE
ignore

### DIFF
--- a/app/javascript/components/useFlashMessage.ts
+++ b/app/javascript/components/useFlashMessage.ts
@@ -1,0 +1,25 @@
+import { router } from "@inertiajs/react";
+import * as React from "react";
+
+import { showAlert, type AlertPayload } from "$app/components/server-components/Alert";
+
+/**
+ * Hook to display flash messages and clear them from Inertia's cache.
+ *
+ * Flash messages were persisting across browser history navigations because
+ * Inertia caches page props. This hook clears the flash prop after displaying
+ * the message, preventing it from re-appearing when navigating back/forward.
+ *
+ * @see https://github.com/antiwork/gumroad/issues/2562
+ */
+export function useFlashMessage(flash?: AlertPayload | null): void {
+  React.useEffect(() => {
+    if (!flash?.message) return;
+
+    showAlert(flash.message, flash.status === "danger" ? "error" : flash.status);
+
+    // Clear flash from Inertia's page cache to prevent re-display on history navigation.
+    // This is a client-side only operation and does not make a server request.
+    router.replaceProp("flash", null);
+  }, [flash]);
+}

--- a/app/javascript/inertia/layout.tsx
+++ b/app/javascript/inertia/layout.tsx
@@ -7,7 +7,8 @@ import { Nav } from "$app/components/client-components/Nav";
 import { CurrentSellerProvider, parseCurrentSeller } from "$app/components/CurrentSeller";
 import LoadingSkeleton from "$app/components/LoadingSkeleton";
 import { type LoggedInUser, LoggedInUserProvider, parseLoggedInUser } from "$app/components/LoggedInUser";
-import Alert, { showAlert, type AlertPayload } from "$app/components/server-components/Alert";
+import Alert, { type AlertPayload } from "$app/components/server-components/Alert";
+import { useFlashMessage } from "$app/components/useFlashMessage";
 import useRouteLoading from "$app/components/useRouteLoading";
 
 type PageProps = {
@@ -33,17 +34,13 @@ export default function Layout({ children }: { children: React.ReactNode }) {
   const { title, flash, logged_in_user, current_seller } = usePage<PageProps>().props;
   const isRouteLoading = useRouteLoading();
 
-  React.useEffect(() => {
-    if (flash?.message) {
-      showAlert(flash.message, flash.status === "danger" ? "error" : flash.status);
-    }
-  }, [flash]);
+  useFlashMessage(flash);
 
   return (
     <LoggedInUserProvider value={parseLoggedInUser(logged_in_user)}>
       <CurrentSellerProvider value={parseCurrentSeller(current_seller)}>
         <Head title={title} />
-        <Alert initial={flash ?? null} />
+        <Alert initial={null} />
         <div id="inertia-shell" className="flex h-screen flex-col lg:flex-row">
           <Nav title="Dashboard" />
           {isRouteLoading ? <LoadingSkeleton /> : null}
@@ -57,17 +54,13 @@ export default function Layout({ children }: { children: React.ReactNode }) {
 export function LoggedInUserLayout({ children }: { children: React.ReactNode }) {
   const { title, flash, logged_in_user, current_seller } = usePage<PageProps>().props;
 
-  React.useEffect(() => {
-    if (flash?.message) {
-      showAlert(flash.message, flash.status === "danger" ? "error" : flash.status);
-    }
-  }, [flash]);
+  useFlashMessage(flash);
 
   return (
     <LoggedInUserProvider value={parseLoggedInUser(logged_in_user)}>
       <CurrentSellerProvider value={parseCurrentSeller(current_seller)}>
         <Head title={title} />
-        <Alert initial={flash ?? null} />
+        <Alert initial={null} />
         {children}
       </CurrentSellerProvider>
     </LoggedInUserProvider>

--- a/app/javascript/layouts/Admin.tsx
+++ b/app/javascript/layouts/Admin.tsx
@@ -7,7 +7,8 @@ import AdminNav from "$app/components/Admin/Nav";
 import AdminNewSalesReportPopover from "$app/components/Admin/SalesReports/NewSalesReportPopover";
 import AdminSearchPopover from "$app/components/Admin/SearchPopover";
 import LoadingSkeleton from "$app/components/LoadingSkeleton";
-import Alert, { showAlert, type AlertPayload } from "$app/components/server-components/Alert";
+import Alert, { type AlertPayload } from "$app/components/server-components/Alert";
+import { useFlashMessage } from "$app/components/useFlashMessage";
 import useRouteLoading from "$app/components/useRouteLoading";
 
 type PageProps = {
@@ -19,11 +20,7 @@ const Admin = ({ children }: { children: React.ReactNode }) => {
   const { title, flash } = usePage<PageProps>().props;
   const isRouteLoading = useRouteLoading();
 
-  React.useEffect(() => {
-    if (flash?.message) {
-      showAlert(flash.message, flash.status === "danger" ? "error" : flash.status);
-    }
-  }, [flash]);
+  useFlashMessage(flash);
 
   return (
     <div id="inertia-shell" className="flex h-screen flex-col lg:flex-row">


### PR DESCRIPTION
## Summary

Fixes #2562: Flash messages were persisting and re-appearing when navigating with browser history (back/forward buttons).

**Root Cause**: Inertia.js caches the entire `page.props` object in browser history state. When users navigate backward/forward, the browser restores the cached props including the flash message, causing it to re-render.

**Solution**: Clear the flash prop from Inertia's cache immediately after displaying the message using `router.replaceProp("flash", null)`. This is a client-side only operation that modifies the current page state without making a server request.

## Changes

- Created `app/javascript/components/useFlashMessage.ts` - A hook that displays flash messages and clears them from Inertia's cache
- Updated `app/javascript/inertia/layout.tsx` - Uses the new hook
- Updated `app/javascript/layouts/Admin.tsx` - Uses the new hook

## Why this approach

This solution is simpler and more elegant than alternatives because:

1. **No server-side changes** - Unlike approaches that generate unique IDs server-side, this is purely client-side
2. **No sessionStorage** - No need to track displayed message IDs in browser storage
3. **No storage management** - No caps or cleanup needed since we're not storing anything
4. **Addresses root cause** - Rather than working around the caching, we simply clear the stale data from the cache

The `router.replaceProp` API was introduced in Inertia v2 specifically for this kind of use case - modifying page props client-side after the initial page load.

## Test plan

1. Navigate to New Email page
2. Publish/send an email
3. Observe the success notification appears
4. Navigate to a different Inertia page
5. Click browser back button to return
6. Verify the flash message does NOT reappear

---

🤖 Generated with [Claude Code](https://claude.ai/code)