### PR TITLE
Fix NoMethodError when seller name is nil in CommunityChatRecapMailer

### DIFF
--- a/app/mailers/community_chat_recap_mailer.rb
+++ b/app/mailers/community_chat_recap_mailer.rb
@@ -14,7 +14,7 @@ class CommunityChatRecapMailer < ApplicationMailer
     recap_run = @recaps.first.community_chat_recap_run
     @recap_frequency = recap_run.recap_frequency
 
-    subject = "Your #{@recap_frequency} #{@seller.name.truncate(20)} community recap: #{humanized_duration(@recap_frequency, recap_run)}"
+    subject = "Your #{@recap_frequency} #{@seller.name.to_s.truncate(20)} community recap: #{humanized_duration(@recap_frequency, recap_run)}"
 
     mail(
       to: user.form_email,

--- a/spec/mailers/community_chat_recap_mailer_spec.rb
+++ b/spec/mailers/community_chat_recap_mailer_spec.rb
@@ -66,6 +66,14 @@ describe CommunityChatRecapMailer do
         end
       end
 
+      context "when seller name is nil" do
+        let(:seller) { create(:user, name: nil) }
+
+        it "does not raise an error" do
+          expect(mail.subject).to eq("Your weekly  community recap: March 17-23, 2025")
+        end
+      end
+
       context "when recap spans different months in same year" do
         let(:from_date) { Date.new(2025, 3, 30) }
         let(:to_date) { Date.new(2025, 4, 5) }


### PR DESCRIPTION
## What

`@seller.name.truncate(20)` in `CommunityChatRecapMailer` raises `NoMethodError` when a seller hasn't set their name (`nil`). Changed to `@seller.name.to_s.truncate(20)` so `nil` becomes an empty string before truncation.

## Why

Sellers without a name set cause the community chat recap email to fail entirely, preventing all recipients from receiving their recap. This was reported via Sentry: https://gumroad-to.sentry.io/issues/7372173010/

## Test Results

Added a test case covering the nil seller name scenario.

---

Generated with Claude Opus 4.6. Prompt: Fix Sentry issue NoMethodError in CommunityChatRecapMailer - undefined method 'truncate' for nil.