### PR TITLE
Fix discount codes not working on product custom domains

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1028,6 +1028,9 @@ Rails.application.routes.draw do
     get "/.well-known/acme-challenge/:token", to: "acme_challenges#show"
     product_tracking_routes(named_routes: false)
     get "/", to: "links#show", defaults: { format: "html" }
+    get "/l/:id", to: "links#show", defaults: { format: "html" }
+    get "/l/:id/:code", to: "links#show", defaults: { format: "html" }
+    get "/:code", to: "links#show", defaults: { format: "html" }
   end
 
   constraints UserCustomDomainConstraint do

--- a/spec/requests/product_custom_domain_spec.rb
+++ b/spec/requests/product_custom_domain_spec.rb
@@ -21,6 +21,36 @@ describe "ProductCustomDomainScenario", type: :system, js: true do
     expect(product.sales.successful.count).to eq(1)
   end
 
+  context "when the URL includes product permalink" do
+    it "successfully purchases the linked product" do
+      visit "http://#{custom_domain.domain}:#{port}/l/#{product.unique_permalink}"
+      click_on "I want this!"
+      check_out(product)
+      expect(product.sales.successful.count).to eq(1)
+    end
+  end
+
+  context "when there is a discount code" do
+    let(:product) { create(:product, price_cents: 600) }
+    let(:offer_code) { create(:percentage_offer_code, products: [product], code: "LAUNCH", amount_percentage: 50) }
+
+    it "applies the discount code when the URL contains only the discount code" do
+      visit "http://#{custom_domain.domain}:#{port}/#{offer_code.code}"
+      expect(page).to have_text("50% off will be applied at checkout (Code LAUNCH)")
+      click_on "I want this!"
+      check_out(product)
+      expect(product.sales.successful.count).to eq(1)
+    end
+
+    it "applies the discount code when the URL contains both the discount code and the product" do
+      visit "http://#{custom_domain.domain}:#{port}/l/#{product.unique_permalink}/#{offer_code.code}"
+      expect(page).to have_text("50% off will be applied at checkout (Code LAUNCH)")
+      click_on "I want this!"
+      check_out(product)
+      expect(product.sales.successful.count).to eq(1)
+    end
+  end
+
   context "when buyer is logged in" do
     let(:buyer) { create(:user) }
     before do


### PR DESCRIPTION
Resolves https://github.com/antiwork/gumroad/issues/4016

## What

Adds missing `/l/:id`, `/l/:id/:code`, and `/:code` routes to the `ProductCustomDomainConstraint` block in `config/routes.rb` so that discount code URLs work on product custom domains.

- `/l/:id` — access product by permalink (backwards compatibility)
- `/l/:id/:code` — product permalink with discount code
- `/:code` — discount code only (product is already identified by the custom domain)

## Why

The `ProductCustomDomainConstraint` block was missing these routes that are already present in `UserCustomDomainConstraint` and `GumroadDomainConstraint`. When a seller shared a discount code URL on their product custom domain (e.g., `customdomain.com/LAUNCH`), it would 404 instead of applying the discount.

The bare `/:code` route is safe here because product custom domains serve a single product, so the code unambiguously refers to a discount code — unlike user custom domains where it could be confused with a product permalink.

## Test results

Added system tests covering:
- Accessing product via `/l/:permalink` on a product custom domain
- Applying a discount code via `/:code`
- Applying a discount code via `/l/:permalink/:code`

---

Based on https://github.com/andev18/gumroad/pull/1 by @andev18.

AI Disclosure: Claude Opus 4.6 was used to review the original PR and import the changes.