### PR TITLE
Fix Failing Spec After Inertia Migration of Checkout Page

### DIFF
--- a/spec/requests/products/show/show_spec.rb
+++ b/spec/requests/products/show/show_spec.rb
@@ -185,6 +185,8 @@ describe("ProductShowScenario", type: :system, js: true) do
       expect(page).to have_selector("[aria-label='Discount code']", text:  @offer_code.code)
       click_on "Remove"
 
+      wait_until_true(sleep_interval: CheckoutPresenter::CART_SAVE_DEBOUNCE_DURATION_IN_SECONDS) { Cart.alive.last.cart_products.alive.count == 0 }
+
       visit "#{@product.long_url}?wanted=true&quantity=3"
 
       within "[role='listitem']" do


### PR DESCRIPTION
Issue: #3042 
Related PR: #3481
- #3481

## Description

This PR fixes a failing spec that got missed while merging #3481. 

## Solution

On checkout page, cart saves are debounced and hence we need to wait for its state to stabilize before re-visiting the page.

We've added `wait_until_true(sleep_interval: CheckoutPresenter::CART_SAVE_DEBOUNCE_DURATION_IN_SECONDS) { Cart.alive.last.cart_products.alive.count == 0 }` check which asserts on the correct stable state before we let the spec move onto the next set of assertions

---


# Test Results

<img width="599" height="117" alt="Screenshot 2026-02-15 at 12 13 58 AM" src="https://github.com/user-attachments/assets/f3615a46-b1c8-4bf9-af78-bdb181958485" />

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

No AI was used for this PR