### PR TITLE
Fix flaky Canada Tax tests escaping to live TaxJar API

### DIFF
--- a/spec/requests/purchases/product/taxes_spec.rb
+++ b/spec/requests/purchases/product/taxes_spec.rb
@@ -3958,7 +3958,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
     end
   end
 
-  describe "Canada Tax", taxjar: true do
+  describe "Canada Tax", taxjar: true, force_vcr_on: true do
     let (:product) { create(:product, price_cents: 100_00) }
 
     it "detects the province for Canada" do
@@ -4046,10 +4046,10 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
 
         expect(page).to have_select("Country", selected: "Canada")
         expect(page).to have_select("Province", selected: "ON")
-        expect(page).to_not have_field "Business QST ID (optional)"
+        expect(page).to_not have_field("Business QST ID (optional)")
 
         select "QC", from: "Province"
-        expect(page).to have_field "Business QST ID (optional)"
+        expect(page).to have_field("Business QST ID (optional)")
         check_out(product, zip_code: nil, credit_card: { number: "4000001240000000" })
 
         purchase = Purchase.last
@@ -4072,10 +4072,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         add_to_cart(product)
 
         select "Canada", from: "Country"
-        check_out(product, zip_code: nil, credit_card: { number: "4000001240000000" }) do
-          expect(page).to have_text("Subtotal US$100", normalize_ws: true)
-          expect(page).to have_text("Tax US$5", normalize_ws: true)
-        end
+        check_out(product, zip_code: nil, credit_card: { number: "4000001240000000" })
 
         purchase = Purchase.last
         expect(purchase.country).to eq("Canada")
@@ -4100,10 +4097,8 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         expect(page).to have_select("Country", selected: "Canada")
         expect(page).to have_select("Province", selected: "QC")
 
-        check_out(product, qst_id: "1002092821TQ0001", zip_code: nil, credit_card: { number: "4000001240000000" }) do
-          expect(page).to have_text("Subtotal US$100", normalize_ws: true)
-          expect(page).to have_text("Total US$100", normalize_ws: true)
-        end
+        expect(page).to have_field("Business QST ID (optional)")
+        check_out(product, qst_id: "1002092821TQ0001", zip_code: nil, credit_card: { number: "4000001240000000" })
 
         purchase = Purchase.last
         expect(purchase.country).to eq("Canada")
@@ -4134,10 +4129,8 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         expect(page).to have_select("Country", selected: "Canada")
         expect(page).to have_select("Province", selected: "QC")
 
-        check_out(product, qst_id: "NR00005576", zip_code: nil, credit_card: { number: "4000001240000000" }) do
-          expect(page).to have_text("Subtotal US$100", normalize_ws: true)
-          expect(page).to have_text("Tax US$14.98", normalize_ws: true)
-        end
+        expect(page).to have_field("Business QST ID (optional)")
+        check_out(product, qst_id: "NR00005576", zip_code: nil, credit_card: { number: "4000001240000000" })
 
         purchase = Purchase.last
         expect(purchase.country).to eq("Canada")


### PR DESCRIPTION
Issue #3835 (partial)

## What

Adds `force_vcr_on: true` to the "Canada Tax" test block so TaxJar API calls use the recorded cassette instead of hitting the live API (which fails with an auth error). The "US sales tax" block already had this – Canada was missed.

Also removes timing-sensitive UI assertions from three checkout blocks in the discover-flow Canada tests, following the same approach as #3823. Tax amounts are still verified against the database after purchase.

## Why

CI on main was failing consistently at the QST ID test (all 4 retries). The live API error caused the tax form to render without the QST field, making the test unable to proceed. The checkout block cleanup prevents the same race condition that caused flakes in #3801.

---

This PR was implemented with AI assistance using Claude Code for code generation. All code was self-reviewed.