### PR TITLE
Skip default offer code validation for unrelated product saves

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1252,6 +1252,7 @@ class Link < ApplicationRecord
     def default_offer_code_must_be_valid
       return unless default_offer_code.present?
       return if being_marked_as_deleted?
+      return unless new_record? || default_offer_code_id_changed?
 
       if !user.offer_codes.alive.where(id: default_offer_code.id).exists?
         errors.add(:default_offer_code, "must belong to your offer codes")

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -161,6 +161,19 @@ describe LinksController, :vcr, inertia: true do
         let(:request_params) { { id: product.unique_permalink } }
       end
 
+      it "succeeds when the product has an expired default offer code" do
+        offer_code = create(:offer_code, user: seller, products: [product])
+        product.update_column(:default_offer_code_id, offer_code.id)
+        offer_code.update_column(:expires_at, 1.day.ago)
+
+        sections = create_list(:seller_profile_products_section, 2, seller:, product:)
+
+        put :update_sections, params: { id: product.unique_permalink, sections: sections.map(&:external_id), main_section_index: 0 }
+
+        expect(response).to have_http_status(:no_content)
+        expect(product.reload.sections).to eq(sections.map(&:id))
+      end
+
       it "updates the SellerProfileSections attached to the product and cleans up orphaned sections" do
         sections = create_list(:seller_profile_products_section, 2, seller:, product:)
         create(:seller_profile_posts_section, seller:, product:)


### PR DESCRIPTION
## What

Added a guard clause to `default_offer_code_must_be_valid` so it only runs when `default_offer_code_id` is actually changing (or on new records). Previously, any product save — including `update_sections` — would fail if the product's default offer code had expired.

## Why

Sentry reported `ActiveRecord::RecordInvalid: Validation failed: Default offer code cannot be expired` in `LinksController#update_sections`. The root cause: the validation fires on every `save!`, even when the save has nothing to do with offer codes. A product whose default offer code expired over time became unsaveable for unrelated updates. The fix scopes the validation to only when the default offer code assignment is actually changing.

## Test results

```
LinksController within seller area PUT sections
  succeeds when the product has an expired default offer code
  updates the SellerProfileSections attached to the product and cleans up orphaned sections
  behaves like authorize called for action
    calls authorize with correct arguments on put: update_sections
  behaves like collaborator can access
    allows a collaborator to access put /update_sections

4 examples, 0 failures
```

---

AI disclosure: Implemented with Claude Opus 4.6. Prompted with the Sentry error, root cause analysis, and implementation plan.