### PR TITLE
fix(test): Run installment plan tax test without TaxJar credentials

### DIFF
--- a/spec/requests/purchases/product/installment_plan_spec.rb
+++ b/spec/requests/purchases/product/installment_plan_spec.rb
@@ -341,7 +341,7 @@ describe "Product with installment plan", type: :system, js: true do
     end
   end
 
-  describe "tax" do
+  describe "tax", :taxjar, :force_vcr_on do
     it "calculates and charges sales tax for all installment payments when applicable" do
       visit product.long_url
 


### PR DESCRIPTION
ref: #959 

## Description : 

### Problem :

The test "calculates and charges sales tax for all installment payments when applicable" in `spec/requests/purchases/product/installment_plan_spec.rb` was making live TaxJar API calls without using VCR cassettes. 
This caused the test to fail in CI environments where `TAXJAR_API_KEY` is not available.

Other TaxJar-dependent tests pass because they use the `:taxjar` RSpec tag which wraps them in VCR cassettes.

### Solution :

Added the `:taxjar` and `:force_vcr_on` metadata tags to the `describe "tax"` block:

`:taxjar` - Wraps the test in a VCR cassette that records/replays TaxJar API responses
`:force_vcr_on` - Required because VCR is turned off by default for JS system tests

This follows the same pattern used by all other TaxJar-dependent tests in the codebase.

## Test Verification :

CI test results will be used for verification. Local JS system tests are currently 
blocked by a webpack compilation issue unrelated to this change. The fix follows 
the same `:taxjar` VCR pattern used by existing tests in the codebase.

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

GLM-4.7 was used to identify the root cause and implement a fix.