### PR TITLE
Fix receipt product price layout to use full width in emails

### DIFF
--- a/app/views/customer_mailer/receipt/_attributes.html.erb
+++ b/app/views/customer_mailer/receipt/_attributes.html.erb
@@ -1,17 +1,21 @@
 <% if attributes.present? %>
-  <table class="table-stack">
+  <table class="table-stack" width="100%" cellpadding="0" cellspacing="0">
     <tbody>
       <% attributes.each do |attribute| %>
         <tr>
-          <td>
+          <td width="70%" style="padding: 6px 8px 6px 0;">
             <% if attribute[:label].present? %>
-              <span style="font-weight: bold"><%= attribute[:label] %></span>
-              <br>
+              <strong><%= attribute[:label] %></strong>
             <% end %>
+          </td>
+          <td
+            width="30%"
+            align="right"
+            style="padding: 6px 0; white-space: nowrap;"
+          >
             <% if attribute[:value].is_a?(Array) %>
               <% attribute[:value].each do |item| %>
-                <%= auto_link(item.to_s, html: { target: "_blank" }) %>
-                <br>
+                <%= auto_link(item.to_s, html: { target: "_blank" }) %><br>
               <% end %>
             <% else %>
               <%= auto_link(attribute[:value].to_s, html: { target: "_blank" }) %>
@@ -22,3 +26,4 @@
     </tbody>
   </table>
 <% end %>
+


### PR DESCRIPTION
Issue: #

# Description

<!-- Briefly describe the problem and your solution -->

## Wasn't able to occupy full width

## Ensured consistent layout in regard label and value

---

# Before/After

<!-- For UI/CSS changes, include screenshots or videos showing both states -->
<!-- Include: Desktop (light + dark) and Mobile (light + dark) -->

---

# Test Results

<!-- Include a screenshot of your test suite passing locally -->
<img width="1470" height="956" alt="Screenshot 2026-01-10 at 07 09 30" src="https://github.com/user-attachments/assets/4d0d9551-a8f0-4dca-8e4e-2a8090e2cca8" />




---

# Checklist
<img width="5090" height="2628" alt="image_2026-01-10_071119873" src="https://github.com/user-attachments/assets/380a54d3-a995-4a3b-a6be-5a150c469376" />


- [ ] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [ ] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [ ] I have performed a self-review and left review comments on my PR
- [ ] I have added/updated tests for my changes

---

# AI Disclosure

<!-- State whether AI was used and for what purpose, or "No AI was used for any part of this contribution." -->
AI was used only for debugging
