### PR TITLE
Fix Rack::Timeout in LinksController#show by adding composite index on purchases

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -838,13 +838,11 @@ class Link < ApplicationRecord
   def purchase_info_for_product_page(requested_user, browser_guid)
     return nil unless requested_user || browser_guid
 
-    eligible_purchases = Purchase.none
-    eligible_purchases = requested_user.purchases.where(link: self) if requested_user
+    eligible_purchases = requested_user&.purchases&.where(link: self)
 
-    # When a gift purchase is made, we set the same browser_guid for the gifter and giftee purchases.
-    # When fetching purchases using browser_guid, exclude gift receiver purchases so that we won't show
-    # the giftee purchase to gifter on the same browser.
-    eligible_purchases = sales.not_is_gift_receiver_purchase.where(browser_guid:, purchaser_id: nil) if browser_guid && eligible_purchases.blank?
+    if browser_guid && !eligible_purchases&.exists?
+      eligible_purchases = sales.not_is_gift_receiver_purchase.where(browser_guid:, purchaser_id: nil)
+    end
 
     eligible_purchases = if is_in_preorder_state
       eligible_purchases.preorder_authorization_successful_or_gift

--- a/db/migrate/20260401081802_add_index_on_purchases_link_id_and_browser_guid.rb
+++ b/db/migrate/20260401081802_add_index_on_purchases_link_id_and_browser_guid.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddIndexOnPurchasesLinkIdAndBrowserGuid < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :purchases, [:link_id, :browser_guid],
+      name: "index_purchases_on_link_id_and_browser_guid"
+  end
+end

--- a/db/migrate/20260401081802_add_index_on_purchases_link_id_and_browser_guid.rb
+++ b/db/migrate/20260401081802_add_index_on_purchases_link_id_and_browser_guid.rb
@@ -5,6 +5,6 @@ class AddIndexOnPurchasesLinkIdAndBrowserGuid < ActiveRecord::Migration[7.1]
 
   def change
     add_index :purchases, [:link_id, :browser_guid],
-      name: "index_purchases_on_link_id_and_browser_guid"
+              name: "index_purchases_on_link_id_and_browser_guid"
   end
 end


### PR DESCRIPTION
## What

- Adds a composite database index on `purchases(link_id, browser_guid)` to speed up the `purchase_info_for_product_page` query
- Replaces `.blank?` with safe-navigation `.exists?` check to avoid an unnecessary COUNT query

## Why

Sentry reports `Rack::Timeout::RequestTimeoutException` (120s) in `LinksController#show` originating from `Link#purchase_info_for_product_page`. The method queries purchases by both `link_id` and `browser_guid`, but only separate single-column indexes exist. For products with many purchases, MySQL picks one index and scans all matching rows for the other condition, causing full table scans.

The composite index lets MySQL efficiently filter on both columns simultaneously. The code optimization avoids a redundant database query when checking if user purchases exist before falling back to the `browser_guid` lookup.

## Test Results

Existing tests for `purchase_info_for_product_page` pass. 7 tests in this group have pre-existing VCR/Stripe cassette failures (confirmed identical on `main`).

---

AI disclosure: Implemented with Claude Opus 4.6. Prompted with the Sentry issue details and stack trace for the Rack::Timeout in LinksController#show, with instructions to add a composite index and optimize the query method.