### PR TITLE
Fix unequal product card widths in receipt email

### DIFF
--- a/app/javascript/stylesheets/_email.scss
+++ b/app/javascript/stylesheets/_email.scss
@@ -617,6 +617,7 @@ $accent-color: map-get($colors, "pink"); // [1]
   @include bg-color(filled);
   border: $border;
   border-radius: border-radius(1);
+  display: grid;
 
   > figure {
     background: url("~images/placeholders/product-cover.png");


### PR DESCRIPTION
Fixes https://github.com/antiwork/gumroad/issues/3475

## What

Adds `display: grid` to `.product-card` in the email stylesheet. This prevents recommended product cards from having unequal widths when displayed side by side in receipt emails.

## Why

The `.product-card .header h4` inherits `white-space: nowrap` from the `text-singleline` mixin applied via `.header > :not(:last-child)`. In a table with `table-layout: auto`, `white-space: nowrap` forces the text onto a single line without wrapping, which causes the table cell to expand to fit the full title length. Cards with longer titles end up wider than cards with shorter titles.

Adding `display: grid` to `.product-card` constrains the card's children to the grid container's width, preventing the nowrap content from pushing the cell wider.

## Before/After

### Before
<img width="1468" height="791" alt="Screenshot 2026-03-03 at 16 31 17" src="https://github.com/user-attachments/assets/50b7734b-2fe9-4dea-b527-2717c7112b41" />

### After
<img width="1470" height="791" alt="Screenshot 2026-03-03 at 16 34 18" src="https://github.com/user-attachments/assets/42d43577-6a44-4484-9372-4b921b9a26a5" />


## Modifing css on prod on the reported receipt ( https://gumroad.com/purchases/1CfxpM21kXlHaXMAzwN0Fg==/receipt?email=mr.osamaarshad%40gmail.com ) :

https://github.com/user-attachments/assets/5deb4aa6-f378-4d8d-bd4f-79cedba8ea30