### PR TITLE
fix: make cta bar sticky

### DIFF
--- a/app/javascript/components/Product/Layout.tsx
+++ b/app/javascript/components/Product/Layout.tsx
@@ -264,7 +264,7 @@ const CtaBar = ({
         boxShadow: visible
           ? "0 var(--border-width) rgb(var(--color)), 0 calc(-1 * var(--border-width)) rgb(var(--color))"
           : undefined,
-        position: "fixed",
+        position: "sticky",
         top: isDesktop ? 0 : undefined,
         bottom: isDesktop ? undefined : 0,
         left: 0,


### PR DESCRIPTION
Fixes: #2995
Previous PR: #3006

# Description

The cta bar is hiding content.

## Problem

## Solution

1. Tried adding a spacer at the Product layout level

- This worked correctly for the standalone ProductPage layout, where the product content starts at the top of the page.
`app/javascript/components/server-components/Product/index.tsx`

- It broke on the Profile layout because that layout has its own header (subscribe bar) above the product.
Since the spacer lived inside the Product layout, it pushed content below the header, while the CTA was fixed relative to the viewport. This caused extra gaps and header/CTA collisions. `app/javascript/components/Profile/Layout.tsx`

- The same limitation applied to the footer (PoweredByFooter).


2. Switching to position `sticky`
---

# Before/After

**Before:**




https://github.com/user-attachments/assets/17532e6f-3d32-4650-98a0-d05629a15dc6



https://github.com/user-attachments/assets/b2f7c61f-606f-4b5d-a977-363469842bf5



https://github.com/user-attachments/assets/aaac7be1-23a3-4460-ba5d-42630c779173


https://github.com/user-attachments/assets/5aabf656-2e43-42a5-8512-29401ec46c0f

<img width="423" height="891" alt="image" src="https://github.com/user-attachments/assets/87fecd17-c586-4ba2-80b4-4d84be519bd1" />




**After:**



https://github.com/user-attachments/assets/b3918771-c37e-4ea7-8754-4d67861aa4dc



https://github.com/user-attachments/assets/0a4393d2-f456-4b89-93c6-e6efcdbb7100


https://github.com/user-attachments/assets/23981b89-457a-4c4e-92ae-1b21ce4a135a


https://github.com/user-attachments/assets/2a18541d-d292-4f5c-a1f2-736d090b9e43


<img width="423" height="891" alt="image" src="https://github.com/user-attachments/assets/b7034607-f271-4f52-97f1-b47c8c300b55" />


---

# Test Results

<!-- Include a screenshot of your test suite passing locally -->

---

# Checklist

- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

None
