### PR TITLE
feat: add backup payment method for refund funding (#1594)

### DIFF
--- a/app/controllers/settings/payments_controller.rb
+++ b/app/controllers/settings/payments_controller.rb
@@ -155,6 +155,47 @@ class Settings::PaymentsController < Settings::BaseController
     end
   end
 
+  def save_refund_funding_card
+    card_data_handling_mode = CardParamsHelper.get_card_data_handling_mode(params)
+    card_data_handling_error = CardParamsHelper.check_for_errors(params)
+
+    if card_data_handling_error.present?
+      return render json: { success: false, error: card_data_handling_error.error_message }, status: :unprocessable_entity
+    end
+
+    chargeable = CardParamsHelper.build_chargeable(params)
+    if chargeable.blank?
+      return render json: { success: false, error: "Invalid card information." }, status: :unprocessable_entity
+    end
+
+    credit_card = CreditCard.create(chargeable, card_data_handling_mode, current_seller)
+    unless credit_card.persisted?
+      return render json: { success: false, error: credit_card.errors.full_messages.join(", ") }, status: :unprocessable_entity
+    end
+
+    current_seller.update!(refund_funding_credit_card: credit_card)
+
+    render json: {
+      success: true,
+      credit_card: {
+        visual: credit_card.visual,
+        card_type: credit_card.card_type,
+        expiry_month: credit_card.expiry_month,
+        expiry_year: credit_card.expiry_year
+      }
+    }
+  end
+
+  def remove_refund_funding_card
+    current_seller.update!(refund_funding_credit_card: nil)
+    render json: { success: true }
+  end
+
+  def dismiss_refund_funding_banner
+    current_seller.update!(dismissed_refund_payment_method_banner: true)
+    render json: { success: true }
+  end
+
   def remediation
     authorize
 

--- a/app/javascript/components/Settings/PaymentsPage/RefundPaymentMethodSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/RefundPaymentMethodSection.tsx
@@ -1,0 +1,229 @@
+import { CardElement, Elements, useElements, useStripe } from "@stripe/react-stripe-js";
+import { StripeElementStyleVariant } from "@stripe/stripe-js";
+import * as React from "react";
+import { cast } from "ts-safe-cast";
+
+import { asyncVoid } from "$app/utils/promise";
+import { assertResponseError, request } from "$app/utils/request";
+import { getStripeInstance } from "$app/utils/stripe_loader";
+import { getCssVariable } from "$app/utils/styles";
+
+import { Button } from "$app/components/Button";
+import { useFont } from "$app/components/DesignSettings";
+import { Icon } from "$app/components/Icons";
+import { showAlert } from "$app/components/server-components/Alert";
+
+export type RefundFundingCard = {
+  visual: string;
+  card_type: string;
+  expiry_month: number;
+  expiry_year: number;
+} | null;
+
+const RefundPaymentMethodForm = ({
+  initialCard,
+  isFormDisabled,
+}: {
+  initialCard: RefundFundingCard;
+  isFormDisabled: boolean;
+}) => {
+  const stripe = useStripe();
+  const elements = useElements();
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const [savedCard, setSavedCard] = React.useState(initialCard);
+  const [isEditing, setIsEditing] = React.useState(!initialCard);
+  const [cardholderName, setCardholderName] = React.useState("");
+  const [baseStripeStyle, setBaseStripeStyle] = React.useState<null | StripeElementStyleVariant>(null);
+
+  const handleSubmit = asyncVoid(async () => {
+    if (!stripe || !elements) return;
+
+    const cardElement = elements.getElement(CardElement);
+    if (!cardElement) return;
+
+    setIsSubmitting(true);
+
+    try {
+      const { paymentMethod, error } = await stripe.createPaymentMethod({
+        type: "card",
+        card: cardElement,
+        ...(cardholderName ? { billing_details: { name: cardholderName } } : {}),
+      });
+
+      if (error) {
+        showAlert(error.message ?? "Card verification failed", "error");
+        setIsSubmitting(false);
+        return;
+      }
+
+      const response = await request({
+        method: "POST",
+        url: Routes.save_refund_funding_card_settings_payments_path(),
+        accept: "json",
+        data: {
+          stripe_payment_method_id: paymentMethod.id,
+          card_data_handling_mode: "stripejs.0",
+        },
+      });
+
+      const result = cast<{ success: boolean; error?: string; credit_card?: NonNullable<RefundFundingCard> }>(
+        await response.json(),
+      );
+
+      if (result.success && result.credit_card) {
+        showAlert("Backup payment method saved successfully!", "success");
+        setSavedCard(result.credit_card);
+        setCardholderName("");
+        setIsEditing(false);
+      } else {
+        showAlert(result.error ?? "Failed to save card", "error");
+      }
+    } catch (e) {
+      assertResponseError(e);
+      showAlert("An error occurred. Please try again.", "error");
+    }
+
+    setIsSubmitting(false);
+  });
+
+  const handleRemove = asyncVoid(async () => {
+    // eslint-disable-next-line no-alert
+    if (!window.confirm("Are you sure you want to remove your backup payment method?")) return;
+
+    setIsSubmitting(true);
+
+    try {
+      const response = await request({
+        method: "DELETE",
+        url: Routes.remove_refund_funding_card_settings_payments_path(),
+        accept: "json",
+      });
+
+      const result = cast<{ success: boolean }>(await response.json());
+
+      if (result.success) {
+        showAlert("Backup payment method removed", "success");
+        setSavedCard(null);
+        setIsEditing(true);
+      } else {
+        showAlert("Failed to remove card", "error");
+      }
+    } catch (e) {
+      assertResponseError(e);
+      showAlert("An error occurred. Please try again.", "error");
+    }
+
+    setIsSubmitting(false);
+  });
+
+  return (
+    <section id="refund-payment-method" className="p-4! md:p-8!">
+      <header>
+        <h2>Refund payment method</h2>
+        <p className="text-muted">
+          Add a backup card to automatically cover refunds when your Gumroad balance is too low. You will only be
+          charged if your balance cannot cover the refund amount.
+        </p>
+      </header>
+
+      <div className="flex flex-col gap-5">
+        {savedCard && !isEditing ? (
+          <div className="flex flex-col gap-4">
+            <div className="input read-only" aria-label="Saved backup card">
+              <Icon name="outline-credit-card" />
+              <span>{savedCard.visual}</span>
+              <span style={{ marginLeft: "auto" }}>
+                {savedCard.expiry_month.toString().padStart(2, "0")}/{savedCard.expiry_year.toString().slice(-2)}
+              </span>
+            </div>
+            {!isFormDisabled ? (
+              <div className="flex gap-4">
+                <Button outline onClick={() => setIsEditing(true)} disabled={isSubmitting}>
+                  Change card
+                </Button>
+                <Button outline color="danger" onClick={handleRemove} disabled={isSubmitting}>
+                  Remove card
+                </Button>
+              </div>
+            ) : null}
+          </div>
+        ) : (
+          <>
+            <fieldset>
+              <label htmlFor="refund_cardholder_name">Name on card</label>
+              <input
+                id="refund_cardholder_name"
+                type="text"
+                placeholder="Full name"
+                value={cardholderName}
+                disabled={isFormDisabled || isSubmitting}
+                onChange={(e) => setCardholderName(e.target.value)}
+              />
+            </fieldset>
+            <fieldset>
+              <label htmlFor="refund_card_element">Card information</label>
+              <div className="input">
+                {baseStripeStyle == null ? (
+                  <input
+                    ref={(el) => {
+                      if (el == null) return;
+                      const inputStyle = window.getComputedStyle(el);
+                      const color = getCssVariable("color").split(" ").join(",");
+                      const placeholderColor = `rgb(${color}, ${getCssVariable("gray-3")})`;
+                      setBaseStripeStyle({
+                        fontFamily: inputStyle.fontFamily,
+                        color: inputStyle.color,
+                        iconColor: placeholderColor,
+                        "::placeholder": { color: placeholderColor },
+                      });
+                    }}
+                  />
+                ) : null}
+                <CardElement
+                  className="flex-1"
+                  id="refund_card_element"
+                  options={{
+                    style: { base: baseStripeStyle ?? {} },
+                    hidePostalCode: true,
+                    hideIcon: true,
+                    disabled: isFormDisabled || isSubmitting,
+                  }}
+                />
+              </div>
+            </fieldset>
+            {!isFormDisabled ? (
+              <div className="flex gap-4">
+                <Button color="accent" onClick={handleSubmit} disabled={isSubmitting}>
+                  {isSubmitting ? "Saving..." : savedCard ? "Update card" : "Save card"}
+                </Button>
+                {savedCard ? (
+                  <Button outline onClick={() => setIsEditing(false)} disabled={isSubmitting}>
+                    Cancel
+                  </Button>
+                ) : null}
+              </div>
+            ) : null}
+          </>
+        )}
+      </div>
+    </section>
+  );
+};
+
+export const RefundPaymentMethodSection = ({
+  initialCard,
+  isFormDisabled,
+}: {
+  initialCard: RefundFundingCard;
+  isFormDisabled: boolean;
+}) => {
+  const [stripePromise] = React.useState(getStripeInstance);
+  const font = useFont();
+  const stripeFonts = [{ family: font.name, src: `url(${font.url})` }];
+
+  return (
+    <Elements stripe={stripePromise} options={{ fonts: stripeFonts, locale: "en" }}>
+      <RefundPaymentMethodForm initialCard={initialCard} isFormDisabled={isFormDisabled} />
+    </Elements>
+  );
+};

--- a/app/javascript/pages/Settings/Payments/Show.tsx
+++ b/app/javascript/pages/Settings/Payments/Show.tsx
@@ -27,6 +27,10 @@ import BankAccountSection, {
 import DebitCardSection from "$app/components/Settings/PaymentsPage/DebitCardSection";
 import PayPalConnectSection, { PayPalConnect } from "$app/components/Settings/PaymentsPage/PayPalConnectSection";
 import PayPalEmailSection from "$app/components/Settings/PaymentsPage/PayPalEmailSection";
+import {
+  RefundPaymentMethodSection,
+  type RefundFundingCard,
+} from "$app/components/Settings/PaymentsPage/RefundPaymentMethodSection";
 import StripeConnectSection, { StripeConnect } from "$app/components/Settings/PaymentsPage/StripeConnectSection";
 import { TypeSafeOptionSelect } from "$app/components/TypeSafeOptionSelect";
 import { Alert } from "$app/components/ui/Alert";
@@ -91,6 +95,8 @@ type PaymentsPageProps = {
   payout_country_name: string | null;
   payout_frequency: PayoutFrequency;
   payout_frequency_daily_supported: boolean;
+  refund_funding_card: RefundFundingCard;
+  show_refund_funding_banner: boolean;
   errors?: {
     base?: string[];
     error_code?: string[];
@@ -1106,6 +1112,7 @@ export default function PaymentsPage() {
             read_only={props.is_form_disabled}
           />
         ) : null}
+        <RefundPaymentMethodSection initialCard={props.refund_funding_card} isFormDisabled={props.is_form_disabled} />
       </form>
     </Layout>
   );

--- a/app/mailers/contacting_creator_mailer.rb
+++ b/app/mailers/contacting_creator_mailer.rb
@@ -525,6 +525,13 @@ class ContactingCreatorMailer < ApplicationMailer
     @subject = "Important: Update Your Payout Method on Gumroad"
   end
 
+  def refund_funding_charge_confirmation(credit_id:)
+    @credit = Credit.find(credit_id)
+    @seller = @credit.user
+    @amount = Money.new(@credit.amount_cents, :usd).format(no_cents_if_whole: true, symbol: true)
+    @subject = "Your backup card was charged #{@amount}"
+  end
+
   def ping_endpoint_failure(user_id, ping_url, response_code)
     @seller = User.find(user_id)
     @ping_url = redact_ping_url(ping_url)

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -14,6 +14,8 @@ class Credit < ApplicationRecord
   belongs_to :financing_paydown_purchase, class_name: "Purchase", optional: true
   belongs_to :fee_retention_refund, class_name: "Refund", optional: true
   belongs_to :backtax_agreement, optional: true
+  belongs_to :refund_funding_purchase, class_name: "Purchase", optional: true
+  belongs_to :credit_card, optional: true
 
   has_one :balance_transaction
 
@@ -24,6 +26,8 @@ class Credit < ApplicationRecord
   validate :validate_associated_entity
 
   attr_json_data_accessor :stripe_loan_paydown_id
+  attr_json_data_accessor :refund_funding_processor_transaction_id
+  attr_json_data_accessor :refund_funding_processor_payment_intent_id
 
   def self.create_for_credit!(user:, amount_cents:, crediting_user:)
     credit = new
@@ -31,6 +35,35 @@ class Credit < ApplicationRecord
     credit.merchant_account = MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id)
     credit.amount_cents = amount_cents
     credit.crediting_user = crediting_user
+    credit.save!
+
+    balance_transaction_amount = BalanceTransaction::Amount.new(
+      currency: Currency::USD,
+      gross_cents: credit.amount_cents,
+      net_cents: credit.amount_cents
+    )
+    balance_transaction = BalanceTransaction.create!(
+      user: credit.user,
+      merchant_account: credit.merchant_account,
+      credit:,
+      issued_amount: balance_transaction_amount,
+      holding_amount: balance_transaction_amount
+    )
+
+    credit.balance = balance_transaction.balance
+    credit.save!
+    credit
+  end
+
+  def self.create_for_refund_funding!(user:, amount_cents:, purchase:, credit_card:, processor_transaction_id:, processor_payment_intent_id:)
+    credit = new
+    credit.user = user
+    credit.merchant_account = MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id)
+    credit.amount_cents = amount_cents
+    credit.refund_funding_purchase = purchase
+    credit.credit_card = credit_card
+    credit.refund_funding_processor_transaction_id = processor_transaction_id
+    credit.refund_funding_processor_payment_intent_id = processor_payment_intent_id
     credit.save!
 
     balance_transaction_amount = BalanceTransaction::Amount.new(
@@ -433,14 +466,17 @@ class Credit < ApplicationRecord
       comment_attrs[:content] = "issued adjustment due to currency conversion differences when payment #{returned_payment.id} returned."
     elsif refund
       comment_attrs[:author_name] = "AutoCredit PayPal Connect VAT refund (#{refund.purchase.id})"
+    elsif refund_funding_purchase
+      comment_attrs[:author_name] = "Refund Funding"
+      comment_attrs[:content] = "credited #{formatted_dollar_amount(amount_cents)} from backup card charge to cover refund for purchase #{refund_funding_purchase.id}."
     end
     user.comments.create(comment_attrs)
   end
 
   private
     def validate_associated_entity
-      return if crediting_user || chargebacked_purchase || returned_payment || refund || financing_paydown_purchase || fee_retention_refund || backtax_agreement
+      return if crediting_user || chargebacked_purchase || returned_payment || refund || financing_paydown_purchase || fee_retention_refund || backtax_agreement || refund_funding_purchase
 
-      errors.add(:base, "A crediting user, chargebacked purchase, returned payment, refund, financing_paydown_purchase, fee_retention_refund or backtax_agreement must be provided.")
+      errors.add(:base, "A crediting user, chargebacked purchase, returned payment, refund, financing_paydown_purchase, fee_retention_refund, backtax_agreement or refund_funding_purchase must be provided.")
     end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,6 +50,7 @@ class User < ApplicationRecord
   has_many :devices
 
   belongs_to :credit_card, optional: true
+  belongs_to :refund_funding_credit_card, class_name: "CreditCard", optional: true
 
   # Associate with CustomDomain.alive objects
   has_one :custom_domain, -> { alive }
@@ -280,6 +281,7 @@ class User < ApplicationRecord
             50 => :paypal_payout_fee_waived,
             51 => :dismissed_create_products_with_ai_promo_alert,
             52 => :disable_affiliate_requests,
+            53 => :dismissed_refund_payment_method_banner,
             :column => "flags",
             :flag_query_mode => :bit_operator,
             check_for_column: false

--- a/app/modules/purchase/refundable.rb
+++ b/app/modules/purchase/refundable.rb
@@ -45,8 +45,27 @@ class Purchase
 
         amount_cents_to_refund = amount_cents.presence || amount_refundable_cents
         if amount_cents_to_refund > seller.unpaid_balance_cents && charged_using_gumroad_merchant_account?
-          errors.add :base, "Your balance is insufficient to process this refund."
-          return false
+          if seller.refund_funding_credit_card.present?
+            shortfall = amount_cents_to_refund - seller.unpaid_balance_cents
+            charge_amount = [shortfall, RefundFundingChargeService::MINIMUM_CHARGE_CENTS].max
+            @refund_funding_service = RefundFundingChargeService.new(user: seller, amount_cents: charge_amount, purchase: self)
+            @refund_funding_result = @refund_funding_service.perform
+
+            unless @refund_funding_result.success?
+              errors.add :base, @refund_funding_result.error_message || "Could not charge your backup card to cover the refund shortfall."
+              return false
+            end
+
+            seller.reload
+            if amount_cents_to_refund > seller.unpaid_balance_cents
+              @refund_funding_service.reverse_charge!(@refund_funding_result.credit.refund_funding_processor_payment_intent_id)
+              errors.add :base, "Refund funding was insufficient due to a concurrent operation. Please try again."
+              return false
+            end
+          else
+            errors.add :base, "Your balance is insufficient to process this refund."
+            return false
+          end
         end
       end
 
@@ -94,19 +113,27 @@ class Purchase
         if charge_refund.flow_of_funds.nil? && StripeChargeProcessor.charge_processor_id != charge_processor_id
           charge_refund.flow_of_funds = FlowOfFunds.build_simple_flow_of_funds(Currency::USD, -(gross_amount_cents.presence || gross_amount_refundable_cents))
         end
-        refund_purchase!(charge_refund.flow_of_funds, refunding_user_id, charge_refund.refund, is_for_fraud)
+        refund_purchase!(charge_refund.flow_of_funds, refunding_user_id, charge_refund.refund, is_for_fraud).tap do |success|
+          if success && @refund_funding_result&.success?
+            ContactingCreatorMailer.refund_funding_charge_confirmation(credit_id: @refund_funding_result.credit.id).deliver_later(queue: "default")
+          end
+        end
       rescue ChargeProcessorAlreadyRefundedError => e
         logger.error "Charge was already refunded in purchase: #{external_id}. Response: #{e.message}"
+        reverse_refund_funding_charge_if_needed!
         false
       rescue ChargeProcessorInsufficientFundsError => e
         logger.error "Creator's PayPal account does not have sufficient funds to refund purchase: #{external_id}. Response: #{e.message}"
+        reverse_refund_funding_charge_if_needed!
         errors.add :base, "Your PayPal account does not have sufficient funds to make this refund."
         false
       rescue ChargeProcessorInvalidRequestError => e
         logger.error "Charge refund encountered an invalid request error in purchase: #{external_id}. Response: #{e.message}. #{e.backtrace_locations}"
+        reverse_refund_funding_charge_if_needed!
         false
       rescue ChargeProcessorUnavailableError => e
         logger.error "Charge processor unavailable in purchase: #{external_id}. Response: #{e.message}"
+        reverse_refund_funding_charge_if_needed!
         errors.add :base, "There is a temporary problem. Try to refund later."
         false
       end
@@ -342,6 +369,12 @@ class Purchase
   end
 
   private
+    def reverse_refund_funding_charge_if_needed!
+      return unless @refund_funding_result&.success? && @refund_funding_service.present?
+
+      @refund_funding_service.reverse_charge!(@refund_funding_result.credit.refund_funding_processor_payment_intent_id)
+    end
+
     def refundable_amounts
       amounts_query = "COALESCE(SUM(total_transaction_cents), 0) AS tt_cents, COALESCE(SUM(amount_cents), 0) AS p_cents, " \
                         "COALESCE(SUM(creator_tax_cents), 0) AS ct_cents, COALESCE(SUM(gumroad_tax_cents), 0) as gt_cents," \

--- a/app/policies/settings/payments/user_policy.rb
+++ b/app/policies/settings/payments/user_policy.rb
@@ -37,6 +37,18 @@ class Settings::Payments::UserPolicy < ApplicationPolicy
     update?
   end
 
+  def save_refund_funding_card?
+    update?
+  end
+
+  def remove_refund_funding_card?
+    update?
+  end
+
+  def dismiss_refund_funding_banner?
+    update?
+  end
+
   def remediation?
     update?
   end

--- a/app/presenters/settings_presenter.rb
+++ b/app/presenters/settings_presenter.rb
@@ -222,6 +222,8 @@ class SettingsPresenter
       payout_country_name: Compliance::Countries.for_select.to_h[seller.alive_user_compliance_info&.legal_entity_country_code],
       payout_frequency: seller.payout_frequency,
       payout_frequency_daily_supported: seller.instant_payouts_supported?,
+      refund_funding_card: refund_funding_card_details,
+      show_refund_funding_banner: !seller.dismissed_refund_payment_method_banner? && seller.refund_funding_credit_card.blank?,
     }
   end
 
@@ -397,6 +399,18 @@ class SettingsPresenter
         ir: Compliance::Countries.subdivisions_for_select(Compliance::Countries::IRL.alpha2).map { |code, name| { code:, name: } },
         br: Compliance::Countries.subdivisions_for_select(Compliance::Countries::BRA.alpha2).map { |code, name| { code:, name: } },
         jp: Compliance::Countries.japan_prefectures_for_select,
+      }
+    end
+
+    def refund_funding_card_details
+      card = seller.refund_funding_credit_card
+      return nil unless card
+
+      {
+        visual: card.visual,
+        card_type: card.card_type,
+        expiry_month: card.expiry_month,
+        expiry_year: card.expiry_year
       }
     end
 

--- a/app/services/refund_funding_charge_service.rb
+++ b/app/services/refund_funding_charge_service.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+class RefundFundingChargeService
+  include CurrencyHelper
+
+  MINIMUM_CHARGE_CENTS = 100
+  MAXIMUM_CHARGE_CENTS = 1_000_000
+
+  Result = Struct.new(:success?, :credit, :error_message, keyword_init: true)
+
+  def initialize(user:, amount_cents:, purchase:)
+    @user = user
+    @amount_cents = amount_cents
+    @purchase = purchase
+    @credit_card = user.refund_funding_credit_card
+  end
+
+  def perform
+    return error("No backup payment method configured.") if @credit_card.blank?
+    return error("Amount must be at least #{formatted_dollar_amount(MINIMUM_CHARGE_CENTS)}.") if @amount_cents < MINIMUM_CHARGE_CENTS
+    return error("Amount cannot exceed #{formatted_dollar_amount(MAXIMUM_CHARGE_CENTS)}.") if @amount_cents > MAXIMUM_CHARGE_CENTS
+
+    charge_result = charge_credit_card
+    return error(charge_result[:error]) if charge_result[:error].present?
+
+    credit = Credit.create_for_refund_funding!(
+      user: @user,
+      amount_cents: @amount_cents,
+      purchase: @purchase,
+      credit_card: @credit_card,
+      processor_transaction_id: charge_result[:charge_id],
+      processor_payment_intent_id: charge_result[:payment_intent_id]
+    )
+
+    Result.new(success?: true, credit:)
+  rescue StandardError => e
+    Bugsnag.notify(e)
+    Rails.logger.error("RefundFundingChargeService error: #{e.message}")
+    error("An unexpected error occurred while processing your backup card charge.")
+  end
+
+  def reverse_charge!(payment_intent_id)
+    Stripe::Refund.create({ payment_intent: payment_intent_id })
+  rescue Stripe::StripeError => e
+    Bugsnag.notify(e)
+    Rails.logger.error("RefundFundingChargeService reversal failed: #{e.message}")
+  end
+
+  private
+    def charge_credit_card
+      payment_intent = Stripe::PaymentIntent.create(
+        {
+          amount: @amount_cents,
+          currency: "usd",
+          customer: @credit_card.stripe_customer_id,
+          payment_method: @credit_card.processor_payment_method_id,
+          off_session: true,
+          confirm: true,
+          description: "Gumroad refund funding charge",
+          metadata: {
+            user_id: @user.id,
+            user_email: @user.email,
+            purchase_id: @purchase.id,
+            type: "refund_funding"
+          }
+        },
+        { idempotency_key: idempotency_key }
+      )
+
+      if payment_intent.status == "succeeded"
+        {
+          payment_intent_id: payment_intent.id,
+          charge_id: payment_intent.latest_charge
+        }
+      elsif payment_intent.status == "requires_action"
+        { error: "Your backup card requires additional authentication (3D Secure). Please update your backup payment method with a card that supports automatic off-session payments." }
+      else
+        { error: "Payment was not successful. Status: #{payment_intent.status}" }
+      end
+    rescue Stripe::CardError => e
+      { error: e.message }
+    rescue Stripe::InvalidRequestError => e
+      Bugsnag.notify(e)
+      { error: "Invalid payment request." }
+    rescue Stripe::StripeError => e
+      Bugsnag.notify(e)
+      { error: "Payment processor error. Please try again." }
+    end
+
+    def idempotency_key
+      "refund_funding_#{@user.id}_#{@purchase.id}"
+    end
+
+    def error(message)
+      Result.new(success?: false, error_message: message)
+    end
+end

--- a/app/views/contacting_creator_mailer/refund_funding_charge_confirmation.html.erb
+++ b/app/views/contacting_creator_mailer/refund_funding_charge_confirmation.html.erb
@@ -1,0 +1,6 @@
+<%= header_section("Your backup card was charged") %>
+<div>
+  <p>Your backup payment method was charged <strong><%= @amount %></strong> to cover a refund that exceeded your Gumroad balance.</p>
+  <p>This amount has been added to your balance and will be reflected in your next payout.</p>
+  <p>You can manage your backup payment method in your <a href="<%= settings_payments_url %>">payment settings</a>.</p>
+</div>

--- a/app/views/contacting_creator_mailer/refund_funding_charge_confirmation.text.erb
+++ b/app/views/contacting_creator_mailer/refund_funding_charge_confirmation.text.erb
@@ -1,0 +1,10 @@
+Your backup card was charged
+
+Amount: <%= @amount %>
+
+Your backup payment method was charged <%= @amount %> to cover a refund that exceeded your Gumroad balance.
+
+This amount has been added to your balance and will be reflected in your next payout.
+
+You can manage your backup payment method in your payment settings:
+<%= settings_payments_url %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -452,6 +452,9 @@ Rails.application.routes.draw do
         post :opt_in_to_au_backtax_collection
         get :paypal_connect
         post :remove_credit_card
+        post :save_refund_funding_card
+        delete :remove_refund_funding_card
+        post :dismiss_refund_funding_banner
       end
       resource :stripe, controller: :stripe, only: [] do
         collection do

--- a/db/migrate/20260209000001_add_refund_funding_credit_card_to_users.rb
+++ b/db/migrate/20260209000001_add_refund_funding_credit_card_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRefundFundingCreditCardToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :users, :refund_funding_credit_card, type: :integer, index: true
+  end
+end

--- a/db/migrate/20260209000002_add_refund_funding_columns_to_credits.rb
+++ b/db/migrate/20260209000002_add_refund_funding_columns_to_credits.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddRefundFundingColumnsToCredits < ActiveRecord::Migration[7.1]
+  def change
+    add_column :credits, :refund_funding_purchase_id, :bigint
+    add_column :credits, :credit_card_id, :bigint
+    add_index :credits, :refund_funding_purchase_id
+    add_index :credits, :credit_card_id
+  end
+end

--- a/db/migrate/20261119011937_add_unique_index_to_credits_refund_funding_purchase_id.rb
+++ b/db/migrate/20261119011937_add_unique_index_to_credits_refund_funding_purchase_id.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexToCreditsRefundFundingPurchaseId < ActiveRecord::Migration[7.1]
+  def change
+    add_index :credits, :refund_funding_purchase_id,
+              unique: true,
+              where: "refund_funding_purchase_id IS NOT NULL",
+              name: "index_credits_unique_refund_funding_purchase"
+  end
+end

--- a/spec/controllers/settings/payments_controller_spec.rb
+++ b/spec/controllers/settings/payments_controller_spec.rb
@@ -1560,4 +1560,105 @@ describe Settings::PaymentsController, :vcr, type: :controller, inertia: true do
       expect(flash[:notice]).to eq("Thanks! You're all set.")
     end
   end
+
+  describe "POST save_refund_funding_card" do
+    before do
+      sign_in seller
+    end
+
+    context "with valid card params" do
+      let(:credit_card) do
+        CreditCard.new(
+          stripe_customer_id: "cus_test_rf",
+          processor_payment_method_id: "pm_test_rf",
+          stripe_fingerprint: "fp_test_rf",
+          visual: "**** **** **** 4242",
+          card_type: CardType::VISA,
+          expiry_month: 12,
+          expiry_year: 2030,
+          charge_processor_id: StripeChargeProcessor.charge_processor_id
+        ).tap(&:save!)
+      end
+
+      before do
+        allow(CardParamsHelper).to receive(:get_card_data_handling_mode).and_return("stripejs.0")
+        allow(CardParamsHelper).to receive(:check_for_errors).and_return(nil)
+        allow(CardParamsHelper).to receive(:build_chargeable).and_return(double("chargeable"))
+        allow(CreditCard).to receive(:create).and_return(credit_card)
+      end
+
+      it "saves the refund funding card and returns success" do
+        post :save_refund_funding_card, params: { card_data_handling_mode: "stripejs.0", stripe_payment_method_id: "pm_test" }
+
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        expect(json["success"]).to be true
+        expect(json["credit_card"]["visual"]).to eq("**** **** **** 4242")
+        expect(seller.reload.refund_funding_credit_card).to eq(credit_card)
+      end
+    end
+
+    context "with invalid card params" do
+      before do
+        allow(CardParamsHelper).to receive(:get_card_data_handling_mode).and_return(nil)
+        allow(CardParamsHelper).to receive(:check_for_errors).and_return(nil)
+        allow(CardParamsHelper).to receive(:build_chargeable).and_return(nil)
+      end
+
+      it "returns an error" do
+        post :save_refund_funding_card, params: {}
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        json = JSON.parse(response.body)
+        expect(json["success"]).to be false
+        expect(json["error"]).to eq("Invalid card information.")
+      end
+    end
+  end
+
+  describe "DELETE remove_refund_funding_card" do
+    let(:credit_card) do
+      CreditCard.new(
+        stripe_customer_id: "cus_test_rf",
+        processor_payment_method_id: "pm_test_rf",
+        stripe_fingerprint: "fp_test_rf",
+        visual: "**** **** **** 4242",
+        card_type: CardType::VISA,
+        expiry_month: 12,
+        expiry_year: 2030,
+        charge_processor_id: StripeChargeProcessor.charge_processor_id
+      ).tap(&:save!)
+    end
+
+    before do
+      sign_in seller
+      seller.update!(refund_funding_credit_card: credit_card)
+    end
+
+    it "removes the refund funding card" do
+      delete :remove_refund_funding_card
+
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json["success"]).to be true
+      expect(seller.reload.refund_funding_credit_card).to be_nil
+    end
+  end
+
+  describe "POST dismiss_refund_funding_banner" do
+    before do
+      sign_in seller
+    end
+
+    it "dismisses the refund funding banner" do
+      expect(seller.dismissed_refund_payment_method_banner?).to be false
+
+      post :dismiss_refund_funding_banner
+
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json["success"]).to be true
+      expect(seller.reload.dismissed_refund_payment_method_banner?).to be true
+    end
+  end
 end

--- a/spec/services/refund_funding_charge_service_spec.rb
+++ b/spec/services/refund_funding_charge_service_spec.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe RefundFundingChargeService do
+  let(:seller) { create(:user) }
+  let(:credit_card) do
+    CreditCard.new(
+      stripe_customer_id: "cus_test_123",
+      processor_payment_method_id: "pm_test_123",
+      stripe_fingerprint: "fingerprint_123",
+      visual: "**** **** **** 4242",
+      card_type: CardType::VISA,
+      expiry_month: 12,
+      expiry_year: 2030,
+      charge_processor_id: StripeChargeProcessor.charge_processor_id
+    ).tap(&:save!)
+  end
+  let(:product) { create(:product, user: seller) }
+  let(:purchase) do
+    create(:purchase_in_progress,
+           link: product,
+           seller:,
+           price_cents: 2000,
+           total_transaction_cents: 2000).tap do |p|
+      p.update_columns(succeeded_at: 1.day.ago, purchase_state: "successful")
+    end
+  end
+
+  before do
+    seller.update!(refund_funding_credit_card: credit_card)
+  end
+
+  describe "#perform" do
+    subject(:result) { described_class.new(user: seller, amount_cents:, purchase:).perform }
+
+    let(:amount_cents) { 1500 }
+
+    context "when credit card is not configured" do
+      before { seller.update!(refund_funding_credit_card: nil) }
+
+      it "returns an error" do
+        expect(result.success?).to be false
+        expect(result.error_message).to eq("No backup payment method configured.")
+      end
+    end
+
+    context "when amount is below minimum" do
+      let(:amount_cents) { 50 }
+
+      it "returns an error" do
+        expect(result.success?).to be false
+        expect(result.error_message).to eq("Amount must be at least $1.")
+      end
+    end
+
+    context "when amount exceeds maximum" do
+      let(:amount_cents) { 1_500_000 }
+
+      it "returns an error" do
+        expect(result.success?).to be false
+        expect(result.error_message).to eq("Amount cannot exceed $10,000.")
+      end
+    end
+
+    context "when Stripe charge succeeds" do
+      before do
+        allow(Stripe::PaymentIntent).to receive(:create).and_return(
+          OpenStruct.new(
+            status: "succeeded",
+            id: "pi_test_123",
+            latest_charge: "ch_test_123"
+          )
+        )
+      end
+
+      it "returns success with a credit" do
+        expect(result.success?).to be true
+        expect(result.error_message).to be_nil
+        expect(result.credit).to be_a(Credit)
+        expect(result.credit.amount_cents).to eq(1500)
+      end
+
+      it "creates a credit with correct attributes" do
+        result
+        credit = Credit.last
+        expect(credit.user).to eq(seller)
+        expect(credit.amount_cents).to eq(1500)
+        expect(credit.refund_funding_purchase).to eq(purchase)
+        expect(credit.credit_card).to eq(credit_card)
+        expect(credit.refund_funding_processor_transaction_id).to eq("ch_test_123")
+        expect(credit.refund_funding_processor_payment_intent_id).to eq("pi_test_123")
+      end
+
+      it "creates a balance transaction" do
+        expect { result }.to change(BalanceTransaction, :count).by(1)
+        balance_transaction = BalanceTransaction.last
+        expect(balance_transaction.user).to eq(seller)
+        expect(balance_transaction.issued_amount_gross_cents).to eq(1500)
+      end
+
+      it "calls Stripe with deterministic idempotency key" do
+        expect(Stripe::PaymentIntent).to receive(:create).with(
+          hash_including(
+            amount: 1500,
+            currency: "usd",
+            customer: "cus_test_123",
+            payment_method: "pm_test_123",
+            off_session: true,
+            confirm: true
+          ),
+          { idempotency_key: "refund_funding_#{seller.id}_#{purchase.id}" }
+        ).and_return(
+          OpenStruct.new(status: "succeeded", id: "pi_test_123", latest_charge: "ch_test_123")
+        )
+        result
+      end
+    end
+
+    context "when Stripe returns requires_action (3D Secure)" do
+      before do
+        allow(Stripe::PaymentIntent).to receive(:create).and_return(
+          OpenStruct.new(status: "requires_action", id: "pi_test_123", latest_charge: nil)
+        )
+      end
+
+      it "returns failure with SCA-specific message" do
+        expect(result.success?).to be false
+        expect(result.error_message).to include("additional authentication")
+        expect { result }.not_to change(Credit, :count)
+      end
+    end
+
+    context "when Stripe card error" do
+      before do
+        allow(Stripe::PaymentIntent).to receive(:create).and_raise(
+          Stripe::CardError.new("Your card was declined.", nil, code: "card_declined")
+        )
+      end
+
+      it "returns failure with card error message" do
+        expect(result.success?).to be false
+        expect(result.error_message).to eq("Your card was declined.")
+        expect { result }.not_to change(Credit, :count)
+      end
+    end
+
+    context "when Stripe generic error" do
+      before do
+        allow(Stripe::PaymentIntent).to receive(:create).and_raise(
+          Stripe::StripeError.new("Network timeout")
+        )
+      end
+
+      it "returns failure with generic message" do
+        expect(result.success?).to be false
+        expect(result.error_message).to eq("Payment processor error. Please try again.")
+      end
+    end
+  end
+
+  describe "#reverse_charge!" do
+    let(:service) { described_class.new(user: seller, amount_cents: 1500, purchase:) }
+
+    it "creates a Stripe refund for the payment intent" do
+      expect(Stripe::Refund).to receive(:create).with({ payment_intent: "pi_test_123" })
+      service.reverse_charge!("pi_test_123")
+    end
+
+    it "handles Stripe errors gracefully" do
+      allow(Stripe::Refund).to receive(:create).and_raise(Stripe::StripeError.new("Refund failed"))
+      expect { service.reverse_charge!("pi_test_123") }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
Issue: #1594

# Description

## Problem

Sellers sometimes have insufficient balance to cover refunds. Currently, when a seller tries to refund a purchase but doesn't have enough balance, the refund fails and they have to manually add funds first. This creates friction and delays for both sellers and buyers.

## Solution

Add the ability for sellers to configure a backup credit card in Settings > Payments that will be automatically charged when their balance is insufficient to process a refund.

**Key improvements over existing PRs (#2425, #2839, #3399):**

- **DB-level idempotency**: Unique partial index on credits.refund_funding_purchase_id (requested in #3399 review by pegasus1134)
- **Charge reversal**: reverse_charge! automatically reverses the backup card charge if refund fails post-charge
- **Race condition fix**: seller.reload + balance re-check after charging prevents double-charges when concurrent refunds read the same balance
- **3D Secure detection**: Cards requiring interactive authentication are rejected with a clear message since off-session payments can't handle it
- **Plain text email**: Both HTML and .text.erb templates for charge confirmation
- **Correct email queue**: Uses default queue instead of critical for non-critical confirmation emails
- **Figma-compliant UI**: Includes "Name on card" field as per approved design

---

### Before

https://github.com/user-attachments/assets/b52d4fd5-1f4a-411d-b854-2603665b3890


### After

https://github.com/user-attachments/assets/42d31229-61ba-4647-96b4-fade13a2d7bd

---

# Test Results

Service spec:

<img width="571" height="105" alt="image" src="https://github.com/user-attachments/assets/e6617f93-5959-4ea1-84a3-772c1d2b9ec9" />

Controller spec (refund_funding):

<img width="564" height="109" alt="image" src="https://github.com/user-attachments/assets/c50cd483-24cf-4ab9-a6e7-8e2dc2646c67" />

Full PaymentsController spec suite confirming no regressions (116 examples, 0 failures)

<img width="537" height="296" alt="image" src="https://github.com/user-attachments/assets/1f780a7e-0821-41e4-9e45-beeb90c37366" />

---

# Checklist
- [x] I have read the contributing guidelines
- [x] I have watched Gumroad PR review livestreams
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure
Model: Claude Opus 4
IDE: VS Code with Claude Code
Usage: Implementation assistance, code review, test writing
