### PR TITLE
Add ES index for audience members

### DIFF
--- a/app/models/audience_member.rb
+++ b/app/models/audience_member.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AudienceMember < ApplicationRecord
+  include AudienceMember::Searchable
+
   VALID_FILTER_TYPES = %w[customer follower affiliate].freeze
 
   belongs_to :seller, class_name: "User"

--- a/app/models/concerns/audience_member/searchable.rb
+++ b/app/models/concerns/audience_member/searchable.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+module AudienceMember::Searchable
+  extend ActiveSupport::Concern
+
+  included do
+    include Elasticsearch::Model
+    include ElasticsearchModelAsyncCallbacks
+    include SearchIndexModelCommon
+
+    index_name "audience_members"
+
+    settings number_of_shards: 1, number_of_replicas: 0
+
+    mapping dynamic: :strict do
+      indexes :id, type: :long
+      indexes :seller_id, type: :long
+      indexes :email, type: :keyword
+      indexes :customer, type: :boolean
+      indexes :follower, type: :boolean
+      indexes :affiliate, type: :boolean
+      indexes :min_paid_cents, type: :long
+      indexes :max_paid_cents, type: :long
+      indexes :min_purchase_created_at, type: :date
+      indexes :max_purchase_created_at, type: :date
+      indexes :follower_created_at, type: :date
+      indexes :min_affiliate_created_at, type: :date
+      indexes :max_affiliate_created_at, type: :date
+      indexes :min_created_at, type: :date
+      indexes :max_created_at, type: :date
+      indexes :created_at, type: :date
+      indexes :updated_at, type: :date
+      indexes :purchased_product_ids, type: :long
+      indexes :purchased_variant_ids, type: :long
+      indexes :purchase_countries, type: :keyword
+      indexes :affiliate_product_ids, type: :long
+      indexes :purchases, type: :nested do
+        indexes :id, type: :long
+        indexes :product_id, type: :long
+        indexes :variant_ids, type: :long
+        indexes :price_cents, type: :long
+        indexes :created_at, type: :date
+        indexes :country, type: :keyword
+      end
+      indexes :follower_details, type: :object do
+        indexes :id, type: :long
+        indexes :created_at, type: :date
+      end
+      indexes :affiliates, type: :nested do
+        indexes :id, type: :long
+        indexes :product_id, type: :long
+        indexes :created_at, type: :date
+      end
+    end
+
+    ATTRIBUTE_TO_SEARCH_FIELDS = {
+      "id" => "id",
+      "seller_id" => "seller_id",
+      "email" => "email",
+      "customer" => "customer",
+      "follower" => "follower",
+      "affiliate" => "affiliate",
+      "min_paid_cents" => "min_paid_cents",
+      "max_paid_cents" => "max_paid_cents",
+      "min_purchase_created_at" => "min_purchase_created_at",
+      "max_purchase_created_at" => "max_purchase_created_at",
+      "follower_created_at" => "follower_created_at",
+      "min_affiliate_created_at" => "min_affiliate_created_at",
+      "max_affiliate_created_at" => "max_affiliate_created_at",
+      "min_created_at" => "min_created_at",
+      "max_created_at" => "max_created_at",
+      "created_at" => "created_at",
+      "updated_at" => "updated_at",
+      "details" => %w[
+        purchased_product_ids
+        purchased_variant_ids
+        purchase_countries
+        affiliate_product_ids
+        purchases
+        follower_details
+        affiliates
+      ],
+    }.freeze
+
+    def search_field_value(field_name)
+      case field_name
+      when "id", "seller_id", "email", "customer", "follower", "affiliate",
+           "min_paid_cents", "max_paid_cents", "min_purchase_created_at", "max_purchase_created_at",
+           "follower_created_at", "min_affiliate_created_at", "max_affiliate_created_at",
+           "min_created_at", "max_created_at", "created_at", "updated_at"
+        attributes[field_name]
+      when "purchased_product_ids"
+        Array.wrap(details&.dig("purchases")).flat_map { |p| p["product_id"] }.compact.uniq
+      when "purchased_variant_ids"
+        Array.wrap(details&.dig("purchases")).flat_map { |p| Array.wrap(p["variant_ids"]) }.flatten.compact.uniq
+      when "purchase_countries"
+        Array.wrap(details&.dig("purchases")).map { |p| p["country"] }.compact.uniq
+      when "affiliate_product_ids"
+        Array.wrap(details&.dig("affiliates")).map { |a| a["product_id"] }.compact.uniq
+      when "purchases"
+        Array.wrap(details&.dig("purchases")).map do |p|
+          {
+            id: p["id"],
+            product_id: p["product_id"],
+            variant_ids: Array.wrap(p["variant_ids"]),
+            price_cents: p["price_cents"],
+            created_at: p["created_at"],
+            country: p["country"],
+          }.compact_blank
+        end
+      when "follower_details"
+        details&.dig("follower").present? ? { id: details["follower"]["id"], created_at: details["follower"]["created_at"] }.compact_blank : nil
+      when "affiliates"
+        Array.wrap(details&.dig("affiliates")).map do |a|
+          { id: a["id"], product_id: a["product_id"], created_at: a["created_at"] }.compact_blank
+        end
+      end.as_json
+    end
+  end
+end

--- a/app/services/onetime/backfill_audience_members_elasticsearch_index.rb
+++ b/app/services/onetime/backfill_audience_members_elasticsearch_index.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class Onetime::BackfillAudienceMembersElasticsearchIndex < Onetime::Base
+  BATCH_SIZE = 5_000
+
+  def initialize(start_id: nil, end_id: nil)
+    @start_id = start_id
+    @end_id = end_id
+  end
+
+  def process
+    scope = AudienceMember.all
+    scope = scope.where("id >= ?", @start_id) if @start_id.present?
+    scope = scope.where("id <= ?", @end_id) if @end_id.present?
+
+    enqueued_count = 0
+    scope.find_in_batches(batch_size: BATCH_SIZE) do |batch|
+      ReplicaLagWatcher.watch
+      batch.each do |audience_member|
+        ElasticsearchIndexerWorker.set(queue: "low").perform_async(
+          "index",
+          "record_id" => audience_member.id,
+          "class_name" => "AudienceMember"
+        )
+        enqueued_count += 1
+      end
+      Rails.logger.info "Enqueued audience members #{batch.first.id} to #{batch.last.id} (#{enqueued_count} total)"
+    end
+
+    Rails.logger.info "Backfill complete. Enqueued #{enqueued_count} index jobs."
+  end
+end

--- a/db/migrate/20260217120000_create_audience_members_elasticsearch_index.rb
+++ b/db/migrate/20260217120000_create_audience_members_elasticsearch_index.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class CreateAudienceMembersElasticsearchIndex < ActiveRecord::Migration[7.1]
+  def up
+    if Rails.env.production? || Rails.env.staging?
+      AudienceMember.__elasticsearch__.create_index!(index: "audience_members_v1")
+      EsClient.indices.put_alias(name: "audience_members", index: "audience_members_v1")
+    else
+      AudienceMember.__elasticsearch__.create_index!
+    end
+  end
+
+  def down
+    if Rails.env.production? || Rails.env.staging?
+      EsClient.indices.delete_alias(name: "audience_members", index: "audience_members_v1")
+      AudienceMember.__elasticsearch__.delete_index!(index: "audience_members_v1")
+    else
+      AudienceMember.__elasticsearch__.delete_index!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_11_19_011937) do
+ActiveRecord::Schema[7.1].define(version: 2026_11_19_011936) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false

--- a/spec/models/concerns/audience_member/searchable_spec.rb
+++ b/spec/models/concerns/audience_member/searchable_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe AudienceMember::Searchable do
+  describe "#as_indexed_json" do
+    let(:seller) { create(:user) }
+    let(:audience_member) do
+      create(:audience_member, seller:, purchases: [
+               { id: 100, product_id: 10, variant_ids: [100], price_cents: 500, created_at: "2024-01-01T00:00:00Z", country: "US" }
+             ])
+    end
+
+    it "includes all fields" do
+      expect(audience_member.as_indexed_json).to eq(
+        "id" => audience_member.id,
+        "seller_id" => audience_member.seller_id,
+        "email" => audience_member.email,
+        "customer" => true,
+        "follower" => false,
+        "affiliate" => false,
+        "min_paid_cents" => 500,
+        "max_paid_cents" => 500,
+        "min_purchase_created_at" => audience_member.min_purchase_created_at.as_json,
+        "max_purchase_created_at" => audience_member.max_purchase_created_at.as_json,
+        "follower_created_at" => nil,
+        "min_affiliate_created_at" => nil,
+        "max_affiliate_created_at" => nil,
+        "min_created_at" => audience_member.min_created_at.as_json,
+        "max_created_at" => audience_member.max_created_at.as_json,
+        "created_at" => audience_member.created_at.as_json,
+        "updated_at" => audience_member.updated_at.as_json,
+        "purchased_product_ids" => [10],
+        "purchased_variant_ids" => [100],
+        "purchase_countries" => ["US"],
+        "affiliate_product_ids" => [],
+        "purchases" => [
+          {
+            "id" => 100,
+            "product_id" => 10,
+            "variant_ids" => [100],
+            "price_cents" => 500,
+            "created_at" => "2024-01-01T00:00:00Z",
+            "country" => "US"
+          }
+        ],
+        "follower_details" => nil,
+        "affiliates" => []
+      )
+    end
+
+    it "allows only a selection of fields to be used" do
+      expect(audience_member.as_indexed_json(only: ["email", "seller_id"])).to eq(
+        "email" => audience_member.email,
+        "seller_id" => audience_member.seller_id
+      )
+    end
+  end
+end

--- a/spec/services/onetime/backfill_audience_members_elasticsearch_index_spec.rb
+++ b/spec/services/onetime/backfill_audience_members_elasticsearch_index_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Onetime::BackfillAudienceMembersElasticsearchIndex do
+  it "enqueues index jobs for all audience members" do
+    seller = create(:user)
+    member1 = create(:audience_member, seller:, purchases: [{ "product_id" => 1 }])
+    member2 = create(:audience_member, seller:, follower: {})
+
+    ElasticsearchIndexerWorker.jobs.clear
+
+    expect do
+      described_class.new.process
+    end.to change { ElasticsearchIndexerWorker.jobs.count }.by(2)
+
+    expect(ElasticsearchIndexerWorker.jobs).to include(
+      hash_including("args" => ["index", hash_including("record_id" => member1.id, "class_name" => "AudienceMember")]),
+      hash_including("args" => ["index", hash_including("record_id" => member2.id, "class_name" => "AudienceMember")])
+    )
+  end
+
+  it "respects start_id and end_id for chunked processing" do
+    seller = create(:user)
+    create(:audience_member, seller:, purchases: [{ "product_id" => 1 }])
+    member2 = create(:audience_member, seller:, follower: {})
+    create(:audience_member, seller:, affiliates: [{}])
+
+    ElasticsearchIndexerWorker.jobs.clear
+
+    described_class.new(start_id: member2.id, end_id: member2.id).process
+
+    expect(ElasticsearchIndexerWorker.jobs.count).to eq(1)
+    expect(ElasticsearchIndexerWorker.jobs.first["args"].last["record_id"]).to eq(member2.id)
+  end
+end


### PR DESCRIPTION
Issue: https://github.com/antiwork/gumroad/issues/3514
Closes: https://github.com/antiwork/gumroad/issues/3514

# Description

Migrate AudienceMember.filter() queries from MySQL to Elasticsearch. This involves:


## Problem
 `AudienceMember.filter()` builds queries using `JSON_CONTAINS` and `JSON_TABLE` to search inside a `details` JSON column. While MySQL supports multi-valued indexes on JSON arrays (which can help `JSON_CONTAINS`), these indexes were removed in August 2023 and `JSON_TABLE` operations cannot use them regardless. This leaves the filtered queries with no index support, requiring full scans of JSON data for each row.

## Solution

- All new and updated AudienceMember records are automatically indexed in ES
- A backfill mechanism exists to index the full existing dataset (~140M rows)
- The ES index mapping supports all filter parameters from AudienceMember.filter()

---

# Before/After
NA
---

# Test Results

<img width="2477" height="618" alt="image" src="https://github.com/user-attachments/assets/da58e00a-118e-40d5-bb6d-6338fb63bbb0" />
<img width="2477" height="618" alt="image" src="https://github.com/user-attachments/assets/9316836d-67a3-494b-a7cc-ae1b87553785" />

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure
Cursor for auto-completion and understanding how ES works in Gumroad.