### PR TITLE
fix: Floating-point precision loss in price/amount to cents conversion (#3408)

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -122,7 +122,7 @@ class LinksController < ApplicationController
       BasePrice::Recurrence::ALLOWED_RECURRENCES.each do |r|
         params[:recurrence] ||= r if params[r] == "true"
       end
-      params[:price] = (params[:price].to_f * 100).to_i if params[:price].present?
+      params[:price] = (params[:price].to_d * 100).to_i if params[:price].present?
       cart_item = @product.cart_item(params)
 
       unless (@product.customizable_price || cart_item[:option]&.[](:is_pwyw)) &&
@@ -503,7 +503,7 @@ class LinksController < ApplicationController
       tier:,
       effective_date: params[:effective_date].present? ? Date.parse(params[:effective_date]) : tier.subscription_price_change_effective_date,
       recurrence: params.require(:recurrence),
-      new_price: (params.require(:amount).to_f * 100).to_i,
+      new_price: (params.require(:amount).to_d * 100).to_i,
       custom_message: strip_tags(params[:custom_message]).present? ? params[:custom_message] : nil,
     ).deliver_later
 


### PR DESCRIPTION
## Summary

Fixes floating-point precision errors in price/amount to cents conversion that cause 1-cent discrepancies.

## Changes

- Line 125: Changed  to  (BigDecimal) for  conversion
- Line 506: Changed  to  for  in 

## Bug Demonstrated

| Price | Old Result (to_f) | Expected (to_d) | Status |
|-------|-------------------|-----------------|--------|
| $19.99 | 1998 cents | 1999 cents | ✗ BUG |
| $4.56 | 455 cents | 456 cents | ✗ BUG |

## Root Cause

Floating-point numbers cannot represent all decimal values exactly in binary. When  is stored as a float, it becomes . Multiplying by 100 gives , and  truncates to .

Using  (via Rails' ) ensures precise decimal arithmetic.

---

Fixes #3408