### PR TITLE
Fix variant selector display

### DIFF
--- a/app/javascript/components/ProductEdit/ContentTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/index.tsx
@@ -35,6 +35,7 @@ import { fetchDropboxFiles, ResponseDropboxFile, uploadDropboxFile } from "$app/
 import { type Post } from "$app/types/workflow";
 import { escapeRegExp } from "$app/utils";
 import { assertDefined } from "$app/utils/assert";
+import { classNames } from "$app/utils/classNames";
 import { formatDate } from "$app/utils/date";
 import FileUtils from "$app/utils/file";
 import GuidGenerator from "$app/utils/guid_generator";
@@ -1187,7 +1188,10 @@ export const ContentTab = () => {
                             }}
                             aria-selected={item.id === selectedVariantId}
                             inert={product.has_same_rich_content_for_all_variants}
-                            className={product.has_same_rich_content_for_all_variants ? "opacity-30" : undefined}
+                            className={classNames(
+                              props.className,
+                              product.has_same_rich_content_for_all_variants ? "opacity-30" : undefined,
+                            )}
                           >
                             <div className="flex-1">
                               <h4>{item.name || "Untitled"}</h4>


### PR DESCRIPTION
Fixes a bug introduced in #4006 which accidentally overrode the option class name.

Before:

<img width="289" height="418" alt="Screenshot 2026-03-20 at 13 50 43" src="https://github.com/user-attachments/assets/ea8e2096-c0da-4291-8386-cf41edbc5417" />

After:

<img width="344" height="488" alt="Screenshot 2026-03-20 at 13 49 27" src="https://github.com/user-attachments/assets/c6b1dcab-20ea-4037-b7be-c93af8af9a4b" />
