### PR TITLE
Fix NoMethodError: undefined method 'downcase' for nil in ShipmentsController#verify_shipping_address

### DIFF
--- a/app/controllers/shipments_controller.rb
+++ b/app/controllers/shipments_controller.rb
@@ -89,10 +89,8 @@ class ShipmentsController < ApplicationController
     # Address suggestion and formatting helpers
 
     def formatted_address(address)
-      # For street address cannot use titlecase directly on string,
-      # since "17th st", gets converted to "17 Th St", instead of "17th St".
-      street = address[:street1].split.map(&:capitalize).join(" ")
-      city = address[:city].titleize
+      street = address[:street1].to_s.split.map(&:capitalize).join(" ")
+      city = address[:city].to_s.titleize
       zip = formatted_zip_for(address)
       state = formatted_state_for(address)
       "#{street}, #{city}, #{state}, #{zip}"
@@ -109,6 +107,7 @@ class ShipmentsController < ApplicationController
     end
 
     def match_field_for(old_addr, new_addr, field)
+      return false if new_addr[field].nil? || old_addr[field].nil?
       new_addr[field].downcase == old_addr[field].downcase
     end
 
@@ -122,14 +121,17 @@ class ShipmentsController < ApplicationController
     end
 
     def formatted_zip_for(address)
+      return address[:zip].to_s if address[:zip].nil?
       in_us?(address) ? address[:zip][0..4] : address[:zip]
     end
 
     def formatted_state_for(address)
+      return address[:state].to_s if address[:state].nil?
       in_us?(address) ? address[:state].upcase : address[:state].titleize
     end
 
     def in_us?(address)
+      return false if address[:country].nil?
       ["US", "UNITED STATES"].include?(address[:country].upcase)
     end
 end

--- a/spec/controllers/shipments_controller_spec.rb
+++ b/spec/controllers/shipments_controller_spec.rb
@@ -82,6 +82,27 @@ describe ShipmentsController, :vcr  do
           expect(response.parsed_body["error_message"]).to eq "We are unable to verify your shipping address. Is your address correct?"
         end
       end
+
+      describe "when EasyPost returns nil address fields" do
+        it "treats nil fields as address mismatch and does not raise" do
+          address = OpenStruct.new(
+            street1: "1640 17TH ST",
+            city: "SAN FRANCISCO",
+            state: nil,
+            zip: "94107",
+            country: "US",
+            verifications: OpenStruct.new(
+              delivery: OpenStruct.new(success: true, errors: [])
+            )
+          )
+          allow_any_instance_of(EasyPost::Services::Address).to receive(:create).and_return(address)
+
+          post :verify_shipping_address, params: @params
+
+          expect(response.parsed_body["success"]).to be(false)
+          expect(response.parsed_body["easypost_verification_required"]).to be(true)
+        end
+      end
     end
 
     describe "international address" do


### PR DESCRIPTION
## What

Guards against `NoMethodError` when EasyPost returns an address with nil fields (e.g., `state`, `city`, `street1`) in `ShipmentsController#verify_shipping_address`.

The following private helpers now handle nil safely:
- `match_field_for` — returns `false` if either value is nil (treats nil as address mismatch)
- `formatted_zip_for` — returns empty string for nil zip
- `formatted_state_for` — returns empty string for nil state
- `in_us?` — returns `false` for nil country
- `formatted_address` — uses `.to_s` on street/city to prevent crashes

## Why

EasyPost can return address objects with nil fields. When this happens, calling `.downcase`, `.split`, `.upcase`, or `.titleize` on nil raises `NoMethodError`, causing 500 errors during checkout address verification.

Sentry: https://gumroad-to.sentry.io/issues/7371119233/

When a field is nil, we treat it as a mismatch so the user gets the verification prompt rather than a crash.

## Test Results

Added a test that stubs EasyPost returning nil `state` and verifies:
- No error is raised
- Response indicates address mismatch (`easypost_verification_required: true`)
- Test fails when the fix is reverted

---

AI disclosure: Built with Claude Opus 4.6. Prompted to fix nil safety issues in ShipmentsController address verification helpers.