### PR TITLE
Fix: Don't report Taxjar::Error::NotFound to Sentry

### DIFF
--- a/app/business/sales_tax/taxjar/taxjar_api.rb
+++ b/app/business/sales_tax/taxjar/taxjar_api.rb
@@ -77,7 +77,7 @@ class TaxjarApi
       end
     rescue *TaxjarErrors::CLIENT => e
       Rails.logger.error "TaxJar Client Error: #{e.inspect}"
-      ErrorNotifier.notify(e)
+      ErrorNotifier.notify(e) unless e.is_a?(Taxjar::Error::NotFound)
       raise e
     rescue *TaxjarErrors::SERVER => e
       Rails.logger.error "TaxJar Server Error: #{e.inspect}"

--- a/spec/business/sales_tax/taxjar/taxjar_api_spec.rb
+++ b/spec/business/sales_tax/taxjar/taxjar_api_spec.rb
@@ -299,6 +299,22 @@ describe TaxjarApi, :vcr do
       end.to raise_error(Taxjar::Error::BadRequest)
     end
 
+    it "propagates a TaxJar NotFound error without notifying error tracker" do
+      expect_any_instance_of(Taxjar::Client).to receive(:tax_for_order).and_raise(Taxjar::Error::NotFound)
+
+      expect(ErrorNotifier).not_to receive(:notify)
+
+      expect do
+        described_class.new.calculate_tax_for_order(origin:,
+                                                    destination:,
+                                                    nexus_address:,
+                                                    quantity: 1,
+                                                    product_tax_code: nil,
+                                                    unit_price_dollars: 100.0,
+                                                    shipping_dollars: 20.0)
+      end.to raise_error(Taxjar::Error::NotFound)
+    end
+
     it "propagates a TaxJar server error" do
       allow_any_instance_of(Taxjar::Client).to receive(:tax_for_order).and_raise(Taxjar::Error::InternalServerError)
 


### PR DESCRIPTION
## Problem

`Taxjar::Error::NotFound` ("Tax location not found") fires when TaxJar can't resolve a buyer's location (e.g., invalid or unrecognized zip code). This error is currently reported to Sentry via `ErrorNotifier.notify`, but it's an expected condition — the caller in `SalesTaxCalculator#calculate_with_taxjar` already rescues all TaxJar client/server errors and gracefully falls back to the lookup table.

This creates unnecessary noise in Sentry.

**Sentry issue:** https://gumroad-to.sentry.io/issues/7370668344/

## Fix

Skip `ErrorNotifier.notify(e)` when the error is `Taxjar::Error::NotFound`. The error is still re-raised so the caller's fallback logic works unchanged. Other client errors (BadRequest, Unauthorized, etc.) continue to be reported to Sentry.

## Changes

- `app/business/sales_tax/taxjar/taxjar_api.rb`: Conditional skip of `ErrorNotifier.notify` for `NotFound`
- `spec/business/sales_tax/taxjar/taxjar_api_spec.rb`: Added test verifying `NotFound` propagates without Sentry notification