### PR TITLE
fix: keep search bar visible when search returns no products

### DIFF
--- a/app/javascript/components/ProductsDashboardPage.tsx
+++ b/app/javascript/components/ProductsDashboardPage.tsx
@@ -36,6 +36,10 @@ export const ProductsDashboardPage = ({
 }: ProductsDashboardPageProps) => {
   const [enableArchiveTab, setEnableArchiveTab] = React.useState(archivedProductsCount > 0);
   const [query, setQuery] = React.useState("");
+  // Track whether products existed on initial load so the search bar stays visible
+  // even when a search query filters all products out (fixes #3262).
+  // useRef avoids unnecessary re-renders since this value never changes.
+  const hadInitialItems = React.useRef(products.length > 0 || memberships.length > 0);
 
   return (
     <ProductsLayout
@@ -44,7 +48,9 @@ export const ProductsDashboardPage = ({
       archivedTabVisible={enableArchiveTab}
       ctaButton={
         <>
-          {products.length > 0 ? <Search value={query} onSearch={setQuery} placeholder="Search products" /> : null}
+          {hadInitialItems.current || query ? (
+            <Search value={query} onSearch={setQuery} placeholder="Search products" />
+          ) : null}
           <NavigationButtonInertia href={Routes.new_product_path()} disabled={!canCreateProduct} color="accent">
             New product
           </NavigationButtonInertia>
@@ -52,7 +58,7 @@ export const ProductsDashboardPage = ({
       }
     >
       <section className="p-4 md:p-8">
-        {memberships.length === 0 && products.length === 0 ? (
+        {!hadInitialItems.current && memberships.length === 0 && products.length === 0 ? (
           <Placeholder>
             <PlaceholderImage src={placeholder} />
             <h2>We’ve never met an idea we didn’t like.</h2>

--- a/app/javascript/components/ProductsPage.tsx
+++ b/app/javascript/components/ProductsPage.tsx
@@ -28,9 +28,14 @@ const ProductsPage = ({
   query: string | null;
   setEnableArchiveTab?: (enable: boolean) => void;
   type?: Tab;
-}) => (
-  <div className="grid gap-12">
-    {memberships.length > 0 ? (
+}) => {
+  const hasResults = memberships.length > 0 || products.length > 0;
+
+  return (
+    <div className="grid gap-12">
+      {/* Always render table components so their useOnChange search effects
+          keep running even when the query returns zero results. The tables
+          internally return null when their entries are empty. */}
       <ProductsPageMembershipsTable
         query={query}
         entries={memberships}
@@ -39,9 +44,6 @@ const ProductsPage = ({
         selectedTab={type}
         setEnableArchiveTab={setEnableArchiveTab}
       />
-    ) : null}
-
-    {products.length > 0 ? (
       <ProductsPageProductsTable
         query={query}
         entries={products}
@@ -50,8 +52,12 @@ const ProductsPage = ({
         selectedTab={type}
         setEnableArchiveTab={setEnableArchiveTab}
       />
-    ) : null}
-  </div>
-);
+
+      {!hasResults && query ? (
+        <p className="text-muted text-center">No products found matching &ldquo;{query}&rdquo;</p>
+      ) : null}
+    </div>
+  );
+};
 
 export default ProductsPage;


### PR DESCRIPTION
## Description
On the Products page, searching for a query that returns zero results caused the search bar to disappear, making it impossible to modify or clear the search.

## Root Cause
Three interacting issues:
1. **Search bar unmounts:** `ProductsDashboardPage` conditionally rendered `<Search>` based on `products.length > 0`. When the server returned zero products for a search query, the search bar unmounted.
2. **Search effects stop:** `ProductsPage` conditionally rendered the table components. When tables unmounted, their `useOnChange` effects (which trigger `router.reload` on query changes) stopped running, breaking subsequent searches.
3. **Wrong empty state:** The first-time-user placeholder ("We've never met an idea...") displayed instead of a search-empty state when a query returned zero results.

## Fix
- **`ProductsDashboardPage`:** Track initial product existence with `useRef` (`hadInitialItems`). The search bar stays visible as long as products existed on page load or a query is active. The first-time placeholder is now guarded by `!hadInitialItems.current` so it only shows for genuinely new users.
- **`ProductsPage`:** Always render both table components (they internally `return null` when empty) so their `useOnChange` search-driven reload effects keep running across zero-result queries.
- **Empty state:** Added a "No products found" message when search is active but returns no results.

## Before/After
- **Before:** Search with 0 results ? search bar disappears ? subsequent searches impossible
- **After:** Search with 0 results ? search bar stays visible ? "No products found" message shown ? user can modify/clear search

Fixes #3262

> This PR was developed with AI assistance (Claude/Anthropic).