### PR TITLE
Fix StateMachines::InvalidTransition in Payouts.create_payment

### DIFF
--- a/app/business/payments/payouts/payouts.rb
+++ b/app/business/payments/payouts/payouts.rb
@@ -183,6 +183,7 @@ class Payouts
     )
     payment.save!
     payment_errors = payout_processor.prepare_payment_and_set_amount(payment, balances)
+    return [payment, payment_errors] if payment.failed?
     payment.mark_processing!
     [payment, payment_errors]
   end

--- a/spec/business/payments/payouts/payouts_spec.rb
+++ b/spec/business/payments/payouts/payouts_spec.rb
@@ -692,4 +692,31 @@ describe Payouts do
       end
     end
   end
+
+  describe ".create_payment" do
+    let(:payout_date) { Date.today - 1 }
+    let(:seller) { create(:user) }
+    let!(:balance) { create(:balance, user: seller, merchant_account: create(:merchant_account, user: nil), date: payout_date - 1, amount_cents: 10_00) }
+
+    before do
+      create(:ach_account, user: seller)
+      allow(StripePayoutProcessor).to receive(:is_balance_payable).and_return(true)
+    end
+
+    context "when prepare_payment_and_set_amount marks the payment as failed" do
+      before do
+        allow(StripePayoutProcessor).to receive(:prepare_payment_and_set_amount) do |payment, _balances|
+          payment.mark_failed!
+          ["Stripe error"]
+        end
+      end
+
+      it "returns the failed payment without raising StateMachines::InvalidTransition" do
+        payment, errors = described_class.create_payment(payout_date, PayoutProcessorType::STRIPE, seller)
+
+        expect(payment.state).to eq(Payment::FAILED)
+        expect(errors).to eq(["Stripe error"])
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What

Skip `mark_processing!` in `Payouts.create_payment` when `prepare_payment_and_set_amount` has already transitioned the payment to the `failed` state.

## Why

`StripePayoutProcessor.prepare_payment_and_set_amount` catches Stripe errors and marks the payment as `failed` in its `ensure` block, then returns error messages. Back in `create_payment`, `mark_processing!` was unconditionally called on the now-failed payment, raising `StateMachines::InvalidTransition` because `failed → processing` is not a valid transition. This crashed the payout flow instead of gracefully returning the failed payment.

The fix adds an early return after `prepare_payment_and_set_amount` if the payment is already failed, allowing the caller to handle the failure normally.

## Test results

Added a regression test that stubs `prepare_payment_and_set_amount` to mark the payment as failed and verifies `create_payment` returns the failed payment without raising.

---

Generated with Claude Opus 4.6. Prompted to investigate and fix Sentry issue `StateMachines::InvalidTransition: Cannot transition state via :mark_processing from :failed` in `Payouts.create_payment`.