### PR TITLE
Fix flaky tax calculation tests

### DIFF
--- a/spec/requests/purchases/product/shipping/shipping_offer_codes_spec.rb
+++ b/spec/requests/purchases/product/shipping/shipping_offer_codes_spec.rb
@@ -70,7 +70,11 @@ describe("Product Page - Shipping with offer codes", type: :system, js: true, sh
     add_to_cart(@product, offer_code: @offer_code)
     expect(page).to have_text("Subtotal US$153.24", normalize_ws: true)
     expect(page).to have_text("Shipping rate US$30.65", normalize_ws: true)
-    check_out(@product, address: { street: "3029 W Sherman Rd", city: "San Tan Valley", state: "AZ", zip_code: "85144" }, should_verify_address: true)
+    check_out(@product, address: { street: "3029 W Sherman Rd", city: "San Tan Valley", state: "AZ", zip_code: "85144" }, should_verify_address: true) do
+      fill_in "ZIP code", with: "85144"
+      page.execute_script("document.activeElement.blur()")
+      wait_for_ajax
+    end
 
     expect(page).to have_alert("Your purchase was successful!")
 

--- a/spec/requests/purchases/product/shipping/shipping_physical_preorder_spec.rb
+++ b/spec/requests/purchases/product/shipping/shipping_physical_preorder_spec.rb
@@ -71,10 +71,22 @@ describe("Product Page - Shipping physical preoder", type: :system, js: true, sh
     expect(preorder.state).to eq("authorization_successful")
   end
 
-  it "charges the proper amount with taxes for preorder" do
+  it "charges the proper amount with taxes for preorder", force_vcr_on: true do
     visit "/l/#{@product.unique_permalink}"
     add_to_cart(@product)
     check_out(@product, address: { street: "3029 W Sherman Rd", city: "San Tan Valley", state: "AZ", zip_code: "85144" }, should_verify_address: true) do
+      zip_field = find_field("ZIP code")
+      page.execute_script(<<~JS, zip_field)
+        var el = arguments[0];
+        var setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
+        setter.call(el, '');
+        el.dispatchEvent(new Event('input', { bubbles: true }));
+        setter.call(el, '85144');
+        el.dispatchEvent(new Event('input', { bubbles: true }));
+        el.dispatchEvent(new Event('change', { bubbles: true }));
+        el.dispatchEvent(new Event('blur', { bubbles: true }));
+      JS
+      wait_for_ajax
       expect(page).to have_text("Subtotal US$16", normalize_ws: true)
       expect(page).to have_text("Sales tax US$1.07", normalize_ws: true)
       expect(page).to have_text("Shipping rate US$4", normalize_ws: true)

--- a/spec/requests/purchases/product/shipping/shipping_physical_subscription_spec.rb
+++ b/spec/requests/purchases/product/shipping/shipping_physical_subscription_spec.rb
@@ -43,6 +43,9 @@ describe("Product Page - Shipping physical subscription", type: :system, js: tru
     visit "/l/#{@sub_link.unique_permalink}"
     add_to_cart(@sub_link)
     check_out(@sub_link, address: { street: "3029 W Sherman Rd", city: "San Tan Valley", state: "AZ", zip_code: "85144" }, should_verify_address: true) do
+      fill_in "ZIP code", with: "85144"
+      page.execute_script("document.activeElement.blur()")
+      wait_for_ajax
       expect(page).to have_text("Subtotal US$16", normalize_ws: true)
       expect(page).to have_text("Sales tax US$1.07", normalize_ws: true)
       expect(page).to have_text("Shipping rate US$4", normalize_ws: true)

--- a/spec/requests/purchases/product/shipping/shipping_spec.rb
+++ b/spec/requests/purchases/product/shipping/shipping_spec.rb
@@ -25,7 +25,11 @@ describe("Product Page - Shipping Scenarios", type: :system, js: true, shipping:
 
     visit "/l/#{@product.unique_permalink}"
     add_to_cart(@product)
-    check_out(@product, address: { street: "3029 W Sherman Rd", city: "San Tan Valley", state: "AZ", zip_code: "85144" }, should_verify_address: true)
+    check_out(@product, address: { street: "3029 W Sherman Rd", city: "San Tan Valley", state: "AZ", zip_code: "85144" }, should_verify_address: true) do
+      expect(page).to have_field("ZIP code", with: "85144")
+      page.execute_script("document.activeElement.blur()")
+      wait_for_ajax
+    end
 
     expect(Purchase.last.price_cents).to eq(18389)
     expect(Purchase.last.shipping_cents).to eq(3065)
@@ -44,7 +48,11 @@ describe("Product Page - Shipping Scenarios", type: :system, js: true, shipping:
 
     visit "/l/#{@product.unique_permalink}"
     add_to_cart(@product)
-    check_out(@product, address: { street: "3029 W Sherman Rd", city: "San Tan Valley", state: "AZ", zip_code: "85144" }, should_verify_address: true)
+    check_out(@product, address: { street: "3029 W Sherman Rd", city: "San Tan Valley", state: "AZ", zip_code: "85144" }, should_verify_address: true) do
+      expect(page).to have_field("ZIP code", with: "85144")
+      page.execute_script("document.activeElement.blur()")
+      wait_for_ajax
+    end
 
     expect(Purchase.last.price_cents).to eq(12000)
     expect(Purchase.last.shipping_cents).to eq(2000)

--- a/spec/requests/purchases/product/taxes_spec.rb
+++ b/spec/requests/purchases/product/taxes_spec.rb
@@ -3,6 +3,21 @@
 require("spec_helper")
 
 describe("Product Page - Tax Scenarios", type: :system, js: true) do
+  def set_zip_code_via_js(zip_code)
+    zip_field = find_field("ZIP code")
+    page.execute_script(<<~JS, zip_field, zip_code)
+      var el = arguments[0];
+      var zip = arguments[1];
+      var setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
+      setter.call(el, '');
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+      setter.call(el, zip);
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+      el.dispatchEvent(new Event('change', { bubbles: true }));
+      el.dispatchEvent(new Event('blur', { bubbles: true }));
+    JS
+  end
+
   describe "sales tax", shipping: true, force_vcr_on: true do
     before do
       @creator = create(:user_with_compliance_info)
@@ -14,8 +29,8 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
       visit("/l/#{@product.unique_permalink}")
       add_to_cart(@product)
       check_out(@product, address: { street: "3029 W Sherman Rd", city: "San Tan Valley", state: "AZ", zip_code: "85144" }, should_verify_address: true) do
-        expect(page).to have_field("ZIP code", with: "85144")
-        find_field("ZIP code").send_keys(:tab)
+        expect(page).to have_select("State", selected: "AZ")
+        set_zip_code_via_js("85144")
         wait_for_ajax
         expect(page).to have_text("Sales tax", normalize_ws: true)
         expect(page).to have_text("Total US$553.50", normalize_ws: true)
@@ -56,7 +71,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         visit("/l/#{@product.unique_permalink}")
         add_to_cart(@product, option: "type 1")
         check_out(@product, address: { street: "3029 W Sherman Rd", city: "San Tan Valley", state: "AZ", zip_code: "85144" }, should_verify_address: true) do
-          find_field("ZIP code").send_keys(:tab)
+          set_zip_code_via_js("85144")
           wait_for_ajax
           expect(page).to have_text("Total US$555.16", normalize_ws: true)
         end
@@ -89,7 +104,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         visit "/l/#{@product.unique_permalink}/taxoffer"
         add_to_cart(@product, offer_code:)
         check_out(@product, address: { street: "3029 W Sherman Rd", city: "San Tan Valley", state: "AZ", zip_code: "85144" }, should_verify_address: true) do
-          find_field("ZIP code").send_keys(:tab)
+          set_zip_code_via_js("85144")
           wait_for_ajax
           expect(page).to have_text("Total US$442.80", normalize_ws: true)
         end
@@ -122,6 +137,8 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         visit @product.long_url
         add_to_cart(@product)
         fill_checkout_form(@product, address: { street: "3029 W Sherman Rd", city: "San Tan Valley", state: "AZ", zip_code: "85144" })
+        set_zip_code_via_js("85144")
+        wait_for_ajax
         expect(page).to have_text("Subtotal US$500", normalize_ws: true)
         expect(page).to_not have_text("Tip US$", normalize_ws: true)
         expect(page).to have_text("Sales tax US$53.50", normalize_ws: true)
@@ -171,7 +188,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
 
       add_to_cart(product)
       check_out(product, zip_code: "53703") do
-        find_field("ZIP code").send_keys(:tab)
+        set_zip_code_via_js("53703")
         wait_for_ajax
         expect(page).to have_text("Total US$105.50", normalize_ws: true)
       end
@@ -191,7 +208,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
 
       add_to_cart(product)
       check_out(product, address: { street: "1 S Pinckney St", state: "WI", city: "Madison", zip_code: "53703" }, should_verify_address: true) do
-        find_field("ZIP code").send_keys(:tab)
+        set_zip_code_via_js("53703")
         wait_for_ajax
         expect(page).to have_text("Total US$105.50", normalize_ws: true)
       end
@@ -211,7 +228,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
 
       add_to_cart(product)
       check_out(product, zip_code: "98121") do
-        find_field("ZIP code").send_keys(:tab)
+        set_zip_code_via_js("98121")
         wait_for_ajax
         expect(page).to have_text("Total US$110.35", normalize_ws: true)
       end
@@ -231,7 +248,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
 
       add_to_cart(product)
       check_out(product, address: { street: "2031 7th Ave", state: "WA", city: "Seattle", zip_code: "98121" }, should_verify_address: true) do
-        find_field("ZIP code").send_keys(:tab)
+        set_zip_code_via_js("98121")
         wait_for_ajax
         expect(page).to have_text("Total US$110.35", normalize_ws: true)
       end
@@ -251,7 +268,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
 
       add_to_cart(product)
       check_out(product, zip_code: "53703") do
-        find_field("ZIP code").send_keys(:tab)
+        set_zip_code_via_js("53703")
         wait_for_ajax
         expect(page).to have_text("Total US$105.50", normalize_ws: true)
       end
@@ -271,7 +288,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
 
       add_to_cart(product)
       check_out(product, zip_code: "98121") do
-        find_field("ZIP code").send_keys(:tab)
+        set_zip_code_via_js("98121")
         wait_for_ajax
         expect(page).to have_text("Total US$110.35", normalize_ws: true)
       end
@@ -3765,7 +3782,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
       expect(page).to have_text("Total US$113", normalize_ws: true)
 
       select "QC", from: "Province"
-      find_field("Province").send_keys(:tab)
+      page.execute_script("document.activeElement.blur()")
       wait_for_ajax
       expect(page).to have_text("Total US$114.98", normalize_ws: true)
 
@@ -3796,8 +3813,17 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
         expect(page).to have_select("Country", selected: "Canada")
         expect(page).to have_select("Province", selected: "ON")
         wait_for_ajax
+        expect(page).to have_text("Total US$113", normalize_ws: true)
 
-        check_out(product, address: { street: "568 Beatty St", city: "Vancouver", state: "BC", zip_code: "V6B 2L3" }, should_verify_address: true)
+        select "BC", from: "Province"
+        page.execute_script("document.activeElement.blur()")
+        wait_for_ajax
+        expect(page).to have_text("Total US$112", normalize_ws: true)
+
+        check_out(product, address: { street: "568 Beatty St", city: "Vancouver", state: "BC", zip_code: "V6B 2L3" }, should_verify_address: true) do
+          wait_for_ajax
+          expect(page).to have_text("Total US$112", normalize_ws: true)
+        end
 
         purchase = Purchase.last
         expect(purchase.total_transaction_cents).to eq(112_00)


### PR DESCRIPTION
## What

Fix intermittently failing tax calculation and shipping tests by ensuring ZIP code fields trigger proper form state updates before checkout:

- Add `set_zip_code_via_js` helper in `taxes_spec.rb` that uses the native input value setter to reliably trigger React state updates for ZIP code fields
- Replace `send_keys(:tab)` with `set_zip_code_via_js` across all US tax tests (Wisconsin, Washington, Arizona)
- Add explicit ZIP code blur + `wait_for_ajax` in shipping checkout blocks for offer codes, physical preorder, physical subscription, and standard shipping tests
- Fix Canadian province tax tests to explicitly select province, blur, and wait for AJAX before asserting totals

## Why

These tests were intermittently failing in CI due to race conditions between ZIP code field input and tax calculation AJAX requests. The `send_keys(:tab)` approach was unreliable in headless Chrome — sometimes the blur event wouldn't fire, causing the tax calculation request to never trigger. The native input value setter approach (`Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set`) reliably triggers React's synthetic event system, ensuring the form state updates and tax calculation fires before checkout proceeds.

---

This PR was implemented with AI assistance using Claude Opus 4.6 via autoresearch (automated experiment loop).

Prompts used: "Fix flaky tests in CI using automated experiment loop"