### PR TITLE
Fix stale workflow grace period and add PR activity tracking

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -16,7 +16,7 @@ jobs:
           script: |
             const MS_PER_DAY = 24 * 60 * 60 * 1000;
             const STALE_DAYS = 7;
-            const CLOSE_DAYS = 8;
+            const GRACE_HOURS = 24;
             const now = Date.now();
             const { owner, repo } = context.repo;
 
@@ -45,11 +45,23 @@ jobs:
               });
 
               let lastActivity = new Date(issue.created_at).getTime();
+              let staleLabeledAt = null;
 
               for (const event of events) {
                 if (event.event === "commented" && event.user?.type !== "Bot") {
                   const ts = new Date(event.created_at).getTime();
                   if (ts > lastActivity) lastActivity = ts;
+                }
+
+                // A linked open PR counts as activity on the issue
+                if (event.event === "cross-referenced" && event.source?.issue?.pull_request && event.source.issue.state === "open") {
+                  const ts = new Date(event.created_at).getTime();
+                  if (ts > lastActivity) lastActivity = ts;
+                }
+
+                // Track when the stale label was added
+                if (event.event === "labeled" && event.label?.name === "stale") {
+                  staleLabeledAt = new Date(event.created_at).getTime();
                 }
               }
 
@@ -58,6 +70,7 @@ jobs:
               core.info(`#${issue.number} — last activity: ${lastActivityDate}, stale days: ${staleDays.toFixed(1)}`);
 
               const hasStaleLabel = issue.labels.some(l => l.name === "stale");
+              const graceElapsedHours = staleLabeledAt ? (now - staleLabeledAt) / (60 * 60 * 1000) : 0;
 
               // Activity resumed — remove stale label
               if (hasStaleLabel && staleDays < STALE_DAYS) {
@@ -67,7 +80,7 @@ jobs:
                 core.info(`#${issue.number} — removed stale label (activity resumed)`);
 
               // Grace period expired — close
-              } else if (hasStaleLabel && staleDays >= CLOSE_DAYS) {
+              } else if (hasStaleLabel && graceElapsedHours >= GRACE_HOURS) {
                 await github.rest.issues.createComment({
                   owner, repo, issue_number: issue.number,
                   body: "Closing this issue due to inactivity. Feel free to reopen if you'd like to continue the discussion!"
@@ -75,7 +88,7 @@ jobs:
                 await github.rest.issues.update({
                   owner, repo, issue_number: issue.number, state: "closed"
                 });
-                core.info(`#${issue.number} — closed (stale for ${staleDays.toFixed(1)} days)`);
+                core.info(`#${issue.number} — closed (grace period of ${GRACE_HOURS}h elapsed)`);
 
               // Newly stale — warn
               } else if (!hasStaleLabel && staleDays >= STALE_DAYS) {

--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -17,7 +17,7 @@ jobs:
           script: |
             const MS_PER_DAY = 24 * 60 * 60 * 1000;
             const STALE_DAYS = 7;
-            const CLOSE_DAYS = 8;
+            const GRACE_HOURS = 24;
             const now = Date.now();
             const { owner, repo } = context.repo;
 
@@ -47,6 +47,7 @@ jobs:
               });
 
               let lastActivity = new Date(pr.created_at).getTime();
+              let staleLabeledAt = null;
 
               for (const event of events) {
                 let ts = null;
@@ -64,6 +65,11 @@ jobs:
                   case "reviewed":
                     if (event.user?.type !== "Bot") ts = new Date(event.submitted_at).getTime();
                     break;
+                  case "labeled":
+                    if (event.label?.name === "stale") {
+                      staleLabeledAt = new Date(event.created_at).getTime();
+                    }
+                    break;
                 }
 
                 if (ts && ts > lastActivity) lastActivity = ts;
@@ -74,6 +80,7 @@ jobs:
               core.info(`#${pr.number} — last activity: ${lastActivityDate}, stale days: ${staleDays.toFixed(1)}`);
 
               const hasStaleLabel = pr.labels.some(l => l.name === "stale");
+              const graceElapsedHours = staleLabeledAt ? (now - staleLabeledAt) / (60 * 60 * 1000) : 0;
 
               // Activity resumed — remove stale label
               if (hasStaleLabel && staleDays < STALE_DAYS) {
@@ -83,7 +90,7 @@ jobs:
                 core.info(`#${pr.number} — removed stale label (activity resumed)`);
 
               // Grace period expired — close
-              } else if (hasStaleLabel && staleDays >= CLOSE_DAYS) {
+              } else if (hasStaleLabel && graceElapsedHours >= GRACE_HOURS) {
                 await github.rest.issues.createComment({
                   owner, repo, issue_number: pr.number,
                   body: "Closing this PR due to inactivity. Feel free to reopen if you'd like to continue working on it!"
@@ -91,7 +98,7 @@ jobs:
                 await github.rest.pulls.update({
                   owner, repo, pull_number: pr.number, state: "closed"
                 });
-                core.info(`#${pr.number} — closed (stale for ${staleDays.toFixed(1)} days)`);
+                core.info(`#${pr.number} — closed (grace period of ${GRACE_HOURS}h elapsed)`);
 
               // Newly stale — warn
               } else if (!hasStaleLabel && staleDays >= STALE_DAYS) {


### PR DESCRIPTION
## What

Fixes two bugs in the stale issues/PRs workflows introduced in #3881:

1. **Grace period not respected**: The close check used `staleDays >= 8` (days since last activity), not time since the stale label was applied. On the first run, issues inactive for 8+ days were labeled stale and then closed ~6 hours later on the next cron run — despite the warning promising 24 hours. Now the close condition checks that 24 hours have elapsed since the stale label was actually added.

2. **Linked PRs ignored**: The issues workflow only counted non-bot comments as activity. Publishing a PR that references an issue didn't reset the stale clock, so issues could be marked stale while actively being worked on. Now `cross-referenced` events from open PRs count as activity on the issue.

Both fixes also apply the same grace period correction to the stale PRs workflow.

## Why

After #3881 shipped, issues like #3810 were warned and closed within hours of each other because they had been inactive long before the workflow existed. The "24 hours" promise in the stale warning should be a real guarantee. And developers working on a fix via PR shouldn't have the issue closed underneath them.

---

This PR was implemented with AI assistance using Claude Opus 4.6.