### PR TITLE
Fix ambiguous created_at column in AdminSearchService

### DIFF
--- a/app/services/admin_search_service.rb
+++ b/app/services/admin_search_service.rb
@@ -4,7 +4,7 @@ class AdminSearchService
   class InvalidDateError < StandardError; end
 
   def search_purchases(query: nil, email: nil, product_title_query: nil, purchase_status: nil, creator_email: nil, license_key: nil, transaction_date: nil, last_4: nil, card_type: nil, price: nil, expiry_date: nil, limit: nil)
-    purchases = Purchase.order(created_at: :desc)
+    purchases = Purchase.order("purchases.created_at DESC")
 
     if email.present?
       purchases = purchases.where(email: email)
@@ -77,7 +77,7 @@ class AdminSearchService
         formatted_date = parse_date!(transaction_date)
         start_date = (formatted_date - 1.days).beginning_of_day.to_fs(:db)
         end_date = (formatted_date + 1.days).end_of_day.to_fs(:db)
-        purchases = purchases.where("created_at between ? and ?", start_date, end_date)
+        purchases = purchases.where("purchases.created_at between ? and ?", start_date, end_date)
       end
       purchases = purchases.where(card_type:) if card_type.present?
       purchases = purchases.where(card_visual_sql_finder(last_4)) if last_4.present?

--- a/spec/services/admin_search_service_spec.rb
+++ b/spec/services/admin_search_service_spec.rb
@@ -89,6 +89,19 @@ describe AdminSearchService do
       expect(purchases).to eq([purchase])
     end
 
+    it "returns purchases when filtering by both creator_email and transaction_date" do
+      seller = create(:user, email: "seller@example.com")
+      product = create(:product, user: seller)
+      purchase = create(:free_purchase, link: product)
+      purchase.update_columns(stripe_fingerprint: "fp_match", created_at: Time.zone.local(2024, 6, 15, 12, 0, 0))
+
+      other_purchase = create(:free_purchase, link: create(:product, user: seller))
+      other_purchase.update_columns(stripe_fingerprint: "fp_other", created_at: Time.zone.local(2023, 1, 1, 12, 0, 0))
+
+      purchases = AdminSearchService.new.search_purchases(creator_email: seller.email, transaction_date: "2024-06-15")
+      expect(purchases).to eq([purchase])
+    end
+
     it "returns no purchases when creator email is not found" do
       create(:purchase)
       purchases = AdminSearchService.new.search_purchases(creator_email: "nonexistent@example.com")


### PR DESCRIPTION
Fixes https://gumroad-to.sentry.io/issues/7368167916/

## What

Qualified two unqualified `created_at` references in `AdminSearchService` with the `purchases` table name:

1. The `ORDER BY` clause on line 8 (`Purchase.order(created_at: :desc)` → `Purchase.order("purchases.created_at DESC")`)
2. The `WHERE` clause on line 80 (`created_at between ? and ?` → `purchases.created_at between ? and ?`)

Added a regression test that searches with both `creator_email` and `transaction_date` to exercise the join + date filter path.

## Why

When both `creator_email` and `transaction_date` are provided, the query joins the `links` table (via `.joins(:link)`). Both `purchases` and `links` have a `created_at` column, so MySQL raises: "Column 'created_at' in where clause is ambiguous". Qualifying the column with the table name resolves the ambiguity.

## Test Results

```
AdminSearchService
  #search_purchases
    returns purchases when filtering by both creator_email and transaction_date

1 example, 0 failures
```

---

This PR was implemented with AI assistance using Claude Opus 4.6.

Prompts used:
- "Fix the ambiguous created_at column bug in AdminSearchService (Sentry issue link + specific lines to fix)"