### PR TITLE
Add close button to nested menu overlay sidebar

### DIFF
--- a/app/javascript/components/Discover/Nav.tsx
+++ b/app/javascript/components/Discover/Nav.tsx
@@ -57,7 +57,6 @@ export const Nav = ({
           if (item.href) onClickTaxonomy(item.href.replace(/^\//u, ""));
         }}
         footer={footer}
-        menuTop="0px"
       />
     </div>
   );

--- a/app/javascript/components/NestedMenu.tsx
+++ b/app/javascript/components/NestedMenu.tsx
@@ -9,7 +9,7 @@ import { Button } from "$app/components/Button";
 import { useCurrentSeller } from "$app/components/CurrentSeller";
 import { Icon } from "$app/components/Icons";
 import { Popover, PopoverContent, PopoverTrigger } from "$app/components/Popover";
-import { Sheet } from "$app/components/ui/Sheet";
+import { Sheet, SheetCloseButton } from "$app/components/ui/Sheet";
 import { useIsOnTouchDevice } from "$app/components/useIsOnTouchDevice";
 import { useOnOutsideClick } from "$app/components/useOnOutsideClick";
 import { useWindowDimensions } from "$app/components/useWindowDimensions";
@@ -34,7 +34,6 @@ type NestedMenuProps = {
   moreLabel?: string;
   buttonLabel?: string;
   footer?: React.ReactNode;
-  menuTop?: string;
 } & React.AriaAttributes;
 
 export const NestedMenu = ({
@@ -45,7 +44,6 @@ export const NestedMenu = ({
   moreLabel,
   buttonLabel,
   footer,
-  menuTop,
   ...extraAriaAttrs
 }: NestedMenuProps) => {
   const itemsMap = React.useMemo(() => {
@@ -79,13 +77,11 @@ export const NestedMenu = ({
 
   return (
     <MenuContext.Provider value={menuContent}>
-      <div>
-        {type === "menubar" ? (
-          <Menubar moreLabel={moreLabel} {...extraAriaAttrs} />
-        ) : (
-          <OverlayMenu buttonLabel={buttonLabel} footer={footer} menuTop={menuTop} {...extraAriaAttrs} />
-        )}
-      </div>
+      {type === "menubar" ? (
+        <Menubar moreLabel={moreLabel} {...extraAriaAttrs} />
+      ) : (
+        <OverlayMenu buttonLabel={buttonLabel} footer={footer} {...extraAriaAttrs} />
+      )}
     </MenuContext.Provider>
   );
 };
@@ -302,12 +298,10 @@ const MenubarItem = ({
 const OverlayMenu = ({
   buttonLabel,
   footer,
-  menuTop,
   ...extraAriaAttrs
 }: {
   buttonLabel?: string | undefined;
   footer?: React.ReactNode;
-  menuTop?: string | undefined;
 } & React.AriaAttributes) => {
   const { onSelectItem, topLevelMenuItems } = useMenuContext();
   const [menuOpen, setMenuOpen] = React.useState(false);
@@ -332,6 +326,7 @@ const OverlayMenu = ({
         modal
         className="right-auto w-80 max-w-80 border-l-0 p-0 md:left-0 md:border-r"
       >
+        <SheetCloseButton className="absolute right-4 top-4" />
         <ItemsList
           key={`${overlayMenuUID}-${menuOpen}`}
           menuId={overlayMenuUID}

--- a/app/javascript/components/ui/Sheet.tsx
+++ b/app/javascript/components/ui/Sheet.tsx
@@ -29,11 +29,14 @@ export const Sheet = ({
     </Dialog.Portal>
   </Dialog.Root>
 );
+export const SheetCloseButton = ({ className }: { className?: string }) => (
+  <Dialog.Close className={classNames("cursor-pointer all-unset", className)} aria-label="Close">
+    <Icon name="x" />
+  </Dialog.Close>
+);
 export const SheetHeader = ({ children }: { children: React.ReactNode }) => (
   <div className="flex items-start gap-4">
     <Dialog.Title>{children}</Dialog.Title>
-    <Dialog.Close className="ml-auto cursor-pointer all-unset" aria-label="Close">
-      <Icon name="x" />
-    </Dialog.Close>
+    <SheetCloseButton className="ml-auto" />
   </div>
 );


### PR DESCRIPTION
Fixes #2724 (close button)

## Summary

The overlay sidebar for the nested menu (shown on mobile/smaller screens) lost its close button during the Tailwind migration in #1851. This restores the X button, matching the [Figma design](https://www.figma.com/design/cqBGWkI4iZe47mhvrEF1SY/Discover-on-homepage?node-id=832-26998&t=JxqMqbpJVWyKT48f-4) shared by @laugardie.

### Changes

- **Close button**: Added `SheetCloseButton` — a reusable close button extracted from `SheetHeader` — and placed it inside the `OverlayMenu` sidebar at the top-right (`absolute right-4 top-4`). This uses Radix's `Dialog.Close` so it works with the existing `Sheet`/`Dialog.Root` state management. The button is inside the sidebar panel (not the overlay), so it remains visible on narrow devices like the Samsung Galaxy Fold.
- **Refactored `SheetHeader`**: Now uses the shared `SheetCloseButton` component, reducing duplication.
- **Removed redundant wrapper `<div>`**: The `NestedMenu` component had an unnecessary `<div>` wrapping the conditional rendering of `Menubar` / `OverlayMenu`.
- **Removed unused `menuTop` prop**: The `menuTop` prop was passed through `NestedMenu` → `OverlayMenu` but was never applied to any element. Removed from `NestedMenuProps`, `NestedMenu`, `OverlayMenu`, and the `Nav` call site.

### Root cause

PR #1851 migrated `_nested_menu.scss` to Tailwind and replaced the sidebar implementation with the `Sheet` component, but did not include a close button. The `Sheet` component supports `Dialog.Close` via Radix UI, but a close button was only rendered through `SheetHeader`, which is not used by the nested menu overlay.

## Test plan

- [ ] Open the Discover page on a mobile viewport or narrow browser window
- [ ] Click the filter/categories button to open the overlay sidebar
- [ ] Verify the X button appears at the top-right corner inside the sidebar
- [ ] Click the X button and confirm the sidebar closes
- [ ] Verify the backdrop click still closes the sidebar
- [ ] Test on narrow devices (e.g. Samsung Galaxy Fold viewport) to confirm the button is not cut off
- [ ] Test in both light and dark mode
- [ ] Verify `SheetHeader` close button still works correctly in other pages (e.g. Emails, Followers, Affiliates)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [ ] I have added/updated tests for my changes

---

## AI Disclosure

This PR was authored with Claude Code (Claude Opus 4.6). The implementation approach and code were reviewed manually.