### PR TITLE
fix : Products Content page Upload file

### DIFF
--- a/app/javascript/components/RichTextEditor.tsx
+++ b/app/javascript/components/RichTextEditor.tsx
@@ -128,7 +128,7 @@ export const PopoverMenuItem = ({
         </div>
       </MenuItemTooltip>
     </PopoverTrigger>
-    <PopoverContent sideOffset={4} className="border-0 p-0 shadow-none">
+    <PopoverContent usePortal sideOffset={4} className="border-0 p-0 shadow-none">
       {children}
     </PopoverContent>
   </Popover>


### PR DESCRIPTION
Issue: https://github.com/antiwork/gumroad/issues/3215

# Description
Products Content page Upload file z fighting issue
<!-- Briefly describe the problem and your solution -->

## Problem
 z fighting issue
## Solution
use the `useportal` prop

---

# Before/After

<!-- For UI/CSS changes, include screenshots or videos showing both states -->
<!-- Include: Desktop (light + dark) and Mobile (light + dark) -->
## Before
<img width="1324" height="719" alt="image" src="https://github.com/user-attachments/assets/f4f2bb45-b5ce-4878-8fe2-6a6ffb0bd05d" />

## After
<img width="1485" height="808" alt="image" src="https://github.com/user-attachments/assets/039349c2-f859-44bd-b35c-cd4b99fedf1f" />

---

# Test Results

<!-- Include a screenshot of your test suite passing locally -->

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [ ] I have added/updated tests for my changes

---

# AI Disclosure

<!-- State whether AI was used and for what purpose, or "No AI was used for any part of this contribution." -->
No use of AI