### PR TITLE
Fix search input not auto-focusing when popover opens

### DIFF
--- a/app/javascript/components/Search.tsx
+++ b/app/javascript/components/Search.tsx
@@ -23,7 +23,7 @@ export const Search = ({ onSearch, value: initialValue, placeholder = "Search" }
           </Button>
         </PopoverTrigger>
       </PopoverAnchor>
-      <PopoverContent sideOffset={4} onOpenAutoFocus={() => searchInputRef.current?.focus()}>
+      <PopoverContent sideOffset={4} onOpenAutoFocus={(e) => { e.preventDefault(); searchInputRef.current?.focus(); }}>
         <div className="input input-wrapper">
           <Icon name="solid-search" />
           <input


### PR DESCRIPTION
## Summary

Clicking the search button in the header opens the popover but doesn't auto-focus the input field, requiring users to click a second time inside the input to start typing.

## Root Cause

Radix UI's `PopoverContent` `onOpenAutoFocus` event handler returns focus to the trigger element after the callback runs. The existing code calls `searchInputRef.current?.focus()` but Radix immediately steals focus back to the trigger button.

## Fix

Call `event.preventDefault()` in the `onOpenAutoFocus` handler to prevent Radix UI from overriding the focus placement, allowing the search input to properly receive focus when the popover opens.

Fixes #3373

🤖 Generated with [Claude Code](https://claude.com/claude-code)