### PR TITLE
Fix variation price pill getting squashed by long descriptions

### DIFF
--- a/app/javascript/components/Product/ConfigurationSelector.tsx
+++ b/app/javascript/components/Product/ConfigurationSelector.tsx
@@ -250,7 +250,7 @@ export const OptionRadioButton = ({
           </Alert>
         ) : null}
         {hidePrice ? null : (
-          <Pill>
+          <Pill className="shrink-0">
             {discountedPriceCents < priceCents ? (
               <>
                 <s>{formatPriceCentsWithCurrencySymbol(currencyCode, priceCents, { symbolFormat: "long" })}</s>{" "}


### PR DESCRIPTION
Fixes https://github.com/antiwork/gumroad-private/issues/174

## Problem
On the product page, the price badge (e.g. "$0+") inside a variation option gets squashed when the variation description is long.

## Solution
Add `shrink-0` (flex-shrink: 0) to the `Pill` component in `ConfigurationSelector.tsx` to prevent it from shrinking.

## Before
<img width="410" height="317" alt="image" src="https://github.com/user-attachments/assets/43961d64-049c-420a-860d-a254975f9043" />

## After
<img width="426" height="316" alt="image" src="https://github.com/user-attachments/assets/a48dd635-a7dc-40a6-9142-3fd63e13077a" />
