### PR TITLE
fix: prevent Redo button tooltip from overflowing viewport

### DIFF
--- a/app/javascript/components/RichTextEditor.tsx
+++ b/app/javascript/components/RichTextEditor.tsx
@@ -48,7 +48,15 @@ export const useImageUploadSettings = () => React.useContext(ImageUploadSettings
 
 const TOOLBAR_TOOLTIP_DEFAULT_DELAY = 800; // in milliseconds
 
-const MenuItemTooltip = ({ tip, children }: { tip: string; children: React.ReactNode }) => {
+const MenuItemTooltip = ({
+  tip,
+  children,
+  position = "bottom",
+}: {
+  tip: string;
+  children: React.ReactNode;
+  position?: "top" | "left" | "bottom" | "right";
+}) => {
   const [showTooltip, setShowTooltip] = assertDefined(React.useContext(ToolbarTooltipContext));
 
   const hoverTimeoutRef = React.useRef<ReturnType<typeof setTimeout>>();
@@ -65,7 +73,7 @@ const MenuItemTooltip = ({ tip, children }: { tip: string; children: React.React
   };
 
   return (
-    <WithTooltip position="bottom" tip={showTooltip ? tip : null}>
+    <WithTooltip position={position} tip={showTooltip ? tip : null}>
       <span onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
         {children}
       </span>
@@ -79,14 +87,16 @@ export const MenuItem = ({
   active,
   disabled,
   onClick,
+  tooltipPosition = "bottom",
 }: {
   name: string;
   icon: IconName;
   active?: boolean;
   disabled?: boolean;
   onClick?: () => void;
+  tooltipPosition?: "top" | "left" | "bottom" | "right";
 }) => (
-  <MenuItemTooltip tip={name}>
+  <MenuItemTooltip tip={name} position={tooltipPosition}>
     <button
       type="button"
       className="toolbar-item cursor-pointer all-unset"
@@ -525,6 +535,7 @@ export const RichTextEditorToolbar = ({
             active={editor.isActive("redo")}
             disabled={redoDepth(editor.state) === 0}
             onClick={() => editor.chain().focus().redo().run()}
+            tooltipPosition="left"
           />
         </div>
       </div>


### PR DESCRIPTION
## Problem
Fixes #3307

On the product content page, hovering over the Redo button causes its tooltip ('Redo last undone change') to overflow beyond the right edge of the viewport, requiring horizontal scrolling to see the full text.

## Solution
Position the Redo button's tooltip to appear on the left side instead of the bottom, preventing it from overflowing the right edge of the viewport.

## Changes
1. Added optional `position` prop to `MenuItemTooltip` component (defaults to 'bottom')
2. Added optional `tooltipPosition` prop to `MenuItem` component (defaults to 'bottom') 
3. Set `tooltipPosition='left'` on the Redo button

## Testing
- Hover over Redo button → tooltip appears to the left, within viewport ✓
- Other toolbar buttons still show tooltips on bottom ✓
- No visual regressions in toolbar appearance ✓