### PR TITLE
Fix NoMethodError: undefined method 'prices' for nil in Link#cart_item

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1042,7 +1042,7 @@ class Link < ApplicationRecord
     attrs[:options] = options
     attrs[:option] = attrs[:options].find { |o| o[:id] == params[:option] } || (native_type != NATIVE_TYPE_COFFEE ? attrs[:options].find { |o| o[:quantity_left] != 0 } : nil)
     variant = attrs[:option] ? Variant.find_by_external_id(attrs[:option][:id]) : nil
-    prices = (is_tiered_membership ? variant : self).prices.is_buy.alive
+    prices = (is_tiered_membership && variant ? variant : self).prices.is_buy.alive
     recurrence = is_recurring_billing ? prices.find { |price| price.recurrence == params[:recurrence] } || prices.find { |price| price.recurrence == default_price_recurrence.recurrence } : nil
     attrs[:recurrence] = recurrence&.recurrence
     attrs[:pay_in_installments] = !!params[:pay_in_installments] && allow_installment_plan?

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -4800,4 +4800,22 @@ describe Link, :vcr do
       end
     end
   end
+
+  describe "#cart_item" do
+    context "when product is a tiered membership and the variant record is missing" do
+      let(:product) { create(:membership_product) }
+
+      before do
+        product.tier_category.variants.each { |v| v.update!(deleted_at: Time.current) }
+      end
+
+      it "falls back to the product prices instead of raising NoMethodError" do
+        result = product.cart_item({})
+
+        expect(result).to be_a(Hash)
+        expect(result).to have_key(:option)
+        expect(result).to have_key(:price)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What

Fixed a `NoMethodError` in `Link#cart_item` where calling `.prices` on a nil variant crashes the checkout form for tiered membership products.

**Change:** `app/models/link.rb` line 1045 — added a nil check on `variant` in the ternary so it falls back to `self` (the product) when the variant record is missing:

```ruby
# Before
prices = (is_tiered_membership ? variant : self).prices.is_buy.alive

# After
prices = (is_tiered_membership && variant ? variant : self).prices.is_buy.alive
```

## Why

When a tiered membership product has deleted or missing variant records, `Variant.find_by_external_id` returns nil. The original ternary `(is_tiered_membership ? variant : self)` then calls `.prices` on nil, raising `NoMethodError`. This is triggered from `Checkout::FormPresenter#form_props` when loading the checkout form.

Falling back to the product's own prices when the variant is nil is the correct behavior — it matches what already happens for non-tiered products.

Sentry: https://gumroad-to.sentry.io/issues/7373668665/

## Test results

Added a test in `spec/models/link_spec.rb` that creates a tiered membership, deletes its variant records, and verifies `cart_item({})` returns a valid hash instead of raising. The test fails when the fix is reverted.

```
1 example, 0 failures
```

---

Generated with Claude Opus 4.6. Prompt: fix the NoMethodError in Link#cart_item when variant is nil for tiered memberships.