### PR TITLE
Fix library product card action menu blocked by stretched link overlay

### DIFF
--- a/app/javascript/components/Popover.tsx
+++ b/app/javascript/components/Popover.tsx
@@ -21,7 +21,7 @@ export const PopoverTrigger = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <PopoverPrimitive.Trigger
     ref={ref}
-    className={classNames("cursor-pointer outline-none all-unset focus-visible:outline-none", className)}
+    className={classNames("relative cursor-pointer outline-none all-unset focus-visible:outline-none", className)}
     {...props}
   />
 ));


### PR DESCRIPTION
Closes https://github.com/antiwork/gumroad/issues/3907

## What
Add `position: relative` to `PopoverTrigger` so it stacks above the `StretchedLink` overlay on product cards.

## Why
The old Popover (pre-Radix, #2742) used a `.popover` CSS class with `position: relative`, which kept the trigger above the `StretchedLink`'s `::before` pseudo-element. When migrated to Radix UI, this was dropped. Without it, the stretched link overlay intercepts clicks on the three-dots menu in the Library, navigating to the download page instead of opening the action popover.

Adding `relative` to `PopoverTrigger` restores the lost behavior at the source — protecting all popovers used alongside stretched links, not just the Library page.

## Before

https://github.com/user-attachments/assets/be8ffcba-4532-47b1-ada5-6dadebc44eff

## After


https://github.com/user-attachments/assets/65ec0f25-2ea2-4e01-8dfa-68e329786eed



---

Claude Opus 4.6 used for root cause analysis and fix.
