### PR TITLE
Fix NoMethodError: undefined method 'split' for nil in S3UtilityController#generate_multipart_signature

### DIFF
--- a/app/controllers/s3_utility_controller.rb
+++ b/app/controllers/s3_utility_controller.rb
@@ -6,7 +6,8 @@ class S3UtilityController < Sellers::BaseController
   before_action :authorize
 
   def generate_multipart_signature
-    # Prevent attackers from using newlines to split the request body and bypass the seller check
+    return render(json: { success: false, error: "Bad request" }, status: :bad_request) if params["to_sign"].blank?
+
     params["to_sign"].split(/[\n\r\s]/).grep(/\A\//).each do |url|
       return render(json: { success: false, error: "Unauthorized" }, status: :forbidden) if !%r{\A/#{S3_BUCKET}/\w+/#{current_seller.external_id}/}.match?(url)
     end

--- a/spec/controllers/s3_utility_controller_spec.rb
+++ b/spec/controllers/s3_utility_controller_spec.rb
@@ -35,6 +35,13 @@ describe S3UtilityController do
       expect(response).to be_forbidden
     end
 
+    it "returns bad request when to_sign param is missing" do
+      get :generate_multipart_signature
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body["success"]).to be(false)
+    end
+
     it "allows sellers to sign request for buckets they own" do
       sign_string = "POST\n\nvideo/quicktime; charset=UTF-8\n\nx-amz-acl:private\nx-amz-date:Mon, 02 Mar 2015 17:21:19 \
       GMT\n/gumroad-specs/attachments/#{seller.external_id}/bf03be06616f4dfd88da7c37005a9b2f/original/capturedvideo%20(1)-5-2.mov?uploads"


### PR DESCRIPTION
## What

Added a nil guard for `params["to_sign"]` in `S3UtilityController#generate_multipart_signature`. When the parameter is missing or blank, the endpoint now returns a `400 Bad Request` instead of raising a `NoMethodError`.

## Why

`params["to_sign"].split(...)` raises `NoMethodError: undefined method 'split' for nil` when the `to_sign` parameter is absent, resulting in a 500 error. This was reported via Sentry ([issue 7372601750](https://gumroad-to.sentry.io/issues/7372601750/)). The fix returns an explicit 400 response for missing input.

## Test Results

All `generate_multipart_signature` tests pass, including the new test for missing `to_sign`:

- `returns bad request when to_sign param is missing` — verifies 400 status and `success: false`
- Existing tests for authorization and valid signing remain green

---

AI disclosure: Built with Claude Opus 4.6. Prompted to fix the nil `NoMethodError` on `params["to_sign"]` with a guard clause, add a test, and open a PR.