### PR TITLE
fix: reset scroll position on sidebar navigation in Inertia layout

### DIFF
--- a/app/javascript/inertia/layout.tsx
+++ b/app/javascript/inertia/layout.tsx
@@ -43,8 +43,13 @@ export default function Layout({ children }: { children: React.ReactNode }) {
         <Alert initial={null} />
         <div id="inertia-shell" className="flex h-screen flex-col lg:flex-row">
           {logged_in_user ? <Nav title="Dashboard" /> : null}
-          {isRouteLoading ? <LoadingSkeleton /> : null}
-          <main className={classNames("flex-1 overflow-y-auto", { hidden: isRouteLoading })}>{children}</main>
+          {isRouteLoading ? (
+            <LoadingSkeleton />
+          ) : (
+            <main className="flex-1 overflow-y-auto">
+              {children}
+            </main>
+          )}
         </div>
       </CurrentSellerProvider>
     </LoggedInUserProvider>


### PR DESCRIPTION
Issue: #2924

When navigating via the sidebar after scrolling down a long page, the new page sometimes loads scrolled to the middle instead of the top.

<!-- Briefly describe the problem and your solution -->

## Problem

During navigation we were:
- showing a loading skeleton
- hiding <main> with CSS instead of unmounting it

Because the element stayed mounted, its internal scroll position (scrollTop) was preserved.
So when the new page rendered, it reused the old scroll position.


## Solution

unmount `<main> `entirely while the route is loading, remount it once navigation finishes

---

# Before/After

**Before:** 

https://github.com/user-attachments/assets/281236a3-7951-43d1-a217-bdf770f0f55e

**After:**

https://github.com/user-attachments/assets/257677f2-b162-4fe4-aefe-f539f7194d78

---

# Test Results

<!-- Include a screenshot of your test suite passing locally -->

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

None
