### PR TITLE
Fix: Inconsistent padding on product page

### DIFF
--- a/app/javascript/components/Profile/Layout.tsx
+++ b/app/javascript/components/Profile/Layout.tsx
@@ -58,7 +58,7 @@ export const Layout = ({ creatorProfile, hideFollowForm, children }: LayoutProps
             {!isDesktop ? headerButtons : null}
           </div>
           {!hideFollowForm ? (
-            <div className="flex basis-full items-center gap-3 border-b border-border px-4 py-8 lg:basis-auto lg:border-0 lg:p-0">
+            <div className="flex basis-full items-center gap-3 border-b border-border p-4 lg:basis-auto lg:border-0 lg:p-0">
               <FollowForm creatorProfile={creatorProfile} />
             </div>
           ) : null}


### PR DESCRIPTION
Issue: #3662 

# Description

<!-- Briefly describe the problem and your solution -->
Inconsistent padding on product page
## Problem
Inconsistent padding on the product page: the Y padding is double the X padding, making it inconsistent.
## Solution
Aligned the padding by reducing the larger padding value.

---

# Before/After

<!-- For UI/CSS changes, include screenshots or videos showing both states -->
<!-- Include: Desktop (light + dark) and Mobile (light + dark) -->
## Desktop
>no changes

| Before | After |
|-----------|-----------|
|  <img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/5ab85960-ba75-409a-89c6-6f671ca1d971" /> | <img width="1512" height="982" alt="Screenshot 2026-02-17 at 11 49 29 PM" src="https://github.com/user-attachments/assets/a1d16526-1f9a-426b-9b80-8d9597e85b69" />
## Mobile
| Before | After |
|-----------|-----------|
|  <img width="486" height="822" alt="image" src="https://github.com/user-attachments/assets/3ada086e-489d-4bd3-bf8f-089ee143749d" /> | <img width="480" height="816" alt="Screenshot 2026-02-17 at 11 49 46 PM" src="https://github.com/user-attachments/assets/78e68c3c-ebae-47d2-9439-16578374e828" />

---

# Test Results

<!-- Include a screenshot of your test suite passing locally -->

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

<!-- State whether AI was used and for what purpose, or "No AI was used for any part of this contribution." -->
no use of AI