### PR TITLE
Remove dead developers route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -876,11 +876,6 @@ Rails.application.routes.draw do
       api_routes
     end
 
-    # developers pages
-    scope "developers" do
-      get "/", to: "public#developers", as: "developers"
-    end
-
     scope "api" do
       get "/", to: "public#api"
     end


### PR DESCRIPTION
## Summary
Removes the dead `/developers` route that points to a non-existent `public#developers` action.

## Changes
- Removed `developers` route scope from `config/routes.rb` (lines 879-882)
- The route `get "/", to: "public#developers", as: "developers"` was pointing to a controller action that doesn't exist in `PublicController`

## Why
- No `developers` action exists in `PublicController`
- No references to `developers_path` or `developers_url` in the codebase
- No view files for a developers page
- This is dead code that was never implemented or was removed without cleaning up the route
