### PR TITLE
Migrate URL Redirect Video Stream page to Inertia

### DIFF
--- a/app/controllers/url_redirects_controller.rb
+++ b/app/controllers/url_redirects_controller.rb
@@ -6,7 +6,7 @@ class UrlRedirectsController < ApplicationController
   include PageMeta::Favicon
 
   layout "inertia", only: [:expired, :rental_expired_page, :membership_inactive_page]
-  layout "inertia", only: [:confirm_page, :read]
+  layout "inertia", only: [:confirm_page, :read, :stream]
 
   before_action :fetch_url_redirect, except: %i[
     show stream download_subtitle_file read download_archive latest_media_locations download_product_files
@@ -20,7 +20,7 @@ class UrlRedirectsController < ApplicationController
                                              download_archive latest_media_locations download_product_files audio_durations
                                              save_last_content_page]
   before_action :hide_layouts, only: %i[
-    show download_page download_product_files stream smil hls_playlist download_subtitle_file
+    show download_page download_product_files smil hls_playlist download_subtitle_file
   ]
   before_action :mark_rental_as_viewed, only: %i[smil hls_playlist]
   after_action :register_that_user_has_downloaded_product, only: %i[download_page show stream read]
@@ -237,18 +237,21 @@ class UrlRedirectsController < ApplicationController
   # Consumption event is created by front-end code
   def stream
     set_meta_tag(title: "Watch")
-    @body_id = "stream_page"
-    @body_class = "download-page responsive responsive-nav"
 
-    @product_file = @url_redirect.product_file(params[:product_file_id]) || @url_redirect.alive_product_files.find(&:streamable?)
-    e404 unless @product_file&.streamable?
+    product_file = @url_redirect.product_file(params[:product_file_id]) || @url_redirect.alive_product_files.find(&:streamable?)
+    e404 unless product_file&.streamable?
 
-    @videos_playlist = @url_redirect.video_files_playlist(@product_file)
-    @should_show_transcoding_notice = logged_in_user == @url_redirect.seller && !@url_redirect.with_product_files.has_been_transcoded?
+    videos_playlist = @url_redirect.video_files_playlist(product_file)
+    should_show_transcoding_notice = logged_in_user == @url_redirect.seller && !@url_redirect.with_product_files.has_been_transcoded?
 
-    @url_redirect_id = @url_redirect.external_id
-    @purchase_id = @url_redirect.purchase.try(:external_id)
-    render :video_stream
+    render inertia: "UrlRedirects/VideoStreamPage", props: {
+      playlist: videos_playlist[:playlist],
+      index_to_play: videos_playlist[:index_to_play].to_i,
+      url_redirect_id: @url_redirect.external_id,
+      purchase_id: @url_redirect.purchase.try(:external_id),
+      should_show_transcoding_notice:,
+      transcode_on_first_sale: product_file.link&.transcode_videos_on_purchase.present?,
+    }
   end
 
   def latest_media_locations

--- a/app/javascript/packs/video_stream.ts
+++ b/app/javascript/packs/video_stream.ts
@@ -1,9 +1,0 @@
-import ReactOnRails from "react-on-rails";
-
-import BasePage from "$app/utils/base_page";
-
-import VideoStreamPlayer from "$app/components/server-components/VideoStreamPlayer";
-
-BasePage.initialize();
-
-ReactOnRails.register({ VideoStreamPlayer });

--- a/app/javascript/pages/UrlRedirects/VideoStreamPage.tsx
+++ b/app/javascript/pages/UrlRedirects/VideoStreamPage.tsx
@@ -1,0 +1,44 @@
+import * as React from "react";
+import { usePage } from "@inertiajs/react";
+import { cast } from "ts-safe-cast";
+
+import { VideoStreamPlayer } from "$app/components/server-components/VideoStreamPlayer";
+
+type Video = {
+    sources: string[];
+    guid: string;
+    title: string;
+    tracks: { file: string; label: string; kind: "captions" }[];
+    external_id: string;
+    latest_media_location: { location: number } | null;
+    content_length: number | null;
+};
+
+type PageProps = {
+    playlist: Video[];
+    index_to_play: number;
+    url_redirect_id: string;
+    purchase_id: string | null;
+    should_show_transcoding_notice: boolean;
+    transcode_on_first_sale: boolean;
+};
+
+function VideoStreamPage() {
+    const { playlist, index_to_play, url_redirect_id, purchase_id, should_show_transcoding_notice, transcode_on_first_sale } =
+        cast<PageProps>(usePage().props);
+
+    return (
+        <div id="stream_page" className="download-page responsive responsive-nav" style={{ position: "relative", width: "100%", height: "100vh" }}>
+            <VideoStreamPlayer
+                playlist={playlist}
+                index_to_play={index_to_play}
+                url_redirect_id={url_redirect_id}
+                purchase_id={purchase_id}
+                should_show_transcoding_notice={should_show_transcoding_notice}
+                transcode_on_first_sale={transcode_on_first_sale}
+            />
+        </div>
+    );
+}
+
+export default VideoStreamPage;

--- a/app/views/url_redirects/video_stream.html.erb
+++ b/app/views/url_redirects/video_stream.html.erb
@@ -1,8 +1,0 @@
-<%= load_pack("video_stream") %>
-
-<%= react_component "VideoStreamPlayer", props: { playlist: @videos_playlist[:playlist],
-    index_to_play: @videos_playlist[:index_to_play].to_i,
-    url_redirect_id: @url_redirect_id,
-    purchase_id: @purchase_id,
-    should_show_transcoding_notice: @should_show_transcoding_notice,
-    transcode_on_first_sale: @product_file.link&.transcode_videos_on_purchase.present? } %>

--- a/spec/controllers/url_redirects_controller_spec.rb
+++ b/spec/controllers/url_redirects_controller_spec.rb
@@ -563,11 +563,11 @@ describe UrlRedirectsController do
           stub_const("UrlRedirect::GUID_GETTER_FROM_S3_URL_REGEX", /(specs)/)
         end
 
-        it "assigns the first streamable product file to '@product_file' and renders the stream page correctly" do
+        it "assigns the first streamable product file and renders the stream page correctly" do
           get :stream, params: { id: @url_redirect.token }
 
           expect(response).to have_http_status(:ok)
-          expect(assigns(:product_file)).to eq(@product.product_files.first)
+          expect(inertia.props[:playlist]).to be_present
         end
       end
 
@@ -997,27 +997,25 @@ describe UrlRedirectsController do
 
         it "sets the m3u8 playlist url and the original video url in sources for hls-transcoded video" do
           get :stream, params: { id: @multifile_url_redirect.token, product_file_id: @video_file_1.external_id }
-          video_urls = assigns(:videos_playlist)[:playlist]
+          video_urls = inertia.props[:playlist]
 
           expect(response).to be_successful
-          expect(assigns(:hide_layouts)).to eq(true)
           expect(video_urls.size).to eq 1
           expect(video_urls[0][:sources][0]).to include "index.m3u8"
           expect(video_urls[0][:sources][1]).to include @video_file_1.s3_filename
-          expect(assigns(:videos_playlist)[:index_to_play]).to eq 0
+          expect(inertia.props[:index_to_play]).to eq 0
         end
 
         it "sets the smil url and the original video url in sources if the video is not HLS-transcoded yet" do
           @video_file_1.update(is_transcoded_for_hls: false)
           get :stream, params: { id: @multifile_url_redirect.token }
-          video_urls = assigns(:videos_playlist)[:playlist]
+          video_urls = inertia.props[:playlist]
 
           expect(response).to be_successful
-          expect(assigns(:hide_layouts)).to eq(true)
           expect(video_urls.size).to eq 1
           expect(video_urls[0][:sources][0]).to include "stream.smil"
           expect(video_urls[0][:sources][1]).to include @video_file_1.s3_filename
-          expect(assigns(:videos_playlist)[:index_to_play]).to eq 0
+          expect(inertia.props[:index_to_play]).to eq 0
         end
 
         context "when the product has rich content" do
@@ -1038,7 +1036,7 @@ describe UrlRedirectsController do
 
             get :stream, params: { id: @multifile_url_redirect.token, product_file_id: video_file_2.external_id }
 
-            video_urls = assigns(:videos_playlist)[:playlist]
+            video_urls = inertia.props[:playlist]
             expect(response).to be_successful
             expect(video_urls.size).to eq 3
             expect(video_urls[0][:sources][0]).to include "stream.smil"
@@ -1053,7 +1051,7 @@ describe UrlRedirectsController do
             expect(video_urls[2][:sources][0]).to include "stream.smil"
             expect(video_urls[2][:sources][1]).to include video_file_3.s3_filename
             expect(video_urls[2][:title]).to eq "chapter3"
-            expect(assigns(:videos_playlist)[:index_to_play]).to eq 0
+            expect(inertia.props[:index_to_play]).to eq 0
           end
         end
 
@@ -1069,9 +1067,8 @@ describe UrlRedirectsController do
           installment.product_files << video_file_1 << video_file_2 << pdf_file << video_file_3 << mp3_file
           url_redirect = create(:installment_url_redirect, installment:)
           get :stream, params: { id: url_redirect.token, product_file_id: video_file_3.external_id }
-          video_urls = assigns(:videos_playlist)[:playlist]
+          video_urls = inertia.props[:playlist]
           expect(response).to be_successful
-          expect(assigns(:hide_layouts)).to eq(true)
           expect(video_urls.size).to eq(3)
           expect(video_urls[2][:sources][0]).to include "index.m3u8"
           expect(video_urls[2][:sources][1]).to include video_file_1.s3_filename
@@ -1085,7 +1082,7 @@ describe UrlRedirectsController do
           expect(video_urls[0][:sources][0]).to include "stream.smil"
           expect(video_urls[0][:sources][1]).to include video_file_3.s3_filename
           expect(video_urls[0][:title]).to eq video_file_3.display_name
-          expect(assigns(:videos_playlist)[:index_to_play]).to eq 0
+          expect(inertia.props[:index_to_play]).to eq 0
         end
       end
 


### PR DESCRIPTION
Closes #3141

Migrates the video stream page (`/s/:id` and `/s/:id/:product_file_id`) to Inertia, following the same approach as the other recently migrated URL redirect pages (confirm, read, expired, etc).

The existing `VideoStreamPlayer` React component stays as-is — the new Inertia page just wraps it and receives the data through props instead of ReactOnRails.

**What changed:**
- Controller `stream` action now uses `render inertia:` with a props hash instead of instance variables + ERB
- Added `:stream` to the inertia layout, removed from `hide_layouts`  
- Deleted the old ERB view and ReactOnRails pack entry
- Updated specs to assert on `inertia.props` instead of `assigns()`

Custom domains should work fine since the routing and before_actions are unchanged.