### PR TITLE
Fix: Run OpenAI tests without real secrets

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -49,6 +49,7 @@ GOOGLE_CLIENT_ID=524830719781-6h0t2d14kpj9j76utctvs3udl0embkpi.apps.googleuserco
 CIRCLE_API_KEY=test-circle-api-key
 DISCORD_BOT_TOKEN=test-discord-bot-token
 EASYPOST_API_KEY=test-easypost-api-key
+OPENAI_ACCESS_TOKEN=test-openai-access-token
 
 # MinIO
 AWS_S3_ENDPOINT=http://localhost:9000


### PR DESCRIPTION
Issue: #959

# Description

Adds missing `OPENAI_ACCESS_TOKEN` environment variable to `.env.test` so tests can run without Gumroad's internal credentials.

## Problem

Tests that use OpenAI functionality (like `UsernameGeneratorService` and `Ai::ProductDetailsGeneratorService`) fail when the `OPENAI_ACCESS_TOKEN` environment variable is not defined. The VCR cassettes are already sanitized with `<OPENAI_ACCESS_TOKEN>` placeholder, but the env var is missing from `.env.test`.

## Solution

Added `OPENAI_ACCESS_TOKEN=test-openai-access-token` to `.env.test`.

The VCR filter in `spec_helper.rb` already exists (line 100), and all cassettes are already sanitized - this just provides the missing test value.

---

# Before/After

N/A - no UI changes

---

# Test Results

<img width="817" height="351" alt="image" src="https://github.com/user-attachments/assets/23ee8d4a-5a6c-4d54-9b18-023fade6e11b" />


---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

Claude Opus 4.5 via Claude Code was used to identify the missing environment variable. 
