### PR TITLE
Fix payout currency display for business users

### DIFF
--- a/app/presenters/settings_presenter.rb
+++ b/app/presenters/settings_presenter.rb
@@ -247,7 +247,7 @@ class SettingsPresenter
         country_supports_iban: seller.country_supports_iban?,
         need_full_ssn: seller.has_ever_been_requested_for_user_compliance_info_field?(UserComplianceInfoFields::Individual::TAX_ID),
         country_code: user_compliance_info.legal_entity_country_code,
-        payout_currency: Country.new(user_compliance_info.country_code).payout_currency,
+        payout_currency: Country.new(user_compliance_info.legal_entity_country_code).payout_currency,
         is_from_europe: seller.signed_up_from_europe?,
         individual_tax_id_needed_countries: [Compliance::Countries::USA.alpha2,
                                              Compliance::Countries::CAN.alpha2,

--- a/spec/presenters/settings_presenter_spec.rb
+++ b/spec/presenters/settings_presenter_spec.rb
@@ -760,6 +760,14 @@ describe SettingsPresenter do
       end
     end
 
+    context "when the seller is a business with a different personal and business country" do
+      it "returns payout_currency based on the business country, not the personal country" do
+        create(:user_compliance_info_business, user: seller, country: "United States", business_country: "Canada")
+
+        expect(presenter.payments_props[:user][:payout_currency]).to eq("cad")
+      end
+    end
+
     context "when the seller is from Brazil" do
       before do
         @user_compliance_info = create(:user_compliance_info, user: seller, country: "Brazil")


### PR DESCRIPTION
Fixes antiwork/gumroad-private#134

## Problem

Business users whose personal address country differs from their business country see the wrong payout currency on Settings > Payments. The presenter was using the personal address country to determine payout currency, while the backend (Stripe) correctly uses the business country.

## Approach

Changed `SettingsPresenter` to use `legal_entity_country_code` (which returns the business country for businesses, personal country for individuals) instead of `country_code` (always personal) when looking up `payout_currency`. This is consistent with how `stripe_merchant_account_manager.rb` already determines the payout country, and matches the `country_code` field on the line directly above which already used `legal_entity_country_code`.

Added a test covering a business user with mismatched personal/business countries to prevent regression.

---

This PR was implemented with AI assistance using Claude Code for code generation. All code was self-reviewed.