### PR TITLE
Fix Elasticsearch BadRequest when :search param is a string

### DIFF
--- a/app/modules/product/searchable.rb
+++ b/app/modules/product/searchable.rb
@@ -360,7 +360,7 @@ module Product::Searchable
       end
 
       search_options = search_options.to_hash
-      search_options[:query][:bool][:must] << params[:search] if params[:search]
+      search_options[:query][:bool][:must] << params[:search] if params[:search].is_a?(Hash)
 
       if (params[:ids].present? || params[:section].is_a?(SellerProfileSection)) && params[:sort] == ProductSortKey::PAGE_LAYOUT
         product_ids = params[:ids] || params[:section].shown_products

--- a/spec/modules/product/searchable/search_spec.rb
+++ b/spec/modules/product/searchable/search_spec.rb
@@ -635,5 +635,25 @@ describe "Product::Searchable - Search scenarios" do
         expect(Link.search(Link.search_options(user_id: [product1.user_id, product2.user_id])).records.map(&:id)).to eq([product1.id, product2.id])
       end
     end
+
+    describe "the :search param" do
+      it "does not raise BadRequest when :search is a string (e.g. passed via query string)" do
+        index_model_records(Link)
+        expect do
+          Link.search(Link.search_options(search: "AI freelancer template")).response
+        end.not_to raise_error
+      end
+
+      it "appends a Hash :search clause to the bool must array" do
+        options = Link.search_options(search: { term: { is_recommendable: true } })
+        expect(options[:query][:bool][:must]).to include(term: { is_recommendable: true })
+      end
+
+      it "does not append a String :search to the bool must array" do
+        options = Link.search_options(search: "some string")
+        must_clauses = options[:query][:bool][:must]
+        expect(must_clauses).to all(be_a(Hash))
+      end
+    end
   end
 end


### PR DESCRIPTION
## What

When a user visits `/discover?search=some+text`, the `search` query parameter is a plain string. `Link.search_options` was appending `params[:search]` directly to the Elasticsearch `bool.must` array without checking its type. Elasticsearch requires every entry in `must` to be a JSON object, so a raw string caused a `parsing_exception` and a 500.

The fix adds a type guard: `params[:search]` is only appended to `must` when it is a `Hash` (a valid Elasticsearch query clause). String values are silently dropped, which is the safe default — there is no meaningful way to turn an arbitrary string into a valid `must` clause.

## Why

A `GET /discover?search=AI+freelancer+template` request hit production and raised `Elasticsearch::Transport::Transport::Errors::BadRequest` with `[_na] query malformed, must start with start_object`. The `params[:search]` path was added to support programmatic callers that pass a pre-built query hash, but had no guard against user-supplied strings from the query string.

---

This PR was implemented with AI assistance using Claude Sonnet 4.6.

Prompts used:

- "Sentry issue investigation and fix: Elasticsearch BadRequest in DiscoverController#index — must clause gets a string instead of an object"