### PR TITLE
Fix: Add Careers link to React blog footer

### DIFF
--- a/app/javascript/components/Home/Shared/Footer.tsx
+++ b/app/javascript/components/Home/Shared/Footer.tsx
@@ -1,4 +1,10 @@
-import { Link } from "@inertiajs/react";
+import { Link, usePage } from "@inertiajs/react";
+
+interface PageProps {
+  feature_flags: {
+    career_pages: boolean;
+  };
+}
 import * as React from "react";
 
 import logoG from "$assets/images/logo-g.svg";
@@ -37,7 +43,10 @@ const SocialLink = ({ href, children }: { href: string; children: React.ReactNod
   </a>
 );
 
-export const HomeFooter = () => (
+export const HomeFooter = () => {
+  const { feature_flags } = usePage<PageProps>().props;
+
+  return (
   <div className="flex flex-col justify-between gap-16 bg-black px-8 py-16 leading-relaxed text-white lg:flex-row lg:px-[4vw] lg:py-24">
     <div className="flex w-full max-w-3xl flex-col gap-16">
       <div className="flex flex-col gap-8">
@@ -76,6 +85,7 @@ export const HomeFooter = () => (
           <FooterLink href={Routes.pricing_path()}>Pricing</FooterLink>
           <FooterLink href={Routes.features_path()}>Features</FooterLink>
           <FooterLink href={Routes.about_path()}>About</FooterLink>
+          {feature_flags.career_pages && <FooterLink href={Routes.careers_path()}>Careers</FooterLink>}
           <FooterLink href={Routes.small_bets_path()}>Small Bets</FooterLink>
         </div>
         <div className="flex flex-1 flex-col gap-3">
@@ -141,3 +151,4 @@ export const HomeFooter = () => (
     </div>
   </div>
 );
+};

--- a/config/initializers/react_on_rails.rb
+++ b/config/initializers/react_on_rails.rb
@@ -29,6 +29,7 @@ module RenderingExtension
       feature_flags: {
         require_email_typo_acknowledgment: Feature.active?(:require_email_typo_acknowledgment),
         disable_stripe_signup: Feature.active?(:disable_stripe_signup),
+        career_pages: Feature.active?(:career_pages),
       }
     }
   end

--- a/spec/config/rendering_extension_spec.rb
+++ b/spec/config/rendering_extension_spec.rb
@@ -37,7 +37,8 @@ describe "RenderingExtension" do
             locale: "en-US",
             feature_flags: {
               require_email_typo_acknowledgment: false,
-              disable_stripe_signup: false
+              disable_stripe_signup: false,
+              career_pages: false
             }
           }
         )
@@ -147,7 +148,8 @@ describe "RenderingExtension" do
               locale: "en-US",
               feature_flags: {
                 require_email_typo_acknowledgment: false,
-                disable_stripe_signup: false
+                disable_stripe_signup: false,
+                career_pages: false
               }
             }
           )


### PR DESCRIPTION
The React footer used on blog pages did not render the Careers link,
while the ERB footer conditionally renders it behind
`Feature.active?(:career_pages)`.

This patch brings the React footer in parity with the ERB implementation
to ensure consistent behavior across the application.

Fixes #3561.