### PR TITLE
fix: decouple sidebar and content scroll in download page

### DIFF
--- a/app/javascript/components/Download/PageListLayout.tsx
+++ b/app/javascript/components/Download/PageListLayout.tsx
@@ -7,19 +7,28 @@ export const PageListLayout = ({
   pageList,
   children,
   className,
+  contentRef,
 }: {
   pageList: React.ReactNode;
   children: React.ReactNode;
   className?: string;
+  contentRef?: React.RefObject<HTMLDivElement>;
 }) => (
   <div
     className={classNames(
-      "flex min-h-0 flex-col gap-6 bg-background p-4 [scrollbar-gutter:stable] md:p-8 lg:flex-row lg:gap-16 lg:overflow-y-auto",
+      "flex min-h-0 flex-col gap-6 bg-background p-4 [scrollbar-gutter:stable] md:p-8 lg:flex-row lg:gap-16",
       className,
     )}
   >
-    <div className="flex flex-col gap-4 lg:sticky lg:top-0 lg:w-80 lg:pb-8">{pageList}</div>
-    <div className="h-0 flex-1">{children}</div>
+    <div className="flex flex-col gap-4 lg:w-80 lg:max-h-[calc(100vh-4rem)] lg:overflow-y-auto lg:pb-8 [scrollbar-gutter:stable]">
+      {pageList}
+    </div>
+    <div
+      ref={contentRef}
+      className="h-0 flex-1 lg:max-h-[calc(100vh-4rem)] lg:overflow-y-auto [scrollbar-gutter:stable]"
+    >
+      {children}
+    </div>
   </div>
 );
 

--- a/app/javascript/components/server-components/DownloadPage/Layout.tsx
+++ b/app/javascript/components/server-components/DownloadPage/Layout.tsx
@@ -79,7 +79,13 @@ export const Layout = ({
   headerActions,
   pageList,
   children,
-}: LayoutProps & { headerActions?: React.ReactNode; pageList?: React.ReactNode; children: React.ReactNode }) => {
+  contentRef,
+}: LayoutProps & {
+  headerActions?: React.ReactNode;
+  pageList?: React.ReactNode;
+  children: React.ReactNode;
+  contentRef?: React.RefObject<HTMLDivElement>;
+}) => {
   const loggedInUser = useLoggedInUser();
   const [isResendingReceipt, setIsResendingReceipt] = React.useState(false);
   const isDesktop = useIsAboveBreakpoint("lg");
@@ -256,6 +262,7 @@ export const Layout = ({
         {settings || pageList ? (
           <PageListLayout
             className="flex-1"
+            contentRef={contentRef}
             pageList={
               <>
                 {pageList}

--- a/app/javascript/components/server-components/DownloadPage/WithContent.tsx
+++ b/app/javascript/components/server-components/DownloadPage/WithContent.tsx
@@ -216,6 +216,7 @@ const WithContent = ({
   };
   const [activePageIndex, setActivePageIndex] = React.useState(getInitialPageIndex());
   const activePage = pages[activePageIndex];
+  const contentRef = React.useRef<HTMLDivElement>(null);
 
   const handlePageChange = React.useCallback(
     (newIndex: number) => {
@@ -224,6 +225,7 @@ const WithContent = ({
       if (newPage && props.purchase) {
         void saveLastContentPage(props.token, newPage.page_id);
       }
+      contentRef.current?.scrollTo({ top: 0, behavior: "smooth" });
     },
     [pages, props.token, props.purchase],
   );
@@ -276,6 +278,7 @@ const WithContent = ({
   return (
     <Layout
       {...props}
+      contentRef={contentRef}
       headerActions={
         <>
           {props.purchase && content.discord ? (


### PR DESCRIPTION
## Summary
- Split `PageListLayout` into independent scroll containers for sidebar and content area on desktop
- Added `contentRef` prop to enable scroll-to-top when changing pages
- Content smoothly scrolls to top when selecting a different page from the sidebar

Fixes #2924

## Changes
- `PageListLayout.tsx`: Each child div now has its own `lg:max-h-[calc(100vh-4rem)] lg:overflow-y-auto` instead of the parent having overflow
- `Layout.tsx`: Accept and pass `contentRef` prop to `PageListLayout`
- `WithContent.tsx`: Create ref, pass to Layout, scroll to top on page change

## Test Plan
- [ ] On desktop (lg breakpoint), scroll sidebar - content should NOT scroll
- [ ] On desktop, scroll content - sidebar should NOT scroll
- [ ] Click on different page in sidebar - content should scroll to top smoothly
- [ ] On mobile, both should still scroll together (no changes to mobile behavior)