### PR TITLE
fix: enforce HTTPS for OpenExchangeRates API calls

### DIFF
--- a/config/initializers/currency.rb
+++ b/config/initializers/currency.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-OPEN_EXCHANGE_RATES_API_BASE_URL = "http://openexchangerates.org/api"
+OPEN_EXCHANGE_RATES_API_BASE_URL = "https://openexchangerates.org/api"
 OPEN_EXCHANGE_RATE_KEY           = GlobalConfig.get("OPEN_EXCHANGE_RATES_APP_ID")
 
 CURRENCY_SOURCE = if Rails.env.development? || Rails.env.test?


### PR DESCRIPTION
This PR is an upstream of https://github.com/antiwork/gumroad-private/pull/57

# Description

## Problem
The OpenExchangeRates API is being queried over plain HTTP, exposing the API key in cleartext and allowing network attackers to intercept and tamper with exchange rates used in checkout calculations, VAT reports, and payouts.

## Solution
Enforce HTTPS for all OpenExchangeRates API calls and add a regression test to prevent accidental HTTP downgrade