### PR TITLE
Migrate CartItemsCount page to Inertia

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -33,7 +33,7 @@ class LinksController < ApplicationController
   before_action :fetch_product_and_enforce_ownership, only: %i[destroy]
   before_action :fetch_product_and_enforce_access, only: %i[update publish unpublish release_preorder update_sections]
 
-  layout "inertia", only: [:index, :new]
+  layout "inertia", only: [:index, :new, :cart_items_count]
 
   def index
     authorize Link
@@ -170,6 +170,10 @@ class LinksController < ApplicationController
 
   def cart_items_count
     @hide_layouts = true
+    render inertia: "Links/CartItemsCount",
+           props: {
+             cart: CartPresenter.new(logged_in_user:, ip: request.remote_ip, browser_guid: cookies[:_gumroad_guid]).cart_props
+           }
   end
 
   def search

--- a/app/javascript/pages/Links/CartItemsCount.tsx
+++ b/app/javascript/pages/Links/CartItemsCount.tsx
@@ -1,0 +1,14 @@
+import { CartState, newCartState } from "$app/components/Checkout/cartState";
+
+const CartItemsCount = ({ cart }: { cart: CartState | null }) => {
+  void document.hasStorageAccess().then((hasAccess) =>
+    window.parent.postMessage({
+      type: "cart-items-count",
+      cartItemsCount: hasAccess ? (cart ?? newCartState()).items.length : "not-available",
+    }),
+  );
+
+  return null;
+};
+
+export default CartItemsCount;

--- a/app/views/links/cart_items_count.html.erb
+++ b/app/views/links/cart_items_count.html.erb
@@ -1,3 +1,0 @@
-<%= load_pack("product") %>
-
-<%= react_component "ProductCartItemsCountPage", props: { cart: CartPresenter.new(logged_in_user:, ip: request.remote_ip, browser_guid: cookies[:_gumroad_guid]).cart_props } %>


### PR DESCRIPTION
## Summary
- Migrate the CartItemsCount page from React on Rails to Inertia.js
- Create new Inertia page at `app/javascript/pages/Links/CartItemsCount.tsx`
- Update controller to use `render inertia:` with cart props
- Add `cart_items_count` to Inertia layout declaration
- Remove old ERB view file

Fixes #3057

## Test plan
- [ ] Visit `/cart_items_count` in an iframe context
- [ ] Verify the page loads correctly
- [ ] Verify `postMessage` is sent to parent window with cart items count
- [ ] Verify storage access check works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)