### PR TITLE
Remove pre-submit tax UI assertions from checkout tests

### DIFF
--- a/spec/requests/purchases/product/shipping/shipping_spec.rb
+++ b/spec/requests/purchases/product/shipping/shipping_spec.rb
@@ -16,12 +16,7 @@ describe("Product Page - Shipping Scenarios", type: :system, js: true, shipping:
 
     visit "/l/#{@product.unique_permalink}"
     add_to_cart(@product)
-    check_out(@product, address: { street: "3029 W Sherman Rd", city: "San Tan Valley", state: "AZ", zip_code: "85144" }, should_verify_address: true) do
-      expect(page).to have_text("Subtotal US$153.24", normalize_ws: true)
-      expect(page).to have_text("Sales tax US$10.27", normalize_ws: true)
-      expect(page).to have_text("Shipping rate US$30.65", normalize_ws: true)
-      expect(page).to have_text("Total US$194.16", normalize_ws: true)
-    end
+    check_out(@product, address: { street: "3029 W Sherman Rd", city: "San Tan Valley", state: "AZ", zip_code: "85144" }, should_verify_address: true)
 
     expect(Purchase.last.price_cents).to eq(18389)
     expect(Purchase.last.shipping_cents).to eq(3065)
@@ -40,12 +35,7 @@ describe("Product Page - Shipping Scenarios", type: :system, js: true, shipping:
 
     visit "/l/#{@product.unique_permalink}"
     add_to_cart(@product)
-    check_out(@product, address: { street: "3029 W Sherman Rd", city: "San Tan Valley", state: "AZ", zip_code: "85144" }, should_verify_address: true) do
-      expect(page).to have_text("Subtotal US$100", normalize_ws: true)
-      expect(page).to have_text("Sales tax US$6.70", normalize_ws: true)
-      expect(page).to have_text("Shipping rate US$20", normalize_ws: true)
-      expect(page).to have_text("Total US$126.70", normalize_ws: true)
-    end
+    check_out(@product, address: { street: "3029 W Sherman Rd", city: "San Tan Valley", state: "AZ", zip_code: "85144" }, should_verify_address: true)
 
     expect(Purchase.last.price_cents).to eq(12000)
     expect(Purchase.last.shipping_cents).to eq(2000)
@@ -86,10 +76,7 @@ describe("Product Page - Shipping Scenarios", type: :system, js: true, shipping:
     expect(page).to have_selector("[role='status']", text: "$50 off will be applied at checkout (Code #{@offer_code.code.upcase})")
     expect(page).to have_selector("[itemprop='price']", text: "$100 $50")
     add_to_cart(@product, quantity: 2, offer_code: @offer_code)
-    check_out(@product, should_verify_address: true) do
-      expect(page).to have_text("Shipping rate US$35", normalize_ws: true)
-      expect(page).to have_text("Total US$135", normalize_ws: true)
-    end
+    check_out(@product, should_verify_address: true)
 
     expect(Purchase.last.price_cents).to eq(13500)
     expect(Purchase.last.shipping_cents).to eq(3500)

--- a/spec/requests/purchases/product/taxes_spec.rb
+++ b/spec/requests/purchases/product/taxes_spec.rb
@@ -3,7 +3,7 @@
 require("spec_helper")
 
 describe("Product Page - Tax Scenarios", type: :system, js: true) do
-  describe "sales tax", shipping: true do
+  describe "sales tax", shipping: true, force_vcr_on: true do
     before do
       @creator = create(:user_with_compliance_info)
 
@@ -13,10 +13,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
     it "calls the tax endpoint for a real zip code that doesn't show in the enterprise zip codes database" do
       visit("/l/#{@product.unique_permalink}")
       add_to_cart(@product)
-      check_out(@product, address: { street: "3029 W Sherman Rd", city: "San Tan Valley", state: "AZ", zip_code: "85144", country: "US" }, should_verify_address: true) do
-        expect(page).to have_text("Subtotal US$500", normalize_ws: true)
-        expect(page).to have_text("Sales tax US$53.50", normalize_ws: true)
-      end
+      check_out(@product, address: { street: "3029 W Sherman Rd", city: "San Tan Valley", state: "AZ", zip_code: "85144", country: "US" }, should_verify_address: true)
 
       expect(page).to have_text("Your purchase was successful!")
 
@@ -52,11 +49,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
 
         visit("/l/#{@product.unique_permalink}")
         add_to_cart(@product, option: "type 1")
-        check_out(@product, address: { street: "3029 W Sherman Rd", city: "San Tan Valley", state: "AZ", zip_code: "85144" }, should_verify_address: true) do
-          expect(page).to have_text("Subtotal US$501.50", normalize_ws: true)
-          expect(page).to have_text("Sales tax US$53.66", normalize_ws: true)
-          expect(page).to have_text("Total US$555.16", normalize_ws: true)
-        end
+        check_out(@product, address: { street: "3029 W Sherman Rd", city: "San Tan Valley", state: "AZ", zip_code: "85144" }, should_verify_address: true)
 
         expect(page).to have_text("Your purchase was successful!")
 
@@ -85,13 +78,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
 
         visit "/l/#{@product.unique_permalink}/taxoffer"
         add_to_cart(@product, offer_code:)
-        check_out(@product, address: { street: "3029 W Sherman Rd", city: "San Tan Valley", state: "AZ", zip_code: "85144" }, should_verify_address: true) do
-          expect(page).to have_text("$500")
-          expect(page).to have_text("Subtotal US$500", normalize_ws: true)
-          expect(page).to have_text("Sales tax US$42.80", normalize_ws: true)
-          expect(page).to have_text("Discounts taxoffer US$-100", normalize_ws: true)
-          expect(page).to have_text("Total US$442.80", normalize_ws: true)
-        end
+        check_out(@product, address: { street: "3029 W Sherman Rd", city: "San Tan Valley", state: "AZ", zip_code: "85144" }, should_verify_address: true)
 
         expect(page).to have_text("Your purchase was successful!")
 
@@ -169,11 +156,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
       expect(page).to have_text("$100")
 
       add_to_cart(product)
-      check_out(product, zip_code: "53703") do
-        expect(page).to have_text("Subtotal US$100", normalize_ws: true)
-        expect(page).to have_text("Sales tax US$5.50", normalize_ws: true)
-        expect(page).to have_text("Total US$105.50", normalize_ws: true)
-      end
+      check_out(product, zip_code: "53703")
 
       purchase = Purchase.last
       expect(purchase.total_transaction_cents).to eq(105_50)
@@ -189,11 +172,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
       expect(page).to have_text("$100")
 
       add_to_cart(product)
-      check_out(product, address: { street: "1 S Pinckney St", state: "WI", city: "Madison", zip_code: "53703" }, should_verify_address: true) do
-        expect(page).to have_text("Subtotal US$100", normalize_ws: true)
-        expect(page).to have_text("Sales tax US$5.50", normalize_ws: true)
-        expect(page).to have_text("Total US$105.50", normalize_ws: true)
-      end
+      check_out(product, address: { street: "1 S Pinckney St", state: "WI", city: "Madison", zip_code: "53703" }, should_verify_address: true)
 
       purchase = Purchase.last
       expect(purchase.total_transaction_cents).to eq(105_50)
@@ -209,11 +188,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
       expect(page).to have_text("$100")
 
       add_to_cart(product)
-      check_out(product, zip_code: "98121") do
-        expect(page).to have_text("Subtotal US$100", normalize_ws: true)
-        expect(page).to have_text("Sales tax US$10.35", normalize_ws: true)
-        expect(page).to have_text("Total US$110.35", normalize_ws: true)
-      end
+      check_out(product, zip_code: "98121")
 
       purchase = Purchase.last
       expect(purchase.total_transaction_cents).to eq(110_35)
@@ -245,11 +220,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
       expect(page).to have_text("$100")
 
       add_to_cart(product)
-      check_out(product, zip_code: "53703") do
-        expect(page).to have_text("Subtotal US$100", normalize_ws: true)
-        expect(page).to have_text("Sales tax US$5.50", normalize_ws: true)
-        expect(page).to have_text("Total US$105.50", normalize_ws: true)
-      end
+      check_out(product, zip_code: "53703")
 
       purchase = Purchase.last
       expect(purchase.total_transaction_cents).to eq(105_50)
@@ -308,9 +279,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
       add_to_cart(@vat_link)
 
       expect(page).to have_text("VAT US$22", normalize_ws: true)
-      check_out(@vat_link, vat_id: "NL860999063B01", zip_code: nil, credit_card: { number: "4000003800000008" }) do
-        expect(page).not_to have_text("VAT US$", normalize_ws: true)
-      end
+      check_out(@vat_link, vat_id: "NL860999063B01", zip_code: nil, credit_card: { number: "4000003800000008" })
 
       purchase = Purchase.last
       expect(purchase.total_transaction_cents).to eq(100_00)
@@ -347,9 +316,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         visit "/l/#{product.unique_permalink}"
         add_to_cart(product, option: "First Tier")
         expect(page).to(have_text("VAT US$0.66", normalize_ws: true))
-        check_out(product, vat_id: "NL860999063B01", zip_code: nil, credit_card: { number: "4000003800000008" }) do
-          expect(page).not_to have_text("VAT US$", normalize_ws: true)
-        end
+        check_out(product, vat_id: "NL860999063B01", zip_code: nil, credit_card: { number: "4000003800000008" })
 
         purchase = Purchase.last
         expect(purchase.total_transaction_cents).to eq(3_00)
@@ -456,9 +423,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
 
       add_to_cart(@product)
       expect(page).to have_text("Total US$110", normalize_ws: true)
-      check_out(@product, abn_id: "51824753556", zip_code: nil, credit_card: { number: "4000000360000006" }) do
-        expect(page).not_to have_text("GST")
-      end
+      check_out(@product, abn_id: "51824753556", zip_code: nil, credit_card: { number: "4000000360000006" })
 
       purchase = Purchase.last
       expect(purchase.total_transaction_cents).to eq(100_00)
@@ -575,9 +540,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
 
         add_to_cart(@product)
         expect(page).to have_text("GST US$8", normalize_ws: true)
-        check_out(@product, gst_id: "T9100001B", zip_code: nil, credit_card: { number: "4000007020000003" }) do
-          expect(page).not_to have_text("GST US$8", normalize_ws: true)
-        end
+        check_out(@product, gst_id: "T9100001B", zip_code: nil, credit_card: { number: "4000007020000003" })
 
         purchase = Purchase.last
         expect(purchase.total_transaction_cents).to eq(100_00)
@@ -712,9 +675,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
       expect(page).to have_text("$100")
       add_to_cart(@product)
 
-      check_out(@product, zip_code: nil, credit_card: { number: "4000000360000006" }, mva_id: "977074010MVA") do
-        expect(page).not_to have_text("VAT")
-      end
+      check_out(@product, zip_code: nil, credit_card: { number: "4000000360000006" }, mva_id: "977074010MVA")
 
       purchase = Purchase.last
       expect(purchase.total_transaction_cents).to eq(100_00)
@@ -2946,9 +2907,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         add_to_cart(@product)
 
         expect(page).to have_text("VAT US$5", normalize_ws: true)
-        check_out(@product, oman_vat_number: "OM1234567890", zip_code: nil, credit_card: { number: "4000000360000006" }) do
-          expect(page).not_to have_text("VAT US$", normalize_ws: true)
-        end
+        check_out(@product, oman_vat_number: "OM1234567890", zip_code: nil, credit_card: { number: "4000000360000006" })
 
         purchase = Purchase.last
         expect(purchase.total_transaction_cents).to eq(100_00)
@@ -4023,9 +3982,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         expect(page).to have_select("Country", selected: "Canada")
         expect(page).to have_select("Province", selected: "ON")
 
-        check_out(product, address: { street: "568 Beatty St", city: "Vancouver", state: "BC", zip_code: "V6B 2L3" }, should_verify_address: true) do
-          expect(page).to have_text("Tax US$12", normalize_ws: true)
-        end
+        check_out(product, address: { street: "568 Beatty St", city: "Vancouver", state: "BC", zip_code: "V6B 2L3" }, should_verify_address: true)
 
         purchase = Purchase.last
         expect(purchase.total_transaction_cents).to eq(112_00)


### PR DESCRIPTION
Closes #3931

## What

Removed all remaining pre-submit UI assertions from `check_out` blocks in `taxes_spec.rb` (14 blocks) and `shipping_spec.rb` (3 blocks). These assertions checked exact tax/total amounts before clicking "Pay", but tax amounts are computed asynchronously after form fill, so assertions often ran before the response arrived.

Also added `force_vcr_on: true` to the `"sales tax", shipping: true` describe block to fix a VCR/JS conflict where `setup_js` turns off VCR but the shipping hook turns it back on with WebMock still allowing net connections.

## Why

These are the biggest source of CI flakiness by volume. PRs #3822 and #3823 already proved this pattern works for WA and Canada tests. Post-purchase database assertions already verify tax correctness, so the pre-submit UI checks are redundant and just introduce race conditions.

---

This PR was implemented with AI assistance using Claude Opus 4.6.

Prompts used:

- "Investigate issue #3931"
- "Implement the fix following the pattern from #3822 and #3823"
- "Add force_vcr_on: true to the shipping describe block to fix the VCR conflict"