### PR TITLE
Migrate coffee page to Inertia

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,7 +10,7 @@ class UsersController < ApplicationController
 
   after_action :verify_authorized, only: %i[deactivate]
 
-  before_action :hide_layouts, only: %i[show coffee subscribe]
+  before_action :hide_layouts, only: %i[show subscribe]
   before_action :set_as_modal, only: %i[show]
   before_action :set_user_and_custom_domain_config, only: %i[show coffee subscribe subscribe_preview]
   before_action :set_page_attributes, only: %i[show]
@@ -18,7 +18,7 @@ class UsersController < ApplicationController
   before_action :check_if_needs_redirect, only: %i[show]
   before_action :set_affiliate_cookie, only: %i[show]
 
-  layout "inertia", only: [:subscribe_preview]
+  layout "inertia", only: [:coffee, :subscribe_preview]
 
   def show
     format_search_params!
@@ -44,7 +44,15 @@ class UsersController < ApplicationController
     e404 if @product.nil?
 
     set_meta_tag(title: @product.name)
-    @product_props = ProductPresenter.new(pundit_user:, product: @product, request:).product_props(seller_custom_domain_url:, recommended_by: params[:recommended_by])
+    if params[:purchase_email].present?
+      flash[:notice] = "Your purchase was successful! We sent a receipt to #{params[:purchase_email]}."
+      return redirect_to request.path
+    end
+    product_props = ProductPresenter.new(pundit_user:, product: @product, request:).product_props(seller_custom_domain_url:, recommended_by: params[:recommended_by])
+    creator_profile = ProfilePresenter.new(pundit_user:, seller: @product.user).creator_profile
+    custom_styles = @product.user.seller_profile.custom_styles.to_s
+
+    render inertia: "Users/Coffee", props: product_props.merge(creator_profile:, custom_styles:)
   end
 
   def subscribe
@@ -137,6 +145,18 @@ class UsersController < ApplicationController
   end
 
   private
+    def inertia_flash_props
+      if action_name == "coffee"
+        flash_message = flash[:alert] || flash[:warning] || flash[:notice]
+        return if flash_message.blank?
+        status = flash[:alert] ? "danger" : flash[:warning] ? "warning" : "success"
+        flash.clear
+        { message: flash_message, status: status }
+      else
+        super
+      end
+    end
+
     def check_if_needs_redirect
       if !@is_user_custom_domain && @user.subdomain_with_protocol.present?
         redirect_to root_url(host: @user.subdomain_with_protocol, params: request.query_parameters),

--- a/app/javascript/components/Profile/Layout.tsx
+++ b/app/javascript/components/Profile/Layout.tsx
@@ -36,7 +36,7 @@ export const Layout = ({ creatorProfile, hideFollowForm, children }: LayoutProps
     ) : null;
 
   return (
-    <div className="flex min-h-full flex-col">
+    <div className="flex min-h-screen flex-col">
       <header className="z-20 border-border bg-background text-lg lg:border-b lg:px-4 lg:py-6">
         <div className="mx-auto flex max-w-6xl flex-wrap lg:flex-nowrap lg:items-center lg:gap-6">
           <div className="relative flex grow items-center gap-3 border-b border-border px-4 py-8 lg:flex-1 lg:border-0 lg:p-0">
@@ -66,7 +66,7 @@ export const Layout = ({ creatorProfile, hideFollowForm, children }: LayoutProps
           {isDesktop ? headerButtons : null}
         </div>
       </header>
-      <main className="flex-1">
+      <main className="flex flex-1 flex-col">
         {children}
         <PoweredByFooter className="mx-auto w-full max-w-6xl lg:py-6 lg:text-left" />
       </main>

--- a/app/javascript/pages/Users/Coffee.tsx
+++ b/app/javascript/pages/Users/Coffee.tsx
@@ -1,0 +1,36 @@
+import { Head, usePage } from "@inertiajs/react";
+import * as React from "react";
+import { cast } from "ts-safe-cast";
+
+import { CreatorProfile } from "$app/parsers/profile";
+
+import { Product, Purchase } from "$app/components/Product";
+import { Layout } from "$app/components/Profile/Layout";
+import { CoffeeProduct } from "$app/components/server-components/Profile/CoffeePage";
+
+type PageProps = {
+  product: Product;
+  purchase: Purchase | null;
+  creator_profile: CreatorProfile;
+  custom_styles: string;
+};
+
+function CoffeePage() {
+  const { product, purchase, creator_profile, custom_styles } = cast<PageProps>(usePage().props);
+
+  return (
+    <>
+      <Head>
+        <style>{custom_styles}</style>
+      </Head>
+      <div className="coffee-page-wrapper">
+        <Layout creatorProfile={creator_profile} hideFollowForm>
+          <CoffeeProduct product={product} purchase={purchase} className="mx-auto w-full max-w-6xl lg:px-0" />
+        </Layout>
+      </div>
+    </>
+  );
+}
+
+CoffeePage.loggedInUserLayout = true;
+export default CoffeePage;

--- a/app/views/layouts/inertia.html.erb
+++ b/app/views/layouts/inertia.html.erb
@@ -9,6 +9,7 @@
     <div id="design-settings" data-settings="<%= custom_context[:design_settings].to_json %>" style="display: none;"></div>
     <div id="user-agent-info" data-settings="<%= custom_context[:user_agent_info].to_json %>" style="display: none;"></div>
     <%= render("layouts/shared/flash") %>
+    <style>.coffee-page-wrapper { min-height: 100vh; display: flex; flex-direction: column; }</style>
     <%= content_for?(:content) ? yield(:content) : yield %>
     <% if content_for? :footer %>
       <footer>


### PR DESCRIPTION
Issue: #3144

# Description

This PR migrates the following endpoint to Inertia:

* `/coffee` -> `users#coffee`

And moves the "Your purchase was successful! We sent a receipt to ${email}" flash message to server-side instead of client-side.

**Changes:**
- Replace React on Rails/ERB with Inertia component
- Move flash message to server-side with PRG (Post-Redirect-Get) pattern
- Add `inertia_flash_props` override to prevent duplicate flash display
- Remove coffee from `hide_layouts` to load base pack
- Update Layout component for proper vertical centering

---

# Before/After

## Before

https://github.com/user-attachments/assets/3d488b3b-a54d-40c2-b92d-2664f31c40ca

## After

https://github.com/user-attachments/assets/c427b936-563c-4b4b-aa14-006e8b7b6ecf

---

# Test Results

<img width="571" height="155" alt="image" src="https://github.com/user-attachments/assets/3075c9e9-43a1-4ddd-93a0-14d9d998f208" />

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

Model: Claude (Opus 4.5)
IDE: VS Code + Claude Code
Usage: Code understanding, Inertia.js migration, debugging duplicate flash messages, and vertical centering fix
