### PR TITLE
Fix unhandled SsrfFilter::UnresolvedHostname in AssetPreviewsController#create

### DIFF
--- a/config/initializers/004_constants.rb
+++ b/config/initializers/004_constants.rb
@@ -71,7 +71,7 @@ DENYLIST = %w[ a about account activate add admin administrator api app apps
 INTERNET_EXCEPTIONS = [SocketError, Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::ENETUNREACH, Errno::EHOSTUNREACH,
                        Errno::EADDRNOTAVAIL, EOFError, URI::InvalidURIError, Addressable::URI::InvalidURIError,
                        Timeout::Error, Net::HTTPBadResponse, Net::OpenTimeout, Net::ReadTimeout, OpenURI::HTTPError,
-                       OpenSSL::SSL::SSLError, Faraday::ConnectionFailed].freeze
+                       OpenSSL::SSL::SSLError, Faraday::ConnectionFailed, SsrfFilter::Error].freeze
 
 FILE_REGEX = {
   archive: /rar|zip|tar/i,

--- a/spec/controllers/asset_previews_controller_spec.rb
+++ b/spec/controllers/asset_previews_controller_spec.rb
@@ -39,6 +39,14 @@ describe AssetPreviewsController do
       expect(response.parsed_body["success"]).to eq(false)
     end
 
+    it "returns a graceful error when the URL hostname cannot be resolved", skip_ssrf_stub: true do
+      allow(SsrfFilter).to receive(:get).and_raise(SsrfFilter::UnresolvedHostname, "Could not resolve hostname")
+      post(:create, params: { link_id: product.unique_permalink, asset_preview: { url: "https://unresolvable-host.example" }, format: :json })
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["success"]).to eq(false)
+      expect(response.parsed_body["error"]).to eq("Could not process your preview, please try again.")
+    end
+
     it "doesn't add a preview if there are too many previews" do
       stub_const("Link::MAX_PREVIEW_COUNT", 1)
       allow_any_instance_of(AssetPreview).to receive(:analyze_file).and_return(nil)


### PR DESCRIPTION
## What

Add `SsrfFilter::Error` to `INTERNET_EXCEPTIONS` so that `AssetPreviewsController#create` returns a graceful JSON error instead of raising a 500 when a user submits a URL with an unresolvable hostname.

## Why

`SsrfFilter.get` (called from `AssetPreview#url=`) raises `SsrfFilter::UnresolvedHostname` for URLs with invalid hostnames, but this exception class was not included in `INTERNET_EXCEPTIONS`. The controller's `rescue *INTERNET_EXCEPTIONS` handler didn't catch it, resulting in unhandled 500s reported in Sentry.

Adding the base class `SsrfFilter::Error` covers all three SsrfFilter exceptions (`UnresolvedHostname`, `PrivateIPAddress`, `InvalidUriScheme`).

## Test Results

Added a controller spec that stubs `SsrfFilter::UnresolvedHostname` and verifies the controller returns `{ success: false, error: "Could not process your preview, please try again." }`.

---

AI disclosure: Built with Claude Opus 4.6. Prompted with the Sentry error context and asked to add SsrfFilter exceptions to INTERNET_EXCEPTIONS and add a controller spec.