### PR TITLE
fix: auto-apply default discount code when using ?wanted=true

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -131,7 +131,7 @@ class LinksController < ApplicationController
         redirect_to checkout_index_url(**params.permit!, host: DOMAIN, product: @product.unique_permalink,
                                                          rent: cart_item[:rental], recurrence: cart_item[:recurrence],
                                                          price: cart_item[:price],
-                                                         code: params[:offer_code] || params[:code],
+                                                         code: params[:offer_code] || params[:code] || @product.default_offer_code&.code,
                                                          affiliate_id: params[:affiliate_id] || params[:a],
                                                          referrer: params[:referrer] || request.referrer),
                     allow_other_host: true


### PR DESCRIPTION
## Summary

Fixes #3271

When visiting a product URL with `?wanted=true`, the user is redirected directly to checkout, bypassing the product page. The product page normally detects the product's `default_offer_code` and passes it as a `?code=` parameter to checkout via the CTA button. With `?wanted=true`, only URL-supplied discount codes (`offer_code` or `code` params) were forwarded in the redirect, so the product's default auto-apply discount was lost.

## Changes

- `app/controllers/links_controller.rb`: Added `@product.default_offer_code&.code` as a fallback in the redirect's `code` parameter, ensuring auto-apply discount codes work when using `?wanted=true`

## Test plan

- Visit a product with a default offer code and `?wanted=true` → discount should auto-apply at checkout
- Visit a product with explicit `?offer_code=X&wanted=true` → explicit code should take precedence
- Visit a product with `?wanted=true` and no default offer code → no code applied (no regression)