### PR TITLE
fix(dashboard): Align text consistently in getting started items

### DIFF
--- a/app/javascript/components/DashboardPage.tsx
+++ b/app/javascript/components/DashboardPage.tsx
@@ -175,7 +175,7 @@ const GettingStartedItem = ({
   const content = minimized ? (
     <div className="flex w-full items-center gap-2">
       <IconComponent isChecked={completed} width={36} height={36} className="flex-none" />
-      <span className="mb-1 flex-1 leading-tight font-semibold">{name}</span>
+      <span className="mb-1 flex-1 text-center leading-tight font-semibold">{name}</span>
       <Icon name={iconName} className={cx("flex-none", iconClasses)} />
     </div>
   ) : (

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_11_19_011937) do
+ActiveRecord::Schema[7.1].define(version: 2026_11_19_011936) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -1123,7 +1123,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_11_19_011937) do
     t.string "native_type", default: "digital", null: false
     t.integer "discover_fee_per_thousand", default: 100, null: false
     t.string "support_email"
-    t.integer "default_offer_code_id"
+    t.bigint "default_offer_code_id"
     t.index ["banned_at"], name: "index_links_on_banned_at"
     t.index ["custom_permalink"], name: "index_links_on_custom_permalink", length: 191
     t.index ["default_offer_code_id"], name: "index_links_on_default_offer_code_id"


### PR DESCRIPTION
Issue: #3122

## Summary
- Added `text-center` class to the item name span to ensure consistent centering
## Root cause
The getting started items in minimized mode use a flex layout with `flex-1` on the text span, which expands to fill available space. However, the text inside defaulted to left alignment. This caused completed items (rendered as `<Button>`) and incomplete items (rendered as `<NavigationButton>`) to display with different visual text alignment.


## Before/After
| Before | After |
|--------|-------|
| <img width="216" height="470" alt="Before screenshot" src="https://github.com/user-attachments/assets/4b43e8c1-fb9d-42bb-ba04-f4b8108330b0" /> | <img width="215" height="466" alt="After screenshot" src="https://github.com/user-attachments/assets/da65298d-f2ee-45db-b657-063b025b77c6" /> |










# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [ ] I have added/updated tests for my changes

---

# AI Disclosure

No AI used