### PR TITLE
fix: prevent DateRangePicker text overflow in narrow containers

### DIFF
--- a/app/javascript/components/DateRangePicker.tsx
+++ b/app/javascript/components/DateRangePicker.tsx
@@ -53,9 +53,11 @@ export const DateRangePicker = ({
       }}
     >
       <PopoverTrigger>
-        <InputGroup className="whitespace-nowrap" aria-label="Date range selector">
-          <span suppressHydrationWarning>{Intl.DateTimeFormat(locale).formatRange(from, to)}</span>
-          <Icon name="outline-cheveron-down" className="ml-auto" />
+        <InputGroup className="min-w-0 whitespace-nowrap" aria-label="Date range selector">
+          <span className="overflow-hidden text-ellipsis" suppressHydrationWarning>
+            {Intl.DateTimeFormat(locale).formatRange(from, to)}
+          </span>
+          <Icon name="outline-cheveron-down" className="ml-auto shrink-0" />
         </InputGroup>
       </PopoverTrigger>
       <PopoverContent matchTriggerWidth className={isCustom ? "" : "border-0 p-0 shadow-none"}>


### PR DESCRIPTION
## Problem

The `DateRangePicker` component exceeds the container width when displayed in the `PageHeader` on narrow viewports (375px).

The root cause: `InputGroup` had `whitespace-nowrap` but no overflow handling, and the date range text (e.g. "2/12/2026 – 2/13/2026") would push past the grid cell boundary.

## Fix

- Added `min-w-0` to `InputGroup` so it can shrink within flex/grid parents
- Added `overflow-hidden text-ellipsis` to the date text `<span>` to truncate gracefully
- Added `shrink-0` to the chevron icon to prevent it from being squeezed out

## Before / After

**Before:** Date text overflows the container on mobile (375px)
![before](https://github.com/user-attachments/assets/3a9688fc-9c36-4037-97ff-490db57c2bda)

**After:** Text truncates with ellipsis, chevron stays visible, layout intact.

Fixes #3447