### PR TITLE
Fix NoMethodError on nil purchase_as_chargeable in receipt emails

### DIFF
--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -152,11 +152,11 @@ class Charge < ApplicationRecord
   end
 
   def external_id_for_invoice
-    purchase_as_chargeable.external_id
+    purchase_as_chargeable&.external_id || external_id
   end
 
   def external_id_numeric_for_invoice
-    purchase_as_chargeable.external_id_numeric.to_s
+    purchase_as_chargeable&.external_id_numeric&.to_s || external_id_numeric.to_s
   end
 
   def country_or_ip_country

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -197,6 +197,14 @@ describe Charge, :vcr do
     it "returns the external_id of the purchase" do
       expect(charge.external_id_for_invoice).to eq(purchase.external_id)
     end
+
+    context "when there are no successful purchases" do
+      let(:charge) { create(:charge) }
+
+      it "falls back to the charge's own external_id" do
+        expect(charge.external_id_for_invoice).to eq(charge.external_id)
+      end
+    end
   end
 
   describe "#external_id_numeric_for_invoice" do
@@ -205,6 +213,14 @@ describe Charge, :vcr do
 
     it "returns the external_id_numeric of the purchase" do
       expect(charge.external_id_numeric_for_invoice).to eq(purchase.external_id_numeric.to_s)
+    end
+
+    context "when there are no successful purchases" do
+      let(:charge) { create(:charge) }
+
+      it "falls back to the charge's own external_id_numeric" do
+        expect(charge.external_id_numeric_for_invoice).to eq(charge.external_id_numeric.to_s)
+      end
     end
   end
 


### PR DESCRIPTION
## What

When a `Charge` has no successful purchases, `purchase_as_chargeable` returns `nil`. Calling `external_id_for_invoice` or `external_id_numeric_for_invoice` on such a charge raises `NoMethodError: undefined method 'external_id' for nil`, crashing receipt email rendering.

This adds nil guards to both methods, falling back to the charge's own `external_id` / `external_id_numeric` (available via the `ExternalId` concern) when no successful purchase exists.

## Why

This was a Sentry error (`ActionView::Template::Error`) triggered from `ReceiptPresenter::ChargeInfo#order_id` when rendering `customer_mailer/receipt/sections/_header.html.erb`. The root cause is that `purchase_as_chargeable` (which returns `successful_purchases.first`) can be `nil`, and these two methods didn't account for that.

The charge's own `external_id` is a reasonable fallback since it still produces a valid, unique identifier for the receipt.

## Other callers

Other callers of `purchase_as_chargeable` that could also hit nil (lines 23, 55, 71, 90-91, 143, 178) are not fixed here. They cover different code paths (invoice PDF upload, country lookup, buyer blocking, etc.) and should be evaluated separately. This PR only fixes the two methods causing the Sentry crash.

## Test Results

```
2 examples, 0 failures
```

Two new specs confirm both methods return the charge's own external ID when no successful purchases exist.

---

This PR was written with AI assistance using Claude Opus 4.6.
