### PR TITLE
Fix miscellaneous flaky spec timing and selector issues

### DIFF
--- a/spec/requests/checkout/form_spec.rb
+++ b/spec/requests/checkout/form_spec.rb
@@ -208,6 +208,7 @@ describe("Checkout form page", type: :system, js: true) do
         visit checkout_form_path
 
         in_preview do
+          expect(page).to have_selector("h4", text: "Product 1")
           within_cart_item "Product 1" do
             expect(page).to have_text("Seller")
             expect(page).to have_text("Qty: 1")

--- a/spec/requests/discover/discover_spec.rb
+++ b/spec/requests/discover/discover_spec.rb
@@ -414,6 +414,7 @@ describe("Discover", js: true, type: :system) do
 
     create(:thumbnail, product:)
     product.reload
+    product.thumbnail.url
 
     allow(product).to receive(:recommendable?).and_return(true)
     allow(product).to receive(:reviews_count).and_return(1)

--- a/spec/requests/embed_spec.rb
+++ b/spec/requests/embed_spec.rb
@@ -116,9 +116,11 @@ describe "Embed scenario", type: :system, js: true, mock_easypost: true do
 
       within_frame { click_on "Add to cart" }
 
-      check_out(product)
+      expect do
+        check_out(product)
+      end.to change { AffiliateCredit.count }.by(1)
 
-      purchase = product.sales.successful.last
+      purchase = product.sales.successful.last.reload
       expect(purchase.affiliate_credit.affiliate).to eq(direct_affiliate)
       expect(purchase.affiliate_credit.amount_cents).to eq(645)
     end
@@ -131,7 +133,7 @@ describe "Embed scenario", type: :system, js: true, mock_easypost: true do
 
         check_out(product)
 
-        purchase = product.sales.successful.last
+        purchase = product.sales.successful.last.reload
         expect(purchase.affiliate_credit.affiliate).to eq(direct_affiliate)
         expect(purchase.affiliate_credit.amount_cents).to eq(645)
       end

--- a/spec/requests/products/show/sections_spec.rb
+++ b/spec/requests/products/show/sections_spec.rb
@@ -68,7 +68,7 @@ describe "Profile settings on product pages", type: :system, js: true do
       click_on "Products"
       check product2.name
     end
-    toggle_disclosure "Edit section"
+    find(:disclosure_button, "Edit section").execute_script("this.scrollIntoView({block: 'center'}); this.click()")
     click_on "Move section down"
 
     select_disclosure "Add section", match: :first do

--- a/spec/requests/products/show/show_spec.rb
+++ b/spec/requests/products/show/show_spec.rb
@@ -187,7 +187,7 @@ describe("ProductShowScenario", type: :system, js: true) do
 
       visit "#{@product.long_url}?wanted=true&quantity=3"
 
-      within "[role='listitem']" do
+      within("[role='listitem']", match: :first) do
         expect(page).to have_text(@membership.name)
         expect(page).to have_text("Qty: 3")
       end

--- a/spec/requests/secure_redirect_spec.rb
+++ b/spec/requests/secure_redirect_spec.rb
@@ -66,6 +66,7 @@ describe("Secure Redirect", js: true, type: :system) do
       it "redirects to the destination" do
         fill_in field_name, with: confirmation_text_2
         click_button "Continue"
+        wait_for_ajax
 
         expect(page).to have_current_path(destination_url)
       end

--- a/spec/requests/settings/password_spec.rb
+++ b/spec/requests/settings/password_spec.rb
@@ -157,8 +157,8 @@ describe("Password Settings Scenario", type: :system, js: true) do
         click_on("Set up")
         expect(page).to have_text("Scan this QR code")
 
-        credential = user.reload.totp_credential
-        expect(credential).to be_present
+        wait_until_true { user.reload.totp_credential.present? }
+        credential = user.totp_credential
         expect(credential).not_to be_confirmed
 
         fill_in("Enter the code from your authenticator app", with: credential.otp_code)

--- a/spec/requests/settings/payments_spec.rb
+++ b/spec/requests/settings/payments_spec.rb
@@ -4144,6 +4144,8 @@ describe("Payments Settings Scenario", type: :system, js: true) do
 
     describe "Ghanaian creator" do
       before do
+        allow(StripeMerchantAccountManager).to receive(:create_account)
+
         old_user_compliance_info = @user.alive_user_compliance_info
         new_user_compliance_info = old_user_compliance_info.dup
         new_user_compliance_info.country = "Ghana"


### PR DESCRIPTION
## What

Fixes 8 individually small flaky test issues across different spec files:

- **form_spec.rb**: Add explicit selector wait before `within_cart_item`
- **discover_spec.rb**: Preload thumbnail URL to avoid lazy-load race
- **embed_spec.rb**: Wrap checkout in `expect { }.to change { AffiliateCredit.count }` + `.reload` to handle async affiliate credit creation
- **sections_spec.rb**: Use `scrollIntoView` + JS click for disclosure button hidden by viewport
- **show_spec.rb**: Add `match: :first` to ambiguous `within` selector
- **secure_redirect_spec.rb**: Add `wait_for_ajax` before redirect assertion
- **password_spec.rb**: Use `wait_until_true` for TOTP credential creation (async DB write)
- **payments_spec.rb**: Stub `StripeMerchantAccountManager.create_account` to avoid external API call in Ghanaian creator test

## Why

Each fix addresses a specific race condition, timing issue, or selector ambiguity that causes intermittent CI failures. Grouped together because each is a 1-3 line change.

---

Generated with Claude Opus 4.6.