### PR TITLE
Fix refund policy image size check to use optimized image

### DIFF
--- a/app/services/dispute_evidence/generate_refund_policy_image_service.rb
+++ b/app/services/dispute_evidence/generate_refund_policy_image_service.rb
@@ -22,7 +22,7 @@ class DisputeEvidence::GenerateRefundPolicyImageService
     end
 
     optimized_binary_data = optimize_image(binary_data)
-    image = MiniMagick::Image.read(binary_data)
+    image = MiniMagick::Image.read(optimized_binary_data)
     raise ImageTooLargeError if image.size > max_size_allowed
 
     optimized_binary_data

--- a/spec/services/dispute_evidence/generate_refund_policy_image_service_spec.rb
+++ b/spec/services/dispute_evidence/generate_refund_policy_image_service_spec.rb
@@ -25,7 +25,30 @@ describe DisputeEvidence::GenerateRefundPolicyImageService, type: :system, js: t
       expect(binary_data).to end_with("\xFF\xD9".b)
     end
 
-    context "when the image is too large" do
+    context "when the raw image exceeds the limit but the optimized image fits" do
+      it "returns the optimized image without raising an error" do
+        expect_any_instance_of(Selenium::WebDriver::Driver).to receive(:quit)
+
+        raw_data = nil
+        allow_any_instance_of(described_class).to receive(:generate_screenshot).and_wrap_original do |method, *args|
+          raw_data = method.call(*args)
+          raw_data
+        end
+
+        optimized_data = nil
+        allow_any_instance_of(described_class).to receive(:optimize_image).and_wrap_original do |method, data|
+          optimized_data = method.call(data)
+          optimized_data
+        end
+
+        result = described_class.perform(url:, mobile_purchase: false, open_fine_print_modal: false, max_size_allowed: 3_000_000.bytes)
+
+        expect(raw_data.size).to be > optimized_data.size
+        expect(result).to eq(optimized_data)
+      end
+    end
+
+    context "when the optimized image is too large" do
       it "raises an error" do
         expect_any_instance_of(Selenium::WebDriver::Driver).to receive(:quit)
         expect do


### PR DESCRIPTION
## What

Changes the size check in `GenerateRefundPolicyImageService#perform` to validate the optimized image instead of the raw screenshot.

## Why

The `perform` method optimizes the raw PNG screenshot into a compressed JPG (resized + quality-reduced), but the size check was comparing the **raw PNG** against `max_size_allowed`. This caused images that would fit after optimization to be incorrectly rejected with `ImageTooLargeError`.

The fix changes `MiniMagick::Image.read(binary_data)` → `MiniMagick::Image.read(optimized_binary_data)` so the size check reflects the actual returned data.

Sentry: https://gumroad-to.sentry.io/issues/7371831237/

## Test results

Updated the spec to cover:
- When the raw image exceeds the limit but the optimized image fits → returns optimized data (no error)
- When the optimized image is still too large → raises `ImageTooLargeError`

---

Generated with Claude Opus 4.6. Prompts: fix the size check bug in GenerateRefundPolicyImageService, update tests to cover both scenarios.