### PR TITLE
fix: payouts page header action button layout on mobile

### DIFF
--- a/app/javascript/pages/Payouts/Index.tsx
+++ b/app/javascript/pages/Payouts/Index.tsx
@@ -508,10 +508,10 @@ export default function PayoutsIndex() {
         title="Payouts"
         actions={
           settingsAction || bulkExportAction ? (
-            <div className="flex gap-2">
+            <>
               {settingsAction}
               {bulkExportAction}
-            </div>
+            </>
           ) : undefined
         }
       >


### PR DESCRIPTION
Issue: 
N/A (no related issue)

# Description

<!-- Briefly describe the problem and your solution -->

## Problem

Header action buttons on the Payouts page rendered with uneven widths on mobile.

## Solution

Removed the extra flex wrapper around header actions.

---

# Before/After

**Before:**


<img width="460" height="902" alt="image" src="https://github.com/user-attachments/assets/90077896-8dc0-4a84-91c6-cedaa6dffb33" />


<img width="460" height="902" alt="image" src="https://github.com/user-attachments/assets/219ff89b-f53a-4830-aa74-2487e2b3f4a5" />

<img width="1641" height="970" alt="image" src="https://github.com/user-attachments/assets/32e28083-d2d2-4410-9516-4fe3782df283" />



**After:**

<img width="460" height="902" alt="Screenshot from 2026-01-28 17-46-35" src="https://github.com/user-attachments/assets/3d12a810-54dc-49bd-8969-7d860ee7e160" />


<img width="460" height="902" alt="Screenshot from 2026-01-28 17-45-43" src="https://github.com/user-attachments/assets/963bb0b0-f062-414c-9646-c40588528960" />


<img width="1641" height="970" alt="image" src="https://github.com/user-attachments/assets/6c54b834-ff81-41ee-9b50-49570b6db5a1" />


---

# Test Results

N/A

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [ ] I have added/updated tests for my changes

---

# AI Disclosure

None
