### PR TITLE
Fix ActiveStorage::FileNotFoundError in User#resized_avatar_url

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -422,6 +422,9 @@ class User < ApplicationRecord
   def resized_avatar_url(size:)
     return ActionController::Base.helpers.asset_url("gumroad-default-avatar-5.png") unless avatar.attached?
     cdn_url_for(avatar.variant(resize_to_limit: [size, size]).processed.url)
+  rescue ActiveStorage::FileNotFoundError => e
+    Rails.logger.warn("User#resized_avatar_url error (#{id}): #{e.class} => #{e.message}")
+    ActionController::Base.helpers.asset_url("gumroad-default-avatar-5.png")
   end
 
   def avatar_url

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1312,6 +1312,15 @@ describe User, :vcr do
           expect(@user_with_avatar.resized_avatar_url(size: 256)).to match("#{AWS_S3_ENDPOINT}/#{S3_BUCKET}/#{variant}")
         end
       end
+
+      context "when avatar is attached but file is missing from storage" do
+        it "returns URL to default avatar" do
+          allow(@user.avatar).to receive(:attached?).and_return(true)
+          allow(@user.avatar).to receive(:variant).and_raise(ActiveStorage::FileNotFoundError)
+
+          expect(@user.resized_avatar_url(size: 256)).to eq(ActionController::Base.helpers.asset_url("gumroad-default-avatar-5.png"))
+        end
+      end
     end
 
     describe "avatar_url" do


### PR DESCRIPTION
## What

Adds a `rescue ActiveStorage::FileNotFoundError` block to `User#resized_avatar_url` so it falls back to the default avatar when the underlying file is missing from storage.

## Why

`UsersController#subscribe_preview` calls `resized_avatar_url(size: 240)`. When a user's avatar blob exists in the database but the file has been deleted from S3, this raises an unhandled `ActiveStorage::FileNotFoundError` — [Sentry issue](https://gumroad-to.sentry.io/issues/7374818745/).

The sibling `avatar_url` method already handles this with a rescue block. This applies the same pattern to `resized_avatar_url`.

## Test Results

Added a test that stubs an attached avatar raising `ActiveStorage::FileNotFoundError` and verifies the default avatar URL is returned. Confirmed the test fails when the fix is reverted.

---

AI disclosure: Implemented with Claude Opus 4.6. Prompt: fix ActiveStorage::FileNotFoundError in subscribe_preview by adding rescue to resized_avatar_url.

🤖 Generated with [Claude Code](https://claude.com/claude-code)