### PR TITLE
Fix search bar disappearing on Products page when query returns zero …

### DIFF
--- a/app/javascript/components/ProductsDashboardPage.tsx
+++ b/app/javascript/components/ProductsDashboardPage.tsx
@@ -36,6 +36,18 @@ export const ProductsDashboardPage = ({
 }: ProductsDashboardPageProps) => {
   const [enableArchiveTab, setEnableArchiveTab] = React.useState(archivedProductsCount > 0);
   const [query, setQuery] = React.useState("");
+  const [hasExistingProducts, setHasExistingProducts] = React.useState(
+    products.length > 0 || memberships.length > 0,
+  );
+
+  React.useEffect(() => {
+    if (products.length > 0 || memberships.length > 0) {
+      setHasExistingProducts(true);
+    }
+  }, [products.length, memberships.length]);
+
+  const isSearchActive = query.length > 0;
+  const hasNoResults = isSearchActive && memberships.length === 0 && products.length === 0;
 
   return (
     <ProductsLayout
@@ -44,7 +56,9 @@ export const ProductsDashboardPage = ({
       archivedTabVisible={enableArchiveTab}
       ctaButton={
         <>
-          {products.length > 0 ? <Search value={query} onSearch={setQuery} placeholder="Search products" /> : null}
+          {hasExistingProducts ? (
+            <Search value={query} onSearch={setQuery} placeholder="Search products" />
+          ) : null}
           <NavigationButtonInertia href={Routes.new_product_path()} disabled={!canCreateProduct} color="accent">
             New product
           </NavigationButtonInertia>
@@ -52,7 +66,7 @@ export const ProductsDashboardPage = ({
       }
     >
       <section className="p-4 md:p-8">
-        {memberships.length === 0 && products.length === 0 ? (
+        {!hasExistingProducts && memberships.length === 0 && products.length === 0 ? (
           <Placeholder>
             <PlaceholderImage src={placeholder} />
             <h2>We’ve never met an idea we didn’t like.</h2>
@@ -70,16 +84,24 @@ export const ProductsDashboardPage = ({
             </span>
           </Placeholder>
         ) : (
-          <ProductsPage
-            memberships={memberships}
-            membershipsPagination={membershipsPagination}
-            membershipsSort={membershipsSort}
-            products={products}
-            productsPagination={productsPagination}
-            productsSort={productsSort}
-            query={query}
-            setEnableArchiveTab={setEnableArchiveTab}
-          />
+          <>
+            {hasNoResults ? (
+              <Placeholder>
+                <h2>No products found</h2>
+                <p>No products matched your search. Try a different search term.</p>
+              </Placeholder>
+            ) : null}
+            <ProductsPage
+              memberships={memberships}
+              membershipsPagination={membershipsPagination}
+              membershipsSort={membershipsSort}
+              products={products}
+              productsPagination={productsPagination}
+              productsSort={productsSort}
+              query={query}
+              setEnableArchiveTab={setEnableArchiveTab}
+            />
+          </>
         )}
       </section>
     </ProductsLayout>

--- a/app/javascript/components/ProductsPage.tsx
+++ b/app/javascript/components/ProductsPage.tsx
@@ -30,27 +30,22 @@ const ProductsPage = ({
   type?: Tab;
 }) => (
   <div className="grid gap-12">
-    {memberships.length > 0 ? (
-      <ProductsPageMembershipsTable
-        query={query}
-        entries={memberships}
-        pagination={membershipsPagination}
-        sort={membershipsSort}
-        selectedTab={type}
-        setEnableArchiveTab={setEnableArchiveTab}
-      />
-    ) : null}
-
-    {products.length > 0 ? (
-      <ProductsPageProductsTable
-        query={query}
-        entries={products}
-        pagination={productsPagination}
-        sort={productsSort}
-        selectedTab={type}
-        setEnableArchiveTab={setEnableArchiveTab}
-      />
-    ) : null}
+    <ProductsPageMembershipsTable
+      query={query}
+      entries={memberships}
+      pagination={membershipsPagination}
+      sort={membershipsSort}
+      selectedTab={type}
+      setEnableArchiveTab={setEnableArchiveTab}
+    />
+    <ProductsPageProductsTable
+      query={query}
+      entries={products}
+      pagination={productsPagination}
+      sort={productsSort}
+      selectedTab={type}
+      setEnableArchiveTab={setEnableArchiveTab}
+    />
   </div>
 );
 


### PR DESCRIPTION
### Issue
Fixes: #3262

---

### Summary
Fixed an issue where the **search bar on the Products page would disappear** when the search query returned no results.

---

### Fix
Ensured the search bar remains **visible even with zero results** by separating its rendering logic from the search results check.

---

### Before


https://github.com/user-attachments/assets/c7eb9c9d-84e9-45be-803b-c889dccdcaed


### After



https://github.com/user-attachments/assets/c9289d94-0d19-485e-8aec-a8a238504588







---

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [ ] I have added/updated tests for my changes

---

### AI Disclosure
Claude Opus 4.6 is used to assist with code changes