### PR TITLE
fix: cta bar appearing outside product view

### DIFF
--- a/app/javascript/components/Product/Layout.tsx
+++ b/app/javascript/components/Product/Layout.tsx
@@ -240,7 +240,7 @@ const CtaBar = ({
       ([entry]) => {
         if (!entry) return;
 
-        setVisible(!entry.isIntersecting);
+        setVisible(!entry.isIntersecting && entry.boundingClientRect.top < 0);
       },
       { threshold: 0.5 },
     ).observe(ctaButtonRef.current);


### PR DESCRIPTION
fixes: #2995

# Description

Fixes an issue where the sticky CTA bar rendered even when the user was not in the product view.

## Problem

This happened because we were showing the bar anytime the main CTA button wasn’t visible, which also includes cases where the user hasn’t actually scrolled past the product yet.

## Solution

Instead of showing the CTA bar whenever the CTA button is off-screen, we now also check whether the user has scrolled past it.

---

# Before/After

Before:


https://github.com/user-attachments/assets/d1a06479-72fd-4d9d-83f1-0ff5f36692ee



After:

https://github.com/user-attachments/assets/adfee11c-b811-4aa7-b7cc-13c1a371a466



---

# Test Results

<!-- Include a screenshot of your test suite passing locally -->

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

Used Gpt
