### PR TITLE
Fix mobile installment button overflow on purchase page #3319

### DIFF
--- a/app/javascript/components/Product/CtaButton.tsx
+++ b/app/javascript/components/Product/CtaButton.tsx
@@ -142,9 +142,17 @@ export const CtaButton = React.forwardRef<HTMLAnchorElement, Props>(
       style: { alignItems: "unset" },
     };
 
+    const hasInstallments = product.installment_plan && product.installment_plan.number_of_installments > 1;
+
     return (
-      <>
-        <NavigationButton ref={ref} href={url.toString()} color="accent" {...buttonCommonProps}>
+      <div className={hasInstallments ? "flex gap-2" : "contents"}>
+        <NavigationButton
+          ref={ref}
+          href={url.toString()}
+          color="accent"
+          small={hasInstallments}
+          {...buttonCommonProps}
+        >
           {label ??
             (purchase
               ? "Purchase again"
@@ -157,9 +165,14 @@ export const CtaButton = React.forwardRef<HTMLAnchorElement, Props>(
                     : "I want this!")}
         </NavigationButton>
 
-        {product.installment_plan && product.installment_plan.number_of_installments > 1 ? (
+        {hasInstallments ? (
           <>
-            <NavigationButton color="black" href={urlWithInstallments.toString()} {...buttonCommonProps}>
+            <NavigationButton
+              color="black"
+              href={urlWithInstallments.toString()}
+              small
+              {...buttonCommonProps}
+            >
               Pay in {product.installment_plan.number_of_installments} installments
             </NavigationButton>
             {showInstallmentPlanNotes ? (
@@ -173,7 +186,7 @@ export const CtaButton = React.forwardRef<HTMLAnchorElement, Props>(
             ) : null}
           </>
         ) : null}
-      </>
+      </div>
     );
   },
 );


### PR DESCRIPTION
## Summary

Fixes mobile UI overflow when installment plans are enabled on the purchase page. Following [@laugardie's guidance](https://github.com/antiwork/gumroad/issues/3319#issuecomment-3877132253):

- Added `small` prop to CTA buttons when installments active (reduces font size and padding)
- Wrapped buttons in flex container with `gap-2` for tighter spacing
- Used CSS `contents` when no installments to preserve existing layout behavior

## Changes

**`app/javascript/components/Product/CtaButton.tsx`**
- Extract `hasInstallments` boolean for cleaner conditional logic
- Apply `small` prop to both CTA buttons when installments enabled
- Wrap buttons in `<div className="flex gap-2">` container

## Test Plan

- [ ] Test on mobile viewport (320-768px) with installment-enabled product
- [ ] Verify buttons remain visible without horizontal scroll
- [ ] Confirm desktop layout unchanged
- [ ] Test products without installment plans (should render identically to before)

Fixes #3319