### PR TITLE
fix: support IBAN and NIB formats for Angolan bank accounts

### DIFF
--- a/app/models/angola_bank_account.rb
+++ b/app/models/angola_bank_account.rb
@@ -6,6 +6,10 @@ class AngolaBankAccount < BankAccount
   BANK_CODE_FORMAT_REGEX = /^([0-9a-zA-Z]){8,11}$/
   private_constant :BANK_CODE_FORMAT_REGEX
 
+  # Angola NIB (legacy): 21 numeric digits
+  ACCOUNT_NUMBER_NIB_REGEX = /\A\d{21}\z/
+  private_constant :ACCOUNT_NUMBER_NIB_REGEX
+
   alias_attribute :bank_code, :bank_number
 
   validate :validate_bank_code
@@ -46,7 +50,10 @@ class AngolaBankAccount < BankAccount
     end
 
     def validate_account_number
-      return if Ibandit::IBAN.new(account_number_decrypted).valid?
+      sanitized = account_number_decrypted.gsub(/\s/, "")
+      return if ACCOUNT_NUMBER_NIB_REGEX.match?(sanitized)
+      iban = Ibandit::IBAN.new(sanitized)
+      return if iban.valid? && iban.country_code == "AO"
       errors.add :base, "The account number is invalid."
     end
 end

--- a/spec/models/angola_bank_account_spec.rb
+++ b/spec/models/angola_bank_account_spec.rb
@@ -43,4 +43,30 @@ describe AngolaBankAccount do
       expect(build(:angola_bank_account, bank_code: "AAAAAOAOXXXX")).not_to be_valid
     end
   end
+
+  describe "#validate_account_number" do
+    before do
+      allow(Rails.env).to receive(:production?).and_return(true)
+    end
+
+    it "accepts a valid 25-character IBAN" do
+      expect(build(:angola_bank_account, account_number: "AO06004400006729503010102")).to be_valid
+    end
+
+    it "accepts a valid 21-digit NIB" do
+      expect(build(:angola_bank_account, account_number: "004400006729503010102")).to be_valid
+    end
+
+    it "accepts an IBAN with whitespace" do
+      expect(build(:angola_bank_account, account_number: "AO06 0044 0000 6729 5030 10102")).to be_valid
+    end
+
+    it "rejects an invalid account number" do
+      expect(build(:angola_bank_account, account_number: "INVALID")).not_to be_valid
+    end
+
+    it "rejects a non-AO IBAN" do
+      expect(build(:angola_bank_account, account_number: "DE89370400440532013000")).not_to be_valid
+    end
+  end
 end


### PR DESCRIPTION
## Self-review

I confirm that I have done a self-review of my code and that there are no other open pull requests for this issue.

## AI disclosure

AI was used to assist with research and drafting this PR.

## Summary

Fixes #3152

Angolan users were unable to set up payout details because the `Ibandit` gem does not reliably validate AO-prefixed IBANs, and the existing `validate_account_number` method had no fallback.

## Root cause

The `validate_account_number` method relied solely on `Ibandit::IBAN.new(account_number_decrypted).valid?`, which returns `false` for valid Angolan IBANs. Additionally, whitespace in user-entered IBANs was not stripped before validation.

## Fix

Following the established pattern from `OmanBankAccount`:

1. **NIB regex fallback** — Accept the legacy 21-digit NIB format (`/\A\d{21}\z/`) directly, bypassing Ibandit
2. **Whitespace sanitization** — Strip all whitespace from the account number before validation (`"AO06 0044 0000..."` → `"AO06004400006..."`)
3. **Country code verification** — When falling back to Ibandit, verify `iban.country_code == "AO"` to reject non-Angolan IBANs

Validation order: NIB regex → Ibandit with country check → error

## Test plan

- [x] Accepts valid 25-character IBAN (e.g., `AO06004400006729503010102`)
- [x] Accepts valid 21-digit NIB (e.g., `004400006729503010102`)
- [x] Accepts IBAN with whitespace (e.g., `AO06 0044 0000 6729 5030 10102`)
- [x] Rejects invalid account numbers
- [x] Rejects non-AO IBANs (e.g., German IBAN)

/claim #3152