### PR TITLE
fix(payments): auto-format and validate Peru DNI number

### DIFF
--- a/app/javascript/components/Settings/PaymentsPage/AccountDetailsSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/AccountDetailsSection.tsx
@@ -1207,8 +1207,19 @@ const AccountDetailsSection = ({
               required
               disabled={isFormDisabled}
               aria-invalid={errorFieldNames.has("individual_tax_id")}
-              onChange={(evt) => updateComplianceInfo({ individual_tax_id: evt.target.value })}
+              onChange={(evt) => {
+                let value = evt.target.value;
+                if (complianceInfo.country === "PE") {
+                  const digits = value.replace(/\D/g, "");
+                  value = digits.length > 8 ? `${digits.slice(0, 8)}-${digits.slice(8, 9)}` : digits;
+                }
+                updateComplianceInfo({ individual_tax_id: value });
+              }}
+              value={complianceInfo.individual_tax_id ?? ""}
             />
+            {complianceInfo.country === "PE" ? (
+              <FieldsetDescription>Enter your full 10-character DNI (e.g. 12345678-9).</FieldsetDescription>
+            ) : null}
           </div>
         </Fieldset>
       ) : null}

--- a/app/javascript/pages/Settings/Payments/Show.tsx
+++ b/app/javascript/pages/Settings/Payments/Show.tsx
@@ -614,6 +614,14 @@ export default function PaymentsPage() {
     ) {
       markFieldInvalid("individual_tax_id");
     }
+    if (
+      form.data.user.country === "PE" &&
+      form.data.user.individual_tax_id &&
+      !/^\d{8}-\d$/.test(form.data.user.individual_tax_id)
+    ) {
+      markFieldInvalid("individual_tax_id");
+      setClientErrorMessage({ message: "Please enter a valid 10-character DNI number (e.g. 12345678-9)." });
+    }
     if (form.data.user.is_business) {
       if (!form.data.user.business_type) {
         markFieldInvalid("business_type");

--- a/spec/requests/settings/payments_spec.rb
+++ b/spec/requests/settings/payments_spec.rb
@@ -2433,6 +2433,40 @@ describe("Payments Settings Scenario", type: :system, js: true) do
         expect(compliance_info.birthday).to eq(Date.new(1980, 1, 1))
         expect(@user.reload.active_bank_account.send(:account_number_decrypted)).to eq("99934500012345670024")
       end
+
+      it "auto-inserts a hyphen after the 8th digit of the DNI number" do
+        visit settings_payments_path
+
+        expect(page).to have_content("Enter your full 10-character DNI (e.g. 12345678-9).")
+
+        dni_field = find_field("DNI number")
+        dni_field.fill_in(with: "123456789")
+        expect(dni_field.value).to eq("12345678-9")
+      end
+
+      it "shows a validation error for an invalid DNI format" do
+        visit settings_payments_path
+
+        fill_in("First name", with: "barnabas")
+        fill_in("Last name", with: "barnabastein")
+        fill_in("Address", with: "address_full_match")
+        fill_in("City", with: "barnabasville")
+        fill_in("Phone number", with: "14213365")
+        fill_in("Postal code", with: "1001")
+
+        select("1", from: "Day")
+        select("January", from: "Month")
+        select("1980", from: "Year")
+        fill_in("DNI number", with: "1234")
+
+        fill_in("Pay to the order of", with: "barnabas ngagy")
+        fill_in("Account number", with: "99934500012345670024")
+        fill_in("Confirm account number", with: "99934500012345670024")
+
+        click_on("Update settings")
+
+        expect(page).to have_alert(text: "Please enter a valid 10-character DNI number (e.g. 12345678-9).")
+      end
     end
 
     describe "Norwegian creator" do


### PR DESCRIPTION
## Self-review

I confirm that I have done a self-review of my code and that there are no other open pull requests for this issue.

## AI disclosure

AI was used to assist with research and drafting this PR.

## Summary

Fixes #3556

Peru users often enter only the first 8 digits of their DNI, which gets rejected by Stripe (expects the full 10-character `XXXXXXXX-X` format).

## Root cause

The DNI input field accepted any text up to 10 characters without guiding users toward the required format. Users entering `12345678` instead of `12345678-9` would get a confusing Stripe rejection.

## Fix

**`AccountDetailsSection.tsx`**:
1. Auto-inserts a hyphen after the 8th digit — typing `123456789` produces `12345678-9`
2. Strips non-digit characters so users can't enter malformed values
3. Adds help text: "Enter your full 10-character DNI (e.g. 12345678-9)."

**`Show.tsx`**:
4. Adds client-side format validation on submit — rejects DNI values not matching `/^\d{8}-\d$/`

## Test plan

- [x] Auto-formatting: typing `123456789` produces `12345678-9` in the input
- [x] Help text visible for Peru users
- [x] Invalid DNI (e.g. `1234`) shows error on submit
- [x] Valid DNI (`00000000-0`) still submits successfully (existing test)
- [x] No changes to non-Peru countries

/claim #3556