### PR TITLE
Fix NoMethodError when featured product is deleted in profile sections

### DIFF
--- a/app/presenters/profile_sections_presenter.rb
+++ b/app/presenters/profile_sections_presenter.rb
@@ -105,9 +105,10 @@ class ProfileSectionsPresenter
         unless is_owner
           cached_props.merge!(
             {
-              props: cached_props[:featured_product_id].present? ?
-                       ProductPresenter.new(product: seller.products.find_by_external_id(cached_props.delete(:featured_product_id)), pundit_user:, request:).product_props(seller_custom_domain_url:) :
-                       nil,
+              props: begin
+                       product = cached_props[:featured_product_id].present? ? seller.products.find_by_external_id(cached_props.delete(:featured_product_id)) : nil
+                       product ? ProductPresenter.new(product:, pundit_user:, request:).product_props(seller_custom_domain_url:) : nil
+                     end,
             }
           )
         end

--- a/spec/presenters/profile_sections_presenter_spec.rb
+++ b/spec/presenters/profile_sections_presenter_spec.rb
@@ -120,6 +120,22 @@ describe ProfileSectionsPresenter do
                                                                                               sections:
                                                                                             })
     end
+
+    it "returns nil props when featured product no longer exists" do
+      featured_product_section.update_column(:json_data, featured_product_section.json_data.merge("featured_product_id" => 0))
+
+      sections = common_sections_props
+      sections[1][:posts] = posts.map(&method(:post_data))
+      sections[2][:props] = nil
+      sections[2].delete(:featured_product_id)
+      sections[5].merge!(wishlists: WishlistPresenter.cards_props(wishlists: Wishlist.where(id: wishlists.map(&:id)), pundit_user: pundit_user, layout: Product::Layout::PROFILE))
+      expect(subject.props(request:, pundit_user:, seller_custom_domain_url: nil)).to match({
+                                                                                              currency_code: pundit_user.user.currency_type,
+                                                                                              show_ratings_filter: true,
+                                                                                              creator_profile: ProfilePresenter.new(seller:, pundit_user:).creator_profile,
+                                                                                              sections:
+                                                                                            })
+    end
   end
 
   describe "compute_description parameter" do


### PR DESCRIPTION
## What

When a seller's profile has a featured product section referencing a product that no longer exists (deleted or otherwise unavailable), visiting the profile page raises `NoMethodError: undefined method 'user' for nil`. This PR adds a nil check before passing the product to `ProductPresenter`.

## Why

`find_by_external_id` returns `nil` when the referenced product doesn't exist, but the code passed the result directly to `ProductPresenter.new(product: nil, ...)`, which then called `product.user` on nil. This is a straightforward guard — if the product is gone, return nil props instead of crashing.

**Sentry issue:** https://gumroad-to.sentry.io/issues/7371522113/

## Test results

Added a test that sets `featured_product_id` to a non-existent product ID and verifies the presenter returns nil props instead of raising. Confirmed the test fails without the fix and passes with it.

---

AI disclosure: Implementation by Claude Opus 4.6. Prompted with the Sentry error details, stacktrace, and root cause analysis.