### PR TITLE
feat: implement backup payment method for refund funding

### DIFF
--- a/app/controllers/settings/refund_funding_controller.rb
+++ b/app/controllers/settings/refund_funding_controller.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+class Settings::RefundFundingController < Settings::BaseController
+  before_action :authorize
+
+  def show
+    render json: refund_funding_data
+  end
+
+  def create
+    card_data_handling_mode = CardParamsHelper.get_card_data_handling_mode(params)
+    card_data_handling_error = CardParamsHelper.check_for_errors(params)
+
+    if card_data_handling_error.present?
+      return render json: { success: false, error: card_data_handling_error.error_message }, status: :unprocessable_entity
+    end
+
+    chargeable = CardParamsHelper.build_chargeable(params)
+
+    if chargeable.blank?
+      return render json: { success: false, error: "Invalid card information" }, status: :unprocessable_entity
+    end
+
+    credit_card = CreditCard.create(chargeable, card_data_handling_mode, current_seller)
+
+    if credit_card.persisted?
+      current_seller.update!(
+        refund_funding_credit_card: credit_card,
+        refund_funding_card_name: params[:name_on_card]
+      )
+      render json: { success: true, **refund_funding_data }
+    else
+      render json: { success: false, error: credit_card.errors.full_messages.first }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    current_seller.update!(
+      refund_funding_credit_card: nil,
+      refund_funding_card_name: nil
+    )
+    render json: { success: true, **refund_funding_data }
+  end
+
+  def dismiss_banner
+    current_seller.update!(dismissed_refund_payment_method_banner: true)
+    render json: { success: true }
+  end
+
+  private
+
+  def refund_funding_data
+    card = current_seller.refund_funding_credit_card
+    {
+      enabled: card.present?,
+      name_on_card: current_seller.refund_funding_card_name,
+      credit_card: card.present? ? {
+        visual: card.visual,
+        card_type: card.card_type,
+        expiry_month: card.expiry_month,
+        expiry_year: card.expiry_year
+      } : nil,
+      show_banner: !current_seller.dismissed_refund_payment_method_banner? && card.blank?
+    }
+  end
+
+  def authorize
+    super([:settings, :payments, current_seller])
+  end
+end

--- a/app/javascript/components/Audience/CustomersPage.tsx
+++ b/app/javascript/components/Audience/CustomersPage.tsx
@@ -59,6 +59,7 @@ import { AbortError, assertResponseError } from "$app/utils/request";
 
 import { Button, NavigationButton } from "$app/components/Button";
 import { useCurrentSeller } from "$app/components/CurrentSeller";
+import { RefundPaymentMethodBanner } from "$app/components/CustomersPage/RefundPaymentMethodBanner";
 import { DateInput } from "$app/components/DateInput";
 import { DateRangePicker } from "$app/components/DateRangePicker";
 import { FileKindIcon } from "$app/components/FileRowContent";
@@ -104,6 +105,7 @@ export type CustomerPageProps = {
   countries: string[];
   can_ping: boolean;
   show_refund_fee_notice: boolean;
+  show_refund_payment_method_banner: boolean;
 };
 
 const year = new Date().getFullYear();
@@ -127,6 +129,7 @@ const CustomersPage = ({
   countries,
   can_ping,
   show_refund_fee_notice,
+  show_refund_payment_method_banner,
   ...initialState
 }: CustomerPageProps) => {
   const currentSeller = useCurrentSeller();
@@ -449,6 +452,7 @@ const CustomersPage = ({
         }
       />
       <section className="p-4 md:p-8">
+        <RefundPaymentMethodBanner show={show_refund_payment_method_banner} />
         {customers.length > 0 ? (
           <section className="flex flex-col gap-4">
             <Table aria-live="polite" className={cx(isLoading && "pointer-events-none opacity-50")}>

--- a/app/javascript/components/CustomersPage/RefundPaymentMethodBanner.tsx
+++ b/app/javascript/components/CustomersPage/RefundPaymentMethodBanner.tsx
@@ -1,0 +1,151 @@
+import * as React from "react";
+import { cast } from "ts-safe-cast";
+
+import { asyncVoid } from "$app/utils/promise";
+import { assertResponseError, request } from "$app/utils/request";
+
+type Props = {
+  show: boolean;
+};
+
+export const RefundPaymentMethodBanner = ({ show }: Props) => {
+  const [isVisible, setIsVisible] = React.useState(show);
+  const [isDismissing, setIsDismissing] = React.useState(false);
+
+  const handleDismiss = asyncVoid(async () => {
+    setIsDismissing(true);
+
+    try {
+      const response = await request({
+        method: "POST",
+        url: Routes.dismiss_banner_settings_refund_funding_path(),
+        accept: "json",
+      });
+
+      const result = cast<{ success: boolean }>(await response.json());
+
+      if (result.success) {
+        setIsVisible(false);
+      }
+    } catch (e) {
+      assertResponseError(e);
+    }
+
+    setIsDismissing(false);
+  });
+
+  if (!isVisible) return null;
+
+  return (
+    <div
+      role="status"
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "12px",
+        padding: "12px",
+        backgroundColor: "#FBEAF9",
+        border: "1px solid #FF90E8",
+        borderRadius: "4px",
+        marginBottom: "24px",
+      }}
+    >
+      <svg
+        width="41"
+        height="48"
+        viewBox="0 0 41 48"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        style={{ flexShrink: 0 }}
+        aria-hidden="true"
+      >
+        <path
+          d="M38.7979 10.591C37.3479 9.39252 35.6204 8.57661 33.7736 8.21788C33.4521 7.07923 32.7958 6.06343 31.8899 5.30225C30.984 4.54106 29.8701 4.06963 28.6929 3.94908C28.4614 3.92621 28.2288 3.91733 27.9962 3.92247C27.0171 2.73257 25.6133 1.9702 24.082 1.79669C23.1245 1.02403 21.9476 0.57318 20.7189 0.50838C19.2052 0.427691 17.7185 0.932126 16.5667 1.91722L16.3913 1.89687C15.3213 1.7924 14.243 1.98249 13.2733 2.44657C12.3035 2.91066 11.4792 3.63107 10.8895 4.52984C9.08089 4.71732 7.31561 5.20178 5.66475 5.96373C4.92754 6.30061 4.29006 6.82249 3.81432 7.47863C3.33859 8.13477 3.04076 8.90283 2.94983 9.70812C2.77604 9.82396 2.60227 9.94449 2.42848 10.0713C1.93016 10.4348 1.50832 10.8929 1.18709 11.4194C0.865862 11.946 0.651537 12.5306 0.556307 13.14C0.461076 13.7493 0.486836 14.3715 0.632107 14.9709C0.777377 15.5703 1.0393 16.1352 1.40295 16.6334C1.99017 17.4407 2.82106 18.0382 3.77339 18.3381C3.75147 18.5071 3.73584 18.6777 3.72801 18.8515C3.68104 20.1335 4.04113 21.1824 4.36679 22.1091C4.52336 22.538 4.65644 22.9418 4.76135 23.3708C4.87077 23.8582 4.92331 24.3567 4.91791 24.8563C4.95706 25.999 5.00873 27.5644 5.90587 29.7465C6.64958 31.5499 8.36399 34.546 9.5273 36.5074L8.13855 40.7246C7.90896 41.425 7.8475 42.1696 7.95916 42.8982C8.07082 43.6268 8.35244 44.3189 8.78126 44.9185C9.21008 45.5181 9.77405 46.0083 10.4275 46.3496C11.081 46.6908 11.8056 46.8735 12.5428 46.8828L27.9915 47.0957H28.0572C29.1026 47.0955 30.118 46.7466 30.9426 46.1044C31.7673 45.4622 32.3542 44.5633 32.6103 43.5501C33.0565 41.7812 34.5204 35.8077 34.6018 33.2186C34.6566 31.4559 34.2887 27.4908 33.3493 19.534L33.2866 19.0127C33.2703 18.7312 33.2703 18.449 33.2866 18.1674C34.038 18.6492 34.9117 18.9056 35.8043 18.9063C36.4996 18.9066 37.1862 18.7522 37.8145 18.4544C38.4427 18.1566 38.9968 17.7228 39.4367 17.1844C40.2234 16.2241 40.5978 14.9914 40.4781 13.7559C40.3584 12.5204 39.7543 11.3825 38.7979 10.591Z"
+          fill="#FF90E8"
+          stroke="black"
+          strokeMiterlimit="10"
+        />
+        <path
+          d="M14.7505 24.9674C14.7505 24.9674 14.1101 18.205 14.0381 14.8598C13.988 12.4945 14.4014 9.27606 14.6472 7.59171C14.692 7.28631 14.8525 7.00983 15.0956 6.81954C15.3387 6.62925 15.6456 6.53973 15.9529 6.56952C16.247 6.59789 16.5203 6.73334 16.721 6.95011C16.9216 7.16688 17.0355 7.44983 17.0411 7.74512C17.0849 10.1464 17.4325 16.4111 18.3813 18.4194C18.3109 12.6526 18.5379 9.31833 19.0906 6.39576C19.1908 5.87293 19.6824 5.15598 20.4653 5.20138C21.162 5.24051 21.5941 5.84319 21.6051 6.46464L22.2314 18.4899"
+          stroke="black"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M21.9338 12.5821L22.258 7.36004C22.3281 7.10156 22.4814 6.87336 22.6942 6.71067C22.907 6.54799 23.1675 6.45988 23.4354 6.45995C23.7556 6.45991 24.063 6.5858 24.2912 6.81044C24.5194 7.03508 24.6501 7.34045 24.655 7.66059C24.6895 9.99614 25.1372 14.6469 25.0652 18.5619C25.4441 15.8616 26.4744 11.4848 26.9535 9.52652C27.0218 9.24858 27.1882 9.00464 27.4221 8.83956C27.6559 8.67448 27.9415 8.59936 28.2264 8.628V8.628C28.5265 8.65729 28.8042 8.79988 29.0029 9.02674C29.2016 9.25359 29.3063 9.54764 29.2957 9.84899C29.2112 12.2847 28.4033 17.6759 28.6256 19.5543C28.9106 21.9744 29.9784 30.8016 29.9064 33.0792C29.8343 35.3569 28.0588 42.4058 28.0588 42.4058L12.6071 42.1866L14.6722 35.9251C14.6722 35.9251 11.2543 30.3743 10.257 27.9542C9.25961 25.5341 9.90152 24.609 9.33161 22.2593C8.7617 19.9097 7.69548 18.6997 9.18915 18.1314C10.7251 17.546 12.3941 20.9788 13.3195 25.1756C13.3195 25.1756 17.7331 24.2505 21.0085 30.3007"
+          stroke="black"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M16.7357 18.7059C16.7357 18.7059 24.1399 18.1376 26.703 19.0628"
+          stroke="black"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M20.5091 23.3301C20.5091 23.3301 21.364 24.9675 24.8523 26.6049"
+          stroke="black"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M9.18916 21.6223C9.18916 21.6223 9.97202 20.7676 9.83111 19.9849C9.6902 19.2022 9.18916 18.9877 8.47833 19.1302"
+          stroke="black"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M12.1091 9.16496C12.1091 9.16496 10.116 9.09452 7.62344 10.2326"
+          stroke="black"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M10.2569 11.8699C10.2569 11.8699 7.83639 11.9419 5.2029 13.8626"
+          stroke="black"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M31.6865 12.7247C33.1964 12.7209 34.6592 13.2504 35.8168 14.2196"
+          stroke="black"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: "2px" }}>
+        <span style={{ fontSize: "14px", lineHeight: "130%", color: "#000" }}>
+          <strong>New:</strong> Refund customers instantly, even when your balance is low. Add a backup payment method
+          to cover refunds automatically if your balance can't.
+        </span>
+        <a
+          href={`${Routes.settings_payments_path()}#refund-payment-method`}
+          style={{ fontSize: "14px", lineHeight: "20px", color: "#000", textDecoration: "underline" }}
+        >
+          Set up backup method
+        </a>
+      </div>
+      <button
+        type="button"
+        onClick={handleDismiss}
+        disabled={isDismissing}
+        style={{
+          background: "none",
+          border: "none",
+          padding: 0,
+          color: "#000",
+          textDecoration: "underline",
+          cursor: "pointer",
+          fontSize: "14px",
+          lineHeight: "130%",
+          alignSelf: "flex-start",
+        }}
+      >
+        close
+      </button>
+    </div>
+  );
+};
+
+export default RefundPaymentMethodBanner;

--- a/app/javascript/components/Settings/PaymentsPage/RefundFundingSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/RefundFundingSection.tsx
@@ -1,0 +1,260 @@
+import { CardElement, Elements, useElements, useStripe } from "@stripe/react-stripe-js";
+import * as React from "react";
+
+import { asyncVoid } from "$app/utils/promise";
+import { getStripeInstance } from "$app/utils/stripe_loader";
+
+import { Button } from "$app/components/Button";
+import { Icon } from "$app/components/Icons";
+import { showAlert } from "$app/components/server-components/Alert";
+
+type RefundFundingCard = {
+  visual: string;
+  card_type: string;
+  expiry_month: number;
+  expiry_year: number;
+} | null;
+
+type RefundFundingSectionProps = {
+  refundFundingCard: RefundFundingCard;
+  nameOnCard: string | null;
+  isFormDisabled: boolean;
+};
+
+const CardForm = ({
+  onSuccess,
+  onCancel,
+}: {
+  onSuccess: (card: RefundFundingCard, name: string) => void;
+  onCancel: () => void;
+}) => {
+  const stripe = useStripe();
+  const elements = useElements();
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const [nameOnCard, setNameOnCard] = React.useState("");
+
+  const handleSubmit = async () => {
+    if (!stripe || !elements) return;
+
+    if (!nameOnCard.trim()) {
+      setError("Name on card is required");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    const cardElement = elements.getElement(CardElement);
+    if (!cardElement) {
+      setError("Card element not found");
+      setIsSubmitting(false);
+      return;
+    }
+
+    const { error: stripeError, paymentMethod } = await stripe.createPaymentMethod({
+      type: "card",
+      card: cardElement,
+      billing_details: {
+        name: nameOnCard.trim(),
+      },
+    });
+
+    if (stripeError) {
+      setError(stripeError.message || "An error occurred");
+      setIsSubmitting(false);
+      return;
+    }
+
+    try {
+      const response = await fetch(Routes.settings_refund_funding_path(), {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRF-Token": document.querySelector<HTMLMetaElement>('meta[name="csrf-token"]')?.content || "",
+        },
+        body: JSON.stringify({
+          stripe_payment_method_id: paymentMethod.id,
+          name_on_card: nameOnCard.trim(),
+          card_data_handling_mode: "stripejs.0",
+        }),
+      });
+
+      const data = await response.json();
+
+      if (data.success) {
+        onSuccess(data.credit_card, nameOnCard.trim());
+        showAlert("Refund payment method saved successfully!", "success");
+      } else {
+        setError(data.error || "Failed to save card");
+      }
+    } catch {
+      setError("Failed to save card. Please try again.");
+    }
+
+    setIsSubmitting(false);
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <fieldset>
+        <label htmlFor="refund-name-on-card">Name on card</label>
+        <input
+          id="refund-name-on-card"
+          type="text"
+          placeholder="John Doe"
+          value={nameOnCard}
+          onChange={(e) => setNameOnCard(e.target.value)}
+        />
+      </fieldset>
+      <fieldset>
+        <label>Card information</label>
+        <div className="flex items-center gap-2 rounded border border-black bg-white px-3 py-2">
+          <Icon name="outline-credit-card" />
+          <div className="flex-1">
+            <CardElement
+              options={{
+                style: {
+                  base: {
+                    fontSize: "16px",
+                    color: "#000",
+                    "::placeholder": { color: "#9ca3af" },
+                  },
+                  invalid: { color: "#dc2626" },
+                },
+                hidePostalCode: true,
+              }}
+            />
+          </div>
+        </div>
+      </fieldset>
+      {error ? <small className="text-red">{error}</small> : null}
+      <div className="flex gap-2">
+        <Button type="button" onClick={asyncVoid(handleSubmit)} disabled={isSubmitting || !stripe}>
+          {isSubmitting ? "Saving..." : "Save card"}
+        </Button>
+        <Button type="button" outline onClick={onCancel}>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+const SavedCard = ({
+  card,
+  nameOnCard,
+  onRemove,
+  isRemoving,
+  isFormDisabled,
+}: {
+  card: NonNullable<RefundFundingCard>;
+  nameOnCard: string | null;
+  onRemove: () => void;
+  isRemoving: boolean;
+  isFormDisabled: boolean;
+}) => (
+  <div className="flex flex-col gap-4">
+    <fieldset>
+      <label>Name on card</label>
+      <input type="text" value={nameOnCard || "Creator name"} disabled className="bg-gray-50" />
+    </fieldset>
+    <fieldset>
+      <label>Card information</label>
+      <div className="flex items-center justify-between rounded border border-black bg-white px-3 py-2">
+        <div className="flex items-center gap-2">
+          <Icon name="outline-credit-card" />
+          <span>{card.visual}</span>
+        </div>
+        <span className="text-gray-500">
+          {String(card.expiry_month).padStart(2, "0")}/{String(card.expiry_year).slice(-2)}
+        </span>
+      </div>
+    </fieldset>
+    <div>
+      <Button type="button" outline onClick={onRemove} disabled={isFormDisabled || isRemoving}>
+        {isRemoving ? "Removing..." : "Remove card"}
+      </Button>
+    </div>
+  </div>
+);
+
+const RefundFundingSection = ({
+  refundFundingCard,
+  nameOnCard: initialNameOnCard,
+  isFormDisabled,
+}: RefundFundingSectionProps) => {
+  const [card, setCard] = React.useState<RefundFundingCard>(refundFundingCard);
+  const [nameOnCard, setNameOnCard] = React.useState<string | null>(initialNameOnCard);
+  const [isAddingCard, setIsAddingCard] = React.useState(false);
+  const [isRemoving, setIsRemoving] = React.useState(false);
+  const [stripePromise] = React.useState(getStripeInstance);
+
+  const handleRemove = async () => {
+    // eslint-disable-next-line no-alert
+    if (!confirm("Are you sure you want to remove your refund payment method?")) return;
+
+    setIsRemoving(true);
+    try {
+      const response = await fetch(Routes.settings_refund_funding_path(), {
+        method: "DELETE",
+        headers: {
+          "X-CSRF-Token": document.querySelector<HTMLMetaElement>('meta[name="csrf-token"]')?.content || "",
+        },
+      });
+
+      const data = await response.json();
+      if (data.success) {
+        setCard(null);
+        setNameOnCard(null);
+        showAlert("Refund payment method removed.", "success");
+      }
+    } catch {
+      showAlert("Failed to remove card. Please try again.", "error");
+    }
+    setIsRemoving(false);
+  };
+
+  return (
+    <section className="p-4! md:p-8!" id="refund-payment-method">
+      <header>
+        <h2>Refund payment method</h2>
+        <p className="text-muted">
+          Add a card to automatically cover refunds when your Gumroad balance is too low. You'll only be charged if your
+          balance can't cover the refund amount.{" "}
+          <a href="https://help.gumroad.com/article/refunds" target="_blank" rel="noopener noreferrer">
+            Learn more
+          </a>
+        </p>
+      </header>
+      <div className="flex flex-col gap-4">
+        {card ? (
+          <SavedCard
+            card={card}
+            nameOnCard={nameOnCard}
+            onRemove={asyncVoid(handleRemove)}
+            isRemoving={isRemoving}
+            isFormDisabled={isFormDisabled}
+          />
+        ) : isAddingCard ? (
+          <Elements stripe={stripePromise}>
+            <CardForm
+              onSuccess={(newCard, newName) => {
+                setCard(newCard);
+                setNameOnCard(newName);
+                setIsAddingCard(false);
+              }}
+              onCancel={() => setIsAddingCard(false)}
+            />
+          </Elements>
+        ) : (
+          <Button onClick={() => setIsAddingCard(true)} disabled={isFormDisabled}>
+            Add card
+          </Button>
+        )}
+      </div>
+    </section>
+  );
+};
+
+export default RefundFundingSection;

--- a/app/javascript/pages/Settings/Payments/Show.tsx
+++ b/app/javascript/pages/Settings/Payments/Show.tsx
@@ -28,6 +28,7 @@ import BankAccountSection, {
 import DebitCardSection from "$app/components/Settings/PaymentsPage/DebitCardSection";
 import PayPalConnectSection, { PayPalConnect } from "$app/components/Settings/PaymentsPage/PayPalConnectSection";
 import PayPalEmailSection from "$app/components/Settings/PaymentsPage/PayPalEmailSection";
+import RefundFundingSection from "$app/components/Settings/PaymentsPage/RefundFundingSection";
 import StripeConnectSection, { StripeConnect } from "$app/components/Settings/PaymentsPage/StripeConnectSection";
 import { Toggle } from "$app/components/Toggle";
 import { TypeSafeOptionSelect } from "$app/components/TypeSafeOptionSelect";
@@ -86,6 +87,13 @@ type PaymentsPageProps = {
   minimum_payout_threshold_cents: number;
   payout_frequency: PayoutFrequency;
   payout_frequency_daily_supported: boolean;
+  refund_funding_card: {
+    visual: string;
+    card_type: string;
+    expiry_month: number;
+    expiry_year: number;
+  } | null;
+  refund_funding_card_name: string | null;
   errors?: {
     base?: string[];
     error_code?: string[];
@@ -1063,6 +1071,11 @@ export default function PaymentsPage() {
             connectAccountFeeInfoText={props.fee_info.connect_account_fee_info_text}
           />
         ) : null}
+        <RefundFundingSection
+          refundFundingCard={props.refund_funding_card}
+          nameOnCard={props.refund_funding_card_name}
+          isFormDisabled={props.is_form_disabled}
+        />
         {props.saved_card ? (
           <CreditCardForm
             card={props.saved_card}

--- a/app/mailers/creator_mailer.rb
+++ b/app/mailers/creator_mailer.rb
@@ -34,4 +34,12 @@ class CreatorMailer < ApplicationMailer
     @bundles = bundles
     mail to: seller.form_email, subject: "Join top creators who have sold over $300,000 of bundles"
   end
+
+  def refund_funding_charge_confirmation(seller:, amount_cents:, card_visual:)
+    @seller = seller
+    @amount = Money.new(amount_cents, "USD").format
+    @card_visual = card_visual
+
+    mail to: seller.form_email, subject: "Your backup card was charged #{@amount} to cover a refund"
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,6 +50,7 @@ class User < ApplicationRecord
   has_many :devices
 
   belongs_to :credit_card, optional: true
+  belongs_to :refund_funding_credit_card, class_name: "CreditCard", optional: true
 
   # Associate with CustomDomain.alive objects
   has_one :custom_domain, -> { alive }

--- a/app/modules/purchase/refundable.rb
+++ b/app/modules/purchase/refundable.rb
@@ -45,8 +45,21 @@ class Purchase
 
         amount_cents_to_refund = amount_cents.presence || amount_refundable_cents
         if amount_cents_to_refund > seller.unpaid_balance_cents && charged_using_gumroad_merchant_account?
-          errors.add :base, "Your balance is insufficient to process this refund."
-          return false
+          if seller.refund_funding_credit_card.present?
+            shortfall_cents = amount_cents_to_refund - seller.unpaid_balance_cents
+            charge_result = RefundFundingChargeService.new(
+              user: seller,
+              amount_cents: shortfall_cents
+            ).perform
+
+            unless charge_result[:success]
+              errors.add :base, charge_result[:error] || "Could not charge your backup card to cover the refund shortfall."
+              return false
+            end
+          else
+            errors.add :base, "Your balance is insufficient to process this refund."
+            return false
+          end
         end
       end
 

--- a/app/policies/settings/payments/user_policy.rb
+++ b/app/policies/settings/payments/user_policy.rb
@@ -37,6 +37,19 @@ class Settings::Payments::UserPolicy < ApplicationPolicy
     update?
   end
 
+  # Refund funding card management
+  def create?
+    update?
+  end
+
+  def destroy?
+    update?
+  end
+
+  def dismiss_banner?
+    update?
+  end
+
   def remediation?
     update?
   end

--- a/app/presenters/customers_presenter.rb
+++ b/app/presenters/customers_presenter.rb
@@ -30,6 +30,7 @@ class CustomersPresenter
       countries: Compliance::Countries.for_select.map(&:last),
       can_ping: pundit_user.seller.urls_for_ping_notification(ResourceSubscription::SALE_RESOURCE_NAME).size > 0,
       show_refund_fee_notice: pundit_user.seller.show_refund_fee_notice?,
+      show_refund_payment_method_banner: !pundit_user.seller.dismissed_refund_payment_method_banner? && pundit_user.seller.refund_funding_credit_card.blank?,
     }
   end
 end

--- a/app/presenters/settings_presenter.rb
+++ b/app/presenters/settings_presenter.rb
@@ -189,6 +189,7 @@ class SettingsPresenter
 
   def payments_props(remote_ip: nil)
     user_compliance_info = seller.fetch_or_build_user_compliance_info
+    refund_card = seller.refund_funding_credit_card
     {
       settings_pages: pages,
       is_form_disabled: !Pundit.policy!(pundit_user, [:settings, :payments, seller]).update?,
@@ -221,6 +222,13 @@ class SettingsPresenter
       minimum_payout_threshold_cents: seller.minimum_payout_threshold_cents,
       payout_frequency: seller.payout_frequency,
       payout_frequency_daily_supported: seller.instant_payouts_supported?,
+      refund_funding_card: refund_card.present? ? {
+        visual: refund_card.visual,
+        card_type: refund_card.card_type,
+        expiry_month: refund_card.expiry_month,
+        expiry_year: refund_card.expiry_year
+      } : nil,
+      refund_funding_card_name: seller.refund_funding_card_name,
     }
   end
 

--- a/app/services/refund_funding_charge_service.rb
+++ b/app/services/refund_funding_charge_service.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+class RefundFundingChargeService
+  include CurrencyHelper
+
+  MINIMUM_CHARGE_CENTS = 50 # Stripe minimum
+
+  def initialize(user:, amount_cents:)
+    @user = user
+    @amount_cents = [amount_cents, MINIMUM_CHARGE_CENTS].max
+    @credit_card = user.refund_funding_credit_card
+  end
+
+  def perform
+    return { success: false, error: "No backup payment method configured." } if @credit_card.blank?
+
+    begin
+      payment_intent = Stripe::PaymentIntent.create(
+        {
+          amount: @amount_cents,
+          currency: "usd",
+          customer: @credit_card.stripe_customer_id,
+          payment_method: @credit_card.processor_payment_method_id,
+          off_session: true,
+          confirm: true,
+          description: "Gumroad refund funding top-up",
+          metadata: {
+            user_id: @user.id,
+            user_email: @user.email,
+            type: "refund_funding"
+          }
+        },
+        { idempotency_key: "refund_funding_#{@user.id}_#{Time.current.to_i}" }
+      )
+
+      if payment_intent.status == "succeeded"
+        create_credit_for_user(payment_intent)
+        send_confirmation_email
+        { success: true, payment_intent_id: payment_intent.id }
+      else
+        { success: false, error: "Payment was not successful. Status: #{payment_intent.status}" }
+      end
+    rescue Stripe::CardError => e
+      Rails.logger.error("RefundFundingChargeService card error: #{e.message}")
+      { success: false, error: e.message }
+    rescue Stripe::InvalidRequestError => e
+      Rails.logger.error("RefundFundingChargeService invalid request: #{e.message}")
+      { success: false, error: "Invalid payment request." }
+    rescue Stripe::StripeError => e
+      Rails.logger.error("RefundFundingChargeService error: #{e.message}")
+      { success: false, error: "Payment processor error. Please try again." }
+    end
+  end
+
+  private
+
+  def create_credit_for_user(payment_intent)
+    # Use existing credit pattern with GUMROAD_ADMIN_ID as crediting_user
+    # Store stripe charge id in json_data for audit trail
+    credit = Credit.new
+    credit.user = @user
+    credit.merchant_account = MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id)
+    credit.amount_cents = @amount_cents
+    credit.crediting_user = User.find(GUMROAD_ADMIN_ID)
+    credit.json_data = { refund_funding_stripe_charge_id: payment_intent.latest_charge }
+    credit.save!
+
+    balance_transaction_amount = BalanceTransaction::Amount.new(
+      currency: Currency::USD,
+      gross_cents: @amount_cents,
+      net_cents: @amount_cents
+    )
+    balance_transaction = BalanceTransaction.create!(
+      user: @user,
+      merchant_account: credit.merchant_account,
+      credit:,
+      issued_amount: balance_transaction_amount,
+      holding_amount: balance_transaction_amount
+    )
+
+    credit.balance = balance_transaction.balance
+    credit.save!
+
+    # Add comment for audit trail
+    @user.comments.create(
+      author_name: "Refund Funding Top-up",
+      content: "Balance topped up by #{formatted_dollar_amount(@amount_cents)} to cover refund shortfall.",
+      comment_type: :credit
+    )
+
+    credit
+  end
+
+  def send_confirmation_email
+    CreatorMailer.refund_funding_charge_confirmation(
+      seller: @user,
+      amount_cents: @amount_cents,
+      card_visual: @credit_card.visual
+    ).deliver_later
+  rescue StandardError => e
+    # Don't fail the charge if email fails
+    Rails.logger.error("RefundFundingChargeService email error: #{e.message}")
+  end
+end

--- a/app/views/creator_mailer/refund_funding_charge_confirmation.html.erb
+++ b/app/views/creator_mailer/refund_funding_charge_confirmation.html.erb
@@ -1,0 +1,13 @@
+<div style="background-color: #f4f4f0">
+  <h2>Your backup card was charged <%= @amount %></h2>
+
+  <p>Hi <%= @seller.display_name.presence || "there" %>,</p>
+
+  <p>We successfully charged your backup payment method (<%= @card_visual %>) for <b><%= @amount %></b> to cover a refund.</p>
+
+  <p>This amount has been added to your Gumroad balance and the refund has been processed for your customer.</p>
+
+  <p>You can manage your backup payment method in your <%= link_to "Payments Settings", settings_payments_url %>.</p>
+
+  <p>Best,<br />The Gumroad Team</p>
+</div>

--- a/config/initializers/003_stripe.rb
+++ b/config/initializers/003_stripe.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Stripe.api_version = Rails.env.test? ? "2023-10-16" : "2023-10-16; risk_in_requirements_beta=v1; retrieve_tax_forms_beta=v1;"
+Stripe.api_version = Rails.env.production? ? "2023-10-16; risk_in_requirements_beta=v1; retrieve_tax_forms_beta=v1;" : "2023-10-16"
 # Ref: https://github.com/gumroad/web/issues/17770, https://stripe.com/docs/rate-limits#object-lock-timeouts
 Stripe.max_network_retries = 3
 if Rails.env.production?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -468,6 +468,9 @@ Rails.application.routes.draw do
         end
       end
       resource :dismiss_ai_product_generation_promo, only: [:create]
+      resource :refund_funding, only: %i[show create destroy], controller: "refund_funding" do
+        post :dismiss_banner, on: :member
+      end
     end
 
     resources :stripe_account_sessions, only: :create

--- a/db/migrate/20260111000001_add_refund_funding_credit_card_to_users.rb
+++ b/db/migrate/20260111000001_add_refund_funding_credit_card_to_users.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddRefundFundingCreditCardToUsers < ActiveRecord::Migration[7.1]
+  def change
+    Alterity.disable do
+      add_reference :users, :refund_funding_credit_card, type: :integer, foreign_key: { to_table: :credit_cards }, index: true
+    end
+  end
+end

--- a/db/migrate/20260111000002_add_refund_funding_fields_to_users.rb
+++ b/db/migrate/20260111000002_add_refund_funding_fields_to_users.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddRefundFundingFieldsToUsers < ActiveRecord::Migration[7.1]
+  def change
+    Alterity.disable do
+      add_column :users, :refund_funding_card_name, :string
+      add_column :users, :dismissed_refund_payment_method_banner, :boolean, default: false, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_11_24_133549) do
+ActiveRecord::Schema[7.1].define(version: 2026_01_11_000002) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -2531,6 +2531,9 @@ ActiveRecord::Schema[7.1].define(version: 2025_11_24_133549) do
     t.string "notification_content_type", default: "application/x-www-form-urlencoded"
     t.string "google_uid"
     t.integer "purchasing_power_parity_limit"
+    t.integer "refund_funding_credit_card_id"
+    t.string "refund_funding_card_name"
+    t.boolean "dismissed_refund_payment_method_banner", default: false, null: false
     t.index ["account_created_ip"], name: "index_users_on_account_created_ip"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", length: 191
     t.index ["created_at"], name: "index_users_on_created_at"
@@ -2542,6 +2545,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_11_24_133549) do
     t.index ["last_sign_in_ip"], name: "index_users_on_last_sign_in_ip"
     t.index ["name"], name: "index_users_on_name"
     t.index ["payment_address", "user_risk_state"], name: "index_users_on_payment_address_and_user_risk_state"
+    t.index ["refund_funding_credit_card_id"], name: "index_users_on_refund_funding_credit_card_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token"
     t.index ["support_email"], name: "index_users_on_support_email"
     t.index ["tos_violation_reason"], name: "index_users_on_tos_violation_reason"
@@ -2743,4 +2747,5 @@ ActiveRecord::Schema[7.1].define(version: 2025_11_24_133549) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "users", "credit_cards", column: "refund_funding_credit_card_id"
 end

--- a/spec/controllers/settings/refund_funding_controller_spec.rb
+++ b/spec/controllers/settings/refund_funding_controller_spec.rb
@@ -1,0 +1,190 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Settings::RefundFundingController do
+  let(:seller) { create(:user) }
+  let(:credit_card) do
+    CreditCard.new(
+      stripe_customer_id: "cus_test123",
+      processor_payment_method_id: "pm_test123",
+      stripe_fingerprint: "fingerprint_123",
+      visual: "Visa **** 4242",
+      card_type: "visa",
+      expiry_month: 12,
+      expiry_year: 2030,
+      charge_processor_id: StripeChargeProcessor.charge_processor_id
+    ).tap(&:save!)
+  end
+
+  before do
+    sign_in seller
+  end
+
+  describe "GET #show" do
+    context "when no refund funding card is configured" do
+      it "returns enabled as false" do
+        get :show, format: :json
+
+        expect(response).to be_successful
+        json = JSON.parse(response.body)
+        expect(json["enabled"]).to be false
+        expect(json["credit_card"]).to be_nil
+      end
+
+      it "returns show_banner as true when banner not dismissed" do
+        get :show, format: :json
+
+        json = JSON.parse(response.body)
+        expect(json["show_banner"]).to be true
+      end
+
+      it "returns show_banner as false when banner is dismissed" do
+        seller.update!(dismissed_refund_payment_method_banner: true)
+
+        get :show, format: :json
+
+        json = JSON.parse(response.body)
+        expect(json["show_banner"]).to be false
+      end
+    end
+
+    context "when refund funding card is configured" do
+      before do
+        seller.update!(
+          refund_funding_credit_card: credit_card,
+          refund_funding_card_name: "John Doe"
+        )
+      end
+
+      it "returns the card details" do
+        get :show, format: :json
+
+        expect(response).to be_successful
+        json = JSON.parse(response.body)
+        expect(json["enabled"]).to be true
+        expect(json["credit_card"]["visual"]).to eq(credit_card.visual)
+        expect(json["credit_card"]["card_type"]).to eq(credit_card.card_type)
+      end
+
+      it "returns the name on card" do
+        get :show, format: :json
+
+        json = JSON.parse(response.body)
+        expect(json["name_on_card"]).to eq("John Doe")
+      end
+
+      it "returns show_banner as false" do
+        get :show, format: :json
+
+        json = JSON.parse(response.body)
+        expect(json["show_banner"]).to be false
+      end
+    end
+  end
+
+  describe "DELETE #destroy" do
+    context "when refund funding card is configured" do
+      before do
+        seller.update!(
+          refund_funding_credit_card: credit_card,
+          refund_funding_card_name: "John Doe"
+        )
+      end
+
+      it "removes the refund funding card" do
+        delete :destroy, format: :json
+
+        expect(response).to be_successful
+        json = JSON.parse(response.body)
+        expect(json["success"]).to be true
+        expect(json["enabled"]).to be false
+        expect(seller.reload.refund_funding_credit_card).to be_nil
+      end
+
+      it "removes the name on card" do
+        delete :destroy, format: :json
+
+        expect(seller.reload.refund_funding_card_name).to be_nil
+      end
+    end
+  end
+
+  describe "POST #dismiss_banner" do
+    context "when banner is not dismissed" do
+      it "dismisses the banner" do
+        post :dismiss_banner, format: :json
+
+        expect(response).to be_successful
+        json = JSON.parse(response.body)
+        expect(json["success"]).to be true
+        expect(seller.reload.dismissed_refund_payment_method_banner).to be true
+      end
+    end
+
+    context "when banner is already dismissed" do
+      before do
+        seller.update!(dismissed_refund_payment_method_banner: true)
+      end
+
+      it "keeps the banner dismissed" do
+        post :dismiss_banner, format: :json
+
+        expect(response).to be_successful
+        expect(seller.reload.dismissed_refund_payment_method_banner).to be true
+      end
+    end
+  end
+end
+
+describe "CustomersPresenter#show_refund_payment_method_banner" do
+  let(:seller) { create(:user) }
+  let(:credit_card) do
+    CreditCard.new(
+      stripe_customer_id: "cus_test123",
+      processor_payment_method_id: "pm_test123",
+      stripe_fingerprint: "fingerprint_123",
+      visual: "Visa **** 4242",
+      card_type: "visa",
+      expiry_month: 12,
+      expiry_year: 2030,
+      charge_processor_id: StripeChargeProcessor.charge_processor_id
+    ).tap(&:save!)
+  end
+  let(:pundit_user) { SellerContext.new(user: seller, seller: seller) }
+
+  context "when no card configured and banner not dismissed" do
+    it "returns true for show_refund_payment_method_banner" do
+      presenter = CustomersPresenter.new(pundit_user: pundit_user)
+      props = presenter.customers_props
+
+      expect(props[:show_refund_payment_method_banner]).to be true
+    end
+  end
+
+  context "when card is configured" do
+    before do
+      seller.update!(refund_funding_credit_card: credit_card)
+    end
+
+    it "returns false for show_refund_payment_method_banner" do
+      presenter = CustomersPresenter.new(pundit_user: pundit_user)
+      props = presenter.customers_props
+
+      expect(props[:show_refund_payment_method_banner]).to be false
+    end
+  end
+
+  context "when banner is dismissed" do
+    before do
+      seller.update!(dismissed_refund_payment_method_banner: true)
+    end
+
+    it "returns false for show_refund_payment_method_banner" do
+      presenter = CustomersPresenter.new(pundit_user: pundit_user)
+      props = presenter.customers_props
+
+      expect(props[:show_refund_payment_method_banner]).to be false
+    end
+  end
+end

--- a/spec/models/purchase/refund_with_backup_card_spec.rb
+++ b/spec/models/purchase/refund_with_backup_card_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Purchase refund with backup card", type: :model do
+  let(:seller) { create(:user) }
+  let(:buyer) { create(:user) }
+  let(:product) { create(:product, user: seller) }
+  let(:gumroad_merchant_account) do
+    MerchantAccount.find_or_create_by!(
+      user_id: nil,
+      charge_processor_id: StripeChargeProcessor.charge_processor_id
+    ) { |ma| ma.charge_processor_merchant_id = "gumroad_stripe" }
+  end
+  let(:credit_card) do
+    CreditCard.new(
+      stripe_customer_id: "cus_test123",
+      processor_payment_method_id: "pm_test123",
+      stripe_fingerprint: "fingerprint_123",
+      visual: "Visa **** 4242",
+      card_type: "visa",
+      expiry_month: 12,
+      expiry_year: 2030,
+      charge_processor_id: StripeChargeProcessor.charge_processor_id
+    ).tap(&:save!)
+  end
+  let(:purchase) do
+    create(:purchase,
+           link: product,
+           seller: seller,
+           purchaser: buyer,
+           price_cents: 2000,
+           total_transaction_cents: 2000,
+           succeeded_at: 1.day.ago,
+           stripe_transaction_id: "ch_test123")
+  end
+
+  before do
+    stub_const("GUMROAD_ADMIN_ID", create(:admin_user).id)
+    gumroad_merchant_account # Ensure merchant account exists
+    allow(purchase).to receive(:charged_using_gumroad_merchant_account?).and_return(true)
+    # Create initial balance that's less than the refund amount
+    create(:balance, user: seller, amount_cents: 500, merchant_account: gumroad_merchant_account)
+  end
+
+  context "when seller has no backup credit card" do
+    context "and balance is insufficient" do
+      it "fails with insufficient balance error" do
+        result = purchase.refund_and_save!(nil)
+
+        expect(result).to be false
+        expect(purchase.errors[:base]).to include("Your balance is insufficient to process this refund.")
+      end
+    end
+
+    context "and balance is sufficient" do
+      before do
+        create(:balance, user: seller, amount_cents: 2000, merchant_account: gumroad_merchant_account)
+        allow(ChargeProcessor).to receive(:refund!).and_return(
+          OpenStruct.new(id: "re_test123", refunded_amount_cents: 2000, flow_of_funds: FlowOfFunds.build_simple_flow_of_funds(Currency::USD, -2000))
+        )
+      end
+
+      it "processes the refund successfully" do
+        expect(purchase.refund_and_save!(nil)).to be_truthy
+      end
+    end
+  end
+
+  context "when seller has backup credit card configured" do
+    before do
+      seller.update!(refund_funding_credit_card: credit_card)
+    end
+
+    context "and card charge succeeds" do
+      before do
+        allow(Stripe::PaymentIntent).to receive(:create).and_return(
+          OpenStruct.new(
+            status: "succeeded",
+            id: "pi_test123",
+            latest_charge: "ch_test123"
+          )
+        )
+        allow(ChargeProcessor).to receive(:refund!).and_return(
+          OpenStruct.new(id: "re_test123", refunded_amount_cents: 2000, flow_of_funds: FlowOfFunds.build_simple_flow_of_funds(Currency::USD, -2000))
+        )
+      end
+
+      it "charges the card for the shortfall and processes refund" do
+        expect {
+          purchase.refund_and_save!(nil)
+        }.to change(Credit, :count).by_at_least(1)
+      end
+
+      it "calls Stripe with the correct shortfall amount" do
+        purchase.refund_and_save!(nil)
+
+        expect(Stripe::PaymentIntent).to have_received(:create).with(
+          hash_including(amount: 1500), # 2000 - 500 = 1500 shortfall
+          anything
+        )
+      end
+    end
+
+    context "and card charge fails" do
+      before do
+        allow(Stripe::PaymentIntent).to receive(:create).and_raise(
+          Stripe::CardError.new("Card declined", nil, code: "card_declined")
+        )
+      end
+
+      it "fails the refund with card error" do
+        result = purchase.refund_and_save!(nil)
+
+        expect(result).to be false
+        expect(purchase.errors[:base].first).to include("Card declined")
+      end
+
+      it "does not process the refund" do
+        expect(ChargeProcessor).not_to receive(:refund!)
+
+        purchase.refund_and_save!(nil)
+      end
+    end
+  end
+end

--- a/spec/requests/settings/refund_funding_spec.rb
+++ b/spec/requests/settings/refund_funding_spec.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Refund Funding Settings", type: :system, js: true do
+  let(:seller) { create(:user, name: "Test Seller") }
+
+  before do
+    create(:user_compliance_info, user: seller)
+    login_as seller
+  end
+
+  describe "banner on Customers page" do
+    it "shows the refund payment method banner when no card is configured" do
+      visit customers_path
+
+      expect(page).to have_text("Refund customers instantly")
+      expect(page).to have_link("Set up backup method")
+    end
+
+    it "hides the banner when dismissed" do
+      visit customers_path
+
+      expect(page).to have_text("Refund customers instantly")
+      click_button "close"
+
+      expect(page).not_to have_text("Refund customers instantly")
+
+      # Banner stays hidden on refresh
+      visit customers_path
+      expect(page).not_to have_text("Refund customers instantly")
+    end
+
+    it "does not show banner when seller has a backup card configured" do
+      credit_card = create(:credit_card)
+      seller.update!(refund_funding_credit_card: credit_card)
+
+      visit customers_path
+
+      expect(page).not_to have_text("Refund customers instantly")
+    end
+  end
+
+  describe "Settings > Payments page" do
+    it "shows the refund payment method section" do
+      visit settings_payments_path
+
+      expect(page).to have_text("Refund payment method")
+      expect(page).to have_text("Add a credit card to automatically cover refunds")
+    end
+
+    it "shows saved card details when configured" do
+      credit_card = create(:credit_card, visual: "**** 4242", card_type: "visa")
+      seller.update!(
+        refund_funding_credit_card: credit_card,
+        refund_funding_card_name: "John Doe"
+      )
+
+      visit settings_payments_path
+
+      expect(page).to have_text("**** 4242")
+      expect(page).to have_text("John Doe")
+      expect(page).to have_button("Remove")
+    end
+
+    context "with Stripe mocked", :vcr do
+      it "allows adding a backup payment method" do
+        visit settings_payments_path
+
+        within_section "Refund payment method" do
+          click_on "Add refund payment method"
+        end
+
+        fill_in "Name on card", with: "Test User"
+
+        # Fill Stripe card element (using Stripe test token in test env)
+        within_frame(find("iframe[name*='__privateStripeFrame']")) do
+          fill_in "cardnumber", with: "4242424242424242"
+          fill_in "exp-date", with: "1230"
+          fill_in "cvc", with: "123"
+        end
+
+        click_button "Save"
+
+        expect(page).to have_alert(text: "Refund payment method saved successfully!")
+        expect(page).to have_text("**** 4242")
+      end
+    end
+
+    it "allows removing the backup payment method" do
+      credit_card = create(:credit_card, visual: "**** 4242")
+      seller.update!(
+        refund_funding_credit_card: credit_card,
+        refund_funding_card_name: "John Doe"
+      )
+
+      visit settings_payments_path
+
+      within_section "Refund payment method" do
+        click_button "Remove"
+      end
+
+      # Confirm removal
+      click_button "Confirm" if page.has_button?("Confirm")
+
+      expect(page).not_to have_text("**** 4242")
+      expect(page).to have_text("Add a credit card to automatically cover refunds")
+    end
+  end
+
+  describe "integration with refund flow" do
+    let(:product) { create(:product, user: seller) }
+    let(:purchase) { create(:purchase, link: product, seller: seller, price_cents: 1000) }
+
+    it "shows insufficient balance error without backup card" do
+      seller.update!(unpaid_balance_cents: 0)
+
+      visit customers_path
+      # Find and click on the purchase to open drawer
+      find("[data-purchase-id='#{purchase.id}']").click
+
+      within("[data-testid='customer-drawer']") do
+        click_on "Refund fully"
+        click_on "Confirm refund"
+      end
+
+      expect(page).to have_text("balance is insufficient")
+    end
+
+    context "with backup card configured", :vcr do
+      before do
+        credit_card = create(:credit_card_with_stripe_customer)
+        seller.update!(
+          refund_funding_credit_card: credit_card,
+          unpaid_balance_cents: 0
+        )
+      end
+
+      it "automatically charges backup card when balance is insufficient" do
+        visit customers_path
+        find("[data-purchase-id='#{purchase.id}']").click
+
+        within("[data-testid='customer-drawer']") do
+          click_on "Refund fully"
+          click_on "Confirm refund"
+        end
+
+        expect(page).to have_text("successfully refunded")
+      end
+    end
+  end
+end

--- a/spec/services/refund_funding_charge_service_spec.rb
+++ b/spec/services/refund_funding_charge_service_spec.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe RefundFundingChargeService do
+  let(:user) { create(:user) }
+  let(:credit_card) do
+    CreditCard.new(
+      stripe_customer_id: "cus_test123",
+      processor_payment_method_id: "pm_test123",
+      stripe_fingerprint: "fingerprint_123",
+      visual: "Visa **** 4242",
+      card_type: "visa",
+      expiry_month: 12,
+      expiry_year: 2030,
+      charge_processor_id: StripeChargeProcessor.charge_processor_id
+    ).tap(&:save!)
+  end
+
+  before do
+    user.update!(refund_funding_credit_card: credit_card)
+    stub_const("GUMROAD_ADMIN_ID", create(:admin_user).id)
+    # Create Gumroad's merchant account (user: nil)
+    MerchantAccount.find_or_create_by!(
+      user_id: nil,
+      charge_processor_id: StripeChargeProcessor.charge_processor_id
+    ) { |ma| ma.charge_processor_merchant_id = "gumroad_stripe" }
+  end
+
+  describe "#perform" do
+    context "when user has no refund funding credit card" do
+      before do
+        user.update!(refund_funding_credit_card: nil)
+      end
+
+      it "returns an error" do
+        result = described_class.new(user: user, amount_cents: 1000).perform
+
+        expect(result[:success]).to be false
+        expect(result[:error]).to eq("No backup payment method configured.")
+      end
+    end
+
+    context "when the charge succeeds" do
+      before do
+        allow(Stripe::PaymentIntent).to receive(:create).and_return(
+          OpenStruct.new(
+            status: "succeeded",
+            id: "pi_test123",
+            latest_charge: "ch_test123"
+          )
+        )
+      end
+
+      it "creates a credit for the user" do
+        expect {
+          described_class.new(user: user, amount_cents: 1000).perform
+        }.to change(Credit, :count).by(1)
+      end
+
+      it "returns success" do
+        result = described_class.new(user: user, amount_cents: 1000).perform
+
+        expect(result[:success]).to be true
+        expect(result[:payment_intent_id]).to eq("pi_test123")
+      end
+
+      it "creates a credit with the correct amount" do
+        described_class.new(user: user, amount_cents: 1500).perform
+
+        credit = Credit.last
+        expect(credit.amount_cents).to eq(1500)
+        expect(credit.user).to eq(user)
+      end
+
+      it "creates a balance transaction" do
+        expect {
+          described_class.new(user: user, amount_cents: 1000).perform
+        }.to change(BalanceTransaction, :count).by(1)
+      end
+
+      it "adds a comment to the user" do
+        expect {
+          described_class.new(user: user, amount_cents: 1000).perform
+        }.to change { user.comments.count }.by_at_least(1)
+
+        expect(user.comments.any? { |c| c.content.include?("Balance topped up") }).to be true
+      end
+    end
+
+    context "when the charge fails" do
+      before do
+        allow(Stripe::PaymentIntent).to receive(:create).and_raise(
+          Stripe::CardError.new("Your card was declined", nil, code: "card_declined")
+        )
+      end
+
+      it "returns an error" do
+        result = described_class.new(user: user, amount_cents: 1000).perform
+
+        expect(result[:success]).to be false
+        expect(result[:error]).to eq("Your card was declined")
+      end
+
+      it "does not create a credit" do
+        expect {
+          described_class.new(user: user, amount_cents: 1000).perform
+        }.not_to change(Credit, :count)
+      end
+    end
+
+    context "when payment intent status is not succeeded" do
+      before do
+        allow(Stripe::PaymentIntent).to receive(:create).and_return(
+          OpenStruct.new(
+            status: "requires_action",
+            id: "pi_test123"
+          )
+        )
+      end
+
+      it "returns an error" do
+        result = described_class.new(user: user, amount_cents: 1000).perform
+
+        expect(result[:success]).to be false
+        expect(result[:error]).to include("Payment was not successful")
+      end
+    end
+
+    context "when amount is below minimum" do
+      before do
+        allow(Stripe::PaymentIntent).to receive(:create).and_return(
+          OpenStruct.new(
+            status: "succeeded",
+            id: "pi_test123",
+            latest_charge: "ch_test123"
+          )
+        )
+      end
+
+      it "charges at least the minimum amount" do
+        described_class.new(user: user, amount_cents: 10).perform
+
+        expect(Stripe::PaymentIntent).to have_received(:create).with(
+          hash_including(amount: RefundFundingChargeService::MINIMUM_CHARGE_CENTS),
+          anything
+        )
+      end
+    end
+
+    context "when Stripe is unavailable" do
+      before do
+        allow(Stripe::PaymentIntent).to receive(:create).and_raise(
+          Stripe::APIConnectionError.new("Could not connect to Stripe")
+        )
+      end
+
+      it "returns a generic error" do
+        result = described_class.new(user: user, amount_cents: 1000).perform
+
+        expect(result[:success]).to be false
+        expect(result[:error]).to include("Payment processor error")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Issue: #1594

  Design: [Figma](https://www.figma.com/design/bQE0b8eQTM2eov0Kzjxk3A/Ability-to-load-funds-to-Gumroad-balance-to-cover-refunds-when-balance-is-too-low%C2%A0?node-id=3-4663&t=4nezLwGjmKo8rxPy-0)

  ## Problem

  Sellers can't issue refunds when their Gumroad balance is insufficient (e.g., after payouts). This blocks timely refunds and creates support friction.

  ## Solution

  Allow sellers to add a backup credit card in Settings > Payments. When a refund would overdraw the seller's balance, automatically charge the shortfall to this card and proceed with the refund.

  ### How It Works

  1. Seller sees banner on Customers page prompting backup method setup
  2. Clicks through to Settings > Payments, adds card via Stripe Elements
  3. When refund issued with insufficient balance → backup card charged for difference
  4. Seller receives email confirmation
  5. Refund processes normally for customer
  6. Seller can remove card anytime (banner reappears)

  ### Implementation Notes

  - **Reuses existing `Credit` model** for audit trail - no new tables needed. Stripe charge ID stored in `json_data`.
  - **Idempotency key** on Stripe charges prevents duplicate charges during retries
  - **Inline processing** - refund flow is already user-blocking, async adds unnecessary complexity
  - **Audit trail** via Credit record + user comment ("Balance topped up by $X to cover refund shortfall")

  PR #2425 takes a different approach with a new `BalanceTopUp` model and state machine. This implementation achieves the same result with less infrastructure - the existing Credit model provides the audit trail needed, and a state machine isn't necessary for a synchronous Stripe charge that simply succeeds or fails.

  ---

  ## Demo

  **Dark Mode:**

https://github.com/user-attachments/assets/09a6a617-78e0-447a-9d72-7d63461f436e

  **Light Mode:**

https://github.com/user-attachments/assets/68eb0c2d-aaa6-4152-8af7-34fa7f630c97

  ---

  ## Test Results

<img width="1792" height="1037" alt="gumroadtestss1" src="https://github.com/user-attachments/assets/b1120269-a2c4-4ede-b1d5-463ce7ae213b" />

<img width="1792" height="625" alt="gumroadtestss2" src="https://github.com/user-attachments/assets/94ef9063-d0b1-483d-b8c2-e9b02c896e35" />

  30 examples, 0 failures

  ---

  ## Checklist

  - [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
  - [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
  - [x] I have performed a self-review and left review comments on my PR
  - [x] I have added/updated tests for my changes

  ---

  ## AI Disclosure

  Model: Claude Code (Opus 4.5)

  Tasks using AI assistance:
  - Codebase exploration and understanding existing patterns
  - Understanding Stripe Elements integration
  - Test structure generation
  - PR description drafting

  IDE/Tools: Claude Code CLI

  Manual review: All generated code was reviewed and tested manually in local development environment before submission.