### PR TITLE
Fix sub-pixel border misalignment between sidebar and page header

### DIFF
--- a/app/javascript/components/Button.tsx
+++ b/app/javascript/components/Button.tsx
@@ -32,7 +32,7 @@ export const buttonVariants = cva(
         destructive: "",
       },
       size: {
-        default: "px-4 py-3 text-base leading-[1.4]",
+        default: "px-4 py-3 text-base leading-snug",
         sm: "p-2 text-sm leading-[1.3]",
       },
       color: {

--- a/app/javascript/components/Nav.tsx
+++ b/app/javascript/components/Nav.tsx
@@ -139,7 +139,6 @@ export const Nav = ({ title, children, footer }: Props) => {
         </div>
         <header className="hidden p-6 lg:grid">
           <a href={Routes.root_url()} aria-label="Dashboard" className="no-underline">
-            {/* This custom text and line height size is required so the header's bottom border aligns with the main page header’s bottom border */}
             <span className="logo-full w-full text-[2.5rem] leading-[1.2]" />
           </a>
         </header>

--- a/app/javascript/components/ui/Checkbox.tsx
+++ b/app/javascript/components/ui/Checkbox.tsx
@@ -17,7 +17,7 @@ export const Checkbox = React.forwardRef<
         "size-[calc(1lh+0.125rem)]",
         "border border-border",
         "bg-background",
-        "text-base leading-[1.4]",
+        "text-base leading-snug",
         "shrink-0 cursor-pointer",
         "disabled:cursor-not-allowed disabled:opacity-30",
         "checked:bg-accent",

--- a/app/javascript/components/ui/Fieldset.tsx
+++ b/app/javascript/components/ui/Fieldset.tsx
@@ -41,7 +41,7 @@ export const FieldsetTitle = React.forwardRef<
   <legend
     ref={ref}
     className={classNames(
-      "relative mb-2 flex w-full items-center justify-between text-base leading-[1.4] font-bold",
+      "relative mb-2 flex w-full items-center justify-between text-base leading-snug font-bold",
       "[&_a]:font-normal",
       className,
     )}

--- a/app/javascript/components/ui/Input.tsx
+++ b/app/javascript/components/ui/Input.tsx
@@ -6,7 +6,7 @@ import { useFieldset, stateBorderStyles } from "$app/components/ui/Fieldset";
 import { useInputGroup } from "$app/components/ui/InputGroup";
 
 export const baseInputStyles = classNames(
-  "font-[inherit] py-3 px-4 text-base leading-[1.4]",
+  "font-[inherit] py-3 px-4 text-base leading-snug",
   "border border-border rounded block w-full bg-background placeholder:text-muted",
   "focus:outline-2 focus:outline-accent focus:outline-offset-0",
   "disabled:cursor-not-allowed disabled:opacity-30",

--- a/app/javascript/components/ui/PageHeader.tsx
+++ b/app/javascript/components/ui/PageHeader.tsx
@@ -13,7 +13,7 @@ export const PageHeader = React.forwardRef<
   }
 >(({ title, actions, children, className, showTitleOnMobile = false }, ref) => (
   <header className={classNames("flex flex-col gap-4 border-b border-border p-4 md:p-8", className)} ref={ref}>
-    <div className="flex items-center justify-between gap-2">
+    <div className="flex min-h-8 items-center justify-between gap-2">
       <h1 className={classNames("line-clamp-2 text-2xl", !showTitleOnMobile && "hidden! sm:block!")}>{title}</h1>
       <div className="grid flex-1 grid-cols-2 gap-2 has-[>*:only-child]:grid-cols-1 sm:flex sm:flex-none md:-my-2">
         {actions}

--- a/app/javascript/components/ui/Radio.tsx
+++ b/app/javascript/components/ui/Radio.tsx
@@ -15,7 +15,7 @@ export const Radio = React.forwardRef<
         "size-[calc(1lh+0.125rem)]",
         "border border-border",
         "bg-background",
-        "text-base leading-[1.4]",
+        "text-base leading-snug",
         "shrink-0 cursor-pointer",
         "disabled:cursor-not-allowed disabled:opacity-30",
         "checked:bg-accent",

--- a/app/javascript/stylesheets/_definitions.scss
+++ b/app/javascript/stylesheets/_definitions.scss
@@ -65,7 +65,7 @@ $bg-colors: list.join($states, primary "black" accent filled);
 
 $spacers: sizes(0.25, 0.5, 0.75, 1, 1.5, 2, 3, 4);
 $font-sizes: sizes(0.875, 1, 1.15, 1.25, 2.5);
-$line-heights: (1.3, 1.4, 1.4, 1.3, 1.2);
+$line-heights: (1.3, 1.375, 1.375, 1.3, 1.2);
 $breakpoints: (
   sm: 640px,
   lg: 1024px,

--- a/app/views/doorkeeper/authorizations/new.html.erb
+++ b/app/views/doorkeeper/authorizations/new.html.erb
@@ -44,7 +44,7 @@
       <%= hidden_field_tag :state, @pre_auth.state %>
       <%= hidden_field_tag :response_type, @pre_auth.response_type %>
       <%= hidden_field_tag :scope, @pre_auth.scope %>
-      <%= button_tag "Authorize", class: "inline-flex items-center justify-center gap-2 cursor-pointer border border-border rounded font-[inherit] no-underline transition-transform hover:-translate-1 hover:shadow active:translate-0 active:shadow-none disabled:opacity-30 disabled:hover:translate-0 disabled:hover:shadow-none bg-accent text-accent-foreground px-4 py-3 text-base leading-[1.4]" %>
+      <%= button_tag "Authorize", class: "inline-flex items-center justify-center gap-2 cursor-pointer border border-border rounded font-[inherit] no-underline transition-transform hover:-translate-1 hover:shadow active:translate-0 active:shadow-none disabled:opacity-30 disabled:hover:translate-0 disabled:hover:shadow-none bg-accent text-accent-foreground px-4 py-3 text-base leading-snug" %>
     <% end %>
     <%= form_tag oauth_authorization_path, method: :delete, style: "display: contents" do %>
       <%= hidden_field_tag :client_id, @pre_auth.client.uid %>
@@ -52,7 +52,7 @@
       <%= hidden_field_tag :state, @pre_auth.state %>
       <%= hidden_field_tag :response_type, @pre_auth.response_type %>
       <%= hidden_field_tag :scope, @pre_auth.scope %>
-      <%= button_tag "Deny", class: "inline-flex items-center justify-center gap-2 cursor-pointer border border-border rounded font-[inherit] no-underline transition-transform hover:-translate-1 hover:shadow active:translate-0 active:shadow-none disabled:opacity-30 disabled:hover:translate-0 disabled:hover:shadow-none bg-white text-black hover:bg-pink hover:text-black px-4 py-3 text-base leading-[1.4]" %>
+      <%= button_tag "Deny", class: "inline-flex items-center justify-center gap-2 cursor-pointer border border-border rounded font-[inherit] no-underline transition-transform hover:-translate-1 hover:shadow active:translate-0 active:shadow-none disabled:opacity-30 disabled:hover:translate-0 disabled:hover:shadow-none bg-white text-black hover:bg-pink hover:text-black px-4 py-3 text-base leading-snug" %>
     <% end %>
   </footer>
 </main>

--- a/app/views/purchases/confirm_receipt_email.html.erb
+++ b/app/views/purchases/confirm_receipt_email.html.erb
@@ -7,7 +7,7 @@
   <%= form_tag(receipt_purchase_path(@purchase.external_id), method: "get") do %>
     <%= label_tag :email, "Email address:", class: "form-label" %>
     <%= email_field_tag :email, nil, placeholder: "Email address", required: true %>
-    <%= button_tag "View receipt", type: "submit", class: "inline-flex items-center justify-center gap-2 cursor-pointer border border-border rounded font-[inherit] no-underline transition-transform hover:-translate-1 hover:shadow active:translate-0 active:shadow-none disabled:opacity-30 disabled:hover:translate-0 disabled:hover:shadow-none px-4 py-3 text-base leading-[1.4] bg-primary text-primary-foreground hover:bg-accent hover:text-accent-foreground w-full", name: nil %>
+    <%= button_tag "View receipt", type: "submit", class: "inline-flex items-center justify-center gap-2 cursor-pointer border border-border rounded font-[inherit] no-underline transition-transform hover:-translate-1 hover:shadow active:translate-0 active:shadow-none disabled:opacity-30 disabled:hover:translate-0 disabled:hover:shadow-none px-4 py-3 text-base leading-snug bg-primary text-primary-foreground hover:bg-accent hover:text-accent-foreground w-full", name: nil %>
   <% end %>
 </main>
 <% content_for :footer do %>

--- a/app/views/url_redirects/check_purchaser.html.erb
+++ b/app/views/url_redirects/check_purchaser.html.erb
@@ -8,7 +8,7 @@
     <%= hidden_field_tag :next, params[:next] %>
     <%= label_tag :email, "Email address used to purchase this product:", class: "form-label" %>
     <%= email_field_tag :email, nil, placeholder: "Email address", required: true %>
-    <%= button_tag "Change purchase", type: "submit", class: "inline-flex items-center justify-center gap-2 cursor-pointer border border-border rounded font-[inherit] no-underline transition-transform hover:-translate-1 hover:shadow active:translate-0 active:shadow-none disabled:opacity-30 disabled:hover:translate-0 disabled:hover:shadow-none px-4 py-3 text-base leading-[1.4] bg-primary text-primary-foreground hover:bg-accent hover:text-accent-foreground w-full" %>
+    <%= button_tag "Change purchase", type: "submit", class: "inline-flex items-center justify-center gap-2 cursor-pointer border border-border rounded font-[inherit] no-underline transition-transform hover:-translate-1 hover:shadow active:translate-0 active:shadow-none disabled:opacity-30 disabled:hover:translate-0 disabled:hover:shadow-none px-4 py-3 text-base leading-snug bg-primary text-primary-foreground hover:bg-accent hover:text-accent-foreground w-full" %>
   <% end %>
 </main>
 <% content_for :footer do %>


### PR DESCRIPTION
## Problem

On dashboard pages with action buttons or selects in the page header (Collaborators, Settings, Analytics, etc.), the horizontal border between the sidebar and the main content area is misaligned by ~0.4px. The sidebar's NavLink border and the PageHeader's bottom border don't connect into a continuous line at the junction point.

## Approach

The design system uses a line-height of `1.4`, which at 16px gives `22.4px` — not a whole number. That 0.4px fraction adds up through padding and borders, making buttons 48.4px tall, nav links 56.4px, etc. The result: borders on the sidebar and the main content end up at slightly different positions.

The fix changes line-height from `1.4` to `1.375` (Tailwind's `leading-snug`) in both the SCSS design tokens (`$line-heights`) and the React component Tailwind classes (Button, Input, Checkbox, Radio, Fieldset). At 16px this gives exactly `22px`, producing clean integer element heights (buttons 48px, nav links 56px) and pixel-perfect border alignment.

The visual difference between 22.4px and 22px line-height is imperceptible (1.8% change). The existing `DEFAULT_FORM_ELEMENT_HEIGHT_IN_PX = 48` constant was already hardcoded to the integer value, confirming the design intent was always 48px.

The PageHeader title row gets a `min-h-8` (32px) to prevent Safari from collapsing the `<h1>` to 31px on pages without action buttons (a font-metrics rounding difference with `line-clamp-2`).

## Before/After

Before:
<img width="838" height="426" src="https://github.com/user-attachments/assets/e76d7b99-3949-4935-a2bc-4219769bbf22" />

After:
<img width="832" height="420" src="https://github.com/user-attachments/assets/854f88b7-e0d1-4599-912f-d0535c7a7c27" />

---

This PR was implemented with AI assistance using Claude Code for code generation. All code was self-reviewed.