### PR TITLE
Fix YouTube video embed by using proper JSON parser

### DIFF
--- a/config/initializers/oembed.rb
+++ b/config/initializers/oembed.rb
@@ -1,0 +1,3 @@
+require "json"
+require "oembed/formatter/json/backends/jsongem"
+OEmbed::Formatter::JSON.backend = OEmbed::Formatter::JSON::Backends::JSONGem


### PR DESCRIPTION
Fixes #3796

The `ruby-oembed` gem defaulted to a YAML-based JSON parser (`Psych`) which failed on YouTube's oembed response because the embedded HTML characters confused the YAML parser.

Created a new initializer that configures the gem to use the proper JSON gem backend.

## Before

```ruby
OEmbed::Providers.get('https://youtu.be/ffkECKX-WgU')
# => OEmbed::ParseError: Invalid JSON string
# Also fails for full URLs:
OEmbed::Providers.get('https://www.youtube.com/watch?v=ffkECKX-WgU')
# => OEmbed::ParseError: Invalid JSON string
```

## After

```ruby
OEmbed::Providers.get('https://youtu.be/ffkECKX-WgU')
# => #<OEmbed::Response type="video">
OEmbed::Providers.get('https://www.youtube.com/watch?v=ffkECKX-WgU')
# => #<OEmbed::Response type="video">
```

The root cause is that `ruby-oembed` v0.17.0 defaults to parsing JSON via `Psych.safe_load` (YAML parser), which chokes on YouTube's response containing embedded HTML with angle brackets and quotes. Configuring the JSON gem backend fixes all YouTube embed URLs.

AI disclosure: Claude Opus 4.6 via OpenClaw.