### PR TITLE
fix: layout action buttons not stretching to fill grid cells on mobile

### DIFF
--- a/app/javascript/components/Popover.tsx
+++ b/app/javascript/components/Popover.tsx
@@ -10,11 +10,8 @@ export const PopoverAnchor = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Anchor>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Anchor>
 >(({ className, ...props }, ref) => (
-  <PopoverPrimitive.Anchor
-    ref={ref}
-    className={classNames("grid", className)}
-    {...props}
-  />
+  // Grid layout ensures children match the parent width by default
+  <PopoverPrimitive.Anchor ref={ref} className={classNames("grid", className)} {...props} />
 ));
 PopoverAnchor.displayName = PopoverPrimitive.Anchor.displayName;
 


### PR DESCRIPTION
Fixes: #3250

# Description

<!-- Briefly describe the problem and your solution -->

## Problem


Buttons wrapped in PopoverAnchor were not stretching to fill their allocated space in the grid layout. This caused visual inconsistency where some buttons remained at their intrinsic width.

## Solution

The issue stems from how Radix UI's PopoverAnchor component renders in the DOM and participates in CSS layout:

- The Layouts uses a CSS Grid layout on mobile with grid-cols-2, expecting all direct children to stretch and fill their grid cells equally.

- PopoverAnchor renders as a <div> element, but without explicit display properties, it doesn't automatically participate in the parent grid layout as expected.

<img width="489" height="142" alt="image" src="https://github.com/user-attachments/assets/57267896-f972-41e0-9a31-eadd608f26ff" />

the button is wrapped inside div.


**Fix**

Add `display: grid` to the PopoverAnchor component wrapper, making it a proper grid. Allows the button inside to fill the available width.


Alternate approach:
Using `asChild` pattern on PopoverAnchor
-  Layout worked, but popover positioning broke in case of `WithTooltip` usage.
- When `asChild` merges PopoverAnchor functionality into a wrapper div, and that div or its children have position: relative (from WithTooltip), it changes the positioning context. The popover would appear in unexpected locations.

---

# Before/After

Before: 





https://github.com/user-attachments/assets/f3cb7af8-a88b-456b-abb6-75b1dbcfa515



After:

https://github.com/user-attachments/assets/5c1669ab-544e-4a4d-bfc9-34089348a810


https://github.com/user-attachments/assets/f25337b0-c598-41b4-82fd-a45c96bccbbb


---

# Test Results

<!-- Include a screenshot of your test suite passing locally -->

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [ ] I have added/updated tests for my changes

---

# AI Disclosure
used Sonnet 4.5
