### PR TITLE
Handle Aws::S3::Errors::NotFound in ProductFilesUtilityController#download_product_files

### DIFF
--- a/app/controllers/product_files_utility_controller.rb
+++ b/app/controllers/product_files_utility_controller.rb
@@ -26,10 +26,17 @@ class ProductFilesUtilityController < ApplicationController
 
     url_redirect = @product.url_redirects.build
     if request.format.json?
-      render(json: { files: product_files.map { { url: url_redirect.signed_location_for_file(_1), filename: _1.s3_filename } } })
+      files = product_files.filter_map do |product_file|
+        { url: url_redirect.signed_location_for_file(product_file), filename: product_file.s3_filename }
+      rescue Aws::S3::Errors::NotFound
+        nil
+      end
+      e404 if files.blank?
+      render(json: { files: })
     else
-      # Non-JSON requests to this controller route pass an array with a single product file ID for `product_file_ids`
       redirect_to(url_redirect.signed_location_for_file(product_files.first), allow_other_host: true)
+    rescue Aws::S3::Errors::NotFound
+      e404
     end
   end
 

--- a/spec/controllers/products/product_files_utility_controller_spec.rb
+++ b/spec/controllers/products/product_files_utility_controller_spec.rb
@@ -83,6 +83,40 @@ describe ProductFilesUtilityController, :vcr do
 
       expect(response).to redirect_to("https://example.com/file.srt")
     end
+
+    context "when S3 objects are missing" do
+      it "skips files with missing S3 objects in JSON response" do
+        file1 = create(:readable_document, link: product, display_name: "file1")
+        file2 = create(:streamable_video, link: product, display_name: "file2")
+
+        allow_any_instance_of(UrlRedirect).to receive(:signed_location_for_file).with(file1).and_raise(Aws::S3::Errors::NotFound.new(nil, "Not Found"))
+        allow_any_instance_of(UrlRedirect).to receive(:signed_location_for_file).with(file2).and_return("https://example.com/file2.pdf")
+        get :download_product_files, format: :json, params: { product_file_ids: [file1.external_id, file2.external_id], product_id: product.external_id }
+
+        expect(response).to have_http_status(:success)
+        expect(response.parsed_body["files"]).to eq([{ "url" => "https://example.com/file2.pdf", "filename" => file2.s3_filename }])
+      end
+
+      it "returns 404 when all files have missing S3 objects in JSON response" do
+        file1 = create(:readable_document, link: product, display_name: "file1")
+        file2 = create(:streamable_video, link: product, display_name: "file2")
+
+        allow_any_instance_of(UrlRedirect).to receive(:signed_location_for_file).and_raise(Aws::S3::Errors::NotFound.new(nil, "Not Found"))
+
+        expect {
+          get :download_product_files, format: :json, params: { product_file_ids: [file1.external_id, file2.external_id], product_id: product.external_id }
+        }.to raise_error(ActionController::RoutingError)
+      end
+
+      it "returns 404 when the file has a missing S3 object in HTML response" do
+        file = create(:product_file, link: product)
+        allow_any_instance_of(UrlRedirect).to receive(:signed_location_for_file).with(file).and_raise(Aws::S3::Errors::NotFound.new(nil, "Not Found"))
+
+        expect {
+          get :download_product_files, format: :html, params: { product_id: product.external_id, product_file_ids: [file.external_id] }
+        }.to raise_error(ActionController::RoutingError)
+      end
+    end
   end
 
   describe "GET download_folder_archive" do


### PR DESCRIPTION
## What

Handles `Aws::S3::Errors::NotFound` in `ProductFilesUtilityController#download_product_files` so that missing S3 objects return a 404 instead of a 500.

- **JSON requests**: filters out files whose S3 objects are missing from the response. Returns 404 if all requested files are missing.
- **HTML requests**: returns 404 when the S3 object for the file is missing.

## Why

When a product file record exists in the database but the actual S3 object has been deleted or is missing, `signed_location_for_file` calls `content_length` on the S3 object, which raises `Aws::S3::Errors::NotFound`. This bubbles up as an unhandled 500 error. The fix handles this at the controller level, which is the appropriate place since callers should decide how to handle missing S3 objects.

Sentry: `Aws::S3::Errors::NotFound` in `ProductFilesUtilityController#download_product_files`

## Test Results

Added three test cases:
- JSON request where one file is missing from S3 (skips it, returns the rest)
- JSON request where all files are missing from S3 (returns 404)
- HTML request where the file is missing from S3 (returns 404)

---

Generated with Claude Opus 4.6. Prompted to fix `Aws::S3::Errors::NotFound` in `ProductFilesUtilityController#download_product_files` with specific error handling strategy provided.