### PR TITLE
Fix flaky UTM links pagination test race condition

### DIFF
--- a/app/javascript/pages/UtmLinks/Index.tsx
+++ b/app/javascript/pages/UtmLinks/Index.tsx
@@ -120,10 +120,12 @@ export default function UtmLinksIndex() {
   const query = initialQuery ?? "";
 
   const onChangePage = (newPage: number) => {
+    fetchUtmLinksStats.cancel();
     router.reload({ data: { page: newPage } });
   };
 
   const onSetSort = (newSort: Sort<SortKey> | null) => {
+    fetchUtmLinksStats.cancel();
     setSort(newSort);
     router.reload({
       data: {

--- a/spec/requests/analytics/utm_links_spec.rb
+++ b/spec/requests/analytics/utm_links_spec.rb
@@ -125,13 +125,13 @@ describe "UTM links", :js, type: :system do
         expect(page).to have_button("Previous", disabled: true)
         expect(page).to have_button("Next")
         click_on "Next"
-        expect(page).to have_table_row({ "Link" => utm_link1.title })
-        expect(page).to_not have_table_row({ "Link" => utm_link2.title })
+        expect(page).to have_button("Next", disabled: true)
+        expect(page).to have_button("Previous")
         expect(page).to have_button("2", aria: { current: "page" })
         expect(page).to have_button("1")
         expect(page).to_not have_button("3")
-        expect(page).to have_button("Previous")
-        expect(page).to have_button("Next", disabled: true)
+        expect(page).to have_table_row({ "Link" => utm_link1.title })
+        expect(page).to_not have_table_row({ "Link" => utm_link2.title })
         expect(page).to have_current_path(dashboard_utm_links_path({ page: 2 }))
       end
 


### PR DESCRIPTION
Closes #3930

## What

Fixed a race condition in `UtmLinks/Index.tsx` where clicking pagination or sort triggers `router.reload`, which updates `utmLinks` and fires a `useEffect` that calls a debounced `fetchUtmLinksStats` (500ms delay). That stats fetch fires a second `router.reload` mid-navigation, causing page flicker that made Capybara assertions intermittently fail.

Two changes:
1. Cancel the pending debounced `fetchUtmLinksStats` call in `onChangePage` and `onSetSort` before triggering `router.reload`, preventing the competing reload
2. Reorder test assertions so page button state checks (`have_button("Next", disabled: true)`) come first as a sync point, confirming pagination completed before checking table content

## Why

This test was flaky in CI due to the two competing `router.reload` calls. The fix addresses the root cause in the component (not just the test) so the race condition can't affect users either. The assertion reorder makes the test more robust by waiting for the strongest signal that navigation completed.

---

This PR was implemented with AI assistance using Claude Opus 4.6.

Prompts used:

- "Fix flaky UTM links pagination test (router.reload race condition)"
- Gianfranco reviewed the branch and requested PR creation
