### PR TITLE
Fix ActiveRecord::StatementInvalid when license verify receives non-scalar params

### DIFF
--- a/app/controllers/api/v2/licenses_controller.rb
+++ b/app/controllers/api/v2/licenses_controller.rb
@@ -105,6 +105,13 @@ class Api::V2::LicensesController < Api::V2::BaseController
     end
 
     def clean_params
+      %i[license_key product_id product_permalink id link_id].each do |key|
+        next if params[key].blank?
+        next if params[key].is_a?(String)
+
+        return render json: { success: false, message: "The '#{key}' parameter must be a string." }, status: :bad_request
+      end
+
       # `link_id` and `id` are legacy ways to pass in the product's permalink, no longer documented but used in the wild
       # The order of these parameters matters to properly support legacy requests!
       params[:product_permalink] = params[:id].presence || params[:link_id].presence || params[:product_permalink].presence

--- a/spec/controllers/api/v2/licenses_controller_spec.rb
+++ b/spec/controllers/api/v2/licenses_controller_spec.rb
@@ -570,6 +570,28 @@ describe Api::V2::LicensesController do
       end
     end
 
+    context "when params contain non-scalar values" do
+      it "returns a 400 error when license_key is not a string" do
+        post :verify, params: { product_permalink: @product.unique_permalink, license_key: { foo: "bar" } }
+
+        expect(response).to have_http_status(:bad_request)
+        expect(response.parsed_body).to eq({
+          success: false,
+          message: "The 'license_key' parameter must be a string."
+        }.as_json)
+      end
+
+      it "returns a 400 error when product_id is not a string" do
+        post :verify, params: { product_id: { foo: "bar" }, license_key: @purchase.license.serial }
+
+        expect(response).to have_http_status(:bad_request)
+        expect(response.parsed_body).to eq({
+          success: false,
+          message: "The 'product_id' parameter must be a string."
+        }.as_json)
+      end
+    end
+
     context "when product_id is blank" do
       before do
         create(:product, custom_permalink: @product.unique_permalink)


### PR DESCRIPTION
## What

Validates that `license_key`, `product_id`, `product_permalink`, `id`, and `link_id` parameters are scalar strings in `Api::V2::LicensesController#clean_params`. Returns 400 Bad Request if any are nested objects (e.g. `license_key[foo]=bar`).

## Why

When a client sends a nested parameter like `license_key[foo]=bar`, Rails parses it as `ActionController::Parameters` instead of a `String`. This gets passed directly into `find_by(serial: params[:license_key])`, causing `ActiveRecord::StatementInvalid: TypeError: can't quote ActionController::Parameters` because ActiveRecord can't bind non-scalar values.

Sentry issue: https://gumroad-to.sentry.io/issues/7371152065/

The fix validates param types early in `clean_params` (which already runs as a `before_action`) rather than letting them propagate to the database layer.

## Test Results

Added 2 tests covering non-scalar `license_key` and `product_id` parameters.

---

AI disclosure: Built with Claude Opus 4.6. Prompted with the bug description, root cause analysis, and fix instructions.