### PR TITLE
Move mini profiler styles to tailwind.css

### DIFF
--- a/app/javascript/stylesheets/_global.scss
+++ b/app/javascript/stylesheets/_global.scss
@@ -79,9 +79,3 @@
   cursor: not-allowed;
   opacity: $disabled-opacity;
 }
-
-// Unset max-width for Rack::MiniProfiler results to (expectedly) expand beyond
-// the narrow parent container.
-.profiler-results * {
-  max-width: unset;
-}

--- a/app/javascript/stylesheets/tailwind.css
+++ b/app/javascript/stylesheets/tailwind.css
@@ -158,3 +158,8 @@
   content: attr(data-placeholder);
   @apply pointer-events-none float-left h-0 text-muted;
 }
+
+/* Unset max-width for Rack::MiniProfiler results to (expectedly) expand beyond the narrow parent container */
+.profiler-results * {
+  max-width: unset;
+}


### PR DESCRIPTION
Ref #3008 

Keeps `_global.scss` clean and just focused on things currently shared between web and email