### PR TITLE
fix: prevent node actions menu from overlapping toolbar dropdowns

### DIFF
--- a/app/javascript/components/TiptapExtensions/NodeActionsMenu.tsx
+++ b/app/javascript/components/TiptapExtensions/NodeActionsMenu.tsx
@@ -2,6 +2,7 @@ import { Editor } from "@tiptap/core";
 import * as React from "react";
 
 import { assertDefined } from "$app/utils/assert";
+import { classNames } from "$app/utils/classNames";
 
 import { Button } from "$app/components/Button";
 import { Icon } from "$app/components/Icons";
@@ -19,7 +20,7 @@ export const NodeActionsMenu = ({
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
-      <div className="actions-menu">
+      <div className={classNames("actions-menu", { "z-0!": !open })}>
         <PopoverAnchor>
           <PopoverTrigger aria-label="Actions" data-drag-handle draggable asChild>
             <Button small color="filled">

--- a/spec/requests/products/edit/rich_text_editor_spec.rb
+++ b/spec/requests/products/edit/rich_text_editor_spec.rb
@@ -1005,6 +1005,7 @@ describe("Product Edit Rich Text Editor", type: :system, js: true) do
           click_on "Move down"
           click_on "Move down"
         end
+        find("[aria-label='Actions']").click
       end
 
       toggle_file_group("Folder 1")
@@ -1057,18 +1058,21 @@ describe("Product Edit Rich Text Editor", type: :system, js: true) do
           select_disclosure "Actions" do
             expect(page).to have_menuitem("Move to folder...")
           end
+          find("[aria-label='Actions']").click
         end
 
         within find_file_group("Folder 1").hover do
           select_disclosure "Actions" do
             expect(page).to_not have_menuitem("Move to folder...")
           end
+          find("[aria-label='Actions']").click
         end
 
         within find_embed(name: "6F0E4C97-B72A4E69-A11BF6C4-AF6517E7").hover do
           select_disclosure "Actions" do
             expect(page).to_not have_menuitem("Move to folder...")
           end
+          find("[aria-label='Actions']").click
         end
 
         within find_embed(name: "Posts (emails) sent to customers of this product will appear here").hover do


### PR DESCRIPTION
## Summary
- Fixes the NodeActionsMenu (drag handle / adjustment buttons) overlapping the "Upload files" dropdown on the Products Content page
- Applies `z-0!` to `.actions-menu` when its popover is closed so it sits below the toolbar's stacking context
- Updates specs to explicitly close the Actions popover before interacting with another element's menu

Fixes #3215

## Root Cause

Both `.actions-menu` and `.rich-text-editor-toolbar` share `z-index: z-index(overlay)` (value `1`). When the toolbar's "Upload files" dropdown opens, closed `NodeActionsMenu` popovers at the same z-level visually overlap the dropdown, blocking user interaction.

## Solution

Added a conditional `z-0!` class to the `.actions-menu` wrapper div when the popover is not open. This ensures closed node action menus have a lower z-index (`0`) than the toolbar (`1`), allowing toolbar dropdowns to render above them. When the node actions popover is opened, it removes `z-0!` and reverts to its normal `z-index: overlay` stacking.

## Test plan
- [ ] Navigate to `/products/:id/edit/content`
- [ ] Click the "Upload files" button in the toolbar
- [ ] Verify the dropdown appears above all node action buttons (drag handles)
- [ ] Verify dropdown items (Embed media, Computer files, etc.) are fully visible and clickable
- [ ] Verify node action menus still function correctly when opened
- [ ] Verify drag-and-drop reordering still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)