### PR TITLE
fix: copy tooltip position at discount page

### DIFF
--- a/app/javascript/components/CheckoutDashboard/DiscountsPage.tsx
+++ b/app/javascript/components/CheckoutDashboard/DiscountsPage.tsx
@@ -601,7 +601,7 @@ const DiscountsPage = ({
                           {uses != null ? `${uses} ${uses === 1 ? "use" : "uses"}` : null}
                         </div>
                         <CopyToClipboard
-                          tooltipPosition="bottom"
+                          tooltipPosition="left"
                           copyTooltip="Copy link with discount"
                           text={`${product.url}/${selectedOfferCode.code}`}
                         >


### PR DESCRIPTION
Issue: #

# Description

<!-- Briefly describe the problem and your solution -->

## Problem

the `tooltipPosition` was set to bottom causing overflow.


## Solution

set `tooltipPosition` to left.

---

# Before/After

Before:

https://github.com/user-attachments/assets/6edf336d-85f8-47c7-b47e-2018287dbf44



https://github.com/user-attachments/assets/33ce1ceb-aa91-49d5-925a-6992e5c694c6



After:

https://github.com/user-attachments/assets/8ea343dc-971a-4318-a868-c64c0ef6e4b0

https://github.com/user-attachments/assets/89f07805-4752-4966-b8eb-308a5e5f1285

---







# Test Results

<!-- Include a screenshot of your test suite passing locally -->

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

None
