### PR TITLE
Fix N+1 inventory count queries causing Rack::Timeout in LinksController#show

### DIFF
--- a/app/models/base_variant.rb
+++ b/app/models/base_variant.rb
@@ -141,7 +141,7 @@ class BaseVariant < ApplicationRecord
   end
 
   def sales_count_for_inventory
-    purchases.counts_towards_inventory.sum(:quantity)
+    link.variant_inventory_count_for(id) || purchases.counts_towards_inventory.sum(:quantity)
   end
 
   def is_downloadable?

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -643,9 +643,25 @@ class Link < ApplicationRecord
     sales.counts_towards_inventory.sum(:quantity)
   end
 
+  def preload_variant_inventory_counts!
+    return @variant_inventory_counts if @variant_inventory_counts
+
+    @variant_inventory_counts = Purchase
+      .joins("INNER JOIN base_variants_purchases ON base_variants_purchases.purchase_id = purchases.id")
+      .where("base_variants_purchases.base_variant_id IN (?)", alive_variants.select(:id))
+      .counts_towards_inventory
+      .group("base_variants_purchases.base_variant_id")
+      .sum(:quantity)
+  end
+
+  def variant_inventory_count_for(variant_id)
+    @variant_inventory_counts&.fetch(variant_id, 0)
+  end
+
   def variants_available?
     return true if variant_categories_alive.empty?
 
+    preload_variant_inventory_counts!
     variant_categories_alive.any?(&:available?)
   end
 

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -2006,6 +2006,30 @@ describe Link, :vcr do
         expect(bundle.remaining_for_sale_count).to eq(3)
       end
     end
+
+    describe "batch-loads variant inventory counts" do
+      it "uses a constant number of queries regardless of variant count" do
+        product = create(:product, max_purchase_count: 100)
+        category = create(:variant_category, link: product)
+        variants = 5.times.map { |i| create(:variant, variant_category: category, max_purchase_count: i == 0 ? 1 : 10) }
+        variants.each do |v|
+          purchase = create(:purchase, link: product)
+          purchase.variant_attributes << v
+        end
+        product.reload
+
+        sum_query_count = 0
+        counter = ->(_name, _start, _finish, _id, payload) {
+          sum_query_count += 1 if payload[:sql].match?(/SUM/i) && payload[:sql].match?(/quantity/i)
+        }
+
+        ActiveSupport::Notifications.subscribed(counter, "sql.active_record") do
+          product.variants_available?
+        end
+
+        expect(sum_query_count).to eq(1)
+      end
+    end
   end
 
   describe "#remaining_call_availabilities" do


### PR DESCRIPTION
## What

Batch-loads variant inventory counts in a single SQL query instead of executing a separate `SUM(quantity)` query per variant when checking product availability.

**Changes:**
- `Link#preload_variant_inventory_counts!` — fetches all variant inventory counts in one query, grouped by variant ID
- `Link#variant_inventory_count_for` — returns a preloaded count for a given variant (or `nil` if not preloaded, falling back to the per-variant query)
- `Link#variants_available?` — calls the preload before iterating variant categories
- `BaseVariant#sales_count_for_inventory` — uses preloaded count when available

## Why

[Sentry issue](https://gumroad-to.sentry.io/issues/7373992956/) shows `LinksController#show` hitting a 120s Rack::Timeout. The root cause is an N+1 query: for each variant, `BaseVariant#sales_count_for_inventory` runs `purchases.counts_towards_inventory.sum(:quantity)` — a `SUM` with a `LEFT JOIN` on subscriptions. For products with many variants and purchases, this cascades into many slow aggregate queries.

The fix replaces N per-variant queries with 1 batch query that fetches all counts grouped by `base_variant_id`, then uses the cached result when checking each variant's availability.

## Test Results

Added a test that verifies `variants_available?` uses exactly 1 SUM query for a product with 5 limited-quantity variants (instead of 5). The test fails when the fix is reverted.

---

AI disclosure: Implementation by Claude Opus 4.6. Prompted with the Sentry stacktrace and instructions to fix the N+1 inventory count queries.