### PR TITLE
Install gh CLI and use GITHUB_TOKEN for releases

### DIFF
--- a/.buildkite/scripts/create_github_release.sh
+++ b/.buildkite/scripts/create_github_release.sh
@@ -7,6 +7,23 @@ logger() {
   echo -e "${GREEN}$(date "+%Y/%m/%d %H:%M:%S") create_github_release.sh: $1${NC}"
 }
 
+# Install gh CLI if not present
+if ! command -v gh &> /dev/null; then
+  logger "Installing gh CLI"
+  GH_VERSION="2.65.0"
+  curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" -o /tmp/gh.tar.gz
+  tar -xzf /tmp/gh.tar.gz -C /tmp
+  sudo mv "/tmp/gh_${GH_VERSION}_linux_amd64/bin/gh" /usr/local/bin/gh
+  rm -rf /tmp/gh.tar.gz "/tmp/gh_${GH_VERSION}_linux_amd64"
+fi
+
+# Requires GITHUB_TOKEN environment variable in Buildkite (PAT from gumroad-buildkite user)
+if [ -z "$GITHUB_TOKEN" ]; then
+  logger "Error: GITHUB_TOKEN is not set"
+  exit 1
+fi
+export GH_TOKEN="$GITHUB_TOKEN"
+
 COMMIT_SHA=${BUILDKITE_COMMIT}
 
 # Determine calendar version tag (vYYYY.MM.DD.N)


### PR DESCRIPTION
Ref: #4078

## Summary

- Install `gh` CLI (v2.65.0) on the Buildkite agent if not already present
- Authenticate using `GITHUB_TOKEN` env var (PAT from `gumroad-buildkite` machine user) instead of SSH

Follows up on #4111 which added GitHub Releases but failed on deploy because `gh` wasn't installed and no API token was configured.

## Prerequisites

- [ ] Add `GITHUB_TOKEN` to Buildkite pipeline env vars (PAT from `gumroad-buildkite` with Contents read/write permission on `antiwork/gumroad`)

## Test plan

- [ ] Deploy to production and confirm `gh` gets installed and the GitHub Release is created

---

Generated with Claude Opus 4.6.