### PR TITLE
Fix flaky CI tests across 15 spec files

### DIFF
--- a/spec/requests/analytics/utm_links_spec.rb
+++ b/spec/requests/analytics/utm_links_spec.rb
@@ -121,7 +121,7 @@ describe "UTM links", :js, type: :system do
         expect(page).to_not have_table_row({ "Link" => utm_link1.title })
         expect(page).to have_button("1", aria: { current: "page" })
         expect(page).to have_button("2")
-        expect(page).to_not have_button("3")
+        expect(page).to_not have_button("3", exact: true)
         expect(page).to have_button("Previous", disabled: true)
         expect(page).to have_button("Next")
         click_on "Next"
@@ -129,7 +129,7 @@ describe "UTM links", :js, type: :system do
         expect(page).to have_button("Previous")
         expect(page).to have_button("2", aria: { current: "page" })
         expect(page).to have_button("1")
-        expect(page).to_not have_button("3")
+        expect(page).to_not have_button("3", exact: true)
         expect(page).to have_table_row({ "Link" => utm_link1.title })
         expect(page).to_not have_table_row({ "Link" => utm_link2.title })
         expect(page).to have_current_path(dashboard_utm_links_path({ page: 2 }))

--- a/spec/requests/checkout/form_spec.rb
+++ b/spec/requests/checkout/form_spec.rb
@@ -208,6 +208,7 @@ describe("Checkout form page", type: :system, js: true) do
         visit checkout_form_path
 
         in_preview do
+          expect(page).to have_selector("h4", text: "Product 1")
           within_cart_item "Product 1" do
             expect(page).to have_text("Seller")
             expect(page).to have_text("Qty: 1")

--- a/spec/requests/customers/customers_spec.rb
+++ b/spec/requests/customers/customers_spec.rb
@@ -202,11 +202,11 @@ describe "Sales page", type: :system, js: true do
         fill_in "After", with: ""
         find(:label, "Before").click
 
-        expect(page).to have_button("3")
+        expect(page).to have_button("3", exact: true)
         check "Show active customers only"
-        expect(page).to_not have_button("3")
+        expect(page).to_not have_button("3", exact: true)
         uncheck "Show active customers only"
-        expect(page).to have_button("3")
+        expect(page).to have_button("3", exact: true)
       end
 
       it "prevents selecting the same product in both bought and not bought filters" do

--- a/spec/requests/discover/discover_spec.rb
+++ b/spec/requests/discover/discover_spec.rb
@@ -414,6 +414,7 @@ describe("Discover", js: true, type: :system) do
 
     create(:thumbnail, product:)
     product.reload
+    product.thumbnail.url
 
     allow(product).to receive(:recommendable?).and_return(true)
     allow(product).to receive(:reviews_count).and_return(1)

--- a/spec/requests/embed_spec.rb
+++ b/spec/requests/embed_spec.rb
@@ -116,9 +116,11 @@ describe "Embed scenario", type: :system, js: true, mock_easypost: true do
 
       within_frame { click_on "Add to cart" }
 
-      check_out(product)
+      expect do
+        check_out(product)
+      end.to change { AffiliateCredit.count }.by(1)
 
-      purchase = product.sales.successful.last
+      purchase = product.sales.successful.last.reload
       expect(purchase.affiliate_credit.affiliate).to eq(direct_affiliate)
       expect(purchase.affiliate_credit.amount_cents).to eq(645)
     end
@@ -131,7 +133,7 @@ describe "Embed scenario", type: :system, js: true, mock_easypost: true do
 
         check_out(product)
 
-        purchase = product.sales.successful.last
+        purchase = product.sales.successful.last.reload
         expect(purchase.affiliate_credit.affiliate).to eq(direct_affiliate)
         expect(purchase.affiliate_credit.amount_cents).to eq(645)
       end

--- a/spec/requests/products/edit/integrations/circle_integrations_spec.rb
+++ b/spec/requests/products/edit/integrations/circle_integrations_spec.rb
@@ -16,7 +16,7 @@ describe("Product Edit Integrations edit - Circle", :without_circle_rate_limit, 
 
   include_context "with switching account to user as admin for seller"
 
-  describe "circle integration" do
+  describe "circle integration", force_vcr_on: true do
     before do
       @vcr_cassette_prefix = "#{@vcr_cassette_prefix} circle integration"
     end
@@ -25,9 +25,14 @@ describe("Product Edit Integrations edit - Circle", :without_circle_rate_limit, 
       @product.active_integrations << create(:circle_integration)
 
       vcr_turned_on do
-        VCR.use_cassette("#{@vcr_cassette_prefix} modifies an existing integration correctly") do
+        VCR.use_cassette("#{@vcr_cassette_prefix} modifies an existing integration correctly", allow_playback_repeats: true) do
           visit edit_link_path(@product)
+          expect(page).to have_field("Type or paste your API token", with: GlobalConfig.get("CIRCLE_API_KEY"))
+          wait_for_ajax
+          expect(page).to have_select("Select a community", with_options: ["Gumroad [archived]"])
           select("Gumroad [archived]", from: "Select a community")
+          wait_for_ajax
+          expect(page).to have_select("Select a space group", with_options: ["Discover"])
           select("Discover", from: "Select a space group")
           save_change
         end
@@ -44,7 +49,7 @@ describe("Product Edit Integrations edit - Circle", :without_circle_rate_limit, 
 
       expect do
         vcr_turned_on do
-          VCR.use_cassette("#{@vcr_cassette_prefix} disables integration correctly") do
+          VCR.use_cassette("#{@vcr_cassette_prefix} disables integration correctly", allow_playback_repeats: true) do
             visit edit_link_path(@product)
             expect(page).to have_field("Type or paste your API token", with: GlobalConfig.get("CIRCLE_API_KEY"))
             uncheck "Invite your customers to a Circle community", allow_label_click: true
@@ -62,7 +67,7 @@ describe("Product Edit Integrations edit - Circle", :without_circle_rate_limit, 
       expect(page).to_not have_field("Type or paste your API token")
     end
 
-    it "shows error on invalid api_key" do
+    it "shows error on invalid api_key", force_vcr_on: false do
       vcr_turned_on do
         VCR.use_cassette("#{@vcr_cassette_prefix} shows error on invalid api_key") do
           visit edit_link_path(@product)
@@ -87,7 +92,7 @@ describe("Product Edit Integrations edit - Circle", :without_circle_rate_limit, 
         @product.active_integrations << create(:circle_integration)
 
         vcr_turned_on do
-          VCR.use_cassette("#{@vcr_cassette_prefix} shows the integration toggle if product has an integration") do
+          VCR.use_cassette("#{@vcr_cassette_prefix} shows the integration toggle if product has an integration", allow_playback_repeats: true) do
             visit edit_link_path(@product)
           end
         end
@@ -97,7 +102,7 @@ describe("Product Edit Integrations edit - Circle", :without_circle_rate_limit, 
 
       it "hides the integration toggle if product does not have an integration" do
         vcr_turned_on do
-          VCR.use_cassette("#{@vcr_cassette_prefix} hides the integration toggle if product does not have an integration") do
+          VCR.use_cassette("#{@vcr_cassette_prefix} hides the integration toggle if product does not have an integration", allow_playback_repeats: true) do
             visit edit_link_path(@product)
           end
         end
@@ -110,12 +115,17 @@ describe("Product Edit Integrations edit - Circle", :without_circle_rate_limit, 
 
         expect do
           vcr_turned_on do
-            VCR.use_cassette("#{@vcr_cassette_prefix} creates an integration for the product and enables integration for a newly created version") do
+            VCR.use_cassette("#{@vcr_cassette_prefix} creates an integration for the product and enables integration for a newly created version", allow_playback_repeats: true) do
               visit edit_link_path(product)
               check "Invite your customers to a Circle community", allow_label_click: true
               fill_in "Type or paste your API token", with: GlobalConfig.get("CIRCLE_API_KEY")
+              expect(page).to have_button("Load communities")
               click_on("Load communities")
+              wait_for_ajax
+              expect(page).to have_select("Select a community", with_options: ["Gumroad [archived]"])
               select("Gumroad [archived]", from: "Select a community")
+              wait_for_ajax
+              expect(page).to have_select("Select a space group", with_options: ["Tests"])
               select("Tests", from: "Select a space group")
 
               click_on("Add version")
@@ -159,7 +169,7 @@ describe("Product Edit Integrations edit - Circle", :without_circle_rate_limit, 
 
         expect do
           vcr_turned_on do
-            VCR.use_cassette("#{@vcr_cassette_prefix} disables integration for a version") do
+            VCR.use_cassette("#{@vcr_cassette_prefix} disables integration for a version", allow_playback_repeats: true) do
               visit edit_link_path(@product)
               within version_rows[0] do
                 within version_option_rows[0] do
@@ -188,7 +198,7 @@ describe("Product Edit Integrations edit - Circle", :without_circle_rate_limit, 
 
         expect do
           vcr_turned_on do
-            VCR.use_cassette("#{@vcr_cassette_prefix} disables integration for a version if integration is removed from the product") do
+            VCR.use_cassette("#{@vcr_cassette_prefix} disables integration for a version if integration is removed from the product", allow_playback_repeats: true) do
               visit edit_link_path(@product)
               uncheck "Invite your customers to a Circle community", allow_label_click: true
               save_change
@@ -219,7 +229,7 @@ describe("Product Edit Integrations edit - Circle", :without_circle_rate_limit, 
         @subscription_product.active_integrations << create(:circle_integration)
 
         vcr_turned_on do
-          VCR.use_cassette("#{@vcr_cassette_prefix} shows the integration toggle if product has an integration") do
+          VCR.use_cassette("#{@vcr_cassette_prefix} shows the integration toggle if product has an integration", allow_playback_repeats: true) do
             visit edit_link_path(@subscription_product)
           end
         end
@@ -229,7 +239,7 @@ describe("Product Edit Integrations edit - Circle", :without_circle_rate_limit, 
 
       it "hides the integration toggle if product does not have an integration" do
         vcr_turned_on do
-          VCR.use_cassette("#{@vcr_cassette_prefix} hides the integration toggle if product does not have an integration") do
+          VCR.use_cassette("#{@vcr_cassette_prefix} hides the integration toggle if product does not have an integration", allow_playback_repeats: true) do
             visit edit_link_path(@subscription_product)
           end
         end
@@ -242,7 +252,7 @@ describe("Product Edit Integrations edit - Circle", :without_circle_rate_limit, 
 
         expect do
           vcr_turned_on do
-            VCR.use_cassette("#{@vcr_cassette_prefix} enables integration for a tier") do
+            VCR.use_cassette("#{@vcr_cassette_prefix} enables integration for a tier", allow_playback_repeats: true) do
               visit edit_link_path(@subscription_product)
               within tier_rows[1] do
                 check "Enable access to Circle community", allow_label_click: true
@@ -269,7 +279,7 @@ describe("Product Edit Integrations edit - Circle", :without_circle_rate_limit, 
 
         expect do
           vcr_turned_on do
-            VCR.use_cassette("#{@vcr_cassette_prefix} disables integration for a tier") do
+            VCR.use_cassette("#{@vcr_cassette_prefix} disables integration for a tier", allow_playback_repeats: true) do
               visit edit_link_path(@subscription_product)
               within tier_rows[0] do
                 uncheck "Enable access to Circle community", allow_label_click: true
@@ -296,7 +306,7 @@ describe("Product Edit Integrations edit - Circle", :without_circle_rate_limit, 
 
         expect do
           vcr_turned_on do
-            VCR.use_cassette("#{@vcr_cassette_prefix} disables integration for a tier if integration is removed from the product") do
+            VCR.use_cassette("#{@vcr_cassette_prefix} disables integration for a tier if integration is removed from the product", allow_playback_repeats: true) do
               visit edit_link_path(@subscription_product)
               uncheck "Invite your customers to a Circle community", allow_label_click: true
               save_change

--- a/spec/requests/products/show/sections_spec.rb
+++ b/spec/requests/products/show/sections_spec.rb
@@ -68,7 +68,7 @@ describe "Profile settings on product pages", type: :system, js: true do
       click_on "Products"
       check product2.name
     end
-    toggle_disclosure "Edit section"
+    find(:disclosure_button, "Edit section").execute_script("this.scrollIntoView({block: 'center'}); this.click()")
     click_on "Move section down"
 
     select_disclosure "Add section", match: :first do

--- a/spec/requests/products/show/show_spec.rb
+++ b/spec/requests/products/show/show_spec.rb
@@ -187,7 +187,7 @@ describe("ProductShowScenario", type: :system, js: true) do
 
       visit "#{@product.long_url}?wanted=true&quantity=3"
 
-      within "[role='listitem']" do
+      within("[role='listitem']", match: :first) do
         expect(page).to have_text(@membership.name)
         expect(page).to have_text("Qty: 3")
       end

--- a/spec/requests/purchases/product/shipping/shipping_physical_preorder_spec.rb
+++ b/spec/requests/purchases/product/shipping/shipping_physical_preorder_spec.rb
@@ -71,12 +71,24 @@ describe("Product Page - Shipping physical preoder", type: :system, js: true, sh
     expect(preorder.state).to eq("authorization_successful")
   end
 
-  it "charges the proper amount with taxes for preorder" do
+  it "charges the proper amount with taxes for preorder", force_vcr_on: true do
     visit "/l/#{@product.unique_permalink}"
     add_to_cart(@product)
     check_out(@product, address: { street: "3029 W Sherman Rd", city: "San Tan Valley", state: "AZ", zip_code: "85144" }, should_verify_address: true) do
-      expect(page).to have_text("Subtotal US$16", normalize_ws: true)
+      expect(page).to have_select("State", selected: "AZ")
+      zip_field = find_field("ZIP code")
+      page.execute_script(<<~JS, zip_field)
+        var el = arguments[0];
+        var setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
+        setter.call(el, '');
+        el.dispatchEvent(new Event('input', { bubbles: true }));
+        setter.call(el, '85144');
+        el.dispatchEvent(new Event('input', { bubbles: true }));
+        el.dispatchEvent(new Event('change', { bubbles: true }));
+        el.dispatchEvent(new Event('blur', { bubbles: true }));
+      JS
       expect(page).to have_text("Sales tax US$1.07", normalize_ws: true)
+      expect(page).to have_text("Subtotal US$16", normalize_ws: true)
       expect(page).to have_text("Shipping rate US$4", normalize_ws: true)
       expect(page).to have_text("Total US$21.07", normalize_ws: true)
     end

--- a/spec/requests/purchases/product/shipping/shipping_to_virtual_countries_spec.rb
+++ b/spec/requests/purchases/product/shipping/shipping_to_virtual_countries_spec.rb
@@ -14,7 +14,7 @@ describe("Product Page - Shipping to Virtual Countries", type: :system, js: true
     add_to_cart(@product)
     expect(page).to have_text("Shipping rate US$5", normalize_ws: true)
     expect(page).to have_text("Total US$105", normalize_ws: true)
-    check_out(@product)
+    check_out(@product, should_verify_address: true)
 
     expect(Purchase.last.price_cents).to eq(10500)
     expect(Purchase.last.shipping_cents).to eq(500)
@@ -31,7 +31,7 @@ describe("Product Page - Shipping to Virtual Countries", type: :system, js: true
     add_to_cart(@product, quantity: 2)
     expect(page).to have_text("Shipping rate US$6", normalize_ws: true)
     expect(page).to have_text("Total US$206", normalize_ws: true)
-    check_out(@product)
+    check_out(@product, should_verify_address: true)
 
     expect(Purchase.last.price_cents).to eq(20600)
     expect(Purchase.last.shipping_cents).to eq(600)

--- a/spec/requests/purchases/product/taxes_spec.rb
+++ b/spec/requests/purchases/product/taxes_spec.rb
@@ -13,7 +13,13 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
     it "calls the tax endpoint for a real zip code that doesn't show in the enterprise zip codes database" do
       visit("/l/#{@product.unique_permalink}")
       add_to_cart(@product)
-      check_out(@product, address: { street: "3029 W Sherman Rd", city: "San Tan Valley", state: "AZ", zip_code: "85144", country: "US" }, should_verify_address: true)
+      check_out(@product, address: { street: "3029 W Sherman Rd", city: "San Tan Valley", state: "AZ", zip_code: "85144" }, should_verify_address: true) do
+        expect(page).to have_field("ZIP code", with: "85144")
+        find_field("ZIP code").send_keys(:tab)
+        wait_for_ajax
+        expect(page).to have_text("Sales tax", normalize_ws: true)
+        expect(page).to have_text("Total US$553.50", normalize_ws: true)
+      end
 
       expect(page).to have_text("Your purchase was successful!")
 
@@ -49,7 +55,10 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
 
         visit("/l/#{@product.unique_permalink}")
         add_to_cart(@product, option: "type 1")
-        check_out(@product, address: { street: "3029 W Sherman Rd", city: "San Tan Valley", state: "AZ", zip_code: "85144" }, should_verify_address: true)
+        check_out(@product, address: { street: "3029 W Sherman Rd", city: "San Tan Valley", state: "AZ", zip_code: "85144" }, should_verify_address: true) do
+          wait_for_ajax
+          expect(page).to have_text("Total US$555.16", normalize_ws: true)
+        end
 
         expect(page).to have_text("Your purchase was successful!")
 
@@ -78,7 +87,10 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
 
         visit "/l/#{@product.unique_permalink}/taxoffer"
         add_to_cart(@product, offer_code:)
-        check_out(@product, address: { street: "3029 W Sherman Rd", city: "San Tan Valley", state: "AZ", zip_code: "85144" }, should_verify_address: true)
+        check_out(@product, address: { street: "3029 W Sherman Rd", city: "San Tan Valley", state: "AZ", zip_code: "85144" }, should_verify_address: true) do
+          wait_for_ajax
+          expect(page).to have_text("Total US$442.80", normalize_ws: true)
+        end
 
         expect(page).to have_text("Your purchase was successful!")
 
@@ -172,7 +184,10 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
       expect(page).to have_text("$100")
 
       add_to_cart(product)
-      check_out(product, address: { street: "1 S Pinckney St", state: "WI", city: "Madison", zip_code: "53703" }, should_verify_address: true)
+      check_out(product, address: { street: "1 S Pinckney St", state: "WI", city: "Madison", zip_code: "53703" }, should_verify_address: true) do
+        wait_for_ajax
+        expect(page).to have_text("Total US$105.50", normalize_ws: true)
+      end
 
       purchase = Purchase.last
       expect(purchase.total_transaction_cents).to eq(105_50)
@@ -204,7 +219,10 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
       expect(page).to have_text("$100")
 
       add_to_cart(product)
-      check_out(product, address: { street: "2031 7th Ave", state: "WA", city: "Seattle", zip_code: "98121" }, should_verify_address: true)
+      check_out(product, address: { street: "2031 7th Ave", state: "WA", city: "Seattle", zip_code: "98121" }, should_verify_address: true) do
+        wait_for_ajax
+        expect(page).to have_text("Total US$110.35", normalize_ws: true)
+      end
 
       purchase = Purchase.last
       expect(purchase.total_transaction_cents).to eq(110_35)
@@ -3697,8 +3715,10 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
 
       expect(page).to have_select("Country", selected: "Canada")
       expect(page).to have_select("Province", selected: "BC")
+      wait_for_ajax
+      expect(page).to have_text("Total US$112", normalize_ws: true)
 
-      check_out(product, country: "Canada", zip_code: nil, credit_card: { number: "4000001240000000" })
+      check_out(product, zip_code: nil, credit_card: { number: "4000001240000000" })
 
       purchase = Purchase.last
       expect(purchase.country).to eq("Canada")
@@ -3721,8 +3741,14 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
 
       expect(page).to have_select("Country", selected: "Canada")
       expect(page).to have_select("Province", selected: "ON")
+      wait_for_ajax
+      expect(page).to have_text("Total US$113", normalize_ws: true)
 
       select "QC", from: "Province"
+      find_field("Province").send_keys(:tab)
+      wait_for_ajax
+      expect(page).to have_text("Total US$114.98", normalize_ws: true)
+
       check_out(product, zip_code: nil, credit_card: { number: "4000001240000000" })
 
       purchase = Purchase.last
@@ -3749,6 +3775,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
 
         expect(page).to have_select("Country", selected: "Canada")
         expect(page).to have_select("Province", selected: "ON")
+        wait_for_ajax
 
         check_out(product, address: { street: "568 Beatty St", city: "Vancouver", state: "BC", zip_code: "V6B 2L3" }, should_verify_address: true)
 

--- a/spec/requests/secure_redirect_spec.rb
+++ b/spec/requests/secure_redirect_spec.rb
@@ -66,6 +66,7 @@ describe("Secure Redirect", js: true, type: :system) do
       it "redirects to the destination" do
         fill_in field_name, with: confirmation_text_2
         click_button "Continue"
+        wait_for_ajax
 
         expect(page).to have_current_path(destination_url)
       end

--- a/spec/requests/settings/password_spec.rb
+++ b/spec/requests/settings/password_spec.rb
@@ -157,8 +157,8 @@ describe("Password Settings Scenario", type: :system, js: true) do
         click_on("Set up")
         expect(page).to have_text("Scan this QR code")
 
-        credential = user.reload.totp_credential
-        expect(credential).to be_present
+        wait_until_true { user.reload.totp_credential.present? }
+        credential = user.totp_credential
         expect(credential).not_to be_confirmed
 
         fill_in("Enter the code from your authenticator app", with: credential.otp_code)

--- a/spec/requests/settings/payments_spec.rb
+++ b/spec/requests/settings/payments_spec.rb
@@ -4144,6 +4144,8 @@ describe("Payments Settings Scenario", type: :system, js: true) do
 
     describe "Ghanaian creator" do
       before do
+        allow(StripeMerchantAccountManager).to receive(:create_account)
+
         old_user_compliance_info = @user.alive_user_compliance_info
         new_user_compliance_info = old_user_compliance_info.dup
         new_user_compliance_info.country = "Ghana"

--- a/spec/support/checkout_helpers.rb
+++ b/spec/support/checkout_helpers.rb
@@ -154,10 +154,14 @@ module CheckoutHelpers
       click_on is_free ? "Get" : "Pay", exact: true
 
       if should_verify_address
-        if page.has_text?("We are unable to verify your shipping address. Is your address correct?", wait: 5)
-          click_on "Yes, it is"
-        elsif page.has_text?("You entered this address:", wait: 5) && page.has_text?("We recommend using this format:", wait: 5)
-          click_on "No, continue"
+        begin
+          if page.has_text?("We are unable to verify your shipping address. Is your address correct?", wait: 5)
+            click_on "Yes, it is"
+          elsif page.has_text?("You entered this address:", wait: 5) && page.has_text?("We recommend using this format:", wait: 5)
+            click_on "No, continue"
+          end
+        rescue Capybara::ElementNotFound, Selenium::WebDriver::Error::StaleElementReferenceError
+          # Page may still be loading after payment processing or Chrome may be unstable; continue to success assertion
         end
       end
 


### PR DESCRIPTION
Fix flaky CI tests across 15 spec files

## What

Fixes race conditions, timing issues, and element matching problems that caused intermittent CI failures. 15 spec files changed, 100 insertions, 40 deletions. No application code touched.

**Stripe rate limiting** — The Ghanaian creator test in `payments_spec` creates a real Stripe account on every run. With 42 parallel CI nodes all hitting Stripe simultaneously, this fails with "creating accounts too quickly." Stubbed `StripeMerchantAccountManager.create_account` since the test validates form submission and bank account persistence, not Stripe account creation.

**Tax calculation timing** — Multiple tax tests (`taxes_spec`, `shipping_physical_preorder_spec`) asserted on tax totals before the async TaxJar calculation completed. Added `wait_for_ajax` + total amount assertions inside `check_out` blocks to wait for tax to resolve. For React-controlled ZIP fields where `fill_in`/`send_keys` don't trigger `onChange`, used JS `nativeInputValueSetter` to dispatch proper `input`/`change`/`blur` events. For Canada province switching, wait for the first province's tax to settle before changing to the next.

**Circle integration VCR** — Circle dropdown tests failed because the component hadn't mounted when Capybara tried to select options. Added `force_vcr_on: true` at the describe level, `allow_playback_repeats: true` on cassettes (same request replayed during React re-renders), and explicit waits for the API token field and select options to appear before interacting.

**Pagination button matching** — `have_button("3")` matched "30" or "3 of 5" on pages with more content. Added `exact: true` in `utm_links_spec` and `customers_spec`.

**Other fixes:**
- `sections_spec`: Fixed header intercepting clicks on disclosure button. Used JS `scrollIntoView` + `click()`.
- `show_spec`: `within "[role='listitem']"` matched multiple items. Added `match: :first`.
- `secure_redirect_spec`: Missing `wait_for_ajax` before asserting redirect path.
- `discover_spec`: Pre-process thumbnail variant to avoid SAVEPOINT error during test.
- `embed_spec`: Purchase's `affiliate_credit` association stale after checkout. Added `.reload` and wrapped in `expect { }.to change { AffiliateCredit.count }`.
- `password_spec`: TOTP credential created async after clicking "Set up". Replaced immediate `.reload` with `wait_until_true`.
- `checkout_helpers.rb`: Address verification dialog can hit `ElementNotFound` or `StaleElementReferenceError` when Chrome is unstable under load. Wrapped in `begin/rescue` to continue to the success assertion.
- `shipping_to_virtual_countries_spec`: Added `should_verify_address: true` to handle address verification popup.

## Why

CI was failing on nearly every run, blocking merges. The failures were non-deterministic — tests passed locally and individually but failed under the 42-node parallel load on GitHub Actions. Each category of fix targets a specific concurrency or timing issue rather than masking failures with retries.

## Evidence

Ran 26 experiments over ~10 hours using an autonomous loop (push → wait for CI → analyze → fix → repeat). Results:

| Phase | Failed jobs / 60 | Notes |
|-------|-------------------|-------|
| Before fixes | 3-5+ | Consistent multi-failures every run |
| After Stripe + timing fixes | 1-2 | Occasional tax/Circle races |
| After all fixes | **0** | 7 fully green runs achieved |

The last 3 consecutive runs before the final edge case fixes were all 0/60. After fixing the remaining `embed_spec` and preorder races, achieved another streak of clean runs. The remaining occasional 1/60 failures in the experiment branch were infrastructure issues (Stripe rate limit cascades across all 42 nodes, Chrome crashes) rather than test code problems.

Full experiment log: 26 entries in `autoresearch.jsonl` on the `autoresearch/flaky-tests-2026-03-18` branch.

---

This PR was implemented with AI assistance using Claude Opus 4.6 (via OpenClaw autoresearch loop).

Prompts used:

- "Run autoresearch to fix flaky CI tests — analyze recent CI failures, identify root causes, fix one at a time, validate via CI"
- "Continue the loop" (×3, after context limits)
- "Open a PR with all the fixes"
