### PR TITLE
Fix Rack::Timeout::RequestTimeoutException in RecipientCountsController

### DIFF
--- a/app/controllers/api/internal/installments/recipient_counts_controller.rb
+++ b/app/controllers/api/internal/installments/recipient_counts_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Api::Internal::Installments::RecipientCountsController < Api::Internal::BaseController
+  QUERY_TIMEOUT_SECONDS = 30
+
   before_action :authenticate_user!
   after_action :verify_authorized
 
@@ -23,9 +25,13 @@ class Api::Internal::Installments::RecipientCountsController < Api::Internal::Ba
     installment = Installment.new(permitted_params)
     installment.seller = current_seller
 
-    render json: {
-      audience_count: current_seller.audience_members.count,
-      recipient_count: installment.audience_members_count
-    }
+    WithMaxExecutionTime.timeout_queries(seconds: QUERY_TIMEOUT_SECONDS) do
+      render json: {
+        audience_count: current_seller.audience_members.count,
+        recipient_count: installment.audience_members_count
+      }
+    end
+  rescue WithMaxExecutionTime::QueryTimeoutError
+    render json: { success: false, error: "recipient_count_timeout" }, status: :request_timeout
   end
 end

--- a/spec/controllers/api/internal/installments/recipient_counts_controller_spec.rb
+++ b/spec/controllers/api/internal/installments/recipient_counts_controller_spec.rb
@@ -116,5 +116,12 @@ describe Api::Internal::Installments::RecipientCountsController do
       expect(response).to be_successful
       expect(response.parsed_body).to eq("recipient_count" => 1, "audience_count" => 5)
     end
+
+    it "returns a 408 error when the query times out" do
+      allow(WithMaxExecutionTime).to receive(:timeout_queries).and_raise(WithMaxExecutionTime::QueryTimeoutError)
+      get :show, params: { installment_type: "audience" }
+      expect(response).to have_http_status(:request_timeout)
+      expect(response.parsed_body).to eq("success" => false, "error" => "recipient_count_timeout")
+    end
   end
 end


### PR DESCRIPTION
## Problem

The `RecipientCountsController#show` endpoint calls `AudienceMember.filter(...).count` which performs complex JSON queries (JSON_TABLE, JSON_CONTAINS) on the audience_members table. For sellers with very large audiences, this query can exceed the 120-second Rack::Timeout, killing the entire process with a `Rack::Timeout::RequestTimeoutException`.

**Sentry:** https://gumroad-to.sentry.io/issues/7368934065/

## Fix

Wrap the audience member count queries in a 30-second MySQL `max_execution_time` timeout using the existing `WithMaxExecutionTime` utility. If the query exceeds 30 seconds, the endpoint returns a `408 Request Timeout` JSON response (`{success: false, error: "recipient_count_timeout"}`) instead of running until Rack::Timeout kills the process.

This is a better experience for the user (fast failure vs 2+ minute hang) and prevents the process from being SIGTERMed.

## Changes

- `app/controllers/api/internal/installments/recipient_counts_controller.rb`: Wrap queries in `WithMaxExecutionTime.timeout_queries(seconds: 30)` with rescue for `QueryTimeoutError`
- `spec/controllers/api/internal/installments/recipient_counts_controller_spec.rb`: Add test for timeout behavior