### PR TITLE
Fix inconsistent spacing in Referrer table

### DIFF
--- a/app/javascript/components/Analytics/ReferrersTable.tsx
+++ b/app/javascript/components/Analytics/ReferrersTable.tsx
@@ -4,7 +4,6 @@ import { formatPriceCentsWithCurrencySymbol } from "$app/utils/currency";
 
 import { type AnalyticsReferrerTotals } from "$app/components/Analytics";
 import { Button } from "$app/components/Button";
-import { InputGroup } from "$app/components/ui/InputGroup";
 import { Table, TableBody, TableCaption, TableCell, TableHead, TableHeader, TableRow } from "$app/components/ui/Table";
 import { useClientSortingTableDriver } from "$app/components/useSortingTableDriver";
 
@@ -35,7 +34,7 @@ export const ReferrersTable = ({ data }: { data: AnalyticsReferrerTotals }) => {
   }, [data]);
 
   return (
-    <section className="flex flex-col gap-4">
+    <section>
       <Table>
         <TableCaption>
           <a href="/help/article/74-the-analytics-dashboard" target="_blank" rel="noreferrer">
@@ -52,17 +51,23 @@ export const ReferrersTable = ({ data }: { data: AnalyticsReferrerTotals }) => {
           </TableRow>
         </TableHeader>
         <TableBody>
-          {items.slice(0, maxRowsShown).map(({ referrer, sales, views, totals, conversion }) => (
-            <TableRow key={referrer}>
-              <TableCell>{referrer === "direct" ? "Direct, email, IM" : referrer}</TableCell>
-              <TableCell>{views}</TableCell>
-              <TableCell>{sales}</TableCell>
-              <TableCell>{`${(conversion * 100).toFixed(1).replace(".0", "")}%`}</TableCell>
-              <TableCell>
-                {formatPriceCentsWithCurrencySymbol("usd", totals, { symbolFormat: "short", noCentsIfWhole: true })}
-              </TableCell>
+          {items.length ? (
+            items.slice(0, maxRowsShown).map(({ referrer, sales, views, totals, conversion }) => (
+              <TableRow key={referrer}>
+                <TableCell>{referrer === "direct" ? "Direct, email, IM" : referrer}</TableCell>
+                <TableCell>{views}</TableCell>
+                <TableCell>{sales}</TableCell>
+                <TableCell>{`${(conversion * 100).toFixed(1).replace(".0", "")}%`}</TableCell>
+                <TableCell>
+                  {formatPriceCentsWithCurrencySymbol("usd", totals, { symbolFormat: "short", noCentsIfWhole: true })}
+                </TableCell>
+              </TableRow>
+            ))
+          ) : (
+            <TableRow>
+              <TableCell colSpan={5}>Nothing yet</TableCell>
             </TableRow>
-          ))}
+          )}
         </TableBody>
       </Table>
       {items.length > maxRowsShown && (
@@ -70,7 +75,6 @@ export const ReferrersTable = ({ data }: { data: AnalyticsReferrerTotals }) => {
           Show more
         </Button>
       )}
-      {items.length ? null : <InputGroup>Nothing yet</InputGroup>}
     </section>
   );
 };


### PR DESCRIPTION
Fixes #3744

Removed `flex flex-col gap-4` from the Referrer section wrapper and moved the "Nothing yet" empty state inside the table body as a `TableRow`/`TableCell`, matching the Locations table pattern. This ensures both tables render as a single cohesive table whether or not there's data.

## Before (no data period)
![before-referrer-empty](https://github.com/user-attachments/assets/4274e582-8796-4690-a94e-d8c5b62c0932)

## After (no data period)
![after-referrer-fixed](https://github.com/user-attachments/assets/e070bde5-7b00-4304-b4f1-fd955578ddfe)

Both Referrer and Locations tables now look identical in the empty state: a single table with heading, column headers, and "Nothing yet" row.

AI disclosure: Claude Opus 4.6 via OpenClaw.