### PR TITLE
Fix RecordNotUnique race condition in UTM link tracking

### DIFF
--- a/app/controllers/concerns/utm_link_tracking.rb
+++ b/app/controllers/concerns/utm_link_tracking.rb
@@ -31,26 +31,32 @@ module UtmLinkTracking
 
       utm_params = required_params.merge(optional_params).transform_values { _1.to_s.strip.downcase.gsub(/[^a-z0-9\-_]/u, "-").presence }
 
-      ActiveRecord::Base.transaction do
-        utm_link = UtmLink.active.find_or_initialize_by(utm_params.merge(target_resource_type:, target_resource_id:))
-        auto_create_utm_link(utm_link, seller) if utm_link.new_record?
-        return unless utm_link.persisted?
-        return unless Feature.active?(:utm_links, utm_link.seller)
+      utm_link_params = utm_params.merge(target_resource_type:, target_resource_id:)
 
-        utm_link.utm_link_visits.create!(
-          user: current_user,
-          referrer: request.referrer,
-          ip_address: request.remote_ip,
-          user_agent: request.user_agent,
-          browser_guid: cookies[:_gumroad_guid],
-          country_code: GeoIp.lookup(request.remote_ip)&.country_code
-        )
+      begin
+        ActiveRecord::Base.transaction do
+          utm_link = UtmLink.active.find_or_initialize_by(utm_link_params)
+          auto_create_utm_link(utm_link, seller) if utm_link.new_record?
+          return unless utm_link.persisted?
+          return unless Feature.active?(:utm_links, utm_link.seller)
 
-        utm_link.first_click_at ||= Time.current
-        utm_link.last_click_at = Time.current
-        utm_link.save!
+          utm_link.utm_link_visits.create!(
+            user: current_user,
+            referrer: request.referrer,
+            ip_address: request.remote_ip,
+            user_agent: request.user_agent,
+            browser_guid: cookies[:_gumroad_guid],
+            country_code: GeoIp.lookup(request.remote_ip)&.country_code
+          )
 
-        UpdateUtmLinkStatsJob.perform_async(utm_link.id)
+          utm_link.first_click_at ||= Time.current
+          utm_link.last_click_at = Time.current
+          utm_link.save!
+
+          UpdateUtmLinkStatsJob.perform_async(utm_link.id)
+        end
+      rescue ActiveRecord::RecordNotUnique
+        retry if (utm_link = UtmLink.active.find_by(utm_link_params))
       end
     end
 

--- a/spec/controllers/concerns/utm_link_tracking_spec.rb
+++ b/spec/controllers/concerns/utm_link_tracking_spec.rb
@@ -290,6 +290,42 @@ describe UtmLinkTracking, type: :controller do
       end
     end
 
+    it "handles concurrent duplicate UTM link creation gracefully", :sidekiq_inline do
+      request.host = "#{seller.subdomain}"
+      request.path = "/"
+      allow(controller).to receive(:root_path).and_return("/")
+
+      normalized_params = utm_params.transform_values { _1.to_s.strip.downcase.gsub(/[^a-z0-9\-_]/u, "-").presence }
+      existing_utm_link = create(:utm_link, seller:, **normalized_params, target_resource_type: "profile_page", target_resource_id: nil)
+
+      attempted_once = false
+      allow(UtmLink).to receive(:active).and_wrap_original do |original_method|
+        relation = original_method.call
+        if !attempted_once
+          allow(relation).to receive(:find_or_initialize_by).and_wrap_original do |_find_method, *args|
+            attempted_once = true
+            UtmLink.new(args.first)
+          end
+        end
+        relation
+      end
+
+      original_save = UtmLink.instance_method(:save!)
+      allow_any_instance_of(UtmLink).to receive(:save!) do |receiver, **args|
+        if receiver.new_record?
+          raise ActiveRecord::RecordNotUnique, "Duplicate entry"
+        else
+          original_save.bind_call(receiver, **args)
+        end
+      end
+
+      expect do
+        get :action, params: utm_params
+      end.to change(UtmLinkVisit, :count).by(1)
+
+      expect(existing_utm_link.reload.utm_link_visits.count).to eq(1)
+    end
+
     it "does not auto-create UTM link when feature is disabled" do
       Feature.deactivate_user(:utm_links, seller)
       request.host = "#{seller.subdomain}"


### PR DESCRIPTION
## What

Rescues `ActiveRecord::RecordNotUnique` in `UtmLinkTracking#track_utm_link_visit` and retries the transaction, allowing it to find and use the record that was concurrently created by another request.

## Why

Concurrent requests with identical UTM parameters both call `find_or_initialize_by`, both find no existing record, and both attempt to insert. The second insert hits the `index_utm_links_on_utm_fields_and_target_resource` unique composite index and raises `ActiveRecord::RecordNotUnique`, surfacing as an unhandled 500 error.

The fix wraps the transaction in `begin/rescue ActiveRecord::RecordNotUnique` that retries once — on retry, `find_or_initialize_by` finds the now-existing record and proceeds normally to record the visit.

Sentry: https://gumroad-to.sentry.io/issues/7371157831/

## Test results

```
11 examples, 0 failures
```

New test simulates the race by stubbing `find_or_initialize_by` to return an uninitialized record on the first call (even though a matching record exists), then raising `RecordNotUnique` on `save!` of the new record. Verified the test fails when the fix is reverted.

---

AI disclosure: Built with Claude Opus 4.6. Prompt: fix Sentry RecordNotUnique on utm_links unique index in LinksController#show.