### PR TITLE
replace ExternalId with SecureExternalId for cart model

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -18,7 +18,7 @@ class CheckoutController < ApplicationController
       # Always show their own cart to the logged-in user
       return redirect_to(request_path_except_cart_id_param) if logged_in_user.present?
 
-      cart = Cart.includes(:user).alive.find_by_external_id(params[:cart_id])
+      cart = Cart.includes(:user).alive.find_by_secure_external_id(params[:cart_id], scope: "cart_login")
       return redirect_to(request_path_except_cart_id_param) if cart.nil?
 
       # Prompt the user to log in if the cart matching the `cart_id` param is associated with a user

--- a/app/mailers/customer_mailer.rb
+++ b/app/mailers/customer_mailer.rb
@@ -192,7 +192,7 @@ class CustomerMailer < ApplicationMailer
       {
         id: installment.id,
         subject: installment.subject,
-        message: installment.message_with_inline_abandoned_cart_products(products:, checkout_url: checkout_index_url(host: UrlService.domain_with_protocol, cart_id: cart.external_id))
+        message: installment.message_with_inline_abandoned_cart_products(products:, checkout_url: checkout_index_url(host: UrlService.domain_with_protocol, cart_id: cart.secure_external_id(scope: "cart_login")))
       }
     end
 

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Cart < ApplicationRecord
-  include ExternalId
+  include SecureExternalId
   include Deletable
 
   DISCOUNT_CODES_SCHEMA = {

--- a/spec/requests/checkout/cart_spec.rb
+++ b/spec/requests/checkout/cart_spec.rb
@@ -340,7 +340,7 @@ describe "Checkout cart", :js, type: :system do
             create(:cart_product, cart: another_cart, product: create(:product, name: "Product 2"))
 
             login_as buyer
-            visit checkout_index_path(cart_id: another_cart.external_id)
+            visit checkout_index_path(cart_id: another_cart.secure_external_id(scope: "cart_login"))
             expect(page).to have_current_path(checkout_index_path)
             expect(page).to have_text("Product 1")
             expect(page).to_not have_text("Product 2")
@@ -362,7 +362,7 @@ describe "Checkout cart", :js, type: :system do
               wait.until { Cart.alive.count == 2 }
               guest_cart = Cart.alive.last
 
-              visit checkout_index_path(cart_id: user_cart.external_id)
+              visit checkout_index_path(cart_id: user_cart.secure_external_id(scope: "cart_login"))
               expect(page).to have_current_path(login_path(email: user_cart.user.email, next: checkout_index_path(referrer: UrlService.discover_domain_with_protocol)))
               fill_in "Password", with: user_cart.user.password
               click_on "Login"
@@ -389,7 +389,7 @@ describe "Checkout cart", :js, type: :system do
               current_browser_guid = Capybara.current_session.driver.browser.manage.all_cookies.find { _1[:name] == "_gumroad_guid" }&.[](:value)
               current_guest_cart.update!(browser_guid: current_browser_guid)
 
-              visit checkout_index_path(cart_id: cart.external_id)
+              visit checkout_index_path(cart_id: cart.secure_external_id(scope: "cart_login"))
               expect(page).to have_current_path(checkout_index_path)
               expect(page).to have_text("Product 1")
               expect(page).to have_text("Product 2")


### PR DESCRIPTION
This PR is an upstream of https://github.com/antiwork/gumroad-private/pull/51

## Problem
Cart external IDs were deterministic and could collide with product IDs, allowing a crafted checkout URL to expose a user’s email via the login redirect

## Solution
Switched cart lookups and checkout links to `SecureExternalId` with a scoped, unguessable ID, preventing ID reuse and PII disclosure