### PR TITLE
Remove unused tab drag styles

### DIFF
--- a/app/javascript/stylesheets/_legacy.scss
+++ b/app/javascript/stylesheets/_legacy.scss
@@ -11,11 +11,6 @@ button[draggable="true"] {
   -webkit-user-drag: element;
 }
 
-[role="tab"][aria-selected="true"][draggable="true"]::after {
-  transform: translate(-50%);
-  visibility: hidden;
-}
-
 [role="tree"] [role="treeitem"].sortable-ghost {
   background-color: gray(1);
   border: dashed $border-width $border-color;


### PR DESCRIPTION
Issue: #3008 

## Description 
Removes the unused legacy tab drag styles from `_legacy.scss` which was used to strip off the styles on the draggable tabs from the actual tabs. 
It is now completely handled by `.sortable-*` in `PageTab.tsx`

https://github.com/antiwork/gumroad/blob/3753544fc1c783ff740d47658d17c7eee3aec443/app/javascript/components/ProductEdit/ContentTab/PageTab.tsx#L68-L70

## Demo (No visual changes)

https://github.com/user-attachments/assets/2bf4baec-2a5f-44c4-bf3a-10673b7207e5

<img width="880" height="831" alt="image" src="https://github.com/user-attachments/assets/99a1fe0e-c1c7-4ec6-974c-24fcef87b335" />


## AI Disclosure 
Used gemini-3.1-pro via Antigravity to verify the old and new usage. Self-reviewed by me.