### PR TITLE
Fix N+1 query on display_asset_previews causing timeout in mobile purchases API

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -542,7 +542,7 @@ class Purchase < ApplicationRecord
     .not_is_archived_original_subscription_purchase
     .not_rental_expired
     .order(:id)
-    .includes(:preorder, :purchaser, :seller, :subscription, url_redirect: { purchase: { link: [:user, :thumbnail] } })
+    .includes(:preorder, :purchaser, :seller, :subscription, url_redirect: { purchase: { link: [:user, :thumbnail, :display_asset_previews] } })
   }
   scope :for_library, lambda {
     all_success_states

--- a/spec/controllers/api/mobile/purchases_controller_spec.rb
+++ b/spec/controllers/api/mobile/purchases_controller_spec.rb
@@ -100,6 +100,18 @@ describe Api::Mobile::PurchasesController do
       expect(response.parsed_body["products"][0]["file_data"].map { _1["name_displayable"] }).to eq(["Extras", "Move on", "Summer times", "Watch: How do I make music?", "Tricks"])
     end
 
+    it "eager-loads display_asset_previews to avoid N+1 queries" do
+      product = create(:product, user: @user)
+      create(:asset_preview, link: product)
+      create(:purchase_with_balance, link: product, purchaser: @purchaser, seller: @user)
+
+      get :index, params: @params
+
+      purchases_relation = @purchaser.purchases.for_mobile_listing
+      product_link = purchases_relation.first.url_redirect.purchase.link
+      expect(product_link.association(:display_asset_previews)).to be_loaded
+    end
+
     it "includes thumbnail url if available" do
       product = create(:product, user: @user, name: "The Works of Edgar Gumstein", description: "A collection of works spanning 1984 — 1994")
       thumbnail = create(:thumbnail, product:)


### PR DESCRIPTION
## What

Add `display_asset_previews` to the eager-loading `includes` in the `for_mobile_listing` scope in `Purchase`.

## Why

The `for_mobile_listing` scope eager-loads associations for serialization, but was missing `display_asset_previews` on the product. During serialization, `preview_oembed_thumbnail_url` → `main_preview` → `display_asset_previews.first` fires a separate SQL query per product. For users with hundreds of purchases, this creates an N+1 that causes Rack::Timeout (120s+).

Sentry issue: https://gumroad-to.sentry.io/issues/7369903442/

## Test Results

Added a test verifying `display_asset_previews` is eager-loaded when using the `for_mobile_listing` scope.

---

Generated with Claude Opus 4.6. Prompt: fix N+1 on display_asset_previews in mobile purchases API per Sentry issue.