### PR TITLE
Fix profile settings Preview overflow by scaling container height

### DIFF
--- a/app/javascript/components/Preview.tsx
+++ b/app/javascript/components/Preview.tsx
@@ -14,7 +14,7 @@ export const Preview = ({
   const ref = React.useRef<HTMLDivElement>(null);
   const height = useElementDimensions(ref)?.height;
   return (
-    <div role="document" className="overflow-hidden" style={{ height: Math.ceil(height ?? 0) }}>
+    <div role="document" className="overflow-hidden" style={{ height: Math.ceil((height ?? 0) * scaleFactor) }}>
       <div
         ref={ref}
         style={{


### PR DESCRIPTION
Fixes #3388

## Root cause

The `Preview` component renders its children at `1/scaleFactor` width (285.7% when `scaleFactor=0.35`) and then uses CSS `transform: scale(0.35)` to visually shrink it. However, the outer container's `height` is set to the raw `clientHeight` reported by `ResizeObserver`, which returns the **pre-transform** (unscaled) height. This makes the outer container ~2.86x taller than the visually scaled content, causing the preview sidebar to overflow the page.

This was introduced in PR #2944 which changed height handling for the receipt preview.

## Fix

Multiply the observed height by `scaleFactor` so the outer container matches the visual height of the CSS-scaled content:

```diff
- style={{ height: Math.ceil(height ?? 0) }}
+ style={{ height: Math.ceil((height ?? 0) * scaleFactor) }}
```

This is correct for all usages of `Preview` across the codebase (profile settings at `0.35`, product edit with variable scale, checkout preview at `0.4`, bundle edit at `0.4`) since the relationship `visualHeight = clientHeight * scaleFactor` holds universally.

## Before/after videos

**Desktop light mode** — before (overflow) then after (fixed):

https://github.com/makaiachildress-web/gumroad/releases/download/untagged-921c8a3faa524b1956b8/desktop-light.mp4

**Desktop dark mode:**

https://github.com/makaiachildress-web/gumroad/releases/download/untagged-921c8a3faa524b1956b8/desktop-dark.mp4

**Mobile light mode:**

https://github.com/makaiachildress-web/gumroad/releases/download/untagged-921c8a3faa524b1956b8/mobile-light.mp4

**Mobile dark mode:**

https://github.com/makaiachildress-web/gumroad/releases/download/untagged-921c8a3faa524b1956b8/mobile-dark.mp4

## AI disclosure

This PR was developed with assistance from **Claude Opus 4.6** (Anthropic). Claude was used for:
- **Root cause analysis**: Analyzing the `Preview.tsx` component and `useElementDimensions` hook to identify the unscaled height bug
- **Writing the fix**: The one-line scaleFactor multiplication
- **Demo page creation**: Generating an HTML reproduction for video recording

Tools: Claude Code CLI, Playwright (video recording)

## Checklist

- [x] I have read the contributing guidelines
- [x] I have performed a self-review of my code (see inline PR comment)
- [x] My changes are scoped entirely to the reported issue (#3388)
- [x] The fix is a single line change with clear mathematical reasoning
- [x] All existing usages of Preview component are compatible with this fix