### PR TITLE
Handle MerchantRegistrationUserNotReadyError in PaymentsController#update

### DIFF
--- a/app/controllers/settings/payments_controller.rb
+++ b/app/controllers/settings/payments_controller.rb
@@ -81,6 +81,9 @@ class Settings::PaymentsController < Settings::BaseController
     if current_seller.active_bank_account && current_seller.merchant_accounts.stripe.alive.empty? && current_seller.native_payouts_supported?
       begin
         StripeMerchantAccountManager.create_account(current_seller, passphrase: GlobalConfig.get("STRONGBOX_GENERAL_PASSWORD"))
+      rescue MerchantRegistrationUserNotReadyError
+        redirect_with_error("Your bank account currency doesn't match your country's payout currency. Please update your bank account.")
+        return
       rescue Stripe::InvalidRequestError => e
         if e.code == "postal_code_invalid"
           country = current_seller.fetch_or_build_user_compliance_info.legal_entity_country
@@ -89,7 +92,6 @@ class Settings::PaymentsController < Settings::BaseController
           redirect_with_error(e.try(:message) || "Something went wrong.")
         end
         return
-        return redirect_with_error(e.try(:message) || "Something went wrong.")
       end
     end
 

--- a/spec/controllers/settings/payments_controller_spec.rb
+++ b/spec/controllers/settings/payments_controller_spec.rb
@@ -1187,6 +1187,23 @@ describe Settings::PaymentsController, :vcr, type: :controller, inertia: true do
       end
     end
 
+    context "when StripeMerchantAccountManager.create_account raises MerchantRegistrationUserNotReadyError" do
+      before do
+        allow(StripeMerchantAccountManager).to receive(:create_account)
+          .and_raise(MerchantRegistrationUserNotReadyError.new(0, "has bank account currency mismatch"))
+        user.update!(payment_address: nil)
+        create(:ach_account_stripe_succeed, user:)
+      end
+
+      it "redirects with a user-friendly error message" do
+        put :update, params: { user: params }
+
+        expect(response).to redirect_to(settings_payments_path)
+        expect(response).to have_http_status :found
+        expect(session[:inertia_errors][:base]).to eq(["Your bank account currency doesn't match your country's payout currency. Please update your bank account."])
+      end
+    end
+
     context "when updating country" do
       it "calls UpdateUserCountry service" do
         expect(UpdateUserCountry).to receive(:new).with(new_country_code: "GB", user:).and_call_original


### PR DESCRIPTION
## What

- Rescue `MerchantRegistrationUserNotReadyError` in `Settings::PaymentsController#update` when `StripeMerchantAccountManager.create_account` is called
- Show a user-friendly error ("Your bank account currency doesn't match your country's payout currency. Please update your bank account.") instead of an unhandled 500
- Remove an unreachable duplicate `return` statement in the existing `Stripe::InvalidRequestError` rescue block

## Why

When a user's bank account currency doesn't match their legal entity country's payout currency, `StripeMerchantAccountManager` raises `MerchantRegistrationUserNotReadyError`. The admin controller already rescues this error, but the payments controller did not, causing a 500 error for end users.

## Test Results

```
Settings::PaymentsController
  PUT update
    when StripeMerchantAccountManager.create_account raises MerchantRegistrationUserNotReadyError
      redirects with a user-friendly error message

1 example, 0 failures
```

---

AI disclosure: Implemented with Claude Opus 4.6. Prompted with the bug description, root cause analysis, and fix instructions.