### PR TITLE
Fix Rack::Timeout in product search by capping size parameter

### DIFF
--- a/app/modules/product/searchable.rb
+++ b/app/modules/product/searchable.rb
@@ -6,6 +6,7 @@ module Product::Searchable
   # we want to show 9 tags, but this is used as an array indexing which starts at 0
   MAX_NUMBER_OF_TAGS = 8
   RECOMMENDED_PRODUCTS_PER_PAGE = 9
+  MAX_SEARCH_SIZE = 100
   MAX_NUMBER_OF_FILETYPES = 8
   MAX_OFFER_CODES_IN_INDEX = 300
 
@@ -150,7 +151,7 @@ module Product::Searchable
   class_methods do
     def search_options(params)
       search_options = Elasticsearch::DSL::Search.search do
-        size params.fetch(:size, RECOMMENDED_PRODUCTS_PER_PAGE)
+        size [params.fetch(:size, RECOMMENDED_PRODUCTS_PER_PAGE).to_i, MAX_SEARCH_SIZE].min
         from (params[:from].to_i - 1).clamp(0, MAX_RESULT_WINDOW - size)
         _source false
         if params[:track_total_hits]

--- a/spec/modules/product/searchable/search_spec.rb
+++ b/spec/modules/product/searchable/search_spec.rb
@@ -623,6 +623,28 @@ describe "Product::Searchable - Search scenarios" do
       end
     end
 
+    describe "option 'size'" do
+      it "defaults to RECOMMENDED_PRODUCTS_PER_PAGE" do
+        search = Link.search_options({})
+        expect(search.to_hash[:size]).to eq(Product::Searchable::RECOMMENDED_PRODUCTS_PER_PAGE)
+      end
+
+      it "caps size at MAX_SEARCH_SIZE" do
+        search = Link.search_options(size: 10_000)
+        expect(search.to_hash[:size]).to eq(Product::Searchable::MAX_SEARCH_SIZE)
+      end
+
+      it "allows size values within MAX_SEARCH_SIZE" do
+        search = Link.search_options(size: 50)
+        expect(search.to_hash[:size]).to eq(50)
+      end
+
+      it "handles string size params" do
+        search = Link.search_options(size: "10000")
+        expect(search.to_hash[:size]).to eq(Product::Searchable::MAX_SEARCH_SIZE)
+      end
+    end
+
     describe "searching by multiple user IDs" do
       let!(:product1) { create(:product) }
       let!(:product2) { create(:product) }


### PR DESCRIPTION
## Problem

`LinksController#search` hit a `Rack::Timeout::RequestTimeoutException` (120s) on `/products/search`. The `size` parameter in `Product::Searchable#search_options` was passed directly from user input with no upper bound, allowing requests like `?size=10000` to trigger expensive Elasticsearch queries and MySQL eager-loads.

## Root Cause

In `search_options`, the size was set as:
```ruby
size params.fetch(:size, RECOMMENDED_PRODUCTS_PER_PAGE)
```

No cap was applied, so a large `size` value would:
1. Request thousands of results from Elasticsearch
2. Load all those records from MySQL via `.records`
3. Eager-load `ProductPresenter::ASSOCIATIONS_FOR_CARD` for each

Combined with the duplicate ES query for filetype aggregations in `search_products`, this easily exceeded the 120s Rack::Timeout.

## Fix

- Add `MAX_SEARCH_SIZE = 100` constant
- Clamp `size` to `MAX_SEARCH_SIZE` in `search_options`:
  ```ruby
  size [params.fetch(:size, RECOMMENDED_PRODUCTS_PER_PAGE).to_i, MAX_SEARCH_SIZE].min
  ```
- The `.to_i` also handles string params safely

## Tests

Added 4 tests covering:
- Default size behavior
- Capping at MAX_SEARCH_SIZE for large values
- Allowing valid size values through
- Handling string size params