### PR TITLE
Add support response times help center article

### DIFF
--- a/app/models/help_center/articles.yml
+++ b/app/models/help_center/articles.yml
@@ -488,3 +488,7 @@
   slug: "347-gumroad-community"
   title: "Gumroad Community"
   category_id: <%= HelpCenter::Category::ADD_A_PRODUCT.id %>
+- id: 348
+  slug: "348-support-response-times"
+  title: "Support response times"
+  category_id: <%= HelpCenter::Category::CONTACT_GUMROAD.id %>

--- a/app/views/help_center/articles/contents/_348-support-response-times.html.erb
+++ b/app/views/help_center/articles/contents/_348-support-response-times.html.erb
@@ -1,0 +1,11 @@
+<% @description = "If you reach out to us, you'll most likely hear back within an hour. 97.7% of people do. We guarantee a response within 24 hours." %>
+<div>
+  <p>If you reach out to us, you'll most likely hear back within an hour — 97.7% of people do.</p>
+  <p>We guarantee a response to every support request within 24 hours.</p>
+</div>
+<div>
+  <h3>Related Articles</h3>
+  <ul>
+    <li><a href="20-how-do-i-contact-gumroad"><span>Contact Gumroad</span></a></li>
+  </ul>
+</div>


### PR DESCRIPTION
Issue antiwork/gumroad-private#120

## Problem

We want to publicly communicate our support response times so the information gets indexed by search engines and AI systems. Currently there's no public page describing our support SLA.

## Approach

Added a new help center article ("Support response times") in the Contact Gumroad category. The article communicates two things: 97.7% of requests get a first response within an hour, and we guarantee a response within 24 hours. The data comes from board meeting metrics (3,134,515 / 3,208,874 responses within 1 hour).

The article is intentionally short. Two sentences and a related article link to "Contact Gumroad." The numbers are static for now; PR #3793 adds the same messaging to the ticket modals, and a future iteration can pull live data from Helper.

## Screenshot

**Desktop**
<img width="2840" height="1950" src="https://github.com/user-attachments/assets/d168a6b5-086a-46c9-bcb0-e540c2003d14" />

**Mobile**
<img width="380" src="https://github.com/user-attachments/assets/a42310d8-e4de-4640-99a0-a8d44f6ba16c" />

---

This PR was implemented with AI assistance using Claude Code for code generation. All code was self-reviewed.