### PR TITLE
Fix Rack::Timeout in Api::Mobile::PurchasesController#index

### DIFF
--- a/app/models/url_redirect.rb
+++ b/app/models/url_redirect.rb
@@ -394,10 +394,27 @@ class UrlRedirect < ApplicationRecord
     end
 
     def has_purchased_variants_from_categories_with_files?
+      return @_has_purchased_variants_from_categories_with_files if defined?(@_has_purchased_variants_from_categories_with_files)
+
+      @_has_purchased_variants_from_categories_with_files = compute_has_purchased_variants_from_categories_with_files
+    end
+
+    def compute_has_purchased_variants_from_categories_with_files
       return false unless purchase
-      purchase.variant_attributes.any? do |variant|
-        variant.is_a?(Variant) && (variant.has_files? || (variant.variant_category && variant.variant_category.variants.alive.any?(&:has_files?)))
-      end
+
+      purchased_variants = purchase.variant_attributes.select { _1.is_a?(Variant) }
+      return false if purchased_variants.empty?
+
+      variant_ids = purchased_variants.map(&:id)
+      return true if ProductFile.alive.joins(:base_variants).where(base_variants: { id: variant_ids }).exists?
+
+      category_ids = purchased_variants.filter_map(&:variant_category_id).uniq
+      return false if category_ids.empty?
+
+      sibling_variant_ids = Variant.alive.where(variant_category_id: category_ids).where.not(id: variant_ids).pluck(:id)
+      return false if sibling_variant_ids.empty?
+
+      ProductFile.alive.joins(:base_variants).where(base_variants: { id: sibling_variant_ids }).exists?
     end
 
     def has_purchased_variants_from_categories_with_rich_content?

--- a/spec/models/url_redirect_spec.rb
+++ b/spec/models/url_redirect_spec.rb
@@ -483,6 +483,95 @@ describe UrlRedirect do
     end
   end
 
+  describe "#has_purchased_variants_from_categories_with_files?" do
+    it "returns false when there is no purchase" do
+      url_redirect = create(:url_redirect, purchase: nil)
+      expect(url_redirect.send(:has_purchased_variants_from_categories_with_files?)).to be false
+    end
+
+    it "returns false when purchase has no variant attributes" do
+      product = create(:product)
+      purchase = build(:purchase, link: product)
+      url_redirect = create(:url_redirect, purchase:)
+      expect(url_redirect.send(:has_purchased_variants_from_categories_with_files?)).to be false
+    end
+
+    it "returns true when a purchased variant has files" do
+      product = create(:product)
+      product_file = create(:product_file, link: product)
+      variant_category = create(:variant_category, link: product)
+      variant = create(:variant, variant_category:)
+      variant.product_files << product_file
+      purchase = build(:purchase, link: product)
+      purchase.variant_attributes = [variant]
+      url_redirect = create(:url_redirect, purchase:)
+
+      expect(url_redirect.send(:has_purchased_variants_from_categories_with_files?)).to be true
+    end
+
+    it "returns true when a sibling variant in the same category has files" do
+      product = create(:product)
+      product_file = create(:product_file, link: product)
+      variant_category = create(:variant_category, link: product)
+      purchased_variant = create(:variant, variant_category:)
+      sibling_variant = create(:variant, variant_category:)
+      sibling_variant.product_files << product_file
+      purchase = build(:purchase, link: product)
+      purchase.variant_attributes = [purchased_variant]
+      url_redirect = create(:url_redirect, purchase:)
+
+      expect(url_redirect.send(:has_purchased_variants_from_categories_with_files?)).to be true
+    end
+
+    it "returns false when no variant or sibling has files" do
+      product = create(:product)
+      variant_category = create(:variant_category, link: product)
+      variant = create(:variant, variant_category:)
+      purchase = build(:purchase, link: product)
+      purchase.variant_attributes = [variant]
+      url_redirect = create(:url_redirect, purchase:)
+
+      expect(url_redirect.send(:has_purchased_variants_from_categories_with_files?)).to be false
+    end
+
+    it "does not count deleted sibling variants" do
+      product = create(:product)
+      product_file = create(:product_file, link: product)
+      variant_category = create(:variant_category, link: product)
+      purchased_variant = create(:variant, variant_category:)
+      deleted_sibling = create(:variant, variant_category:)
+      deleted_sibling.product_files << product_file
+      deleted_sibling.mark_deleted!
+      purchase = build(:purchase, link: product)
+      purchase.variant_attributes = [purchased_variant]
+      url_redirect = create(:url_redirect, purchase:)
+
+      expect(url_redirect.send(:has_purchased_variants_from_categories_with_files?)).to be false
+    end
+
+    it "uses a bounded number of queries regardless of variant count" do
+      product = create(:product)
+      product_file = create(:product_file, link: product)
+      variant_category = create(:variant_category, link: product)
+      variants = 5.times.map { create(:variant, variant_category:) }
+      variants.first.product_files << product_file
+      purchase = build(:purchase, link: product)
+      purchase.variant_attributes = variants
+      url_redirect = create(:url_redirect, purchase:)
+
+      query_count = 0
+      callback = lambda { |_name, _start, _finish, _id, payload|
+        query_count += 1 if payload[:name] != "SCHEMA" && payload[:name] != "CACHE"
+      }
+
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        url_redirect.send(:has_purchased_variants_from_categories_with_files?)
+      end
+
+      expect(query_count).to be <= 4
+    end
+  end
+
   describe "#rich_content_json" do
     it "returns empty hash if there's no associated object" do
       url_redirect = create(:url_redirect)


### PR DESCRIPTION
## What

Fixes N+1 queries in `UrlRedirect#has_purchased_variants_from_categories_with_files?` that caused `Rack::Timeout::RequestTimeoutException` (120s) on `GET /mobile/purchases/index.json`.

## Why

The method iterated each purchased variant calling `variant.has_files?` (1 DB query per variant) and, when false, loaded all sibling variants in the category and checked `has_files?` on each (N more queries). For users with many purchases, this O(purchases × variants × siblings) query pattern accumulated across `purchases_to_json` → `json_data_for_mobile` → `product_json_data` → `alive_product_files` → `rich_content_provider` → `with_product_files`.

The fix replaces the per-variant loop with at most 3 batched SQL queries:
1. `EXISTS` to check if any purchased variant has files
2. `pluck` sibling variant IDs across all relevant categories
3. `EXISTS` to check if any sibling has files

Also memoizes the result since it's called from both `with_product_files` and `alive_product_files` on the same `UrlRedirect` instance.

Sentry issue: https://gumroad-to.sentry.io/issues/7371034559/

## Test Results

7 new tests covering: no purchase, no variants, variant with files, sibling with files, no files anywhere, deleted siblings excluded, and bounded query count assertion.

---

Generated with Claude Opus 4.6. Prompted with the Sentry stacktrace and asked to fix the N+1 query pattern in `has_purchased_variants_from_categories_with_files?`.