### PR TITLE
Fixed Sales CSV export to respect selected date range

### DIFF
--- a/app/javascript/components/Audience/CustomersPage.tsx
+++ b/app/javascript/components/Audience/CustomersPage.tsx
@@ -230,8 +230,25 @@ const CustomersPage = ({
     debouncedReloadCustomers();
   }, [query, includedItems, excludedItems]);
 
-  const [from, setFrom] = React.useState(subMonths(new Date(), 1));
-  const [to, setTo] = React.useState(new Date());
+  const [from, setFrom] = React.useState(() =>
+    createdAfter ? new Date(createdAfter) : subMonths(new Date(), 1)
+  );
+  const [to, setTo] = React.useState(() =>
+    createdBefore ? new Date(createdBefore) : new Date()
+  );
+
+  // Sync export date range with page filter dates when they change
+  React.useEffect(() => {
+    if (createdAfter) {
+      setFrom(new Date(createdAfter));
+    }
+  }, [createdAfter]);
+
+  React.useEffect(() => {
+    if (createdBefore) {
+      setTo(new Date(createdBefore));
+    }
+  }, [createdBefore]);
 
   const exportNames = React.useMemo(
     () =>


### PR DESCRIPTION
## Issue: #2991

# Description

Fixes an issue where the Sales CSV export on the `/customers` page did not respect the selected date range filter.

## Problem

The Sales CSV download was exporting data using a hardcoded **“last month to today”** date range instead of the date range selected in the page filters.

When users filtered customers by a specific date range (for example, **Jan 1 – Jan 10**), the Export popover initialized with its own independent date range. This resulted in CSV exports that did not match what users were viewing on the page, causing confusion and incorrect reports.

## Solution

The export date range is now synchronized with the page’s date filters:

- Export date range initializes from the page filter’s `createdAfter` / `createdBefore` values when present
- Added `useEffect` hooks to keep export dates in sync when page filters change
- Falls back to the default **“last month to today”** range when no page filter is set

---

# Changes

- `app/javascript/components/Audience/CustomersPage.tsx`

---

# Testing

- Navigated to `/customers`
- Opened the **Filter** popover and set custom **After** and **Before** dates
- Opened the **Export** popover and verified the date picker matched the filter dates
- Downloaded the CSV and confirmed it only contained sales within the selected range

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [ ] I have added/updated tests for my changes  
  _(Manual verification performed; change is scoped to UI state synchronization.)_

---

# AI Disclosure

None
