### PR TITLE
Handle ActiveStorage::PreviewError gracefully in PreviewImageJob

### DIFF
--- a/config/initializers/active_storage_preview_error_handling.rb
+++ b/config/initializers/active_storage_preview_error_handling.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Rails.application.config.after_initialize do
+  ActiveStorage::PreviewImageJob.discard_on(ActiveStorage::PreviewError) do |job, error|
+    Rails.logger.warn("[ActiveStorage] Discarding PreviewImageJob: #{error.message}")
+  end
+end

--- a/spec/jobs/active_storage_preview_image_job_spec.rb
+++ b/spec/jobs/active_storage_preview_image_job_spec.rb
@@ -6,9 +6,9 @@ describe ActiveStorage::PreviewImageJob do
   it "discards the job when ActiveStorage::PreviewError is raised" do
     allow_any_instance_of(described_class).to receive(:perform).and_raise(ActiveStorage::PreviewError, "ffmpeg failed (status 1)")
 
-    expect {
+    expect do
       described_class.perform_now("fake_blob_id")
-    }.not_to raise_error
+    end.not_to raise_error
   end
 
   it "logs a warning when discarding due to PreviewError" do

--- a/spec/jobs/active_storage_preview_image_job_spec.rb
+++ b/spec/jobs/active_storage_preview_image_job_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe ActiveStorage::PreviewImageJob do
+  it "discards the job when ActiveStorage::PreviewError is raised" do
+    allow_any_instance_of(described_class).to receive(:perform).and_raise(ActiveStorage::PreviewError, "ffmpeg failed (status 1)")
+
+    expect {
+      described_class.perform_now("fake_blob_id")
+    }.not_to raise_error
+  end
+
+  it "logs a warning when discarding due to PreviewError" do
+    allow_any_instance_of(described_class).to receive(:perform).and_raise(ActiveStorage::PreviewError, "ffmpeg failed (status 1)")
+    allow(Rails.logger).to receive(:warn)
+
+    described_class.perform_now("fake_blob_id")
+
+    expect(Rails.logger).to have_received(:warn).with(/Discarding PreviewImageJob.*ffmpeg failed/)
+  end
+end


### PR DESCRIPTION
## Problem

`ActiveStorage::PreviewImageJob` raises `ActiveStorage::PreviewError` when ffmpeg can't decode a video (e.g., videos encoded with the APV codec from DaVinci Resolve). Since our server's ffmpeg build doesn't support this codec, the job fails and retries indefinitely, flooding Sentry with noise.

## Fix

Added an initializer that configures `ActiveStorage::PreviewImageJob` to `discard_on ActiveStorage::PreviewError`. When ffmpeg fails on an unsupported codec, the job is discarded with a warning log instead of retrying.

This is a safe change since the error is unrecoverable (upgrading ffmpeg would be the real fix, but discarding prevents pointless retries in the meantime).

## Changes

- `config/initializers/active_storage_preview_error_handling.rb`: Patches the job to discard on `PreviewError`
- `spec/jobs/active_storage_preview_image_job_spec.rb`: Tests verifying the discard behavior