### PR TITLE
Fix Rack::Timeout in CheckoutController#show from N+1 queries in recommended bundle products

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -116,6 +116,7 @@ class CheckoutController < ApplicationController
           target: product_info.target,
           recommender_model_name: product_info.recommender_model_name,
           affiliate_id: product_info.affiliate_id,
+          skip_quantity_remaining: true,
         )
       end
     end

--- a/app/presenters/product_presenter.rb
+++ b/app/presenters/product_presenter.rb
@@ -43,8 +43,8 @@ class ProductPresenter
   end
 
   ASSOCIATIONS_FOR_CARD = ProductPresenter::Card::ASSOCIATIONS
-  def self.card_for_web(product:, request: nil, recommended_by: nil, recommender_model_name: nil, target: nil, show_seller: true, affiliate_id: nil, query: nil, offer_code: nil, compute_description: true)
-    ProductPresenter::Card.new(product:).for_web(request:, recommended_by:, recommender_model_name:, target:, show_seller:, affiliate_id:, query:, offer_code:, compute_description:)
+  def self.card_for_web(product:, request: nil, recommended_by: nil, recommender_model_name: nil, target: nil, show_seller: true, affiliate_id: nil, query: nil, offer_code: nil, compute_description: true, skip_quantity_remaining: false)
+    ProductPresenter::Card.new(product:).for_web(request:, recommended_by:, recommender_model_name:, target:, show_seller:, affiliate_id:, query:, offer_code:, compute_description:, skip_quantity_remaining:)
   end
 
   def self.card_for_email(product:)

--- a/app/presenters/product_presenter/card.rb
+++ b/app/presenters/product_presenter/card.rb
@@ -19,7 +19,7 @@ class ProductPresenter::Card
     @product = product
   end
 
-  def for_web(request: nil, recommended_by: nil, recommender_model_name: nil, target: nil, show_seller: true, affiliate_id: nil, query: nil, offer_code: nil, compute_description: true)
+  def for_web(request: nil, recommended_by: nil, recommender_model_name: nil, target: nil, show_seller: true, affiliate_id: nil, query: nil, offer_code: nil, compute_description: true, skip_quantity_remaining: false)
     default_recurrence = product.default_price_recurrence
     base_price_cents = product.display_price_cents(for_default_duration: true)
     price_cents = compute_discounted_price_cents(base_price_cents)
@@ -35,7 +35,7 @@ class ProductPresenter::Card
       } : nil,
       thumbnail_url: product.thumbnail_or_cover_url,
       native_type: product.native_type,
-      quantity_remaining: product.remaining_for_sale_count,
+      quantity_remaining: skip_quantity_remaining ? nil : product.remaining_for_sale_count,
       is_sales_limited: product.max_purchase_count?,
       price_cents:,
       currency_code: product.price_currency_type.downcase,

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -176,6 +176,7 @@ describe CheckoutController, type: :controller, inertia: true do
             recommended_by:,
             recommender_model_name:,
             target:,
+            skip_quantity_remaining: true,
           )
         end
       end

--- a/spec/presenters/product_presenter/card_spec.rb
+++ b/spec/presenters/product_presenter/card_spec.rb
@@ -76,6 +76,15 @@ describe ProductPresenter::Card do
 
         expect(result).not_to have_key(:description)
       end
+
+      it "sets quantity_remaining to nil when skip_quantity_remaining is true" do
+        product.update!(max_purchase_count: 100)
+        result_with = described_class.new(product:).for_web
+        result_without = described_class.new(product:).for_web(skip_quantity_remaining: true)
+
+        expect(result_with[:quantity_remaining]).to be_present
+        expect(result_without[:quantity_remaining]).to be_nil
+      end
     end
 
     context "membership product" do


### PR DESCRIPTION
## What

Skip the expensive `remaining_for_sale_count` computation when building product cards for checkout recommendations. Added a `skip_quantity_remaining` parameter to `ProductPresenter::Card#for_web` and set it to `true` in `CheckoutController#recommended_products`.

## Why

`CheckoutController#show` was hitting Rack::Timeout (120s) due to N+1 queries in the recommended products flow. When a recommended product is a bundle, `remaining_for_sale_count` recursively loads each bundle product's variants and fires individual `purchases.counts_towards_inventory.sum(:quantity)` queries — one per variant. For a bundle with N products each having M inventory-limited variants, this creates N×M queries per recommended product. With 6 recommendations, this cascades into hundreds of queries.

The `quantity_remaining` field is not critical for recommended product cards on checkout — they just need to display the product card, not the exact inventory count.

**Sentry issue:** https://gumroad-to.sentry.io/issues/7372067158/

## Test results

All existing tests pass. Added a new test verifying `skip_quantity_remaining` correctly returns `nil` for `quantity_remaining`.

```
20 examples, 0 failures  (checkout_controller_spec.rb)
1 example, 0 failures    (card_spec.rb — new test)
```

---

AI disclosure: Implemented with Claude Opus 4.6. Prompted with the Sentry issue URL, root cause analysis, and fix approach.