### PR TITLE
Fix unhandled RecordInvalid in ActiveStorage direct uploads when checksum is blank

### DIFF
--- a/app/controllers/active_storage/direct_uploads_controller.rb
+++ b/app/controllers/active_storage/direct_uploads_controller.rb
@@ -9,15 +9,14 @@ class ActiveStorage::DirectUploadsController < ActiveStorage::BaseController
   end
 
   private
+    def blob_args
+      params.require(:blob).permit(:filename, :byte_size, :checksum, :content_type, metadata: {}).to_h.symbolize_keys
+    end
 
-  def blob_args
-    params.require(:blob).permit(:filename, :byte_size, :checksum, :content_type, metadata: {}).to_h.symbolize_keys
-  end
-
-  def direct_upload_json(blob)
-    blob.as_json(root: false, methods: :signed_id).merge(direct_upload: {
-      url: blob.service_url_for_direct_upload,
-      headers: blob.service_headers_for_direct_upload
-    })
-  end
+    def direct_upload_json(blob)
+      blob.as_json(root: false, methods: :signed_id).merge(direct_upload: {
+                                                             url: blob.service_url_for_direct_upload,
+                                                             headers: blob.service_headers_for_direct_upload
+                                                           })
+    end
 end

--- a/app/controllers/active_storage/direct_uploads_controller.rb
+++ b/app/controllers/active_storage/direct_uploads_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class ActiveStorage::DirectUploadsController < ActiveStorage::BaseController
+  def create
+    blob = ActiveStorage::Blob.create_before_direct_upload!(**blob_args)
+    render json: direct_upload_json(blob)
+  rescue ActiveRecord::RecordInvalid => e
+    render json: { error: e.record.errors.full_messages.join(", ") }, status: :unprocessable_entity
+  end
+
+  private
+
+  def blob_args
+    params.require(:blob).permit(:filename, :byte_size, :checksum, :content_type, metadata: {}).to_h.symbolize_keys
+  end
+
+  def direct_upload_json(blob)
+    blob.as_json(root: false, methods: :signed_id).merge(direct_upload: {
+      url: blob.service_url_for_direct_upload,
+      headers: blob.service_headers_for_direct_upload
+    })
+  end
+end

--- a/spec/requests/active_storage/direct_uploads_spec.rb
+++ b/spec/requests/active_storage/direct_uploads_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "ActiveStorage::DirectUploadsController" do
+  describe "POST /rails/active_storage/direct_uploads" do
+    it "returns 422 when checksum is blank" do
+      post rails_direct_uploads_url, params: {
+        blob: {
+          filename: "test.png",
+          byte_size: 1024,
+          checksum: "",
+          content_type: "image/png"
+        }
+      }, as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["error"]).to include("Checksum")
+    end
+
+    it "returns 422 when checksum is missing" do
+      post rails_direct_uploads_url, params: {
+        blob: {
+          filename: "test.png",
+          byte_size: 1024,
+          content_type: "image/png"
+        }
+      }, as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+end


### PR DESCRIPTION
## What

Override `ActiveStorage::DirectUploadsController` to rescue `ActiveRecord::RecordInvalid` and return a 422 JSON error response instead of letting the exception bubble up as a 500.

## Why

The `checksum` field is computed client-side by the `@rails/activestorage` DirectUpload JS library. In edge cases (browser bugs, file read failures, network issues), a blank checksum can be sent to the server. `ActiveStorage::Blob` validates checksum presence, so `create_before_direct_upload!` raises `RecordInvalid` — which was unhandled, causing a 500 error reported in Sentry ([GUMROAD-TO-1J](https://gumroad-to.sentry.io/issues/7372339016/)).

The fix catches `RecordInvalid` and returns the validation errors as a 422 JSON response, which is the expected behavior for invalid input.

## Test Results

Added request specs that verify:
- Blank checksum returns 422 with error message
- Missing checksum returns 422

---

Generated with Claude Opus 4.6. Prompt: Fix Sentry issue for `ActiveRecord::RecordInvalid: Validation failed: Checksum can't be blank` in `ActiveStorage::DirectUploadsController#create`.