### PR TITLE
fix: use Inertia Link for Subscribers tab to enable SPA navigation

### DIFF
--- a/app/javascript/components/EmailsPage/Layout.tsx
+++ b/app/javascript/components/EmailsPage/Layout.tsx
@@ -40,8 +40,8 @@ export const EmailsLayout = ({ selectedTab, children, hasPosts, query, onQueryCh
         <Tab asChild isSelected={selectedTab === "drafts"}>
           <Link href={Routes.drafts_emails_path()}>Drafts</Link>
         </Tab>
-        <Tab href={Routes.followers_path()} isSelected={false}>
-          Subscribers
+        <Tab asChild isSelected={selectedTab === "subscribers"}>
+          <Link href={Routes.followers_path()}>Subscribers</Link>
         </Tab>
       </Tabs>
     </PageHeader>


### PR DESCRIPTION
## Description
The Subscribers tab on the Emails page caused a full page reload instead of client-side SPA navigation, inconsistent with the Published, Scheduled, and Drafts tabs.

## Root Cause
The Subscribers tab used <Tab href={Routes.followers_path()}> which renders a standard <a> tag, while all other tabs use <Tab asChild><Link href={...}> with Inertia's <Link> component for client-side routing.

## Fix
- Changed the Subscribers tab to use <Tab asChild> with an Inertia <Link> wrapper, matching the pattern of the other three tabs
- Added isSelected logic using the existing subscribers EmailTab type

## Before/After
- **Before:** Clicking Subscribers tab ? full page reload (flash of white, scroll position reset)
- **After:** Clicking Subscribers tab ? smooth SPA transition (no reload, consistent with other tabs)

Fixes #2952

> This PR was developed with AI assistance (Claude/Anthropic).