### PR TITLE
fix(receipts): Fix broken product recommendations UI in purchase receipts

### DIFF
--- a/app/javascript/stylesheets/_email.scss
+++ b/app/javascript/stylesheets/_email.scss
@@ -652,9 +652,13 @@ $accent-color: map-get($colors, "pink"); // [1]
 
     .items {
       position: unset;
+      aspect-ratio: 1;
+      overflow: hidden;
 
       & img {
         width: 100%;
+        height: 100%;
+        object-fit: cover;
       }
     }
   }

--- a/app/views/customer_mailer/receipt/_product_card.html.erb
+++ b/app/views/customer_mailer/receipt/_product_card.html.erb
@@ -9,13 +9,13 @@
     <h4>
       <%= link_to(product[:name], product[:url], target: "_blank") %>
     </h4>
-    <% if product[:creator].present? %>
+    <% if product[:seller].present? %>
       <div>
         <div class="user">
-          <% if product[:creator][:avatar_url].present? %>
-            <%= link_to(image_tag(product[:creator][:avatar_url], alt: "Avatar of #{product[:creator][:name]}", class: "user-avatar"), product[:creator][:profile_url], target: "_blank") %>
+          <% if product[:seller][:avatar_url].present? %>
+            <%= link_to(image_tag(product[:seller][:avatar_url], alt: "Avatar of #{product[:seller][:name]}", class: "user-avatar"), product[:seller][:profile_url], target: "_blank") %>
           <% end %>
-          <%= link_to(product[:creator][:name], product[:creator][:profile_url], target: "_blank", class: "user-name") %>
+          <%= link_to(product[:seller][:name], product[:seller][:profile_url], target: "_blank", class: "user-name") %>
         </div>
       </div>
     <% end %>


### PR DESCRIPTION
## Summary

Fixes two root causes of the broken product recommendations in purchase receipts (#3475):

1. **Data key mismatch** — `_product_card.html.erb` accessed `product[:creator]` for seller info (avatar, name, profile link), but `ProductPresenter.card_for_web` returns data under `product[:seller]`. This caused seller information to silently not render on recommended product cards.

2. **Unconstrained cover images** — Product thumbnail images in the `.items` container rendered at their full original resolution, blowing out the card layout. Added `aspect-ratio: 1`, `overflow: hidden`, and `object-fit: cover` to properly constrain the images within their cards.

## Changes

- `app/views/customer_mailer/receipt/_product_card.html.erb` — Changed `product[:creator]` → `product[:seller]` in 4 places
- `app/javascript/stylesheets/_email.scss` — Added image sizing constraints to `.product-card .carousel .items`

## Test plan

- [ ] Verify product recommendation cards render correctly on the web receipt view
- [ ] Verify seller avatar, name, and profile link are displayed on recommended product cards
- [ ] Verify cover images are properly constrained (square aspect ratio, cropped to fit)
- [ ] Verify email receipt renders correctly

> **AI Disclosure:** This PR was authored with the assistance of AI (Claude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)