### PR TITLE
fix: date range picker not responsive on small screens

### DIFF
--- a/app/javascript/components/DateRangePicker.tsx
+++ b/app/javascript/components/DateRangePicker.tsx
@@ -14,7 +14,7 @@ import * as React from "react";
 
 import { DateInput } from "$app/components/DateInput";
 import { Icon } from "$app/components/Icons";
-import { Popover, PopoverContent, PopoverTrigger } from "$app/components/Popover";
+import { Popover, PopoverAnchor, PopoverContent, PopoverTrigger } from "$app/components/Popover";
 import { Fieldset, FieldsetDescription, FieldsetTitle } from "$app/components/ui/Fieldset";
 import { InputGroup } from "$app/components/ui/InputGroup";
 import { Label } from "$app/components/ui/Label";
@@ -52,12 +52,14 @@ export const DateRangePicker = ({
         setOpen(open);
       }}
     >
-      <PopoverTrigger>
+      <PopoverAnchor>
+      <PopoverTrigger asChild>
         <InputGroup className="whitespace-nowrap" aria-label="Date range selector">
           <span suppressHydrationWarning>{Intl.DateTimeFormat(locale).formatRange(from, to)}</span>
           <Icon name="outline-cheveron-down" className="ml-auto" />
         </InputGroup>
       </PopoverTrigger>
+      </PopoverAnchor>
       <PopoverContent matchTriggerWidth className={isCustom ? "" : "border-0 p-0 shadow-none"}>
         {isCustom ? (
           <div className="flex flex-col gap-4">


### PR DESCRIPTION
Issue: #

# Description

<!-- Briefly describe the problem and your solution -->

## Problem

On small screens, the date range picker popover was misaligned and partially clipped.

## Solution

Wrapped the `PopoverTrigger` with `PopoverAnchor`

---

# Before/After

Before:

<img width="490" height="909" alt="Screenshot from 2026-02-04 21-27-43" src="https://github.com/user-attachments/assets/e09118c6-7aec-4de4-a015-eb8a5430eb08" />



After:

<img width="490" height="909" alt="image" src="https://github.com/user-attachments/assets/817cc51d-0ade-47d6-bf99-867ea7f69c4e" />


---

# Test Results

<!-- Include a screenshot of your test suite passing locally -->

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [ ] I have added/updated tests for my changes

---

# AI Disclosure

None
