### PR TITLE
Fix incorrect escaping in 2FA callback URL

### DIFF
--- a/app/controllers/user/omniauth_callbacks_controller.rb
+++ b/app/controllers/user/omniauth_callbacks_controller.rb
@@ -68,7 +68,7 @@ class User::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
       if user.email.present?
         sign_in_or_prepare_for_two_factor_auth(user)
-        return safe_redirect_to two_factor_authentication_path(next: oauth_completions_stripe_path)
+        return redirect_to two_factor_authentication_path(next: oauth_completions_stripe_path)
       else
         sign_in user
         return safe_redirect_to oauth_completions_stripe_path
@@ -96,7 +96,7 @@ class User::OmniauthCallbacksController < Devise::OmniauthCallbacksController
         redirect_to login_path
       elsif @user.email.present?
         sign_in_or_prepare_for_two_factor_auth(@user)
-        safe_redirect_to two_factor_authentication_path(next: post_auth_redirect(@user))
+        redirect_to two_factor_authentication_path(next: post_auth_redirect(@user))
       else
         sign_in @user
         safe_redirect_to post_auth_redirect(@user)
@@ -124,7 +124,7 @@ class User::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     def post_auth_redirect(user)
       referer = params[:referer].presence || request.env["omniauth.origin"]
       if referer.present? && referer != "/"
-        referer
+        safe_redirect_path(referer)
       else
         safe_redirect_path(helpers.signed_in_user_home(user))
       end

--- a/spec/controllers/user/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/user/omniauth_callbacks_controller_spec.rb
@@ -40,7 +40,7 @@ describe User::OmniauthCallbacksController do
         user = User.last
         expect(user.email).to eq("stripe.connect@gum.co")
         expect(user.confirmed?).to be true
-        expect(response).to redirect_to safe_redirect_path(two_factor_authentication_path(next: oauth_completions_stripe_path))
+        expect(response).to redirect_to two_factor_authentication_path(next: oauth_completions_stripe_path)
       end
 
       it "redirects directly to completion when user has no email" do
@@ -61,7 +61,7 @@ describe User::OmniauthCallbacksController do
         user = User.last
         expect(user.email).to eq("stripe.connect@gum.co")
         expect(controller.user_signed_in?).to be false
-        expect(response).to redirect_to safe_redirect_path(two_factor_authentication_path(next: oauth_completions_stripe_path))
+        expect(response).to redirect_to two_factor_authentication_path(next: oauth_completions_stripe_path)
       end
 
       it "does not create a new user if the email is already taken" do
@@ -69,7 +69,7 @@ describe User::OmniauthCallbacksController do
 
         expect { post :stripe_connect }.not_to change { User.count }
 
-        expect(response).to redirect_to safe_redirect_path(two_factor_authentication_path(next: oauth_completions_stripe_path))
+        expect(response).to redirect_to two_factor_authentication_path(next: oauth_completions_stripe_path)
       end
     end
 
@@ -147,7 +147,7 @@ describe User::OmniauthCallbacksController do
         expect(user.email).to eq("stripe.connect@gum.co")
         expect(purchase1.reload.purchaser_id).to eq(user.id)
         expect(purchase2.reload.purchaser_id).to eq(user.id)
-        expect(response).to redirect_to safe_redirect_path(two_factor_authentication_path(next: oauth_completions_stripe_path))
+        expect(response).to redirect_to two_factor_authentication_path(next: oauth_completions_stripe_path)
       end
     end
 
@@ -172,7 +172,7 @@ describe User::OmniauthCallbacksController do
 
         expect { post :stripe_connect }.not_to change { User.count }
 
-        expect(response).to redirect_to safe_redirect_path(two_factor_authentication_path(next: oauth_completions_stripe_path))
+        expect(response).to redirect_to two_factor_authentication_path(next: oauth_completions_stripe_path)
       end
 
       it "allows existing users with matching email (without Stripe connected) to log in" do
@@ -180,7 +180,7 @@ describe User::OmniauthCallbacksController do
 
         expect { post :stripe_connect }.not_to change { User.count }
 
-        expect(response).to redirect_to safe_redirect_path(two_factor_authentication_path(next: oauth_completions_stripe_path))
+        expect(response).to redirect_to two_factor_authentication_path(next: oauth_completions_stripe_path)
       end
 
       it "allows existing users without email to log in" do
@@ -240,13 +240,19 @@ describe User::OmniauthCallbacksController do
 
       it "does not allow user to login with Google only" do
         post :google_oauth2
-        expect(response).to redirect_to CGI.unescape(two_factor_authentication_path(next: dashboard_path))
+        expect(response).to redirect_to two_factor_authentication_path(next: dashboard_path)
       end
 
       it "keeps referral intact" do
         request.env["omniauth.origin"] = balance_path
         post :google_oauth2
-        expect(response).to redirect_to CGI.unescape(two_factor_authentication_path(next: balance_path))
+        expect(response).to redirect_to two_factor_authentication_path(next: balance_path)
+      end
+
+      it "sanitizes external domain in referral to a relative path" do
+        request.env["omniauth.origin"] = "https://evil.com/phishing"
+        post :google_oauth2
+        expect(response).to redirect_to two_factor_authentication_path(next: "/phishing")
       end
     end
 


### PR DESCRIPTION
## Problem

The mobile app Google authentication was still broken after https://github.com/antiwork/gumroad/pull/4074 because query parameters would be stripped when redirecting.

The two-factor authentication redirect was passing its entire URL through `safe_redirect_to`, which unescapes it. This decoded the `%3F` and `%26` characters in the `next` query parameter value back to literal `?` and `&`, making them into part of the outer URL. So a URL like:

```
/two-factor?next=%2Foauth%2Fauthorize%3Fcode_challenge%3Dxxx%26code_challenge_method%3DS256
```

became:

```
/two-factor?next=/oauth/authorize?code_challenge=xxx&code_challenge_method=S256
```

## Solution

Move the open-redirect protection (`safe_redirect_path`) to sanitize the `next` value *before* it's encoded into `two_factor_authentication_path`, rather than wrapping the entire encoded URL after.