### PR TITLE
Fix Rack::Timeout in mobile purchases index

### DIFF
--- a/app/controllers/api/mobile/purchases_controller.rb
+++ b/app/controllers/api/mobile/purchases_controller.rb
@@ -4,6 +4,7 @@ class Api::Mobile::PurchasesController < Api::Mobile::BaseController
   before_action { doorkeeper_authorize! :mobile_api }
   before_action :fetch_purchase, only: [:purchase_attributes, :archive, :unarchive]
   DEFAULT_SEARCH_RESULTS_SIZE = 10
+  DEFAULT_PURCHASES_LIMIT = 100
 
   def index
     purchases = current_resource_owner.purchases.for_mobile_listing
@@ -12,12 +13,11 @@ class Api::Mobile::PurchasesController < Api::Mobile::BaseController
         purchases.page_with_kaminari(params[:page]).per(params[:per_page])
       )
     else
+      purchases = purchases.limit(DEFAULT_PURCHASES_LIMIT)
       media_locations_scope = MediaLocation.where(product_id: purchases.pluck(:link_id))
       cache [purchases, media_locations_scope], expires_in: 10.minutes do
         purchases_to_json(purchases)
       rescue => e
-        # Cache empty array for requests that timeout to reduce the load on database.
-        # TODO: Remove this once we fix the bottleneck with the purchases_json generation
         Rails.logger.info "Error generating purchases json for user: #{current_resource_owner.id}, #{e.class} => #{e.message}"
         ErrorNotifier.notify(e)
         []

--- a/spec/controllers/api/mobile/purchases_controller_spec.rb
+++ b/spec/controllers/api/mobile/purchases_controller_spec.rb
@@ -304,7 +304,7 @@ describe Api::Mobile::PurchasesController do
 
       it "limits unpaginated results to DEFAULT_PURCHASES_LIMIT" do
         products = create_list(:product, 3, user: @user)
-        purchases = products.map { |product| create(:purchase_with_balance, link: product, purchaser: @purchaser, seller: @user) }
+        products.map { |product| create(:purchase_with_balance, link: product, purchaser: @purchaser, seller: @user) }
 
         stub_const("Api::Mobile::PurchasesController::DEFAULT_PURCHASES_LIMIT", 2)
 

--- a/spec/controllers/api/mobile/purchases_controller_spec.rb
+++ b/spec/controllers/api/mobile/purchases_controller_spec.rb
@@ -302,6 +302,18 @@ describe Api::Mobile::PurchasesController do
                                              user_id: @purchaser.external_id }.as_json(api_scopes: ["mobile_api"]))
       end
 
+      it "limits unpaginated results to DEFAULT_PURCHASES_LIMIT" do
+        products = create_list(:product, 3, user: @user)
+        purchases = products.map { |product| create(:purchase_with_balance, link: product, purchaser: @purchaser, seller: @user) }
+
+        stub_const("Api::Mobile::PurchasesController::DEFAULT_PURCHASES_LIMIT", 2)
+
+        get :index, params: @params
+
+        expect(response.parsed_body[:success]).to eq(true)
+        expect(response.parsed_body[:products].size).to eq(2)
+      end
+
       it "paginates results when pagination params are given" do
         created_at_minute_advance = 0
         purchases = [@mobile_friendly_pdf_product, @mobile_friendly_movie_product, @mobile_zip_file_product].map do |product|


### PR DESCRIPTION
## What

The unpaginated path in `Api::Mobile::PurchasesController#index` loads ALL purchases for a user with no limit — both the `pluck(:link_id)` and `purchases_to_json` calls are unbounded. For users with thousands of purchases, this causes `Rack::Timeout::RequestTimeoutException` (120s).

This adds a `DEFAULT_PURCHASES_LIMIT` of 100 to the unpaginated `else` branch, capping the query before both the `pluck` and serialization. Also removes the stale TODO comment since this addresses the bottleneck.

## Why

Sentry issue: https://gumroad-to.sentry.io/issues/7371171322/

The `for_mobile_listing` scope includes heavy eager loading (`:preorder, :purchaser, :seller, :subscription, url_redirect: { purchase: { link: [:user, :thumbnail] } }`). Combined with no limit, this produces queries that exceed the 120s Rack::Timeout for power users. The paginated path (Kaminari) already bounds results — the unpaginated path needed the same treatment.

## Test Results

Added a test that stubs `DEFAULT_PURCHASES_LIMIT` to 2 and verifies that the unpaginated response is capped accordingly. Unable to run tests locally (Ruby 3.4.3 environment required) — CI will validate.

---

Built with Claude Opus 4.6.

Prompt: Fix Rack::Timeout (120s) in `Api::Mobile::PurchasesController#index` — add a default limit to the unpaginated path to prevent unbounded queries for users with many purchases.