### PR TITLE
Fix admin "Issue Payout" button returning 404 error

### DIFF
--- a/app/controllers/admin/paydays_controller.rb
+++ b/app/controllers/admin/paydays_controller.rb
@@ -3,7 +3,7 @@
 class Admin::PaydaysController < Admin::BaseController
   # Pay the seller for all their balances up to and including `params[:payout_period_end_date]`.
   def pay_user
-    user = User.find(params[:id])
+    user = User.find_by_external_id!(params[:id])
     date = Date.parse(payday_params[:payout_period_end_date])
 
     payout_processor_type = if payday_params[:payout_processor] == PayoutProcessorType::STRIPE

--- a/spec/controllers/admin/paydays_controller_spec.rb
+++ b/spec/controllers/admin/paydays_controller_spec.rb
@@ -24,7 +24,7 @@ describe Admin::PaydaysController do
     it "pays the seller for balances up to and including the date passed in params" do
       WebMock.stub_request(:post, PAYPAL_ENDPOINT).to_return(body: "CORRELATIONID=c51c5e0cecbce&ACK=Success")
 
-      post :pay_user, params: { id: @user.id, payday: { payout_processor: PayoutProcessorType::PAYPAL, payout_period_end_date: next_scheduled_payout_end_date } }
+      post :pay_user, params: { id: @user.external_id, payday: { payout_processor: PayoutProcessorType::PAYPAL, payout_period_end_date: next_scheduled_payout_end_date } }
 
       expect(response).to be_redirect
       expect(flash[:notice]).to eq("Payment was sent.")
@@ -38,7 +38,7 @@ describe Admin::PaydaysController do
     it "does not pay the user if there are pending payments" do
       create(:payment, user: @user)
 
-      post :pay_user, params: { id: @user.id, payday: { payout_processor: PayoutProcessorType::PAYPAL, payout_period_end_date: next_scheduled_payout_end_date } }
+      post :pay_user, params: { id: @user.external_id, payday: { payout_processor: PayoutProcessorType::PAYPAL, payout_period_end_date: next_scheduled_payout_end_date } }
 
       expect(response).to be_redirect
       expect(flash[:notice]).to eq("Payment was not sent.")
@@ -50,7 +50,7 @@ describe Admin::PaydaysController do
                                                                                           PayoutProcessorType::STRIPE, [@user], from_admin: true
                                                                                           ).and_return([Payment.last])
 
-      post :pay_user, params: { id: @user.id, payday: { payout_processor: PayoutProcessorType::STRIPE, payout_period_end_date: next_scheduled_payout_end_date } }
+      post :pay_user, params: { id: @user.external_id, payday: { payout_processor: PayoutProcessorType::STRIPE, payout_period_end_date: next_scheduled_payout_end_date } }
 
       expect(response).to be_redirect
       expect(flash[:notice]).to eq("Payment was not sent.")


### PR DESCRIPTION
Fixes https://github.com/antiwork/gumroad-private/issues/67

## Root Cause

The `Admin::PaydaysController#pay_user` action uses `User.find(params[:id])` which looks up users by database ID. However, the Inertia-based admin UI passes the `external_id` in the URL, causing `ActiveRecord::RecordNotFound` (404 error).

**Verification in production console:**
```ruby
User.find_by(external_id: "<external_id>")  # Found user
User.find_by(id: <external_id>)             # nil
```

The ERB-based admin views pass `user.id` (database ID) and work correctly, but the Inertia components pass `user.external_id`.

## Solution

Change the controller to look up users by `external_id` instead of database `id`, matching the pattern used by other admin controllers.

## Why This Approach

Alternative approaches considered:
- **Change frontend to pass database ID** - Would require changes to presenter, TypeScript types, and multiple React components
- **Accept both ID types** - Adds complexity and potential for confusion

**This PR** uses the simplest fix: update the controller to match what the frontend sends. This is consistent with how other admin endpoints handle user lookups.

## Test Plan

- Production verification: Manually issued payout using curl with database ID - succeeded
- Unit tests pass with `external_id`
- Deploy and verify "Issue Payout" button works in admin UI

---

## AI Assistance Notice

This PR was implemented with AI assistance using Claude Code for code generation and debugging. All code was self-reviewed.