### PR TITLE
fix: footer text to center

### DIFF
--- a/app/views/purchases/confirm_receipt_email.html.erb
+++ b/app/views/purchases/confirm_receipt_email.html.erb
@@ -11,5 +11,7 @@
   <% end %>
 </main>
 <% content_for :footer do %>
-  <%= default_footer_content %>
+  <div class="text-center pb-4">
+    <%= default_footer_content %>
+  </div>
 <% end %>


### PR DESCRIPTION
Issue: #2861 

# Description

## Problem

On the `/purchases/[purchase_id]/confirm_receipt_email`page, the “Powered by Gumroad” text in the footer is not properly centered.

## Solution

To resolve this issue, I updated the footer on the confirm receipt email page by wrapping it in a div and applying a text
center property.


# Before

![Before](https://github.com/user-attachments/assets/3ffa4f7d-35ab-4a19-81cb-b76dfaac9669)
![Before web](https://github.com/user-attachments/assets/487e37b5-d783-45aa-9c18-964473fbc701)

# After

![After 1](https://github.com/user-attachments/assets/9d75dbe2-0978-4a03-9208-68d9c1d67ebe)
![After web](https://github.com/user-attachments/assets/6d1dc5e4-fcc4-4d72-a5af-d13f43e58747)


# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

Used Claude AI to better understand the application flow.