### PR TITLE
fix: persist offer code discount across installment charges

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -1999,7 +1999,7 @@ class Purchase < ApplicationRecord
   end
 
   def does_not_count_towards_max_purchases
-    is_recurring_subscription_charge || is_additional_contribution || is_preorder_charge? || is_gift_receiver_purchase || is_updated_original_subscription_purchase || is_commission_completion_purchase
+    is_recurring_subscription_charge || is_additional_contribution || is_preorder_charge? || is_gift_receiver_purchase || is_updated_original_subscription_purchase || is_commission_completion_purchase || (is_installment_payment && !is_original_subscription_purchase)
   end
 
   # Public: Determine if this purchase is a test purchase by the links owner.
@@ -2411,13 +2411,13 @@ class Purchase < ApplicationRecord
   end
 
   def original_offer_code(include_deleted: false)
-    return nil if offer_code&.deleted? && !include_deleted
-
     if has_cached_offer_code?
-      code = purchase_offer_code_discount.offer_code.code
+      code = purchase_offer_code_discount.offer_code&.code
       purchase_offer_code_discount.offer_code_is_percent ?
         OfferCode.new(amount_percentage: purchase_offer_code_discount.offer_code_amount, code:) :
         OfferCode.new(amount_cents: purchase_offer_code_discount.offer_code_amount, code:)
+    elsif offer_code&.deleted? && !include_deleted
+      nil
     else
       offer_code
     end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -248,7 +248,18 @@ class Subscription < ApplicationRecord
     purchase = Purchase.new(purchase_params)
     purchase.variant_attributes = original_purchase.variant_attributes
 
-    purchase.offer_code = original_purchase.offer_code if discount_applies_to_next_charge?
+    if discount_applies_to_next_charge?
+      purchase.offer_code = original_purchase.offer_code
+      if (original_discount = original_purchase.purchase_offer_code_discount)
+        purchase.build_purchase_offer_code_discount(
+          offer_code: original_discount.offer_code,
+          offer_code_amount: original_discount.offer_code_amount,
+          offer_code_is_percent: original_discount.offer_code_is_percent,
+          pre_discount_minimum_price_cents: original_discount.pre_discount_minimum_price_cents,
+          duration_in_months: original_discount.duration_in_months
+        )
+      end
+    end
 
     purchase.purchaser = user
     purchase.link = link

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -3614,6 +3614,43 @@ describe Subscription, :vcr do
     end
   end
 
+  describe "#build_purchase offer code persistence" do
+    let(:product) { create(:product, :with_installment_plan, user: seller, price_cents: 10_00) }
+    let(:offer_code) { create(:offer_code, products: [product], amount_cents: 2_00, max_purchase_count: 1) }
+    let(:subscription) { create(:subscription, link: product, is_installment_plan: true, user: create(:user)) }
+    let!(:original_purchase) do
+      purchase = create(:installment_plan_purchase, subscription:, link: product, offer_code:, purchaser: subscription.user)
+      purchase.create_purchase_offer_code_discount!(
+        offer_code:, offer_code_amount: 2_00, offer_code_is_percent: false,
+        pre_discount_minimum_price_cents: 10_00
+      )
+      purchase
+    end
+
+    it "copies the cached offer code discount when the offer code is deleted" do
+      offer_code.mark_deleted!
+
+      new_purchase = subscription.build_purchase
+      expect(new_purchase.purchase_offer_code_discount).to be_present
+      expect(new_purchase.purchase_offer_code_discount.offer_code_amount).to eq(2_00)
+    end
+
+    it "copies the cached offer code discount when the offer code is maxed out" do
+      create(:purchase, link: product, offer_code:, is_original_subscription_purchase: true)
+
+      new_purchase = subscription.build_purchase
+      expect(new_purchase.purchase_offer_code_discount).to be_present
+      expect(new_purchase.purchase_offer_code_discount.offer_code_amount).to eq(2_00)
+    end
+
+    it "preserves the original discount amount even if the offer code amount changes" do
+      offer_code.update!(amount_cents: 5_00)
+
+      new_purchase = subscription.build_purchase
+      expect(new_purchase.purchase_offer_code_discount.offer_code_amount).to eq(2_00)
+    end
+  end
+
   describe "#cookie_key" do
     it "returns the cookie key" do
       expect(@subscription.cookie_key).to eq("subscription_#{@subscription.external_id_numeric}")


### PR DESCRIPTION
## Summary
- Copies the cached `purchase_offer_code_discount` from the original purchase to subsequent installment/membership charges in `Subscription#build_purchase`, so the discount is preserved even when the offer code is deleted, maxed out, or modified
- Reorders `Purchase#original_offer_code` to check cached discount data before the deleted-code check, with safe navigation for deleted offer codes
- Adds subsequent installment payments to `does_not_count_towards_max_purchases` so product inventory limits don't block existing installment plans

Fixes #1410

## Test plan
- [x] Added spec: offer code discount persists when offer code is deleted
- [x] Added spec: offer code discount persists when offer code reaches max purchases
- [x] Added spec: original discount amount preserved even if offer code amount changes later

---

> [!NOTE]
> This change was made with the assistance of AI (Claude Opus 4.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)