### PR TITLE
Re-add close button to NestedMenu overlay

### DIFF
--- a/app/javascript/components/NestedMenu.tsx
+++ b/app/javascript/components/NestedMenu.tsx
@@ -1,3 +1,4 @@
+import * as Dialog from "@radix-ui/react-dialog";
 import * as React from "react";
 import { CSSProperties } from "react";
 
@@ -330,8 +331,12 @@ const OverlayMenu = ({
         open={menuOpen}
         onOpenChange={setMenuOpen}
         modal
-        className="right-auto w-80 max-w-80 border-l-0 p-0 md:left-0 md:border-r"
+        className="bg-backdrop p-0 pr-12 md:left-0 md:w-full md:border-l-0"
       >
+        <Dialog.Close className="absolute top-4 right-4 z-40 bg-transparent" aria-label="Close Menu">
+          <Icon name="x" className="text-xl text-white" />
+        </Dialog.Close>
+
         <ItemsList
           key={`${overlayMenuUID}-${menuOpen}`}
           menuId={overlayMenuUID}
@@ -375,7 +380,7 @@ const ItemsList = ({
       style={displayedItem.css}
       role="menu"
       aria-label={displayedItem.label}
-      className={classNames("overflow-hidden border-none! p-0! shadow-none!", className)}
+      className={classNames("w-80 overflow-hidden border-none! p-0! shadow-none!", className)}
     >
       {footer}
       {displayedItem.key !== initialMenuItem.key ? (

--- a/app/javascript/components/ui/Sheet.tsx
+++ b/app/javascript/components/ui/Sheet.tsx
@@ -8,27 +8,24 @@ import { Icon } from "$app/components/Icons";
 export const Sheet = ({
   children,
   className,
-  modal = false,
   ...props
-}: { className?: string; modal?: boolean } & React.ComponentProps<typeof Dialog.Root>) => (
-  <Dialog.Root {...props} modal={modal}>
+}: { className?: string } & React.ComponentProps<typeof Dialog.Root>) => (
+  <Dialog.Root {...props} modal={false}>
     <Dialog.Portal>
-      {modal ? <Dialog.Overlay className="fixed inset-0 z-40 bg-black/80" /> : null}
       <Dialog.Content
         className={classNames(
           "bg-filled fixed inset-0 z-40 flex flex-col gap-4 overflow-auto border-border p-6 md:left-[unset] md:w-[40vw] md:border-l",
           className,
         )}
         aria-modal
-        onPointerDownOutside={(e) => {
-          if (!modal) e.preventDefault();
-        }}
+        onPointerDownOutside={(e) => e.preventDefault()}
       >
         {children}
       </Dialog.Content>
     </Dialog.Portal>
   </Dialog.Root>
 );
+
 export const SheetHeader = ({ children }: { children: React.ReactNode }) => (
   <div className="flex items-start gap-4">
     <Dialog.Title>{children}</Dialog.Title>


### PR DESCRIPTION
Issue: #2724 

# Description

<!-- Briefly describe the problem and your solution -->

Close button was missing in the sidebar after migration of NestedMenu. 
Added it again for better UX.

---

# Before/After

| Mode | Before | After |
|:--:|:----:|:----:|
| Light | <img width="320" alt="before-light" src="https://github.com/user-attachments/assets/d99ee2cc-b14f-4030-9435-6952b631f830" /> | <img width="320" alt="after-light" src="https://github.com/user-attachments/assets/3464c649-735d-4da1-b9fd-c67b6210238c" /> |
| Dark | <img width="320" alt="before-light" src="https://github.com/user-attachments/assets/c4294410-670b-4b9f-9044-7d81f2c5bd16" /> | <img width="320" alt="after-dark" src="https://github.com/user-attachments/assets/456e230c-f6d1-4cf1-bd89-dbcb31be5e56" /> |

https://github.com/user-attachments/assets/917941aa-f3f5-4a11-b9d3-76088c8ea117

---

<!-- # Test Results -->

<!-- Include a screenshot of your test suite passing locally -->

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [ ] I have added/updated tests for my changes

---

# AI Disclosure

No AI was used for any part of this contribution.
<!-- State whether AI was used and for what purpose, or "No AI was used for any part of this contribution." -->
