### PR TITLE
feat(stream): Migrate video stream page to Inertia

### DIFF
--- a/app/controllers/url_redirects_controller.rb
+++ b/app/controllers/url_redirects_controller.rb
@@ -6,7 +6,7 @@ class UrlRedirectsController < ApplicationController
   include PageMeta::Favicon
 
   layout "inertia", only: [:expired, :rental_expired_page, :membership_inactive_page]
-  layout "inertia", only: [:confirm_page, :read]
+  layout "inertia", only: [:confirm_page, :read, :stream]
 
   before_action :fetch_url_redirect, except: %i[
     show stream download_subtitle_file read download_archive latest_media_locations download_product_files
@@ -20,7 +20,7 @@ class UrlRedirectsController < ApplicationController
                                              download_archive latest_media_locations download_product_files audio_durations
                                              save_last_content_page]
   before_action :hide_layouts, only: %i[
-    show download_page download_product_files stream smil hls_playlist download_subtitle_file
+    show download_page download_product_files smil hls_playlist download_subtitle_file
   ]
   before_action :mark_rental_as_viewed, only: %i[smil hls_playlist]
   after_action :register_that_user_has_downloaded_product, only: %i[download_page show stream read]
@@ -240,15 +240,17 @@ class UrlRedirectsController < ApplicationController
     @body_id = "stream_page"
     @body_class = "download-page responsive responsive-nav"
 
-    @product_file = @url_redirect.product_file(params[:product_file_id]) || @url_redirect.alive_product_files.find(&:streamable?)
-    e404 unless @product_file&.streamable?
+    product_file = @url_redirect.product_file(params[:product_file_id]) || @url_redirect.alive_product_files.find(&:streamable?)
+    e404 unless product_file&.streamable?
 
-    @videos_playlist = @url_redirect.video_files_playlist(@product_file)
-    @should_show_transcoding_notice = logged_in_user == @url_redirect.seller && !@url_redirect.with_product_files.has_been_transcoded?
+    videos_playlist = @url_redirect.video_files_playlist(product_file)
+    should_show_transcoding_notice = logged_in_user == @url_redirect.seller && !@url_redirect.with_product_files.has_been_transcoded?
 
-    @url_redirect_id = @url_redirect.external_id
-    @purchase_id = @url_redirect.purchase.try(:external_id)
-    render :video_stream
+    render inertia: "UrlRedirects/VideoStream", props: UrlRedirectPresenter.new(url_redirect: @url_redirect, logged_in_user:).video_stream_props(
+      product_file:,
+      videos_playlist:,
+      should_show_transcoding_notice:,
+    )
   end
 
   def latest_media_locations

--- a/app/javascript/packs/video_stream.ts
+++ b/app/javascript/packs/video_stream.ts
@@ -1,9 +1,0 @@
-import ReactOnRails from "react-on-rails";
-
-import BasePage from "$app/utils/base_page";
-
-import VideoStreamPlayer from "$app/components/server-components/VideoStreamPlayer";
-
-BasePage.initialize();
-
-ReactOnRails.register({ VideoStreamPlayer });

--- a/app/javascript/pages/UrlRedirects/VideoStream.tsx
+++ b/app/javascript/pages/UrlRedirects/VideoStream.tsx
@@ -1,12 +1,12 @@
+import { usePage } from "@inertiajs/react";
 import { throttle } from "lodash-es";
 import * as React from "react";
-import { createCast } from "ts-safe-cast";
+import { cast } from "ts-safe-cast";
 
 import { createConsumptionEvent } from "$app/data/consumption_analytics";
 import { trackMediaLocationChanged } from "$app/data/media_location";
 import GuidGenerator from "$app/utils/guid_generator";
 import { createJWPlayer } from "$app/utils/jwPlayer";
-import { register } from "$app/utils/serverComponentUtil";
 
 import { TranscodingNoticeModal } from "$app/components/Download/TranscodingNoticeModal";
 import { useRunOnce } from "$app/components/useRunOnce";
@@ -29,23 +29,19 @@ type Video = {
   content_length: number | null;
 };
 
-const fakeVideoUrlGuidForObfuscation = "ef64f2fef0d6c776a337050020423fc0";
-
-export const VideoStreamPlayer = ({
-  playlist: initialPlaylist,
-  index_to_play,
-  url_redirect_id,
-  purchase_id,
-  should_show_transcoding_notice,
-  transcode_on_first_sale,
-}: {
+type Props = {
   playlist: Video[];
   index_to_play: number;
   url_redirect_id: string;
   purchase_id: string | null;
   should_show_transcoding_notice: boolean;
   transcode_on_first_sale: boolean;
-}) => {
+};
+
+const fakeVideoUrlGuidForObfuscation = "ef64f2fef0d6c776a337050020423fc0";
+
+const VideoStream = () => {
+  const { playlist: initialPlaylist, index_to_play, url_redirect_id, purchase_id, should_show_transcoding_notice, transcode_on_first_sale } = cast<Props>(usePage().props);
   const containerRef = React.useRef<HTMLDivElement>(null);
 
   useRunOnce(() => {
@@ -161,4 +157,5 @@ export const VideoStreamPlayer = ({
   );
 };
 
-export default register({ component: VideoStreamPlayer, propParser: createCast() });
+VideoStream.loggedInUserLayout = true;
+export default VideoStream;

--- a/app/javascript/ssr.ts
+++ b/app/javascript/ssr.ts
@@ -24,7 +24,6 @@ import SubscriptionManager from "$app/components/server-components/SubscriptionM
 import SubscriptionManagerMagicLink from "$app/components/server-components/SubscriptionManagerMagicLink";
 import SupportHeader from "$app/components/server-components/support/Header";
 import TaxesCollectionModal from "$app/components/server-components/TaxesCollectionModal";
-import VideoStreamPlayer from "$app/components/server-components/VideoStreamPlayer";
 import CodeSnippet from "$app/components/ui/CodeSnippet";
 import { Pill } from "$app/components/ui/Pill";
 
@@ -52,5 +51,4 @@ ReactOnRails.register({
   SubscriptionManager,
   SubscriptionManagerMagicLink,
   TaxesCollectionModal,
-  VideoStreamPlayer,
 });

--- a/app/presenters/url_redirect_presenter.rb
+++ b/app/presenters/url_redirect_presenter.rb
@@ -53,6 +53,17 @@ class UrlRedirectPresenter
     download_page_layout_props(email_confirmation_required: extra_props[:content_unavailability_reason_code] == CONTENT_UNAVAILABILITY_REASON_CODES[:email_confirmation_required]).merge(extra_props)
   end
 
+  def video_stream_props(product_file:, videos_playlist:, should_show_transcoding_notice:)
+    {
+      playlist: videos_playlist[:playlist],
+      index_to_play: videos_playlist[:index_to_play].to_i,
+      url_redirect_id: url_redirect.external_id,
+      purchase_id: purchase&.external_id,
+      should_show_transcoding_notice:,
+      transcode_on_first_sale: product_file.link&.transcode_videos_on_purchase.present?,
+    }
+  end
+
   def read_page_props(product_file:, read_url:, title:)
     {
       read_id: product_file.external_id,

--- a/app/views/url_redirects/video_stream.html.erb
+++ b/app/views/url_redirects/video_stream.html.erb
@@ -1,8 +1,0 @@
-<%= load_pack("video_stream") %>
-
-<%= react_component "VideoStreamPlayer", props: { playlist: @videos_playlist[:playlist],
-    index_to_play: @videos_playlist[:index_to_play].to_i,
-    url_redirect_id: @url_redirect_id,
-    purchase_id: @purchase_id,
-    should_show_transcoding_notice: @should_show_transcoding_notice,
-    transcode_on_first_sale: @product_file.link&.transcode_videos_on_purchase.present? } %>


### PR DESCRIPTION
Fixes #3141

## Summary

- Migrates the `/s/:id` and `/s/:id/:product_file_id` video stream endpoints from ReactOnRails server-rendering to Inertia, following the same pattern used by the `Read` page migration
- Custom domain support works unchanged since both regular and custom domain routes map to the same controller action
- Net reduction of ~170 lines by removing the ReactOnRails boilerplate (dedicated webpack pack, SSR registration, ERB template)

## Changes

**New file: `app/javascript/pages/UrlRedirects/VideoStream.tsx`**
- Inertia page component that replaces the old `VideoStreamPlayer` server-component
- Uses `usePage().props` with `cast<Props>()` to receive props from the controller
- All player logic (JWPlayer, media tracking, consumption events, resume from last position) is preserved exactly as-is

**Modified: `app/controllers/url_redirects_controller.rb`**
- Added `:stream` to the `layout "inertia"` declaration
- Changed `stream` action to use `render inertia: "UrlRedirects/VideoStream"` with props from the presenter
- Removed `stream` from `hide_layouts` since the Inertia layout handles this
- Changed instance variables to local variables (no longer needed for ERB)

**Modified: `app/presenters/url_redirect_presenter.rb`**
- Added `video_stream_props` method following the same pattern as `read_page_props`

**Removed files:**
- `app/views/url_redirects/video_stream.html.erb` (ERB template)
- `app/javascript/packs/video_stream.ts` (ReactOnRails webpack pack)
- `app/javascript/components/server-components/VideoStreamPlayer.tsx` (ReactOnRails component)
- Removed `VideoStreamPlayer` from `app/javascript/ssr.ts` SSR registration

## AI Disclosure

This PR was authored with the assistance of Claude (AI). All changes were reviewed for correctness and adherence to project conventions.