### PR TITLE
Fix Rack::Timeout in LinksController#show by caching structured data availability

### DIFF
--- a/app/models/concerns/product/structured_data.rb
+++ b/app/models/concerns/product/structured_data.rb
@@ -88,7 +88,11 @@ module Product::StructuredData
     def availability_for_schema_org
       return AVAILABILITY_IN_STOCK unless max_purchase_count?
 
-      if remaining_for_sale_count&.zero?
+      cached_remaining = Rails.cache.fetch("product/#{id}/structured_data_remaining_for_sale_count", expires_in: 5.minutes) do
+        remaining_for_sale_count
+      end
+
+      if cached_remaining&.zero?
         AVAILABILITY_SOLD_OUT
       else
         AVAILABILITY_LIMITED

--- a/spec/models/concerns/product/structured_data_spec.rb
+++ b/spec/models/concerns/product/structured_data_spec.rb
@@ -128,11 +128,30 @@ describe Product::StructuredData do
         context "when the product is sold out" do
           before do
             product.update!(max_purchase_count: 10)
+            Rails.cache.clear
             allow(product).to receive(:remaining_for_sale_count).and_return(0)
           end
 
           it "sets availability to SoldOut" do
             expect(product.structured_data["offers"]["availability"]).to eq(Product::StructuredData::AVAILABILITY_SOLD_OUT)
+          end
+        end
+
+        context "when availability is cached" do
+          before do
+            product.update!(max_purchase_count: 10)
+            Rails.cache.clear
+          end
+
+          it "caches remaining_for_sale_count and reuses it on subsequent calls" do
+            allow(product).to receive(:remaining_for_sale_count).and_return(5, 0)
+
+            first_result = product.structured_data["offers"]["availability"]
+            second_result = product.structured_data["offers"]["availability"]
+
+            expect(first_result).to eq(Product::StructuredData::AVAILABILITY_LIMITED)
+            expect(second_result).to eq(Product::StructuredData::AVAILABILITY_LIMITED)
+            expect(product).to have_received(:remaining_for_sale_count).once
           end
         end
       end


### PR DESCRIPTION
## What

Caches `remaining_for_sale_count` in the `availability_for_schema_org` method (used for schema.org structured data on product pages) with a 5-minute TTL.

## Why

`LinksController#show` times out (120s `Rack::Timeout`) for products with very large numbers of purchases. The root cause is `sales_count_for_inventory`, which performs a complex left join query on subscriptions via the `counts_towards_inventory` scope. This query runs on every product page load through the `structured_data` → `availability_for_schema_org` → `remaining_for_sale_count` → `sales_count_for_inventory` call chain.

Schema.org availability metadata doesn't need real-time accuracy, so a 5-minute cache is appropriate. The cache is scoped only to the structured data path — purchase validation in `Purchase#sold_out` continues using uncached queries to prevent overselling.

Sentry: https://gumroad-to.sentry.io/issues/7376628854/

## Test results

37 examples, 0 failures (including new caching behavior test)

---

AI disclosure: Implemented with Claude Opus 4.6. Prompted with Sentry issue context and instructions to fix the Rack::Timeout by caching `sales_count_for_inventory` in the structured data path.