### PR TITLE
fix: checkout email remains stuck to old account email

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -294,6 +294,7 @@ class User < ApplicationRecord
   after_update :update_audience_members_affiliates
   after_update :update_product_search_index!
   after_commit :move_purchases_to_new_email, on: :update, if: :email_previously_changed?
+  after_commit :sync_cart_email_to_account_email, on: :update, if: :email_previously_changed?
   after_commit :make_affiliate_of_the_matching_approved_affiliate_requests, on: [:create, :update], if: ->(user) { user.confirmed_at_previously_changed? && user.confirmed? }
   after_commit :generate_subscribe_preview, on: [:create, :update], if: :should_subscribe_preview_be_regenerated?
   after_create :insert_null_chargeback_state
@@ -1070,6 +1071,13 @@ class User < ApplicationRecord
       if unconfirmed_email.blank? && purchases.exists?
         UpdatePurchaseEmailToMatchAccountWorker.perform_in(10.seconds, id)
       end
+    end
+
+    def sync_cart_email_to_account_email
+      return if unconfirmed_email.present?
+      return unless alive_cart.present?
+
+      alive_cart.update!(email: email)
     end
 
     def products_recommendable_conditions_changed?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2528,6 +2528,46 @@ describe User, :vcr do
     end
   end
 
+  describe "#sync_cart_email_to_account_email" do
+    it "updates cart email when user email is confirmed" do
+      user = create(:user, email: "old@example.com")
+      cart = create(:cart, user:, email: "old@example.com")
+
+      user.update!(email: "new@example.com")
+      user.confirm
+
+      expect(cart.reload.email).to eq("new@example.com")
+    end
+
+    it "does not update cart email if email is not yet confirmed" do
+      user = create(:user, email: "old@example.com")
+      cart = create(:cart, user:, email: "old@example.com")
+
+      user.update!(email: "new@example.com")
+
+      expect(cart.reload.email).to eq("old@example.com")
+    end
+
+    it "does not raise error if user has no alive cart" do
+      user = create(:user, email: "old@example.com")
+
+      expect do
+        user.update!(email: "new@example.com")
+        user.confirm
+      end.not_to raise_error
+    end
+
+    it "does not update deleted cart" do
+      user = create(:user, email: "old@example.com")
+      cart = create(:cart, user:, email: "old@example.com", deleted_at: 1.hour.ago)
+
+      user.update!(email: "new@example.com")
+      user.confirm
+
+      expect(cart.reload.email).to eq("old@example.com")
+    end
+  end
+
   describe "#make_affiliate_of_the_matching_approved_affiliate_requests" do
     let(:requester_email) { "requester@example.com" }
     let!(:approved_affiliate_request_one) { create(:affiliate_request, email: requester_email, state: :approved) }


### PR DESCRIPTION
Issue: https://github.com/antiwork/gumroad/issues/2703

# Description

<!-- Briefly describe the problem and your solution -->
Issue: When a logged-in user changes their account email, the cart email is not automatically synced with the new account email



## Problem

Root cause: There was no callback to update the cart email when the user's account email changes

## Solution

---

I added an `after_commit` callback in the User model to sync the cart email whenever the user's email changes and is confirmed

`sync_cart_email_to_account_email` runs → updates `alive_cart.email` to match new `user.email`

--> Fix the issue

# Before/After

<!-- For UI/CSS changes, include screenshots or videos showing both states -->
<!-- Include: Desktop (light + dark) and Mobile (light + dark) -->

---
It is purely BE fix


# Test Results

<!-- Include a screenshot of your test suite passing locally -->

Before:

<img width="866" height="391" alt="image" src="https://github.com/user-attachments/assets/5e0d6923-f7a9-4580-ba0c-d531f8275729" />


After:

<img width="858" height="392" alt="image" src="https://github.com/user-attachments/assets/e726885b-cf4a-4dbe-b645-437bbd8ea911" />

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

Claude-code sonnet-4.5 was used to help on debugging and writing tests. All AI-generated codes are well reviewed by me

<!-- State whether AI was used and for what purpose, or "No AI was used for any part of this contribution." -->
