### PR TITLE
fix: product page double scroll on small screen

### DIFF
--- a/app/javascript/components/ui/Table.tsx
+++ b/app/javascript/components/ui/Table.tsx
@@ -165,7 +165,7 @@ export const TableCell = ({
   return (
     <td
       className={classNames(
-        "block p-4 text-left align-middle not-first:border-t not-first:border-border lg:table-cell lg:border-t lg:border-border",
+        "relative block p-4 text-left align-middle not-first:border-t not-first:border-border lg:table-cell lg:border-t lg:border-border",
         cellRoundingClasses,
         className,
       )}


### PR DESCRIPTION
Issue: #2757
Ref: https://mskelton.dev/bytes/preventing-overflow-with-sr-only

# Description

The products list page shows two vertical scroll areas ( small screens only) .

## Problem

The document body starts scrolling, even though the cards themselves already live inside a scroll container.

The root cause is the use of the `sr-only` utility inside table cells.

The sr-only class looks something like this:

.sr-only {
  position: absolute;
  width: 1px;
  height: 1px;
  padding: 0;
  margin: -1px;
  overflow: hidden;
  clip: rect(0, 0, 0, 0);
  white-space: nowrap;
  border-width: 0;
}
`.sr-only uses position: absolute`


Because the table cells do not establish a positioning context (position: relative), 
these sr-only elements are positioned relative to the nearest positioned ancestor,
which ends up being the document body.

## Solution

Added `position: relative` to table cells so that `sr-only` elements (which use absolute positioning) are scoped correctly within the scroll container instead of the document body.

---

# Before/After

BEFORE:

Mobile: 

https://github.com/user-attachments/assets/5e0a98b0-9197-47d2-afa9-ae00e26c5919

Desktop:

https://github.com/user-attachments/assets/b9bf4ef6-393a-4110-932f-ce003fd9a41f

AFTER:

Mobile:

https://github.com/user-attachments/assets/270ba5f1-b5ac-44f3-acb7-3acad6f039fc



Desktop:

https://github.com/user-attachments/assets/07763262-92ca-4e21-a42f-3ec8d6167685


---

# Test Results

<!-- Include a screenshot of your test suite passing locally -->

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

Used GPT for researching the issue.
