### PR TITLE
Defer heavy controller data for Communities page

### DIFF
--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -17,8 +17,12 @@ class CommunitiesController < ApplicationController
     else
       render inertia: "Communities/Index", props: {
         has_products: -> { communities_presenter.has_products? },
-        communities: -> { communities_presenter.communities_props },
-        notification_settings: -> { communities_presenter.notification_settings_props }
+        communities_data: InertiaRails.defer do
+          {
+            communities: communities_presenter.communities_props,
+            notification_settings: communities_presenter.notification_settings_props,
+          }
+        end,
       }
     end
   end
@@ -28,8 +32,12 @@ class CommunitiesController < ApplicationController
 
     render inertia: "Communities/Index", props: {
       has_products: -> { communities_presenter.has_products? },
-      communities: -> { communities_presenter.communities_props },
-      notification_settings: -> { communities_presenter.notification_settings_props },
+      communities_data: InertiaRails.defer do
+        {
+          communities: communities_presenter.communities_props,
+          notification_settings: communities_presenter.notification_settings_props,
+        }
+      end,
       selectedCommunityId: @community.external_id,
       messages: messages_scroll_prop
     }

--- a/app/javascript/components/Communities/ContentLoading.tsx
+++ b/app/javascript/components/Communities/ContentLoading.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+import { Skeleton } from "$app/components/Skeleton";
+
+export const CommunitiesContentLoading = () => (
+  <div className="p-4 md:p-8">
+    <div className="space-y-4">
+      <Skeleton className="h-8 w-48" />
+      <Skeleton className="h-16 w-full" />
+      <Skeleton className="h-16 w-full" />
+      <Skeleton className="h-16 w-full" />
+    </div>
+  </div>
+);

--- a/app/javascript/components/Communities/useCommunities.ts
+++ b/app/javascript/components/Communities/useCommunities.ts
@@ -10,10 +10,14 @@ export type CommunityDraft = {
   isSending: boolean;
 };
 
-interface PageProps {
-  has_products: boolean;
+interface CommunitiesData {
   communities: Community[];
   notification_settings: CommunityNotificationSettings;
+}
+
+interface PageProps {
+  has_products: boolean;
+  communities_data?: CommunitiesData;
   selectedCommunityId?: string;
 }
 
@@ -22,12 +26,10 @@ const sortByName = <T extends { name: string }>(items: readonly T[]) =>
 
 export const useCommunities = () => {
   const pageProps = cast<PageProps>(usePage().props);
-  const {
-    has_products,
-    communities: initialCommunities,
-    notification_settings,
-    selectedCommunityId: initialSelectedCommunityId,
-  } = pageProps;
+  const { has_products, communities_data, selectedCommunityId: initialSelectedCommunityId } = pageProps;
+
+  const initialCommunities = communities_data?.communities ?? [];
+  const notification_settings = communities_data?.notification_settings ?? {};
 
   const [communities, setCommunities] = React.useState<Community[]>(sortByName(initialCommunities));
   const [notificationSettings, setNotificationSettings] =
@@ -78,6 +80,7 @@ export const useCommunities = () => {
   );
 
   return {
+    isLoading: !communities_data,
     hasProducts: has_products,
     communities,
     notificationSettings,

--- a/app/javascript/pages/Communities/Index.tsx
+++ b/app/javascript/pages/Communities/Index.tsx
@@ -14,6 +14,7 @@ import { Button, NavigationButton } from "$app/components/Button";
 import { ChatMessageInput } from "$app/components/Communities/ChatMessageInput";
 import { ChatMessageList } from "$app/components/Communities/ChatMessageList";
 import { CommunityList } from "$app/components/Communities/CommunityList";
+import { CommunitiesContentLoading } from "$app/components/Communities/ContentLoading";
 import { ScrollToBottomButton } from "$app/components/Communities/ScrollToBottomButton";
 import { DateSeparator } from "$app/components/Communities/Separator";
 import { useCommunities } from "$app/components/Communities/useCommunities";
@@ -86,6 +87,7 @@ function CommunitiesIndex() {
 
   const isAboveBreakpoint = useIsAboveBreakpoint("lg");
   const {
+    isLoading,
     hasProducts,
     communities,
     notificationSettings,
@@ -516,7 +518,9 @@ function CommunitiesIndex() {
       <div className="flex h-screen flex-col">
         <GoBackHeader />
 
-        {communities.length === 0 ? (
+        {isLoading ? (
+          <CommunitiesContentLoading />
+        ) : communities.length === 0 ? (
           <EmptyCommunitiesPlaceholder hasProducts={hasProducts} />
         ) : selectedCommunity ? (
           <div className="flex flex-1 overflow-hidden">


### PR DESCRIPTION
## Summary

Defers the expensive communities and notification settings presenter calls on the Communities page using `InertiaRails.defer`, so the page shell renders immediately while community data loads asynchronously.

- Groups `communities` and `notification_settings` into a single `communities_data` deferred prop in both `index` and `show` actions
- Updates the `useCommunities` hook to handle optional `communities_data` with safe defaults, and exposes an `isLoading` flag
- Adds `CommunitiesContentLoading` skeleton component shown as fallback during the deferred fetch
- Uses `isLoading` in `CommunitiesIndex` to display the skeleton before community data is available

Part of #3810; replaces #3951.

## Test plan

- [ ] Visit `/communities` — page shell renders immediately, then community list loads
- [ ] Skeleton loading state is visible briefly before communities appear
- [ ] Community list, messages, and notification settings work correctly after load
- [ ] Empty state (no communities) still shows correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)