### PR TITLE
Fix NoMethodError in ContactingCreatorMailer#video_transcode_failed when link is nil

### DIFF
--- a/app/mailers/contacting_creator_mailer.rb
+++ b/app/mailers/contacting_creator_mailer.rb
@@ -432,6 +432,8 @@ class ContactingCreatorMailer < ApplicationMailer
   def video_transcode_failed(product_file_id)
     @subject = "A video failed to transcode."
     product_file = ProductFile.find(product_file_id)
+    return do_not_send if product_file.link.nil?
+
     @video_transcode_error = "We attempted to transcode a video (#{product_file.s3_filename}) from your product #{product_file.link.name}, but were unable to do so."
     @seller = product_file.user
   end

--- a/spec/mailers/contacting_creator_mailer_spec.rb
+++ b/spec/mailers/contacting_creator_mailer_spec.rb
@@ -1625,6 +1625,15 @@ describe ContactingCreatorMailer do
       expect(mail.body.encoded).to include @product_file.link.name
       expect(mail.body.encoded).to include "Please try re-encoding it locally on your computer and uploading it again."
     end
+
+    it "returns early without error when the associated link has been deleted" do
+      product_file = create(:product_file, link: @product)
+      product_file.update_column(:link_id, nil)
+
+      mail = ContactingCreatorMailer.video_transcode_failed(product_file.id)
+
+      expect(mail.message).to be_a(ActionMailer::Base::NullMail)
+    end
   end
 
   describe "tax_form_1099k" do


### PR DESCRIPTION
When a ProductFile's associated link/product is deleted before the transcode failure email is sent, `product_file.link` returns nil, and calling `.name` on it causes a NoMethodError.

This fix adds an early return from the mailer when the link is nil, since there's no point notifying the creator about a transcode failure for a deleted product.

Sentry: https://gumroad-to.sentry.io/issues/7369951152/