### PR TITLE
Migrate URL Redirect Video Stream page to Inertia

### DIFF
--- a/app/controllers/url_redirects_controller.rb
+++ b/app/controllers/url_redirects_controller.rb
@@ -236,19 +236,19 @@ class UrlRedirectsController < ApplicationController
 
   # Consumption event is created by front-end code
   def stream
-    set_meta_tag(title: "Watch")
-    @body_id = "stream_page"
-    @body_class = "download-page responsive responsive-nav"
-
     @product_file = @url_redirect.product_file(params[:product_file_id]) || @url_redirect.alive_product_files.find(&:streamable?)
     e404 unless @product_file&.streamable?
 
-    @videos_playlist = @url_redirect.video_files_playlist(@product_file)
-    @should_show_transcoding_notice = logged_in_user == @url_redirect.seller && !@url_redirect.with_product_files.has_been_transcoded?
+    videos_playlist = @url_redirect.video_files_playlist(@product_file)
 
-    @url_redirect_id = @url_redirect.external_id
-    @purchase_id = @url_redirect.purchase.try(:external_id)
-    render :video_stream
+    render inertia: "UrlRedirects/VideoStream", props: {
+      playlist: videos_playlist[:playlist],
+      index_to_play: videos_playlist[:index_to_play].to_i,
+      url_redirect_id: @url_redirect.external_id,
+      purchase_id: @url_redirect.purchase.try(:external_id),
+      should_show_transcoding_notice: logged_in_user == @url_redirect.seller && !@url_redirect.with_product_files.has_been_transcoded?,
+      transcode_on_first_sale: @product_file.link&.transcode_videos_on_purchase.present?,
+    }
   end
 
   def latest_media_locations

--- a/app/javascript/packs/video_stream.ts
+++ b/app/javascript/packs/video_stream.ts
@@ -1,9 +1,0 @@
-import ReactOnRails from "react-on-rails";
-
-import BasePage from "$app/utils/base_page";
-
-import VideoStreamPlayer from "$app/components/server-components/VideoStreamPlayer";
-
-BasePage.initialize();
-
-ReactOnRails.register({ VideoStreamPlayer });

--- a/app/javascript/pages/UrlRedirects/VideoStream.tsx
+++ b/app/javascript/pages/UrlRedirects/VideoStream.tsx
@@ -1,0 +1,52 @@
+import { Head, usePage } from "@inertiajs/react";
+import * as React from "react";
+import { cast } from "ts-safe-cast";
+
+import { VideoStreamPlayer } from "$app/components/server-components/VideoStreamPlayer";
+
+type SubtitleFile = {
+  file: string;
+  label: string;
+  kind: "captions";
+};
+
+type Video = {
+  sources: string[];
+  guid: string;
+  title: string;
+  tracks: SubtitleFile[];
+  external_id: string;
+  latest_media_location: { location: number } | null;
+  content_length: number | null;
+};
+
+type PageProps = {
+  playlist: Video[];
+  index_to_play: number;
+  url_redirect_id: string;
+  purchase_id: string | null;
+  should_show_transcoding_notice: boolean;
+  transcode_on_first_sale: boolean;
+};
+
+const VideoStreamPage = () => {
+  const props = cast<PageProps>(usePage().props);
+
+  return (
+    <>
+      <Head title="Watch" />
+      <div id="stream_page" className="download-page responsive responsive-nav">
+        <VideoStreamPlayer
+          playlist={props.playlist}
+          index_to_play={props.index_to_play}
+          url_redirect_id={props.url_redirect_id}
+          purchase_id={props.purchase_id}
+          should_show_transcoding_notice={props.should_show_transcoding_notice}
+          transcode_on_first_sale={props.transcode_on_first_sale}
+        />
+      </div>
+    </>
+  );
+};
+
+export default VideoStreamPage;

--- a/app/javascript/ssr.ts
+++ b/app/javascript/ssr.ts
@@ -24,7 +24,6 @@ import SubscriptionManager from "$app/components/server-components/SubscriptionM
 import SubscriptionManagerMagicLink from "$app/components/server-components/SubscriptionManagerMagicLink";
 import SupportHeader from "$app/components/server-components/support/Header";
 import TaxesCollectionModal from "$app/components/server-components/TaxesCollectionModal";
-import VideoStreamPlayer from "$app/components/server-components/VideoStreamPlayer";
 import CodeSnippet from "$app/components/ui/CodeSnippet";
 import { Pill } from "$app/components/ui/Pill";
 
@@ -52,5 +51,4 @@ ReactOnRails.register({
   SubscriptionManager,
   SubscriptionManagerMagicLink,
   TaxesCollectionModal,
-  VideoStreamPlayer,
 });

--- a/app/views/url_redirects/video_stream.html.erb
+++ b/app/views/url_redirects/video_stream.html.erb
@@ -1,8 +1,0 @@
-<%= load_pack("video_stream") %>
-
-<%= react_component "VideoStreamPlayer", props: { playlist: @videos_playlist[:playlist],
-    index_to_play: @videos_playlist[:index_to_play].to_i,
-    url_redirect_id: @url_redirect_id,
-    purchase_id: @purchase_id,
-    should_show_transcoding_notice: @should_show_transcoding_notice,
-    transcode_on_first_sale: @product_file.link&.transcode_videos_on_purchase.present? } %>

--- a/spec/controllers/url_redirects_controller_spec.rb
+++ b/spec/controllers/url_redirects_controller_spec.rb
@@ -536,7 +536,7 @@ describe UrlRedirectsController do
       end
     end
 
-    describe "streaming" do
+    describe "streaming", inertia: true do
       before do
         @product = create(:product_with_video_file)
         @url_redirect = create(:url_redirect, link: @product, purchase: nil)
@@ -567,7 +567,10 @@ describe UrlRedirectsController do
           get :stream, params: { id: @url_redirect.token }
 
           expect(response).to have_http_status(:ok)
-          expect(assigns(:product_file)).to eq(@product.product_files.first)
+          expect_inertia.to render_component("UrlRedirects/VideoStream")
+          expect(inertia.props[:url_redirect_id]).to eq(@url_redirect.external_id)
+          expect(inertia.props[:purchase_id]).to be_nil
+          expect(inertia.props[:playlist]).to be_an(Array)
         end
       end
 


### PR DESCRIPTION
Issue: #3141

## Summary
Migrates the video stream page (`/s/:id` and `/s/:id/:product_file_id`) from legacy ERB + React-on-Rails to Inertia.js. Works for both standard and custom domain routes.

## Changes
- **Controller**: Replace `render :video_stream` with `render inertia: "UrlRedirects/VideoStream"`, passing props inline
- **New Inertia page**: `app/javascript/pages/UrlRedirects/VideoStream.tsx` — renders the existing `VideoStreamPlayer` component with props from Inertia
- **Remove old files**: ERB view (`video_stream.html.erb`) and webpack pack (`video_stream.ts`)
- **Remove from SSR**: `VideoStreamPlayer` no longer registered in `ssr.ts` (now loaded via Inertia page)
- **Tests**: Updated controller specs to use Inertia test helpers (`expect_inertia`, `inertia.props`)

## Custom domain support
Both route groups render the same Inertia component:
- Standard: `/s/:id` → `url_redirects#stream`
- Custom domain: `/s/:id` → `url_redirects#stream` (custom domain constraints)

No changes needed to routing — both already point to the same controller action.

## Tests
`bundle exec rspec spec/controllers/url_redirects_controller_spec.rb`

# Checklist
- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure
Claude was used to assist with code changes