### PR TITLE
fix(checkout): Apply default offer code when using wanted=true parameter

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -131,7 +131,7 @@ class LinksController < ApplicationController
         redirect_to checkout_index_url(**params.permit!, host: DOMAIN, product: @product.unique_permalink,
                                                          rent: cart_item[:rental], recurrence: cart_item[:recurrence],
                                                          price: cart_item[:price],
-                                                         code: params[:offer_code] || params[:code],
+                                                         code: params[:offer_code] || params[:code] || @product.default_offer_code&.code,
                                                          affiliate_id: params[:affiliate_id] || params[:a],
                                                          referrer: params[:referrer] || request.referrer),
                     allow_other_host: true

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -3186,6 +3186,33 @@ describe LinksController, :vcr, inertia: true do
           expect(response).to be_successful
           expect(response).not_to be_redirect
         end
+
+        it "applies product's default offer code when no code in URL params" do
+          offer_code = create(:offer_code, user: @user, products: [product], code: "DEFAULT10")
+          product.update!(default_offer_code: offer_code)
+
+          get :show, params: { id: product.to_param, wanted: "true" }
+
+          expect(response).to be_redirect
+
+          redirect_url = URI.parse(response.location)
+          query_params = Rack::Utils.parse_query(redirect_url.query)
+          expect(query_params["code"]).to eq("DEFAULT10")
+        end
+
+        it "prefers URL offer code over product's default offer code" do
+          offer_code = create(:offer_code, user: @user, products: [product], code: "DEFAULT10")
+          url_code = create(:offer_code, user: @user, products: [product], code: "URL20")
+          product.update!(default_offer_code: offer_code)
+
+          get :show, params: { id: product.to_param, wanted: "true", code: "URL20" }
+
+          expect(response).to be_redirect
+
+          redirect_url = URI.parse(response.location)
+          query_params = Rack::Utils.parse_query(redirect_url.query)
+          expect(query_params["code"]).to eq("URL20")
+        end
       end
 
       context "with user signed in" do


### PR DESCRIPTION
## Summary

Fixes #3271 - Discount codes don't automatically apply with `?wanted=true` parameter.

**Root cause:** When redirecting to checkout with `?wanted=true`, the `code` parameter was only set from URL params (`offer_code` or `code`). It didn't fall back to the product's `default_offer_code`, unlike the normal product page rendering which considers both URL code and default_offer_code (in `product_props.rb` lines 84-105).

**Fix:** Add `@product.default_offer_code&.code` as a fallback in the redirect URL construction when neither `params[:offer_code]` nor `params[:code]` are present.

## Changes

- `app/controllers/links_controller.rb`: Added fallback to product's default offer code in the `wanted=true` redirect logic
- `spec/controllers/links_controller_spec.rb`: Added two tests:
  1. Verifies default offer code is applied when no code in URL
  2. Verifies URL code takes precedence over default offer code

## Test plan

- [ ] Visit a product URL with `?wanted=true` that has a default offer code set
- [ ] Verify the checkout page shows the discount code applied
- [ ] Visit the same product with `?wanted=true&code=OTHER` (explicit code)
- [ ] Verify the explicit code is used instead of the default

## AI Disclosure

This PR was created with AI assistance (Claude).

---

Generated with [Claude Code](https://claude.ai/code)