### PR TITLE
Remove processing state for audio files on the mobile web view

### DIFF
--- a/app/javascript/components/Download/FileList.tsx
+++ b/app/javascript/components/Download/FileList.tsx
@@ -472,14 +472,13 @@ const MobileAppAudioFileRow = ({ file }: { file: FileItem }) => {
 
   const isCompleted =
     latestMediaLocation && latestMediaLocation > 0 && file.duration && latestMediaLocation >= file.duration;
-  const isProcessing = file.duration === null;
 
   return (
     <Row ref={selfRef} className="embed" {...touchAndHoldEventListeners}>
       <WithTooltip tip={showTooltip ? file.file_name : null} position="top">
         <TrackClick
           eventName="play_click"
-          file={isProcessing || showTooltip ? null : file} // Prevent playback when processing or showing tooltip
+          file={showTooltip ? null : file}
           type="audio"
           isPlaying={isPlaying}
           resumeAt={latestMediaLocation || 0}
@@ -487,7 +486,7 @@ const MobileAppAudioFileRow = ({ file }: { file: FileItem }) => {
         >
           <RowContent asChild>
             <button
-              className={classNames("content all-unset", { "text-muted": isProcessing })}
+              className="content all-unset"
               style={{
                 gridColumn: "3 span",
                 userSelect: "none",
@@ -495,7 +494,6 @@ const MobileAppAudioFileRow = ({ file }: { file: FileItem }) => {
                 WebkitTouchCallout: "none",
                 outline: "none",
               }}
-              disabled={isProcessing}
             >
               <FileRowContent
                 hideIcon
@@ -503,25 +501,18 @@ const MobileAppAudioFileRow = ({ file }: { file: FileItem }) => {
                 name={file.file_name}
                 externalLinkUrl={file.external_link_url}
                 details={
-                  isProcessing ? (
-                    <li>Processing...</li>
-                  ) : (
-                    <>
-                      {file.extension ? <li>{file.extension}</li> : null}
-                      {file.file_size ? <li>{FileUtils.getFullFileSizeString(file.file_size)}</li> : null}
-                      {file.duration ? <li>{humanizedDuration(file.duration)}</li> : null}
-                    </>
-                  )
+                  <>
+                    {file.extension ? <li>{file.extension}</li> : null}
+                    {file.file_size ? <li>{FileUtils.getFullFileSizeString(file.file_size)}</li> : null}
+                    {file.duration ? <li>{humanizedDuration(file.duration)}</li> : null}
+                  </>
                 }
               />
             </button>
           </RowContent>
         </TrackClick>
       </WithTooltip>
-      <RowActions
-        className={classNames({ "text-muted": isProcessing })}
-        style={{ gridColumn: "4", gap: "var(--spacer-4)", flexWrap: "nowrap" }}
-      >
+      <RowActions style={{ gridColumn: "4", gap: "var(--spacer-4)", flexWrap: "nowrap" }}>
         {file.download_url ? (
           <TrackClick eventName="download_click" file={file}>
             <button aria-label="Download" className="cursor-pointer all-unset">
@@ -531,14 +522,14 @@ const MobileAppAudioFileRow = ({ file }: { file: FileItem }) => {
         ) : null}
         <TrackClick
           eventName="play_click"
-          file={isProcessing ? null : file}
+          file={file}
           type="audio"
           isPlaying={isPlaying}
           resumeAt={latestMediaLocation || 0}
           contentLength={file.duration || 0}
         >
           {isPlaying ? (
-            <button aria-label="Pause" disabled={isProcessing} className="cursor-pointer all-unset">
+            <button aria-label="Pause" className="cursor-pointer all-unset">
               <Icon
                 className="type-icon"
                 name="circle-pause"
@@ -546,7 +537,7 @@ const MobileAppAudioFileRow = ({ file }: { file: FileItem }) => {
               />
             </button>
           ) : isCompleted ? (
-            <button aria-label="Play" disabled={isProcessing} className="cursor-pointer all-unset">
+            <button aria-label="Play" className="cursor-pointer all-unset">
               <Icon
                 className="type-icon text-muted"
                 name="outline-check-circle"
@@ -554,7 +545,7 @@ const MobileAppAudioFileRow = ({ file }: { file: FileItem }) => {
               />
             </button>
           ) : (
-            <button aria-label="Play" disabled={isProcessing} className="cursor-pointer all-unset">
+            <button aria-label="Play" className="cursor-pointer all-unset">
               <Icon
                 className="type-icon"
                 name={latestMediaLocation && latestMediaLocation > 0 ? "outline-circle-play" : "circle-play"}

--- a/spec/requests/download_page/rich_text_editor_spec.rb
+++ b/spec/requests/download_page/rich_text_editor_spec.rb
@@ -238,7 +238,6 @@ describe("Download Page – Rich Text Editor Content", type: :system, js: true) 
         expect(page).to have_text("MP3")
         expect(page).to have_text("0m 46s")
         expect(page).to have_text("Audio description")
-        expect(page).to_not have_text("Processing...")
         expect(page).to_not have_button("Pause")
         expect(page).to_not have_text(" left")
         expect(page).to_not have_selector("meter")
@@ -247,26 +246,7 @@ describe("Download Page – Rich Text Editor Content", type: :system, js: true) 
         ).squish
         expect(page).to have_button("Pause")
         expect(page).to have_text("0m 22s left")
-        expect(page).to_not have_text("Processing...")
         expect(page).to have_selector("meter[value*='0.52']")
-      end
-
-      @audio_file.update!(duration: nil, description: nil)
-
-      visit("/d/#{@url_redirect.token}?display=mobile_app")
-
-      within(find_embed(name: "Audio file")) do
-        expect(page).to have_button("Play", disabled: true)
-        expect(page).to_not have_text("MP3")
-        expect(page).to_not have_text("0m 46s")
-        expect(page).to_not have_text("Audio description")
-        expect(page).to have_text("Processing...")
-
-        @audio_file.update!(duration: 46)
-        expect(page).to have_text("0m 46s", wait: 10)
-        expect(page).to have_text("MP3")
-        expect(page).to_not have_text("Processing...")
-        expect(page).to have_button("Play")
       end
     end
 


### PR DESCRIPTION
Issue: https://github.com/antiwork/gumroad-ios/issues/13

# Description

## Problem

A creator's audio file cannot be played on iOS because the duration hasn't been filled in. However, it works fine on web and nothing appears to prevent it from playing fine on mobile as well if we just enable the button.

## Solution

Remove the `isProcessing` state on the mobile file list as this doesn't appear to affect whether the file can be played back.

---

# AI Disclosure

Claude Opus 4.6 used for identifying the issue and checking if the logic is required.
