### PR TITLE
Fix Preview component overflow by accounting for scaleFactor in height

### DIFF
--- a/app/javascript/components/Preview.tsx
+++ b/app/javascript/components/Preview.tsx
@@ -14,7 +14,7 @@ export const Preview = ({
   const ref = React.useRef<HTMLDivElement>(null);
   const height = useElementDimensions(ref)?.height;
   return (
-    <div role="document" className="overflow-hidden" style={{ height: Math.ceil(height ?? 0) }}>
+    <div role="document" className="overflow-hidden" style={{ height: Math.ceil((height ?? 0) * scaleFactor) }}>
       <div
         ref={ref}
         style={{


### PR DESCRIPTION
## Summary
- Fixed the `Preview` component's outer container height calculation to account for the CSS `transform: scale()` factor
- The `clientHeight` reported by `ResizeObserver` reflects pre-transform dimensions, so without multiplying by `scaleFactor`, the container was ~3x taller than the visible scaled content
- This caused vertical overflow on the profile settings page and all other pages using the `Preview` component (product edit, bundle edit, checkout dashboard)

## Changes
- `app/javascript/components/Preview.tsx`: Changed `height: Math.ceil(height ?? 0)` to `height: Math.ceil((height ?? 0) * scaleFactor)` on line 17

## Test plan
- [ ] Navigate to `/settings/profile` and verify the preview sidebar no longer overflows vertically
- [ ] Check product edit page preview is correctly sized
- [ ] Check bundle edit page preview is correctly sized
- [ ] Check checkout dashboard preview is correctly sized

Fixes #3388

🤖 Generated with [Claude Code](https://claude.com/claude-code)