### PR TITLE
Fix Pagy::OverflowError in Wishlists::ProductsController#index

### DIFF
--- a/app/presenters/wishlist_presenter.rb
+++ b/app/presenters/wishlist_presenter.rb
@@ -112,7 +112,11 @@ class WishlistPresenter
 
   private
     def paginated_public_items(request:, pundit_user:, recommended_by:, page:)
-      pagination, wishlist_products = pagy(wishlist.alive_wishlist_products, page:, limit: PER_PAGE)
+      begin
+        pagination, wishlist_products = pagy(wishlist.alive_wishlist_products, page:, limit: PER_PAGE)
+      rescue Pagy::OverflowError
+        pagination, wishlist_products = pagy(wishlist.alive_wishlist_products, page: 1, limit: PER_PAGE)
+      end
 
       paginated_products = wishlist_products
       .includes(product: ProductPresenter::ASSOCIATIONS_FOR_CARD)

--- a/spec/controllers/wishlists/products_controller_spec.rb
+++ b/spec/controllers/wishlists/products_controller_spec.rb
@@ -179,6 +179,15 @@ describe Wishlists::ProductsController do
         expect(response.parsed_body["items"].map { |wp| wp["id"] }).to match_array([wishlist_product1.external_id, wishlist_product2.external_id])
       end
     end
+
+    it "returns first page when requested page exceeds total pages" do
+      wishlist_product = create(:wishlist_product, wishlist:)
+
+      get :index, params: { wishlist_id: wishlist.external_id, page: 999 }
+
+      expect(response).to be_successful
+      expect(response.parsed_body["items"].map { |wp| wp["id"] }).to eq([wishlist_product.external_id])
+    end
   end
 
   describe "DELETE destroy" do


### PR DESCRIPTION
## What

Rescue `Pagy::OverflowError` in `WishlistPresenter#paginated_public_items` and fall back to page 1 when the requested page exceeds total pages.

## Why

When a user requests a page that doesn't exist (e.g., `?page=2` on a wishlist with fewer than 20 products), `pagy()` raises `Pagy::OverflowError` because the global config sets `Pagy::DEFAULT[:overflow] = :exception`. This causes a 500 error. Falling back to page 1 is the most user-friendly behavior and keeps the fix localized to the presenter.

Sentry: https://gumroad-to.sentry.io/issues/7369073349/

## Test results

Added a test that requests a page beyond the total pages and verifies the response returns successfully with the first page of results. Verified the test fails when the fix is reverted.

---

AI disclosure: Built with Claude Opus 4.6. Prompted with the Sentry error details and fix approach.