### PR TITLE
fix(content): Reduce unnecessary re-renders on Content tab

### DIFF
--- a/app/javascript/components/ProductEdit/ContentTab/FileEmbed.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/FileEmbed.tsx
@@ -154,14 +154,14 @@ const FileEmbedNodeView = ({ node, editor, getPos, updateAttributes }: NodeViewP
   // The `selected` prop from Tiptap also returns true when the parent folder is selected,
   // but we only want to show the outline when this exact node is selected
   const selected = editor.state.selection instanceof NodeSelection && editor.state.selection.node === node;
-  const fileEmbedGroups = React.useMemo(
+  const getFileEmbedGroups = React.useCallback(
     () =>
       findChildren(editor.state.doc, ({ type }) => type.name === FileEmbedGroup.name).flatMap(({ node: groupNode }) =>
         groupNode === parentNode
           ? []
           : [{ uid: cast<string>(groupNode.attrs.uid), name: titleWithFallback(groupNode.attrs.name) }],
       ),
-    [selected],
+    [editor.state.doc, parentNode],
   );
 
   const isInGroup = parentNode?.type.name === FileEmbedGroup.name;
@@ -287,34 +287,37 @@ const FileEmbedNodeView = ({ node, editor, getPos, updateAttributes }: NodeViewP
         <span>Move to folder...</span>
       </>
     ),
-    menu: () => (
-      <>
-        {parentNode?.childCount === 1 ? null : (
-          <div
-            onClick={() => editor.commands.moveFileEmbedToGroup({ fileUid: cast(node.attrs.uid), groupUid: null })}
-            role="menuitem"
-          >
-            <Icon name="folder-plus" />
-            <span>New folder</span>
-          </div>
-        )}
-        {fileEmbedGroups.map(({ uid, name }) => (
-          <div
-            key={uid}
-            onClick={() => {
-              editor.commands.moveFileEmbedToGroup({ fileUid: cast(node.attrs.uid), groupUid: uid });
+    menu: () => {
+      const groups = getFileEmbedGroups();
+      return (
+        <>
+          {parentNode?.childCount === 1 ? null : (
+            <div
+              onClick={() => editor.commands.moveFileEmbedToGroup({ fileUid: cast(node.attrs.uid), groupUid: null })}
+              role="menuitem"
+            >
+              <Icon name="folder-plus" />
+              <span>New folder</span>
+            </div>
+          )}
+          {groups.map(({ uid, name }) => (
+            <div
+              key={uid}
+              onClick={() => {
+                editor.commands.moveFileEmbedToGroup({ fileUid: cast(node.attrs.uid), groupUid: uid });
 
-              const fileName = filesById.get(cast<string>(node.attrs.id))?.display_name;
-              if (fileName) showAlert(`Moved "${fileName}" to "${name}".`, "success");
-            }}
-            role="menuitem"
-          >
-            <Icon name="solid-folder-open" />
-            <span>{name || "Untitled"}</span>
-          </div>
-        ))}
-      </>
-    ),
+                const fileName = filesById.get(cast<string>(node.attrs.id))?.display_name;
+                if (fileName) showAlert(`Moved "${fileName}" to "${name}".`, "success");
+              }}
+              role="menuitem"
+            >
+              <Icon name="solid-folder-open" />
+              <span>{name || "Untitled"}</span>
+            </div>
+          ))}
+        </>
+      );
+    },
   };
 
   return (
@@ -436,7 +439,7 @@ const FileEmbedNodeView = ({ node, editor, getPos, updateAttributes }: NodeViewP
         ) : null}
         <NodeActionsMenu
           editor={editor}
-          actions={!isInGroup || fileEmbedGroups.length > 0 || parentNode.childCount > 1 ? [folderAction] : []}
+          actions={!isInGroup || parentNode.childCount > 1 || getFileEmbedGroups().length > 0 ? [folderAction] : []}
         />
         <RowContent className="content">
           {file.is_streamable && node.attrs.collapsed ? (

--- a/app/javascript/components/ProductEdit/ContentTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/index.tsx
@@ -19,7 +19,6 @@ import { assertResponseError, request, ResponseError } from "$app/utils/request"
 import { generatePageIcon } from "$app/utils/rich_content_page";
 
 import { Button } from "$app/components/Button";
-import { InputtedDiscount } from "$app/components/CheckoutDashboard/DiscountInput";
 import { ComboBox } from "$app/components/ComboBox";
 import { PageList, PageListItem, PageListLayout } from "$app/components/Download/PageListLayout";
 import { EvaporateUploaderProvider, useEvaporateUploader } from "$app/components/EvaporateUploader";
@@ -45,7 +44,6 @@ import { S3UploadConfigProvider, useS3UploadConfig } from "$app/components/S3Upl
 import { Separator } from "$app/components/Separator";
 import { showAlert } from "$app/components/server-components/Alert";
 import { EntityInfo } from "$app/components/server-components/DownloadPage/Layout";
-import { TestimonialSelectModal } from "$app/components/TestimonialSelectModal";
 import { FileUpload } from "$app/components/TiptapExtensions/FileUpload";
 import { uploadImages } from "$app/components/TiptapExtensions/Image";
 import { LicenseKey, LicenseProvider } from "$app/components/TiptapExtensions/LicenseKey";
@@ -60,11 +58,20 @@ import { UpsellCard } from "$app/components/TiptapExtensions/UpsellCard";
 import { Card, CardContent } from "$app/components/ui/Card";
 import { Row, RowContent, Rows } from "$app/components/ui/Rows";
 import { Tab, Tabs } from "$app/components/ui/Tabs";
-import { Product, ProductOption, UpsellSelectModal } from "$app/components/UpsellSelectModal";
 import { useConfigureEvaporate } from "$app/components/useConfigureEvaporate";
 import { useIsAboveBreakpoint } from "$app/components/useIsAboveBreakpoint";
 import { useRefToLatest } from "$app/components/useRefToLatest";
 import { WithTooltip } from "$app/components/WithTooltip";
+
+import type { InputtedDiscount } from "$app/components/CheckoutDashboard/DiscountInput";
+import type { Product, ProductOption } from "$app/components/UpsellSelectModal";
+
+const UpsellSelectModal = React.lazy(() =>
+  import("$app/components/UpsellSelectModal").then((m) => ({ default: m.UpsellSelectModal })),
+);
+const TestimonialSelectModal = React.lazy(() =>
+  import("$app/components/TestimonialSelectModal").then((m) => ({ default: m.TestimonialSelectModal })),
+);
 
 import { FileEmbed, FileEmbedConfig } from "./FileEmbed";
 import { Page, PageTab, titleWithFallback } from "./PageTab";
@@ -274,6 +281,7 @@ const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: string | 
     };
   }, [editor]);
 
+  const pagesKey = React.useMemo(() => pages.map((p) => `${p.id}:${JSON.stringify(p.description)}`).join("|"), [pages]);
   const pageIcons = React.useMemo(
     () =>
       new Map(
@@ -293,7 +301,7 @@ const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: string | 
             })
           : [],
       ),
-    [pages],
+    [pagesKey],
   );
 
   const findPageWithNode = (type: string) =>
@@ -961,14 +969,20 @@ const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: string | 
           </Modal>
         </>
       ) : null}
-      <UpsellSelectModal isOpen={showUpsellModal} onClose={() => setShowUpsellModal(false)} onInsert={onInsertUpsell} />
-      {id ? (
-        <TestimonialSelectModal
-          isOpen={showReviewModal}
-          onClose={() => setShowReviewModal(false)}
-          onInsert={onInsertReviews}
-          productId={id}
-        />
+      {showUpsellModal ? (
+        <React.Suspense fallback={null}>
+          <UpsellSelectModal isOpen onClose={() => setShowUpsellModal(false)} onInsert={onInsertUpsell} />
+        </React.Suspense>
+      ) : null}
+      {showReviewModal && id ? (
+        <React.Suspense fallback={null}>
+          <TestimonialSelectModal
+            isOpen
+            onClose={() => setShowReviewModal(false)}
+            onInsert={onInsertReviews}
+            productId={id}
+          />
+        </React.Suspense>
       ) : null}
     </>
   );

--- a/app/javascript/components/TiptapExtensions/NodeActionsMenu.tsx
+++ b/app/javascript/components/TiptapExtensions/NodeActionsMenu.tsx
@@ -7,7 +7,7 @@ import { Button } from "$app/components/Button";
 import { Icon } from "$app/components/Icons";
 import { Popover, PopoverAnchor, PopoverContent, PopoverTrigger } from "$app/components/Popover";
 
-export const NodeActionsMenu = ({
+export const NodeActionsMenu = React.memo(({
   editor,
   actions,
 }: {
@@ -27,48 +27,50 @@ export const NodeActionsMenu = ({
             </Button>
           </PopoverTrigger>
         </PopoverAnchor>
-        <PopoverContent
-          sideOffset={4}
-          className="border-0 p-0 shadow-none"
-          onInteractOutside={(e) => e.preventDefault()}
-        >
-          <div role="menu">
-            {actions && selectedActionIndex !== null ? (
-              <>
-                <div onClick={() => setSelectedActionIndex(null)} role="menuitem">
-                  <Icon name="outline-cheveron-left" />
-                  <span>Back</span>
-                </div>
-                {assertDefined(actions[selectedActionIndex]).menu(() => setOpen(false))}
-              </>
-            ) : (
-              <>
-                <div onClick={() => editor.commands.moveNodeUp()} role="menuitem">
-                  <Icon name="arrow-up" />
-                  <span>Move up</span>
-                </div>
-                <div onClick={() => editor.commands.moveNodeDown()} role="menuitem">
-                  <Icon name="arrow-down" />
-                  <span>Move down</span>
-                </div>
-                {actions?.map(({ item }, index) => (
-                  <div key={index} onClick={() => setSelectedActionIndex(index)} role="menuitem">
-                    {item()}
+        {open ? (
+          <PopoverContent
+            sideOffset={4}
+            className="border-0 p-0 shadow-none"
+            onInteractOutside={(e) => e.preventDefault()}
+          >
+            <div role="menu">
+              {actions && selectedActionIndex !== null ? (
+                <>
+                  <div onClick={() => setSelectedActionIndex(null)} role="menuitem">
+                    <Icon name="outline-cheveron-left" />
+                    <span>Back</span>
                   </div>
-                ))}
-                <div
-                  style={{ color: "rgb(var(--danger))" }}
-                  onClick={() => editor.commands.deleteSelection()}
-                  role="menuitem"
-                >
-                  <Icon name="trash2" />
-                  <span>Delete</span>
-                </div>
-              </>
-            )}
-          </div>
-        </PopoverContent>
+                  {assertDefined(actions[selectedActionIndex]).menu(() => setOpen(false))}
+                </>
+              ) : (
+                <>
+                  <div onClick={() => editor.commands.moveNodeUp()} role="menuitem">
+                    <Icon name="arrow-up" />
+                    <span>Move up</span>
+                  </div>
+                  <div onClick={() => editor.commands.moveNodeDown()} role="menuitem">
+                    <Icon name="arrow-down" />
+                    <span>Move down</span>
+                  </div>
+                  {actions?.map(({ item }, index) => (
+                    <div key={index} onClick={() => setSelectedActionIndex(index)} role="menuitem">
+                      {item()}
+                    </div>
+                  ))}
+                  <div
+                    style={{ color: "rgb(var(--danger))" }}
+                    onClick={() => editor.commands.deleteSelection()}
+                    role="menuitem"
+                  >
+                    <Icon name="trash2" />
+                    <span>Delete</span>
+                  </div>
+                </>
+              )}
+            </div>
+          </PopoverContent>
+        ) : null}
       </div>
     </Popover>
   );
-};
+});

--- a/app/javascript/components/server-components/ProductEditPage.tsx
+++ b/app/javascript/components/server-components/ProductEditPage.tsx
@@ -192,6 +192,11 @@ const ProductEditPage = (props: Props) => {
     setSaving(false);
   };
 
+  const filesById = React.useMemo(
+    () => new Map(product.files.map((file) => [file.id, { ...file, url: getDownloadUrl(props.id, file) }])),
+    [product.files],
+  );
+
   const contextValue = React.useMemo(
     () => ({
       ...createContextValue({ ...props, product }),
@@ -204,8 +209,9 @@ const ProductEditPage = (props: Props) => {
       saving,
       contentUpdates,
       setContentUpdates,
+      filesById,
     }),
-    [product, updateProduct, existingFiles, setExistingFiles],
+    [product, updateProduct, existingFiles, setExistingFiles, filesById],
   );
 
   const imageSettings = React.useMemo(


### PR DESCRIPTION
/claim #2042

## Problem

The Content tab for products with many files is slow because of excessive re-rendering. Several components re-render unnecessarily on every product state change, even when the data they depend on hasn't changed.

The main bottlenecks:

1. `UpsellSelectModal` and `TestimonialSelectModal` are always mounted in the render tree, re-rendering on every state change even though they are rarely opened.

2. Every `FileEmbedNodeView` runs `findChildren` (an O(n) document traversal) on every render via `useMemo` keyed on `selected` — with hundreds of file embeds this multiplies into a major cost.

3. `NodeActionsMenu` renders its full `PopoverContent` (menu items, icons, handlers) for every file embed, even when the menu is closed, because the Popover uses `forceMount`.

4. `pageIcons` recomputes on every render because its `useMemo` dependency (`pages`) is a new array reference on every product state change.

5. `filesById` is recreated inside `createContextValue` on every product update, even when `product.files` hasn't changed.

## Solution

1. **Lazy-load modals** — `UpsellSelectModal` and `TestimonialSelectModal` are now loaded with `React.lazy` and only mounted when the user opens them. This removes them from the render tree during normal editing.

2. **Defer fileEmbedGroups computation** — Converted the eager `useMemo` into a `useCallback` (`getFileEmbedGroups`) that is invoked only when the "Move to folder" menu is actually opened. The condition for showing the folder action uses short-circuit evaluation so the expensive call only happens in the uncommon case (file alone in its group).

3. **Conditionally render NodeActionsMenu popover content** — Menu items are only mounted while the popover is open. The component is wrapped in `React.memo` to skip re-renders when props haven't changed.

4. **Stabilize pageIcons memo dependency** — Uses a serialized key (`pagesKey`) derived from page IDs and descriptions, so the expensive icon computation only runs when page content actually changes.

5. **Memoize filesById separately** — The `filesById` Map is now memoized with `[product.files]` as the dependency, so it stays stable when non-file product fields (name, description, etc.) are edited.

## Test plan

- [ ] Open a product's Content tab with many files (50+)
- [ ] Verify files display correctly and can be expanded/collapsed
- [ ] Verify "Move to folder" action still works correctly
- [ ] Verify uploading new files works
- [ ] Verify the Insert menu (upsell, review) still opens and functions correctly
- [ ] Verify page icons update when adding/removing file embeds from pages

## Self-review

I have self-reviewed all the code that I have written.