### PR TITLE
Fix flaky preorder tax test with explicit AJAX wait

### DIFF
--- a/spec/requests/purchases/product/shipping/shipping_physical_preorder_spec.rb
+++ b/spec/requests/purchases/product/shipping/shipping_physical_preorder_spec.rb
@@ -75,8 +75,10 @@ describe("Product Page - Shipping physical preoder", type: :system, js: true, sh
     visit "/l/#{@product.unique_permalink}"
     add_to_cart(@product)
     check_out(@product, address: { street: "3029 W Sherman Rd", city: "San Tan Valley", state: "AZ", zip_code: "85144" }, should_verify_address: true) do
-      expect(page).to have_text("Subtotal US$16", normalize_ws: true)
+      find_field("ZIP code").send_keys(:tab)
+      wait_for_ajax
       expect(page).to have_text("Sales tax US$1.07", normalize_ws: true)
+      expect(page).to have_text("Subtotal US$16", normalize_ws: true)
       expect(page).to have_text("Shipping rate US$4", normalize_ws: true)
       expect(page).to have_text("Total US$21.07", normalize_ws: true)
     end


### PR DESCRIPTION
## What

Fixes the flaky test `shipping_physical_preorder_spec.rb:74` ("charges the proper amount with taxes for preorder") by adding `send_keys(:tab)` + `wait_for_ajax` before asserting tax amounts.

## Why

The test was flaky because `fill_checkout_form` fills the ZIP code field but doesn't reliably trigger React's blur event, which is what initiates the TaxJar API call. Without an explicit blur trigger and AJAX wait, the "Sales tax US$1.07" assertion sometimes runs before the tax calculation completes.

This follows the established pattern from `taxes_spec.rb` where the same fix was applied to 8+ US sales tax tests.

## Test Results

The `shipping: true` tag already wraps the test in a VCR cassette via `vcr_turned_on`, so `force_vcr_on: true` is not needed.

---

Generated with Claude Opus 4.6.