### PR TITLE
Require katakana in kana street address fields

### DIFF
--- a/app/javascript/pages/Settings/Payments/Show.tsx
+++ b/app/javascript/pages/Settings/Payments/Show.tsx
@@ -48,6 +48,7 @@ const KANA_NAME_ERROR = "may only contain katakana characters, spaces, dashes, a
 const KANA_ADDRESS_ERROR = "may only contain katakana, latin characters, digits, spaces, dashes, and dots.";
 
 const HAS_JAPANESE_CHARS = /[\u3000-\u303F\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF\uFF65-\uFF9F]/u;
+const HAS_KATAKANA = /[\u30A0-\u30FF\u31F0-\u31FF\uFF65-\uFF9F]/u;
 
 const PAYOUT_FREQUENCIES = ["daily", "weekly", "monthly", "quarterly"] as const;
 type PayoutFrequency = (typeof PAYOUT_FREQUENCIES)[number];
@@ -565,6 +566,13 @@ export default function PaymentsPage() {
         "Street address (Kana)",
         KANA_ADDRESS_ERROR,
       );
+      validateKanaField(
+        "street_address_kana",
+        form.data.user.street_address_kana,
+        HAS_KATAKANA,
+        "Street address (Kana)",
+        "must include katakana characters.",
+      );
     } else if (
       !form.data.user.street_address ||
       (form.data.user.country === "US" && isStreetAddressPOBox(form.data.user.street_address))
@@ -661,6 +669,13 @@ export default function PaymentsPage() {
           KANA_ADDRESS_REGEX,
           "Business street address (Kana)",
           KANA_ADDRESS_ERROR,
+        );
+        validateKanaField(
+          "business_street_address_kana",
+          form.data.user.business_street_address_kana,
+          HAS_KATAKANA,
+          "Business street address (Kana)",
+          "must include katakana characters.",
         );
         if (form.data.user.business_name && HAS_JAPANESE_CHARS.test(form.data.user.business_name)) {
           markFieldInvalid("business_name");

--- a/app/models/user_compliance_info.rb
+++ b/app/models/user_compliance_info.rb
@@ -13,6 +13,7 @@ class UserComplianceInfo < ApplicationRecord
   MINIMUM_DATE_OF_BIRTH_AGE = 13
   KANA_NAME_REGEX = /\A[\p{In_Katakana}\p{In_Katakana_Phonetic_Extensions}\uFF65-\uFF9F\s\u3000\-.]*\z/
   KANA_ADDRESS_REGEX = /\A[\p{In_Katakana}\p{In_Katakana_Phonetic_Extensions}\uFF65-\uFF9F\p{Latin}\d\s\u3000\-.]*\z/
+  HAS_KATAKANA = /[\p{In_Katakana}\p{In_Katakana_Phonetic_Extensions}\uFF65-\uFF9F]/
   ROMAJI_REGEX = /\A[^\p{Han}\p{Hiragana}\p{Katakana}]*\z/
 
   belongs_to :user, optional: true
@@ -32,6 +33,7 @@ class UserComplianceInfo < ApplicationRecord
 
   validate :birthday_is_over_minimum_age
   validate :kana_fields_format
+  validate :street_address_kana_must_contain_katakana
   validate :business_name_romaji_format
 
   after_create_commit :handle_stripe_compliance_info
@@ -214,6 +216,18 @@ class UserComplianceInfo < ApplicationRecord
         next if value.blank?
         next if value.match?(regex)
         errors.add(:base, "#{label} may only contain #{allowed_description}")
+      end
+    end
+
+    def street_address_kana_must_contain_katakana
+      return if country_code != Compliance::Countries::JPN.alpha2
+
+      { street_address_kana: "Street address (Kana)",
+        business_street_address_kana: "Business street address (Kana)" }.each do |field, label|
+        value = send(field)
+        next if value.blank?
+        next if value.match?(HAS_KATAKANA)
+        errors.add(:base, "#{label} must include katakana characters")
       end
     end
 

--- a/spec/models/user_compliance_info_spec.rb
+++ b/spec/models/user_compliance_info_spec.rb
@@ -359,6 +359,50 @@ describe UserComplianceInfo do
     end
   end
 
+  describe "street_address_kana_must_contain_katakana" do
+    it "rejects Latin-only street_address_kana" do
+      uci = build(:user_compliance_info, country: "Japan", json_data: { street_address_kana: "Shibuya" })
+      uci.valid?
+      expect(uci.errors[:base]).to include("Street address (Kana) must include katakana characters")
+    end
+
+    it "accepts street_address_kana with katakana" do
+      uci = build(:user_compliance_info, country: "Japan", json_data: { street_address_kana: "シブヤ" })
+      uci.valid?
+      expect(uci.errors[:base]).not_to include(a_string_matching(/must include katakana/))
+    end
+
+    it "accepts street_address_kana with mixed katakana and Latin" do
+      uci = build(:user_compliance_info, country: "Japan", json_data: { street_address_kana: "シブヤ1-2-3" })
+      uci.valid?
+      expect(uci.errors[:base]).not_to include(a_string_matching(/must include katakana/))
+    end
+
+    it "does not apply to building_number_kana" do
+      uci = build(:user_compliance_info, country: "Japan", json_data: { building_number_kana: "123" })
+      uci.valid?
+      expect(uci.errors[:base]).not_to include(a_string_matching(/must include katakana/))
+    end
+
+    it "rejects Latin-only business_street_address_kana" do
+      uci = build(:user_compliance_info, country: "Japan", json_data: { business_street_address_kana: "Chiyoda" })
+      uci.valid?
+      expect(uci.errors[:base]).to include("Business street address (Kana) must include katakana characters")
+    end
+
+    it "accepts business_street_address_kana with katakana" do
+      uci = build(:user_compliance_info, country: "Japan", json_data: { business_street_address_kana: "チヨダ" })
+      uci.valid?
+      expect(uci.errors[:base]).not_to include(a_string_matching(/must include katakana/))
+    end
+
+    it "accepts business_street_address_kana with mixed katakana and Latin" do
+      uci = build(:user_compliance_info, country: "Japan", json_data: { business_street_address_kana: "チヨダ1-2" })
+      uci.valid?
+      expect(uci.errors[:base]).not_to include(a_string_matching(/must include katakana/))
+    end
+  end
+
   describe "business_name_romaji_format" do
     describe "for Japanese business accounts" do
       it "allows latin business name" do


### PR DESCRIPTION
Fixes #3868

## What

The `street_address_kana` and `business_street_address_kana` fields now require at least one katakana character. Previously, the `KANA_ADDRESS_REGEX` allowed fully Latin text (e.g., "Sunshine 301") in these fields, which Stripe rejects with a confusing error that doesn't indicate which field is wrong.

A new `HAS_KATAKANA` regex check is added on both backend and frontend, applied only to street address kana fields. `building_number_kana` remains lenient — digits-only values like "5-3-4" are still valid there.

## Why

Sellers entering Latin-only text in the Town/Cho-me (Kana) field see a generic Stripe error with no way to identify the problem field, leading to support escalations. Catching this at form validation gives a clear, actionable error message before the data reaches Stripe.

## Screenshots
**Before**
<img width="580" src="https://github.com/user-attachments/assets/062e24e5-9543-4327-9a38-1667e5a83028" />

**After**
<img width="580" src="https://github.com/user-attachments/assets/24e816fb-732c-4e5c-8507-6511b2fd442b" />

---

This PR was implemented with AI assistance using Claude Opus 4.6.