### PR TITLE
fix: prevent Redo button tooltip from overflowing viewport

### DIFF
--- a/app/javascript/components/RichTextEditor.tsx
+++ b/app/javascript/components/RichTextEditor.tsx
@@ -513,14 +513,14 @@ export const RichTextEditorToolbar = ({
         )}
         <div className="ml-auto flex">
           <MenuItem
-            name="Undo last change"
+            name="Undo"
             icon="undo"
             active={editor.isActive("undo")}
             disabled={undoDepth(editor.state) === 0}
             onClick={() => editor.chain().focus().undo().run()}
           />
           <MenuItem
-            name="Redo last undone change"
+            name="Redo"
             icon="redo"
             active={editor.isActive("redo")}
             disabled={redoDepth(editor.state) === 0}


### PR DESCRIPTION
## Summary
- Shortened Undo/Redo tooltip labels from "Undo last change"/"Redo last undone change" to "Undo"/"Redo"
- The long tooltip on the Redo button (far right of the content toolbar) overflowed beyond the viewport edge
- "Undo" and "Redo" are standard tooltip labels used across major editors

## Test plan
- [ ] Navigate to /products/:id/edit/content
- [ ] Hover over the Redo button
- [ ] Verify tooltip no longer overflows the viewport

Fixes #3307