### PR TITLE
fix(auth): prevent mass assignment of privileged attributes during signup

### DIFF
--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -94,7 +94,14 @@ class SignupController < Devise::RegistrationsController
     end
 
     def permitted_params
-      params.require(:user).permit(UsersController::USER_PERMITTED_ATTRS)
+      params.require(:user).permit(
+        :email,
+        :password,
+        :password_confirmation,
+        :terms_accepted,
+        :buyer_signup,
+        :remember_me
+      )
     end
 
     def verify_captcha_and_handle_existing_users

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,26 +17,6 @@ class UsersController < ApplicationController
   before_action :check_if_needs_redirect, only: %i[show]
   before_action :set_affiliate_cookie, only: %i[show]
 
-  USER_PERMITTED_ATTRS = [:username, :email, :bio, :password,
-                          :password_confirmation, :remember_me, :name, :payment_address,
-                          :currency_type, :country, :state,
-                          :city, :zip_code, :street_address,
-                          :facebook_access_token, :manage_pages, :verified,
-                          :weekly_notification,
-                          :twitter_oauth_token, :twitter_oauth_secret,
-                          :notification_endpoint, :locale, :announcement_notification_enabled,
-                          :google_analytics_id, :timezone, :user_risk_state,
-                          :tos_violation_reason, :terms_accepted,
-                          :buyer_signup, :support_email,
-                          :background_opacity_percent, :should_paypal_payout_be_split,
-                          :check_merchant_account_is_linked, :collect_eu_vat, :is_eu_vat_exclusive,
-                          :facebook_pixel_id, :skip_free_sale_analytics,
-                          :disable_third_party_analytics, :two_factor_authentication_enabled, :facebook_meta_tag,
-                          :enable_verify_domain_third_party_services,
-                          :enable_payment_email, :enable_payment_push_notification, :enable_free_downloads_email, :enable_free_downloads_push_notification,
-                          :enable_recurring_subscription_charge_email, :enable_recurring_subscription_charge_push_notification,
-                          :disable_comments_email, :disable_reviews_email]
-
   def show
     format_search_params!
 

--- a/spec/controllers/signup_controller_spec.rb
+++ b/spec/controllers/signup_controller_spec.rb
@@ -394,6 +394,24 @@ describe SignupController, type: :controller, inertia: true do
       expect(last_user.purchases.first.id).to eq purchase.id
     end
 
+    it "rejects mass assignment of privileged attributes" do
+      params = {
+        user: {
+          email: generate(:email),
+          password: "password",
+          verified: true,
+          user_risk_state: "compliant",
+          tos_violation_reason: "fraud",
+        }
+      }
+      post "create", params:, format: :json
+      last_user = User.last
+      expect(last_user).to be_present
+      expect(last_user.verified).to be_falsey
+      expect(last_user.user_risk_state).not_to eq "compliant"
+      expect(last_user.tos_violation_reason).to be_nil
+    end
+
     it "associates the preorder with the newly created user", :vcr do
       purchase = create(:purchase)
       preorder = create(:preorder)


### PR DESCRIPTION
This PR is an upstream of https://github.com/antiwork/gumroad-private/pull/54

# Description

Fixes a mass assignment vulnerability in the signup endpoint that allowed attackers to create fully verified, compliant seller accounts without any vetting.

## Problem
The `SignupController#create` action was using `UsersController::USER_PERMITTED_ATTRS` to filter user parameters during signup. This list included highly privileged attributes that should never be assignable by unauthenticated users:
- `verified` - bypasses price caps and seller protections
- `user_risk_state` - skips fraud review workflows
- `two_factor_authentication_enabled` - disables security features

## Solution
Replaced the `UsersController::USER_PERMITTED_ATTRS` with a minimal inline whitelist in the `permitted_params` method, containing only safe attributes appropriate for unauthenticated account creation
