### PR TITLE
Fix Aws::S3::Errors::NotFound in archive size estimation

### DIFF
--- a/app/sidekiq/update_product_files_archive_worker.rb
+++ b/app/sidekiq/update_product_files_archive_worker.rb
@@ -132,7 +132,11 @@ class UpdateProductFilesArchiveWorker
         estimated_size += product_file.size
       else
         Rails.logger.info("Fetching product file size from S3.")
-        estimated_size += product_file.s3_object.content_length if product_file.s3?
+        begin
+          estimated_size += product_file.s3_object.content_length if product_file.s3?
+        rescue Aws::S3::Errors::NotFound
+          Rails.logger.info("Product file not found on S3, skipping size estimation.")
+        end
       end
     end
     estimated_size

--- a/spec/sidekiq/update_product_files_archive_worker_spec.rb
+++ b/spec/sidekiq/update_product_files_archive_worker_spec.rb
@@ -188,4 +188,25 @@ describe UpdateProductFilesArchiveWorker, :vcr do
       end
     end
   end
+
+  describe "#calculate_estimated_size" do
+    let(:worker) { described_class.new }
+    let(:product) { create(:product) }
+    let(:product_files_archive) { create(:product_files_archive, link: product) }
+
+    it "skips files missing from S3 instead of raising" do
+      product_file_with_size = create(:product_file, link: product, size: 1000)
+      product_file_missing_on_s3 = create(:product_file, link: product, size: nil)
+      product_files_archive.product_files << [product_file_with_size, product_file_missing_on_s3]
+
+      s3_object = instance_double(Aws::S3::Object)
+      allow(product_file_missing_on_s3).to receive(:s3?).and_return(true)
+      allow(product_file_missing_on_s3).to receive(:s3_object).and_return(s3_object)
+      allow(s3_object).to receive(:content_length).and_raise(Aws::S3::Errors::NotFound.new(nil, "Not Found"))
+
+      result = worker.calculate_estimated_size(product_files_archive)
+
+      expect(result).to eq(1000)
+    end
+  end
 end


### PR DESCRIPTION
## What
Handle `Aws::S3::Errors::NotFound` in `UpdateProductFilesArchiveWorker#calculate_estimated_size`.

## Why
When a product file's S3 object is missing, `s3_object.content_length` raises `Aws::S3::Errors::NotFound`. The download phase of the worker already handles missing files gracefully, but the size estimation step did not, causing the entire job to crash.

Now rescues the error and skips that file's size (treats it as 0). The archive will either fail during download (which handles this) or succeed with the files that exist.

## Test Results
Added spec confirming a missing S3 file is skipped and the remaining file sizes are summed correctly.

Fixes https://gumroad-to.sentry.io/issues/7367969485/