### PR TITLE
Fix InvalidTransition when marking failed payment as processing

### DIFF
--- a/app/business/payments/payouts/payouts.rb
+++ b/app/business/payments/payouts/payouts.rb
@@ -183,7 +183,7 @@ class Payouts
     )
     payment.save!
     payment_errors = payout_processor.prepare_payment_and_set_amount(payment, balances)
-    payment.mark_processing!
+    payment.mark_processing! if payment_errors.blank?
     [payment, payment_errors]
   end
 

--- a/spec/business/payments/payouts/payouts_spec.rb
+++ b/spec/business/payments/payouts/payouts_spec.rb
@@ -692,4 +692,38 @@ describe Payouts do
       end
     end
   end
+
+  describe ".create_payment" do
+    let(:seller) { create(:user_with_compliance_info, payment_address: "seller@example.com") }
+    let(:merchant_account) { create(:merchant_account, user: seller) }
+    let(:payout_date) { Date.today - 1 }
+
+    before do
+      create(:balance, user: seller, merchant_account:, date: payout_date - 3, amount_cents: 1000_00)
+      allow(StripePayoutProcessor).to receive(:is_balance_payable).and_return(true)
+    end
+
+    context "when prepare_payment_and_set_amount fails and marks the payment as failed" do
+      it "does not raise an InvalidTransition error" do
+        allow(StripePayoutProcessor).to receive(:prepare_payment_and_set_amount) do |payment, _balances|
+          payment.mark_failed!
+          ["Something went wrong"]
+        end
+
+        payment, errors = described_class.create_payment(payout_date, PayoutProcessorType::STRIPE, seller)
+        expect(errors).to eq(["Something went wrong"])
+        expect(payment.state).to eq("failed")
+      end
+    end
+
+    context "when prepare_payment_and_set_amount succeeds" do
+      it "marks the payment as processing" do
+        allow(StripePayoutProcessor).to receive(:prepare_payment_and_set_amount).and_return([])
+
+        payment, errors = described_class.create_payment(payout_date, PayoutProcessorType::STRIPE, seller)
+        expect(errors).to eq([])
+        expect(payment.state).to eq("processing")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Problem

Sentry error: `StateMachines::InvalidTransition: Cannot transition state via :mark_processing from :failed`

In `Payouts.create_payment`, when `prepare_payment_and_set_amount` hits a Stripe error, its `ensure` block calls `payment.mark_failed!` (creating → failed). Then `create_payment` unconditionally calls `payment.mark_processing!` on the now-failed payment, causing the InvalidTransition.

Culprit: `Admin::PaydaysController#pay_user`

## Fix

Only call `payment.mark_processing!` when there are no errors (`payment_errors.blank?`). When there are errors, the payment is already in the correct `failed` state from the `ensure` block.

## Tests

Added specs for `Payouts.create_payment` covering both the error and success paths.