### PR TITLE
Fix Rack::Timeout in mobile purchases index by adding default limit

### DIFF
--- a/app/controllers/api/mobile/purchases_controller.rb
+++ b/app/controllers/api/mobile/purchases_controller.rb
@@ -4,6 +4,7 @@ class Api::Mobile::PurchasesController < Api::Mobile::BaseController
   before_action { doorkeeper_authorize! :mobile_api }
   before_action :fetch_purchase, only: [:purchase_attributes, :archive, :unarchive]
   DEFAULT_SEARCH_RESULTS_SIZE = 10
+  DEFAULT_PURCHASES_LIMIT = 25
 
   def index
     purchases = current_resource_owner.purchases.for_mobile_listing
@@ -12,6 +13,7 @@ class Api::Mobile::PurchasesController < Api::Mobile::BaseController
         purchases.page_with_kaminari(params[:page]).per(params[:per_page])
       )
     else
+      purchases = purchases.limit(DEFAULT_PURCHASES_LIMIT)
       media_locations_scope = MediaLocation.where(product_id: purchases.pluck(:link_id))
       cache [purchases, media_locations_scope], expires_in: 10.minutes do
         purchases_to_json(purchases)

--- a/spec/controllers/api/mobile/purchases_controller_spec.rb
+++ b/spec/controllers/api/mobile/purchases_controller_spec.rb
@@ -302,6 +302,18 @@ describe Api::Mobile::PurchasesController do
                                              user_id: @purchaser.external_id }.as_json(api_scopes: ["mobile_api"]))
       end
 
+      it "applies a default limit when pagination params are not given" do
+        product = @mobile_friendly_pdf_product
+        30.times do |i|
+          create(:free_purchase, link: product, purchaser: @purchaser, seller: @user,
+                                 created_at: (i + 1).minutes.from_now)
+        end
+
+        get :index, params: @params
+
+        expect(response.parsed_body[:products].size).to eq(25)
+      end
+
       it "paginates results when pagination params are given" do
         created_at_minute_advance = 0
         purchases = [@mobile_friendly_pdf_product, @mobile_friendly_movie_product, @mobile_zip_file_product].map do |product|


### PR DESCRIPTION
## Problem

The non-paginated path in `Api::Mobile::PurchasesController#index` loaded ALL purchases for a user, causing Rack::Timeout errors for users with many purchases ([Sentry issue](https://gumroad-to.sentry.io/issues/7370399506/)).

The unlimited query affected both:
- `purchases.pluck(:link_id)` for the MediaLocation cache key
- `purchases_to_json(purchases)` which iterates every purchase calling `json_data_for_mobile`

## Fix

Added `DEFAULT_PURCHASES_LIMIT = 25` to cap the non-paginated path. The limit is applied before the `pluck` and serialization so both benefit. The paginated path (with `per_page`/`page` params) is unchanged.

## Test

Added a test that creates 30 purchases and verifies the non-paginated response returns only 25.