### PR TITLE
Fix Nav SSR crash when helper_session is null

### DIFF
--- a/app/javascript/components/server-components/Nav.tsx
+++ b/app/javascript/components/server-components/Nav.tsx
@@ -34,7 +34,7 @@ type Props = {
       links?: Record<string, string> | null;
     } | null;
     currentToken?: string | null;
-  };
+  } | null;
 };
 
 export const Nav = (props: Props) => {


### PR DESCRIPTION
Issue: https://github.com/antiwork/gumroad/issues/2689

# Description

Follow-up to https://github.com/antiwork/gumroad/pull/2717.

## Problem

The product edit page was crashing (through the Nav component?) during server-side rendering with:

> Error: Expected root.helper_session to be an object, got null

This occurred because the `helper_session` prop wasn't typed to be nullable (`null`), and so this wasn't part of the runtime validator generated by `createCast`.

## Solution
Added `| null` to the `helper_session` type definition.

---

# Test Results

Verified the page loads without errors when `helper_session` is null.

---

# AI Disclosure

Claude Opus 4.5 (Thinking) to locate the bug based on logs.