### PR TITLE
fix: search bar disappears when no results match query

### DIFF
--- a/app/javascript/components/CheckoutDashboard/DiscountsPage.tsx
+++ b/app/javascript/components/CheckoutDashboard/DiscountsPage.tsx
@@ -297,7 +297,7 @@ const DiscountsPage = ({
       pages={pages}
       actions={
         <>
-          {(offerCodes.length > 0 || searchQuery) ? (
+          {offerCodes.length > 0 || searchQuery ? (
             <Search
               onSearch={(query) => {
                 setSearchQuery(query);

--- a/app/javascript/components/CheckoutDashboard/UpsellsPage.tsx
+++ b/app/javascript/components/CheckoutDashboard/UpsellsPage.tsx
@@ -228,7 +228,7 @@ const UpsellsPage = (props: UpsellsPageProps) => {
       pages={props.pages}
       actions={
         <>
-          {(upsells.length > 0 || searchQuery) && (
+          {upsells.length > 0 || searchQuery ? (
             <Search
               onSearch={(query) => {
                 setSearchQuery(query);
@@ -236,7 +236,7 @@ const UpsellsPage = (props: UpsellsPageProps) => {
               }}
               value={searchQuery ?? ""}
             />
-          )}
+          ) : null}
           <Button color="accent" onClick={() => setView("create")} disabled={isReadOnly}>
             New upsell
           </Button>


### PR DESCRIPTION
Issue: #

# Description

Ensures the  search bar remains visible even when no items match the search query.

## Problem

When searching for **discounts/upsells** that return no matching results, the search bar disappears entirely.

## Solution

Keep the search bar visible whenever a search query is present.

---

# Before/After

BEFORE:



https://github.com/user-attachments/assets/c574eaf9-3de2-40cd-ab7a-63301ef361f8



AFTER:


https://github.com/user-attachments/assets/93c9233c-bedb-47b0-9033-e264cf510764


https://github.com/user-attachments/assets/7202f8ed-b26d-46b5-8e8b-675ec9b54d30



---

# Test Results

<!-- Include a screenshot of your test suite passing locally -->

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [ ] I have added/updated tests for my changes

---

# AI Disclosure

Copilot
