### PR TITLE
Fix: Persist `chargeback_reversed` flag of disputed purchases when dispute is won for a `Charge`

### DIFF
--- a/app/models/concerns/charge/disputable.rb
+++ b/app/models/concerns/charge/disputable.rb
@@ -175,7 +175,7 @@ module Charge::Disputable
     mark_as_dispute_reversed!(dispute_reversed_at: event.created_at)
 
     disputed_purchases.each do |purchase|
-      purchase.chargeback_reversed = true
+      purchase.update!(chargeback_reversed: true)
       purchase.mark_giftee_purchase_as_chargeback_reversed if purchase.is_gift_sender_purchase
 
       purchase.mark_product_purchases_as_chargeback_reversed!


### PR DESCRIPTION
Fixes #2055 and https://github.com/antiwork/gumroad-private/issues/65

# Description

## Problem

When a dispute is won in seller's favor for purchases associated with a `Charge` object (instead of handling the event directly on a `Purchase`), the corresponding purchases' `chargeback_reversed` flag is set in memory but does not persist to the database. This causes customers to be blocked from accessing their purchased products even though the seller won the dispute.

## Solution

Replaced the `purchase.chargeback_reversed = true` with `purchase.update!(chargeback_reversed: true)` while handling `charge.dispute.closed` event with `status: "won"`.