### PR TITLE
Add delete button for application icon in Settings Advanced

### DIFF
--- a/app/javascript/components/Settings/AdvancedPage/ApplicationForm.tsx
+++ b/app/javascript/components/Settings/AdvancedPage/ApplicationForm.tsx
@@ -10,6 +10,7 @@ import { asyncVoid } from "$app/utils/promise";
 import { assertResponseError, request, ResponseError } from "$app/utils/request";
 
 import { Button } from "$app/components/Button";
+import { Icon } from "$app/components/Icons";
 import { showAlert } from "$app/components/server-components/Alert";
 import { Fieldset, FieldsetTitle } from "$app/components/ui/Fieldset";
 import { Input } from "$app/components/ui/Input";
@@ -138,7 +139,21 @@ const ApplicationForm = ({ application }: { application?: Application }) => {
           <Label>Application icon</Label>
         </FieldsetTitle>
         <div style={{ display: "flex", gap: "var(--spacer-4)", alignItems: "flex-start" }}>
-          <img className="application-icon" src={icon?.url || placeholderAppIcon} width={80} height={80} />
+          <div className="relative inline-block">
+            <img className="application-icon" src={icon?.url || placeholderAppIcon} width={80} height={80} />
+            {icon ? (
+              <Button
+                color="primary"
+                small
+                className="absolute top-2 right-2 p-0.5 leading-none text-xs"
+                aria-label="Remove icon"
+                onClick={() => setIcon(null)}
+                disabled={isUploadingIcon || isSubmitting}
+              >
+                <Icon name="trash2" />
+              </Button>
+            ) : null}
+          </div>
           <Button onClick={() => iconInputRef.current?.click()} disabled={isUploadingIcon || isSubmitting}>
             {isUploadingIcon ? "Uploading..." : "Upload icon"}
           </Button>


### PR DESCRIPTION
### Issue
Fixes: #3650 

---

### Summary
This PR improves the Application Icon upload experience in
Settings → Advanced → Create Application.

After uploading an application icon, there was no direct and intuitive way to remove it from the UI.

This change introduces a small trash icon overlay on the image preview, similar to the existing behavior in the Profile Logo section.


---

### Fix

####	•	Displays a trash icon overlay on the uploaded application icon preview
####	•	Allows users to remove the icon directly from the preview
####	•	Aligns the UI behavior with the Profile Logo component for consistency

---

### Before

<img width="958" height="770" alt="Screenshot 2026-02-16 at 11 35 07 PM" src="https://github.com/user-attachments/assets/bd368310-c286-45c9-86a2-47e079c09c36" />


### After

<img width="1077" height="724" alt="Screenshot 2026-02-16 at 11 34 01 PM" src="https://github.com/user-attachments/assets/708d8da9-ed7b-4b8b-87b3-bffcb8a1caf7" />

<img width="882" height="711" alt="Screenshot 2026-02-16 at 11 33 34 PM" src="https://github.com/user-attachments/assets/76368602-573c-41d0-94b7-87e518b7cb06" />



---

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

### AI Disclosure
No AI used
