### PR TITLE
fix: prevent search bar disappearing when no products match query

### DIFF
--- a/app/javascript/components/ProductsDashboardPage.tsx
+++ b/app/javascript/components/ProductsDashboardPage.tsx
@@ -36,6 +36,8 @@ export const ProductsDashboardPage = ({
 }: ProductsDashboardPageProps) => {
   const [enableArchiveTab, setEnableArchiveTab] = React.useState(archivedProductsCount > 0);
   const [query, setQuery] = React.useState("");
+  // Track if products existed on initial load to keep search bar visible during empty search results
+  const hasInitialProducts = React.useRef(products.length > 0 || memberships.length > 0);
 
   return (
     <ProductsLayout
@@ -44,7 +46,7 @@ export const ProductsDashboardPage = ({
       archivedTabVisible={enableArchiveTab}
       ctaButton={
         <>
-          {products.length > 0 ? <Search value={query} onSearch={setQuery} placeholder="Search products" /> : null}
+          {hasInitialProducts.current ? <Search value={query} onSearch={setQuery} placeholder="Search products" /> : null}
           <NavigationButtonInertia href={Routes.new_product_path()} disabled={!canCreateProduct} color="accent">
             New product
           </NavigationButtonInertia>

--- a/app/javascript/components/ProductsPage.tsx
+++ b/app/javascript/components/ProductsPage.tsx
@@ -28,30 +28,37 @@ const ProductsPage = ({
   query: string | null;
   setEnableArchiveTab?: (enable: boolean) => void;
   type?: Tab;
-}) => (
-  <div className="grid gap-12">
-    {memberships.length > 0 ? (
-      <ProductsPageMembershipsTable
-        query={query}
-        entries={memberships}
-        pagination={membershipsPagination}
-        sort={membershipsSort}
-        selectedTab={type}
-        setEnableArchiveTab={setEnableArchiveTab}
-      />
-    ) : null}
+}) => {
+  // Track if tables had entries on initial load to keep them mounted during search
+  // This ensures the search useEffect continues to run even when results are empty
+  const hadInitialMemberships = React.useRef(memberships.length > 0);
+  const hadInitialProducts = React.useRef(products.length > 0);
 
-    {products.length > 0 ? (
-      <ProductsPageProductsTable
-        query={query}
-        entries={products}
-        pagination={productsPagination}
-        sort={productsSort}
-        selectedTab={type}
-        setEnableArchiveTab={setEnableArchiveTab}
-      />
-    ) : null}
-  </div>
-);
+  return (
+    <div className="grid gap-12">
+      {hadInitialMemberships.current ? (
+        <ProductsPageMembershipsTable
+          query={query}
+          entries={memberships}
+          pagination={membershipsPagination}
+          sort={membershipsSort}
+          selectedTab={type}
+          setEnableArchiveTab={setEnableArchiveTab}
+        />
+      ) : null}
+
+      {hadInitialProducts.current ? (
+        <ProductsPageProductsTable
+          query={query}
+          entries={products}
+          pagination={productsPagination}
+          sort={productsSort}
+          selectedTab={type}
+          setEnableArchiveTab={setEnableArchiveTab}
+        />
+      ) : null}
+    </div>
+  );
+};
 
 export default ProductsPage;

--- a/app/javascript/components/ProductsPage/MembershipsTable.tsx
+++ b/app/javascript/components/ProductsPage/MembershipsTable.tsx
@@ -80,7 +80,13 @@ export const ProductsPageMembershipsTable = (props: {
 
   const reloadMemberships = () => loadMemberships(pagination.page);
 
-  if (!memberships.length) return null;
+  if (!memberships.length) {
+    return (
+      <div className="py-8 text-center">
+        <p className="text-muted-foreground">No memberships found</p>
+      </div>
+    );
+  }
 
   return (
     <section className="flex flex-col gap-4">

--- a/app/javascript/components/ProductsPage/ProductsTable.tsx
+++ b/app/javascript/components/ProductsPage/ProductsTable.tsx
@@ -80,7 +80,13 @@ export const ProductsPageProductsTable = (props: {
 
   const reloadProducts = () => loadProducts(pagination.page);
 
-  if (!products.length) return null;
+  if (!products.length) {
+    return (
+      <div className="py-8 text-center">
+        <p className="text-muted-foreground">No products found</p>
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col gap-4">


### PR DESCRIPTION
## Summary

Fixes #3262 - Search bar disappears when no products match the search query

**The Problem:**
When a user searches for products and the query returns zero results:
1. The search bar disappears because it was conditionally rendered based on `products.length > 0`
2. The product table unmounts, causing its search `useEffect` to stop running
3. Subsequent searches cannot be performed because the search effect is no longer active

**The Fix:**
- Use `React.useRef` to track whether products/memberships existed on initial page load
- Keep the search bar visible as long as products existed initially (not based on current filtered results)
- Keep tables mounted during search by checking initial state, showing an empty state message when no results match
- This ensures the search `useEffect` continues to run even when search returns zero results

## Changes

| File | Change |
|------|--------|
| `ProductsDashboardPage.tsx` | Use `hasInitialProducts` ref to keep search bar visible |
| `ProductsPage.tsx` | Use refs to keep tables mounted based on initial state |
| `ProductsTable.tsx` | Show "No products found" message instead of returning null |
| `MembershipsTable.tsx` | Show "No memberships found" message instead of returning null |

## Test plan

- [ ] Navigate to Products page with existing products
- [ ] Search for a term that matches no products
- [ ] Verify search bar remains visible
- [ ] Verify "No products found" message appears
- [ ] Clear search or type new search term
- [ ] Verify search works and results appear when matching products exist
- [ ] Repeat with memberships if applicable