### PR TITLE
Fix edit button hidden behind top bar on product page

### DIFF
--- a/app/javascript/components/Product/Layout.tsx
+++ b/app/javascript/components/Product/Layout.tsx
@@ -124,7 +124,7 @@ const SectionEditor = ({
             {section.id ? (
               <EditSection section={section} />
             ) : (
-              <div className="mx-auto w-full max-w-6xl">{children}</div>
+              <div className="relative mx-auto w-full max-w-6xl">{children}</div>
             )}
             {i === sections.length - 1 ? <AddSectionButton index={i + 1} side="top" /> : null}
           </SectionLayout>
@@ -168,7 +168,7 @@ export const Layout = (
     <section className="border-b border-border">
       <div
         className={classNames(
-          "mx-auto w-full max-w-product-page lg:py-16",
+          "relative mx-auto w-full max-w-product-page lg:py-16",
           props.sections.length > 0 ? "px-4 py-8" : "p-4 lg:px-8",
         )}
       >


### PR DESCRIPTION
## Summary

The edit button on the product page is hidden behind the profile header at desktop screen sizes. It becomes visible at smaller (mobile) screen sizes due to different header layout.

## Root Cause

The `EditButton` component uses `position: absolute` with `z-index: var(--z-index-overlay)` but has no positioned ancestor (`position: relative`), causing it to position relative to the initial containing block (viewport). The profile header creates a stacking context with a higher z-index, rendering above the edit button.

This explains the behavior described in the issue:
- **Desktop**: Button hidden behind header (both near viewport top, header has higher z-index)
- **Mobile**: Button visible due to different header layout
- **Scrolling**: Button briefly flashes into view as scroll position moves it

## Fix

Add `position: relative` (Tailwind `relative` class) to the product container `div` in both render paths:
1. `mainSection` wrapper — for standard product pages
2. `SectionEditor` wrapper — for editor mode

This creates a positioned ancestor for the `EditButton`, so it positions within the product section below the header instead of at the viewport level.

Fixes #2995

🤖 Generated with [Claude Code](https://claude.com/claude-code)