### PR TITLE
Add workflow to close support request issues

### DIFF
--- a/.github/workflows/close-support-issues.yml
+++ b/.github/workflows/close-support-issues.yml
@@ -1,4 +1,3 @@
-# TODO: auto-close support issues once false positive rate is acceptable
 name: Close support issues
 
 on:


### PR DESCRIPTION
Addresses #3690 (partial)

## What

New GitHub Actions workflow that uses Claude to detect when an issue is a support request about a specific Gumroad account (suspended account, payout problems, refund requests, etc.) rather than a bug report or feature request. Posts a fixed comment directing the user to https://help.gumroad.com and does not close the issue (yet).

Uses the same patterns as the other issue triage workflows: shared concurrency group to avoid race conditions, skips maintainers, checks if the issue is still open before invoking Claude.

## Why

Users frequently open GitHub issues for account-specific support requests that maintainers need to manually redirect. This automates the redirect to the help center, where an AI agent handles common questions and escalates to a human when needed.

---

This PR was implemented with AI assistance using Claude Opus 4.6.