### PR TITLE
fix: use BigDecimal for price/amount to cents conversion

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -123,7 +123,7 @@ class LinksController < ApplicationController
       BasePrice::Recurrence::ALLOWED_RECURRENCES.each do |r|
         params[:recurrence] ||= r if params[r] == "true"
       end
-      params[:price] = (params[:price].to_f * 100).to_i if params[:price].present?
+      params[:price] = (params[:price].to_d * 100).to_i if params[:price].present?
       cart_item = @product.cart_item(params)
 
       unless (@product.customizable_price || cart_item[:option]&.[](:is_pwyw)) &&
@@ -494,7 +494,7 @@ class LinksController < ApplicationController
       tier:,
       effective_date: params[:effective_date].present? ? Date.parse(params[:effective_date]) : tier.subscription_price_change_effective_date,
       recurrence: params.require(:recurrence),
-      new_price: (params.require(:amount).to_f * 100).to_i,
+      new_price: (params.require(:amount).to_d * 100).to_i,
       custom_message: strip_tags(params[:custom_message]).present? ? params[:custom_message] : nil,
     ).deliver_later
 

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -3121,6 +3121,14 @@ describe LinksController, :vcr, inertia: true do
           custom_message: "<p>hi!</p>",
         )
       end
+
+      it "converts price with decimal precision" do
+        expect do
+          post :send_sample_price_change_email, params: required_params.merge(amount: "19.99")
+        end.to have_enqueued_mail(CustomerLowPriorityMailer, :sample_subscription_price_change_notification).with(
+          hash_including(new_price: 19_99)
+        )
+      end
     end
 
     it "allows updating and publishing a product without files" do


### PR DESCRIPTION
Fixes #3408

## Summary
- Replace `to_f` with `to_d` in two price-to-cents conversions in `links_controller.rb`
- `"19.99".to_f * 100` produces `1998.9999...` which truncates to `1998` (off by 1 cent)
- `"19.99".to_d * 100` produces exact `1999`

## Changes
| File | Line | Before | After |
|------|------|--------|-------|
| `links_controller.rb` | 126 | `params[:price].to_f * 100` | `params[:price].to_d * 100` |
| `links_controller.rb` | 497 | `params.require(:amount).to_f * 100` | `params.require(:amount).to_d * 100` |

## Test plan
- [ ] Added spec verifying `"19.99"` converts to `1999` cents (fails when reverted to `to_f`)
- [ ] Existing spec for `"7.50"` -> `750` continues to pass

> [!NOTE]
> This PR was authored with the assistance of AI (Claude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)