### PR TITLE
Run Open Exchange Rates tests without real secrets

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -49,6 +49,7 @@ GOOGLE_CLIENT_ID=524830719781-6h0t2d14kpj9j76utctvs3udl0embkpi.apps.googleuserco
 CIRCLE_API_KEY=test-circle-api-key
 DISCORD_BOT_TOKEN=test-discord-bot-token
 EASYPOST_API_KEY=test-easypost-api-key
+OPEN_EXCHANGE_RATES_APP_ID=test-open-exchange-rates-app-id
 
 # MinIO
 AWS_S3_ENDPOINT=http://localhost:9000


### PR DESCRIPTION
Issue: #959

# Description

Adds missing `OPEN_EXCHANGE_RATES_APP_ID` environment variable to `.env.test` so tests can run without Gumroad's internal credentials.

## Problem

Tests that use currency exchange rate functionality fail when the `OPEN_EXCHANGE_RATES_APP_ID` environment variable is not defined. The VCR cassettes are already sanitized with `<OPEN_EXCHANGE_RATES_APP_ID>` placeholder, but the env var is missing from `.env.test`.

## Solution

Added `OPEN_EXCHANGE_RATES_APP_ID=test-open-exchange-rates-app-id` to `.env.test`.

The VCR filter in `spec_helper.rb` already exists (line 94), and cassettes are already sanitized - this just provides the missing test value.

---

# Before/After

N/A - no UI changes

---

# Test Results

Verified that:
- VCR filter exists in `spec_helper.rb` (line 94)
- VCR cassette `CreateGstReportJob/happy_case/returns_a_csv_file_for_the_quarter.yml` uses `<OPEN_EXCHANGE_RATES_APP_ID>` placeholder
- Env var now provides the test value needed for filter to work

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

Claude Sonnet 4.5 was used to identify the missing environment variable
