### PR TITLE
Fix Elasticsearch result window overflow in CustomersController#paged

### DIFF
--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -8,6 +8,8 @@ class CustomersController < Sellers::BaseController
   before_action :set_on_page_type
 
   CUSTOMERS_PER_PAGE = 20
+  MAX_ES_RESULT_WINDOW = 10_000
+  MAX_PAGE = (MAX_ES_RESULT_WINDOW / CUSTOMERS_PER_PAGE) - 1
 
   layout "inertia", only: [:index]
 
@@ -28,7 +30,7 @@ class CustomersController < Sellers::BaseController
   end
 
   def paged
-    params[:page] = params[:page].to_i - 1
+    params[:page] = [params[:page].to_i - 1, MAX_PAGE].min
     sales = fetch_sales(
       query: params[:query],
       sort: params[:sort] ? { params[:sort][:key] => { order: params[:sort][:direction] } } : nil,

--- a/spec/controllers/customers_controller_spec.rb
+++ b/spec/controllers/customers_controller_spec.rb
@@ -103,6 +103,12 @@ describe CustomersController, :vcr, type: :controller, inertia: true do
       expect(response).to be_successful
       expect(customer_ids[response]).to match_array([purchases.third.external_id, purchases.fourth.external_id])
     end
+
+    it "caps the page parameter to avoid Elasticsearch result window overflow" do
+      get :paged, params: { page: 100_000 }
+      expect(response).to be_successful
+      expect(response.parsed_body.deep_symbolize_keys[:pagination][:page]).to be <= (CustomersController::MAX_PAGE + 1)
+    end
   end
 
   describe "GET charges" do


### PR DESCRIPTION
## What

Caps the page parameter in `CustomersController#paged` to prevent the Elasticsearch `from + size` value from exceeding the default `max_result_window` of 10,000.

- Added `MAX_ES_RESULT_WINDOW` (10,000) and `MAX_PAGE` (499, 0-indexed) constants
- Clamped the page parameter in `paged` using `[page, MAX_PAGE].min`
- Added test verifying high page numbers return a successful response

## Why

Sellers with large customer lists could trigger a 400 error by navigating to extremely high page numbers (e.g., page 6127), causing `from + size` to reach values like 122,540 — well beyond the 10,000 limit. This was surfacing as unhandled Elasticsearch `BadRequest` errors in Sentry.

## Test Results

Added a spec that requests page 100,000 and asserts the response succeeds with a capped page value.

---

AI disclosure: Built with Claude Opus 4.6. Prompted with the Sentry error details and root cause analysis pointing to the uncapped page parameter in `fetch_sales`.