### PR TITLE
Fix empty products page after deleting/archiving the last product

### DIFF
--- a/app/javascript/components/ProductsPage/MembershipsTable.tsx
+++ b/app/javascript/components/ProductsPage/MembershipsTable.tsx
@@ -169,10 +169,20 @@ export const ProductsPageMembershipsTable = (props: {
                   <ActionsPopover
                     product={membership}
                     onDuplicate={() => loadMemberships()}
-                    onDelete={() => reloadMemberships()}
+                    onDelete={() => {
+                      if (memberships.length <= 1) {
+                        router.get(Routes.products_path());
+                      } else {
+                        reloadMemberships();
+                      }
+                    }}
                     onArchive={() => {
                       props.setEnableArchiveTab?.(true);
-                      reloadMemberships();
+                      if (memberships.length <= 1) {
+                        router.get(Routes.products_path());
+                      } else {
+                        reloadMemberships();
+                      }
                     }}
                     onUnarchive={(hasRemainingArchivedProducts) => {
                       props.setEnableArchiveTab?.(hasRemainingArchivedProducts);

--- a/app/javascript/components/ProductsPage/ProductsTable.tsx
+++ b/app/javascript/components/ProductsPage/ProductsTable.tsx
@@ -160,10 +160,20 @@ export const ProductsPageProductsTable = (props: {
                     <ActionsPopover
                       product={product}
                       onDuplicate={() => loadProducts()}
-                      onDelete={() => reloadProducts()}
+                      onDelete={() => {
+                        if (products.length <= 1) {
+                          router.get(Routes.products_path());
+                        } else {
+                          reloadProducts();
+                        }
+                      }}
                       onArchive={() => {
                         props.setEnableArchiveTab?.(true);
-                        reloadProducts();
+                        if (products.length <= 1) {
+                          router.get(Routes.products_path());
+                        } else {
+                          reloadProducts();
+                        }
                       }}
                       onUnarchive={(hasRemainingArchivedProducts) => {
                         props.setEnableArchiveTab?.(hasRemainingArchivedProducts);


### PR DESCRIPTION
## Summary
- When the last product or membership is deleted/archived, performs a full page visit (`router.get(Routes.products_path())`) instead of a partial Inertia reload
- This ensures the server returns complete page state so the empty-state placeholder renders correctly
- Applied to both ProductsTable and MembershipsTable for consistency

## Root cause
After deleting/archiving the last product, `reloadProducts()` does a partial Inertia reload with `only: ["products_data"]`. The partial reload returns `products: []` but the page re-renders with an empty grid instead of the placeholder illustration.

The fix detects when the current page has only one remaining product (`products.length <= 1`) and uses a full page visit instead, which properly triggers the server-side empty-state check and renders the "We've never met an idea we didn't like" placeholder.

## Test plan
- [ ] Create a single product, then delete it — page should show the empty-state placeholder
- [ ] Create a single product, then archive it — page should show the empty-state placeholder
- [ ] With multiple products, delete one — page should reload normally showing remaining products
- [ ] Same behavior verified for memberships

Fixes #2643