### PR TITLE
fix: show placeholder after deleting last product

### DIFF
--- a/app/javascript/components/ArchivedProductsPage.tsx
+++ b/app/javascript/components/ArchivedProductsPage.tsx
@@ -9,6 +9,7 @@ import { PaginationProps } from "$app/components/Pagination";
 import { Popover } from "$app/components/Popover";
 import { ProductsLayout } from "$app/components/ProductsLayout";
 import ProductsPage from "$app/components/ProductsPage";
+import { Placeholder } from "$app/components/ui/Placeholder";
 import { Sort } from "$app/components/useSortingTableDriver";
 import { WithTooltip } from "$app/components/WithTooltip";
 
@@ -85,6 +86,17 @@ export const ArchivedProductsPage = ({
           productsSort={productsSort}
           query={query}
           type="archived"
+          emptyPlaceholder={
+            <Placeholder>
+              <h2>No archived products</h2>
+              <p>Products you archive will appear here.</p>
+              <div>
+                <NavigationButtonInertia href={Routes.products_path()} color="accent">
+                  Back to products
+                </NavigationButtonInertia>
+              </div>
+            </Placeholder>
+          }
         />
       </section>
     </ProductsLayout>

--- a/app/javascript/components/ProductsDashboardPage.tsx
+++ b/app/javascript/components/ProductsDashboardPage.tsx
@@ -53,7 +53,7 @@ export const ProductsDashboardPage = ({
       archivedTabVisible={enableArchiveTab}
       ctaButton={
         <>
-          {products.length > 0 ? (
+          {products.length > 0 || memberships.length > 0 ? (
             <Popover
               open={isSearchPopoverOpen}
               onToggle={setIsSearchPopoverOpen}
@@ -86,35 +86,34 @@ export const ProductsDashboardPage = ({
       }
     >
       <section className="p-4 md:p-8">
-        {memberships.length === 0 && products.length === 0 ? (
-          <Placeholder>
-            <PlaceholderImage src={placeholder} />
-            <h2>We’ve never met an idea we didn’t like.</h2>
-            <p>Your first product doesn’t need to be perfect. Just put it out there, and see if it sticks.</p>
-            <div>
-              <NavigationButtonInertia href={Routes.new_product_path()} disabled={!canCreateProduct} color="accent">
-                New product
-              </NavigationButtonInertia>
-            </div>
-            <span>
-              or{" "}
-              <a href="/help/article/304-products-dashboard" target="_blank" rel="noreferrer">
-                learn more about the products dashboard
-              </a>
-            </span>
-          </Placeholder>
-        ) : (
-          <ProductsPage
-            memberships={memberships}
-            membershipsPagination={membershipsPagination}
-            membershipsSort={membershipsSort}
-            products={products}
-            productsPagination={productsPagination}
-            productsSort={productsSort}
-            query={query}
-            setEnableArchiveTab={setEnableArchiveTab}
-          />
-        )}
+        <ProductsPage
+          memberships={memberships}
+          membershipsPagination={membershipsPagination}
+          membershipsSort={membershipsSort}
+          products={products}
+          productsPagination={productsPagination}
+          productsSort={productsSort}
+          query={query}
+          setEnableArchiveTab={setEnableArchiveTab}
+          emptyPlaceholder={
+            <Placeholder>
+              <PlaceholderImage src={placeholder} />
+              <h2>We've never met an idea we didn't like.</h2>
+              <p>Your first product doesn't need to be perfect. Just put it out there, and see if it sticks.</p>
+              <div>
+                <NavigationButtonInertia href={Routes.new_product_path()} disabled={!canCreateProduct} color="accent">
+                  New product
+                </NavigationButtonInertia>
+              </div>
+              <span>
+                or{" "}
+                <a href="/help/article/304-products-dashboard" target="_blank" rel="noreferrer">
+                  learn more about the products dashboard
+                </a>
+              </span>
+            </Placeholder>
+          }
+        />
       </section>
     </ProductsLayout>
   );

--- a/app/javascript/components/ProductsPage.tsx
+++ b/app/javascript/components/ProductsPage.tsx
@@ -18,6 +18,7 @@ const ProductsPage = ({
   query,
   setEnableArchiveTab,
   type = "products",
+  emptyPlaceholder,
 }: {
   memberships: Membership[];
   membershipsPagination: PaginationProps;
@@ -28,30 +29,37 @@ const ProductsPage = ({
   query: string | null;
   setEnableArchiveTab?: (enable: boolean) => void;
   type?: Tab;
-}) => (
-  <div className="grid gap-12">
-    {memberships.length > 0 ? (
-      <ProductsPageMembershipsTable
-        query={query}
-        entries={memberships}
-        pagination={membershipsPagination}
-        sort={membershipsSort}
-        selectedTab={type}
-        setEnableArchiveTab={setEnableArchiveTab}
-      />
-    ) : null}
+  emptyPlaceholder?: React.ReactNode;
+}) => {
+  if (memberships.length === 0 && products.length === 0) {
+    return <>{emptyPlaceholder}</>;
+  }
 
-    {products.length > 0 ? (
-      <ProductsPageProductsTable
-        query={query}
-        entries={products}
-        pagination={productsPagination}
-        sort={productsSort}
-        selectedTab={type}
-        setEnableArchiveTab={setEnableArchiveTab}
-      />
-    ) : null}
-  </div>
-);
+  return (
+    <div className="grid gap-12">
+      {memberships.length > 0 ? (
+        <ProductsPageMembershipsTable
+          query={query}
+          entries={memberships}
+          pagination={membershipsPagination}
+          sort={membershipsSort}
+          selectedTab={type}
+          setEnableArchiveTab={setEnableArchiveTab}
+        />
+      ) : null}
+
+      {products.length > 0 ? (
+        <ProductsPageProductsTable
+          query={query}
+          entries={products}
+          pagination={productsPagination}
+          sort={productsSort}
+          selectedTab={type}
+          setEnableArchiveTab={setEnableArchiveTab}
+        />
+      ) : null}
+    </div>
+  );
+};
 
 export default ProductsPage;


### PR DESCRIPTION
## Summary
- Added `emptyPlaceholder` prop to `ProductsPage` component
- ProductsPage now handles empty state internally instead of relying on parent's conditional rendering
- This ensures placeholder shows correctly after Inertia partial reload

Fixes #2643

## Changes
- `ProductsPage.tsx`: Added `emptyPlaceholder` prop, returns placeholder when both arrays are empty
- `ProductsDashboardPage.tsx`: Passes placeholder via prop instead of wrapping in conditional
- `ArchivedProductsPage.tsx`: Added empty state placeholder with "Back to products" link

## Root Cause
The original conditional rendering in `ProductsDashboardPage` checked empty state BEFORE rendering `ProductsPage`. After a product deletion via partial Inertia reload (`only: ["products_data"]`), the component re-renders but `ProductsPage` was already rendered and just returned an empty div.

By moving the empty check INTO `ProductsPage` and having it render the placeholder directly, the empty state is properly shown after deletion.

## Test Plan
- [ ] On Products Dashboard, delete the last product - placeholder should appear
- [ ] On Archived Products, unarchive the last product - placeholder should appear with "Back to products" link
- [ ] Search popover should hide when no products exist
- [ ] Existing behavior with multiple products unchanged