### PR TITLE
Display creation date and link for duplicate-named products in Bundle search results

### DIFF
--- a/app/javascript/components/BundleEdit/ContentTab/BundleProductSelector.tsx
+++ b/app/javascript/components/BundleEdit/ContentTab/BundleProductSelector.tsx
@@ -11,14 +11,21 @@ import {
 } from "$app/components/CartItemList";
 import { Thumbnail } from "$app/components/Product/Thumbnail";
 
+const formatCreatedAt = (iso: string) => {
+  const date = new Date(iso);
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+};
+
 export const BundleProductSelector = ({
   bundleProduct,
   selected,
   onToggle,
+  showDetails = false,
 }: {
   bundleProduct: BundleProduct;
   selected?: boolean;
   onToggle: () => void;
+  showDetails?: boolean;
 }) => (
   <CartItem>
     <CartItemMedia className="sm:w-24">
@@ -26,12 +33,30 @@ export const BundleProductSelector = ({
     </CartItemMedia>
     <CartItemMain>
       <CartItemTitle>{bundleProduct.name}</CartItemTitle>
-      {bundleProduct.variants ? (
-        <CartItemFooter>
-          {bundleProduct.variants.list.length} {bundleProduct.variants.list.length === 1 ? "version" : "versions"}{" "}
-          available
-        </CartItemFooter>
+      {showDetails && bundleProduct.url ? (
+        <a href={bundleProduct.url} target="_blank" rel="noopener noreferrer" className="text-sm underline">
+          {bundleProduct.url.replace(/^https?:\/\//u, "")}
+        </a>
       ) : null}
+      <CartItemFooter>
+        {showDetails && bundleProduct.created_at ? (
+          <span>
+            {formatCreatedAt(bundleProduct.created_at)}
+            {bundleProduct.variants ? (
+              <>
+                {" \u00b7 "}
+                {bundleProduct.variants.list.length} {bundleProduct.variants.list.length === 1 ? "version" : "versions"}{" "}
+                available
+              </>
+            ) : null}
+          </span>
+        ) : bundleProduct.variants ? (
+          <span>
+            {bundleProduct.variants.list.length} {bundleProduct.variants.list.length === 1 ? "version" : "versions"}{" "}
+            available
+          </span>
+        ) : null}
+      </CartItemFooter>
     </CartItemMain>
     <CartItemEnd className="justify-center">
       <input type="checkbox" aria-label={bundleProduct.name} checked={!!selected} onChange={onToggle} />

--- a/app/javascript/pages/Bundles/Content/Edit.tsx
+++ b/app/javascript/pages/Bundles/Content/Edit.tsx
@@ -64,6 +64,14 @@ export default function BundlesContentEdit() {
   const [isSearchLoading, setIsSearchLoading] = React.useState(false);
   const [query, setQuery] = React.useState("");
 
+  const duplicateNames = React.useMemo(() => {
+    const nameCounts = new Map<string, number>();
+    for (const p of results) {
+      nameCounts.set(p.name, (nameCounts.get(p.name) ?? 0) + 1);
+    }
+    return new Set([...nameCounts].filter(([, count]) => count > 1).map(([name]) => name));
+  }, [results]);
+
   const form = useForm<ContentFormData>({
     products: bundle.products,
   });
@@ -288,6 +296,7 @@ export default function BundlesContentEdit() {
                           bundleProduct={bundleProduct}
                           selected={selected}
                           onToggle={() => toggleProductSelection(bundleProduct, selected)}
+                          showDetails={duplicateNames.has(bundleProduct.name)}
                         />
                       );
                     })}

--- a/app/javascript/parsers/product.ts
+++ b/app/javascript/parsers/product.ts
@@ -50,6 +50,7 @@ export type CardProduct = {
   is_sales_limited: boolean;
   duration_in_months: number | null;
   recurrence: RecurrenceId | null;
+  created_at?: string;
   description?: string;
 };
 

--- a/app/presenters/product_presenter/card.rb
+++ b/app/presenters/product_presenter/card.rb
@@ -43,6 +43,7 @@ class ProductPresenter::Card
       url: url_for_product_page(product, request:, recommended_by:, recommender_model_name:, layout: target, affiliate_id:, query:, offer_code:),
       duration_in_months: product.duration_in_months,
       recurrence: default_recurrence&.recurrence,
+      created_at: product.created_at.iso8601,
     }
 
     # Include base_price_cents when there's a discount to show original price with strikethrough

--- a/spec/services/bundle_search_products_service_spec.rb
+++ b/spec/services/bundle_search_products_service_spec.rb
@@ -136,5 +136,14 @@ describe BundleSearchProductsService do
 
       expect(result[:total_count]).to eq(12)
     end
+
+    it "includes created_at in product results" do
+      create(:product, user: seller)
+      index_model_records(Link)
+
+      result = described_class.new(bundle:, seller:).call
+
+      expect(result[:products].first[:created_at]).to be_present
+    end
   end
 end


### PR DESCRIPTION
Closes #2029                                                                                                    

  ## Summary
  - Shows product URL and creation date in bundle search results **only when multiple products share the same
  name**, as discussed by @ershad in [this
  comment](https://github.com/antiwork/gumroad/issues/2029#issuecomment-3886827123)
  - Adds `created_at` to the product card presenter so the date is available to the frontend
  - Uses a memoized duplicate-name detection to conditionally show extra details

  ## Changes
  - **app/presenters/product_presenter/card.rb** — Include `created_at` in card props
  - **app/javascript/parsers/product.ts** — Add `created_at` to `CardProduct` type
  - **app/javascript/components/BundleEdit/ContentTab/BundleProductSelector.tsx** — Accept `showDetails` prop;
  render URL, creation date, and version count when true
  - **app/javascript/pages/Bundles/Content/Edit.tsx** — Detect duplicate product names and pass `showDetails` prop
  - **spec/services/bundle_search_products_service_spec.rb** — Test that `created_at` is present in results

  ## Before
<img width="1512" height="982" alt="Screenshot 2026-02-12 at 6 00 47 PM" src="https://github.com/user-attachments/assets/ee3c8db5-7ba4-48c8-bdb0-27e4be8f3f2a" />

<img width="1512" height="982" alt="Screenshot 2026-02-12 at 6 00 56 PM" src="https://github.com/user-attachments/assets/ec799160-2123-4fe2-a91d-cd67d3829d25" />


  ## After

<img width="1512" height="982" alt="Screenshot 2026-02-12 at 5 43 26 PM" src="https://github.com/user-attachments/assets/c73c15fd-fe7c-4991-b23d-e3a6a4f503f2" />

<img width="1512" height="982" alt="Screenshot 2026-02-12 at 5 43 38 PM" src="https://github.com/user-attachments/assets/f1556c94-ea73-4ad0-9b3a-7253e5395700" />



  ## Test plan
  - [x] `bin/rspec spec/services/bundle_search_products_service_spec.rb` — 12 examples, 0 failures
  - [x] Manual: Create bundle → search products with duplicate names → verify URL + date shown
  - [x ] Manual: Search products with unique names → verify compact view (no extra details)
  - [x] Manual: Verify dark mode renders correctly

  ## Checklist
  - [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
  - [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
  - [x] I have performed a self-review and left review comments on my PR
  - [x] I have added/updated tests for my changes

  ## AI Disclosure
  Claude for implementation assistance