### PR TITLE
Add MAILER_HEADERS_ENCRYPTION_KEY_V1 to Docker test image

### DIFF
--- a/docker/web/Dockerfile.test
+++ b/docker/web/Dockerfile.test
@@ -66,6 +66,7 @@ ENV DATABASE_HOST=db_test \
     AWS_S3_ENDPOINT=http://minio:9000 \
     MEMCACHE_SERVERS=memcached \
     RAILS_LOG_LEVEL=info \
+    MAILER_HEADERS_ENCRYPTION_KEY_V1=test_encryption_key \
     IN_DOCKER=true
 
 WORKDIR $APP_DIR


### PR DESCRIPTION
Closes: #2725

# Description

## Problem

Email-related tests fail in CI with `no implicit conversion of nil into String` errors. This happens because the `MAILER_HEADERS_ENCRYPTION_KEY_V1` environment variable is not set in the Docker test container, even though it exists in `.env.test`.

The Docker test image sets environment variables directly in the Dockerfile rather than loading them from `.env.test`, and this key was missing.

## Solution

Add `MAILER_HEADERS_ENCRYPTION_KEY_V1=test_encryption_key` to the ENV block in `docker/web/Dockerfile.test`. This matches the value already defined in `.env.test` and makes the Docker test environment consistent with local test runs.

---

# Before/After

N/A - No UI changes.

---

# Test Results

Verified by comparing CI runs:
- Old run ([20626922491](https://github.com/antiwork/gumroad/actions/runs/20626922491)): Multiple `Digest::SHA256.digest(key) - no implicit conversion of nil` errors
- New run ([20761329770](https://github.com/antiwork/gumroad/actions/runs/20761329770)): Zero encryption key errors

---

# AI Disclosure
This PR was implemented with AI assistance using Cursor for code generation. All code was self-reviewed and directed throughout the development process.