### PR TITLE
Fix IBAN validation for Angolla

### DIFF
--- a/app/models/angola_bank_account.rb
+++ b/app/models/angola_bank_account.rb
@@ -6,9 +6,10 @@ class AngolaBankAccount < BankAccount
   BANK_CODE_FORMAT_REGEX = /^([0-9a-zA-Z]){8,11}$/
   private_constant :BANK_CODE_FORMAT_REGEX
 
-  # Angola IBAN: AO + 2 check digits + 21 numeric (BBAN). Ibandit may not support AO.
-  ACCOUNT_NUMBER_FORMAT_REGEX = /\AAO\d{23}\z/
-  private_constant :ACCOUNT_NUMBER_FORMAT_REGEX
+  # Angola IBAN: AO + 2 check digits + 21 digits (25 chars). NIB (legacy): 21 digits only.
+  IBAN_FORMAT_REGEX = /\AAO\d{23}\z/
+  NIB_FORMAT_REGEX = /\A\d{21}\z/
+  private_constant :IBAN_FORMAT_REGEX, :NIB_FORMAT_REGEX
 
   alias_attribute :bank_code, :bank_number
 
@@ -50,7 +51,8 @@ class AngolaBankAccount < BankAccount
     end
 
     def validate_account_number
-      return if ACCOUNT_NUMBER_FORMAT_REGEX.match?(account_number_decrypted)
+      return if IBAN_FORMAT_REGEX.match?(account_number_decrypted)
+      return if NIB_FORMAT_REGEX.match?(account_number_decrypted)
       return if Ibandit::IBAN.new(account_number_decrypted).valid?
       errors.add :base, "The account number is invalid."
     end

--- a/spec/models/angola_bank_account_spec.rb
+++ b/spec/models/angola_bank_account_spec.rb
@@ -45,10 +45,14 @@ describe AngolaBankAccount do
   end
 
   describe "#validate_account_number" do
-    it "allows 25 character Angola IBAN format when Ibandit does not support AO" do
-      allow(Rails.env).to receive(:production?).and_return(true)
+    before { allow(Rails.env).to receive(:production?).and_return(true) }
 
+    it "allows 25 character Angola IBAN format when Ibandit does not support AO" do
       expect(build(:angola_bank_account, account_number: "AO06004000009439667010104")).to be_valid
+    end
+
+    it "allows 21 digit NIB (legacy) format" do
+      expect(build(:angola_bank_account, account_number: "600400000943966701010", account_number_last_four: "1010")).to be_valid
     end
   end
 end


### PR DESCRIPTION
Issue: https://github.com/antiwork/gumroad/issues/3152
Closes: https://github.com/antiwork/gumroad/issues/3152

# Description

The current validation logic for Angolan bank accounts (AngolaBankAccount) fails to support both standard local bank identification codes and the full IBAN format. This prevents users in Angola from successfully setting up their payout details.

## Problem

Ibandit gem validation (_**even on latest version**_) doesn't work properly with Angola, and it considers `AO06004000009439667010104` as invalid 
<img width="1770" height="1422" alt="image" src="https://github.com/user-attachments/assets/b76abb80-d2bb-4746-bd47-6fcad6ec74fb" />

while it's valid
<img width="2455" height="845" alt="image" src="https://github.com/user-attachments/assets/c882676c-65c0-48ac-bc41-737396ee6f2e" />

## Solution
Add regex validation for the 25-character IBANs for Angola

---

# Test Results

<img width="2931" height="1124" alt="image" src="https://github.com/user-attachments/assets/0be3670c-b17f-47be-99e5-a5a40ac07d94" />

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

Used Cursor for auto-completion