### PR TITLE
Fix Rack::Timeout on Discover page by adding timeout to curated products fetch

### DIFF
--- a/app/controllers/concerns/discover_curated_products.rb
+++ b/app/controllers/concerns/discover_curated_products.rb
@@ -1,14 +1,21 @@
 # frozen_string_literal: true
 
 module DiscoverCuratedProducts
+  CURATED_PRODUCTS_TIMEOUT_SECONDS = 10
+
   def taxonomies_for_nav(recommended_products: nil)
     Discover::TaxonomyPresenter.new.taxonomies_for_nav(recommended_products: curated_products.map(&:product))
   end
 
   def curated_products
     @root_recommended_products ||= begin
-                                     cart_product_ids = Cart.fetch_by(user: logged_in_user, browser_guid: cookies[:_gumroad_guid])&.cart_products&.alive&.pluck(:product_id) || []
-                                     RecommendedProducts::DiscoverService.fetch(purchaser: logged_in_user, cart_product_ids:, recommender_model_name: session[:recommender_model_name])
+                                     Timeout.timeout(CURATED_PRODUCTS_TIMEOUT_SECONDS) do
+                                       cart_product_ids = Cart.fetch_by(user: logged_in_user, browser_guid: cookies[:_gumroad_guid])&.cart_products&.alive&.pluck(:product_id) || []
+                                       RecommendedProducts::DiscoverService.fetch(purchaser: logged_in_user, cart_product_ids:, recommender_model_name: session[:recommender_model_name])
+                                     end
+                                   rescue Timeout::Error, StandardError => e
+                                     Rails.logger.error("Failed to fetch curated products: #{e.class} - #{e.message}")
+                                     []
                                    end
   end
 end

--- a/spec/controllers/discover_controller_spec.rb
+++ b/spec/controllers/discover_controller_spec.rb
@@ -229,6 +229,30 @@ describe DiscoverController, type: :controller, inertia: true do
       expect(DiscoverSearch.last!.discover_search_suggestion).to be_present
     end
 
+    context "when curated products fetch times out" do
+      it "renders the page with empty curated products" do
+        allow(RecommendedProducts::DiscoverService).to receive(:fetch).and_raise(Timeout::Error)
+
+        get :index
+
+        expect(response).to be_successful
+        expect_inertia.to render_component("Discover/Index")
+        expect(inertia.props[:curated_product_ids]).to eq([])
+      end
+    end
+
+    context "when curated products fetch raises an error" do
+      it "renders the page with empty curated products" do
+        allow(RecommendedProducts::DiscoverService).to receive(:fetch).and_raise(StandardError, "connection lost")
+
+        get :index
+
+        expect(response).to be_successful
+        expect_inertia.to render_component("Discover/Index")
+        expect(inertia.props[:curated_product_ids]).to eq([])
+      end
+    end
+
     context "meta tags" do
       let(:default_description) { "Browse over 1.6 million free and premium digital products in education, tech, design, and more categories from Gumroad creators and online entrepreneurs." }
 


### PR DESCRIPTION
## What

Wraps the `curated_products` recommendation pipeline in `DiscoverCuratedProducts` with a 10-second `Timeout.timeout`. On timeout or any error, logs the failure and falls back to an empty array so the Discover page still renders with regular search results.

## Why

Sentry reported `Rack::Timeout::RequestTimeoutException` (120s) in `DiscoverController#index`. The `curated_products` method runs the full recommendation pipeline synchronously — fetching cart/purchased product IDs, querying `CachedSalesRelatedProductsInfo`, and loading up to 40 products with deep associations. If any step is slow (DB contention, lock waits, cold caches), the entire request times out. A 10-second timeout with graceful degradation ensures the page always renders.

## Test results

Added two controller tests:
- `Timeout::Error` → page renders with empty curated products
- `StandardError` → page renders with empty curated products

All 23 specs in `spec/controllers/discover_controller_spec.rb` pass.

---

AI disclosure: Built with Claude Opus 4.6. Prompted with the Sentry error context and instructions to add timeout protection to the curated products fetch path with graceful fallback.