### PR TITLE
Migrate _rich_text.scss to Tailwind CSS

### DIFF
--- a/app/javascript/components/ProductEdit/ProductTab/DescriptionEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/DescriptionEditor.tsx
@@ -343,9 +343,18 @@ export const DescriptionEditor = ({
       <label htmlFor={uid}>Description</label>
       <PublicFilesSettingsContext.Provider value={publicFilesSettings}>
         <ImageUploadSettingsContext.Provider value={imageSettings}>
-          <div className="rich-text-editor" data-gumroad-ignore>
-            {editor ? <RichTextEditorToolbar editor={editor} productId={id} /> : null}
-            <EditorContent className="rich-text" editor={editor} />
+          <div className="grid grid-rows-[max-content_1fr] min-h-56 rounded" data-gumroad-ignore>
+            {editor ? (
+              <RichTextEditorToolbar
+                editor={editor}
+                productId={id}
+                className="border border-b-0 rounded-t-[inherit] rounded-b-none"
+              />
+            ) : null}
+            <EditorContent
+              className="rich-text [&>.tiptap.textarea]:rounded-t-none [&>.tiptap.textarea]:min-h-full [&>.tiptap.textarea:focus-within]:outline-2 [&>.tiptap.textarea:focus-within]:outline-accent"
+              editor={editor}
+            />
           </div>
         </ImageUploadSettingsContext.Provider>
       </PublicFilesSettingsContext.Provider>

--- a/app/javascript/components/RichTextEditor.tsx
+++ b/app/javascript/components/RichTextEditor.tsx
@@ -16,7 +16,6 @@ import { assertDefined } from "$app/utils/assert";
 import { InputtedDiscount } from "$app/components/CheckoutDashboard/DiscountInput";
 import { Icon } from "$app/components/Icons";
 import { Popover, PopoverClose, PopoverContent, PopoverTrigger } from "$app/components/Popover";
-import { Separator } from "$app/components/Separator";
 import { TestimonialSelectModal } from "$app/components/TestimonialSelectModal";
 import { CodeBlock } from "$app/components/TiptapExtensions/CodeBlock";
 import { Image, uploadImages } from "$app/components/TiptapExtensions/Image";
@@ -89,7 +88,7 @@ export const MenuItem = ({
   <MenuItemTooltip tip={name}>
     <button
       type="button"
-      className="toolbar-item cursor-pointer all-unset"
+      className="cursor-pointer all-unset rounded px-2 py-1 hover:bg-active-bg aria-pressed:text-accent"
       aria-pressed={active}
       disabled={disabled}
       aria-label={name}
@@ -112,7 +111,7 @@ export const PopoverMenuItem = ({
   <Popover>
     <PopoverTrigger aria-label={name} className="all-unset">
       <MenuItemTooltip tip={name}>
-        <div className="toolbar-item">
+        <div className="rounded px-2 py-1 hover:bg-active-bg">
           <Icon name={icon} />
         </div>
       </MenuItemTooltip>
@@ -387,11 +386,15 @@ export const RichTextEditorToolbar = ({
     <ToolbarTooltipContext.Provider value={showTooltipState}>
       <div
         role="toolbar"
-        className={cx("rich-text-editor-toolbar", color, className)}
+        className={cx(
+            "sticky top-0 z-1 flex flex-wrap gap-1 py-1 px-2",
+            color === "ghost" ? "bg-background text-foreground" : "bg-primary text-primary-foreground",
+            className,
+          )}
         onMouseLeave={() => setShowTooltip(false)}
       >
         <Popover>
-          <PopoverTrigger aria-label="Text formats" className="toolbar-item all-unset">
+          <PopoverTrigger aria-label="Text formats" className="all-unset rounded px-2 py-1 hover:bg-active-bg">
             {activeFormatOption?.name ?? "Text"} <Icon name="outline-cheveron-down" />
           </PopoverTrigger>
           <PopoverContent sideOffset={4} className="border-0 p-0 shadow-none">
@@ -401,6 +404,7 @@ export const RichTextEditorToolbar = ({
                   <div
                     role="menuitemradio"
                     aria-checked={option === activeFormatOption}
+                    className="aria-checked:bg-active-bg"
                     onClick={() => {
                       const commands = editor.chain();
                       if (isList(option.type, editor.extensionManager.extensions))
@@ -417,7 +421,7 @@ export const RichTextEditorToolbar = ({
             </div>
           </PopoverContent>
         </Popover>
-        <Separator aria-orientation="vertical" />
+        <div role="separator" className="hidden sm:block border-r border-border my-2" />
         <MenuItem
           name="Bold"
           icon="bold"
@@ -448,7 +452,7 @@ export const RichTextEditorToolbar = ({
           active={editor.isActive("blockquote")}
           onClick={() => editor.chain().focus().toggleBlockquote().run()}
         />
-        <Separator aria-orientation="vertical" />
+        <div role="separator" className="hidden sm:block border-r border-border my-2" />
         {custom ?? (
           <>
             {topMenuItems.map((extension, i) => (
@@ -467,9 +471,9 @@ export const RichTextEditorToolbar = ({
 
             {insertMenuItems.length > 1 ? (
               <>
-                <Separator aria-orientation="vertical" />
+                <div role="separator" className="hidden sm:block border-r border-border my-2" />
                 <Popover>
-                  <PopoverTrigger className="toolbar-item all-unset">
+                  <PopoverTrigger className="all-unset rounded px-2 py-1 hover:bg-active-bg">
                     Insert <Icon name="outline-cheveron-down" />
                   </PopoverTrigger>
                   <PopoverContent sideOffset={4} className="border-0 p-0 shadow-none">
@@ -576,9 +580,14 @@ export const RichTextEditor = ({
   });
 
   return (
-    <div className="rich-text-editor" data-gumroad-ignore>
-      {editor ? <RichTextEditorToolbar editor={editor} /> : null}
-      <EditorContent className="rich-text" editor={editor} />
+    <div className="grid grid-rows-[max-content_1fr] min-h-56 rounded" data-gumroad-ignore>
+      {editor ? (
+        <RichTextEditorToolbar editor={editor} className="border border-b-0 rounded-t-[inherit] rounded-b-none" />
+      ) : null}
+      <EditorContent
+        className="rich-text [&>.tiptap.textarea]:rounded-t-none [&>.tiptap.textarea]:min-h-full [&>.tiptap.textarea:focus-within]:outline-2 [&>.tiptap.textarea:focus-within]:outline-accent"
+        editor={editor}
+      />
     </div>
   );
 };

--- a/app/javascript/packs/design.scss
+++ b/app/javascript/packs/design.scss
@@ -8,7 +8,6 @@
 @import "../stylesheets/icons";
 
 @import "../stylesheets/forms";
-@import "../stylesheets/rich_text";
 @import "../stylesheets/stack";
 
 @import "../stylesheets/legacy";

--- a/app/javascript/stylesheets/rich-text.css
+++ b/app/javascript/stylesheets/rich-text.css
@@ -1,0 +1,287 @@
+/*
+ * Styles for Prosemirror-generated rich text content.
+ * These elements are rendered by the editor and cannot receive Tailwind classes directly.
+ * Toolbar and editor wrapper styles are inlined in RichTextEditor.tsx.
+ */
+.rich-text {
+  &,
+  & .ProseMirror {
+    > * {
+      margin-bottom: calc(var(--spacing) * 4);
+    }
+  }
+
+  & h1 {
+    margin-bottom: calc(var(--spacing) * 6);
+  }
+
+  & h2,
+  & h3 {
+    margin-top: calc(var(--spacing) * 8);
+
+    &:first-child {
+      margin-top: 0;
+    }
+  }
+
+  & ul:not(.inline),
+  & ol {
+    margin-left: calc(var(--spacing) * 4);
+  }
+
+  & li:not(:last-child) {
+    margin-bottom: calc(var(--spacing) * 4);
+  }
+
+  & hr {
+    margin: calc(var(--spacing) * 8) 0;
+  }
+
+  & p {
+    margin-bottom: calc(var(--spacing) * 4);
+  }
+
+  & blockquote {
+    padding-left: calc(var(--spacing) * 8);
+  }
+
+  & figure:not(.tailwind-override) {
+    margin-bottom: calc(var(--spacing) * 6);
+
+    & img {
+      width: 100%;
+      object-fit: contain;
+      border-radius: 0.25rem;
+    }
+
+    & figcaption,
+    & .figcaption {
+      padding-left: calc(var(--spacing) * 1);
+      margin: calc(var(--spacing) * 3) 0 0 0;
+    }
+  }
+
+  & pre {
+    border: 1px solid var(--color-border);
+    border-radius: 0.25rem;
+    margin-bottom: calc(var(--spacing) * 4);
+    padding: calc(var(--spacing) * 2) calc(var(--spacing) * 3);
+    white-space: pre-wrap;
+
+    & .copy-wrapper {
+      float: right;
+      display: none;
+    }
+
+    &:hover .copy-wrapper {
+      display: initial;
+    }
+
+    & .hljs-comment,
+    & .hljs-quote {
+      color: var(--color-muted);
+    }
+
+    & .hljs-variable,
+    & .hljs-template-variable,
+    & .hljs-attribute,
+    & .hljs-name,
+    & .hljs-regexp,
+    & .hljs-link,
+    & .hljs-selector-id,
+    & .hljs-selector-class {
+      color: #99568b;
+    }
+
+    & .hljs-tag,
+    & .hljs-number,
+    & .hljs-meta,
+    & .hljs-built_in,
+    & .hljs-builtin-name,
+    & .hljs-literal,
+    & .hljs-type,
+    & .hljs-params {
+      color: #667399;
+    }
+
+    & .hljs-string,
+    & .hljs-symbol,
+    & .hljs-bullet {
+      color: #156059;
+    }
+
+    & .hljs-title,
+    & .hljs-section {
+      color: #78716c;
+    }
+
+    & .hljs-keyword,
+    & .hljs-selector-tag {
+      color: #91921f;
+    }
+
+    & .hljs-attr {
+      color: var(--color-foreground);
+    }
+
+    & .hljs-emphasis {
+      font-style: italic;
+    }
+
+    & .hljs-strong {
+      font-weight: 700;
+    }
+  }
+
+  & .actions-menu {
+    position: absolute;
+    bottom: calc(var(--spacing) * 4);
+    left: 0;
+    font-size: 1rem;
+    line-height: 1.4;
+    z-index: 1;
+
+    @media (width >= 1024px) {
+      display: none;
+      bottom: unset;
+      top: calc(var(--spacing) * 6);
+      left: calc(-1 * var(--spacing) * 2);
+      translate: -100% 0;
+    }
+  }
+
+  & :has(> .actions-menu) {
+    position: relative;
+
+    &::before {
+      content: "";
+      position: absolute;
+      inset: 0 100% 0 calc(-1 * var(--spacing) * 12);
+    }
+
+    &:hover:not(:has(.react-renderer:hover)) > .actions-menu,
+    &.selected > .actions-menu,
+    & > .menu[open] {
+      display: unset;
+      grid-column: unset;
+    }
+
+    &.selected {
+      border-radius: 0.25rem;
+      outline: 2px solid var(--color-accent);
+      position: relative;
+    }
+
+    & [role="group"] {
+      padding-left: calc(var(--spacing) * 6);
+    }
+  }
+
+  & .react-renderer[draggable] {
+    cursor: unset;
+  }
+
+  & .embed {
+    border: 1px solid var(--color-border);
+    border-radius: 0.25rem;
+    background-color: var(--color-background);
+    color: var(--color-foreground);
+
+    & > .preview {
+      background-color: var(--color-body);
+      border-radius: 0.25rem 0.25rem 0 0;
+      grid-template-columns: 1fr;
+      border-bottom: 1px solid var(--color-border);
+      margin: calc(-1 * var(--spacing) * 4);
+      max-width: unset;
+      margin-bottom: calc(var(--spacing) * 2);
+      position: relative;
+      aspect-ratio: 16 / 9;
+
+      & > :first-child {
+        top: 0;
+
+        &.placeholder {
+          height: calc(100% - var(--spacing) * 8);
+          place-content: center;
+          margin: calc(var(--spacing) * 4);
+        }
+      }
+    }
+
+    & .content h4 {
+      font-weight: bold;
+      overflow: hidden;
+      display: -webkit-box;
+      -webkit-line-clamp: 1;
+      -webkit-box-orient: vertical;
+    }
+
+    & .content > .thumbnail {
+      position: relative;
+      width: 4rem;
+      height: 3rem;
+      margin-right: calc(var(--spacing) * 2);
+
+      & img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        border-radius: 0.25rem;
+      }
+
+      & .placeholder {
+        position: absolute;
+        inset: 0;
+        padding: 0;
+        background: var(--color-backdrop);
+      }
+
+      &:hover .placeholder {
+        border-color: var(--color-accent);
+        color: var(--color-accent);
+      }
+
+      &:not(:hover) img + .placeholder {
+        opacity: 0;
+      }
+    }
+  }
+}
+
+/* Prosemirror editable area */
+.ProseMirror[contenteditable="true"] {
+  white-space: break-spaces;
+
+  &:focus-within {
+    outline: none;
+  }
+
+  & figure {
+    & > img {
+      cursor: pointer;
+    }
+
+    & br::selection {
+      background: none;
+    }
+
+    & img::selection {
+      background: var(--color-muted);
+    }
+
+    &[data-has-focus] img {
+      outline: 2px solid var(--color-accent);
+    }
+  }
+}
+
+/* Placeholder plugin */
+.ProseMirror p.is-editor-empty:first-child::before,
+.ProseMirror .node-image.is-empty .figcaption::before {
+  content: attr(data-placeholder);
+  pointer-events: none;
+  float: left;
+  height: 0;
+  color: var(--color-muted);
+}

--- a/app/javascript/stylesheets/tailwind.css
+++ b/app/javascript/stylesheets/tailwind.css
@@ -73,6 +73,8 @@
   }
 }
 
+@import "./rich-text.css";
+
 @utility all-unset {
   /* Ensure low precedence so it doesn't override other styles */
   :where(&) {


### PR DESCRIPTION
## Part of #3010 (split from #1055)

### Description

Migrates `_rich_text.scss` from SCSS with custom design-system functions to Tailwind CSS v4 theme variables and utility classes.

**Approach:** Inline Tailwind classes into React components wherever possible; keep a minimal CSS file only for Prosemirror-generated DOM elements that cannot receive class names directly.

### Changes

**Inlined into React components (`RichTextEditor.tsx`, `DescriptionEditor.tsx`):**
- `.rich-text-editor` wrapper → `grid grid-rows-[max-content_1fr] min-h-56 rounded`
- `.rich-text-editor-toolbar` → `sticky top-0 z-1 flex flex-wrap gap-1 py-1 px-2 bg-primary text-primary-foreground`
- `.toolbar-item` → `rounded px-2 py-1 hover:bg-active-bg aria-pressed:text-accent`
- `[role="separator"]` → replaced `<Separator>` with `<div role="separator" className="hidden sm:block border-r border-border my-2" />`
- `[role="menuitemradio"][aria-checked]` → `aria-checked:bg-active-bg`
- `.textarea` focus/radius overrides → Tailwind arbitrary selectors on `EditorContent`

**Kept in CSS (`rich-text.css`) — Prosemirror content styles:**
- Typography spacing (h1–h3, p, li, hr, blockquote, figure)
- Code block and highlight.js syntax coloring
- Actions menu positioning (editor block controls)
- Embed card layout
- Editable area and placeholder plugin styles

**SCSS → Tailwind v4 mapping:**
| SCSS | CSS/Tailwind |
|------|-------------|
| `spacer(N)` | `calc(var(--spacing) * M)` |
| `border-radius(1)` | `0.25rem` |
| `$border` | `1px solid var(--color-border)` |
| `$outline` | `2px solid var(--color-accent)` |
| `@include text-muted` | `color: var(--color-muted)` |
| `@include bg-color(primary)` | `bg-primary text-primary-foreground` |
| `z-index(overlay)` | `z-1` |
| `@include breakpoint-up(lg)` | `@media (width >= 1024px)` |

**Import changes:**
- Removed `@import "../stylesheets/rich_text"` from `design.scss`
- Added `@import "./rich-text.css"` to `tailwind.css`
- Kept `_rich_text.scss` for `email.scss` (uses `$unit: 16px`, no Tailwind)

### AI Disclosure
This PR was authored with AI assistance (Claude).

### Self-review
I reviewed the diff and confirmed all SCSS function calls have been correctly mapped to their Tailwind v4 CSS variable equivalents. The toolbar and editor wrapper styles are fully inlined as Tailwind utilities. Only Prosemirror-generated content styles remain in CSS since those elements cannot receive class names.