### PR TITLE
Fix Rack::Timeout in mobile analytics by_date for date_range=all

### DIFF
--- a/app/controllers/api/mobile/analytics_controller.rb
+++ b/app/controllers/api/mobile/analytics_controller.rb
@@ -54,7 +54,12 @@ class Api::Mobile::AnalyticsController < Api::Mobile::BaseController
       if params[:date_range]
         @end_date = ActiveSupport::TimeZone[current_resource_owner.timezone].today
         if params[:date_range] == "all"
-          @start_date = GUMROAD_STARTED_DATE
+          first_sale_at = current_resource_owner.first_sale_created_at_for_analytics
+          @start_date = if first_sale_at
+            first_sale_at.in_time_zone(current_resource_owner.timezone).to_date
+          else
+            @end_date - 29
+          end
         else
           offset = { "1d" => 0, "1w" => 6, "1m" => 29, "1y" => 364 }.fetch(params[:date_range])
           @start_date = @end_date - offset

--- a/spec/controllers/api/mobile/analytics_controller_spec.rb
+++ b/spec/controllers/api/mobile/analytics_controller_spec.rb
@@ -147,7 +147,17 @@ describe Api::Mobile::AnalyticsController do
         expect(assigns(:end_date)).to eq(Date.new(2021, 6, 15))
 
         get action_name, params: @params.merge(date_range: "all")
-        expect(assigns(:start_date)).to eq(Date.new(2011, 4, 4))
+        expect(assigns(:start_date)).to eq(Date.new(2021, 5, 17))
+        expect(assigns(:end_date)).to eq(Date.new(2021, 6, 15))
+      end
+    end
+
+    it "uses the first sale date as start_date for date_range=all when the user has sales" do
+      @user.update!(timezone: "Eastern Time (US & Canada)")
+      create(:purchase, link: build(:product, user: @user), created_at: Time.utc(2020, 3, 15))
+      travel_to Time.utc(2021, 6, 16) do
+        get action_name, params: @params.merge(date_range: "all")
+        expect(assigns(:start_date)).to eq(Date.new(2020, 3, 14))
         expect(assigns(:end_date)).to eq(Date.new(2021, 6, 15))
       end
     end


### PR DESCRIPTION
## What

When the mobile analytics endpoint receives `date_range=all`, it now uses the seller's first sale date as the start date instead of `GUMROAD_STARTED_DATE` (2011-04-04). If the seller has no sales, it falls back to the default 29-day range.

## Why

Using `GUMROAD_STARTED_DATE` creates a ~15-year query range that hits Elasticsearch with thousands of dates, causing `Rack::Timeout::RequestTimeoutException` after 120s. The web analytics controller doesn't even offer an "all" option — it defaults to 29 days. This fix bounds the query to only dates where the seller could have data, matching the pattern already used by `CachingProxy#generate_cache`.

Sentry: https://gumroad-to.sentry.io/issues/7372702979/

## Test Results

All 25 specs pass in `spec/controllers/api/mobile/analytics_controller_spec.rb`, including a new test verifying `date_range=all` uses the first sale date when sales exist.

---

AI disclosure: This fix was implemented with Claude Opus 4.6. Prompts: fix the Rack::Timeout in mobile analytics by_date endpoint when date_range=all by capping the start date to the seller's first sale date.