### PR TITLE
Fix the unclaimed balance collection specs failing on main

### DIFF
--- a/spec/sidekiq/collect_unclaimed_balances_of_inactive_stripe_accounts_job_spec.rb
+++ b/spec/sidekiq/collect_unclaimed_balances_of_inactive_stripe_accounts_job_spec.rb
@@ -154,7 +154,9 @@ describe CollectUnclaimedBalancesOfInactiveStripeAccountsJob do
       expect(Stripe::Balance).not_to receive(:retrieve)
       expect(Stripe::Transfer).not_to receive(:create)
 
-      CollectUnclaimedBalancesOfInactiveStripeAccountsJob.new.perform
+      travel_to(Date.new(2026, 2, 11)) do
+        CollectUnclaimedBalancesOfInactiveStripeAccountsJob.new.perform
+      end
     end
 
     it "does not attempt to collect balance if the Stripe account is considered active based on last payout date" do
@@ -167,7 +169,9 @@ describe CollectUnclaimedBalancesOfInactiveStripeAccountsJob do
       expect(Stripe::Balance).not_to receive(:retrieve)
       expect(Stripe::Transfer).not_to receive(:create)
 
-      CollectUnclaimedBalancesOfInactiveStripeAccountsJob.new.perform
+      travel_to(Date.new(2026, 2, 11)) do
+        CollectUnclaimedBalancesOfInactiveStripeAccountsJob.new.perform
+      end
     end
 
     it "does not attempt to collect balance if the Stripe account is considered active based on last charge date" do
@@ -180,7 +184,9 @@ describe CollectUnclaimedBalancesOfInactiveStripeAccountsJob do
       expect(Stripe::Balance).not_to receive(:retrieve)
       expect(Stripe::Transfer).not_to receive(:create)
 
-      CollectUnclaimedBalancesOfInactiveStripeAccountsJob.new.perform
+      travel_to(Date.new(2026, 2, 11)) do
+        CollectUnclaimedBalancesOfInactiveStripeAccountsJob.new.perform
+      end
     end
 
     it "does not attempt to collect balance if the Stripe account is a standard Stripe account" do


### PR DESCRIPTION
### What

Fix the unclaimed balance collection specs failing on `main`.

### Why

Fix the specs failing on `main` (failed on a development branch [here](https://github.com/antiwork/gumroad/actions/runs/22353185744/job/64691531410?pr=3800), will start failing on `main` CI with the next commit).