### PR TITLE
fix: replace 2-digit bank code with SWIFT/BIC for Paraguay users

### DIFF
--- a/app/javascript/components/Settings/PaymentsPage/BankAccountSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/BankAccountSection.tsx
@@ -736,7 +736,7 @@ const BankAccountSection = ({
   const uid = React.useId();
 
   const BANK_AND_BRANCH_CODE_COUNTRIES = ["AZ", "SG", "JP", "DO", "UZ", "LK", "TT", "JM"];
-  const BANK_CODE_COUNTRIES = ["BD", "BO", "CL", "CO", "GH", "ID", "KR", "PY", "TH", "UY", "VN"];
+  const BANK_CODE_COUNTRIES = ["BD", "BO", "CL", "CO", "GH", "ID", "KR", "TH", "UY", "VN"];
   const SWIFT_BIC_CODE_COUNTRIES = [
     "AG",
     "AL",
@@ -776,6 +776,7 @@ const BankAccountSection = ({
     "OM",
     "PA",
     "PK",
+    "PY",
     "QA",
     "RS",
     "RW",
@@ -1616,13 +1617,13 @@ const BankAccountSection = ({
               ) : user.country_code === "PY" ? (
                 <Fieldset state={errorFieldNames.has("bank_code") ? "danger" : undefined}>
                   <FieldsetTitle>
-                    <Label htmlFor={`${uid}-bank-code`}>Bank code</Label>
+                    <Label htmlFor={`${uid}-bank-code`}>SWIFT / BIC Code</Label>
                   </FieldsetTitle>
                   <Input
                     type="text"
                     id={`${uid}-bank-code`}
-                    placeholder="27"
-                    maxLength={2}
+                    placeholder="ABCDPYXX"
+                    maxLength={11}
                     required
                     disabled={isFormDisabled}
                     aria-invalid={errorFieldNames.has("bank_code")}

--- a/app/models/paraguay_bank_account.rb
+++ b/app/models/paraguay_bank_account.rb
@@ -3,7 +3,7 @@
 class ParaguayBankAccount < BankAccount
   BANK_ACCOUNT_TYPE = "PY"
 
-  BANK_CODE_FORMAT_REGEX = /\A[0-9]{1,2}\z/
+  BANK_CODE_FORMAT_REGEX = /\A[a-zA-Z]{4}[a-zA-Z]{2}[0-9a-zA-Z]{2}([0-9a-zA-Z]{3})?\z/
   private_constant :BANK_CODE_FORMAT_REGEX
 
   ACCOUNT_NUMBER_FORMAT_REGEX = /\A[0-9]{1,16}\z/

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -7300,7 +7300,7 @@ describe StripeMerchantAccountManager, :vcr do
             country: "PY",
             currency: "pyg",
             account_number: "0567890123456789",
-            routing_number: "0"
+            routing_number: "ABCDPYXX"
           },
           settings: {
             payouts: {

--- a/spec/models/paraguay_bank_account_spec.rb
+++ b/spec/models/paraguay_bank_account_spec.rb
@@ -22,9 +22,14 @@ describe ParaguayBankAccount do
   end
 
   describe "#bank_code" do
-    it "returns valid for 1 to 2 characters" do
-      expect(create(:paraguay_bank_account, bank_code: "12")).to be_valid
-      expect(create(:paraguay_bank_account, bank_code: "1")).to be_valid
+    it "returns valid for SWIFT/BIC codes" do
+      expect(create(:paraguay_bank_account, bank_code: "ABCDPYXX")).to be_valid
+      expect(create(:paraguay_bank_account, bank_code: "ABCDPYXXYYY")).to be_valid
+    end
+
+    it "returns invalid for non-SWIFT codes" do
+      expect(build(:paraguay_bank_account, bank_code: "12")).to_not be_valid
+      expect(build(:paraguay_bank_account, bank_code: "ABC")).to_not be_valid
     end
   end
 

--- a/spec/support/factories/paraguay_bank_accounts.rb
+++ b/spec/support/factories/paraguay_bank_accounts.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     user
     account_number { "0567890123456789" }
     account_number_last_four { "6789" }
-    bank_code { "0" }
+    bank_code { "ABCDPYXX" }
     account_holder_full_name { "Paraguayan Creator" }
   end
 end


### PR DESCRIPTION
Fixes #3646

Paraguay users were asked for a 1-2 digit bank code, but Stripe Support confirmed they need the SWIFT/BIC code instead (8 or 11 characters).

### Changes
- Update `BANK_CODE_FORMAT_REGEX` in `ParaguayBankAccount` to accept SWIFT/BIC format
- Move PY from `BANK_CODE_COUNTRIES` to `SWIFT_BIC_CODE_COUNTRIES`
- Update input label to "SWIFT / BIC Code", placeholder to "ABCDPYXX", maxLength to 11
- Update factory and specs