### PR TITLE
Fix TypeError in EmailsController#create when installment save fails

### DIFF
--- a/app/services/save_installment_service.rb
+++ b/app/services/save_installment_service.rb
@@ -28,12 +28,14 @@ class SaveInstallmentService
         installment.message = SaveContentUpsellsService.new(seller:, content: installment.message, old_content: installment.message_was).from_html
         save_installment
 
-        if params[:to_be_published_at].present?
-          schedule_installment
-        elsif params[:publish].present?
-          publish_installment
-        elsif params[:send_preview_email].present?
-          installment.send_preview_email(preview_email_recipient)
+        if error.blank?
+          if params[:to_be_published_at].present?
+            schedule_installment
+          elsif params[:publish].present?
+            publish_installment
+          elsif params[:send_preview_email].present?
+            installment.send_preview_email(preview_email_recipient)
+          end
         end
 
         raise ActiveRecord::Rollback if error.present?

--- a/spec/services/save_installment_service_spec.rb
+++ b/spec/services/save_installment_service_spec.rb
@@ -263,6 +263,19 @@ describe SaveInstallmentService do
       expect(service.error).to eq("Please include a message as part of the update.")
     end
 
+    it "does not send preview email when installment save fails" do
+      service = described_class.new(
+        seller:,
+        installment:,
+        params: params.deep_merge(send_preview_email: true, installment: { message: nil }),
+        preview_email_recipient:,
+      )
+
+      expect_any_instance_of(Installment).not_to receive(:send_preview_email)
+      expect(service.process).to be(false)
+      expect(service.error).to eq("Please include a message as part of the update.")
+    end
+
     it "invokes SaveContentUpsellsService with correct arguments" do
       expect(SaveContentUpsellsService).to receive(:new).with(seller:, content: "<p>Hello, world!</p>", old_content: nil).and_call_original
 


### PR DESCRIPTION
## What

When `save_installment` fails (e.g., due to validation errors), the `process` method in `SaveInstallmentService` continued executing post-save actions — including `send_preview_email`. This caused `PostSendgridApi#build_mail` to construct a `SendGrid::CustomArg` with a nil installment id, resulting in `TypeError: no implicit conversion of nil into Hash`.

This wraps the post-save actions (schedule, publish, preview email) in an `error.blank?` guard so they only execute when the installment was saved successfully.

## Why

Sentry: https://gumroad-to.sentry.io/issues/7376208453/

`schedule_installment` and `publish_installment` already have internal `return if error.present?` guards, but the `send_preview_email` path had no such protection. Rather than adding a guard only to the preview path, the fix wraps all three branches, which is more defensive and consistent.

## Test results

Added a test that verifies `send_preview_email` is not called when the installment fails to save (e.g., missing message). All existing tests continue to pass (1 pre-existing failure unrelated to this change).

---

Generated with Claude Opus 4.6. Prompts: fix Sentry TypeError from nil installment id in preview email path.