### PR TITLE
Fix Rack::Timeout in LibraryController#index caused by N+1 third_party_analytics queries

### DIFF
--- a/app/presenters/library_presenter.rb
+++ b/app/presenters/library_presenter.rb
@@ -20,6 +20,7 @@ class LibraryPresenter
         :variant_attributes,
         :bundle_purchase,
         link: {
+          alive_third_party_analytics: [],
           display_asset_previews: { file_attachment: { blob: { variant_records: { image_attachment: :blob } } } },
           thumbnail_alive: { file_attachment: { blob: { variant_records: { image_attachment: :blob } } } },
           user: { avatar_attachment: :blob }
@@ -27,6 +28,11 @@ class LibraryPresenter
       )
       .find_each(batch_size: 3000, order: :desc) # required to avoid full table scans. See https://github.com/gumroad/web/pull/25970
       .to_a
+
+    user_ids = purchases.map { |p| p.link.user_id }.uniq
+    users_with_universal_analytics = ThirdPartyAnalytic.where(user_id: user_ids, link_id: nil)
+      .alive.where(location: ["receipt", "all"]).distinct.pluck(:user_id).to_set
+
     creators_infos = purchases.flat_map { |purchase| purchase.link.user }.uniq.group_by(&:id).transform_values(&:first)
     creators = creators_infos.values.map do |creator|
       { id: creator.external_id, name: creator.name || creator.username || creator.external_id }
@@ -54,7 +60,8 @@ class LibraryPresenter
           native_type: product.native_type,
           updated_at: product.content_updated_at || product.created_at,
           permalink: product.unique_permalink,
-          has_third_party_analytics: product.has_third_party_analytics?("receipt"),
+          has_third_party_analytics: product.alive_third_party_analytics.any? { |a| a.location == "receipt" || a.location == "all" } ||
+            users_with_universal_analytics.include?(product.user_id),
         },
         purchase: {
           id: purchase.external_id,

--- a/spec/presenters/library_presenter_spec.rb
+++ b/spec/presenters/library_presenter_spec.rb
@@ -203,6 +203,43 @@ describe LibraryPresenter do
       end
     end
 
+    describe "has_third_party_analytics" do
+      it "detects product-level receipt analytics" do
+        create(:third_party_analytic, user: creator, link: product, location: "receipt", analytics_code: "<script>test</script>")
+
+        purchases, _ = described_class.new(buyer).library_cards
+        expect(purchases.first[:product][:has_third_party_analytics]).to eq(true)
+      end
+
+      it "detects product-level analytics with 'all' location" do
+        create(:third_party_analytic, user: creator, link: product, location: "all", analytics_code: "<script>test</script>")
+
+        purchases, _ = described_class.new(buyer).library_cards
+        expect(purchases.first[:product][:has_third_party_analytics]).to eq(true)
+      end
+
+      it "detects user-level universal receipt analytics" do
+        create(:third_party_analytic, user: creator, link: nil, location: "receipt", analytics_code: "<script>test</script>")
+
+        purchases, _ = described_class.new(buyer).library_cards
+        expect(purchases.first[:product][:has_third_party_analytics]).to eq(true)
+      end
+
+      it "ignores deleted analytics" do
+        create(:third_party_analytic, user: creator, link: product, location: "receipt", analytics_code: "<script>test</script>", deleted_at: 1.day.ago)
+
+        purchases, _ = described_class.new(buyer).library_cards
+        expect(purchases.first[:product][:has_third_party_analytics]).to eq(false)
+      end
+
+      it "ignores analytics for non-receipt locations" do
+        create(:third_party_analytic, user: creator, link: product, location: "product", analytics_code: "<script>test</script>")
+
+        purchases, _ = described_class.new(buyer).library_cards
+        expect(purchases.first[:product][:has_third_party_analytics]).to eq(false)
+      end
+    end
+
     describe "bundle purchase" do
       let(:purchase1) { create(:purchase, purchaser: buyer, link: create(:product, :bundle)) }
       let(:purchase2) { create(:purchase, purchaser: buyer, link: create(:product, :bundle)) }


### PR DESCRIPTION
## What

Eliminates N+1 queries in `LibraryPresenter#library_cards` when checking `has_third_party_analytics?("receipt")` for each purchase.

**Before:** `product.has_third_party_analytics?("receipt")` fired 2 SQL queries per purchase — one for product-level `alive_third_party_analytics` and one for user-level universal `third_party_analytics`. For buyers with hundreds of purchases, this produced hundreds of queries.

**After:** 
- Product-level analytics are eager-loaded via `.includes(link: { alive_third_party_analytics: [] })` and filtered in-memory
- User-level universal analytics are batch-loaded into a `Set` with a single query before the loop
- Total analytics queries reduced from `2 × N` to `2` (one eager load, one batch query)

## Why

Users with large libraries were hitting Rack::Timeout (120s) on `GET /library`. The N+1 on `has_third_party_analytics?` was the root cause — each iteration issued 2 uncached DB queries, compounding linearly with purchase count.

Sentry: https://gumroad-to.sentry.io/issues/7379366917/

## Test results

Added 5 tests covering:
- Product-level receipt analytics detection
- Product-level "all" location analytics detection
- User-level universal receipt analytics detection
- Deleted analytics are excluded
- Non-receipt location analytics are excluded

All 16 non-pre-existing tests pass (2 pre-existing failures unrelated to this change).

---

AI disclosure: Built with Claude Opus 4.6. Prompted with the root cause analysis and fix strategy from the issue description.