### PR TITLE
Fix floating-point precision loss in price/amount to cents conversion

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -122,7 +122,7 @@ class LinksController < ApplicationController
       BasePrice::Recurrence::ALLOWED_RECURRENCES.each do |r|
         params[:recurrence] ||= r if params[r] == "true"
       end
-      params[:price] = (params[:price].to_f * 100).to_i if params[:price].present?
+      params[:price] = (params[:price].to_d * 100).to_i if params[:price].present?
       cart_item = @product.cart_item(params)
 
       unless (@product.customizable_price || cart_item[:option]&.[](:is_pwyw)) &&
@@ -503,7 +503,7 @@ class LinksController < ApplicationController
       tier:,
       effective_date: params[:effective_date].present? ? Date.parse(params[:effective_date]) : tier.subscription_price_change_effective_date,
       recurrence: params.require(:recurrence),
-      new_price: (params.require(:amount).to_f * 100).to_i,
+      new_price: (params.require(:amount).to_d * 100).to_i,
       custom_message: strip_tags(params[:custom_message]).present? ? params[:custom_message] : nil,
     ).deliver_later
 


### PR DESCRIPTION
## Description

Use BigDecimal (`.to_d`) instead of Float (`.to_f`) to prevent 1-cent discrepancies when converting decimal prices to cents.

## Changes

- Line 125: `params[:price].to_f * 100` → `params[:price].to_d * 100`
- Line 506: `params.require(:amount).to_f * 100` → `params.require(:amount).to_d * 100`

## Root Cause

Floating-point numbers cannot represent all decimal values exactly in binary. For example:
- $19.99 → 1998 cents (buggy) instead of 1999 cents
- $4.56 → 455 cents (buggy) instead of 456 cents

BigDecimal handles decimal arithmetic precisely, eliminating these rounding errors.

## Testing

```ruby
# Before (buggy)
19.99.to_f * 100  # => 1998

# After (fixed)
19.99.to_d * 100  # => 1999
```

Fixes #3408