### PR TITLE
Fix N+1 query in Api::V2::LinksController#index causing request timeouts

### DIFF
--- a/app/controllers/api/v2/links_controller.rb
+++ b/app/controllers/api/v2/links_controller.rb
@@ -9,7 +9,7 @@ class Api::V2::LinksController < Api::V2::BaseController
 
   def index
     products = current_resource_owner.products.visible.includes(
-      :preorder_link, :tags, :taxonomy,
+      :preorder_link, :tags, :taxonomy, :ordered_alive_product_files,
       variant_categories_alive: [:alive_variants],
     ).order(created_at: :desc)
 

--- a/app/modules/with_product_files.rb
+++ b/app/modules/with_product_files.rb
@@ -17,7 +17,11 @@ module WithProductFiles
   # Use this method in order to hit the db once and cache the results on the Link object and reuse them later.
   # Call this method only if you're sure that you're not changing the files within the same action.
   def alive_product_files
-    cached_alive_product_files || self.cached_alive_product_files = product_files.alive.in_order.to_a
+    cached_alive_product_files || self.cached_alive_product_files = if association(:ordered_alive_product_files).loaded?
+      ordered_alive_product_files.to_a
+    else
+      product_files.alive.in_order.to_a
+    end
   end
 
   def has_files?

--- a/app/modules/with_product_files.rb
+++ b/app/modules/with_product_files.rb
@@ -18,10 +18,10 @@ module WithProductFiles
   # Call this method only if you're sure that you're not changing the files within the same action.
   def alive_product_files
     cached_alive_product_files || self.cached_alive_product_files = if association(:ordered_alive_product_files).loaded?
-      ordered_alive_product_files.to_a
-    else
-      product_files.alive.in_order.to_a
-    end
+                                    ordered_alive_product_files.to_a
+                                  else
+                                    product_files.alive.in_order.to_a
+                                  end
   end
 
   def has_files?

--- a/spec/controllers/api/v2/links_controller_spec.rb
+++ b/spec/controllers/api/v2/links_controller_spec.rb
@@ -55,6 +55,22 @@ describe Api::V2::LinksController do
       expect(response).to be_successful
       expect(response.parsed_body["products"]).to be_present
     end
+
+    describe "eager loading product files" do
+      before do
+        @token = create("doorkeeper/access_token", application: @app, resource_owner_id: @user.id, scopes: "view_public")
+        @params.merge!(format: :json, access_token: @token.token)
+        create_list(:product_file, 3, link: @product1)
+        create(:product_file, link: @product2)
+      end
+
+      it "returns products with files without N+1 queries" do
+        get @action, params: @params
+
+        expect(response).to be_successful
+        expect(response.parsed_body["products"].size).to eq(2)
+      end
+    end
   end
 
   describe "POST 'create'" do


### PR DESCRIPTION
## What

Adds eager loading of `ordered_alive_product_files` to the `Api::V2::LinksController#index` action and updates `alive_product_files` in `WithProductFiles` to use the preloaded association when available.

## Why

Sentry shows `Rack::Timeout::RequestTimeoutException` (120s) on this endpoint. The root cause is an N+1 query: for each product, `multifile_aware_product_file_info` calls `alive_product_files`, which hits the DB separately. For sellers with many products, this compounds into hundreds of queries and timeouts.

The fix adds `:ordered_alive_product_files` to the `.includes()` call and teaches `alive_product_files` to use the preloaded data when present, falling back to the existing query for other callers.

## Test results

```
39 examples, 0 failures
```

---

AI disclosure: Claude Opus 4.6, prompted with the Sentry stacktrace analysis and fix plan.