### PR TITLE
Fix admin product file access 404

### DIFF
--- a/app/javascript/components/Admin/Products/Header.tsx
+++ b/app/javascript/components/Admin/Products/Header.tsx
@@ -76,7 +76,7 @@ const AdminUsersProductsHeader = ({ product, isCurrentUrl }: Props) => (
       {product.alive_product_files.map((file) => (
         <a
           key={file.external_id}
-          href={Routes.admin_access_product_file_admin_product_path(product.unique_permalink, file.external_id)}
+          href={Routes.admin_access_product_file_admin_product_path(product.external_id, file.external_id)}
           className={buttonVariants({ size: "sm" })}
           target="_blank"
           rel="noreferrer noopener"


### PR DESCRIPTION
Fixes: #4082

## What

The file access buttons on the admin product page were generating URLs with `product.unique_permalink` instead of `product.external_id`, causing a 404 because `fetch_product!` expects an obfuscated external ID.

## Why

Every other admin link on the page uses `product.external_id`, but the file access link was the sole outlier using `product.unique_permalink`. The `fetch_product!` before action decrypts the parameter via `ObfuscateIds.decrypt`, which fails on a permalink string, resulting in a 404.
