### PR TITLE
Fix ActiveRecord::RecordInvalid in LinksController#destroy for stale default_offer_code

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1245,6 +1245,7 @@ class Link < ApplicationRecord
 
     def default_offer_code_must_be_valid
       return unless default_offer_code.present?
+      return if being_marked_as_deleted?
 
       if !user.offer_codes.alive.where(id: default_offer_code.id).exists?
         errors.add(:default_offer_code, "must belong to your offer codes")

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -198,6 +198,17 @@ describe LinksController, :vcr, inertia: true do
           expect(@product.reload.deleted_at.present?).to be(true)
         end
       end
+
+      it "allows deletion when default_offer_code is no longer associated with the product" do
+        product = create(:product, user: seller)
+        offer_code = create(:offer_code, user: seller, products: [product])
+        product.update!(default_offer_code: offer_code)
+        offer_code.products = []
+
+        delete :destroy, params: { id: product.unique_permalink }
+
+        expect(product.reload.deleted_at).to be_present
+      end
     end
 
     describe "GET edit" do


### PR DESCRIPTION
## What

Skips the `default_offer_code_must_be_valid` validation when a product is being soft-deleted via `mark_deleted!`. Previously, if a product had a `default_offer_code` that was no longer associated with it, the validation would fail and block deletion entirely.

## Why

`LinksController#destroy` calls `link.delete!` → `mark_deleted!` → `save!`, which runs all validations. The `default_offer_code_must_be_valid` validation raises `ActiveRecord::RecordInvalid` when the offer code is stale (no longer associated with the product). Since the product is being deleted, the validity of its default offer code is irrelevant. The `being_marked_as_deleted?` guard (already defined in `Deletable`) is the established pattern for skipping validations during soft-deletion.

Sentry issue: https://gumroad-to.sentry.io/issues/7372293410/

## Test results

Added a test that creates a product with a default offer code, disassociates the offer code, then verifies the product can still be deleted. The test fails without the fix and passes with it.

---

AI disclosure: Built with Claude Opus 4.6. Prompted with the Sentry error details, root cause analysis, and fix instructions.