### PR TITLE
Fix Firefox CSRF token error on login and signup pages

### DIFF
--- a/app/javascript/components/SocialAuthButton.tsx
+++ b/app/javascript/components/SocialAuthButton.tsx
@@ -1,9 +1,8 @@
+import { usePage } from "@inertiajs/react";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
-import { cast } from "ts-safe-cast";
 
 import { BrandName, Button, ButtonProps } from "$app/components/Button";
-import { useRunOnce } from "$app/components/useRunOnce";
 
 export const SocialAuthButton = ({
   href,
@@ -14,8 +13,7 @@ export const SocialAuthButton = ({
   provider: BrandName;
 } & ButtonProps) => {
   const formRef = React.useRef<HTMLFormElement>(null);
-  const [csrfToken, setCsrfToken] = React.useState("");
-  useRunOnce(() => setCsrfToken(cast(document.querySelector("meta[name=csrf-token]")?.getAttribute("content"))));
+  const { authenticity_token: csrfToken } = usePage<{ authenticity_token: string }>().props;
 
   return (
     // Omniauth requires a non-AJAX POST request to redirect to the provider, so we need to submit a form.


### PR DESCRIPTION
Fixes https://github.com/antiwork/gumroad/issues/3313

# Description

## Problem

On production Firefox, the login and signup pages throw a console error:

```
Error: Expected root to be a union, but no branches matched:
• Error: Expected root to be a string, got undefined
• Error: Expected root to be an object, got undefined
```

This originates from `SocialAuthButton.tsx`, which reads the CSRF token from the DOM via `document.querySelector("meta[name=csrf-token]")` but on Firefox meta tag not exist

## Solution
Replace DOM-based CSRF token lookup (`$("meta[name=csrf-token]").attr("content")`) with `usePage().props.authenticity_token` from Inertia's shared page props. This token is already provided server-side via `inertia_share` in `InertiaRendering` and is always available.

---

# Before/After

## Before
The issue not reproducible on localhost
But on production on Firefox there is no csrf-token meta:
<img width="758" height="380" alt="image" src="https://github.com/user-attachments/assets/985015af-3d2c-4bdb-aaa5-9058d537110e" />


## After

https://github.com/user-attachments/assets/a4bf4a6d-c1a5-40b4-8e4f-d94ad43bed08




---

# AI Disclosure

Claude Opus 4.6 for code generation, all codes self reviewed
