### PR TITLE
Append purchase_id to post URLs on download page rich content

### DIFF
--- a/app/javascript/components/Download/RichContent.tsx
+++ b/app/javascript/components/Download/RichContent.tsx
@@ -13,6 +13,7 @@ import { asyncVoid } from "$app/utils/promise";
 import { assertResponseError } from "$app/utils/request";
 
 import { Button, buttonVariants, NavigationButton } from "$app/components/Button";
+import { useDomains } from "$app/components/DomainSettings";
 import { FileRow, shouldShowSubtitlesForFile } from "$app/components/Download/FileList";
 import { License, useContentFiles } from "$app/components/DownloadPage/WithContent";
 import { LoadingSpinner } from "$app/components/LoadingSpinner";
@@ -41,15 +42,16 @@ export const RichContentView = ({
   saleInfo: SaleInfo | null;
   license: License | null;
 }) => {
+  const { rootDomain } = useDomains();
   const editor = useRichTextEditor({
     ariaLabel: "Product content",
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- to be fixed with product edit refactor
     initialValue: richContent as Content,
     editable: false,
     extensions: [
-      Link.configure({ saleInfo }),
-      TiptapLink.configure({ saleInfo }),
-      TiptapButton.configure({ saleInfo }),
+      Link.configure({ saleInfo, rootDomain }),
+      TiptapLink.configure({ saleInfo, rootDomain }),
+      TiptapButton.configure({ saleInfo, rootDomain }),
       FileEmbed,
       FileEmbedGroup,
       ExternalMediaFileEmbed,
@@ -76,17 +78,13 @@ export const RichContentView = ({
 
 const SALE_INFO_PLACEHOLDER_QUERY_PARAM = "__sale_info__";
 
-const isGumroadPostUrl = (url: URL) => {
-  const isGumroadDomain =
-    url.hostname.endsWith(".gumroad.com") ||
-    url.hostname === "gumroad.com" ||
-    url.hostname.endsWith(".gumroad.dev") ||
-    url.hostname === "gumroad.dev";
+const isGumroadPostUrl = (url: URL, rootDomain: string) => {
+  const isGumroadDomain = url.host.endsWith(`.${rootDomain}`) || url.host === rootDomain;
   const isPostPath = /^\/([^/]+\/)?p\/[^/]+$/u.test(url.pathname);
   return isGumroadDomain && isPostPath;
 };
 
-const addSaleInfoQueryParams = (href: string, saleInfo: SaleInfo | null) => {
+const addSaleInfoQueryParams = (href: string, saleInfo: SaleInfo | null, rootDomain: string) => {
   if (!saleInfo) return href;
 
   try {
@@ -100,7 +98,7 @@ const addSaleInfoQueryParams = (href: string, saleInfo: SaleInfo | null) => {
       return url.href;
     }
 
-    if (isGumroadPostUrl(url) && !url.searchParams.has("purchase_id")) {
+    if (isGumroadPostUrl(url, rootDomain)) {
       url.searchParams.set("purchase_id", saleInfo.sale_id);
       return url.href;
     }
@@ -111,7 +109,7 @@ const addSaleInfoQueryParams = (href: string, saleInfo: SaleInfo | null) => {
   }
 };
 
-const Link = Mark.create<BaseLinkOptions & { saleInfo: SaleInfo | null }>({
+const Link = Mark.create<BaseLinkOptions & { saleInfo: SaleInfo | null; rootDomain: string }>({
   name: "link",
   addAttributes: () => ({
     href: { default: null },
@@ -124,7 +122,7 @@ const Link = Mark.create<BaseLinkOptions & { saleInfo: SaleInfo | null }>({
       "a",
       {
         ...HTMLAttributes,
-        href: addSaleInfoQueryParams(cast<string>(HTMLAttributes.href), this.options.saleInfo),
+        href: addSaleInfoQueryParams(cast<string>(HTMLAttributes.href), this.options.saleInfo, this.options.rootDomain),
         target: "_blank",
       },
       0,
@@ -132,7 +130,7 @@ const Link = Mark.create<BaseLinkOptions & { saleInfo: SaleInfo | null }>({
   },
 });
 
-const TiptapLink = TiptapNode.create<{ saleInfo: SaleInfo | null }>({
+const TiptapLink = TiptapNode.create<{ saleInfo: SaleInfo | null; rootDomain: string }>({
   name: "tiptap-link",
   group: "inline",
   inline: true,
@@ -145,14 +143,14 @@ const TiptapLink = TiptapNode.create<{ saleInfo: SaleInfo | null }>({
         ...HTMLAttributes,
         target: "_blank",
         rel: "noopener noreferrer nofollow",
-        href: addSaleInfoQueryParams(cast<string>(HTMLAttributes.href), this.options.saleInfo),
+        href: addSaleInfoQueryParams(cast<string>(HTMLAttributes.href), this.options.saleInfo, this.options.rootDomain),
       },
       0,
     ];
   },
 });
 
-const TiptapButton = TiptapNode.create<{ saleInfo: SaleInfo | null }>({
+const TiptapButton = TiptapNode.create<{ saleInfo: SaleInfo | null; rootDomain: string }>({
   name: "button",
   group: "block",
   content: "inline+",
@@ -168,7 +166,11 @@ const TiptapButton = TiptapNode.create<{ saleInfo: SaleInfo | null }>({
           class: buttonVariants({ size: "default", color: "primary" }),
           target: "_blank",
           rel: "noopener noreferrer nofollow",
-          href: addSaleInfoQueryParams(cast<string>(HTMLAttributes.href), this.options.saleInfo),
+          href: addSaleInfoQueryParams(
+            cast<string>(HTMLAttributes.href),
+            this.options.saleInfo,
+            this.options.rootDomain,
+          ),
         },
         0,
       ],

--- a/spec/requests/download_page/rich_text_editor_spec.rb
+++ b/spec/requests/download_page/rich_text_editor_spec.rb
@@ -778,29 +778,58 @@ describe("Download Page – Rich Text Editor Content", type: :system, js: true) 
     end
 
     it "appends purchase_id to Gumroad post URLs in links and buttons" do
-      post_url = "https://#{@user.username}.gumroad.com/p/test-post"
+      post_url = "#{PROTOCOL}://#{@user.username}.#{ROOT_DOMAIN}/p/test-post"
       product_rich_content = @product.alive_rich_contents.first
       product_rich_content.update!(description: [
-                                     { "type" => "paragraph",
-                                       "content" =>
-                                        [{ "text" => "Post link",
+                                     {
+                                       "type" => "paragraph",
+                                       "content" => [
+                                         {
+                                           "text" => "Post link",
                                            "type" => "text",
-                                           "marks" =>
-                                            [{ "type" => "link",
-                                               "attrs" =>
-                                              { "rel" => "noopener noreferrer nofollow",
-                                                "href" => post_url,
-                                                "class" => nil,
-                                                "target" => "_blank" } }] }] },
-                                     { "type" => "paragraph",
-                                       "content" =>
-                                        [{ "type" => "tiptap-link",
-                                           "attrs" => { "href" => post_url },
-                                           "content" => [{ "text" => "Tiptap post link", "type" => "text" }] }] },
-                                     { "type" => "button",
-                                       "attrs" => { "href" => post_url },
-                                       "content" =>
-                                        [{ "text" => "Post button", "type" => "text" }] },
+                                           "marks" => [
+                                             {
+                                               "type" => "link",
+                                               "attrs" => {
+                                                 "rel" => "noopener noreferrer nofollow",
+                                                 "href" => post_url,
+                                                 "class" => nil,
+                                                 "target" => "_blank",
+                                               },
+                                             },
+                                           ],
+                                         },
+                                       ],
+                                     },
+                                     {
+                                       "type" => "paragraph",
+                                       "content" => [
+                                         {
+                                           "type" => "tiptap-link",
+                                           "attrs" => {
+                                             "href" => post_url,
+                                           },
+                                           "content" => [
+                                             {
+                                               "text" => "Tiptap post link",
+                                               "type" => "text",
+                                             },
+                                           ],
+                                         },
+                                       ],
+                                     },
+                                     {
+                                       "type" => "button",
+                                       "attrs" => {
+                                         "href" => post_url,
+                                       },
+                                       "content" => [
+                                         {
+                                           "text" => "Post button",
+                                           "type" => "text",
+                                         },
+                                       ],
+                                     },
                                    ])
 
       visit("/d/#{@url_redirect.token}")
@@ -814,17 +843,26 @@ describe("Download Page – Rich Text Editor Content", type: :system, js: true) 
       external_url = "https://example.com/p/some-post"
       product_rich_content = @product.alive_rich_contents.first
       product_rich_content.update!(description: [
-                                     { "type" => "paragraph",
-                                       "content" =>
-                                        [{ "text" => "External link",
+                                     {
+                                       "type" => "paragraph",
+                                       "content" => [
+                                         {
+                                           "text" => "External link",
                                            "type" => "text",
-                                           "marks" =>
-                                            [{ "type" => "link",
-                                               "attrs" =>
-                                              { "rel" => "noopener noreferrer nofollow",
-                                                "href" => external_url,
-                                                "class" => nil,
-                                                "target" => "_blank" } }] }] },
+                                           "marks" => [
+                                             {
+                                               "type" => "link",
+                                               "attrs" => {
+                                                 "rel" => "noopener noreferrer nofollow",
+                                                 "href" => external_url,
+                                                 "class" => nil,
+                                                 "target" => "_blank",
+                                               },
+                                             },
+                                           ],
+                                         },
+                                       ],
+                                     },
                                    ])
 
       visit("/d/#{@url_redirect.token}")
@@ -832,20 +870,29 @@ describe("Download Page – Rich Text Editor Content", type: :system, js: true) 
     end
 
     it "does not append purchase_id to Gumroad URLs without /p/ paths" do
-      gumroad_product_url = "https://#{@user.username}.gumroad.com/l/test-product"
+      gumroad_product_url = "#{PROTOCOL}://#{@user.username}.#{ROOT_DOMAIN}/l/test-product"
       product_rich_content = @product.alive_rich_contents.first
       product_rich_content.update!(description: [
-                                     { "type" => "paragraph",
-                                       "content" =>
-                                        [{ "text" => "Product link",
+                                     {
+                                       "type" => "paragraph",
+                                       "content" => [
+                                         {
+                                           "text" => "Product link",
                                            "type" => "text",
-                                           "marks" =>
-                                            [{ "type" => "link",
-                                               "attrs" =>
-                                              { "rel" => "noopener noreferrer nofollow",
-                                                "href" => gumroad_product_url,
-                                                "class" => nil,
-                                                "target" => "_blank" } }] }] },
+                                           "marks" => [
+                                             {
+                                               "type" => "link",
+                                               "attrs" => {
+                                                 "rel" => "noopener noreferrer nofollow",
+                                                 "href" => gumroad_product_url,
+                                                 "class" => nil,
+                                                 "target" => "_blank",
+                                               },
+                                             },
+                                           ],
+                                         },
+                                       ],
+                                     },
                                    ])
 
       visit("/d/#{@url_redirect.token}")


### PR DESCRIPTION
Fixes https://github.com/antiwork/gumroad-private/issues/186

## What

Auto-appends `?purchase_id=` to Gumroad post URLs (`*.gumroad.com/p/*`) in download page rich content, so purchasers without a Gumroad account can access posts linked from the download page.

## Why

When a seller includes a link to a Gumroad post in the download page rich content, purchasers without a Gumroad account get a "not found" error. The `PostPresenter#e404?` already supports bypassing visibility checks when a valid `purchase_id` param is provided, but links in rich content were not including it. The `saleInfo.sale_id` (which equals `purchase.external_id`) is already available on the download page, so we use it to append `?purchase_id=` to detected Gumroad post URLs.

## Before/After

### Before

https://github.com/user-attachments/assets/3c3441b9-2d68-4b13-b66b-30076b493457

### After

https://github.com/user-attachments/assets/a505102c-cac4-4523-add4-9809403abba6

