### PR TITLE
Add close (X) button to nested menu overlay sidebar

### DIFF
--- a/app/javascript/components/NestedMenu.tsx
+++ b/app/javascript/components/NestedMenu.tsx
@@ -332,6 +332,11 @@ const OverlayMenu = ({
         modal
         className="right-auto w-80 max-w-80 border-l-0 p-0 md:left-0 md:border-r"
       >
+        <div className="flex justify-end px-4 pt-4">
+          <Button onClick={() => setMenuOpen(false)} aria-label="Close menu">
+            <Icon name="x" />
+          </Button>
+        </div>
         <ItemsList
           key={`${overlayMenuUID}-${menuOpen}`}
           menuId={overlayMenuUID}


### PR DESCRIPTION
## Summary
- Adds a close (X) button to the top-right of the nested menu overlay sidebar, restoring the functionality that was lost during the Tailwind migration (PR #2068)
- Uses the existing `Button` and `Icon` components with proper `aria-label` for accessibility
- Minimal change: 5 lines added to the `OverlayMenu` component in `NestedMenu.tsx`

## Details
The overlay menu sidebar (shown on mobile/smaller screens) previously had a close button that was removed during the CSS-to-Tailwind migration. While clicking the backdrop does close the sidebar, having an explicit X button provides better UX as noted by @ershad and @laugardie.

The close button is positioned at the top-right of the sidebar with appropriate padding (`px-4 pt-4`) and uses the same `Button` component pattern used elsewhere in the file.

Fixes #2724

## Test plan
- [ ] Open the Discover page on a mobile viewport or narrow browser window
- [ ] Click the filter/categories button to open the overlay sidebar
- [ ] Verify the X button appears at the top-right of the sidebar
- [ ] Click the X button — sidebar should close
- [ ] Verify the backdrop click still works to close the sidebar
- [ ] Test on narrow devices (e.g. Samsung Galaxy Fold viewport) to confirm the button doesn't get cut off

🤖 Generated with [Claude Code](https://claude.com/claude-code)