### PR TITLE
Fix Peru DNI 10-char validation and formatting (#3556)

### DIFF
--- a/app/javascript/components/Settings/PaymentsPage/AccountDetailsSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/AccountDetailsSection.tsx
@@ -31,6 +31,9 @@ type TaxIdConfig = {
   minLength?: number;
   maxLength?: number;
   idSuffix: string;
+  description?: string;
+  pattern?: RegExp;
+  formatter?: (value: string) => string;
 };
 
 const AccountDetailsSection = ({
@@ -227,7 +230,20 @@ const AccountDetailsSection = ({
         maxLength: 13,
         idSuffix: "argentina-id-number",
       },
-      PE: { label: "DNI number", placeholder: "12345678-9", minLength: 10, maxLength: 10, idSuffix: "peru-id-number" },
+      PE: {
+        label: "DNI number",
+        placeholder: "12345678-9",
+        minLength: 10,
+        maxLength: 10,
+        idSuffix: "peru-id-number",
+        description: "Enter all 10 characters, e.g. 12345678-9",
+        pattern: /^\d{8}-\d$/u,
+        formatter: (value: string) => {
+          const digits = value.replace(/\D/gu, "");
+          if (digits.length <= 8) return digits;
+          return `${digits.slice(0, 8)}-${digits.slice(8, 9)}`;
+        },
+      },
       PK: {
         label: "National Identity Card Number (SNIC or CNIC)",
         placeholder: "•••••••••",
@@ -364,6 +380,8 @@ const AccountDetailsSection = ({
       </Fieldset>
     );
   };
+
+  const [taxIdFormatError, setTaxIdFormatError] = React.useState(false);
 
   const businessTypes = getBusinessTypes();
   const businessStateConfig = getBusinessStateConfig();
@@ -1182,7 +1200,7 @@ const AccountDetailsSection = ({
         </Fieldset>
       ) : null}
       {needsIndividualTaxId && individualTaxIdConfig ? (
-        <Fieldset state={errorFieldNames.has("individual_tax_id") ? "danger" : undefined}>
+        <Fieldset state={errorFieldNames.has("individual_tax_id") || taxIdFormatError ? "danger" : undefined}>
           <div>
             <FieldsetTitle>
               <Label htmlFor={`${uid}-${individualTaxIdConfig.idSuffix}`}>{individualTaxIdConfig.label}</Label>
@@ -1195,9 +1213,30 @@ const AccountDetailsSection = ({
               placeholder={user.individual_tax_id_entered ? "Hidden for security" : individualTaxIdConfig.placeholder}
               required
               disabled={isFormDisabled}
-              aria-invalid={errorFieldNames.has("individual_tax_id")}
-              onChange={(evt) => updateComplianceInfo({ individual_tax_id: evt.target.value })}
+              aria-invalid={errorFieldNames.has("individual_tax_id") || taxIdFormatError}
+              onChange={(evt) => {
+                const formatted = individualTaxIdConfig.formatter
+                  ? individualTaxIdConfig.formatter(evt.target.value)
+                  : evt.target.value;
+                if (individualTaxIdConfig.formatter) {
+                  evt.target.value = formatted;
+                }
+                setTaxIdFormatError(false);
+                updateComplianceInfo({ individual_tax_id: formatted });
+              }}
+              onBlur={(evt) => {
+                if (
+                  individualTaxIdConfig.pattern &&
+                  evt.target.value &&
+                  !individualTaxIdConfig.pattern.test(evt.target.value)
+                ) {
+                  setTaxIdFormatError(true);
+                }
+              }}
             />
+            {individualTaxIdConfig.description ? (
+              <FieldsetDescription>{individualTaxIdConfig.description}</FieldsetDescription>
+            ) : null}
           </div>
         </Fieldset>
       ) : null}

--- a/app/javascript/pages/Settings/Payments/Show.tsx
+++ b/app/javascript/pages/Settings/Payments/Show.tsx
@@ -565,6 +565,13 @@ export default function PaymentsPage() {
     ) {
       markFieldInvalid("individual_tax_id");
     }
+    if (
+      (form.data.user.country === "PE" || form.data.user.business_country === "PE") &&
+      form.data.user.individual_tax_id &&
+      !/^\d{8}-\d$/u.test(form.data.user.individual_tax_id)
+    ) {
+      markFieldInvalid("individual_tax_id");
+    }
     if (form.data.user.is_business) {
       if (!form.data.user.business_type) {
         markFieldInvalid("business_type");

--- a/spec/requests/settings/payments_spec.rb
+++ b/spec/requests/settings/payments_spec.rb
@@ -2433,6 +2433,47 @@ describe("Payments Settings Scenario", type: :system, js: true) do
         expect(compliance_info.birthday).to eq(Date.new(1980, 1, 1))
         expect(@user.reload.active_bank_account.send(:account_number_decrypted)).to eq("99934500012345670024")
       end
+
+      it "displays help text for DNI field" do
+        visit settings_payments_path
+
+        expect(page).to have_content("Enter all 10 characters, e.g. 12345678-9")
+      end
+
+      it "auto-formats DNI with hyphen after 8th digit" do
+        visit settings_payments_path
+
+        dni_field = find_field("DNI number")
+        dni_field.native.clear
+        dni_field.send_keys("123456789")
+
+        expect(dni_field.value).to eq("12345678-9")
+      end
+
+      it "rejects incomplete DNI on form submission" do
+        visit settings_payments_path
+
+        fill_in("First name", with: "barnabas")
+        fill_in("Last name", with: "barnabastein")
+        fill_in("Address", with: "address_full_match")
+        fill_in("City", with: "barnabasville")
+        fill_in("Phone number", with: "14213365")
+        fill_in("Postal code", with: "1001")
+
+        select("1", from: "Day")
+        select("January", from: "Month")
+        select("1980", from: "Year")
+        fill_in("DNI number", with: "12345678")
+
+        fill_in("Pay to the order of", with: "barnabas ngagy")
+        fill_in("Account number", with: "99934500012345670024")
+        fill_in("Confirm account number", with: "99934500012345670024")
+
+        click_on("Update settings")
+
+        expect(page).not_to have_alert(text: "Thanks! You're all set.")
+        expect(find_field("DNI number")["aria-invalid"]).to eq("true")
+      end
     end
 
     describe "Norwegian creator" do


### PR DESCRIPTION
Fixes: #3556

# Description

## Problem

Stripe requires the full 10-character DNI for Peru users (format: `12345678-9`), but users often enter only the first 8 digits. This causes Stripe rejections and failed payouts.

## Solution

- Added help text below the DNI field: "Enter all 10 characters, e.g. 12345678-9"
- Auto-inserts hyphen after the 8th digit as the user types
- Inline validation on blur rejects incomplete/malformed DNI values
- Form-level validation blocks submission if the DNI doesn't match `^\d{8}-\d$`

---

# Before/After

**Before:** DNI field has no help text, no auto-formatting, and accepts incomplete 8-digit values that Stripe rejects.
<img width="2298" height="284" alt="image" src="https://github.com/user-attachments/assets/92d1fcfe-f381-4400-aede-19b3e1c4e6cb" />

**After:** DNI field shows help text, auto-formats with hyphen after 8th digit, and validates format on blur and on submit.

https://github.com/user-attachments/assets/fbc1076b-a8f1-44bd-9968-77c821f62897


---

# Test Results


<img width="532" height="188" alt="image" src="https://github.com/user-attachments/assets/b6a70ec9-0222-4917-bb1f-199ca2add20c" />

4 examples, 0 failures:
- `allows to enter bank account details` (existing, still passes)
- `displays help text for DNI field` (new)
- `auto-formats DNI with hyphen after 8th digit` (new)
- `rejects incomplete DNI on form submission` (new)

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

Claude Opus 4.6 was used to write tests.
