### PR TITLE
Fix leaked VCR ignore_request hooks causing flaky tax tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -528,15 +528,20 @@ def vcr_turned_on
 end
 
 def only_matching_vcr_request_from(hosts)
+  hooks = VCR.request_ignorer.hooks[:ignore_request]
+
   VCR.configure do |c|
     c.ignore_request do |request|
       !hosts.any? { |host| request.uri.match?(host) }
     end
   end
 
+  added_hook = hooks.last
+
   begin
     yield
   ensure
+    hooks.delete(added_hook)
     configure_vcr
   end
 end


### PR DESCRIPTION
# Fix leaked VCR ignore_request hooks causing flaky tax tests

## What

`only_matching_vcr_request_from` adds an `ignore_request` hook via `VCR.configure` but never removes it. The `configure_vcr` call in the `ensure` block reconfigures VCR but doesn't clear previously added hooks. Over multiple `:taxjar`/`:shipping` tests, stale hooks accumulate, causing TaxJar requests to be incorrectly ignored in later tests.

This fix tracks the specific hook added and deletes only that hook in the `ensure` block, so each test cleans up after itself.

## Why

This was one of the most common flaky test failures. Tax calculation tests would pass in isolation but fail when run after other tests that also used `only_matching_vcr_request_from`. The leaked hooks silently swallowed HTTP requests that later tests depended on.

---

This PR was implemented with AI assistance using Claude Opus 4.6.
