### PR TITLE
fix(risk): TOS violation suspensions no longer trigger fraud suspensions

### DIFF
--- a/app/sidekiq/check_payment_address_worker.rb
+++ b/app/sidekiq/check_payment_address_worker.rb
@@ -6,15 +6,33 @@ class CheckPaymentAddressWorker
 
   def perform(user_id)
     user = User.find_by(id: user_id)
-    return if !user.can_flag_for_fraud? || user.payment_address.blank?
-
-    banned_accounts_with_same_payment_address = User.where(
-      payment_address: user.payment_address,
-      user_risk_state: ["suspended_for_tos_violation", "suspended_for_fraud"]
-    )
+    return if user.nil? || user.payment_address.blank?
 
     blocked_email = BlockedObject.find_active_object(user.payment_address)
 
-    user.flag_for_fraud!(author_name: "CheckPaymentAddress") if banned_accounts_with_same_payment_address.exists? || blocked_email.present?
+    fraud_accounts = User.where(
+      payment_address: user.payment_address,
+      user_risk_state: "suspended_for_fraud"
+    )
+
+    if (fraud_accounts.exists? || blocked_email.present?) && user.can_flag_for_fraud?
+      user.flag_for_fraud!(author_name: "CheckPaymentAddress")
+      return
+    end
+
+    return unless user.not_reviewed? || user.compliant?
+
+    tos_accounts = User.where(
+      payment_address: user.payment_address,
+      user_risk_state: "suspended_for_tos_violation"
+    )
+
+    if tos_accounts.exists?
+      related_account = tos_accounts.first
+      user.put_on_probation!(
+        author_name: "CheckPaymentAddress",
+        content: "Probated for having the same payout address as a previously suspended account (User##{related_account.id})"
+      )
+    end
   end
 end

--- a/app/sidekiq/suspend_accounts_with_payment_address_worker.rb
+++ b/app/sidekiq/suspend_accounts_with_payment_address_worker.rb
@@ -10,15 +10,24 @@ class SuspendAccountsWithPaymentAddressWorker
     return if suspended_user.payment_address.blank?
 
     User.where(payment_address: suspended_user.payment_address).where.not(id: suspended_user.id).not_suspended.find_each do |user|
-      user.flag_for_fraud(
-        author_name: "suspend_sellers_other_accounts",
-        content: "Flagged for fraud automatically on #{Time.current.to_fs(:formatted_date_full_month)} because of usage of payment address #{suspended_user.payment_address} (from User##{suspended_user.id})"
-      )
-      user.suspend_for_fraud(
-        author_name: "suspend_sellers_other_accounts",
-        content: "Suspended for fraud automatically on #{Time.current.to_fs(:formatted_date_full_month)} because of usage of payment address #{suspended_user.payment_address} (from User##{suspended_user.id})",
-        skip_transition_callback: :suspend_sellers_other_accounts
-      )
+      if suspended_user.suspended_for_fraud?
+        user.flag_for_fraud(
+          author_name: "suspend_sellers_other_accounts",
+          content: "Flagged for fraud automatically on #{Time.current.to_fs(:formatted_date_full_month)} because of usage of payment address #{suspended_user.payment_address} (from User##{suspended_user.id})"
+        )
+        user.suspend_for_fraud(
+          author_name: "suspend_sellers_other_accounts",
+          content: "Suspended for fraud automatically on #{Time.current.to_fs(:formatted_date_full_month)} because of usage of payment address #{suspended_user.payment_address} (from User##{suspended_user.id})",
+          skip_transition_callback: :suspend_sellers_other_accounts
+        )
+      elsif suspended_user.suspended_for_tos_violation?
+        next if user.on_probation? || user.flagged?
+
+        user.put_on_probation!(
+          author_name: "suspend_sellers_other_accounts",
+          content: "Probated automatically on #{Time.current.to_fs(:formatted_date_full_month)} for having the same payout address as a previously suspended account (User##{suspended_user.id})"
+        )
+      end
     end
   end
 end

--- a/spec/sidekiq/check_payment_address_worker_spec.rb
+++ b/spec/sidekiq/check_payment_address_worker_spec.rb
@@ -14,12 +14,14 @@ describe CheckPaymentAddressWorker do
     expect(@user.reload.flagged?).to be(false)
   end
 
-  it "flags the user for fraud if there are other banned users with the same payment address" do
-    @user = create(:user, payment_address: "tuhins@gmail.com")
+  context "when there is a fraud-suspended account with the same payment address" do
+    it "flags the user for fraud" do
+      @user = create(:user, payment_address: "tuhins@gmail.com")
 
-    CheckPaymentAddressWorker.new.perform(@user.id)
+      CheckPaymentAddressWorker.new.perform(@user.id)
 
-    expect(@user.reload.flagged?).to be(true)
+      expect(@user.reload.flagged_for_fraud?).to be(true)
+    end
   end
 
   it "flags the user for fraud if a blocked email object exists for their payment address" do
@@ -28,5 +30,61 @@ describe CheckPaymentAddressWorker do
     CheckPaymentAddressWorker.new.perform(@user.id)
 
     expect(@user.reload.flagged?).to be(true)
+  end
+
+  context "when there is only a TOS-suspended account with the same payment address" do
+    before do
+      @tos_suspended_user = create(:user, user_risk_state: "suspended_for_tos_violation", payment_address: "tosviolator@gmail.com")
+    end
+
+    it "puts the user on probation instead of flagging for fraud" do
+      @user = create(:user, payment_address: "tosviolator@gmail.com")
+
+      CheckPaymentAddressWorker.new.perform(@user.id)
+
+      expect(@user.reload.on_probation?).to be(true)
+      expect(@user.flagged?).to be(false)
+      expect(@user.comments.last.content).to eq("Probated for having the same payout address as a previously suspended account (User##{@tos_suspended_user.id})")
+    end
+
+    it "does not put the user on probation if already on probation" do
+      @user = create(:user, payment_address: "tosviolator@gmail.com", user_risk_state: "on_probation")
+
+      expect { CheckPaymentAddressWorker.new.perform(@user.id) }.not_to change { @user.comments.count }
+    end
+
+    it "does not put the user on probation if already flagged" do
+      @user = create(:user, payment_address: "tosviolator@gmail.com", user_risk_state: "flagged_for_fraud")
+
+      CheckPaymentAddressWorker.new.perform(@user.id)
+
+      expect(@user.reload.flagged_for_fraud?).to be(true)
+      expect(@user.on_probation?).to be(false)
+    end
+  end
+
+  context "when there are both fraud-suspended and TOS-suspended accounts with the same payment address" do
+    before do
+      @tos_suspended_user = create(:user, user_risk_state: "suspended_for_tos_violation", payment_address: "tuhins@gmail.com")
+    end
+
+    it "flags the user for fraud (fraud takes precedence)" do
+      @user = create(:user, payment_address: "tuhins@gmail.com")
+
+      CheckPaymentAddressWorker.new.perform(@user.id)
+
+      expect(@user.reload.flagged_for_fraud?).to be(true)
+      expect(@user.on_probation?).to be(false)
+    end
+  end
+
+  it "does nothing if the user has no payment address" do
+    @user = create(:user, payment_address: nil)
+
+    expect { CheckPaymentAddressWorker.new.perform(@user.id) }.not_to change { @user.reload.user_risk_state }
+  end
+
+  it "does nothing if the user is not found" do
+    expect { CheckPaymentAddressWorker.new.perform(0) }.not_to raise_error
   end
 end

--- a/spec/sidekiq/suspend_accounts_with_payment_address_worker_spec.rb
+++ b/spec/sidekiq/suspend_accounts_with_payment_address_worker_spec.rb
@@ -8,12 +8,52 @@ describe SuspendAccountsWithPaymentAddressWorker do
       create(:user) # admin user
     end
 
-    it "suspends other accounts with the same payment address" do
-      described_class.new.perform(@user.id)
+    context "when suspended for fraud" do
+      before do
+        @user.update!(user_risk_state: "suspended_for_fraud")
+      end
 
-      expect(@user_2.reload.suspended?).to be(true)
-      expect(@user_2.comments.first.content).to eq("Flagged for fraud automatically on #{Time.current.to_fs(:formatted_date_full_month)} because of usage of payment address #{@user.payment_address} (from User##{@user.id})")
-      expect(@user_2.comments.last.content).to eq("Suspended for fraud automatically on #{Time.current.to_fs(:formatted_date_full_month)} because of usage of payment address #{@user.payment_address} (from User##{@user.id})")
+      it "suspends other accounts with the same payment address for fraud" do
+        described_class.new.perform(@user.id)
+
+        expect(@user_2.reload.suspended_for_fraud?).to be(true)
+        expect(@user_2.comments.first.content).to eq("Flagged for fraud automatically on #{Time.current.to_fs(:formatted_date_full_month)} because of usage of payment address #{@user.payment_address} (from User##{@user.id})")
+        expect(@user_2.comments.last.content).to eq("Suspended for fraud automatically on #{Time.current.to_fs(:formatted_date_full_month)} because of usage of payment address #{@user.payment_address} (from User##{@user.id})")
+      end
+    end
+
+    context "when suspended for TOS violation" do
+      before do
+        @user.update!(user_risk_state: "suspended_for_tos_violation")
+      end
+
+      it "puts other accounts on probation instead of suspending for fraud" do
+        described_class.new.perform(@user.id)
+
+        expect(@user_2.reload.on_probation?).to be(true)
+        expect(@user_2.suspended?).to be(false)
+        expect(@user_2.comments.last.content).to eq("Probated automatically on #{Time.current.to_fs(:formatted_date_full_month)} for having the same payout address as a previously suspended account (User##{@user.id})")
+      end
+
+      it "skips users who are already on probation" do
+        @user_2.update!(user_risk_state: "on_probation")
+
+        expect { described_class.new.perform(@user.id) }.not_to change { @user_2.comments.count }
+        expect(@user_2.reload.on_probation?).to be(true)
+      end
+
+      it "skips users who are already flagged" do
+        @user_2.update!(user_risk_state: "flagged_for_fraud")
+
+        expect { described_class.new.perform(@user.id) }.not_to change { @user_2.comments.count }
+        expect(@user_2.reload.flagged_for_fraud?).to be(true)
+      end
+    end
+
+    it "does nothing if the suspended user has no payment address" do
+      @user.update!(payment_address: nil, user_risk_state: "suspended_for_fraud")
+
+      expect { described_class.new.perform(@user.id) }.not_to change { @user_2.reload.user_risk_state }
     end
   end
 end


### PR DESCRIPTION
Closes #2830

## Summary

- TOS violation suspensions now put related accounts (same payment address) **on probation** instead of suspending them for fraud
- Fraud suspensions continue to suspend related accounts for fraud (unchanged behavior)
- Both `SuspendAccountsWithPaymentAddressWorker` and `CheckPaymentAddressWorker` now handle TOS and fraud cases separately
- Probation notes include the suspended user's ID for traceability

## Root Cause

The previous implementation treated TOS violations and fraud suspensions identically when processing related accounts with the same payment address. Both `SuspendAccountsWithPaymentAddressWorker` (triggered on suspension) and `CheckPaymentAddressWorker` (triggered on payment address update) would flag and suspend accounts for fraud regardless of the original suspension reason.

Per @gumroadsteve2's specification in #2830, TOS violations should result in probation with an explanatory admin note, not fraud suspension.

## Changes

### `SuspendAccountsWithPaymentAddressWorker`
- Added conditional logic based on `suspended_user.suspended_for_fraud?` vs `suspended_user.suspended_for_tos_violation?`
- Fraud: flag + suspend for fraud (unchanged)
- TOS: put on probation with note: "Probated automatically on [date] for having the same payout address as a previously suspended account (User#123)"
- Skips users already on probation or flagged

### `CheckPaymentAddressWorker`  
- Separated fraud and TOS account queries
- Fraud accounts or blocked email → flag for fraud (fraud takes precedence)
- TOS accounts only → put on probation with note
- Only probates users who are `not_reviewed` or `compliant`

## Test Plan

- [x] All 14 worker spec tests pass
- [x] All 6 existing "seller with multiple accounts" user model tests pass
- [x] Manual verification in staging

### Test Commands
```bash
bin/rspec spec/sidekiq/check_payment_address_worker_spec.rb
bin/rspec spec/sidekiq/suspend_accounts_with_payment_address_worker_spec.rb
bin/rspec spec/models/user_spec.rb -e "seller with multiple accounts"
```

## Screenshots

### Tests Passing

<img width="1242" height="436" alt="image" src="https://github.com/user-attachments/assets/b8934aec-b68b-481d-ad63-84d7d0f13198" />


## Videos

### Demo Setup (Rails Console)
```ruby
# Create two users with the same payment address
user1 = User.create!(email: "tosuser1@example.com", password: "password123", payment_address: "shared@paypal.com")
user2 = User.create!(email: "tosuser2@example.com", password: "password123", payment_address: "shared@paypal.com")
product = Link.create!(user: user1, name: "Test Product", price_cents: 100)
admin = User.find_by(email: "seller@gumroad.com")

# Open User2's admin page in browser:
puts "User2 URL: https://gumroad.dev/admin/users/#{user2.external_id}"

# Then suspend User1 for TOS violation:
user1.flag_for_tos_violation!(author_id: admin.id, product_id: product.id)
user1.suspend_for_tos_violation!(author_id: admin.id)
SuspendAccountsWithPaymentAddressWorker.new.perform(user1.id)

# Refresh browser to see User2's new state
```

### Before (Bug)
User2 incorrectly shows **"Suspended for fraud"** when User1 was only suspended for TOS violation.

https://github.com/user-attachments/assets/f593785a-f144-48ad-a41e-f145a495039e




### After (Fix)
User2 correctly shows **"On probation"** with the note: "Probated automatically on [date] for having the same payout address as a previously suspended account (User#XX)"


https://github.com/user-attachments/assets/d307afbe-20a8-4eb3-b738-5c00c352cbdc



**AI Disclosure:** This PR was implemented with assistance from Claude Code (Opus 4.5).

Checklist

- [x]  I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x]  I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x]  I have performed a self-review and left review comments on my PR
- [x]  I have added/updated tests for my changes