### PR TITLE
Remove Inertia navigation progress bar

### DIFF
--- a/app/javascript/packs/admin.ts
+++ b/app/javascript/packs/admin.ts
@@ -36,7 +36,7 @@ const resolvePageComponent = async (name: string): Promise<PageComponent> => {
 };
 
 void createInertiaApp<GlobalProps>({
-  progress: { delay: 100, color: "#FF90E8" },
+  progress: false,
   resolve: (name: string) => resolvePageComponent(name),
   setup({ el, App, props }) {
     const global = props.initialPage.props;

--- a/app/javascript/packs/inertia.js
+++ b/app/javascript/packs/inertia.js
@@ -77,7 +77,7 @@ async function resolvePageComponent(name) {
 }
 
 createInertiaApp({
-  progress: { delay: 100, color: "#FF90E8" },
+  progress: false,
   resolve: resolvePageComponent,
   title: (title) => title || "Gumroad",
   setup({ el, App, props }) {


### PR DESCRIPTION
Towards #3810

## What

Disable the Inertia navigation progress bar in both the main app and admin app by setting `progress: false` in `createInertiaApp`.

## Why

This is the first step toward making sidebar navigation feel instant (see #3810). The visible pink loading bar on every page transition reinforces the perception of slowness.

---

This PR was implemented with AI assistance using Claude Opus 4.6.