### PR TITLE
Fix NoMethodError when updating bank account holder name without existing bank account

### DIFF
--- a/app/services/update_payout_method.rb
+++ b/app/services/update_payout_method.rb
@@ -161,7 +161,7 @@ class UpdatePayoutMethod
         return { error: :bank_account_error, data: bank_account.errors.full_messages.to_sentence } if bank_account.errors.present?
 
         user.update!(payment_address: "") if user.payment_address.present?
-      elsif params[:bank_account][:account_holder_full_name].present?
+      elsif params[:bank_account][:account_holder_full_name].present? && old_bank_account.present?
         old_bank_account.update(account_holder_full_name: params[:bank_account][:account_holder_full_name])
       end
     elsif params[:payment_address].present?

--- a/spec/controllers/settings/payments_controller_spec.rb
+++ b/spec/controllers/settings/payments_controller_spec.rb
@@ -791,6 +791,26 @@ describe Settings::PaymentsController, :vcr, type: :controller, inertia: true do
         end
       end
 
+      describe "updating account holder name without an existing bank account" do
+        let(:params) do
+          {
+            bank_account: {
+              type: AchAccount.name,
+              account_holder_full_name: "gumbot"
+            }
+          }
+        end
+
+        it "does not raise an error" do
+          expect(user.active_bank_account).to be_nil
+
+          put(:update, params:)
+
+          expect(response).to redirect_to(settings_payments_path)
+          expect(response).to have_http_status :see_other
+        end
+      end
+
       describe "canadian bank account" do
         let(:user) { create(:user) }
 


### PR DESCRIPTION
## What

Fixes `NoMethodError: undefined method 'update' for nil` in `Settings::PaymentsController#update`.

In `UpdatePayoutMethod#process`, `old_bank_account` (`user.active_bank_account`) is `nil` when the user has no active bank account. When the form submits `bank_account` params with only `account_holder_full_name` (no `account_number`), the code falls through to `old_bank_account.update(...)`, which raises on nil.

Added a `&& old_bank_account.present?` guard to the elsif condition so we skip the update when there's nothing to update.

## Why

This is a crash in production tracked in Sentry. The fix is minimal — a nil guard on the existing conditional.

## Test Results

Added a test that reproduces the exact scenario: a user with no active bank account submitting only `account_holder_full_name`. Verified the test fails without the fix and passes with it.

```
1 example, 0 failures
```

---

AI disclosure: implemented with Claude Opus 4.6. Prompted with the Sentry error details, root cause analysis, and fix approach.