### PR TITLE
Fix membership price change not applied for customizable-price tiers

### DIFF
--- a/app/sidekiq/schedule_membership_price_updates_job.rb
+++ b/app/sidekiq/schedule_membership_price_updates_job.rb
@@ -48,6 +48,8 @@ class ScheduleMembershipPriceUpdatesJob
         end
       else
         ActiveRecord::Base.transaction do
+          original_purchase.perceived_price_cents = nil
+          original_purchase.price_range = nil
           original_purchase.set_price_and_rate
           new_price = original_purchase.displayed_price_cents
           raise ActiveRecord::Rollback

--- a/spec/sidekiq/schedule_membership_price_updates_job_spec.rb
+++ b/spec/sidekiq/schedule_membership_price_updates_job_spec.rb
@@ -210,6 +210,25 @@ describe ScheduleMembershipPriceUpdatesJob do
           end
         end
 
+        context "when the tier has customizable pricing" do
+          it "records a plan change based on the updated tier price, not the buyer's pay-what-you-want price" do
+            enabled_tier.update!(customizable_price: true)
+            buyer_pwyw_price = original_price
+            enabled_subscription.original_purchase.update!(
+              perceived_price_cents: buyer_pwyw_price,
+              price_range: "#{buyer_pwyw_price / 100}+",
+              displayed_price_cents: buyer_pwyw_price
+            )
+
+            expect do
+              described_class.new.perform(enabled_tier.id)
+            end.to change { enabled_subscription.subscription_plan_changes.for_product_price_change.alive.count }.by(1)
+
+            plan_change = enabled_subscription.subscription_plan_changes.for_product_price_change.alive.last
+            expect(plan_change.perceived_price_cents).to eq(new_price)
+          end
+        end
+
         context "when the price for a recurrence is deleted" do
           it "does nothing but notify error tracker" do
             enabled_tier.prices.alive.find_by(recurrence: "monthly").mark_deleted!


### PR DESCRIPTION
## What

Fixes `ScheduleMembershipPriceUpdatesJob` failing to create plan changes for subscriptions on customizable-price (pay-what-you-want) tiers when the creator updates the tier's price.

## Why

When computing the new price in the no-plan-change branch, `set_price_and_rate` calls `determine_customized_price_cents`, which returns the buyer's stored `perceived_price_cents` for customizable-price tiers. This makes the computed `new_price` equal to the existing `displayed_price_cents`, so the `existing_price == new_price` check triggers the "price has not changed" error and skips plan change creation.

The fix nils out `perceived_price_cents` and `price_range` on the original purchase before calling `set_price_and_rate`, so price calculation falls through to `minimum_paid_price_cents` which reflects the updated Price record. The transaction is rolled back anyway, so these temporary changes don't persist. This matches how the plan_change branch already works — `update_current_plan!` creates a new purchase with nil `perceived_price_cents`.

## Test Results

All 17 tests pass, including new test for customizable-price tier scenario:

```
17 examples, 0 failures
```

The new test fails when the fix is reverted, confirming it covers the bug.

---

Generated with Claude Opus 4.6. Prompted with bug description, root cause analysis, and fix approach.