### PR TITLE
Fix NoMethodError for unpaid_balance_cents_up_to_date_held_by_stripe

### DIFF
--- a/app/modules/user/money_balance.rb
+++ b/app/modules/user/money_balance.rb
@@ -23,6 +23,13 @@ class User
       balances.unpaid.where("date <= ?", date).where(merchant_account_id: gumroad_merchant_account_ids).sum(:amount_cents)
     end
 
+    def unpaid_balance_cents_up_to_date_held_by_stripe(date)
+      creator_stripe_account = stripe_account
+      return 0 if creator_stripe_account.blank?
+
+      balances.unpaid.where("date <= ?", date).where(merchant_account_id: creator_stripe_account.id).sum(:amount_cents)
+    end
+
     def unpaid_balance_holding_cents_up_to_date_held_by_stripe(date)
       creator_stripe_account = stripe_account
       return 0 unless creator_stripe_account.present?

--- a/spec/modules/user/money_balance_spec.rb
+++ b/spec/modules/user/money_balance_spec.rb
@@ -121,6 +121,45 @@ describe User::MoneyBalance do
   end
 
 
+  describe "#unpaid_balance_cents_up_to_date_held_by_stripe" do
+    let(:stripe_connect_merchant_account) { create(:merchant_account, user: @user, currency: "aud") }
+
+    it "returns unpaid amount cents held in stripe connect account with date up to the given date" do
+      create(:balance, user: @user, merchant_account: stripe_connect_merchant_account,
+                       holding_currency: stripe_connect_merchant_account.currency,
+                       amount_cents: 100, holding_amount_cents: 129, state: "unpaid", date: 3.days.ago)
+      create(:balance, user: @user, merchant_account: stripe_connect_merchant_account,
+                       holding_currency: stripe_connect_merchant_account.currency,
+                       amount_cents: 200, holding_amount_cents: 258, state: "unpaid", date: 5.days.ago)
+
+      expect(@user.unpaid_balance_cents_up_to_date_held_by_stripe(1.day.ago)).to eq(300)
+    end
+
+    it "does not include balance held by gumroad" do
+      create(:balance, user: @user, merchant_account: MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id),
+                       amount_cents: 100, state: "unpaid", date: 3.days.ago)
+
+      expect(@user.unpaid_balance_cents_up_to_date_held_by_stripe(1.day.ago)).to eq(0)
+    end
+
+    it "does not include paid balance" do
+      create(:balance, user: @user, merchant_account: stripe_connect_merchant_account,
+                       amount_cents: 100, state: "paid", date: 3.days.ago)
+      expect(@user.unpaid_balance_cents_up_to_date_held_by_stripe(1.day.ago)).to eq(0)
+    end
+
+    it "does not include balance with date after the given date" do
+      create(:balance, user: @user, merchant_account: stripe_connect_merchant_account,
+                       amount_cents: 100, state: "unpaid", date: 1.day.ago)
+      expect(@user.unpaid_balance_cents_up_to_date_held_by_stripe(3.days.ago)).to eq(0)
+    end
+
+    it "returns 0 when user has no stripe account" do
+      allow(@user).to receive(:stripe_account).and_return(nil)
+      expect(@user.unpaid_balance_cents_up_to_date_held_by_stripe(1.day.ago)).to eq(0)
+    end
+  end
+
   describe "#unpaid_balance_holding_cents_up_to_date_held_by_stripe" do
     let(:stripe_connect_merchant_account) { create(:merchant_account, user: @user, currency: "aud") }
 


### PR DESCRIPTION
## What

Adds the missing `unpaid_balance_cents_up_to_date_held_by_stripe` method to `User::MoneyBalance`.

The gumroad variant follows the naming pattern `unpaid_balance_cents_up_to_date_held_by_gumroad` (sums `amount_cents`), but the stripe variant was only defined as `unpaid_balance_holding_cents_up_to_date_held_by_stripe` (sums `holding_amount_cents`). The symmetrical method that sums `amount_cents` for stripe-held balances was never defined, causing a `NoMethodError` at runtime.

## Why

A Sentry error (`NoMethodError: undefined method 'unpaid_balance_cents_up_to_date_held_by_stripe'`) was triggered because the expected method name — following the established `_held_by_*` convention — did not exist. The naming inconsistency between the gumroad and stripe methods made this a likely source of confusion for any caller.

## Test results

All 47 related tests pass:
- `spec/modules/user/money_balance_spec.rb` (40 examples, including 5 new tests for the added method)
- `spec/models/concerns/user/payout_info_spec.rb` (7 examples)

---

AI disclosure: Implemented with Claude Opus 4.6. Prompted with Sentry error details and instructions to investigate root cause, add tests, and open a PR.