### PR TITLE
Fix Google OAuth login failures

### DIFF
--- a/app/models/concerns/user/social_google.rb
+++ b/app/models/concerns/user/social_google.rb
@@ -86,7 +86,7 @@ module User::SocialGoogle
       user.google_uid ||= data["uid"]
 
       if user.name.blank? && data["info"]["name"].present?
-        sanitized_name = data["info"]["name"].delete(":")
+        sanitized_name = data["info"]["name"].gsub(User::INVALID_NAME_FOR_EMAIL_DELIVERY_REGEX, "")
         user.name = sanitized_name
       end
 

--- a/spec/modules/user/social_google_spec.rb
+++ b/spec/modules/user/social_google_spec.rb
@@ -53,6 +53,7 @@ describe User::SocialGoogle do
       user = User.find_or_create_for_google_oauth2(@data_with_colon)
 
       expect(user).to be_persisted
+      expect(user).to be_valid
       expect(user.name).to eq("Test User")
     end
   end


### PR DESCRIPTION
Issue: https://github.com/antiwork/gumroad-private/issues/96

# Description

## Problem
Google OAuth login failed due to strict validations rejecting names with colons, unsupported avatar formats, and oversized profile pictures from Google accounts.


## Solution
Pre-validate and sanitize Google user data (remove colons from names, check avatar content types and file sizes) before database validation to prevent login failures.

---

# Before/After

## Before

https://github.com/user-attachments/assets/095f4fb9-e11c-4f80-9c15-089970c80be1



## After

https://github.com/user-attachments/assets/89f75d8f-11af-4b91-b2f2-5597d97649b6

# AI Disclosure

Cursor - Claude Sonnet 4.5 for code generation and all code self reviewed