### PR TITLE
Migrate URL Redirect Confirm page to Inertia #3143

### DIFF
--- a/app/controllers/url_redirects_controller.rb
+++ b/app/controllers/url_redirects_controller.rb
@@ -3,6 +3,7 @@
 class UrlRedirectsController < ApplicationController
   include SignedUrlHelper
   include ProductsHelper
+  include InertiaRendering
   include PageMeta::Favicon
 
   before_action :fetch_url_redirect, except: %i[
@@ -17,8 +18,9 @@ class UrlRedirectsController < ApplicationController
                                              download_archive latest_media_locations download_product_files audio_durations
                                              save_last_content_page]
   before_action :hide_layouts, only: %i[
-    confirm_page membership_inactive_page expired rental_expired_page show download_page download_product_files stream smil hls_playlist download_subtitle_file read
+    membership_inactive_page expired rental_expired_page show download_page download_product_files stream smil hls_playlist download_subtitle_file read
   ]
+  layout "inertia", only: [:confirm_page]
   before_action :mark_rental_as_viewed, only: %i[smil hls_playlist]
   after_action :register_that_user_has_downloaded_product, only: %i[download_page show stream read]
   after_action -> { create_consumption_event!(ConsumptionEvent::EVENT_TYPE_READ) }, only: [:read]
@@ -162,7 +164,8 @@ class UrlRedirectsController < ApplicationController
         email: params[:email],
       },
     )
-    @react_component_props = UrlRedirectPresenter.new(url_redirect: @url_redirect, logged_in_user:).download_page_without_content_props(extra_props)
+    props = UrlRedirectPresenter.new(url_redirect: @url_redirect, logged_in_user:).download_page_without_content_props(extra_props)
+    render inertia: "UrlRedirects/ConfirmPage", props:
   end
 
   def expired

--- a/app/javascript/components/server-components/DownloadPage/WithoutContent.tsx
+++ b/app/javascript/components/server-components/DownloadPage/WithoutContent.tsx
@@ -10,7 +10,21 @@ import { Layout, LayoutProps } from "./Layout";
 
 import placeholderImage from "$assets/images/placeholders/comic-stars.png";
 
-const WithoutContent = ({ confirmation_info, authenticity_token, ...props }: LayoutProps & EmailConfirmationProps) => (
+export type EmailConfirmationProps = {
+  authenticity_token?: string | undefined;
+  confirmation_info?:
+    | {
+        id: string;
+        destination: string | null;
+        display: string | null;
+        email: string | null;
+      }
+    | undefined;
+};
+
+export type WithoutContentProps = LayoutProps & EmailConfirmationProps;
+
+export const WithoutContent = ({ confirmation_info, authenticity_token, ...props }: WithoutContentProps) => (
   <Layout {...props}>
     {props.content_unavailability_reason_code === "inactive_membership" ? (
       props.purchase?.membership?.is_installment_plan ? (
@@ -117,17 +131,6 @@ const RentalExpired = () => (
   </Placeholder>
 );
 
-type EmailConfirmationProps = {
-  authenticity_token?: string | undefined;
-  confirmation_info?:
-    | {
-        id: string;
-        destination: string | null;
-        display: string | null;
-        email: string | null;
-      }
-    | undefined;
-};
 const EmailConfirmation = ({ confirmation_info, authenticity_token }: EmailConfirmationProps) => (
   <Placeholder>
     <h2>You've viewed this product a few times already</h2>

--- a/app/javascript/pages/UrlRedirects/ConfirmPage.tsx
+++ b/app/javascript/pages/UrlRedirects/ConfirmPage.tsx
@@ -1,0 +1,84 @@
+import * as React from "react";
+import { useForm, usePage } from "@inertiajs/react";
+
+import { Layout, LayoutProps } from "$app/components/server-components/DownloadPage/Layout";
+import { Button } from "$app/components/Button";
+import { Placeholder } from "$app/components/ui/Placeholder";
+
+type ConfirmationInfo = {
+  id: string;
+  destination: string | null;
+  display: string | null;
+  email: string | null;
+};
+
+type PageProps = LayoutProps & {
+  confirmation_info: ConfirmationInfo;
+};
+
+function ConfirmPage() {
+  const props = usePage<PageProps>().props;
+  const {
+    confirmation_info,
+    content_unavailability_reason_code,
+    is_mobile_app_web_view,
+    terms_page_url,
+    token,
+    redirect_id,
+    creator,
+    add_to_library_option,
+    installment,
+    purchase,
+  } = props;
+
+  return (
+    <Layout
+      content_unavailability_reason_code={content_unavailability_reason_code}
+      is_mobile_app_web_view={is_mobile_app_web_view}
+      terms_page_url={terms_page_url}
+      token={token}
+      redirect_id={redirect_id}
+      creator={creator}
+      add_to_library_option={add_to_library_option}
+      installment={installment}
+      purchase={purchase}
+    >
+      <EmailConfirmation confirmation_info={confirmation_info} />
+    </Layout>
+  );
+}
+
+const EmailConfirmation = ({ confirmation_info }: { confirmation_info: ConfirmationInfo }) => {
+  const { data, setData, post, processing } = useForm({
+    id: confirmation_info.id,
+    destination: confirmation_info.destination ?? "",
+    display: confirmation_info.display ?? "",
+    email: confirmation_info.email ?? "",
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    post(Routes.confirm_redirect_path());
+  };
+
+  return (
+    <Placeholder>
+      <h2>You've viewed this product a few times already</h2>
+      <p>Once you enter the email address used to purchase this product, you'll be able to access it again.</p>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4" style={{ width: "calc(min(428px, 100%))" }}>
+        <input
+          type="text"
+          name="email"
+          placeholder="Email address"
+          value={data.email}
+          onChange={(e) => setData("email", e.target.value)}
+        />
+        <Button type="submit" color="accent" disabled={processing}>
+          {processing ? "Confirming..." : "Confirm email"}
+        </Button>
+      </form>
+    </Placeholder>
+  );
+};
+
+export default ConfirmPage;

--- a/app/views/url_redirects/confirm_page.html.erb
+++ b/app/views/url_redirects/confirm_page.html.erb
@@ -1,3 +1,0 @@
-<%= load_pack("url_redirect_download") %>
-
-<%= react_component "DownloadPageWithoutContent", props: @react_component_props.merge(authenticity_token: form_authenticity_token), prerender: true %>

--- a/spec/controllers/url_redirects_controller_spec.rb
+++ b/spec/controllers/url_redirects_controller_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "inertia_rails/rspec"
 
 describe UrlRedirectsController do
   render_views
@@ -1307,7 +1308,7 @@ describe UrlRedirectsController do
     end
   end
 
-  describe "GET 'confirm_page'" do
+  describe "GET 'confirm_page'", inertia: true do
     before do
       @url_redirect = create(:url_redirect)
     end
@@ -1317,12 +1318,11 @@ describe UrlRedirectsController do
       expect(response.headers["X-Robots-Tag"]).to eq("noindex")
     end
 
-
     it "renders the confirm page correctly" do
       get :confirm_page, params: { id: @url_redirect.token }
       expect(response).to be_successful
-      expect(assigns(:hide_layouts)).to eq(true)
-      expect(assigns(:react_component_props)).to eq(UrlRedirectPresenter.new(url_redirect: @url_redirect, logged_in_user: nil).download_page_without_content_props(content_unavailability_reason_code: UrlRedirectPresenter::CONTENT_UNAVAILABILITY_REASON_CODES[:email_confirmation_required]).merge(
+      expect(inertia.component).to eq("UrlRedirects/ConfirmPage")
+      expect(inertia.props).to match(hash_including(
         is_mobile_app_web_view: false,
         content_unavailability_reason_code: UrlRedirectPresenter::CONTENT_UNAVAILABILITY_REASON_CODES[:email_confirmation_required],
         add_to_library_option: "none",
@@ -1331,7 +1331,7 @@ describe UrlRedirectsController do
           destination: nil,
           display: nil,
           email: nil,
-        }
+        },
       ))
     end
 
@@ -1341,10 +1341,10 @@ describe UrlRedirectsController do
     end
 
     context "when params[:destination] is set" do
-      it "assigns @destination with params[:destination]" do
+      it "sets destination in confirmation_info" do
         get :confirm_page, params: { id: @url_redirect.token, destination: "stream" }
 
-        expect(assigns(:react_component_props)[:confirmation_info][:destination]).to eq "stream"
+        expect(inertia.props[:confirmation_info][:destination]).to eq "stream"
       end
     end
 
@@ -1355,21 +1355,21 @@ describe UrlRedirectsController do
           create(:rich_content, entity: product, description: [{ "type" => "paragraph", "content" => [{ "type" => "text", "text" => "Hello world" }] }])
         end
 
-        it "assigns @destination with 'download_page'" do
+        it "sets destination to 'download_page' in confirmation_info" do
           get :confirm_page, params: { id: @url_redirect.token }
 
-          expect(assigns(:react_component_props)[:confirmation_info][:destination]).to eq "download_page"
+          expect(inertia.props[:confirmation_info][:destination]).to eq "download_page"
         end
       end
 
-      it "assigns @destination with nil value for an installment" do
+      it "sets destination to nil for an installment" do
         installment = create(:installment)
         installment.product_files << create(:product_file)
         url_redirect = create(:installment_url_redirect, installment:)
 
         get :confirm_page, params: { id: url_redirect.token }
 
-        expect(assigns(:react_component_props)[:confirmation_info][:destination]).to be_nil
+        expect(inertia.props[:confirmation_info][:destination]).to be_nil
       end
     end
   end


### PR DESCRIPTION
Addresses #3143

Migrate the url_redirects#confirm_page action to render Inertia pages instead of using
react_component helper.

## Problem
The confirm page (url_redirects#confirm_page) uses the legacy react_component helper
for rendering, which is inconsistent with the newer Inertia.js pattern being adopted across
the codebase.

## Solution
Migrated the url_redirects#confirm_page action to render Inertia pages:

### Controller changes:
- Added `include InertiaRendering` to the controller
- Added `layout "inertia", only: [:confirm_page]`
- Removed `confirm_page` from `hide_layouts` before_action
- Updated `confirm_page` action to use `render inertia:` with props
- Added `@body_class = "download-page responsive responsive-nav"` for proper styling

### Frontend changes:
- Created new Inertia page component at `pages/UrlRedirects/ConfirmPage.tsx`
- Added full-height flex container wrapper to match application layout structure
- Added `layout = (page) => page` to bypass default Inertia layout (page has its own layout)
- Wrapped content with `LoggedInUserProvider` since we bypass the default Inertia layout
- Exported `WithoutContent` component and `WithoutContentProps` type from server-components
  for direct import by Inertia pages

### Code notes:

**Why the flex container wrapper?**
```tsx
<div className="flex h-screen flex-col">
  <main className="flex flex-1 flex-col overflow-y-auto">
    <div className="flex flex-1 flex-col">
      ...
    </div>
  </main>
</div>
```
The Inertia layout doesn't have the same wrapper structure as the application layout.
The `WithoutContent` component expects to be in a full-height flex container, so we
replicate the structure from `application.html.erb`.

**Why LoggedInUserProvider wrapper?**
```tsx
<LoggedInUserProvider value={parseLoggedInUser(logged_in_user)}>
  <WithoutContent {...props} />
</LoggedInUserProvider>
```
Since we bypass the default Inertia layout (which normally provides this context),
we need to wrap manually. The `WithoutContent` component uses `useLoggedInUser()` internally.

### Removed files:
- `app/views/url_redirects/confirm_page.html.erb` - replaced by Inertia page

### Tests:
- Added `require "inertia_rails/rspec"` to spec file
- Added `inertia: true` to the confirm_page describe block
- Updated assertions to use `inertia.component` and `inertia.props` helpers
- Verify correct Inertia component (`UrlRedirects/ConfirmPage`) is rendered
- Verify props include `confirmation_info` and `authenticity_token`

## Screenshots
[Screencast from 2026-01-26 23-45-11.webm](https://github.com/user-attachments/assets/d6311745-18e3-464c-ba36-98d2a50a817c)


## Checklist
- [x] I have performed a self-review of my code
- [x] I have added/updated tests for my changes
- [x] I have added screenshots

Had some help from AI (opus) for debugging the flex container layout issue and             
understanding the Inertia layout structure