### PR TITLE
FIx(ui): Buttons are not vertically stacked in product content download page

### DIFF
--- a/app/javascript/components/Download/RichContent.tsx
+++ b/app/javascript/components/Download/RichContent.tsx
@@ -142,15 +142,19 @@ const TiptapButton = TiptapNode.create<{ saleInfo: SaleInfo | null }>({
   addAttributes: () => ({ href: { default: null } }),
   renderHTML({ HTMLAttributes }) {
     return [
-      "a",
-      {
-        ...HTMLAttributes,
-        class: buttonVariants({ size: "default", color: "primary" }),
-        target: "_blank",
-        rel: "noopener noreferrer nofollow",
-        href: addSaleInfoQueryParams(cast<string>(HTMLAttributes.href), this.options.saleInfo),
-      },
-      0,
+      "div",
+      {},
+      [
+        "a",
+        {
+          ...HTMLAttributes,
+          class: buttonVariants({ size: "default", color: "primary" }),
+          target: "_blank",
+          rel: "noopener noreferrer nofollow",
+          href: addSaleInfoQueryParams(cast<string>(HTMLAttributes.href), this.options.saleInfo),
+        },
+        0,
+      ],
     ];
   },
 });


### PR DESCRIPTION
Issue: #3025 

# Description
  Buttons in the product content page appear side-by-side horizontally, but in the product content editor they are stacked vertically. The customer-facing view should match what the creator sees in the editor.

### Root cause: 
- The editor renders buttons wrapped in a `<div>`, which forces vertical stacking. However, the customer-facing content page rendered buttons directly as `<a>` tags with inline-flex styling from buttonVariants(), allowing them to flow horizontally.


## Solution
-   Wrap the button <a> element inside a block-level <div> wrapper, ensuring each button occupies its own line and stacks vertically to match the editor layout.


---

# Before/After


| **Before – Rich Text** | **Before – Product Content** |
|------------------------|------------------------------|
| ![](https://github.com/user-attachments/assets/3ec37a24-552a-44a0-9cb8-1e9b56b896c2) | ![](https://github.com/user-attachments/assets/60c469e7-3ea8-439f-931f-15988fce1171) |
| **After – Rich Text**  | **After – Product Content**  |
| ![](https://github.com/user-attachments/assets/1003d22e-1453-4dc4-aeee-3ce050f9c7b1) | ![](https://github.com/user-attachments/assets/89ecae9e-ec86-4f6b-b049-a417fa51ed8b) |



---
---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes (not required here)

---

# AI Disclosure

- used claude-code with opus-4.5 to find root cause. 