### PR TITLE
Fix UnsafeRedirectError in SignupController for existing user redirect

### DIFF
--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -131,7 +131,7 @@ class SignupController < Devise::RegistrationsController
       if !user.deleted? && user.try(:valid_password?, params[:user][:password])
         sign_in_or_prepare_for_two_factor_auth(user)
         respond_to do |format|
-          format.html { redirect_to login_path_for(user) }
+          format.html { redirect_to login_path_for(user), allow_other_host: true }
           format.json { render json: { success: true, redirect_location: login_path_for(user) } }
         end
       else

--- a/spec/controllers/signup_controller_spec.rb
+++ b/spec/controllers/signup_controller_spec.rb
@@ -113,6 +113,14 @@ describe SignupController, type: :controller, inertia: true do
           expect(controller.user_signed_in?).to eq true
         end
 
+        it "redirects to a subdomain next URL without raising UnsafeRedirectError" do
+          subdomain_url = "https://app.#{ROOT_DOMAIN}/dashboard"
+          post "create", params: { user: { email: @user.email, password: "password" }, next: subdomain_url }
+
+          expect(response).to redirect_to(subdomain_url)
+          expect(controller.user_signed_in?).to eq true
+        end
+
         it "returns json response" do
           post "create", params: { user: { email: @user.email, password: "password" } }, format: :json
 


### PR DESCRIPTION
## Problem

`ActionController::Redirecting::UnsafeRedirectError` is raised in `SignupController#create` when an existing user signs up with correct credentials and `login_path_for` returns a cross-host URL (e.g. via a subdomain in the `next` parameter).

**Sentry:** https://gumroad-to.sentry.io/issues/7370404857/

## Root Cause

In `verify_captcha_and_handle_existing_users`, the redirect on line 134 was missing `allow_other_host: true`. The same option was already correctly set in the main `create` action (line 58).

## Fix

Add `allow_other_host: true` to the existing-user redirect path, matching the behavior of the main create redirect.

## Test

Added a test that verifies subdomain redirects work without raising `UnsafeRedirectError` when an existing user signs in during signup.