### PR TITLE
Fix mobile library query to include purchases before the account was created

### DIFF
--- a/app/models/concerns/purchase/searchable.rb
+++ b/app/models/concerns/purchase/searchable.rb
@@ -148,6 +148,7 @@ module Purchase::Searchable
       "card_visual" => "paypal_email",
       "subscription_id" => "subscription_id",
       "license_serial" => "license_serial",
+      "purchaser_id" => "purchaser_id",
     }
 
     def search_field_value(field_name)

--- a/spec/models/concerns/purchase/searchable_spec.rb
+++ b/spec/models/concerns/purchase/searchable_spec.rb
@@ -523,6 +523,28 @@ describe Purchase::Searchable do
     end
   end
 
+  describe "purchaser_id reindexing" do
+    it "enqueues ES update when purchaser_id changes" do
+      purchase = create(:purchase, purchaser: nil)
+      ElasticsearchIndexerWorker.jobs.clear
+
+      user = create(:user)
+      purchase.update!(purchaser: user)
+
+      expect(ElasticsearchIndexerWorker).to have_enqueued_sidekiq_job("update", hash_including("record_id" => purchase.id, "class_name" => "Purchase", "fields" => ["purchaser_id"]))
+    end
+
+    it "updates purchaser_id in Elasticsearch document", :sidekiq_inline, :elasticsearch_wait_for_refresh do
+      purchase = create(:purchase, purchaser: nil)
+      expect(get_document_attributes(purchase)["purchaser_id"]).to be_nil
+
+      user = create(:user)
+      purchase.update!(purchaser: user)
+
+      expect(get_document_attributes(purchase)["purchaser_id"]).to eq(user.id)
+    end
+  end
+
   context "updating a purchase", :sidekiq_inline, :elasticsearch_wait_for_refresh do
     it "sets the subscription id" do
       subscription = create(:subscription)


### PR DESCRIPTION
## Why

Some users [reported missing purchases](https://gumroad-to.sentry.io/issues/feedback/?feedbackSlug=gumroad-mobile%3A7369622837&project=4511019959517184&referrer=feedback_list_page&statsPeriod=14d) in the library in the new mobile app. This is because we don't automatically reindex purchases when `purchaser_id` changes, so when a user creates an account and links their old purchases the database is updated but Elasticsearch isn't.

## What

Updated purchase search logic to reindex when `purchaser_id` is changed, so the library stays up to date. We will need to reindex existing purchases after deploying.