### PR TITLE
Enable force_vcr_on for shipping test suites

### DIFF
--- a/spec/requests/purchases/product/shipping/shipping_offer_codes_spec.rb
+++ b/spec/requests/purchases/product/shipping/shipping_offer_codes_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe("Product Page - Shipping with offer codes", type: :system, js: true, shipping: true) do
+describe("Product Page - Shipping with offer codes", type: :system, js: true, shipping: true, force_vcr_on: true) do
   before do
     # Pin GBP exchange rate to avoid flakiness from currency fluctuations.
     # Rate 0.652578 gives: 100 GBP = $153.24 USD, shipping 20 GBP = $30.65 USD

--- a/spec/requests/purchases/product/shipping/shipping_physical_preorder_spec.rb
+++ b/spec/requests/purchases/product/shipping/shipping_physical_preorder_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe("Product Page - Shipping physical preoder", type: :system, js: true, shipping: true) do
+describe("Product Page - Shipping physical preoder", type: :system, js: true, shipping: true, force_vcr_on: true) do
   before do
     @creator = create(:user_with_compliance_info)
     @product = create(:physical_product, user: @creator, name: "physical preorder", price_cents: 16_00, require_shipping: true, is_in_preorder_state: true)

--- a/spec/requests/purchases/product/shipping/shipping_physical_subscription_spec.rb
+++ b/spec/requests/purchases/product/shipping/shipping_physical_subscription_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe("Product Page - Shipping physical subscription", type: :system, js: true, shipping: true) do
+describe("Product Page - Shipping physical subscription", type: :system, js: true, shipping: true, force_vcr_on: true) do
   before do
     MerchantAccount.find_or_create_by!(user_id: nil, charge_processor_id: StripeChargeProcessor.charge_processor_id) do |ma|
       ma.charge_processor_alive_at = Time.current

--- a/spec/requests/purchases/product/shipping/shipping_spec.rb
+++ b/spec/requests/purchases/product/shipping/shipping_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe("Product Page - Shipping Scenarios", type: :system, js: true, shipping: true) do
+describe("Product Page - Shipping Scenarios", type: :system, js: true, shipping: true, force_vcr_on: true) do
   before do
     # Pin exchange rates to avoid flakiness from currency fluctuations.
     # GBP rate 0.652578 gives: 100 GBP = $153.24 USD, shipping 20 GBP = $30.65 USD

--- a/spec/requests/purchases/product/shipping/shipping_to_virtual_countries_spec.rb
+++ b/spec/requests/purchases/product/shipping/shipping_to_virtual_countries_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe("Product Page - Shipping to Virtual Countries", type: :system, js: true, shipping: true) do
+describe("Product Page - Shipping to Virtual Countries", type: :system, js: true, shipping: true, force_vcr_on: true) do
   it "does not show the blurb if there is shipping, but no tax" do
     @product = create(:product, user: create(:user), require_shipping: true, price_cents: 100_00)
 


### PR DESCRIPTION
## What

Add `force_vcr_on: true` metadata at the describe level for all shipping test suites:

- `shipping_offer_codes_spec.rb`
- `shipping_physical_preorder_spec.rb`
- `shipping_physical_subscription_spec.rb`
- `shipping_spec.rb`
- `shipping_to_virtual_countries_spec.rb`

## Why

These shipping tests make external HTTP calls (address verification, tax calculation) that are intermittently slow or fail in CI when VCR cassettes aren't active. Adding `force_vcr_on: true` at the describe level ensures all tests in these suites use recorded HTTP responses, eliminating network-related flakiness. This is consistent with the existing pattern used in `taxes_spec.rb` and other test suites that depend on external services.

---

This PR was implemented with AI assistance using Claude Opus 4.6 via autoresearch (automated experiment loop).

Prompts used: "Fix flaky tests in CI using automated experiment loop"