### PR TITLE
fix(product): Remove invisible border on "Share on X" button

### DIFF
--- a/app/javascript/components/Button.tsx
+++ b/app/javascript/components/Button.tsx
@@ -49,7 +49,7 @@ export const buttonVariants = cva(
         discord: "bg-[#7289da] text-white border-[#7289da]",
         stripe: "bg-[#625bf6] text-white border-[#625bf6]",
         facebook: "bg-[#4267b2] text-white border-[#4267b2]",
-        twitter: "bg-black text-white border-black",
+        twitter: "bg-black text-white",
         apple: "bg-black text-white",
         android: "bg-[#142f40] text-white",
         kindle: "bg-[#f3a642] text-black border-[#f3a642]",


### PR DESCRIPTION
Issue: #3647 

## Summary
The "Share on X" button in the product page share popover has an invisible border because the twitter color variant in `Button.tsx` uses `border-black` on a `bg-black background`. This makes the button appear borderless, unlike adjacent share buttons (Facebook, Copy link) which have visible borders.

Root cause: The twitter color variant explicitly sets `border-black`, which overrides the default `border-border` from the base CVA class.


<table>
  <thead>
    <tr>
      <th width="50%">Before</th>
      <th width="50%">After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td align="center">
<img width="1512" height="821" alt="Screenshot 2026-02-17 at 12 11 55 PM" src="https://github.com/user-attachments/assets/99e4f949-73b7-4675-a426-18e28645d6b4" />
      </td>
      <td align="center">
<img width="1511" height="819" alt="Screenshot 2026-02-17 at 12 09 18 PM" src="https://github.com/user-attachments/assets/b6d6d42b-0f0d-49bc-9ba0-f8e218eaf46c" />
      </td>
    </tr>
  </tbody>
</table>





## Tests

N/A


# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [ ] I have added/updated tests for my changes

---

# AI Disclosure
No AI used.