### PR TITLE
Fix NoMethodError on nil merchant_account in StripePayoutProcessor#prepare_payment_and_set_amount

### DIFF
--- a/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
+++ b/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
@@ -134,6 +134,12 @@ class StripePayoutProcessor
   # Returns an array of errors.
   def self.prepare_payment_and_set_amount(payment, balances)
     merchant_account, balances_held_by_gumroad, balances_held_by_stripe = get_payout_details(payment.user, balances)
+
+    if merchant_account.nil?
+      payment.mark_failed!
+      return ["Cannot process payout: no valid merchant account found for user."]
+    end
+
     payment.stripe_connect_account_id = merchant_account.charge_processor_merchant_id
     payment.currency = merchant_account.currency
     payment.amount_cents = 0

--- a/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
+++ b/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
@@ -264,6 +264,23 @@ describe StripePayoutProcessor, :vcr do
     end
   end
 
+  describe "prepare_payment_and_set_amount when merchant_account is nil" do
+    let(:user) { create(:user) }
+    let(:payment) { create(:payment, user:, currency: nil, amount_cents: nil) }
+    let(:balance) { create(:balance, user:, merchant_account: create(:merchant_account, user:)) }
+
+    before do
+      allow(described_class).to receive(:get_payout_details).and_return([nil, [balance], []])
+    end
+
+    it "returns an error and marks the payment as failed" do
+      errors = described_class.prepare_payment_and_set_amount(payment, [balance])
+
+      expect(errors).to eq(["Cannot process payout: no valid merchant account found for user."])
+      expect(payment.reload.state).to eq("failed")
+    end
+  end
+
   describe "prepare_payment_and_set_amount for Korean bank account" do
     let(:user) { create(:user) }
     let(:bank_account) { create(:korea_bank_account, user:) }


### PR DESCRIPTION
## What

Adds a nil guard for `merchant_account` in `StripePayoutProcessor#prepare_payment_and_set_amount`. When `get_payout_details` returns a nil merchant account, the payment is now marked as failed with an error message instead of raising `NoMethodError: undefined method 'charge_processor_merchant_id' for nil`.

## Why

`merchant_account` can be nil when a user's Stripe Connect account has been deleted or deauthorized after `has_stripe_account_connected?` returns true, or when `stripe_account` is nil with no Stripe-held balances. This edge case causes an unhandled `NoMethodError` in production.

Sentry: https://gumroad-to.sentry.io/issues/7380845181/

## Test Results

Added a test that stubs `get_payout_details` to return nil for `merchant_account` and verifies:
- The method returns an error array
- The payment is marked as failed

```
1 example, 0 failures
```

---

AI Disclosure: This fix was implemented with Claude Opus 4.6. Prompts: fix NoMethodError in StripePayoutProcessor.prepare_payment_and_set_amount where merchant_account is nil, add nil guard and test.