### PR TITLE
Improvement: replace GitHub icon image with svg

### DIFF
--- a/app/javascript/pages/HelpCenter/Layout.tsx
+++ b/app/javascript/pages/HelpCenter/Layout.tsx
@@ -11,7 +11,6 @@ import { PageHeader } from "$app/components/ui/PageHeader";
 import { Tab, Tabs } from "$app/components/ui/Tabs";
 import { useOriginalLocation } from "$app/components/useOriginalLocation";
 
-import githubIcon from "$assets/images/help-center/github-icon.svg";
 
 type HelperSession = {
   email?: string | null;
@@ -40,7 +39,20 @@ function ReportBugButton() {
       rel="noopener noreferrer"
       className="flex items-center gap-2"
     >
-      <img src={githubIcon} alt="" className="h-4 w-4" />
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 98 96"
+        xmlns="http://www.w3.org/2000/svg"
+        className="fill-current"
+      >
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z"
+          fill="currentColor"
+        />
+      </svg>
       Report a bug
     </NavigationButton>
   );


### PR DESCRIPTION
Issue: 
N/A (no related issue)

# Description

<!-- Briefly describe the problem and your solution -->

## Problem

The Github icon is not compatible with dark mode.

## Solution

Replaces the  GitHub icon image with an inline SVG element to fix dark mode compatibility issues.

---

# Before/After

Before:

<img width="391" height="118" alt="image" src="https://github.com/user-attachments/assets/e0068c5e-f2e7-44a3-82f4-14ce0694a2fb" />

<img width="391" height="118" alt="image" src="https://github.com/user-attachments/assets/07b78e29-0dec-463c-9980-26d2c1c1df5c" />


After:

<img width="391" height="118" alt="image" src="https://github.com/user-attachments/assets/4cae1bb5-e597-4bc0-890d-b166d4efc316" />

<img width="391" height="118" alt="image" src="https://github.com/user-attachments/assets/c7c26712-c64b-4d0c-a497-39a2313a1199" />


---

# Test Results

N/A

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [ ] I have added/updated tests for my changes

---

# AI Disclosure

None