### PR TITLE
Fix Subscribers tab to use Inertia SPA navigation

### DIFF
--- a/app/javascript/components/EmailsPage/Layout.tsx
+++ b/app/javascript/components/EmailsPage/Layout.tsx
@@ -40,8 +40,8 @@ export const EmailsLayout = ({ selectedTab, children, hasPosts, query, onQueryCh
         <Tab asChild isSelected={selectedTab === "drafts"}>
           <Link href={Routes.drafts_emails_path()}>Drafts</Link>
         </Tab>
-        <Tab href={Routes.followers_path()} isSelected={false}>
-          Subscribers
+        <Tab asChild isSelected={false}>
+          <Link href={Routes.followers_path()}>Subscribers</Link>
         </Tab>
       </Tabs>
     </PageHeader>

--- a/app/javascript/pages/Followers/Index.tsx
+++ b/app/javascript/pages/Followers/Index.tsx
@@ -1,4 +1,4 @@
-import { router, useForm, usePage } from "@inertiajs/react";
+import { Link, router, useForm, usePage } from "@inertiajs/react";
 import * as React from "react";
 import { cast } from "ts-safe-cast";
 
@@ -38,21 +38,21 @@ const Layout = ({
     <div>
       <PageHeader title={title} actions={actions}>
         <Tabs>
-          <Tab href={Routes.published_emails_path()} isSelected={false}>
-            Published
+          <Tab asChild isSelected={false}>
+            <Link href={Routes.published_emails_path()}>Published</Link>
           </Tab>
           {loggedInUser?.policies.installment.create ? (
             <>
-              <Tab href={Routes.scheduled_emails_path()} isSelected={false}>
-                Scheduled
+              <Tab asChild isSelected={false}>
+                <Link href={Routes.scheduled_emails_path()}>Scheduled</Link>
               </Tab>
-              <Tab href={Routes.drafts_emails_path()} isSelected={false}>
-                Drafts
+              <Tab asChild isSelected={false}>
+                <Link href={Routes.drafts_emails_path()}>Drafts</Link>
               </Tab>
             </>
           ) : null}
-          <Tab href={Routes.followers_path()} isSelected>
-            Subscribers
+          <Tab asChild isSelected>
+            <Link href={Routes.followers_path()}>Subscribers</Link>
           </Tab>
         </Tabs>
       </PageHeader>


### PR DESCRIPTION
## Summary
- Fixed the Subscribers tab on the Emails page (`EmailsPage/Layout.tsx`) to use Inertia's `<Link>` component with the `asChild` pattern instead of a plain `<a>` tag, preventing full page reloads
- Fixed all tabs (Published, Scheduled, Drafts, Subscribers) on the Followers page (`Followers/Index.tsx`) to also use Inertia `<Link>` for consistent SPA navigation across both pages

Fixes #2952

## Details

The `Tab` component renders either a plain `<a>` tag (when using `href` prop directly) or delegates to a child component via Radix `Slot` (when using `asChild`). The other tabs on the Emails page already used the correct `asChild` + `<Link>` pattern for Inertia SPA navigation, but the Subscribers tab was using `<Tab href={...}>` which rendered a plain `<a>` tag causing a full page refresh.

The same issue existed in the Followers/Index.tsx page where all four tabs (Published, Scheduled, Drafts, Subscribers) were using plain `<a>` tags.

## Test plan
- [ ] Click the Subscribers tab on the Emails page and verify it navigates without a full page refresh
- [ ] Click Published, Scheduled, and Drafts tabs from the Subscribers/Followers page and verify they navigate without a full page refresh
- [ ] Verify all tab selections and active states still display correctly
- [ ] Verify browser back/forward navigation works correctly between tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)