### PR TITLE
Add padding to tax form banner on dashboard

### DIFF
--- a/app/javascript/components/DashboardPage.tsx
+++ b/app/javascript/components/DashboardPage.tsx
@@ -330,7 +330,7 @@ export const DashboardPage = ({
         }
         className="border-b-0 sm:border-b"
       />
-      {(stripe_verification_message || show_1099_download_notice) ? (
+      {stripe_verification_message || show_1099_download_notice ? (
         <div className="grid gap-4 px-4 pt-4 md:px-8 md:pt-8">
           {stripe_verification_message ? (
             <Alert variant="warning">
@@ -341,7 +341,9 @@ export const DashboardPage = ({
             <Alert variant="info">
               Your 1099 tax form for {new Date().getFullYear() - 1} is ready!{" "}
               {tax_center_enabled ? (
-                <Link href={Routes.tax_center_path({ year: new Date().getFullYear() - 1 })}>Click here to download</Link>
+                <Link href={Routes.tax_center_path({ year: new Date().getFullYear() - 1 })}>
+                  Click here to download
+                </Link>
               ) : (
                 <a href={Routes.dashboard_download_tax_form_path()}>Click here to download</a>
               )}


### PR DESCRIPTION
## What

Fixes #3730

The 1099 tax form alert (and the stripe verification alert) on the dashboard had no padding, causing them to sit flush against the left nav and top separator despite having rounded corners.

## Changes

Wrapped both dashboard banner alerts (`stripe_verification_message` and `show_1099_download_notice`) in a container with `px-4 pt-4 md:px-8 md:pt-8`. This matches the padding pattern used by the payouts page banners and the rest of the dashboard content sections (e.g. "Getting started", "Best selling").

Only `DashboardPage.tsx` was modified.

## Before

Banner touches left nav edge with no spacing:

![before](https://github.com/user-attachments/assets/6c320b87-ab9f-44ef-9a63-d94531d89f3d)

## After

Banner aligns with the rest of the dashboard content:

![after](https://github.com/user-attachments/assets/f181869e-2b09-4034-bc16-086362fd5c56)