### PR TITLE
fix: prevent profile settings preview from overflowing container

### DIFF
--- a/app/javascript/components/PreviewSidebar.tsx
+++ b/app/javascript/components/PreviewSidebar.tsx
@@ -5,7 +5,7 @@ import { Icon } from "$app/components/Icons";
 import { WithTooltip } from "$app/components/WithTooltip";
 
 export const WithPreviewSidebar = ({ children, className, ...props }: React.ComponentProps<"div">) => (
-  <div className={cx("squished lg:grid lg:grid-cols-[1fr_30vw]", className)} {...props}>
+  <div className={cx("squished lg:grid lg:grid-cols-[1fr_30vw] [&>*]:min-w-0", className)} {...props}>
     {children}
   </div>
 );


### PR DESCRIPTION
## Problem

The profile settings Preview sidebar overflows its container, as reported in #3388.

![overflow](https://github.com/user-attachments/assets/b7e994bc-78e8-4ad1-9428-a5a586c81c0c)

## Root Cause

`WithPreviewSidebar` uses a CSS grid with `lg:grid-cols-[1fr_30vw]`. However, grid children default to `min-width: auto`, which prevents them from shrinking below their intrinsic content size.

The `Preview` component inside the sidebar scales content to `285.7%` width (`100 / 0.35`) with `transform: scale(0.35)` and uses `overflow: hidden` to clip it. But the grid cell expands beyond its `30vw` track to accommodate the unscaled content width, causing the visible overflow.

## Fix

Added `[&>*]:min-w-0` to the grid container, allowing both grid children to properly shrink to their designated track sizes. This lets the existing `overflow: hidden` on the Preview wrapper do its job.

Single class addition, no layout changes.

Fixes #3388