### PR TITLE
Fix RecordInvalid on PPP settings update for bundles without products

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -526,7 +526,9 @@ class User < ApplicationRecord
     products.purchasing_power_parity_disabled.or(products.by_external_ids(external_ids)).each do |product|
       should_disable = external_ids.include?(product.external_id)
 
-      product.update!(purchasing_power_parity_disabled: should_disable) unless should_disable && product.purchasing_power_parity_disabled?
+      next if should_disable && product.purchasing_power_parity_disabled?
+      product.purchasing_power_parity_disabled = should_disable
+      product.save!(validate: false)
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3112,6 +3112,16 @@ describe User, :vcr do
       expect(@user.reload.purchasing_power_parity_excluded_product_external_ids).to eq([@product_1.external_id])
       expect(@product_2.reload.purchasing_power_parity_disabled).to eq(false)
     end
+
+    it "updates PPP flag on a published bundle with no bundle products" do
+      bundle = create(:product, user: @user, is_bundle: true, purchase_disabled_at: nil)
+
+      expect do
+        @user.update_purchasing_power_parity_excluded_products!([bundle.external_id])
+      end.not_to raise_error
+
+      expect(bundle.reload.purchasing_power_parity_disabled).to eq(true)
+    end
   end
 
   describe "#eligible_for_service_products?" do


### PR DESCRIPTION
## Summary

- Fix `ActiveRecord::RecordInvalid` error in `Settings::MainController#update` when a seller has a published bundle with no bundle products
- Change `product.update!` to `product.save!(validate: false)` in `update_purchasing_power_parity_excluded_products!` to skip unrelated model validations when toggling the PPP flag
- Add test covering published bundles with no bundle products

## What

In `User#update_purchasing_power_parity_excluded_products!`, `product.update!` triggers all model validations, including `published_bundle_must_have_at_least_one_product`. If a published bundle has lost all its bundle_products (edge case), this unrelated validation blocks the PPP settings update with `"Bundles must have at least one product."`.

The fix uses `save!(validate: false)` since `purchasing_power_parity_disabled` is a FlagShihTzu bit flag with no associated callbacks, making it safe to skip validations for this targeted attribute change.

## Why

This approach was chosen over `update_column` because `purchasing_power_parity_disabled` is a virtual attribute backed by a FlagShihTzu bit flag (bit 27), not a real database column. `save!(validate: false)` correctly handles the bit manipulation while skipping unrelated validations.

## Test plan

- [ ] Verify new test passes: published bundle with no bundle products can have PPP flag toggled
- [ ] Verify existing PPP tests still pass
- [ ] Verify the test fails when the fix is reverted (using `product.update!` instead of `product.save!(validate: false)`)

---

AI disclosure: Implemented with Claude Opus 4.6. Prompted to fix a Sentry error where `ActiveRecord::RecordInvalid` was raised in `Settings::MainController#update` due to bundle validation triggering during PPP settings update.