### PR TITLE
fix: theme issue on download app button

### DIFF
--- a/app/javascript/components/Download/OpenInAppButton.tsx
+++ b/app/javascript/components/Download/OpenInAppButton.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { Button, buttonVariants } from "$app/components/Button";
+import { Button } from "$app/components/Button";
 import { Popover } from "$app/components/Popover";
 
 type Props = { iosAppUrl: string; androidAppUrl: string };
@@ -32,24 +32,14 @@ export const OpenInAppButton = ({ iosAppUrl, androidAppUrl }: Props) => (
           justifyContent: "space-between",
         }}
       >
-        <Button asChild>
-          <a
-            className={buttonVariants({ size: "default", color: "apple" })}
-            href={iosAppUrl}
-            target="_blank"
-            rel="noreferrer"
-          >
+        <Button asChild color="apple">
+          <a href={iosAppUrl} target="_blank" rel="noreferrer">
             <span className="brand-icon brand-icon-apple" />
             App Store
           </a>
         </Button>
-        <Button asChild>
-          <a
-            className={buttonVariants({ size: "default", color: "android" })}
-            href={androidAppUrl}
-            target="_blank"
-            rel="noreferrer"
-          >
+        <Button asChild color="android">
+          <a href={androidAppUrl} target="_blank" rel="noreferrer">
             <span className="brand-icon brand-icon-android" />
             Play Store
           </a>


### PR DESCRIPTION
Issue: #3121

# Description

Fixed App Store and Play Store button labels not being visible in light mode on the "Open in app" popup.

## Problem

The buttons used `Button asChild` with `buttonVariants` applied directly to child anchor elements, causing CSS class conflicts. The Button component's default `bg-transparent` style overrode the intended brand colors (`bg-black` for Apple, `bg-[#142f40]` for Android`), making white text invisible against the white popup background in light mode.

## Solution

Changed to follow the existing codebase convention (as seen in `DiscordButton.tsx`) by passing the `color` prop directly to the `Button` component instead of applying `buttonVariants` on child elements. This ensures proper CSS class application and correct styling in both light and dark modes.

---

# Before/After

**Before:** Button labels were invisible in light mode (white text on white background)
<img width="1116" height="799" alt="image" src="https://github.com/user-attachments/assets/0e05cbe7-41d5-434e-b7d3-88ab4d4c31d4" />

**After:** Buttons display correctly with black background (Apple) and dark teal background (Android) with visible white text in both light and dark modes

<!-- Screenshots/videos to be added showing Desktop (light + dark) and Mobile (light + dark) -->

---


<!-- Screenshot of test suite passing to be added -->
<img width="1116" height="799" alt="Screenshot from 2026-01-26 11-54-30" src="https://github.com/user-attachments/assets/148417ee-9f30-4827-8f7b-53366988e81d" />
<img width="1116" height="799" alt="Screenshot from 2026-01-26 11-54-13" src="https://github.com/user-attachments/assets/347d1bf8-d76a-4686-a50c-2734862706a3" />

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

AI was used to identify the root cause of the CSS class conflict and suggest the fix pattern based on existing codebase conventions (specifically the `DiscordButton` component pattern).