### PR TITLE
Skip payout pause for verified sellers on failed purchases

### DIFF
--- a/app/models/concerns/purchase/blockable.rb
+++ b/app/models/concerns/purchase/blockable.rb
@@ -181,6 +181,7 @@ module Purchase::Blockable
     def pause_payouts_for_seller_based_on_recent_failures!
       return if Feature.inactive?(:block_seller_based_on_recent_failures)
       return if IGNORED_ERROR_CODES.include?(error_code)
+      return if seller.verified?
 
       failed_seller_purchases_watch_minutes,
       max_seller_failed_purchases_price_cents,

--- a/spec/models/concerns/purchase/blockable_spec.rb
+++ b/spec/models/concerns/purchase/blockable_spec.rb
@@ -597,6 +597,31 @@ describe Purchase::Blockable do
         end
       end
 
+      context "when seller is verified" do
+        let(:verified_seller) { create(:user, verified: true) }
+        let(:verified_product) { create(:product, user: verified_seller) }
+        let!(:verified_purchase) { create(:purchase, link: verified_product, purchase_state: "in_progress") }
+
+        it "does not pause payouts for the seller" do
+          create_list(:failed_purchase, 5, link: verified_product, price_cents: 250)
+          verified_purchase.mark_failed!
+
+          expect(verified_seller.reload.payouts_paused_internally).to be(false)
+          expect(verified_seller.payouts_paused_by_source).to be_nil
+        end
+      end
+
+      context "when seller is not verified" do
+        it "pauses payouts when threshold is exceeded" do
+          expect(seller.verified?).to be(false)
+          create_list(:failed_purchase, 5, link: product, price_cents: 250)
+          purchase.mark_failed!
+
+          expect(seller.reload.payouts_paused_internally).to be(true)
+          expect(seller.payouts_paused_by_source).to eq(User::PAYOUT_PAUSE_SOURCE_SYSTEM)
+        end
+      end
+
       context "when error code is ignored" do
         it "does not pause payouts for the seller" do
           create_list(:failed_purchase, 5, link: product, price_cents: 250)


### PR DESCRIPTION
Fixes antiwork/gumroad-private#140

## What

Added an early return `return if seller.verified?` to `pause_payouts_for_seller_based_on_recent_failures!` in `Purchase::Blockable`, so verified sellers are exempt from automatic payout pausing triggered by high volumes of failed purchases.

## Why

Verified sellers (toggled via the admin "Verify" button) are trusted creators. When their customers' cards fail in high volume, the system auto-pauses their payouts with a "security review" message, causing unnecessary anxiety and repeat support tickets. This check is only added to the failed-purchases trigger — not the chargeback-rate trigger — since chargebacks represent a different risk profile. Admin and Stripe can still manually pause payouts if needed.

---

This PR was implemented with AI assistance using Claude Opus 4.6.

Prompts used:

- "Implement the fix for antiwork/gumroad-private#140: The 'Verify' button on admin should bypass automatic payout pausing from failed purchases. In `app/models/concerns/purchase/blockable.rb`, add `return if seller.verified?` as an early return in `pause_payouts_for_seller_based_on_recent_failures!` only. Add tests verifying verified sellers skip the pause and non-verified sellers still get paused."