### PR TITLE
Allow close-non-english workflow to run for external users

### DIFF
--- a/.github/workflows/close-non-english-issues.yml
+++ b/.github/workflows/close-non-english-issues.yml
@@ -21,6 +21,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          allowed_non_write_users: "*"
           prompt: |
             You are a language detection bot. Your only job is to determine whether
             GitHub issue #${{ github.event.issue.number }} is written in English.


### PR DESCRIPTION
Issue #3690 (partial)

## What

Adds `github_token` and `allowed_non_write_users: "*"` to the close-non-english-issues workflow so it can process issues opened by users without write access to the repo.

## Why

The workflow was failing for every issue opened by an external contributor (e.g. [run #22532120093](https://github.com/antiwork/gumroad/actions/runs/22532120093)). The `claude-code-action` checks whether the triggering user has write access before running — a security measure that makes sense for PR review workflows but blocks moderation workflows that need to act on all incoming issues.

This is safe because the workflow triggers on `issues.opened`, which always runs from `main` (no fork code execution), the prompt is hardcoded, and Claude's tools are restricted to `gh issue view/close/comment` only. The `GITHUB_TOKEN` is short-lived, auto-masked in logs, and scoped to `contents: read` + `issues: write`.

---

This PR was implemented with AI assistance using Claude Code for code generation. All code was self-reviewed.