### PR TITLE
feature: membership restart flow for canceled subscription

### DIFF
--- a/app/javascript/components/Product/CtaButton.tsx
+++ b/app/javascript/components/Product/CtaButton.tsx
@@ -78,18 +78,7 @@ const PARAMETERS_NOT_INHERITED_FROM_URL = new Set([
 ]);
 
 export const CtaButton = React.forwardRef<HTMLAnchorElement, Props>(
-  (
-    {
-      product,
-      purchase,
-      discountCode,
-      selection,
-      label,
-      onClick,
-      showInstallmentPlanNotes = false,
-    },
-    ref,
-  ) => {
+  ({ product, purchase, discountCode, selection, label, onClick, showInstallmentPlanNotes = false }, ref) => {
     const { searchParams } = new URL(useOriginalLocation());
 
     const [referrer, setReferrer] = React.useState("");
@@ -143,7 +132,6 @@ export const CtaButton = React.forwardRef<HTMLAnchorElement, Props>(
       onClick: (evt: React.MouseEvent<HTMLAnchorElement>) => {
         onClick?.(evt);
         if (evt.defaultPrevented) return;
-
         trackCtaClick({
           sellerId: product.seller?.id,
           name: product.name,

--- a/app/javascript/components/Product/Layout.tsx
+++ b/app/javascript/components/Product/Layout.tsx
@@ -140,15 +140,7 @@ export const Layout = (
     hasHero?: boolean;
   },
 ) => {
-  const {
-    product,
-    purchase,
-    discount_code: discountCode,
-    cart,
-    hasHero,
-    wishlists,
-    main_section_index,
-  } = props;
+  const { product, purchase, discount_code: discountCode, cart, hasHero, wishlists, main_section_index } = props;
   const [selection, setSelection] = useSelectionFromUrl(product);
   const ctaButtonRef = React.useRef<HTMLAnchorElement>(null);
   const ctaLabel = cart ? "Add to cart" : undefined;


### PR DESCRIPTION
### Fixes: #173 

### Design : [comment from the issue #173 ](https://github.com/antiwork/gumroad/issues/173#issuecomment-3027712902)

### Problem

Currently all the users who have a canceled membership, don't see a way to resume their subscription and end up buying a new subscription. This leads to data duplicacy, user losing his purchase history, and increase in support load.

### Solution

We introduce a `resume` membership flow for users with canceled membership by interrupting the `subscribe` button click flow and prompting user with a modal to either resume or start afresh. 

### How

#### Backend:
 1. Link Model - Added `restartable_subscription_for(user)` method, queries database for user's canceled subscriptions on this product
  - Filters out test subscriptions and admin-cancelled ones to reduce noice
  - Returns the most recently canceled subscription

  2. ProductPresenter - Added `restartable_subscription_props(user)`  method, formats subscription data (id, price, recurrence)
  - Generates magic link URL with authentication token
  - Passes data to frontend in product page props
  - Magic link uses existing token authentication (same as subscription management emails)

#### Frontend:
  - New `RestartSubscriptionModal` component with two options
  - Modified `CtaButton` to intercept checkout and show modal
       - "Resume" redirects to subscription management page (no login required via token)
       - "Start new" proceeds to normal checkout
---

### After Video for reference:


https://github.com/user-attachments/assets/a77d63a6-107f-495f-b20e-391bda954956



---

# Test Results

<img width="889" height="823" alt="Screenshot 2026-01-06 at 10 23 13 PM" src="https://github.com/user-attachments/assets/8a6f7575-e159-48ea-a735-d8d07efb386a" />

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

I have used Claude Sonnet 4.5 for ui refactoring, writing tests and understanding gumroad codebase. 
