### PR TITLE
Fix NoMethodError: undefined method 'id' for nil in LoginsController#destroy

### DIFF
--- a/app/controllers/concerns/impersonate.rb
+++ b/app/controllers/concerns/impersonate.rb
@@ -57,7 +57,10 @@ module Impersonate
     def can_impersonate? = current_user_from_api_or_web&.is_team_member?
 
     def reset_impersonated_user
-      $redis.del(RedisKey.impersonated_user(current_user_from_api_or_web.id))
+      user = current_user_from_api_or_web
+      return if user.nil?
+
+      $redis.del(RedisKey.impersonated_user(user.id))
       remove_instance_variable(:@_impersonated_user) if defined?(@_impersonated_user)
     end
 end

--- a/spec/controllers/concerns/impersonate_spec.rb
+++ b/spec/controllers/concerns/impersonate_spec.rb
@@ -26,6 +26,10 @@ describe Impersonate, type: :controller do
       expect(controller.impersonating_user).to eq(nil)
       expect(controller.impersonated_user).to eq(nil)
     end
+
+    it "handles reset_impersonated_user without raising" do
+      expect { controller.stop_impersonating_user }.not_to raise_error
+    end
   end
 
   let(:user) { create(:named_user) }


### PR DESCRIPTION
## What

Adds a nil guard to `reset_impersonated_user` in `app/controllers/concerns/impersonate.rb`.

`reset_impersonated_user` calls `current_user_from_api_or_web.id` without checking for nil. When `LoginsController#destroy` (logout) triggers this as a `before_action`, both `current_api_user` and `current_user` can be nil (session already cleared), causing `NoMethodError: undefined method 'id' for nil`.

The fix adds an early return when the user is nil.

## Why

This error is firing in production on logout — tracked in [Sentry](https://gumroad-to.sentry.io/issues/7369491371/). The fix is minimal: guard against nil before accessing `.id`.

## Test Results

Added a spec that calls `stop_impersonating_user` (which delegates to `reset_impersonated_user`) when no user is authenticated. The test fails without the fix and passes with it.

```
14 examples, 0 failures
```

---

Generated with Claude Opus 4.6. Prompt: fix the nil guard bug in `reset_impersonated_user` per Sentry issue, add regression test, open PR.