### PR TITLE
fix: overlapping node action menu at rich text editor

### DIFF
--- a/app/javascript/components/TiptapExtensions/NodeActionsMenu.tsx
+++ b/app/javascript/components/TiptapExtensions/NodeActionsMenu.tsx
@@ -7,6 +7,7 @@ import { assertDefined } from "$app/utils/assert";
 import { buttonVariants } from "$app/components/Button";
 import { Icon } from "$app/components/Icons";
 import { Popover } from "$app/components/Popover";
+import { classNames } from "$app/utils/classNames";
 
 export const NodeActionsMenu = ({
   editor,
@@ -27,7 +28,7 @@ export const NodeActionsMenu = ({
     <Popover
       open={open}
       onToggle={setOpen}
-      className="actions-menu"
+      className={classNames("actions-menu", { "z-0!": !open })}
       aria-label="Actions"
       trigger={
         <div className={buttonVariants({ size: "sm", color: "filled" })} data-drag-handle draggable>


### PR DESCRIPTION
Fixes: #3215

# Description

<!-- Briefly describe the problem and your solution -->

## Problem

The NodeActionsMenu popover was overlaying other menus (e.g. toolbar / upload menus) .

## Solution

The NodeActionsMenu trigger was appearing on top of other open popovers due to its CSS class .actions-menu having z-index: z-index(overlay)
`app/javascript/stylesheets/_rich_text.scss`

Added conditional z-index override to the NodeActionsMenu component. When the menu is closed, we apply z-0 to ensure it doesn't overlap other open popovers.

---

# Before/After

**Before:**


https://github.com/user-attachments/assets/15fdf172-9500-4438-bc14-43118a0e75f2




**After**

https://github.com/user-attachments/assets/170edf57-cd03-4f5f-bb7e-faef9255f284

---





# Test Results

<!-- Include a screenshot of your test suite passing locally -->

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

GPT
