### PR TITLE
fix: validate Angolan accounts as 25-character IBAN only

### DIFF
--- a/app/models/angola_bank_account.rb
+++ b/app/models/angola_bank_account.rb
@@ -6,10 +6,6 @@ class AngolaBankAccount < BankAccount
   BANK_CODE_FORMAT_REGEX = /^([0-9a-zA-Z]){8,11}$/
   private_constant :BANK_CODE_FORMAT_REGEX
 
-  # Angola NIB (legacy): 21 numeric digits
-  ACCOUNT_NUMBER_NIB_REGEX = /\A\d{21}\z/
-  private_constant :ACCOUNT_NUMBER_NIB_REGEX
-
   alias_attribute :bank_code, :bank_number
 
   validate :validate_bank_code
@@ -51,7 +47,6 @@ class AngolaBankAccount < BankAccount
 
     def validate_account_number
       sanitized = account_number_decrypted.gsub(/\s/, "")
-      return if ACCOUNT_NUMBER_NIB_REGEX.match?(sanitized)
       iban = Ibandit::IBAN.new(sanitized)
       return if iban.valid? && iban.country_code == "AO"
       errors.add :base, "The account number is invalid."

--- a/spec/models/angola_bank_account_spec.rb
+++ b/spec/models/angola_bank_account_spec.rb
@@ -53,12 +53,12 @@ describe AngolaBankAccount do
       expect(build(:angola_bank_account, account_number: "AO06004400006729503010102")).to be_valid
     end
 
-    it "accepts a valid 21-digit NIB" do
-      expect(build(:angola_bank_account, account_number: "004400006729503010102")).to be_valid
-    end
-
     it "accepts an IBAN with whitespace" do
       expect(build(:angola_bank_account, account_number: "AO06 0044 0000 6729 5030 10102")).to be_valid
+    end
+
+    it "rejects a 21-digit NIB (Stripe requires 25-character IBAN)" do
+      expect(build(:angola_bank_account, account_number: "004400006729503010102")).not_to be_valid
     end
 
     it "rejects an invalid account number" do


### PR DESCRIPTION
## Self-review

I confirm that I have done a self-review of my code and that there are no other open pull requests for this issue.

## AI disclosure

AI was used to assist with research and drafting this PR.

## Summary

Fixes #3152

Angolan users were unable to set up payout details because the `Ibandit` gem does not reliably validate AO-prefixed IBANs.

## Root cause

The `validate_account_number` method relied solely on `Ibandit::IBAN.new(account_number_decrypted).valid?`, which returns `false` for valid Angolan IBANs. Additionally, whitespace in user-entered IBANs was not stripped before validation.

## Fix

Per [Stripe's Angola payout documentation](https://docs.stripe.com/payouts?account-country=AO), only 25-character IBANs are accepted. This PR:

1. **Whitespace sanitization** — Strips all whitespace before validation (`"AO06 0044 0000..."` → `"AO06004400006..."`)
2. **Country code verification** — Verifies `iban.country_code == "AO"` to reject non-Angolan IBANs

Previous revision included a 21-digit NIB fallback, which was removed based on maintainer feedback — Stripe rejects non-IBAN account numbers for Angola.

## Test plan

- [x] Accepts valid 25-character IBAN (e.g., `AO06004400006729503010102`)
- [x] Accepts IBAN with whitespace (e.g., `AO06 0044 0000 6729 5030 10102`)
- [x] Rejects 21-digit NIB (Stripe requires 25-character IBAN)
- [x] Rejects invalid account numbers
- [x] Rejects non-AO IBANs (e.g., German IBAN)

/claim #3152