### PR TITLE
fix: keep search bar visible when search returns no results

### DIFF
--- a/app/javascript/components/ProductsDashboardPage.tsx
+++ b/app/javascript/components/ProductsDashboardPage.tsx
@@ -44,7 +44,9 @@ export const ProductsDashboardPage = ({
       archivedTabVisible={enableArchiveTab}
       ctaButton={
         <>
-          {products.length > 0 ? <Search value={query} onSearch={setQuery} placeholder="Search products" /> : null}
+          {products.length > 0 || memberships.length > 0 || query ? (
+            <Search value={query} onSearch={setQuery} placeholder="Search products" />
+          ) : null}
           <NavigationButtonInertia href={Routes.new_product_path()} disabled={!canCreateProduct} color="accent">
             New product
           </NavigationButtonInertia>


### PR DESCRIPTION
## Summary
- Fixed the search bar disappearing when a search query returned zero products on the Products page
- The `Search` component was conditionally rendered only when `products.length > 0`, causing it to vanish when the server returned an empty result set
- Changed the condition to also show the search bar when there are memberships or an active search query

## Technical Changes
- `app/javascript/components/ProductsDashboardPage.tsx`: Changed Search visibility condition from `products.length > 0` to `products.length > 0 || memberships.length > 0 || query`

## Test plan
- [ ] Navigate to Products page with existing products
- [ ] Search for a term that returns no results
- [ ] Verify the search bar remains visible and functional
- [ ] Verify clearing the search shows all products again

Fixes #3262

> Automated fix by buildingvibes