### PR TITLE
Fix TypeError: no implicit conversion of nil into String in redirect_to_next

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,7 +44,11 @@ class ApplicationController < ActionController::Base
   add_flash_types :warning
 
   def redirect_to_next
-    safe_redirect_to(params[:next])
+    if params[:next].present?
+      safe_redirect_to(params[:next])
+    else
+      redirect_to root_path
+    end
   end
 
   def safe_redirect_path(path, allow_subdomain_host: true)

--- a/spec/controllers/url_redirects_controller_spec.rb
+++ b/spec/controllers/url_redirects_controller_spec.rb
@@ -1939,6 +1939,15 @@ describe UrlRedirectsController, inertia: true do
       expect(response).to redirect_to("/r/#{@token}")
     end
 
+    it "redirects to root path when next param is missing" do
+      user = create(:user)
+
+      sign_in user
+      post :change_purchaser, params: { id: @token, email: @url_redirect.purchase.email }
+
+      expect(response).to redirect_to(root_path)
+    end
+
     it "redirects to the check_purchaser page if the email is incorrect" do
       user = create(:user)
 

--- a/spec/services/safe_redirect_path_service_spec.rb
+++ b/spec/services/safe_redirect_path_service_spec.rb
@@ -90,5 +90,19 @@ describe "SafeRedirectPathService" do
         expect(service.process).to eq "?query=param"
       end
     end
+
+    context "when path is nil" do
+      it "raises TypeError" do
+        @path = nil
+        expect { service.process }.to raise_error(TypeError)
+      end
+    end
+
+    context "when path is an empty string" do
+      it "raises an error" do
+        @path = ""
+        expect { service.process }.to raise_error(URI::InvalidURIError)
+      end
+    end
   end
 end


### PR DESCRIPTION
## What

Guards against `nil`/blank `params[:next]` in `redirect_to_next` by falling back to `root_path`.

## Why

When `params[:next]` is nil (e.g. in `UrlRedirectsController#change_purchaser`), it flows through to `SafeRedirectPathService#url` which calls `CGI.unescape(nil)`, raising `TypeError: no implicit conversion of nil into String`. This was generating noise in Sentry ([issue](https://gumroad-to.sentry.io/issues/7378804631/)).

The fix checks `params[:next].present?` before passing it to `safe_redirect_to`, redirecting to `root_path` when the param is missing.

## Test Results

- `spec/services/safe_redirect_path_service_spec.rb` — 12 examples, 0 failures
- `spec/controllers/url_redirects_controller_spec.rb` (change_purchaser) — 3 examples, 0 failures

---

Generated with Claude Opus 4.6. Prompt: fix the Sentry TypeError in redirect_to_next when params[:next] is nil.