### PR TITLE
Change PDF stamping flash message from error to warning

### DIFF
--- a/app/controllers/url_redirects_controller.rb
+++ b/app/controllers/url_redirects_controller.rb
@@ -95,7 +95,7 @@ class UrlRedirectsController < ApplicationController
       @product_file = product_files.first
 
       if @product_file.must_be_pdf_stamped? && @url_redirect.missing_stamped_pdf?(@product_file)
-        flash[:alert] = "We are preparing the file for download. You will receive an email when it is ready."
+        flash[:warning] = "We are preparing the file for download. You will receive an email when it is ready."
 
         # Do not enqueue the job more than once in 2 hours
         Rails.cache.fetch(PdfStampingService.cache_key_for_purchase(@url_redirect.purchase_id), expires_in: 4.hours) do

--- a/spec/controllers/url_redirects_controller_spec.rb
+++ b/spec/controllers/url_redirects_controller_spec.rb
@@ -856,7 +856,7 @@ describe UrlRedirectsController do
         get :download_product_files, format: :html, params: { id: @token, product_file_ids: [product_file.external_id] }
 
         expect(response).to redirect_to(url_redirect.download_page_url)
-        expect(flash[:alert]).to eq("We are preparing the file for download. You will receive an email when it is ready.")
+        expect(flash[:warning]).to eq("We are preparing the file for download. You will receive an email when it is ready.")
         expect(StampPdfForPurchaseJob).to have_enqueued_sidekiq_job(url_redirect.purchase_id, true).on("critical")
       end
     end


### PR DESCRIPTION
Fixes https://github.com/antiwork/gumroad-private/issues/124

# Description

<!-- Briefly describe the problem and your solution -->

## Problem
When a customer downloads a PDF-stamped file for the first time, the "We are preparing the file for download" message displays with error style, which makes it look like something is broken

## Solution
Changed `flash[:alert]` to `flash[:warning]` to better reflect that this is an informational message, not an error.



---

# Before/After

## Before
<img width="397" height="78" alt="image" src="https://github.com/user-attachments/assets/b8ebc8d9-8022-4249-8ecc-e02fe5b4daa6" />

## After
<img width="423" height="105" alt="Screenshot 2026-02-09 at 15 30 00" src="https://github.com/user-attachments/assets/a2a2a697-ceaa-4206-af0f-f84ded6c0b09" />

---

# AI Disclosure

No AI was used for any part of this contribution.
