### PR TITLE
fix: typo on help article

### DIFF
--- a/app/views/help_center/articles/contents/_128-discount-codes.html.erb
+++ b/app/views/help_center/articles/contents/_128-discount-codes.html.erb
@@ -19,7 +19,7 @@
   <p>Choose the product(s) you want this discount code to apply to, or check “All products” if you want it to apply to all your products.</p>
   <p>Enter the discount code and the amount or percentage off of your full price.</p>
   <h3 id="Allow-customers-to-enter-discount-codes-IN4wU">Allow customers to enter discount codes</h3>
-  <p>To show the discount code input box on the checkout page, toggle  "Only if a discount is available" in the <a href="https://gumroad.com/checkout/form">Checkout form</a> tab, otherwise, it will only be possible to apply a discount code by using a  <a href="270-url-parameters">a URL parameter</a>.</p>
+  <p>To show the discount code input box on the checkout page, toggle  "Only if a discount is available" in the <a href="https://gumroad.com/checkout/form">Checkout form</a> tab, otherwise, it will only be possible to apply a discount code by using a <a href="270-url-parameters">URL parameter</a>.</p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/657b142ea55b5524fb50d6a5/file-RPDfnvrDVr.png" %></figure>
   <h3 id="Discounts-for-memberships-_Pxb_">Discounts for memberships</h3>
   <p>If your discount code applies to a membership, you can choose if you want it to be valid for all recurring charges or just the first billing period. A code meant for just the first billing period can help you boost recurring sales without being stuck to the discounted price for the entire membership duration.</p>


### PR DESCRIPTION
Typo on https://gumroad.com/help/article/128-discount-codes

### Before
<img width="780" height="152" alt="image" src="https://github.com/user-attachments/assets/abe0e50c-ffb7-4f00-ade1-b49c0e914c2a" />

### After
<img width="769" height="169" alt="image" src="https://github.com/user-attachments/assets/b27f95b3-0d2f-43da-a740-f805eb8c23aa" />