### PR TITLE
Fix TypeError: String can't be coerced into Integer in search_options

### DIFF
--- a/app/modules/product/searchable.rb
+++ b/app/modules/product/searchable.rb
@@ -150,7 +150,7 @@ module Product::Searchable
   class_methods do
     def search_options(params)
       search_options = Elasticsearch::DSL::Search.search do
-        size params.fetch(:size, RECOMMENDED_PRODUCTS_PER_PAGE)
+        size params.fetch(:size, RECOMMENDED_PRODUCTS_PER_PAGE).to_i
         from (params[:from].to_i - 1).clamp(0, MAX_RESULT_WINDOW - size)
         _source false
         if params[:track_total_hits]

--- a/spec/modules/product/searchable/search_spec.rb
+++ b/spec/modules/product/searchable/search_spec.rb
@@ -635,5 +635,16 @@ describe "Product::Searchable - Search scenarios" do
         expect(Link.search(Link.search_options(user_id: [product1.user_id, product2.user_id])).records.map(&:id)).to eq([product1.id, product2.id])
       end
     end
+
+    describe "search_options with string params" do
+      it "does not raise TypeError when size param is a string" do
+        expect { Link.search_options(size: "9") }.not_to raise_error
+      end
+
+      it "converts string size param to integer in the search body" do
+        options = Link.search_options(size: "5")
+        expect(options.to_hash[:size]).to eq(5)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Problem

`UsersController#show` raises `TypeError: String can't be coerced into Integer` when the `:size` param reaches `search_options` as a string.

In `Product::Searchable#search_options`, the Elasticsearch DSL block sets:

```ruby
size params.fetch(:size, RECOMMENDED_PRODUCTS_PER_PAGE)
from (params[:from].to_i - 1).clamp(0, MAX_RESULT_WINDOW - size)
```

When `:size` is a String (which happens via presenter paths that call `search_products` without the controller's `format_search_params!` having sanitized params), the DSL `size` getter returns that string. Then `MAX_RESULT_WINDOW - size` attempts `Integer - String`, raising TypeError.

## Fix

Add `.to_i` to ensure the size value is always an integer:

```ruby
size params.fetch(:size, RECOMMENDED_PRODUCTS_PER_PAGE).to_i
```

## Tests

Added two specs confirming:
1. `Link.search_options(size: "9")` does not raise TypeError
2. String size params are properly converted to integers in the search body

Fixes [SENTRY-7367736997](https://gumroad-to.sentry.io/issues/7367736997/)