### PR TITLE
Increase CI test parallelization (fast 15→20, slow 45→55)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -157,8 +157,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ci_node_total: [15]
-        ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+        ci_node_total: [20]
+        ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -260,7 +260,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ci_node_total: [45]
+        ci_node_total: [55]
         ci_node_index:
           [
             0,
@@ -308,6 +308,16 @@ jobs:
             42,
             43,
             44,
+            45,
+            46,
+            47,
+            48,
+            49,
+            50,
+            51,
+            52,
+            53,
+            54,
           ]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## What

Increase the number of parallel CI test nodes:
- **Test Fast**: 15 → 20 nodes
- **Test Slow**: 45 → 55 nodes

Knapsack Pro dynamically rebalances test splits across nodes, so this is a config-only change.

## Why

Analyzed a recent successful CI run:

| Suite | Nodes | Longest node | Average | Bottleneck |
|-------|-------|-------------|---------|------------|
| Test Fast | 15 | 12.0min | 11.9min | Evenly balanced |
| Test Slow | 45 | **23.2min** | 10.6min | Node 0 is 2x the average |

The wall clock is **30.7min** (build ~6min + slowest test ~23min). Test Slow node 0 takes 23min while 36 of 45 nodes finish in 10-12min. That single outlier determines the total CI time.

Adding 10 more slow nodes lets Knapsack Pro redistribute the heavy request specs (which use browser/Capybara and are inherently slower) across more runners, reducing the longest node time.

**Expected improvement**: ~5-8min reduction in total CI wall clock (from ~31min to ~23-26min).