### PR TITLE
Fix NoMethodError when LinksController#create called without link params

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -51,6 +51,7 @@ class LinksController < ApplicationController
 
   def create
     authorize Link
+    return head :bad_request if params[:link].blank?
 
     if params[:link][:is_physical]
       return head :forbidden unless current_seller.can_create_physical_products?

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -2831,6 +2831,10 @@ describe LinksController, :vcr, inertia: true do
         let(:record) { Link }
       end
 
+      it "returns bad request when link params are missing" do
+        post :create, params: {}
+        expect(response).to have_http_status(:bad_request)
+      end
 
       it "creates link with display_product_reviews set to true" do
         params = { price_cents: 100, name: "test link" }


### PR DESCRIPTION
## What

Adds an early guard clause in `LinksController#create` to return `400 Bad Request` when the `link` parameter is missing from the request.

## Why

The `create` action accesses `params[:link][:is_physical]` (line 55) before `params.require(:link)` is called via `link_params` (line 60). When a request lacks the `link` parameter, `params[:link]` is `nil` and the `[]` call raises `NoMethodError`. The guard clause catches this before any nil access, returning a proper 400 instead of a 500.

Sentry: `NoMethodError: undefined method '[]' for nil (NoMethodError)` at `app/controllers/links_controller.rb:55`

## Test Results

Added a request spec confirming POST create without `link` params returns 400.

```
1 example, 0 failures
```

---

AI disclosure: Implementation by Claude Opus 4.6 with the following prompt: fix the NoMethodError in LinksController#create where params[:link] can be nil, add guard clause and test.