### PR TITLE
Fix ActiveRecord::RecordInvalid in UtmLinksController#destroy

### DIFF
--- a/app/models/utm_link.rb
+++ b/app/models/utm_link.rb
@@ -141,6 +141,7 @@ class UtmLink < ApplicationRecord
     end
 
     def utm_fields_are_unique_per_target_resource
+      return if being_marked_as_deleted?
       return if self.class.alive.where(
         seller_id:,
         utm_source:,

--- a/spec/controllers/utm_links_controller_spec.rb
+++ b/spec/controllers/utm_links_controller_spec.rb
@@ -436,6 +436,26 @@ describe UtmLinksController, type: :controller, inertia: true do
       expect(utm_link.reload).to be_deleted
     end
 
+    it "soft deletes the UTM link when a duplicate with the same UTM params exists" do
+      create(:utm_link, seller:).tap do |duplicate|
+        duplicate.utm_source = utm_link.utm_source
+        duplicate.utm_medium = utm_link.utm_medium
+        duplicate.utm_campaign = utm_link.utm_campaign
+        duplicate.utm_term = utm_link.utm_term
+        duplicate.utm_content = utm_link.utm_content
+        duplicate.target_resource_type = utm_link.target_resource_type
+        duplicate.target_resource_id = utm_link.target_resource_id
+        duplicate.save!(validate: false)
+      end
+
+      expect do
+        delete :destroy, params: { id: utm_link.external_id }
+      end.to change { utm_link.reload.deleted_at }.from(nil).to(be_within(5.seconds).of(DateTime.current))
+
+      expect(response).to redirect_to(dashboard_utm_links_path)
+      expect(flash[:notice]).to eq("Link deleted!")
+    end
+
     it "preserves query, page, and sort params in redirect" do
       delete :destroy, params: {
         id: utm_link.external_id,


### PR DESCRIPTION
## What

Skip the `utm_fields_are_unique_per_target_resource` validation when soft-deleting a UTM link by adding an early `return if being_marked_as_deleted?` guard.

## Why

When a user deletes a UTM link, `mark_deleted!` calls `save!`, which runs all validations — including the UTM uniqueness check. If a duplicate alive record exists (possible via race conditions during creation), the validation fails with `ActiveRecord::RecordInvalid`, preventing deletion entirely. The uniqueness check is irrelevant when deleting a record.

Sentry: https://gumroad-to.sentry.io/issues/7374092199/

## Test results

Added a test that creates a duplicate UTM link (bypassing validation) and verifies that deleting the original still succeeds.

---

AI disclosure: Claude Opus 4.6 was used to implement this fix based on a detailed prompt describing the bug, root cause, and fix strategy.