### PR TITLE
fix(products): Keep search bar visible when search returns no results

### DIFF
--- a/app/javascript/components/ProductsDashboardPage.tsx
+++ b/app/javascript/components/ProductsDashboardPage.tsx
@@ -44,7 +44,7 @@ export const ProductsDashboardPage = ({
       archivedTabVisible={enableArchiveTab}
       ctaButton={
         <>
-          {products.length > 0 ? <Search value={query} onSearch={setQuery} placeholder="Search products" /> : null}
+          {products.length > 0 || query ? <Search value={query} onSearch={setQuery} placeholder="Search products" /> : null}
           <NavigationButtonInertia href={Routes.new_product_path()} disabled={!canCreateProduct} color="accent">
             New product
           </NavigationButtonInertia>
@@ -52,7 +52,7 @@ export const ProductsDashboardPage = ({
       }
     >
       <section className="p-4 md:p-8">
-        {memberships.length === 0 && products.length === 0 ? (
+        {memberships.length === 0 && products.length === 0 && !query ? (
           <Placeholder>
             <PlaceholderImage src={placeholder} />
             <h2>We’ve never met an idea we didn’t like.</h2>

--- a/app/javascript/components/ProductsPage.tsx
+++ b/app/javascript/components/ProductsPage.tsx
@@ -30,7 +30,7 @@ const ProductsPage = ({
   type?: Tab;
 }) => (
   <div className="grid gap-12">
-    {memberships.length > 0 ? (
+    {memberships.length > 0 || query ? (
       <ProductsPageMembershipsTable
         query={query}
         entries={memberships}
@@ -41,7 +41,7 @@ const ProductsPage = ({
       />
     ) : null}
 
-    {products.length > 0 ? (
+    {products.length > 0 || query ? (
       <ProductsPageProductsTable
         query={query}
         entries={products}

--- a/app/javascript/components/ProductsPage/MembershipsTable.tsx
+++ b/app/javascript/components/ProductsPage/MembershipsTable.tsx
@@ -80,7 +80,10 @@ export const ProductsPageMembershipsTable = (props: {
 
   const reloadMemberships = () => loadMemberships(pagination.page);
 
-  if (!memberships.length) return null;
+  if (!memberships.length)
+    return props.query ? (
+      <div className="text-center text-gray-500 py-8">No memberships found matching your search.</div>
+    ) : null;
 
   return (
     <section className="flex flex-col gap-4">

--- a/app/javascript/components/ProductsPage/ProductsTable.tsx
+++ b/app/javascript/components/ProductsPage/ProductsTable.tsx
@@ -80,7 +80,10 @@ export const ProductsPageProductsTable = (props: {
 
   const reloadProducts = () => loadProducts(pagination.page);
 
-  if (!products.length) return null;
+  if (!products.length)
+    return props.query ? (
+      <div className="text-center text-gray-500 py-8">No products found matching your search.</div>
+    ) : null;
 
   return (
     <div className="flex flex-col gap-4">


### PR DESCRIPTION
Fixes #3262

## Summary

- The search bar and product/membership tables unmounted when a search query returned zero results, making it impossible to modify or clear the search
- Root cause: conditional rendering checks only considered `products.length > 0` / `memberships.length > 0`, without accounting for an active search query
- When Inertia reloaded page props with empty results, the components unmounted, destroying the `useOnChange` hooks that drive the search

## Changes

**`ProductsDashboardPage.tsx`**
- Search bar now stays visible when there is an active query (`products.length > 0 || query`)
- Placeholder (empty state for new users) only shows when there is no active query

**`ProductsPage.tsx`**
- Table components stay mounted when there is an active query, keeping `useOnChange` hooks alive

**`ProductsTable.tsx` / `MembershipsTable.tsx`**
- Show "No products/memberships found" message instead of rendering nothing when search yields zero results

## AI Disclosure

This PR was authored with the assistance of Claude (AI). All changes were reviewed for correctness and adherence to project conventions.