### PR TITLE
Show business-state field on the payment settings page for Brazilian business accounts

### DIFF
--- a/app/javascript/components/Settings/PaymentsPage/AccountDetailsSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/AccountDetailsSection.tsx
@@ -442,6 +442,29 @@ const AccountDetailsSection = ({
                   ))}
                 </select>
               </fieldset>
+            ) : complianceInfo.business_country === "BR" ? (
+              <fieldset className={cx({ danger: errorFieldNames.has("business_state") })}>
+                <legend>
+                  <label htmlFor={`${uid}-business-state`}>State</label>
+                </legend>
+                <select
+                  id={`${uid}-business-state`}
+                  required={complianceInfo.is_business}
+                  disabled={isFormDisabled}
+                  aria-invalid={errorFieldNames.has("business_state")}
+                  value={complianceInfo.business_state || ""}
+                  onChange={(evt) => updateComplianceInfo({ business_state: evt.target.value })}
+                >
+                  <option value="" disabled>
+                    State
+                  </option>
+                  {states.br.map((state) => (
+                    <option key={state.code} value={state.code}>
+                      {state.name}
+                    </option>
+                  ))}
+                </select>
+              </fieldset>
             ) : null}
             <fieldset className={cx({ danger: errorFieldNames.has("business_zip_code") })}>
               <legend>


### PR DESCRIPTION
Issue: https://github.com/antiwork/gumroad-private/issues/97

# Description

Show business-state field on the payment settings page for Brazilian business accounts

## Problem

The "State" input field is missing from the business info section for Brazilian accounts, so they are not able to submit the payout info and are seeing "Please select a valid state or province" error when trying to submit.

## Solution

Show business-state field on the payment settings page for Brazilian business accounts

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

No AI was used for any part of this contribution.
