### PR TITLE
Forms styling fixes

### DIFF
--- a/app/javascript/components/CheckoutDashboard/FormPage.tsx
+++ b/app/javascript/components/CheckoutDashboard/FormPage.tsx
@@ -196,6 +196,7 @@ const FormPage = ({
                         <div className="flex gap-2">
                           <TypeSafeOptionSelect
                             id={`${uid}-${field.key}-type`}
+                            wrapperClassName="flex-1"
                             value={field.type}
                             onChange={(type) => updateCustomField(i, { type })}
                             options={[
@@ -205,6 +206,7 @@ const FormPage = ({
                             ]}
                           />
                           <Button
+                            size="icon"
                             onClick={() => setCustomFields(customFields.filter((_, index) => index !== i))}
                             color="danger"
                             outline

--- a/app/javascript/components/TypeSafeOptionSelect.tsx
+++ b/app/javascript/components/TypeSafeOptionSelect.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { Select } from "$app/components/ui/Select";
+import { Select, SelectProps } from "$app/components/ui/Select";
 
 type Props<OptionId extends string> = {
   value: OptionId;
@@ -16,7 +16,7 @@ export const TypeSafeOptionSelect = <OptionId extends string>({
   className,
   disabled,
   ...rest
-}: Props<OptionId> & Omit<React.HTMLAttributes<HTMLSelectElement>, "value" | "onChange"> & { name?: string }) => (
+}: Props<OptionId> & Omit<SelectProps, "value" | "onChange"> & { name?: string }) => (
   <Select
     value={value}
     /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */

--- a/app/javascript/components/ui/Select.tsx
+++ b/app/javascript/components/ui/Select.tsx
@@ -3,26 +3,27 @@ import * as React from "react";
 
 import { classNames } from "$app/utils/classNames";
 
-import { useFieldset, stateBorderStyles } from "$app/components/ui/Fieldset";
+import { stateBorderStyles, useFieldset } from "$app/components/ui/Fieldset";
 import { baseInputStyles } from "$app/components/ui/Input";
 
-export const Select = React.forwardRef<
-  HTMLSelectElement,
-  { wrapperClassName?: string } & React.SelectHTMLAttributes<HTMLSelectElement>
->(({ className, wrapperClassName, children, ...props }, ref) => {
-  const { state } = useFieldset();
+export type SelectProps = { wrapperClassName?: string } & React.SelectHTMLAttributes<HTMLSelectElement>;
 
-  return (
-    <div className={classNames("relative inline-grid", wrapperClassName)}>
-      <select
-        ref={ref}
-        className={classNames(baseInputStyles, "appearance-none bg-none pr-10", stateBorderStyles[state], className)}
-        {...props}
-      >
-        {children}
-      </select>
-      <ChevronDown className="pointer-events-none absolute top-1/2 right-4 size-5 -translate-y-1/2 text-muted" />
-    </div>
-  );
-});
+export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
+  ({ className, wrapperClassName, children, ...props }, ref) => {
+    const { state } = useFieldset();
+
+    return (
+      <div className={classNames("relative inline-grid", wrapperClassName)}>
+        <select
+          ref={ref}
+          className={classNames(baseInputStyles, "appearance-none bg-none pr-10", stateBorderStyles[state], className)}
+          {...props}
+        >
+          {children}
+        </select>
+        <ChevronDown className="pointer-events-none absolute top-1/2 right-4 size-5 -translate-y-1/2 text-muted" />
+      </div>
+    );
+  },
+);
 Select.displayName = "Select";

--- a/app/javascript/pages/Settings/ThirdPartyAnalytics/Show.tsx
+++ b/app/javascript/pages/Settings/ThirdPartyAnalytics/Show.tsx
@@ -269,10 +269,11 @@ const SnippetRow = ({
         </div>
       </RowContent>
       <RowActions>
-        <Button onClick={() => setExpanded((prevExpanded) => !prevExpanded)} aria-label="Edit snippet">
+        <Button size="icon" onClick={() => setExpanded((prevExpanded) => !prevExpanded)} aria-label="Edit snippet">
           {expanded ? <ChevronUp className="size-5" /> : <ChevronDown className="size-5" />}
         </Button>
         <Button
+          size="icon"
           onClick={() =>
             updateThirdPartyAnalytics({
               snippets: thirdPartyAnalytics.snippets.filter(({ id }) => id !== snippet.id),


### PR DESCRIPTION
Follow-up to #3891 

Minor styling fixes after the Tailwind forms and icons migrations, restoring the previous appearance in a few places.