### PR TITLE
Handle Taxjar::Error::NotFound in TaxjarApi without notifying Sentry

### DIFF
--- a/app/business/sales_tax/taxjar/taxjar_api.rb
+++ b/app/business/sales_tax/taxjar/taxjar_api.rb
@@ -77,7 +77,7 @@ class TaxjarApi
       end
     rescue *TaxjarErrors::CLIENT => e
       Rails.logger.error "TaxJar Client Error: #{e.inspect}"
-      ErrorNotifier.notify(e)
+      ErrorNotifier.notify(e) unless e.is_a?(Taxjar::Error::NotFound)
       raise e
     rescue *TaxjarErrors::SERVER => e
       Rails.logger.error "TaxJar Server Error: #{e.inspect}"

--- a/spec/business/sales_tax/taxjar/taxjar_api_spec.rb
+++ b/spec/business/sales_tax/taxjar/taxjar_api_spec.rb
@@ -299,6 +299,22 @@ describe TaxjarApi, :vcr do
       end.to raise_error(Taxjar::Error::BadRequest)
     end
 
+    it "does not notify error tracker for NotFound errors" do
+      expect_any_instance_of(Taxjar::Client).to receive(:tax_for_order).and_raise(Taxjar::Error::NotFound)
+
+      expect(ErrorNotifier).not_to receive(:notify)
+
+      expect do
+        described_class.new.calculate_tax_for_order(origin:,
+                                                    destination:,
+                                                    nexus_address:,
+                                                    quantity: 1,
+                                                    product_tax_code: nil,
+                                                    unit_price_dollars: 100.0,
+                                                    shipping_dollars: 20.0)
+      end.to raise_error(Taxjar::Error::NotFound)
+    end
+
     it "propagates a TaxJar server error" do
       allow_any_instance_of(Taxjar::Client).to receive(:tax_for_order).and_raise(Taxjar::Error::InternalServerError)
 


### PR DESCRIPTION
## Problem

`Taxjar::Error::NotFound` ("Tax location not found") errors from the TaxJar API are being reported to Sentry via `ErrorNotifier.notify`, creating noise. These occur when a buyer's location (zip/state/country) isn't recognized by TaxJar.

**Sentry issue:** https://gumroad-to.sentry.io/issues/7370100923/

## Root Cause

In `TaxjarApi#with_caching`, all `TaxjarErrors::CLIENT` errors (including `NotFound`) are reported to Sentry before being re-raised. The caller (`SalesTaxCalculator#calculate_with_taxjar`) already rescues these errors gracefully and falls back to the lookup table. So the error is handled, but Sentry still gets notified unnecessarily.

## Fix

Skip `ErrorNotifier.notify` for `Taxjar::Error::NotFound` since it's an expected scenario (invalid buyer location), not a bug. Other client errors (`BadRequest`, `Unauthorized`, etc.) continue to be reported.

## Changes

- **`app/business/sales_tax/taxjar/taxjar_api.rb`**: Skip `ErrorNotifier.notify` when the error is `Taxjar::Error::NotFound`
- **`spec/business/sales_tax/taxjar/taxjar_api_spec.rb`**: Added test verifying `NotFound` errors don't trigger error notification