### PR TITLE
Don't report validation errors to Sentry in settings update

### DIFF
--- a/app/controllers/settings/main_controller.rb
+++ b/app/controllers/settings/main_controller.rb
@@ -28,6 +28,10 @@ class Settings::MainController < Settings::BaseController
     current_seller.update_product_level_support_emails!(params[:user][:product_level_support_emails])
 
     redirect_to settings_main_path, status: :see_other, notice: "Your account has been updated!"
+  rescue ActiveRecord::RecordInvalid
+    error_message = current_seller.errors.full_messages.to_sentence.presence ||
+      "Something broke. We're looking into what happened. Sorry about this!"
+    redirect_to settings_main_path, alert: error_message
   rescue StandardError => e
     ErrorNotifier.notify(e)
     error_message = current_seller.errors.full_messages.to_sentence.presence ||

--- a/spec/controllers/settings/main_controller_spec.rb
+++ b/spec/controllers/settings/main_controller_spec.rb
@@ -49,8 +49,9 @@ describe Settings::MainController, type: :controller, inertia: true do
       expect(seller.reload.unconfirmed_email).to eq("hello@example.com")
     end
 
-    it "returns error message when StandardError is raised" do
+    it "returns error message and notifies Sentry when StandardError is raised" do
       allow_any_instance_of(User).to receive(:save!).and_raise(StandardError)
+      expect(ErrorNotifier).to receive(:notify).with(an_instance_of(StandardError))
       put :update, params: { user: user_params.merge(email: "hello@example.com") }
       expect(response).to redirect_to(settings_main_path)
       expect(response).to have_http_status :found
@@ -81,6 +82,15 @@ describe Settings::MainController, type: :controller, inertia: true do
       expect(response).to redirect_to(settings_main_path)
       expect(response).to have_http_status :found
       expect(flash[:alert]).to eq("Email is invalid")
+    end
+
+    it "does not notify Sentry when updating email to one that already exists" do
+      create(:user, email: "existing@example.com")
+      expect(ErrorNotifier).not_to receive(:notify)
+      put :update, params: { user: user_params.merge(email: "existing@example.com") }
+      expect(response).to redirect_to(settings_main_path)
+      expect(response).to have_http_status :found
+      expect(flash[:alert]).to eq("An account already exists with this email.")
     end
 
     describe "email changing" do


### PR DESCRIPTION
# Don't report validation errors to Sentry in settings update

## What

`Settings::MainController#update` catches all `StandardError` exceptions and reports them to Sentry via `ErrorNotifier.notify`. This means expected validation failures (like a user trying to change their email to one that's already taken) create Sentry issues that look like bugs but aren't.

This PR adds a separate `rescue ActiveRecord::RecordInvalid` clause before the general `StandardError` catch. Validation errors now show the user-friendly message without pinging Sentry. Truly unexpected errors still get reported.

## Why

Validation failures are expected user behavior, not application errors. Reporting them to Sentry creates noise that makes it harder to spot real issues. The user already sees the correct error message either way; the only difference is whether Sentry gets a false alarm.

## Test Results

All 36 specs in `settings/main_controller_spec.rb` pass. Added a new test confirming `ErrorNotifier` is not called for duplicate-email validation, and strengthened the existing `StandardError` test to verify `ErrorNotifier` IS called for unexpected errors.

---

This PR was implemented with AI assistance using Claude Opus 4.6.

Prompts used:

- Sentry webhook with exception details and workflow instructions
