### PR TITLE
fix: auto-focus search input when popover opens

### DIFF
--- a/app/javascript/components/Popover.tsx
+++ b/app/javascript/components/Popover.tsx
@@ -44,6 +44,7 @@ export const PopoverContent = React.forwardRef<
       collisionPadding = 16,
       matchTriggerWidth = false,
       usePortal = false,
+      onOpenAutoFocus,
       ...props
     },
     ref,
@@ -55,7 +56,7 @@ export const PopoverContent = React.forwardRef<
         collisionPadding={collisionPadding}
         autoFocus={false}
         forceMount
-        onOpenAutoFocus={(e: Event) => e.preventDefault()}
+        onOpenAutoFocus={onOpenAutoFocus ?? ((e: Event) => e.preventDefault())}
         className={classNames(
           "z-30 w-max max-w-[calc(100vw-2rem)] rounded-sm border border-border bg-background p-4 text-foreground shadow outline-none focus-visible:outline-none data-[state=closed]:hidden",
           { "w-[var(--radix-popover-trigger-width)] min-w-[var(--radix-popover-trigger-width)]": matchTriggerWidth },

--- a/app/javascript/components/Search.tsx
+++ b/app/javascript/components/Search.tsx
@@ -23,7 +23,7 @@ export const Search = ({ onSearch, value: initialValue, placeholder = "Search" }
           </Button>
         </PopoverTrigger>
       </PopoverAnchor>
-      <PopoverContent sideOffset={4} onOpenAutoFocus={() => searchInputRef.current?.focus()}>
+      <PopoverContent sideOffset={4} onOpenAutoFocus={(e) => { e.preventDefault(); searchInputRef.current?.focus(); }}>
         <div className="input input-wrapper">
           <Icon name="solid-search" />
           <input

--- a/spec/requests/products/index_spec.rb
+++ b/spec/requests/products/index_spec.rb
@@ -486,6 +486,16 @@ describe "Products Page Scenario", type: :system, js: true do
       stub_const("DashboardProductsPagePresenter::PER_PAGE", per_page)
     end
 
+    it "auto-focuses the search input when the search popover opens" do
+      create(:product, user: seller)
+      visit(products_path)
+
+      select_disclosure "Toggle Search" do
+        expect(page).to have_field("Search products")
+      end
+      expect(page).to have_selector("input[placeholder='Search products']:focus")
+    end
+
     it "shows the search results" do
       product = create(:product, user: seller, name: "Chicken", unique_permalink: "chicken")
       visit(products_path)


### PR DESCRIPTION
Fixes #3373

`PopoverContent` was hardcoding `onOpenAutoFocus` to `preventDefault()`, which blocked all consumers from focusing elements when the popover opens. Users had to click a second time inside the search input to start typing.

### Root cause
In `Popover.tsx`, the `PopoverContent` component always overrides `onOpenAutoFocus` with `(e) => e.preventDefault()`, ignoring any handler passed by consumers like `Search.tsx`.

### Changes
- Forward `onOpenAutoFocus` prop through `PopoverContent`, falling back to `preventDefault()` when not provided (preserving existing behavior for all other popovers)
- Update `Search` component to `preventDefault` and manually focus the input ref
- Add e2e test verifying search input receives focus when the popover opens