### PR TITLE
Fix RecordInvalid when destroying wishlist product for versioned product

### DIFF
--- a/app/controllers/wishlists/products_controller.rb
+++ b/app/controllers/wishlists/products_controller.rb
@@ -39,7 +39,7 @@ class Wishlists::ProductsController < ApplicationController
 
     authorize wishlist_product
 
-    wishlist_product.mark_deleted!
+    wishlist_product.mark_deleted(validate: false)
 
     head :no_content
   end

--- a/spec/controllers/wishlists/products_controller_spec.rb
+++ b/spec/controllers/wishlists/products_controller_spec.rb
@@ -195,5 +195,16 @@ describe Wishlists::ProductsController do
       expect(response).to be_successful
       expect(wishlist_product.reload).to be_deleted
     end
+
+    it "marks the wishlist product as deleted even when the product has since gained variants" do
+      product = wishlist_product.product
+      category = create(:variant_category, title: "Category", link: product)
+      create(:variant, variant_category: category, name: "Untitled 1")
+
+      delete :destroy, params: { wishlist_id: wishlist.external_id, id: wishlist_product.external_id }
+
+      expect(response).to have_http_status(:no_content)
+      expect(wishlist_product.reload).to be_deleted
+    end
   end
 end


### PR DESCRIPTION
## What

Changed `wishlist_product.mark_deleted!` to `wishlist_product.mark_deleted(validate: false)` in the `destroy` action of `Wishlists::ProductsController`.

## Why

`mark_deleted!` calls `save!`, which triggers all model validations. The `versioned_product_has_variant` validation fails when a wishlist product was created before variants were added to the product (or the variant was later deleted). This causes an `ActiveRecord::RecordInvalid` error reported in Sentry.

Soft-deleting a wishlist product should always succeed regardless of the product's current variant state — creation-time validations are irrelevant when removing an item from a wishlist. `mark_deleted(validate: false)` is already supported by the `Deletable` module.

## Test Results

Added a test that creates a wishlist product for a product without variants, then adds variants to the product, and verifies the destroy action still succeeds. The test fails when the fix is reverted.

```
3 examples, 0 failures
```

---

AI disclosure: Implemented with Claude Opus 4.6. Prompted with the Sentry error details and asked to fix the validation issue on wishlist product destroy.