### PR TITLE
Handle Aws::S3::Errors::NotFound in UrlRedirectsController#download_product_files

### DIFF
--- a/app/controllers/url_redirects_controller.rb
+++ b/app/controllers/url_redirects_controller.rb
@@ -115,6 +115,13 @@ class UrlRedirectsController < ApplicationController
       redirect_to(@url_redirect.signed_location_for_file(@product_file), allow_other_host: true)
       create_consumption_event!(ConsumptionEvent::EVENT_TYPE_DOWNLOAD)
     end
+  rescue Aws::S3::Errors::NotFound
+    if request.format.json?
+      render(json: { error: "The file is no longer available." }, status: :not_found)
+    else
+      flash[:warning] = "The file is no longer available. Please contact the seller."
+      redirect_to(@url_redirect.download_page_url)
+    end
   end
 
   def download_archive

--- a/spec/controllers/url_redirects_controller_spec.rb
+++ b/spec/controllers/url_redirects_controller_spec.rb
@@ -971,6 +971,29 @@ describe UrlRedirectsController, inertia: true do
       expect(response).to redirect_to("https://example.com/file.srt")
     end
 
+    context "when the S3 object is missing" do
+      it "returns a 404 JSON error for JSON requests" do
+        file = create(:product_file, link: @product)
+        allow_any_instance_of(UrlRedirect).to receive(:signed_location_for_file).with(file).and_raise(Aws::S3::Errors::NotFound.new(nil, "Not Found"))
+
+        get :download_product_files, format: :json, params: { product_file_ids: [file.external_id], id: @token }
+
+        expect(response).to have_http_status(:not_found)
+        expect(response.parsed_body["error"]).to eq("The file is no longer available.")
+      end
+
+      it "redirects to the download page with a warning for HTML requests" do
+        file = create(:product_file, link: @product)
+        url_redirect = UrlRedirect.find_by(token: @token)
+        allow_any_instance_of(UrlRedirect).to receive(:signed_location_for_file).with(file).and_raise(Aws::S3::Errors::NotFound.new(nil, "Not Found"))
+
+        get :download_product_files, format: :html, params: { id: @token, product_file_ids: [file.external_id] }
+
+        expect(response).to redirect_to(url_redirect.download_page_url)
+        expect(flash[:warning]).to eq("The file is no longer available. Please contact the seller.")
+      end
+    end
+
     context "when a PDF must be stamped and stamped file is missing" do
       it "shows alert, enqueues job (critical, notify=true), and redirects to download page" do
         product_file = create(:readable_document, link: @product, pdf_stamp_enabled: true)


### PR DESCRIPTION
## What

Rescue `Aws::S3::Errors::NotFound` in `download_product_files` so buyers get a graceful error instead of a 500 when a product file's S3 object no longer exists.

- JSON requests: returns `{ error: "The file is no longer available." }` with HTTP 404
- HTML requests: sets a flash warning and redirects to the download page

## Why

`download_archive` already handles this exception (lines 135-141), but `download_product_files` did not. When S3 objects are deleted or expire, `signed_location_for_file` raises `Aws::S3::Errors::NotFound`, causing an unhandled 500 error for buyers.

## Test results

```
UrlRedirectsController
  GET download_product_files
    returns a 404 if no files exist
    returns the file download info for all requested files
    redirects to the first product file if the format is HTML
    when the S3 object is missing
      returns a 404 JSON error for JSON requests
      redirects to the download page with a warning for HTML requests
    when a PDF must be stamped and stamped file is missing
      shows alert, enqueues job (critical, notify=true), and redirects to download page

6 examples, 0 failures
```

---

AI disclosure: Implemented with Claude Opus 4.6. Prompted to fix the unhandled `Aws::S3::Errors::NotFound` exception in `download_product_files`, following the existing pattern from `download_archive`.