### PR TITLE
Update affiliates help article: Affiliates is now in the main sidebar

### DIFF
--- a/app/views/help_center/articles/contents/_333-affiliates-on-gumroad.html.erb
+++ b/app/views/help_center/articles/contents/_333-affiliates-on-gumroad.html.erb
@@ -46,7 +46,6 @@
     <li>After 7 days, your affiliate can be paid out for that sale. The same <a href="13-getting-paid"> payout rules</a> apply!</li>
   </ul>
   <p>To get started, go to your <a href="https://gumroad.com/affiliates">Affiliates Dashboard</a>. You can find the link in the main sidebar, under Analytics.</p>
-  <figure><%= image_tag "https://lh7-us.googleusercontent.com/docsz/AD_4nXdb98RI4F0VScrX8SURh3SaT-OYpepncrreGJa6K-iaUpHzO0BmfuJ1z_HW669GBQLUOY2JQox1x5KaM3Fllykw_D2vlY4mzHzmiwGWYAPdpFTQrvw77uduVMJMSbg4vRDwM4HuDOQOEgIR_jI0uyNT1uMc?key=IlXfEmf2yu_7yhYw2YKmPA" %></figure>
   <h3 id="Adding-a-new-affiliate"><span>Adding a new affiliate</span></h3>
   <p>You can either add an affiliate manually or let them sign up through an affiliate sign-up form.</p>
   <h3 id="Method-1-Adding-affiliates-manually"><span>Method 1: Adding affiliates manually</span></h3>


### PR DESCRIPTION
## What

Updates the navigation instructions in the "Affiliates on Gumroad" help article (`_333-affiliates-on-gumroad.html.erb`).

**Before:** "You can find the link at the bottom left of your dashboard. Click the arrow next to your username, then click Affiliates"
**After:** "You can find the link in the main sidebar, under Analytics."

## Why

[#4047](https://github.com/antiwork/gumroad/pull/4047) moved Affiliates from the avatar dropdown to the main sidebar under Analytics, but the help article wasn't updated.

Fixes https://github.com/antiwork/gumroad/issues/4213