### PR TITLE
fix(content): Raise toolbar z-index above node actions menu

### DIFF
--- a/app/javascript/stylesheets/_rich_text.scss
+++ b/app/javascript/stylesheets/_rich_text.scss
@@ -254,7 +254,7 @@
   gap: spacer(1);
   flex-wrap: wrap;
   padding-block: spacer(1);
-  z-index: z-index(overlay);
+  z-index: z-index(above-overlay);
 
   &.ghost {
     @include bg-color(filled);


### PR DESCRIPTION
Fixes #3215

## Summary

- The "Upload files" dropdown in the rich text editor toolbar was rendered behind the node actions-menu (drag handle) buttons on file embeds
- Root cause: both the toolbar (`.rich-text-editor-toolbar`) and `.actions-menu` used `z-index(overlay)` (= 1). Since the editor content area follows the toolbar in DOM order, same-z-index elements in the content area painted on top of the toolbar's popover dropdown
- Fix: bump the toolbar's z-index from `z-index(overlay)` to `z-index(above-overlay)` (= 2), which is already defined in the project's z-index scale for exactly this purpose

## Changes

**`_rich_text.scss`** (line 257)
- Changed `.rich-text-editor-toolbar` z-index from `z-index(overlay)` to `z-index(above-overlay)`

## AI Disclosure

This PR was authored with the assistance of Claude (AI). All changes were reviewed for correctness.