### PR TITLE
Fix mobile library query to include purchases before the account was created

### DIFF
--- a/app/controllers/api/mobile/purchases_controller.rb
+++ b/app/controllers/api/mobile/purchases_controller.rb
@@ -89,7 +89,7 @@ class Api::Mobile::PurchasesController < Api::Mobile::BaseController
 
       options = {
         buyer_query: params[:q],
-        purchaser: current_resource_owner,
+        email: current_resource_owner.email,
         for_library: true,
         track_total_hits: true,
         from: ((@page - 1) * @items),

--- a/spec/controllers/api/mobile/purchases_controller_spec.rb
+++ b/spec/controllers/api/mobile/purchases_controller_spec.rb
@@ -488,8 +488,8 @@ describe Api::Mobile::PurchasesController do
 
   describe "GET search", :elasticsearch_wait_for_refresh do
     it "returns purchases for a given user" do
-      purchase_1 = create(:purchase, purchaser: @purchaser)
-      purchase_2 = create(:purchase, purchaser: @purchaser)
+      purchase_1 = create(:purchase, purchaser: @purchaser, email: @purchaser.email)
+      purchase_2 = create(:purchase, purchaser: @purchaser, email: @purchaser.email)
       create(:purchase)
       index_model_records(Purchase)
 
@@ -519,9 +519,9 @@ describe Api::Mobile::PurchasesController do
     it "returns aggregation based on sellers" do
       seller_1 = create(:named_user)
       seller_2 = create(:named_user)
-      create(:purchase, purchaser: @purchaser, link: create(:product, user: seller_1))
-      create(:purchase, purchaser: @purchaser, link: create(:product, user: seller_2))
-      create(:purchase, purchaser: @purchaser, link: create(:product, user: seller_2))
+      create(:purchase, purchaser: @purchaser, email: @purchaser.email, link: create(:product, user: seller_1))
+      create(:purchase, purchaser: @purchaser, email: @purchaser.email, link: create(:product, user: seller_2))
+      create(:purchase, purchaser: @purchaser, email: @purchaser.email, link: create(:product, user: seller_2))
       index_model_records(Purchase)
 
       get :search, params: @params
@@ -539,9 +539,9 @@ describe Api::Mobile::PurchasesController do
       it "returns purchases for a given user and seller" do
         seller_1 = create(:named_user)
         seller_2 = create(:named_user)
-        purchase_1 = create(:purchase, purchaser: @purchaser, link: create(:product, user: seller_1))
-        create(:purchase, purchaser: @purchaser, link: create(:product, user: seller_2))
-        create(:purchase, purchaser: @purchaser, link: create(:product, user: seller_2))
+        purchase_1 = create(:purchase, purchaser: @purchaser, email: @purchaser.email, link: create(:product, user: seller_1))
+        create(:purchase, purchaser: @purchaser, email: @purchaser.email, link: create(:product, user: seller_2))
+        create(:purchase, purchaser: @purchaser, email: @purchaser.email, link: create(:product, user: seller_2))
         index_model_records(Purchase)
 
         get :search, params: @params.merge(seller: seller_1.external_id)
@@ -564,9 +564,9 @@ describe Api::Mobile::PurchasesController do
       it "returns archived purchases for a given user" do
         seller_1 = create(:named_user)
         seller_2 = create(:named_user)
-        purchase_1 = create(:purchase, purchaser: @purchaser, link: create(:product, user: seller_1), is_archived: true)
-        purchase_2 = create(:purchase, purchaser: @purchaser, link: create(:product, user: seller_2))
-        purchase_3 = create(:purchase, purchaser: @purchaser, link: create(:product, user: seller_2))
+        purchase_1 = create(:purchase, purchaser: @purchaser, email: @purchaser.email, link: create(:product, user: seller_1), is_archived: true)
+        purchase_2 = create(:purchase, purchaser: @purchaser, email: @purchaser.email, link: create(:product, user: seller_2))
+        purchase_3 = create(:purchase, purchaser: @purchaser, email: @purchaser.email, link: create(:product, user: seller_2))
         index_model_records(Purchase)
 
         get :search, params: @params.merge(archived: "true")
@@ -588,9 +588,9 @@ describe Api::Mobile::PurchasesController do
 
     describe "filter by purchase_ids" do
       it "returns purchases for the specified purchase IDs" do
-        purchase_1 = create(:purchase, purchaser: @purchaser, link: create(:product, user: create(:named_user)))
-        purchase_2 = create(:purchase, purchaser: @purchaser, link: create(:product, user: create(:named_user)))
-        create(:purchase, purchaser: @purchaser, link: create(:product, user: create(:named_user)))
+        purchase_1 = create(:purchase, purchaser: @purchaser, email: @purchaser.email, link: create(:product, user: create(:named_user)))
+        purchase_2 = create(:purchase, purchaser: @purchaser, email: @purchaser.email, link: create(:product, user: create(:named_user)))
+        create(:purchase, purchaser: @purchaser, email: @purchaser.email, link: create(:product, user: create(:named_user)))
         index_model_records(Purchase)
 
         get :search, params: @params.merge(purchase_ids: [ObfuscateIds.encrypt(purchase_1.id), ObfuscateIds.encrypt(purchase_2.id)])
@@ -601,7 +601,7 @@ describe Api::Mobile::PurchasesController do
       end
 
       it "returns no purchases when all purchase IDs are invalid" do
-        create(:purchase, purchaser: @purchaser, link: create(:product, user: create(:named_user)))
+        create(:purchase, purchaser: @purchaser, email: @purchaser.email, link: create(:product, user: create(:named_user)))
         index_model_records(Purchase)
 
         get :search, params: @params.merge(purchase_ids: ["invalid_id_1", "invalid_id_2"])
@@ -611,8 +611,8 @@ describe Api::Mobile::PurchasesController do
       end
 
       it "returns purchases for a single purchase ID" do
-        purchase_1 = create(:purchase, purchaser: @purchaser, link: create(:product, user: create(:named_user)))
-        create(:purchase, purchaser: @purchaser, link: create(:product, user: create(:named_user)))
+        purchase_1 = create(:purchase, purchaser: @purchaser, email: @purchaser.email, link: create(:product, user: create(:named_user)))
+        create(:purchase, purchaser: @purchaser, email: @purchaser.email, link: create(:product, user: create(:named_user)))
         index_model_records(Purchase)
 
         get :search, params: @params.merge(purchase_ids: ObfuscateIds.encrypt(purchase_1.id))
@@ -624,8 +624,8 @@ describe Api::Mobile::PurchasesController do
     end
 
     it "excludes purchases deleted by buyer" do
-      purchase = create(:purchase, purchaser: @purchaser)
-      create(:purchase, purchaser: @purchaser, is_deleted_by_buyer: true)
+      purchase = create(:purchase, purchaser: @purchaser, email: @purchaser.email)
+      create(:purchase, purchaser: @purchaser, email: @purchaser.email, is_deleted_by_buyer: true)
       index_model_records(Purchase)
 
       get :search, params: @params
@@ -635,8 +635,8 @@ describe Api::Mobile::PurchasesController do
     end
 
     it "excludes expired rental purchases" do
-      purchase = create(:purchase, purchaser: @purchaser)
-      rental_purchase = create(:purchase, purchaser: @purchaser)
+      purchase = create(:purchase, purchaser: @purchaser, email: @purchaser.email)
+      rental_purchase = create(:purchase, purchaser: @purchaser, email: @purchaser.email)
       rental_purchase.update_columns(rental_expired: true)
       index_model_records(Purchase)
 
@@ -650,9 +650,9 @@ describe Api::Mobile::PurchasesController do
       it "returns purchases for a given user matching creator description" do
         seller_1 = create(:named_user, name: "Daniel")
         seller_2 = create(:named_user, name: "Julia")
-        purchase_1 = create(:purchase, purchaser: @purchaser, link: create(:product, user: seller_1, name: "Profit & Loss"))
-        purchase_2 = create(:purchase, purchaser: @purchaser, link: create(:product, user: seller_2))
-        purchase_3 = create(:purchase, purchaser: @purchaser, link: create(:product, user: seller_2, description: "classic"))
+        purchase_1 = create(:purchase, purchaser: @purchaser, email: @purchaser.email, link: create(:product, user: seller_1, name: "Profit & Loss"))
+        purchase_2 = create(:purchase, purchaser: @purchaser, email: @purchaser.email, link: create(:product, user: seller_2))
+        purchase_3 = create(:purchase, purchaser: @purchaser, email: @purchaser.email, link: create(:product, user: seller_2, description: "classic"))
         index_model_records(Purchase)
 
         get :search, params: @params.merge(q: "daniel")
@@ -678,8 +678,8 @@ describe Api::Mobile::PurchasesController do
 
     describe "ordering" do
       it "returns purchases for a given user sorted by the requested order" do
-        purchase_1 = create(:purchase, purchaser: @purchaser, link: create(:product, name: "money money money cash"))
-        purchase_2 = create(:purchase, purchaser: @purchaser, link: create(:product, name: "money cash cash cash"))
+        purchase_1 = create(:purchase, purchaser: @purchaser, email: @purchaser.email, link: create(:product, name: "money money money cash"))
+        purchase_2 = create(:purchase, purchaser: @purchaser, email: @purchaser.email, link: create(:product, name: "money cash cash cash"))
         index_model_records(Purchase)
 
         # by default, the score is the most important
@@ -714,7 +714,7 @@ describe Api::Mobile::PurchasesController do
       before do
         @action = :search
         @response_key_name = "purchases"
-        @records = create_list(:purchase, 2, purchaser: @purchaser)
+        @records = create_list(:purchase, 2, purchaser: @purchaser, email: @purchaser.email)
         index_model_records(Purchase)
       end
     end

--- a/spec/controllers/api/mobile/purchases_controller_spec.rb
+++ b/spec/controllers/api/mobile/purchases_controller_spec.rb
@@ -501,6 +501,21 @@ describe Api::Mobile::PurchasesController do
       expect(response.parsed_body[:purchases][0][:purchase_id]).to eq(purchase_2.external_id)
     end
 
+    it "includes purchases with the same email but no linked user" do
+      purchase_with_user = create(:purchase, purchaser: @purchaser, email: @purchaser.email)
+      purchase_without_user = create(:purchase, purchaser: nil, email: @purchaser.email)
+      create(:purchase, email: "other@example.com")
+      index_model_records(Purchase)
+
+      get :search, params: @params
+
+      expect(response).to match_json_schema("api/mobile/purchases")
+      returned_ids = response.parsed_body[:purchases].pluck(:purchase_id)
+      expect(returned_ids).to include(purchase_with_user.external_id)
+      expect(returned_ids).to include(purchase_without_user.external_id)
+      expect(returned_ids.size).to eq(2)
+    end
+
     it "returns aggregation based on sellers" do
       seller_1 = create(:named_user)
       seller_2 = create(:named_user)


### PR DESCRIPTION
Fixes #4209, see also #4205 

## Why

The mobile library is currently missing purchases from before the account was created (i.e. ones which didn't originally have `purchaser_id`). This is because we don't update Elasticsearch when the `purchaser_id` changes.

## What

For now we can search by `email` rather than `purchaser` since this will be the same on purchases before and after the account creation.