### PR TITLE
Fix Rack::Timeout in Mobile Purchases API by limiting unpaginated results

### DIFF
--- a/app/controllers/api/mobile/purchases_controller.rb
+++ b/app/controllers/api/mobile/purchases_controller.rb
@@ -4,6 +4,7 @@ class Api::Mobile::PurchasesController < Api::Mobile::BaseController
   before_action { doorkeeper_authorize! :mobile_api }
   before_action :fetch_purchase, only: [:purchase_attributes, :archive, :unarchive]
   DEFAULT_SEARCH_RESULTS_SIZE = 10
+  DEFAULT_UNPAGINATED_LIMIT = 100
 
   def index
     purchases = current_resource_owner.purchases.for_mobile_listing
@@ -12,6 +13,7 @@ class Api::Mobile::PurchasesController < Api::Mobile::BaseController
         purchases.page_with_kaminari(params[:page]).per(params[:per_page])
       )
     else
+      purchases = purchases.limit(DEFAULT_UNPAGINATED_LIMIT)
       media_locations_scope = MediaLocation.where(product_id: purchases.pluck(:link_id))
       cache [purchases, media_locations_scope], expires_in: 10.minutes do
         purchases_to_json(purchases)

--- a/spec/controllers/api/mobile/purchases_controller_spec.rb
+++ b/spec/controllers/api/mobile/purchases_controller_spec.rb
@@ -316,6 +316,19 @@ describe Api::Mobile::PurchasesController do
                                              user_id: @purchaser.external_id }.as_json(api_scopes: ["mobile_api"]))
       end
     end
+
+    it "limits unpaginated results to DEFAULT_UNPAGINATED_LIMIT" do
+      stub_const("Api::Mobile::PurchasesController::DEFAULT_UNPAGINATED_LIMIT", 3)
+      products = 4.times.map { create(:product, user: @user, price_cents: 0) }
+      products.each do |product|
+        create(:purchase, link: product, purchaser: @purchaser, seller: @user)
+      end
+
+      get :index, params: @params
+
+      expect(response.parsed_body["success"]).to eq(true)
+      expect(response.parsed_body["products"].size).to eq(3)
+    end
   end
 
   describe "POST archive" do


### PR DESCRIPTION
## Problem

The unpaginated code path in `Api::Mobile::PurchasesController#index` loads all of a user's purchases without any limit, then serializes every one through `json_data_for_mobile` (which triggers additional queries per purchase). For users with many purchases, this causes Rack::Timeout (120s) errors.

**Sentry:** https://gumroad-to.sentry.io/issues/7370420031/

## Fix

Added a `DEFAULT_UNPAGINATED_LIMIT = 100` constant and applied `.limit(DEFAULT_UNPAGINATED_LIMIT)` to the unpaginated code path. This caps the number of purchases loaded and serialized, preventing timeouts while still returning a reasonable number of results.

The paginated path (using `per_page`/`page` params) is unchanged.

## Changes

- `app/controllers/api/mobile/purchases_controller.rb`: Added limit to unpaginated purchases query
- `spec/controllers/api/mobile/purchases_controller_spec.rb`: Added test verifying the limit is applied