### PR TITLE
Cleanup Temporary URL Stripping Logic Used On Checkout Page

### DIFF
--- a/app/javascript/components/Checkout/payment.ts
+++ b/app/javascript/components/Checkout/payment.ts
@@ -1,3 +1,4 @@
+import { router } from "@inertiajs/react";
 import { enableMapSet, produce } from "immer";
 import { groupBy } from "lodash-es";
 import * as React from "react";
@@ -403,14 +404,12 @@ export function createReducer(initial: {
     },
   );
   const [state, dispatch] = reducer;
+  // Clean URL params after initial render to avoid stale URL references during Inertia updates
   useRunOnce(() => {
     const url = new URL(window.location.href);
-    if (url.pathname.startsWith(Routes.checkout_path())) return;
     const searchParams = new URLSearchParams([...url.searchParams].filter(([key]) => key === "_gl"));
     url.search = searchParams.toString();
-    // TODO (sm17p) Replace with Inertia's router.replace once subscription manager page is migrated to Inertia
-    // then remove the checkout-path early return above so this runs on checkout too.
-    window.history.replaceState(window.history.state, "", url.toString());
+    router.replace({ url: url.toString(), preserveState: true, preserveScroll: true });
   });
 
   const updateSurcharges = useDebouncedCallback(

--- a/app/javascript/pages/Checkout/Show.tsx
+++ b/app/javascript/pages/Checkout/Show.tsx
@@ -51,7 +51,6 @@ import { useAddThirdPartyAnalytics } from "$app/components/useAddThirdPartyAnaly
 import { useDebouncedCallback } from "$app/components/useDebouncedCallback";
 import { useIsAboveBreakpoint } from "$app/components/useIsAboveBreakpoint";
 import { useOnChange, useOnChangeSync } from "$app/components/useOnChange";
-import { useRunOnce } from "$app/components/useRunOnce";
 
 const GUMROAD_PARAMS = [
   "product",
@@ -567,13 +566,6 @@ const CheckoutIndexPage = () => {
     });
   }, cart_save_debounce_ms);
 
-  // Clean URL params after initial render to avoid stale URL references during Inertia updates
-  useRunOnce(() => {
-    const url = new URL(window.location.href);
-    const searchParams = new URLSearchParams([...url.searchParams].filter(([key]) => key === "_gl"));
-    url.search = searchParams.toString();
-    router.replace({ url: url.toString(), preserveState: true, preserveScroll: true });
-  });
   React.useEffect(() => {
     debouncedSaveCartState();
     if (state.status.type === "input") {


### PR DESCRIPTION
Follow up on issues
- #3042
- #3073

# Description

During Inertia migration of "Checkout" page, the URL stripping logic inside `payment.ts` was duplicated and moved into `Checkout/Show` using Inertia's client side route helper (`router.replace`). 

This was done because of two reasons 
1. Firstly, Inertia's server side route helpers were picking up the unstripped URL during their render cycle, causing the stripped URL to be over-written by unstripped one (not ideal and shouldn't happen)
2. Secondly, "Subscription Manager" page had a dependency on `payment.ts` and was still rendered server side using react of rails

Now that both the pages are migrated to Inertia, we can put the logic back at it's original location

# Solution

Updates the URL stripping logic in `payment.ts` to user `router.replace`, and removes the duplicate code from `Checkout/Show` page

# Test Results (Attaching ss of the most critical request specs)
### `spec/requests/checkout/cart_spec.rb`

<img width="881" height="386" alt="cart" src="https://github.com/user-attachments/assets/6bec97fe-98a0-459a-b9d8-52b56df046b1" />

### `spec/requests/products/third_party_analytics_spec.rb`

<img width="881" height="386" alt="tpa" src="https://github.com/user-attachments/assets/d2906c56-46d9-4b29-a0e7-b0624264f2fb" />

### Subscription Manager (Ran a few specs, and it seems to be working)

<img width="792" height="250" alt="sub" src="https://github.com/user-attachments/assets/62e714d0-b87d-4f6a-a86f-33c7ff4f3a0e" />


# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes - N.A.

---

# AI Disclosure

Cursor Auto Mode was used for editing the files