### PR TITLE
Fix Rack::Timeout in AssetPreviewsController#create for large images

### DIFF
--- a/app/models/asset_preview.rb
+++ b/app/models/asset_preview.rb
@@ -9,6 +9,7 @@ class AssetPreview < ApplicationRecord
   RETINA_DISPLAY_WIDTH = (DEFAULT_DISPLAY_WIDTH * 1.5).to_i
 
   after_commit :invalidate_product_cache
+  after_commit :enqueue_retina_variant_processing, on: :create
   after_create :reset_moderated_by_iffy_flag
 
   # Update updated_at of product to regenerate the sitemap in RefreshSitemapMonthlyWorker
@@ -84,6 +85,12 @@ class AssetPreview < ApplicationRecord
     file.variant(resize_to_limit: [retina_width, nil]).processed
   end
 
+  def retina_variant_processed?
+    return false unless file.attached?
+    variation = ActiveStorage::Variation.wrap(resize_to_limit: [retina_width, nil])
+    file.blob.variant_records.exists?(variation_digest: variation.digest)
+  end
+
   def display_type
     return "unsplash" if unsplash_url
     return "oembed" if oembed
@@ -149,6 +156,10 @@ class AssetPreview < ApplicationRecord
 
     style ||= default_style
 
+    if style == :retina && !retina_variant_processed?
+      return file.url
+    end
+
     Rails.cache.fetch("attachment_#{file.id}_#{style}_url") do
       if style == :retina
         retina_variant.url
@@ -204,6 +215,10 @@ class AssetPreview < ApplicationRecord
   end
 
   private
+    def enqueue_retina_variant_processing
+      PreprocessAssetPreviewVariantJob.perform_async(id) if should_post_process?
+    end
+
     def set_position
       previous = link.asset_previews.in_order.last
       if previous

--- a/app/sidekiq/preprocess_asset_preview_variant_job.rb
+++ b/app/sidekiq/preprocess_asset_preview_variant_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class PreprocessAssetPreviewVariantJob
+  include Sidekiq::Job
+  sidekiq_options queue: :default, retry: 3
+
+  def perform(asset_preview_id)
+    asset_preview = AssetPreview.find_by(id: asset_preview_id)
+    return unless asset_preview&.should_post_process? && asset_preview.file.attached?
+
+    asset_preview.retina_variant
+    # Warm the URL cache after processing
+    Rails.cache.delete("attachment_#{asset_preview.file.id}_retina_url")
+  end
+end

--- a/spec/controllers/asset_previews_controller_spec.rb
+++ b/spec/controllers/asset_previews_controller_spec.rb
@@ -33,6 +33,12 @@ describe AssetPreviewsController do
       end.to change { product.asset_previews.alive.count }.by(1)
     end
 
+    it "enqueues a background job to process the retina variant" do
+      expect do
+        post(:create, params: { link_id: product.unique_permalink, asset_preview: { url: s3_url }, format: :json })
+      end.to change(PreprocessAssetPreviewVariantJob.jobs, :size).by(1)
+    end
+
     it "doesn't add a preview if there are too many previews" do
       stub_const("Link::MAX_PREVIEW_COUNT", 1)
       allow_any_instance_of(AssetPreview).to receive(:analyze_file).and_return(nil)

--- a/spec/models/asset_preview_spec.rb
+++ b/spec/models/asset_preview_spec.rb
@@ -266,8 +266,25 @@ describe AssetPreview, :vcr do
         expect(asset_preview.display_height).to eq(210)
       end
 
+      describe "#retina_variant_processed?" do
+        it "returns false before variant is processed" do
+          expect(asset_preview.retina_variant_processed?).to eq(false)
+        end
+
+        it "returns true after variant is processed" do
+          asset_preview.retina_variant
+          expect(asset_preview.retina_variant_processed?).to eq(true)
+        end
+      end
+
       describe "#url" do
-        it "returns retina variant" do
+        it "returns original file URL when retina variant is not yet processed" do
+          expect(asset_preview.url).to match(asset_preview.file.key)
+        end
+
+        it "returns retina variant URL when variant has been processed" do
+          asset_preview.retina_variant # pre-process the variant
+          Rails.cache.clear
           expect(asset_preview.url).to match(asset_preview.retina_variant.key)
         end
 
@@ -291,6 +308,20 @@ describe AssetPreview, :vcr do
   end
 
   describe "callbacks" do
+    describe "#enqueue_retina_variant_processing" do
+      it "enqueues a background job on create for image previews" do
+        expect do
+          create(:asset_preview)
+        end.to change(PreprocessAssetPreviewVariantJob.jobs, :size).by(1)
+      end
+
+      it "does not enqueue a background job for non-image previews" do
+        expect do
+          create(:asset_preview_mov)
+        end.not_to change(PreprocessAssetPreviewVariantJob.jobs, :size)
+      end
+    end
+
     describe "#reset_moderated_by_iffy_flag" do
       let(:product) { create(:product, moderated_by_iffy: true) }
       let(:asset_preview) { create(:asset_preview, link: product) }

--- a/spec/sidekiq/preprocess_asset_preview_variant_job_spec.rb
+++ b/spec/sidekiq/preprocess_asset_preview_variant_job_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+describe PreprocessAssetPreviewVariantJob do
+  describe "#perform" do
+    it "processes the retina variant for an image asset preview" do
+      asset_preview = create(:asset_preview)
+      expect(asset_preview).to receive(:retina_variant).and_return(double(url: "https://example.com/retina.png"))
+      allow(AssetPreview).to receive(:find_by).with(id: asset_preview.id).and_return(asset_preview)
+
+      PreprocessAssetPreviewVariantJob.new.perform(asset_preview.id)
+    end
+
+    it "is a no-op for non-image files" do
+      asset_preview = create(:asset_preview_mov)
+      expect(asset_preview).not_to receive(:retina_variant)
+      allow(AssetPreview).to receive(:find_by).with(id: asset_preview.id).and_return(asset_preview)
+
+      PreprocessAssetPreviewVariantJob.new.perform(asset_preview.id)
+    end
+
+    it "is a no-op for missing asset previews" do
+      expect { PreprocessAssetPreviewVariantJob.new.perform(0) }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
Fix Rack::Timeout in AssetPreviewsController#create for large images

## What

When a user uploads a large image as an asset preview, the controller renders `display_asset_previews` as JSON. This triggers synchronous retina variant processing (download blob, resize with libvips, re-upload to S3), which can exceed the 120s rack timeout for large images.

This PR makes three changes:

1. **Defers retina variant processing to a background job.** A new `PreprocessAssetPreviewVariantJob` processes the retina variant asynchronously after creation via an `after_commit` callback.

2. **Returns the original file URL until the variant is ready.** `url_from_file` now checks whether the variant record already exists (via `retina_variant_processed?`) before attempting to serve it. If the variant hasn't been processed yet, it returns the original file URL instead of blocking.

3. **`retina_variant_processed?`** checks for the variant record existence using `variant_records.exists?` without triggering processing.

## Why

The synchronous `.processed` call during the HTTP request is the root cause of the Rack::Timeout errors in Sentry. Moving this work to Sidekiq keeps the controller response fast regardless of image size. Users see the original (unresized) image briefly until the background job completes, which is an acceptable tradeoff vs. a timeout error.

---

This PR was implemented with AI assistance using Claude Opus 4.6.

Prompts used:

- "Sentry Fix: Rack::Timeout in AssetPreviewsController#create" (full implementation plan with root cause analysis and fix steps)
