### PR TITLE
fix: profile page editor menu styling

### DIFF
--- a/app/javascript/components/Profile/EditSections.tsx
+++ b/app/javascript/components/Profile/EditSections.tsx
@@ -180,7 +180,7 @@ export const EditorMenu = ({
           {activeSubmenu}
         </div>
       ) : (
-        <div className="grid w-75 !divide-y !divide-border rounded  bg-background shadow-none">
+        <div className="grid w-75 !divide-y !divide-border rounded bg-background shadow-none">
           {items.map((item, key) =>
             isSubmenu(item) ? (
               <CardContent asChild key={key}>


### PR DESCRIPTION
Fixes: #2986

# Description

Fixes incorrect border rendering in the  EditorMenu popover caused by `divide-*` utilities.

<!-- Briefly describe the problem and your solution -->

## Problem

The popover used `divide-*` utilities for borders, resulting in a broken or inconsistent outer border.

## Solution

Removed reliance on `divide-solid`, which was unintentionally activating side borders on children.

---

# Before/After

Before: 

<img width="1834" height="503" alt="Screenshot from 2026-01-20 15-56-40" src="https://github.com/user-attachments/assets/0b9572fa-94f3-4616-89c8-b9f8bd5c3b68" />

After: 

<img width="738" height="438" alt="image" src="https://github.com/user-attachments/assets/43e267a5-5eb7-48bf-85f6-8911836e8151" />
---

# Test Results

<!-- Include a screenshot of your test suite passing locally -->

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

None
