### PR TITLE
fix(download): scroll content to top when navigating between pages

### DIFF
--- a/app/javascript/components/Download/PageListLayout.tsx
+++ b/app/javascript/components/Download/PageListLayout.tsx
@@ -3,6 +3,11 @@ import * as React from "react";
 
 import { classNames } from "$app/utils/classNames";
 
+type ScrollToTopContextValue = () => void;
+const ScrollToTopContext = React.createContext<ScrollToTopContextValue | null>(null);
+
+export const useScrollToTop = () => React.useContext(ScrollToTopContext);
+
 export const PageListLayout = ({
   pageList,
   children,
@@ -11,17 +16,29 @@ export const PageListLayout = ({
   pageList: React.ReactNode;
   children: React.ReactNode;
   className?: string;
-}) => (
-  <div
-    className={classNames(
-      "flex min-h-0 flex-col gap-6 bg-background p-4 [scrollbar-gutter:stable] md:p-8 lg:flex-row lg:gap-16 lg:overflow-y-auto",
-      className,
-    )}
-  >
-    <div className="flex flex-col gap-4 lg:sticky lg:top-0 lg:w-80 lg:pb-8">{pageList}</div>
-    <div className="h-0 flex-1">{children}</div>
-  </div>
-);
+}) => {
+  const contentRef = React.useRef<HTMLDivElement>(null);
+
+  const scrollToTop = React.useCallback(() => {
+    contentRef.current?.scrollTo({ top: 0, behavior: "instant" });
+  }, []);
+
+  return (
+    <ScrollToTopContext.Provider value={scrollToTop}>
+      <div
+        className={classNames(
+          "flex min-h-0 flex-col gap-6 bg-background p-4 [scrollbar-gutter:stable] md:p-8 lg:flex-row lg:gap-16",
+          className,
+        )}
+      >
+        <div className="flex flex-col gap-4 lg:w-80 lg:shrink-0 lg:overflow-y-auto">{pageList}</div>
+        <div ref={contentRef} className="flex-1 lg:overflow-y-auto">
+          {children}
+        </div>
+      </div>
+    </ScrollToTopContext.Provider>
+  );
+};
 
 export const PageList = React.forwardRef<HTMLDivElement, React.HTMLProps<HTMLDivElement>>(
   ({ className, ...props }, ref) => (

--- a/app/javascript/components/server-components/DownloadPage/WithContent.tsx
+++ b/app/javascript/components/server-components/DownloadPage/WithContent.tsx
@@ -14,7 +14,7 @@ import { DiscordButton } from "$app/components/DiscordButton";
 import { DownloadAllButton } from "$app/components/Download/DownloadAllButton";
 import { FileItem, FileList as DownloadFileList, FolderItem } from "$app/components/Download/FileList";
 import { OpenInAppButton } from "$app/components/Download/OpenInAppButton";
-import { PageList, PageListItem } from "$app/components/Download/PageListLayout";
+import { PageList, PageListItem, useScrollToTop } from "$app/components/Download/PageListLayout";
 import { DownloadPagePostList, Post } from "$app/components/Download/PostList";
 import {
   FileDownloadInfo,
@@ -209,6 +209,14 @@ const WithContent = ({
   const isDesktop = useIsAboveBreakpoint("lg");
   const pages = content.rich_content_pages ?? [];
   const [activePageIndex, setActivePageIndex] = React.useState(0);
+  const scrollToTop = useScrollToTop();
+  const goToPage = React.useCallback(
+    (index: number) => {
+      setActivePageIndex(index);
+      scrollToTop?.();
+    },
+    [scrollToTop],
+  );
   const activePage = pages[activePageIndex];
   const showPageList = pages.length > 1 || (pages.length === 1 && (pages[0]?.title ?? "").trim() !== "");
   const hasPreviousPage = activePageIndex > 0;
@@ -287,7 +295,7 @@ const WithContent = ({
               <PageListItem
                 key={page.page_id}
                 isSelected={index === activePageIndex}
-                onClick={() => setActivePageIndex(index)}
+                onClick={() => goToPage(index)}
                 role="tab"
               >
                 <Icon
@@ -357,7 +365,7 @@ const WithContent = ({
                       role="menuitemradio"
                       aria-checked={index === activePageIndex}
                       onClick={() => {
-                        setActivePageIndex(index);
+                        goToPage(index);
                         close();
                       }}
                     >
@@ -376,7 +384,7 @@ const WithContent = ({
           <WithTooltip position="top" tip={hasPreviousPage ? null : "No more pages"}>
             <Button
               disabled={!hasPreviousPage}
-              onClick={() => setActivePageIndex(activePageIndex - 1)}
+              onClick={() => goToPage(activePageIndex - 1)}
               className="flex-1 lg:flex-none"
             >
               <Icon name="arrow-left" />
@@ -386,7 +394,7 @@ const WithContent = ({
           <WithTooltip position="top" tip={hasNextPage ? null : "No more pages"}>
             <Button
               disabled={!hasNextPage}
-              onClick={() => setActivePageIndex(activePageIndex + 1)}
+              onClick={() => goToPage(activePageIndex + 1)}
               className="flex-1 lg:flex-none"
             >
               Next


### PR DESCRIPTION
## Summary

Resolves the issue where content doesn't scroll to top when navigating between pages in multi-page content.

**Changes:**
- Split sidebar and content into independent scroll areas on desktop
- Added scroll context to `PageListLayout` for programmatic scroll control
- Created `goToPage` helper that combines page navigation with scroll-to-top
- Applied scroll behavior to sidebar clicks, mobile menu, and Previous/Next buttons

## Technical Approach

The fix adds a React context (`ScrollToTopContext`) in `PageListLayout` that exposes a `scrollToTop` function. The content area now has its own `overflow-y-auto` instead of the entire container scrolling, allowing independent scroll control.

In `WithContent`, the new `goToPage` callback wraps `setActivePageIndex` to also trigger `scrollToTop()`, ensuring the content resets to the top whenever the user navigates to a different page.

## Test plan

- [ ] Navigate between pages using sidebar - content scrolls to top
- [ ] Navigate using Previous/Next buttons - content scrolls to top
- [ ] Navigate using mobile popover menu - content scrolls to top
- [ ] Sidebar remains independently scrollable when content is tall
- [ ] Test in both light and dark mode
- [ ] Test on mobile and desktop breakpoints

Closes #2924