### PR TITLE
feat(subscriptions): migrate subscription manager page to Inertia

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -7,8 +7,10 @@ class SubscriptionsController < ApplicationController
   before_action :authenticate_user!, except: PUBLIC_ACTIONS
   after_action :verify_authorized, except: PUBLIC_ACTIONS
 
+  layout "inertia", only: [:manage]
+
   before_action :fetch_subscription, only: %i[unsubscribe_by_seller unsubscribe_by_user magic_link send_magic_link]
-  before_action :hide_layouts, only: [:manage, :magic_link, :send_magic_link]
+  before_action :hide_layouts, only: [:magic_link, :send_magic_link]
   before_action :set_noindex_header, only: [:manage]
   before_action :check_can_manage, only: [:manage, :unsubscribe_by_user]
 
@@ -29,16 +31,9 @@ class SubscriptionsController < ApplicationController
   end
 
   def manage
-    @product = @subscription.link
-    @card = @subscription.credit_card_to_charge
-    @card_data_handling_mode = CardDataHandlingMode.get_card_data_handling_mode(@product.user)
-
-    @body_id = "product_page"
-
-    set_meta_tag(title: @subscription.is_installment_plan ? "Manage installment plan" : "Manage membership")
-    set_product_page_meta(@product)
-
     set_subscription_confirmed_redirect_cookie
+
+    render inertia: "Subscriptions/Manage", props: CheckoutPresenter.new(logged_in_user: logged_in_user, ip: request.remote_ip).subscription_manager_props(subscription: @subscription)
   end
 
   def magic_link

--- a/app/javascript/packs/subscription_edit.ts
+++ b/app/javascript/packs/subscription_edit.ts
@@ -1,8 +1,0 @@
-import ReactOnRails from "react-on-rails";
-
-import BasePage from "$app/utils/base_page";
-
-import SubscriptionManager from "$app/components/server-components/SubscriptionManager";
-
-BasePage.initialize();
-ReactOnRails.register({ SubscriptionManager });

--- a/app/javascript/pages/Subscriptions/Manage.tsx
+++ b/app/javascript/pages/Subscriptions/Manage.tsx
@@ -1,6 +1,7 @@
+import { usePage } from "@inertiajs/react";
 import { parseISO } from "date-fns";
 import * as React from "react";
-import { createCast } from "ts-safe-cast";
+import { cast } from "ts-safe-cast";
 
 import { confirmLineItem } from "$app/data/purchase";
 import { cancelSubscriptionByUser, updateSubscription } from "$app/data/subscription";
@@ -16,7 +17,6 @@ import {
 import { asyncVoid } from "$app/utils/promise";
 import { recurrenceLabels, RecurrenceId } from "$app/utils/recurringPricing";
 import { assertResponseError } from "$app/utils/request";
-import { register } from "$app/utils/serverComponentUtil";
 
 import { Button } from "$app/components/Button";
 import { Creator } from "$app/components/Checkout/cartState";
@@ -38,9 +38,8 @@ import {
 import { showAlert } from "$app/components/server-components/Alert";
 import { Alert } from "$app/components/ui/Alert";
 import { Card, CardContent } from "$app/components/ui/Card";
+import { useOnChangeSync } from "$app/components/useOnChange";
 import { useOriginalLocation } from "$app/components/useOriginalLocation";
-
-import { useOnChangeSync } from "../useOnChange";
 
 type Props = {
   product: {
@@ -98,17 +97,19 @@ type Props = {
   paypal_client_id: string;
 };
 
-const SubscriptionManager = ({
-  product,
-  subscription,
-  recaptcha_key,
-  paypal_client_id,
-  contact_info,
-  countries,
-  us_states,
-  ca_provinces,
-  used_card,
-}: Props) => {
+function ManageSubscriptionPage() {
+  const {
+    product,
+    subscription,
+    recaptcha_key,
+    paypal_client_id,
+    contact_info,
+    countries,
+    us_states,
+    ca_provinces,
+    used_card,
+  } = cast<Props>(usePage().props);
+
   const url = new URL(useOriginalLocation());
 
   const subscriptionEntity = subscription.is_installment_plan ? "installment plan" : "membership";
@@ -196,7 +197,7 @@ const SubscriptionManager = ({
     price: Math.round(amountDueToday / product.exchange_rate),
     payInInstallments: subscription.is_installment_plan,
     requireShipping: product.require_shipping,
-    customFields: [], // Custom fields were already collected during original purchase
+    customFields: [],
     bundleProductCustomFields: [],
     supportsPaypal: product.supports_paypal,
     testPurchase: subscription.is_test,
@@ -293,9 +294,6 @@ const SubscriptionManager = ({
   }
   React.useEffect(() => void pay(), [state.status]);
 
-  // show (the Stripe Payment Request method that triggers the Apple Pay
-  // modal) can't be called in asynchronous code, so we have to use a
-  // synchronous layout effect.
   useOnChangeSync(() => {
     if (state.status.type === "offering") dispatchAction({ type: "validate" });
   }, [state.status.type]);
@@ -388,6 +386,7 @@ const SubscriptionManager = ({
       ) : null}
     </Card>
   );
-};
+}
 
-export default register({ component: SubscriptionManager, propParser: createCast() });
+ManageSubscriptionPage.publicLayout = true;
+export default ManageSubscriptionPage;

--- a/app/javascript/ssr.ts
+++ b/app/javascript/ssr.ts
@@ -20,7 +20,6 @@ import ProductEditPage from "$app/components/server-components/ProductEditPage";
 import Profile from "$app/components/server-components/Profile";
 import ProfileProductPage from "$app/components/server-components/Profile/ProductPage";
 import SubscribePage from "$app/components/server-components/SubscribePage";
-import SubscriptionManager from "$app/components/server-components/SubscriptionManager";
 import SubscriptionManagerMagicLink from "$app/components/server-components/SubscriptionManagerMagicLink";
 import SupportHeader from "$app/components/server-components/support/Header";
 import TaxesCollectionModal from "$app/components/server-components/TaxesCollectionModal";
@@ -49,7 +48,6 @@ ReactOnRails.register({
   Profile,
   ProfileProductPage,
   SubscribePage,
-  SubscriptionManager,
   SubscriptionManagerMagicLink,
   TaxesCollectionModal,
   VideoStreamPlayer,

--- a/app/views/subscriptions/manage.html.erb
+++ b/app/views/subscriptions/manage.html.erb
@@ -1,4 +1,0 @@
-<%= render("shared/recaptcha_script") %>
-<%= load_pack("subscription_edit") %>
-
-<%= react_component "SubscriptionManager", props: CheckoutPresenter.new(logged_in_user: logged_in_user, ip: request.remote_ip).subscription_manager_props(subscription: @subscription), prerender: true %>


### PR DESCRIPTION
## Summary
- Migrates the Subscription Manager page (`GET /subscriptions/:id/manage`) from ReactOnRails server-side rendering to Inertia.js
- Creates new Inertia page component `Subscriptions/Manage.tsx` adapted from the `SubscriptionManager` server component
- Controller now uses `render inertia:` with existing `CheckoutPresenter#subscription_manager_props`
- JSON endpoints (`POST unsubscribe_by_user`, `PUT update_subscription`) remain unchanged as they already serve the Inertia page via client-side fetch

## What changed
| File | Change |
|------|--------|
| `app/javascript/pages/Subscriptions/Manage.tsx` | New Inertia page component (adapted from server component) |
| `app/controllers/subscriptions_controller.rb` | `manage` action now renders via Inertia; added `layout "inertia"` for manage; removed `hide_layouts` for manage |
| `app/javascript/ssr.ts` | Removed `SubscriptionManager` registration |

### Deleted files
- `app/views/subscriptions/manage.html.erb` — old ERB template
- `app/javascript/packs/subscription_edit.ts` — old webpack pack
- `app/javascript/components/server-components/SubscriptionManager.tsx` — old server component

## Test plan
- [ ] Verify manage page renders for authenticated users (cookie, token, signed-in)
- [ ] Verify unauthenticated users are redirected to magic link page
- [ ] Verify subscription update (plan change, payment method update) works
- [ ] Verify subscription cancellation works
- [ ] Verify installment plan management works
- [ ] Verify gift subscription management works

Closes #3073

## AI Disclosure
This PR was authored with the assistance of Claude (AI). All code changes were reviewed for correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)