### PR TITLE
feat(exports): add chunked job pipeline for large audience exports

### DIFF
--- a/app/models/audience_export.rb
+++ b/app/models/audience_export.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class AudienceExport < ApplicationRecord
+  include JsonData
+
+  belongs_to :seller, class_name: "User"
+  belongs_to :recipient, class_name: "User"
+  has_many :audience_export_chunks, dependent: :delete_all
+
+  attr_json_data_accessor :followers, default: false
+  attr_json_data_accessor :customers, default: false
+  attr_json_data_accessor :affiliates, default: false
+
+  validate :at_least_one_audience_type_selected
+
+  private
+    def at_least_one_audience_type_selected
+      return if followers || customers || affiliates
+
+      errors.add(:base, "At least one audience type (followers, customers, or affiliates) must be selected")
+    end
+end

--- a/app/models/audience_export_chunk.rb
+++ b/app/models/audience_export_chunk.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AudienceExportChunk < ApplicationRecord
+  belongs_to :audience_export
+
+  serialize :member_ids, type: Array, coder: YAML
+  serialize :members_data, type: Array, coder: YAML
+end

--- a/app/sidekiq/exports/audience/compile_chunks_job.rb
+++ b/app/sidekiq/exports/audience/compile_chunks_job.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "csv"
+
+class Exports::Audience::CompileChunksJob
+  include Sidekiq::Job
+  sidekiq_options retry: 5, queue: :low, lock: :until_executed
+
+  FIELDS = ["Subscriber Email", "Subscribed Time"].freeze
+
+  def perform(export_id)
+    @export = AudienceExport.find(export_id)
+
+    tempfile = generate_csv
+    send_email(tempfile)
+    cleanup
+  end
+
+  private
+    def generate_csv
+      timestamp = Time.current.strftime("%Y-%m-%d-%H-%M-%S")
+      @filename = "Subscribers-#{@export.seller.username}_#{timestamp}.csv"
+
+      tempfile = Tempfile.new(["Subscribers", ".csv"], encoding: "UTF-8")
+
+      CSV.open(tempfile, "wb", headers: FIELDS, write_headers: true) do |csv|
+        @export.audience_export_chunks.order(:id).find_each(batch_size: 1) do |chunk|
+          chunk.members_data&.each do |email, created_at|
+            csv << [email, created_at]
+          end
+        end
+      end
+
+      tempfile.rewind
+      tempfile
+    end
+
+    def send_email(tempfile)
+      ContactingCreatorMailer.subscribers_data(
+        recipient: @export.recipient,
+        tempfile: tempfile,
+        filename: @filename
+      ).deliver_now
+    end
+
+    def cleanup
+      @export.audience_export_chunks.in_batches(of: 100).delete_all
+      @export.destroy!
+    end
+end

--- a/app/sidekiq/exports/audience/create_and_enqueue_chunks_job.rb
+++ b/app/sidekiq/exports/audience/create_and_enqueue_chunks_job.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class Exports::Audience::CreateAndEnqueueChunksJob
+  include Sidekiq::Job
+  sidekiq_options retry: 5, queue: :low, lock: :until_executed
+
+  CHUNK_SIZE = 1_000
+
+  def perform(export_id)
+    @export = AudienceExport.find(export_id)
+    create_chunks
+    enqueue_chunks
+  end
+
+  private
+    def create_chunks
+      @export.audience_export_chunks.in_batches(of: 100).delete_all
+
+      if build_query.none?
+        Exports::Audience::CompileChunksJob.perform_async(@export.id)
+        return
+      end
+
+      build_query.select(:id).order(:id).in_batches(of: CHUNK_SIZE) do |members|
+        @export.audience_export_chunks.create!(member_ids: members.ids)
+      end
+    end
+
+    def enqueue_chunks
+      return if @export.audience_export_chunks.empty?
+      Exports::Audience::ProcessChunkJob.perform_bulk(@export.audience_export_chunks.ids.map { [_1] })
+    end
+
+    def build_query
+      query = @export.seller.audience_members
+
+      scopes = []
+      scopes << query.where(follower: true) if @export.followers
+      scopes << query.where(customer: true) if @export.customers
+      scopes << query.where(affiliate: true) if @export.affiliates
+
+      scopes.any? ? scopes.reduce(&:or) : query.none
+    end
+end

--- a/app/sidekiq/exports/audience/process_chunk_job.rb
+++ b/app/sidekiq/exports/audience/process_chunk_job.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Exports::Audience::ProcessChunkJob
+  include Sidekiq::Job
+  sidekiq_options retry: 5, queue: :low, lock: :until_executed
+
+  def perform(chunk_id)
+    @chunk = AudienceExportChunk.find(chunk_id)
+    @export = @chunk.audience_export
+
+    process_chunk
+    trigger_compile_if_complete
+  end
+
+  private
+    def process_chunk
+      members = AudienceMember.where(id: @chunk.member_ids)
+                              .select(:email, :min_created_at)
+                              .order(:min_created_at)
+
+      members_data = members.map { |m| [m.email, m.min_created_at&.to_s] }
+
+      @chunk.update!(members_data: members_data, processed: true)
+    end
+
+    def trigger_compile_if_complete
+      return if @export.audience_export_chunks.where(processed: false).exists?
+      Exports::Audience::CompileChunksJob.perform_async(@export.id)
+    end
+end

--- a/app/sidekiq/exports/audience_export_worker.rb
+++ b/app/sidekiq/exports/audience_export_worker.rb
@@ -4,16 +4,51 @@ class Exports::AudienceExportWorker
   include Sidekiq::Job
   sidekiq_options retry: 5, queue: :low, lock: :until_executed
 
+  SYNC_EXPORT_THRESHOLD = 1_000
+
   def perform(seller_id, recipient_id, audience_options = {})
-    seller, recipient = User.find(seller_id, recipient_id)
-    recipient ||= seller
+    @seller, @recipient = User.find(seller_id, recipient_id)
+    @recipient ||= @seller
+    @audience_options = audience_options.with_indifferent_access
 
-    result = Exports::AudienceExportService.new(seller, audience_options).perform
-
-    ContactingCreatorMailer.subscribers_data(
-      recipient:,
-      tempfile: result.tempfile,
-      filename: result.filename,
-    ).deliver_now
+    if audience_count <= SYNC_EXPORT_THRESHOLD
+      perform_sync_export
+    else
+      perform_async_export
+    end
   end
+
+  private
+    def audience_count
+      query = @seller.audience_members
+
+      scopes = []
+      scopes << query.where(follower: true) if @audience_options[:followers]
+      scopes << query.where(customer: true) if @audience_options[:customers]
+      scopes << query.where(affiliate: true) if @audience_options[:affiliates]
+
+      scopes.any? ? scopes.reduce(&:or).count : 0
+    end
+
+    def perform_sync_export
+      result = Exports::AudienceExportService.new(@seller, @audience_options).perform
+
+      ContactingCreatorMailer.subscribers_data(
+        recipient: @recipient,
+        tempfile: result.tempfile,
+        filename: result.filename
+      ).deliver_now
+    end
+
+    def perform_async_export
+      export = AudienceExport.create!(
+        seller: @seller,
+        recipient: @recipient,
+        followers: @audience_options[:followers],
+        customers: @audience_options[:customers],
+        affiliates: @audience_options[:affiliates]
+      )
+
+      Exports::Audience::CreateAndEnqueueChunksJob.perform_async(export.id)
+    end
 end

--- a/db/migrate/20251229113511_create_audience_exports.rb
+++ b/db/migrate/20251229113511_create_audience_exports.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateAudienceExports < ActiveRecord::Migration[7.1]
+  def change
+    create_table :audience_exports do |t|
+      t.bigint :seller_id, null: false, index: true
+      t.bigint :recipient_id, null: false, index: true
+      t.text :json_data
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20251229113512_create_audience_export_chunks.rb
+++ b/db/migrate/20251229113512_create_audience_export_chunks.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateAudienceExportChunks < ActiveRecord::Migration[7.1]
+  def change
+    create_table :audience_export_chunks do |t|
+      t.bigint :audience_export_id, null: false, index: true
+      t.longtext :member_ids
+      t.longtext :members_data
+      t.boolean :processed, default: false, null: false
+      t.timestamps
+    end
+  end
+end

--- a/spec/models/audience_export_chunk_spec.rb
+++ b/spec/models/audience_export_chunk_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe AudienceExportChunk do
+  describe "associations" do
+    it "belongs to audience_export" do
+      export = create(:audience_export)
+      chunk = create(:audience_export_chunk, audience_export: export)
+      expect(chunk.audience_export).to eq(export)
+    end
+  end
+
+  describe "serialization" do
+    it "serializes member_ids as Array" do
+      ids = [1, 2, 3, 4, 5]
+      chunk = create(:audience_export_chunk, member_ids: ids)
+      chunk.reload
+      expect(chunk.member_ids).to eq(ids)
+    end
+
+    it "serializes members_data as Array" do
+      data = [
+        ["user1@example.com", "2024-01-01 00:00:00"],
+        ["user2@example.com", "2024-01-02 00:00:00"]
+      ]
+      chunk = create(:audience_export_chunk, members_data: data)
+      chunk.reload
+      expect(chunk.members_data).to eq(data)
+    end
+  end
+
+  describe "defaults" do
+    it "defaults processed to false" do
+      chunk = create(:audience_export_chunk)
+      expect(chunk.processed).to be(false)
+    end
+  end
+
+  describe "processed flag" do
+    it "can be marked as processed" do
+      chunk = create(:audience_export_chunk, processed: false)
+      chunk.update!(processed: true)
+      expect(chunk.reload.processed).to be(true)
+    end
+  end
+end

--- a/spec/models/audience_export_spec.rb
+++ b/spec/models/audience_export_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe AudienceExport do
+  describe "validations" do
+    it "requires at least one audience type to be selected" do
+      export = build(:audience_export, followers: false, customers: false, affiliates: false)
+      expect(export).not_to be_valid
+      expect(export.errors[:base]).to include("At least one audience type (followers, customers, or affiliates) must be selected")
+    end
+
+    it "is valid with followers selected" do
+      export = build(:audience_export, followers: true, customers: false, affiliates: false)
+      expect(export).to be_valid
+    end
+
+    it "is valid with customers selected" do
+      export = build(:audience_export, followers: false, customers: true, affiliates: false)
+      expect(export).to be_valid
+    end
+
+    it "is valid with affiliates selected" do
+      export = build(:audience_export, followers: false, customers: false, affiliates: true)
+      expect(export).to be_valid
+    end
+
+    it "is valid with multiple audience types selected" do
+      export = build(:audience_export, followers: true, customers: true, affiliates: true)
+      expect(export).to be_valid
+    end
+  end
+
+  describe "associations" do
+    it "belongs to seller" do
+      seller = create(:user)
+      export = create(:audience_export, seller: seller)
+      expect(export.seller).to eq(seller)
+    end
+
+    it "belongs to recipient" do
+      recipient = create(:user)
+      export = create(:audience_export, recipient: recipient)
+      expect(export.recipient).to eq(recipient)
+    end
+
+    it "has many audience_export_chunks" do
+      export = create(:audience_export)
+      chunk1 = create(:audience_export_chunk, audience_export: export)
+      chunk2 = create(:audience_export_chunk, audience_export: export)
+      expect(export.audience_export_chunks).to contain_exactly(chunk1, chunk2)
+    end
+  end
+
+  describe "#destroy" do
+    it "deletes associated chunks" do
+      export = create(:audience_export)
+      create(:audience_export_chunk, audience_export: export)
+      create(:audience_export_chunk, audience_export: export)
+      expect(AudienceExportChunk.count).to eq(2)
+
+      export.destroy!
+
+      expect(AudienceExportChunk.count).to eq(0)
+    end
+  end
+
+  describe "json_data accessors" do
+    it "stores and retrieves followers" do
+      export = create(:audience_export, followers: true)
+      export.reload
+      expect(export.followers).to eq(true)
+    end
+
+    it "stores and retrieves customers" do
+      export = create(:audience_export, customers: true)
+      export.reload
+      expect(export.customers).to eq(true)
+    end
+
+    it "stores and retrieves affiliates" do
+      export = create(:audience_export, affiliates: true)
+      export.reload
+      expect(export.affiliates).to eq(true)
+    end
+
+    it "defaults to false when not set" do
+      export = create(:audience_export, followers: true)
+      export.reload
+      expect(export.customers).to eq(false)
+      expect(export.affiliates).to eq(false)
+    end
+  end
+end

--- a/spec/sidekiq/exports/audience/compile_chunks_job_spec.rb
+++ b/spec/sidekiq/exports/audience/compile_chunks_job_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Exports::Audience::CompileChunksJob do
+  let(:seller) { create(:user) }
+  let(:recipient) { create(:user) }
+  let(:export) { create(:audience_export, seller: seller, recipient: recipient) }
+
+  before do
+    ActionMailer::Base.deliveries.clear
+  end
+
+  describe "#perform" do
+    context "with processed chunks" do
+      before do
+        create(:audience_export_chunk, audience_export: export, processed: true,
+          members_data: [["user1@example.com", "2024-01-01 00:00:00"], ["user2@example.com", "2024-01-02 00:00:00"]])
+        create(:audience_export_chunk, audience_export: export, processed: true,
+          members_data: [["user3@example.com", "2024-01-03 00:00:00"]])
+      end
+
+      it "sends email with CSV containing all members" do
+        described_class.new.perform(export.id)
+
+        expect(ActionMailer::Base.deliveries.count).to eq(1)
+        mail = ActionMailer::Base.deliveries.last
+        expect(mail.to).to eq([recipient.email])
+      end
+
+      it "generates CSV with correct content" do
+        described_class.new.perform(export.id)
+
+        mail = ActionMailer::Base.deliveries.last
+        attachment = mail.attachments.first
+        csv_content = CSV.parse(attachment.read)
+
+        expect(csv_content.size).to eq(4)
+        expect(csv_content[0]).to eq(["Subscriber Email", "Subscribed Time"])
+        expect(csv_content[1]).to eq(["user1@example.com", "2024-01-01 00:00:00"])
+        expect(csv_content[2]).to eq(["user2@example.com", "2024-01-02 00:00:00"])
+        expect(csv_content[3]).to eq(["user3@example.com", "2024-01-03 00:00:00"])
+      end
+
+      it "generates filename with seller username and timestamp" do
+        described_class.new.perform(export.id)
+
+        mail = ActionMailer::Base.deliveries.last
+        attachment = mail.attachments.first
+        expect(attachment.filename).to start_with("Subscribers-#{seller.username}_")
+        expect(attachment.filename).to end_with(".csv")
+      end
+
+      it "deletes chunks after completion" do
+        expect(AudienceExportChunk.count).to eq(2)
+
+        described_class.new.perform(export.id)
+
+        expect(AudienceExportChunk.count).to eq(0)
+      end
+
+      it "deletes export after completion" do
+        expect(AudienceExport.count).to eq(1)
+
+        described_class.new.perform(export.id)
+
+        expect(AudienceExport.count).to eq(0)
+      end
+    end
+
+    context "with empty chunks" do
+      it "sends email with headers-only CSV" do
+        described_class.new.perform(export.id)
+
+        mail = ActionMailer::Base.deliveries.last
+        attachment = mail.attachments.first
+        csv_content = CSV.parse(attachment.read)
+
+        expect(csv_content.size).to eq(1)
+        expect(csv_content[0]).to eq(["Subscriber Email", "Subscribed Time"])
+      end
+    end
+  end
+end

--- a/spec/sidekiq/exports/audience/create_and_enqueue_chunks_job_spec.rb
+++ b/spec/sidekiq/exports/audience/create_and_enqueue_chunks_job_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Exports::Audience::CreateAndEnqueueChunksJob do
+  let(:seller) { create(:user) }
+  let(:recipient) { create(:user) }
+  let(:export) { create(:audience_export, seller: seller, recipient: recipient, followers: true) }
+
+  before do
+    stub_const("#{described_class}::CHUNK_SIZE", 2)
+  end
+
+  describe "#perform" do
+    context "with audience members" do
+      before do
+        3.times do |i|
+          create(:audience_member,
+            seller: seller,
+            email: "follower#{i}@example.com",
+            details: { "follower" => { "id" => i, "created_at" => Time.current.iso8601 } }
+          )
+        end
+      end
+
+      it "creates chunks and enqueues ProcessChunkJob for each" do
+        described_class.new.perform(export.id)
+        export.reload
+
+        expect(export.audience_export_chunks.count).to eq(2)
+        expect(export.audience_export_chunks.first.member_ids.size).to eq(2)
+        expect(export.audience_export_chunks.second.member_ids.size).to eq(1)
+
+        expect(Exports::Audience::ProcessChunkJob).to have_enqueued_sidekiq_job(export.audience_export_chunks.first.id)
+        expect(Exports::Audience::ProcessChunkJob).to have_enqueued_sidekiq_job(export.audience_export_chunks.second.id)
+      end
+
+      it "deletes stale chunks on retry" do
+        create(:audience_export_chunk, audience_export: export, member_ids: [999])
+        expect(export.audience_export_chunks.count).to eq(1)
+
+        described_class.new.perform(export.id)
+        export.reload
+
+        expect(export.audience_export_chunks.count).to eq(2)
+        expect(export.audience_export_chunks.pluck(:member_ids).flatten).not_to include(999)
+      end
+    end
+
+    context "with empty audience" do
+      it "triggers CompileChunksJob immediately" do
+        described_class.new.perform(export.id)
+
+        expect(export.audience_export_chunks.count).to eq(0)
+        expect(Exports::Audience::CompileChunksJob).to have_enqueued_sidekiq_job(export.id)
+      end
+    end
+
+    context "with different audience types" do
+      before do
+        create(:audience_member, seller: seller, email: "follower@example.com",
+          details: { "follower" => { "id" => 1, "created_at" => Time.current.iso8601 } })
+        create(:audience_member, seller: seller, email: "customer@example.com",
+          details: { "purchases" => [{ "id" => 1, "product_id" => 1, "price_cents" => 1000, "created_at" => Time.current.iso8601 }] })
+      end
+
+      it "only includes followers when followers option is set" do
+        described_class.new.perform(export.id)
+        export.reload
+
+        expect(export.audience_export_chunks.count).to eq(1)
+        expect(export.audience_export_chunks.first.member_ids.size).to eq(1)
+      end
+
+      it "includes both when both options are set" do
+        export.update!(followers: true, customers: true)
+        described_class.new.perform(export.id)
+        export.reload
+
+        expect(export.audience_export_chunks.first.member_ids.size).to eq(2)
+      end
+    end
+  end
+end

--- a/spec/sidekiq/exports/audience/process_chunk_job_spec.rb
+++ b/spec/sidekiq/exports/audience/process_chunk_job_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Exports::Audience::ProcessChunkJob do
+  let(:seller) { create(:user) }
+  let(:export) { create(:audience_export, seller: seller) }
+
+  describe "#perform" do
+    context "when there are still chunks to process" do
+      let!(:chunk_1) { create(:audience_export_chunk, audience_export: export, processed: false) }
+      let!(:chunk_2) { create(:audience_export_chunk, audience_export: export, processed: false) }
+
+      before do
+        member1 = create(:audience_member, seller: seller, email: "user1@example.com",
+          details: { "follower" => { "id" => 1, "created_at" => "2024-01-01 00:00:00" } })
+        member2 = create(:audience_member, seller: seller, email: "user2@example.com",
+          details: { "follower" => { "id" => 2, "created_at" => "2024-01-02 00:00:00" } })
+        chunk_1.update!(member_ids: [member1.id])
+        chunk_2.update!(member_ids: [member2.id])
+      end
+
+      it "processes the chunk and marks it as processed" do
+        described_class.new.perform(chunk_1.id)
+        chunk_1.reload
+
+        expect(chunk_1.processed).to be(true)
+        expect(chunk_1.members_data.size).to eq(1)
+        expect(chunk_1.members_data.first.first).to eq("user1@example.com")
+      end
+
+      it "does not trigger CompileChunksJob when other chunks are pending" do
+        described_class.new.perform(chunk_1.id)
+
+        expect(Exports::Audience::CompileChunksJob).not_to have_enqueued_sidekiq_job(export.id)
+      end
+    end
+
+    context "when this is the last chunk" do
+      let!(:chunk_1) { create(:audience_export_chunk, audience_export: export, processed: true, members_data: [["done@example.com", "2024-01-01"]]) }
+      let!(:chunk_2) { create(:audience_export_chunk, audience_export: export, processed: false) }
+
+      before do
+        member = create(:audience_member, seller: seller, email: "last@example.com",
+          details: { "follower" => { "id" => 1, "created_at" => "2024-01-03 00:00:00" } })
+        chunk_2.update!(member_ids: [member.id])
+      end
+
+      it "triggers CompileChunksJob" do
+        described_class.new.perform(chunk_2.id)
+
+        expect(Exports::Audience::CompileChunksJob).to have_enqueued_sidekiq_job(export.id)
+      end
+    end
+
+    context "with multiple members in a chunk" do
+      let!(:chunk) { create(:audience_export_chunk, audience_export: export) }
+
+      before do
+        members = 3.times.map do |i|
+          create(:audience_member, seller: seller, email: "user#{i}@example.com",
+            details: { "follower" => { "id" => i, "created_at" => (3 - i).days.ago.iso8601 } })
+        end
+        chunk.update!(member_ids: members.map(&:id))
+      end
+
+      it "processes all members and orders by min_created_at" do
+        described_class.new.perform(chunk.id)
+        chunk.reload
+
+        expect(chunk.members_data.size).to eq(3)
+        emails = chunk.members_data.map(&:first)
+        expect(emails).to eq(["user0@example.com", "user1@example.com", "user2@example.com"])
+      end
+    end
+  end
+end

--- a/spec/sidekiq/exports/audience_export_worker_spec.rb
+++ b/spec/sidekiq/exports/audience_export_worker_spec.rb
@@ -1,29 +1,110 @@
 # frozen_string_literal: true
 
+require "spec_helper"
+
 describe Exports::AudienceExportWorker do
   describe "#perform" do
     let(:seller) { create(:user) }
-    let(:audience_options) { { followers: true } }
+    let(:audience_options) { { "followers" => true } }
     let(:recipient) { create(:user) }
 
     before do
       ActionMailer::Base.deliveries.clear
     end
 
-    it "sends email to seller when it is also the recipient" do
-      expect(ContactingCreatorMailer).to receive(:subscribers_data).and_call_original
-      described_class.new.perform(seller.id, seller.id, audience_options)
+    describe "sync export path (small audience)" do
+      it "sends email to seller when it is also the recipient" do
+        expect(ContactingCreatorMailer).to receive(:subscribers_data).and_call_original
+        described_class.new.perform(seller.id, seller.id, audience_options)
 
-      mail = ActionMailer::Base.deliveries.last
-      expect(mail.to).to eq([seller.email])
+        mail = ActionMailer::Base.deliveries.last
+        expect(mail.to).to eq([seller.email])
+      end
+
+      it "sends email to recipient" do
+        expect(ContactingCreatorMailer).to receive(:subscribers_data).and_call_original
+        described_class.new.perform(seller.id, recipient.id, audience_options)
+
+        mail = ActionMailer::Base.deliveries.last
+        expect(mail.to).to eq([recipient.email])
+      end
+
+      it "does not create AudienceExport record for small audiences" do
+        create(:audience_member, seller: seller, email: "follower@example.com",
+          details: { "follower" => { "id" => 1, "created_at" => Time.current.iso8601 } })
+
+        expect {
+          described_class.new.perform(seller.id, recipient.id, audience_options)
+        }.not_to change { AudienceExport.count }
+      end
     end
 
-    it "sends email to recipient" do
-      expect(ContactingCreatorMailer).to receive(:subscribers_data).and_call_original
-      described_class.new.perform(seller.id, recipient.id, audience_options)
+    describe "async export path (large audience)" do
+      before do
+        stub_const("#{described_class}::SYNC_EXPORT_THRESHOLD", 2)
+        3.times do |i|
+          create(:audience_member, seller: seller, email: "follower#{i}@example.com",
+            details: { "follower" => { "id" => i, "created_at" => Time.current.iso8601 } })
+        end
+      end
 
-      mail = ActionMailer::Base.deliveries.last
-      expect(mail.to).to eq([recipient.email])
+      it "creates AudienceExport record" do
+        expect {
+          described_class.new.perform(seller.id, recipient.id, audience_options)
+        }.to change { AudienceExport.count }.by(1)
+
+        export = AudienceExport.last
+        expect(export.seller).to eq(seller)
+        expect(export.recipient).to eq(recipient)
+        expect(export.followers).to eq(true)
+        expect(export.customers).to eq(false)
+        expect(export.affiliates).to eq(false)
+      end
+
+      it "enqueues CreateAndEnqueueChunksJob" do
+        described_class.new.perform(seller.id, recipient.id, audience_options)
+
+        export = AudienceExport.last
+        expect(Exports::Audience::CreateAndEnqueueChunksJob).to have_enqueued_sidekiq_job(export.id)
+      end
+
+      it "does not send email synchronously" do
+        described_class.new.perform(seller.id, recipient.id, audience_options)
+
+        expect(ActionMailer::Base.deliveries).to be_empty
+      end
+    end
+
+    describe "threshold boundary" do
+      before do
+        stub_const("#{described_class}::SYNC_EXPORT_THRESHOLD", 2)
+      end
+
+      it "uses sync export at exactly threshold" do
+        2.times do |i|
+          create(:audience_member, seller: seller, email: "follower#{i}@example.com",
+            details: { "follower" => { "id" => i, "created_at" => Time.current.iso8601 } })
+        end
+
+        expect {
+          described_class.new.perform(seller.id, recipient.id, audience_options)
+        }.not_to change { AudienceExport.count }
+
+        expect(ActionMailer::Base.deliveries.count).to eq(1)
+      end
+
+      it "uses async export at threshold + 1" do
+        3.times do |i|
+          create(:audience_member, seller: seller, email: "follower#{i}@example.com",
+            details: { "follower" => { "id" => i, "created_at" => Time.current.iso8601 } })
+        end
+
+        expect {
+          described_class.new.perform(seller.id, recipient.id, audience_options)
+        }.to change { AudienceExport.count }.by(1)
+
+        expect(ActionMailer::Base.deliveries).to be_empty
+      end
     end
   end
 end

--- a/spec/support/factories/audience_export_chunks.rb
+++ b/spec/support/factories/audience_export_chunks.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :audience_export_chunk do
+    association :audience_export
+    member_ids { [] }
+    members_data { [] }
+    processed { false }
+  end
+end

--- a/spec/support/factories/audience_exports.rb
+++ b/spec/support/factories/audience_exports.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :audience_export do
+    association :seller, factory: :user
+    association :recipient, factory: :user
+    followers { true }
+  end
+end


### PR DESCRIPTION
Issue: #2092

This is a revised implementation addressing feedback from #2533.

# Description

## Problem

Large audience exports (followers/subscribers CSV) timeout because the entire export happens in a single Sidekiq job. Users with large audiences never receive their export emails.

## Solution

Implement a chunked export pipeline (following the existing `SalesExport` pattern):

- **CreateAndEnqueueChunksJob** - splits audience into 1000-member chunks using `in_batches` (memory-efficient)
- **ProcessChunkJob** - processes each chunk independently with `lock: :until_executed`
- **CompileChunksJob** - assembles final CSV and sends email

Small audiences (≤1000 members) continue using the existing synchronous path for efficiency.

**Key implementation details:**
- Uses `JsonData` module with `attr_json_data_accessor` for options (per maintainer feedback)
- Uses `in_batches` for memory-efficient chunking (no `pluck` into memory)
- Uses `scopes.reduce(&:or)` pattern for query building
- All jobs use `lock: :until_executed` for idempotency
- Follows Rails conventions for association naming (`audience_export_id`)

---

# Before/After

Backend-only change

---

# Test Results

<img width="1091" height="619" alt="Screenshot 2026-01-23 at 3 02 46 pm" src="https://github.com/user-attachments/assets/1c9ef4da-977b-408d-9653-3939ae011575" />


---

# Checklist

- [x] I have read the contributing guidelines
- [x] I have watched Gumroad PR review livestreams
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

AI (Claude Code) was used for:
- Code implementation (Sidekiq job classes, chunking logic, CSV compilation)
- Addressing maintainer feedback from PR #2533 (JsonData module, in_batches, scopes pattern)
- Test writing (RSpec specs including edge cases)
- Code review and debugging