### PR TITLE
Fix Claude Code Review workflow unable to post reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 


### PR DESCRIPTION
## What

Changes `pull-requests: read` to `pull-requests: write` in the Claude Code Review workflow permissions.

## Why

The workflow has had `pull-requests: read` since it was first added (Jan 28, `ed3420977`). This means the automated code-review has never successfully posted a review — Claude runs, analyzes the PR (~$1/run), but can't write back. The logs show `PullRequests: read` and `permission_denials_count: 1`.

With `write` permissions, Claude Code can post reviews via `gh` CLI during the run.

Note: there's a secondary issue where the `claude-code-action` post-step can't detect the PR number in `workflow_run` context (`PR_NUMBER` is empty), but the primary review posting should work through Claude's direct API/CLI access during the run.

---

Generated with Claude Opus 4.6.