### PR TITLE
Fix `Details` import in API docs

### DIFF
--- a/app/javascript/components/ApiDocumentation/ApiResponseFields.tsx
+++ b/app/javascript/components/ApiDocumentation/ApiResponseFields.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import { Card, CardContent } from "$app/components/ui/Card";
-import { Details } from "$app/components/ui/Details";
+import { Details, DetailsToggle } from "$app/components/ui/Details";
 
 export type FieldDefinition = {
   name: string;
@@ -14,7 +14,12 @@ export type FieldDefinition = {
 export const ApiResponseFields = ({ children }: { children: React.ReactNode }) => (
   <Card>
     <CardContent>
-      <Details summary={<h4>Response fields</h4>}>{children}</Details>
+      <Details>
+        <DetailsToggle>
+          <h4>Response fields</h4>
+        </DetailsToggle>
+        {children}
+      </Details>
     </CardContent>
   </Card>
 );


### PR DESCRIPTION
See https://github.com/antiwork/gumroad/pull/3911#issuecomment-4075679603

Fixes the API response fields toggle to be compatible with #3968 