### PR TITLE
Fix customer name not appearing on customer detail page

### DIFF
--- a/app/presenters/customer_presenter.rb
+++ b/app/presenters/customer_presenter.rb
@@ -31,7 +31,7 @@ class CustomerPresenter
       id: purchase.external_id,
       email: purchase.email,
       giftee_email: purchase.giftee_email,
-      name: purchase.full_name || "",
+      name: purchase.full_name.try(:strip).presence || purchase.purchaser&.name || "",
       physical: purchase.sku.present? ?
         {
           sku: purchase.sku.custom_name_or_external_id,

--- a/spec/presenters/customer_presenter_spec.rb
+++ b/spec/presenters/customer_presenter_spec.rb
@@ -316,6 +316,35 @@ describe CustomerPresenter do
       end
     end
 
+    context "when purchase has no full_name but purchaser has a name" do
+      let(:purchaser) { create(:named_user) }
+      let(:purchase) { create(:purchase, full_name: nil, purchaser:) }
+
+      it "falls back to the purchaser name" do
+        props = described_class.new(purchase:).customer(pundit_user:)
+        expect(props[:name]).to eq(purchaser.name)
+      end
+    end
+
+    context "when purchase has a whitespace-only full_name but purchaser has a name" do
+      let(:purchaser) { create(:named_user) }
+      let(:purchase) { create(:purchase, full_name: "  ", purchaser:) }
+
+      it "falls back to the purchaser name" do
+        props = described_class.new(purchase:).customer(pundit_user:)
+        expect(props[:name]).to eq(purchaser.name)
+      end
+    end
+
+    context "when purchase has no full_name and no purchaser" do
+      let(:purchase) { create(:purchase, full_name: nil, purchaser: nil) }
+
+      it "returns an empty string" do
+        props = described_class.new(purchase:).customer(pundit_user:)
+        expect(props[:name]).to eq("")
+      end
+    end
+
     context "purchase has review videos" do
       let(:purchase) { create(:purchase) }
       let(:product_review) { create(:product_review, purchase:) }


### PR DESCRIPTION
## Problem

Customer name doesn't appear on the customer detail page for digital product purchases where the buyer uses a registered account with a profile name. The name exists in the exported CSV but is blank in the UI.

## Root cause

`CustomerPresenter#customer` used `purchase.full_name || ""` directly. For digital products (no shipping required), `full_name` on the purchase record is `nil` since it's not collected at checkout. However, the buyer's account (`purchaser`) has a name.

The CSV export already handled this correctly with `full_name.try(:strip).presence || purchaser&.name`, but the UI presenter didn't have the same fallback.

## Fix

Updated the presenter to match the CSV export behavior: fall back to `purchase.purchaser&.name` when `full_name` is blank.

Added tests for:
- Purchase with no full_name but a named purchaser (falls back to purchaser name)
- Purchase with whitespace-only full_name (falls back to purchaser name)
- Purchase with no full_name and no purchaser (returns empty string)

Fixes #4246