### PR TITLE
Fix ActiveStorage::FileNotFoundError in AnalyzeJob by discarding missing files

### DIFF
--- a/config/initializers/active_storage_analyze_job.rb
+++ b/config/initializers/active_storage_analyze_job.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Rails.application.config.after_initialize do
+  ActiveStorage::AnalyzeJob.discard_on(ActiveStorage::FileNotFoundError)
+end

--- a/spec/config/initializers/active_storage_analyze_job_spec.rb
+++ b/spec/config/initializers/active_storage_analyze_job_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe ActiveStorage::AnalyzeJob do
+  it "discards the job when ActiveStorage::FileNotFoundError is raised" do
+    rescue_handlers = described_class.rescue_handlers.map(&:first)
+    expect(rescue_handlers).to include("ActiveStorage::FileNotFoundError")
+  end
+end


### PR DESCRIPTION
## What

Adds an initializer that calls `discard_on(ActiveStorage::FileNotFoundError)` on `ActiveStorage::AnalyzeJob`, so the job silently discards instead of raising when the backing file has already been deleted from S3.

## Why

`ActiveStorage::AnalyzeJob` runs asynchronously after uploads to extract metadata. When a blob's file is removed from S3 before analysis runs, it raises `ActiveStorage::FileNotFoundError`. Retrying is pointless since the file is permanently gone. This race condition is generating noise in Sentry ([issue](https://gumroad-to.sentry.io/issues/7375474911/)).

## Test results

Added a spec in `spec/config/initializers/active_storage_analyze_job_spec.rb` that verifies the rescue handler is registered.

---

Generated with Claude Opus 4.6. Prompt: "Fix ActiveStorage::FileNotFoundError in ActiveStorage::AnalyzeJob by discarding on missing files, with initializer and test."