### PR TITLE
Improve instant payout error message when funds are settling

### DIFF
--- a/app/business/payments/payouts/payouts.rb
+++ b/app/business/payments/payouts/payouts.rb
@@ -42,6 +42,11 @@ class Payouts
       end
 
       amount_payable = user.instantly_payable_unpaid_balance_cents_up_to_date(date)
+
+      if amount_payable < MIN_AMOUNT_CENTS && add_comment && user.unpaid_balance_cents_up_to_date(date) >= MIN_AMOUNT_CENTS
+        user.add_payout_note(content: "Instant Payout on #{payout_date} was skipped because funds are still settling. This should resolve within 1-2 days.")
+        return false
+      end
     end
 
     processor_types = processor_type ? [processor_type] : ::PayoutProcessorType.all


### PR DESCRIPTION
Fixes antiwork/gumroad-private#89

## Root Cause

When instant payouts are skipped due to insufficient settled funds on Stripe, the system incorrectly reports "balance less than $10 minimum" even when users have substantial earnings (e.g., $439.50).

The payout logic checks balances oldest-first to determine what can be paid instantly. When the oldest balance exceeds Stripe's available settled funds, the code excludes that balance and everything after it, returning $0. The daily job then sees $0 and creates a misleading note about the minimum threshold.

## Solution

Detect when instant payout is skipped specifically because funds are settling (user has balance ≥ $10 but instantly payable amount is < $10) and display an accurate message instead.

## Changes

- Added check in `Payouts.is_user_payable` to differentiate between actual low balance and settling funds scenarios
- Added appropriate payout note: "Instant Payout on {date} was skipped because funds are still settling. This should resolve within 1-2 days."
- Added tests for the new settling funds scenario

## Test Plan

- [x] User with balance ≥ $10 but $0 instantly payable gets "funds are still settling" note
- [x] User with actual low balance still gets the existing minimum threshold message
- [x] Note is only added when `add_comment: true`

---

## AI Assistance Notice
This PR was implemented with AI assistance using Claude Code for code generation. All code was self-reviewed.