### PR TITLE
Send Top Creator badge email when admin verifies a creator

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -28,17 +28,17 @@ class Admin::UsersController < Admin::BaseController
   end
 
   def verify
-    newly_verified = !@user.verified
-    @user.verified = newly_verified
+    @user.verified = !@user.verified
     begin
       @user.save!
     rescue => e
       return render json: { success: false, message: e.message }
     end
-    if newly_verified
+    if @user.verified
       begin
         CreatorMailer.top_creator_announcement(user_id: @user.id).deliver_later
       rescue => e
+        Bugsnag.notify(e)
         Rails.logger.error("Failed to enqueue top_creator_announcement for user #{@user.id}: #{e.message}")
       end
     end

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -50,6 +50,21 @@ describe Admin::UsersController, type: :controller, inertia: true do
       end.not_to have_enqueued_mail(CreatorMailer, :top_creator_announcement)
     end
 
+    context "when email enqueue fails" do
+      before do
+        mail_double = double("mail")
+        allow(mail_double).to receive(:deliver_later).and_raise(Redis::ConnectionError, "connection refused")
+        allow(CreatorMailer).to receive(:top_creator_announcement).and_return(mail_double)
+      end
+
+      it "still returns success and keeps the user verified" do
+        get :verify, params: @params
+
+        expect(response.parsed_body["success"]).to be(true)
+        expect(@user.reload.verified).to be(true)
+      end
+    end
+
     context "when error is raised" do
       before do
         allow_any_instance_of(User).to receive(:save!).and_raise("Error!")


### PR DESCRIPTION
Fixes #3890

## What

When an admin verifies a creator via the admin panel, the `CreatorMailer#top_creator_announcement` email is now automatically enqueued. This only fires when toggling verified from false/nil to true. Un-verifying does not send an email.

The error handling was also restructured: the `save!` and `deliver_later` calls have separate rescue blocks so that a job enqueue failure (e.g., Redis outage) is logged but doesn't return `success: false` to the admin when the verification itself succeeded.

## Why

The Top Creator badge email (added in #3834) was only used for the one-time batch send to existing verified creators. Newly verified creators would silently receive the badge with no notification. This closes the gap so every creator learns about their badge the moment they earn it.

---

This PR was implemented with AI assistance using Claude Opus 4.6.