### PR TITLE
Fix: Handle "card doesn't appear to support payouts" Stripe error

### DIFF
--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -261,7 +261,8 @@ module StripeMerchantAccountManager
     save_stripe_bank_account_info(bank_account, stripe_account.refresh)
   rescue Stripe::InvalidRequestError => e
     return ContactingCreatorMailer.invalid_bank_account(user.id).deliver_later(queue: "critical") if e.message["Invalid account number"] ||
-                                                                            e.message["couldn't find that transit"] || e.message["previous attempts to deliver payouts"]
+                                                                            e.message["couldn't find that transit"] || e.message["previous attempts to deliver payouts"] ||
+                                                                            e.message["doesn't appear to support payouts"]
 
     ErrorNotifier.notify(e)
   rescue Stripe::CardError => e

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -9131,6 +9131,18 @@ describe StripeMerchantAccountManager, :vcr do
           end.to have_enqueued_mail(ContactingCreatorMailer, :invalid_bank_account).with(user.id)
         end
       end
+
+      describe "card doesn't support payouts" do
+        before do
+          expect(Stripe::Account).to receive(:update).and_raise(Stripe::InvalidRequestError.new("This card doesn't appear to support payouts.", "invalid_request"))
+        end
+
+        it "emails the creator" do
+          expect do
+            subject.update_bank_account(user, passphrase: "1234")
+          end.to have_enqueued_mail(ContactingCreatorMailer, :invalid_bank_account).with(user.id)
+        end
+      end
     end
 
     describe "all info provided previously, bank account not changed" do


### PR DESCRIPTION
## What

Added handling for the Stripe `InvalidRequestError` with message "This card doesn't appear to support payouts." in `StripeMerchantAccountManager#update_bank_account`. This error now triggers the `invalid_bank_account` email to the creator, matching the behavior of other invalid bank account errors.

## Why

This error was falling through to `ErrorNotifier.notify(e)` without notifying the creator, so they had no way to know they needed to update their payout method. The fix adds this error message to the existing condition that sends the `invalid_bank_account` email.

## Test Results

```
9 examples, 0 failures
```

All `update_bank_account` tests pass, including the new test for this specific error message.

---

Generated with Claude Opus 4.6. Prompt: fix Sentry issue for "This card doesn't appear to support payouts" error in update_bank_account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)