### PR TITLE
fix(flash): prevent flash messages persisting across browser history

### DIFF
--- a/app/javascript/components/useFlashMessage.ts
+++ b/app/javascript/components/useFlashMessage.ts
@@ -1,0 +1,13 @@
+import { router } from "@inertiajs/react";
+import * as React from "react";
+
+import { showAlert, type AlertPayload } from "$app/components/server-components/Alert";
+
+export function useFlashMessage(flash?: AlertPayload | null): void {
+  React.useEffect(() => {
+    if (!flash?.message) return;
+
+    showAlert(flash.message, flash.status === "danger" ? "error" : flash.status);
+    router.replaceProp("flash", null);
+  }, [flash]);
+}

--- a/app/javascript/inertia/layout.tsx
+++ b/app/javascript/inertia/layout.tsx
@@ -7,7 +7,8 @@ import { Nav } from "$app/components/client-components/Nav";
 import { CurrentSellerProvider, parseCurrentSeller } from "$app/components/CurrentSeller";
 import LoadingSkeleton from "$app/components/LoadingSkeleton";
 import { type LoggedInUser, LoggedInUserProvider, parseLoggedInUser } from "$app/components/LoggedInUser";
-import Alert, { showAlert, type AlertPayload } from "$app/components/server-components/Alert";
+import Alert, { type AlertPayload } from "$app/components/server-components/Alert";
+import { useFlashMessage } from "$app/components/useFlashMessage";
 import useRouteLoading from "$app/components/useRouteLoading";
 
 type PageProps = {
@@ -33,17 +34,13 @@ export default function Layout({ children }: { children: React.ReactNode }) {
   const { title, flash, logged_in_user, current_seller } = usePage<PageProps>().props;
   const isRouteLoading = useRouteLoading();
 
-  React.useEffect(() => {
-    if (flash?.message) {
-      showAlert(flash.message, flash.status === "danger" ? "error" : flash.status);
-    }
-  }, [flash]);
+  useFlashMessage(flash);
 
   return (
     <LoggedInUserProvider value={parseLoggedInUser(logged_in_user)}>
       <CurrentSellerProvider value={parseCurrentSeller(current_seller)}>
         <Head title={title} />
-        <Alert initial={flash ?? null} />
+        <Alert initial={null} />
         <div id="inertia-shell" className="flex h-screen flex-col lg:flex-row">
           <Nav title="Dashboard" />
           {isRouteLoading ? <LoadingSkeleton /> : null}
@@ -57,17 +54,13 @@ export default function Layout({ children }: { children: React.ReactNode }) {
 export function LoggedInUserLayout({ children }: { children: React.ReactNode }) {
   const { title, flash, logged_in_user, current_seller } = usePage<PageProps>().props;
 
-  React.useEffect(() => {
-    if (flash?.message) {
-      showAlert(flash.message, flash.status === "danger" ? "error" : flash.status);
-    }
-  }, [flash]);
+  useFlashMessage(flash);
 
   return (
     <LoggedInUserProvider value={parseLoggedInUser(logged_in_user)}>
       <CurrentSellerProvider value={parseCurrentSeller(current_seller)}>
         <Head title={title} />
-        <Alert initial={flash ?? null} />
+        <Alert initial={null} />
         {children}
       </CurrentSellerProvider>
     </LoggedInUserProvider>

--- a/app/javascript/layouts/Admin.tsx
+++ b/app/javascript/layouts/Admin.tsx
@@ -7,7 +7,8 @@ import AdminNav from "$app/components/Admin/Nav";
 import AdminNewSalesReportPopover from "$app/components/Admin/SalesReports/NewSalesReportPopover";
 import AdminSearchPopover from "$app/components/Admin/SearchPopover";
 import LoadingSkeleton from "$app/components/LoadingSkeleton";
-import Alert, { showAlert, type AlertPayload } from "$app/components/server-components/Alert";
+import Alert, { type AlertPayload } from "$app/components/server-components/Alert";
+import { useFlashMessage } from "$app/components/useFlashMessage";
 import useRouteLoading from "$app/components/useRouteLoading";
 
 type PageProps = {
@@ -19,11 +20,7 @@ const Admin = ({ children }: { children: React.ReactNode }) => {
   const { title, flash } = usePage<PageProps>().props;
   const isRouteLoading = useRouteLoading();
 
-  React.useEffect(() => {
-    if (flash?.message) {
-      showAlert(flash.message, flash.status === "danger" ? "error" : flash.status);
-    }
-  }, [flash]);
+  useFlashMessage(flash);
 
   return (
     <div id="inertia-shell" className="flex h-screen flex-col lg:flex-row">


### PR DESCRIPTION
Fixes #2562

## Root Cause

Inertia.js caches the entire `page.props` object in browser history state. When users navigate backward/forward, the browser restores the cached props including the flash message, causing it to re-render even though it was already displayed.

## Solution

Clear the flash prop from Inertia's cache immediately after displaying the message using `router.replaceProp("flash", null)`. This is a client-side operation that modifies the current page state without making a server request.

## Changes

- Created `useFlashMessage` hook that displays flash and clears it from cache
- Updated `layout.tsx` and `Admin.tsx` to use the new hook

## Why This Approach

Other open PRs for this issue:
- **#2655** uses server-side ID generation + sessionStorage tracking (adds backend changes and storage management)
- **#2614** removes flash from Inertia props entirely (invasive restructure)
- **#2613** uses `router.replace({ props: ... })` (similar concept, older API)

**This PR** uses `router.replaceProp()` - the direct Inertia v2 API designed specifically for single-prop updates. No server changes, no storage management, minimal code.

## Test Plan

- [x] Navigate to Settings, save changes → success toast appears
- [x] Navigate to another page
- [x] Click browser back button
- [x] Verify flash does NOT reappear

## Videos

Before: 
https://github.com/user-attachments/assets/46a53f8e-cb14-4930-8301-34943af3a5f2

After: 
https://github.com/user-attachments/assets/23efb2b5-c533-4ec4-9a29-59ee7a07c1cd


## Test Suite
<img width="602" height="141" alt="Screenshot 2026-01-06 at 23 10 31" src="https://github.com/user-attachments/assets/d7b2ba00-5007-4100-bb0a-85b6fb04d87f" />

---

## AI Assistance Notice

**Model:** Claude Code (Opus 4.5)

**Tasks using AI assistance:**
- Codebase exploration and understanding existing flash message handling
- Code generation for `useFlashMessage` hook
- Debugging development environment setup
- PR description generation

**IDE/Tools:** Claude Code CLI

**Manual review:** All generated code was reviewed and tested manually in a local development environment before submission.