### PR TITLE
Fix frontend affiliate commission max validation (90% → 75%)

### DIFF
--- a/app/javascript/pages/Affiliates/Edit.tsx
+++ b/app/javascript/pages/Affiliates/Edit.tsx
@@ -87,10 +87,10 @@ export default function AffiliatesEdit() {
 
     if (
       applyToAllProducts &&
-      (!data.affiliate.fee_percent || data.affiliate.fee_percent < 1 || data.affiliate.fee_percent > 90)
+      (!data.affiliate.fee_percent || data.affiliate.fee_percent < 1 || data.affiliate.fee_percent > 75)
     ) {
-      form.setError("affiliate.fee_percent", "Commission must be between 1% and 90%");
-      showAlert("Commission must be between 1% and 90%", "error");
+      form.setError("affiliate.fee_percent", "Commission must be between 1% and 75%");
+      showAlert("Commission must be between 1% and 75%", "error");
       return;
     }
 
@@ -102,10 +102,10 @@ export default function AffiliatesEdit() {
 
     if (
       !applyToAllProducts &&
-      data.affiliate.products.some((p) => p.enabled && (!p.fee_percent || p.fee_percent < 1 || p.fee_percent > 90))
+      data.affiliate.products.some((p) => p.enabled && (!p.fee_percent || p.fee_percent < 1 || p.fee_percent > 75))
     ) {
-      form.setError("affiliate.products", "All enabled products must have commission between 1% and 90%");
-      showAlert("All enabled products must have commission between 1% and 90%", "error");
+      form.setError("affiliate.products", "All enabled products must have commission between 1% and 75%");
+      showAlert("All enabled products must have commission between 1% and 75%", "error");
       return;
     }
 

--- a/app/javascript/pages/Affiliates/New.tsx
+++ b/app/javascript/pages/Affiliates/New.tsx
@@ -81,10 +81,10 @@ export default function AffiliatesNew() {
 
     if (
       data.affiliate.apply_to_all_products &&
-      (!data.affiliate.fee_percent || data.affiliate.fee_percent < 1 || data.affiliate.fee_percent > 90)
+      (!data.affiliate.fee_percent || data.affiliate.fee_percent < 1 || data.affiliate.fee_percent > 75)
     ) {
-      form.setError("affiliate.fee_percent", "Commission must be between 1% and 90%");
-      showAlert("Commission must be between 1% and 90%", "error");
+      form.setError("affiliate.fee_percent", "Commission must be between 1% and 75%");
+      showAlert("Commission must be between 1% and 75%", "error");
       return;
     }
 
@@ -96,10 +96,10 @@ export default function AffiliatesNew() {
 
     if (
       !data.affiliate.apply_to_all_products &&
-      data.affiliate.products.some((p) => p.enabled && (!p.fee_percent || p.fee_percent < 1 || p.fee_percent > 90))
+      data.affiliate.products.some((p) => p.enabled && (!p.fee_percent || p.fee_percent < 1 || p.fee_percent > 75))
     ) {
-      form.setError("affiliate.products", "All enabled products must have commission between 1% and 90%");
-      showAlert("All enabled products must have commission between 1% and 90%", "error");
+      form.setError("affiliate.products", "All enabled products must have commission between 1% and 75%");
+      showAlert("All enabled products must have commission between 1% and 75%", "error");
       return;
     }
 

--- a/app/javascript/pages/Affiliates/Onboarding.tsx
+++ b/app/javascript/pages/Affiliates/Onboarding.tsx
@@ -38,7 +38,7 @@ type Props = {
 };
 
 const MIN_FEE_PERCENT = 1;
-const MAX_FEE_PERCENT = 90;
+const MAX_FEE_PERCENT = 75;
 const isValidFeePercent = (fee: number | null) => fee !== null && fee >= MIN_FEE_PERCENT && fee <= MAX_FEE_PERCENT;
 const validateProduct = (product: SelfServeAffiliateProduct): InvalidProductAttrs => {
   const invalidAttributes: InvalidProductAttrs = new Set();


### PR DESCRIPTION
## What

Updates the frontend max affiliate commission validation from 90% to 75% in three files:

- `app/javascript/pages/Affiliates/New.tsx` — hardcoded `> 90` checks and error messages → `> 75`
- `app/javascript/pages/Affiliates/Edit.tsx` — same hardcoded checks and error messages → `> 75`
- `app/javascript/pages/Affiliates/Onboarding.tsx` — `MAX_FEE_PERCENT = 90` → `75`

## Why

The backend already validates the max at 75% (7500 basis points) in `Affiliate::BasisPointsValidations`. This mismatch was introduced when the limit was lowered from 90% to 75% in [gumroad-old#25365](https://github.com/antiwork/gumroad-old/pull/25365) but the frontend wasn't updated during migration.

Setting a commission between 76-90% on the frontend would pass client validation but fail on the backend.

Fixes https://github.com/antiwork/gumroad/issues/4211