### PR TITLE
Fix: Search input not auto-focusing when popover opens

### DIFF
--- a/app/javascript/components/Search.tsx
+++ b/app/javascript/components/Search.tsx
@@ -23,7 +23,13 @@ export const Search = ({ onSearch, value: initialValue, placeholder = "Search" }
           </Button>
         </PopoverTrigger>
       </PopoverAnchor>
-      <PopoverContent sideOffset={4} onOpenAutoFocus={() => searchInputRef.current?.focus()}>
+      <PopoverContent
+        sideOffset={4}
+        onOpenAutoFocus={(e: Event) => {
+          e.preventDefault(); // Prevent Radix from auto-focusing the trigger
+          searchInputRef.current?.focus();
+        }}
+      >
         <div className="input input-wrapper">
           <Icon name="solid-search" />
           <input


### PR DESCRIPTION
## Summary

Clicking the search button in the header now properly focuses the input field on the first click.

## Root Cause

Radix UI's  was not explicitly calling , causing focus to be stolen back to the trigger button.

## Fix

Added  in the  handler.

Fixes #3373