### PR TITLE
Fix NoMethodError in ThumbnailsController#create when receiving raw file upload

### DIFF
--- a/app/controllers/thumbnails_controller.rb
+++ b/app/controllers/thumbnails_controller.rb
@@ -6,6 +6,10 @@ class ThumbnailsController < Sellers::BaseController
   def create
     authorize Thumbnail
 
+    if !params[:thumbnail].respond_to?(:permit)
+      return render(json: { success: false, error: "Invalid thumbnail parameter. Expected signed_blob_id." }, status: :bad_request)
+    end
+
     thumbnail = @product.thumbnail || @product.build_thumbnail
 
     if permitted_params[:signed_blob_id].present?

--- a/spec/controllers/thumbnails_controller_spec.rb
+++ b/spec/controllers/thumbnails_controller_spec.rb
@@ -39,6 +39,15 @@ describe ThumbnailsController, :vcr do
       end
     end
 
+    it "returns error when thumbnail param is a raw file upload instead of signed_blob_id" do
+      expect do
+        post(:create, params: { link_id: product.unique_permalink, thumbnail: fixture_file_upload("Austin's Mojo.png", "image/png"), format: :json })
+      end.to_not change { Thumbnail.count }
+
+      expect(response.status).to eq(400)
+      expect(response.parsed_body).to eq({ "success" => false, "error" => "Invalid thumbnail parameter. Expected signed_blob_id." })
+    end
+
     context "with using image file" do
       it "fails for an invalid thumbnail" do
         expect(product.thumbnail).to eq(nil)


### PR DESCRIPTION
## What

Added a guard in `ThumbnailsController#create` that returns a 400 error when `params[:thumbnail]` is a raw file upload (an `UploadedFile` object) instead of the expected hash with `signed_blob_id`.

## Why

When a client sends a traditional file upload directly as the `thumbnail` param (instead of nesting it as `thumbnail[signed_blob_id]`), `params.require(:thumbnail)` returns an `ActionDispatch::Http::UploadedFile`. Calling `.permit()` on it raises `NoMethodError: undefined method 'permit' for an instance of ActionDispatch::Http::UploadedFile`. The controller expects an Active Storage direct upload `signed_blob_id`, so a raw file upload is invalid input and should return a proper error.

Sentry: https://gumroad-to.sentry.io/issues/7371233419/

## Test Results

Added a test that sends a raw file upload as `thumbnail` and verifies a 400 response with an error message is returned instead of a 500.

---

Generated with Claude Opus 4.6. Prompt: Fix the Sentry NoMethodError in ThumbnailsController#create when params[:thumbnail] is an UploadedFile.