### PR TITLE
Fix Net::ReadTimeout crashing validation services

### DIFF
--- a/app/services/abn_validation_service.rb
+++ b/app/services/abn_validation_service.rb
@@ -27,5 +27,7 @@ class AbnValidationService
     return false if response["valid"].nil?
 
     response["valid"] && response["active"]
+  rescue Net::ReadTimeout, Net::OpenTimeout, Errno::ECONNREFUSED, SocketError
+    false
   end
 end

--- a/app/services/gst_validation_service.rb
+++ b/app/services/gst_validation_service.rb
@@ -25,6 +25,8 @@ class GstValidationService
       response = HTTParty.post(IRAS_ENDPOINT, body:, timeout: 5, headers:)
 
       response["returnCode"] == "10" && response["data"]["Status"] == "Registered"
+    rescue Net::ReadTimeout, Net::OpenTimeout, Errno::ECONNREFUSED, SocketError
+      false
     end
   end
 end

--- a/app/services/mva_validation_service.rb
+++ b/app/services/mva_validation_service.rb
@@ -27,5 +27,7 @@ class MvaValidationService
     return false if response["valid"].nil?
 
     response["valid"] && response["active"]
+  rescue Net::ReadTimeout, Net::OpenTimeout, Errno::ECONNREFUSED, SocketError
+    false
   end
 end

--- a/app/services/qst_validation_service.rb
+++ b/app/services/qst_validation_service.rb
@@ -23,5 +23,7 @@ class QstValidationService
     def valid_qst?
       response = HTTParty.get(QST_VALIDATION_ENDPOINT_TEMPLATE.expand(qst_id:).to_s, timeout: 5)
       response.code == 200 && response.parsed_response.dig("Resultat", "StatutSousDossierUsager") == "R"
+    rescue Net::ReadTimeout, Net::OpenTimeout, Errno::ECONNREFUSED, SocketError
+      false
     end
 end

--- a/spec/services/abn_validation_service_spec.rb
+++ b/spec/services/abn_validation_service_spec.rb
@@ -48,6 +48,22 @@ describe AbnValidationService do
     expect(described_class.new("   ").process).to be(false)
   end
 
+  it "returns false when the Vatstack API times out" do
+    abn_id = "51824753556"
+
+    expect(HTTParty).to receive(:post).and_raise(Net::ReadTimeout)
+
+    expect(described_class.new(abn_id).process).to be(false)
+  end
+
+  it "returns false when the Vatstack API connection is refused" do
+    abn_id = "51824753556"
+
+    expect(HTTParty).to receive(:post).and_raise(Errno::ECONNREFUSED)
+
+    expect(described_class.new(abn_id).process).to be(false)
+  end
+
   it "returns false when abn with invalid format is provided" do
     abn_id = "some-invalid-id"
     query_response = "SOMEINVALIDID"

--- a/spec/services/gst_validation_service_spec.rb
+++ b/spec/services/gst_validation_service_spec.rb
@@ -64,6 +64,22 @@ describe GstValidationService do
     expect(described_class.new(gst_id).process).to be(false)
   end
 
+  it "returns false when the IRAS API times out" do
+    gst_id = "T9100001B"
+
+    expect(HTTParty).to receive(:post).and_raise(Net::ReadTimeout)
+
+    expect(described_class.new(gst_id).process).to be(false)
+  end
+
+  it "returns false when the IRAS API connection is refused" do
+    gst_id = "T9100001B"
+
+    expect(HTTParty).to receive(:post).and_raise(Errno::ECONNREFUSED)
+
+    expect(described_class.new(gst_id).process).to be(false)
+  end
+
   it "returns false when a gst id is provided with an invalid format" do
     gst_id = "asdf"
 

--- a/spec/services/mvn_validation_service_spec.rb
+++ b/spec/services/mvn_validation_service_spec.rb
@@ -47,6 +47,22 @@ describe MvaValidationService do
     expect(described_class.new("   ").process).to be(false)
   end
 
+  it "returns false when the Vatstack API times out" do
+    mva_id = "977074010MVA"
+
+    expect(HTTParty).to receive(:post).and_raise(Net::ReadTimeout)
+
+    expect(described_class.new(mva_id).process).to be(false)
+  end
+
+  it "returns false when the Vatstack API connection is refused" do
+    mva_id = "977074010MVA"
+
+    expect(HTTParty).to receive(:post).and_raise(Errno::ECONNREFUSED)
+
+    expect(described_class.new(mva_id).process).to be(false)
+  end
+
   it "returns false when mva with invalid format is provided" do
     mva_id = "some-invalid-id"
     query_response = "SOMEINVALIDID"

--- a/spec/services/qst_validation_service_spec.rb
+++ b/spec/services/qst_validation_service_spec.rb
@@ -44,6 +44,18 @@ describe QstValidationService, :vcr do
     expect(described_class.new(qst_id).process).to be(false)
   end
 
+  it "returns false when the Revenu Quebec API times out" do
+    expect(HTTParty).to receive(:get).and_raise(Net::ReadTimeout)
+
+    expect(described_class.new(qst_id).process).to be(false)
+  end
+
+  it "returns false when the Revenu Quebec API connection is refused" do
+    expect(HTTParty).to receive(:get).and_raise(Errno::ECONNREFUSED)
+
+    expect(described_class.new(qst_id).process).to be(false)
+  end
+
   it "handles QST IDs that need encoding" do
     expect(described_class.new("needs encoding").process).to be(false)
   end


### PR DESCRIPTION
## What

Adds rescue blocks for network errors (`Net::ReadTimeout`, `Net::OpenTimeout`, `Errno::ECONNREFUSED`, `SocketError`) in four tax ID validation services that make HTTP calls to external APIs:

- `GstValidationService` (IRAS API)
- `AbnValidationService` (Vatstack API)
- `MvaValidationService` (Vatstack API)
- `QstValidationService` (Revenu Quebec API)

When a network error occurs, the service now returns `false` instead of letting the exception bubble up.

## Why

`Net::ReadTimeout` exceptions from `GstValidationService` are crashing `CustomerSurchargeController#calculate_all` with 500 errors when the IRAS API is slow or down ([Sentry](https://gumroad-to.sentry.io/issues/7373418552/)). The same vulnerability exists in the other three services. Returning `false` on network failure degrades gracefully — the buyer is not blocked by a temporary API outage.

The existing `VatValidationService` already uses `rescue nil` for similar external calls, so this aligns with the established pattern.

## Test Results

All 35 tests pass:
```
35 examples, 0 failures
```

---

Generated with Claude Opus 4.6. Prompt: fix Net::ReadTimeout in GstValidationService and similar validation services that make HTTP calls without rescuing network errors.