### PR TITLE
Add test mailer encryption key to Docker test environment

### DIFF
--- a/docker/web/Dockerfile.test
+++ b/docker/web/Dockerfile.test
@@ -66,6 +66,7 @@ ENV DATABASE_HOST=db_test \
     AWS_S3_ENDPOINT=http://minio:9000 \
     MEMCACHE_SERVERS=memcached \
     RAILS_LOG_LEVEL=info \
+    MAILER_HEADERS_ENCRYPTION_KEY_V1=test_encryption_key \
     IN_DOCKER=true
 
 WORKDIR $APP_DIR


### PR DESCRIPTION
Issue: #2725 

# Description

## Problem

Email-related tests fail in CI with the error:

```
no implicit conversion of nil into String
```

This happens because `MAILER_HEADERS_ENCRYPTION_KEY_V1` is not set in the Docker test container. The `MailerInfo::Encryption` module calls `Digest::SHA256.digest(key)` where `key` is `nil`, causing the error.

## Solution

Add `MAILER_HEADERS_ENCRYPTION_KEY_V1=test_encryption_key` to the ENV block in `docker/web/Dockerfile.test`, matching the value already present in `.env.test`.


# Test Results

<img width="723" height="376" alt="image" src="https://github.com/user-attachments/assets/7fc86927-4359-448d-85d7-3f22c29e5842" />

**CI verification:** Pending - the "no implicit conversion of nil" error only occurs in Docker (CI), not locally. Full verification requires CI run before merge.

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

No AI was used
