### PR TITLE
Fix ArgumentError when price contains multiple decimal points

### DIFF
--- a/app/helpers/currency_helper.rb
+++ b/app/helpers/currency_helper.rb
@@ -22,7 +22,12 @@ module CurrencyHelper
   end
 
   def string_to_price_cents(currency_type, price_string)
-    (BigDecimal(price_string.to_s.delete(",").presence || 0) * (is_currency_type_single_unit?(currency_type) ? 1 : 100)).round
+    sanitized = price_string.to_s.delete(",")
+    if sanitized.count(".") > 1
+      first_dot = sanitized.index(".")
+      sanitized = sanitized[0..first_dot] + sanitized[(first_dot + 1)..].delete(".")
+    end
+    (BigDecimal(sanitized.presence || 0) * (is_currency_type_single_unit?(currency_type) ? 1 : 100)).round
   end
 
   def query_rate(currency_type)

--- a/spec/helpers/currency_helper_spec.rb
+++ b/spec/helpers/currency_helper_spec.rb
@@ -43,6 +43,18 @@ describe CurrencyHelper do
       expect(string_to_price_cents(:usd, "1,200")).to eq 120_000
       expect(string_to_price_cents(:usd, "1,200.99")).to eq 120_099
     end
+
+    it "handles multiple decimal points by keeping only the first" do
+      expect(string_to_price_cents(:usd, "50.00.000")).to eq 5000
+      expect(string_to_price_cents(:usd, "1.000.00")).to eq 100
+      expect(string_to_price_cents(:usd, "1.2.3.4")).to eq 123
+    end
+
+    it "handles normal prices with a single decimal point" do
+      expect(string_to_price_cents(:usd, "9.99")).to eq 999
+      expect(string_to_price_cents(:usd, "100.00")).to eq 10_000
+      expect(string_to_price_cents(:usd, "0.50")).to eq 50
+    end
   end
 
   describe "#unit_scaling_factor" do


### PR DESCRIPTION
## What

Sanitize price strings in `string_to_price_cents` to handle multiple decimal points before passing to `BigDecimal`. When a malformed price string like `"50.00.000"` reaches `BigDecimal()`, it raises `ArgumentError: invalid value for BigDecimal()`. The fix strips all dots after the first one.

## Why

Sentry reports `ArgumentError: invalid value for BigDecimal(): "50.00.000"` in `LinksController#create`. The call chain is:

1. `LinksController#create` → `price_range=`
2. `Product::Prices#price_range=` → `clean_price(price_string)`
3. `BasePrice::Shared#clean_price` → strips non-numeric chars but keeps `.` → passes to `string_to_price_cents`
4. `CurrencyHelper#string_to_price_cents` → `BigDecimal(price_string)` → ArgumentError

The `clean_price` method in `base_price/shared.rb` handles European-style commas but doesn't account for strings with multiple dots. The fix is in `string_to_price_cents` as the more defensive location since other callers may also pass malformed data.

## Test Results

Added tests for multiple decimal points, normal prices still passing. All 19 specs in `currency_helper_spec.rb` green.

---

Generated with Claude Opus 4.6. Prompt: fix Sentry bug for ArgumentError in BigDecimal when price string has multiple decimal points.