### PR TITLE
Guard prefetch side effects in controllers

### DIFF
--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -21,7 +21,7 @@ class CustomersController < Sellers::BaseController
       pagination: { page: 1, pages: (sales.results.total / CUSTOMERS_PER_PAGE.to_f).ceil, next: nil },
       count: sales.results.total
     )
-    create_user_event("customers_view")
+    create_user_event("customers_view") unless request.headers["X-Inertia-Partial-Data"]
 
     render inertia: "Customers/Index",
            props: { customers_presenter: customers_presenter.customers_props }

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -13,7 +13,7 @@ class DashboardController < Sellers::BaseController
     if current_seller.suspended_for_tos_violation?
       redirect_to products_url
     else
-      LargeSeller.create_if_warranted(current_seller)
+      LargeSeller.create_if_warranted(current_seller) unless request.headers["X-Inertia-Partial-Data"]
       presenter = CreatorHomePresenter.new(pundit_user)
       render inertia: "Dashboard/Index",
              props: { creator_home: presenter.creator_home_props }


### PR DESCRIPTION
Part of #3810

## What

Guard two write side effects behind `unless request.headers["X-Inertia-Partial-Data"]`:

- `LargeSeller.create_if_warranted(current_seller)` in `DashboardController#index`
- `create_user_event("customers_view")` in `CustomersController#index`

## Why

Inertia prefetch fires real controller requests before the user navigates to a page. Without these guards, hovering or mount-prefetching those pages would trigger writes — creating a LargeSeller record or logging a user event — on every prefetch, not just on actual navigation.

Phase 2 of #3810 will defer heavy data behind `InertiaRails.defer`, which causes Inertia to issue partial refetch requests (with `X-Inertia-Partial-Data` set). These guards ensure those requests also skip the side effects. This PR lands the guards first as a safe prerequisite.

---

This PR was implemented with AI assistance using Claude Sonnet 4.6.

Prompts used:

- "PR 2 of 4 — Guard prefetch side effects in controllers"