### PR TITLE
Close button in mobile view of nested menu

### DIFF
--- a/app/javascript/components/NestedMenu.tsx
+++ b/app/javascript/components/NestedMenu.tsx
@@ -330,7 +330,7 @@ const OverlayMenu = ({
         open={menuOpen}
         onOpenChange={setMenuOpen}
         modal
-        showCloseButton={true}
+        showCloseButton
         className="right-auto w-80 max-w-80 border-l-0 p-0 md:left-0 md:border-r"
       >
         <ItemsList

--- a/app/javascript/components/ui/Sheet.tsx
+++ b/app/javascript/components/ui/Sheet.tsx
@@ -11,16 +11,19 @@ export const Sheet = ({
   modal = false,
   showCloseButton = false,
   ...props
-}: { className?: string; modal?: boolean; showCloseButton?: boolean  } & React.ComponentProps<typeof Dialog.Root>) => (
+}: { className?: string; modal?: boolean; showCloseButton?: boolean } & React.ComponentProps<typeof Dialog.Root>) => (
   <Dialog.Root {...props} modal={modal}>
     <Dialog.Portal>
       {modal ? (
         <Dialog.Overlay className="fixed inset-0 z-40 bg-black/80">
-          {showCloseButton && (
-          <Dialog.Close className="absolute right-4 top-4 cursor-pointer text-white bg-transparent" aria-label="Close">
-            <Icon name="x" className="text-2xl bg-white" />
-          </Dialog.Close>
-          )}
+          {showCloseButton ? (
+            <Dialog.Close
+              className="absolute top-4 right-4 cursor-pointer bg-transparent text-white"
+              aria-label="Close"
+            >
+              <Icon name="x" className="bg-white text-2xl" />
+            </Dialog.Close>
+          ) : null}
         </Dialog.Overlay>
       ) : null}
       <Dialog.Content


### PR DESCRIPTION
Issue: #2724 

# Description
In nested menu mobile view close button 'x' was missing

# Before/After

<table>
  <tr>
    <td align="center"><b>Before</b></td>
    <td align="center"><b>After</b></td>
  </tr>
  <tr>
  <td>
<img width="635" height="950" alt="image" src="https://github.com/user-attachments/assets/df745e79-c8c9-4678-a196-5a7df45423b1" />
</td>
    <td>
<img width="632" height="946" alt="image" src="https://github.com/user-attachments/assets/a608b6b6-7935-459e-a712-39ddf80ff509" />
</td>
<tr>
</table>


# Checklist

- [X] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [X] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [X] I have performed a self-review and left review comments on my PR
- [ ] I have added/updated tests for my changes

---

# AI Disclosure
No ai was used