### PR TITLE
Remove header tab text-decoration override from _legacy.scss

### DIFF
--- a/app/javascript/stylesheets/_legacy.scss
+++ b/app/javascript/stylesheets/_legacy.scss
@@ -50,11 +50,3 @@ body#overlay-page {
     }
   }
 }
-
-body > header,
-header.sticky-top,
-main > header {
-  [role="tablist"] a[role="tab"] {
-    text-decoration: none;
-  }
-}


### PR DESCRIPTION
Issue #3008

Removes the `a[role="tab"]` text-decoration override from `_legacy.scss`.

The rule was originally needed to strip underlines from anchor tabs inside headers. This is now handled directly in [ui/Tabs.tsx](https://github.com/antiwork/gumroad/blob/a7890a99f78aacad54d0e7ffd64b6051aa54cd09/app/javascript/components/ui/Tabs.tsx#L80) via the `no-underline`, making the SCSS rule redundant.

