### PR TITLE
fix: make receipt preview item boxes occupy full width

### DIFF
--- a/app/javascript/stylesheets/_email.scss
+++ b/app/javascript/stylesheets/_email.scss
@@ -451,6 +451,20 @@ $accent-color: map-get($colors, "pink"); // [1]
     }
   }
 
+  .items {
+    padding: 0;
+
+    > .item {
+      border-radius: 0;
+      border-left: none;
+      border-right: none;
+
+      &:first-child {
+        border-top: none;
+      }
+    }
+  }
+
   .item {
     border: $border;
     border-radius: border-radius(1);

--- a/app/views/customer_mailer/receipt/sections/_items.html.erb
+++ b/app/views/customer_mailer/receipt/sections/_items.html.erb
@@ -1,5 +1,5 @@
 <% charge_info = receipt_presenter.charge_info %>
-<div>
+<div class="items">
   <% receipt_presenter.items_infos.each do |item_info| %>
     <div class="item">
       <%= render("customer_mailer/receipt/item", item_info: item_info) %>


### PR DESCRIPTION
## Summary

Fixes #2773

The item boxes in the receipt preview had extra padding between them and the main container edges, making them appear narrower than other sections (header, payment info).

## Root cause

The items section container (`<div>`) is a direct child of `.main`, inheriting `padding: spacer(3)` from the `.email > .main > *` rule. Inside it, `.item` boxes have their own border and internal padding. This double padding created inconsistent visual spacing.

## Changes

- `_items.html.erb`: Added `class="items"` to the items container div
- `_email.scss`: Added `.items` rule that removes padding from the container, removes left/right borders and border-radius from items, and removes the top border from the first item — so item boxes extend edge-to-edge within the receipt

## Test plan

- View receipt preview in product edit → item boxes should be full-width with consistent padding
- Send a test receipt email → verify items display correctly in email clients
- Multiple items should stack with clean border separation