### PR TITLE
Fix NoMethodError in Order::ChargeService#ensure_all_purchases_processed

### DIFF
--- a/app/services/order/charge_service.rb
+++ b/app/services/order/charge_service.rb
@@ -233,6 +233,8 @@ class Order::ChargeService
   end
 
   def ensure_all_purchases_processed(purchases)
+    return if purchases.nil?
+
     purchases.each do |purchase|
       line_item_uid = params[:line_items].find do |line_item|
         purchase.link.unique_permalink == line_item[:permalink] &&

--- a/spec/services/order/charge_service_spec.rb
+++ b/spec/services/order/charge_service_spec.rb
@@ -727,6 +727,39 @@ describe Order::ChargeService, :vcr do
     end
   end
 
+  describe "#ensure_all_purchases_processed" do
+    it "does not raise when purchases is nil" do
+      order = create(:order)
+      service = Order::ChargeService.new(order:, params: { line_items: [] })
+      expect { service.send(:ensure_all_purchases_processed, nil) }.not_to raise_error
+    end
+
+    it "does not raise NoMethodError when an error occurs before non_free_seller_purchases is assigned" do
+      seller = create(:user)
+      product = create(:product, user: seller, price_cents: 10_00)
+      line_items = {
+        line_items: [
+          { uid: "uid-1", permalink: product.unique_permalink, perceived_price_cents: product.price_cents, quantity: 1 }
+        ]
+      }
+      params = line_items.merge(
+        email: "buyer@example.com",
+        cc_zipcode: "12345",
+        purchase: { full_name: "Test Buyer", street_address: "123 Test St", country: "US", state: "CA", city: "San Francisco", zip_code: "94117" },
+        browser_guid: SecureRandom.uuid,
+        ip_address: "0.0.0.0",
+        session_id: SecureRandom.hex,
+        is_mobile: false,
+      )
+
+      order, _ = Order::CreateService.new(params:).perform
+
+      allow(order.charges).to receive(:create!).and_raise(ActiveRecord::RecordInvalid)
+
+      expect { Order::ChargeService.new(order:, params:).perform }.not_to raise_error
+    end
+  end
+
   describe "#mandate_options_for_stripe" do
     let!(:seller) { create(:user) }
     let!(:membership_product) { create(:membership_product_with_preset_tiered_pricing, user: seller) }


### PR DESCRIPTION
## What

Adds a nil guard in `Order::ChargeService#ensure_all_purchases_processed` to prevent `NoMethodError: undefined method 'each' for nil` when the method receives `nil`.

## Why

In `perform`, the `ensure` block calls `ensure_all_purchases_processed(non_free_seller_purchases)`. But `non_free_seller_purchases` is assigned partway through the `begin` block. If an exception occurs before that assignment (e.g., during `order.charges.create!` or the `seller_purchases.each` loop), `non_free_seller_purchases` is still `nil` when the `ensure` block runs, causing a `NoMethodError`.

The fix is a single `return if purchases.nil?` guard at the top of the method.

## Test results

Two new tests added:
- Unit test: calling `ensure_all_purchases_processed(nil)` does not raise
- Integration test: simulating an error before `non_free_seller_purchases` assignment doesn't crash `perform`

Both tests fail without the fix and pass with it.

Sentry: https://gumroad-to.sentry.io/issues/7371647591/

---

Generated with Claude Opus 4.6. Prompt: fix the Sentry NoMethodError in ChargeService#ensure_all_purchases_processed.