### PR TITLE
Fix UI issues in Careers page

### DIFF
--- a/app/views/home/shared/_office_carousel.html.erb
+++ b/app/views/home/shared/_office_carousel.html.erb
@@ -89,7 +89,7 @@
 <% else %>
 
   <div data-office-carousel>
-    <div class="rounded-2xl overflow-hidden relative w-full">
+    <div class="rounded-2xl overflow-hidden relative w-full border-0 outline-none">
       <div class="flex gap-6 md:gap-16 transition-transform duration-500 ease-in-out" data-office-carousel-slides>
         <% if images.any? %>
           <% ([images.last] + images + [images.first]).each do |image| %>
@@ -109,12 +109,12 @@
         </div>
       <% end %>
       <div class="absolute right-0 flex gap-6">
-        <button type="button" aria-label="Previous" data-office-carousel-prev class="w-10 h-10 rounded-full bg-white flex items-center justify-center hover:bg-gray-100">
+        <button type="button" aria-label="Previous" data-office-carousel-prev class="w-10 h-10 rounded-full bg-white flex items-center justify-center hover:bg-gray-100 cursor-pointer border-0 outline-none">
           <svg class="w-5 h-5 text-dark-gray" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path>
           </svg>
         </button>
-        <button type="button" aria-label="Next" data-office-carousel-next class="w-10 h-10 rounded-full bg-white flex items-center justify-center hover:bg-gray-100">
+        <button type="button" aria-label="Next" data-office-carousel-next class="w-10 h-10 rounded-full bg-white flex items-center justify-center hover:bg-gray-100 cursor-pointer border-0 outline-none">
           <svg class="w-5 h-5 text-dark-gray" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
           </svg>


### PR DESCRIPTION
Fixes #3612

## Changes
1. **Added cursor-pointer to carousel navigation buttons**: The left/right navigation arrows now show a pointer cursor when hovered, providing better visual feedback that they are clickable.

2. **Added border-0 and outline-none to prevent unwanted borders**: This fixes the thin horizontal line that appears below the office carousel/caption area at certain screen sizes. The issue was likely caused by default browser borders or outlines on interactive elements.

## Testing
- Navigation buttons now show proper cursor pointer on hover
- No unwanted borders or outlines visible on carousel elements
- UI remains consistent across different screen sizes