### PR TITLE
Fix business state code method to use business country instead of individual country

### DIFF
--- a/app/models/user_compliance_info.rb
+++ b/app/models/user_compliance_info.rb
@@ -107,7 +107,7 @@ class UserComplianceInfo < ApplicationRecord
   end
 
   def business_state_code
-    Compliance::Countries.find_subdivision_code(country_code, business_state)
+    Compliance::Countries.find_subdivision_code(business_country_code, business_state)
   end
 
   def legal_entity_business_type

--- a/spec/models/user_compliance_info_spec.rb
+++ b/spec/models/user_compliance_info_spec.rb
@@ -144,6 +144,28 @@ describe UserComplianceInfo do
         end
       end
     end
+
+    describe "legal_entity_state_code" do
+      describe "is an individual" do
+        let(:user_compliance_info) { create(:user_compliance_info, country: "Canada", state: "Ontario") }
+
+        it "returns the individual state code" do
+          expect(user_compliance_info.legal_entity_state_code).to eq("ON")
+        end
+      end
+
+      describe "is a business" do
+        let(:user_compliance_info) do create(:user_compliance_info_business,
+                                             country: "Canada",
+                                             state: "Ontario",
+                                             business_country: "United States",
+                                             business_state: "New York") end
+
+        it "returns the business state code" do
+          expect(user_compliance_info.legal_entity_state_code).to eq("NY")
+        end
+      end
+    end
   end
 
   describe "legal_entity_payable_business_type" do


### PR DESCRIPTION
Ref https://github.com/antiwork/gumroad/pull/3366#pullrequestreview-3758538009

# Description

Fix business state code method to use business country instead of individual country

## Problem

`business_state_code` in `user_compliance_info.rb:109` uses `country_code` instead of `business_country_code`. This could return incorrect results for the (currently) ~700 users whose business country differs from their personal country.

## Solution

Fix `business_state_code` method to use `business_country` instead of individual `country`.

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

No AI was used for any part of this contribution.
