### PR TITLE
Fix: Stop reporting handled Taxjar::Error::BadRequest to Sentry

### DIFF
--- a/app/business/sales_tax/taxjar/taxjar_api.rb
+++ b/app/business/sales_tax/taxjar/taxjar_api.rb
@@ -77,7 +77,7 @@ class TaxjarApi
       end
     rescue *TaxjarErrors::CLIENT => e
       Rails.logger.error "TaxJar Client Error: #{e.inspect}"
-      ErrorNotifier.notify(e)
+      ErrorNotifier.notify(e) unless e.is_a?(Taxjar::Error::BadRequest)
       raise e
     rescue *TaxjarErrors::SERVER => e
       Rails.logger.error "TaxJar Server Error: #{e.inspect}"

--- a/spec/business/sales_tax/taxjar/taxjar_api_spec.rb
+++ b/spec/business/sales_tax/taxjar/taxjar_api_spec.rb
@@ -283,10 +283,10 @@ describe TaxjarApi, :vcr do
                                                          shipping_dollars: 20.0)).to eq(expected_calculation)
     end
 
-    it "notifies error tracker and propagates a TaxJar client error" do
+    it "propagates a TaxJar BadRequest error without notifying error tracker" do
       expect_any_instance_of(Taxjar::Client).to receive(:tax_for_order).and_raise(Taxjar::Error::BadRequest)
 
-      expect(ErrorNotifier).to receive(:notify).exactly(:once)
+      expect(ErrorNotifier).not_to receive(:notify)
 
       expect do
         described_class.new.calculate_tax_for_order(origin:,
@@ -297,6 +297,22 @@ describe TaxjarApi, :vcr do
                                                     unit_price_dollars: 100.0,
                                                     shipping_dollars: 20.0)
       end.to raise_error(Taxjar::Error::BadRequest)
+    end
+
+    it "notifies error tracker and propagates other TaxJar client errors" do
+      expect_any_instance_of(Taxjar::Client).to receive(:tax_for_order).and_raise(Taxjar::Error::Unauthorized)
+
+      expect(ErrorNotifier).to receive(:notify).exactly(:once)
+
+      expect do
+        described_class.new.calculate_tax_for_order(origin:,
+                                                    destination:,
+                                                    nexus_address:,
+                                                    quantity: 1,
+                                                    product_tax_code: nil,
+                                                    unit_price_dollars: 100.0,
+                                                    shipping_dollars: 20.0)
+      end.to raise_error(Taxjar::Error::Unauthorized)
     end
 
     it "propagates a TaxJar server error" do


### PR DESCRIPTION
## What

Stop calling `ErrorNotifier.notify` for `Taxjar::Error::BadRequest` errors in `TaxjarApi#with_caching`. Other TaxJar client errors (Unauthorized, Forbidden, etc.) continue to be reported.

## Why

`Taxjar::Error::BadRequest` errors represent invalid user input (e.g. mismatched zip/state combinations like "zip 55555 is not used within state MN"). These errors are already gracefully handled by `SalesTaxCalculator#calculate_with_taxjar`, which rescues all TaxJar client errors and falls back to lookup table calculation. The `ErrorNotifier.notify` call in `with_caching` was redundant and spamming Sentry with noise from handled errors.

Sentry issue: `Taxjar::Error::BadRequest: to_zip 55555 is not used within to_state MN`
Culprit: `CustomerSurchargeController#calculate_all`

## Test Results

```
8 examples, 0 failures
```

- Updated existing test to verify BadRequest is re-raised but does NOT trigger ErrorNotifier
- Added new test verifying other client errors (e.g. Unauthorized) still DO trigger ErrorNotifier

---

AI disclosure: Implemented with Claude Opus 4.6. Prompted with the bug description, root cause analysis, and fix instructions.