### PR TITLE
Fix search bar disappearing when no products match query

### DIFF
--- a/app/javascript/components/ProductsDashboardPage.tsx
+++ b/app/javascript/components/ProductsDashboardPage.tsx
@@ -36,6 +36,7 @@ export const ProductsDashboardPage = ({
 }: ProductsDashboardPageProps) => {
   const [enableArchiveTab, setEnableArchiveTab] = React.useState(archivedProductsCount > 0);
   const [query, setQuery] = React.useState("");
+  const initialHasProducts = React.useRef(products.length > 0 || memberships.length > 0);
 
   return (
     <ProductsLayout
@@ -44,7 +45,7 @@ export const ProductsDashboardPage = ({
       archivedTabVisible={enableArchiveTab}
       ctaButton={
         <>
-          {products.length > 0 ? <Search value={query} onSearch={setQuery} placeholder="Search products" /> : null}
+          {initialHasProducts.current ? <Search value={query} onSearch={setQuery} placeholder="Search products" /> : null}
           <NavigationButtonInertia href={Routes.new_product_path()} disabled={!canCreateProduct} color="accent">
             New product
           </NavigationButtonInertia>
@@ -52,7 +53,7 @@ export const ProductsDashboardPage = ({
       }
     >
       <section className="p-4 md:p-8">
-        {memberships.length === 0 && products.length === 0 ? (
+        {!initialHasProducts.current && memberships.length === 0 && products.length === 0 ? (
           <Placeholder>
             <PlaceholderImage src={placeholder} />
             <h2>We’ve never met an idea we didn’t like.</h2>

--- a/app/javascript/components/ProductsPage.tsx
+++ b/app/javascript/components/ProductsPage.tsx
@@ -28,7 +28,7 @@ const ProductsPage = ({
   query: string | null;
   setEnableArchiveTab?: (enable: boolean) => void;
   type?: Tab;
-}) => (
+) => (
   <div className="grid gap-12">
     {memberships.length > 0 ? (
       <ProductsPageMembershipsTable
@@ -50,6 +50,10 @@ const ProductsPage = ({
         selectedTab={type}
         setEnableArchiveTab={setEnableArchiveTab}
       />
+    ) : null}
+
+    {memberships.length === 0 && products.length === 0 && query ? (
+      <p className="text-center text-muted">No products match your search.</p>
     ) : null}
   </div>
 );


### PR DESCRIPTION
## Summary

Fixes the bug where the search bar on the Products page disappears when a search query returns no results.

**Root cause:** The search bar visibility was tied to `products.length > 0`, which updates after each Inertia reload. When a search returned zero results, the search bar would disappear, making it impossible to clear or modify the search.

**Solution:**
- Added `initialHasProducts` ref to track whether the user had products when the page first loaded
- Search bar visibility now uses this ref instead of the current (filtered) products length
- Added "No products match your search" message for empty search results
- Placeholder for new users only shows when they've never had any products

## Test plan

- [ ] Navigate to Products page with at least one product
- [ ] Enter a search query that matches no products
- [ ] Verify search bar remains visible
- [ ] Verify "No products match your search" message appears
- [ ] Clear the search and verify products reappear
- [ ] Verify new accounts without products still see the onboarding placeholder

Fixes #3262

🤖 Generated with [Claude Code](https://claude.ai/code)