### PR TITLE
Show gifted membership purchases in library

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -474,8 +474,9 @@ class Purchase < ApplicationRecord
   scope :not_additional_contribution, -> { where("purchases.flags IS NULL OR purchases.flags & ? = 0", Purchase.flag_mapping["flags"][:is_additional_contribution]) }
   scope :for_products, ->(products) { where(link_id: products) if products.present? }
   scope :not_subscription_or_original_purchase, -> {
-    where("purchases.subscription_id IS NULL OR purchases.flags & ? = ?",
-          Purchase.flag_mapping["flags"][:is_original_subscription_purchase], Purchase.flag_mapping["flags"][:is_original_subscription_purchase])
+    where("purchases.subscription_id IS NULL OR purchases.flags & ? = ? OR purchases.flags & ? = ?",
+          Purchase.flag_mapping["flags"][:is_original_subscription_purchase], Purchase.flag_mapping["flags"][:is_original_subscription_purchase],
+          Purchase.flag_mapping["flags"][:is_gift_receiver_purchase], Purchase.flag_mapping["flags"][:is_gift_receiver_purchase])
   }
   # TODO: since Memberships, `not_recurring_charge` & `recurring_charge` are not an accurate names for what the scopes filter, and they should be renamed.
   scope :not_recurring_charge, lambda { not_subscription_or_original_purchase }

--- a/spec/presenters/library_presenter_spec.rb
+++ b/spec/presenters/library_presenter_spec.rb
@@ -183,6 +183,26 @@ describe LibraryPresenter do
       end
     end
 
+    context "when the user has a gifted membership purchase" do
+      let(:gifted_product) { create(:membership_product, name: "Gifted Membership", user: creator) }
+      let(:subscription) { create(:subscription, link: gifted_product, user: buyer) }
+      let!(:gift_receiver_purchase) do
+        create(:purchase,
+               :gift_receiver,
+               link: gifted_product,
+               purchaser: buyer,
+               subscription: subscription,
+               is_original_subscription_purchase: false).tap { _1.create_url_redirect! }
+      end
+
+      it "includes gifted membership purchases in the library" do
+        purchases, _ = described_class.new(buyer).library_cards
+
+        gift_purchase_ids = purchases.map { |p| p[:purchase][:id] }
+        expect(gift_purchase_ids).to include(gift_receiver_purchase.external_id)
+      end
+    end
+
     describe "bundle purchase" do
       let(:purchase1) { create(:purchase, purchaser: buyer, link: create(:product, :bundle)) }
       let(:purchase2) { create(:purchase, purchaser: buyer, link: create(:product, :bundle)) }


### PR DESCRIPTION
Resolves https://github.com/antiwork/gumroad/issues/2756

# Description

<!-- Briefly describe the problem and your solution -->

## Problem
Gifted membership/subscription purchases are not visible in the giftee's library. The `for_library` scope uses `not_recurring_charge`, which calls `not_subscription_or_original_purchase`. This scope only includes purchases where `subscription_id IS NULL` or `is_original_subscription_purchase` is set. Gift receiver subscription purchases have a `subscription_id` (not null) but `is_original_subscription_purchase` is explicitly `false`, causing them to be incorrectly filtered out as recurring charges.

## Solution

Updated the `not_subscription_or_original_purchase` scope in `Purchase` to also include purchases with the `is_gift_receiver_purchase` flag set.

---

# Before/After

## Before (Gift not visible on library)
<img width="1470" height="790" alt="image" src="https://github.com/user-attachments/assets/0032c7c5-7e3b-424b-9f7c-ca06ad28c53b" />


## After
<img width="1470" height="793" alt="image" src="https://github.com/user-attachments/assets/5fefb7c9-0f19-48fa-847f-7c71be8488d4" />


---

# AI Disclosure

Claude Opus 4.6 for code generation. All code was self reviewed.
