### PR TITLE
Fix incorrect card styling on the checkout form

### DIFF
--- a/app/javascript/components/Checkout/PaymentForm.tsx
+++ b/app/javascript/components/Checkout/PaymentForm.tsx
@@ -1240,7 +1240,7 @@ export const PaymentForm = ({
       <EmailAddress card />
       {!isFreePurchase ? (
         <>
-          <CardContent className="border-b-0">
+          <CardContent className={state.paymentMethod === "card" ? "border-b-0" : ""}>
             <div className="flex grow flex-col gap-4">
               <h4 className="font-bold">Pay with</h4>
               {state.availablePaymentMethods.length > 1 ? (


### PR DESCRIPTION
See https://github.com/antiwork/gumroad/pull/2558#issuecomment-3744119649 (@sm17p thanks for the ping!)

# Description

## Problem

The changes in #2558 caused a couple of layout issues with the checkout form: a top border was unintentionally added to the card details form and the PayPal pay button stopped being full width.

---

# Before/After

| Before | After |
| --- | --- |
| <img width="446" height="741" alt="Screenshot 2026-01-14 at 14 32 29" src="https://github.com/user-attachments/assets/c78b2480-090d-4d17-8601-623f47d1aa11" /> | <img width="452" height="746" alt="Screenshot 2026-01-14 at 14 31 40" src="https://github.com/user-attachments/assets/6915c780-4c38-42b1-b110-fc1ad6a7d669" /> |
| <img width="444" height="643" alt="Screenshot 2026-01-14 at 14 32 43" src="https://github.com/user-attachments/assets/8728186c-ee65-4adc-bf9f-eb0a91c85b7b" /> | <img width="439" height="638" alt="Screenshot 2026-01-14 at 14 36 18" src="https://github.com/user-attachments/assets/9fcd3bb3-d415-4187-93c9-793e2a006507" /> |

---

# AI Disclosure

Not used for this PR.
