### PR TITLE
Fix Elasticsearch alias rejection in purchase mapping migration

### DIFF
--- a/db/migrate/20210920213746_add_product_and_seller_names_to_purchase_mapping.rb
+++ b/db/migrate/20210920213746_add_product_and_seller_names_to_purchase_mapping.rb
@@ -2,9 +2,11 @@
 
 class AddProductAndSellerNamesToPurchaseMapping < ActiveRecord::Migration[6.1]
   def up
-    EsClient.indices.close(index: Purchase.index_name)
+    concrete_index = resolve_concrete_index(Purchase.index_name)
+
+    EsClient.indices.close(index: concrete_index)
     EsClient.indices.put_settings(
-      index: Purchase.index_name,
+      index: concrete_index,
       body: {
         settings: {
           index: {
@@ -31,7 +33,7 @@ class AddProductAndSellerNamesToPurchaseMapping < ActiveRecord::Migration[6.1]
         }
       }
     )
-    EsClient.indices.open(index: Purchase.index_name)
+    EsClient.indices.open(index: concrete_index)
 
     EsClient.indices.put_mapping(
       index: Purchase.index_name,
@@ -54,4 +56,12 @@ class AddProductAndSellerNamesToPurchaseMapping < ActiveRecord::Migration[6.1]
       }
     )
   end
+
+  private
+    def resolve_concrete_index(name)
+      aliases = EsClient.indices.get_alias(name: name)
+      aliases.keys.first
+    rescue Elasticsearch::Transport::Transport::Errors::NotFound
+      name
+    end
 end

--- a/spec/db/migrate/add_product_and_seller_names_to_purchase_mapping_spec.rb
+++ b/spec/db/migrate/add_product_and_seller_names_to_purchase_mapping_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require_relative "../../../db/migrate/20210920213746_add_product_and_seller_names_to_purchase_mapping"
+
+describe AddProductAndSellerNamesToPurchaseMapping do
+  subject(:migration) { described_class.new }
+
+  describe "#resolve_concrete_index" do
+    context "when the index name is an alias" do
+      it "resolves to the concrete index name" do
+        allow(EsClient.indices).to receive(:get_alias)
+          .with(name: "purchases")
+          .and_return({ "purchases_v1" => { "aliases" => { "purchases" => {} } } })
+
+        result = migration.send(:resolve_concrete_index, "purchases")
+
+        expect(result).to eq("purchases_v1")
+      end
+    end
+
+    context "when the index name is not an alias" do
+      it "returns the original index name" do
+        allow(EsClient.indices).to receive(:get_alias)
+          .with(name: "purchases")
+          .and_raise(Elasticsearch::Transport::Transport::Errors::NotFound)
+
+        result = migration.send(:resolve_concrete_index, "purchases")
+
+        expect(result).to eq("purchases")
+      end
+    end
+  end
+
+  describe "#up" do
+    let(:concrete_index) { "purchases_v1" }
+
+    before do
+      allow(migration).to receive(:resolve_concrete_index)
+        .with(Purchase.index_name)
+        .and_return(concrete_index)
+      allow(EsClient.indices).to receive(:close)
+      allow(EsClient.indices).to receive(:put_settings)
+      allow(EsClient.indices).to receive(:open)
+      allow(EsClient.indices).to receive(:put_mapping)
+    end
+
+    it "uses the concrete index for close, put_settings, and open operations" do
+      migration.up
+
+      expect(EsClient.indices).to have_received(:close).with(index: concrete_index)
+      expect(EsClient.indices).to have_received(:put_settings).with(hash_including(index: concrete_index))
+      expect(EsClient.indices).to have_received(:open).with(index: concrete_index)
+    end
+
+    it "uses the alias for put_mapping" do
+      migration.up
+
+      expect(EsClient.indices).to have_received(:put_mapping).with(hash_including(index: Purchase.index_name))
+    end
+  end
+end


### PR DESCRIPTION
## What

Resolves the `purchases` Elasticsearch alias to its concrete index name before calling `close`, `put_settings`, and `open` in the `AddProductAndSellerNamesToPurchaseMapping` migration.

## Why

In production, `purchases` is an alias pointing to a versioned concrete index (e.g. `purchases_v1`). Elasticsearch 8.x rejects alias names for `close`, `put_settings`, and `open` operations, causing `db:prepare` to fail with:

```
Elasticsearch::Transport::Transport::Errors::BadRequest: [400]
The provided expression [purchases] matches an alias, specify the corresponding concrete indices instead.
```

The fix adds a `resolve_concrete_index` helper that calls `get_alias` to resolve the alias, falling back to the original name if it's already a concrete index. `put_mapping` still works with aliases and is left unchanged.

Sentry: https://gumroad-to.sentry.io/issues/7376869512/

## Test Results

Added spec for the migration covering both alias resolution paths and verifying the correct index name is passed to each ES API call. Tests could not be run locally (missing bundler setup).

---

AI disclosure: Built with Claude Opus 4.6. Prompted to investigate and fix the Sentry error for Elasticsearch alias rejection in migrations.