### PR TITLE
feat: add Send all button for missed posts in customer drawer

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -8,10 +8,10 @@ class PostsController < ApplicationController
 
   layout "inertia", only: [:show]
 
-  before_action :authenticate_user!, only: %i[send_for_purchase]
-  after_action :verify_authorized, only: %i[send_for_purchase]
+  before_action :authenticate_user!, only: %i[send_for_purchase send_all_for_purchase]
+  after_action :verify_authorized, only: %i[send_for_purchase send_all_for_purchase]
   before_action :fetch_post, only: %i[send_for_purchase]
-  before_action :ensure_seller_is_eligible_to_send_emails, only: %i[send_for_purchase]
+  before_action :ensure_seller_is_eligible_to_send_emails, only: %i[send_for_purchase send_all_for_purchase]
   before_action :set_user_and_custom_domain_config, only: %i[show]
   before_action :check_if_needs_redirect, only: %i[show]
 
@@ -74,6 +74,32 @@ class PostsController < ApplicationController
     head :no_content
   end
 
+  def send_all_for_purchase
+    authorize Installment
+
+    purchase = current_seller.sales.find_by_external_id!(params[:purchase_id])
+    missed_posts = Installment.missed_for_purchase(purchase)
+    sent_count = 0
+
+    missed_posts.each do |post|
+      Rails.cache.fetch("post_email:#{post.id}:#{purchase.id}", expires_in: 8.hours) do
+        CreatorContactingCustomersEmailInfo.where(purchase:, installment: post).destroy_all
+        PostEmailApi.process(
+          post:,
+          recipients: [{
+            email: purchase.email,
+            purchase:,
+            url_redirect: purchase.url_redirect,
+            subscription: purchase.subscription,
+          }.compact_blank])
+        true
+      end
+      sent_count += 1
+    end
+
+    render json: { sent_count: }
+  end
+
   def increment_post_views
     fetch_post(false)
 
@@ -119,7 +145,7 @@ class PostsController < ApplicationController
     end
 
     def ensure_seller_is_eligible_to_send_emails
-      seller = @post.seller || @post.link.seller
+      seller = @post&.seller || @post&.link&.seller || current_seller
       unless seller&.eligible_to_send_emails?
         render json: { message: "You are not eligible to resend this email." }, status: :unauthorized
       end

--- a/app/javascript/components/Audience/CustomersPage.tsx
+++ b/app/javascript/components/Audience/CustomersPage.tsx
@@ -35,6 +35,7 @@ import {
   refund,
   rejectReviewVideo,
   resendPing,
+  resendAllPosts,
   resendPost,
   resendReceipt,
   revokeAccess,
@@ -695,6 +696,8 @@ const CustomerDrawer = ({
     });
   });
 
+  const [sendingAll, setSendingAll] = React.useState(false);
+
   const onSend = async (id: string, type: "receipt" | "post") => {
     setLoadingId(id);
     try {
@@ -706,6 +709,19 @@ const CustomerDrawer = ({
       showAlert(e.message, "error");
     }
     setLoadingId(null);
+  };
+
+  const onSendAll = async () => {
+    setSendingAll(true);
+    try {
+      const { sent_count } = await resendAllPosts(customer.id);
+      missedPosts?.forEach((post) => sentEmailIds.current.add(post.id));
+      showAlert(`${sent_count} missed post${sent_count === 1 ? "" : "s"} sent`, "success");
+    } catch (e) {
+      assertResponseError(e);
+      showAlert(e.message, "error");
+    }
+    setSendingAll(false);
   };
 
   const [productPurchases, setProductPurchases] = React.useState<Customer[]>([]);
@@ -1225,6 +1241,15 @@ const CustomerDrawer = ({
             <CardContent asChild>
               <header>
                 <h3 className="grow">Send missed posts</h3>
+                {missedPosts && missedPosts.length > 1 ? (
+                  <Button
+                    color="primary"
+                    disabled={sendingAll || !!loadingId}
+                    onClick={() => void onSendAll()}
+                  >
+                    {sendingAll ? "Sending all..." : "Send all"}
+                  </Button>
+                ) : null}
               </header>
             </CardContent>
             {missedPosts ? (
@@ -1242,7 +1267,7 @@ const CustomerDrawer = ({
                       </div>
                       <Button
                         color="primary"
-                        disabled={!!loadingId || sentEmailIds.current.has(post.id)}
+                        disabled={sendingAll || !!loadingId || sentEmailIds.current.has(post.id)}
                         onClick={() => void onSend(post.id, "post")}
                       >
                         {sentEmailIds.current.has(post.id) ? "Sent" : loadingId === post.id ? "Sending...." : "Send"}

--- a/app/javascript/data/customers.ts
+++ b/app/javascript/data/customers.ts
@@ -241,6 +241,16 @@ export const resendPost = async (purchaseId: string, postId: string) => {
   if (!response.ok) throw new ResponseError(cast<{ message: string }>(await response.json()).message);
 };
 
+export const resendAllPosts = async (purchaseId: string): Promise<{ sent_count: number }> => {
+  const response = await request({
+    method: "POST",
+    accept: "json",
+    url: Routes.send_all_for_purchase_path(purchaseId),
+  });
+  if (!response.ok) throw new ResponseError(cast<{ message: string }>(await response.json()).message);
+  return cast<{ sent_count: number }>(await response.json());
+};
+
 export const updatePurchase = (
   purchaseId: string,
   update: Partial<{ email: string; giftee_email: string; quantity: number } & Address>,

--- a/app/policies/installment_policy.rb
+++ b/app/policies/installment_policy.rb
@@ -63,4 +63,8 @@ class InstallmentPolicy < ApplicationPolicy
     create? ||
     user.role_support_for?(seller)
   end
+
+  def send_all_for_purchase?
+    send_for_purchase?
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -794,6 +794,7 @@ Rails.application.routes.draw do
     # posts
     post "/posts/:id/increment_post_views", to: "posts#increment_post_views", as: :increment_post_views
     post "/posts/:id/send_for_purchase/:purchase_id", to: "posts#send_for_purchase", as: :send_for_purchase
+    post "/posts/send_all_for_purchase/:purchase_id", to: "posts#send_all_for_purchase", as: :send_all_for_purchase
 
     # communities
     get "/communities(/:seller_id/:community_id)", to: "communities#index", as: :community

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -98,6 +98,27 @@ describe PostsController, type: :controller, inertia: true do
         expect(response).to have_http_status(:no_content)
       end
     end
+
+    describe "POST send_all_for_purchase" do
+      before do
+        link = create(:product, user: seller)
+        @post1 = create(:installment, link:)
+        @post2 = create(:installment, link:, name: "Second Post")
+        @purchase = create(:purchase, seller:, link:, created_at: Time.current)
+        create(:creator_contacting_customers_email_info_delivered, installment: @post1, purchase: @purchase)
+        create(:creator_contacting_customers_email_info_delivered, installment: @post2, purchase: @purchase)
+        create(:payment_completed, user: seller)
+        allow_any_instance_of(User).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE)
+      end
+
+      it "sends all missed posts and returns the count" do
+        @purchase.create_url_redirect!
+        expect(PostEmailApi).to receive(:process).twice
+        post :send_all_for_purchase, params: { purchase_id: @purchase.external_id }
+        expect(response).to be_successful
+        expect(response.parsed_body["sent_count"]).to eq(2)
+      end
+    end
   end
 
   context "within consumer area" do


### PR DESCRIPTION
## Summary
- Adds a `send_all_for_purchase` endpoint to `PostsController` that sends all missed posts for a purchase in a single request, reusing the existing per-post `PostEmailApi.process` + `Rails.cache` deduplication pattern
- Adds a "Send all" button in the customer drawer header next to "Send missed posts" (only shown when there are 2+ missed posts)
- Individual send buttons are disabled while bulk send is in progress

Fixes #1814

## Test plan
- [x] Added controller spec: sends all missed posts and returns the count
- [x] Verified existing `send_for_purchase` specs still pass in the diff
- [x] UI: "Send all" button disabled during send, shows "Sending all..." state, success alert with count

---

> [!NOTE]
> This change was made with the assistance of AI (Claude Opus 4.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)