### PR TITLE
Show mobile audio player UI for products without rich content

### DIFF
--- a/app/javascript/components/Download/FileList.tsx
+++ b/app/javascript/components/Download/FileList.tsx
@@ -198,7 +198,7 @@ export const FileRow = ({
     toggleAudioDrawer();
   };
 
-  if (isMobileAppWebView && isEmbed && FileUtils.isAudioExtension(file.extension)) {
+  if (isMobileAppWebView && FileUtils.isAudioExtension(file.extension)) {
     return <MobileAppAudioFileRow file={file} />;
   }
 

--- a/spec/requests/download_page/audio_files_spec.rb
+++ b/spec/requests/download_page/audio_files_spec.rb
@@ -258,4 +258,25 @@ describe("Download Page Audio files", type: :system, js: true) do
       end
     end
   end
+
+  describe "mobile app display" do
+    it "renders the mobile app audio row on legacy file list pages" do
+      audio_file = @product.product_files.first
+      visit("/d/#{@url_redirect.token}?display=mobile_app")
+
+      expect(page).to have_button("Play")
+      expect(page).to have_text("MP3")
+      expect(page).to have_text("0m 46s")
+      expect(page).to_not have_button("Pause")
+      expect(page).to_not have_text(" left")
+      expect(page).to_not have_selector("meter")
+
+      page.execute_script %Q(
+        window.dispatchEvent(new CustomEvent("mobile_app_audio_player_info", { detail: { fileId: "#{audio_file.external_id}", isPlaying: true, latestMediaLocation: "24" } }));
+      ).squish
+      expect(page).to have_button("Pause")
+      expect(page).to have_text("0m 22s left")
+      expect(page).to have_selector("meter[value*='0.52']")
+    end
+  end
 end


### PR DESCRIPTION
Ref #4018

Customers are complaining that the new app doesn't play audio correctly, and instead just tries to download the file. This is because the mobile audio player currently only shows for files with rich content. It works in the old app because we have a custom native file list renderer for products without rich content, but in the new app we just render a WebView for all products for consistency.

The fix is just to show the mobile audio player on all files regardless of whether they're using the rich text editor or legacy file list.

## Before

<img width="1438" height="146" alt="Screenshot 2026-03-31 at 14 18 55" src="https://github.com/user-attachments/assets/f116abac-4dab-4de8-b644-646912898c33" />

## After

<img width="1431" height="144" alt="Screenshot 2026-03-31 at 14 20 35" src="https://github.com/user-attachments/assets/cbf5d850-a09c-4c55-a39c-bc577af3ffe3" />
