### PR TITLE
Fix NoMethodError when purchase_as_orderable is nil in Order#email

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -40,7 +40,7 @@ class Order < ApplicationRecord
   end
 
   def email
-    purchase_as_orderable.email
+    purchase_as_orderable&.email
   end
 
   def locale

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -73,6 +73,14 @@ describe Order do
     it "returns the email of the purchase" do
       expect(order.email).to eq(purchase.email)
     end
+
+    context "when there are no successful purchases" do
+      let(:purchase) { create(:failed_purchase) }
+
+      it "returns nil" do
+        expect(order.email).to be_nil
+      end
+    end
   end
 
   describe "#locale" do


### PR DESCRIPTION
## What

- Guard `Order#email` with safe navigation (`&.`) so it returns `nil` instead of raising `NoMethodError` when `purchase_as_orderable` is nil (i.e., the order has no successful purchases).

## Why

Production `NoMethodError: undefined method 'email' for nil` in `Order#email` → `CustomerMailer#grouped_receipt`. This happens when an order exists but has no successful purchases (e.g., all purchases were deleted or the order is in an inconsistent state). The safe navigation operator lets the mailer gracefully handle a nil email address instead of crashing.

## Test Results

Added a spec for the nil case under `Order#email` — passes locally. The test correctly fails when the fix is reverted.

---

AI disclosure: Fix developed with Claude Opus 4.6. Prompt: investigate Sentry NoMethodError in Order#email, apply minimal defensive fix, add test coverage.