### PR TITLE
Migrate scrollbar styles to Tailwind

### DIFF
--- a/app/javascript/stylesheets/_global.scss
+++ b/app/javascript/stylesheets/_global.scss
@@ -38,17 +38,6 @@
     color: full-color(color);
   }
 
-  body:not(.mac) * {
-    &::-webkit-scrollbar {
-      width: size(0.75);
-      background-color: gray(1);
-    }
-    &::-webkit-scrollbar-thumb {
-      background-color: gray(3);
-      border-radius: border-radius(2);
-    }
-  }
-
   @for $i from 1 through 5 {
     h#{$i} {
       @include font-size(6 - $i);

--- a/app/javascript/stylesheets/tailwind.css
+++ b/app/javascript/stylesheets/tailwind.css
@@ -72,6 +72,14 @@
       border-color: var(--color-border);
     }
   }
+
+  body:not(.mac) *::-webkit-scrollbar {
+    @apply w-3 bg-active-bg;
+  }
+
+  body:not(.mac) *::-webkit-scrollbar-thumb {
+    @apply rounded-lg bg-muted;
+  }
 }
 
 @utility all-unset {


### PR DESCRIPTION
Issue #3008 

These are a bit awkward to inline because `body` elements are in various ERB templates, so I think it's fine to have them in `tailwind.css` for now.