### PR TITLE
Fix Rack::Timeout in mobile purchases index by adding default limit

### DIFF
--- a/app/controllers/api/mobile/purchases_controller.rb
+++ b/app/controllers/api/mobile/purchases_controller.rb
@@ -4,6 +4,7 @@ class Api::Mobile::PurchasesController < Api::Mobile::BaseController
   before_action { doorkeeper_authorize! :mobile_api }
   before_action :fetch_purchase, only: [:purchase_attributes, :archive, :unarchive]
   DEFAULT_SEARCH_RESULTS_SIZE = 10
+  DEFAULT_MAX_PURCHASES = 100
 
   def index
     purchases = current_resource_owner.purchases.for_mobile_listing
@@ -12,12 +13,11 @@ class Api::Mobile::PurchasesController < Api::Mobile::BaseController
         purchases.page_with_kaminari(params[:page]).per(params[:per_page])
       )
     else
-      media_locations_scope = MediaLocation.where(product_id: purchases.pluck(:link_id))
-      cache [purchases, media_locations_scope], expires_in: 10.minutes do
-        purchases_to_json(purchases)
+      limited_purchases = purchases.limit(DEFAULT_MAX_PURCHASES)
+      media_locations_scope = MediaLocation.where(product_id: limited_purchases.pluck(:link_id))
+      cache [limited_purchases, media_locations_scope], expires_in: 10.minutes do
+        purchases_to_json(limited_purchases)
       rescue => e
-        # Cache empty array for requests that timeout to reduce the load on database.
-        # TODO: Remove this once we fix the bottleneck with the purchases_json generation
         Rails.logger.info "Error generating purchases json for user: #{current_resource_owner.id}, #{e.class} => #{e.message}"
         ErrorNotifier.notify(e)
         []

--- a/spec/controllers/api/mobile/purchases_controller_spec.rb
+++ b/spec/controllers/api/mobile/purchases_controller_spec.rb
@@ -302,6 +302,19 @@ describe Api::Mobile::PurchasesController do
                                              user_id: @purchaser.external_id }.as_json(api_scopes: ["mobile_api"]))
       end
 
+      it "limits non-paginated results to DEFAULT_MAX_PURCHASES" do
+        [@mobile_friendly_pdf_product, @mobile_friendly_movie_product, @mobile_zip_file_product].each do |product|
+          create(:purchase_with_balance, link: product, purchaser: @purchaser, seller: @user)
+        end
+
+        stub_const("Api::Mobile::PurchasesController::DEFAULT_MAX_PURCHASES", 2)
+
+        get :index, params: @params
+
+        expect(response.parsed_body[:success]).to eq(true)
+        expect(response.parsed_body[:products].size).to eq(2)
+      end
+
       it "paginates results when pagination params are given" do
         created_at_minute_advance = 0
         purchases = [@mobile_friendly_pdf_product, @mobile_friendly_movie_product, @mobile_zip_file_product].map do |product|

--- a/spec/controllers/api/mobile/purchases_controller_spec.rb
+++ b/spec/controllers/api/mobile/purchases_controller_spec.rb
@@ -316,6 +316,17 @@ describe Api::Mobile::PurchasesController do
                                              user_id: @purchaser.external_id }.as_json(api_scopes: ["mobile_api"]))
       end
     end
+
+    it "limits results to DEFAULT_MAX_PURCHASES when no pagination params are given" do
+      stub_const("Api::Mobile::PurchasesController::DEFAULT_MAX_PURCHASES", 3)
+      products = 4.times.map { create(:product, user: @user) }
+      products.each { |product| create(:purchase_with_balance, link: product, purchaser: @purchaser, seller: @user) }
+
+      get :index, params: @params
+
+      expect(response.parsed_body["success"]).to be true
+      expect(response.parsed_body["products"].size).to eq(3)
+    end
   end
 
   describe "POST archive" do


### PR DESCRIPTION
## What

Adds a default limit of 100 to the non-paginated path in `Api::Mobile::PurchasesController#index`. Previously, when called without `per_page`/`page` params, the endpoint loaded ALL purchases for a user — causing `Rack::Timeout::RequestTimeoutException` for users with many purchases.

## Why

Sentry reports `Rack::Timeout` errors on this endpoint. The root cause is the `else` branch doing an unbounded `purchases.pluck(:link_id)` followed by `purchases_to_json(purchases)` — both scale linearly with the number of purchases. Adding `.limit(100)` caps the work and prevents timeouts.

## Changes

- Add `DEFAULT_MAX_PURCHASES = 100` constant
- Apply `.limit(DEFAULT_MAX_PURCHASES)` to the non-paginated query path
- Use the limited scope for both the cache key and serialization
- Add test verifying the limit is applied

## Test plan

- [ ] Existing mobile purchases controller specs pass
- [ ] New test verifies non-paginated path returns at most `DEFAULT_MAX_PURCHASES` results

---
Generated with Claude Opus 4.6. Prompt: fix Sentry Rack::Timeout in mobile purchases index by adding default pagination limit.