### PR TITLE
Fix NoMethodError: nil.products in Settings::Profile::ProductsController

### DIFF
--- a/app/controllers/settings/profile/products_controller.rb
+++ b/app/controllers/settings/profile/products_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Settings::Profile::ProductsController < ApplicationController
+class Settings::Profile::ProductsController < Settings::BaseController
   def show
     product = current_seller.products.find_by_external_id!(params[:id])
     authorize product

--- a/spec/controllers/settings/profile/products_controller_spec.rb
+++ b/spec/controllers/settings/profile/products_controller_spec.rb
@@ -1,24 +1,37 @@
 # frozen_string_literal: true
 
 require "shared_examples/authorize_called"
+require "shared_examples/sellers_base_controller_concern"
 
 describe Settings::Profile::ProductsController do
+  it_behaves_like "inherits from Sellers::BaseController"
+
   let(:seller) { create(:user) }
   let(:product) { create(:product, user: seller) }
 
-  include_context "with user signed in as admin for seller"
-
-  describe "GET show" do
-    it_behaves_like "authorize called for action", :get, :show do
-      let!(:record) { product }
-      let(:policy_klass) { LinkPolicy }
-      let(:request_params) { { id: product.external_id } }
+  describe "GET show (unauthenticated)" do
+    it "redirects to login" do
+      get :show, params: { id: "any" }
+      expect(response).to have_http_status(:found)
+      expect(response.location).to include(login_path)
     end
+  end
 
-    it "returns props for that product" do
-      get :show, params: { id: product.external_id }
-      expect(response).to be_successful
-      expect(response.parsed_body).to eq(ProductPresenter.new(product:, request:).product_props(seller_custom_domain_url: nil).as_json)
+  context "when authenticated" do
+    include_context "with user signed in as admin for seller"
+
+    describe "GET show" do
+      it_behaves_like "authorize called for action", :get, :show do
+        let!(:record) { product }
+        let(:policy_klass) { LinkPolicy }
+        let(:request_params) { { id: product.external_id } }
+      end
+
+      it "returns props for that product" do
+        get :show, params: { id: product.external_id }
+        expect(response).to be_successful
+        expect(response.parsed_body).to eq(ProductPresenter.new(product:, request:).product_props(seller_custom_domain_url: nil).as_json)
+      end
     end
   end
 end


### PR DESCRIPTION
# Fix NoMethodError: nil.products in Settings::Profile::ProductsController

## What

Changed `Settings::Profile::ProductsController` to inherit from `Settings::BaseController` instead of `ApplicationController`. Added a test covering unauthenticated access to the `show` action.

## Why

The controller was missing the `authenticate_user!` before-action that every other settings controller gets through `Settings::BaseController`. Unauthenticated requests would reach the `show` action where `current_seller` returns `nil`, causing a `NoMethodError: undefined method 'products' for nil`. This was surfacing as a Sentry error in production.

---

This PR was implemented with AI assistance using Claude Sonnet 4.6.

Prompts used:

- "Fix Sentry issue: NoMethodError on current_seller.products in Settings::Profile::ProductsController#show"
