### PR TITLE
Fix Pagy::OverflowError in LinksController#index

### DIFF
--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -101,7 +101,7 @@ module ProductsHelper
     if collection.elasticsearch_key?(key)
       collection.elasticsearch_sorted_and_paginated_by(key:, direction:, page:, per_page:, user_id:)
     else
-      pagination, products = pagy(collection.sorted_by(key:, direction:, user_id:).order(created_at: :desc), limit: per_page, page:)
+      pagination, products = pagy(collection.sorted_by(key:, direction:, user_id:).order(created_at: :desc), limit: per_page, page:, overflow: :last_page)
       [PagyPresenter.new(pagination).props, products]
     end
   end

--- a/spec/presenters/dashboard_products_page_presenter_spec.rb
+++ b/spec/presenters/dashboard_products_page_presenter_spec.rb
@@ -235,8 +235,9 @@ describe DashboardProductsPagePresenter do
       expect((page1_ids + page2_ids) - products.map(&:id)).to be_empty
     end
 
-    it "raises on page overflow" do
-      expect { described_class.new(pundit_user:, products_page: 10).products_table_props }.to raise_error(Pagy::OverflowError)
+    it "returns last page on page overflow" do
+      props = described_class.new(pundit_user:, products_page: 10).products_table_props
+      expect(props[:products_pagination]).to eq(page: 3, pages: 3)
     end
 
     context "when some products are deleted" do
@@ -280,8 +281,9 @@ describe DashboardProductsPagePresenter do
       expect((page1_ids + page2_ids) - memberships.map(&:id)).to be_empty
     end
 
-    it "raises on page overflow" do
-      expect { described_class.new(pundit_user:, memberships_page: 10).memberships_table_props }.to raise_error(Pagy::OverflowError)
+    it "returns last page on page overflow" do
+      props = described_class.new(pundit_user:, memberships_page: 10).memberships_table_props
+      expect(props[:memberships_pagination]).to eq(page: 3, pages: 3)
     end
 
     context "when some memberships are deleted" do


### PR DESCRIPTION
## What

When a user requests a page number that exceeds the total number of pages on the products dashboard (e.g., `?products_page=4` when there's only 1 page), Pagy raises a `Pagy::OverflowError` instead of handling it gracefully. This change sets `overflow: :last_page` on the `pagy` call in `sort_and_paginate_products`, so out-of-range page numbers return the last valid page instead of a 500 error.

## Why

This was causing 41 occurrences in Sentry ([issue 7373313980](https://gumroad-to.sentry.io/issues/7373313980/)). Users can reach invalid page numbers via stale bookmarks, browser history, or manual URL editing. Other presenters in the codebase already use `overflow: :last_page` (e.g., `PaginatedUtmLinksPresenter`).

## Test results

```
2 examples, 0 failures
```

Both overflow tests updated from expecting `Pagy::OverflowError` to verifying the last page is returned.

---

AI disclosure: Claude Opus 4.6 was used to implement this fix based on the Sentry error report and instructions to fix the `Pagy::OverflowError` in `LinksController#index`.