### PR TITLE
Fix Rack::Timeout on CheckoutController#show by adding timeout guard to recommendations

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -99,6 +99,8 @@ class CheckoutController < ApplicationController
       true
     end
 
+    RECOMMENDED_PRODUCTS_TIMEOUT_SECONDS = 10
+
     def recommended_products
       args = {
         purchaser: logged_in_user,
@@ -108,16 +110,21 @@ class CheckoutController < ApplicationController
         recommendation_type: params[:recommendation_type],
       }
 
-      RecommendedProducts::CheckoutService.fetch_for_cart(**args).map do |product_info|
-        ProductPresenter.card_for_web(
-          product: product_info.product,
-          request:,
-          recommended_by: product_info.recommended_by,
-          target: product_info.target,
-          recommender_model_name: product_info.recommender_model_name,
-          affiliate_id: product_info.affiliate_id,
-        )
+      Timeout.timeout(RECOMMENDED_PRODUCTS_TIMEOUT_SECONDS) do
+        RecommendedProducts::CheckoutService.fetch_for_cart(**args).map do |product_info|
+          ProductPresenter.card_for_web(
+            product: product_info.product,
+            request:,
+            recommended_by: product_info.recommended_by,
+            target: product_info.target,
+            recommender_model_name: product_info.recommender_model_name,
+            affiliate_id: product_info.affiliate_id,
+          )
+        end
       end
+    rescue Timeout::Error
+      Rails.logger.warn("[CheckoutController] Recommended products timed out after #{RECOMMENDED_PRODUCTS_TIMEOUT_SECONDS}s")
+      []
     end
 
     def update_permitted_params

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -225,6 +225,16 @@ describe CheckoutController, type: :controller, inertia: true do
         expect(inertia.component).to eq("Checkout/Show")
         expect(inertia.props.deep_symbolize_keys[:recommended_products]).to eq([product_cards.first])
       end
+
+      it "returns empty array when recommendations time out" do
+        allow(RecommendedProducts::CheckoutService).to receive(:fetch_for_cart).and_raise(Timeout::Error)
+
+        get :show, params: { cart_product_ids: [cart_product.external_id], on_discover_page: "false", limit: "5" }, session: { recommender_model_name: }
+
+        expect(response).to be_successful
+        expect(inertia.component).to eq("Checkout/Show")
+        expect(inertia.props.deep_symbolize_keys[:recommended_products]).to eq([])
+      end
     end
   end
 


### PR DESCRIPTION
## Problem

`CheckoutController#show` hit a `Rack::Timeout::RequestTimeoutException` (120s) in production. The stack trace shows the bottleneck path:

```
CheckoutController#show
  → recommended_products
    → CheckoutService.fetch_for_cart
      → recommendable?
        → recommendable_reasons
          → sales_count_for_inventory (SUM query on purchases)
```

The `sales_count_for_inventory` method runs `sales.counts_towards_inventory.sum(:quantity)` per product in the recommendations loop. For high-volume products, this query is slow enough to push the entire request past Rack::Timeout.

Sentry: https://gumroad-to.sentry.io/issues/7376613995/

## Fix

Wrap the `recommended_products` private method in a 10-second `Timeout.timeout` guard. On timeout, it logs a warning and returns an empty array instead of letting the slow query kill the entire checkout page.

This is safe because:
- Recommended products are already an `InertiaRails.optional` prop (only loaded on partial visits)
- The checkout page functions normally without recommendations
- The 10s budget is generous for recommendations but well under the 120s Rack::Timeout

## Test

Added a spec that verifies the controller returns a successful response with an empty recommendations array when `CheckoutService.fetch_for_cart` raises `Timeout::Error`.