### PR TITLE
Fix overly specific Iffy suspend message

### DIFF
--- a/app/services/iffy/user/ban_service.rb
+++ b/app/services/iffy/user/ban_service.rb
@@ -9,7 +9,7 @@ class Iffy::User::BanService
 
   def perform
     ActiveRecord::Base.transaction do
-      reason = "Adult (18+) content"
+      reason = "General non-compliance"
       user.update!(tos_violation_reason: reason)
       comment_content = "Banned for a policy violation on #{Time.current.to_fs(:formatted_date_full_month)} (#{reason})"
       user.flag_for_tos_violation!(author_name: "Iffy", content: comment_content, bulk: true) unless user.flagged_for_tos_violation? || user.on_probation? || user.suspended?

--- a/app/services/iffy/user/suspend_service.rb
+++ b/app/services/iffy/user/suspend_service.rb
@@ -11,7 +11,7 @@ class Iffy::User::SuspendService
     return if !user.can_flag_for_tos_violation?
 
     ActiveRecord::Base.transaction do
-      reason = "Adult (18+) content"
+      reason = "General non-compliance"
       user.update!(tos_violation_reason: reason)
       comment_content = "Suspended for a policy violation on #{Time.current.to_fs(:formatted_date_full_month)} (#{reason})"
       user.flag_for_tos_violation!(author_name: "Iffy", content: comment_content, bulk: true)

--- a/spec/services/iffy/user/ban_service_spec.rb
+++ b/spec/services/iffy/user/ban_service_spec.rb
@@ -11,12 +11,12 @@ describe Iffy::User::BanService do
       it "suspends the user and adds a comment" do
         expect_any_instance_of(User).to receive(:flag_for_tos_violation!).with(
           author_name: "Iffy",
-          content: "Banned for a policy violation on #{Time.current.to_fs(:formatted_date_full_month)} (Adult (18+) content)",
+          content: "Banned for a policy violation on #{Time.current.to_fs(:formatted_date_full_month)} (General non-compliance)",
           bulk: true
         ).and_call_original
         expect_any_instance_of(User).to receive(:suspend_for_tos_violation!).with(
           author_name: "Iffy",
-          content: "Banned for a policy violation on #{Time.current.to_fs(:formatted_date_full_month)} (Adult (18+) content)",
+          content: "Banned for a policy violation on #{Time.current.to_fs(:formatted_date_full_month)} (General non-compliance)",
           bulk: true
         ).and_call_original
 
@@ -24,7 +24,7 @@ describe Iffy::User::BanService do
           service.perform
         end.to change { user.reload.user_risk_state }.from("not_reviewed").to("suspended_for_tos_violation")
 
-        expect(user.tos_violation_reason).to eq("Adult (18+) content")
+        expect(user.tos_violation_reason).to eq("General non-compliance")
       end
     end
   end

--- a/spec/services/iffy/user/suspend_service_spec.rb
+++ b/spec/services/iffy/user/suspend_service_spec.rb
@@ -29,7 +29,7 @@ describe Iffy::User::SuspendService do
       it "flags the user and adds a comment" do
         expect_any_instance_of(User).to receive(:flag_for_tos_violation!).with(
           author_name: "Iffy",
-          content: "Suspended for a policy violation on #{Time.current.to_fs(:formatted_date_full_month)} (Adult (18+) content)",
+          content: "Suspended for a policy violation on #{Time.current.to_fs(:formatted_date_full_month)} (General non-compliance)",
           bulk: true
         ).and_call_original
 
@@ -37,7 +37,7 @@ describe Iffy::User::SuspendService do
           service.perform
         end.to change { user.reload.user_risk_state }.from("not_reviewed").to("flagged_for_tos_violation")
 
-        expect(user.tos_violation_reason).to eq("Adult (18+) content")
+        expect(user.tos_violation_reason).to eq("General non-compliance")
       end
     end
   end


### PR DESCRIPTION
# Description

## Problem

Iffy has a hardcoded 18+ message when suspending or banning users, but it doesn't just deal with that case any more. This data is passed to Helper, which makes it give creators incorrect information about the suspension.

## Solution

Changed it to the generic non-compliance message (from `lib/utilities/compliance.rb`) so that Helper realises it's not a specific reason.

---

# AI Disclosure

No AI used for this PR.
