### PR TITLE
fix(purchase): ensure offer code persistence on installments even if …

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -1999,7 +1999,7 @@ class Purchase < ApplicationRecord
   end
 
   def does_not_count_towards_max_purchases
-    is_recurring_subscription_charge || is_additional_contribution || is_preorder_charge? || is_gift_receiver_purchase || is_updated_original_subscription_purchase || is_commission_completion_purchase
+    is_recurring_subscription_charge || is_additional_contribution || is_preorder_charge? || is_gift_receiver_purchase || is_updated_original_subscription_purchase || is_commission_completion_purchase || (is_installment_payment && !is_original_subscription_purchase)
   end
 
   # Public: Determine if this purchase is a test purchase by the links owner.
@@ -2411,13 +2411,14 @@ class Purchase < ApplicationRecord
   end
 
   def original_offer_code(include_deleted: false)
-    return nil if offer_code&.deleted? && !include_deleted
-
     if has_cached_offer_code?
-      code = purchase_offer_code_discount.offer_code.code
-      purchase_offer_code_discount.offer_code_is_percent ?
-        OfferCode.new(amount_percentage: purchase_offer_code_discount.offer_code_amount, code:) :
-        OfferCode.new(amount_cents: purchase_offer_code_discount.offer_code_amount, code:)
+      p_discount = purchase_offer_code_discount
+      code = p_discount.offer_code.code
+      p_discount.offer_code_is_percent ?
+        OfferCode.new(amount_percentage: p_discount.offer_code_amount, code:) :
+        OfferCode.new(amount_cents: p_discount.offer_code_amount, code:)
+    elsif offer_code&.deleted? && !include_deleted
+      nil
     else
       offer_code
     end
@@ -3358,8 +3359,7 @@ class Purchase < ApplicationRecord
 
     def validate_offer_code
       return if errors.present?
-      # accept the offer code that was used when the buyer preordered/subscribed
-      return if is_preorder_charge? || is_recurring_subscription_charge || is_gift_receiver_purchase
+      return if is_preorder_charge? || is_recurring_subscription_charge || is_gift_receiver_purchase || (is_installment_payment && !is_original_subscription_purchase) || is_updated_original_subscription_purchase || is_commission_completion_purchase
       return if discount_code.blank?
 
       if offer_code.nil?

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -248,7 +248,18 @@ class Subscription < ApplicationRecord
     purchase = Purchase.new(purchase_params)
     purchase.variant_attributes = original_purchase.variant_attributes
 
-    purchase.offer_code = original_purchase.offer_code if discount_applies_to_next_charge?
+    if discount_applies_to_next_charge?
+      purchase.offer_code = original_purchase.offer_code
+      if original_discount = original_purchase.purchase_offer_code_discount
+        purchase.build_purchase_offer_code_discount(
+          offer_code: original_discount.offer_code,
+          offer_code_amount: original_discount.offer_code_amount,
+          offer_code_is_percent: original_discount.offer_code_is_percent,
+          pre_discount_minimum_price_cents: original_discount.pre_discount_minimum_price_cents,
+          duration_in_months: original_discount.duration_in_months
+        )
+      end
+    end
 
     purchase.purchaser = user
     purchase.link = link

--- a/spec/models/installment_offer_code_persistence_spec.rb
+++ b/spec/models/installment_offer_code_persistence_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Installment Plan Offer Code Discount Persistence", type: :model do
+
+  let(:seller) { create(:user) }
+  let(:product) { create(:product, :with_installment_plan, user: seller, price_cents: 30_00) }
+  let(:buyer) { create(:user) }
+  let(:credit_card) { create(:credit_card, user: buyer) }
+
+  before do
+    card_hash = { fingerprint: "f123", brand: "visa", last4: "4242", country: "US", exp_month: 12, exp_year: 2030, wallet: nil }
+    pm_hash = { id: "pm_123", customer: "cus_123", card: card_hash }
+    stripe_pm = Stripe::Util.convert_to_stripe_object(pm_hash)
+
+    allow(Stripe::PaymentMethod).to receive(:create).and_return(stripe_pm)
+    allow(Stripe::PaymentMethod).to receive(:retrieve).and_return(stripe_pm)
+    allow(Stripe::Customer).to receive(:create).and_return(double(id: "cus_123").as_null_object)
+
+    buyer.update!(credit_card: credit_card)
+    # Create the text fixture MerchantAccount needed for the purchase factory to be valid
+    # This satisfies MerchantAccount.gumroad(charge_processor_id) lookup
+    unless MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id)
+      MerchantAccount.create!(
+        user: nil,
+        charge_processor_id: StripeChargeProcessor.charge_processor_id,
+        charge_processor_alive_at: Time.current
+      )
+    end
+
+  end
+
+  describe "discount persistence when offer code max usage is reached" do
+    let(:offer_code) do
+      create(:offer_code,
+             products: [product],
+             amount_cents: 5_00,
+             max_purchase_count: 1) # Only allows 1 use
+    end
+
+    it "applies the cached discount to subsequent installments even after offer code is exhausted" do
+      original_purchase = create(:installment_plan_purchase,
+                                 link: product,
+                                 offer_code: offer_code,
+                                 purchaser: buyer,
+                                 seller: seller)
+
+      subscription = original_purchase.subscription
+
+      # Verify the discount was initially applied and cached
+      expect(original_purchase.purchase_offer_code_discount).to be_present
+      expect(original_purchase.purchase_offer_code_discount.offer_code).to eq(offer_code)
+
+      expect(offer_code.reload.is_valid_for_purchase?).to eq(false)
+
+      # Simulate time passing for next installment
+      travel_to(1.month.from_now) do
+        # Build next installment
+        next_purchase = subscription.build_purchase
+        next_purchase.set_price_and_rate
+
+        # Verify the discount is copied
+        expect(next_purchase.purchase_offer_code_discount).to be_present
+        expect(next_purchase.price_cents).to be < 10_00
+
+        next_purchase.send(:validate_offer_code)
+
+        expect(next_purchase.errors[:base]).to be_empty
+        expect(next_purchase.purchase_offer_code_discount.offer_code_amount).to eq(5_00)
+
+        expect(next_purchase.price_cents).to be < 10_00
+      end
+    end
+
+    it "correctly calculates the discounted price using cached discount values" do
+      original_purchase = create(:installment_plan_purchase,
+                                 link: product,
+                                 offer_code: offer_code,
+                                 purchaser: buyer,
+                                 seller: seller)
+
+      subscription = original_purchase.subscription
+
+      # Exhaust the offer code by creating another purchase that uses it
+      another_buyer = create(:user)
+      create(:purchase, link: product, offer_code: offer_code, purchaser: another_buyer, seller: seller)
+
+      # Verify offer code is exhausted
+      expect(offer_code.reload.is_valid_for_purchase?).to eq(false)
+
+      travel_to(1.month.from_now) do
+        next_purchase = subscription.build_purchase
+
+        # Verify original_offer_code returns a reconstructed OfferCode from cached values
+        reconstructed_code = next_purchase.original_offer_code
+        expect(reconstructed_code).to be_present
+        expect(reconstructed_code.amount_cents).to eq(5_00)
+        expect(reconstructed_code.is_cents?).to eq(true)
+      end
+    end
+  end
+
+  describe "discount persistence when offer code is deleted" do
+    let(:offer_code) do
+      create(:offer_code,
+             products: [product],
+             amount_percentage: 50) # 50% off
+    end
+
+    it "applies the cached discount even after offer code is soft-deleted" do
+      original_purchase = create(:installment_plan_purchase,
+                                 link: product,
+                                 offer_code: offer_code,
+                                 purchaser: buyer,
+                                 seller: seller)
+
+      subscription = original_purchase.subscription
+
+      # Soft-delete the offer code
+      offer_code.update!(deleted_at: Time.current)
+      expect(offer_code.reload.deleted?).to eq(true)
+
+      travel_to(1.month.from_now) do
+        next_purchase = subscription.build_purchase
+
+        # Discount should still be present from cached values
+        expect(next_purchase.purchase_offer_code_discount).to be_present
+        expect(next_purchase.purchase_offer_code_discount.offer_code_amount).to eq(50)
+        expect(next_purchase.purchase_offer_code_discount.offer_code_is_percent).to eq(true)
+
+        # original_offer_code should return reconstructed OfferCode from cache
+        reconstructed_code = next_purchase.original_offer_code
+        expect(reconstructed_code).to be_present
+        expect(reconstructed_code.amount_percentage).to eq(50)
+        expect(reconstructed_code.is_percent?).to eq(true)
+      end
+    end
+  end
+
+  describe "#discount_applies_to_next_charge?" do
+    it "always returns true for installment plans" do
+      original_purchase = create(:installment_plan_purchase,
+                                 link: product,
+                                 purchaser: buyer,
+                                 seller: seller)
+
+      subscription = original_purchase.subscription
+
+      # Installment plans should always apply discounts
+      expect(subscription.discount_applies_to_next_charge?).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
Issue: #1410 

# Description

This PR fixes a bug where offer code discounts were not consistently applied to non-first installments or subscription charges once the offer code was deleted or its global usage limit was reached.
The solution makes sure the discount is saved when the customer makes the first purchase and is automatically applied to all future related charges.

## Problem
When a customer started an installment or subscription purchase using an offer code with a limited usage count:

- The first installment correctly applied the discount.
- Subsequent installments failed to apply the discount if the offer code became “sold out” or was deleted in the meantime.
- This caused inconsistent pricing and broke customer expectations.

## Solution

- Save the discount details from the first purchase so they can be reused later.
- Skip offer code checks for later installments, subscription updates, and commission payments.
- Make sure later installments do not reduce product inventory or use up the offer code again.
- Use the saved discount information instead of checking the current offer code data for future charges.

This makes sure the same price and discount are applied to all installments and subscription payments.

---

# Before/After

Before:

- Discount applied only to the first installment.
- Later installments ignored the discount if the offer code was exhausted or deleted.

After:

- Discount is consistently applied to all installments and subscription charges originating from the initial purchase.
- Offer code deletion or exhaustion no longer affects existing installment plans.

---

# Test Results

https://github.com/user-attachments/assets/b6f3488c-f3c9-45a1-a377-84f4f9213064

<img width="724" height="136" alt="Screenshot from 2026-02-04 23-15-31" src="https://github.com/user-attachments/assets/fead7c81-910f-492b-8c08-cfcfd65e8abc" />

Confirmed:
- First installment succeeds with a one-time-use offer code.
- Subsequent installments retain the same discount after the code is exhausted.
- Discount persists even if the offer code record is deleted.

All tests pass locally.
---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

Model: Claude Opus 4.5 via Antigravity
Used for:

- Reproduction test generation.
- Framing the manual testing steps used in the demo video.

All code and tests were manually reviewed and modified by me to ensure correctness and consistency with existing behavior.
