### PR TITLE
Fix Rack::Timeout in LinksController#show by removing expensive sales count cache key query

### DIFF
--- a/app/presenters/product_presenter/product_props.rb
+++ b/app/presenters/product_presenter/product_props.rb
@@ -120,8 +120,7 @@ class ProductPresenter::ProductProps
     def cached_sales_count
       return unless product.should_show_sales_count?
 
-      cache_key_digest = Digest::SHA256.hexdigest("#{product.cache_key}-#{product.price_cents}-#{product.sales.order(id: :desc).pick(:id)}")
-      cache_key = "#{SALES_COUNT_CACHE_KEY_REFIX}_#{cache_key_digest}"
+      cache_key = "#{SALES_COUNT_CACHE_KEY_REFIX}_#{product.id}_#{product.price_cents}"
       Rails.cache.fetch(cache_key, expires_in: 1.minute) { product.successful_sales_count }
     end
 

--- a/app/presenters/profile_sections_presenter.rb
+++ b/app/presenters/profile_sections_presenter.rb
@@ -17,7 +17,7 @@ class ProfileSectionsPresenter
 
     props = {
       currency_code: pundit_user.user&.currency_type || Currency::USD,
-      show_ratings_filter: seller.links.alive.where(display_product_reviews: true).exists?,
+      show_ratings_filter: seller.links.alive.display_product_reviews.exists?,
       creator_profile: ProfilePresenter.new(seller:, pundit_user:).creator_profile,
       sections: cached_sections.map do |props|
         section_props(sections.find { _1.external_id == props[:id] }, cached_props: props, request:, pundit_user:, seller_custom_domain_url:)

--- a/app/presenters/profile_sections_presenter.rb
+++ b/app/presenters/profile_sections_presenter.rb
@@ -17,7 +17,7 @@ class ProfileSectionsPresenter
 
     props = {
       currency_code: pundit_user.user&.currency_type || Currency::USD,
-      show_ratings_filter: seller.links.alive.any?(&:display_product_reviews?),
+      show_ratings_filter: seller.links.alive.where(display_product_reviews: true).exists?,
       creator_profile: ProfilePresenter.new(seller:, pundit_user:).creator_profile,
       sections: cached_sections.map do |props|
         section_props(sections.find { _1.external_id == props[:id] }, cached_props: props, request:, pundit_user:, seller_custom_domain_url:)

--- a/spec/presenters/product_presenter/product_props_spec.rb
+++ b/spec/presenters/product_presenter/product_props_spec.rb
@@ -571,6 +571,10 @@ describe ProductPresenter::ProductProps do
 
       create(:purchase, link: product)
 
+      # The sales count cache key is time-based (1 minute TTL) rather than
+      # purchase-dependent, so we clear the cache to pick up the new count.
+      Rails.cache.clear
+
       expect(presenter.props(seller_custom_domain_url: nil, request:, pundit_user: nil)[:product][:sales_count]).to eq(1)
       expect($redis.hgetall(metrics_key)).to eq("misses" => "2", "hits" => "1")
 

--- a/spec/requests/products/show/sales_count_spec.rb
+++ b/spec/requests/products/show/sales_count_spec.rb
@@ -83,10 +83,12 @@ describe("Product page sales count", js: true, type: :system) do
       expect(page).to have_text("0 sales")
 
       create(:purchase, link: @product, succeeded_at: 1.hour.ago)
+      Rails.cache.clear
       visit @product.long_url
       expect(page).to have_text("1 sale")
 
       create(:purchase, link: @product, succeeded_at: 1.hour.ago)
+      Rails.cache.clear
       visit @product.long_url
       expect(page).to have_text("2 sales")
     end

--- a/spec/requests/products/show/supporter_count_spec.rb
+++ b/spec/requests/products/show/supporter_count_spec.rb
@@ -49,10 +49,12 @@ describe("The supporter count", js: true, type: :system) do
       expect(page).to have_text("0 members")
 
       create(:membership_purchase, link: product, succeeded_at: 1.hour.ago, price_cents: 100)
+      Rails.cache.clear
       visit("/l/#{product.unique_permalink}")
       expect(page).to have_text("1 member")
 
       create(:membership_purchase, link: product, succeeded_at: 1.hour.ago, price_cents: 100)
+      Rails.cache.clear
       visit("/l/#{product.unique_permalink}")
       expect(page).to have_text("2 members")
     end


### PR DESCRIPTION
## Problem

`LinksController#show` was hitting `Rack::Timeout::RequestTimeoutException` (120s) in production.

**Sentry**: https://gumroad-to.sentry.io/issues/7370399239/

## Root cause

The `cached_sales_count` method in `ProductPresenter::ProductProps` was computing its cache key by running:

```ruby
product.sales.order(id: :desc).pick(:id)
```

This queries the `purchases` table ordered by `id DESC` on **every single request** to a product page, just to build a cache key. For products with a large number of sales, this query alone can be extremely slow, and it completely defeats the purpose of caching.

## Fix

**1. Simplified cache key** (product_props.rb)

Replaced the expensive purchase-dependent cache key with a simple `product.id + price_cents` key. The existing 1-minute TTL already ensures freshness, so busting the cache on every new purchase was unnecessary overhead. The sales count display being at most 1 minute stale is perfectly acceptable.

**2. SQL `exists?` instead of Ruby `any?`** (profile_sections_presenter.rb)

Changed `seller.links.alive.any?(&:display_product_reviews?)` to `seller.links.alive.where(display_product_reviews: true).exists?`. The old code loaded ALL alive products for a seller into Ruby memory just to check a boolean flag. The new version uses a single SQL `EXISTS` query.

## Test changes

Updated the `cached_sales_count` spec to call `Rails.cache.clear` before asserting the post-purchase count, since the cache key no longer changes when a new purchase is created.