### PR TITLE
Fix search bar disappearing when no products match query

### DIFF
--- a/app/javascript/components/ProductsDashboardPage.tsx
+++ b/app/javascript/components/ProductsDashboardPage.tsx
@@ -36,6 +36,7 @@ export const ProductsDashboardPage = ({
 }: ProductsDashboardPageProps) => {
   const [enableArchiveTab, setEnableArchiveTab] = React.useState(archivedProductsCount > 0);
   const [query, setQuery] = React.useState("");
+  const [hasProducts] = React.useState(() => products.length > 0 || memberships.length > 0);
 
   return (
     <ProductsLayout
@@ -44,7 +45,7 @@ export const ProductsDashboardPage = ({
       archivedTabVisible={enableArchiveTab}
       ctaButton={
         <>
-          {products.length > 0 ? <Search value={query} onSearch={setQuery} placeholder="Search products" /> : null}
+          {hasProducts ? <Search value={query} onSearch={setQuery} placeholder="Search products" /> : null}
           <NavigationButtonInertia href={Routes.new_product_path()} disabled={!canCreateProduct} color="accent">
             New product
           </NavigationButtonInertia>
@@ -52,7 +53,7 @@ export const ProductsDashboardPage = ({
       }
     >
       <section className="p-4 md:p-8">
-        {memberships.length === 0 && products.length === 0 ? (
+        {memberships.length === 0 && products.length === 0 && !query ? (
           <Placeholder>
             <PlaceholderImage src={placeholder} />
             <h2>We’ve never met an idea we didn’t like.</h2>

--- a/app/javascript/components/ProductsPage.tsx
+++ b/app/javascript/components/ProductsPage.tsx
@@ -30,27 +30,23 @@ const ProductsPage = ({
   type?: Tab;
 }) => (
   <div className="grid gap-12">
-    {memberships.length > 0 ? (
-      <ProductsPageMembershipsTable
-        query={query}
-        entries={memberships}
-        pagination={membershipsPagination}
-        sort={membershipsSort}
-        selectedTab={type}
-        setEnableArchiveTab={setEnableArchiveTab}
-      />
-    ) : null}
+    <ProductsPageMembershipsTable
+      query={query}
+      entries={memberships}
+      pagination={membershipsPagination}
+      sort={membershipsSort}
+      selectedTab={type}
+      setEnableArchiveTab={setEnableArchiveTab}
+    />
 
-    {products.length > 0 ? (
-      <ProductsPageProductsTable
-        query={query}
-        entries={products}
-        pagination={productsPagination}
-        sort={productsSort}
-        selectedTab={type}
-        setEnableArchiveTab={setEnableArchiveTab}
-      />
-    ) : null}
+    <ProductsPageProductsTable
+      query={query}
+      entries={products}
+      pagination={productsPagination}
+      sort={productsSort}
+      selectedTab={type}
+      setEnableArchiveTab={setEnableArchiveTab}
+    />
   </div>
 );
 

--- a/app/javascript/components/ProductsPage/MembershipsTable.tsx
+++ b/app/javascript/components/ProductsPage/MembershipsTable.tsx
@@ -79,7 +79,7 @@ export const ProductsPageMembershipsTable = (props: {
 
   const reloadMemberships = () => loadMemberships(pagination.page);
 
-  if (!memberships.length) return null;
+  if (!memberships.length) return <div aria-live="polite" />;
 
   return (
     <section className="flex flex-col gap-4">

--- a/app/javascript/components/ProductsPage/ProductsTable.tsx
+++ b/app/javascript/components/ProductsPage/ProductsTable.tsx
@@ -79,7 +79,7 @@ export const ProductsPageProductsTable = (props: {
 
   const reloadProducts = () => loadProducts(pagination.page);
 
-  if (!products.length) return null;
+  if (!products.length) return <div aria-live="polite" />;
 
   return (
     <div className="flex flex-col gap-4">


### PR DESCRIPTION
Fixes #3262

## Problem

On the Products page, when a user searches for products and the query returns zero results, the search bar disappears. This happens because:

1. The search bar was conditionally rendered based on `products.length > 0` — so when the Inertia reload returns zero products, the search bar unmounts
2. The `ProductsPage` component conditionally rendered both table components only when their entry arrays had items, causing them to unmount on empty results
3. When the table components unmount, their `useEffect` hooks that watch `props.query` stop running, preventing any subsequent searches
4. The empty-state placeholder replaces the entire products view when both arrays become empty, even during an active search

## Solution

- Track whether products existed on initial page load using lazy state initialization (`useState(() => ...)`) and use that to control search bar visibility, so the search bar persists across searches
- Always render the `ProductsPageProductsTable` and `ProductsPageMembershipsTable` components regardless of current entry count, keeping them mounted so their query-watching effects continue to fire
- In the table components, return an empty `<div>` instead of `null` when entries are empty to keep the component mounted
- Add a `!query` check to the empty-state placeholder condition so it doesn't show during an active search

/claim #3262