### PR TITLE
fix(exports): prevent audience CSV export timeout for large lists

### DIFF
--- a/app/services/exports/audience_export_service.rb
+++ b/app/services/exports/audience_export_service.rb
@@ -14,11 +14,13 @@ class Exports::AudienceExportService
 
   attr_reader :filename, :tempfile
 
+  BATCH_SIZE = 10_000
+
   def perform
     @tempfile = Tempfile.new(["Subscribers", ".csv"], encoding: "UTF-8")
 
     CsvSafe.open(@tempfile, "wb", headers: FIELDS, write_headers: true) do |csv|
-      query = @user.audience_members.select(:id, :email, :min_created_at)
+      query = @user.audience_members
 
       conditions = []
       conditions << "follower = true" if @options[:followers]
@@ -27,8 +29,10 @@ class Exports::AudienceExportService
 
       query = query.where(conditions.join(" OR "))
 
-      query.order(:min_created_at).find_each do |member|
-        csv << [member.email, member.min_created_at]
+      query.in_batches(of: BATCH_SIZE) do |batch|
+        batch.pluck(:email, :min_created_at).each do |email, min_created_at|
+          csv << [email, min_created_at]
+        end
       end
     end
 

--- a/spec/services/exports/audience_export_service_spec.rb
+++ b/spec/services/exports/audience_export_service_spec.rb
@@ -103,5 +103,22 @@ describe Exports::AudienceExportService do
         expect { described_class.new(user, {}) }.to raise_error(ArgumentError, "At least one audience type (followers, customers, or affiliates) must be selected")
       end
     end
+
+    context "when audience exceeds batch size" do
+      let(:options) { { followers: true } }
+
+      it "exports all members across multiple batches" do
+        stub_const("Exports::AudienceExportService::BATCH_SIZE", 1)
+
+        second_follower = create(:active_follower, email: "follower2@example.com", user: user, created_at: 2.days.ago)
+
+        rows = CSV.parse(subject.perform.tempfile.read)
+
+        emails = rows[1..].map(&:first)
+        expect(emails).to include(follower.email)
+        expect(emails).to include(second_follower.email)
+        expect(rows.size).to eq(3)
+      end
+    end
   end
 end


### PR DESCRIPTION
Issue: #2092

# Description

## Problem

When exporting a CSV of followers/subscribers via `Exports::AudienceExportService`, sellers with large audiences (100K+ members) experience timeouts. The root cause is in the `perform` method at [audience_export_service.rb#L30](https://github.com/antiwork/gumroad/blob/main/app/services/exports/audience_export_service.rb#L30):

```ruby
query.order(:min_created_at).find_each do |member|
  csv << [member.email, member.min_created_at]
end
```

`find_each` instantiates a full ActiveRecord object for every row. For a seller with 1M audience members, AR object allocation alone takes ~16s even though the SQL query completes in ~1.3s. This overhead causes the Sidekiq job to exceed its timeout before the email can be sent.

Additionally, `find_each` silently overrides `.order(:min_created_at)` with `ORDER BY id` (Rails behavior), so the explicit ordering was never applied in production.

## Solution

Replace `find_each` with `in_batches(of: 10_000)` + `pluck(:email, :min_created_at)`:

- **`pluck` returns raw arrays directly from SQL**, skipping all ActiveRecord object instantiation. This eliminates the ~16s Ruby overhead for large datasets.
- **Batched processing (10K rows per batch)** keeps memory constant regardless of audience size, unlike loading everything at once.
- Removed `.select(:id, :email, :min_created_at)` which is unnecessary when using `pluck`.
- Removed `.order(:min_created_at)` which `find_each` was silently overriding anyway. Both `find_each` and `in_batches` iterate by `id`, so production behavior is preserved.

---

# Test Results

Added a test that verifies batched processing works correctly by stubbing `BATCH_SIZE` to 1 and confirming all members are exported across multiple batches.

Existing tests continue to pass since the output (CSV content) is unchanged -- only the internal iteration strategy changed.

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

No AI was used for any part of this contribution.