### PR TITLE
Fix UnsafeRedirectError in UrlRedirectsController#download_archive

### DIFF
--- a/app/controllers/url_redirects_controller.rb
+++ b/app/controllers/url_redirects_controller.rb
@@ -136,7 +136,7 @@ class UrlRedirectsController < ApplicationController
         archive.mark_in_progress!
         archive.generate_zip_archive!
         flash[:warning] = "We are preparing the file for download. Please try again shortly."
-        redirect_to(@url_redirect.download_page_url)
+        redirect_to(@url_redirect.download_page_url, allow_other_host: true)
       end
     end
   end


### PR DESCRIPTION
## What

Adds `allow_other_host: true` to the `redirect_to(@url_redirect.download_page_url)` call in the `rescue Aws::S3::Errors::NotFound` block of `UrlRedirectsController#download_archive`.

## Why

`download_page_url` returns `"https://gumroad.com/d/#{token}"` which is a different host from the app server. Without `allow_other_host: true`, Rails 7 raises `ActionController::Redirecting::UnsafeRedirectError`. Every other `redirect_to` in this controller already has this flag set.

Sentry: https://gumroad-to.sentry.io/issues/7376192325/

## Test Results

Existing test `"triggers archive regeneration and redirects to download page when the S3 object is missing"` passes and covers this code path:

```
1 example, 0 failures
```

---

AI disclosure: This fix was generated by Claude Opus 4.6. Prompt: fix Sentry issue ActionController::Redirecting::UnsafeRedirectError in UrlRedirectsController#download_archive by adding allow_other_host: true.