### PR TITLE
Fix NoMethodError when price param is an array in checkout

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1047,7 +1047,7 @@ class Link < ApplicationRecord
     attrs[:recurrence] = recurrence&.recurrence
     attrs[:pay_in_installments] = !!params[:pay_in_installments] && allow_installment_plan?
     attrs[:price] = [
-      customizable_price.present? || variant&.customizable_price.present? ? params[:price].to_i : 0,
+      customizable_price.present? || variant&.customizable_price.present? ? Array(params[:price]).first.to_i : 0,
       (recurrence&.price_cents || (attrs[:rental] ? rental_price_cents : price_cents)) +
       (attrs[:option]&.fetch(:price_difference_cents) || 0)
     ].max

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -4723,6 +4723,27 @@ describe Link, :vcr do
     end
   end
 
+  describe "#cart_item" do
+    context "when price param is an array (malformed request)" do
+      it "does not raise NoMethodError and returns a valid price" do
+        product = create(:product, customizable_price: true, price_cents: 100)
+        # Simulates a malformed request like ?price[]=500 where Rails parses price as an Array
+        params = ActionController::Parameters.new(price: ["500"])
+        expect { product.cart_item(params) }.not_to raise_error
+        result = product.cart_item(params)
+        expect(result[:price]).to eq(500)
+      end
+
+      it "returns 0 when price array is empty" do
+        product = create(:product, customizable_price: true, price_cents: 100)
+        params = ActionController::Parameters.new(price: [])
+        expect { product.cart_item(params) }.not_to raise_error
+        result = product.cart_item(params)
+        expect(result[:price]).to eq(100)
+      end
+    end
+  end
+
   describe "installment plan" do
     let!(:product) { create(:product, price_cents: 1000) }
     let!(:installment_plan) { create(:product_installment_plan, link: product, number_of_installments: 2) }


### PR DESCRIPTION
## Summary

Fixes a `NoMethodError: undefined method 'to_i' for an instance of Array` in `CheckoutController#show`.

**Sentry issue:** https://gumroad-to.sentry.io/issues/7370808053/

## Root cause

In `app/models/link.rb`, `cart_item` calls `params[:price].to_i`. When a malformed request sends `price` as an array (e.g. `?price[]=100`), Rails parses it as an `Array`, and `Array#to_i` does not exist.

## Fix

Replace `params[:price].to_i` with `Array(params[:price]).first.to_i`. This safely handles both scalar strings and arrays, and returns `0` for `nil`.

## Testing

Added unit tests to `spec/models/link_spec.rb` covering:
- Array price param returns correctly parsed value
- Empty array price param falls back to product price