### PR TITLE
Fix ActiveModel::ValidationError in Settings::MainController#update

### DIFF
--- a/app/controllers/settings/main_controller.rb
+++ b/app/controllers/settings/main_controller.rb
@@ -28,6 +28,10 @@ class Settings::MainController < Settings::BaseController
     current_seller.update_product_level_support_emails!(params[:user][:product_level_support_emails])
 
     redirect_to settings_main_path, status: :see_other, notice: "Your account has been updated!"
+  rescue ActiveModel::ValidationError => e
+    error_message = current_seller.errors.full_messages.to_sentence.presence ||
+      e.model.errors.full_messages.to_sentence
+    redirect_to settings_main_path, alert: error_message
   rescue StandardError => e
     ErrorNotifier.notify(e)
     error_message = current_seller.errors.full_messages.to_sentence.presence ||

--- a/spec/controllers/settings/main_controller_spec.rb
+++ b/spec/controllers/settings/main_controller_spec.rb
@@ -396,7 +396,7 @@ describe Settings::MainController, type: :controller, inertia: true do
           expect(product2.reload.support_email).to eq("contact@example.com")
         end
 
-        it "fails when email isn't valid" do
+        it "returns validation error when product support email is invalid" do
           product_level_support_emails = [
             { email: "invalid-email", product_ids: [product1.external_id] }
           ]
@@ -404,7 +404,7 @@ describe Settings::MainController, type: :controller, inertia: true do
 
           expect(response).to redirect_to(settings_main_path)
           expect(response).to have_http_status :found
-          expect(flash[:alert]).to eq("Something broke. We're looking into what happened. Sorry about this!")
+          expect(flash[:alert]).to eq("Support email is invalid")
         end
 
         it "only associates products belonging to current seller" do


### PR DESCRIPTION
## What

Adds a specific `rescue ActiveModel::ValidationError` clause in `Settings::MainController#update` so that invalid product-level support emails return the actual validation message (e.g., "Support email is invalid") instead of a generic 500-style error.

## Why

`Product::BulkUpdateSupportEmailService#validate_email!` raises `ActiveModel::ValidationError` when a product support email is invalid. This was caught by the generic `rescue StandardError`, which:
1. Sent an unnecessary Sentry alert for a user input error
2. Showed "Something broke. We're looking into what happened." instead of the validation message

The fix catches `ActiveModel::ValidationError` before `StandardError`, returns the validation message to the user, and avoids notifying Sentry for expected input validation failures.

## Test Results

```
8 examples, 0 failures (targeted)
35 examples, 0 failures (full controller spec)
```

---

AI disclosure: Claude Opus 4.6 was used to implement this fix. Prompts: fix Sentry issue where ActiveModel::ValidationError in settings update causes 500 instead of validation error.