### PR TITLE
Fix flaky UTM links pagination test race condition

### DIFF
--- a/app/javascript/pages/UtmLinks/Index.tsx
+++ b/app/javascript/pages/UtmLinks/Index.tsx
@@ -120,10 +120,12 @@ export default function UtmLinksIndex() {
   const query = initialQuery ?? "";
 
   const onChangePage = (newPage: number) => {
+    fetchUtmLinksStats.cancel();
     router.reload({ data: { page: newPage } });
   };
 
   const onSetSort = (newSort: Sort<SortKey> | null) => {
+    fetchUtmLinksStats.cancel();
     setSort(newSort);
     router.reload({
       data: {

--- a/spec/requests/analytics/utm_links_spec.rb
+++ b/spec/requests/analytics/utm_links_spec.rb
@@ -125,13 +125,13 @@ describe "UTM links", :js, type: :system do
         expect(page).to have_button("Previous", disabled: true)
         expect(page).to have_button("Next")
         click_on "Next"
-        expect(page).to have_table_row({ "Link" => utm_link1.title })
-        expect(page).to_not have_table_row({ "Link" => utm_link2.title })
+        expect(page).to have_button("Next", disabled: true)
+        expect(page).to have_button("Previous")
         expect(page).to have_button("2", aria: { current: "page" })
         expect(page).to have_button("1")
         expect(page).to_not have_button("3")
-        expect(page).to have_button("Previous")
-        expect(page).to have_button("Next", disabled: true)
+        expect(page).to have_table_row({ "Link" => utm_link1.title })
+        expect(page).to_not have_table_row({ "Link" => utm_link2.title })
         expect(page).to have_current_path(dashboard_utm_links_path({ page: 2 }))
       end
 


### PR DESCRIPTION
Fixes #3930

## What

Cancels the debounced `fetchUtmLinksStats` call in `onChangePage` and `onSetSort` before triggering `router.reload`. This prevents a competing reload from the stats fetch (500ms debounce) from firing mid-navigation, which caused page flicker and intermittent Capybara assertion failures.

Also reordered the test assertions so the disabled "Next" button check comes first as a reliable sync point before checking table content.

## Why

Two `router.reload` calls were racing: one from pagination and one from the debounced stats fetch. Capybara assertions would intermittently fail when the second reload caused a page flicker mid-assertion. This test failed in ~30% of CI runs on main. Canceling the pending debounce on user-initiated actions eliminates the race condition entirely.

---

This PR was implemented with AI assistance using Claude Opus 4.6.

Prompts used:

- "Investigate issue #3930"
- "Fix the race condition between pagination reload and debounced stats fetch"
- "Reorder test assertions to use button state as sync point"