### PR TITLE
Fix NoMethodError: undefined method 'all?' for ActionController::Parameters in OrdersController#create

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -3,6 +3,7 @@
 class OrdersController < ApplicationController
   include ValidateRecaptcha, Events, Order::ResponseHelpers
 
+  before_action :normalize_line_items, only: :create
   before_action :validate_order_request, only: :create
   before_action :fetch_affiliates, only: :create
 
@@ -55,6 +56,12 @@ class OrdersController < ApplicationController
   end
 
   private
+    def normalize_line_items
+      if params[:line_items].is_a?(ActionController::Parameters)
+        params[:line_items] = params[:line_items].values
+      end
+    end
+
     def validate_order_request
       # Don't allow the order to go through if the buyer is a bot. Pretend that the order succeeded instead.
       return render json: { success: true } if is_bot?

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -966,6 +966,25 @@ describe OrdersController, :vcr do
           end.to change(Purchase.successful, :count).by(2)
         end
 
+        it "does not attempt to verify reCAPTCHA when line_items are submitted as hash-like params" do
+          allow_any_instance_of(Link).to receive(:require_captcha?).and_return(false)
+
+          product_1.update!(price_cents: 0)
+          product_2.update!(price_cents: 0)
+
+          hash_params = multiple_purchase_params.dup
+          hash_params[:line_items] = {
+            "0" => { uid: "unique-id-0", permalink: product_1.unique_permalink, perceived_price_cents: "0", quantity: 1 },
+            "1" => { uid: "unique-id-1", permalink: product_2.unique_permalink, perceived_price_cents: "0", quantity: 1 }
+          }
+
+          expect_any_instance_of(OrdersController).to_not receive(:valid_recaptcha_response_and_hostname?)
+
+          expect do
+            post :create, params: hash_params
+          end.to change(Purchase.successful, :count).by(2)
+        end
+
         it "verifies reCAPTCHA if any of the purchases require it" do
           allow_any_instance_of(Link).to receive(:require_captcha?).and_return(true)
 

--- a/spec/support/fixtures/vcr_cassettes/OrdersController/POST_create/multiple_purchases/reCAPTCHA_skipping_behavior/does_not_attempt_to_verify_reCAPTCHA_when_line_items_are_submitted_as_hash-like_params.yml
+++ b/spec/support/fixtures/vcr_cassettes/OrdersController/POST_create/multiple_purchases/reCAPTCHA_skipping_behavior/does_not_attempt_to_verify_reCAPTCHA_when_line_items_are_submitted_as_hash-like_params.yml
@@ -1,0 +1,370 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_IeyaPjMcfBGdBY","request_duration_ms":2}}'
+      Idempotency-Key:
+      - a811b1f6-d927-49bd-abb2-e00f242c213d
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        GumClaws-Mini 25.3.0 Darwin Kernel Version 25.3.0: Wed Jan 28 20:49:24 PST
+        2026; root:xnu-12377.81.4~5/RELEASE_ARM64_T8132 arm64","hostname":"GumClaws-Mini"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 31 Mar 2026 06:19:16 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1082'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=TydduQS_JmsK7og0_nJhRAQbpxBLYKXkHhBVKGnr-AtvodANTw551xbNTfJghYS3pWQgmjpVonEV4vMO
+      Idempotency-Key:
+      - a811b1f6-d927-49bd-abb2-e00f242c213d
+      Original-Request:
+      - req_3ahuhH1VsuNGTl
+      Request-Id:
+      - req_3ahuhH1VsuNGTl
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - ABGHIJ
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TGvdwIBOqvOFDrf8s8CBibI",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 3,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1774937956,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "type": "card"
+        }
+  recorded_at: Tue, 31 Mar 2026 06:19:16 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers
+    body:
+      encoding: UTF-8
+      string: payment_method=pm_1TGvdwIBOqvOFDrf8s8CBibI
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_3ahuhH1VsuNGTl","request_duration_ms":262}}'
+      Idempotency-Key:
+      - 380f3791-0776-4f81-b5b2-5073ad81242a
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        GumClaws-Mini 25.3.0 Darwin Kernel Version 25.3.0: Wed Jan 28 20:49:24 PST
+        2026; root:xnu-12377.81.4~5/RELEASE_ARM64_T8132 arm64","hostname":"GumClaws-Mini"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 31 Mar 2026 06:19:17 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '642'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=TydduQS_JmsK7og0_nJhRAQbpxBLYKXkHhBVKGnr-AtvodANTw551xbNTfJghYS3pWQgmjpVonEV4vMO
+      Idempotency-Key:
+      - 380f3791-0776-4f81-b5b2-5073ad81242a
+      Original-Request:
+      - req_1MlZOByXNXPhP5
+      Request-Id:
+      - req_1MlZOByXNXPhP5
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - ABGHIJ
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "cus_UFQUutaJqc9AYK",
+          "object": "customer",
+          "address": null,
+          "balance": 0,
+          "created": 1774937956,
+          "currency": null,
+          "customer_account": null,
+          "default_source": null,
+          "delinquent": false,
+          "description": null,
+          "discount": null,
+          "email": null,
+          "invoice_prefix": "F21PF7SS",
+          "invoice_settings": {
+            "custom_fields": null,
+            "default_payment_method": null,
+            "footer": null,
+            "rendering_options": null
+          },
+          "livemode": false,
+          "metadata": {},
+          "name": null,
+          "next_invoice_sequence": 1,
+          "phone": null,
+          "preferred_locales": [],
+          "shipping": null,
+          "tax_exempt": "none",
+          "test_clock": null
+        }
+  recorded_at: Tue, 31 Mar 2026 06:19:17 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/setup_intents
+    body:
+      encoding: UTF-8
+      string: payment_method=pm_1TGvdwIBOqvOFDrf8s8CBibI&customer=cus_UFQUutaJqc9AYK&payment_method_types[0]=card&confirm=true&usage=off_session
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_1MlZOByXNXPhP5","request_duration_ms":688}}'
+      Idempotency-Key:
+      - 3c2cbdca-f069-4e22-98f4-ea24c249fa40
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        GumClaws-Mini 25.3.0 Darwin Kernel Version 25.3.0: Wed Jan 28 20:49:24 PST
+        2026; root:xnu-12377.81.4~5/RELEASE_ARM64_T8132 arm64","hostname":"GumClaws-Mini"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 31 Mar 2026 06:19:17 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '998'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=TydduQS_JmsK7og0_nJhRAQbpxBLYKXkHhBVKGnr-AtvodANTw551xbNTfJghYS3pWQgmjpVonEV4vMO
+      Idempotency-Key:
+      - 3c2cbdca-f069-4e22-98f4-ea24c249fa40
+      Original-Request:
+      - req_HWOF7CDEDeuoiv
+      Request-Id:
+      - req_HWOF7CDEDeuoiv
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - ABGHIJ
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "seti_1TGvdxIBOqvOFDrfu758e28s",
+          "object": "setup_intent",
+          "application": null,
+          "automatic_payment_methods": null,
+          "cancellation_reason": null,
+          "client_secret": "seti_1TGvdxIBOqvOFDrfu758e28s_secret_UFQUUgSXPV3b2t7IZItBi1CZ54bT5gT",
+          "created": 1774937957,
+          "customer": "cus_UFQUutaJqc9AYK",
+          "customer_account": null,
+          "description": null,
+          "excluded_payment_method_types": null,
+          "flow_directions": null,
+          "last_setup_error": null,
+          "latest_attempt": "setatt_1TGvdxIBOqvOFDrfEuUXnekr",
+          "livemode": false,
+          "mandate": null,
+          "metadata": {},
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1TGvdwIBOqvOFDrf8s8CBibI",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "single_use_mandate": null,
+          "status": "succeeded",
+          "usage": "off_session"
+        }
+  recorded_at: Tue, 31 Mar 2026 06:19:17 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
## What

Fixes `NoMethodError: undefined method 'all?' for an instance of ActionController::Parameters` in `OrdersController#create`.

When `line_items` are submitted as form-encoded data with indexed keys (e.g. `line_items[0][permalink]=...`), Rails parses them as a hash-like `ActionController::Parameters` object rather than an array. Enumerable methods like `all?`, `any?`, and `each` don't work as expected on these objects, causing the error.

## Why

This affects real users in production — the error was reported in [Sentry](https://gumroad-to.sentry.io/issues/7376404881/). The fix normalizes `line_items` to an array early via a `before_action`, so all downstream code (validation, captcha checks, affiliate fetching) works regardless of how the params were encoded.

## Test results

All 122 OrdersController specs pass, including a new test that specifically exercises hash-like `line_items` params.

---

AI disclosure: Implemented with Claude Opus 4.6. Prompted to fix the Sentry error with the specific root cause and fix approach provided.