### PR TITLE
fix: default footer content

### DIFF
--- a/app/views/purchases/confirm_receipt_email.html.erb
+++ b/app/views/purchases/confirm_receipt_email.html.erb
@@ -11,7 +11,7 @@
   <% end %>
 </main>
 <% content_for :footer do %>
-  <div class="text-center py-4">
+  <div style="text-align: center; padding-bottom: 10px;">
     <%= default_footer_content %>
   </div>
 <% end %>


### PR DESCRIPTION
Issue: #2861

## Problem
The legacy footer rendered via `content_for :footer` on the `confirm_receipt_email` page was left-aligned by default. This made the footer look misaligned on an otherwise centered page.
 ```html
<%= default_footer_content %>
```
## Solution
 ```html
 <div class="text-center py-4">
    <%= default_footer_content %>
  </div>
```
---

# Before/After
## Before 
<img width="841" height="487" alt="Screenshot from 2026-01-14 14-45-19" src="https://github.com/user-attachments/assets/80391883-3ac3-4c27-8c52-de2752882c98" />

## After 
### Desktop /Mobile
[Screencast from 2026-01-14 14-32-59.webm](https://github.com/user-attachments/assets/ff5718f2-b27b-4931-b6b5-94d3b00f210b)


---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [ ] I have added/updated tests for my changes

---

# AI Disclosure

No AI was used for any part of this contribution
