### PR TITLE
Fix ActiveRecord::RecordNotUnique race condition in audience member upsert

### DIFF
--- a/app/models/concerns/affiliate/audience_member.rb
+++ b/app/models/concerns/affiliate/audience_member.rb
@@ -18,6 +18,13 @@ module Affiliate::AudienceMember
     member.details["affiliates"] ||= []
     member.details["affiliates"] << audience_member_details(product_id:)
     member.save!
+  rescue ActiveRecord::RecordNotUnique
+    member = AudienceMember.find_by!(email: affiliate_user.email, seller:)
+    return if member.details["affiliates"]&.any? { _1["id"] == id && _1["product_id"] == product_id }
+
+    member.details["affiliates"] ||= []
+    member.details["affiliates"] << audience_member_details(product_id:)
+    member.save!
   end
 
   def update_audience_member_with_removed_product(product_or_id)
@@ -48,6 +55,13 @@ module Affiliate::AudienceMember
       return if product_affiliates.empty?
 
       member = AudienceMember.find_or_initialize_by(email: affiliate_user.email, seller:)
+      member.details["affiliates"] ||= []
+      product_affiliates.each do
+        member.details["affiliates"] << audience_member_details(product_id: _1.link_id)
+      end
+      member.save!
+    rescue ActiveRecord::RecordNotUnique
+      member = AudienceMember.find_by!(email: affiliate_user.email, seller:)
       member.details["affiliates"] ||= []
       product_affiliates.each do
         member.details["affiliates"] << audience_member_details(product_id: _1.link_id)

--- a/app/models/concerns/follower/audience_member.rb
+++ b/app/models/concerns/follower/audience_member.rb
@@ -25,6 +25,10 @@ module Follower::AudienceMember
       member = AudienceMember.find_or_initialize_by(email:, seller: user)
       member.details["follower"] = audience_member_details
       member.save!
+    rescue ActiveRecord::RecordNotUnique
+      member = AudienceMember.find_by!(email:, seller: user)
+      member.details["follower"] = audience_member_details
+      member.save!
     end
 
     def remove_from_audience_member_details(email = attributes["email"])

--- a/app/models/concerns/purchase/audience_member.rb
+++ b/app/models/concerns/purchase/audience_member.rb
@@ -44,6 +44,12 @@ module Purchase::AudienceMember
     member.details["purchases"] ||= []
     member.details["purchases"] << audience_member_details
     member.save!
+  rescue ActiveRecord::RecordNotUnique
+    member = AudienceMember.find_by!(email:, seller:)
+    return if member.details["purchases"]&.any? { _1["id"] == id }
+    member.details["purchases"] ||= []
+    member.details["purchases"] << audience_member_details
+    member.save!
   end
 
   def remove_from_audience_member_details(email = attributes["email"])

--- a/spec/models/direct_affiliate_spec.rb
+++ b/spec/models/direct_affiliate_spec.rb
@@ -453,6 +453,31 @@ describe DirectAffiliate do
       end.to raise_error(ActiveRecord::RecordNotFound)
     end
 
+    it "handles race condition when two concurrent requests create the same audience member" do
+      affiliate = create(:direct_affiliate)
+      product = create(:product, user: affiliate.seller)
+      existing_member = create(:audience_member, email: affiliate.affiliate_user.email, seller: affiliate.seller)
+
+      call_count = 0
+      original_method = AudienceMember.method(:find_or_initialize_by)
+      allow(AudienceMember).to receive(:find_or_initialize_by).and_wrap_original do |method, **args|
+        call_count += 1
+        if call_count == 1
+          AudienceMember.new(email: args[:email], seller: args[:seller])
+        else
+          original_method.call(**args)
+        end
+      end
+
+      expect do
+        affiliate.products << product
+      end.not_to raise_error
+
+      existing_member.reload
+      expect(existing_member.details["affiliates"]).to be_present
+      expect(existing_member.details["affiliates"].first["product_id"]).to eq(product.id)
+    end
+
     it "removes the member when the affiliate user unsubscribes from a seller post" do
       affiliate = create(:direct_affiliate)
       product = create(:product, user: affiliate.seller)

--- a/spec/models/follower_spec.rb
+++ b/spec/models/follower_spec.rb
@@ -287,6 +287,29 @@ RSpec.describe Follower do
       expect(member).to be_nil
     end
 
+    it "handles race condition when two concurrent requests create the same audience member" do
+      follower = create(:follower)
+      existing_member = create(:audience_member, email: follower.email, seller: follower.user)
+
+      call_count = 0
+      original_method = AudienceMember.method(:find_or_initialize_by)
+      allow(AudienceMember).to receive(:find_or_initialize_by).and_wrap_original do |method, **args|
+        call_count += 1
+        if call_count == 1
+          AudienceMember.new(email: args[:email], seller: args[:seller])
+        else
+          original_method.call(**args)
+        end
+      end
+
+      expect do
+        follower.confirm!
+      end.not_to raise_error
+
+      existing_member.reload
+      expect(existing_member.details["follower"]).to eq({ "id" => follower.id, "created_at" => follower.created_at.iso8601 })
+    end
+
     it "recreates audience member when changing email" do
       follower = create(:active_follower)
       old_email = follower.email

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -5103,6 +5103,31 @@ describe Purchase, :vcr do
       expect(old_member).to be_nil
       expect(new_member).to be_present
     end
+
+    it "handles race condition when two concurrent requests create the same audience member" do
+      purchase = create(:purchase_in_progress)
+      purchase.update_column(:purchase_state, "successful")
+      existing_member = create(:audience_member, email: purchase.email, seller: purchase.seller)
+
+      call_count = 0
+      original_method = AudienceMember.method(:find_or_initialize_by)
+      allow(AudienceMember).to receive(:find_or_initialize_by).and_wrap_original do |method, **args|
+        call_count += 1
+        if call_count == 1
+          AudienceMember.new(email: args[:email], seller: args[:seller])
+        else
+          original_method.call(**args)
+        end
+      end
+
+      expect do
+        purchase.add_to_audience_member_details
+      end.not_to raise_error
+
+      existing_member.reload
+      expect(existing_member.details["purchases"]).to be_present
+      expect(existing_member.details["purchases"].first["id"]).to eq(purchase.id)
+    end
   end
 
   describe "purchasing power parity validations" do


### PR DESCRIPTION
## What

Adds `rescue ActiveRecord::RecordNotUnique` to the `find_or_initialize_by` + `save!` pattern in all three audience member concerns:
- `Follower::AudienceMember`
- `Purchase::AudienceMember`
- `Affiliate::AudienceMember`

On rescue, retries with `find_by!` + `save!` to update the existing record.

## Why

Under concurrent requests (e.g., user double-clicks the confirm link), two processes both call `find_or_initialize_by`, both get a new (unsaved) record, both try to insert, and the second hits the unique constraint on `(seller_id, email)` → `ActiveRecord::RecordNotUnique`.

[Sentry issue](https://gumroad-to.sentry.io/issues/7370393309/)

## Test Results

Added race condition tests for all three concerns that stub `find_or_initialize_by` to return a new record even when one exists, verifying the rescue path handles it correctly.

---

Built with Claude Opus 4.6. Prompt: fix the `ActiveRecord::RecordNotUnique` race condition in audience member upsert by rescuing and retrying with `find_by!`.