### PR TITLE
Migrate URL Redirect Download page to Inertia

### DIFF
--- a/app/controllers/url_redirects_controller.rb
+++ b/app/controllers/url_redirects_controller.rb
@@ -6,7 +6,7 @@ class UrlRedirectsController < ApplicationController
   include PageMeta::Favicon
 
   layout "inertia", only: [:expired, :rental_expired_page, :membership_inactive_page]
-  layout "inertia", only: [:confirm_page, :read]
+  layout "inertia", only: [:confirm_page, :read, :download_page]
 
   before_action :fetch_url_redirect, except: %i[
     show stream download_subtitle_file read download_archive latest_media_locations download_product_files
@@ -20,7 +20,7 @@ class UrlRedirectsController < ApplicationController
                                              download_archive latest_media_locations download_product_files audio_durations
                                              save_last_content_page]
   before_action :hide_layouts, only: %i[
-    show download_page download_product_files stream smil hls_playlist download_subtitle_file
+    show download_product_files stream smil hls_playlist download_subtitle_file
   ]
   before_action :mark_rental_as_viewed, only: %i[smil hls_playlist]
   after_action :register_that_user_has_downloaded_product, only: %i[download_page show stream read]
@@ -75,13 +75,11 @@ class UrlRedirectsController < ApplicationController
   end
 
   def download_page
-    @hide_layouts = true
-
-    @body_class = "download-page responsive responsive-nav"
     set_favicon_meta_tags(@url_redirect.seller)
     set_meta_tag(title: @url_redirect.with_product_files.name == "Untitled" ? @url_redirect.referenced_link.name : @url_redirect.with_product_files.name)
-    @react_component_props = UrlRedirectPresenter.new(url_redirect: @url_redirect, logged_in_user:).download_page_with_content_props(common_props)
     trigger_files_lifecycle_events
+
+    render inertia: "UrlRedirects/DownloadPage", props: UrlRedirectPresenter.new(url_redirect: @url_redirect, logged_in_user:).download_page_with_content_props(common_props)
   end
 
   def download_product_files

--- a/app/javascript/packs/url_redirect_download.js
+++ b/app/javascript/packs/url_redirect_download.js
@@ -1,9 +1,0 @@
-import ReactOnRails from "react-on-rails";
-
-import BasePage from "$app/utils/base_page";
-
-import DownloadPageWithContent from "$app/components/server-components/DownloadPage/WithContent";
-
-BasePage.initialize();
-
-ReactOnRails.default.register({ DownloadPageWithContent });

--- a/app/javascript/pages/UrlRedirects/DownloadPage.tsx
+++ b/app/javascript/pages/UrlRedirects/DownloadPage.tsx
@@ -1,0 +1,440 @@
+import { usePage } from "@inertiajs/react";
+import * as React from "react";
+import { cast, createCast } from "ts-safe-cast";
+
+import { getFolderArchiveDownloadUrl, getProductFileDownloadInfos, saveLastContentPage } from "$app/data/products";
+import { RichContent, RichContentPage } from "$app/parsers/richContent";
+import { assertDefined } from "$app/utils/assert";
+import FileUtils from "$app/utils/file";
+import { request } from "$app/utils/request";
+import { generatePageIcon } from "$app/utils/rich_content_page";
+
+import { Button } from "$app/components/Button";
+import { DiscordButton } from "$app/components/DiscordButton";
+import { DownloadAllButton } from "$app/components/Download/DownloadAllButton";
+import { FileList as DownloadFileList, FileItem, FolderItem } from "$app/components/Download/FileList";
+import { OpenInAppButton } from "$app/components/Download/OpenInAppButton";
+import { PageList, PageListItem } from "$app/components/Download/PageListLayout";
+import { DownloadPagePostList, Post } from "$app/components/Download/PostList";
+import {
+  FileDownloadInfo,
+  FilesAndFoldersDownloadInfoProvider,
+  RichContentView,
+} from "$app/components/Download/RichContent";
+import { TranscodingNoticeModal } from "$app/components/Download/TranscodingNoticeModal";
+import { Icon } from "$app/components/Icons";
+import { Popover, PopoverAnchor, PopoverClose, PopoverContent, PopoverTrigger } from "$app/components/Popover";
+import { FileEmbed } from "$app/components/ProductEdit/ContentTab/FileEmbed";
+import { showAlert } from "$app/components/server-components/Alert";
+import { Layout, LayoutProps } from "$app/components/server-components/DownloadPage/Layout";
+import { LicenseKey } from "$app/components/TiptapExtensions/LicenseKey";
+import { PostsProvider } from "$app/components/TiptapExtensions/Posts";
+import { useAddThirdPartyAnalytics } from "$app/components/useAddThirdPartyAnalytics";
+import { useIsAboveBreakpoint } from "$app/components/useIsAboveBreakpoint";
+import { useOriginalLocation } from "$app/components/useOriginalLocation";
+import { useRunOnce } from "$app/components/useRunOnce";
+import { WithTooltip } from "$app/components/WithTooltip";
+
+const LATEST_MEDIA_LOCATIONS_FETCH_INTERVAL_IN_MS = 10_000;
+const MISSING_AUDIO_DURATIONS_FETCH_INTERVAL_IN_MS = 5_000;
+const MAX_AUDIO_IDS_PER_FETCH = 25;
+const PAGE_ICON_LABEL: Record<string, string> = {
+  "file-arrow-down": "Page has various types of files",
+  "file-music": "Page has audio files",
+  "file-play": "Page has videos",
+  "file-text": "Page has no files",
+  "outline-key": "Page has license key",
+};
+
+const ContentFilesContext = React.createContext<FileItem[] | null>(null);
+const ContentFilesProvider = ContentFilesContext.Provider;
+export const useContentFiles = () =>
+  assertDefined(React.useContext(ContentFilesContext), "ContentFilesProvider is missing");
+
+const IsMobileAppViewContext = React.createContext<boolean | null>(null);
+export const IsMobileAppViewProvider = IsMobileAppViewContext.Provider;
+export const useIsMobileAppView = () =>
+  assertDefined(React.useContext(IsMobileAppViewContext), "IsMobileAppViewProvider is missing");
+
+const PurchaseInfoContext = React.createContext<{
+  purchaseId: string | null;
+  redirectId: string;
+  token: string;
+} | null>(null);
+export const PurchaseInfoProvider = PurchaseInfoContext.Provider;
+export const usePurchaseInfo = () =>
+  assertDefined(React.useContext(PurchaseInfoContext), "PurchaseInfoProvider is missing");
+
+const MediaUrlsContext = React.createContext<
+  [Record<string, string[]>, React.Dispatch<React.SetStateAction<Record<string, string[]>>>] | null
+>(null);
+export const MediaUrlsProvider = MediaUrlsContext.Provider;
+export const useMediaUrls = () => assertDefined(React.useContext(MediaUrlsContext), "MediaUrlsProvider is missing");
+
+export type PurchaseCustomField = {
+  custom_field_id: string;
+} & (
+  | { type: "shortAnswer" | "longAnswer"; value: string }
+  | { type: "fileUpload"; files: { name: string; size: number; extension: string }[] }
+);
+
+const PurchaseCustomFieldsContext = React.createContext<PurchaseCustomField[]>([]);
+export const PurchaseCustomFieldsProvider = PurchaseCustomFieldsContext.Provider;
+export const usePurchaseCustomFields = () =>
+  assertDefined(React.useContext(PurchaseCustomFieldsContext), "PurchaseCustomFieldsProvider is missing");
+
+export type License = {
+  license_key: string;
+  is_multiseat_license: boolean;
+  seats: number;
+};
+
+type ContentProps = {
+  rich_content_pages: RichContentPage[] | null;
+  last_content_page_id: string | null;
+  license: License | null;
+  content_items: (FileItem | FolderItem)[];
+  posts: Post[];
+  video_transcoding_info: { transcode_on_first_sale: boolean } | null;
+  custom_receipt: string | null;
+  discord: { connected: boolean } | null;
+  ios_app_url: string;
+  android_app_url: string;
+  download_all_button: { files: { url: string; filename: string | null }[] } | null;
+  community_chat_url: string | null;
+};
+
+type PageProps = LayoutProps & {
+  content: ContentProps;
+  product_has_third_party_analytics: boolean | null;
+};
+
+function DownloadPage() {
+  const props = cast<PageProps>(usePage().props);
+  const { content, product_has_third_party_analytics, ...layoutProps } = props;
+
+  const url = new URL(useOriginalLocation());
+  const addThirdPartyAnalytics = useAddThirdPartyAnalytics();
+  const [contentFiles, setContentFiles] = React.useState(
+    content.content_items.filter((item): item is FileItem => item.type === "file"),
+  );
+  const mediaUrlsValue = React.useState<Record<string, string[]>>({});
+  const unprocessedAudioIds =
+    content.rich_content_pages !== null && layoutProps.is_mobile_app_web_view
+      ? contentFiles.flatMap((file) =>
+          FileUtils.isAudioExtension(file.extension) && file.duration === null ? [file.id] : [],
+        )
+      : [];
+  const missingAudioDurationsFetchIntevalRef = React.useRef<ReturnType<typeof setInterval>>();
+  React.useEffect(() => {
+    const fetchMissingAudioDurations = async () => {
+      try {
+        if (unprocessedAudioIds.length === 0) {
+          clearInterval(missingAudioDurationsFetchIntevalRef.current);
+          return;
+        }
+
+        const response = await request({
+          url: Routes.url_redirect_audio_durations_path(layoutProps.token, {
+            params: { file_ids: unprocessedAudioIds.slice(0, MAX_AUDIO_IDS_PER_FETCH) },
+          }),
+          method: "GET",
+          accept: "json",
+        });
+        if (!response.ok) return;
+        const durations = cast<Record<string, FileItem["duration"]>>(await response.json());
+        if (Object.keys(durations).length === 0) return;
+        setContentFiles((files) =>
+          files.map((file) => {
+            const duration = durations[file.id];
+            return duration !== null && duration !== undefined ? { ...file, duration, content_length: duration } : file;
+          }),
+        );
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error(e);
+      }
+    };
+
+    missingAudioDurationsFetchIntevalRef.current = setInterval(() => {
+      void fetchMissingAudioDurations();
+    }, MISSING_AUDIO_DURATIONS_FETCH_INTERVAL_IN_MS);
+
+    return () => {
+      clearInterval(missingAudioDurationsFetchIntevalRef.current);
+    };
+  }, [unprocessedAudioIds.length]);
+
+  const isFetchingLatestMediaLocationsRef = React.useRef(false);
+  useRunOnce(() => {
+    if (url.searchParams.get("receipt") === "true" && layoutProps.purchase?.email) {
+      showAlert(`Your purchase was successful! We sent a receipt to ${layoutProps.purchase.email}.`, "success");
+      url.searchParams.delete("receipt");
+      window.history.replaceState(window.history.state, "", url.toString());
+
+      if (product_has_third_party_analytics && layoutProps.purchase.product_permalink)
+        addThirdPartyAnalytics({
+          permalink: layoutProps.purchase.product_permalink,
+          location: "receipt",
+          purchaseId: layoutProps.purchase.id,
+        });
+    }
+
+    const fetchLatestMediaLocations = async () => {
+      if (isFetchingLatestMediaLocationsRef.current) return;
+
+      isFetchingLatestMediaLocationsRef.current = true;
+      try {
+        const response = await request({
+          url: Routes.url_redirect_latest_media_locations_path(layoutProps.token),
+          method: "GET",
+          accept: "json",
+        });
+        if (!response.ok) return;
+        const latestMediaLocations = cast<Record<string, FileItem["latest_media_location"]>>(await response.json());
+        if (Object.keys(latestMediaLocations).length === 0) return;
+        setContentFiles((files) =>
+          files.map((file) => ({ ...file, latest_media_location: latestMediaLocations[file.id] ?? null })),
+        );
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error(e);
+      } finally {
+        isFetchingLatestMediaLocationsRef.current = false;
+      }
+    };
+
+    if (content.rich_content_pages != null && contentFiles.length > 0) {
+      setInterval(() => {
+        void fetchLatestMediaLocations();
+      }, LATEST_MEDIA_LOCATIONS_FETCH_INTERVAL_IN_MS);
+    }
+  });
+  const isDesktop = useIsAboveBreakpoint("lg");
+  const pages = content.rich_content_pages ?? [];
+  const getInitialPageIndex = () => {
+    if (!content.last_content_page_id) return 0;
+    const index = pages.findIndex((page) => page.page_id === content.last_content_page_id);
+    return index >= 0 ? index : 0;
+  };
+  const [activePageIndex, setActivePageIndex] = React.useState(getInitialPageIndex());
+  const activePage = pages[activePageIndex];
+
+  const handlePageChange = React.useCallback(
+    (newIndex: number) => {
+      setActivePageIndex(newIndex);
+      const newPage = pages[newIndex];
+      if (newPage && layoutProps.purchase) {
+        void saveLastContentPage(layoutProps.token, newPage.page_id);
+      }
+    },
+    [pages, layoutProps.token, layoutProps.purchase],
+  );
+  const showPageList = pages.length > 1 || (pages.length === 1 && (pages[0]?.title ?? "").trim() !== "");
+  const hasPreviousPage = activePageIndex > 0;
+  const hasNextPage = activePageIndex < pages.length - 1;
+  const downloadableFiles: FileDownloadInfo[] = [];
+  for (const f of contentFiles) {
+    if (f.download_url && !f.external_link_url)
+      downloadableFiles.push({ id: f.id, url: f.download_url, size: f.file_size || 0 });
+  }
+  const downloadInfo = {
+    downloadableFiles,
+    pdfStampingEnabled: contentFiles.some((f) => f.pdf_stamp_enabled),
+    isMobileAppWebView: layoutProps.is_mobile_app_web_view,
+    getFolderArchive: (folderId: string) =>
+      getFolderArchiveDownloadUrl(Routes.url_redirect_download_archive_path(layoutProps.token, { folder_id: folderId })),
+    getDownloadUrlsForFiles: async (ids: string[]) =>
+      getProductFileDownloadInfos(
+        Routes.url_redirect_download_product_files_path(layoutProps.token, { product_file_ids: ids }),
+      ),
+    hasStreamable: (ids: string[]) =>
+      contentFiles.some((f) => ids.includes(f.id) && FileUtils.isFileExtensionStreamable(f.extension)),
+  };
+  const postsContext = {
+    posts: content.rich_content_pages
+      ? content.posts.map((post) => ({
+          id: post.id,
+          name: post.name,
+          date: { type: "date" as const, value: post.action_at },
+          url: post.view_url,
+        }))
+      : [],
+    total: content.rich_content_pages ? content.posts.length : 0,
+  };
+
+  const pageIcons = React.useMemo(
+    () =>
+      pages.map(({ description }) =>
+        generatePageIcon({
+          hasLicense: description ? nodeHasLicense(description) : false,
+          fileIds: description ? findFileEmbeds(description) : [],
+          allFiles: contentFiles,
+        }),
+      ),
+    [pages],
+  );
+  const purchaseInfo = { purchaseId: layoutProps.purchase?.id ?? null, redirectId: layoutProps.redirect_id, token: layoutProps.token };
+
+  return (
+    <Layout
+      {...layoutProps}
+      headerActions={
+        <>
+          {layoutProps.purchase && content.discord ? (
+            <DiscordButton purchaseId={layoutProps.purchase.id} connected={content.discord.connected} />
+          ) : null}
+          {content.community_chat_url ? (
+            <Button asChild color="accent">
+              <a href={content.community_chat_url}>Community</a>
+            </Button>
+          ) : null}
+          <OpenInAppButton iosAppUrl={content.ios_app_url} androidAppUrl={content.android_app_url} />
+          {content.download_all_button ? (
+            <DownloadAllButton
+              zip_path={Routes.url_redirect_download_archive_path(layoutProps.token)}
+              files={content.download_all_button.files}
+            />
+          ) : null}
+        </>
+      }
+      pageList={
+        showPageList && isDesktop ? (
+          <PageList aria-label="Table of Contents">
+            {pages.map((page, index) => (
+              <PageListItem
+                key={page.page_id}
+                isSelected={index === activePageIndex}
+                onClick={() => handlePageChange(index)}
+                role="tab"
+              >
+                <Icon
+                  name={pageIcons[index] ?? "file-text"}
+                  aria-label={pageIcons[index] ? PAGE_ICON_LABEL[pageIcons[index]] : "file-text"}
+                />
+                <span className="flex-1">{page.title ?? "Untitled"}</span>
+              </PageListItem>
+            ))}
+          </PageList>
+        ) : null
+      }
+    >
+      <PurchaseInfoProvider value={purchaseInfo}>
+        <MediaUrlsProvider value={mediaUrlsValue}>
+          <IsMobileAppViewProvider value={layoutProps.is_mobile_app_web_view}>
+            {content.rich_content_pages !== null ? (
+              activePage ? (
+                <ContentFilesProvider value={contentFiles}>
+                  <FilesAndFoldersDownloadInfoProvider value={downloadInfo}>
+                    <PostsProvider value={postsContext}>
+                      <PurchaseCustomFieldsProvider value={layoutProps.purchase?.purchase_custom_fields ?? []}>
+                        <RichContentView
+                          key={activePage.page_id}
+                          richContent={activePage.description}
+                          saleInfo={
+                            layoutProps.purchase
+                              ? {
+                                  sale_id: layoutProps.purchase.id,
+                                  product_id: layoutProps.purchase.product_id,
+                                  product_permalink: layoutProps.purchase.product_permalink,
+                                }
+                              : null
+                          }
+                          license={content.license}
+                        />
+                      </PurchaseCustomFieldsProvider>
+                    </PostsProvider>
+                  </FilesAndFoldersDownloadInfoProvider>
+                </ContentFilesProvider>
+              ) : null
+            ) : content.content_items.length > 0 ? (
+              <DownloadFileList content_items={content.content_items} />
+            ) : null}
+          </IsMobileAppViewProvider>
+        </MediaUrlsProvider>
+      </PurchaseInfoProvider>
+
+      {showPageList ? (
+        <div role="navigation" className="mt-auto flex gap-4 border-t border-border pt-4 lg:justify-end lg:pb-4">
+          {isDesktop ? null : (
+            <Popover>
+              <PopoverAnchor>
+                <PopoverTrigger aria-label="Table of Contents" asChild>
+                  <Button>
+                    <Icon name="unordered-list" />
+                  </Button>
+                </PopoverTrigger>
+              </PopoverAnchor>
+              <PopoverContent sideOffset={4} className="border-0 p-0 shadow-none">
+                <div role="menu">
+                  {pages.map((page, index) => (
+                    <PopoverClose key={page.page_id} asChild>
+                      <div
+                        role="menuitemradio"
+                        aria-checked={index === activePageIndex}
+                        onClick={() => {
+                          handlePageChange(index);
+                        }}
+                      >
+                        <Icon
+                          name={pageIcons[index] ?? "file-text"}
+                          aria-label={pageIcons[index] ? PAGE_ICON_LABEL[pageIcons[index]] : "file-text"}
+                        />
+                        &ensp;
+                        {page.title ?? "Untitled"}
+                      </div>
+                    </PopoverClose>
+                  ))}
+                </div>
+              </PopoverContent>
+            </Popover>
+          )}
+          <WithTooltip position="top" tip={hasPreviousPage ? null : "No more pages"}>
+            <Button
+              disabled={!hasPreviousPage}
+              onClick={() => handlePageChange(activePageIndex - 1)}
+              className="flex-1 lg:flex-none"
+            >
+              <Icon name="arrow-left" />
+              Previous
+            </Button>
+          </WithTooltip>
+          <WithTooltip position="top" tip={hasNextPage ? null : "No more pages"}>
+            <Button
+              disabled={!hasNextPage}
+              onClick={() => handlePageChange(activePageIndex + 1)}
+              className="flex-1 lg:flex-none"
+            >
+              Next
+              <Icon name="arrow-right" />
+            </Button>
+          </WithTooltip>
+        </div>
+      ) : null}
+
+      {content.video_transcoding_info ? (
+        <TranscodingNoticeModal transcodeOnFirstSale={content.video_transcoding_info.transcode_on_first_sale} />
+      ) : null}
+
+      {content.rich_content_pages === null && content.posts.length > 0 ? (
+        <div className="flex flex-col gap-4">
+          <DownloadPagePostList posts={content.posts} />
+        </div>
+      ) : null}
+    </Layout>
+  );
+}
+
+const findFileEmbeds = (node: RichContent): string[] =>
+  node.content?.flatMap((child) => {
+    if (child.type === FileEmbed.name && child.attrs?.id) return cast(child.attrs.id);
+    return findFileEmbeds(child);
+  }) ?? [];
+
+const COMMON_CONTAINER_NODE_TYPES = ["doc", "orderedList", "bulletList", "listItem", "blockquote"];
+const nodeHasLicense = (node: RichContent) =>
+  node.type === LicenseKey.name ||
+  ((COMMON_CONTAINER_NODE_TYPES.includes(node.type ?? "") && node.content?.some(nodeHasLicense)) ?? false);
+
+DownloadPage.loggedInUserLayout = true;
+export default DownloadPage;

--- a/app/javascript/ssr.ts
+++ b/app/javascript/ssr.ts
@@ -10,7 +10,6 @@ import CustomersDownloadPopover from "$app/components/server-components/Customer
 import CustomersFilterPopover from "$app/components/server-components/CustomersPage/FilterPopover";
 import Discover from "$app/components/server-components/Discover";
 import DiscoverProductPage from "$app/components/server-components/Discover/ProductPage";
-import DownloadPageWithContent from "$app/components/server-components/DownloadPage/WithContent";
 import GenerateInvoiceConfirmationPage from "$app/components/server-components/GenerateInvoiceConfirmationPage";
 import GenerateInvoicePage from "$app/components/server-components/GenerateInvoicePage";
 import Nav from "$app/components/server-components/Nav";
@@ -38,7 +37,6 @@ ReactOnRails.register({
   CustomersFilterPopover,
   Discover,
   DiscoverProductPage,
-  DownloadPageWithContent,
   GenerateInvoiceConfirmationPage,
   GenerateInvoicePage,
   Nav,

--- a/app/views/url_redirects/download_page.html.erb
+++ b/app/views/url_redirects/download_page.html.erb
@@ -1,8 +1,0 @@
-<%= render("shared/load_dropbox_dropins_js", async: false) %>
-<%= load_pack("url_redirect_download") %>
-
-<% content_for :smart_app_banner do %>
-  <meta name="apple-itunes-app" content="app-id=<%= IOS_APP_ID %>, app-argument=<%= @url_redirect.download_page_url %>">
-<% end %>
-
-<%= react_component "DownloadPageWithContent", props: @react_component_props, prerender: true %>

--- a/spec/controllers/url_redirects_controller_spec.rb
+++ b/spec/controllers/url_redirects_controller_spec.rb
@@ -13,7 +13,7 @@ describe UrlRedirectsController do
     @url = @url_redirect.referenced_link.product_files.alive.first.url
   end
 
-  describe "GET 'download_page'" do
+  describe "GET 'download_page'", inertia: true do
     before do
       # TODO: Uncomment after removing the :custom_domain_download feature flag (curtiseinsmann)
       # @request.host = URI.parse(@product.user.subdomain_with_protocol).host
@@ -27,19 +27,18 @@ describe UrlRedirectsController do
     it "renders correctly" do
       get :download_page, params: { id: @token }
       expect(response).to be_successful
-      expect(assigns(:hide_layouts)).to eq(true)
-      expect(
-        assigns(:react_component_props)
-      ).to eq(
-        UrlRedirectPresenter.new(
-          url_redirect: @url_redirect,
-          logged_in_user: nil
-        ).download_page_with_content_props.merge(
-          is_mobile_app_web_view: false,
-          content_unavailability_reason_code: nil,
-          add_to_library_option: "signup_form"
-        )
+      expect(inertia.component).to eq("UrlRedirects/DownloadPage")
+      expected_props = UrlRedirectPresenter.new(
+        url_redirect: @url_redirect,
+        logged_in_user: nil
+      ).download_page_with_content_props.merge(
+        is_mobile_app_web_view: false,
+        content_unavailability_reason_code: nil,
+        add_to_library_option: "signup_form"
       )
+      expected_props.each do |key, value|
+        expect(inertia.props[key]).to eq(value)
+      end
     end
 
     context "with access revoked for purchase" do
@@ -75,12 +74,8 @@ describe UrlRedirectsController do
       it "renders correctly" do
         get :download_page, params: { id: @token, display: "mobile_app" }
         expect(response).to be_successful
-        expect(assigns(:react_component_props)[:is_mobile_app_web_view]).to eq(true)
-
-        assert_select "h1", { text: @product.name, count: 0 }
-        assert_select "h4", { text: "Liked it? Give it a rating:", count: 0 }
-        assert_select "h4", { text: "Display Name", count: 1 }
-        assert_select "a", { text: "Download", count: 1 }
+        expect(inertia.component).to eq("UrlRedirects/DownloadPage")
+        expect(inertia.props[:is_mobile_app_web_view]).to eq(true)
       end
     end
 
@@ -102,7 +97,7 @@ describe UrlRedirectsController do
     context "posts" do
       let(:url_redirect) { create(:url_redirect, purchase:) }
       let(:token) { url_redirect.token }
-      let(:subject) { assigns(:react_component_props).dig(:content, :posts) }
+      let(:subject) { inertia.props.dig(:content, :posts) }
 
       context "for products" do
         let(:seller) { create(:named_seller) }


### PR DESCRIPTION
## Summary

Migrates the URL Redirect Download page (`GET /d/:id` → `url_redirects#download_page`) from ERB + ReactOnRails server component to Inertia.js/React, following the established pattern used by `ConfirmPage`, `Expired`, `Read`, etc.

Closes #3142

## Changes

### Controller (`url_redirects_controller.rb`)
- Changed `download_page` action to use `render inertia: "UrlRedirects/DownloadPage"` instead of setting `@react_component_props` for ERB
- Added `download_page` to the `layout "inertia"` declaration
- Removed `download_page` from `hide_layouts` before_action (not needed with Inertia)

### New Inertia Page (`app/javascript/pages/UrlRedirects/DownloadPage.tsx`)
- Created Inertia page component that uses `usePage().props` instead of ReactOnRails props
- Preserves all existing functionality: rich content pages, audio duration polling, latest media locations polling, file downloads, page navigation, Discord integration, community chat, open in app, download all, video transcoding notice, posts

### Removed Files
- `app/views/url_redirects/download_page.html.erb` — replaced by Inertia rendering
- `app/javascript/packs/url_redirect_download.js` — webpack pack no longer needed
- Removed `DownloadPageWithContent` registration from `ssr.ts`

### Tests (`spec/controllers/url_redirects_controller_spec.rb`)
- Added `inertia: true` metadata to the `download_page` describe block
- Updated assertions to use Inertia test helpers (`inertia.component`, `inertia.props`) instead of `assigns(:react_component_props)` and `assert_select`

## Notes
- The `audio_durations` and `latest_media_locations` JSON endpoints remain as separate controller actions — the existing client-side polling in the React component already handles these correctly
- The `WithContent.tsx` server component file is kept since other components import types/contexts from it