### PR TITLE
Fix ActiveRecord::RecordInvalid on Google OAuth when email conflicts

### DIFF
--- a/app/models/concerns/user/social_google.rb
+++ b/app/models/concerns/user/social_google.rb
@@ -94,7 +94,9 @@ module User::SocialGoogle
       # on google's side
       # https://support.google.com/accounts/answer/19870?hl=en
       if EmailFormatValidator.valid?(email) && user.email&.downcase != email.downcase
-        user.email = email
+        if user.new_record? || User.by_email(email).where.not(id: user.id).empty?
+          user.email = email
+        end
       end
 
       # Set user's avatar if they don't have one

--- a/spec/modules/user/social_google_spec.rb
+++ b/spec/modules/user/social_google_spec.rb
@@ -45,6 +45,22 @@ describe User::SocialGoogle do
       expect(createdUser.reload.google_uid).to eq(@dataCopy2["uid"])
     end
 
+    it "signs in the user without updating email when Google email conflicts with another account" do
+      existing_user = create(:user, email: "taken@example.com")
+      oauth_user = create(:user, email: "original@example.com", google_uid: "conflict_test_uid")
+
+      conflict_data = @data.deep_dup
+      conflict_data["uid"] = "conflict_test_uid"
+      conflict_data["info"]["email"] = "taken@example.com"
+      conflict_data["extra"]["raw_info"]["email"] = "taken@example.com"
+
+      result = User.find_or_create_for_google_oauth2(conflict_data)
+
+      expect(result).to eq(oauth_user)
+      expect(oauth_user.reload.email).to eq("original@example.com")
+      expect(existing_user.reload.email).to eq("taken@example.com")
+    end
+
     it "creates user with sanitized name when name contains colons" do
       @data_with_colon = @data.deep_dup
       @data_with_colon["uid"] = "unique_colon_test_uid"
@@ -98,6 +114,27 @@ describe User::SocialGoogle do
         @user = create(:user, email: "spongebob@example.com")
 
         expect { User.query_google(@user, @data) }.to change { @user.reload.email }.from("spongebob@example.com").to(@data["info"]["email"])
+      end
+
+      context "when the Google email is already used by another account" do
+        before do
+          @existing_user = create(:user, email: @data["info"]["email"])
+          @user = create(:user, email: "other@example.com", google_uid: @data["uid"])
+        end
+
+        it "does not update the email" do
+          expect { User.query_google(@user, @data) }.not_to change { @user.reload.email }
+        end
+
+        it "does not raise an error" do
+          expect { User.query_google(@user, @data) }.not_to raise_error
+        end
+
+        it "still signs the user in successfully" do
+          result = User.query_google(@user, @data)
+          expect(result).to eq(@user)
+          expect(@user.reload.email).to eq("other@example.com")
+        end
       end
 
       context "when the email already exists in a different case" do


### PR DESCRIPTION
## What

When a user signs in via Google OAuth and their Google email has changed to one already used by another Gumroad account, `query_google` would set the new email on the user and `save!` would raise `ActiveRecord::RecordInvalid` due to the `email_almost_unique` validation. While the exception was caught in `find_or_create_for_google_oauth2`, it resulted in Sentry errors on every occurrence and the user seeing a generic "something went wrong" instead of being signed in.

This PR adds a check in `query_google` before updating the email: if the Google email already belongs to another account, the email update is skipped and the user is signed in with their existing email. The check only applies to existing users. New users still get the email set normally since `find_or_create_for_google_oauth2` already handles duplicate detection for new accounts.

## Why

This eliminates a class of Sentry noise (`ActiveRecord::RecordInvalid: Validation failed: An account already exists with this email.`) and, more importantly, lets users sign in successfully even when their Google email has changed to one that conflicts with another Gumroad account. The alternative of merging accounts or prompting the user was considered too complex for this edge case. Silently keeping the old email and signing them in is the least disruptive behavior.

---

This PR was implemented with AI assistance using Claude Opus 4.6.

Prompts used:

- "Fix ActiveRecord::RecordInvalid on Google OAuth when email conflicts (with detailed bug description and fix specification)"
