### PR TITLE
fix: improve mobile layout for installment plan payment options

### DIFF
--- a/app/javascript/components/Product/ConfigurationSelector.tsx
+++ b/app/javascript/components/Product/ConfigurationSelector.tsx
@@ -488,7 +488,7 @@ const PaymentOptionSelector = ({
   return (
     <section>
       <h4 className="mb-2">Payment option</h4>
-      <div role="radiogroup" className="radio-buttons">
+      <div role="radiogroup" className="radio-buttons" style={{ gridTemplateColumns: "repeat(auto-fit, minmax(min(18rem, 100%), 1fr))" }}>
         <Button
           role="radio"
           aria-checked={!selection.payInInstallments}

--- a/app/javascript/stylesheets/_forms.scss
+++ b/app/javascript/stylesheets/_forms.scss
@@ -231,6 +231,8 @@ input[type="checkbox"]:not([role="switch"]) {
 
   button[role="radio"] {
     @extend %select-button;
+    min-width: 0;
+    overflow-wrap: break-word;
 
     &[aria-checked="true"] {
       @extend %select-button-active;


### PR DESCRIPTION
## Summary

Fixes #3319

The payment option radio buttons ("Pay in full" / "Pay in X installments") had a design issue on mobile when the installment plan text was too long for the button width.

## Changes

- `_forms.scss`: Added `min-width: 0` and `overflow-wrap: break-word` to radio button elements so text wraps properly within buttons on narrow screens
- `ConfigurationSelector.tsx`: Increased the minimum grid column width for payment option buttons from 15rem (240px) to 18rem (288px), causing them to stack vertically on screens narrower than ~576px instead of ~480px. This ensures the installment schedule text has enough room.

## Test plan

- View a product with installment plan on mobile (375px viewport) → buttons should stack vertically with readable text
- View on tablet/desktop → buttons should display side-by-side
- Other radio button groups (e.g., product options) should be unaffected