### PR TITLE
fix: prevent product edit button from being hidden behind top bar

### DIFF
--- a/app/javascript/components/Product/Layout.tsx
+++ b/app/javascript/components/Product/Layout.tsx
@@ -340,12 +340,12 @@ const EditButton = ({ product }: { product: Product }) => {
   return (
     <div
       style={{
-        position: "absolute",
+        position: "fixed",
         top: isDesktop ? "var(--spacer-3)" : "var(--spacer-4)",
         right: isDesktop ? undefined : "var(--spacer-4)",
         left: isDesktop ? "var(--spacer-3)" : undefined,
-        // Render above the product `article`
-        zIndex: "var(--z-index-overlay)",
+        // Render above the fixed product information bar
+        zIndex: "calc(var(--z-index-menubar) + 1)",
       }}
     >
       <WithTooltip tip="Edit product" position={isDesktop ? "right" : "left"}>


### PR DESCRIPTION
Fixes #2995

The edit button on the product page was hidden behind the fixed top navigation bar at larger screen sizes.

### Root cause
The edit button used `position: absolute` with `z-index: var(--z-index-overlay)` (1), while the fixed product information bar uses `position: fixed` with `z-index: var(--z-index-menubar)` (10). Since the info bar creates a separate stacking context, it always renders above the absolutely-positioned edit button regardless of z-index values.

### Fix
Changed the edit button to `position: fixed` with `z-index: calc(var(--z-index-menubar) + 1)` so it stays visible above the information bar at all screen sizes.