### PR TITLE
Fix cursor pointer on shared buttons

### DIFF
--- a/app/views/home/shared/_button.html.erb
+++ b/app/views/home/shared/_button.html.erb
@@ -10,7 +10,7 @@
     'default' => 'h-14 px-8 text-xl lg:h-16 lg:px-10 lg:text-xl'
   }
 
-  button_classes = "relative inline-flex rounded-sm no-underline items-center justify-center border border-black transition-all duration-150 group-hover:-translate-x-2 group-hover:-translate-y-2 z-3 w-full lg:w-auto #{size_classes[local_assigns[:size] || 'default']} #{variant_classes[local_assigns[:variant] || 'light']}"
+  button_classes = "relative inline-flex rounded-sm no-underline items-center justify-center border border-black transition-all duration-150 group-hover:-translate-x-2 group-hover:-translate-y-2 z-3 w-full lg:w-auto cursor-pointer #{size_classes[local_assigns[:size] || 'default']} #{variant_classes[local_assigns[:variant] || 'light']}"
 %>
 
 <div class="relative inline-block group">


### PR DESCRIPTION
Issue: #3281 


## Summary
The underlying ERB partial (app/views/home/shared/_button.html.erb) was missing the cursor-pointer Tailwind CSS utility


## Before
<img width="1512" height="849" alt="Screenshot 2026-01-31 at 7 24 05 PM" src="https://github.com/user-attachments/assets/c46bde7d-7f32-4ea0-8ea8-b0acadea823a" />






## After

<img width="1512" height="847" alt="Screenshot 2026-01-31 at 7 23 24 PM" src="https://github.com/user-attachments/assets/ac69e27c-814d-4006-8802-63819fbeaca1" />







# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [ ] I have performed a self-review and left review comments on my PR
- [ ] I have added/updated tests for my changes

---

# AI Disclosure
No AI used