### PR TITLE
Fix NoMethodError on ActionController::Parameters#map in CheckoutController#show

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -102,7 +102,7 @@ class CheckoutController < ApplicationController
     def recommended_products
       args = {
         purchaser: logged_in_user,
-        cart_product_ids: params.fetch(:cart_product_ids, []).map { ObfuscateIds.decrypt(_1) },
+        cart_product_ids: Array(params[:cart_product_ids]).map { ObfuscateIds.decrypt(_1) },
         recommender_model_name: session[:recommender_model_name],
         limit: params[:limit].present? ? params[:limit].to_i : 6,
         recommendation_type: params[:recommendation_type],

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -163,6 +163,18 @@ describe CheckoutController, type: :controller, inertia: true do
       end
     end
 
+    it "handles cart_product_ids as a single string param without raising" do
+      product = create(:product)
+
+      request.headers["X-Inertia"] = "true"
+      request.headers["X-Inertia-Partial-Component"] = "Checkout/Show"
+      request.headers["X-Inertia-Partial-Data"] = "recommended_products"
+
+      get :show, params: { cart_product_ids: product.external_id }
+
+      expect(response).to be_successful
+    end
+
     describe "for partial visits" do
       let(:recommender_model_name) { RecommendedProductsService::MODEL_SALES }
       let(:cart_product) { create(:product) }


### PR DESCRIPTION
## What

Fixes `NoMethodError: undefined method 'map' for an instance of ActionController::Parameters` in `CheckoutController#show` when `cart_product_ids` is present in request params.

Changed `params.fetch(:cart_product_ids, []).map` to `Array(params[:cart_product_ids]).map` in the `recommended_products` private method.

## Why

`params.fetch(:cart_product_ids, [])` returns an `ActionController::Parameters` instance (not a plain Array) when the param is present. `ActionController::Parameters` does not respond to `map`, causing the NoMethodError. `Array()` safely handles nil (returns `[]`), a single string value (wraps in array), and array params.

This was causing ~11 errors in Sentry: https://gumroad-to.sentry.io/issues/7371077986/

## Test Results

Added a test that passes a single string `cart_product_ids` param and verifies no error is raised. The test fails when the fix is reverted.

---

AI disclosure: This fix was implemented with Claude Opus 4.6. Prompt: fix the Sentry NoMethodError for ActionController::Parameters#map in CheckoutController#show.