### PR TITLE
fix: keep search bar visible when search returns no products

### DIFF
--- a/app/javascript/components/ProductsDashboardPage.tsx
+++ b/app/javascript/components/ProductsDashboardPage.tsx
@@ -44,7 +44,7 @@ export const ProductsDashboardPage = ({
       archivedTabVisible={enableArchiveTab}
       ctaButton={
         <>
-          {products.length > 0 ? <Search value={query} onSearch={setQuery} placeholder="Search products" /> : null}
+          {products.length > 0 || query ? <Search value={query} onSearch={setQuery} placeholder="Search products" /> : null}
           <NavigationButtonInertia href={Routes.new_product_path()} disabled={!canCreateProduct} color="accent">
             New product
           </NavigationButtonInertia>
@@ -52,11 +52,11 @@ export const ProductsDashboardPage = ({
       }
     >
       <section className="p-4 md:p-8">
-        {memberships.length === 0 && products.length === 0 ? (
+        {memberships.length === 0 && products.length === 0 && !query ? (
           <Placeholder>
             <PlaceholderImage src={placeholder} />
-            <h2>We’ve never met an idea we didn’t like.</h2>
-            <p>Your first product doesn’t need to be perfect. Just put it out there, and see if it sticks.</p>
+            <h2>We've never met an idea we didn't like.</h2>
+            <p>Your first product doesn't need to be perfect. Just put it out there, and see if it sticks.</p>
             <div>
               <NavigationButtonInertia href={Routes.new_product_path()} disabled={!canCreateProduct} color="accent">
                 New product

--- a/app/javascript/components/ProductsPage.tsx
+++ b/app/javascript/components/ProductsPage.tsx
@@ -41,7 +41,7 @@ const ProductsPage = ({
       />
     ) : null}
 
-    {products.length > 0 ? (
+    {products.length > 0 || query ? (
       <ProductsPageProductsTable
         query={query}
         entries={products}

--- a/app/javascript/components/ProductsPage/MembershipsTable.tsx
+++ b/app/javascript/components/ProductsPage/MembershipsTable.tsx
@@ -80,7 +80,12 @@ export const ProductsPageMembershipsTable = (props: {
 
   const reloadMemberships = () => loadMemberships(pagination.page);
 
-  if (!memberships.length) return null;
+  if (!memberships.length) {
+    if (props.query) {
+      return <p>No memberships found matching your search.</p>;
+    }
+    return null;
+  }
 
   return (
     <section className="flex flex-col gap-4">

--- a/app/javascript/components/ProductsPage/ProductsTable.tsx
+++ b/app/javascript/components/ProductsPage/ProductsTable.tsx
@@ -80,7 +80,12 @@ export const ProductsPageProductsTable = (props: {
 
   const reloadProducts = () => loadProducts(pagination.page);
 
-  if (!products.length) return null;
+  if (!products.length) {
+    if (props.query) {
+      return <p>No products found matching your search.</p>;
+    }
+    return null;
+  }
 
   return (
     <div className="flex flex-col gap-4">


### PR DESCRIPTION
Fixes #3262

## Problem

On the Products page, when a user searches for products and the query returns zero results, the search bar disappears. The user is then unable to clear or modify their search because the input field has been unmounted.

## Root Cause

Three layers of conditional rendering all used `array.length > 0` checks without accounting for active search state:

1. **`ProductsDashboardPage.tsx:47`** — Search component only rendered when `products.length > 0`
2. **`ProductsDashboardPage.tsx:55`** — Empty-state placeholder shown (hiding ProductsPage) when `products.length === 0`
3. **`ProductsTable.tsx:83`** / **`MembershipsTable.tsx:83`** — Early return `null` when entries array is empty, which also kills the `useOnChange` hook that triggers search reloads

When a search returned no results:
- Server returns empty `products_data.products` array via Inertia partial reload
- `products.length` becomes 0
- Search component unmounts → user can't clear search
- ProductsPage unmounts → "create first product" placeholder appears
- Table's `useOnChange` hook unmounts → no way to trigger new searches

## Fix

Added `|| query` checks alongside the existing `array.length > 0` conditions:

| File | Before | After |
|------|--------|-------|
| `ProductsDashboardPage.tsx:47` | `products.length > 0` | `products.length > 0 \|\| query` |
| `ProductsDashboardPage.tsx:55` | `memberships.length === 0 && products.length === 0` | `... && !query` |
| `ProductsPage.tsx:44` | `products.length > 0` | `products.length > 0 \|\| query` |
| `ProductsTable.tsx:83` | `return null` | Show "No products found" message when query is active |
| `MembershipsTable.tsx:83` | `return null` | Show "No memberships found" message when query is active |

This ensures:
- Search bar stays visible during empty search results
- The `useOnChange` hook in the table remains mounted to handle subsequent query changes
- A "no results" message is shown instead of hiding the table or showing the placeholder
- Original behavior is preserved when there are genuinely no products (no search active)

## Test Plan
- [ ] Search for a product that exists → results appear
- [ ] Search for a non-existent product → "No products found" message shown, search bar stays visible
- [ ] Clear the search → all products reappear
- [ ] With no products at all (new account) → placeholder still shows correctly