### PR TITLE
Fix Aws::S3::Errors::MetadataTooLarge in asset preview uploads

### DIFF
--- a/app/controllers/asset_previews_controller.rb
+++ b/app/controllers/asset_previews_controller.rb
@@ -23,7 +23,7 @@ class AssetPreviewsController < ApplicationController
       asset_preview.file&.blob&.purge
       render(json: { success: false, error: asset_preview.errors.any? ? asset_preview.errors.full_messages.to_sentence : "Could not process your preview, please try again." })
     end
-  rescue *INTERNET_EXCEPTIONS
+  rescue *INTERNET_EXCEPTIONS, Aws::S3::Errors::MetadataTooLarge
     render(json: { success: false, error: "Could not process your preview, please try again." })
   end
 

--- a/app/models/asset_preview.rb
+++ b/app/models/asset_preview.rb
@@ -189,8 +189,13 @@ class AssetPreview < ApplicationRecord
       tempfile = Tempfile.new(binmode: true)
       tempfile.write(response.body)
       tempfile.rewind
+      filename = File.basename(new_uri.path)
+      if filename.length > 200
+        ext = File.extname(filename)
+        filename = "#{filename[0, 200 - ext.length]}#{ext}"
+      end
       blob = ActiveStorage::Blob.create_and_upload!(io: tempfile,
-                                                    filename: File.basename(new_url),
+                                                    filename: filename,
                                                     content_type: response.content_type)
       self.file.attach(blob.signed_id)
       self.file.analyze

--- a/spec/controllers/asset_previews_controller_spec.rb
+++ b/spec/controllers/asset_previews_controller_spec.rb
@@ -33,6 +33,15 @@ describe AssetPreviewsController do
       end.to change { product.asset_previews.alive.count }.by(1)
     end
 
+    it "handles Aws::S3::Errors::MetadataTooLarge gracefully" do
+      allow_any_instance_of(AssetPreview).to receive(:url=).and_raise(Aws::S3::Errors::MetadataTooLarge.new(nil, "Metadata too large"))
+      post(:create, params: { link_id: product.unique_permalink, asset_preview: { url: s3_url }, format: :json })
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["success"]).to be(false)
+      expect(response.parsed_body["error"]).to be_present
+    end
+
     it "doesn't add a preview if there are too many previews" do
       stub_const("Link::MAX_PREVIEW_COUNT", 1)
       allow_any_instance_of(AssetPreview).to receive(:analyze_file).and_return(nil)

--- a/spec/models/asset_preview_spec.rb
+++ b/spec/models/asset_preview_spec.rb
@@ -189,6 +189,27 @@ describe AssetPreview, :vcr do
         asset_preview.save!
       end.to raise_error(SsrfFilter::PrivateIPAddress)
     end
+
+    it "strips query parameters from the filename" do
+      url_with_query = "#{AWS_S3_ENDPOINT}/#{S3_BUCKET}/specs/test.png?token=abc123&sig=xyz"
+      asset_preview.url = url_with_query
+      asset_preview.analyze_file
+      asset_preview.save!
+
+      expect(asset_preview.file.filename.to_s).to eq("test.png")
+    end
+
+    it "truncates extremely long filenames while preserving the extension" do
+      long_name = "a" * 250
+      url_with_long_name = "#{AWS_S3_ENDPOINT}/#{S3_BUCKET}/specs/#{long_name}.png"
+      asset_preview.url = url_with_long_name
+      asset_preview.analyze_file
+      asset_preview.save!
+
+      filename = asset_preview.file.filename.to_s
+      expect(filename.length).to be <= 200
+      expect(filename).to end_with(".png")
+    end
   end
 
   it "auto-generates a GUID on creation" do


### PR DESCRIPTION
## Problem

When uploading asset previews via URL, `File.basename(new_url)` was used to generate the S3 filename. If the URL contained long query parameters (e.g. signed URLs with tokens), the entire query string became part of the filename. This filename is stored as S3 metadata in the Content-Disposition header, and when it exceeds S3's 2KB metadata limit, it raises `Aws::S3::Errors::MetadataTooLarge`, resulting in a 500 error.

## Fix

**1. Strip query params from filename** (`app/models/asset_preview.rb`)
- Use `File.basename(new_uri.path)` instead of `File.basename(new_url)` to exclude query parameters from the filename
- Add safety truncation: filenames longer than 200 characters are truncated while preserving the file extension

**2. Rescue the S3 error in the controller** (`app/controllers/asset_previews_controller.rb`)
- Added `Aws::S3::Errors::MetadataTooLarge` to the rescue clause so it returns a user-friendly error instead of a 500

## Tests
- Test that `url=` strips query parameters from the filename
- Test that very long filenames are truncated while preserving the extension
- Test that `Aws::S3::Errors::MetadataTooLarge` is handled gracefully in the controller