### PR TITLE
fix: show empty-state placeholder after deleting/archiving last product

### DIFF
--- a/app/javascript/components/ArchivedProductsPage.tsx
+++ b/app/javascript/components/ArchivedProductsPage.tsx
@@ -7,6 +7,7 @@ import { PaginationProps } from "$app/components/Pagination";
 import { ProductsLayout } from "$app/components/ProductsLayout";
 import ProductsPage from "$app/components/ProductsPage";
 import { Search } from "$app/components/Search";
+import { Placeholder } from "$app/components/ui/Placeholder";
 import { Sort } from "$app/components/useSortingTableDriver";
 
 export type ArchivedProductsPageProps = {
@@ -54,6 +55,17 @@ export const ArchivedProductsPage = ({
           productsSort={productsSort}
           query={query}
           type="archived"
+          emptyPlaceholder={
+            <Placeholder>
+              <h2>No archived products</h2>
+              <p>Products you archive will appear here.</p>
+              <div>
+                <NavigationButtonInertia href={Routes.products_path()} color="accent">
+                  Back to products
+                </NavigationButtonInertia>
+              </div>
+            </Placeholder>
+          }
         />
       </section>
     </ProductsLayout>

--- a/app/javascript/components/ProductsDashboardPage.tsx
+++ b/app/javascript/components/ProductsDashboardPage.tsx
@@ -44,7 +44,7 @@ export const ProductsDashboardPage = ({
       archivedTabVisible={enableArchiveTab}
       ctaButton={
         <>
-          {products.length > 0 ? <Search value={query} onSearch={setQuery} placeholder="Search products" /> : null}
+          {products.length > 0 || memberships.length > 0 ? <Search value={query} onSearch={setQuery} placeholder="Search products" /> : null}
           <NavigationButtonInertia href={Routes.new_product_path()} disabled={!canCreateProduct} color="accent">
             New product
           </NavigationButtonInertia>
@@ -52,35 +52,34 @@ export const ProductsDashboardPage = ({
       }
     >
       <section className="p-4 md:p-8">
-        {memberships.length === 0 && products.length === 0 ? (
-          <Placeholder>
-            <PlaceholderImage src={placeholder} />
-            <h2>We’ve never met an idea we didn’t like.</h2>
-            <p>Your first product doesn’t need to be perfect. Just put it out there, and see if it sticks.</p>
-            <div>
-              <NavigationButtonInertia href={Routes.new_product_path()} disabled={!canCreateProduct} color="accent">
-                New product
-              </NavigationButtonInertia>
-            </div>
-            <span>
-              or{" "}
-              <a href="/help/article/304-products-dashboard" target="_blank" rel="noreferrer">
-                learn more about the products dashboard
-              </a>
-            </span>
-          </Placeholder>
-        ) : (
-          <ProductsPage
-            memberships={memberships}
-            membershipsPagination={membershipsPagination}
-            membershipsSort={membershipsSort}
-            products={products}
-            productsPagination={productsPagination}
-            productsSort={productsSort}
-            query={query}
-            setEnableArchiveTab={setEnableArchiveTab}
-          />
-        )}
+        <ProductsPage
+          memberships={memberships}
+          membershipsPagination={membershipsPagination}
+          membershipsSort={membershipsSort}
+          products={products}
+          productsPagination={productsPagination}
+          productsSort={productsSort}
+          query={query}
+          setEnableArchiveTab={setEnableArchiveTab}
+          emptyPlaceholder={
+            <Placeholder>
+              <PlaceholderImage src={placeholder} />
+              <h2>We've never met an idea we didn't like.</h2>
+              <p>Your first product doesn't need to be perfect. Just put it out there, and see if it sticks.</p>
+              <div>
+                <NavigationButtonInertia href={Routes.new_product_path()} disabled={!canCreateProduct} color="accent">
+                  New product
+                </NavigationButtonInertia>
+              </div>
+              <span>
+                or{" "}
+                <a href="/help/article/304-products-dashboard" target="_blank" rel="noreferrer">
+                  learn more about the products dashboard
+                </a>
+              </span>
+            </Placeholder>
+          }
+        />
       </section>
     </ProductsLayout>
   );

--- a/app/javascript/components/ProductsPage.tsx
+++ b/app/javascript/components/ProductsPage.tsx
@@ -18,6 +18,7 @@ const ProductsPage = ({
   query,
   setEnableArchiveTab,
   type = "products",
+  emptyPlaceholder,
 }: {
   memberships: Membership[];
   membershipsPagination: PaginationProps;
@@ -28,30 +29,37 @@ const ProductsPage = ({
   query: string | null;
   setEnableArchiveTab?: (enable: boolean) => void;
   type?: Tab;
-}) => (
-  <div className="grid gap-12">
-    {memberships.length > 0 ? (
-      <ProductsPageMembershipsTable
-        query={query}
-        entries={memberships}
-        pagination={membershipsPagination}
-        sort={membershipsSort}
-        selectedTab={type}
-        setEnableArchiveTab={setEnableArchiveTab}
-      />
-    ) : null}
+  emptyPlaceholder?: React.ReactNode;
+}) => {
+  if (memberships.length === 0 && products.length === 0 && emptyPlaceholder) {
+    return <>{emptyPlaceholder}</>;
+  }
 
-    {products.length > 0 ? (
-      <ProductsPageProductsTable
-        query={query}
-        entries={products}
-        pagination={productsPagination}
-        sort={productsSort}
-        selectedTab={type}
-        setEnableArchiveTab={setEnableArchiveTab}
-      />
-    ) : null}
-  </div>
-);
+  return (
+    <div className="grid gap-12">
+      {memberships.length > 0 ? (
+        <ProductsPageMembershipsTable
+          query={query}
+          entries={memberships}
+          pagination={membershipsPagination}
+          sort={membershipsSort}
+          selectedTab={type}
+          setEnableArchiveTab={setEnableArchiveTab}
+        />
+      ) : null}
+
+      {products.length > 0 ? (
+        <ProductsPageProductsTable
+          query={query}
+          entries={products}
+          pagination={productsPagination}
+          sort={productsSort}
+          selectedTab={type}
+          setEnableArchiveTab={setEnableArchiveTab}
+        />
+      ) : null}
+    </div>
+  );
+};
 
 export default ProductsPage;


### PR DESCRIPTION
## Summary

Fixes #2643

When the last product on the Products page is deleted or archived, the page becomes completely empty instead of showing the empty-state illustration.

## Root Cause

The empty-state check in `ProductsDashboardPage` used a conditional branch: if products and memberships were empty, render the placeholder; otherwise render `ProductsPage`. After a product deletion, Inertia's partial reload (`only: ['products_data']`) updates the product list to empty, but since `ProductsPage` was already rendered in the `else` branch, both its inner tables returned `null` (no entries), leaving a blank page.

## Changes

- **`ProductsPage.tsx`**: Added `emptyPlaceholder` prop. When both `products` and `memberships` arrays are empty and an `emptyPlaceholder` is provided, it renders the placeholder instead of an empty grid.
- **`ProductsDashboardPage.tsx`**: Always renders `ProductsPage`, passing the empty-state placeholder via the new prop. Also fixed the search bar to show when there are memberships (not just products).
- **`ArchivedProductsPage.tsx`**: Added empty-state placeholder for the archived products view.

## Testing

1. Navigate to Products page with one product
2. Delete or archive that product
3. ✅ Empty-state illustration now appears correctly