### PR TITLE
fix(preview): Prevent receipt preview from being cut off in sidebar

### DIFF
--- a/app/javascript/components/PreviewSidebar.tsx
+++ b/app/javascript/components/PreviewSidebar.tsx
@@ -23,7 +23,7 @@ export const PreviewSidebar = ({
   return (
     <aside
       className={cx(
-        "bg-filled sticky top-0 hidden h-screen flex-col gap-4 self-start overflow-auto p-6 lg:flex lg:border-l lg:border-border",
+        "bg-filled sticky top-0 hidden min-h-screen flex-col gap-4 self-start overflow-auto p-6 lg:flex lg:border-l lg:border-border",
         className,
       )}
       aria-labelledby={`${uid}-title`}


### PR DESCRIPTION
Issue: #3310 


## Summary
Fixes the receipt preview being cut off on the product edit receipt page (`/products/:id/edit/receipt`).
## Problem
The `PreviewSidebar` component used `h-screen` which sets a fixed height of 100vh. For pages with tall preview content like the receipt page (which displays at full size with `scaleFactor={1}`), the content exceeded this fixed height and was clipped.
## Solution
Changed `h-screen` to `min-h-screen` in the `PreviewSidebar` component. This ensures:
- Short content (Product/Content tabs): Sidebar fills at least the viewport height
- Tall content (Receipt tab): Sidebar grows to fit the full content


## Before



https://github.com/user-attachments/assets/579f5958-9a50-4ee5-bea9-6c9cb0a46b37






## After


https://github.com/user-attachments/assets/102509df-4659-4a4b-abcf-92679383a2d6













# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [ ] I have performed a self-review and left review comments on my PR
- [ ] I have added/updated tests for my changes

---

# AI Disclosure
No AI used

