### PR TITLE
Add delete button to images in product description editor

### DIFF
--- a/app/javascript/components/TiptapExtensions/Image.tsx
+++ b/app/javascript/components/TiptapExtensions/Image.tsx
@@ -8,6 +8,7 @@ import { cast } from "ts-safe-cast";
 import { assertDefined } from "$app/utils/assert";
 
 import { LoadingSpinner } from "$app/components/LoadingSpinner";
+import { RemoveButton } from "$app/components/RemoveButton";
 import {
   getInsertAtFromSelection,
   ImageUploadSettings,
@@ -93,6 +94,12 @@ const ImageNodeView = ({ node, editor, getPos }: NodeViewProps) => {
     />
   );
 
+  const handleDelete = React.useCallback(() => {
+    if (getPos !== undefined) {
+      editor.commands.deleteNode();
+    }
+  }, [editor, getPos]);
+
   return (
     <NodeViewWrapper>
       <figure
@@ -100,6 +107,13 @@ const ImageNodeView = ({ node, editor, getPos }: NodeViewProps) => {
         data-has-focus={hasFocus || undefined}
         style={isUploading ? { position: "relative" } : undefined}
       >
+        {hasFocus && editor.isEditable && (
+          <RemoveButton
+            onClick={handleDelete}
+            style={{ position: "absolute", top: "8px", right: "8px", zIndex: 10 }}
+            aria-label="Remove image"
+          />
+        )}
         {attrs.link ? (
           <a href={cast(attrs.link)} target="_blank" rel="noopener noreferrer nofollow">
             {imageMarkup}


### PR DESCRIPTION
## Summary
Adds a delete button (X) to images in the product description rich text editor, making the UX consistent with cover image deletion.

## Changes
- Import RemoveButton component in `Image.tsx`
- Add delete button that appears when an image has focus
- Button positioned at top-right corner of the image

## Testing
- Click on an image in the product description editor
- Delete button should appear in the top-right corner
- Clicking the button removes the image

## Screenshots
Before: No delete button visible
After: X button appears on image focus (similar to cover images)

Fixes #3533