### PR TITLE
Support logging in via mobile access token on the URL redirect page

### DIFF
--- a/app/controllers/url_redirects_controller.rb
+++ b/app/controllers/url_redirects_controller.rb
@@ -356,9 +356,9 @@ class UrlRedirectsController < ApplicationController
         return redirect_to url_redirect_membership_inactive_page_path(@url_redirect.token)
       end
 
-      if params[:access_token].present?
+      if params[:access_token].present? && params[:mobile_token] == Api::Mobile::BaseController::MOBILE_TOKEN
         doorkeeper_authorize! :mobile_api
-        return if purchase.purchaser && purchase.purchaser == current_api_user
+        return if purchase && purchase.purchaser && purchase.purchaser == current_api_user
       end
 
       if cookies.encrypted[:confirmed_redirect] == @url_redirect.token ||

--- a/spec/controllers/url_redirects_controller_spec.rb
+++ b/spec/controllers/url_redirects_controller_spec.rb
@@ -658,10 +658,18 @@ describe UrlRedirectsController do
       context "with valid mobile_api token for the purchaser" do
         let(:access_token) { create("doorkeeper/access_token", application: oauth_app, resource_owner_id: purchaser.id, scopes: "mobile_api") }
 
-        it "grants access when the token owner is the purchaser" do
-          get :download_page, params: { id: @token, access_token: access_token.token }
+        it "grants access when the token owner is the purchaser and mobile_token is present" do
+          get :download_page, params: { id: @token, access_token: access_token.token, mobile_token: Api::Mobile::BaseController::MOBILE_TOKEN }
 
           expect(response).to be_successful
+        end
+
+        it "requires mobile_token to match the expected value" do
+          @url_redirect.update!(has_been_seen: true)
+
+          get :download_page, params: { id: @token, access_token: access_token.token, mobile_token: "wrong_token" }
+
+          expect(response).to redirect_to(confirm_page_path(id: @url_redirect.token, destination: "download_page"))
         end
       end
 
@@ -672,7 +680,7 @@ describe UrlRedirectsController do
         it "redirects to confirm page" do
           @url_redirect.update!(has_been_seen: true)
 
-          get :download_page, params: { id: @token, access_token: access_token.token }
+          get :download_page, params: { id: @token, access_token: access_token.token, mobile_token: Api::Mobile::BaseController::MOBILE_TOKEN }
 
           expect(response).to redirect_to(confirm_page_path(id: @url_redirect.token, destination: "download_page"))
         end
@@ -680,7 +688,7 @@ describe UrlRedirectsController do
 
       context "with invalid token" do
         it "returns 401" do
-          get :download_page, params: { id: @token, access_token: "invalid_token" }
+          get :download_page, params: { id: @token, access_token: "invalid_token", mobile_token: Api::Mobile::BaseController::MOBILE_TOKEN }
 
           expect(response).to have_http_status(:unauthorized)
         end
@@ -690,9 +698,21 @@ describe UrlRedirectsController do
         let(:access_token) { create("doorkeeper/access_token", application: oauth_app, resource_owner_id: purchaser.id, scopes: "creator_api") }
 
         it "returns 403" do
-          get :download_page, params: { id: @token, access_token: access_token.token }
+          get :download_page, params: { id: @token, access_token: access_token.token, mobile_token: Api::Mobile::BaseController::MOBILE_TOKEN }
 
           expect(response).to have_http_status(:forbidden)
+        end
+      end
+
+      context "with valid token but no purchase is attached to the url redirect" do
+        let(:access_token) { create("doorkeeper/access_token", application: oauth_app, resource_owner_id: purchaser.id, scopes: "mobile_api") }
+
+        it "does not require redirect" do
+          @url_redirect.update!(purchase: nil, has_been_seen: true)
+
+          get :download_page, params: { id: @url_redirect.token, access_token: access_token.token, mobile_token: Api::Mobile::BaseController::MOBILE_TOKEN }
+
+          expect(response).to be_successful
         end
       end
     end


### PR DESCRIPTION
# Description

## Problem

Currently the mobile apps use the regular download page at /d/:token to load product content. However, it feels very clunky because we run into the email confirmation check and show an extra form to confirm the email before viewing product details.

## Solution

Added an option to bypass the confirmation check by providing a valid OAuth access token in a query param. The apps can pass this to verify the correct user is viewing the content.

---

# AI Disclosure

Used Claude Opus 4.5 for exploring the codebase and refactoring specs.
