### PR TITLE
Fix ArgumentError: comparison of NilClass in LinksController#update

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -352,7 +352,7 @@ class LinksController < ApplicationController
         end
 
         if @product.native_type === Link::NATIVE_TYPE_COFFEE
-          @product.suggested_price_cents = product_permitted_params[:variants].map { _1[:price_difference_cents] }.max
+          @product.suggested_price_cents = product_permitted_params[:variants].map { _1[:price_difference_cents] }.compact.max
         end
 
         # TODO clean this up

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -385,6 +385,21 @@ describe LinksController, :vcr, inertia: true do
           expect(response).to be_successful
           expect(coffee_product.reload.suggested_price_cents).to eq(500)
         end
+
+        it "does not raise ArgumentError when price_difference_cents is nil" do
+          coffee_product = create(:coffee_product)
+          sign_in coffee_product.user
+
+          post :update, params: {
+            id: coffee_product.unique_permalink,
+            variants: [
+              { price_difference_cents: nil },
+              { price_difference_cents: 700 }
+            ]
+          }, as: :json
+
+          expect(response.parsed_body["error_message"]).not_to include("comparison of NilClass")
+        end
       end
 
       describe "content_updated_at" do


### PR DESCRIPTION
## What

Added `.compact` before `.max` when computing `suggested_price_cents` for coffee products in `LinksController#update` (line 355).

## Why

When a coffee product update includes variants with nil `price_difference_cents`, `Array#max` raises `ArgumentError: comparison of NilClass with 700 failed` because it cannot compare nil with integers. Adding `.compact` filters out nil values before comparison. If all values are nil, `max` returns nil, which is acceptable for `suggested_price_cents`.

## Test results

- Added test confirming no `ArgumentError` when `price_difference_cents` is nil
- Test fails when fix is reverted, passes with fix applied
- All existing coffee product tests continue to pass

---

Generated with Claude Opus 4.6. Prompted to fix the nil comparison Sentry bug in `LinksController#update`.