### PR TITLE
Fix(receipt): make attribute boxes full width

### DIFF
--- a/app/views/customer_mailer/receipt/_attributes.html.erb
+++ b/app/views/customer_mailer/receipt/_attributes.html.erb
@@ -1,5 +1,5 @@
 <% if attributes.present? %>
-  <table class="table-stack">
+  <table class="table-stack" style="width: 100%;">
     <tbody>
       <% attributes.each do |attribute| %>
         <tr>


### PR DESCRIPTION
Issue: #2773

# Description

## Problem

Receipt attribute boxes ("Product price", etc.) now occupy full width instead of shrinking to content width.

## Solution

Added `style="width: 100%;"` to the table in `_attributes.html.erb`.

---

# Before/After

## Before
### Light
<img width="505" height="1020" alt="image" src="https://github.com/user-attachments/assets/9e6d9611-7fae-48ae-8883-8bd651b042c1" />

### Dark
<img width="505" height="1020" alt="image" src="https://github.com/user-attachments/assets/b02dfb3d-1455-41b9-857d-351898e5d847" />

## After

### Light
<img width="505" height="1020" alt="image" src="https://github.com/user-attachments/assets/aa59479d-b9dc-451b-8408-1bcb0d3f9b85" />

### Dark
<img width="505" height="1020" alt="image" src="https://github.com/user-attachments/assets/09f6ec1e-8868-402a-9824-bd59c1e8f7aa" />

---

# Test Results

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

Used Claude Opus 4.5 via Cursor for exploring and understanding the codebase
