### PR TITLE
Refactor: Replace manual polling with Inertia's usePoll for Admin Sales Reports polling

### DIFF
--- a/spec/requests/download_page/download_page_spec.rb
+++ b/spec/requests/download_page/download_page_spec.rb
@@ -979,3 +979,4 @@ describe("Download Page", type: :system, js: true) do
       expect(page).to have_text("We are preparing the file for download. You will receive an email when it is ready.")
     end
   end
+end


### PR DESCRIPTION
followup PR of: #2785

# Description

- Removed manual `setInterval` polling logic and Replaced with Inertia's `usePoll` hook. 


---

# Before/After

### After: 
https://github.com/user-attachments/assets/6be8a261-b515-45f3-a427-8a500584fcdf

---

# Test Results

<img width="756" height="181" alt="Screenshot 2026-01-20 at 9 33 21 PM" src="https://github.com/user-attachments/assets/c1082c9a-088a-43d5-93b3-ae8057ae907f" />


---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

no AI used. 