### PR TITLE
Do not redirect admin user page for non-get requests

### DIFF
--- a/app/controllers/concerns/admin/fetch_user.rb
+++ b/app/controllers/concerns/admin/fetch_user.rb
@@ -14,7 +14,7 @@ module Admin::FetchUser
       if @user.nil? && User.id?(user_param) && (user = User.find_by(id: user_param))
         if request.get?
           new_path = request.fullpath.sub("/#{user_param}", "/#{user.external_id}")
-          return redirect_to new_path
+          return redirect_to new_path, status: :see_other
         else
           @user = user
           return

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -107,6 +107,7 @@ describe Admin::UsersController, type: :controller, inertia: true do
         get :show, params: { external_id: user.id }
 
         expect(response).to redirect_to(admin_user_path(user.external_id))
+        expect(response).to have_http_status(:see_other)
       end
     end
   end


### PR DESCRIPTION
POST requests from Iffy fail otherwise. Ideally, we shouldn't redirect non-GET requests.

Reported by @gumroadsteve2 