### PR TITLE
Fix WorkflowsController#destroy raising RecordInvalid on blank installment message

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -53,10 +53,10 @@ class Workflow < ApplicationRecord
   def mark_deleted!
     self.deleted_at = Time.current
     installments.each do |installment|
-      installment.mark_deleted!
-      installment.installment_rule.mark_deleted!
+      installment.mark_deleted(validate: false)
+      installment.installment_rule.mark_deleted(validate: false)
     end
-    save!
+    save!(validate: false)
   end
 
   def publish!

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -135,6 +135,18 @@ describe Workflow do
       expect(seller_workflow.reload.deleted_at.present?).to be(true)
       expect(installment1.reload.deleted_at.present?).to be(true)
     end
+
+    it "succeeds when an installment has a blank message" do
+      seller = create(:user)
+      workflow = create(:workflow, seller:, link: nil)
+      installment = create(:installment, workflow:)
+      create(:installment_rule, installment:, delayed_delivery_time: 3.days)
+      installment.update_column(:message, "")
+
+      expect { workflow.mark_deleted! }.not_to raise_error
+      expect(workflow.reload.deleted_at).to be_present
+      expect(installment.reload.deleted_at).to be_present
+    end
   end
 
   describe "#schedule_installment", :freeze_time do


### PR DESCRIPTION
## What

When deleting a workflow via `WorkflowsController#destroy`, `mark_deleted!` calls `save!` on each installment, which triggers the `message_must_be_provided` validation. If an installment has a blank message, this raises `ActiveRecord::RecordInvalid`.

This PR changes `Workflow#mark_deleted!` to skip validations when soft-deleting installments, their installment rules, and the workflow itself—since we're only setting `deleted_at` and don't need to enforce content validations.

## Why

Soft-deletion should always succeed regardless of the record's current validity. The `message_must_be_provided` validation is meant to ensure installments have content when being created or edited, not when being deleted.

## Test Results

- 88 examples, 0 failures across `workflow_spec.rb` and `workflows_controller_spec.rb`
- New test verifies deletion succeeds with a blank-message installment
- Test fails when the fix is reverted, confirming it covers the bug

---

AI disclosure: Implemented with Claude Opus 4.6. Prompted with root cause analysis and fix instructions for the Sentry issue.