### PR TITLE
Add onetime script to enable membership renewal reminders

### DIFF
--- a/app/services/onetime/enable_membership_renewal_reminders.rb
+++ b/app/services/onetime/enable_membership_renewal_reminders.rb
@@ -36,7 +36,6 @@ module Onetime
 
         begin
           puts "\nSubscription #{subscription.id}"
-          puts "  Product: #{subscription.link&.name}"
           puts "  Customer: #{subscription.email}"
           puts "  Next renewal: #{subscription.end_time_of_subscription.strftime('%Y-%m-%d %H:%M')}"
           puts "  Reminder at: #{subscription.send_renewal_reminder_at.strftime('%Y-%m-%d %H:%M')}"


### PR DESCRIPTION
Issue: https://github.com/antiwork/gumroad-private/issues/88

# Description

Add a one-time script to enable the `membership_renewal_reminders` feature for sellers and schedule reminder jobs for their existing active subscriptions

## Problem
Enabling the `membership_renewal_reminders` feature flag only affects new subscriptions, leaving existing active subscriptions without scheduled reminder jobs

## Solution
Created `Onetime::EnableMembershipRenewalReminders` service that activates the feature flag for a seller and schedules `RecurringChargeReminderWorker` jobs for all their eligible existing subscriptions, with dry run mode for safe testing

# Result
### Dry Run `true`
<img width="681" height="354" alt="Screenshot 2026-01-23 at 20 30 04" src="https://github.com/user-attachments/assets/cd6d3fb2-5eeb-4a60-bcd1-1dc2a17a60da" />


### Dry Run `false`
<img width="679" height="346" alt="Screenshot 2026-01-23 at 20 31 47" src="https://github.com/user-attachments/assets/2e05973e-1ffe-48ac-9e76-93c579d5912d" />

### After (`RecurringChargeReminderWorker` job scheduled)
<img width="1470" height="512" alt="Screenshot 2026-01-23 at 20 32 41" src="https://github.com/user-attachments/assets/3fbe50dc-3d4c-48d9-a41e-90319b99e71f" />

# AI Disclosure

Cursor - Claude Sonnet 4.5 for code generation, self reviewed by me


```
# DRY RUN
Onetime::EnableMembershipRenewalReminders.perform(user_id: "1")

# LIVE
Onetime::EnableMembershipRenewalReminders.perform(user_id: "1", dry_run: false)
```