### PR TITLE
Fix Stripe::InvalidRequestError when retrieving balance transaction in get_charge_object

### DIFF
--- a/app/business/payments/charging/implementations/stripe/stripe_charge.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge.rb
@@ -12,14 +12,16 @@ class StripeCharge < BaseProcessorCharge
     self.refunded = stripe_charge[:refunded]
     self.disputed = stripe_charge[:dispute].present?
 
-    stripe_fee_detail = stripe_charge_balance_transaction[:fee_details].find { |fee_detail| fee_detail[:type] == "stripe_fee" }
-    if stripe_fee_detail.present?
-      self.fee_currency = stripe_fee_detail[:currency]
-      self.fee = stripe_fee_detail[:amount]
-    end
+    if stripe_charge_balance_transaction.present?
+      stripe_fee_detail = stripe_charge_balance_transaction[:fee_details].find { |fee_detail| fee_detail[:type] == "stripe_fee" }
+      if stripe_fee_detail.present?
+        self.fee_currency = stripe_fee_detail[:currency]
+        self.fee = stripe_fee_detail[:amount]
+      end
 
-    self.flow_of_funds = build_flow_of_funds(stripe_charge, stripe_charge_balance_transaction, stripe_application_fee_balance_transaction,
-                                             stripe_destination_payment_balance_transaction, stripe_destination_transfer)
+      self.flow_of_funds = build_flow_of_funds(stripe_charge, stripe_charge_balance_transaction, stripe_application_fee_balance_transaction,
+                                               stripe_destination_payment_balance_transaction, stripe_destination_transfer)
+    end
 
 
     return if stripe_charge["payment_method_details"].nil?

--- a/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
@@ -126,10 +126,15 @@ class StripeChargeProcessor
     end
     balance_transaction = charge.balance_transaction
     if balance_transaction.is_a?(String)
-      merchant_account = Purchase.find(charge.transfer_group).merchant_account rescue nil
-      balance_transaction = merchant_account&.is_a_stripe_connect_account? ?
-                              Stripe::BalanceTransaction.retrieve({ id: balance_transaction }, { stripe_account: merchant_account.charge_processor_merchant_id }) :
-                              Stripe::BalanceTransaction.retrieve({ id: balance_transaction })
+      begin
+        merchant_account = Purchase.find(charge.transfer_group).merchant_account rescue nil
+        balance_transaction = merchant_account&.is_a_stripe_connect_account? ?
+                                Stripe::BalanceTransaction.retrieve({ id: balance_transaction }, { stripe_account: merchant_account.charge_processor_merchant_id }) :
+                                Stripe::BalanceTransaction.retrieve({ id: balance_transaction })
+      rescue Stripe::InvalidRequestError => e
+        Rails.logger.error("Failed to retrieve balance transaction: #{e.message}")
+        balance_transaction = nil
+      end
     end
     StripeCharge.new(charge, balance_transaction, charge.application_fee.try(:balance_transaction),
                      stripe_destination_payment.try(:balance_transaction), destination_transfer)

--- a/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
@@ -215,6 +215,37 @@ describe StripeChargeProcessor, :vcr do
         expect(charge.fee_currency).to eq(stripe_charge.balance_transaction.fee_details.first.currency)
       end
     end
+
+    describe "when Stripe::BalanceTransaction.retrieve raises Stripe::InvalidRequestError" do
+      it "returns a charge with nil balance transaction data" do
+        mock_charge = Stripe::Charge.construct_from(
+          id: "ch_test_123",
+          status: "succeeded",
+          refunded: false,
+          dispute: nil,
+          amount: 100,
+          currency: "usd",
+          destination: nil,
+          transfer_data: nil,
+          transfer_group: nil,
+          balance_transaction: "txn_test_123",
+          application_fee: nil,
+          payment_method: "pm_test_123",
+          payment_method_details: nil,
+          outcome: nil
+        )
+
+        allow(Stripe::Charge).to receive(:retrieve).and_return(mock_charge)
+        allow(Stripe::BalanceTransaction).to receive(:retrieve)
+          .and_raise(Stripe::InvalidRequestError.new("No such balance transaction: 'txn_test_123'", "id"))
+
+        charge = subject.get_charge("ch_test_123")
+
+        expect(charge).to be_a(BaseProcessorCharge)
+        expect(charge.id).to eq("ch_test_123")
+        expect(charge.fee).to be_nil
+      end
+    end
   end
 
   describe "#search_charge" do


### PR DESCRIPTION
## What

Rescues `Stripe::InvalidRequestError` in `StripeChargeProcessor#get_charge_object` when `Stripe::BalanceTransaction.retrieve` fails. Also adds a nil guard in `StripeCharge#initialize` so it handles nil `balance_transaction` without crashing on `[:fee_details]`.

## Why

When `charge.balance_transaction` is a String ID and the balance transaction belongs to a connected account that doesn't match the lookup context (e.g., `transfer_group` is nil or the purchase's merchant account isn't found), the retrieve call falls to the platform account path and raises `Stripe::InvalidRequestError: No such balance transaction`. This was showing up as an unhandled exception in Sentry. With this fix, the error is logged and the charge is returned with nil fee/flow-of-funds data instead of blowing up.

## Test results

```
21 examples, 0 failures
```

---

AI disclosure: Implemented with Claude Opus 4.6. Prompted to fix the Sentry error `Stripe::InvalidRequestError: No such balance transaction` in `get_charge_object` by adding rescue handling and a nil guard in the StripeCharge constructor.