### PR TITLE
fix(ui): center footer elements with vertical spacing

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,13 +10,15 @@ module ApplicationHelper
   end
 
   def default_footer_content
-    safe_join(
-      [
-        "Powered by",
-        tag.span("Gumroad", class: "logo-full", aria: { label: "Gumroad" })
-      ],
-      " "
-    )
+    tag.div(style: "text-align: center; padding: 20px 0;") do
+      safe_join(
+        [
+          "Powered by",
+          tag.span("Gumroad", class: "logo-full", aria: { label: "Gumroad" })
+        ],
+        " "
+      )
+    end
   end
 
   def current_user_props(current_user, impersonated_user)

--- a/app/views/doorkeeper/authorizations/_footer.html.erb
+++ b/app/views/doorkeeper/authorizations/_footer.html.erb
@@ -1,3 +1,5 @@
-<%= image_tag(logged_in_user.avatar_url, class: "user-avatar", size: "32", alt: logged_in_user.display_name) %>
-<span><%= logged_in_user.email %></span>
-<%= link_to "Logout", logout_path %>
+<div style="text-align: center; padding: 20px 0;">
+  <%= image_tag(logged_in_user.avatar_url, class: "user-avatar", size: "32", alt: logged_in_user.display_name) %>
+  <span><%= logged_in_user.email %></span>
+  <%= link_to "Logout", logout_path %>
+</div>


### PR DESCRIPTION
Center footer content on OAuth authorize and purchase pages using inline CSS for email template compatibility.

Issue: #2861  

# Description

Centers the "Powered by Gumroad" footer and OAuth authorization footer elements across the application. This fix affects 11 pages that use the [default_footer_content](vscode-file://vscode-app/private/var/folders/kd/w28mbv3n069f74lvt56cxkqc0000gn/T/AppTranslocation/1330B239-359B-4F45-8C8A-A22F67019BAE/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) helper, including purchase confirmation emails, subscription management pages, and the OAuth authorize page.
## Problem
Footer elements were left-aligned on multiple pages, creating an inconsistent and unprofessional appearance. The issue was particularly noticeable on:

* Purchase confirmation pages ([/purchases/[id]/confirm_receipt_email](vscode-file://vscode-app/private/var/folders/kd/w28mbv3n069f74lvt56cxkqc0000gn/T/AppTranslocation/1330B239-359B-4F45-8C8A-A22F67019BAE/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html))
* OAuth authorization page ([/oauth/authorize](vscode-file://vscode-app/private/var/folders/kd/w28mbv3n069f74lvt56cxkqc0000gn/T/AppTranslocation/1330B239-359B-4F45-8C8A-A22F67019BAE/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html))
* Subscription management pages (subscribe, unsubscribe, update payment, etc.)


# Before/After

<!-- For UI/CSS changes, include screenshots or videos showing both states -->
<!-- Include: Desktop (light + dark) and Mobile (light + dark) -->
Dekstop
<div style="display: flex; gap: 12px;">
  <img src="https://github.com/user-attachments/assets/27b41b19-2afd-458f-9631-d1e4e9564be5" width="48%" />
  <img src="https://github.com/user-attachments/assets/d141828f-e1c8-4953-be74-2a0fa3e16a7f" width="48%" />
</div>
<div style="display: flex; gap: 12px;">
<img width="48%" alt="Screenshot 2026-01-16 at 7 02 55 PM" src="https://github.com/user-attachments/assets/6b4a3937-8d72-4a88-a62a-481ed912c5f4" />
<img width="48%" alt="Screenshot 2026-01-16 at 7 08 33 PM" src="https://github.com/user-attachments/assets/b0d9e70b-9fdb-48d4-9406-130c3be5618b" />
</div>
<div style="display: flex; gap: 12px;">
<img width="48%" alt="Screenshot 2026-01-16 at 6 36 56 PM" src="https://github.com/user-attachments/assets/d3cc5b4d-c167-439c-8b54-bc47d493b465" />
<img width="48%" alt="Screenshot 2026-01-16 at 7 09 32 PM" src="https://github.com/user-attachments/assets/5dd6901c-a402-4a18-8775-0f803a297f77" />
</div>

 Mobile
 
<div style="display: flex; gap: 12px;">
<img width="48%" alt="Screenshot 2026-01-16 at 6 37 40 PM" src="https://github.com/user-attachments/assets/605812c6-c905-4948-b959-a33f4a3faa8d" />
<img width="48%" alt="Screenshot 2026-01-16 at 7 09 57 PM" src="https://github.com/user-attachments/assets/d175ce00-e3aa-4b7b-a66f-995b6991f157" />
</div>
<div style="display: flex; gap: 12px;">
<img width="48%" alt="Screenshot 2026-01-16 at 6 37 52 PM" src="https://github.com/user-attachments/assets/dd4123a4-fb58-4482-bf21-43c92e39ed37" />
<img width="48%" alt="Screenshot 2026-01-16 at 7 10 06 PM" src="https://github.com/user-attachments/assets/7388d587-61d2-4f03-bccc-27defe6c19a6" />
</div>

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [ ] I have added/updated tests for my changes

---

# AI Disclosure

No AI was used for any part of this contribution.

