### PR TITLE
Fix NoMethodError when variant is nil for tiered membership checkout

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1042,7 +1042,7 @@ class Link < ApplicationRecord
     attrs[:options] = options
     attrs[:option] = attrs[:options].find { |o| o[:id] == params[:option] } || (native_type != NATIVE_TYPE_COFFEE ? attrs[:options].find { |o| o[:quantity_left] != 0 } : nil)
     variant = attrs[:option] ? Variant.find_by_external_id(attrs[:option][:id]) : nil
-    prices = (is_tiered_membership ? variant : self).prices.is_buy.alive
+    prices = (is_tiered_membership ? variant || self : self).prices.is_buy.alive
     recurrence = is_recurring_billing ? prices.find { |price| price.recurrence == params[:recurrence] } || prices.find { |price| price.recurrence == default_price_recurrence.recurrence } : nil
     attrs[:recurrence] = recurrence&.recurrence
     attrs[:pay_in_installments] = !!params[:pay_in_installments] && allow_installment_plan?

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -4800,4 +4800,19 @@ describe Link, :vcr do
       end
     end
   end
+
+  describe "#cart_item" do
+    context "when product is a tiered membership with an invalid variant ID" do
+      let(:seller) { create(:user) }
+      let(:membership) { create(:membership_product, user: seller) }
+
+      it "falls back to product prices when variant is not found" do
+        allow(Variant).to receive(:find_by_external_id).and_return(nil)
+        params = { option: membership.options.first[:id] }
+        result = membership.cart_item(params)
+        expect(result).to be_a(Hash)
+        expect(result).to have_key(:price)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What

In `Link#cart_item`, when `is_tiered_membership` is true but the variant lookup returns nil (e.g. deleted variant or invalid option ID), the code calls `.prices` on nil, raising `NoMethodError`.

The fix adds a nil-safe fallback: `variant || self`, so the product's own prices are used when the variant can't be found.

## Why

This crashes `CheckoutController#show` when a buyer visits a tiered membership checkout with a stale or invalid variant ID in the URL params. Falling back to the product's prices is safe — it mirrors the non-tiered-membership behavior and allows the checkout to render.

## Test Results

Added a spec that reproduces the crash (passes with fix, fails without).

```
1 example, 0 failures
```

---

AI disclosure: fix authored with Claude Opus 4.6, prompted to investigate and fix the Sentry-reported NoMethodError in `Link#cart_item`.