### PR TITLE
Fix: Migrated URL Redirect Unavailable Pages to Inertia

### DIFF
--- a/app/javascript/pages/UrlRedirects/Expired.tsx
+++ b/app/javascript/pages/UrlRedirects/Expired.tsx
@@ -1,0 +1,29 @@
+import { usePage } from "@inertiajs/react";
+import * as React from "react";
+import { cast } from "ts-safe-cast";
+
+import {
+  AccessExpiredContent,
+  UnavailablePageLayout,
+  type UnavailablePageProps,
+} from "./UnavailablePageLayout";
+
+type Props = UnavailablePageProps;
+
+const ExpiredPage = () => {
+  const props = cast<Props>(usePage().props);
+
+  return (
+    <UnavailablePageLayout
+      {...props}
+      titleSuffix="Access expired"
+      contentUnavailabilityReasonCode="access_expired"
+    >
+      <AccessExpiredContent />
+    </UnavailablePageLayout>
+  );
+};
+
+ExpiredPage.loggedInUserLayout = true;
+
+export default ExpiredPage;

--- a/app/javascript/pages/UrlRedirects/MembershipInactive.tsx
+++ b/app/javascript/pages/UrlRedirects/MembershipInactive.tsx
@@ -1,0 +1,55 @@
+import { usePage } from "@inertiajs/react";
+import * as React from "react";
+import { cast } from "ts-safe-cast";
+
+import {
+  InstallmentPlanInactiveContent,
+  MembershipInactiveContent,
+  UnavailablePageLayout,
+  type UnavailablePageProps,
+} from "./UnavailablePageLayout";
+
+type Props = UnavailablePageProps;
+
+const MembershipInactivePage = () => {
+  const props = cast<Props>(usePage().props);
+
+  const isInstallmentPlan = props.purchase?.membership?.is_installment_plan ?? false;
+  const productName = props.purchase?.product_name ?? "";
+  const productLongUrl = props.purchase?.product_long_url ?? null;
+  const membership =
+    props.purchase?.email && props.purchase.membership
+      ? {
+          is_alive_or_restartable: props.purchase.membership.is_alive_or_restartable,
+          subscription_id: props.purchase.membership.subscription_id,
+        }
+      : null;
+
+  return (
+    <UnavailablePageLayout
+      {...props}
+      titleSuffix="Your membership is inactive"
+      contentUnavailabilityReasonCode="inactive_membership"
+    >
+      {isInstallmentPlan ? (
+        <InstallmentPlanInactiveContent
+          product_name={productName}
+          installment_plan={{
+            is_alive_or_restartable: props.purchase?.membership?.is_alive_or_restartable ?? null,
+            subscription_id: props.purchase?.membership?.subscription_id ?? "",
+          }}
+        />
+      ) : (
+        <MembershipInactiveContent
+          product_name={productName}
+          product_long_url={productLongUrl}
+          membership={membership}
+        />
+      )}
+    </UnavailablePageLayout>
+  );
+};
+
+MembershipInactivePage.loggedInUserLayout = true;
+
+export default MembershipInactivePage;

--- a/app/javascript/pages/UrlRedirects/RentalExpired.tsx
+++ b/app/javascript/pages/UrlRedirects/RentalExpired.tsx
@@ -1,0 +1,29 @@
+import { usePage } from "@inertiajs/react";
+import * as React from "react";
+import { cast } from "ts-safe-cast";
+
+import {
+  RentalExpiredContent,
+  UnavailablePageLayout,
+  type UnavailablePageProps,
+} from "./UnavailablePageLayout";
+
+type Props = UnavailablePageProps;
+
+const RentalExpiredPage = () => {
+  const props = cast<Props>(usePage().props);
+
+  return (
+    <UnavailablePageLayout
+      {...props}
+      titleSuffix="Your rental has expired"
+      contentUnavailabilityReasonCode="rental_expired"
+    >
+      <RentalExpiredContent />
+    </UnavailablePageLayout>
+  );
+};
+
+RentalExpiredPage.loggedInUserLayout = true;
+
+export default RentalExpiredPage;

--- a/app/javascript/pages/UrlRedirects/UnavailablePageLayout.tsx
+++ b/app/javascript/pages/UrlRedirects/UnavailablePageLayout.tsx
@@ -1,0 +1,105 @@
+import { Head } from "@inertiajs/react";
+import * as React from "react";
+
+import { Button } from "$app/components/Button";
+import { Layout, type LayoutProps } from "$app/components/server-components/DownloadPage/Layout";
+import { Placeholder, PlaceholderImage } from "$app/components/ui/Placeholder";
+
+import placeholderImage from "$assets/images/placeholders/comic-stars.png";
+
+export type UnavailablePageProps = Omit<LayoutProps, "content_unavailability_reason_code" | "children">;
+
+export const UnavailablePageLayout = ({
+  titleSuffix,
+  contentUnavailabilityReasonCode,
+  children,
+  ...layoutProps
+}: UnavailablePageProps & {
+  titleSuffix: string;
+  contentUnavailabilityReasonCode: LayoutProps["content_unavailability_reason_code"];
+  children: React.ReactNode;
+}) => {
+  const productName = layoutProps.purchase?.product_name ?? layoutProps.installment?.name ?? "";
+  const title = productName ? `${productName} - ${titleSuffix}` : titleSuffix;
+
+  return (
+    <>
+      <Head title={title} />
+      <Layout {...layoutProps} content_unavailability_reason_code={contentUnavailabilityReasonCode}>
+        {children}
+      </Layout>
+    </>
+  );
+};
+
+export const AccessExpiredContent = () => (
+  <Placeholder>
+    <PlaceholderImage src={placeholderImage} />
+    <h2>Access expired</h2>
+    <p>It looks like your access to this product has expired. Please contact the creator for further assistance.</p>
+  </Placeholder>
+);
+
+export const RentalExpiredContent = () => (
+  <Placeholder>
+    <PlaceholderImage src={placeholderImage} />
+    <h2>Your rental has expired</h2>
+    <p>Rentals expire 30 days after purchase or 72 hours after you've begun watching it.</p>
+  </Placeholder>
+);
+
+export const MembershipInactiveContent = ({
+  product_name,
+  product_long_url,
+  membership,
+}: {
+  product_name: string;
+  product_long_url: string | null;
+  membership: {
+    is_alive_or_restartable: boolean | null;
+    subscription_id: string;
+  } | null;
+}) => (
+  <Placeholder>
+    <PlaceholderImage src={placeholderImage} />
+    <h2>Your membership is inactive</h2>
+    <p>You cannot access the content of {product_name} because your membership is no longer active.</p>
+    {membership ? (
+      membership.is_alive_or_restartable ? (
+        <Button asChild color="primary">
+          <a href={Routes.manage_subscription_url(membership.subscription_id)}>Manage membership</a>
+        </Button>
+      ) : product_long_url ? (
+        <Button asChild color="primary">
+          <a href={product_long_url}>Resubscribe</a>
+        </Button>
+      ) : null
+    ) : null}
+  </Placeholder>
+);
+
+export const InstallmentPlanInactiveContent = ({
+  product_name,
+  installment_plan,
+}: {
+  product_name: string;
+  installment_plan: {
+    subscription_id: string;
+    is_alive_or_restartable: boolean | null;
+  };
+}) => (
+  <Placeholder>
+    <PlaceholderImage src={placeholderImage} />
+    <h2>Your installment plan is inactive</h2>
+    {installment_plan.is_alive_or_restartable ? (
+      <>
+        <p>Please update your payment method to continue accessing the content of {product_name}.</p>
+        <Button asChild color="primary">
+          <a href={Routes.manage_subscription_url(installment_plan.subscription_id)}>Update payment method</a>
+        </Button>
+      </>
+    ) : (
+      <p>You cannot access the content of {product_name} because your installment plan is no longer active.</p>
+    )}
+  </Placeholder>
+);

--- a/app/views/url_redirects/unavailable.html.erb
+++ b/app/views/url_redirects/unavailable.html.erb
@@ -1,4 +1,0 @@
-<%= render("shared/load_dropbox_dropins_js", async: false) %>
-<%= load_pack("url_redirect_download") %>
-
-<%= react_component "DownloadPageWithoutContent", props: @react_component_props, prerender: true %>


### PR DESCRIPTION
Issue: #3139 

#  Description

  Migrates the "unavailable" pages (expired, rental expired, membership inactive) from the legacy Rails React component rendering to Inertia.

  - Created new Inertia page components: Expired.tsx, RentalExpired.tsx, MembershipInactive.tsx
  - Created shared UnavailablePageLayout.tsx component with content components for each unavailability reason
  - Updated UrlRedirectsController to render Inertia components instead of the old ERB view
  - Removed the legacy unavailable.html.erb view
  - Updated controller specs to use Inertia test helpers


---

# Before/After

<!-- For UI/CSS changes, include screenshots or videos showing both states -->
<!-- Include: Desktop (light + dark) and Mobile (light + dark) -->

---

# Test Results

```
 bundle exec rspec spec/controllers/url_redirects_controller_spec.rb spec/presenters/url_redirect_presenter_spec.rb spec/models/url_redirect_spec.rb spec/controllers/api/mobile/url_redirects_controller_spec.rb
```

<img width="1323" height="876" alt="Screenshot 2026-01-28 at 12 39 42 AM" src="https://github.com/user-attachments/assets/cce16888-ae08-41f5-98cc-b3d77da1cff2" />


---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [ ] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

IDE: Cursor
Model: Claude Sonnet 4.5
Purpose: creating migration plan

