### PR TITLE
Chore(inertia): Migrate Subscription Manager page to Inertia

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -8,9 +8,11 @@ class SubscriptionsController < ApplicationController
   after_action :verify_authorized, except: PUBLIC_ACTIONS
 
   before_action :fetch_subscription, only: %i[unsubscribe_by_seller unsubscribe_by_user magic_link send_magic_link]
-  before_action :hide_layouts, only: [:manage, :magic_link, :send_magic_link]
+  before_action :hide_layouts, only: [:magic_link, :send_magic_link]
   before_action :set_noindex_header, only: [:manage]
   before_action :check_can_manage, only: [:manage, :unsubscribe_by_user]
+
+  layout "inertia", only: [:manage]
 
   SUBSCRIPTION_COOKIE_EXPIRY = 1.week
 
@@ -23,22 +25,25 @@ class SubscriptionsController < ApplicationController
 
   def unsubscribe_by_user
     @subscription.cancel!(by_seller: false)
-    render json: { success: true }
+    subscription_entity = @subscription.is_installment_plan ? "installment plan" : "membership"
+    redirect_to manage_subscription_path(@subscription.external_id), notice: "Your #{subscription_entity} has been cancelled."
   rescue ActiveRecord::RecordInvalid => e
-    render json: { success: false, error: e.message }
+    redirect_to manage_subscription_path(@subscription.external_id), alert: e.message
   end
 
   def manage
-    @product = @subscription.link
-    @card = @subscription.credit_card_to_charge
-    @card_data_handling_mode = CardDataHandlingMode.get_card_data_handling_mode(@product.user)
+    product = @subscription.link
 
     @body_id = "product_page"
 
     set_meta_tag(title: @subscription.is_installment_plan ? "Manage installment plan" : "Manage membership")
-    set_product_page_meta(@product)
+    set_product_page_meta(product)
 
     set_subscription_confirmed_redirect_cookie
+
+    render inertia: "Subscriptions/Manage",
+           props: CheckoutPresenter.new(logged_in_user:, ip: request.remote_ip)
+                    .subscription_manager_props(subscription: @subscription)
   end
 
   def magic_link

--- a/app/javascript/data/subscription.ts
+++ b/app/javascript/data/subscription.ts
@@ -5,26 +5,7 @@ import {
   StripeErrorParams,
   serializeCardParamsIntoQueryParamsObject,
 } from "$app/data/payment_method_params";
-import { request, ResponseError } from "$app/utils/request";
-
-export const cancelSubscriptionByUser = async (subscriptionId: string): Promise<void> => {
-  const response = await request({
-    url: Routes.unsubscribe_by_user_subscription_path(subscriptionId),
-    method: "POST",
-    accept: "json",
-  });
-  if (response.ok) {
-    const responseData = cast<{ success: boolean; redirect_to?: string }>(await response.json());
-    if (responseData.success) {
-      return;
-    } else if (responseData.redirect_to) {
-      window.location.href = responseData.redirect_to;
-    } else {
-      throw new ResponseError();
-    }
-  }
-  throw new ResponseError();
-};
+import { request } from "$app/utils/request";
 
 export type UpdateSubscriptionPayload = {
   cardParams: AnyPaymentMethodParams | StripeErrorParams | null;

--- a/app/javascript/packs/subscription_edit.ts
+++ b/app/javascript/packs/subscription_edit.ts
@@ -1,8 +1,0 @@
-import ReactOnRails from "react-on-rails";
-
-import BasePage from "$app/utils/base_page";
-
-import SubscriptionManager from "$app/components/server-components/SubscriptionManager";
-
-BasePage.initialize();
-ReactOnRails.register({ SubscriptionManager });

--- a/app/javascript/pages/Subscriptions/Manage.tsx
+++ b/app/javascript/pages/Subscriptions/Manage.tsx
@@ -1,0 +1,383 @@
+import { router, useForm, usePage } from "@inertiajs/react";
+import { parseISO } from "date-fns";
+import * as React from "react";
+import { cast } from "ts-safe-cast";
+
+import { confirmLineItem } from "$app/data/purchase";
+import { updateSubscription } from "$app/data/subscription";
+import { SavedCreditCard } from "$app/parsers/card";
+import { Discount } from "$app/parsers/checkout";
+import { CustomFieldDescriptor, ProductNativeType } from "$app/parsers/product";
+import {
+  CurrencyCode,
+  formatPriceCentsWithCurrencySymbol,
+  formatUSDCentsWithExpandedCurrencySymbol,
+  getMinPriceCents,
+} from "$app/utils/currency";
+import { recurrenceLabels, RecurrenceId } from "$app/utils/recurringPricing";
+
+import { Button } from "$app/components/Button";
+import { Creator } from "$app/components/Checkout/cartState";
+import {
+  createReducer,
+  StateContext,
+  Product as PaymentProduct,
+  getTotalPrice,
+} from "$app/components/Checkout/payment";
+import { PaymentForm } from "$app/components/Checkout/PaymentForm";
+import { useFeatureFlags } from "$app/components/FeatureFlags";
+import {
+  Option,
+  PriceSelection,
+  ConfigurationSelector,
+  Product as ConfigurationSelectorProduct,
+  applySelection,
+} from "$app/components/Product/ConfigurationSelector";
+import { showAlert } from "$app/components/server-components/Alert";
+import { Alert } from "$app/components/ui/Alert";
+import { Card, CardContent } from "$app/components/ui/Card";
+import { useOnChangeSync } from "$app/components/useOnChange";
+import { useOriginalLocation } from "$app/components/useOriginalLocation";
+
+type Props = {
+  product: {
+    permalink: string;
+    name: string;
+    native_type: ProductNativeType;
+    require_shipping: boolean;
+    custom_fields: CustomFieldDescriptor[];
+    supports_paypal: "native" | "braintree" | null;
+    creator: Creator;
+    currency_code: CurrencyCode;
+    options: Option[];
+    price_cents: number;
+    is_tiered_membership: boolean;
+    is_legacy_subscription: boolean;
+    is_multiseat_license: boolean;
+    recurrences: { id: string; recurrence: RecurrenceId; price_cents: number }[];
+    pwyw: { suggested_price_cents: number | null } | null;
+    installment_plan: { number_of_installments: number } | null;
+    exchange_rate: number;
+    shippable_country_codes: string[];
+  };
+  subscription: {
+    id: string;
+    recurrence: RecurrenceId;
+    option_id: string | null;
+    price: number;
+    quantity: number;
+    alive: boolean;
+    pending_cancellation: boolean;
+    prorated_discount_price_cents: number;
+    discount: Discount | null;
+    end_time_of_subscription: string;
+    successful_purchases_count: number;
+    is_in_free_trial: boolean;
+    is_test: boolean;
+    is_overdue_for_charge: boolean;
+    is_gift: boolean;
+    is_installment_plan: boolean;
+  };
+  contact_info: {
+    email: string;
+    full_name: string;
+    street: string;
+    city: string;
+    state: string;
+    zip: string;
+    country: string;
+  };
+  countries: Record<string, string>;
+  us_states: string[];
+  ca_provinces: string[];
+  used_card: SavedCreditCard | null;
+  recaptcha_key: string | null;
+  paypal_client_id: string;
+};
+
+const SubscriptionsManage = () => {
+  const {
+    product,
+    subscription,
+    recaptcha_key,
+    paypal_client_id,
+    contact_info,
+    countries,
+    us_states,
+    ca_provinces,
+    used_card,
+  } = cast<Props>(usePage().props);
+  const url = new URL(useOriginalLocation());
+
+  const subscriptionEntity = subscription.is_installment_plan ? "installment plan" : "membership";
+  const restartable = !subscription.alive || subscription.pending_cancellation;
+  const initialSelection = {
+    recurrence: subscription.recurrence,
+    rent: false,
+    optionId: subscription.option_id,
+    quantity: subscription.quantity,
+    price: { value: subscription.price / subscription.quantity, error: false },
+    callStartTime: null,
+    payInInstallments: subscription.is_installment_plan,
+  };
+  const [selection, setSelection] = React.useState<PriceSelection>(() => initialSelection);
+  const currentOption = product.options.find(({ id }) => id === subscription.option_id);
+  const hasPriceChanged =
+    Math.round(subscription.price / subscription.quantity) !==
+    currentOption?.recurrence_price_values?.[subscription.recurrence]?.price_cents;
+  const configurationSelectorProduct: ConfigurationSelectorProduct = {
+    ...product,
+    options: product.options.map((option) =>
+      option.id === subscription.option_id
+        ? {
+            ...option,
+            status: hasPriceChanged
+              ? `Your current plan is ${formatPriceCentsWithCurrencySymbol(
+                  product.currency_code,
+                  Math.round(subscription.price / subscription.quantity),
+                  { symbolFormat: "long" },
+                )} ${recurrenceLabels[subscription.recurrence]}, based on previous pricing. This price will remain the same when updating your payment method.`
+              : undefined,
+          }
+        : option,
+    ),
+    recurrences: { default: subscription.recurrence, enabled: product.recurrences },
+    is_tiered_membership: product.is_tiered_membership,
+    is_legacy_subscription: product.is_legacy_subscription,
+    rental: null,
+    is_quantity_enabled: false,
+    quantity_remaining: null,
+    is_multiseat_license: product.is_multiseat_license,
+    ppp_details: null,
+  };
+
+  const { isPWYW, discountedPriceCents } = applySelection(
+    configurationSelectorProduct,
+    subscription.discount,
+    selection,
+  );
+  const isQuantityChanged = selection.quantity !== subscription.quantity;
+  const isRecurrenceChanged = selection.recurrence !== subscription.recurrence;
+  const noChangesToNonPriceOptions =
+    selection.optionId === subscription.option_id && !isRecurrenceChanged && !isQuantityChanged;
+
+  let warning = null;
+  if (selection.optionId === subscription.option_id && hasPriceChanged) {
+    const price = `${formatPriceCentsWithCurrencySymbol(product.currency_code, discountedPriceCents, { symbolFormat: "long" })} ${recurrenceLabels[selection.recurrence ?? subscription.recurrence]}`;
+    if (isQuantityChanged && isRecurrenceChanged) {
+      warning = `Changing the number of seats and adjusting the billing frequency will update your subscription to the current price of ${price} per seat.`;
+    } else if (isQuantityChanged) {
+      warning = `Changing the number of seats will update your subscription to the current price of ${price} per seat.`;
+    } else if (isRecurrenceChanged) {
+      warning = `Changing the billing frequency will update your subscription to the current price of ${price} per seat.`;
+    }
+  }
+
+  const price =
+    (isPWYW || noChangesToNonPriceOptions ? (selection.price.value ?? discountedPriceCents) : discountedPriceCents) *
+    selection.quantity;
+  const requirePayment = price > 0;
+  const noChangesToCurrentPlan = noChangesToNonPriceOptions && (!isPWYW || price === subscription.price);
+  let amountDueToday =
+    (subscription.alive || subscription.pending_cancellation) &&
+    !subscription.is_overdue_for_charge &&
+    (price < subscription.price || subscription.is_in_free_trial || noChangesToCurrentPlan)
+      ? 0
+      : Math.max(price - subscription.prorated_discount_price_cents, 0);
+  if (amountDueToday > 0) amountDueToday = Math.max(amountDueToday, getMinPriceCents(product.currency_code));
+  const paymentProduct: PaymentProduct = {
+    permalink: product.permalink,
+    name: product.name,
+    creator: product.creator,
+    quantity: 1,
+    price: Math.round(amountDueToday / product.exchange_rate),
+    payInInstallments: subscription.is_installment_plan,
+    requireShipping: product.require_shipping,
+    customFields: [], // Custom fields were already collected during original purchase
+    bundleProductCustomFields: [],
+    supportsPaypal: product.supports_paypal,
+    testPurchase: subscription.is_test,
+    requirePayment,
+    subscription_id: subscription.id,
+    recommended_by: null,
+    shippableCountryCodes: product.shippable_country_codes,
+    hasTippingEnabled: false,
+    hasFreeTrial: false,
+    nativeType: product.native_type,
+    canGift: false,
+  };
+  const payLabel = restartable ? `Restart ${subscriptionEntity}` : `Update ${subscriptionEntity}`;
+  const { require_email_typo_acknowledgment } = useFeatureFlags();
+  const reducer = createReducer({
+    country: contact_info.country,
+    email: contact_info.email,
+    fullName: contact_info.full_name,
+    address: contact_info,
+    countries,
+    usStates: us_states,
+    caProvinces: ca_provinces,
+    tipOptions: [],
+    defaultTipOption: 0,
+    savedCreditCard: used_card,
+    state: contact_info.state,
+    products: [paymentProduct],
+    payLabel,
+    recaptchaKey: recaptcha_key,
+    paypalClientId: paypal_client_id,
+    gift: null,
+    requireEmailTypoAcknowledgment: require_email_typo_acknowledgment,
+  });
+  const [state, dispatchAction] = reducer;
+  React.useEffect(
+    () => dispatchAction({ type: "update-products", products: [paymentProduct] }),
+    [amountDueToday, requirePayment],
+  );
+  React.useEffect(() => dispatchAction({ type: "set-value", warning }), [warning]);
+  React.useEffect(() => dispatchAction({ type: "set-value", payLabel }), [payLabel]);
+  const totalPrice = getTotalPrice(state) ?? 0;
+  const vat = state.surcharges.type === "loaded" ? state.surcharges.result.tax_cents : 0;
+
+  async function pay() {
+    if (state.status.type !== "finished") return;
+    const result = await updateSubscription({
+      cardParams:
+        state.status.paymentMethod.type === "not-applicable" || state.status.paymentMethod.type === "saved"
+          ? null
+          : state.status.paymentMethod.cardParamsResult.cardParams,
+      recaptchaResponse: state.status.recaptchaResponse ?? null,
+      declined: url.searchParams.get("declined") === "true",
+      subscription_id: subscription.id,
+      variants: selection.optionId ? [selection.optionId] : [],
+      price_id: product.recurrences.find((recurrence) => recurrence.recurrence === selection.recurrence)?.id,
+      perceived_price_cents: price,
+      perceived_upgrade_price_cents: amountDueToday,
+      quantity: selection.quantity,
+      price_range: isPWYW ? (selection.price.value ?? 0) * selection.quantity : undefined,
+      contact_info: {
+        country: state.country,
+        email: state.email,
+        state: state.state,
+        full_name: state.fullName,
+        street_address: state.address,
+        zip_code: state.zipCode,
+        city: state.city,
+      },
+    });
+    if (result.type === "done") {
+      showAlert(result.message, "success");
+      if (result.next != null) {
+        router.get(result.next);
+      } else {
+        router.reload();
+      }
+    } else if (result.type === "requires_card_action") {
+      await confirmLineItem({
+        success: true,
+        requires_card_action: true,
+        client_secret: result.client_secret,
+        purchase: result.purchase,
+      }).then((itemResult) => {
+        if (itemResult.success) {
+          showAlert(`Your ${subscriptionEntity} has been updated.`, "success");
+          router.reload();
+        }
+      });
+    } else {
+      showAlert(result.message, "error", { html: true });
+    }
+    dispatchAction({ type: "cancel" });
+  }
+  React.useEffect(() => void pay(), [state.status]);
+
+  // show (the Stripe Payment Request method that triggers the Apple Pay
+  // modal) can't be called in asynchronous code, so we have to use a
+  // synchronous layout effect.
+  useOnChangeSync(() => {
+    if (state.status.type === "offering") dispatchAction({ type: "validate" });
+  }, [state.status.type]);
+
+  const cancelForm = useForm({});
+  const handleCancel = () => {
+    cancelForm.post(Routes.unsubscribe_by_user_subscription_path(subscription.id), {
+      preserveScroll: true,
+      onSuccess: () => router.reload(),
+      onError: () => showAlert("Sorry, something went wrong.", "error"),
+    });
+  };
+
+  const hasSavedCard = state.savedCreditCard != null;
+  const isPendingFirstGifteePayment = subscription.is_gift && subscription.successful_purchases_count === 1;
+  const formattedSubscriptionEndDate = parseISO(subscription.end_time_of_subscription).toLocaleDateString(undefined, {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+  const isFutureEndDate = parseISO(subscription.end_time_of_subscription) > new Date();
+  const paymentNotice =
+    isPendingFirstGifteePayment && isFutureEndDate && subscription.alive
+      ? `Your first charge will be on ${formattedSubscriptionEndDate}.`
+      : null;
+
+  return (
+    <Card className="input-group mx-auto my-8 max-w-2xl">
+      <CardContent asChild>
+        <header>
+          {`Manage ${subscriptionEntity}`}
+          <h2 className="grow">{product.name}</h2>
+        </header>
+      </CardContent>
+
+      {!hasSavedCard && subscription.is_gift ? (
+        <CardContent>
+          <Alert variant="warning" className="grow">
+            Your {subscriptionEntity} is paid up until {formattedSubscriptionEndDate}. Add your own payment method below
+            to ensure that your {subscriptionEntity} renews.
+          </Alert>
+        </CardContent>
+      ) : null}
+
+      {!subscription.is_installment_plan ? (
+        <CardContent style={{ display: "grid", gap: "1rem", gridTemplateColumns: "1fr" }}>
+          <ConfigurationSelector
+            product={configurationSelectorProduct}
+            selection={selection}
+            setSelection={setSelection}
+            initialSelection={initialSelection}
+            discount={subscription.discount}
+          />
+        </CardContent>
+      ) : null}
+
+      <StateContext.Provider value={reducer}>
+        <CardContent>
+          <PaymentForm className="w-full" borderless notice={paymentNotice} showCustomFields={false} />
+          {totalPrice > 0 ? (
+            <div>
+              <div className="text-center">
+                {vat > 0
+                  ? `You'll be charged ${formatUSDCentsWithExpandedCurrencySymbol(totalPrice)} today, including ${formatUSDCentsWithExpandedCurrencySymbol(vat)} for VAT in ${state.countries[state.country] ?? ""}.`
+                  : `You'll be charged ${formatUSDCentsWithExpandedCurrencySymbol(totalPrice)} today.`}
+              </div>
+            </div>
+          ) : null}
+        </CardContent>
+      </StateContext.Provider>
+
+      {!restartable && !subscription.is_installment_plan ? (
+        <CardContent>
+          <Button
+            color="danger"
+            outline
+            onClick={handleCancel}
+            disabled={cancelForm.processing}
+            className="grow basis-0"
+          >
+            {`Cancel ${subscriptionEntity}`}
+          </Button>
+        </CardContent>
+      ) : null}
+    </Card>
+  );
+};
+
+export default SubscriptionsManage;

--- a/app/javascript/ssr.ts
+++ b/app/javascript/ssr.ts
@@ -20,7 +20,6 @@ import ProductEditPage from "$app/components/server-components/ProductEditPage";
 import Profile from "$app/components/server-components/Profile";
 import ProfileProductPage from "$app/components/server-components/Profile/ProductPage";
 import SubscribePage from "$app/components/server-components/SubscribePage";
-import SubscriptionManager from "$app/components/server-components/SubscriptionManager";
 import SubscriptionManagerMagicLink from "$app/components/server-components/SubscriptionManagerMagicLink";
 import SupportHeader from "$app/components/server-components/support/Header";
 import TaxesCollectionModal from "$app/components/server-components/TaxesCollectionModal";
@@ -49,7 +48,6 @@ ReactOnRails.register({
   Profile,
   ProfileProductPage,
   SubscribePage,
-  SubscriptionManager,
   SubscriptionManagerMagicLink,
   TaxesCollectionModal,
   VideoStreamPlayer,

--- a/app/views/subscriptions/manage.html.erb
+++ b/app/views/subscriptions/manage.html.erb
@@ -1,4 +1,0 @@
-<%= render("shared/recaptcha_script") %>
-<%= load_pack("subscription_edit") %>
-
-<%= react_component "SubscriptionManager", props: CheckoutPresenter.new(logged_in_user: logged_in_user, ip: request.remote_ip).subscription_manager_props(subscription: @subscription), prerender: true %>

--- a/spec/controllers/subscriptions_controller_spec.rb
+++ b/spec/controllers/subscriptions_controller_spec.rb
@@ -2,8 +2,9 @@
 
 require "spec_helper"
 require "shared_examples/authorize_called"
+require "inertia_rails/rspec"
 
-describe SubscriptionsController do
+describe SubscriptionsController, inertia: true do
   let(:seller) { create(:named_seller) }
   let(:subscriber) { create(:user) }
 
@@ -66,9 +67,10 @@ describe SubscriptionsController do
         post :unsubscribe_by_user, params: { id: @subscription.external_id }
       end
 
-      it "returns json success" do
+      it "redirects to manage page with success notice" do
         post :unsubscribe_by_user, params: { id: @subscription.external_id }
-        expect(response.parsed_body["success"]).to be(true)
+        expect(response).to redirect_to(manage_subscription_path(@subscription.external_id))
+        expect(flash[:notice]).to eq("Your membership has been cancelled.")
       end
 
       it "is not allowed for installment plans" do
@@ -79,8 +81,8 @@ describe SubscriptionsController do
 
         post :unsubscribe_by_user, params: { id: subscription.external_id }
 
-        expect(response.parsed_body["success"]).to be(false)
-        expect(response.parsed_body["error"]).to include("Installment plans cannot be cancelled by the customer")
+        expect(response).to redirect_to(manage_subscription_path(subscription.external_id))
+        expect(flash[:alert]).to include("Installment plans cannot be cancelled by the customer")
       end
 
       context "when the encrypted cookie is not present" do
@@ -88,13 +90,12 @@ describe SubscriptionsController do
           cookies.encrypted[@subscription.cookie_key] = nil
         end
 
-        it "renders success false with redirect_to URL" do
+        it "redirects to magic link page" do
           expect do
-            post :unsubscribe_by_user, params: { id: @subscription.external_id }, format: :json
+            post :unsubscribe_by_user, params: { id: @subscription.external_id }
           end.to_not change { @subscription.reload.user_requested_cancellation_at }
 
-          expect(response.parsed_body["success"]).to be(false)
-          expect(response.parsed_body["redirect_to"]).to eq(magic_link_subscription_path(@subscription.external_id))
+          expect(response).to redirect_to(magic_link_subscription_path(@subscription.external_id))
         end
       end
     end
@@ -129,20 +130,24 @@ describe SubscriptionsController do
       end
 
       context "when encrypted cookie is present" do
-        it "renders the manage page" do
+        it "renders the Inertia manage page with correct props" do
           cookies.encrypted[@subscription.cookie_key] = @subscription.external_id
           get :manage, params: { id: @subscription.external_id }
 
           expect(response).to be_successful
+          expect(inertia).to render_component("Subscriptions/Manage")
+          expect(inertia.props[:subscription]).to be_present
+          expect(inertia.props[:product]).to be_present
         end
       end
 
       context "when the user is signed in" do
-        it "renders the manage page" do
+        it "renders the Inertia manage page" do
           sign_in subscriber
           get :manage, params: { id: @subscription.external_id }
 
           expect(response).to be_successful
+          expect(inertia).to render_component("Subscriptions/Manage")
         end
       end
 

--- a/spec/requests/subscription/non_tiered_membership_spec.rb
+++ b/spec/requests/subscription/non_tiered_membership_spec.rb
@@ -204,10 +204,10 @@ describe "Non Tiered Membership Subscriptions", type: :system, js: true do
       visit "/subscriptions/#{@subscription_with_purchaser.external_id}/manage?token=#{@subscription_with_purchaser.token}"
 
       click_on "Cancel membership"
-      wait_for_ajax
 
-      expect(page).to have_button("Cancelled", disabled: true)
+      expect(page).to have_alert(text: "Your membership has been cancelled.")
       expect(page).to have_button("Restart membership")
+      expect(page).not_to have_button("Cancel membership")
 
       click_on "Restart membership"
       wait_for_ajax


### PR DESCRIPTION
Issue: #3073
Fixes: #3073

# Description

Migrates the Subscription Manager page from ReactOnRails server component to an Inertia.js page component, following the established patterns from other Inertia migrations in the codebase.

## Changes

### Controller (`subscriptions_controller.rb`)
- Renders via `render inertia: "Subscriptions/Manage"` with props from `CheckoutPresenter`
- Removed unused instance variables (`@card`, `@card_data_handling_mode`, `@product`) — made `product` a local variable
- Added `layout "inertia"` for the manage action
- Removed `hide_layouts` for manage (handled by Inertia layout)
- Changed `unsubscribe_by_user` to redirect back with flash notice instead of JSON response (works naturally with Inertia's redirect handling)

### React Component
- Moved from `app/javascript/components/server-components/SubscriptionManager.tsx` → `app/javascript/pages/Subscriptions/Manage.tsx`
- Props accessed via `usePage().props` instead of function parameters
- Replaced custom `cancelSubscriptionByUser` with Inertia `useForm` for cancellation
- Replaced `window.location.href` navigation with `router.get()` and `router.reload()`
- Removed stale client-side `cancelled` state — uses server state via Inertia reload instead
- Fixed import path for `useOnChangeSync`

### Cleanup
- Removed ERB template `app/views/subscriptions/manage.html.erb`
- Removed webpack pack `app/javascript/packs/subscription_edit.ts`
- Removed `SubscriptionManager` from SSR registry (`ssr.ts`)
- Removed unused `cancelSubscriptionByUser` function and `ResponseError` import from `data/subscription.ts`

### Tests
- Updated controller specs to verify Inertia component rendering and props
- Updated unsubscribe specs to expect redirects with flash messages
- Updated integration spec for cancel flow

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes