### PR TITLE
Fix Rack::Timeout in AssetPreviewsController#create by moving file analysis to background

### DIFF
--- a/app/controllers/asset_previews_controller.rb
+++ b/app/controllers/asset_previews_controller.rb
@@ -15,9 +15,8 @@ class AssetPreviewsController < ApplicationController
       asset_preview.url = permitted_params[:url]
     end
 
-    asset_preview.analyze_file
-
     if asset_preview.save
+      AnalyzeFileWorker.perform_async(asset_preview.id, AssetPreview.name)
       render(json: { success: true, asset_previews: @product.display_asset_previews, active_preview_id: asset_preview.guid })
     else
       asset_preview.file&.blob&.purge

--- a/app/models/asset_preview.rb
+++ b/app/models/asset_preview.rb
@@ -193,7 +193,6 @@ class AssetPreview < ApplicationRecord
                                                     filename: File.basename(new_url),
                                                     content_type: response.content_type)
       self.file.attach(blob.signed_id)
-      self.file.analyze
     end
   end
 
@@ -202,6 +201,8 @@ class AssetPreview < ApplicationRecord
       file.analyze
     end
   end
+
+  alias_method :analyze, :analyze_file
 
   private
     def set_position

--- a/spec/controllers/asset_previews_controller_spec.rb
+++ b/spec/controllers/asset_previews_controller_spec.rb
@@ -26,16 +26,21 @@ describe AssetPreviewsController do
     end
 
     it "adds a preview if one already exists" do
-      allow_any_instance_of(AssetPreview).to receive(:analyze_file).and_return(nil)
       product = create(:product, user: seller, preview: fixture_file_upload("kFDzu.png", "image/png"))
       expect do
         post(:create, params: { link_id: product.unique_permalink, asset_preview: { url: s3_url }, format: :json })
       end.to change { product.asset_previews.alive.count }.by(1)
     end
 
+    it "enqueues a background job to analyze the file" do
+      post(:create, params: { link_id: product.unique_permalink, asset_preview: { url: s3_url }, format: :json })
+      asset_preview = product.asset_previews.last
+      expect(AnalyzeFileWorker.jobs.size).to eq(1)
+      expect(AnalyzeFileWorker.jobs.last["args"]).to eq([asset_preview.id, "AssetPreview"])
+    end
+
     it "doesn't add a preview if there are too many previews" do
       stub_const("Link::MAX_PREVIEW_COUNT", 1)
-      allow_any_instance_of(AssetPreview).to receive(:analyze_file).and_return(nil)
       allow_any_instance_of(ActiveStorage::Blob).to receive(:purge).and_return(nil)
       create(:asset_preview, link: product)
       expect do


### PR DESCRIPTION
## What

- Remove synchronous `asset_preview.analyze_file` call from `AssetPreviewsController#create`
- Enqueue `AnalyzeFileWorker` after save to analyze the file in the background
- Remove synchronous `self.file.analyze` from the `AssetPreview#url=` setter
- Add `analyze` alias on `AssetPreview` for `AnalyzeFileWorker` compatibility

## Why

The `create` action called `file.analyze` synchronously during the HTTP request. For large uploads (especially videos), this downloads the blob and extracts metadata (width, height, duration), which easily exceeds the 120s Rack::Timeout threshold (Sentry GUMROAD-61).

The existing `height_and_width_presence` and `duration_presence_for_video` validations already gate on `file.analyzed?`, so they naturally skip for unanalyzed files and will enforce correctly when the background job completes.

## Test Results

- Removed stale `allow_any_instance_of(AssetPreview).to receive(:analyze_file)` stubs from controller tests (no longer needed since analysis is async)
- Added test verifying `AnalyzeFileWorker` is enqueued with correct args after create
- Existing model tests for `#analyze_file` and validations remain unchanged

---

AI disclosure: This change was developed with Claude Opus 4.6. Prompt: fix Rack::Timeout in AssetPreviewsController#create by moving file analysis to background job.