### PR TITLE
Remove old links#index view

### DIFF
--- a/app/views/links/index.html.erb
+++ b/app/views/links/index.html.erb
@@ -1,2 +1,0 @@
-<%= load_pack("products") %>
-<%= react_component "ProductsDashboardPage", props: @react_products_page_props, prerender: true %>


### PR DESCRIPTION
Left over from the migration of the Products Dashboard page to Inertia. This PR removes the old ERB view.