### PR TITLE
Fix profile settings overflow

### DIFF
--- a/app/javascript/pages/Settings/Profile/Show.tsx
+++ b/app/javascript/pages/Settings/Profile/Show.tsx
@@ -253,41 +253,39 @@ export default function SettingsPage() {
             </Button>
           )}
         >
-          <div className="max-h-[calc(100vh-8rem)] overflow-y-auto">
-            <Preview
-              scaleFactor={0.35}
-              style={{
-                border: "var(--border)",
-                fontFamily: profileSettings.font === "ABC Favorit" ? undefined : profileSettings.font,
-                "--accent": hexToRgb(profileSettings.highlight_color),
-                "--contrast-accent": hexToRgb(getContrastColor(profileSettings.highlight_color)),
-                "--filled": hexToRgb(profileSettings.background_color),
-                "--color": hexToRgb(getContrastColor(profileSettings.background_color)),
-                "--primary": "var(--color)",
-                "--body-bg": "rgb(var(--filled))",
-                "--contrast-primary": "var(--filled)",
-                "--contrast-filled": "var(--color)",
-                "--color-body": "var(--body-bg)",
-                "--color-background": "rgb(var(--filled))",
-                "--color-foreground": "rgb(var(--color))",
-                "--color-border": "rgb(var(--color) / var(--border-alpha))",
-                "--color-accent": "rgb(var(--accent))",
-                "--color-accent-foreground": "rgb(var(--contrast-accent))",
-                "--color-primary": "rgb(var(--primary))",
-                "--color-primary-foreground": "rgb(var(--contrast-primary))",
-                "--color-active-bg": "rgb(var(--color) / var(--gray-1))",
-                "--color-muted": "rgb(var(--color) / var(--gray-3))",
-                backgroundColor: "rgb(var(--filled))",
-                color: "rgb(var(--color))",
-              }}
-            >
-              <Profile
-                creator_profile={creatorProfile}
-                {...(() => ({ profile_settings, settings_pages, ...profileProps }))()}
-                bio={profileSettings.bio}
-              />
-            </Preview>
-          </div>
+          <Preview
+            scaleFactor={0.35}
+            style={{
+              border: "var(--border)",
+              fontFamily: profileSettings.font === "ABC Favorit" ? undefined : profileSettings.font,
+              "--accent": hexToRgb(profileSettings.highlight_color),
+              "--contrast-accent": hexToRgb(getContrastColor(profileSettings.highlight_color)),
+              "--filled": hexToRgb(profileSettings.background_color),
+              "--color": hexToRgb(getContrastColor(profileSettings.background_color)),
+              "--primary": "var(--color)",
+              "--body-bg": "rgb(var(--filled))",
+              "--contrast-primary": "var(--filled)",
+              "--contrast-filled": "var(--color)",
+              "--color-body": "var(--body-bg)",
+              "--color-background": "rgb(var(--filled))",
+              "--color-foreground": "rgb(var(--color))",
+              "--color-border": "rgb(var(--color) / var(--border-alpha))",
+              "--color-accent": "rgb(var(--accent))",
+              "--color-accent-foreground": "rgb(var(--contrast-accent))",
+              "--color-primary": "rgb(var(--primary))",
+              "--color-primary-foreground": "rgb(var(--contrast-primary))",
+              "--color-active-bg": "rgb(var(--color) / var(--gray-1))",
+              "--color-muted": "rgb(var(--color) / var(--gray-3))",
+              backgroundColor: "rgb(var(--filled))",
+              color: "rgb(var(--color))",
+            }}
+          >
+            <Profile
+              creator_profile={creatorProfile}
+              {...(() => ({ profile_settings, settings_pages, ...profileProps }))()}
+              bio={profileSettings.bio}
+            />
+          </Preview>
         </PreviewSidebar>
       </WithPreviewSidebar>
     </SettingsLayout>


### PR DESCRIPTION
From @SalmanNajah 

Issue #3388

Fixes the height calculation in the preview component to avoid extra blank space below it.

### Before

<img width="1898" height="1311" alt="Screenshot 2026-03-08 at 22 31 11" src="https://github.com/user-attachments/assets/c99fe0cb-d000-4985-ac90-05908857c052" />

### After

<img width="1897" height="1311" alt="Screenshot 2026-03-08 at 22 31 45" src="https://github.com/user-attachments/assets/ebca5a91-1b86-471f-bebb-25021b7fd39e" />
