### PR TITLE
Fix admin user page showing 'No payout info' before async load completes

### DIFF
--- a/app/javascript/components/Admin/Users/MerchantAccounts.tsx
+++ b/app/javascript/components/Admin/Users/MerchantAccounts.tsx
@@ -40,9 +40,10 @@ const MerchantAccount = ({ external_id, charge_processor_id, alive, charge_proce
 const AdminUserMerchantAccounts = ({ user }: AdminUserMerchantAccountsProps) => {
   const [isLoading, setIsLoading] = React.useState(false);
   const [data, setData] = React.useState<AdminUserMerchantAccountsData | null>(null);
+  const [hasFetched, setHasFetched] = React.useState(false);
 
   const elementRef = useIsIntersecting<HTMLDivElement>((isIntersecting) => {
-    if (!isIntersecting || data) return;
+    if (!isIntersecting || hasFetched) return;
 
     const fetchMerchantAccounts = async () => {
       setIsLoading(true);
@@ -53,30 +54,35 @@ const AdminUserMerchantAccounts = ({ user }: AdminUserMerchantAccountsProps) => 
       });
       setData(cast<AdminUserMerchantAccountsData>(await response.json()));
       setIsLoading(false);
+      setHasFetched(true);
     };
 
     void fetchMerchantAccounts();
   });
 
+  const pending = isLoading || !hasFetched;
+
   return (
     <div ref={elementRef}>
       <h3>Merchant Accounts</h3>
 
-      {isLoading ? <LoadingSpinner /> : null}
+      {pending ? <LoadingSpinner /> : null}
 
-      {data?.merchant_accounts && data.merchant_accounts.length > 0 ? (
+      {!pending && data?.merchant_accounts && data.merchant_accounts.length > 0 ? (
         <InlineList>
           {data.merchant_accounts.map((merchant_account: MerchantAccountProps) => (
             <MerchantAccount key={merchant_account.external_id} {...merchant_account} />
           ))}
         </InlineList>
-      ) : (
+      ) : null}
+
+      {!pending && (!data?.merchant_accounts || data.merchant_accounts.length === 0) ? (
         <Alert role="status" variant="info">
           No merchant accounts.
         </Alert>
-      )}
+      ) : null}
 
-      {!data?.has_stripe_account && (
+      {!pending && !data?.has_stripe_account && (
         <div className="mt-2 flex flex-wrap gap-2">
           <AdminActionButton
             label="Create Managed Account"

--- a/app/javascript/components/Admin/Users/PayoutInfo/index.tsx
+++ b/app/javascript/components/Admin/Users/PayoutInfo/index.tsx
@@ -14,9 +14,10 @@ type AdminUserPayoutInfoProps = {
 const AdminUserPayoutInfo = ({ user }: AdminUserPayoutInfoProps) => {
   const [isLoading, setIsLoading] = React.useState(false);
   const [data, setData] = React.useState<PayoutInfoProps | null>(null);
+  const [hasFetched, setHasFetched] = React.useState(false);
 
   const elementRef = useIsIntersecting<HTMLDivElement>((isIntersecting) => {
-    if (!isIntersecting || data) return;
+    if (!isIntersecting || hasFetched) return;
 
     const fetchPayoutInfo = async () => {
       setIsLoading(true);
@@ -27,6 +28,7 @@ const AdminUserPayoutInfo = ({ user }: AdminUserPayoutInfoProps) => {
       });
       setData(cast<PayoutInfoProps>(await response.json()));
       setIsLoading(false);
+      setHasFetched(true);
     };
 
     void fetchPayoutInfo();
@@ -35,7 +37,7 @@ const AdminUserPayoutInfo = ({ user }: AdminUserPayoutInfoProps) => {
   return (
     <div ref={elementRef}>
       <h3>Payout Info</h3>
-      <PayoutInfo user_external_id={user.external_id} payoutInfo={data} isLoading={isLoading} />
+      <PayoutInfo user_external_id={user.external_id} payoutInfo={data} isLoading={isLoading || !hasFetched} />
     </div>
   );
 };


### PR DESCRIPTION
## What

Both the **PayoutInfo** and **MerchantAccounts** sections on the admin user page use `useIsIntersecting` to lazy-load data when they scroll into view. Before the fetch triggers or completes, they show misleading messages:

- "No payout info found." (PayoutInfo)
- "No merchant accounts." (MerchantAccounts)

This is confusing because the user may actually have payout/merchant data — it just hasn't loaded yet.

## Why

The components start with `isLoading: false` and `data: null`. Since the intersection observer hasn't fired yet, the render path hits the "no data" fallback immediately. There's no way to distinguish between "data hasn't been fetched yet" and "data was fetched and is genuinely empty."

## How

Added a `hasFetched` state flag to both components. A loading spinner shows until the fetch completes. The "no data" messages only appear after the API confirms there's nothing to show.

## Before / After

**Before** (current behavior — shows misleading "No payout info found" and "No merchant accounts" before async data loads):

The Payout Info section says "No payout info found" and Merchant Accounts says "No merchant accounts" even though this user (nushiai) has an ACH account at Wells Fargo and a Stripe merchant account. The data only appears after scrolling triggers the intersection observer.

**After** (with this fix):

A loading spinner shows in both sections until the async fetch completes. "No payout info" / "No merchant accounts" only displays after the API confirms there's genuinely no data.

## Testing

Verified on production (`/admin/users/nushiai`):
1. On initial page load (before scrolling to the section), the DOM shows "No payout info found" and "No merchant accounts"
2. After scrolling to trigger the intersection observer, the `/admin/users/{id}/payout_info` endpoint returns actual data (Wells Fargo ACH account, payouts paused by system)
3. The `/admin/users/{id}/merchant_accounts` endpoint also returns a Stripe merchant account
4. The fix ensures a loading spinner shows instead of the misleading empty-state messages until the fetch completes