### PR TITLE
Migrate `<main>` base styles from _global.scss to Tailwind

### DIFF
--- a/app/javascript/components/Profile/Layout.tsx
+++ b/app/javascript/components/Profile/Layout.tsx
@@ -72,7 +72,7 @@ export const Layout = ({ creatorProfile, hideFollowForm, children }: LayoutProps
           {isDesktop ? headerButtons : null}
         </div>
       </header>
-      <main className="flex-1">
+      <main className="flex flex-1 flex-col">
         {children}
         <PoweredByFooter className="mx-auto w-full max-w-6xl lg:py-6 lg:text-left" />
       </main>

--- a/app/javascript/inertia/layout.tsx
+++ b/app/javascript/inertia/layout.tsx
@@ -39,7 +39,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
         <Alert initial={null} />
         <div id="inertia-shell" className="flex h-screen flex-col lg:flex-row">
           {logged_in_user ? <Nav title="Dashboard" /> : null}
-          <main scroll-region="" className="flex-1 overflow-y-auto">
+          <main scroll-region="" className="flex flex-1 flex-col overflow-y-auto">
             {children}
           </main>
         </div>
@@ -89,7 +89,7 @@ export function StandaloneLayout({ children }: { children: React.ReactNode }) {
         <MetaTags />
         <Alert initial={null} />
         <div className="flex min-h-screen flex-col lg:flex-row">
-          <main className="flex-1">{children}</main>
+          <main className="flex flex-1 flex-col">{children}</main>
         </div>
       </CurrentSellerProvider>
     </LoggedInUserProvider>

--- a/app/javascript/stylesheets/_global.scss
+++ b/app/javascript/stylesheets/_global.scss
@@ -49,11 +49,6 @@
     }
   }
 
-  main {
-    display: flex;
-    flex-direction: column;
-  }
-
   @for $i from 1 through 5 {
     h#{$i} {
       @include font-size(6 - $i);


### PR DESCRIPTION
Issue https://github.com/antiwork/gumroad/issues/3008

Removes `main { display: flex; flex-direction: column }` from `_global.scss` and adds `flex flex-col` explicitly to the layouts whose direct children depend on a flex parent.

Not all `<main>` elements needed updating, ones inside `<Card asChild>` already receive `display: grid` from Card's className, and others have no direct children using `flex-1`.

## Screenshots of pages that need `flex flex-col`
| Page    | With 'flex flex-col' | If without 'flex flex-col' |
| -------- | ------- | ------- |
| Profile page, when a creator has no sections  |  <img width="221" height="476" alt="Screenshot 2026-03-12 at 15 34 35" src="https://github.com/user-attachments/assets/079d12e9-b32b-4e59-ab82-107c039de599" />   |  <img width="223" height="476" alt="Screenshot 2026-03-12 at 15 34 44" src="https://github.com/user-attachments/assets/fef08131-9939-481c-8649-281c5381db89" /> |
| Secure Redirect |   <img width="309" height="659" alt="Screenshot 2026-03-12 at 15 29 23" src="https://github.com/user-attachments/assets/95fb2c7e-2a63-4f04-a6b5-d9285961f931" />   | <img width="307" height="656" alt="Screenshot 2026-03-12 at 15 29 10" src="https://github.com/user-attachments/assets/c088645f-4a7f-481f-8747-d67d5a8f5048" />| 
| Download Page |  <img width="1218" height="793" alt="image" src="https://github.com/user-attachments/assets/9d30ce65-431b-4918-803d-cfebfb4687f3" />  | <img width="1220" height="793" alt="image" src="https://github.com/user-attachments/assets/ebbbdf5a-60d6-49ed-ac6b-fab648d834c3" /> |
