### PR TITLE
Fix: Show loading indicator immediately when cover image is selected

### DIFF
--- a/app/javascript/components/ProductEdit/ProductTab/CoverEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/CoverEditor.tsx
@@ -169,6 +169,9 @@ const CoverUploader = ({
                 onChange={asyncVoid(async (event) => {
                   if (!event.target.files?.length) return;
 
+                  // Show loading indicator immediately when user selects files
+                  setIsUploading(true);
+
                   for (const file of event.target.files) {
                     if (!FileUtils.isFileNameExtensionAllowed(file.name, ALLOWED_EXTENSIONS)) {
                       showAlert("Invalid file type.", "error");


### PR DESCRIPTION
Fixes #3588

The issue was that the loading spinner appeared 4-5 seconds after file selection because `setIsUploading(true)` was only called inside the `saveCover` function, which is invoked after `DirectUpload.create` completes (which takes time to generate the upload signature).

This fix sets `isUploading` to `true` immediately when the user selects files, providing instant visual feedback that the upload has started.