### PR TITLE
Fix inconsistent padding on archived products page

### DIFF
--- a/app/javascript/pages/Products/Archived/Index.tsx
+++ b/app/javascript/pages/Products/Archived/Index.tsx
@@ -39,11 +39,9 @@ const ArchivedProductsIndexPage = () => {
       archivedTabVisible
       ctaButton={<HeaderButtons query={query} setQuery={setQuery} />}
     >
-      <section className="p-4 md:p-8">
-        <Deferred data={["products_data", "memberships_data"]} fallback={<ProductsContentLoading />}>
-          <ProductsContent query={query} />
-        </Deferred>
-      </section>
+      <Deferred data={["products_data", "memberships_data"]} fallback={<ProductsContentLoading />}>
+        <ProductsContent query={query} />
+      </Deferred>
     </ProductsLayout>
   );
 };


### PR DESCRIPTION
## Summary
- Removed redundant `<section className="p-4 md:p-8">` wrapper around the `Deferred` component on the archived products page
- The padding was already applied inside `ProductsContent`, causing double padding compared to the main products page
- Introduced in #3739 which added deferred props but wrapped the `Deferred` component in an extra section with padding

## Test plan
- [ ] Visit `/products/archived` and verify padding matches `/products`
- [ ] Verify loading skeleton state also has correct padding
- [ ] Check responsive padding at mobile and desktop breakpoints

Fixes #3977

🤖 Generated with [Claude Code](https://claude.com/claude-code)