### PR TITLE
Fix button color variant styling

### DIFF
--- a/app/javascript/components/Button.tsx
+++ b/app/javascript/components/Button.tsx
@@ -22,7 +22,7 @@ export const brandNames = [
 export type BrandName = (typeof brandNames)[number];
 
 export const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 cursor-pointer border border-border rounded bg-transparent text-current font-[inherit] no-underline transition-transform hover:-translate-1 hover:shadow active:translate-0 active:shadow-none disabled:opacity-30 disabled:hover:translate-0 disabled:hover:shadow-none",
+  "inline-flex items-center justify-center gap-2 cursor-pointer border border-border rounded text-current font-[inherit] no-underline transition-transform hover:-translate-1 hover:shadow active:translate-0 active:shadow-none disabled:opacity-30 disabled:hover:translate-0 disabled:hover:shadow-none",
   {
     variants: {
       variant: {
@@ -36,6 +36,7 @@ export const buttonVariants = cva(
         sm: "p-2 text-sm leading-[1.3]",
       },
       color: {
+        default: "bg-transparent",
         primary: "bg-primary text-primary-foreground hover:bg-accent hover:text-accent-foreground",
         black: "bg-black text-white",
         accent: "bg-accent text-accent-foreground",
@@ -101,6 +102,7 @@ export const buttonVariants = cva(
     defaultVariants: {
       variant: "default",
       size: "default",
+      color: "default",
     },
   },
 );

--- a/app/javascript/components/design.ts
+++ b/app/javascript/components/design.ts
@@ -6,5 +6,5 @@ export type VisualState = (typeof visualStates)[number];
 export const mainColors = ["primary", "black", "accent", "filled"] as const;
 export type MainColor = (typeof mainColors)[number];
 
-export const buttonColors = [...visualStates, ...mainColors];
+export const buttonColors = ["default", ...visualStates, ...mainColors] as const;
 export type ButtonColor = (typeof buttonColors)[number];


### PR DESCRIPTION
Issue: #2984

# Description

## Problem

After the Tailwind migration, buttons using color variants (like `color="primary"`) were appearing invisible or with incorrect backgrounds in certain contexts. This was particularly noticeable in:
- **ImageUploader** (thumbnail/logo upload button) - invisible against gray placeholder background
- **Rich text editor** buttons in product descriptions

The root cause was `bg-transparent` in the base `buttonVariants` class string. This conflicted with color variant classes like `bg-primary`, and due to CSS specificity/ordering, the transparent background was winning over the intended colored background.

## Solution

Instead of using `!important` modifiers (bad practice), implemented a clean fix:

1. **Removed `bg-transparent` from base styles** ([Button.tsx]
2. **Added a new `default` color variant** with `bg-transparent`
3. **Set `color: "default"` in `defaultVariants`** so buttons without a color prop still get transparent background

---

# Before/After

# Before
<img width="656" height="327" alt="Screenshot 2026-01-20 at 5 03 08 PM" src="https://github.com/user-attachments/assets/2ebc9690-2ef9-4bbc-8c88-1613746e467b" />

<img width="1178" height="569" alt="Screenshot 2026-01-20 at 5 03 31 PM" src="https://github.com/user-attachments/assets/45079837-f3dc-4843-bde6-4b5984b3b15e" />

---
# After
<img width="659" height="499" alt="Screenshot 2026-01-20 at 5 01 41 PM" src="https://github.com/user-attachments/assets/6976af42-5089-4061-a9ce-a697bcc2e461" />

<img width="1198" height="681" alt="Screenshot 2026-01-20 at 5 02 26 PM" src="https://github.com/user-attachments/assets/c658e3a7-8839-4437-9d8c-1dc1518f31a3" />

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure
None
