### PR TITLE
fix(library): allow gift recipients to access purchases with null purchaser_id

### DIFF
--- a/app/controllers/library_controller.rb
+++ b/app/controllers/library_controller.rb
@@ -5,7 +5,7 @@ class LibraryController < Sellers::BaseController
 
   skip_before_action :check_suspended
 
-  before_action :check_user_confirmed, only: [:index]
+  before_action :check_user_confirmed
   before_action :set_purchase, only: [:archive, :unarchive, :delete]
 
   RESEND_CONFIRMATION_EMAIL_TIME_LIMIT = 24.hours
@@ -52,7 +52,10 @@ class LibraryController < Sellers::BaseController
 
   private
     def set_purchase
-      @purchase = logged_in_user.purchases.find_by_external_id!(params[:id])
+      gift_receiver_flag = Purchase.flag_mapping["flags"][:is_gift_receiver_purchase]
+      @purchase = Purchase.where(purchaser_id: logged_in_user.id)
+        .or(Purchase.where(purchaser_id: nil).where("flags & ? != 0", gift_receiver_flag).where(email: logged_in_user.email))
+        .find_by_external_id!(params[:id])
     end
 
     def check_user_confirmed

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1073,9 +1073,14 @@ class User < ApplicationRecord
     end
 
     def move_purchases_to_new_email
-      if unconfirmed_email.blank? && purchases.exists?
-        UpdatePurchaseEmailToMatchAccountWorker.perform_in(10.seconds, id)
-      end
+      old_email = previous_changes[:email]&.first
+      return if unconfirmed_email.present? || old_email.blank?
+
+      gift_receiver_flag = Purchase.flag_mapping["flags"][:is_gift_receiver_purchase]
+      has_purchases = purchases.exists? ||
+        Purchase.where(purchaser_id: nil, email: old_email).where("flags & ? != 0", gift_receiver_flag).exists?
+
+      UpdatePurchaseEmailToMatchAccountWorker.perform_in(10.seconds, id, old_email) if has_purchases
     end
 
     def update_alive_cart_email

--- a/app/presenters/library_presenter.rb
+++ b/app/presenters/library_presenter.rb
@@ -10,7 +10,9 @@ class LibraryPresenter
   end
 
   def library_cards
-    purchases = logged_in_user.purchases
+    gift_receiver_flag = Purchase.flag_mapping["flags"][:is_gift_receiver_purchase]
+    purchases = Purchase.where(purchaser_id: logged_in_user.id)
+      .or(Purchase.where(purchaser_id: nil).where("flags & ? != 0", gift_receiver_flag).where(email: logged_in_user.email))
       .for_library
       .not_rental_expired
       .not_is_deleted_by_buyer

--- a/app/sidekiq/update_purchase_email_to_match_account_worker.rb
+++ b/app/sidekiq/update_purchase_email_to_match_account_worker.rb
@@ -4,10 +4,18 @@ class UpdatePurchaseEmailToMatchAccountWorker
   include Sidekiq::Job
   sidekiq_options retry: 5, queue: :default
 
-  def perform(user_id)
+  def perform(user_id, old_email = nil)
     user = User.find(user_id)
+
     user.purchases.find_each do |purchase|
       purchase.update!(email: user.email)
+    end
+
+    if old_email.present?
+      gift_receiver_flag = Purchase.flag_mapping["flags"][:is_gift_receiver_purchase]
+      Purchase.where(purchaser_id: nil, email: old_email).where("flags & ? != 0", gift_receiver_flag).find_each do |purchase|
+        purchase.update!(email: user.email)
+      end
     end
   end
 end

--- a/spec/controllers/library_controller_spec.rb
+++ b/spec/controllers/library_controller_spec.rb
@@ -60,6 +60,17 @@ describe LibraryController, :vcr, type: :controller, inertia: true do
         product_names = inertia.props[:results].map { |r| r.dig(:product, :name) }
         expect(product_names).to_not include(link.name)
       end
+
+      it "shows gift receiver purchases with null purchaser_id when email matches" do
+        link = create(:product, name: "Gift Product")
+        gift_purchase = create(:purchase, link:, is_gift_receiver_purchase: true, purchaser: nil, email: user.email)
+        gift_purchase.update_columns(purchaser_id: nil)
+
+        get :index
+        expect(response).to be_successful
+        product_names = inertia.props[:results].map { |r| r.dig(:product, :name) }
+        expect(product_names).to include("Gift Product")
+      end
     end
 
     describe "failed webhooks" do
@@ -168,6 +179,13 @@ describe LibraryController, :vcr, type: :controller, inertia: true do
         expect(flash[:notice]).to eq("Product archived!")
       end.to change { purchase.reload.is_archived }.from(false).to(true)
     end
+
+    it "requires email confirmation" do
+      user.update_attribute(:confirmed_at, nil)
+      patch :archive, params: { id: purchase.external_id }
+      expect(response).to redirect_to(settings_main_path)
+      expect(purchase.reload.is_archived).to be false
+    end
   end
 
   describe "PATCH unarchive" do
@@ -186,6 +204,24 @@ describe LibraryController, :vcr, type: :controller, inertia: true do
         expect(flash[:notice]).to eq("Product unarchived!")
       end.to change { purchase.reload.is_archived }.from(true).to(false)
     end
+
+    it "unarchives gift purchases with null purchaser_id when email matches" do
+      gift_purchase = create(:purchase, is_gift_receiver_purchase: true, purchaser: nil, email: user.email, is_archived: true)
+      gift_purchase.update_columns(purchaser_id: nil)
+
+      expect do
+        patch :unarchive, params: { id: gift_purchase.external_id }
+        expect(response).to redirect_to(library_path)
+        expect(flash[:notice]).to eq("Product unarchived!")
+      end.to change { gift_purchase.reload.is_archived }.from(true).to(false)
+    end
+
+    it "requires email confirmation" do
+      user.update_attribute(:confirmed_at, nil)
+      patch :unarchive, params: { id: purchase.external_id }
+      expect(response).to redirect_to(settings_main_path)
+      expect(purchase.reload.is_archived).to be true
+    end
   end
 
   describe "PATCH delete" do
@@ -203,6 +239,13 @@ describe LibraryController, :vcr, type: :controller, inertia: true do
         expect(response).to redirect_to(library_path)
         expect(flash[:notice]).to eq("Product deleted!")
       end.to change { purchase.reload.is_deleted_by_buyer }.from(false).to(true)
+    end
+
+    it "requires email confirmation" do
+      user.update_attribute(:confirmed_at, nil)
+      patch :delete, params: { id: purchase.external_id }
+      expect(response).to redirect_to(settings_main_path)
+      expect(purchase.reload.is_deleted_by_buyer).to be false
     end
   end
 end

--- a/spec/presenters/library_presenter_spec.rb
+++ b/spec/presenters/library_presenter_spec.rb
@@ -183,6 +183,20 @@ describe LibraryPresenter do
       end
     end
 
+    describe "gift purchase with null purchaser_id" do
+      let(:gift_product) { create(:product, name: "Gift Product", user: creator) }
+
+      it "includes gift purchases where email matches but purchaser_id is null" do
+        gift_purchase = create(:purchase, link: gift_product, is_gift_receiver_purchase: true, purchaser: nil, email: buyer.email)
+        gift_purchase.update_columns(purchaser_id: nil)
+        gift_purchase.create_url_redirect!
+
+        purchases, _ = described_class.new(buyer).library_cards
+
+        expect(purchases.map { |p| p[:purchase][:id] }).to include(gift_purchase.external_id)
+      end
+    end
+
     describe "bundle purchase" do
       let(:purchase1) { create(:purchase, purchaser: buyer, link: create(:product, :bundle)) }
       let(:purchase2) { create(:purchase, purchaser: buyer, link: create(:product, :bundle)) }

--- a/spec/sidekiq/update_purchase_email_to_match_account_worker_spec.rb
+++ b/spec/sidekiq/update_purchase_email_to_match_account_worker_spec.rb
@@ -17,5 +17,25 @@ describe UpdatePurchaseEmailToMatchAccountWorker do
       expect(@purchase_a.reload.email).to eq @user.email
       expect(@purchase_b.reload.email).to eq @user.email
     end
+
+    it "updates gift purchases with null purchaser_id when old_email is provided" do
+      old_email = "old@gmail.com"
+      gift_purchase = create(:purchase, email: old_email, is_gift_receiver_purchase: true, purchaser: nil)
+      gift_purchase.update_columns(purchaser_id: nil)
+
+      described_class.new.perform(@user.id, old_email)
+
+      expect(gift_purchase.reload.email).to eq @user.email
+    end
+
+    it "does not update gift purchases when old_email is not provided" do
+      old_email = "old@gmail.com"
+      gift_purchase = create(:purchase, email: old_email, is_gift_receiver_purchase: true, purchaser: nil)
+      gift_purchase.update_columns(purchaser_id: nil)
+
+      described_class.new.perform(@user.id)
+
+      expect(gift_purchase.reload.email).to eq old_email
+    end
   end
 end


### PR DESCRIPTION
Issue: #2756

# Description

## Problem

Gift purchases created for users who don't have a Gumroad account at purchase time have `purchaser_id = NULL`. When the giftee later creates an account with the matching email, they cannot see or unarchive these gift purchases because the library queries only match on `purchaser_id`.

Root cause: `LibraryController#set_purchase` and `LibraryPresenter#library_cards` use `logged_in_user.purchases` which is a `has_many` association that only queries by `purchaser_id`. Gift receiver purchases with `purchaser_id = NULL` are never found, even when the user's email matches.

## Solution

- Modified `LibraryController#set_purchase` and `LibraryPresenter#library_cards` to query by `purchaser_id` OR by email for gift receiver purchases (using bitmask flag check)
- Extended `check_user_confirmed` to all library actions (not just index) to prevent unconfirmed accounts from accessing gift purchases via email
- Updated `User#move_purchases_to_new_email` to pass the old email to the worker
- Updated `UpdatePurchaseEmailToMatchAccountWorker` to migrate gift receiver purchases with `purchaser_id = NULL` when a user changes their email

---

# Before/After

N/A - Backend-only fix, no UI changes

---

# Test Results

```
LibraryController
  GET index
    normal products
      shows gift receiver purchases with null purchaser_id when email matches
  PATCH archive
    requires email confirmation
  PATCH unarchive
    unarchives gift purchases with null purchaser_id when email matches
    requires email confirmation
  PATCH delete
    requires email confirmation

LibraryPresenter
  #library_cards
    gift purchase with null purchaser_id
      includes gift purchases where email matches but purchaser_id is null

UpdatePurchaseEmailToMatchAccountWorker
  #perform
    updates gift purchases with null purchaser_id when old_email is provided
    does not update gift purchases when old_email is not provided

Finished in 6.26 seconds (files took 3.17 seconds to load)
39 examples, 0 failures
```

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [ ] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

Claude Code (Anthropic) was used for implementation and code generation. OpenAI Codex was used for code review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)