### PR TITLE
Fix ActiveRecord::RecordInvalid in Settings::Team::InvitationsController#update

### DIFF
--- a/app/controllers/settings/team/invitations_controller.rb
+++ b/app/controllers/settings/team/invitations_controller.rb
@@ -20,8 +20,11 @@ class Settings::Team::InvitationsController < Sellers::BaseController
   def update
     authorize [:settings, :team, @team_invitation]
 
-    @team_invitation.update!(update_params)
-    render json: { success: true }
+    if @team_invitation.update(update_params)
+      render json: { success: true }
+    else
+      render json: { success: false, error_message: @team_invitation.errors.full_messages.to_sentence }
+    end
   end
 
   def destroy

--- a/spec/controllers/settings/team/invitations_controller_spec.rb
+++ b/spec/controllers/settings/team/invitations_controller_spec.rb
@@ -68,6 +68,21 @@ describe Settings::Team::InvitationsController do
       expect(response.parsed_body["success"]).to eq(true)
       expect(team_invitation.reload.role_admin?).to eq(true)
     end
+
+    context "when the invitation email belongs to an existing team member" do
+      before do
+        member = create(:user, email: team_invitation.email)
+        create(:team_membership, seller:, user: member)
+      end
+
+      it "returns an error instead of raising an exception" do
+        put :update, params: { id: team_invitation.external_id, team_invitation: { role: TeamMembership::ROLE_ADMIN } }, as: :json
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to eq(false)
+        expect(response.parsed_body["error_message"]).to eq("Email is associated with an existing team member")
+        expect(team_invitation.reload.role_marketing?).to eq(true)
+      end
+    end
   end
 
   describe "DELETE destroy" do


### PR DESCRIPTION
## What

The `update` action in `Settings::Team::InvitationsController` uses `update!` which raises `ActiveRecord::RecordInvalid` when the `email_cannot_belong_to_existing_member` validation fails (e.g., when updating the role on an invitation whose email now belongs to an existing team member).

## Why

The `create` action already handles validation errors gracefully by using `save` and returning error messages in the JSON response. The `update` action should follow the same pattern instead of letting the exception propagate to Sentry.

Sentry issue: https://gumroad-to.sentry.io/issues/7374700100/

## Test results

```
25 examples, 0 failures
```

---

AI disclosure: Claude Opus 4.6 — prompted with the root cause analysis and fix plan for the Sentry error.