### PR TITLE
Fix tooltip overflow for Redo button on product content page

### DIFF
--- a/app/javascript/components/RichTextEditor.tsx
+++ b/app/javascript/components/RichTextEditor.tsx
@@ -48,7 +48,15 @@ export const useImageUploadSettings = () => React.useContext(ImageUploadSettings
 
 const TOOLBAR_TOOLTIP_DEFAULT_DELAY = 800; // in milliseconds
 
-const MenuItemTooltip = ({ tip, children }: { tip: string; children: React.ReactNode }) => {
+const MenuItemTooltip = ({
+  tip,
+  children,
+  position = "bottom",
+}: {
+  tip: string;
+  children: React.ReactNode;
+  position?: "top" | "left" | "bottom" | "right";
+}) => {
   const [showTooltip, setShowTooltip] = assertDefined(React.useContext(ToolbarTooltipContext));
 
   const hoverTimeoutRef = React.useRef<ReturnType<typeof setTimeout>>();
@@ -65,7 +73,7 @@ const MenuItemTooltip = ({ tip, children }: { tip: string; children: React.React
   };
 
   return (
-    <WithTooltip position="bottom" tip={showTooltip ? tip : null}>
+    <WithTooltip position={position} tip={showTooltip ? tip : null}>
       <span onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
         {children}
       </span>
@@ -79,14 +87,16 @@ export const MenuItem = ({
   active,
   disabled,
   onClick,
+  tooltipPosition,
 }: {
   name: string;
   icon: IconName;
   active?: boolean;
   disabled?: boolean;
   onClick?: () => void;
+  tooltipPosition?: "top" | "left" | "bottom" | "right";
 }) => (
-  <MenuItemTooltip tip={name}>
+  <MenuItemTooltip tip={name} position={tooltipPosition}>
     <button
       type="button"
       className="toolbar-item cursor-pointer all-unset"
@@ -518,6 +528,7 @@ export const RichTextEditorToolbar = ({
             active={editor.isActive("undo")}
             disabled={undoDepth(editor.state) === 0}
             onClick={() => editor.chain().focus().undo().run()}
+            tooltipPosition="left"
           />
           <MenuItem
             name="Redo last undone change"
@@ -525,6 +536,7 @@ export const RichTextEditorToolbar = ({
             active={editor.isActive("redo")}
             disabled={redoDepth(editor.state) === 0}
             onClick={() => editor.chain().focus().redo().run()}
+            tooltipPosition="left"
           />
         </div>
       </div>


### PR DESCRIPTION
## Problem

Resolves #3307

On the product content page (/products/:id/edit/content), hovering over the Redo button causes its tooltip ("Redo last undone change") to overflow beyond the right edge of the viewport, requiring horizontal scrolling to see the full text.

The issue occurred because the tooltip was positioned using the default "bottom" alignment with center positioning. Since the Redo (and Undo) buttons are positioned at the far right of the toolbar (using `ml-auto flex`), their tooltips would extend beyond the viewport edge.

## Solution

This PR fixes the overflow by changing the tooltip positioning for the Undo and Redo buttons:

1. Added a `position` prop to the `MenuItemTooltip` component to allow custom tooltip positioning
2. Added a `tooltipPosition` prop to the `MenuItem` component to pass through position preferences
3. Set both Undo and Redo buttons to use "left" tooltip positioning

Now the tooltips appear to the left of these buttons instead of centered below them, preventing any overflow when the buttons are at the right edge of the viewport.

## Changes

- Modified `MenuItemTooltip` to accept an optional `position` prop (defaults to "bottom" for backward compatibility)
- Modified `MenuItem` to accept an optional `tooltipPosition` prop
- Updated Undo and Redo buttons in `RichTextEditorToolbar` to use `tooltipPosition="left"`

## Testing

The fix ensures that hovering over the Redo button no longer causes horizontal scrolling. The tooltip will now appear to the left of the button, staying within the viewport boundaries.

---

🤖 This PR was implemented with AI assistance using Claude Code.