### PR TITLE
Fix CountrySelectionModal navigation when no Inertia history exists

### DIFF
--- a/app/javascript/components/CountrySelectionModal.tsx
+++ b/app/javascript/components/CountrySelectionModal.tsx
@@ -1,4 +1,3 @@
-import { router } from "@inertiajs/react";
 import * as React from "react";
 import { cast } from "ts-safe-cast";
 
@@ -57,7 +56,7 @@ export const CountrySelectionModal = ({ country: initialCountry, countries }: Pr
           if (previousRoute) {
             window.history.back();
           } else {
-            router.get(Routes.dashboard_path());
+            window.location.href = Routes.dashboard_path();
           }
         }}
         title="Where are you located?"


### PR DESCRIPTION
Fixes #3945

## What

Replace `router.get(Routes.dashboard_path())` with `window.location.href = Routes.dashboard_path()` in `CountrySelectionModal`'s `onClose` handler (the `else` branch, when there's no Inertia history). Remove the now-unused `router` import.

## Why

`router.get()` performs an Inertia XHR navigation, which silently fails when there's no Inertia session context (Capybara does a full `visit`, not an Inertia navigation). This caused the test to see `nil` for the current path because the navigation never actually happened. Using `window.location.href` does a real page navigation that works regardless of Inertia state.

---

This PR was implemented with AI assistance using Claude Opus 4.6.

Prompts used:

- "Fix flaky payments_spec.rb:6202 — country selection modal close navigation test times out because router.get() silently fails without Inertia context"
- "Replace router.get with window.location.href since there's no Inertia history in this branch"
