### PR TITLE
Don't report TaxJar BadRequest errors to Sentry

### DIFF
--- a/app/business/sales_tax/taxjar/taxjar_api.rb
+++ b/app/business/sales_tax/taxjar/taxjar_api.rb
@@ -75,6 +75,9 @@ class TaxjarApi
         @cache.set(cache_key, response_json, ex: 10.minutes.to_i)
         JSON.parse(response_json)
       end
+    rescue Taxjar::Error::BadRequest => e
+      Rails.logger.error "TaxJar Bad Request: #{e.inspect}"
+      raise e
     rescue *TaxjarErrors::CLIENT => e
       Rails.logger.error "TaxJar Client Error: #{e.inspect}"
       ErrorNotifier.notify(e)

--- a/spec/business/sales_tax/taxjar/taxjar_api_spec.rb
+++ b/spec/business/sales_tax/taxjar/taxjar_api_spec.rb
@@ -283,10 +283,10 @@ describe TaxjarApi, :vcr do
                                                          shipping_dollars: 20.0)).to eq(expected_calculation)
     end
 
-    it "notifies error tracker and propagates a TaxJar client error" do
+    it "propagates a TaxJar BadRequest error without notifying error tracker" do
       expect_any_instance_of(Taxjar::Client).to receive(:tax_for_order).and_raise(Taxjar::Error::BadRequest)
 
-      expect(ErrorNotifier).to receive(:notify).exactly(:once)
+      expect(ErrorNotifier).not_to receive(:notify)
 
       expect do
         described_class.new.calculate_tax_for_order(origin:,
@@ -297,6 +297,22 @@ describe TaxjarApi, :vcr do
                                                     unit_price_dollars: 100.0,
                                                     shipping_dollars: 20.0)
       end.to raise_error(Taxjar::Error::BadRequest)
+    end
+
+    it "notifies error tracker and propagates other TaxJar client errors" do
+      expect_any_instance_of(Taxjar::Client).to receive(:tax_for_order).and_raise(Taxjar::Error::NotFound)
+
+      expect(ErrorNotifier).to receive(:notify).exactly(:once)
+
+      expect do
+        described_class.new.calculate_tax_for_order(origin:,
+                                                    destination:,
+                                                    nexus_address:,
+                                                    quantity: 1,
+                                                    product_tax_code: nil,
+                                                    unit_price_dollars: 100.0,
+                                                    shipping_dollars: 20.0)
+      end.to raise_error(Taxjar::Error::NotFound)
     end
 
     it "propagates a TaxJar server error" do


### PR DESCRIPTION
## Problem

`Taxjar::Error::BadRequest` exceptions (e.g. zip code / state mismatches like "to_zip 46223 is not used within to_state IN") were being reported to Sentry via `ErrorNotifier.notify`, creating noise for what is essentially invalid buyer input.

The caller (`SalesTaxCalculator#calculate_with_taxjar`) already rescues these errors and falls back gracefully to the lookup table, so the order still completes successfully.

## Fix

Rescue `Taxjar::Error::BadRequest` separately from other client errors in `TaxjarApi#with_caching`, skipping the `ErrorNotifier.notify` call. Other client errors (e.g. `NotFound`, `Unauthorized`) continue to be reported to Sentry.

## Tests

- Updated existing test to verify BadRequest does NOT notify error tracker
- Added new test to verify other client errors (e.g. NotFound) still notify error tracker
- All 8 TaxjarApi specs pass
- All 181 SalesTaxCalculator specs pass

[Sentry issue](https://gumroad-to.sentry.io/issues/7370673412/)