### PR TITLE
Fix Aws::S3::Errors::NoSuchKey in HLS playlist fetch

### DIFF
--- a/app/models/concerns/streamable.rb
+++ b/app/models/concerns/streamable.rb
@@ -45,7 +45,11 @@ module Streamable
     hls_key_prefix = "#{File.dirname(playlist_key)}/" # Extract path without the filename
 
     playlist_s3_object = Aws::S3::Resource.new.bucket(S3_BUCKET).object(playlist_key)
-    playlist = playlist_s3_object.get.body.read
+    begin
+      playlist = playlist_s3_object.get.body.read
+    rescue Aws::S3::Errors::NoSuchKey
+      return nil
+    end
     playlist_content_with_signed_urls = ""
 
     playlist.split("\n").each do |playlist_line|

--- a/spec/models/product_file_spec.rb
+++ b/spec/models/product_file_spec.rb
@@ -490,6 +490,18 @@ describe ProductFile do
       expect(file.hls_playlist).to include("attachments/0000134abcdefghhijkl354sfdg/chapter+2/hls/hls_480p_.m3u8")
     end
 
+    it "returns nil when the S3 playlist object does not exist" do
+      s3_object = double("s3_object")
+      allow(s3_object).to receive(:get).and_raise(Aws::S3::Errors::NoSuchKey.new(nil, "The specified key does not exist."))
+      s3_bucket = double("s3_bucket")
+      allow(s3_bucket).to receive(:object).and_return(s3_object)
+      s3_resource = double("s3_resource")
+      allow(s3_resource).to receive(:bucket).and_return(s3_bucket)
+      allow(Aws::S3::Resource).to receive(:new).and_return(s3_resource)
+
+      expect(@file_1.hls_playlist).to be_nil
+    end
+
     it "escapes the newlines in the filename" do
       file = create(:product_file, url: "#{AWS_S3_ENDPOINT}/#{S3_BUCKET}/attachments/12345/abcd12345/original/YouTube + Marketing Is Powerful\n.mp4", is_transcoded_for_hls: true)
       @multifile_product.product_files << file


### PR DESCRIPTION
## What

Rescue `Aws::S3::Errors::NoSuchKey` in `Streamable#hls_playlist` and return `nil` when the S3 playlist object is missing.

## Why

When a `TranscodedVideo` record exists in the database but the corresponding S3 object has been deleted, `hls_playlist` raises an unhandled `Aws::S3::Errors::NoSuchKey` exception, resulting in a 500 error. The controller already handles a `nil` return from `hls_playlist` by returning a 404, so this fix lets the existing error handling work as intended.

Sentry issue: https://gumroad-to.sentry.io/issues/7378977309/

## Test plan

- [x] Added unit test for `#hls_playlist` when the S3 object does not exist (returns `nil`)
- [ ] Existing HLS playlist tests continue to pass
- [ ] Verify in Sentry that `Aws::S3::Errors::NoSuchKey` errors stop occurring for `UrlRedirectsController#hls_playlist`

---

AI disclosure: This PR was authored with Claude Opus 4.6. Prompts: fix Sentry issue for `Aws::S3::Errors::NoSuchKey` in `Streamable#hls_playlist` by rescuing and returning nil.