### PR TITLE
Fix backend kana validation rejects valid Japanese characters

### DIFF
--- a/app/models/user_compliance_info.rb
+++ b/app/models/user_compliance_info.rb
@@ -11,8 +11,8 @@ class UserComplianceInfo < ApplicationRecord
   stripped_fields :first_name, :last_name, :street_address, :city, :zip_code, :business_name, :business_street_address, :business_city, :business_zip_code, on: :create
 
   MINIMUM_DATE_OF_BIRTH_AGE = 13
-  KANA_NAME_REGEX = /\A[\p{Katakana}\s\-.]*\z/
-  KANA_ADDRESS_REGEX = /\A[\p{Katakana}\p{Latin}\d\s\-.]*\z/
+  KANA_NAME_REGEX = /\A[\p{In_Katakana}\p{In_Katakana_Phonetic_Extensions}\uFF65-\uFF9F\s\u3000\-.]*\z/
+  KANA_ADDRESS_REGEX = /\A[\p{In_Katakana}\p{In_Katakana_Phonetic_Extensions}\uFF65-\uFF9F\p{Latin}\d\s\u3000\-.]*\z/
   ROMAJI_REGEX = /\A[^\p{Han}\p{Hiragana}\p{Katakana}]*\z/
 
   belongs_to :user, optional: true

--- a/spec/models/user_compliance_info_spec.rb
+++ b/spec/models/user_compliance_info_spec.rb
@@ -290,6 +290,24 @@ describe UserComplianceInfo do
           uci.valid?
           expect(uci.errors[:base]).not_to include(a_string_matching(/Kana/))
         end
+
+        it "allows prolonged vowel mark (ー U+30FC)" do
+          uci = build(:user_compliance_info, country: "Japan", json_data: { first_name_kana: "テイラー" })
+          uci.valid?
+          expect(uci.errors[:base]).not_to include(a_string_matching(/Kana/))
+        end
+
+        it "allows full-width space (U+3000)" do
+          uci = build(:user_compliance_info, country: "Japan", json_data: { first_name_kana: "ジョン\u3000トレッゲサー" })
+          uci.valid?
+          expect(uci.errors[:base]).not_to include(a_string_matching(/Kana/))
+        end
+
+        it "allows half-width katakana (U+FF65-U+FF9F)" do
+          uci = build(:user_compliance_info, country: "Japan", json_data: { first_name_kana: "ｶﾀｶﾅ" })
+          uci.valid?
+          expect(uci.errors[:base]).not_to include(a_string_matching(/Kana/))
+        end
       end
 
       describe "address kana fields" do
@@ -314,6 +332,18 @@ describe UserComplianceInfo do
 
         it "allows blank address kana fields" do
           uci = build(:user_compliance_info, country: "Japan", json_data: { building_number_kana: nil, street_address_kana: "" })
+          uci.valid?
+          expect(uci.errors[:base]).not_to include(a_string_matching(/Kana/))
+        end
+
+        it "allows full-width space in address kana" do
+          uci = build(:user_compliance_info, country: "Japan", json_data: { street_address_kana: "シブヤ\u3000ヒカリエ" })
+          uci.valid?
+          expect(uci.errors[:base]).not_to include(a_string_matching(/Kana/))
+        end
+
+        it "allows prolonged vowel mark in address kana" do
+          uci = build(:user_compliance_info, country: "Japan", json_data: { street_address_kana: "シブヤヒカリエドオリー" })
           uci.valid?
           expect(uci.errors[:base]).not_to include(a_string_matching(/Kana/))
         end


### PR DESCRIPTION
Fixes antiwork/gumroad-private#81

## Problem

Two users reported on Feb 18 that the payment settings page rejects valid katakana names containing prolonged vowel marks (ー, e.g. テイラー) and full-width spaces (e.g. ジョン　トレッゲサー). The frontend validation accepts these characters, but the backend regex rejects them, producing a generic Stripe error with no useful feedback.

The root cause: the backend uses `\p{Katakana}` (Unicode *Script* property) which excludes ー (U+30FC) because its script is `Common`, not `Katakana`. It also uses `\s` which doesn't match the full-width space U+3000.

## Approach

Switched the backend regex from `\p{Katakana}` (script property) to `\p{In_Katakana}` (block property), which covers the entire U+30A0–U+30FF range including ー. Also added `\p{In_Katakana_Phonetic_Extensions}` (U+31F0–U+31FF), half-width katakana (`\uFF65-\uFF9F`), and the full-width space (`\u3000`) — matching what the frontend already accepts.

No frontend changes needed since it already handles these characters correctly.

---

This PR was implemented with AI assistance using Claude Code for code generation. All code was self-reviewed.