### PR TITLE
Typo: Remove duplicate "page" work in tax center link

### DIFF
--- a/app/views/creator_mailer/year_in_review.html.erb
+++ b/app/views/creator_mailer/year_in_review.html.erb
@@ -161,7 +161,7 @@
               <td>
                 <% if @seller.eligible_for_1099?(@year) %>
                   Your 1099 form is available for download on your
-                  <%= link_to "Gumroad Tax Center page", tax_center_url %> page.
+                  <%= link_to "Gumroad Tax Center", tax_center_url %> page.
                 <% else %>
                   You do not qualify for a 1099 this year.
                 <% end %>


### PR DESCRIPTION
The title says it all. Will merge when CI's green.

Related issue: https://github.com/antiwork/gumroad/issues/2599