### PR TITLE
fix: Search input not auto-focusing when popover opens #3373

### DIFF
--- a/app/javascript/components/Admin/SearchPopover.tsx
+++ b/app/javascript/components/Admin/SearchPopover.tsx
@@ -22,6 +22,11 @@ const SearchPopover = () => {
   const currentUrl = useOriginalLocation();
   const searchParams = new URL(currentUrl).searchParams;
   const [open, setOpen] = React.useState(false);
+  const userQueryRef = React.useRef<HTMLInputElement>(null);
+
+  React.useEffect(() => {
+    if (open) userQueryRef.current?.focus();
+  }, [open]);
 
   const getInitialQuery = () => {
     const queryValue = searchParams.get("query") || "";
@@ -103,7 +108,7 @@ const SearchPopover = () => {
             <InputGroup>
               <Icon name="person" />
               <Input
-                autoFocus
+                ref={userQueryRef}
                 name="query"
                 placeholder="Search users (email, name, ID)"
                 type="text"

--- a/app/javascript/components/Search.tsx
+++ b/app/javascript/components/Search.tsx
@@ -13,9 +13,14 @@ type SearchProps = {
 export const Search = ({ onSearch, value: initialValue, placeholder = "Search" }: SearchProps) => {
   const searchInputRef = React.useRef<HTMLInputElement>(null);
   const [searchQuery, setSearchQuery] = React.useState(initialValue);
+  const [open, setOpen] = React.useState(false);
+
+  React.useEffect(() => {
+    if (open) searchInputRef.current?.focus();
+  }, [open]);
 
   return (
-    <Popover>
+    <Popover open={open} onOpenChange={setOpen}>
       <PopoverAnchor>
         <PopoverTrigger aria-label="Toggle Search" asChild>
           <Button>
@@ -23,13 +28,12 @@ export const Search = ({ onSearch, value: initialValue, placeholder = "Search" }
           </Button>
         </PopoverTrigger>
       </PopoverAnchor>
-      <PopoverContent sideOffset={4} onOpenAutoFocus={() => searchInputRef.current?.focus()}>
+      <PopoverContent sideOffset={4}>
         <div className="input input-wrapper">
           <Icon name="solid-search" />
           <input
             ref={searchInputRef}
             value={searchQuery}
-            autoFocus
             type="text"
             placeholder={placeholder}
             onChange={(e) => {

--- a/app/javascript/pages/UtmLinks/Index.tsx
+++ b/app/javascript/pages/UtmLinks/Index.tsx
@@ -161,7 +161,7 @@ export default function UtmLinksIndex() {
       selectedTab="utm_links"
       actions={
         <>
-          <Search value={query} onSearch={onSearch} />
+          {utmLinks.length > 0 || query ? <Search value={query} onSearch={onSearch} /> : null}
           <NavigationButtonInertia href={Routes.new_dashboard_utm_link_path()} color="accent">
             Create link
           </NavigationButtonInertia>

--- a/spec/requests/admin/pages_spec.rb
+++ b/spec/requests/admin/pages_spec.rb
@@ -48,6 +48,10 @@ describe "Admin Pages Scenario", type: :system, js: true do
       select_disclosure "Toggle Search"
     end
 
+    it "autofocuses the search input when the popover is opened" do
+      expect_focused find_field("Search users (email, name, ID)")
+    end
+
     it "searches users by query field" do
       fill_in "Search users (email, name, ID)", with: "joe@example.com\n"
       expect(page).to have_selector("h1", text: "Search for joe@example.com")

--- a/spec/requests/analytics/utm_links_spec.rb
+++ b/spec/requests/analytics/utm_links_spec.rb
@@ -226,6 +226,14 @@ describe "UTM links", :js, type: :system do
         expect(page).to_not have_table_row({ "Link" => "A Link", "Conversion" => "66.67%" })
       end
 
+      it "autofocuses the search input when the popover is opened" do
+        create(:utm_link, seller:)
+        visit dashboard_utm_links_path
+        select_disclosure "Toggle Search" do
+          expect_focused find_field("Search")
+        end
+      end
+
       it "filters UTM links by search query by adhering to the current column sort order" do
         stub_const("PaginatedUtmLinksPresenter::PER_PAGE", 1)
 

--- a/spec/requests/checkout/discounts_spec.rb
+++ b/spec/requests/checkout/discounts_spec.rb
@@ -886,6 +886,13 @@ describe("Checkout discounts page", type: :system, js: true) do
       stub_const("Checkout::DiscountsController::PER_PAGE", 2)
     end
 
+    it "autofocuses the search input when the popover is opened" do
+      visit checkout_discounts_path
+      select_disclosure "Toggle Search" do
+        expect_focused find_field("Search")
+      end
+    end
+
     it "searches the offer codes" do
       visit checkout_discounts_path
 

--- a/spec/requests/checkout/upsells_spec.rb
+++ b/spec/requests/checkout/upsells_spec.rb
@@ -119,6 +119,13 @@ describe("Checkout upsells page", type: :system, js: true) do
       end
     end
 
+    it "autofocuses the search input when the popover is opened" do
+      visit checkout_upsells_path
+      select_disclosure "Toggle Search" do
+        expect_focused find_field("Search")
+      end
+    end
+
     describe "sorting and pagination" do
       before do
         stub_const("Checkout::UpsellsController::PER_PAGE", 1)

--- a/spec/requests/customers/customers_spec.rb
+++ b/spec/requests/customers/customers_spec.rb
@@ -79,6 +79,14 @@ describe "Sales page", type: :system, js: true do
       expect(page).to have_nth_table_row_record(3, "Customer 6")
     end
 
+    it "autofocuses the search input when the popover is opened" do
+      login_as seller
+      visit customers_path
+      select_disclosure "Toggle Search" do
+        expect_focused find_field("Search sales")
+      end
+    end
+
     it "allows searching the table" do
       create(:purchase, link: product1, full_name: "Customer 11", email: "customer11@gumroad.com", created_at: 11.days.ago, seller:)
       index_model_records(Purchase)

--- a/spec/requests/emails/list_spec.rb
+++ b/spec/requests/emails/list_spec.rb
@@ -264,6 +264,13 @@ describe("Email List", :js, :sidekiq_inline, :elasticsearch_wait_for_refresh, ty
     end
 
     describe "search" do
+      it "autofocuses the search input when the popover is opened" do
+        visit "#{emails_path}/published"
+        select_disclosure "Toggle Search" do
+          expect_focused find_field("Search emails")
+        end
+      end
+
       it "displays filtered and paginated emails for the search query" do
         stub_const("PaginatedInstallmentsPresenter::PER_PAGE", 1)
 

--- a/spec/requests/followers/followers_spec.rb
+++ b/spec/requests/followers/followers_spec.rb
@@ -54,6 +54,12 @@ describe("Followers", js: true, type: :system) do
       expect(page).to_not have_button "Load more"
     end
 
+    it "autofocuses the search input when the popover is opened" do
+      select_disclosure "Toggle Search" do
+        expect_focused find_field("Search followers")
+      end
+    end
+
     it "supports search functionality" do
       expect(page).to_not have_selector(:table_row, text: "test@example.com")
       select_disclosure "Toggle Search" do

--- a/spec/requests/products/affiliated_products_spec.rb
+++ b/spec/requests/products/affiliated_products_spec.rb
@@ -15,6 +15,17 @@ describe "Affiliated Products", type: :system, js: true do
     let(:url) { products_affiliated_index_path }
   end
 
+  it "autofocuses the search input when the popover is opened" do
+    creator = create(:named_user)
+    product = create(:product, user: creator)
+    direct_affiliate = create(:direct_affiliate, affiliate_user:, seller: creator)
+    create(:product_affiliate, affiliate: direct_affiliate, product:)
+    visit products_affiliated_index_path
+    select_disclosure "Toggle Search" do
+      expect_focused find_field("Search")
+    end
+  end
+
   shared_examples "accesses global affiliates page" do
     it "provides details about the program" do
       visit products_affiliated_index_path

--- a/spec/requests/products/archived_products_spec.rb
+++ b/spec/requests/products/archived_products_spec.rb
@@ -14,6 +14,14 @@ describe "Archived Products", type: :system, js: true do
     let(:url) { products_archived_index_path }
   end
 
+  it "autofocuses the search input when the popover is opened" do
+    create(:product, user: seller, archived: true)
+    visit products_archived_index_path
+    select_disclosure "Toggle Search" do
+      expect_focused find_field("Search products")
+    end
+  end
+
   describe "pagination" do
     before do
       stub_const("DashboardProductsPagePresenter::PER_PAGE", 1)

--- a/spec/requests/products/index_spec.rb
+++ b/spec/requests/products/index_spec.rb
@@ -486,6 +486,13 @@ describe "Products Page Scenario", type: :system, js: true do
       stub_const("DashboardProductsPagePresenter::PER_PAGE", per_page)
     end
 
+    it "autofocuses the search input when the popover is opened" do
+      visit(products_path)
+      select_disclosure "Toggle Search" do
+        expect_focused find_field("Search products")
+      end
+    end
+
     it "shows the search results" do
       product = create(:product, user: seller, name: "Chicken", unique_permalink: "chicken")
       visit(products_path)


### PR DESCRIPTION
Issue: #3373

# Description

This PR fixes the search input not autofocusing when the popover is opened across all pages using the Search component and Admin/SearchPopover. Also fixes the UTM Links page showing the search bar on empty state, inconsistent with all other pages

## Problem

The search input does not receive focus when the search popover is opened. `onOpenAutoFocus` doesn't call `e.preventDefault()`, so Radix steals focus back, and autoFocus is dead code since forceMount keeps the input always mounted in the DOM.

## Solution

  - Replace `onOpenAutoFocus` and autoFocus with controlled open state + useEffect for reliable focus
  - Apply the same fix to Admin/SearchPopover
  - Conditionally render Search on UTM Links page
  - Add autofocus tests for all related specs


---

# Before/After
## Before 
[Screencast from 2026-02-17 21-55-25.webm](https://github.com/user-attachments/assets/3bd6954f-e3e1-4a8c-9549-7b83876f8a02)

## After
[Screencast from 2026-02-17 21-59-13.webm](https://github.com/user-attachments/assets/26d4a374-8750-48a6-b915-cfa887c9b8b8)

---

# Test Results

<img width="1087" height="550" alt="Screenshot from 2026-02-17 19-56-45" src="https://github.com/user-attachments/assets/c3913488-c0d1-4a0d-89be-7a28e75cc9c6" />


---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

Claude opus 4.5  was used for updating specs

