### PR TITLE
Fix fixed-length membership receipt for test purchases

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -754,11 +754,11 @@ class Subscription < ApplicationRecord
   end
 
   def charges_completed?
-    has_fixed_length? && purchases.successful.count == charge_occurrence_count
+    has_fixed_length? && successful_purchases.count == charge_occurrence_count
   end
 
   def remaining_charges_count
-    has_fixed_length? ? charge_occurrence_count - purchases.successful.count : 0
+    has_fixed_length? ? charge_occurrence_count - successful_purchases.count : 0
   end
 
   # Certain events should transition the subscription from pending cancellation to cancelled thus not allowing the customer access to updates.

--- a/app/presenters/receipt_presenter/payment_info.rb
+++ b/app/presenters/receipt_presenter/payment_info.rb
@@ -373,10 +373,9 @@ class ReceiptPresenter::PaymentInfo
       if @_subscription_charge_number.key?(purchase.id)
         @_subscription_charge_number[purchase.id]
       else
-        @_subscription_charge_number[purchase.id] = purchase
-          .subscription
-          .purchases
-          .successful
+        subscription = purchase.subscription
+        scope = subscription.is_test_subscription ? subscription.purchases.test_successful : subscription.purchases.successful
+        @_subscription_charge_number[purchase.id] = scope
           .where("succeeded_at < ?", purchase.succeeded_at)
           .count + 1
       end

--- a/spec/presenters/receipt_presenter/payment_info_spec.rb
+++ b/spec/presenters/receipt_presenter/payment_info_spec.rb
@@ -336,6 +336,34 @@ describe ReceiptPresenter::PaymentInfo do
               expect(upcoming_payment_attributes).to eq([])
             end
           end
+
+          context "when the purchase is a test purchase with no more remaining charges" do
+            let(:product) { create(:membership_product, name: "Membership product") }
+            let(:purchase) do
+              create(
+                :test_purchase,
+                link: product,
+                is_original_subscription_purchase: true,
+                price_cents: 1_00,
+                created_at: DateTime.parse("January 1, 2023")
+              )
+            end
+
+            before do
+              purchase.subscription ||= create(:subscription, link: product, user: purchase.purchaser, is_test_subscription: true, charge_occurrence_count: 1)
+              purchase.save!
+            end
+
+            it "does not show upcoming payment for test purchase" do
+              expect(upcoming_payment_attributes).to eq([])
+            end
+
+            it "shows correct charge progress for test purchase" do
+              expect(today_payment_attributes).to include(
+                hash_including(label: "Membership product: 1 of 1")
+              )
+            end
+          end
         end
       end
 


### PR DESCRIPTION
Closes https://github.com/antiwork/gumroad/issues/3850

## Problem

Fixed-length membership receipts show "2 of 1" payment count and a spurious upcoming payment section when the purchase is a test purchase. This happens because `charges_completed?` and `remaining_charges_count` on Subscription use `purchases.successful` which only matches `purchase_state: "successful"`, but test purchases have state `"test_successful"`.

## Solution
- Changed `charges_completed?` and `remaining_charges_count` to use the existing private `successful_purchases` helper, which returns `purchases.test_successful` for test subscriptions and `purchases.successful` for regular ones
- Fixed `subscription_charge_number` in the receipt presenter to use the correct scope for test subscriptions

## Before
<img width="559" height="587" alt="Screenshot 2026-03-02 at 14 28 54" src="https://github.com/user-attachments/assets/7d44d3a2-4c3c-4931-b305-0d03d515bda9" />


## After
<img width="527" height="374" alt="Screenshot 2026-03-02 at 14 44 22" src="https://github.com/user-attachments/assets/25cab9c5-1167-4b6a-974f-5dd05dc3a0fb" />