### PR TITLE
fix: increase z-index of ComboBox dropdown to prevent it from being hidden behind files in Content tab

### DIFF
--- a/app/javascript/components/ComboBox.tsx
+++ b/app/javascript/components/ComboBox.tsx
@@ -122,7 +122,7 @@ export const ComboBox = <Option extends unknown>({
           aria-multiselectable={multiple}
           style={maxHeight ? { maxHeight } : undefined}
           className={classNames(
-            "absolute top-full left-0 z-10 block w-full overflow-auto rounded-b border border-t-0 border-border bg-background py-2 shadow",
+            "absolute top-full left-0 z-50 block w-full overflow-auto rounded-b border border-t-0 border-border bg-background py-2 shadow",
           )}
         >
           {options.map((item, index) => (


### PR DESCRIPTION
Fixes #3463

## Problem
The page dropdown menu in the Content tab gets hidden behind file content elements due to insufficient z-index.

## Solution
Increased the z-index of the ComboBox dropdown from  to  to ensure it appears above all other elements in the Content tab.

## Testing
- Verified dropdown now appears above file content
- No visual regressions observed