### PR TITLE
Fix Date::Error: invalid date in Settings::PaymentsController#update

### DIFF
--- a/app/services/update_user_compliance_info.rb
+++ b/app/services/update_user_compliance_info.rb
@@ -47,7 +47,12 @@ class UpdateUserComplianceInfo
         if compliance_params[:business_tax_id].present?
           new_compliance_info.business_tax_id = compliance_params[:business_tax_id].gsub(/\D/, "")
         end
-        new_compliance_info.birthday = Date.new(compliance_params[:dob_year].to_i, compliance_params[:dob_month].to_i, compliance_params[:dob_day].to_i) if compliance_params[:dob_year].present? && compliance_params[:dob_year].to_i > 0
+        if compliance_params[:dob_year].present? && compliance_params[:dob_year].to_i > 0
+          year = compliance_params[:dob_year].to_i
+          month = compliance_params[:dob_month].to_i
+          day = compliance_params[:dob_day].to_i
+          new_compliance_info.birthday = Date.new(year, month, day) if Date.valid_date?(year, month, day)
+        end
         new_compliance_info.skip_stripe_job_on_create = true
         new_compliance_info.phone =                   compliance_params[:phone]                   if compliance_params[:phone].present?
         new_compliance_info.business_phone =          compliance_params[:business_phone]          if compliance_params[:business_phone].present?

--- a/spec/controllers/settings/payments_controller_spec.rb
+++ b/spec/controllers/settings/payments_controller_spec.rb
@@ -356,6 +356,32 @@ describe Settings::PaymentsController, :vcr, type: :controller, inertia: true do
         end
       end
 
+      describe "user enters invalid date of birth components" do
+        before do
+          put :update, params: { user: params }
+        end
+
+        it "does not raise an error when dob_month and dob_day are blank" do
+          params.merge!(dob_year: "1990", dob_month: "", dob_day: "")
+          old_birthday = user.alive_user_compliance_info.birthday
+
+          put :update, params: { user: params }
+
+          expect(response).to redirect_to(settings_payments_path)
+          expect(user.alive_user_compliance_info.birthday).to eq(old_birthday)
+        end
+
+        it "does not raise an error when dob_day is invalid for the given month" do
+          params.merge!(dob_year: "1990", dob_month: "2", dob_day: "31")
+          old_birthday = user.alive_user_compliance_info.birthday
+
+          put :update, params: { user: params }
+
+          expect(response).to redirect_to(settings_payments_path)
+          expect(user.alive_user_compliance_info.birthday).to eq(old_birthday)
+        end
+      end
+
       describe "creator enters an invalid zip code" do
         before do
           params.merge!(


### PR DESCRIPTION
## What

Fixes `Date::Error: invalid date` crash in `Settings::PaymentsController#update` when `dob_month` or `dob_day` params are missing or invalid.

## Why

The guard on line 50 of `UpdateUserComplianceInfo` only checked that `dob_year` was present and positive, but `dob_month` and `dob_day` could be blank/nil. Calling `.to_i` on blank returns `0`, and `Date.new(1990, 0, 0)` raises `Date::Error`. This also covers impossible dates like February 31st.

The fix uses `Date.valid_date?` to validate all three components before constructing the `Date` object. If the date is invalid, the birthday field is simply not updated (matching the existing pattern for other optional fields).

## Test Results

Added two test cases that confirm:
1. Blank `dob_month`/`dob_day` with valid `dob_year` does not raise an error
2. Impossible date (Feb 31) does not raise an error

Both tests fail with `Date::Error` when the fix is reverted.

---

Generated with Claude Opus 4.6. Prompt: fix Sentry bug for Date::Error in payments controller update, with test validation.