### PR TITLE
Fix NoMethodError in Order::ChargeService when ensure block runs before non_free_seller_purchases is assigned

### DIFF
--- a/app/services/order/charge_service.rb
+++ b/app/services/order/charge_service.rb
@@ -233,6 +233,8 @@ class Order::ChargeService
   end
 
   def ensure_all_purchases_processed(purchases)
+    return if purchases.blank?
+
     purchases.each do |purchase|
       line_item_uid = params[:line_items].find do |line_item|
         purchase.link.unique_permalink == line_item[:permalink] &&

--- a/spec/services/order/charge_service_spec.rb
+++ b/spec/services/order/charge_service_spec.rb
@@ -727,6 +727,22 @@ describe Order::ChargeService, :vcr do
     end
   end
 
+  describe "#ensure_all_purchases_processed" do
+    it "does not raise when called with nil" do
+      order = create(:order)
+      charge_service = Order::ChargeService.new(order:, params: nil)
+
+      expect { charge_service.send(:ensure_all_purchases_processed, nil) }.not_to raise_error
+    end
+
+    it "does not raise when called with an empty array" do
+      order = create(:order)
+      charge_service = Order::ChargeService.new(order:, params: nil)
+
+      expect { charge_service.send(:ensure_all_purchases_processed, []) }.not_to raise_error
+    end
+  end
+
   describe "#mandate_options_for_stripe" do
     let!(:seller) { create(:user) }
     let!(:membership_product) { create(:membership_product_with_preset_tiered_pricing, user: seller) }


### PR DESCRIPTION
## Problem

`NoMethodError: undefined method 'each' for nil (NoMethodError)` in `Order::ChargeService#ensure_all_purchases_processed`.

**Sentry:** https://gumroad-to.sentry.io/issues/7369875979/

## Root Cause

In `Order::ChargeService#perform`, there's a `begin/rescue/ensure` block inside the `purchases_by_seller.each` loop. The `ensure` block calls `ensure_all_purchases_processed(non_free_seller_purchases)`.

However, `non_free_seller_purchases` is assigned partway through the `begin` block. If an exception occurs **before** that assignment (e.g., during `order.charges.create!` or `purchase.save!`), the variable is still `nil` when the `ensure` block runs. This passes `nil` to `ensure_all_purchases_processed`, which then calls `.each` on it and raises `NoMethodError`.

## Fix

Added a `return if purchases.blank?` guard at the top of `ensure_all_purchases_processed` so it gracefully handles `nil` or empty inputs.

## Tests

Added tests verifying that `ensure_all_purchases_processed` does not raise when called with `nil` or an empty array.