### PR TITLE
fix: pagination for seller profile product sections

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -225,7 +225,7 @@ class LinksController < ApplicationController
     on_profile = search_params[:user_id].present?
     if on_profile
       user = User.find_by_external_id(search_params[:user_id])
-      section = user && user.seller_profile_products_sections.on_profile.find_by_external_id(search_params[:section_id])
+      section = user && user.seller_profile_products_sections.find_by_external_id(search_params[:section_id])
       return render json: { total: 0, filetypes_data: [], tags_data: [], products: [] } if section.nil?
       search_params[:section] = section
       search_params[:is_alive_on_profile] = true

--- a/app/presenters/profile_sections_presenter.rb
+++ b/app/presenters/profile_sections_presenter.rb
@@ -130,6 +130,7 @@ class ProfileSectionsPresenter
           }
         )
       )
+      search_results[:total] = section.shown_products.length
       search_results[:products] = search_results[:products].ids
       search_results
     end


### PR DESCRIPTION
## Issue #2476

# Description

When viewing a creator’s featured products at the bottom of a product page, pagination would stop after only 9 products, preventing users from seeing the full set (even if the seller had selected more). Even though additional products existed in the section, subsequent paginated requests returned empty results.

---

## Problem

- The frontend paginates featured products using subsequent `/products/search` requests.
- These paginated requests previously returned empty results, even when more products existed, causing the UI to stop at 9 products.

**Example paginated request:**
```http
GET /products/search?
  sort=page_layout
  &user_id=9775531653219
  &section_id=Ndi2r61ahsr4VqEFanuDyw==
  &ids[]=RSfkeohPxPSCisCW8nZr7A==
  ...
  &from=10
```

**Previous response:**  
```json
{
  "total": 0,
  "filetypes_data": [],
  "tags_data": [],
  "products": []
}
```

---

### Root Cause

1. **Incorrect section lookup**

The backend resolved profile sections using an overly restrictive scope, which could fail for valid profile sections during paginated requests:

   ```ruby
   section = user && user.seller_profile_products_sections.on_profile.find_by_external_id(search_params[:section_id])
   ```
   This caused valid seller profile sections to fail lookup, resulting in empty product lists being returned.

2. **Inaccurate `total` count**

   The total field returned from the backend did not reflect the actual number of products in the seller’s profile section. Since frontend pagination relies on total to determine whether more pages exist, pagination stopped prematurely.

---

## Solution

1. **Fix section resolution**  
Sections are now resolved directly from the seller’s profile product sections without applying the restrictive `.on_profile scope` :
   ```ruby
   section = user && user.seller_profile_products_sections.find_by_external_id(search_params[:section_id])
   ```
This ensures the correct seller-owned section is consistently found during paginated requests.

2. **Return accurate `total` for section searches**  
  The backend now explicitly returns the actual number of products assigned to the profile section, allowing the frontend to paginate until all products are loaded.

---

## Testing

- **Local testing:**  
Verified locally by loading additional products in seller profile sections and confirming that paginated requests now return complete, non-empty results. While i was testing i saw that setting pagination = "button" also works!

## Before
  - Only 9 products shown, even if more are assigned to the section.
  - Requests for additional pages return:
    ```json
    { "total": 0, ... }
    ```
  - ![Screenshot showing 9 products](https://github.com/user-attachments/assets/2c5de702-7c1e-4631-ae87-80b8e2d3d13d)

## After
 
[Screencast from 2026-01-12 09-57-14.webm](https://github.com/user-attachments/assets/1f056266-9060-4a71-ae02-1a3933ad78ba)

### Mobile - version

[Screencast from 2026-01-12 11-38-37.webm](https://github.com/user-attachments/assets/9832df4a-be52-439d-a75c-4283d05f10c8)

---

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work) 
- [x] I have performed a self-review and left review comments on my PR
- [ ] I have added/updated tests for my changes

**Note**:
This change fixes how profile sections are looked up and ensures the correct total is returned from an existing endpoint. It doesn’t add any new logic paths, and the issue couldn’t be reliably reproduced using the current test helpers, so I verified the fix manually as documented above.

---

### AI Disclosure

Model: GPT-4  
Used for: Debugging and code review  
All code changes were implemented and verified manually

