### PR TITLE
Fix design issues on purchase page on mobile when installment plan is enabled #3319

### DIFF
--- a/app/javascript/components/Product/CtaButton.tsx
+++ b/app/javascript/components/Product/CtaButton.tsx
@@ -143,8 +143,8 @@ export const CtaButton = React.forwardRef<HTMLAnchorElement, Props>(
     };
 
     return (
-      <>
-        <NavigationButton ref={ref} href={url.toString()} color="accent" {...buttonCommonProps}>
+      <div className="flex flex-col gap-2 lg:gap-3">
+        <NavigationButton ref={ref} href={url.toString()} color="accent" className="w-full" {...buttonCommonProps}>
           {label ??
             (purchase
               ? "Purchase again"
@@ -159,11 +159,11 @@ export const CtaButton = React.forwardRef<HTMLAnchorElement, Props>(
 
         {product.installment_plan && product.installment_plan.number_of_installments > 1 ? (
           <>
-            <NavigationButton color="black" href={urlWithInstallments.toString()} {...buttonCommonProps}>
+            <NavigationButton color="black" href={urlWithInstallments.toString()} className="w-full" {...buttonCommonProps}>
               Pay in {product.installment_plan.number_of_installments} installments
             </NavigationButton>
             {showInstallmentPlanNotes ? (
-              <small className="text-center">
+              <small className="text-center text-xs">
                 {formatInstallmentPaymentSchedule(
                   discountedPriceCents,
                   product.currency_code,
@@ -173,7 +173,7 @@ export const CtaButton = React.forwardRef<HTMLAnchorElement, Props>(
             ) : null}
           </>
         ) : null}
-      </>
+      </div>
     );
   },
 );

--- a/app/javascript/components/Product/Layout.tsx
+++ b/app/javascript/components/Product/Layout.tsx
@@ -276,54 +276,58 @@ const CtaBar = ({
     >
       <div
         ref={ref}
-        className="mx-auto flex max-w-product-page items-center justify-between gap-4 p-4 lg:px-8"
+        className="mx-auto flex max-w-product-page flex-col gap-3 p-4 lg:flex-row lg:items-center lg:justify-between lg:gap-4 lg:px-8 lg:py-0"
         style={{
           transition: "var(--transition-duration)",
           marginTop: visible || !isDesktop ? undefined : -height,
         }}
       >
-        <PriceTag
-          currencyCode={product.currency_code}
-          oldPrice={discountedPriceCents < priceCents ? priceCents : undefined}
-          price={discountedPriceCents}
-          url={product.long_url}
-          recurrence={
-            product.recurrences
-              ? {
-                  id: selection.recurrence ?? product.recurrences.default,
-                  duration_in_months: product.duration_in_months,
-                }
-              : undefined
-          }
-          isPayWhatYouWant={isPWYW}
-          isSalesLimited={product.is_sales_limited}
-          creatorName={product.seller?.name}
-        />
-        <h3 className="hidden flex-1 lg:block">{product.name}</h3>
-        {product.ratings != null && product.ratings.count > 0 ? (
-          <RatingsSummary className="hidden lg:flex" ratings={product.ratings} />
-        ) : null}
-        <CtaButton
-          product={product}
-          purchase={purchase}
-          discountCode={discountCode ?? null}
-          selection={selection}
-          label={ctaLabel}
-          onClick={(evt) => {
-            if (
-              isPWYW ||
-              product.options.length > 1 ||
-              hasRentOption ||
-              hasMultipleRecurrences ||
-              hasConfigurableQuantity
-            ) {
-              evt.preventDefault();
-              ctaButtonRef.current?.scrollIntoView(false);
-              configurationSelectorRef.current?.focusRequiredInput();
-              if (isPWYW && selection.price.value === null) showAlert("You must input an amount", "warning");
+        <div className="flex flex-shrink-0 items-center gap-3 lg:gap-4">
+          <PriceTag
+            currencyCode={product.currency_code}
+            oldPrice={discountedPriceCents < priceCents ? priceCents : undefined}
+            price={discountedPriceCents}
+            url={product.long_url}
+            recurrence={
+              product.recurrences
+                ? {
+                    id: selection.recurrence ?? product.recurrences.default,
+                    duration_in_months: product.duration_in_months,
+                  }
+                : undefined
             }
-          }}
-        />
+            isPayWhatYouWant={isPWYW}
+            isSalesLimited={product.is_sales_limited}
+            creatorName={product.seller?.name}
+          />
+          <h3 className="hidden flex-1 lg:block">{product.name}</h3>
+          {product.ratings != null && product.ratings.count > 0 ? (
+            <RatingsSummary className="hidden lg:flex" ratings={product.ratings} />
+          ) : null}
+        </div>
+        <div className="lg:min-w-fit lg:flex-shrink-0">
+          <CtaButton
+            product={product}
+            purchase={purchase}
+            discountCode={discountCode ?? null}
+            selection={selection}
+            label={ctaLabel}
+            onClick={(evt) => {
+              if (
+                isPWYW ||
+                product.options.length > 1 ||
+                hasRentOption ||
+                hasMultipleRecurrences ||
+                hasConfigurableQuantity
+              ) {
+                evt.preventDefault();
+                ctaButtonRef.current?.scrollIntoView(false);
+                configurationSelectorRef.current?.focusRequiredInput();
+                if (isPWYW && selection.price.value === null) showAlert("You must input an amount", "warning");
+              }
+            }}
+          />
+        </div>
       </div>
     </section>
   );

--- a/app/javascript/components/Product/PriceTag.tsx
+++ b/app/javascript/components/Product/PriceTag.tsx
@@ -60,11 +60,11 @@ export const PriceTag = ({
   const borderClasses = "border-r-transparent border-[calc(0.5lh+--spacing(1))] border-l-1";
 
   return (
-    <div itemScope itemProp="offers" itemType="https://schema.org/Offer" className="flex items-center">
+    <div itemScope itemProp="offers" itemType="https://schema.org/Offer" className="flex flex-shrink-0 items-center">
       <WithTooltip position={tooltipPosition} tip={priceTag}>
-        <div className="relative grid grid-flow-col border border-r-0 border-border">
+        <div className="relative grid grid-flow-col border border-r-0 border-border whitespace-nowrap">
           <div
-            className="bg-accent px-2 py-1 text-accent-foreground"
+            className="bg-accent px-2 py-1 text-sm text-accent-foreground lg:text-base"
             itemProp="price"
             content={formatPriceCentsWithoutCurrencySymbolAndComma(currencyCode, price)}
           >


### PR DESCRIPTION
Description:

Fixes mobile UI/UX issues on the purchase page when installment plans are enabled. Sticky CTA bar and price display now render correctly on small screens without wrapping.

Problem:

Text and buttons in the navbar wrapped unexpectedly on mobile.

Sticky CtaBar did not stack elements properly (price, product name, buttons).

Root cause:
CtaButton lacked flex constraints, PriceTag had no mobile styling, and CtaBar used a rigid horizontal layout.

Solution:

CtaButton.tsx

Vertical stacking on mobile (flex flex-col)

w-full buttons and text-xs notes

PriceTag.tsx

Prevent shrinking (flex-shrink-0)

Keep price on one line (whitespace-nowrap)

Responsive font size (text-sm lg:text-base)

Layout.tsx (CtaBar)

Mobile: vertical layout (flex-col)

Desktop: horizontal layout (lg:flex-row)

Proper padding, spacing, and shrink constraints

Components Modified:

CtaButton.tsx

PriceTag.tsx

Layout.tsx

Testing:

✅ Mobile (320–768px), Tablet (768–1024px), Desktop (1024px+)

✅ Products with and without installment plans

✅ Safari compatibility

✅ Fixes issue: #3319