### PR TITLE
fix: show loading immediately when cover image is selected

### DIFF
--- a/app/javascript/components/ProductEdit/ProductTab/CoverEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/CoverEditor.tsx
@@ -169,6 +169,9 @@ const CoverUploader = ({
                 onChange={asyncVoid(async (event) => {
                   if (!event.target.files?.length) return;
 
+                  // Show loading immediately when files are selected
+                  setIsUploading(true);
+
                   for (const file of event.target.files) {
                     if (!FileUtils.isFileNameExtensionAllowed(file.name, ALLOWED_EXTENSIONS)) {
                       showAlert("Invalid file type.", "error");


### PR DESCRIPTION
## Summary

Fixes issue #3588 - Cover image upload does not show immediate loading feedback

## Problem
When uploading a cover image on the product edit page, there is a noticeable delay (around 4-5 seconds) before the loading indicator appears. During this time, there is no visible feedback to users, which may create confusion about whether the upload has started.

## Solution
Set `isUploading=true` immediately when files are selected, before the upload process begins. This provides instant visual feedback to users.

## Changes
- Modified `CoverEditor.tsx` to set loading state immediately on file selection

---
Fixes #3588