### PR TITLE
feat: Remember last visited page

### DIFF
--- a/app/controllers/url_redirects_controller.rb
+++ b/app/controllers/url_redirects_controller.rb
@@ -13,7 +13,7 @@ class UrlRedirectsController < ApplicationController
   before_action :redirect_to_coffee_page_if_needed, only: :download_page
   before_action :check_permissions, only: %i[show stream download_page
                                              hls_playlist download_subtitle_file read
-                                             download_archive latest_media_locations download_product_files audio_durations]
+                                             download_archive latest_media_locations download_product_files audio_durations update_last_visited_page]
   before_action :hide_layouts, only: %i[
     confirm_page membership_inactive_page expired rental_expired_page show download_page download_product_files stream smil hls_playlist download_subtitle_file read
   ]
@@ -277,6 +277,17 @@ class UrlRedirectsController < ApplicationController
     end
 
     render json:
+  end
+
+  def update_last_visited_page
+    fetch_url_redirect
+    page_index = params[:page_index]&.to_i
+    if page_index.present? && page_index >= 0
+      @url_redirect.update(last_visited_page_index: page_index)
+      render json: { success: true }
+    else
+      render json: { success: false, error: "Invalid page_index" }, status: :bad_request
+    end
   end
 
   private

--- a/app/javascript/components/server-components/DownloadPage/WithContent.tsx
+++ b/app/javascript/components/server-components/DownloadPage/WithContent.tsx
@@ -92,6 +92,7 @@ export type License = {
 const WithContent = ({
   content,
   product_has_third_party_analytics,
+  last_visited_page_index,
   ...props
 }: LayoutProps & {
   content: {
@@ -108,6 +109,7 @@ const WithContent = ({
     community_chat_url: string | null;
   };
   product_has_third_party_analytics: boolean | null;
+  last_visited_page_index: number | null;
 }) => {
   const url = new URL(useOriginalLocation());
   const addThirdPartyAnalytics = useAddThirdPartyAnalytics();
@@ -208,7 +210,11 @@ const WithContent = ({
   });
   const isDesktop = useIsAboveBreakpoint("lg");
   const pages = content.rich_content_pages ?? [];
-  const [activePageIndex, setActivePageIndex] = React.useState(0);
+  const initialPageIndex =
+    last_visited_page_index != null && last_visited_page_index >= 0 && last_visited_page_index < pages.length
+      ? last_visited_page_index
+      : 0;
+  const [activePageIndex, setActivePageIndex] = React.useState(initialPageIndex);
   const activePage = pages[activePageIndex];
   const showPageList = pages.length > 1 || (pages.length === 1 && (pages[0]?.title ?? "").trim() !== "");
   const hasPreviousPage = activePageIndex > 0;
@@ -255,6 +261,23 @@ const WithContent = ({
     [pages],
   );
   const purchaseInfo = { purchaseId: props.purchase?.id ?? null, redirectId: props.redirect_id, token: props.token };
+
+  const isInitialMountRef = React.useRef(true);
+  React.useEffect(() => {
+    if (isInitialMountRef.current) {
+      isInitialMountRef.current = false;
+      return;
+    }
+
+    if (pages.length === 0) return;
+
+    void request({
+      url: Routes.url_redirect_update_last_visited_page_path(props.token),
+      method: "PATCH",
+      accept: "json",
+      data: { page_index: activePageIndex },
+    });
+  }, [activePageIndex, pages.length, props.token]);
 
   return (
     <Layout

--- a/app/presenters/url_redirect_presenter.rb
+++ b/app/presenters/url_redirect_presenter.rb
@@ -46,6 +46,7 @@ class UrlRedirectPresenter
     {
       content: content_props,
       product_has_third_party_analytics: purchase&.link&.has_third_party_analytics?("receipt"),
+      last_visited_page_index: url_redirect.last_visited_page_index,
     }.merge(download_page_layout_props).merge(extra_props)
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -866,6 +866,7 @@ Rails.application.routes.draw do
     post "/confirm-redirect", to: "url_redirects#confirm"
     post "/r/:id/send_to_kindle", to: "url_redirects#send_to_kindle", as: :send_to_kindle
     post "/r/:id/change_purchaser", to: "url_redirects#change_purchaser", as: :url_redirect_change_purchaser
+    patch "/r/:id/last_visited_page", to: "url_redirects#update_last_visited_page", as: :url_redirect_update_last_visited_page
 
     get "crossdomain", to: "public#crossdomain"
 

--- a/db/migrate/20260116163451_add_last_visited_page_index_to_url_redirects.rb
+++ b/db/migrate/20260116163451_add_last_visited_page_index_to_url_redirects.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLastVisitedPageIndexToUrlRedirects < ActiveRecord::Migration[7.1]
+  def change
+    add_column :url_redirects, :last_visited_page_index, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_11_24_133549) do
+ActiveRecord::Schema[7.1].define(version: 2026_01_16_163451) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -144,6 +144,24 @@ ActiveRecord::Schema[7.1].define(version: 2025_11_24_133549) do
     t.string "unsplash_url"
     t.index ["deleted_at"], name: "index_asset_previews_on_deleted_at"
     t.index ["link_id"], name: "index_asset_previews_on_link_id"
+  end
+
+  create_table "audience_export_chunks", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "export_id", null: false
+    t.text "member_ids", size: :long
+    t.text "members_data", size: :long
+    t.boolean "processed", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["export_id"], name: "index_audience_export_chunks_on_export_id"
+  end
+
+  create_table "audience_exports", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "recipient_id", null: false
+    t.text "audience_options"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["recipient_id"], name: "index_audience_exports_on_recipient_id"
   end
 
   create_table "audience_members", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -2396,6 +2414,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_11_24_133549) do
     t.bigint "preorder_id"
     t.bigint "imported_customer_id"
     t.datetime "rental_first_viewed_at", precision: nil
+    t.integer "last_visited_page_index"
     t.index ["imported_customer_id"], name: "index_url_redirects_on_imported_customer_id"
     t.index ["installment_id", "imported_customer_id"], name: "index_url_redirects_on_installment_id_and_imported_customer_id"
     t.index ["installment_id", "purchase_id"], name: "index_url_redirects_on_installment_id_and_purchase_id"


### PR DESCRIPTION
Issue: #2923 

# Description

## Problem

When buyers revisit content pages, they always land on the first page instead of the last page they viewed.

## Solution

Persist the last visited page index in the database (`url_redirects.last_visited_page_index`) and restore it when buyers return. The page index is saved automatically when users navigate between pages and loaded on page initialization.

**Changes:**
- Added `last_visited_page_index` column to `url_redirects` table
- Added API endpoint `PATCH /r/:id/last_visited_page` to save page index
- Frontend saves page index when navigating between pages
- Frontend initializes from saved page index on load

---

## After



https://github.com/user-attachments/assets/a9e55d13-a1e5-4fd2-9d5b-093e373d151e


---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)




- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---



