### PR TITLE
Fix Elasticsearch BadRequest: clamp price filter to prevent long overflow

### DIFF
--- a/app/modules/product/searchable.rb
+++ b/app/modules/product/searchable.rb
@@ -8,6 +8,7 @@ module Product::Searchable
   RECOMMENDED_PRODUCTS_PER_PAGE = 9
   MAX_NUMBER_OF_FILETYPES = 8
   MAX_OFFER_CODES_IN_INDEX = 300
+  MAX_PRICE_FILTER_CENTS = 10_000_000_000 # $100,000,000 — upper bound for ES long-typed price range filters
 
   ATTRIBUTE_TO_SEARCH_FIELDS_MAP = {
     "name" => ["name", "rated_as_adult"],
@@ -231,10 +232,12 @@ module Product::Searchable
             end
 
             if params[:min_price].present? || params[:max_price].present?
+              min_cents = (params[:min_price].to_f * 100).to_i.clamp(0, MAX_PRICE_FILTER_CENTS) if params[:min_price].present?
+              max_cents = (params[:max_price].to_f * 100).to_i.clamp(0, MAX_PRICE_FILTER_CENTS) if params[:max_price].present?
               filter do
                 range :available_price_cents do
-                  gte params[:min_price].to_f * 100 if params[:min_price].present?
-                  lte params[:max_price].to_f * 100 if params[:max_price].present?
+                  gte min_cents if min_cents
+                  lte max_cents if max_cents
                 end
               end
             end

--- a/spec/modules/product/searchable/search_spec.rb
+++ b/spec/modules/product/searchable/search_spec.rb
@@ -114,6 +114,24 @@ describe "Product::Searchable - Search scenarios" do
         assert_equal expected, records.map(&:id)
       end
 
+      it "clamps extremely large price filter values to prevent Elasticsearch long overflow" do
+        # Values like 2_344_444_444_444.44 would produce floats exceeding ES long max (~9.22E18)
+        params = { min_price: "0", max_price: "2344444444444444" }
+        search_options = Link.search_options(params)
+
+        # Should not raise Elasticsearch::Transport::Transport::Errors::BadRequest
+        records = Link.search(search_options).records
+        expect(records).to be_an(Elasticsearch::Model::Response::Records)
+      end
+
+      it "clamps negative price filter values to zero" do
+        params = { min_price: "-100", max_price: "1" }
+        search_options = Link.search_options(params)
+
+        records = Link.search(search_options).records
+        expect(records).to be_an(Elasticsearch::Model::Response::Records)
+      end
+
       describe "is_alive_on_profile" do
         let(:seller) { create(:user) }
         let!(:product) { create(:product, user: seller) }


### PR DESCRIPTION
## Problem

When extremely large price values are passed as search params (e.g. via URL), `to_f * 100` produces a float like `2.34E20` which exceeds the Elasticsearch `long` max (~9.22E18), causing:

```
Elasticsearch::Transport::Transport::Errors::BadRequest: [400]
"failed to create query: Value [2.3444444444444446E20] is out of range for a long"
```

**Sentry:** https://gumroad-to.sentry.io/issues/7369717174/
**Culprit:** `LinksController#search`

## Fix

- Add `MAX_PRICE_FILTER_CENTS = 10_000_000_000` constant ($100M upper bound)
- Clamp computed min/max price cents to `[0, MAX_PRICE_FILTER_CENTS]` before passing to the ES range filter
- Convert to integer to avoid sending floats to an ES long field

## Tests

Added two test cases:
- Extremely large price values are clamped (prevents the BadRequest)
- Negative price values are clamped to zero