### PR TITLE
Add `gh issue view` permission to close-non-english-issues workflow

### DIFF
--- a/.github/workflows/close-non-english-issues.yml
+++ b/.github/workflows/close-non-english-issues.yml
@@ -43,4 +43,4 @@ jobs:
 
             If the issue is in English or you are unsure, do absolutely nothing.
           claude_args: |
-            --allowedTools "Bash(gh issue close:*),Bash(gh issue comment:*)"
+            --allowedTools "Bash(gh issue view:*),Bash(gh issue close:*),Bash(gh issue comment:*)"


### PR DESCRIPTION
Issue #3690

## What

Adds `Bash(gh issue view:*)` to the `allowedTools` list in the close-non-english-issues workflow. Without it, Claude Code can't read the issue content to detect the language, so the workflow silently does nothing.

## Why

The workflow prompts Claude to run `gh issue view` to read the issue title and body, but `allowedTools` only permitted `gh issue close` and `gh issue comment`. The permission denial was confirmed in [run #22504829799](https://github.com/antiwork/gumroad/actions/runs/22504829799).

---

This PR was implemented with AI assistance using Claude Code for code generation. All code was self-reviewed.