### PR TITLE
Fix(test): Stubs tax ID validation services to remove Tax ID validation API requirements

### DIFF
--- a/spec/requests/purchases/product/taxes_spec.rb
+++ b/spec/requests/purchases/product/taxes_spec.rb
@@ -309,7 +309,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
       expect(purchase.was_purchase_taxable).to be(true)
     end
 
-    it "allows entry of VAT ID and doesn't charge VAT" do
+    it "allows entry of VAT ID and doesn't charge VAT", :stub_tax_id_validation do
       visit "/l/#{@vat_link.unique_permalink}"
       expect(page).to have_selector("[itemprop='offers']", text: "$100")
 
@@ -351,7 +351,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         expect(purchase.was_purchase_taxable).to be(true)
       end
 
-      it "allows entry of VAT ID and doesn't charge VAT" do
+      it "allows entry of VAT ID and doesn't charge VAT", :stub_tax_id_validation do
         visit "/l/#{product.unique_permalink}"
         add_to_cart(product, option: "First Tier")
         expect(page).to(have_text("VAT US$0.66", normalize_ws: true))
@@ -458,12 +458,12 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
       expect(purchase.was_purchase_taxable).to be(true)
     end
 
-    it "allows entry of ABN ID and doesn't charge GST" do
+    it "allows entry of ABN ID and doesn't charge GST", :stub_tax_id_validation do
       visit "/l/#{@product.unique_permalink}"
       expect(page).to have_selector("[itemprop='offers']", text: "$100")
 
       add_to_cart(@product)
-      expect(page).to have_text("GST")
+      expect(page).to have_text("Total US$110", normalize_ws: true)
       check_out(@product, abn_id: "51824753556", zip_code: nil, credit_card: { number: "4000000360000006" }) do
         expect(page).not_to have_text("GST")
       end
@@ -715,7 +715,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
       expect(purchase.was_purchase_taxable).to be(false)
     end
 
-    it "allows entry of MVA ID and doesn't charge tax" do
+    it "allows entry of MVA ID and doesn't charge tax", :stub_tax_id_validation do
       visit "/l/#{@product.unique_permalink}"
       expect(page).to have_text("$100")
       add_to_cart(@product)
@@ -820,7 +820,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         expect(purchase.was_purchase_taxable).to be(true)
       end
 
-      it "allows entry of the Tax ID and doesn't charge tax" do
+      it "allows entry of the Tax ID and doesn't charge tax", :stub_tax_id_validation do
         visit "/l/#{@product.unique_permalink}"
         expect(page).to have_text("$100")
         add_to_cart(@product)
@@ -902,7 +902,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         expect(purchase.was_purchase_taxable).to be(true)
       end
 
-      it "allows entry of the Tax ID and doesn't charge tax" do
+      it "allows entry of the Tax ID and doesn't charge tax", :stub_tax_id_validation do
         visit "/l/#{@product.unique_permalink}"
         expect(page).to have_text("$100")
         add_to_cart(@product)
@@ -984,7 +984,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         expect(purchase.was_purchase_taxable).to be(true)
       end
 
-      it "allows entry of the Tax ID and doesn't charge tax" do
+      it "allows entry of the Tax ID and doesn't charge tax", :stub_tax_id_validation do
         visit "/l/#{@product.unique_permalink}"
         expect(page).to have_text("$100")
         add_to_cart(@product)
@@ -1066,7 +1066,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         expect(purchase.was_purchase_taxable).to be(true)
       end
 
-      it "allows entry of the Tax ID and doesn't charge tax" do
+      it "allows entry of the Tax ID and doesn't charge tax", :stub_tax_id_validation do
         visit "/l/#{@product.unique_permalink}"
         expect(page).to have_text("$100")
         add_to_cart(@product)
@@ -1169,7 +1169,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         expect(purchase.was_purchase_taxable).to be(true)
       end
 
-      it "allows entry of the Tax ID and doesn't charge tax" do
+      it "allows entry of the Tax ID and doesn't charge tax", :stub_tax_id_validation do
         visit "/l/#{@product.unique_permalink}"
         expect(page).to have_text("$100")
         add_to_cart(@product)
@@ -1251,7 +1251,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         expect(purchase.was_purchase_taxable).to be(true)
       end
 
-      it "allows entry of the Tax ID and doesn't charge tax" do
+      it "allows entry of the Tax ID and doesn't charge tax", :stub_tax_id_validation do
         visit "/l/#{@product.unique_permalink}"
         expect(page).to have_text("$100")
         add_to_cart(@product)
@@ -1333,7 +1333,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         expect(purchase.was_purchase_taxable).to be(true)
       end
 
-      it "allows entry of the Tax ID and doesn't charge tax" do
+      it "allows entry of the Tax ID and doesn't charge tax", :stub_tax_id_validation do
         visit "/l/#{@product.unique_permalink}"
         expect(page).to have_text("$100")
         add_to_cart(@product)
@@ -1532,7 +1532,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         expect(purchase.was_purchase_taxable).to be(false)
       end
 
-      it "allows entry of the Tax ID and doesn't charge tax" do
+      it "allows entry of the Tax ID and doesn't charge tax", :stub_tax_id_validation do
         visit "/l/#{@product.unique_permalink}"
         expect(page).to have_text("$100")
         add_to_cart(@product)
@@ -1632,7 +1632,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         expect(purchase.was_purchase_taxable).to be(false)
       end
 
-      it "allows entry of the Tax ID and doesn't charge tax" do
+      it "allows entry of the Tax ID and doesn't charge tax", :stub_tax_id_validation do
         visit "/l/#{@product.unique_permalink}"
         expect(page).to have_text("$100")
         add_to_cart(@product)
@@ -1732,7 +1732,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         expect(purchase.was_purchase_taxable).to be(false)
       end
 
-      it "allows entry of the Tax ID and doesn't charge tax" do
+      it "allows entry of the Tax ID and doesn't charge tax", :stub_tax_id_validation do
         visit "/l/#{@product.unique_permalink}"
         expect(page).to have_text("$100")
         add_to_cart(@product)
@@ -1832,7 +1832,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         expect(purchase.was_purchase_taxable).to be(false)
       end
 
-      it "allows entry of the Tax ID and doesn't charge tax" do
+      it "allows entry of the Tax ID and doesn't charge tax", :stub_tax_id_validation do
         visit "/l/#{@product.unique_permalink}"
         expect(page).to have_text("$100")
         add_to_cart(@product)
@@ -1932,7 +1932,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         expect(purchase.was_purchase_taxable).to be(false)
       end
 
-      it "allows entry of the Tax ID and doesn't charge tax" do
+      it "allows entry of the Tax ID and doesn't charge tax", :stub_tax_id_validation do
         visit "/l/#{@product.unique_permalink}"
         expect(page).to have_text("$100")
         add_to_cart(@product)
@@ -2032,7 +2032,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         expect(purchase.was_purchase_taxable).to be(false)
       end
 
-      it "allows entry of the Tax ID and doesn't charge tax" do
+      it "allows entry of the Tax ID and doesn't charge tax", :stub_tax_id_validation do
         visit "/l/#{@product.unique_permalink}"
         expect(page).to have_text("$100")
         add_to_cart(@product)
@@ -2132,7 +2132,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         expect(purchase.was_purchase_taxable).to be(false)
       end
 
-      it "allows entry of the Tax ID and doesn't charge tax" do
+      it "allows entry of the Tax ID and doesn't charge tax", :stub_tax_id_validation do
         visit "/l/#{@product.unique_permalink}"
         expect(page).to have_text("$100")
         add_to_cart(@product)
@@ -2232,7 +2232,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         expect(purchase.was_purchase_taxable).to be(false)
       end
 
-      it "allows entry of the Tax ID and doesn't charge tax" do
+      it "allows entry of the Tax ID and doesn't charge tax", :stub_tax_id_validation do
         visit "/l/#{@product.unique_permalink}"
         expect(page).to have_text("$100")
         add_to_cart(@product)
@@ -2430,7 +2430,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         expect(purchase.was_purchase_taxable).to be(false)
       end
 
-      it "allows entry of the Tax ID and doesn't charge tax" do
+      it "allows entry of the Tax ID and doesn't charge tax", :stub_tax_id_validation do
         visit "/l/#{@product.unique_permalink}"
         expect(page).to have_text("$100")
         add_to_cart(@product)
@@ -2550,7 +2550,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         expect(purchase.was_purchase_taxable).to be(false)
       end
 
-      it "allows entry of the Tax ID and doesn't charge tax" do
+      it "allows entry of the Tax ID and doesn't charge tax", :stub_tax_id_validation do
         visit "/l/#{@product.unique_permalink}"
         expect(page).to have_text("$100")
         add_to_cart(@product)
@@ -2650,7 +2650,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         expect(purchase.was_purchase_taxable).to be(false)
       end
 
-      it "allows entry of the Tax ID and doesn't charge tax" do
+      it "allows entry of the Tax ID and doesn't charge tax", :stub_tax_id_validation do
         visit "/l/#{@product.unique_permalink}"
         expect(page).to have_text("$100")
         add_to_cart(@product)
@@ -2750,7 +2750,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         expect(purchase.was_purchase_taxable).to be(false)
       end
 
-      it "allows entry of the Tax ID and doesn't charge tax" do
+      it "allows entry of the Tax ID and doesn't charge tax", :stub_tax_id_validation do
         visit "/l/#{@product.unique_permalink}"
         expect(page).to have_text("$100")
         add_to_cart(@product)
@@ -3045,7 +3045,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         expect(purchase.was_purchase_taxable).to be(false)
       end
 
-      it "allows entry of the Tax ID and doesn't charge tax" do
+      it "allows entry of the Tax ID and doesn't charge tax", :stub_tax_id_validation do
         visit "/l/#{@product.unique_permalink}"
         expect(page).to have_text("$100")
         add_to_cart(@product)
@@ -3145,7 +3145,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         expect(purchase.was_purchase_taxable).to be(false)
       end
 
-      it "allows entry of the Tax ID and doesn't charge tax" do
+      it "allows entry of the Tax ID and doesn't charge tax", :stub_tax_id_validation do
         visit "/l/#{@product.unique_permalink}"
         expect(page).to have_text("$100")
         add_to_cart(@product)
@@ -3245,7 +3245,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         expect(purchase.was_purchase_taxable).to be(false)
       end
 
-      it "allows entry of the Tax ID and doesn't charge tax" do
+      it "allows entry of the Tax ID and doesn't charge tax", :stub_tax_id_validation do
         visit "/l/#{@product.unique_permalink}"
         expect(page).to have_text("$100")
         add_to_cart(@product)
@@ -3345,7 +3345,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         expect(purchase.was_purchase_taxable).to be(false)
       end
 
-      it "allows entry of the Tax ID and doesn't charge tax" do
+      it "allows entry of the Tax ID and doesn't charge tax", :stub_tax_id_validation do
         visit "/l/#{@product.unique_permalink}"
         expect(page).to have_text("$100")
         add_to_cart(@product)
@@ -3543,7 +3543,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         expect(purchase.was_purchase_taxable).to be(false)
       end
 
-      it "allows entry of the Tax ID and doesn't charge tax" do
+      it "allows entry of the Tax ID and doesn't charge tax", :stub_tax_id_validation do
         visit "/l/#{@product.unique_permalink}"
         expect(page).to have_text("$100")
         add_to_cart(@product)
@@ -3643,7 +3643,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         expect(purchase.was_purchase_taxable).to be(false)
       end
 
-      it "allows entry of the Tax ID and doesn't charge tax" do
+      it "allows entry of the Tax ID and doesn't charge tax", :stub_tax_id_validation do
         visit "/l/#{@product.unique_permalink}"
         expect(page).to have_text("$100")
         add_to_cart(@product)
@@ -3743,7 +3743,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         expect(purchase.was_purchase_taxable).to be(false)
       end
 
-      it "allows entry of the Tax ID and doesn't charge tax" do
+      it "allows entry of the Tax ID and doesn't charge tax", :stub_tax_id_validation do
         visit "/l/#{@product.unique_permalink}"
         expect(page).to have_text("$100")
         add_to_cart(@product)
@@ -3843,7 +3843,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         expect(purchase.was_purchase_taxable).to be(false)
       end
 
-      it "allows entry of the Tax ID and doesn't charge tax" do
+      it "allows entry of the Tax ID and doesn't charge tax", :stub_tax_id_validation do
         visit "/l/#{@product.unique_permalink}"
         expect(page).to have_text("$100")
         add_to_cart(@product)
@@ -3943,7 +3943,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         expect(purchase.was_purchase_taxable).to be(false)
       end
 
-      it "allows entry of the Tax ID and doesn't charge tax" do
+      it "allows entry of the Tax ID and doesn't charge tax", :stub_tax_id_validation do
         visit "/l/#{@product.unique_permalink}"
         expect(page).to have_text("$100")
         add_to_cart(@product)

--- a/spec/support/tax_id_validation_stubs.rb
+++ b/spec/support/tax_id_validation_stubs.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module TaxIdValidationStubs
+  def stub_tax_id_validation_services
+    allow_any_instance_of(TaxIdValidationService).to receive(:process) { |service| service.tax_id.present? }
+    allow_any_instance_of(AbnValidationService).to receive(:process) { |service| service.abn_id.present? }
+    allow_any_instance_of(MvaValidationService).to receive(:process) { |service| service.mva_id.present? }
+    allow_any_instance_of(GstValidationService).to receive(:process) { |service| service.gst_id.present? }
+    allow_any_instance_of(QstValidationService).to receive(:process) { |service| service.qst_id.present? }
+    allow_any_instance_of(VatValidationService).to receive(:process) { |service| service.vat_id.present? }
+    allow_any_instance_of(KraPinValidationService).to receive(:process) { |service| service.kra_pin.present? }
+    allow_any_instance_of(TrnValidationService).to receive(:process) { |service| service.trn.present? }
+    allow_any_instance_of(OmanVatNumberValidationService).to receive(:process) { |service| service.vat_number.present? }
+    allow_any_instance_of(FirsTinValidationService).to receive(:process) { |service| service.tin.present? }
+    allow_any_instance_of(TraTinValidationService).to receive(:process) { |service| service.tra_tin.present? }
+  end
+end
+
+RSpec.configure do |config|
+  config.include TaxIdValidationStubs
+  config.before(:each, :stub_tax_id_validation) do
+    stub_tax_id_validation_services
+  end
+end


### PR DESCRIPTION
fixes: #2841 

# Description

<!-- Briefly describe the problem and your solution -->

## Problem
-   30 tax scenario tests fail in CI because they rely on external Tax ID validation APIs that require credentials not available in secretless runs.
- When a customer provides a business Tax ID (VAT, ABN, GST, etc.) at checkout, Gumroad validates it against external APIs to determine if tax should be exempted. Without valid API credentials, validation returns false and tax is still charged, causing tests to fail.


## Solution
- Created a shared RSpec stub helper that mocks all Tax ID validation services to return true when a non-blank Tax ID is provided. This allows tests to verify the checkout flow and tax exemption logic without requiring real API credentials.
  - Stubs all 6 Tax ID validation services (TaxIdValidationService, AbnValidationService, MvaValidationService, GstValidationService, QstValidationService, VatValidationService)
  - Returns `true` if Tax ID is present, `false` otherwise
  - Allows tests to pass without requiring external API credentials (TAX_ID_PRO_API_KEY, VATSTACK_API_KEY, etc.)
  
```rb
# frozen_string_literal: true

module TaxIdValidationStubs
  def stub_tax_id_validation_services
    allow_any_instance_of(TaxIdValidationService).to receive(:process) { |service| service.tax_id.present? }
    allow_any_instance_of(AbnValidationService).to receive(:process) { |service| service.abn_id.present? }
    allow_any_instance_of(MvaValidationService).to receive(:process) { |service| service.mva_id.present? }
    allow_any_instance_of(GstValidationService).to receive(:process) { |service| service.gst_id.present? }
    allow_any_instance_of(QstValidationService).to receive(:process) { |service| service.qst_id.present? }
    allow_any_instance_of(VatValidationService).to receive(:process) { |service| service.vat_id.present? }
    allow_any_instance_of(KraPinValidationService).to receive(:process) { |service| service.kra_pin.present? }
    allow_any_instance_of(TrnValidationService).to receive(:process) { |service| service.trn.present? }
    allow_any_instance_of(OmanVatNumberValidationService).to receive(:process) { |service| service.vat_number.present? }
    allow_any_instance_of(FirsTinValidationService).to receive(:process) { |service| service.tin.present? }
    allow_any_instance_of(TraTinValidationService).to receive(:process) { |service| service.tra_tin.present? }
  end
end

RSpec.configure do |config|
  config.include TaxIdValidationStubs
  config.before(:each, :stub_tax_id_validation) do
    stub_tax_id_validation_services
  end
end
```

- Added :stub_tax_id_validation metadata to 32 affected tests:
  This tag triggers the `stub_tax_id_validation_services` helper (defined in `spec/support/tax_id_validation_stubs.rb`) which:


-   Tests across 30+ countries are now stubbed: Iceland, Japan, New Zealand, South Africa, Switzerland, UAE, India, Australia (ABN), Norway (MVA), Belarus, Chile, Colombia, Costa Rica, Ecuador, Egypt, Georgia, Kazakhstan, Malaysia, Mexico, Moldova, Morocco, Russia, Saudi Arabia, Serbia, South Korea, Thailand, Turkey,
  Ukraine, Uzbekistan, Vietnam, and EU countries (VAT).

---

# Test Results (without credentials)

## Before: 
<img width="1278" height="1111" alt="Screenshot 2026-01-13 at 4 45 06 AM" src="https://github.com/user-attachments/assets/382ec1ae-b7b0-418e-9417-5b0704b47ce9" />

## After: 
<img width="1708" height="616" alt="Screenshot 2026-01-13 at 3 49 17 AM" src="https://github.com/user-attachments/assets/b28c4e14-9182-43da-8807-d6b513471610" />


---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

- used claude-code with opus-4.5 for debugging purposes. 