### PR TITLE
Fix the 1099 form download button on Tax Center page to download the latest corrected form

### DIFF
--- a/app/services/stripe_tax_forms_api.rb
+++ b/app/services/stripe_tax_forms_api.rb
@@ -40,6 +40,7 @@ class StripeTaxFormsApi
       response = Stripe.raw_request(:get, "/v1/tax/forms", params, opts)
       Stripe.deserialize(response.http_body).auto_paging_each do |tax_form|
         year = tax_form[tax_form.type].reporting_year
+        next if tax_forms[year].present? || tax_form[:corrected_by].present?
         tax_forms[year] = tax_form
       end
 

--- a/spec/services/stripe_tax_forms_api_spec.rb
+++ b/spec/services/stripe_tax_forms_api_spec.rb
@@ -15,7 +15,7 @@ describe StripeTaxFormsApi, vcr: { cassette_name: "StripeTaxFormsApi/tax_forms" 
       expect(result.keys).to eq([2024, 2023, 2022, 2021, 2020])
 
       tax_form_2024 = result[2024]
-      expect(tax_form_2024.id).to eq("taxform_1")
+      expect(tax_form_2024.id).to eq("taxform_1c")
       expect(tax_form_2024.object).to eq("tax.form")
       expect(tax_form_2024.type).to eq("us_1099_k")
       expect(tax_form_2024.livemode).to be(true)
@@ -49,7 +49,7 @@ describe StripeTaxFormsApi, vcr: { cassette_name: "StripeTaxFormsApi/tax_forms" 
       expect(result.path).to include("tax_form_us_1099_k_2024_acct_1234567890")
       expect(result.path).to end_with(".pdf")
       expect(HTTParty).to have_received(:get).with(
-        "https://files.stripe.com/v1/tax/forms/taxform_1/pdf",
+        "https://files.stripe.com/v1/tax/forms/taxform_1c/pdf",
         hash_including(headers: hash_including("Authorization" => /Bearer/))
       )
       result.close

--- a/spec/support/fixtures/vcr_cassettes/StripeTaxFormsApi/tax_forms.yml
+++ b/spec/support/fixtures/vcr_cassettes/StripeTaxFormsApi/tax_forms.yml
@@ -75,12 +75,66 @@ http_interactions:
       string: |-
         {
           "object": "list",
-          "count": 5,
+          "count": 7,
           "data": [
+            {
+              "id": "taxform_1c",
+              "object": "tax.form",
+              "corrected_by": null,
+              "created": 1737614172,
+              "filing_statuses": [
+                {
+                  "effective_at": 1737803275,
+                  "jurisdiction": {
+                    "country": "US",
+                    "level": "country",
+                    "state": null
+                  },
+                  "value": "accepted"
+                }
+              ],
+              "livemode": true,
+              "payee": {
+                "account": "acct_1234567890",
+                "external_reference": null,
+                "type": "account"
+              },
+              "type": "us_1099_k",
+              "us_1099_k": {
+                "reporting_year": 2024
+              }
+            },
+            {
+              "id": "taxform_1b",
+              "object": "tax.form",
+              "corrected_by": "taxform_1c",
+              "created": 1737614172,
+              "filing_statuses": [
+                {
+                  "effective_at": 1737803274,
+                  "jurisdiction": {
+                    "country": "US",
+                    "level": "country",
+                    "state": null
+                  },
+                  "value": "accepted"
+                }
+              ],
+              "livemode": true,
+              "payee": {
+                "account": "acct_1234567890",
+                "external_reference": null,
+                "type": "account"
+              },
+              "type": "us_1099_k",
+              "us_1099_k": {
+                "reporting_year": 2024
+              }
+            },
             {
               "id": "taxform_1",
               "object": "tax.form",
-              "corrected_by": null,
+              "corrected_by": "taxform_1b",
               "created": 1737614171,
               "filing_statuses": [
                 {


### PR DESCRIPTION
Fixes https://github.com/antiwork/gumroad-private/issues/128

### What

Fix the 1099 form download button on Tax Center page to download the latest corrected form for the corresponding calendar year, and not the original form that was initially filed.

### Why

Sometimes creators contact support to update their TIN or address on the 1099 after receiving the initially filed form, in which case a corrected form is filed for them again. If a corrected form has been filed, that form should be downloaded and not the original.