### PR TITLE
Fix NoMethodError when affiliate_credit is nil in collaborator sale email

### DIFF
--- a/app/mailers/affiliate_mailer.rb
+++ b/app/mailers/affiliate_mailer.rb
@@ -206,7 +206,7 @@ class AffiliateMailer < ApplicationMailer
       @quantity = @purchase.quantity
       @variants = @purchase.variants_list
       @variants_count = @purchase.variant_names&.count || 0
-      @cut = MoneyFormatter.format(@purchase.affiliate_credit_cents + @purchase.affiliate_credit.fee_cents, :usd, no_cents_if_whole: true, symbol: true)
+      @cut = MoneyFormatter.format(@purchase.affiliate_credit_cents + (@purchase.affiliate_credit&.fee_cents || 0), :usd, no_cents_if_whole: true, symbol: true)
 
       @subject = "You made a sale!"
       set_notify_of_sale_headers(is_preorder: @is_preorder)

--- a/spec/mailers/affiliate_mailer_spec.rb
+++ b/spec/mailers/affiliate_mailer_spec.rb
@@ -106,6 +106,22 @@ describe AffiliateMailer do
         expect(mail.body.encoded).to include "(Blue, Small)"
       end
     end
+
+    context "for a collaborator with no affiliate_credit record" do
+      it "handles missing affiliate_credit gracefully" do
+        product = create(:product, user: seller, name: product_name, price_cents: 0)
+        collaborator = create(:collaborator, seller:, affiliate_basis_points: 40_00, products: [product])
+        purchase = create(:purchase, link: product, seller:, price_cents: 0)
+        purchase.update_columns(affiliate_id: collaborator.id, affiliate_credit_cents: 8_00)
+
+        expect(purchase.reload.affiliate_credit).to be_nil
+
+        mail = AffiliateMailer.notify_affiliate_of_sale(purchase.id)
+        expect(mail.to).to eq([collaborator.affiliate_user.form_email])
+        expect(mail.body.encoded).to include "Your cut"
+        expect(mail.body.encoded).to include "$8"
+      end
+    end
   end
 
   describe "#notify_direct_affiliate_of_updated_products" do


### PR DESCRIPTION
Fix NoMethodError when affiliate_credit is nil in collaborator sale email

## What

`AffiliateMailer#notify_collaborator_of_sale` calls `@purchase.affiliate_credit.fee_cents` without guarding against nil. When a purchase has no associated `AffiliateCredit` record, this raises a `NoMethodError`. Added safe navigation (`&.fee_cents || 0`) so the mailer gracefully handles the missing record.

## Why

The `AffiliateCredit` record is only created during `create_affiliate_balances!`, which is skipped when `affiliate_credit_cents` is 0. If a collaborator sale email fires for a purchase in this state, the mailer crashes. This was caught in production via [Sentry](https://gumroad-to.sentry.io/issues/7367295224/).

---

This PR was implemented with AI assistance using Claude Opus 4.6.

Prompts used:

- Sentry webhook trigger: "NoMethodError: undefined method 'fee_cents' for nil"
- Investigated stacktrace, identified nil guard fix, wrote regression test
