### PR TITLE
Fix ActiveRecord::RecordInvalid when archiving products with missing call durations or variant options

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1317,6 +1317,7 @@ class Link < ApplicationRecord
 
     def alive_category_variants_presence
       return if deleted_at.present?
+      return if archived?
 
       has_alive_categories_without_variants = variant_categories.alive.left_joins(:alive_variants).where(base_variants: { id: nil }).exists?
 
@@ -1326,6 +1327,8 @@ class Link < ApplicationRecord
     end
 
     def valid_tier_version_structure
+      return if archived?
+
       if variant_categories.alive.size != 1
         errors.add(:base, "Memberships should only have one Tier version category.")
         raise LinkInvalid, "Memberships should only have one Tier version category."

--- a/app/modules/product/validations.rb
+++ b/app/modules/product/validations.rb
@@ -82,6 +82,7 @@ module Product::Validations
     def calls_must_have_at_least_one_duration
       return unless native_type == Link::NATIVE_TYPE_CALL
       return if deleted_at.present?
+      return if archived?
       return if variant_categories.alive.first&.alive_variants&.exists?
 
       errors.add(:base, "Calls must have at least one duration")

--- a/spec/controllers/products/archived_controller_spec.rb
+++ b/spec/controllers/products/archived_controller_spec.rb
@@ -84,6 +84,39 @@ describe Products::ArchivedController, inertia: true do
       expect(membership.purchase_disabled_at).to be_present
     end
 
+    context "when archiving a call product without durations" do
+      let(:call_product) do
+        seller.update_column(:created_at, User::MIN_AGE_FOR_SERVICE_PRODUCTS.ago - 1.day)
+        create(:call_product, user: seller)
+      end
+
+      before do
+        call_product.variant_categories.first.variants.destroy_all
+      end
+
+      it "archives successfully" do
+        post :create, params: { id: call_product.unique_permalink }, as: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(call_product.reload.archived?).to be(true)
+      end
+    end
+
+    context "when archiving a product with empty variant categories" do
+      let(:product_with_versions) { create(:product, user: seller) }
+
+      before do
+        create(:variant_category, link: product_with_versions)
+      end
+
+      it "archives successfully" do
+        post :create, params: { id: product_with_versions.unique_permalink }, as: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(product_with_versions.reload.archived?).to be(true)
+      end
+    end
+
     it "does not change purchase_disabled_at on an already unpublished product" do
       original_disabled_at = 1.week.ago.floor
       membership.update!(purchase_disabled_at: original_disabled_at)


### PR DESCRIPTION
## What

Adds `return if archived?` guard to three product validations that block archiving:
- `calls_must_have_at_least_one_duration` (in `app/modules/product/validations.rb`)
- `alive_category_variants_presence` (in `app/models/link.rb`)
- `valid_tier_version_structure` (in `app/models/link.rb`)

## Why

When archiving a product via `Products::ArchivedController#create`, the `update!` call triggers on-update validations. These validations already skip for soft-deleted products (`return if deleted_at.present?`) but did not skip for archived products. This caused `ActiveRecord::RecordInvalid` errors in Sentry for call products without durations and products with empty variant categories.

The fix matches the existing `deleted_at` guard pattern since archived products should not be held to active-product constraints.

Sentry: https://gumroad-to.sentry.io/issues/7373788228/

## Test results

Added two test cases to `spec/controllers/products/archived_controller_spec.rb`:
- Archiving a call product without durations succeeds
- Archiving a product with empty variant categories succeeds

All 11 tests in the file pass.

---

AI disclosure: Claude Opus 4.6 was used to implement the fix and write tests based on a prompt describing the Sentry issue, root cause analysis, and fix strategy.