### PR TITLE
Fix flaky payments modal close test

### DIFF
--- a/spec/requests/settings/payments_spec.rb
+++ b/spec/requests/settings/payments_spec.rb
@@ -6203,7 +6203,7 @@ describe("Payments Settings Scenario", type: :system, js: true) do
       visit settings_payments_path
       expect(page).to have_content("Where are you located?")
       find("button[aria-label='Close']").click
-      expect(page).to have_current_path(dashboard_path)
+      expect(page).to have_current_path(dashboard_path, wait: 10)
     end
   end
 


### PR DESCRIPTION
## Summary
- Fixes the intermittently failing test "navigates to dashboard page when modal is closed and no previous page exists" (`payments_spec.rb:6202`)
- The modal close triggers `router.get(Routes.dashboard_path())`, an async Inertia XHR navigation. The test was asserting `have_current_path(dashboard_path)` without waiting, so Capybara sometimes saw `nil` before navigation completed.
- Added `wait: 10` to `have_current_path` so Capybara polls until the async navigation finishes.

## Test plan
- [x] The fix is a single-line change adding Capybara's built-in wait mechanism
- [ ] CI should pass with no flaky failures on this test

Fixes #3945

🤖 Generated with [Claude Code](https://claude.com/claude-code)