### PR TITLE
Fix NoMethodError in PasswordsController#create when params[:user] is nil

### DIFF
--- a/app/controllers/user/passwords_controller.rb
+++ b/app/controllers/user/passwords_controller.rb
@@ -17,7 +17,7 @@ class User::PasswordsController < Devise::PasswordsController
   end
 
   def create
-    email = params[:user][:email]
+    email = params.dig(:user, :email)
     user = User.alive.by_email(email).first if EmailFormatValidator.valid?(email)
 
     if user&.send_reset_password_instructions

--- a/spec/controllers/user/passwords_controller_spec.rb
+++ b/spec/controllers/user/passwords_controller_spec.rb
@@ -43,6 +43,12 @@ describe User::PasswordsController, type: :controller, inertia: true do
       expect(flash[:warning]).to eq("An account does not exist with that email.")
     end
 
+    it "redirects with warning when user param is missing entirely" do
+      post(:create, params: {})
+      expect(response).to redirect_to(login_url)
+      expect(flash[:warning]).to eq("An account does not exist with that email.")
+    end
+
     it "redirects with warning if email is not valid" do
       post(:create, params: { user: { email: "this is no sort of valid email address" } })
       expect(response).to redirect_to(login_url)


### PR DESCRIPTION
## What

Use `params.dig(:user, :email)` instead of `params[:user][:email]` in `PasswordsController#create` to prevent a `NoMethodError` when `params[:user]` is nil.

## Why

When someone POSTs to `/users/forgot_password` without the expected nested `user[email]` parameter (e.g. bots, malformed requests), `params[:user]` returns `nil` and calling `[:email]` on it raises `NoMethodError: undefined method '[]' for nil`. With `dig`, the controller gracefully falls through to the "account not found" redirect instead of crashing.

Sentry issue: https://gumroad-to.sentry.io/issues/7371852359/

## Test Results

All `#create` controller tests pass (4 examples, 0 failures), including a new test for the missing `params[:user]` case.

---

AI disclosure: Built with Claude Opus 4.6. Prompt: fix the NoMethodError in PasswordsController#create when params[:user] is nil, add a test, and open a PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)