### PR TITLE
Fix: Sync cart email when user updates their account email

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -294,6 +294,7 @@ class User < ApplicationRecord
   after_update :update_audience_members_affiliates
   after_update :update_product_search_index!
   after_commit :move_purchases_to_new_email, on: :update, if: :email_previously_changed?
+  after_commit :sync_cart_email_with_account_email, on: :update, if: :email_previously_changed?
   after_commit :make_affiliate_of_the_matching_approved_affiliate_requests, on: [:create, :update], if: ->(user) { user.confirmed_at_previously_changed? && user.confirmed? }
   after_commit :generate_subscribe_preview, on: [:create, :update], if: :should_subscribe_preview_be_regenerated?
   after_create :insert_null_chargeback_state
@@ -1070,6 +1071,12 @@ class User < ApplicationRecord
       if unconfirmed_email.blank? && purchases.exists?
         UpdatePurchaseEmailToMatchAccountWorker.perform_in(10.seconds, id)
       end
+    end
+
+    def sync_cart_email_with_account_email
+      return unless unconfirmed_email.blank?
+
+      reload_alive_cart&.update!(email: email)
     end
 
     def products_recommendable_conditions_changed?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3043,6 +3043,41 @@ describe User, :vcr do
     end
   end
 
+  describe "#sync_cart_email_with_account_email" do
+    let(:user) { create(:user, email: "old@example.com") }
+
+    it "updates the cart email when the user confirms their new email" do
+      cart = create(:cart, user:, email: "old@example.com")
+
+      user.update!(email: "new@example.com")
+      user.confirm
+
+      expect(cart.reload.email).to eq("new@example.com")
+    end
+
+    it "does not update the cart email before the new email is confirmed" do
+      cart = create(:cart, user:, email: "old@example.com")
+
+      user.update!(email: "new@example.com")
+
+      expect(cart.reload.email).to eq("old@example.com")
+    end
+
+    it "does not fail if the user has no cart" do
+      user.update!(email: "new@example.com")
+      expect { user.confirm }.not_to raise_error
+    end
+
+    it "sets cart email to user email when cart email was nil" do
+      cart = create(:cart, user:, email: nil)
+
+      user.update!(email: "new@example.com")
+      user.confirm
+
+      expect(cart.reload.email).to eq("new@example.com")
+    end
+  end
+
   describe "#update_audience_members_affiliates" do
     it "changing email updates members records" do
       user = create(:user, email: "original@example.com")


### PR DESCRIPTION
## Summary

Fixes #2703

When a logged-in user changes their account email, the checkout page continues to auto-fill the previous email instead of the updated one. This happens because the `alive_cart.email` field retains the old value.

## Problem

The cart stores an email field that is used to prefill the checkout email. When a user updates their account email:
1. The user changes their email in settings
2. They confirm the new email
3. The `email` column in the `users` table is updated
4. However, the `email` column in their `alive_cart` still has the old value
5. The checkout page displays the stale cart email

## Solution

Added an `after_commit` callback `sync_cart_email_with_account_email` that:
- Triggers when `email_previously_changed?` (after email is confirmed and committed)
- Only runs when `unconfirmed_email.blank?` (ensures email is fully confirmed)
- Uses `reload_alive_cart` to get fresh cart data
- Updates the cart email to match the user's new email

### Why `after_commit` instead of `after_update`?

Following the existing pattern in the codebase (see `move_purchases_to_new_email`), `after_commit` ensures:
- The database transaction has completed
- We're not making changes during a transaction that could be rolled back
- Consistent with how similar email sync operations are handled

## Changes

- `app/models/user.rb`: Added callback and private method
- `spec/models/user_spec.rb`: Added 4 test cases

## Testing

Tests verify:
- Cart email updates when user confirms their new email
- Cart email does NOT update before the new email is confirmed
- No errors when user has no cart
- Cart email is set even when previously nil

---

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

## AI Disclosure

Used Claude (via OpenCode/Sisyphus) to:
- Analyze the issue and explore the codebase
- Implement the solution following existing patterns
- Write tests following project conventions