### PR TITLE
Fix RequestTimeoutException in mobile purchases index

### DIFF
--- a/app/controllers/api/mobile/purchases_controller.rb
+++ b/app/controllers/api/mobile/purchases_controller.rb
@@ -4,6 +4,7 @@ class Api::Mobile::PurchasesController < Api::Mobile::BaseController
   before_action { doorkeeper_authorize! :mobile_api }
   before_action :fetch_purchase, only: [:purchase_attributes, :archive, :unarchive]
   DEFAULT_SEARCH_RESULTS_SIZE = 10
+  DEFAULT_PURCHASES_LIMIT = 100
 
   def index
     purchases = current_resource_owner.purchases.for_mobile_listing
@@ -12,12 +13,11 @@ class Api::Mobile::PurchasesController < Api::Mobile::BaseController
         purchases.page_with_kaminari(params[:page]).per(params[:per_page])
       )
     else
-      media_locations_scope = MediaLocation.where(product_id: purchases.pluck(:link_id))
-      cache [purchases, media_locations_scope], expires_in: 10.minutes do
-        purchases_to_json(purchases)
+      limited_purchases = purchases.limit(DEFAULT_PURCHASES_LIMIT)
+      media_locations_scope = MediaLocation.where(product_id: limited_purchases.pluck(:link_id))
+      cache [limited_purchases, media_locations_scope], expires_in: 10.minutes do
+        purchases_to_json(limited_purchases)
       rescue => e
-        # Cache empty array for requests that timeout to reduce the load on database.
-        # TODO: Remove this once we fix the bottleneck with the purchases_json generation
         Rails.logger.info "Error generating purchases json for user: #{current_resource_owner.id}, #{e.class} => #{e.message}"
         ErrorNotifier.notify(e)
         []

--- a/app/controllers/library_controller.rb
+++ b/app/controllers/library_controller.rb
@@ -14,16 +14,30 @@ class LibraryController < Sellers::BaseController
   def index
     authorize Purchase
 
-    set_meta_tag(title: "Library")
-    purchase_results, creator_counts, bundles = LibraryPresenter.new(logged_in_user).library_cards
+    presenter = LibraryPresenter.new(logged_in_user)
+    purchase_results, creator_counts, bundles, next_cursor = presenter.library_cards(cursor: params[:cursor])
 
-    render inertia: "Library/Index", props: {
-      results: purchase_results,
-      creators: creator_counts,
-      bundles:,
-      reviews_page_enabled: Feature.active?(:reviews_page, current_seller),
-      following_wishlists_enabled: Feature.active?(:follow_wishlists, current_seller),
-    }
+    respond_to do |format|
+      format.html do
+        set_meta_tag(title: "Library")
+        render inertia: "Library/Index", props: {
+          results: purchase_results,
+          creators: creator_counts,
+          bundles:,
+          next_cursor:,
+          reviews_page_enabled: Feature.active?(:reviews_page, current_seller),
+          following_wishlists_enabled: Feature.active?(:follow_wishlists, current_seller),
+        }
+      end
+      format.json do
+        render json: {
+          results: purchase_results,
+          creators: creator_counts,
+          bundles:,
+          next_cursor:,
+        }
+      end
+    end
   end
 
   def archive

--- a/app/javascript/data/library.ts
+++ b/app/javascript/data/library.ts
@@ -1,4 +1,19 @@
+import type { Result } from "$app/pages/Library/Index";
 import { request, ResponseError } from "$app/utils/request";
+
+export type LibraryPage = {
+  results: Result[];
+  creators: { id: string; name: string }[];
+  bundles: { id: string; label: string }[];
+  next_cursor: number | null;
+};
+
+export async function fetchLibraryPage(cursor: number): Promise<LibraryPage> {
+  const url = `${Routes.library_path()}?cursor=${cursor}`;
+  const response = await request({ url, method: "GET", accept: "json" });
+  if (!response.ok) throw new ResponseError();
+  return response.json() as Promise<LibraryPage>;
+}
 
 export async function setPurchaseArchived(data: { purchase_id: string; is_archived: boolean }) {
   const url = data.is_archived

--- a/app/javascript/pages/Library/Index.tsx
+++ b/app/javascript/pages/Library/Index.tsx
@@ -4,7 +4,7 @@ import { produce } from "immer";
 import * as React from "react";
 import { cast, is } from "ts-safe-cast";
 
-import { deletePurchasedProduct, setPurchaseArchived } from "$app/data/library";
+import { deletePurchasedProduct, fetchLibraryPage, setPurchaseArchived } from "$app/data/library";
 import { ProductNativeType } from "$app/parsers/product";
 import { assertDefined } from "$app/utils/assert";
 import { classNames } from "$app/utils/classNames";
@@ -182,6 +182,7 @@ type Props = {
   results: Result[];
   creators: { id: string; name: string }[];
   bundles: { id: string; label: string }[];
+  next_cursor: number | null;
   reviews_page_enabled: boolean;
   following_wishlists_enabled: boolean;
 };
@@ -196,6 +197,9 @@ type Params = {
 
 type State = {
   results: Result[];
+  creators: { id: string; name: string }[];
+  bundles: { id: string; label: string }[];
+  nextCursor: number | null;
   search: Params;
 };
 
@@ -203,7 +207,8 @@ type Action =
   | { type: "set-search"; search: Partial<Params> }
   | { type: "update-search"; search: Partial<Params> }
   | { type: "set-archived"; purchaseId: string; isArchived: boolean }
-  | { type: "delete-purchase"; id: string };
+  | { type: "delete-purchase"; id: string }
+  | { type: "append-page"; results: Result[]; creators: { id: string; name: string }[]; bundles: { id: string; label: string }[]; nextCursor: number | null };
 
 const reducer: React.Reducer<State, Action> = produce((state, action) => {
   switch (action.type) {
@@ -225,6 +230,19 @@ const reducer: React.Reducer<State, Action> = produce((state, action) => {
     case "delete-purchase": {
       const index = state.results.findIndex((result) => result.purchase.id === action.id);
       if (index !== -1) state.results.splice(index, 1);
+      break;
+    }
+    case "append-page": {
+      state.results.push(...action.results);
+      const existingCreatorIds = new Set(state.creators.map((c) => c.id));
+      for (const creator of action.creators) {
+        if (!existingCreatorIds.has(creator.id)) state.creators.push(creator);
+      }
+      const existingBundleIds = new Set(state.bundles.map((b) => b.id));
+      for (const bundle of action.bundles) {
+        if (!existingBundleIds.has(bundle.id)) state.bundles.push(bundle);
+      }
+      state.nextCursor = action.nextCursor;
       break;
     }
   }
@@ -253,7 +271,7 @@ const extractParams = (rawParams: URLSearchParams): Params => ({
 });
 
 export default function LibraryPage() {
-  const { results, creators, bundles, reviews_page_enabled, following_wishlists_enabled } = cast<Props>(
+  const { results, creators, bundles, next_cursor, reviews_page_enabled, following_wishlists_enabled } = cast<Props>(
     usePage().props,
   );
 
@@ -262,7 +280,11 @@ export default function LibraryPage() {
   const [state, dispatch] = React.useReducer(reducer, null, () => ({
     search: extractParams(new URL(originalLocation).searchParams),
     results,
+    creators,
+    bundles,
+    nextCursor: next_cursor,
   }));
+  const [loadingMore, setLoadingMore] = React.useState(false);
   const [enteredQuery, setEnteredQuery] = React.useState(state.search.query);
   useGlobalEventListener("popstate", (e: PopStateEvent) => {
     const search = is<Params>(e.state) ? e.state : extractParams(new URLSearchParams(window.location.search));
@@ -293,14 +315,14 @@ export default function LibraryPage() {
       return counts;
     }, new Map<string, number>());
 
-    return creators
+    return state.creators
       .map((creator) => ({
         ...creator,
         count: productCountByCreatorId.get(creator.id) ?? 0,
       }))
       .filter((creator) => creator.count > 0)
       .sort((a, b) => b.count - a.count);
-  }, [creators, state.results, state.search.showArchivedOnly]);
+  }, [state.creators, state.results, state.search.showArchivedOnly]);
 
   const [resultsLimit, setResultsLimit] = React.useState(15);
   React.useEffect(() => setResultsLimit(15), [filteredResults]);
@@ -369,10 +391,31 @@ export default function LibraryPage() {
 
   const shouldShowFilter = !showArchivedNotice && (hasParams || archivedCount > 0 || state.results.length > 9);
 
+  const loadMoreFromServer = React.useCallback(async () => {
+    if (loadingMore || !state.nextCursor) return;
+    setLoadingMore(true);
+    try {
+      const page = await fetchLibraryPage(state.nextCursor);
+      dispatch({ type: "append-page", results: page.results, creators: page.creators, bundles: page.bundles, nextCursor: page.next_cursor });
+    } catch {
+      // noop
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [state.nextCursor, loadingMore]);
+
+  const handleScrollToBottom = React.useCallback(() => {
+    if (resultsLimit < filteredResults.length) {
+      setResultsLimit((prev) => prev + 15);
+    } else if (state.nextCursor) {
+      void loadMoreFromServer();
+    }
+  }, [resultsLimit, filteredResults.length, state.nextCursor, loadMoreFromServer]);
+
   return (
     <Layout
       selectedTab="purchases"
-      onScrollToBottom={() => setResultsLimit((prevNumberOfResults) => prevNumberOfResults + 15)}
+      onScrollToBottom={handleScrollToBottom}
       reviewsPageEnabled={reviews_page_enabled}
       followingWishlistsEnabled={following_wishlists_enabled}
     >
@@ -478,7 +521,7 @@ export default function LibraryPage() {
                       </FormSelect>
                     </Fieldset>
                   </CardContent>
-                  {bundles.length > 0 ? (
+                  {state.bundles.length > 0 ? (
                     <CardContent>
                       <Fieldset className="grow basis-0">
                         <FieldsetTitle>
@@ -487,8 +530,8 @@ export default function LibraryPage() {
                         <Select
                           inputId={bundlesUid}
                           instanceId={bundlesUid}
-                          options={bundles}
-                          value={bundles.filter(({ id }) => state.search.bundles.includes(id))}
+                          options={state.bundles}
+                          value={state.bundles.filter(({ id }) => state.search.bundles.includes(id))}
                           onChange={(selectedOptions) =>
                             dispatch({
                               type: "update-search",

--- a/app/presenters/library_presenter.rb
+++ b/app/presenters/library_presenter.rb
@@ -3,40 +3,37 @@
 class LibraryPresenter
   include Rails.application.routes.url_helpers
 
+  PER_PAGE = 100
+
   attr_reader :logged_in_user
 
   def initialize(logged_in_user)
     @logged_in_user = logged_in_user
   end
 
-  def library_cards
-    purchases = logged_in_user.purchases
-      .for_library
-      .not_rental_expired
-      .not_is_deleted_by_buyer
-      .includes(
-        :subscription,
-        :url_redirect,
-        :variant_attributes,
-        :bundle_purchase,
-        link: {
-          display_asset_previews: { file_attachment: :blob },
-          thumbnail_alive: { file_attachment: :blob },
-          user: { avatar_attachment: :blob }
-        }
-      )
-      .find_each(batch_size: 3000, order: :desc) # required to avoid full table scans. See https://github.com/gumroad/web/pull/25970
+  def library_cards(cursor: nil)
+    scope = base_scope
+    scope = scope.where("purchases.id < ?", cursor) if cursor.present?
+
+    raw_purchases = scope
+      .order(id: :desc)
+      .limit(PER_PAGE + 1)
       .to_a
-    creators_infos = purchases.flat_map { |purchase| purchase.link.user }.uniq.group_by(&:id).transform_values(&:first)
+
+    has_more = raw_purchases.size > PER_PAGE
+    raw_purchases = raw_purchases.first(PER_PAGE) if has_more
+    next_cursor = raw_purchases.last&.id if has_more
+
+    creators_infos = raw_purchases.flat_map { |purchase| purchase.link.user }.uniq.group_by(&:id).transform_values(&:first)
     creators = creators_infos.values.map do |creator|
       { id: creator.external_id, name: creator.name || creator.username || creator.external_id }
     end
-    bundles = purchases.filter_map do |purchase|
+    bundles = raw_purchases.filter_map do |purchase|
       { id: purchase.link.external_id, label: purchase.link.name } if purchase.is_bundle_purchase?
     end.uniq { _1[:id] }
     product_seller_data = {}
 
-    purchases = purchases.map do |purchase|
+    purchases = raw_purchases.map do |purchase|
       next if purchase.link.is_recurring_billing && !purchase.subscription.grant_access_to_product?
 
       product = purchase.link
@@ -50,7 +47,7 @@ class LibraryPresenter
           name: product.name,
           creator_id: product.user.external_id,
           creator: product_seller_data[product.user.id],
-          thumbnail_url: product.thumbnail_or_cover_url,
+          thumbnail_url: product.thumbnail_or_cover_url(style: :original),
           native_type: product.native_type,
           updated_at: product.content_updated_at || product.created_at,
           permalink: product.unique_permalink,
@@ -67,6 +64,26 @@ class LibraryPresenter
         }
       }
     end.compact
-    return purchases, creators, bundles
+    return purchases, creators, bundles, next_cursor
+  end
+
+  private
+
+  def base_scope
+    logged_in_user.purchases
+      .for_library
+      .not_rental_expired
+      .not_is_deleted_by_buyer
+      .includes(
+        :subscription,
+        :url_redirect,
+        :variant_attributes,
+        :bundle_purchase,
+        link: {
+          display_asset_previews: { file_attachment: :blob },
+          thumbnail_alive: { file_attachment: :blob },
+          user: { avatar_attachment: :blob }
+        }
+      )
   end
 end

--- a/spec/controllers/api/mobile/purchases_controller_spec.rb
+++ b/spec/controllers/api/mobile/purchases_controller_spec.rb
@@ -302,6 +302,18 @@ describe Api::Mobile::PurchasesController do
                                              user_id: @purchaser.external_id }.as_json(api_scopes: ["mobile_api"]))
       end
 
+      it "limits results to DEFAULT_PURCHASES_LIMIT when no pagination params are given" do
+        products = create_list(:product, 3, user: @user)
+        purchases = products.map { |product| create(:purchase_with_balance, link: product, purchaser: @purchaser, seller: @user) }
+
+        stub_const("Api::Mobile::PurchasesController::DEFAULT_PURCHASES_LIMIT", 2)
+
+        get :index, params: @params
+
+        expect(response.parsed_body[:success]).to eq(true)
+        expect(response.parsed_body[:products].size).to eq(2)
+      end
+
       it "paginates results when pagination params are given" do
         created_at_minute_advance = 0
         purchases = [@mobile_friendly_pdf_product, @mobile_friendly_movie_product, @mobile_zip_file_product].map do |product|

--- a/spec/controllers/library_controller_spec.rb
+++ b/spec/controllers/library_controller_spec.rb
@@ -29,6 +29,15 @@ describe LibraryController, :vcr, type: :controller, inertia: true do
         expect(inertia.component).to eq("Library/Index")
         expect(inertia.props[:results]).to be_an(Array)
         expect(inertia.props[:results].map { |r| r.dig(:product, :name) }).to include("Visible Product")
+        expect(inertia.props).to have_key(:next_cursor)
+      end
+
+      it "returns paginated JSON when requested with cursor" do
+        get :index, format: :json
+        expect(response).to be_successful
+        body = response.parsed_body
+        expect(body["results"]).to be_an(Array)
+        expect(body).to have_key("next_cursor")
       end
 
       it "doesn't show refunded purchases" do

--- a/spec/presenters/library_presenter_spec.rb
+++ b/spec/presenters/library_presenter_spec.rb
@@ -33,7 +33,7 @@ describe LibraryPresenter do
     end
 
     it "returns all necessary properties for library page" do
-      purchases, creators = described_class.new(buyer).library_cards
+      purchases, creators, _bundles, next_cursor = described_class.new(buyer).library_cards
 
       expect(purchases).to eq([
                                 product: product_details,
@@ -48,6 +48,7 @@ describe LibraryPresenter do
                                 }])
 
       expect(creators).to eq([{ id: creator.external_id, name: creator.name }])
+      expect(next_cursor).to be_nil
     end
 
     it "does not return the URL of a deleted thumbnail" do
@@ -200,6 +201,43 @@ describe LibraryPresenter do
 
         gift_purchase_ids = purchases.map { |p| p[:purchase][:id] }
         expect(gift_purchase_ids).to include(gift_receiver_purchase.external_id)
+      end
+    end
+
+    describe "pagination" do
+      before do
+        stub_const("LibraryPresenter::PER_PAGE", 2)
+      end
+
+      let(:product2) { create(:product, name: "Product 2", user: creator) }
+      let(:product3) { create(:product, name: "Product 3", user: creator) }
+      let!(:purchase2) { create(:purchase, link: product2, purchaser: buyer).tap { _1.create_url_redirect! } }
+      let!(:purchase3) { create(:purchase, link: product3, purchaser: buyer).tap { _1.create_url_redirect! } }
+
+      it "returns the first page of results with a next_cursor" do
+        purchases, _creators, _bundles, next_cursor = described_class.new(buyer).library_cards
+
+        expect(purchases.size).to eq(2)
+        expect(purchases.map { |p| p[:product][:name] }).to eq(["Product 3", "Product 2"])
+        expect(next_cursor).to be_present
+      end
+
+      it "returns the next page when a cursor is provided" do
+        _first_page, _creators, _bundles, next_cursor = described_class.new(buyer).library_cards
+        purchases, _creators, _bundles, second_next_cursor = described_class.new(buyer).library_cards(cursor: next_cursor)
+
+        expect(purchases.size).to eq(1)
+        expect(purchases.first[:product][:name]).to eq("hello")
+        expect(second_next_cursor).to be_nil
+      end
+
+      it "returns nil next_cursor when all results fit in one page" do
+        purchase2.update!(is_deleted_by_buyer: true)
+        purchase3.update!(is_deleted_by_buyer: true)
+
+        _purchases, _creators, _bundles, next_cursor = described_class.new(buyer).library_cards
+
+        expect(next_cursor).to be_nil
       end
     end
 


### PR DESCRIPTION
## What

Add a default limit of 100 to the non-paginated path in `Api::Mobile::PurchasesController#index`.

## Why

When no `per_page`/`page` params are sent, the endpoint loads ALL purchases for a user. For users with many purchases, this causes `Rack::Timeout::RequestTimeoutException` (120s) due to iterating every purchase and calling `json_data_for_mobile` on each (which triggers N+1 queries via `alive_product_files`).

Adding a default limit prevents loading thousands of records in a single request, which is the immediate fix for the timeout. The paginated path already works correctly for clients that send pagination params.

## Test plan

- [ ] Verify existing mobile purchases tests pass
- [ ] Verify the new test confirms the limit is applied when no pagination params are sent
- [ ] Verify paginated requests (with `per_page`/`page`) are unaffected

---

AI disclosure: Claude Opus 4.6, prompted to fix the Sentry timeout issue in mobile purchases controller.