### PR TITLE
fix(dashboard): Remove extra padding when best selling section is abs…

### DIFF
--- a/app/javascript/components/DashboardPage.tsx
+++ b/app/javascript/components/DashboardPage.tsx
@@ -384,7 +384,7 @@ export const DashboardPage = ({
         </div>
       ) : null}
 
-      <div className="p-4 md:p-8">
+      <div className={cx({ "p-4 md:p-8": sales.length > 0 })}>
         <ProductsTable sales={sales} />
       </div>
 


### PR DESCRIPTION
Issue: #3659                                                                                                                                                                                                           
                                                            
  ## Problem                                                                                                                                                                                                             
                                                                                                                                                                                                                         
  The wrapper `<div>` around the best selling `ProductsTable` always renders with `p-4 md:p-8` padding, even when `ProductsTable` returns `null` (no sales data). This creates unnecessary spacing above the Activity section on the dashboard.

  ## Solution

  Conditionally apply the padding class using `cx` (already imported and used throughout the component) so the wrapper only has padding when sales data is present. When `sales` is empty, the div renders classless and collapses to zero height since it has no content.

  **1 file changed, 1 line modified.**

  ## Screenshots

  ### Before (light)
<img width="1792" height="1119" alt="before_light_gap" src="https://github.com/user-attachments/assets/713eac16-d997-4f7f-89c3-65b20f560ffc" />


  ### Before (dark)
<img width="1792" height="1120" alt="before_dark_gap" src="https://github.com/user-attachments/assets/b1a5d090-ab33-43db-8be9-e81120df1067" />


  ### After (light)
 
<img width="1792" height="1119" alt="after_light_nogap" src="https://github.com/user-attachments/assets/303ceb10-5fe2-4c1c-b2da-702643b027b1" />


  ### After (dark)
<img width="1792" height="1119" alt="after_dark_nogap" src="https://github.com/user-attachments/assets/7d1c44ca-1ff5-4ee6-ab4e-e298748f034a" />


  ## Checklist

  - [x] I have read the contributing guidelines
  - [x] I have watched the Gumroad livestreams
  - [x] I have performed a self-review of my code
  - [x] Screenshots attached

  ## AI Disclosure

  No AI was used.
