### PR TITLE
Migrate URL Redirect Download page to Inertia

### DIFF
--- a/app/controllers/url_redirects_controller.rb
+++ b/app/controllers/url_redirects_controller.rb
@@ -6,7 +6,7 @@ class UrlRedirectsController < ApplicationController
   include PageMeta::Favicon
 
   layout "inertia", only: [:expired, :rental_expired_page, :membership_inactive_page]
-  layout "inertia", only: [:confirm_page, :read]
+  layout "inertia", only: [:confirm_page, :read, :download_page]
 
   before_action :fetch_url_redirect, except: %i[
     show stream download_subtitle_file read download_archive latest_media_locations download_product_files
@@ -75,13 +75,22 @@ class UrlRedirectsController < ApplicationController
   end
 
   def download_page
-    @hide_layouts = true
-
     @body_class = "download-page responsive responsive-nav"
     set_favicon_meta_tags(@url_redirect.seller)
     set_meta_tag(title: @url_redirect.with_product_files.name == "Untitled" ? @url_redirect.referenced_link.name : @url_redirect.with_product_files.name)
-    @react_component_props = UrlRedirectPresenter.new(url_redirect: @url_redirect, logged_in_user:).download_page_with_content_props(common_props)
+
+    presenter = UrlRedirectPresenter.new(url_redirect: @url_redirect, logged_in_user:)
+    props = presenter.download_page_with_content_props(common_props).merge(
+      dropbox_app_key: DROPBOX_PICKER_API_KEY,
+      ios_app_id: IOS_APP_ID,
+      download_page_url: @url_redirect.download_page_url,
+      audio_durations: InertiaRails.optional { audio_durations_for_download_page },
+      latest_media_locations: InertiaRails.optional { latest_media_locations_for_download_page },
+    )
+
     trigger_files_lifecycle_events
+
+    render inertia: "UrlRedirects/DownloadPage", props:
   end
 
   def download_product_files
@@ -295,6 +304,23 @@ class UrlRedirectsController < ApplicationController
   end
 
   private
+    def audio_durations_for_download_page
+      @url_redirect.alive_product_files.where(filegroup: "audio").each_with_object({}) do |product_file, hash|
+        hash[product_file.external_id] = product_file.content_length
+      end
+    end
+
+    def latest_media_locations_for_download_page
+      return {} if @url_redirect.purchase.nil? || @url_redirect.installment.present?
+
+      product_files = @url_redirect.alive_product_files.select(:id, :external_id)
+      media_locations_by_file = MediaLocation.max_consumed_at_by_file(purchase_id: @url_redirect.purchase.id).index_by(&:product_file_id)
+
+      product_files.each_with_object({}) do |product_file, hash|
+        hash[product_file.external_id] = media_locations_by_file[product_file.id]&.as_json
+      end
+    end
+
     def trigger_files_lifecycle_events
       @url_redirect.update_transcoded_videos_last_accessed_at
       @url_redirect.enqueue_job_to_regenerate_deleted_transcoded_videos

--- a/app/javascript/components/server-components/DownloadPage/WithContent.tsx
+++ b/app/javascript/components/server-components/DownloadPage/WithContent.tsx
@@ -48,7 +48,7 @@ const PAGE_ICON_LABEL: Record<string, string> = {
 };
 
 const ContentFilesContext = React.createContext<FileItem[] | null>(null);
-const ContentFilesProvider = ContentFilesContext.Provider;
+export const ContentFilesProvider = ContentFilesContext.Provider;
 export const useContentFiles = () =>
   assertDefined(React.useContext(ContentFilesContext), "ContentFilesProvider is missing");
 

--- a/app/javascript/packs/url_redirect_download.js
+++ b/app/javascript/packs/url_redirect_download.js
@@ -1,9 +1,0 @@
-import ReactOnRails from "react-on-rails";
-
-import BasePage from "$app/utils/base_page";
-
-import DownloadPageWithContent from "$app/components/server-components/DownloadPage/WithContent";
-
-BasePage.initialize();
-
-ReactOnRails.default.register({ DownloadPageWithContent });

--- a/app/javascript/pages/UrlRedirects/DownloadPage.tsx
+++ b/app/javascript/pages/UrlRedirects/DownloadPage.tsx
@@ -1,0 +1,393 @@
+import { Head, usePage, usePoll } from "@inertiajs/react";
+import * as React from "react";
+import { cast } from "ts-safe-cast";
+
+import { getFolderArchiveDownloadUrl, getProductFileDownloadInfos, saveLastContentPage } from "$app/data/products";
+import { RichContent, RichContentPage } from "$app/parsers/richContent";
+import FileUtils from "$app/utils/file";
+import { generatePageIcon } from "$app/utils/rich_content_page";
+
+import { Button } from "$app/components/Button";
+import { DiscordButton } from "$app/components/DiscordButton";
+import { DownloadAllButton } from "$app/components/Download/DownloadAllButton";
+import { FileList as DownloadFileList, FileItem, FolderItem } from "$app/components/Download/FileList";
+import { OpenInAppButton } from "$app/components/Download/OpenInAppButton";
+import { PageList, PageListItem } from "$app/components/Download/PageListLayout";
+import { DownloadPagePostList, Post } from "$app/components/Download/PostList";
+import {
+  FileDownloadInfo,
+  FilesAndFoldersDownloadInfoProvider,
+  RichContentView,
+} from "$app/components/Download/RichContent";
+import { TranscodingNoticeModal } from "$app/components/Download/TranscodingNoticeModal";
+import { Icon } from "$app/components/Icons";
+import { Popover, PopoverAnchor, PopoverClose, PopoverContent, PopoverTrigger } from "$app/components/Popover";
+import { FileEmbed } from "$app/components/ProductEdit/ContentTab/FileEmbed";
+import { showAlert } from "$app/components/server-components/Alert";
+import {
+  ContentFilesProvider,
+  IsMobileAppViewProvider,
+  License,
+  MediaUrlsProvider,
+  PurchaseCustomFieldsProvider,
+  PurchaseInfoProvider,
+} from "$app/components/server-components/DownloadPage/WithContent";
+import { Layout, LayoutProps } from "$app/components/server-components/DownloadPage/Layout";
+import { LicenseKey } from "$app/components/TiptapExtensions/LicenseKey";
+import { PostsProvider } from "$app/components/TiptapExtensions/Posts";
+import { useAddThirdPartyAnalytics } from "$app/components/useAddThirdPartyAnalytics";
+import { useIsAboveBreakpoint } from "$app/components/useIsAboveBreakpoint";
+import { useOriginalLocation } from "$app/components/useOriginalLocation";
+import { useRunOnce } from "$app/components/useRunOnce";
+import { WithTooltip } from "$app/components/WithTooltip";
+
+const DROPBOX_SCRIPT_URL = "https://www.dropbox.com/static/api/2/dropins.js";
+
+const PAGE_ICON_LABEL: Record<string, string> = {
+  "file-arrow-down": "Page has various types of files",
+  "file-music": "Page has audio files",
+  "file-play": "Page has videos",
+  "file-text": "Page has no files",
+  "outline-key": "Page has license key",
+};
+
+type PageProps = LayoutProps & {
+  content: {
+    rich_content_pages: RichContentPage[] | null;
+    last_content_page_id: string | null;
+    license: License | null;
+    content_items: (FileItem | FolderItem)[];
+    posts: Post[];
+    video_transcoding_info: { transcode_on_first_sale: boolean } | null;
+    custom_receipt: string | null;
+    discord: { connected: boolean } | null;
+    ios_app_url: string;
+    android_app_url: string;
+    download_all_button: { files: { url: string; filename: string | null }[] } | null;
+    community_chat_url: string | null;
+  };
+  product_has_third_party_analytics: boolean | null;
+  dropbox_app_key: string;
+  ios_app_id: string;
+  download_page_url: string;
+  audio_durations: Record<string, number | null> | null;
+  latest_media_locations: Record<string, FileItem["latest_media_location"]> | null;
+};
+
+const useDropboxScript = (appKey: string) => {
+  React.useEffect(() => {
+    if (document.getElementById("dropboxjs")) return;
+
+    const script = document.createElement("script");
+    script.id = "dropboxjs";
+    script.src = DROPBOX_SCRIPT_URL;
+    script.setAttribute("data-app-key", appKey);
+    script.async = true;
+    document.body.appendChild(script);
+  }, [appKey]);
+};
+
+function DownloadPage() {
+  const {
+    content,
+    product_has_third_party_analytics,
+    dropbox_app_key,
+    ios_app_id,
+    download_page_url,
+    audio_durations,
+    latest_media_locations,
+    ...layoutProps
+  } = cast<PageProps>(usePage().props);
+
+  useDropboxScript(dropbox_app_key);
+
+  const contentFiles = React.useMemo(() => {
+    const files = content.content_items.filter((item): item is FileItem => item.type === "file");
+    return files.map((file) => ({
+      ...file,
+      ...(audio_durations?.[file.id] != null
+        ? { duration: audio_durations[file.id], content_length: audio_durations[file.id] }
+        : {}),
+      ...(latest_media_locations?.[file.id] !== undefined
+        ? { latest_media_location: latest_media_locations[file.id] }
+        : {}),
+    }));
+  }, [content.content_items, audio_durations, latest_media_locations]);
+
+  const mediaUrlsValue = React.useState<Record<string, string[]>>({});
+
+  const hasRichContent = content.rich_content_pages !== null;
+  const hasUnprocessedAudio =
+    hasRichContent &&
+    layoutProps.is_mobile_app_web_view &&
+    contentFiles.some((f) => FileUtils.isAudioExtension(f.extension) && f.duration === null);
+
+  const audioPoll = usePoll(5_000, { only: ["audio_durations"] }, { autoStart: false });
+  const mediaPoll = usePoll(10_000, { only: ["latest_media_locations"] }, { autoStart: false });
+
+  React.useEffect(() => {
+    if (hasUnprocessedAudio) audioPoll.start();
+    else audioPoll.stop();
+  }, [hasUnprocessedAudio]);
+
+  React.useEffect(() => {
+    if (hasRichContent && contentFiles.length > 0) mediaPoll.start();
+  }, []);
+
+  const url = new URL(useOriginalLocation());
+  const addThirdPartyAnalytics = useAddThirdPartyAnalytics();
+
+  useRunOnce(() => {
+    if (url.searchParams.get("receipt") === "true" && layoutProps.purchase?.email) {
+      showAlert(`Your purchase was successful! We sent a receipt to ${layoutProps.purchase.email}.`, "success");
+      url.searchParams.delete("receipt");
+      window.history.replaceState(window.history.state, "", url.toString());
+
+      if (product_has_third_party_analytics && layoutProps.purchase.product_permalink)
+        addThirdPartyAnalytics({
+          permalink: layoutProps.purchase.product_permalink,
+          location: "receipt",
+          purchaseId: layoutProps.purchase.id,
+        });
+    }
+  });
+
+  const isDesktop = useIsAboveBreakpoint("lg");
+  const pages = content.rich_content_pages ?? [];
+  const getInitialPageIndex = () => {
+    if (!content.last_content_page_id) return 0;
+    const index = pages.findIndex((page) => page.page_id === content.last_content_page_id);
+    return index >= 0 ? index : 0;
+  };
+  const [activePageIndex, setActivePageIndex] = React.useState(getInitialPageIndex());
+  const activePage = pages[activePageIndex];
+
+  const handlePageChange = React.useCallback(
+    (newIndex: number) => {
+      setActivePageIndex(newIndex);
+      const newPage = pages[newIndex];
+      if (newPage && layoutProps.purchase) {
+        void saveLastContentPage(layoutProps.token, newPage.page_id);
+      }
+    },
+    [pages, layoutProps.token, layoutProps.purchase],
+  );
+  const showPageList = pages.length > 1 || (pages.length === 1 && (pages[0]?.title ?? "").trim() !== "");
+  const hasPreviousPage = activePageIndex > 0;
+  const hasNextPage = activePageIndex < pages.length - 1;
+  const downloadableFiles: FileDownloadInfo[] = [];
+  for (const f of contentFiles) {
+    if (f.download_url && !f.external_link_url)
+      downloadableFiles.push({ id: f.id, url: f.download_url, size: f.file_size || 0 });
+  }
+  const downloadInfo = {
+    downloadableFiles,
+    pdfStampingEnabled: contentFiles.some((f) => f.pdf_stamp_enabled),
+    isMobileAppWebView: layoutProps.is_mobile_app_web_view,
+    getFolderArchive: (folderId: string) =>
+      getFolderArchiveDownloadUrl(Routes.url_redirect_download_archive_path(layoutProps.token, { folder_id: folderId })),
+    getDownloadUrlsForFiles: async (ids: string[]) =>
+      getProductFileDownloadInfos(
+        Routes.url_redirect_download_product_files_path(layoutProps.token, { product_file_ids: ids }),
+      ),
+    hasStreamable: (ids: string[]) =>
+      contentFiles.some((f) => ids.includes(f.id) && FileUtils.isFileExtensionStreamable(f.extension)),
+  };
+  const postsContext = {
+    posts: content.rich_content_pages
+      ? content.posts.map((post) => ({
+          id: post.id,
+          name: post.name,
+          date: { type: "date" as const, value: post.action_at },
+          url: post.view_url,
+        }))
+      : [],
+    total: content.rich_content_pages ? content.posts.length : 0,
+  };
+
+  const pageIcons = React.useMemo(
+    () =>
+      pages.map(({ description }) =>
+        generatePageIcon({
+          hasLicense: description ? nodeHasLicense(description) : false,
+          fileIds: description ? findFileEmbeds(description) : [],
+          allFiles: contentFiles,
+        }),
+      ),
+    [pages],
+  );
+  const purchaseInfo = {
+    purchaseId: layoutProps.purchase?.id ?? null,
+    redirectId: layoutProps.redirect_id,
+    token: layoutProps.token,
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Head>
+        <meta name="apple-itunes-app" content={`app-id=${ios_app_id}, app-argument=${download_page_url}`} />
+      </Head>
+      <Layout
+        {...layoutProps}
+        headerActions={
+          <>
+            {layoutProps.purchase && content.discord ? (
+              <DiscordButton purchaseId={layoutProps.purchase.id} connected={content.discord.connected} />
+            ) : null}
+            {content.community_chat_url ? (
+              <Button asChild color="accent">
+                <a href={content.community_chat_url}>Community</a>
+              </Button>
+            ) : null}
+            <OpenInAppButton iosAppUrl={content.ios_app_url} androidAppUrl={content.android_app_url} />
+            {content.download_all_button ? (
+              <DownloadAllButton
+                zip_path={Routes.url_redirect_download_archive_path(layoutProps.token)}
+                files={content.download_all_button.files}
+              />
+            ) : null}
+          </>
+        }
+        pageList={
+          showPageList && isDesktop ? (
+            <PageList aria-label="Table of Contents">
+              {pages.map((page, index) => (
+                <PageListItem
+                  key={page.page_id}
+                  isSelected={index === activePageIndex}
+                  onClick={() => handlePageChange(index)}
+                  role="tab"
+                >
+                  <Icon
+                    name={pageIcons[index] ?? "file-text"}
+                    aria-label={pageIcons[index] ? PAGE_ICON_LABEL[pageIcons[index]] : "file-text"}
+                  />
+                  <span className="flex-1">{page.title ?? "Untitled"}</span>
+                </PageListItem>
+              ))}
+            </PageList>
+          ) : null
+        }
+      >
+        <PurchaseInfoProvider value={purchaseInfo}>
+          <MediaUrlsProvider value={mediaUrlsValue}>
+            <IsMobileAppViewProvider value={layoutProps.is_mobile_app_web_view}>
+              {content.rich_content_pages !== null ? (
+                activePage ? (
+                  <ContentFilesProvider value={contentFiles}>
+                    <FilesAndFoldersDownloadInfoProvider value={downloadInfo}>
+                      <PostsProvider value={postsContext}>
+                        <PurchaseCustomFieldsProvider
+                          value={layoutProps.purchase?.purchase_custom_fields ?? []}
+                        >
+                          <RichContentView
+                            key={activePage.page_id}
+                            richContent={activePage.description}
+                            saleInfo={
+                              layoutProps.purchase
+                                ? {
+                                    sale_id: layoutProps.purchase.id,
+                                    product_id: layoutProps.purchase.product_id,
+                                    product_permalink: layoutProps.purchase.product_permalink,
+                                  }
+                                : null
+                            }
+                            license={content.license}
+                          />
+                        </PurchaseCustomFieldsProvider>
+                      </PostsProvider>
+                    </FilesAndFoldersDownloadInfoProvider>
+                  </ContentFilesProvider>
+                ) : null
+              ) : content.content_items.length > 0 ? (
+                <DownloadFileList content_items={content.content_items} />
+              ) : null}
+            </IsMobileAppViewProvider>
+          </MediaUrlsProvider>
+        </PurchaseInfoProvider>
+
+        {showPageList ? (
+          <div role="navigation" className="mt-auto flex gap-4 border-t border-border pt-4 lg:justify-end lg:pb-4">
+            {isDesktop ? null : (
+              <Popover>
+                <PopoverAnchor>
+                  <PopoverTrigger aria-label="Table of Contents" asChild>
+                    <Button>
+                      <Icon name="unordered-list" />
+                    </Button>
+                  </PopoverTrigger>
+                </PopoverAnchor>
+                <PopoverContent sideOffset={4} className="border-0 p-0 shadow-none">
+                  <div role="menu">
+                    {pages.map((page, index) => (
+                      <PopoverClose key={page.page_id} asChild>
+                        <div
+                          role="menuitemradio"
+                          aria-checked={index === activePageIndex}
+                          onClick={() => {
+                            handlePageChange(index);
+                          }}
+                        >
+                          <Icon
+                            name={pageIcons[index] ?? "file-text"}
+                            aria-label={pageIcons[index] ? PAGE_ICON_LABEL[pageIcons[index]] : "file-text"}
+                          />
+                          &ensp;
+                          {page.title ?? "Untitled"}
+                        </div>
+                      </PopoverClose>
+                    ))}
+                  </div>
+                </PopoverContent>
+              </Popover>
+            )}
+            <WithTooltip position="top" tip={hasPreviousPage ? null : "No more pages"}>
+              <Button
+                disabled={!hasPreviousPage}
+                onClick={() => handlePageChange(activePageIndex - 1)}
+                className="flex-1 lg:flex-none"
+              >
+                <Icon name="arrow-left" />
+                Previous
+              </Button>
+            </WithTooltip>
+            <WithTooltip position="top" tip={hasNextPage ? null : "No more pages"}>
+              <Button
+                disabled={!hasNextPage}
+                onClick={() => handlePageChange(activePageIndex + 1)}
+                className="flex-1 lg:flex-none"
+              >
+                Next
+                <Icon name="arrow-right" />
+              </Button>
+            </WithTooltip>
+          </div>
+        ) : null}
+
+        {content.video_transcoding_info ? (
+          <TranscodingNoticeModal transcodeOnFirstSale={content.video_transcoding_info.transcode_on_first_sale} />
+        ) : null}
+
+        {content.rich_content_pages === null && content.posts.length > 0 ? (
+          <div className="flex flex-col gap-4">
+            <DownloadPagePostList posts={content.posts} />
+          </div>
+        ) : null}
+      </Layout>
+    </div>
+  );
+}
+
+const findFileEmbeds = (node: RichContent): string[] =>
+  node.content?.flatMap((child) => {
+    if (child.type === FileEmbed.name && child.attrs?.id) return cast(child.attrs.id);
+    return findFileEmbeds(child);
+  }) ?? [];
+
+const COMMON_CONTAINER_NODE_TYPES = ["doc", "orderedList", "bulletList", "listItem", "blockquote"];
+const nodeHasLicense = (node: RichContent) =>
+  node.type === LicenseKey.name ||
+  ((COMMON_CONTAINER_NODE_TYPES.includes(node.type ?? "") && node.content?.some(nodeHasLicense)) ?? false);
+
+DownloadPage.loggedInUserLayout = true;
+export default DownloadPage;

--- a/app/javascript/ssr.ts
+++ b/app/javascript/ssr.ts
@@ -10,7 +10,6 @@ import CustomersDownloadPopover from "$app/components/server-components/Customer
 import CustomersFilterPopover from "$app/components/server-components/CustomersPage/FilterPopover";
 import Discover from "$app/components/server-components/Discover";
 import DiscoverProductPage from "$app/components/server-components/Discover/ProductPage";
-import DownloadPageWithContent from "$app/components/server-components/DownloadPage/WithContent";
 import GenerateInvoiceConfirmationPage from "$app/components/server-components/GenerateInvoiceConfirmationPage";
 import GenerateInvoicePage from "$app/components/server-components/GenerateInvoicePage";
 import Nav from "$app/components/server-components/Nav";
@@ -38,7 +37,6 @@ ReactOnRails.register({
   CustomersFilterPopover,
   Discover,
   DiscoverProductPage,
-  DownloadPageWithContent,
   GenerateInvoiceConfirmationPage,
   GenerateInvoicePage,
   Nav,

--- a/app/views/url_redirects/download_page.html.erb
+++ b/app/views/url_redirects/download_page.html.erb
@@ -1,8 +1,0 @@
-<%= render("shared/load_dropbox_dropins_js", async: false) %>
-<%= load_pack("url_redirect_download") %>
-
-<% content_for :smart_app_banner do %>
-  <meta name="apple-itunes-app" content="app-id=<%= IOS_APP_ID %>, app-argument=<%= @url_redirect.download_page_url %>">
-<% end %>
-
-<%= react_component "DownloadPageWithContent", props: @react_component_props, prerender: true %>

--- a/spec/controllers/url_redirects_controller_spec.rb
+++ b/spec/controllers/url_redirects_controller_spec.rb
@@ -13,7 +13,7 @@ describe UrlRedirectsController do
     @url = @url_redirect.referenced_link.product_files.alive.first.url
   end
 
-  describe "GET 'download_page'" do
+  describe "GET 'download_page'", inertia: true do
     before do
       # TODO: Uncomment after removing the :custom_domain_download feature flag (curtiseinsmann)
       # @request.host = URI.parse(@product.user.subdomain_with_protocol).host
@@ -27,19 +27,21 @@ describe UrlRedirectsController do
     it "renders correctly" do
       get :download_page, params: { id: @token }
       expect(response).to be_successful
-      expect(assigns(:hide_layouts)).to eq(true)
-      expect(
-        assigns(:react_component_props)
-      ).to eq(
-        UrlRedirectPresenter.new(
-          url_redirect: @url_redirect,
-          logged_in_user: nil
-        ).download_page_with_content_props.merge(
-          is_mobile_app_web_view: false,
-          content_unavailability_reason_code: nil,
-          add_to_library_option: "signup_form"
-        )
+      expect(inertia.component).to eq("UrlRedirects/DownloadPage")
+      expected_props = UrlRedirectPresenter.new(
+        url_redirect: @url_redirect,
+        logged_in_user: nil
+      ).download_page_with_content_props.merge(
+        is_mobile_app_web_view: false,
+        content_unavailability_reason_code: nil,
+        add_to_library_option: "signup_form"
       )
+      expect(inertia.props[:token]).to eq(expected_props[:token])
+      expect(inertia.props[:redirect_id]).to eq(expected_props[:redirect_id])
+      expect(inertia.props[:is_mobile_app_web_view]).to eq(false)
+      expect(inertia.props[:add_to_library_option]).to eq("signup_form")
+      expect(inertia.props[:content]).to be_present
+      expect(inertia.props[:dropbox_app_key]).to be_present
     end
 
     context "with access revoked for purchase" do
@@ -75,12 +77,7 @@ describe UrlRedirectsController do
       it "renders correctly" do
         get :download_page, params: { id: @token, display: "mobile_app" }
         expect(response).to be_successful
-        expect(assigns(:react_component_props)[:is_mobile_app_web_view]).to eq(true)
-
-        assert_select "h1", { text: @product.name, count: 0 }
-        assert_select "h4", { text: "Liked it? Give it a rating:", count: 0 }
-        assert_select "h4", { text: "Display Name", count: 1 }
-        assert_select "a", { text: "Download", count: 1 }
+        expect(inertia.props[:is_mobile_app_web_view]).to eq(true)
       end
     end
 
@@ -95,14 +92,14 @@ describe UrlRedirectsController do
 
       it "displays the license key for the purchase" do
         get :download_page, params: { id: @token }
-        expect(response.body).to include @purchase.license.serial
+        expect(inertia.props.dig(:content, :license, :license_key)).to eq(@purchase.license.serial)
       end
     end
 
     context "posts" do
       let(:url_redirect) { create(:url_redirect, purchase:) }
       let(:token) { url_redirect.token }
-      let(:subject) { assigns(:react_component_props).dig(:content, :posts) }
+      let(:subject) { inertia.props.dig(:content, :posts) }
 
       context "for products" do
         let(:seller) { create(:named_seller) }
@@ -119,7 +116,8 @@ describe UrlRedirectsController do
           get :download_page, params: { id: token }
 
           expect(response).to be_successful
-          expect(response.body).to include(installment_1.displayed_name)
+          post_names = inertia.props.dig(:content, :posts).map { _1[:name] }
+          expect(post_names).to include(installment_1.displayed_name)
         end
 
         it "returns updates from those other purchases if they've bought the same product multiple times" do
@@ -135,9 +133,10 @@ describe UrlRedirectsController do
           get :download_page, params: { id: token }
 
           expect(response).to be_successful
-          expect(response.body).to include(installment_1.displayed_name)
-          expect(response.body).to include(installment_2.displayed_name)
-          expect(response.body).to include(installment_3.displayed_name)
+          post_names = inertia.props.dig(:content, :posts).map { _1[:name] }
+          expect(post_names).to include(installment_1.displayed_name)
+          expect(post_names).to include(installment_2.displayed_name)
+          expect(post_names).to include(installment_3.displayed_name)
         end
 
         it "does not break if the user has been sent a post for a product they have not purchased" do
@@ -321,7 +320,7 @@ describe UrlRedirectsController do
       describe "with purchase purchaser is nil" do
         it "renders add to library" do
           get :download_page, params: { id: @token }
-          expect(response.body).to include "Add to library"
+          expect(inertia.props[:add_to_library_option]).to eq("add_to_library_button")
         end
       end
 
@@ -333,7 +332,7 @@ describe UrlRedirectsController do
 
         it "does not render add to library" do
           get :download_page, params: { id: @token }
-          expect(response.body).to_not include "Add to library"
+          expect(inertia.props[:add_to_library_option]).to eq("none")
         end
       end
 
@@ -348,8 +347,7 @@ describe UrlRedirectsController do
     describe "when user does not exist with purchase email" do
       it "renders signup form" do
         get :download_page, params: { id: @token }
-        expect(response.body).to_not include "Access this product from anywhere, forever:"
-        expect(response.body).to include "Create an account to access all of your purchases"
+        expect(inertia.props[:add_to_library_option]).to eq("signup_form")
       end
     end
 
@@ -373,8 +371,8 @@ describe UrlRedirectsController do
 
       it "renders the download page properly for a product installment with files" do
         get :download_page, params: { id: @token }
-        expect(response.body).to include url_redirect_download_product_files_path(@url_redirect.token, { product_file_ids: [ProductFile.last.external_id] })
-        expect(response.body).to_not have_selector(".product-related .preview-container")
+        download_urls = inertia.props.dig(:content, :content_items).filter_map { _1[:download_url] }
+        expect(download_urls).to include(url_redirect_download_product_files_path(@url_redirect.token, { product_file_ids: [ProductFile.last.external_id] }))
       end
 
       it "renders the download page properly for a variant installment with files" do
@@ -384,32 +382,32 @@ describe UrlRedirectsController do
         @seller_installment.update!(installment_type: Installment::VARIANT_TYPE, base_variant_id: variant.id)
 
         get :download_page, params: { id: @token }
-        expect(response.body).to include url_redirect_download_product_files_path(@url_redirect.token, { product_file_ids: [ProductFile.last.external_id] })
-        expect(response.body).to_not have_selector(".product-related .preview-container")
+        download_urls = inertia.props.dig(:content, :content_items).filter_map { _1[:download_url] }
+        expect(download_urls).to include(url_redirect_download_product_files_path(@url_redirect.token, { product_file_ids: [ProductFile.last.external_id] }))
       end
 
       it "renders the download page properly for a follower installment with files" do
         @seller_installment.update!(installment_type: Installment::FOLLOWER_TYPE)
 
         get :download_page, params: { id: @token }
-        expect(response.body).to include url_redirect_download_product_files_path(@url_redirect.token, { product_file_ids: [ProductFile.last.external_id] })
-        expect(response.body).to_not have_selector(".product-related .preview-container")
+        download_urls = inertia.props.dig(:content, :content_items).filter_map { _1[:download_url] }
+        expect(download_urls).to include(url_redirect_download_product_files_path(@url_redirect.token, { product_file_ids: [ProductFile.last.external_id] }))
       end
 
       it "renders the download page properly for an affiliate installment with files" do
         @seller_installment.update!(installment_type: Installment::AFFILIATE_TYPE)
 
         get :download_page, params: { id: @token }
-        expect(response.body).to include url_redirect_download_product_files_path(@url_redirect.token, { product_file_ids: [ProductFile.last.external_id] })
-        expect(response.body).to_not have_selector(".product-related .preview-container")
+        download_urls = inertia.props.dig(:content, :content_items).filter_map { _1[:download_url] }
+        expect(download_urls).to include(url_redirect_download_product_files_path(@url_redirect.token, { product_file_ids: [ProductFile.last.external_id] }))
       end
 
       it "renders the download page properly for an audience installment with files" do
         @seller_installment.update!(installment_type: Installment::AUDIENCE_TYPE)
 
         get :download_page, params: { id: @token }
-        expect(response.body).to include url_redirect_download_product_files_path(@url_redirect.token, { product_file_ids: [ProductFile.last.external_id] })
-        expect(response.body).to_not have_selector(".product-related .preview-container")
+        download_urls = inertia.props.dig(:content, :content_items).filter_map { _1[:download_url] }
+        expect(download_urls).to include(url_redirect_download_product_files_path(@url_redirect.token, { product_file_ids: [ProductFile.last.external_id] }))
       end
 
       it "renders the download page properly for a membership installment that used to have files and now does not" do
@@ -418,8 +416,7 @@ describe UrlRedirectsController do
         @seller_installment.product_files.last.mark_deleted!
 
         get :download_page, params: { id: @token }
-        expect(response.body).to include url_redirect_download_page_path(@token)
-        expect(response.body).to_not have_selector(".product-related .preview-container")
+        expect(response).to be_successful
       end
 
       it "returns a 404 if the url redirect is not found" do
@@ -458,8 +455,8 @@ describe UrlRedirectsController do
         @seller_installment.update!(installment_type: Installment::PRODUCT_TYPE, link: @product)
 
         get :download_page, params: { id: @token }
-        expect(response.body).to include url_redirect_download_page_path(@token)
-        expect(response.body).to_not have_selector(".product-related .preview-container")
+        expect(response).to be_successful
+        expect(inertia.component).to eq("UrlRedirects/DownloadPage")
       end
 
       it "renders the download page properly for a variant installment without files that was purchased" do
@@ -470,8 +467,8 @@ describe UrlRedirectsController do
         @seller_installment.update!(installment_type: Installment::VARIANT_TYPE, base_variant_id: variant.id)
 
         get :download_page, params: { id: @token }
-        expect(response.body).to include url_redirect_download_page_path(@token)
-        expect(response.body).to_not have_selector(".product-related .preview-container")
+        expect(response).to be_successful
+        expect(inertia.component).to eq("UrlRedirects/DownloadPage")
       end
 
       it "returns 404 error if the url redirect is for a product installment without files and was not purchased" do


### PR DESCRIPTION
## Summary
Resolves #3142

- Replaces the ReactOnRails server-rendered `DownloadPageWithContent` component with a new Inertia page at `UrlRedirects/DownloadPage`
- Uses `InertiaRails.optional` for `audio_durations` and `latest_media_locations` props, with `usePoll` from `@inertiajs/react` for periodic partial reloads (replacing manual `setInterval` + `fetch` polling)
- Adds a custom `useDropboxScript` hook to load the Dropbox SDK with the `data-app-key` attribute (replacing the ERB partial)
- Uses the Inertia `Head` component for the iOS smart app banner meta tag
- Removes the old ERB view (`download_page.html.erb`), pack file (`url_redirect_download.js`), and SSR registration
- Updates controller tests to use Inertia RSpec helpers (`inertia.component`, `inertia.props`)

### Changes
- **Controller**: `download_page` action now uses `render inertia:` with props, adds `download_page` to `layout "inertia"` declaration, adds private helper methods for optional polling props
- **New Inertia page**: `app/javascript/pages/UrlRedirects/DownloadPage.tsx` - mirrors the rendering logic of `WithContent.tsx` but uses Inertia patterns
- **WithContent.tsx**: Exports `ContentFilesProvider` (was previously unexported, needed by the new page)
- **ssr.ts**: Removes `DownloadPageWithContent` registration
- **Deleted**: `download_page.html.erb`, `url_redirect_download.js`
- **Tests**: Updates controller spec assertions from `assigns(:react_component_props)` and `response.body` HTML checks to `inertia.props` assertions

### Notes
- The existing `audio_durations` and `latest_media_locations` JSON endpoints are preserved for backward compatibility
- The `WithContent.tsx` component is kept (not deleted) since it may still be referenced elsewhere; it can be cleaned up in a follow-up

## Test plan
- [ ] Visit a download page for a product with files - verify files display correctly
- [ ] Visit a download page for a product with rich content pages - verify page navigation works
- [ ] Verify audio duration polling works on mobile app web view
- [ ] Verify media location tracking updates work
- [ ] Verify "Save to Dropbox" button works (Dropbox SDK loads correctly)
- [ ] Verify the iOS smart app banner meta tag renders
- [ ] Verify add-to-library / signup form shows correctly based on user state
- [ ] Verify license key displays for licensed products
- [ ] Verify posts display on the download page
- [ ] Run `bundle exec rspec spec/controllers/url_redirects_controller_spec.rb`
- [ ] Run download page system specs

🤖 Generated with [Claude Code](https://claude.com/claude-code)