### PR TITLE
Fix product thumbnail images broken on Safari

### DIFF
--- a/app/javascript/components/ProductsPage/ProductIconCell.tsx
+++ b/app/javascript/components/ProductsPage/ProductIconCell.tsx
@@ -15,7 +15,7 @@ export const ProductIconCell = ({
   <TableCell hideLabel className="text-center text-xl lg:w-20 lg:min-w-20 lg:border-r lg:border-border lg:p-0">
     <a href={href}>
       {thumbnail ? (
-        <div className="lg:aspect-square lg:overflow-hidden">
+        <div className="lg:h-20 lg:overflow-hidden">
           <img className="max-w-20 lg:size-full lg:object-cover" role="presentation" src={thumbnail} />
         </div>
       ) : (


### PR DESCRIPTION
## What

Replace `lg:aspect-square` with explicit `lg:h-20` on the product thumbnail container in `ProductIconCell`.

**Before**
<img width="300" height="144" alt="image" src="https://github.com/user-attachments/assets/a4006e3c-c9e5-41d1-8a79-ecc519e9e58e" />

**After**
<img width="282" height="142" alt="image" src="https://github.com/user-attachments/assets/4a804271-8a34-436a-86cd-cf581cca8455" />



## Why

Safari has a bug where `aspect-ratio` doesn't work correctly on elements inside table cells (`<td>`). The browser can't resolve the element's width to compute the height from the ratio, causing thumbnails to collapse to near-zero height — appearing as thin colored strips or broken image icons.

Since the table cell already has `lg:w-20 lg:min-w-20`, the div naturally takes that width. Setting `lg:h-20` (matching the 5rem width) creates the intended square without relying on `aspect-ratio`.

## Before/After

| | Safari | Chrome |
|---|---|---|
| **Before** | Thumbnails collapsed/broken | Works correctly |
| **After** | Thumbnails display as squares | No change |

---

Generated with Claude Opus 4.6.