### PR TITLE
Fix US business tax ID (EIN) validation to prevent Stripe::InvalidRequestError

### DIFF
--- a/app/services/update_user_compliance_info.rb
+++ b/app/services/update_user_compliance_info.rb
@@ -10,6 +10,15 @@ class UpdateUserComplianceInfo
 
   def process
     if compliance_params.present?
+      if compliance_params[:business_tax_id].present? && compliance_params[:is_business]
+        stripped_ein = compliance_params[:business_tax_id].gsub(/\D/, "")
+        country_code = compliance_params[:business_country].presence || compliance_params[:country].presence ||
+          user.fetch_or_build_user_compliance_info.legal_entity_country_code
+        if country_code == Compliance::Countries::USA.alpha2 && stripped_ein.length != 9
+          return { success: false, error_message: "US business tax IDs (EIN) must have 9 digits." }
+        end
+      end
+
       old_compliance_info = user.fetch_or_build_user_compliance_info
       saved, new_compliance_info = old_compliance_info.dup_and_save do |new_compliance_info|
         # if the following fields are submitted and are blank, we don't clear the field for the user
@@ -57,11 +66,6 @@ class UpdateUserComplianceInfo
       end
 
       return { success: false, error_message: new_compliance_info.errors.full_messages.to_sentence } unless saved
-
-      if new_compliance_info.is_business && new_compliance_info.legal_entity_country_code == "US" &&
-          new_compliance_info.business_tax_id.present? && new_compliance_info.business_tax_id.length != 9
-        return { success: false, error_message: "US business tax IDs (EIN) must have 9 digits." }
-      end
 
       begin
         StripeMerchantAccountManager.handle_new_user_compliance_info(new_compliance_info)

--- a/spec/services/update_user_compliance_info_spec.rb
+++ b/spec/services/update_user_compliance_info_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe UpdateUserComplianceInfo do
+  describe "#process" do
+    let(:seller) { create(:user) }
+
+    before do
+      create(:user_compliance_info, user: seller)
+    end
+
+    context "when submitting a US business with an invalid EIN" do
+      let(:compliance_params) do
+        {
+          is_business: true,
+          country: "US",
+          business_tax_id: "12-345",
+          first_name: "Jane",
+          last_name: "Doe",
+        }
+      end
+
+      it "returns an error before saving to the database" do
+        expect(StripeMerchantAccountManager).not_to receive(:handle_new_user_compliance_info)
+
+        result = described_class.new(compliance_params:, user: seller).process
+
+        expect(result).to eq({ success: false, error_message: "US business tax IDs (EIN) must have 9 digits." })
+        expect(seller.alive_user_compliance_info.business_tax_id).to be_blank
+      end
+    end
+
+    context "when submitting a US business with a valid EIN" do
+      let(:compliance_params) do
+        {
+          is_business: true,
+          country: "US",
+          business_tax_id: "12-3456789",
+          first_name: "Jane",
+          last_name: "Doe",
+          business_name: "Test Corp",
+          business_street_address: "123 Main St",
+          business_city: "San Francisco",
+          business_state: "CA",
+          business_zip_code: "94107",
+          business_type: UserComplianceInfo::BusinessTypes::LLC,
+        }
+      end
+
+      it "does not return an EIN validation error" do
+        allow(StripeMerchantAccountManager).to receive(:handle_new_user_compliance_info)
+
+        result = described_class.new(compliance_params:, user: seller).process
+
+        expect(result[:error_message]).not_to eq("US business tax IDs (EIN) must have 9 digits.")
+      end
+    end
+
+    context "when submitting a non-US business with a tax ID of any length" do
+      let(:compliance_params) do
+        {
+          is_business: true,
+          country: "CA",
+          business_tax_id: "12345",
+          first_name: "Jane",
+          last_name: "Doe",
+        }
+      end
+
+      it "does not return a US EIN validation error" do
+        allow(StripeMerchantAccountManager).to receive(:handle_new_user_compliance_info)
+
+        result = described_class.new(compliance_params:, user: seller).process
+
+        expect(result[:error_message]).not_to eq("US business tax IDs (EIN) must have 9 digits.")
+      end
+    end
+
+    context "when submitting a US business with a too-long EIN" do
+      let(:compliance_params) do
+        {
+          is_business: true,
+          country: "US",
+          business_tax_id: "1234567890",
+          first_name: "Jane",
+          last_name: "Doe",
+        }
+      end
+
+      it "returns an error" do
+        result = described_class.new(compliance_params:, user: seller).process
+
+        expect(result).to eq({ success: false, error_message: "US business tax IDs (EIN) must have 9 digits." })
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

Moves the US business EIN (tax ID) length validation in `UpdateUserComplianceInfo` to **before** `dup_and_save`, validating the raw params value instead of the encrypted field.

## Why

The `business_tax_id` field is encrypted with `encrypt_with_public_key`. The previous validation ran **after** save, so `.length` checked the encrypted ciphertext — not the plaintext digits. Invalid EINs (not 9 digits) passed validation, were persisted to the database, and later caused `Stripe::InvalidRequestError: US tax IDs must have 9 digits` when sent to Stripe.

## Test results

```
4 examples, 0 failures
```

New spec file: `spec/services/update_user_compliance_info_spec.rb` covers:
- Invalid EIN (too short) → returns error, does not save or call Stripe
- Invalid EIN (too long) → returns error
- Valid 9-digit EIN → no EIN error
- Non-US business → no US EIN validation applied

---

AI disclosure: Implemented with Claude Opus 4.6. Prompt: fix Sentry bug where US EIN validation runs after encryption, causing Stripe::InvalidRequestError.