### PR TITLE
List eurozone countries individually in help article

### DIFF
--- a/app/views/help_center/articles/contents/_13-getting-paid.html.erb
+++ b/app/views/help_center/articles/contents/_13-getting-paid.html.erb
@@ -57,18 +57,24 @@
         <tr>
           <td>Australia</td>
           <td>AUD</td>
+          <td>Austria</td>
+          <td>EUR</td>
+        </tr>
+        <tr>
           <td>Azerbaijan</td>
           <td>AZN (min 50)</td>
-        </tr>
-        <tr>
           <td>Bahamas</td>
           <td>BSD</td>
-          <td>Bahrain</td>
-          <td>BHD</td>
         </tr>
         <tr>
+          <td>Bahrain</td>
+          <td>BHD</td>
           <td>Bangladesh</td>
           <td>BDT</td>
+        </tr>
+        <tr>
+          <td>Belgium</td>
+          <td>EUR</td>
           <td>Benin</td>
           <td>XOF</td>
         </tr>
@@ -109,6 +115,12 @@
           <td>XOF</td>
         </tr>
         <tr>
+          <td>Croatia</td>
+          <td>EUR</td>
+          <td>Cyprus</td>
+          <td>EUR</td>
+        </tr>
+        <tr>
           <td>Czech Republic</td>
           <td>CZK</td>
           <td>Denmark</td>
@@ -127,20 +139,32 @@
           <td>USD (min 30)</td>
         </tr>
         <tr>
+          <td>Estonia</td>
+          <td>EUR</td>
           <td>Ethiopia</td>
           <td>ETB</td>
-          <td>European Union</td>
+        </tr>
+        <tr>
+          <td>Finland</td>
+          <td>EUR</td>
+          <td>France</td>
           <td>EUR</td>
         </tr>
         <tr>
           <td>Gabon</td>
           <td>XAF</td>
-          <td>Ghana</td>
-          <td>GHS</td>
+          <td>Germany</td>
+          <td>EUR</td>
         </tr>
         <tr>
+          <td>Ghana</td>
+          <td>GHS</td>
           <td>Gibraltar</td>
           <td>GBP</td>
+        </tr>
+        <tr>
+          <td>Greece</td>
+          <td>EUR</td>
           <td>Guatemala</td>
           <td>GTQ</td>
         </tr>
@@ -163,8 +187,14 @@
           <td>IDR</td>
         </tr>
         <tr>
+          <td>Ireland</td>
+          <td>EUR</td>
           <td>Israel</td>
           <td>ILS</td>
+        </tr>
+        <tr>
+          <td>Italy</td>
+          <td>EUR</td>
           <td>Jamaica</td>
           <td>JMD</td>
         </tr>
@@ -189,18 +219,30 @@
         <tr>
           <td>Laos</td>
           <td>LAK (min 516,000)</td>
+          <td>Latvia</td>
+          <td>EUR</td>
+        </tr>
+        <tr>
           <td>Liechtenstein</td>
           <td>CHF</td>
+          <td>Lithuania</td>
+          <td>EUR</td>
         </tr>
         <tr>
+          <td>Luxembourg</td>
+          <td>EUR</td>
           <td>Macao</td>
           <td>MOP</td>
-          <td>Madagascar</td>
-          <td>MGA (min 132,300)</td>
         </tr>
         <tr>
+          <td>Madagascar</td>
+          <td>MGA (min 132,300)</td>
           <td>Malaysia</td>
           <td>MYR (min 133)</td>
+        </tr>
+        <tr>
+          <td>Malta</td>
+          <td>EUR</td>
           <td>Mauritius</td>
           <td>MUR</td>
         </tr>
@@ -225,42 +267,48 @@
         <tr>
           <td>Namibia</td>
           <td>NAD (min 550)</td>
+          <td>Netherlands</td>
+          <td>EUR</td>
+        </tr>
+        <tr>
           <td>New Zealand</td>
           <td>NZD</td>
-        </tr>
-        <tr>
           <td>Niger</td>
           <td>XOF</td>
+        </tr>
+        <tr>
           <td>Nigeria</td>
           <td>NGN</td>
-        </tr>
-        <tr>
           <td>North Macedonia</td>
           <td>MKD (min 1,500)</td>
+        </tr>
+        <tr>
           <td>Norway</td>
           <td>NOK</td>
-        </tr>
-        <tr>
           <td>Oman</td>
           <td>OMR</td>
+        </tr>
+        <tr>
           <td>Pakistan</td>
           <td>PKR</td>
-        </tr>
-        <tr>
           <td>Panama</td>
           <td>USD (min 50)</td>
+        </tr>
+        <tr>
           <td>Paraguay</td>
           <td>PYG (min 210,000)</td>
-        </tr>
-        <tr>
           <td>Peru</td>
           <td>PEN</td>
-          <td>Philippines</td>
-          <td>PHP</td>
         </tr>
         <tr>
+          <td>Philippines</td>
+          <td>PHP</td>
           <td>Poland</td>
           <td>PLN</td>
+        </tr>
+        <tr>
+          <td>Portugal</td>
+          <td>EUR</td>
           <td>Qatar</td>
           <td>QAR</td>
         </tr>
@@ -287,6 +335,12 @@
           <td>RSD (min 3,000)</td>
           <td>Singapore</td>
           <td>SGD</td>
+        </tr>
+        <tr>
+          <td>Slovakia</td>
+          <td>EUR</td>
+          <td>Slovenia</td>
+          <td>EUR</td>
         </tr>
         <tr>
           <td>South Africa</td>
@@ -335,12 +389,6 @@
           <td>UZS (min 343,000)</td>
           <td>Vietnam</td>
           <td>VND</td>
-        </tr>
-        <tr>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
## Problem

The bank payouts table listed "European Union" as a single entry in our [help center](https://gumroad.com/help/article/13-getting-paid), but other EU countries (like Spain) were also listed individually. This was inconsistent - both are eurozone countries paid in EUR.

## Solution

List all eurozone countries individually and remove the "European Union" entry.

## Before/After

**Before – Desktop**
<img width="800" src="https://github.com/user-attachments/assets/331ae562-c1f1-4ebd-9791-12d93dc23108" />

**After – Desktop (new additions highlighted in red)**
<img width="800" src="https://github.com/user-attachments/assets/3ba55a5e-1793-4763-a001-7e08ce2e714e" />

## Verification

- [x] All countries match `EUROPEAN_COUNTRIES` in `app/modules/user/compliance.rb`
- [x] All use EUR per `app/models/country.rb`

---
AI disclaimer: This PR was implemented with AI assistance using Cursor for code generation. All code was self-reviewed.