### PR TITLE
fix: use client-side navigation for Subscribers tab on Emails page

### DIFF
--- a/app/javascript/components/EmailsPage/Layout.tsx
+++ b/app/javascript/components/EmailsPage/Layout.tsx
@@ -40,8 +40,8 @@ export const EmailsLayout = ({ selectedTab, children, hasPosts, query, onQueryCh
         <Tab asChild isSelected={selectedTab === "drafts"}>
           <Link href={Routes.drafts_emails_path()}>Drafts</Link>
         </Tab>
-        <Tab href={Routes.followers_path()} isSelected={false}>
-          Subscribers
+        <Tab asChild isSelected={false}>
+          <Link href={Routes.followers_path()}>Subscribers</Link>
         </Tab>
       </Tabs>
     </PageHeader>


### PR DESCRIPTION
Subscribers tab triggers a full page reload — other tabs (Published, Scheduled, Drafts) use Inertia Link for SPA nav but Subscribers was using a plain href on Tab.

Switched to the same asChild + Link pattern. One-line change.

Fixes #2952