### PR TITLE
Add workflow to comment on non-compliant PRs

### DIFF
--- a/.github/workflows/close-non-compliant-prs.yml
+++ b/.github/workflows/close-non-compliant-prs.yml
@@ -1,0 +1,62 @@
+# TODO: auto-close non-compliant PRs once false positive rate is acceptable
+name: Close non-compliant PRs
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  close-non-compliant:
+    if: >-
+      github.event.pull_request.author_association != 'MEMBER' &&
+      github.event.pull_request.author_association != 'OWNER'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Check PR against contributing guidelines
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          allowed_non_write_users: "*"
+          prompt: |
+            You are a contributing guidelines bot. Your job is to check whether
+            pull request #${{ github.event.pull_request.number }} follows the rules
+            outlined in CONTRIBUTING.md.
+
+            Step 1: Read the PR.
+            gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json title,body,files
+
+            Step 2: Read the contributing guidelines.
+            cat CONTRIBUTING.md
+
+            Step 3: Check compliance against the Pull requests section in
+            CONTRIBUTING.md. Be lenient — check for the substance, not exact
+            formatting.
+
+            Step 4: Decide.
+
+            If the PR is compliant or you are unsure, do absolutely nothing.
+
+            If the PR is clearly missing required elements, post a comment using
+            exactly this template (fill in the bullet points):
+
+            gh pr comment ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --body "Thanks for opening this PR! It's missing a few things we look for:
+
+            - [what's missing]
+
+            Please see our [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md) for the expected structure."
+
+            Do NOT close the PR.
+
+            When in doubt, do nothing. False positives are worse than false negatives.
+          claude_args: |
+            --allowedTools "Bash(gh pr view:*),Bash(gh pr comment:*),Bash(cat CONTRIBUTING.md)"


### PR DESCRIPTION
Addresses #3690 (partial)

## What

New GitHub Actions workflow that uses Claude to check external contributors' PRs against the Pull requests section in CONTRIBUTING.md. Posts a deterministic comment listing what's missing. Does not close the PR (yet).

Uses `pull_request_target` so the workflow has write permissions to comment on fork PRs while only checking out the base branch (no fork code executed).

## Why

External PRs frequently miss AI disclosures, tests, or description structure. This automates the feedback so maintainers don't have to leave the same comments repeatedly. Skips maintainers to give them flexibility.

---

This PR was implemented with AI assistance using Claude Opus 4.6.