### PR TITLE
Fix: Preserve chat scroll after message actions

### DIFF
--- a/app/javascript/pages/Communities/Index.tsx
+++ b/app/javascript/pages/Communities/Index.tsx
@@ -205,7 +205,7 @@ function CommunitiesIndex() {
       if (searchParams.has("notifications")) {
         searchParams.delete("notifications");
         const newUrl = `${window.location.pathname}${searchParams.size ? `?${searchParams.toString()}` : ""}`;
-        window.history.replaceState({}, "", newUrl);
+        router.replace({ url: newUrl, preserveState: true });
         setShowNotificationsSettings(true);
       }
     }


### PR DESCRIPTION
ref: #3045, #3233 

# Description
  Community chat messages reset when performing actions (delete, send, update) after scrolling up through paginated history

## Problem
Mutations (send/delete/update message) used only: [] which Inertia treats as a full visit, `[].length === 0` then `isPartial()` returns false. The 303 redirect response replaces all props, including messages, wiping out InfiniteScroll's accumulated pages and resetting to a single page.

## Solution
- Changed `only: []` to `except: ["messages"]` on all three mutation handlers so Inertia treats them as partial visits and preserves the existing messages prop. 
- Also moved `scrollTo` in `sendMessage` to fire immediately instead of waiting for the server round trip, and 
- Added `showProgress: false` to avoid the progress bar flash on chat actions.
-  Added `preserveUrl: true` to `markAsRead` to prevent the browser URL from changing on background visits, which could cause a `RecordNotFound` error on refresh.
---

# Before/After
## Before
[Screencast from 2026-02-13 13-33-28.webm](https://github.com/user-attachments/assets/30a09ced-50f8-4739-8e10-84318b58f6d8)

## After 

[Screencast from 2026-02-13 11-34-27.webm](https://github.com/user-attachments/assets/85bf2a45-bd42-460e-9652-e82a809e744c)

### Notification Settings
[Screencast from 2026-02-13 15-38-17.webm](https://github.com/user-attachments/assets/066d0e75-228e-42c2-9376-83b97f5bf0b0)

---

# Test Results
### Tested all related specs

<img width="1733" height="552" alt="Screenshot from 2026-02-13 09-39-50" src="https://github.com/user-attachments/assets/3952b59d-2652-49b3-a306-c44577846aea" />

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

Used Claude Opus 4.6 to review and refine the changes. All modifications were implemented and tested manually.