### PR TITLE
Make product thumbnails square and unclipped

### DIFF
--- a/app/javascript/components/ProductsPage/ProductIconCell.tsx
+++ b/app/javascript/components/ProductsPage/ProductIconCell.tsx
@@ -12,14 +12,12 @@ export const ProductIconCell = ({
   thumbnail: string | null;
   placeholder?: React.ReactNode;
 }) => (
-  <TableCell hideLabel className="relative text-center text-xl lg:w-20 lg:min-w-20 lg:border-r lg:border-border">
+  <TableCell hideLabel className="text-center text-xl lg:w-20 lg:min-w-20 lg:border-r lg:border-border lg:p-0">
     <a href={href}>
       {thumbnail ? (
-        <img
-          className="max-w-20 lg:absolute lg:inset-0 lg:h-full lg:w-full lg:object-cover"
-          role="presentation"
-          src={thumbnail}
-        />
+        <div className="lg:aspect-square lg:overflow-hidden">
+          <img className="max-w-20 lg:size-full lg:object-cover" role="presentation" src={thumbnail} />
+        </div>
       ) : (
         placeholder
       )}


### PR DESCRIPTION
Fixes #3732

The thumbnails in the Home and Products sections were rendering non-square because `ProductIconCell` used absolute positioning (`lg:absolute lg:inset-0`) which stretched images to fill the table cell's variable height. Wrapped the thumbnail in an `aspect-square` container to enforce square dimensions.

## Before (from issue)
<img width="809" alt="before" src="https://github.com/user-attachments/assets/03647f5e-5af2-43c9-8983-43c98f4a7672" />
<img width="742" alt="before-2" src="https://github.com/user-attachments/assets/3690df66-8f98-4509-8976-035449b9edb5" />

## After
Thumbnails render as squares in both the Home dashboard and Products table. The `aspect-square` wrapper constrains the image dimensions regardless of the table row height.

AI disclosure: Claude Opus 4.6 via OpenClaw.