### PR TITLE
Fix products page auto-scrolling on initial navigation

### DIFF
--- a/app/javascript/components/ProductsPage/MembershipsTable.tsx
+++ b/app/javascript/components/ProductsPage/MembershipsTable.tsx
@@ -20,6 +20,7 @@ import {
   TableRow,
 } from "$app/components/ui/Table";
 import { useDebouncedCallback } from "$app/components/useDebouncedCallback";
+import { useOnChange } from "$app/components/useOnChange";
 import { useUserAgentInfo } from "$app/components/UserAgent";
 import { Sort, useSortingTableDriver } from "$app/components/useSortingTableDriver";
 
@@ -72,13 +73,9 @@ export const ProductsPageMembershipsTable = (props: {
   };
 
   const debouncedLoadMemberships = useDebouncedCallback(() => loadMemberships(1), 300);
-  const prevQueryRef = React.useRef(props.query);
 
-  React.useEffect(() => {
-    if (props.query !== null && prevQueryRef.current !== props.query) {
-      debouncedLoadMemberships();
-    }
-    prevQueryRef.current = props.query;
+  useOnChange(() => {
+    if (props.query !== null) debouncedLoadMemberships();
   }, [props.query]);
 
   const reloadMemberships = () => loadMemberships(pagination.page);

--- a/app/javascript/components/ProductsPage/ProductsTable.tsx
+++ b/app/javascript/components/ProductsPage/ProductsTable.tsx
@@ -20,6 +20,7 @@ import {
   TableRow,
 } from "$app/components/ui/Table";
 import { useDebouncedCallback } from "$app/components/useDebouncedCallback";
+import { useOnChange } from "$app/components/useOnChange";
 import { useUserAgentInfo } from "$app/components/UserAgent";
 import { Sort, useSortingTableDriver } from "$app/components/useSortingTableDriver";
 
@@ -72,13 +73,9 @@ export const ProductsPageProductsTable = (props: {
   };
 
   const debouncedLoadProducts = useDebouncedCallback(() => loadProducts(1), 300);
-  const prevQueryRef = React.useRef(props.query);
 
-  React.useEffect(() => {
-    if (props.query !== null && prevQueryRef.current !== props.query) {
-      debouncedLoadProducts();
-    }
-    prevQueryRef.current = props.query;
+  useOnChange(() => {
+    if (props.query !== null) debouncedLoadProducts();
   }, [props.query]);
 
   const reloadProducts = () => loadProducts(pagination.page);


### PR DESCRIPTION
Issue: #3258 


## Root cause

The Products page was unexpectedly scrolling down on initial navigation due to how the search query state was initialized.

In ProductsDashboardPage.tsx, the query state was initialized to an empty string (""). The ProductsTable component contains a useEffect that triggers a reload whenever props.query !== null. Since an empty string is not null, this effect ran immediately on initial mount. As a result, debouncedLoadProducts() was called, which eventually invoked scrollIntoView({ behavior: "smooth" }), causing the unwanted scroll.

Fixed by using a ref to track the previous query value and only triggering the search reload when the query actually changes from user input, not on initial render


## Before

https://github.com/user-attachments/assets/b8040736-7e70-4d19-b97f-7adf1469943c






## After



https://github.com/user-attachments/assets/c047899c-289d-4550-8c58-0e6ef17ae7cf






# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [ ] I have added/updated tests for my changes

---

# AI Disclosure
No AI used