### PR TITLE
Support both bank and PayPal payouts to Kazakhstan

### DIFF
--- a/app/modules/user/compliance.rb
+++ b/app/modules/user/compliance.rb
@@ -92,6 +92,7 @@ module User::Compliance
     Compliance::Countries::BTN,
     Compliance::Countries::LAO,
     Compliance::Countries::MOZ,
+    Compliance::Countries::KAZ,
     Compliance::Countries::ECU,
     Compliance::Countries::MYS,
     Compliance::Countries::URY,
@@ -216,6 +217,7 @@ module User::Compliance
         signed_up_from_norway? ||
         signed_up_from_saudi_arabia? ||
         signed_up_from_mauritius? ||
+        signed_up_from_kazakhstan? ||
         signed_up_from_tunisia? ||
         signed_up_from_el_salvador? ||
         signed_up_from_kuwait? ||

--- a/app/modules/user/feature_status.rb
+++ b/app/modules/user/feature_status.rb
@@ -29,7 +29,7 @@ class User
     end
 
     def can_setup_paypal_payouts?
-      payment_address.present? || !native_payouts_supported? || signed_up_from_united_arab_emirates? || signed_up_from_egypt?
+      payment_address.present? || !native_payouts_supported? || signed_up_from_united_arab_emirates? || signed_up_from_egypt? || signed_up_from_kazakhstan?
     end
 
     def charge_paypal_payout_fee?

--- a/spec/business/payments/merchant_registration/paypal/paypal_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/paypal/paypal_merchant_account_manager_spec.rb
@@ -249,49 +249,5 @@ describe PaypalMerchantAccountManager, :vcr do
       expect(old_records.count).to eq(0)
       expect(creator.merchant_account("paypal").charge_processor_merchant_id).to eq(new_paypal_merchant_id)
     end
-
-    context "when PayPal account belongs to a Kazakhstan seller" do
-      it "stores the country and currency from PayPal and verifies the account" do
-        creator = create(:user)
-        create(:user_compliance_info, user: creator, country: "Kazakhstan")
-        creator.mark_compliant!(author_name: "Iffy")
-        allow_any_instance_of(User).to receive(:sales_cents_total).and_return(150_00)
-        create(:payment_completed, user: creator)
-
-        mailer = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
-        allow(MerchantRegistrationMailer).to receive(:paypal_account_updated).and_return(mailer)
-
-        paypal_details = {
-          "country" => "KZ",
-          "primary_currency" => "KZT",
-          "primary_email" => "kazakhstan@example.com",
-          "primary_email_confirmed" => true,
-          "payments_receivable" => true,
-          "oauth_integrations" => [
-            {
-              "integration_type" => "OAUTH_THIRD_PARTY",
-              "integration_method" => "PAYPAL",
-              "oauth_third_party" => [
-                {
-                  "partner_client_id" => PAYPAL_PARTNER_CLIENT_ID
-                }
-              ]
-            }
-          ]
-        }
-
-        allow_any_instance_of(MerchantAccount).to receive(:paypal_account_details).and_return(paypal_details)
-
-        response = subject.update_merchant_account(user: creator, paypal_merchant_id: "KZPAYPAL123")
-
-        merchant_account = creator.merchant_account("paypal")
-
-        expect(response).to eq("You have successfully connected your PayPal account with Gumroad.")
-        expect(merchant_account.country).to eq("KZ")
-        expect(merchant_account.currency).to eq("kzt")
-        expect(merchant_account.charge_processor_verified?).to be(true)
-        expect(MerchantRegistrationMailer).to have_received(:paypal_account_updated).with(creator.id)
-      end
-    end
   end
 end

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -1533,6 +1533,88 @@ describe StripeMerchantAccountManager, :vcr do
       end
     end
 
+    describe "all info provided of a Kazakhstan individual" do
+      let(:user_compliance_info) do create(:user_compliance_info, user:, city: "Almaty",
+                                                                  street_address: "address_full_match", state: nil, zip_code: "050000",
+                                                                  country: "Kazakhstan", individual_tax_id: "000000000") end
+      let(:bank_account) { create(:kazakhstan_bank_account, user:) }
+      let(:tos_agreement) { create(:tos_agreement, user:) }
+
+      before do
+        user_compliance_info
+        bank_account
+        travel_to(Time.find_zone("UTC").local(2015, 4, 1)) do
+          tos_agreement
+        end
+      end
+
+      let(:expected_account_params) do
+        {
+          type: "custom",
+          country: "KZ",
+          metadata: {
+            user_id: user.external_id,
+            tos_agreement_id: tos_agreement.external_id,
+            user_compliance_info_id: user_compliance_info.external_id,
+            bank_account_id: bank_account.external_id
+          },
+          tos_acceptance: { date: 1427846400, ip: "54.234.242.13", service_agreement: "recipient" },
+          default_currency: "kzt",
+          business_type: "individual",
+          business_profile: {
+            name: user_compliance_info.legal_entity_name,
+            url: user.business_profile_url,
+            product_description: user_compliance_info.legal_entity_name
+          },
+          individual: {
+            address: {
+              line1: "address_full_match",
+              line2: nil,
+              city: "Almaty",
+              state: nil,
+              postal_code: "050000",
+              country: "KZ"
+            },
+            dob: { day: 1, month: 1, year: 1901 },
+            first_name: "Chuck",
+            last_name: "Bartowski",
+            phone: "0000000000",
+            email: user.email,
+            id_number: "000000000"
+          },
+          bank_account: {
+            country: "KZ",
+            currency: "kzt",
+            account_number: "KZ221251234567890123",
+            routing_number: "AAAAKZKZXXX"
+          },
+          settings: {
+            payouts: {
+              schedule: {
+                interval: "manual"
+              },
+              debit_negative_balances: false
+            }
+          },
+          requested_capabilities: StripeMerchantAccountManager::CROSS_BORDER_PAYOUTS_ONLY_CAPABILITIES
+        }
+      end
+
+      it "creates an account at stripe with all the params and returns the corresponding merchant account" do
+        expect(Stripe::Account).to receive(:create).with(expected_account_params).and_call_original
+
+        merchant_account = subject.create_account(user, passphrase: "1234")
+
+        expect(merchant_account.charge_processor_id).to eq(StripeChargeProcessor.charge_processor_id)
+        expect(merchant_account.charge_processor_merchant_id).to be_present
+        expect(merchant_account.country).to eq("KZ")
+        expect(merchant_account.currency).to eq("kzt")
+        expect(bank_account.reload.stripe_connect_account_id).to eq(merchant_account.charge_processor_merchant_id)
+        expect(bank_account.reload.stripe_bank_account_id).to match(/ba_[a-zA-Z0-9]+/)
+        expect(bank_account.reload.stripe_fingerprint).to match(/[a-zA-Z0-9]+/)
+      end
+    end
+
     describe "all info provided of an Ecuadorian individual" do
       let(:user_compliance_info) do create(:user_compliance_info, user:, city: "Quito",
                                                                   street_address: "address_full_match", state: nil, zip_code: "170102",

--- a/spec/modules/user/compliance_spec.rb
+++ b/spec/modules/user/compliance_spec.rb
@@ -36,13 +36,6 @@ describe User::Compliance do
       expect(venezuela_user.native_payouts_supported?).to be false
     end
 
-    it "returns false for Kazakhstan (PayPal-only country)" do
-      kazakhstan_user = create(:user)
-      create(:user_compliance_info_empty, user: kazakhstan_user, country: "Kazakhstan")
-
-      expect(kazakhstan_user.native_payouts_supported?).to be false
-    end
-
     it "accepts country_code as optional argument" do
       jordan_user = create(:user)
       create(:user_compliance_info_empty, user: jordan_user, country: "Jordan")

--- a/spec/modules/user/feature_status_spec.rb
+++ b/spec/modules/user/feature_status_spec.rb
@@ -229,8 +229,14 @@ describe User::FeatureStatus do
       expect(seller.can_setup_paypal_payouts?).to be true
     end
 
-    it "returns false for all Stripe supported countries except UAE and Egypt" do
-      (User::Compliance.const_get(:SUPPORTED_COUNTRIES) - [Compliance::Countries::ARE, Compliance::Countries::EGY]).each do |country|
+    it "returns true if user is from Kazakhstan" do
+      seller = create(:user, payment_address: nil)
+      create(:user_compliance_info, user: seller, country: "Kazakhstan")
+      expect(seller.can_setup_paypal_payouts?).to be true
+    end
+
+    it "returns false for all Stripe supported countries except UAE, Kazakhstan, and Egypt" do
+      (User::Compliance.const_get(:SUPPORTED_COUNTRIES) - [Compliance::Countries::ARE, Compliance::Countries::KAZ, Compliance::Countries::EGY]).each do |country|
         seller = create(:user, payment_address: nil)
         create(:user_compliance_info, user: seller, country: country.common_name)
         expect(seller.can_setup_paypal_payouts?).to be false

--- a/spec/presenters/settings_presenter_spec.rb
+++ b/spec/presenters/settings_presenter_spec.rb
@@ -853,6 +853,13 @@ describe SettingsPresenter do
 
         expect(presenter.payments_props[:bank_account_details][:show_paypal]).to eq(true)
       end
+
+      it "returns true for show_paypal if user country is Kazakhstan" do
+        create(:user_compliance_info, user: seller, country: "Kazakhstan")
+        seller.update!(payment_address: nil)
+
+        expect(presenter.payments_props[:bank_account_details][:show_paypal]).to eq(true)
+      end
     end
 
     context "when seller's payouts are paused" do

--- a/spec/requests/settings/payments_spec.rb
+++ b/spec/requests/settings/payments_spec.rb
@@ -1725,55 +1725,6 @@ describe("Payments Settings Scenario", type: :system, js: true) do
       end
     end
 
-    describe "Kazakhstan creator" do
-      before do
-        old_user_compliance_info = @user.alive_user_compliance_info
-        new_user_compliance_info = old_user_compliance_info.dup
-        new_user_compliance_info.country = "Kazakhstan"
-
-        ActiveRecord::Base.transaction do
-          old_user_compliance_info.mark_deleted!
-          new_user_compliance_info.save!
-        end
-
-        @user.active_bank_account&.mark_deleted!
-        @user.update!(payment_address: nil)
-      end
-
-      it "collects PayPal payout info instead of bank details" do
-        visit settings_payments_path
-
-        fill_in("First name", with: "barnabas")
-        fill_in("Last name", with: "barnabastein")
-        fill_in("Address", with: "address_full_match")
-        fill_in("City", with: "Almaty")
-        fill_in("Phone number", with: "7012345678")
-        fill_in("Postal code", with: "050000")
-
-        select("1", from: "Day")
-        select("January", from: "Month")
-        select("1980", from: "Year")
-        select("Kazakhstan", from: "Country")
-        fill_in("Individual identification number (IIN)", with: "000000000")
-
-        expect(page).to have_field("PayPal Email")
-        fill_in("PayPal Email", with: "kazakh@example.com")
-
-        click_on("Update settings")
-
-        expect(page).to have_alert(text: "Thanks! You're all set.")
-        compliance_info = @user.alive_user_compliance_info
-        expect(compliance_info.first_name).to eq("barnabas")
-        expect(compliance_info.last_name).to eq("barnabastein")
-        expect(compliance_info.street_address).to eq("address_full_match")
-        expect(compliance_info.city).to eq("Almaty")
-        expect(compliance_info.zip_code).to eq("050000")
-        expect(compliance_info.phone).to eq("+77012345678")
-        expect(@user.reload.payment_address).to eq("kazakh@example.com")
-        expect(@user.reload.active_bank_account).to be_nil
-      end
-    end
-
     describe "AE business" do
       before do
         old_user_compliance_info = @user.alive_user_compliance_info
@@ -3133,6 +3084,95 @@ describe("Payments Settings Scenario", type: :system, js: true) do
         expect(compliance_info.birthday).to eq(Date.new(1980, 1, 1))
         expect(@user.reload.active_bank_account.send(:account_number_decrypted)).to eq("RS35105008123123123173")
         expect(@user.reload.active_bank_account.routing_number).to eq("TESTSERBXXX")
+      end
+    end
+
+    describe "KZ creator" do
+      before do
+        old_user_compliance_info = @user.alive_user_compliance_info
+        new_user_compliance_info = old_user_compliance_info.dup
+        new_user_compliance_info.country = "Kazakhstan"
+        ActiveRecord::Base.transaction do
+          old_user_compliance_info.mark_deleted!
+          new_user_compliance_info.save!
+        end
+      end
+
+      it "allows to enter bank account details" do
+        visit settings_payments_path
+
+        choose "Bank Account"
+
+        fill_in("First name", with: "barnabas")
+        fill_in("Last name", with: "barnabastein")
+        fill_in("Address", with: "address_full_match")
+        fill_in("City", with: "Almaty")
+        fill_in("Phone number", with: "7012345678")
+        fill_in("Postal code", with: "050000")
+
+        select("1", from: "Day")
+        select("January", from: "Month")
+        select("1980", from: "Year")
+
+        fill_in("Pay to the order of", with: "barnabas ngagy")
+        fill_in("SWIFT / BIC Code", with: "AAAAKZKZXXX")
+        fill_in("IBAN", with: "KZ221251234567890123")
+        fill_in("Confirm IBAN", with: "KZ221251234567890123")
+
+        fill_in("Individual identification number (IIN)", with: "000000000")
+
+        expect(page).to have_content("Must exactly match the name on your bank account")
+        expect(page).to have_content("Payouts will be made in KZT.")
+
+        click_on("Update settings")
+
+        expect(page).to have_content("Thanks! You're all set.")
+        expect(page).to have_content("SWIFT / BIC code")
+        compliance_info = @user.alive_user_compliance_info
+        expect(compliance_info.first_name).to eq("barnabas")
+        expect(compliance_info.last_name).to eq("barnabastein")
+        expect(compliance_info.street_address).to eq("address_full_match")
+        expect(compliance_info.city).to eq("Almaty")
+        expect(compliance_info.zip_code).to eq("050000")
+        expect(compliance_info.phone).to eq("+77012345678")
+        expect(compliance_info.birthday).to eq(Date.new(1980, 1, 1))
+        expect(@user.reload.active_bank_account.send(:account_number_decrypted)).to eq("KZ221251234567890123")
+        expect(@user.reload.active_bank_account.routing_number).to eq("AAAAKZKZXXX")
+      end
+
+      it "allows to enter PayPal details" do
+        visit settings_payments_path
+
+        choose "PayPal"
+
+        fill_in("First name", with: "barnabas")
+        fill_in("Last name", with: "barnabastein")
+        fill_in("Address", with: "address_full_match")
+        fill_in("City", with: "barnabasville")
+        fill_in("Phone number", with: "9876543210")
+        fill_in("Postal code", with: "10110")
+
+        select("1", from: "Day")
+        select("January", from: "Month")
+        select("1980", from: "Year")
+
+        expect(page).to have_status(text: "PayPal payouts are subject to a 2% processing fee.")
+        fill_in("PayPal Email", with: "kzcr@example.com")
+
+        click_on("Update settings")
+
+        expect(page).to have_content("Thanks! You're all set.")
+        compliance_info = @user.alive_user_compliance_info
+        expect(compliance_info.first_name).to eq("barnabas")
+        expect(compliance_info.last_name).to eq("barnabastein")
+        expect(compliance_info.street_address).to eq("address_full_match")
+        expect(compliance_info.city).to eq("barnabasville")
+        expect(compliance_info.zip_code).to eq("10110")
+        expect(compliance_info.country).to eq("Kazakhstan")
+        expect(compliance_info.phone).to eq("+79876543210")
+        expect(compliance_info.birthday).to eq(Date.new(1980, 1, 1))
+        expect(@user.reload.payment_address).to eq("kzcr@example.com")
+        expect(@user.active_bank_account).to be nil
       end
     end
 


### PR DESCRIPTION
Issue: https://github.com/antiwork/gumroad-private/issues/37

# Description

Support both bank and PayPal payouts to Kazakhstan

## Problem

A bug was introduced in https://github.com/antiwork/gumroad/pull/2220 due to which the SWIFT code field is not visible to sellers from KZ when they try to update their existing bank account info. The Update button doesn't work because that field is mandatory, so creators from KZ are not able to update their existing bank payout info.

## Solution

Fix it by allowing both bank and PayPal for KZ i.e. revert #2220 + allow PayPal in KZ similar to #2178 .

---

# Before/After

### Before

https://github.com/user-attachments/assets/6fd7081f-ec9e-48bc-aa98-add03b4f7d90

### After

https://github.com/user-attachments/assets/e86484f1-02d5-47f4-b76e-a20b1d335315

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

No AI was used for any part of this contribution.
