### PR TITLE
feat(payments): Add backup payment method for refund funding

### DIFF
--- a/app/controllers/settings/refund_funding_controller.rb
+++ b/app/controllers/settings/refund_funding_controller.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+class Settings::RefundFundingController < Settings::BaseController
+  before_action :authorize
+
+  def show
+    render json: refund_funding_data
+  end
+
+  def create
+    card_data_handling_mode = CardParamsHelper.get_card_data_handling_mode(params)
+    card_data_handling_error = CardParamsHelper.check_for_errors(params)
+
+    if card_data_handling_error.present?
+      return render json: { success: false, error: card_data_handling_error.error_message }, status: :unprocessable_entity
+    end
+
+    chargeable = CardParamsHelper.build_chargeable(params)
+
+    if chargeable.blank?
+      return render json: { success: false, error: "Invalid card information" }, status: :unprocessable_entity
+    end
+
+    credit_card = CreditCard.create(chargeable, card_data_handling_mode, current_seller)
+
+    if !credit_card.persisted?
+      return render json: { success: false, error: credit_card.errors.full_messages.join(", ") }, status: :unprocessable_entity
+    end
+
+    current_seller.update!(refund_funding_credit_card: credit_card)
+
+    render json: { success: true, **refund_funding_data }
+  end
+
+  def destroy
+    current_seller.update!(refund_funding_credit_card: nil, dismissed_refund_payment_method_banner: false)
+
+    render json: { success: true, **refund_funding_data }
+  end
+
+  def dismiss_banner
+    current_seller.update!(dismissed_refund_payment_method_banner: true)
+
+    render json: { success: true }
+  end
+
+  private
+
+  def refund_funding_data
+    funding_card = current_seller.refund_funding_credit_card
+
+    {
+      enabled: funding_card.present?,
+      credit_card: funding_card.present? ? {
+        visual: funding_card.visual,
+        card_type: funding_card.card_type,
+        expiry_month: funding_card.expiry_month,
+        expiry_year: funding_card.expiry_year
+      } : nil
+    }
+  end
+
+  def authorize
+    super([:settings, :refund_funding, current_seller])
+  end
+end

--- a/app/javascript/components/Audience/CustomersPage.tsx
+++ b/app/javascript/components/Audience/CustomersPage.tsx
@@ -60,6 +60,7 @@ import { AbortError, assertResponseError } from "$app/utils/request";
 
 import { Button, NavigationButton, buttonVariants } from "$app/components/Button";
 import { useCurrentSeller } from "$app/components/CurrentSeller";
+import { RefundPaymentMethodBanner } from "$app/components/CustomersPage/RefundPaymentMethodBanner";
 import { DateInput } from "$app/components/DateInput";
 import { DateRangePicker } from "$app/components/DateRangePicker";
 import { FileKindIcon } from "$app/components/FileRowContent";
@@ -107,6 +108,7 @@ export type CustomerPageProps = {
   countries: string[];
   can_ping: boolean;
   show_refund_fee_notice: boolean;
+  show_refund_payment_method_banner: boolean;
 };
 
 const year = new Date().getFullYear();
@@ -130,6 +132,7 @@ const CustomersPage = ({
   countries,
   can_ping,
   show_refund_fee_notice,
+  show_refund_payment_method_banner,
   ...initialState
 }: CustomerPageProps) => {
   const currentSeller = useCurrentSeller();
@@ -432,6 +435,7 @@ const CustomersPage = ({
         }
       />
       <section className="p-4 md:p-8">
+        <RefundPaymentMethodBanner show={show_refund_payment_method_banner} />
         {customers.length > 0 ? (
           <section className="flex flex-col gap-4">
             <Table aria-live="polite" className={cx(isLoading && "pointer-events-none opacity-50")}>

--- a/app/javascript/components/CustomersPage/RefundPaymentMethodBanner.tsx
+++ b/app/javascript/components/CustomersPage/RefundPaymentMethodBanner.tsx
@@ -1,0 +1,54 @@
+import { Link } from "@inertiajs/react";
+import * as React from "react";
+import { cast } from "ts-safe-cast";
+
+import { asyncVoid } from "$app/utils/promise";
+import { assertResponseError, request } from "$app/utils/request";
+
+import { showAlert } from "$app/components/server-components/Alert";
+import { Alert } from "$app/components/ui/Alert";
+
+export const RefundPaymentMethodBanner = ({ show }: { show: boolean }) => {
+  const [isVisible, setIsVisible] = React.useState(show);
+  const [isDismissing, setIsDismissing] = React.useState(false);
+
+  const handleDismiss = asyncVoid(async () => {
+    setIsDismissing(true);
+
+    try {
+      const response = await request({
+        method: "POST",
+        url: Routes.dismiss_banner_settings_refund_funding_path(),
+        accept: "json",
+      });
+
+      const result = cast<{ success: boolean }>(await response.json());
+
+      if (result.success) {
+        setIsVisible(false);
+      }
+    } catch (e) {
+      assertResponseError(e);
+      showAlert("Sorry, something went wrong.", "error");
+    }
+
+    setIsDismissing(false);
+  });
+
+  if (!isVisible) return null;
+
+  return (
+    <Alert variant="accent" role="status">
+      <div>
+        <strong>New:</strong> Refund customers instantly, even when your balance is low. Add a backup payment method to
+        cover refunds automatically if your balance can&apos;t.
+        <div style={{ marginTop: "0.25rem" }}>
+          <Link href={`${Routes.settings_payments_path()}#refund-payment-method`}>Set up backup method</Link>
+        </div>
+      </div>
+      <button type="button" className="link" onClick={handleDismiss} disabled={isDismissing} aria-label="Dismiss">
+        close
+      </button>
+    </Alert>
+  );
+};

--- a/app/javascript/components/Settings/PaymentsPage/RefundPaymentMethodSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/RefundPaymentMethodSection.tsx
@@ -1,0 +1,266 @@
+import { CardElement, useElements, useStripe } from "@stripe/react-stripe-js";
+import * as React from "react";
+import { cast } from "ts-safe-cast";
+
+import { asyncVoid } from "$app/utils/promise";
+import { assertResponseError, request } from "$app/utils/request";
+import { getCssVariable } from "$app/utils/styles";
+
+import { Button } from "$app/components/Button";
+import { StripeElementsProvider } from "$app/components/Checkout/CreditCardInput";
+import { Icon } from "$app/components/Icons";
+import { Modal } from "$app/components/Modal";
+import { showAlert } from "$app/components/server-components/Alert";
+import { Fieldset, FieldsetTitle } from "$app/components/ui/Fieldset";
+import { Input } from "$app/components/ui/Input";
+import { InputGroup } from "$app/components/ui/InputGroup";
+
+export type RefundPaymentMethod = {
+  enabled: boolean;
+  credit_card: {
+    visual: string;
+    card_type: string;
+    expiry_month: number;
+    expiry_year: number;
+  } | null;
+};
+
+const RefundPaymentMethodForm = ({
+  refundPaymentMethod,
+  isFormDisabled,
+}: {
+  refundPaymentMethod: RefundPaymentMethod;
+  isFormDisabled: boolean;
+}) => {
+  const stripe = useStripe();
+  const elements = useElements();
+  const [zipCode, setZipCode] = React.useState("");
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const [savedCard, setSavedCard] = React.useState(refundPaymentMethod.credit_card);
+  const [isEditing, setIsEditing] = React.useState(!refundPaymentMethod.enabled);
+  const [confirmingRemove, setConfirmingRemove] = React.useState(false);
+  const [stripeStyle, setStripeStyle] = React.useState<Record<string, unknown> | null>(null);
+
+  const handleSubmit = asyncVoid(async () => {
+    if (!stripe || !elements) return;
+
+    const cardElement = elements.getElement(CardElement);
+    if (!cardElement) return;
+
+    setIsSubmitting(true);
+
+    try {
+      const { paymentMethod, error } = await stripe.createPaymentMethod({
+        type: "card",
+        card: cardElement,
+        billing_details: {
+          address: {
+            postal_code: zipCode,
+          },
+        },
+      });
+
+      if (error) {
+        showAlert(error.message || "Card verification failed", "error");
+        setIsSubmitting(false);
+        return;
+      }
+
+      const response = await request({
+        method: "POST",
+        url: Routes.settings_refund_funding_path(),
+        accept: "json",
+        data: {
+          stripe_payment_method_id: paymentMethod.id,
+          card_data_handling_mode: "stripejs.0",
+        },
+      });
+
+      const result = cast<{ success: boolean; error?: string; credit_card?: RefundPaymentMethod["credit_card"] }>(
+        await response.json(),
+      );
+
+      if (result.success && result.credit_card) {
+        showAlert("Refund payment method saved successfully!", "success");
+        setSavedCard(result.credit_card);
+        setIsEditing(false);
+      } else {
+        showAlert(result.error || "Failed to save card", "error");
+      }
+    } catch (e) {
+      assertResponseError(e);
+      showAlert("An error occurred. Please try again.", "error");
+    }
+
+    setIsSubmitting(false);
+  });
+
+  const handleRemove = asyncVoid(async () => {
+    setIsSubmitting(true);
+
+    try {
+      const response = await request({
+        method: "DELETE",
+        url: Routes.settings_refund_funding_path(),
+        accept: "json",
+      });
+
+      const result = cast<{ success: boolean; error?: string }>(await response.json());
+
+      if (result.success) {
+        showAlert("Refund payment method removed", "success");
+        setSavedCard(null);
+        setIsEditing(true);
+      } else {
+        showAlert(result.error || "Failed to remove card", "error");
+      }
+    } catch (e) {
+      assertResponseError(e);
+      showAlert("An error occurred. Please try again.", "error");
+    }
+
+    setIsSubmitting(false);
+  });
+
+  return (
+    <section id="refund-payment-method" className="p-4 md:p-8">
+      <header>
+        <h2>Refund payment method</h2>
+        <p className="text-muted">
+          Add a card to automatically cover refunds when your Gumroad balance is too low. You&apos;ll only be charged if
+          your balance can&apos;t cover the refund amount.{" "}
+          <a href="/help/article/refunds" target="_blank" rel="noreferrer">
+            Learn more
+          </a>
+        </p>
+      </header>
+
+      <div className="flex flex-col gap-5">
+        {savedCard && !isEditing ? (
+          <div className="flex flex-col gap-4">
+            <Fieldset>
+              <FieldsetTitle>Card information</FieldsetTitle>
+              <InputGroup readOnly>
+                <Icon name="outline-credit-card" />
+                <Input readOnly value={`•••• •••• •••• ${savedCard.visual}`} />
+                <span className="text-muted">
+                  {savedCard.expiry_month.toString().padStart(2, "0")}/{savedCard.expiry_year.toString().slice(-2)}
+                </span>
+              </InputGroup>
+            </Fieldset>
+            {!isFormDisabled ? (
+              <div className="flex gap-4">
+                <Button outline onClick={() => setIsEditing(true)} disabled={isSubmitting}>
+                  Change card
+                </Button>
+                <Button outline color="danger" onClick={() => setConfirmingRemove(true)} disabled={isSubmitting}>
+                  Remove card
+                </Button>
+              </div>
+            ) : null}
+          </div>
+        ) : (
+          <>
+            <Fieldset>
+              <FieldsetTitle>ZIP / Postal code</FieldsetTitle>
+              <Input
+                type="text"
+                id="refund_zip_code"
+                placeholder="12345"
+                value={zipCode}
+                onChange={(e) => setZipCode(e.target.value)}
+                disabled={isFormDisabled || isSubmitting}
+              />
+            </Fieldset>
+            <Fieldset>
+              <FieldsetTitle>Card information</FieldsetTitle>
+              <InputGroup disabled={isFormDisabled || isSubmitting}>
+                <Icon name="outline-credit-card" />
+                <div style={{ flex: 1 }}>
+                  {stripeStyle == null ? (
+                    <input
+                      ref={(el) => {
+                        if (el == null) return;
+                        const inputStyle = window.getComputedStyle(el);
+                        const color = getCssVariable("color").split(" ").join(",");
+                        const placeholderColor = `rgb(${color}, ${getCssVariable("gray-3")})`;
+                        setStripeStyle({
+                          fontSize: "16px",
+                          fontFamily: inputStyle.fontFamily,
+                          color: inputStyle.color,
+                          iconColor: placeholderColor,
+                          "::placeholder": { color: placeholderColor },
+                        });
+                      }}
+                    />
+                  ) : null}
+                  <CardElement
+                    options={{
+                      style: { base: stripeStyle ?? {} },
+                      hideIcon: true,
+                      hidePostalCode: true,
+                      disabled: isFormDisabled || isSubmitting,
+                    }}
+                  />
+                </div>
+              </InputGroup>
+            </Fieldset>
+            {!isFormDisabled ? (
+              <div className="flex gap-4">
+                <Button onClick={handleSubmit} disabled={isSubmitting || !zipCode}>
+                  {isSubmitting ? "Saving..." : savedCard ? "Update card" : "Save card"}
+                </Button>
+                {savedCard ? (
+                  <Button outline onClick={() => setIsEditing(false)} disabled={isSubmitting}>
+                    Cancel
+                  </Button>
+                ) : null}
+              </div>
+            ) : null}
+          </>
+        )}
+      </div>
+      {confirmingRemove ? (
+        <Modal
+          open
+          onClose={() => setConfirmingRemove(false)}
+          title="Remove refund payment method?"
+          footer={
+            <>
+              <Button onClick={() => setConfirmingRemove(false)} disabled={isSubmitting}>
+                Cancel
+              </Button>
+              <Button
+                color="danger"
+                onClick={() => {
+                  setConfirmingRemove(false);
+                  void handleRemove();
+                }}
+                disabled={isSubmitting}
+              >
+                Remove
+              </Button>
+            </>
+          }
+        >
+          <h4>
+            Are you sure you want to remove your refund payment method? Refunds that exceed your balance will no longer
+            be covered automatically.
+          </h4>
+        </Modal>
+      ) : null}
+    </section>
+  );
+};
+
+export const RefundPaymentMethodSection = ({
+  refundPaymentMethod,
+  isFormDisabled,
+}: {
+  refundPaymentMethod: RefundPaymentMethod;
+  isFormDisabled: boolean;
+}) => (
+  <StripeElementsProvider>
+    <RefundPaymentMethodForm refundPaymentMethod={refundPaymentMethod} isFormDisabled={isFormDisabled} />
+  </StripeElementsProvider>
+);

--- a/app/javascript/pages/Settings/Payments/Show.tsx
+++ b/app/javascript/pages/Settings/Payments/Show.tsx
@@ -27,6 +27,7 @@ import BankAccountSection, {
 import DebitCardSection from "$app/components/Settings/PaymentsPage/DebitCardSection";
 import PayPalConnectSection, { PayPalConnect } from "$app/components/Settings/PaymentsPage/PayPalConnectSection";
 import PayPalEmailSection from "$app/components/Settings/PaymentsPage/PayPalEmailSection";
+import { RefundPaymentMethodSection, RefundPaymentMethod } from "$app/components/Settings/PaymentsPage/RefundPaymentMethodSection";
 import StripeConnectSection, { StripeConnect } from "$app/components/Settings/PaymentsPage/StripeConnectSection";
 import { TypeSafeOptionSelect } from "$app/components/TypeSafeOptionSelect";
 import { Alert } from "$app/components/ui/Alert";
@@ -91,6 +92,7 @@ type PaymentsPageProps = {
   payout_country_name: string | null;
   payout_frequency: PayoutFrequency;
   payout_frequency_daily_supported: boolean;
+  refund_payment_method: RefundPaymentMethod;
   errors?: {
     base?: string[];
     error_code?: string[];
@@ -1106,6 +1108,10 @@ export default function PaymentsPage() {
             read_only={props.is_form_disabled}
           />
         ) : null}
+        <RefundPaymentMethodSection
+          refundPaymentMethod={props.refund_payment_method}
+          isFormDisabled={props.is_form_disabled}
+        />
       </form>
     </Layout>
   );

--- a/app/mailers/contacting_creator_mailer.rb
+++ b/app/mailers/contacting_creator_mailer.rb
@@ -525,6 +525,13 @@ class ContactingCreatorMailer < ApplicationMailer
     @subject = "Important: Update Your Payout Method on Gumroad"
   end
 
+  def refund_funding_charge_confirmation(credit_id:)
+    @credit = Credit.find(credit_id)
+    @seller = @credit.user
+    @amount = Money.new(@credit.amount_cents, :usd).format(no_cents_if_whole: true, symbol: true)
+    @subject = "Your backup card was charged #{@amount}"
+  end
+
   def ping_endpoint_failure(user_id, ping_url, response_code)
     @seller = User.find(user_id)
     @ping_url = redact_ping_url(ping_url)

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -14,6 +14,8 @@ class Credit < ApplicationRecord
   belongs_to :financing_paydown_purchase, class_name: "Purchase", optional: true
   belongs_to :fee_retention_refund, class_name: "Refund", optional: true
   belongs_to :backtax_agreement, optional: true
+  belongs_to :refund_funding_purchase, class_name: "Purchase", optional: true
+  belongs_to :credit_card, optional: true
 
   has_one :balance_transaction
 
@@ -24,6 +26,8 @@ class Credit < ApplicationRecord
   validate :validate_associated_entity
 
   attr_json_data_accessor :stripe_loan_paydown_id
+  attr_json_data_accessor :refund_funding_processor_transaction_id
+  attr_json_data_accessor :refund_funding_processor_payment_intent_id
 
   def self.create_for_credit!(user:, amount_cents:, crediting_user:)
     credit = new
@@ -31,6 +35,35 @@ class Credit < ApplicationRecord
     credit.merchant_account = MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id)
     credit.amount_cents = amount_cents
     credit.crediting_user = crediting_user
+    credit.save!
+
+    balance_transaction_amount = BalanceTransaction::Amount.new(
+      currency: Currency::USD,
+      gross_cents: credit.amount_cents,
+      net_cents: credit.amount_cents
+    )
+    balance_transaction = BalanceTransaction.create!(
+      user: credit.user,
+      merchant_account: credit.merchant_account,
+      credit:,
+      issued_amount: balance_transaction_amount,
+      holding_amount: balance_transaction_amount
+    )
+
+    credit.balance = balance_transaction.balance
+    credit.save!
+    credit
+  end
+
+  def self.create_for_refund_funding!(user:, amount_cents:, purchase:, credit_card:, processor_transaction_id:, processor_payment_intent_id:)
+    credit = new
+    credit.user = user
+    credit.merchant_account = MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id)
+    credit.amount_cents = amount_cents
+    credit.refund_funding_purchase = purchase
+    credit.credit_card = credit_card
+    credit.refund_funding_processor_transaction_id = processor_transaction_id
+    credit.refund_funding_processor_payment_intent_id = processor_payment_intent_id
     credit.save!
 
     balance_transaction_amount = BalanceTransaction::Amount.new(
@@ -433,14 +466,17 @@ class Credit < ApplicationRecord
       comment_attrs[:content] = "issued adjustment due to currency conversion differences when payment #{returned_payment.id} returned."
     elsif refund
       comment_attrs[:author_name] = "AutoCredit PayPal Connect VAT refund (#{refund.purchase.id})"
+    elsif refund_funding_purchase
+      comment_attrs[:author_name] = "Refund Funding"
+      comment_attrs[:content] = "credited #{formatted_dollar_amount(amount_cents)} from backup card charge to cover refund."
     end
     user.comments.create(comment_attrs)
   end
 
   private
     def validate_associated_entity
-      return if crediting_user || chargebacked_purchase || returned_payment || refund || financing_paydown_purchase || fee_retention_refund || backtax_agreement
+      return if crediting_user || chargebacked_purchase || returned_payment || refund || financing_paydown_purchase || fee_retention_refund || backtax_agreement || refund_funding_purchase
 
-      errors.add(:base, "A crediting user, chargebacked purchase, returned payment, refund, financing_paydown_purchase, fee_retention_refund or backtax_agreement must be provided.")
+      errors.add(:base, "A crediting user, chargebacked purchase, returned payment, refund, financing_paydown_purchase, fee_retention_refund, backtax_agreement or refund_funding_purchase must be provided.")
     end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,6 +50,7 @@ class User < ApplicationRecord
   has_many :devices
 
   belongs_to :credit_card, optional: true
+  belongs_to :refund_funding_credit_card, class_name: "CreditCard", optional: true
 
   # Associate with CustomDomain.alive objects
   has_one :custom_domain, -> { alive }
@@ -280,6 +281,7 @@ class User < ApplicationRecord
             50 => :paypal_payout_fee_waived,
             51 => :dismissed_create_products_with_ai_promo_alert,
             52 => :disable_affiliate_requests,
+            53 => :dismissed_refund_payment_method_banner,
             :column => "flags",
             :flag_query_mode => :bit_operator,
             check_for_column: false

--- a/app/modules/purchase/refundable.rb
+++ b/app/modules/purchase/refundable.rb
@@ -44,9 +44,31 @@ class Purchase
         end
 
         amount_cents_to_refund = amount_cents.presence || amount_refundable_cents
+        funding_result = nil
         if amount_cents_to_refund > seller.unpaid_balance_cents && charged_using_gumroad_merchant_account?
-          errors.add :base, "Your balance is insufficient to process this refund."
-          return false
+          if seller.refund_funding_credit_card.present?
+            shortfall = amount_cents_to_refund - seller.unpaid_balance_cents
+            charge_amount = [shortfall, RefundFundingChargeService::MINIMUM_CHARGE_CENTS].max
+            funding_result = RefundFundingChargeService.new(
+              user: seller,
+              amount_cents: charge_amount,
+              purchase: self
+            ).perform
+
+            if !funding_result.success?
+              errors.add :base, funding_result.error_message || "Could not charge your backup card to cover the refund shortfall."
+              return false
+            end
+
+            if amount_cents_to_refund > seller.reload.unpaid_balance_cents
+              RefundFundingChargeService.reverse_charge!(payment_intent_id: funding_result.payment_intent_id) if funding_result.payment_intent_id
+              errors.add :base, "Your balance is insufficient to process this refund."
+              return false
+            end
+          else
+            errors.add :base, "Your balance is insufficient to process this refund."
+            return false
+          end
         end
       end
 
@@ -94,19 +116,27 @@ class Purchase
         if charge_refund.flow_of_funds.nil? && StripeChargeProcessor.charge_processor_id != charge_processor_id
           charge_refund.flow_of_funds = FlowOfFunds.build_simple_flow_of_funds(Currency::USD, -(gross_amount_cents.presence || gross_amount_refundable_cents))
         end
-        refund_purchase!(charge_refund.flow_of_funds, refunding_user_id, charge_refund.refund, is_for_fraud)
+        refund_purchase!(charge_refund.flow_of_funds, refunding_user_id, charge_refund.refund, is_for_fraud).tap do
+          if funding_result&.credit.present?
+            ContactingCreatorMailer.refund_funding_charge_confirmation(credit_id: funding_result.credit.id).deliver_later
+          end
+        end
       rescue ChargeProcessorAlreadyRefundedError => e
         logger.error "Charge was already refunded in purchase: #{external_id}. Response: #{e.message}"
+        RefundFundingChargeService.reverse_charge!(payment_intent_id: funding_result.payment_intent_id) if funding_result&.success? && funding_result.payment_intent_id
         false
       rescue ChargeProcessorInsufficientFundsError => e
         logger.error "Creator's PayPal account does not have sufficient funds to refund purchase: #{external_id}. Response: #{e.message}"
+        RefundFundingChargeService.reverse_charge!(payment_intent_id: funding_result.payment_intent_id) if funding_result&.success? && funding_result.payment_intent_id
         errors.add :base, "Your PayPal account does not have sufficient funds to make this refund."
         false
       rescue ChargeProcessorInvalidRequestError => e
         logger.error "Charge refund encountered an invalid request error in purchase: #{external_id}. Response: #{e.message}. #{e.backtrace_locations}"
+        RefundFundingChargeService.reverse_charge!(payment_intent_id: funding_result.payment_intent_id) if funding_result&.success? && funding_result.payment_intent_id
         false
       rescue ChargeProcessorUnavailableError => e
         logger.error "Charge processor unavailable in purchase: #{external_id}. Response: #{e.message}"
+        RefundFundingChargeService.reverse_charge!(payment_intent_id: funding_result.payment_intent_id) if funding_result&.success? && funding_result.payment_intent_id
         errors.add :base, "There is a temporary problem. Try to refund later."
         false
       end

--- a/app/policies/settings/refund_funding/user_policy.rb
+++ b/app/policies/settings/refund_funding/user_policy.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Settings::RefundFunding::UserPolicy < ApplicationPolicy
+  def show?
+    user.role_admin_for?(seller)
+  end
+
+  def create?
+    user.role_owner_for?(seller) && record == seller
+  end
+
+  def destroy?
+    create?
+  end
+
+  def dismiss_banner?
+    create?
+  end
+end

--- a/app/presenters/customers_presenter.rb
+++ b/app/presenters/customers_presenter.rb
@@ -30,6 +30,7 @@ class CustomersPresenter
       countries: Compliance::Countries.for_select.map(&:last),
       can_ping: pundit_user.seller.urls_for_ping_notification(ResourceSubscription::SALE_RESOURCE_NAME).size > 0,
       show_refund_fee_notice: pundit_user.seller.show_refund_fee_notice?,
+      show_refund_payment_method_banner: !pundit_user.seller.dismissed_refund_payment_method_banner? && pundit_user.seller.refund_funding_credit_card.blank?,
     }
   end
 end

--- a/app/presenters/settings_presenter.rb
+++ b/app/presenters/settings_presenter.rb
@@ -222,6 +222,20 @@ class SettingsPresenter
       payout_country_name: Compliance::Countries.for_select.to_h[seller.alive_user_compliance_info&.legal_entity_country_code],
       payout_frequency: seller.payout_frequency,
       payout_frequency_daily_supported: seller.instant_payouts_supported?,
+      refund_payment_method: refund_payment_method_data,
+    }
+  end
+
+  def refund_payment_method_data
+    funding_card = seller.refund_funding_credit_card
+    {
+      enabled: funding_card.present?,
+      credit_card: funding_card.present? ? {
+        visual: funding_card.visual,
+        card_type: funding_card.card_type,
+        expiry_month: funding_card.expiry_month,
+        expiry_year: funding_card.expiry_year
+      } : nil
     }
   end
 

--- a/app/services/refund_funding_charge_service.rb
+++ b/app/services/refund_funding_charge_service.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+class RefundFundingChargeService
+  include CurrencyHelper
+
+  MINIMUM_CHARGE_CENTS = 100
+  MAXIMUM_CHARGE_CENTS = 1_000_000
+
+  Result = Struct.new(:success?, :credit, :error_message, :payment_intent_id, keyword_init: true)
+
+  def initialize(user:, amount_cents:, purchase:)
+    @user = user
+    @amount_cents = amount_cents
+    @purchase = purchase
+    @credit_card = user.refund_funding_credit_card
+  end
+
+  def perform
+    return error("No backup payment method configured.") if credit_card.blank?
+    return error("Amount must be at least #{formatted_dollar_amount(MINIMUM_CHARGE_CENTS)}.") if amount_cents < MINIMUM_CHARGE_CENTS
+    return error("Amount cannot exceed #{formatted_dollar_amount(MAXIMUM_CHARGE_CENTS)}.") if amount_cents > MAXIMUM_CHARGE_CENTS
+
+    charge_result = charge_credit_card
+    return error(charge_result[:error]) if charge_result[:error].present?
+
+    credit = create_credit(charge_result)
+
+    Result.new(success?: true, credit:, payment_intent_id: charge_result[:payment_intent_id])
+  rescue StandardError => e
+    Bugsnag.notify(e)
+    Rails.logger.error("RefundFundingChargeService error: #{e.message}")
+    error("An unexpected error occurred while processing your backup card charge.")
+  end
+
+  def self.reverse_charge!(payment_intent_id:)
+    Stripe::Refund.create({ payment_intent: payment_intent_id })
+  rescue Stripe::StripeError => e
+    Bugsnag.notify(e)
+    Rails.logger.error("Failed to reverse refund funding charge #{payment_intent_id}: #{e.message}")
+  end
+
+  private
+
+  attr_reader :user, :amount_cents, :purchase, :credit_card
+
+  def charge_credit_card
+    payment_intent = Stripe::PaymentIntent.create(
+      {
+        amount: amount_cents,
+        currency: Currency::USD,
+        customer: credit_card.stripe_customer_id,
+        payment_method: credit_card.processor_payment_method_id,
+        off_session: true,
+        confirm: true,
+        description: "Gumroad refund funding charge",
+        metadata: {
+          user_id: user.id,
+          user_email: user.email,
+          purchase_id: purchase.id,
+          type: "refund_funding"
+        }
+      },
+      { idempotency_key: "refund_funding_#{user.id}_#{purchase.id}" }
+    )
+
+    if payment_intent.status == "succeeded"
+      {
+        success: true,
+        payment_intent_id: payment_intent.id,
+        charge_id: payment_intent.latest_charge
+      }
+    elsif payment_intent.status == "requires_action"
+      { success: false, error: "Your backup card requires additional authentication (3D Secure) and cannot be charged automatically. Please update your backup payment method with a card that does not require 3D Secure verification." }
+    else
+      { success: false, error: "Payment was not successful. Please try again or update your backup payment method." }
+    end
+  rescue Stripe::CardError => e
+    { success: false, error: e.message }
+  rescue Stripe::InvalidRequestError => e
+    Bugsnag.notify(e)
+    { success: false, error: "Invalid payment request." }
+  rescue Stripe::StripeError => e
+    Bugsnag.notify(e)
+    { success: false, error: "Payment processor error. Please try again." }
+  end
+
+  def create_credit(charge_result)
+    Credit.create_for_refund_funding!(
+      user:,
+      amount_cents:,
+      purchase:,
+      credit_card:,
+      processor_transaction_id: charge_result[:charge_id],
+      processor_payment_intent_id: charge_result[:payment_intent_id]
+    )
+  end
+
+  def error(message)
+    Result.new(success?: false, error_message: message)
+  end
+end

--- a/app/views/contacting_creator_mailer/refund_funding_charge_confirmation.html.erb
+++ b/app/views/contacting_creator_mailer/refund_funding_charge_confirmation.html.erb
@@ -1,0 +1,10 @@
+<% card_visual = @credit.credit_card&.visual || "****" %>
+<% product_name = @credit.refund_funding_purchase&.link&.name %>
+<%= header_section("Your backup card was charged #{@amount}") %>
+<div>
+  <p>Hi <%= @seller.display_name.presence || "there" %>,</p>
+  <p>We successfully charged your backup payment method (ending in <%= card_visual %>) for <strong><%= @amount %></strong> to cover a refund<%= product_name.present? ? " for #{product_name}" : "" %>.</p>
+  <p>This amount has been added to your Gumroad balance and the refund has been processed for your customer.</p>
+  <p>You can manage your backup payment method in your <%= link_to "Payments Settings", settings_payments_url %>.</p>
+  <p>Best,<br />The Gumroad Team</p>
+</div>

--- a/app/views/contacting_creator_mailer/refund_funding_charge_confirmation.text.erb
+++ b/app/views/contacting_creator_mailer/refund_funding_charge_confirmation.text.erb
@@ -1,0 +1,14 @@
+<% card_visual = @credit.credit_card&.visual || "****" %>
+<% product_name = @credit.refund_funding_purchase&.link&.name %>
+Your backup card was charged <%= @amount %>
+
+Hi <%= @seller.display_name.presence || "there" %>,
+
+We successfully charged your backup payment method (ending in <%= card_visual %>) for <%= @amount %> to cover a refund<%= product_name.present? ? " for #{product_name}" : "" %>.
+
+This amount has been added to your Gumroad balance and the refund has been processed for your customer.
+
+You can manage your backup payment method in your Payments Settings: <%= settings_payments_url %>
+
+Best,
+The Gumroad Team

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -472,6 +472,9 @@ Rails.application.routes.draw do
         end
       end
       resource :dismiss_ai_product_generation_promo, only: [:create]
+      resource :refund_funding, only: %i[show create destroy], controller: "refund_funding" do
+        post :dismiss_banner
+      end
     end
 
     resources :stripe_account_sessions, only: :create

--- a/db/migrate/20260211000001_add_refund_funding_credit_card_to_users.rb
+++ b/db/migrate/20260211000001_add_refund_funding_credit_card_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRefundFundingCreditCardToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :users, :refund_funding_credit_card, type: :integer, index: true
+  end
+end

--- a/db/migrate/20260211000002_add_refund_funding_to_credits.rb
+++ b/db/migrate/20260211000002_add_refund_funding_to_credits.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddRefundFundingToCredits < ActiveRecord::Migration[7.1]
+  def change
+    add_column :credits, :refund_funding_purchase_id, :bigint
+    add_column :credits, :credit_card_id, :bigint
+    add_index :credits, :refund_funding_purchase_id, unique: true
+    add_index :credits, :credit_card_id
+  end
+end

--- a/spec/controllers/settings/refund_funding_controller_spec.rb
+++ b/spec/controllers/settings/refund_funding_controller_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "shared_examples/authentication_required"
+
+describe Settings::RefundFundingController, :vcr do
+  let(:seller) { create(:user) }
+  let(:credit_card) { create(:credit_card, user: seller) }
+
+  before { sign_in seller }
+
+  describe "GET #show" do
+    it_behaves_like "authentication required for action", :get, :show
+
+    context "when no funding card is configured" do
+      it "returns enabled as false" do
+        get :show, format: :json
+
+        expect(response).to be_successful
+        json = JSON.parse(response.body)
+        expect(json["enabled"]).to be false
+        expect(json["credit_card"]).to be_nil
+      end
+    end
+
+    context "when funding card is configured" do
+      before { seller.update!(refund_funding_credit_card: credit_card) }
+
+      it "returns enabled as true with card details" do
+        get :show, format: :json
+
+        expect(response).to be_successful
+        json = JSON.parse(response.body)
+        expect(json["enabled"]).to be true
+        expect(json["credit_card"]["visual"]).to be_present
+      end
+    end
+  end
+
+  describe "POST #create" do
+    it_behaves_like "authentication required for action", :post, :create
+
+    context "when chargeable cannot be built" do
+      before do
+        allow(CardParamsHelper).to receive(:get_card_data_handling_mode).and_return("stripejs.0")
+        allow(CardParamsHelper).to receive(:check_for_errors).and_return(nil)
+        allow(CardParamsHelper).to receive(:build_chargeable).and_return(nil)
+      end
+
+      it "returns an error" do
+        post :create, params: { stripe_payment_method_id: "pm_test", card_data_handling_mode: "stripejs.0" }, format: :json
+
+        expect(response).to have_http_status(:unprocessable_content)
+        json = JSON.parse(response.body)
+        expect(json["success"]).to be false
+        expect(json["error"]).to eq("Invalid card information")
+      end
+    end
+
+    context "when chargeable is valid" do
+      let(:chargeable) { build(:chargeable) }
+
+      before do
+        allow(CardParamsHelper).to receive(:get_card_data_handling_mode).and_return("stripejs.0")
+        allow(CardParamsHelper).to receive(:check_for_errors).and_return(nil)
+        allow(CardParamsHelper).to receive(:build_chargeable).and_return(chargeable)
+      end
+
+      it "creates the card and associates it with the seller" do
+        expect {
+          post :create, params: { stripe_payment_method_id: "pm_test", card_data_handling_mode: "stripejs.0" }, format: :json
+        }.to change(CreditCard, :count).by(1)
+
+        expect(response).to be_successful
+        json = JSON.parse(response.body)
+        expect(json["success"]).to be true
+        expect(json["enabled"]).to be true
+        expect(json["credit_card"]).to be_present
+        expect(seller.reload.refund_funding_credit_card).to be_present
+      end
+    end
+  end
+
+  describe "DELETE #destroy" do
+    it_behaves_like "authentication required for action", :delete, :destroy
+
+    context "when funding card exists" do
+      before { seller.update!(refund_funding_credit_card: credit_card) }
+
+      it "removes the funding card association and resets the banner flag" do
+        seller.update!(dismissed_refund_payment_method_banner: true)
+
+        delete :destroy, format: :json
+
+        expect(response).to be_successful
+        json = JSON.parse(response.body)
+        expect(json["success"]).to be true
+        expect(json["enabled"]).to be false
+        expect(json["credit_card"]).to be_nil
+        expect(seller.reload.refund_funding_credit_card).to be_nil
+        expect(seller.reload.dismissed_refund_payment_method_banner?).to be false
+      end
+    end
+
+    context "when no funding card exists" do
+      it "still returns success" do
+        delete :destroy, format: :json
+
+        expect(response).to be_successful
+        json = JSON.parse(response.body)
+        expect(json["success"]).to be true
+        expect(json["enabled"]).to be false
+      end
+    end
+  end
+
+  describe "POST #dismiss_banner" do
+    it "dismisses the banner" do
+      expect(seller.dismissed_refund_payment_method_banner?).to be false
+
+      post :dismiss_banner, format: :json
+
+      expect(response).to be_successful
+      expect(seller.reload.dismissed_refund_payment_method_banner?).to be true
+    end
+
+    context "when banner is already dismissed" do
+      before { seller.update!(dismissed_refund_payment_method_banner: true) }
+
+      it "still returns success" do
+        post :dismiss_banner, format: :json
+
+        expect(response).to be_successful
+        expect(seller.reload.dismissed_refund_payment_method_banner?).to be true
+      end
+    end
+  end
+end

--- a/spec/models/purchase/refund_with_backup_card_spec.rb
+++ b/spec/models/purchase/refund_with_backup_card_spec.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Refund with backup card", :vcr, type: :model do
+  let(:seller) { create(:user) }
+  let(:buyer) { create(:user) }
+  let(:product) { create(:product, user: seller) }
+  let(:credit_card) { create(:credit_card, user: seller) }
+  let(:purchase) do
+    create(:purchase_in_progress,
+           link: product,
+           seller:,
+           purchaser: buyer,
+           price_cents: 2000,
+           total_transaction_cents: 2000).tap do |p|
+      p.update_columns(succeeded_at: 1.day.ago, purchase_state: "successful")
+    end
+  end
+
+  def build_charge_refund_mock(amount_cents)
+    flow_of_funds = FlowOfFunds.new(
+      issued_amount: FlowOfFunds::Amount.new(currency: Currency::USD, cents: -amount_cents),
+      settled_amount: FlowOfFunds::Amount.new(currency: Currency::USD, cents: -amount_cents),
+      gumroad_amount: FlowOfFunds::Amount.new(currency: Currency::USD, cents: 0),
+      merchant_account_gross_amount: FlowOfFunds::Amount.new(currency: Currency::USD, cents: -amount_cents),
+      merchant_account_net_amount: FlowOfFunds::Amount.new(currency: Currency::USD, cents: -amount_cents)
+    )
+    stripe_refund = double("StripeRefund", id: "re_test_123", status: "succeeded")
+    double("ChargeRefund", id: "re_test_123", flow_of_funds:, status: "succeeded", refund: stripe_refund)
+  end
+
+  let(:payment_intent_double) do
+    Struct.new(:status, :id, :latest_charge, keyword_init: true).new(
+      status: "succeeded",
+      id: "pi_test_123",
+      latest_charge: "ch_test_123"
+    )
+  end
+
+  before do
+    MerchantAccount.find_or_create_by!(user_id: nil, charge_processor_id: StripeChargeProcessor.charge_processor_id)
+    allow(purchase).to receive(:charged_using_gumroad_merchant_account?).and_return(true)
+    create(:balance, user: seller, amount_cents: 500, merchant_account: MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id))
+  end
+
+  context "when seller has no backup payment method" do
+    it "fails with insufficient balance error" do
+      result = purchase.refund_and_save!(nil)
+
+      expect(result).to be false
+      expect(purchase.errors[:base]).to include("Your balance is insufficient to process this refund.")
+    end
+  end
+
+  context "when seller has a backup payment method" do
+    before do
+      seller.update!(refund_funding_credit_card: credit_card)
+    end
+
+    context "when backup card charge succeeds and refund completes" do
+      before do
+        allow(Stripe::PaymentIntent).to receive(:create).and_return(payment_intent_double)
+        allow(ChargeProcessor).to receive(:refund!).and_return(build_charge_refund_mock(2000))
+      end
+
+      it "charges the backup card for the shortfall, creates a credit, and processes the refund" do
+        expect {
+          purchase.refund_and_save!(nil)
+        }.to change { Credit.where.not(refund_funding_purchase_id: nil).count }.by(1)
+
+        credit = Credit.find_by(refund_funding_purchase: purchase)
+        expect(credit.amount_cents).to eq(1500) # 2000 - 500 = 1500 shortfall
+        expect(credit.refund_funding_purchase).to eq(purchase)
+        expect(credit.credit_card).to eq(credit_card)
+        expect(credit.refund_funding_processor_transaction_id).to eq("ch_test_123")
+        expect(credit.refund_funding_processor_payment_intent_id).to eq("pi_test_123")
+      end
+
+      it "sends a confirmation email" do
+        expect {
+          purchase.refund_and_save!(nil)
+        }.to have_enqueued_job.on_queue("default").with("ContactingCreatorMailer", "refund_funding_charge_confirmation", "deliver_now", a_hash_including(credit_id: kind_of(Integer)))
+      end
+    end
+
+    context "when shortfall is less than minimum charge" do
+      before do
+        create(:balance, user: seller, amount_cents: 1450, merchant_account: MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id))
+        allow(Stripe::PaymentIntent).to receive(:create).and_return(payment_intent_double)
+        allow(ChargeProcessor).to receive(:refund!).and_return(build_charge_refund_mock(2000))
+      end
+
+      it "charges the minimum amount of $1.00" do
+        purchase.refund_and_save!(nil)
+
+        credit = Credit.find_by(refund_funding_purchase: purchase)
+        expect(credit.amount_cents).to eq(100)
+      end
+    end
+
+    context "when backup card charge fails" do
+      before do
+        allow(Stripe::PaymentIntent).to receive(:create).and_raise(
+          Stripe::CardError.new("Card declined", nil, code: "card_declined")
+        )
+      end
+
+      it "fails the refund without processing" do
+        expect(ChargeProcessor).not_to receive(:refund!)
+        expect { purchase.refund_and_save!(nil) }.not_to change(Credit, :count)
+
+        expect(purchase.errors[:base].first).to include("Card declined")
+      end
+    end
+
+    context "when ChargeProcessor.refund! fails after backup card charge succeeds" do
+      before do
+        allow(Stripe::PaymentIntent).to receive(:create).and_return(payment_intent_double)
+        allow(ChargeProcessor).to receive(:refund!).and_raise(
+          ChargeProcessorUnavailableError.new("Stripe unavailable")
+        )
+      end
+
+      it "reverses the backup card charge" do
+        expect(RefundFundingChargeService).to receive(:reverse_charge!).with(payment_intent_id: "pi_test_123")
+
+        purchase.refund_and_save!(nil)
+      end
+    end
+
+    context "when balance re-check fails after backup card charge (concurrent refund)" do
+      before do
+        allow(Stripe::PaymentIntent).to receive(:create).and_return(payment_intent_double)
+        # Simulate a concurrent refund draining the balance between charge and check
+        allow(seller).to receive(:reload).and_return(seller)
+        allow(seller).to receive(:unpaid_balance_cents).and_return(500, 0)
+      end
+
+      it "reverses the backup card charge and returns insufficient balance error" do
+        expect(RefundFundingChargeService).to receive(:reverse_charge!).with(payment_intent_id: "pi_test_123")
+
+        result = purchase.refund_and_save!(nil)
+        expect(result).to be false
+        expect(purchase.errors[:base]).to include("Your balance is insufficient to process this refund.")
+      end
+    end
+  end
+end

--- a/spec/presenters/settings_presenter_spec.rb
+++ b/spec/presenters/settings_presenter_spec.rb
@@ -574,6 +574,10 @@ describe SettingsPresenter do
         payout_country_name: nil,
         payout_frequency: User::PayoutSchedule::WEEKLY,
         payout_frequency_daily_supported: false,
+        refund_payment_method: {
+          enabled: false,
+          credit_card: nil
+        },
       }
     end
 

--- a/spec/services/refund_funding_charge_service_spec.rb
+++ b/spec/services/refund_funding_charge_service_spec.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe RefundFundingChargeService, :vcr do
+  let(:seller) { create(:user) }
+  let(:credit_card) { create(:credit_card, user: seller) }
+  let(:product) { create(:product, user: seller) }
+  let(:purchase) do
+    create(:purchase_in_progress,
+           link: product,
+           seller:,
+           price_cents: 2000,
+           total_transaction_cents: 2000).tap do |p|
+      p.update_columns(succeeded_at: 1.day.ago, purchase_state: "successful")
+    end
+  end
+
+  before do
+    MerchantAccount.find_or_create_by!(user_id: nil, charge_processor_id: StripeChargeProcessor.charge_processor_id)
+    seller.update!(refund_funding_credit_card: credit_card)
+  end
+
+  describe "#perform" do
+    subject(:result) { described_class.new(user: seller, amount_cents:, purchase:).perform }
+
+    let(:amount_cents) { 1500 }
+
+    context "when credit card is not configured" do
+      before { seller.update!(refund_funding_credit_card: nil) }
+
+      it "returns an error" do
+        expect(result.success?).to be false
+        expect(result.error_message).to eq("No backup payment method configured.")
+      end
+    end
+
+    context "when amount is below minimum" do
+      let(:amount_cents) { 50 }
+
+      it "returns an error" do
+        expect(result.success?).to be false
+        expect(result.error_message).to include("at least")
+      end
+    end
+
+    context "when amount exceeds maximum" do
+      let(:amount_cents) { 1_500_000 }
+
+      it "returns an error" do
+        expect(result.success?).to be false
+        expect(result.error_message).to include("cannot exceed")
+      end
+    end
+
+    context "when Stripe charge succeeds" do
+      let(:payment_intent_double) do
+        Struct.new(:status, :id, :latest_charge, keyword_init: true).new(
+          status: "succeeded",
+          id: "pi_test_123",
+          latest_charge: "ch_test_123"
+        )
+      end
+
+      before do
+        allow(Stripe::PaymentIntent).to receive(:create).and_return(payment_intent_double)
+      end
+
+      it "returns success with credit and calls Stripe correctly" do
+        expect(Stripe::PaymentIntent).to receive(:create).with(
+          hash_including(
+            amount: 1500,
+            currency: Currency::USD,
+            customer: credit_card.stripe_customer_id,
+            payment_method: credit_card.processor_payment_method_id,
+            off_session: true,
+            confirm: true
+          ),
+          hash_including(:idempotency_key)
+        ).and_return(payment_intent_double)
+
+        expect { result }.to change(Credit, :count).by(1)
+          .and change(BalanceTransaction, :count).by(1)
+
+        expect(result.success?).to be true
+        expect(result.error_message).to be_nil
+        expect(result.payment_intent_id).to eq("pi_test_123")
+
+        credit = result.credit
+        expect(credit.user).to eq(seller)
+        expect(credit.amount_cents).to eq(1500)
+        expect(credit.refund_funding_purchase).to eq(purchase)
+        expect(credit.credit_card).to eq(credit_card)
+        expect(credit.refund_funding_processor_transaction_id).to eq("ch_test_123")
+        expect(credit.refund_funding_processor_payment_intent_id).to eq("pi_test_123")
+        expect(credit.balance).to be_present
+      end
+    end
+
+    context "when Stripe charge fails with card error" do
+      before do
+        allow(Stripe::PaymentIntent).to receive(:create).and_raise(
+          Stripe::CardError.new("Your card was declined.", nil, code: "card_declined")
+        )
+      end
+
+      it "returns failure without creating a credit" do
+        expect { result }.not_to change(Credit, :count)
+        expect(result.success?).to be false
+        expect(result.error_message).to eq("Your card was declined.")
+      end
+    end
+
+    context "when Stripe returns invalid request error" do
+      before do
+        allow(Stripe::PaymentIntent).to receive(:create).and_raise(
+          Stripe::InvalidRequestError.new("Invalid customer", nil)
+        )
+      end
+
+      it "returns failure with generic error" do
+        expect(result.success?).to be false
+        expect(result.error_message).to eq("Invalid payment request.")
+      end
+    end
+
+    context "when Stripe returns generic error" do
+      before do
+        allow(Stripe::PaymentIntent).to receive(:create).and_raise(
+          Stripe::StripeError.new("Network timeout")
+        )
+      end
+
+      it "returns failure with payment processor error" do
+        expect(result.success?).to be false
+        expect(result.error_message).to eq("Payment processor error. Please try again.")
+      end
+    end
+
+    context "when payment intent requires 3D Secure" do
+      before do
+        allow(Stripe::PaymentIntent).to receive(:create).and_return(
+          Struct.new(:status, :id, :latest_charge, keyword_init: true).new(
+            status: "requires_action",
+            id: "pi_test_123",
+            latest_charge: nil
+          )
+        )
+      end
+
+      it "returns failure with SCA message and does not create a credit" do
+        expect { result }.not_to change(Credit, :count)
+        expect(result.success?).to be false
+        expect(result.error_message).to include("3D Secure")
+      end
+    end
+  end
+
+  describe ".reverse_charge!" do
+    it "creates a Stripe refund for the payment intent" do
+      expect(Stripe::Refund).to receive(:create).with({ payment_intent: "pi_test_123" })
+
+      described_class.reverse_charge!(payment_intent_id: "pi_test_123")
+    end
+
+    it "logs and reports errors without raising" do
+      allow(Stripe::Refund).to receive(:create).and_raise(Stripe::StripeError.new("Network error"))
+      expect(Bugsnag).to receive(:notify)
+
+      expect { described_class.reverse_charge!(payment_intent_id: "pi_test_123") }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implements the ability for sellers to add a **backup credit card** that automatically covers refunds when their Gumroad balance is insufficient (#1594).

### What this does

- **Settings > Payments**: New "Refund payment method" section where sellers can add, change, or remove a backup credit card via Stripe Elements
- **Customers page**: An accent banner prompting sellers to set up a backup payment method (dismissible, reappears if card is removed)
- **Refund flow**: When a refund would fail due to insufficient balance, the system automatically charges the backup card for the shortfall amount
- **Charge reversal**: If the refund fails *after* the backup card has been charged (due to concurrent refunds, ChargeProcessor errors, or other failures), the charge is **automatically reversed** via `Stripe::Refund.create`
- **Confirmation email**: Seller receives an email confirming the backup card charge (both HTML and text templates)

### Key improvements over prior approaches

1. **Charge reversal on refund failure** — Every rescue path in `refund_and_save!` that can fail after a successful backup card charge now calls `RefundFundingChargeService.reverse_charge!` to refund the Stripe PaymentIntent
2. **Race condition handling** — `seller.reload.unpaid_balance_cents` re-check after charge; if balance was drained by a concurrent refund, the charge is reversed
3. **Unique index** on `credits.refund_funding_purchase_id` prevents duplicate credits for the same purchase
4. **Explicit variable initialization** — Uses `funding_result = nil` instead of fragile `defined?(funding_result)` checks
5. **Both email templates** — HTML and plain text `.text.erb` for email client compatibility
6. **Inertia `Link`** in banner instead of plain `<a href>` for proper SPA navigation
7. **3D Secure handling** — Clear error message when a card requires authentication and cannot be charged off-session

### Files changed (22 files)

**New files (12):**
- Controller, service, policy, migrations, email templates, frontend components, specs

**Modified files (10):**
- `credit.rb` — New `create_for_refund_funding!` factory, associations, validation
- `user.rb` — `refund_funding_credit_card` association, `dismissed_refund_payment_method_banner` flag
- `purchase/refundable.rb` — Backup card charge + reversal logic in `refund_and_save!`
- `contacting_creator_mailer.rb` — New `refund_funding_charge_confirmation` method
- `customers_presenter.rb`, `settings_presenter.rb` — New props
- `CustomersPage.tsx`, `Payments/Show.tsx` — Integrate new components
- `routes.rb` — `refund_funding` resource routes
- `settings_presenter_spec.rb` — Updated expected props

## Test plan

- [ ] Seller can add a backup credit card in Settings > Payments
- [ ] Seller can change or remove the backup card (with confirmation modal)
- [ ] Banner appears on Customers page when no backup card is set
- [ ] Banner can be dismissed and stays dismissed
- [ ] Banner reappears if backup card is removed
- [ ] Refund succeeds when balance is insufficient but backup card is configured
- [ ] Backup card is charged only for the shortfall (not the full refund amount)
- [ ] Confirmation email is sent after successful backup card charge
- [ ] If refund fails after backup card charge, charge is reversed
- [ ] Cards requiring 3D Secure show an appropriate error message
- [ ] Works correctly with concurrent refunds (race condition test)

> **AI Disclosure:** This PR was authored with the assistance of AI (Claude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)