### PR TITLE
Fix: Run Zoom tests without real secrets

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -49,6 +49,8 @@ GOOGLE_CLIENT_ID=524830719781-6h0t2d14kpj9j76utctvs3udl0embkpi.apps.googleuserco
 CIRCLE_API_KEY=test-circle-api-key
 DISCORD_BOT_TOKEN=test-discord-bot-token
 EASYPOST_API_KEY=test-easypost-api-key
+ZOOM_CLIENT_ID=test-zoom-client-id
+ZOOM_CLIENT_SECRET=test-zoom-client-secret
 
 # MinIO
 AWS_S3_ENDPOINT=http://localhost:9000


### PR DESCRIPTION
Issue: Part of #959 

# Description

## Problem
Zoom tests are failing without real secrets. Even though the requests are mocked, the code still tries to grab `ZOOM_CLIENT_ID` and `ZOOM_CLIENT_SECRET`.

## Solution
Added placeholder credentials to `.env.test`.

---

# Before/After

NA

---

# Test Results

<img width="1073" height="314" alt="Screenshot_20260115_153347" src="https://github.com/user-attachments/assets/05b01fe5-d53d-4ff7-a2b7-0819c5ac5fbb" />


---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [ ] I have performed a self-review and left review comments on my PR
- [ ] I have added/updated tests for my changes

---

# AI Disclosure
Gemini 3 Pro (High) on Antigravity for finding related tests and error handling.

