### PR TITLE
fix: reset scroll position on route change

### DIFF
--- a/app/javascript/inertia/layout.tsx
+++ b/app/javascript/inertia/layout.tsx
@@ -44,8 +44,10 @@ export default function Layout({ children }: { children: React.ReactNode }) {
         <Alert initial={null} />
         <div id="inertia-shell" className="flex h-screen flex-col lg:flex-row">
           {logged_in_user ? <Nav title="Dashboard" /> : null}
-          {isRouteLoading ? <LoadingSkeleton /> : null}
-          <main className={classNames("flex-1 overflow-y-auto", { hidden: isRouteLoading })}>{children}</main>
+         <main scroll-region="" className="flex-1 overflow-y-auto">
+            {isRouteLoading ? <LoadingSkeleton /> : null}
+            <div className={classNames({ hidden: isRouteLoading })}>{children}</div>
+          </main>
         </div>
       </CurrentSellerProvider>
     </LoggedInUserProvider>


### PR DESCRIPTION
Issue: https://github.com/antiwork/gumroad/issues/2924
Prev PR: https://github.com/antiwork/gumroad/pull/3024 , https://github.com/antiwork/gumroad/pull/3397

# Description

<!-- Briefly describe the problem and your solution -->

## Problem

Scroll position persists across page navigations when using Inertia.js client-side routing. When users scroll down on one page and navigate to another, the new page loads with the scroll position from the previous page instead of resetting to the top.


## Solution


Added the `scroll-region` attribute to the `<main>` element in the Layout component.

Additionally, restructured the loading skeleton logic to render both the skeleton and children simultaneously, hiding children with CSS instead of unmounting them. 
This:

- Allows scroll-region to work properly (main element is never hidden)
- Preserves form state/errors during navigation (children aren't unmounted)

---

# Before/After

**Before:**



https://github.com/user-attachments/assets/2f329da3-de3e-444f-aa8b-ed42d9807bc0



**After:**


https://github.com/user-attachments/assets/96f49a23-25ee-4200-98d0-75a6878ad880





---

# Test Results

N/A

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [ ] I have added/updated tests for my changes

---

# AI Disclosure

Used Claude Opus 4.5 
