### PR TITLE
fix: prevent tooltip overflow for Redo button on product content page

### DIFF
--- a/app/javascript/components/RichTextEditor.tsx
+++ b/app/javascript/components/RichTextEditor.tsx
@@ -48,7 +48,15 @@ export const useImageUploadSettings = () => React.useContext(ImageUploadSettings
 
 const TOOLBAR_TOOLTIP_DEFAULT_DELAY = 800; // in milliseconds
 
-const MenuItemTooltip = ({ tip, children }: { tip: string; children: React.ReactNode }) => {
+const MenuItemTooltip = ({
+  tip,
+  children,
+  position = "bottom",
+}: {
+  tip: string;
+  children: React.ReactNode;
+  position?: "bottom" | "bottom-start" | "bottom-end";
+}) => {
   const [showTooltip, setShowTooltip] = assertDefined(React.useContext(ToolbarTooltipContext));
 
   const hoverTimeoutRef = React.useRef<ReturnType<typeof setTimeout>>();
@@ -65,7 +73,7 @@ const MenuItemTooltip = ({ tip, children }: { tip: string; children: React.React
   };
 
   return (
-    <WithTooltip position="bottom" tip={showTooltip ? tip : null}>
+    <WithTooltip position={position} tip={showTooltip ? tip : null}>
       <span onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
         {children}
       </span>
@@ -79,14 +87,16 @@ export const MenuItem = ({
   active,
   disabled,
   onClick,
+  tooltipPosition = "bottom",
 }: {
   name: string;
   icon: IconName;
   active?: boolean;
   disabled?: boolean;
   onClick?: () => void;
+  tooltipPosition?: "bottom" | "bottom-start" | "bottom-end";
 }) => (
-  <MenuItemTooltip tip={name}>
+  <MenuItemTooltip tip={name} position={tooltipPosition}>
     <button
       type="button"
       className="toolbar-item cursor-pointer all-unset"
@@ -525,6 +535,7 @@ export const RichTextEditorToolbar = ({
             active={editor.isActive("redo")}
             disabled={redoDepth(editor.state) === 0}
             onClick={() => editor.chain().focus().redo().run()}
+            tooltipPosition="bottom-end"
           />
         </div>
       </div>

--- a/app/javascript/components/WithTooltip.tsx
+++ b/app/javascript/components/WithTooltip.tsx
@@ -2,11 +2,13 @@ import * as React from "react";
 
 import { classNames } from "$app/utils/classNames";
 
-export type Position = "top" | "left" | "bottom" | "right";
+export type Position = "top" | "left" | "bottom" | "right" | "bottom-start" | "bottom-end";
 
 const centerClasses = (position: Position) => ({
   "left-1/2 -translate-x-1/2": position === "top" || position === "bottom",
   "top-1/2 -translate-y-1/2": position === "left" || position === "right",
+  "left-0": position === "bottom-start",
+  "right-0": position === "bottom-end",
 });
 
 type Props = {
@@ -34,7 +36,7 @@ export const WithTooltip = ({ tip, children, position = "bottom", className, too
             {
               "bottom-full -translate-y-2": position === "top",
               "right-full -translate-x-2": position === "left",
-              "top-full translate-y-2": position === "bottom",
+              "top-full translate-y-2": position === "bottom" || position === "bottom-start" || position === "bottom-end",
               "left-full translate-x-2": position === "right",
             },
             tooltipProps?.className,
@@ -44,7 +46,7 @@ export const WithTooltip = ({ tip, children, position = "bottom", className, too
             className={classNames("absolute border-6 border-transparent", centerClasses(position), {
               "top-full border-t-primary": position === "top",
               "left-full border-l-primary": position === "left",
-              "bottom-full border-b-primary": position === "bottom",
+              "bottom-full border-b-primary": position === "bottom" || position === "bottom-start" || position === "bottom-end",
               "right-full border-r-primary": position === "right",
             })}
           ></div>


### PR DESCRIPTION
## Summary
- Adds `bottom-start` and `bottom-end` positions to `WithTooltip` component for edge-aligned tooltips
- Updates `MenuItem` to accept a `tooltipPosition` prop for flexibility
- Applies `bottom-end` position to Redo button tooltip so it aligns to the right edge instead of centering

## Test plan
- [ ] Navigate to `/products/:id/edit/content`
- [ ] Hover over the Redo button
- [ ] Verify tooltip appears below the button aligned to the right edge
- [ ] Verify tooltip does not overflow beyond the viewport

Fixes #3307