### PR TITLE
Migrate .link and .text-singleline to Tailwind

### DIFF
--- a/app/javascript/components/DashboardPage.tsx
+++ b/app/javascript/components/DashboardPage.tsx
@@ -252,10 +252,10 @@ const ProductsTable = ({ sales }: TableProps) => {
           <TableHead {...thProps("revenue")}>Revenue</TableHead>
           <TableHead {...thProps("visits")}>Visits</TableHead>
           <TableHead {...thProps("today")}>Today</TableHead>
-          <TableHead className="text-singleline" {...thProps("last_7")}>
+          <TableHead className="truncate" {...thProps("last_7")}>
             Last 7 days
           </TableHead>
-          <TableHead className="text-singleline" {...thProps("last_30")}>
+          <TableHead className="truncate" {...thProps("last_30")}>
             Last 30 days
           </TableHead>
         </TableRow>

--- a/app/javascript/components/Product/ShareSection.tsx
+++ b/app/javascript/components/Product/ShareSection.tsx
@@ -105,7 +105,7 @@ export const ShareSection = ({
               )}
               aria-label="Add to wishlist"
             >
-              <span className="text-singleline flex-1">
+              <span className="flex-1 truncate">
                 {saveState.type === "success"
                   ? saveState.wishlist.name
                   : saveState.type === "saving"

--- a/app/javascript/components/ProductEdit/ContentTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/index.tsx
@@ -1168,7 +1168,7 @@ export const ContentTab = () => {
                     <ComboBox<Variant>
                       input={(props) => (
                         <InputGroup {...props} className="cursor-pointer py-3" aria-label="Select a version">
-                          <span className="text-singleline flex-1">
+                          <span className="flex-1 truncate">
                             {selectedVariant && !product.has_same_rich_content_for_all_variants
                               ? `Editing: ${selectedVariant.name || "Untitled"}`
                               : "Editing: All versions"}

--- a/app/javascript/components/Profile/EditSections.tsx
+++ b/app/javascript/components/Profile/EditSections.tsx
@@ -409,7 +409,7 @@ const ProductsSettings = ({ section }: { section: ProductsSection }) => {
                     {section.default_product_sort === "page_layout" ? (
                       <RowDragHandle aria-grabbed={product.chosen} />
                     ) : null}
-                    <span className="text-singleline">{product.name}</span>
+                    <span className="truncate">{product.name}</span>
                   </RowContent>
                   <RowActions>
                     <Checkbox

--- a/app/javascript/components/Profile/EditSections/WishlistsSectionView.tsx
+++ b/app/javascript/components/Profile/EditSections/WishlistsSectionView.tsx
@@ -70,7 +70,7 @@ export const WishlistsSectionView = ({ section }: { section: WishlistsSection })
                     <Label role="listitem">
                       <RowContent>
                         <RowDragHandle aria-grabbed={wishlist.chosen} />
-                        <span className="text-singleline">{wishlist.name}</span>
+                        <span className="truncate">{wishlist.name}</span>
                       </RowContent>
                       <RowActions>
                         <Checkbox

--- a/app/javascript/components/TiptapExtensions/CodeBlock.tsx
+++ b/app/javascript/components/TiptapExtensions/CodeBlock.tsx
@@ -84,7 +84,7 @@ const CodeBlockComponent = ({ node, updateAttributes, editor }: NodeViewProps) =
         ) : (
           <CopyToClipboard text={node.textContent}>
             <button
-              className="link cursor-pointer all-unset"
+              className="cursor-pointer text-foreground all-unset"
               style={{ padding: "0 var(--spacer-1)" }}
               aria-label="Copy"
             >

--- a/app/javascript/components/TiptapExtensions/LicenseKey.tsx
+++ b/app/javascript/components/TiptapExtensions/LicenseKey.tsx
@@ -55,7 +55,7 @@ const LicenseKeyNodeView = ({ editor, selected }: NodeViewProps) => {
           <RowContent className="content" contentEditable={false}>
             <Key pack="filled" className="type-icon size-5" />
             <div>
-              <h4 className="text-singleline">{licenseKey}</h4>
+              <h4 className="truncate">{licenseKey}</h4>
               <ul className="inline">
                 <li>{editor.isEditable ? "License key (sample)" : "License key"}</li>
                 {isMultiSeatLicense && seats !== null ? <li>{`${seats} ${seats === 1 ? "Seat" : "Seats"}`}</li> : null}

--- a/app/javascript/components/TiptapExtensions/MediaEmbed.tsx
+++ b/app/javascript/components/TiptapExtensions/MediaEmbed.tsx
@@ -249,9 +249,9 @@ export const ExternalMediaFileEmbed = TiptapNode.create({
           <RowContent className="content">
             <PlayCircle pack="filled" className="type-icon size-5" />
             <div>
-              <h4 className="text-singleline">{node.attrs.title}</h4>
+              <h4 className="truncate">{node.attrs.title}</h4>
               {node.attrs.url ? (
-                <div className="text-singleline">
+                <div className="truncate">
                   <a href={cast(node.attrs.url)} target="_blank" rel="noreferrer">
                     {node.attrs.url}
                   </a>

--- a/app/javascript/components/WorkflowsPage/WorkflowEmails.tsx
+++ b/app/javascript/components/WorkflowsPage/WorkflowEmails.tsx
@@ -662,7 +662,7 @@ const AbandonedCartProductListNodeView = (props: NodeViewProps) => {
       </WithTooltip>
       {abandonedCartProducts.length > shownProductCount ? (
         <button
-          className="link cursor-pointer all-unset"
+          className="cursor-pointer text-foreground underline all-unset"
           onClick={() =>
             setShownProductCount(
               shownProductCount + ABANDONED_CART_PRODUCTS_TO_LOAD_PER_PAGE > abandonedCartProducts.length

--- a/app/javascript/pages/Affiliates/Onboarding.tsx
+++ b/app/javascript/pages/Affiliates/Onboarding.tsx
@@ -170,7 +170,7 @@ export default function AffiliatesOnboarding() {
                   readOnly
                   disabled={!enableAffiliateLink}
                   defaultValue={affiliateRequestUrl}
-                  className="text-singleline"
+                  className="truncate"
                 />
                 {enableAffiliateLink ? (
                   <CopyToClipboard text={affiliateRequestUrl}>

--- a/app/javascript/stylesheets/_global.scss
+++ b/app/javascript/stylesheets/_global.scss
@@ -56,18 +56,10 @@
     }
   }
 
-  .text-singleline {
-    @include text-singleline;
-  }
-
   a {
     color: var(--color);
     text-decoration: underline;
     cursor: pointer;
-  }
-
-  .link {
-    @extend a;
   }
 
   sub {


### PR DESCRIPTION
Issue #3008

Replaces `.text-singleline` and `.link` custom CSS classes with Tailwind utilities, removing both from `_global.scss`.

- `.text-singleline` replaced with Tailwind's built-in `truncate` (identical CSS: `overflow: hidden; white-space: nowrap; text-overflow: ellipsis`)
- `.link` (which used `@extend a`) replaced with `text-foreground underline cursor-pointer`

The `text-singleline` mixin in `_definitions.scss` is kept since it's still used via `@include` in `_global.scss` and `_email.scss`.

## Screenshots (after)

(No visual changes)

### `.text-singleline` to `.truncate`
| Page    | After |
| -------- | ------- | 
| Product page (Long Wishlist name) |  <img width="453" height="201" alt="image" src="https://github.com/user-attachments/assets/1c74ccdd-52da-466d-a2ee-8875fe0b8c8c" />  |
| Product Edit page (Long version name) | <img width="340" height="108" alt="image" src="https://github.com/user-attachments/assets/cd5709a7-37e9-4d9a-8957-ae17a186dcc1" /> |
| Profile page (Long product name on products list)  | <img width="312" height="135" alt="image" src="https://github.com/user-attachments/assets/f54f06e7-424d-4854-bfa2-61fe0f27b1e2" />  |
|  Product edit page (Embed media title and url)  | <img width="493" height="130" alt="image" src="https://github.com/user-attachments/assets/b907384b-f34d-4e87-8f1f-8a829fe84dec" />  |

### `.link` to `text-foreground underline cursor-pointer`
| Page    | After |
| -------- | ------- | 
| Workflow email ("add ... more product" link) |  <img width="746" height="192" alt="image" src="https://github.com/user-attachments/assets/cf459f84-f08a-4ea3-b9a3-e309ad7dd6aa" /> |

---

AI disclosure: Claude Opus 4.6 assisted with identifying all usages, suggesting Tailwind equivalents, and performing the replacements.
