### PR TITLE
fix(search): Auto-focus search input when popover opens

### DIFF
--- a/app/javascript/components/Search.tsx
+++ b/app/javascript/components/Search.tsx
@@ -13,9 +13,18 @@ type SearchProps = {
 export const Search = ({ onSearch, value: initialValue, placeholder = "Search" }: SearchProps) => {
   const searchInputRef = React.useRef<HTMLInputElement>(null);
   const [searchQuery, setSearchQuery] = React.useState(initialValue);
+  const [open, setOpen] = React.useState(false);
+
+  React.useEffect(() => {
+    if (open) {
+      requestAnimationFrame(() => {
+        searchInputRef.current?.focus();
+      });
+    }
+  }, [open]);
 
   return (
-    <Popover>
+    <Popover open={open} onOpenChange={setOpen}>
       <PopoverAnchor>
         <PopoverTrigger aria-label="Toggle Search" asChild>
           <Button>
@@ -23,13 +32,12 @@ export const Search = ({ onSearch, value: initialValue, placeholder = "Search" }
           </Button>
         </PopoverTrigger>
       </PopoverAnchor>
-      <PopoverContent sideOffset={4} onOpenAutoFocus={() => searchInputRef.current?.focus()}>
+      <PopoverContent sideOffset={4}>
         <div className="input input-wrapper">
           <Icon name="solid-search" />
           <input
             ref={searchInputRef}
             value={searchQuery}
-            autoFocus
             type="text"
             placeholder={placeholder}
             onChange={(e) => {


### PR DESCRIPTION
Issue: #3373 


## Summary
Clicking the search button now auto-focuses the input field, allowing users to start typing immediately without a second click.

## Problem
The search popover's input field wasn't receiving focus when opened. Users had to click the search button, then click again inside the input field to start typing.


## Root Cause
The PopoverContent component uses forceMount which keeps the content always in the DOM (hidden with CSS). This prevents Radix UI's onOpenAutoFocus callback from firing, as it relies on mount/unmount behavior.


## Solution

Use controlled open state with useEffect to programmatically focus the input when the popover opens. This pattern doesn't depend on Radix UI's internal focus management.


## Before


https://github.com/user-attachments/assets/84f3e8e8-31b6-44b9-be2c-bb6858b200f3


## After


https://github.com/user-attachments/assets/819f8e6f-f222-444b-afe0-ceac67ffdc65



# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [ ] I have added/updated tests for my changes

---

# AI Disclosure
Claude Opus 4.5 was used to understand the issue and make code changes


