### PR TITLE
Fix discover page dropdown menu items cut off at viewport edge

### DIFF
--- a/app/javascript/components/NestedMenu.tsx
+++ b/app/javascript/components/NestedMenu.tsx
@@ -287,7 +287,7 @@ const MenubarItem = ({
               if (newSelectedItem === selectedItem) handleToggleMenu(false);
               onSelectItem?.(newSelectedItem, e);
             }}
-            className="flex h-full w-48 flex-col bg-white dark:bg-dark-gray"
+            className="flex h-full w-48 flex-col bg-white dark:bg-dark-gray max-h-[80vh] overflow-y-auto"
           />
         </PopoverContent>
       </Popover>


### PR DESCRIPTION
Fixes #3467

## Problem
The dropdown menus in the Discover page navigation extend beyond the viewport when they contain many items. Items at the bottom of these dropdowns become inaccessible as they're rendered outside the visible screen area with no way to scroll to them.

## Solution
Add  and  to the dropdown menu container to:
1. Limit the maximum height to 80% of the viewport height
2. Enable vertical scrolling when content exceeds the max height

## Changes
- Modified  to add  to the dropdown menu className

## Testing
Tested by checking that long dropdown menus now show scrollbars and all items are accessible.