### PR TITLE
fix: prevent tooltip overflow on last data point (#3448)

### DIFF
--- a/app/javascript/components/Analytics/useChartTooltip.ts
+++ b/app/javascript/components/Analytics/useChartTooltip.ts
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 const Y_OFFSET = 16;
+const TOOLTIP_WIDTH = 150; // approximate tooltip width in pixels
 
 const useChartTooltip = () => {
   const [tooltipState, setTooltipState] = React.useState<{ x: number; y: number; index: number } | null>(null);
@@ -35,8 +36,18 @@ const useChartTooltip = () => {
           setTooltipState(null);
           return;
         }
-        const x = dotRect.x - containerRect.x + dotRect.width / 2;
-        const y = dotRect.y - containerRect.y + dotRect.height / 2;
+        let x = dotRect.x - containerRect.x + dotRect.width / 2;
+        let y = dotRect.y - containerRect.y + dotRect.height / 2;
+        
+        // Prevent tooltip from overflowing on the right edge
+        if (x + TOOLTIP_WIDTH / 2 > containerRect.width) {
+          x = containerRect.width - TOOLTIP_WIDTH / 2 - 8;
+        }
+        // Prevent tooltip from overflowing on the left edge
+        if (x - TOOLTIP_WIDTH / 2 < 0) {
+          x = TOOLTIP_WIDTH / 2 + 8;
+        }
+        
         setTooltipState({ x, y, index: e.activeTooltipIndex });
       },
       onMouseLeave: () => setTooltipState(null),


### PR DESCRIPTION
## Summary
Fixes issue #3448 where the ChurnChart tooltip causes screen overflow when hovering over the last data point.

## Changes
- Added boundary detection in  to prevent tooltip from overflowing the container edges
- Tooltip now adjusts its position when too close to the left or right edge

## Testing
- The fix constrains the tooltip position within the chart container boundaries
- Works for both left-edge and right-edge cases