### PR TITLE
Fix offer code discount not applied to subsequent installments

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -1999,7 +1999,11 @@ class Purchase < ApplicationRecord
   end
 
   def does_not_count_towards_max_purchases
-    is_recurring_subscription_charge || is_additional_contribution || is_preorder_charge? || is_gift_receiver_purchase || is_updated_original_subscription_purchase || is_commission_completion_purchase
+    is_recurring_subscription_charge || is_additional_contribution || is_preorder_charge? || is_gift_receiver_purchase || is_updated_original_subscription_purchase || is_commission_completion_purchase || is_subsequent_installment_payment?
+  end
+
+  def is_subsequent_installment_payment?
+    is_installment_payment && !is_original_subscription_purchase
   end
 
   # Public: Determine if this purchase is a test purchase by the links owner.
@@ -2411,13 +2415,14 @@ class Purchase < ApplicationRecord
   end
 
   def original_offer_code(include_deleted: false)
-    return nil if offer_code&.deleted? && !include_deleted
-
+    # Check cached discount data first - this preserves the discount even if the offer code is deleted/maxed
     if has_cached_offer_code?
-      code = purchase_offer_code_discount.offer_code.code
+      code = purchase_offer_code_discount.offer_code&.code
       purchase_offer_code_discount.offer_code_is_percent ?
         OfferCode.new(amount_percentage: purchase_offer_code_discount.offer_code_amount, code:) :
         OfferCode.new(amount_cents: purchase_offer_code_discount.offer_code_amount, code:)
+    elsif offer_code&.deleted? && !include_deleted
+      nil
     else
       offer_code
     end
@@ -3361,7 +3366,8 @@ class Purchase < ApplicationRecord
     def validate_offer_code
       return if errors.present?
       # accept the offer code that was used when the buyer preordered/subscribed
-      return if is_preorder_charge? || is_recurring_subscription_charge || is_gift_receiver_purchase
+      # also skip validation for subsequent installment payments - discount was already validated on first payment
+      return if is_preorder_charge? || is_recurring_subscription_charge || is_gift_receiver_purchase || is_subsequent_installment_payment?
       return if discount_code.blank?
 
       if offer_code.nil?

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -248,7 +248,20 @@ class Subscription < ApplicationRecord
     purchase = Purchase.new(purchase_params)
     purchase.variant_attributes = original_purchase.variant_attributes
 
-    purchase.offer_code = original_purchase.offer_code if discount_applies_to_next_charge?
+    if discount_applies_to_next_charge?
+      purchase.offer_code = original_purchase.offer_code
+      # Copy the cached discount data from the original purchase
+      # This ensures the discount is preserved even if the offer code is deleted/expired/maxed out
+      if (original_discount = original_purchase.purchase_offer_code_discount)
+        purchase.build_purchase_offer_code_discount(
+          offer_code: original_discount.offer_code,
+          offer_code_amount: original_discount.offer_code_amount,
+          offer_code_is_percent: original_discount.offer_code_is_percent,
+          pre_discount_minimum_price_cents: original_discount.pre_discount_minimum_price_cents,
+          duration_in_months: original_discount.duration_in_months
+        )
+      end
+    end
 
     purchase.purchaser = user
     purchase.link = link

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -3839,4 +3839,236 @@ describe Subscription, :vcr do
       expect(subscription.reload.business_vat_id).to be_nil
     end
   end
+
+  describe "offer code discount persistence for subsequent charges" do
+    describe "installment plans" do
+      let(:seller) { create(:user) }
+      let!(:product) { create(:product, user: seller, price_cents: 3000) }
+      let!(:installment_plan) { create(:product_installment_plan, link: product, number_of_installments: 3) }
+      let!(:offer_code) { create(:offer_code, products: [product], amount_cents: 500) }
+      let(:buyer) { create(:user, credit_card: create(:credit_card)) }
+
+      context "when offer code max usage is reached after initial purchase" do
+        before { offer_code.update!(max_purchase_count: 1) }
+
+        it "preserves the discount for subsequent installments and passes validation" do
+          purchase = create(:installment_plan_purchase, link: product, offer_code: offer_code, purchaser: buyer)
+          subscription = purchase.subscription
+
+          # Verify offer code is now exhausted
+          expect(offer_code.reload.quantity_left).to be <= 0
+          expect(offer_code.is_valid_for_purchase?).to be false
+
+          # Build next installment
+          new_purchase = subscription.build_purchase
+
+          # Discount should be copied from original purchase
+          expect(new_purchase.purchase_offer_code_discount).to be_present
+          expect(new_purchase.purchase_offer_code_discount.offer_code_amount).to eq(500)
+          expect(new_purchase.purchase_offer_code_discount.offer_code_is_percent).to be false
+
+          # Critical: validation should pass even though offer code is exhausted
+          new_purchase.valid?
+          expect(new_purchase.errors[:base]).to be_empty
+        end
+
+        it "does not count subsequent installments towards max purchase count" do
+          purchase = create(:installment_plan_purchase, link: product, offer_code: offer_code, purchaser: buyer)
+          subscription = purchase.subscription
+
+          new_purchase = subscription.build_purchase
+          expect(new_purchase.does_not_count_towards_max_purchases).to be true
+        end
+      end
+
+      context "when offer code is deleted after initial purchase" do
+        it "preserves the discount for subsequent installments" do
+          purchase = create(:installment_plan_purchase, link: product, offer_code: offer_code, purchaser: buyer)
+          subscription = purchase.subscription
+
+          offer_code.mark_deleted!
+
+          new_purchase = subscription.build_purchase
+          expect(new_purchase.purchase_offer_code_discount).to be_present
+          expect(new_purchase.purchase_offer_code_discount.offer_code_amount).to eq(500)
+
+          # Validation should pass
+          new_purchase.valid?
+          expect(new_purchase.errors[:base]).to be_empty
+        end
+      end
+
+      context "when offer code expires after initial purchase" do
+        it "preserves the discount for subsequent installments" do
+          offer_code.update!(valid_at: 1.week.ago, expires_at: 1.day.from_now)
+          purchase = create(:installment_plan_purchase, link: product, offer_code: offer_code, purchaser: buyer)
+          subscription = purchase.subscription
+
+          offer_code.update!(expires_at: 1.day.ago)
+
+          new_purchase = subscription.build_purchase
+          expect(new_purchase.purchase_offer_code_discount).to be_present
+          expect(new_purchase.purchase_offer_code_discount.offer_code_amount).to eq(500)
+        end
+      end
+
+      context "when offer code amount changes after initial purchase" do
+        it "uses the original cached amount" do
+          purchase = create(:installment_plan_purchase, link: product, offer_code: offer_code, purchaser: buyer)
+          subscription = purchase.subscription
+
+          offer_code.update!(amount_cents: 100)
+
+          new_purchase = subscription.build_purchase
+          expect(new_purchase.purchase_offer_code_discount.offer_code_amount).to eq(500)
+        end
+      end
+
+      context "with percentage discount" do
+        let!(:percent_offer_code) { create(:offer_code, products: [product], amount_percentage: 25, code: "PERCENT25") }
+
+        it "preserves percentage discount when offer code is deleted" do
+          purchase = create(:installment_plan_purchase, link: product, offer_code: percent_offer_code, purchaser: buyer)
+          subscription = purchase.subscription
+
+          percent_offer_code.mark_deleted!
+
+          new_purchase = subscription.build_purchase
+          expect(new_purchase.purchase_offer_code_discount).to be_present
+          expect(new_purchase.purchase_offer_code_discount.offer_code_amount).to eq(25)
+          expect(new_purchase.purchase_offer_code_discount.offer_code_is_percent).to be true
+        end
+      end
+    end
+
+    describe "memberships with duration_in_months" do
+      let(:seller) { create(:user) }
+      let(:product) { create(:membership_product_with_preset_tiered_pricing, user: seller) }
+      let(:offer_code) { create(:offer_code, products: [product], amount_cents: 100, duration_in_months: 3) }
+      let(:buyer) { create(:user, credit_card: create(:credit_card)) }
+
+      context "when offer code is deleted within duration" do
+        it "preserves the discount for subsequent charges within duration" do
+          purchase = create(:membership_purchase, link: product, offer_code: offer_code, purchaser: buyer, variant_attributes: [product.alive_variants.first])
+          subscription = purchase.subscription
+          subscription.original_purchase.create_purchase_offer_code_discount!(
+            offer_code: offer_code,
+            offer_code_amount: 100,
+            offer_code_is_percent: false,
+            pre_discount_minimum_price_cents: 300,
+            duration_in_months: 3
+          )
+
+          offer_code.mark_deleted!
+
+          new_purchase = subscription.build_purchase
+          expect(new_purchase.purchase_offer_code_discount).to be_present
+          expect(new_purchase.purchase_offer_code_discount.offer_code_amount).to eq(100)
+          expect(new_purchase.purchase_offer_code_discount.duration_in_months).to eq(3)
+        end
+      end
+
+      context "when offer code max usage is reached within duration" do
+        before { offer_code.update!(max_purchase_count: 1) }
+
+        it "preserves the discount for subsequent charges within duration" do
+          purchase = create(:membership_purchase, link: product, offer_code: offer_code, purchaser: buyer, variant_attributes: [product.alive_variants.first])
+          subscription = purchase.subscription
+          subscription.original_purchase.create_purchase_offer_code_discount!(
+            offer_code: offer_code,
+            offer_code_amount: 100,
+            offer_code_is_percent: false,
+            pre_discount_minimum_price_cents: 300,
+            duration_in_months: 3
+          )
+
+          # Offer code is now exhausted
+          expect(offer_code.reload.is_valid_for_purchase?).to be false
+
+          new_purchase = subscription.build_purchase
+          expect(new_purchase.purchase_offer_code_discount).to be_present
+          expect(new_purchase.purchase_offer_code_discount.offer_code_amount).to eq(100)
+        end
+      end
+
+      context "when duration has elapsed" do
+        it "does not apply the discount after duration expires" do
+          purchase = create(:membership_purchase, link: product, offer_code: offer_code, purchaser: buyer, variant_attributes: [product.alive_variants.first])
+          subscription = purchase.subscription
+          subscription.original_purchase.create_purchase_offer_code_discount!(
+            offer_code: offer_code,
+            offer_code_amount: 100,
+            offer_code_is_percent: false,
+            pre_discount_minimum_price_cents: 300,
+            duration_in_months: 1
+          )
+
+          # Create enough successful purchases to exceed duration
+          create(:membership_purchase, subscription: subscription, link: product, purchaser: buyer, variant_attributes: [product.alive_variants.first])
+
+          new_purchase = subscription.build_purchase
+          expect(new_purchase.purchase_offer_code_discount).to be_nil
+        end
+      end
+    end
+
+    describe "backwards compatibility" do
+      let(:seller) { create(:user) }
+      let(:product) { create(:membership_product_with_preset_tiered_pricing, user: seller) }
+      let(:offer_code) { create(:offer_code, products: [product], amount_cents: 100) }
+      let(:buyer) { create(:user, credit_card: create(:credit_card)) }
+
+      context "when original purchase has no cached discount (legacy)" do
+        it "falls back to live offer code" do
+          purchase = create(:membership_purchase, link: product, offer_code: offer_code, purchaser: buyer, variant_attributes: [product.alive_variants.first])
+          subscription = purchase.subscription
+          subscription.original_purchase.purchase_offer_code_discount&.destroy
+
+          new_purchase = subscription.build_purchase
+          expect(new_purchase.offer_code).to eq(offer_code)
+          expect(new_purchase.purchase_offer_code_discount).to be_nil
+        end
+      end
+
+      context "when purchase has no offer code" do
+        it "does not create a discount" do
+          purchase = create(:membership_purchase, link: product, purchaser: buyer, variant_attributes: [product.alive_variants.first])
+          subscription = purchase.subscription
+
+          new_purchase = subscription.build_purchase
+          expect(new_purchase.offer_code).to be_nil
+          expect(new_purchase.purchase_offer_code_discount).to be_nil
+        end
+      end
+    end
+
+    describe "#original_offer_code" do
+      let(:seller) { create(:user) }
+      let!(:product) { create(:product, user: seller, price_cents: 3000) }
+      let!(:installment_plan) { create(:product_installment_plan, link: product, number_of_installments: 3) }
+      let!(:offer_code) { create(:offer_code, products: [product], amount_cents: 500) }
+      let(:buyer) { create(:user, credit_card: create(:credit_card)) }
+
+      it "returns reconstructed offer code from cached data when offer code is deleted" do
+        purchase = create(:installment_plan_purchase, link: product, offer_code: offer_code, purchaser: buyer)
+
+        offer_code.mark_deleted!
+
+        reconstructed = purchase.original_offer_code
+        expect(reconstructed).to be_present
+        expect(reconstructed.amount_cents).to eq(500)
+        expect(reconstructed.is_cents?).to be true
+      end
+
+      it "prioritizes cached data over checking deleted status" do
+        purchase = create(:installment_plan_purchase, link: product, offer_code: offer_code, purchaser: buyer)
+
+        offer_code.mark_deleted!
+
+        # Should return the reconstructed offer code, not nil
+        expect(purchase.original_offer_code).to be_present
+        expect(purchase.original_offer_code(include_deleted: false)).to be_present
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Fixes #1410 - Offer code not applied to non-first installments when max usage limit is reached.

When an offer code with `max_purchase_count` is used for an installment plan purchase, subsequent installment payments fail because the offer code validation rejects them as "sold out."

This PR fixes the issue by:

1. **Copying cached discount data** from `original_purchase.purchase_offer_code_discount` to subsequent charges, preserving the discount even when the offer code is deleted, expired, or maxed out (per maintainer guidance).

2. **Skipping offer code validation** for subsequent installment payments via new `is_subsequent_installment_payment?` helper - the discount was already validated on first payment.

3. **Excluding subsequent installments from max_purchase_count** in `does_not_count_towards_max_purchases` - only the original purchase should count.

4. **Fixing original_offer_code** to check cached data first before checking deleted status.

### Key Difference from Existing PRs

- **PR #3066**: Copies discount data but doesn't skip validation - subsequent installments would still fail `validate_offer_code` when offer code is maxed out.
- **PR #3356**: Skips validation but lacks comprehensive membership tests.

This PR combines both approaches with complete coverage.

### Also Covers (per maintainer comment)

Memberships with `duration_in_months` - if the offer code is deleted/maxed within duration, subsequent charges still honor the original discount.

## Test Plan

- [x] Installment plan with maxed offer code - subsequent payments get discount
- [x] Installment plan with deleted offer code - subsequent payments get discount  
- [x] Installment plan with expired offer code - subsequent payments get discount
- [x] Membership with duration_in_months + maxed offer code - discount persists within duration
- [x] Membership with duration_in_months + deleted offer code - discount persists within duration
- [x] Backwards compatibility - legacy purchases without cached discount fall back to live offer code
- [x] Validation passes for subsequent installments (critical test missing from #3066)

🤖 Generated with [Claude Code](https://claude.com/claude-code)