### PR TITLE
Probate related accounts instead of suspending for fraud on TOS violation

### DIFF
--- a/app/sidekiq/check_payment_address_worker.rb
+++ b/app/sidekiq/check_payment_address_worker.rb
@@ -6,40 +6,86 @@ class CheckPaymentAddressWorker
 
   def perform(user_id)
     user = User.find_by(id: user_id)
-    return unless user&.can_flag_for_fraud?
+    return unless user
 
-    should_flag = payment_address_matches_suspended_account?(user) ||
-                  stripe_fingerprint_matches_suspended_account?(user)
+    fraud_match = matches_fraud_suspended_account?(user)
+    tos_match = matches_tos_suspended_account?(user)
 
-    user.flag_for_fraud!(author_name: "CheckPaymentAddress") if should_flag
+    if fraud_match && user.can_flag_for_fraud?
+      user.flag_for_fraud!(author_name: "CheckPaymentAddress")
+    elsif tos_match && !fraud_match && !user.suspended? && !user.on_probation?
+      suspended_user_ids = tos_suspended_user_ids_for(user)
+      user.put_on_probation(
+        author_name: "CheckPaymentAddress",
+        content: "Probated (payouts suspended) automatically on #{Time.current.to_fs(:formatted_date_full_month)} because of usage of payment address matching suspended for TOS violation #{suspended_user_ids.map { |uid| "User##{uid}" }.join(" and ")}"
+      )
+    end
   end
 
   private
-    def payment_address_matches_suspended_account?(user)
-      return false if user.payment_address.blank?
-
-      banned_accounts_with_same_payment_address = User.where(
-        payment_address: user.payment_address,
-        user_risk_state: User::Risk::SUSPENDED_STATES
-      )
-
-      blocked_email = BlockedObject.find_active_object(user.payment_address)
-
-      banned_accounts_with_same_payment_address.exists? || blocked_email.present?
+    def matches_fraud_suspended_account?(user)
+      payment_address_matches_state?(user, "suspended_for_fraud") ||
+        stripe_fingerprint_matches_state?(user, "suspended_for_fraud") ||
+        blocked_payment_address?(user) ||
+        blocked_stripe_fingerprint?(user)
     end
 
-    def stripe_fingerprint_matches_suspended_account?(user)
+    def matches_tos_suspended_account?(user)
+      payment_address_matches_state?(user, "suspended_for_tos_violation") ||
+        stripe_fingerprint_matches_state?(user, "suspended_for_tos_violation")
+    end
+
+    def payment_address_matches_state?(user, state)
+      return false if user.payment_address.blank?
+
+      User.where(payment_address: user.payment_address, user_risk_state: state)
+        .where.not(id: user.id)
+        .exists?
+    end
+
+    def stripe_fingerprint_matches_state?(user, state)
       fingerprints = user.alive_bank_accounts.where.not(stripe_fingerprint: [nil, ""]).distinct.pluck(:stripe_fingerprint)
       return false if fingerprints.empty?
 
-      suspended_accounts_with_same_fingerprint = BankAccount
-        .joins(:user)
+      BankAccount.joins(:user)
         .where(stripe_fingerprint: fingerprints)
         .where.not(user_id: user.id)
-        .where(users: { user_risk_state: User::Risk::SUSPENDED_STATES })
+        .where(users: { user_risk_state: state })
+        .exists?
+    end
 
-      return true if suspended_accounts_with_same_fingerprint.exists?
+    def blocked_payment_address?(user)
+      return false if user.payment_address.blank?
+
+      BlockedObject.find_active_object(user.payment_address).present?
+    end
+
+    def blocked_stripe_fingerprint?(user)
+      fingerprints = user.alive_bank_accounts.where.not(stripe_fingerprint: [nil, ""]).distinct.pluck(:stripe_fingerprint)
+      return false if fingerprints.empty?
 
       BlockedObject.find_active_objects(fingerprints).present?
+    end
+
+    def tos_suspended_user_ids_for(user)
+      ids = []
+
+      if user.payment_address.present?
+        ids += User.where(payment_address: user.payment_address, user_risk_state: "suspended_for_tos_violation")
+          .where.not(id: user.id)
+          .pluck(:id)
+      end
+
+      fingerprints = user.alive_bank_accounts.where.not(stripe_fingerprint: [nil, ""]).distinct.pluck(:stripe_fingerprint)
+      if fingerprints.any?
+        ids += BankAccount.joins(:user)
+          .where(stripe_fingerprint: fingerprints)
+          .where.not(user_id: user.id)
+          .where(users: { user_risk_state: "suspended_for_tos_violation" })
+          .distinct
+          .pluck(:user_id)
+      end
+
+      ids.uniq
     end
 end

--- a/app/sidekiq/suspend_accounts_with_payment_address_worker.rb
+++ b/app/sidekiq/suspend_accounts_with_payment_address_worker.rb
@@ -40,6 +40,21 @@ class SuspendAccountsWithPaymentAddressWorker
     end
 
     def flag_and_suspend_user(user, suspended_user, identifier_type, identifier_value)
+      if suspended_user.suspended_for_tos_violation?
+        probate_user(user, suspended_user, identifier_type, identifier_value)
+      else
+        suspend_user_for_fraud(user, suspended_user, identifier_type, identifier_value)
+      end
+    end
+
+    def probate_user(user, suspended_user, identifier_type, identifier_value)
+      user.put_on_probation(
+        author_name: "suspend_sellers_other_accounts",
+        content: "Probated (payouts suspended) automatically on #{Time.current.to_fs(:formatted_date_full_month)} because of usage of #{identifier_type} #{identifier_value} (from suspended for TOS violation User##{suspended_user.id})"
+      )
+    end
+
+    def suspend_user_for_fraud(user, suspended_user, identifier_type, identifier_value)
       user.flag_for_fraud(
         author_name: "suspend_sellers_other_accounts",
         content: "Flagged for fraud automatically on #{Time.current.to_fs(:formatted_date_full_month)} because of usage of #{identifier_type} #{identifier_value} (from User##{suspended_user.id})"

--- a/spec/sidekiq/check_payment_address_worker_spec.rb
+++ b/spec/sidekiq/check_payment_address_worker_spec.rb
@@ -15,12 +15,12 @@ describe CheckPaymentAddressWorker do
       expect(@user.reload.flagged?).to be(false)
     end
 
-    it "flags the user for fraud if there are other banned users with the same payment address" do
+    it "flags the user for fraud if there are other fraud-suspended users with the same payment address" do
       @user = create(:user, payment_address: "tuhins@gmail.com")
 
       CheckPaymentAddressWorker.new.perform(@user.id)
 
-      expect(@user.reload.flagged?).to be(true)
+      expect(@user.reload.flagged_for_fraud?).to be(true)
     end
 
     it "flags the user for fraud if a blocked email object exists for their payment address" do
@@ -28,7 +28,28 @@ describe CheckPaymentAddressWorker do
 
       CheckPaymentAddressWorker.new.perform(@user.id)
 
-      expect(@user.reload.flagged?).to be(true)
+      expect(@user.reload.flagged_for_fraud?).to be(true)
+    end
+
+    it "probates the user if matching account is suspended for TOS violation" do
+      tos_user = create(:user, user_risk_state: "suspended_for_tos_violation", payment_address: "tos_violator@gmail.com")
+      user = create(:user, payment_address: "tos_violator@gmail.com")
+
+      CheckPaymentAddressWorker.new.perform(user.id)
+
+      expect(user.reload.on_probation?).to be(true)
+      expect(user.comments.where(comment_type: "on").last.content).to include("suspended for TOS violation")
+      expect(user.comments.where(comment_type: "on").last.content).to include("User##{tos_user.id}")
+    end
+
+    it "flags for fraud instead of probation when both fraud and TOS matches exist" do
+      tos_user = create(:user, user_risk_state: "suspended_for_tos_violation", payment_address: "shared@gmail.com")
+      fraud_user = create(:user, user_risk_state: "suspended_for_fraud", payment_address: "shared@gmail.com")
+      user = create(:user, payment_address: "shared@gmail.com")
+
+      CheckPaymentAddressWorker.new.perform(user.id)
+
+      expect(user.reload.flagged_for_fraud?).to be(true)
     end
   end
 
@@ -45,7 +66,7 @@ describe CheckPaymentAddressWorker do
       expect(user.reload.flagged?).to be(false)
     end
 
-    it "flags the user for fraud if a suspended user has the same stripe fingerprint" do
+    it "flags the user for fraud if a fraud-suspended user has the same stripe fingerprint" do
       suspended_user = create(:user, user_risk_state: "suspended_for_fraud")
       create(:ach_account, user: suspended_user, stripe_fingerprint: "same_fingerprint_123")
 
@@ -54,10 +75,10 @@ describe CheckPaymentAddressWorker do
 
       CheckPaymentAddressWorker.new.perform(user.id)
 
-      expect(user.reload.flagged?).to be(true)
+      expect(user.reload.flagged_for_fraud?).to be(true)
     end
 
-    it "flags the user for fraud if a suspended_for_tos_violation user has the same stripe fingerprint" do
+    it "probates the user if a TOS-suspended user has the same stripe fingerprint" do
       suspended_user = create(:user, user_risk_state: "suspended_for_tos_violation")
       create(:ach_account, user: suspended_user, stripe_fingerprint: "same_fingerprint_456")
 
@@ -66,7 +87,8 @@ describe CheckPaymentAddressWorker do
 
       CheckPaymentAddressWorker.new.perform(user.id)
 
-      expect(user.reload.flagged?).to be(true)
+      expect(user.reload.on_probation?).to be(true)
+      expect(user.comments.where(comment_type: "on").last.content).to include("suspended for TOS violation")
     end
 
     it "flags the user for fraud if a blocked fingerprint object exists" do
@@ -76,7 +98,7 @@ describe CheckPaymentAddressWorker do
 
       CheckPaymentAddressWorker.new.perform(user.id)
 
-      expect(user.reload.flagged?).to be(true)
+      expect(user.reload.flagged_for_fraud?).to be(true)
     end
 
     it "flags the user even if the suspended user's bank account is deleted (fraud history is preserved)" do
@@ -89,7 +111,7 @@ describe CheckPaymentAddressWorker do
 
       CheckPaymentAddressWorker.new.perform(user.id)
 
-      expect(user.reload.flagged?).to be(true)
+      expect(user.reload.flagged_for_fraud?).to be(true)
     end
 
     it "does not flag if the new user's bank account is deleted" do
@@ -124,7 +146,7 @@ describe CheckPaymentAddressWorker do
 
       CheckPaymentAddressWorker.new.perform(user.id)
 
-      expect(user.reload.flagged?).to be(true)
+      expect(user.reload.flagged_for_fraud?).to be(true)
     end
 
     it "flags if any of the user's fingerprints is blocked" do
@@ -135,7 +157,7 @@ describe CheckPaymentAddressWorker do
 
       CheckPaymentAddressWorker.new.perform(user.id)
 
-      expect(user.reload.flagged?).to be(true)
+      expect(user.reload.flagged_for_fraud?).to be(true)
     end
   end
 
@@ -150,6 +172,28 @@ describe CheckPaymentAddressWorker do
       CheckPaymentAddressWorker.new.perform(already_flagged_user.id)
 
       expect(already_flagged_user.reload.user_risk_state).to eq("flagged_for_fraud")
+    end
+
+    it "does not probate a user who is already on probation" do
+      tos_user = create(:user, user_risk_state: "suspended_for_tos_violation", payment_address: "tos@example.com")
+      user = create(:user, user_risk_state: "on_probation", payment_address: "tos@example.com")
+      initial_comment_count = user.comments.count
+
+      CheckPaymentAddressWorker.new.perform(user.id)
+
+      expect(user.reload.on_probation?).to be(true)
+      expect(user.comments.count).to eq(initial_comment_count)
+    end
+
+    it "does not probate a suspended user" do
+      tos_user = create(:user, user_risk_state: "suspended_for_tos_violation", payment_address: "tos@example.com")
+      user = create(:user, user_risk_state: "suspended_for_fraud", payment_address: "tos@example.com")
+      initial_comment_count = user.comments.count
+
+      CheckPaymentAddressWorker.new.perform(user.id)
+
+      expect(user.reload.suspended_for_fraud?).to be(true)
+      expect(user.comments.count).to eq(initial_comment_count)
     end
 
     it "does not raise error if user is not found" do

--- a/spec/sidekiq/suspend_accounts_with_payment_address_worker_spec.rb
+++ b/spec/sidekiq/suspend_accounts_with_payment_address_worker_spec.rb
@@ -2,111 +2,121 @@
 
 describe SuspendAccountsWithPaymentAddressWorker do
   describe "#perform" do
-    context "with payment address" do
-      before do
-        @user = create(:user, payment_address: "sameuser@paypal.com")
-        @user_2 = create(:user, payment_address: "sameuser@paypal.com")
-        create(:user) # admin user
+    context "when suspended for fraud" do
+      context "with payment address" do
+        before do
+          @user = create(:user, payment_address: "sameuser@paypal.com")
+          @user_2 = create(:user, payment_address: "sameuser@paypal.com")
+          create(:user) # admin user
+          @user.flag_for_fraud!(author_name: "test")
+          @user.suspend_for_fraud!(author_name: "test")
+        end
+
+        it "suspends other accounts with the same payment address for fraud" do
+          described_class.new.perform(@user.id)
+
+          expect(@user_2.reload.suspended_for_fraud?).to be(true)
+          expect(@user_2.comments.where(comment_type: "flagged").last.content).to eq("Flagged for fraud automatically on #{Time.current.to_fs(:formatted_date_full_month)} because of usage of payment address #{@user.payment_address} (from User##{@user.id})")
+          expect(@user_2.comments.where(comment_type: "suspended").last.content).to eq("Suspended for fraud automatically on #{Time.current.to_fs(:formatted_date_full_month)} because of usage of payment address #{@user.payment_address} (from User##{@user.id})")
+        end
+
+        it "does not suspend already suspended users with same payment address" do
+          @user_2.flag_for_fraud!(author_name: "test")
+          @user_2.suspend_for_fraud!(author_name: "test")
+          initial_comment_count = @user_2.comments.count
+
+          described_class.new.perform(@user.id)
+
+          expect(@user_2.reload.comments.count).to eq(initial_comment_count)
+        end
       end
 
-      it "suspends other accounts with the same payment address" do
-        described_class.new.perform(@user.id)
+      context "with stripe fingerprint" do
+        before do
+          @user = create(:user)
+          @user_2 = create(:user)
+          @user_3 = create(:user)
 
-        expect(@user_2.reload.suspended?).to be(true)
-        expect(@user_2.comments.first.content).to eq("Flagged for fraud automatically on #{Time.current.to_fs(:formatted_date_full_month)} because of usage of payment address #{@user.payment_address} (from User##{@user.id})")
-        expect(@user_2.comments.last.content).to eq("Suspended for fraud automatically on #{Time.current.to_fs(:formatted_date_full_month)} because of usage of payment address #{@user.payment_address} (from User##{@user.id})")
-      end
+          @bank_account_1 = create(:ach_account, user: @user, stripe_fingerprint: "same_fingerprint_123")
+          @bank_account_2 = create(:ach_account, user: @user_2, stripe_fingerprint: "same_fingerprint_123")
+          @bank_account_3 = create(:ach_account, user: @user_3, stripe_fingerprint: "different_fingerprint")
 
-      it "does not suspend already suspended users with same payment address" do
-        @user_2.flag_for_fraud!(author_name: "test")
-        @user_2.suspend_for_fraud!(author_name: "test")
-        initial_comment_count = @user_2.comments.count
+          @user.flag_for_fraud!(author_name: "test")
+          @user.suspend_for_fraud!(author_name: "test")
+        end
 
-        described_class.new.perform(@user.id)
+        it "suspends other accounts with the same stripe fingerprint for fraud" do
+          described_class.new.perform(@user.id)
 
-        expect(@user_2.reload.comments.count).to eq(initial_comment_count)
+          expect(@user_2.reload.suspended_for_fraud?).to be(true)
+          expect(@user_3.reload.suspended?).to be(false)
+        end
+
+        it "creates both flagged and suspended comments with fingerprint details" do
+          described_class.new.perform(@user.id)
+
+          expect(@user_2.reload.comments.where(comment_type: "flagged").last.content).to eq("Flagged for fraud automatically on #{Time.current.to_fs(:formatted_date_full_month)} because of usage of bank account fingerprint same_fingerprint_123 (from User##{@user.id})")
+          expect(@user_2.comments.where(comment_type: "suspended").last.content).to eq("Suspended for fraud automatically on #{Time.current.to_fs(:formatted_date_full_month)} because of usage of bank account fingerprint same_fingerprint_123 (from User##{@user.id})")
+        end
       end
     end
 
-    context "with stripe fingerprint" do
-      before do
-        @user = create(:user)
-        @user_2 = create(:user)
-        @user_3 = create(:user)
+    context "when suspended for TOS violation" do
+      context "with payment address" do
+        before do
+          @user = create(:user, payment_address: "sameuser@paypal.com")
+          @user_2 = create(:user, payment_address: "sameuser@paypal.com")
+          create(:user) # admin user
+          @user.flag_for_tos_violation!(author_name: "test")
+          @user.suspend_for_tos_violation!(author_name: "test", skip_transition_callback: :suspend_sellers_other_accounts)
+        end
 
-        @bank_account_1 = create(:ach_account, user: @user, stripe_fingerprint: "same_fingerprint_123")
-        @bank_account_2 = create(:ach_account, user: @user_2, stripe_fingerprint: "same_fingerprint_123")
-        @bank_account_3 = create(:ach_account, user: @user_3, stripe_fingerprint: "different_fingerprint")
+        it "probates other accounts instead of suspending for fraud" do
+          described_class.new.perform(@user.id)
+
+          expect(@user_2.reload.on_probation?).to be(true)
+          expect(@user_2.suspended?).to be(false)
+          expect(@user_2.comments.where(comment_type: "on").last.content).to eq("Probated (payouts suspended) automatically on #{Time.current.to_fs(:formatted_date_full_month)} because of usage of payment address #{@user.payment_address} (from suspended for TOS violation User##{@user.id})")
+        end
+
+        it "does not probate already suspended users" do
+          @user_2.flag_for_fraud!(author_name: "test")
+          @user_2.suspend_for_fraud!(author_name: "test")
+          initial_comment_count = @user_2.comments.count
+
+          described_class.new.perform(@user.id)
+
+          expect(@user_2.reload.comments.count).to eq(initial_comment_count)
+        end
       end
 
-      it "suspends other accounts with the same stripe fingerprint" do
-        described_class.new.perform(@user.id)
+      context "with stripe fingerprint" do
+        before do
+          @user = create(:user)
+          @user_2 = create(:user)
+          @user_3 = create(:user)
 
-        expect(@user_2.reload.suspended?).to be(true)
-        expect(@user_3.reload.suspended?).to be(false)
-      end
+          @bank_account_1 = create(:ach_account, user: @user, stripe_fingerprint: "same_fingerprint_123")
+          @bank_account_2 = create(:ach_account, user: @user_2, stripe_fingerprint: "same_fingerprint_123")
+          @bank_account_3 = create(:ach_account, user: @user_3, stripe_fingerprint: "different_fingerprint")
 
-      it "creates both flagged and suspended comments with fingerprint details" do
-        described_class.new.perform(@user.id)
+          @user.flag_for_tos_violation!(author_name: "test")
+          @user.suspend_for_tos_violation!(author_name: "test", skip_transition_callback: :suspend_sellers_other_accounts)
+        end
 
-        expect(@user_2.reload.comments.first.content).to eq("Flagged for fraud automatically on #{Time.current.to_fs(:formatted_date_full_month)} because of usage of bank account fingerprint same_fingerprint_123 (from User##{@user.id})")
-        expect(@user_2.comments.last.content).to eq("Suspended for fraud automatically on #{Time.current.to_fs(:formatted_date_full_month)} because of usage of bank account fingerprint same_fingerprint_123 (from User##{@user.id})")
-      end
+        it "probates other accounts with the same stripe fingerprint" do
+          described_class.new.perform(@user.id)
 
-      it "does not suspend if fingerprint is blank" do
-        @bank_account_1.update!(stripe_fingerprint: nil)
+          expect(@user_2.reload.on_probation?).to be(true)
+          expect(@user_2.suspended?).to be(false)
+          expect(@user_3.reload.on_probation?).to be(false)
+        end
 
-        described_class.new.perform(@user.id)
+        it "creates probation comment with fingerprint details" do
+          described_class.new.perform(@user.id)
 
-        expect(@user_2.reload.suspended?).to be(false)
-      end
-
-      it "does not suspend users whose bank accounts are deleted" do
-        @bank_account_2.mark_deleted!
-
-        described_class.new.perform(@user.id)
-
-        expect(@user_2.reload.suspended?).to be(false)
-      end
-
-      it "does not suspend already suspended users" do
-        @user_2.flag_for_fraud!(author_name: "test")
-        @user_2.suspend_for_fraud!(author_name: "test")
-        initial_comment_count = @user_2.comments.count
-
-        described_class.new.perform(@user.id)
-
-        expect(@user_2.reload.comments.count).to eq(initial_comment_count)
-      end
-
-      it "still suspends related accounts even if suspended user's bank account is deleted" do
-        @bank_account_1.mark_deleted!
-
-        described_class.new.perform(@user.id)
-
-        expect(@user_2.reload.suspended?).to be(true)
-        expect(@user_2.comments.first.content).to include("bank account fingerprint same_fingerprint_123")
-      end
-
-      it "checks all fingerprints when suspended user has multiple bank accounts" do
-        create(:ach_account, user: @user, stripe_fingerprint: "another_fingerprint")
-        user_with_another_fingerprint = create(:user)
-        create(:ach_account, user: user_with_another_fingerprint, stripe_fingerprint: "another_fingerprint")
-
-        described_class.new.perform(@user.id)
-
-        expect(@user_2.reload.suspended?).to be(true)
-        expect(user_with_another_fingerprint.reload.suspended?).to be(true)
-      end
-
-      it "uses the matching fingerprint in the comment when user has multiple fingerprints" do
-        create(:ach_account, user: @user, stripe_fingerprint: "another_fingerprint")
-        user_with_another_fingerprint = create(:user)
-        create(:ach_account, user: user_with_another_fingerprint, stripe_fingerprint: "another_fingerprint")
-
-        described_class.new.perform(@user.id)
-
-        expect(user_with_another_fingerprint.reload.comments.first.content).to include("another_fingerprint")
+          expect(@user_2.reload.comments.where(comment_type: "on").last.content).to eq("Probated (payouts suspended) automatically on #{Time.current.to_fs(:formatted_date_full_month)} because of usage of bank account fingerprint same_fingerprint_123 (from suspended for TOS violation User##{@user.id})")
+        end
       end
     end
 
@@ -120,11 +130,89 @@ describe SuspendAccountsWithPaymentAddressWorker do
         @bank_account_2 = create(:ach_account, user: @user_fingerprint_match, stripe_fingerprint: "same_fingerprint_123")
       end
 
-      it "suspends accounts matching either payment address or stripe fingerprint" do
+      it "suspends accounts matching either payment address or stripe fingerprint when suspended for fraud" do
+        @user.flag_for_fraud!(author_name: "test")
+        @user.suspend_for_fraud!(author_name: "test")
+
         described_class.new.perform(@user.id)
 
-        expect(@user_paypal_match.reload.suspended?).to be(true)
-        expect(@user_fingerprint_match.reload.suspended?).to be(true)
+        expect(@user_paypal_match.reload.suspended_for_fraud?).to be(true)
+        expect(@user_fingerprint_match.reload.suspended_for_fraud?).to be(true)
+      end
+
+      it "probates accounts matching either payment address or stripe fingerprint when suspended for TOS violation" do
+        @user.flag_for_tos_violation!(author_name: "test")
+        @user.suspend_for_tos_violation!(author_name: "test", skip_transition_callback: :suspend_sellers_other_accounts)
+
+        described_class.new.perform(@user.id)
+
+        expect(@user_paypal_match.reload.on_probation?).to be(true)
+        expect(@user_fingerprint_match.reload.on_probation?).to be(true)
+      end
+    end
+
+    context "edge cases" do
+      it "does not suspend if fingerprint is blank" do
+        user = create(:user)
+        user_2 = create(:user)
+        bank_account_1 = create(:ach_account, user: user, stripe_fingerprint: nil)
+        create(:ach_account, user: user_2, stripe_fingerprint: nil)
+
+        user.flag_for_fraud!(author_name: "test")
+        user.suspend_for_fraud!(author_name: "test")
+
+        described_class.new.perform(user.id)
+
+        expect(user_2.reload.suspended?).to be(false)
+      end
+
+      it "does not suspend users whose bank accounts are deleted" do
+        user = create(:user)
+        user_2 = create(:user)
+        create(:ach_account, user: user, stripe_fingerprint: "same_fp")
+        bank_account_2 = create(:ach_account, user: user_2, stripe_fingerprint: "same_fp")
+        bank_account_2.mark_deleted!
+
+        user.flag_for_fraud!(author_name: "test")
+        user.suspend_for_fraud!(author_name: "test")
+
+        described_class.new.perform(user.id)
+
+        expect(user_2.reload.suspended?).to be(false)
+      end
+
+      it "still suspends related accounts even if suspended user's bank account is deleted" do
+        user = create(:user)
+        user_2 = create(:user)
+        bank_account_1 = create(:ach_account, user: user, stripe_fingerprint: "same_fp")
+        create(:ach_account, user: user_2, stripe_fingerprint: "same_fp")
+        bank_account_1.mark_deleted!
+
+        user.flag_for_fraud!(author_name: "test")
+        user.suspend_for_fraud!(author_name: "test")
+
+        described_class.new.perform(user.id)
+
+        expect(user_2.reload.suspended?).to be(true)
+        expect(user_2.comments.where(comment_type: "flagged").last.content).to include("bank account fingerprint same_fp")
+      end
+
+      it "checks all fingerprints when suspended user has multiple bank accounts" do
+        user = create(:user)
+        user_2 = create(:user)
+        user_3 = create(:user)
+        create(:ach_account, user: user, stripe_fingerprint: "fp_1")
+        create(:ach_account, user: user, stripe_fingerprint: "fp_2")
+        create(:ach_account, user: user_2, stripe_fingerprint: "fp_1")
+        create(:ach_account, user: user_3, stripe_fingerprint: "fp_2")
+
+        user.flag_for_fraud!(author_name: "test")
+        user.suspend_for_fraud!(author_name: "test")
+
+        described_class.new.perform(user.id)
+
+        expect(user_2.reload.suspended?).to be(true)
+        expect(user_3.reload.suspended?).to be(true)
       end
     end
   end


### PR DESCRIPTION
## Self-review

I confirm that I have done a self-review of my code and that there are no other open pull requests for this issue.

## AI disclosure

AI was used to assist with research and drafting this PR.

## Summary

Fixes #2830

When a user is suspended for a TOS violation, `SuspendAccountsWithPaymentAddressWorker` was incorrectly flagging and suspending related accounts (matching payment address or bank account fingerprint) for **fraud**. Per @gumroadsteve2's guidance, these related accounts should instead be **probated** — suspending their payouts while leaving a note for support/risk staff to investigate further.

Similarly, `CheckPaymentAddressWorker` (which runs when a user updates their payment address) was flagging users for fraud if their payment address matched any suspended account, regardless of suspension type. This is now updated to distinguish between fraud and TOS matches.

## Changes

### `SuspendAccountsWithPaymentAddressWorker`

The `flag_and_suspend_user` method now checks the suspended user's risk state:

- **Suspended for fraud** (existing behavior): Flag and suspend related accounts for fraud
- **Suspended for TOS violation** (new behavior): Probate related accounts with a comment noting the TOS-suspended account's UID

This applies to both payment address matches and bank account fingerprint matches.

### `CheckPaymentAddressWorker`

Refactored to distinguish between fraud and TOS suspension matches:

- **Fraud match** (existing behavior): Flag user for fraud. Matches include `suspended_for_fraud` accounts, blocked email objects, and blocked fingerprint objects
- **TOS match only** (new behavior): Probate user with a comment listing the TOS-suspended account UIDs
- **Both fraud and TOS match**: Fraud takes priority (flag for fraud)
- Added guard: does not probate users who are already on probation or already suspended

### Comment format

Per the approved format from #2830 discussion:

**Fraud case:**
> Flagged for fraud automatically on January 26, 2026 because of usage of payment address hi@example.com (from User#12345)

**Probation case (SuspendAccountsWithPaymentAddressWorker):**
> Probated (payouts suspended) automatically on January 26, 2026 because of usage of payment address hi@example.com (from suspended for TOS violation User#12345)

**Probation case (CheckPaymentAddressWorker):**
> Probated (payouts suspended) automatically on January 26, 2026 because of usage of payment address matching suspended for TOS violation User#12345 and User#67890

## Test plan

### `SuspendAccountsWithPaymentAddressWorker` specs
- [x] Suspends related accounts for fraud when original is suspended for fraud (payment address + fingerprint)
- [x] Probates related accounts when original is suspended for TOS violation (payment address + fingerprint)
- [x] Creates correct comment type and content for both fraud and probation paths
- [x] Does not suspend already-suspended users
- [x] Does not probate already-suspended users
- [x] Handles both payment address and fingerprint matches together
- [x] Edge cases: blank fingerprint, deleted bank accounts, multiple fingerprints

### `CheckPaymentAddressWorker` specs
- [x] Flags user for fraud when matching fraud-suspended account
- [x] Probates user when matching TOS-suspended account
- [x] Fraud takes priority when both fraud and TOS matches exist
- [x] Does not probate user already on probation
- [x] Does not probate suspended users
- [x] All existing fraud-flagging tests pass (blocked emails, blocked fingerprints, etc.)