### PR TITLE
Fix mobile CTA bar layout when installment plan is enabled

### DIFF
--- a/app/javascript/components/Product/CtaButton.tsx
+++ b/app/javascript/components/Product/CtaButton.tsx
@@ -144,7 +144,13 @@ export const CtaButton = React.forwardRef<HTMLAnchorElement, Props>(
 
     return (
       <>
-        <NavigationButton ref={ref} href={url.toString()} color="accent" {...buttonCommonProps}>
+        <NavigationButton
+          ref={ref}
+          href={url.toString()}
+          color="accent"
+          {...buttonCommonProps}
+          className={product.installment_plan && product.installment_plan.number_of_installments > 1 ? "max-lg:text-sm max-lg:px-2 max-lg:py-2" : undefined}
+        >
           {label ??
             (purchase
               ? "Purchase again"
@@ -159,7 +165,7 @@ export const CtaButton = React.forwardRef<HTMLAnchorElement, Props>(
 
         {product.installment_plan && product.installment_plan.number_of_installments > 1 ? (
           <>
-            <NavigationButton color="black" href={urlWithInstallments.toString()} {...buttonCommonProps}>
+            <NavigationButton color="black" href={urlWithInstallments.toString()} {...buttonCommonProps} className="max-lg:text-sm max-lg:px-2 max-lg:py-2">
               Pay in {product.installment_plan.number_of_installments} installments
             </NavigationButton>
             {showInstallmentPlanNotes ? (

--- a/app/javascript/components/Product/Layout.tsx
+++ b/app/javascript/components/Product/Layout.tsx
@@ -276,7 +276,7 @@ const CtaBar = ({
     >
       <div
         ref={ref}
-        className="mx-auto flex max-w-product-page items-center justify-between gap-4 p-4 lg:px-8"
+        className="mx-auto flex max-w-product-page items-center justify-between gap-2 p-4 lg:gap-4 lg:px-8"
         style={{
           transition: "var(--transition-duration)",
           marginTop: visible || !isDesktop ? undefined : -height,

--- a/app/javascript/components/Product/PriceTag.tsx
+++ b/app/javascript/components/Product/PriceTag.tsx
@@ -60,7 +60,7 @@ export const PriceTag = ({
   const borderClasses = "border-r-transparent border-[calc(0.5lh+--spacing(1))] border-l-1";
 
   return (
-    <div itemScope itemProp="offers" itemType="https://schema.org/Offer" className="flex items-center">
+    <div itemScope itemProp="offers" itemType="https://schema.org/Offer" className="flex shrink-0 items-center whitespace-nowrap">
       <WithTooltip position={tooltipPosition} tip={priceTag}>
         <div className="relative grid grid-flow-col border border-r-0 border-border">
           <div


### PR DESCRIPTION
## Summary
- Fixed the sticky CTA bar layout overflow on mobile when installment payments are enabled
- Following maintainer guidance from @slavingia and @laugardie to keep the single-row layout compact using Tailwind responsive utilities
- Three targeted changes:
  - **PriceTag**: Added `shrink-0` and `whitespace-nowrap` to prevent price text from wrapping (e.g., "$370" breaking into "$37" + "0")
  - **CtaButton**: Conditionally applies `max-lg:text-sm max-lg:px-2 max-lg:py-2` to both CTA buttons when installments are active, reducing font size and padding on mobile only
  - **Layout**: Reduced CTA bar gap from `gap-4` to `gap-2` on mobile (`gap-2 lg:gap-4`)

## Test plan
- [ ] Open a product page with installment plan enabled on a mobile viewport (< 1024px)
- [ ] Verify the price tag, CTA button, and installment button all fit on one line without overflow
- [ ] Verify the sticky CTA bar does not increase in height
- [ ] Verify desktop layout (>= 1024px) remains unchanged
- [ ] Verify layout on products without installment plans is unaffected

Fixes #3319

🤖 Generated with [Claude Code](https://claude.com/claude-code)