### PR TITLE
fix: render Upload files dropdown in portal to fix z-index overlap

### DIFF
--- a/app/javascript/components/RichTextEditor.tsx
+++ b/app/javascript/components/RichTextEditor.tsx
@@ -127,7 +127,7 @@ export const PopoverMenuItem = ({
         </div>
       </MenuItemTooltip>
     </PopoverTrigger>
-    <PopoverContent sideOffset={4} className="border-0 p-0 shadow-none">
+    <PopoverContent sideOffset={4} className="border-0 p-0 shadow-none" usePortal>
       {children}
     </PopoverContent>
   </Popover>


### PR DESCRIPTION
## Summary
- Adds `usePortal` prop to `PopoverMenuItem`'s `PopoverContent` so the dropdown renders outside the toolbar's stacking context
- Fixes the "Upload files" dropdown being overlapped by adjacent toolbar items

## Root Cause
The toolbar has `position: sticky` and `z-index: 1`, creating a stacking context. Without `usePortal`, the `PopoverContent` renders as a child of the toolbar, so its `z-30` is relative to the toolbar rather than the document root.

## Test plan
- [ ] Navigate to `/products/:id/edit/content`
- [ ] Click the "Upload files" button in the toolbar
- [ ] Verify the dropdown appears above all other toolbar elements
- [ ] Verify dropdown items (Embed media, Computer files, etc.) are fully visible

Fixes #3215