### PR TITLE
fix: account for scaleFactor in Preview component height

### DIFF
--- a/app/javascript/components/Preview.tsx
+++ b/app/javascript/components/Preview.tsx
@@ -14,7 +14,7 @@ export const Preview = ({
   const ref = React.useRef<HTMLDivElement>(null);
   const height = useElementDimensions(ref)?.height;
   return (
-    <div role="document" className="overflow-hidden" style={{ height: Math.ceil(height ?? 0) }}>
+    <div role="document" className="overflow-hidden" style={{ height: Math.ceil((height ?? 0) * scaleFactor) }}>
       <div
         ref={ref}
         style={{


### PR DESCRIPTION
## Summary

Fixes the preview overflow issue in the profile settings page.

## Problem

The `Preview` component was setting its container height to the full content height (`height`) without accounting for the CSS `scale()` transform. When `scaleFactor` is 0.35, the visual height is 35% of the original, but the container was sized for the full 100%.

## Solution

Multiply the height by `scaleFactor` to match the visual height after transformation:

```diff
- style={{ height: Math.ceil(height ?? 0) }}
+ style={{ height: Math.ceil((height ?? 0) * scaleFactor) }}
```

## Before/After

**Before:** Preview container overflows because it is sized for unscaled content
**After:** Preview container matches the scaled visual height

Fixes #3388

---

### AI Disclosure
This PR was created with AI assistance (Claude) for code analysis and solution development. The fix was verified manually by testing the preview component behavior.

### Screencast
The fix is a single-line CSS calculation change. The visual result is that the preview container no longer overflows - it correctly sizes to the scaled content height.