### PR TITLE
Improve performance of AudienceExportService

### DIFF
--- a/app/services/exports/audience_export_service.rb
+++ b/app/services/exports/audience_export_service.rb
@@ -18,16 +18,9 @@ class Exports::AudienceExportService
     @tempfile = Tempfile.new(["Subscribers", ".csv"], encoding: "UTF-8")
 
     CsvSafe.open(@tempfile, "wb", headers: FIELDS, write_headers: true) do |csv|
-      query = @user.audience_members.select(:id, :email, :min_created_at)
+      query = build_query
 
-      conditions = []
-      conditions << "follower = true" if @options[:followers]
-      conditions << "customer = true" if @options[:customers]
-      conditions << "affiliate = true" if @options[:affiliates]
-
-      query = query.where(conditions.join(" OR "))
-
-      query.order(:min_created_at).find_each do |member|
+      query.find_each do |member|
         csv << [member.email, member.min_created_at]
       end
     end
@@ -36,6 +29,22 @@ class Exports::AudienceExportService
 
     self
   end
+
+  def build_query
+    # NOTE: Build separate queries for each type to allow efficient index usage using UNION.
+    queries = []
+    queries << @user.audience_members.where(follower: true) if @options[:followers]
+    queries << @user.audience_members.where(customer: true) if @options[:customers]
+    queries << @user.audience_members.where(affiliate: true) if @options[:affiliates]
+
+    return AudienceMember.none if queries.empty?
+
+    union_sql = queries.map { |q| q.select(:id, :email, :min_created_at).to_sql }.join(" UNION ")
+
+    # NOTE: Wrap in subquery to allow ordering.
+    AudienceMember.from("(#{union_sql}) AS audience_members").order(:min_created_at)
+  end
+
 
   private
     def validate_options!

--- a/db/migrate/20261119011937_add_indexes_to_audience_members.rb
+++ b/db/migrate/20261119011937_add_indexes_to_audience_members.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+#
+class AddIndexesToAudienceMembers < ActiveRecord::Migration[7.1]
+  def change
+    change_table :audience_members, bulk: true do |t|
+      t.index [:seller_id, :customer, :min_created_at],
+              name: "idx_audience_customer_created_at"
+
+      t.index [:seller_id, :follower, :min_created_at],
+              name: "idx_audience_follower_created_at_flag"
+
+      t.index [:seller_id, :affiliate, :min_created_at],
+              name: "idx_audience_affiliate_created_at"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -164,8 +164,11 @@ ActiveRecord::Schema[7.1].define(version: 2026_11_19_011937) do
     t.datetime "follower_created_at", precision: nil
     t.datetime "min_affiliate_created_at", precision: nil
     t.datetime "max_affiliate_created_at", precision: nil
+    t.index ["seller_id", "affiliate", "min_created_at"], name: "idx_audience_affiliate_created_at"
     t.index ["seller_id", "customer", "follower", "affiliate"], name: "idx_audience_on_seller_and_types"
+    t.index ["seller_id", "customer", "min_created_at"], name: "idx_audience_customer_created_at"
     t.index ["seller_id", "email"], name: "index_audience_members_on_seller_id_and_email", unique: true
+    t.index ["seller_id", "follower", "min_created_at"], name: "idx_audience_follower_created_at_flag"
     t.index ["seller_id", "follower_created_at"], name: "idx_audience_on_seller_and_follower_created_at"
     t.index ["seller_id", "min_affiliate_created_at", "max_affiliate_created_at"], name: "idx_audience_on_seller_and_minmax_affiliate_created_at"
     t.index ["seller_id", "min_created_at", "max_created_at"], name: "idx_audience_on_seller_and_minmax_created_at"


### PR DESCRIPTION
Issue: https://github.com/antiwork/gumroad/issues/2092
Closes: https://github.com/antiwork/gumroad/issues/2092

# Description

<!-- Briefly describe the problem and your solution -->

## Problem


Audience CSV exports were intermittently timing out in Sidekiq for large sellers.

The export query filtered audience members using an `OR` condition across multiple boolean columns:

```sql
WHERE seller_id = ?
  AND (follower = true OR customer = true OR affiliate = true)
ORDER BY min_created_at
```

Despite having several indexes, this query was **not able to efficiently use them**, leading to long-running scans in production.

---

## Root cause (confirmed by EXPLAIN ANALYZE)

`EXPLAIN` and `EXPLAIN ANALYZE` showed that MySQL was **not using any index on the boolean flags**.

Instead, MySQL consistently chose this index:

```
idx_audience_on_seller_and_minmax_created_at (seller_id, min_created_at, max_created_at)
```

Execution plan (simplified):

```
Index lookup on (seller_id)
→ scan rows in min_created_at order
→ apply (follower OR customer OR affiliate) as a filter
```

Key observations from `EXPLAIN ANALYZE`:

- Boolean conditions (`follower/customer/affiliate`) were applied **after** the index lookup
- No boolean columns participated in index access
- Performance depended entirely on data distribution
- If matching rows were sparse, MySQL scanned a large portion of the seller’s audience
- This caused queries to run for seconds or minutes, triggering Sidekiq timeouts

This behavior is a known MySQL limitation with `OR` conditions across low-cardinality (boolean) columns.


## Solution


### 1. Rewrite the query to use `UNION` instead of `OR`

The query is now built as multiple independent queries:

```sql
WHERE seller_id = ? AND follower = true
UNION
WHERE seller_id = ? AND customer = true
UNION
WHERE seller_id = ? AND affiliate = true
```

Each branch can be optimized independently by MySQL.

---

### 2. Add narrow, order-aware indexes per flag

Added indexes:

```sql
(seller_id, follower,  min_created_at)
(seller_id, customer,  min_created_at)
(seller_id, affiliate, min_created_at)
```

These indexes support both:
- Filtering (`seller_id + flag`)
- Ordering (`min_created_at`)

---

## Evidence this fixes the issue

`EXPLAIN ANALYZE` for the new query shows:

```
Index lookup using idx_audience_follower_created_at_flag (seller_id=?, follower=true)
Index lookup using idx_audience_customer_created_at      (seller_id=?, customer=true)
Index lookup using idx_audience_affiliate_created_at     (seller_id=?, affiliate=true)
→ Union materialize
→ Sort by min_created_at
```

Facts confirmed by the plan:

- Each UNION branch uses a **dedicated index**
- No boolean filtering happens outside the index
- No full seller scans
- Sorting happens only on the **already-filtered result set**
- Query runtime scales with the number of matching rows, not total audience size

---

## Why this prevents Sidekiq timeouts

Before:
- Query scanned potentially **all audience rows for a seller**
- Runtime was data-dependent and unpredictable
- Sidekiq jobs blocked on slow SQL

After:
- Each query scans **only matching rows**
- No OR-based filtering
- Predictable and bounded query time
- Sidekiq jobs complete consistently even for large sellers



# Test Results

<img width="1521" height="541" alt="image" src="https://github.com/user-attachments/assets/8a5f6bc4-207d-4962-8021-0e4d79fbc549" />


<img width="1501" height="573" alt="image" src="https://github.com/user-attachments/assets/ee6fae81-d736-471a-ab10-ec0628979ecc" />

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes **_(No new behavior, existing tests pass)_**

---

# AI Disclosure

Used Cursor (Claude Sonnet 4.5) to reason about index selection and query planner behavior