### PR TITLE
fix: prevent content toolbar dropdown from being overlapped by row actions

### DIFF
--- a/app/javascript/components/ProductEdit/ContentTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/index.tsx
@@ -490,7 +490,7 @@ const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: string | 
         {editor ? (
           <RichTextEditorToolbar
             color="ghost"
-            className="border-b border-border px-8"
+            className="relative z-10 border-b border-border px-8"
             editor={editor}
             productId={id}
             custom={


### PR DESCRIPTION
## Summary

Fixes #3215

The "Upload files" dropdown in the Content tab toolbar was being overlapped by the RowActions buttons (Download, expand/collapse, Edit) from file rows below it.

## Root cause

The toolbar's PopoverContent renders inline (without a portal) with `z-index: 30`. However, the file row buttons use `transition-transform` and `hover:-translate-1` which create new stacking contexts, causing the buttons to appear above the toolbar's dropdown.

## Changes

- `ContentTab/index.tsx`: Added `relative z-10` to the toolbar container's className, creating a stacking context that ensures the toolbar and its dropdowns render above the file rows below

## Test plan

- Open Content tab with uploaded files → click "Upload files" in toolbar → dropdown should appear above file row buttons
- Verify other toolbar dropdowns (e.g., link) also appear above file rows
- Verify file row buttons still work correctly when hovered/clicked