### PR TITLE
Fix tiered membership restart failing when changing billing recurrence

### DIFF
--- a/app/services/subscription/restart_at_checkout_service.rb
+++ b/app/services/subscription/restart_at_checkout_service.rb
@@ -28,7 +28,7 @@ class Subscription::RestartAtCheckoutService
     return error_result(error) if error.present?
 
     ActiveRecord::Base.transaction do
-      handle_tier_change if tier_changed?
+      handle_plan_change if plan_changed?
       update_payment_method if should_update_payment_method?
       subscription.resubscribe!
 
@@ -60,30 +60,44 @@ class Subscription::RestartAtCheckoutService
       nil
     end
 
-    def tier_changed?
-      return false unless product.is_tiered_membership?
-      return false unless params[:variants].present?
+    def plan_changed?
+      tier_changed? || recurrence_changed?
+    end
 
-      selected_tier_ids = params[:variants].map { |id| product.tiers.find_by_external_id(id)&.id }.compact
+    def tier_changed?
+      return false if !product.is_tiered_membership?
+      return false if params[:variants].blank?
+
+      selected_tier_ids = selected_variants.map(&:id)
       current_tier_ids = subscription.original_purchase.variant_attributes.map(&:id)
 
       selected_tier_ids.sort != current_tier_ids.sort
     end
 
-    def handle_tier_change
-      new_variants = params[:variants].map { |id| product.tiers.find_by_external_id(id) }.compact
+    def recurrence_changed?
+      return false if new_price.blank?
+
+      new_price.recurrence != subscription.price.recurrence
+    end
+
+    def handle_plan_change
       perceived_price_cents = params.dig(:purchase, :perceived_price_cents)&.to_i
 
       subscription.update_current_plan!(
-        new_variants: new_variants,
-        new_price: determine_new_price,
-        perceived_price_cents: perceived_price_cents
+        new_variants: selected_variants,
+        new_price: new_price,
+        perceived_price_cents: perceived_price_cents,
+        skip_preparing_for_charge: true
       )
       subscription.reload
     end
 
-    def determine_new_price
-      if params[:price_id].present?
+    def selected_variants
+      @selected_variants ||= params[:variants]&.map { |id| product.tiers.find_by_external_id(id) }&.compact || []
+    end
+
+    def new_price
+      @new_price ||= if params[:price_id].present?
         product.prices.alive.find_by_external_id(params[:price_id])
       else
         product.default_price
@@ -106,13 +120,13 @@ class Subscription::RestartAtCheckoutService
           "There is a temporary problem, please try again (your card was not charged)."
       end
 
-      unless chargeable.present?
+      if chargeable.blank?
         raise Subscription::UpdateFailed, "We couldn't process your card. Try again or use a different card."
       end
 
       credit_card = CreditCard.create(chargeable, card_data_handling_mode, buyer)
 
-      unless credit_card.errors.empty?
+      if credit_card.errors.present?
         raise Subscription::UpdateFailed, credit_card.errors.messages[:base].first
       end
 

--- a/spec/services/subscription/restart_at_checkout_service_spec.rb
+++ b/spec/services/subscription/restart_at_checkout_service_spec.rb
@@ -191,5 +191,104 @@ describe Subscription::RestartAtCheckoutService do
         expect(result[:error_message]).to eq("This subscription cannot be restarted.")
       end
     end
+
+    context "with a tiered membership and recurrence change" do
+      let(:recurrence_price_values) do
+        [
+          { "monthly" => { enabled: true, price: 3 }, "yearly" => { enabled: true, price: 30 } },
+          { "monthly" => { enabled: true, price: 5 }, "yearly" => { enabled: true, price: 50 } }
+        ]
+      end
+      let(:tiered_product) do
+        create(:membership_product_with_preset_tiered_pricing,
+               user: seller,
+               subscription_duration: :monthly,
+               recurrence_price_values: recurrence_price_values)
+      end
+      let(:tier) { tiered_product.tiers.first }
+      let(:monthly_price) { tiered_product.prices.alive.find_by(recurrence: BasePrice::Recurrence::MONTHLY) }
+      let(:yearly_price) { tiered_product.prices.alive.find_by(recurrence: BasePrice::Recurrence::YEARLY) }
+      let(:tier_monthly_price_cents) { tier.prices.find_by(recurrence: "monthly").price_cents }
+      let(:tier_yearly_price_cents) { tier.prices.find_by(recurrence: "yearly").price_cents }
+
+      let!(:subscription) do
+        create_subscription_for_product(
+          product: tiered_product,
+          purchaser: buyer,
+          email: email,
+          cancelled_at: 1.day.ago,
+          cancelled_by_buyer: true,
+          deactivated_at: 1.day.ago
+        )
+      end
+
+      before do
+        allow_any_instance_of(Subscription).to receive(:end_time_of_last_paid_period).and_return(1.week.from_now)
+      end
+
+      context "when changing from monthly to yearly recurrence" do
+        let(:params_with_yearly_price) do
+          {
+            purchase: {
+              email: email,
+              perceived_price_cents: tier_yearly_price_cents,
+              browser_guid: browser_guid
+            },
+            price_id: yearly_price.external_id,
+            variants: [tier.external_id]
+          }
+        end
+
+        it "updates the subscription price to yearly and restarts successfully" do
+          expect(subscription.price.recurrence).to eq("monthly")
+
+          service = described_class.new(
+            subscription: subscription,
+            product: tiered_product,
+            params: params_with_yearly_price,
+            buyer: buyer
+          )
+
+          result = service.perform
+
+          expect(result[:success]).to be(true), "Expected success but got: #{result[:error_message]}"
+          expect(result[:restarted_subscription]).to be true
+
+          subscription.reload
+          expect(subscription.price.recurrence).to eq("yearly")
+          expect(subscription.cancelled_at).to be_nil
+          expect(subscription.deactivated_at).to be_nil
+        end
+      end
+
+      context "when keeping the same recurrence" do
+        let(:params_with_same_price) do
+          {
+            purchase: {
+              email: email,
+              perceived_price_cents: tier_monthly_price_cents,
+              browser_guid: browser_guid
+            },
+            price_id: monthly_price.external_id
+          }
+        end
+
+        it "restarts without triggering plan change" do
+          expect(subscription.price.recurrence).to eq("monthly")
+
+          service = described_class.new(
+            subscription: subscription,
+            product: tiered_product,
+            params: params_with_same_price,
+            buyer: buyer
+          )
+
+          result = service.perform
+
+          expect(result[:success]).to be true
+          expect(subscription.reload.price.recurrence).to eq("monthly")
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/antiwork/gumroad-private/issues/117
Fixes https://github.com/antiwork/gumroad-private/issues/112

## Root Cause

When a customer with a cancelled monthly membership tries to restart with yearly billing, they see: 
```text
The price just changed! Refresh the page for the updated price.
```

**Frontend:** Customer selects yearly billing ($77/year) and submits. Sends `perceived_price_cents: 7700`.

**Backend:** Only checked if the customer changed their tier. Since the tier was the same (only billing cycle changed), it skipped updating the subscription's price. The subscription stayed on monthly pricing.

**Validation:** Compared what the customer sent ($77) against what the backend expected ($15/month). Mismatch → error.

## Solution

Extended the change detection in `RestartAtCheckoutService` to check if either the tier OR the billing cycle changed. Now when a customer changes from monthly to yearly (same tier), the subscription's price is updated before validation.

**Validation now:** Compares $77 (sent) vs $77 (expected yearly). Match → success.

## Test Plan

- [x] Run `bundle exec rspec spec/services/subscription/restart_at_checkout_service_spec.rb` - all 8 tests pass
- [x] Verified in Rails console: `recurrence_changed?` correctly detects monthly→yearly change
- [x] Verified in Rails console: `handle_plan_change` successfully updates subscription price from monthly to yearly

---

## AI Assistance Notice
This PR was implemented with AI assistance using Claude Code for code generation. All code was self-reviewed.