### PR TITLE
Fix broken "Version selected" UI in upsell creation form

### DIFF
--- a/app/javascript/components/CheckoutDashboard/UpsellsPage.tsx
+++ b/app/javascript/components/CheckoutDashboard/UpsellsPage.tsx
@@ -895,7 +895,7 @@ const Form = ({
                   />
                 </Fieldset>
                 {selectedProduct ? (
-                  <div className="grid grid-cols-[1fr_auto_1fr] gap-2" aria-label="Upsell versions">
+                  <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-2" aria-label="Upsell versions">
                     <b>Version selected</b>
                     <div />
                     <b>Version to offer</b>
@@ -907,7 +907,7 @@ const Form = ({
                       );
                       return (
                         <React.Fragment key={option.id}>
-                          <InputGroup readOnly>{option.name}</InputGroup>
+                          <InputGroup>{option.name}</InputGroup>
                           <ArrowRightCircle className="size-5" />
                           <Select
                             options={selectedProduct.options.flatMap(({ id, name: label }) =>


### PR DESCRIPTION
Fixes https://github.com/antiwork/gumroad/issues/4010

## What
- Fix version names displaying as plain text instead of bordered input boxes in the upsell "Version selected" column
- Fix arrow icon not vertically centered between the two columns

## Why
Regression from #3891 (Migrate `_forms.scss` to Tailwind: Part 4). That PR added a `readOnly` variant to `InputGroup` applying `bg-inherit border-none px-0`, which strips the bordered appearance. The upsell version grid passed `readOnly` to `InputGroup`, so version names lost their box styling. The grid also lacked `items-center`, leaving the arrow icon top-aligned.

## Before/After
### Before
<img width="1470" height="794" alt="image" src="https://github.com/user-attachments/assets/c9cdc9fa-d461-4237-9e9d-bc33395ca895" />


<img width="313" height="665" alt="image" src="https://github.com/user-attachments/assets/ca718fb8-63f5-44b8-853d-6fbc7e186411" />


### After
<img width="1470" height="794" alt="image" src="https://github.com/user-attachments/assets/0dce9547-1227-40f0-a78b-b3b9dbeff337" />
<img width="317" height="668" alt="image" src="https://github.com/user-attachments/assets/d434bd6a-56b5-47bc-972a-55f0fc72731d" />


---

AI disclosure: Claude Opus 4.6 was used to identify the root cause, trace the regression to #3891, and draft the fix.
