### PR TITLE
feat: Add block options menu to input blocks and fix styling

### DIFF
--- a/app/javascript/components/TiptapExtensions/FileUpload.tsx
+++ b/app/javascript/components/TiptapExtensions/FileUpload.tsx
@@ -6,8 +6,8 @@ import { cast } from "ts-safe-cast";
 import { Button } from "$app/components/Button";
 import { FileInput } from "$app/components/Download/CustomField/FileInput";
 import { Icon } from "$app/components/Icons";
+import { NodeActionsMenu } from "$app/components/TiptapExtensions/NodeActionsMenu";
 import { createInsertCommand } from "$app/components/TiptapExtensions/utils";
-import { Placeholder } from "$app/components/ui/Placeholder";
 
 declare module "@tiptap/core" {
   interface Commands<ReturnType> {
@@ -38,13 +38,14 @@ export const FileUpload = TiptapNode.create({
 
 const FileUploadNodeView = ({ editor, node }: NodeViewProps) => (
   <NodeViewWrapper data-drag-handle={editor.isEditable ? true : undefined}>
+    {editor.isEditable ? <NodeActionsMenu editor={editor} /> : null}
     {editor.isEditable ? (
-      <Placeholder>
+      <fieldset className="flex items-center justify-center rounded border border-border bg-background p-6">
         <Button color="primary">
           <Icon name="upload-fill" />
           Upload files
         </Button>
-      </Placeholder>
+      </fieldset>
     ) : (
       <FileInput customFieldId={cast<string>(node.attrs.id)} />
     )}

--- a/app/javascript/components/TiptapExtensions/TextInputNodeView.tsx
+++ b/app/javascript/components/TiptapExtensions/TextInputNodeView.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import { cast } from "ts-safe-cast";
 
 import { TextInput } from "$app/components/Download/CustomField/TextInput";
+import { NodeActionsMenu } from "$app/components/TiptapExtensions/NodeActionsMenu";
 
 export const TextInputNodeView = ({ editor, node, updateAttributes }: NodeViewProps) => {
   const label = cast<string | null>(node.attrs.label);
@@ -16,6 +17,7 @@ export const TextInputNodeView = ({ editor, node, updateAttributes }: NodeViewPr
 
   return (
     <NodeViewWrapper data-drag-handle>
+      {editor.isEditable ? <NodeActionsMenu editor={editor} /> : null}
       <fieldset>
         {editor.isEditable ? (
           <>
@@ -23,16 +25,7 @@ export const TextInputNodeView = ({ editor, node, updateAttributes }: NodeViewPr
               value={label ?? ""}
               placeholder="Title"
               onChange={(evt) => updateAttributes({ label: evt.target.value })}
-              className="border-0"
-              style={{
-                background: "none",
-                padding: 0,
-                margin: 0,
-                font: "inherit",
-                color: "inherit",
-                outline: "none",
-                borderRadius: 0,
-              }}
+              className="w-full border-0 bg-transparent p-0 font-inherit text-inherit outline-none"
             />
             {type === "shortAnswer" ? <input {...sharedProps} /> : <textarea {...sharedProps} />}
           </>


### PR DESCRIPTION
Issue: #2959 

# Description

## Problem
Input blocks (File Upload, Short Answer, Long Answer) in the Product Content Editor lacked the standard block options menu, making them difficult to delete or reorder. The styling was also inconsistent with other editor blocks.

## Solution
- Added `NodeActionsMenu` component to File Upload and Text Input blocks
- Enabled Move up/Move down/Delete actions via block options menu
- Fixed visual styling by replacing `Placeholder` component with `fieldset` 
- Removed inline styles in favor of utility classes for better consistency

---

# Before/After
| State| Light | Dark |
|------------|--------|-------|
| **Before** | <img width="1920" height="1080" alt="light" src="https://github.com/user-attachments/assets/c04c1dda-6104-47c2-878e-908d8f782264" /> | <img width="1920" height="1080" alt="dark" src="https://github.com/user-attachments/assets/8567cb76-24b2-4307-9815-64523446a404" /> |
| **After** | <video src="https://github.com/user-attachments/assets/72dbfa6b-ccb6-4a99-ae61-a39c9cbf26ba" width="400" controls></video> | <video src="https://github.com/user-attachments/assets/4fcf9b67-809f-420d-a4b3-6f6be037b08e" width="400" controls></video> |

---

# Test Results
- [x] Block options menu appears on hover/selection
- [x] Move up/Move down commands work correctly
- [x] Delete action removes block from editor
- [x] Visual styling matches other input blocks
- [x] File upload button maintains original appearance

---

# Checklist

- [X] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [X] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [X] I have performed a self-review and left review comments on my PR
- [X] I have added/updated tests for my changes

---

# AI Disclosure

GitHub Copilot was used to help locate the correct components for the "Block Options" menu and debug the CSS styling issues. All implementation logic was verified manually.