### PR TITLE
Fix add section button position

### DIFF
--- a/app/javascript/components/Popover.tsx
+++ b/app/javascript/components/Popover.tsx
@@ -21,7 +21,7 @@ export const PopoverTrigger = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <PopoverPrimitive.Trigger
     ref={ref}
-    className={classNames("relative cursor-pointer outline-none all-unset focus-visible:outline-none", className)}
+    className={classNames("cursor-pointer outline-none all-unset focus-visible:outline-none", className)}
     {...props}
   />
 ));

--- a/app/javascript/pages/Library/Index.tsx
+++ b/app/javascript/pages/Library/Index.tsx
@@ -116,7 +116,7 @@ export const Card = ({
         </div>
         <div className="p-4">
           <Popover open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
-            <PopoverTrigger aria-label="Open product action menu">
+            <PopoverTrigger aria-label="Open product action menu" className="relative">
               <DotsHorizontalRounded className="size-5" />
             </PopoverTrigger>
             <PopoverContent className="border-0 p-0 shadow-none" usePortal>


### PR DESCRIPTION
Issue https://github.com/antiwork/gumroad/issues/3907

https://github.com/antiwork/gumroad/pull/3908 introduced a visual bug where the add section button is shifted down instead of being connected to the divider. There may be similar issues on other popovers, so I think the best solution is to revert the global `PopoverTrigger` change that the PR introduced and instead do a targeted fix on the Library page (which is what the original issue was about)

## Before

<img width="1897" height="1114" alt="Screenshot 2026-03-15 at 16 53 47" src="https://github.com/user-attachments/assets/edb4eef9-f26d-4328-a28f-c1d9413abc0f" />

## After

Profile is fixed:

<img width="1897" height="1209" alt="Screenshot 2026-03-15 at 16 49 02" src="https://github.com/user-attachments/assets/ee7ab8a4-d9ff-40c9-ace7-e71c2c020a90" />

Clicking the ellipsis works in Library so the original issue is still solved:

<img width="1658" height="643" alt="Screenshot 2026-03-15 at 16 50 35" src="https://github.com/user-attachments/assets/3739c969-b4d6-4c70-9878-f0231e5b5e6b" />
