### PR TITLE
chore(inertia): Migrate Subscription Manager page to Inertia

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -7,8 +7,10 @@ class SubscriptionsController < ApplicationController
   before_action :authenticate_user!, except: PUBLIC_ACTIONS
   after_action :verify_authorized, except: PUBLIC_ACTIONS
 
+  layout "inertia", only: [:manage]
+
   before_action :fetch_subscription, only: %i[unsubscribe_by_seller unsubscribe_by_user magic_link send_magic_link]
-  before_action :hide_layouts, only: [:manage, :magic_link, :send_magic_link]
+  before_action :hide_layouts, only: [:magic_link, :send_magic_link]
   before_action :set_noindex_header, only: [:manage]
   before_action :check_can_manage, only: [:manage, :unsubscribe_by_user]
 
@@ -23,22 +25,23 @@ class SubscriptionsController < ApplicationController
 
   def unsubscribe_by_user
     @subscription.cancel!(by_seller: false)
-    render json: { success: true }
+    subscription_entity = @subscription.is_installment_plan ? "installment plan" : "membership"
+    redirect_to manage_subscription_path(@subscription.external_id), notice: "Your #{subscription_entity} has been cancelled."
   rescue ActiveRecord::RecordInvalid => e
-    render json: { success: false, error: e.message }
+    redirect_to manage_subscription_path(@subscription.external_id), alert: e.message
   end
 
   def manage
-    @product = @subscription.link
-    @card = @subscription.credit_card_to_charge
-    @card_data_handling_mode = CardDataHandlingMode.get_card_data_handling_mode(@product.user)
-
+    product = @subscription.link
     @body_id = "product_page"
 
     set_meta_tag(title: @subscription.is_installment_plan ? "Manage installment plan" : "Manage membership")
-    set_product_page_meta(@product)
-
+    set_product_page_meta(product)
     set_subscription_confirmed_redirect_cookie
+
+    render inertia: "Subscriptions/Manage",
+           props: CheckoutPresenter.new(logged_in_user:, ip: request.remote_ip)
+                    .subscription_manager_props(subscription: @subscription)
   end
 
   def magic_link
@@ -74,10 +77,7 @@ class SubscriptionsController < ApplicationController
         return redirect_to magic_link_subscription_path(params[:id], { invalid: true })
       end
 
-      respond_to do |format|
-        format.html { redirect_to magic_link_subscription_path(params[:id]) }
-        format.json { render json: { success: false, redirect_to: magic_link_subscription_path(params[:id]) } }
-      end
+      redirect_to magic_link_subscription_path(params[:id])
     end
 
     def gifter_user

--- a/app/javascript/data/subscription.ts
+++ b/app/javascript/data/subscription.ts
@@ -5,26 +5,7 @@ import {
   StripeErrorParams,
   serializeCardParamsIntoQueryParamsObject,
 } from "$app/data/payment_method_params";
-import { request, ResponseError } from "$app/utils/request";
-
-export const cancelSubscriptionByUser = async (subscriptionId: string): Promise<void> => {
-  const response = await request({
-    url: Routes.unsubscribe_by_user_subscription_path(subscriptionId),
-    method: "POST",
-    accept: "json",
-  });
-  if (response.ok) {
-    const responseData = cast<{ success: boolean; redirect_to?: string }>(await response.json());
-    if (responseData.success) {
-      return;
-    } else if (responseData.redirect_to) {
-      window.location.href = responseData.redirect_to;
-    } else {
-      throw new ResponseError();
-    }
-  }
-  throw new ResponseError();
-};
+import { request } from "$app/utils/request";
 
 export type UpdateSubscriptionPayload = {
   cardParams: AnyPaymentMethodParams | StripeErrorParams | null;

--- a/app/javascript/packs/subscription_edit.ts
+++ b/app/javascript/packs/subscription_edit.ts
@@ -1,8 +1,0 @@
-import ReactOnRails from "react-on-rails";
-
-import BasePage from "$app/utils/base_page";
-
-import SubscriptionManager from "$app/components/server-components/SubscriptionManager";
-
-BasePage.initialize();
-ReactOnRails.register({ SubscriptionManager });

--- a/app/javascript/pages/Subscriptions/Manage.tsx
+++ b/app/javascript/pages/Subscriptions/Manage.tsx
@@ -1,9 +1,10 @@
+import { router, usePage } from "@inertiajs/react";
 import { parseISO } from "date-fns";
 import * as React from "react";
-import { createCast } from "ts-safe-cast";
+import { cast } from "ts-safe-cast";
 
 import { confirmLineItem } from "$app/data/purchase";
-import { cancelSubscriptionByUser, updateSubscription } from "$app/data/subscription";
+import { updateSubscription } from "$app/data/subscription";
 import { SavedCreditCard } from "$app/parsers/card";
 import { Discount } from "$app/parsers/checkout";
 import { CustomFieldDescriptor, ProductNativeType } from "$app/parsers/product";
@@ -16,7 +17,6 @@ import {
 import { asyncVoid } from "$app/utils/promise";
 import { recurrenceLabels, RecurrenceId } from "$app/utils/recurringPricing";
 import { assertResponseError } from "$app/utils/request";
-import { register } from "$app/utils/serverComponentUtil";
 
 import { Button } from "$app/components/Button";
 import { Creator } from "$app/components/Checkout/cartState";
@@ -40,7 +40,7 @@ import { Alert } from "$app/components/ui/Alert";
 import { Card, CardContent } from "$app/components/ui/Card";
 import { useOriginalLocation } from "$app/components/useOriginalLocation";
 
-import { useOnChangeSync } from "../useOnChange";
+import { useOnChangeSync } from "$app/components/useOnChange";
 
 type Props = {
   product: {
@@ -98,22 +98,23 @@ type Props = {
   paypal_client_id: string;
 };
 
-const SubscriptionManager = ({
-  product,
-  subscription,
-  recaptcha_key,
-  paypal_client_id,
-  contact_info,
-  countries,
-  us_states,
-  ca_provinces,
-  used_card,
-}: Props) => {
+const SubscriptionsManage = () => {
+  const {
+    product,
+    subscription,
+    recaptcha_key,
+    paypal_client_id,
+    contact_info,
+    countries,
+    us_states,
+    ca_provinces,
+    used_card,
+  } = cast<Props>(usePage().props);
+
   const url = new URL(useOriginalLocation());
 
   const subscriptionEntity = subscription.is_installment_plan ? "installment plan" : "membership";
   const restartable = !subscription.alive || subscription.pending_cancellation;
-  const [cancelled, setCancelled] = React.useState(restartable);
   const initialSelection = {
     recurrence: subscription.recurrence,
     rent: false,
@@ -196,7 +197,7 @@ const SubscriptionManager = ({
     price: Math.round(amountDueToday / product.exchange_rate),
     payInInstallments: subscription.is_installment_plan,
     requireShipping: product.require_shipping,
-    customFields: [], // Custom fields were already collected during original purchase
+    customFields: [],
     bundleProductCustomFields: [],
     supportsPaypal: product.supports_paypal,
     testPurchase: subscription.is_test,
@@ -209,7 +210,7 @@ const SubscriptionManager = ({
     nativeType: product.native_type,
     canGift: false,
   };
-  const payLabel = cancelled ? `Restart ${subscriptionEntity}` : `Update ${subscriptionEntity}`;
+  const payLabel = restartable ? `Restart ${subscriptionEntity}` : `Update ${subscriptionEntity}`;
   const { require_email_typo_acknowledgment } = useFeatureFlags();
   const reducer = createReducer({
     country: contact_info.country,
@@ -268,10 +269,10 @@ const SubscriptionManager = ({
     });
     if (result.type === "done") {
       showAlert(result.message, "success");
-      setCancelled(false);
-      setCancellationStatus("initial");
       if (result.next != null) {
-        window.location.href = result.next;
+        router.get(result.next);
+      } else {
+        router.reload();
       }
     } else if (result.type === "requires_card_action") {
       await confirmLineItem({
@@ -282,8 +283,7 @@ const SubscriptionManager = ({
       }).then((itemResult) => {
         if (itemResult.success) {
           showAlert(`Your ${subscriptionEntity} has been updated.`, "success");
-          setCancelled(false);
-          setCancellationStatus("initial");
+          router.reload();
         }
       });
     } else {
@@ -293,24 +293,25 @@ const SubscriptionManager = ({
   }
   React.useEffect(() => void pay(), [state.status]);
 
-  // show (the Stripe Payment Request method that triggers the Apple Pay
-  // modal) can't be called in asynchronous code, so we have to use a
-  // synchronous layout effect.
   useOnChangeSync(() => {
     if (state.status.type === "offering") dispatchAction({ type: "validate" });
   }, [state.status.type]);
 
-  const [cancellationStatus, setCancellationStatus] = React.useState<"initial" | "processing" | "done">("initial");
+  const [cancelling, setCancelling] = React.useState(false);
   const handleCancel = asyncVoid(async () => {
-    if (cancellationStatus === "processing" || cancellationStatus === "done") return;
-    setCancellationStatus("processing");
+    if (cancelling) return;
+    setCancelling(true);
     try {
-      await cancelSubscriptionByUser(subscription.id);
-      setCancellationStatus("done");
-      setCancelled(true);
+      router.post(Routes.unsubscribe_by_user_subscription_path(subscription.id), {}, {
+        preserveScroll: true,
+        onError: () => {
+          setCancelling(false);
+          showAlert("Sorry, something went wrong.", "error");
+        },
+      });
     } catch (e) {
       assertResponseError(e);
-      setCancellationStatus("initial");
+      setCancelling(false);
       showAlert("Sorry, something went wrong.", "error");
     }
   });
@@ -379,10 +380,10 @@ const SubscriptionManager = ({
             color="danger"
             outline
             onClick={handleCancel}
-            disabled={cancellationStatus === "processing" || cancellationStatus === "done"}
+            disabled={cancelling}
             className="grow basis-0"
           >
-            {cancellationStatus === "done" ? "Cancelled" : `Cancel ${subscriptionEntity}`}
+            {`Cancel ${subscriptionEntity}`}
           </Button>
         </CardContent>
       ) : null}
@@ -390,4 +391,6 @@ const SubscriptionManager = ({
   );
 };
 
-export default register({ component: SubscriptionManager, propParser: createCast() });
+export default SubscriptionsManage;
+
+SubscriptionsManage.publicLayout = true;

--- a/app/javascript/ssr.ts
+++ b/app/javascript/ssr.ts
@@ -20,7 +20,6 @@ import ProductEditPage from "$app/components/server-components/ProductEditPage";
 import Profile from "$app/components/server-components/Profile";
 import ProfileProductPage from "$app/components/server-components/Profile/ProductPage";
 import SubscribePage from "$app/components/server-components/SubscribePage";
-import SubscriptionManager from "$app/components/server-components/SubscriptionManager";
 import SubscriptionManagerMagicLink from "$app/components/server-components/SubscriptionManagerMagicLink";
 import SupportHeader from "$app/components/server-components/support/Header";
 import TaxesCollectionModal from "$app/components/server-components/TaxesCollectionModal";
@@ -49,7 +48,6 @@ ReactOnRails.register({
   Profile,
   ProfileProductPage,
   SubscribePage,
-  SubscriptionManager,
   SubscriptionManagerMagicLink,
   TaxesCollectionModal,
   VideoStreamPlayer,

--- a/app/views/subscriptions/manage.html.erb
+++ b/app/views/subscriptions/manage.html.erb
@@ -1,4 +1,0 @@
-<%= render("shared/recaptcha_script") %>
-<%= load_pack("subscription_edit") %>
-
-<%= react_component "SubscriptionManager", props: CheckoutPresenter.new(logged_in_user: logged_in_user, ip: request.remote_ip).subscription_manager_props(subscription: @subscription), prerender: true %>

--- a/spec/controllers/subscriptions_controller_spec.rb
+++ b/spec/controllers/subscriptions_controller_spec.rb
@@ -2,8 +2,9 @@
 
 require "spec_helper"
 require "shared_examples/authorize_called"
+require "inertia_rails/rspec"
 
-describe SubscriptionsController do
+describe SubscriptionsController, inertia: true do
   let(:seller) { create(:named_seller) }
   let(:subscriber) { create(:user) }
 
@@ -66,9 +67,10 @@ describe SubscriptionsController do
         post :unsubscribe_by_user, params: { id: @subscription.external_id }
       end
 
-      it "returns json success" do
+      it "redirects back with success notice" do
         post :unsubscribe_by_user, params: { id: @subscription.external_id }
-        expect(response.parsed_body["success"]).to be(true)
+        expect(response).to redirect_to(manage_subscription_path(@subscription.external_id))
+        expect(flash[:notice]).to eq("Your membership has been cancelled.")
       end
 
       it "is not allowed for installment plans" do
@@ -79,8 +81,8 @@ describe SubscriptionsController do
 
         post :unsubscribe_by_user, params: { id: subscription.external_id }
 
-        expect(response.parsed_body["success"]).to be(false)
-        expect(response.parsed_body["error"]).to include("Installment plans cannot be cancelled by the customer")
+        expect(response).to redirect_to(manage_subscription_path(subscription.external_id))
+        expect(flash[:alert]).to include("Installment plans cannot be cancelled by the customer")
       end
 
       context "when the encrypted cookie is not present" do
@@ -88,13 +90,12 @@ describe SubscriptionsController do
           cookies.encrypted[@subscription.cookie_key] = nil
         end
 
-        it "renders success false with redirect_to URL" do
+        it "redirects to the magic link page" do
           expect do
-            post :unsubscribe_by_user, params: { id: @subscription.external_id }, format: :json
+            post :unsubscribe_by_user, params: { id: @subscription.external_id }
           end.to_not change { @subscription.reload.user_requested_cancellation_at }
 
-          expect(response.parsed_body["success"]).to be(false)
-          expect(response.parsed_body["redirect_to"]).to eq(magic_link_subscription_path(@subscription.external_id))
+          expect(response).to redirect_to(magic_link_subscription_path(@subscription.external_id))
         end
       end
     end
@@ -134,6 +135,7 @@ describe SubscriptionsController do
           get :manage, params: { id: @subscription.external_id }
 
           expect(response).to be_successful
+          expect(inertia.component).to eq("Subscriptions/Manage")
         end
       end
 
@@ -143,6 +145,7 @@ describe SubscriptionsController do
           get :manage, params: { id: @subscription.external_id }
 
           expect(response).to be_successful
+          expect(inertia.component).to eq("Subscriptions/Manage")
         end
       end
 


### PR DESCRIPTION
Fixes #3073

## Summary
- Migrated the Subscription Manager page (`GET /subscriptions/:id/manage`) from React on Rails to Inertia.js
- Converted `unsubscribe_by_user` from JSON API to redirect-based flow with flash messages
- Removed unused server component, webpack pack, and ERB template
- Cleaned up `cancelSubscriptionByUser` client-side API function (now handled via `router.post`)
- Kept `updateSubscription` as client-side fetch (requires Stripe 3D Secure handling)

## Changes
| File | Change |
|------|--------|
| `subscriptions_controller.rb` | Added `layout "inertia"`, `render inertia:`, redirect-based cancel |
| `pages/Subscriptions/Manage.tsx` | Renamed from server component, adapted for Inertia |
| `data/subscription.ts` | Removed `cancelSubscriptionByUser` |
| `ssr.ts` | Removed SSR registration |
| `subscription_edit.ts` | Deleted |
| `manage.html.erb` | Deleted |
| `subscriptions_controller_spec.rb` | Updated for Inertia + redirect assertions |

## Test plan
- [ ] Visit `/subscriptions/:id/manage` with valid cookie — page renders via Inertia
- [ ] Cancel membership — redirects with flash notice
- [ ] Update payment method — Stripe 3D Secure flow works
- [ ] Visit without auth — redirects to magic link page
- [ ] Installment plan cancel attempt — redirects with flash alert
- [ ] Controller specs pass with `inertia: true`

> [!NOTE]
> This PR was authored with the assistance of AI (Claude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)