### PR TITLE
fix: prevent profile settings preview from overflowing

### DIFF
--- a/app/javascript/components/PreviewSidebar.tsx
+++ b/app/javascript/components/PreviewSidebar.tsx
@@ -5,7 +5,7 @@ import { Icon } from "$app/components/Icons";
 import { WithTooltip } from "$app/components/WithTooltip";
 
 export const WithPreviewSidebar = ({ children, className, ...props }: React.ComponentProps<"div">) => (
-  <div className={cx("squished lg:grid lg:grid-cols-[1fr_30vw]", className)} {...props}>
+  <div className={cx("squished lg:grid lg:grid-cols-[1fr_30vw] [&>*]:min-w-0", className)} {...props}>
     {children}
   </div>
 );


### PR DESCRIPTION
Fixes #3388

The profile settings Preview section was overflowing its container.

### Root cause
`WithPreviewSidebar` uses a CSS grid with `grid-template-columns: 1fr 30vw`. Grid children default to `min-width: auto`, which allows content to grow beyond their assigned track size, causing the overflow.

### Fix
Added `min-w-0` to all grid children via `[&>*]:min-w-0` so they respect the column constraints (`1fr` / `30vw`).