### PR TITLE
fix: add meta description tags to help center article pages

### DIFF
--- a/app/controllers/help_center/articles_controller.rb
+++ b/app/controllers/help_center/articles_controller.rb
@@ -27,16 +27,21 @@ class HelpCenter::ArticlesController < HelpCenter::BaseController
 
     title = "#{article.title} - Gumroad Help Center"
     canonical_url = help_center_article_url(article)
+    article_content = render_to_string(article)
+    description = @description
 
     set_meta_tag(title:)
     set_meta_tag(tag_name: "link", rel: "canonical", href: canonical_url, head_key: "canonical")
+    set_meta_tag(name: "description", content: description)
 
     set_meta_tag(property: "og:title", value: title)
+    set_meta_tag(property: "og:description", value: description)
     set_meta_tag(property: "og:url", value: canonical_url)
 
     set_meta_tag(name: "twitter:title", content: title)
+    set_meta_tag(name: "twitter:description", content: description)
 
-    render inertia: "HelpCenter/Articles/Show", props: help_center_presenter.article_props(article)
+    render inertia: "HelpCenter/Articles/Show", props: help_center_presenter.article_props(article, article_content:)
   end
 
   private

--- a/app/presenters/help_center_presenter.rb
+++ b/app/presenters/help_center_presenter.rb
@@ -17,12 +17,12 @@ class HelpCenterPresenter
     }
   end
 
-  def article_props(article)
+  def article_props(article, article_content: nil)
     {
       article: {
         title: article.title,
         slug: article.slug,
-        content: view_context.render(article),
+        content: article_content || view_context.render(article),
         category: category_data(article.category)
       },
       sidebar_categories: same_audience_categories_data(article.category)

--- a/spec/controllers/help_center/articles_controller_spec.rb
+++ b/spec/controllers/help_center/articles_controller_spec.rb
@@ -57,6 +57,15 @@ describe HelpCenter::ArticlesController, inertia: true do
       expect(response.body).to include("#{CGI.escapeHTML(article.title)} - Gumroad Help Center</title>")
     end
 
+    it "sets description meta tags" do
+      get :show, params: { slug: article.slug }
+      html = Nokogiri::HTML.parse(response.body)
+      description = html.xpath("//meta[@name='description']/@content").text
+      expect(description).to be_present
+      expect(html.xpath("//meta[@property='og:description']/@value").text).to eq(description)
+      expect(html.xpath("//meta[@name='twitter:description']/@content").text).to eq(description)
+    end
+
     it "redirects to help center root for non-existent articles" do
       get :show, params: { slug: "non-existent-article" }
       expect(response).to redirect_to(help_center_root_path)


### PR DESCRIPTION
Fixes #3795

Adds missing `description`, `og:description`, and `twitter:description` meta tags to help center article pages (`/help/<slug>`), matching the pattern already used by the index page.

### Changes
- Pre-render article partial via `render_to_string` to capture `@description`
- Add three `set_meta_tag` calls matching the index action's pattern
- Pass pre-rendered content to presenter to avoid double-rendering
- Add spec verifying all three meta tags are present