### PR TITLE
FIx(ui):  wrap ApiResource children in CardContent for proper padding

### DIFF
--- a/app/javascript/components/ApiDocumentation/ApiResource.tsx
+++ b/app/javascript/components/ApiDocumentation/ApiResource.tsx
@@ -7,6 +7,6 @@ export const ApiResource = ({ name, id, children }: { name: string; id: string; 
     <CardContent>
       <h2 className="grow">{name}</h2>
     </CardContent>
-    {children}
+    <CardContent details>{children}</CardContent>
   </Card>
 );


### PR DESCRIPTION

# Problem: 
###  Root Cause
 - The ApiResource component was rendering children directly inside the Card without wrapping it in CardContent. This caused the children to miss the standard card styling. 

# Solution
- Wrap children in <CardContent details> to apply the correct styling. The details prop uses block layout instead of flex, which is appropriate for the detailed content within API
  resources.



---

# Before/After

## Before: 
<img width="1512" height="904" alt="Screenshot 2026-01-17 at 10 36 24 PM" src="https://github.com/user-attachments/assets/f65aaf5a-1d2b-489e-aa89-a132a46ad612" />

```tsx
...
    {children}
...
```

## After: 
<img width="1512" height="905" alt="Screenshot 2026-01-17 at 10 38 06 PM" src="https://github.com/user-attachments/assets/04f2287d-6de0-4a53-b3fc-9612e07670f6" />


```tsx
...
    <CardContent details>{children}</CardContent>
...
```

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

- no AI used. 