### PR TITLE
update: replace alert with a delete modal at Applications

### DIFF
--- a/app/javascript/components/Settings/AdvancedPage/ApplicationsSection.tsx
+++ b/app/javascript/components/Settings/AdvancedPage/ApplicationsSection.tsx
@@ -3,6 +3,7 @@ import placeholderAppIcon from "images/gumroad_app.png";
 import * as React from "react";
 
 import { Button } from "$app/components/Button";
+import { Modal } from "$app/components/Modal";
 import { showAlert } from "$app/components/server-components/Alert";
 import ApplicationForm from "$app/components/Settings/AdvancedPage/ApplicationForm";
 import { FormSection } from "$app/components/ui/FormSection";
@@ -41,17 +42,21 @@ const ApplicationList = (props: { applications: Application[] }) => {
 };
 
 const ApplicationRow = ({ application, onRemove }: { application: Application; onRemove: () => void }) => {
-  const deleteApp = () => {
-    // eslint-disable-next-line no-alert
-    if (!confirm("Delete this application forever?")) return;
+  const [deleteConfirmation, setDeleteConfirmation] = React.useState<{
+    state: "delete-confirmation" | "deleting";
+  } | null>(null);
 
+  const deleteApp = () => {
+    setDeleteConfirmation({ state: "deleting" });
     router.delete(Routes.oauth_application_path(application.id), {
       preserveScroll: true,
       onSuccess: () => {
+        setDeleteConfirmation(null);
         showAlert("Application deleted.", "success");
         onRemove(); // This will update the local state immediately
       },
       onError: () => {
+        setDeleteConfirmation({ state: "delete-confirmation" });
         showAlert("Failed to delete app.", "error");
       },
     });
@@ -69,10 +74,30 @@ const ApplicationRow = ({ application, onRemove }: { application: Application; o
             Edit
           </Link>
         </Button>
-        <Button color="danger" onClick={deleteApp}>
+        <Button color="danger" onClick={() => setDeleteConfirmation({ state: "delete-confirmation" })}>
           Delete
         </Button>
       </RowActions>
+      {deleteConfirmation ? (
+        <Modal
+          open
+          allowClose={deleteConfirmation.state === "delete-confirmation"}
+          onClose={() => setDeleteConfirmation(null)}
+          title="Delete application"
+          footer={
+            <>
+              <Button disabled={deleteConfirmation.state === "deleting"} onClick={() => setDeleteConfirmation(null)}>
+                Cancel
+              </Button>
+              <Button color="danger" disabled={deleteConfirmation.state === "deleting"} onClick={deleteApp}>
+                {deleteConfirmation.state === "deleting" ? "Deleting..." : "Delete"}
+              </Button>
+            </>
+          }
+        >
+          <h4>Are you sure you want to delete {application.name}? This action cannot be undone.</h4>
+        </Modal>
+      ) : null}
     </Row>
   );
 };

--- a/spec/requests/oauth_applications_pages_spec.rb
+++ b/spec/requests/oauth_applications_pages_spec.rb
@@ -66,6 +66,48 @@ describe "OauthApplicationsPages", type: :system, js: true do
         expect(page).to have_current_path(/\/oauth\/applications\/.*\/edit/)
       end.to change { OauthApplication.count }.by(1)
     end
+
+    context "when the user has an existing application" do
+      let!(:application) { create(:oauth_application, owner: user, name: "My Test App") }
+
+      before do
+        visit settings_advanced_path
+      end
+
+      it "deletes the application after confirming in the modal" do
+        within_section "Applications", section_element: :section do
+          expect(page).to have_text("My Test App")
+          click_on "Delete"
+        end
+
+        within_modal "Delete application" do
+          expect(page).to have_text("Are you sure you want to delete My Test App? This action cannot be undone.")
+          click_on "Delete"
+        end
+
+        expect(page).to have_alert(text: "Application deleted.")
+        within_section "Applications", section_element: :section do
+          expect(page).not_to have_text("My Test App")
+        end
+        expect(application.reload.deleted_at).not_to be_nil
+      end
+
+      it "does not delete the application when cancelling the modal" do
+        within_section "Applications", section_element: :section do
+          click_on "Delete"
+        end
+
+        within_modal "Delete application" do
+          click_on "Cancel"
+        end
+
+        expect(page).not_to have_selector("[role='dialog']")
+        within_section "Applications", section_element: :section do
+          expect(page).to have_text("My Test App")
+        end
+        expect(application.reload.deleted_at).to be_nil
+      end
+    end
   end
 
   it "allows seller to generate an access token for their application without breaking '/settings/authorized_applications'" do


### PR DESCRIPTION
Issue: N/A
Ref: https://github.com/antiwork/gumroad/pull/1783#pullrequestreview-3373377373
# Description

<!-- Briefly describe the problem and your solution -->

## Problem



The application deletion flow in Settings > Advanced uses a native browser `confirm()` dialog, which is inconsistent with the rest of the app where `<Modal />` is used for destructive confirmations (e.g. account deletion, workflow deletion, comment deletion).

## Solution

Replaced the native Alert with a `<Modal />` component 

- State tracked via `deleteConfirmation` object with `"delete-confirmation" | "deleting"` states
- `allowClose` disabled while deletion is in progress
- Delete buttons in footer shows "Deleting..." loading state
- On error, reverts to confirmation state so the user can retry

---

# Before/After

Before:



https://github.com/user-attachments/assets/37a130e0-4c44-4472-b978-d8bcb88a8a99


After:


https://github.com/user-attachments/assets/53302b2e-b264-40ca-976a-dd5b3135210e


---

# Test Results
<img width="828" height="290" alt="image" src="https://github.com/user-attachments/assets/cb16b2c8-44f0-4ec6-8cb9-c350cebd12da" />


---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

Used Claude Opus 4.6