### PR TITLE
Handle known 'Cannot create transfers' Stripe error in prepare_payment_and_set_amount

### DIFF
--- a/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
+++ b/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
@@ -182,7 +182,7 @@ class StripePayoutProcessor
     []
   rescue Stripe::InvalidRequestError => e
     failed = true
-    ErrorNotifier.notify(e)
+    ErrorNotifier.notify(e) if !e.message["Cannot create transfers"]
     [e.message]
   rescue Stripe::AuthenticationError, Stripe::APIConnectionError
     failed = true

--- a/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
+++ b/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
@@ -299,6 +299,78 @@ describe StripePayoutProcessor, :vcr do
     end
   end
 
+  describe ".prepare_payment_and_set_amount error notifications" do
+    let(:user) { create(:user) }
+    let(:bank_account) { create(:ach_account_stripe_succeed, user:) }
+    let(:merchant_account) { create(:merchant_account, user:) }
+    let!(:gumroad_merchant_account) do
+      MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id) ||
+        MerchantAccount.create!(charge_processor_id: StripeChargeProcessor.charge_processor_id, charge_processor_merchant_id: "gumroad_stripe")
+    end
+
+    before do
+      user
+      bank_account
+      merchant_account
+      bank_account.reload
+      user.reload
+    end
+
+    let(:balances) do
+      [
+        create(:balance, user:, state: "processing", merchant_account: gumroad_merchant_account, amount_cents: 10_00)
+      ]
+    end
+    let(:payment) do
+      payment = create(:payment, user:, currency: nil, amount_cents: nil)
+      payment.balances << balances
+      payment
+    end
+
+    context "when the internal transfer raises 'Cannot create transfers'" do
+      before do
+        allow(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account).and_raise(
+          Stripe::InvalidRequestError.new("Cannot create transfers; please contact us via https://support.stripe.com/contact with details for assistance.", "amount_cents")
+        )
+      end
+
+      it "does not notify error tracker" do
+        expect(ErrorNotifier).not_to receive(:notify)
+        described_class.prepare_payment_and_set_amount(payment, payment.balances.to_a)
+      end
+
+      it "returns the error message" do
+        errors = described_class.prepare_payment_and_set_amount(payment, payment.balances.to_a)
+        expect(errors).to eq(["Cannot create transfers; please contact us via https://support.stripe.com/contact with details for assistance."])
+      end
+
+      it "marks the payment as failed" do
+        described_class.prepare_payment_and_set_amount(payment, payment.balances.to_a)
+        payment.reload
+        expect(payment.state).to eq("failed")
+      end
+    end
+
+    context "when the internal transfer raises an unknown InvalidRequestError" do
+      before do
+        allow(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account).and_raise(
+          Stripe::InvalidRequestError.new("Something unexpected happened", "amount_cents")
+        )
+      end
+
+      it "notifies error tracker" do
+        expect(ErrorNotifier).to receive(:notify)
+        described_class.prepare_payment_and_set_amount(payment, payment.balances.to_a)
+      end
+
+      it "marks the payment as failed" do
+        described_class.prepare_payment_and_set_amount(payment, payment.balances.to_a)
+        payment.reload
+        expect(payment.state).to eq("failed")
+      end
+    end
+  end
+
   describe ".enqueue_payments" do
     let!(:yesterday) { Date.yesterday.to_s }
     let!(:user_ids) { [1, 2, 3, 4] }


### PR DESCRIPTION
## What

In `StripePayoutProcessor.prepare_payment_and_set_amount`, skip `ErrorNotifier.notify` for Stripe `InvalidRequestError`s containing "Cannot create transfers". This is a known Stripe account-level restriction (e.g., account under review, not yet verified) that should not fire Sentry alerts.

## Why

The rescue block for `Stripe::InvalidRequestError` in `prepare_payment_and_set_amount` was calling `ErrorNotifier.notify(e)` for all errors indiscriminately, including "Cannot create transfers" which is an expected, known error. Compare with `perform_payment` in the same file, which already handles known errors and only notifies for truly unexpected ones. The payment is still marked as failed via the `ensure` block — this change only suppresses the unnecessary Sentry noise.

## Test Results

Added tests verifying:
- "Cannot create transfers" errors do not notify error tracker
- "Cannot create transfers" errors still return the error message and mark payment as failed
- Unknown `InvalidRequestError`s continue to notify error tracker

---

AI disclosure: Implemented with Claude Opus 4.6. Prompted to fix the "Cannot create transfers" Stripe error handling in `prepare_payment_and_set_amount` to skip ErrorNotifier for known errors, matching the pattern already used in `perform_payment`.