### PR TITLE
Use numeric keyboard for 2FA code

### DIFF
--- a/app/javascript/pages/TwoFactorAuthentication/Show.tsx
+++ b/app/javascript/pages/TwoFactorAuthentication/Show.tsx
@@ -65,6 +65,7 @@ function TwoFactorAuthentication() {
             <Input
               id={uid}
               type="text"
+              inputMode="numeric"
               value={form.data.token}
               onChange={(e) => form.setData("token", e.target.value)}
               required


### PR DESCRIPTION
As brought up by Ershad [here](https://chat.google.com/room/AAQA779E0g4/Dg1WmGcxXoU/r7oP6V2GZy0?cls=10)

Before:

<img width="393" height="852" alt="Simulator Screenshot - iPhone 16 - 2026-03-09 at 20 31 03" src="https://github.com/user-attachments/assets/399bea5a-61bb-4ace-93eb-0c1eea9871c5" />

After:

<img width="393" height="852" alt="Simulator Screenshot - iPhone 16 - 2026-03-09 at 20 31 20" src="https://github.com/user-attachments/assets/8d64d9fe-912f-4ec4-983b-f09534a1d5c4" />
