### PR TITLE
Skip Sentry notification for TaxJar BadRequest errors

### DIFF
--- a/app/business/sales_tax/taxjar/taxjar_api.rb
+++ b/app/business/sales_tax/taxjar/taxjar_api.rb
@@ -77,7 +77,7 @@ class TaxjarApi
       end
     rescue *TaxjarErrors::CLIENT => e
       Rails.logger.error "TaxJar Client Error: #{e.inspect}"
-      ErrorNotifier.notify(e)
+      ErrorNotifier.notify(e) unless e.is_a?(Taxjar::Error::BadRequest)
       raise e
     rescue *TaxjarErrors::SERVER => e
       Rails.logger.error "TaxJar Server Error: #{e.inspect}"

--- a/spec/business/sales_tax/taxjar/taxjar_api_spec.rb
+++ b/spec/business/sales_tax/taxjar/taxjar_api_spec.rb
@@ -283,10 +283,10 @@ describe TaxjarApi, :vcr do
                                                          shipping_dollars: 20.0)).to eq(expected_calculation)
     end
 
-    it "notifies error tracker and propagates a TaxJar client error" do
+    it "does not notify error tracker for TaxJar BadRequest errors" do
       expect_any_instance_of(Taxjar::Client).to receive(:tax_for_order).and_raise(Taxjar::Error::BadRequest)
 
-      expect(ErrorNotifier).to receive(:notify).exactly(:once)
+      expect(ErrorNotifier).not_to receive(:notify)
 
       expect do
         described_class.new.calculate_tax_for_order(origin:,
@@ -297,6 +297,22 @@ describe TaxjarApi, :vcr do
                                                     unit_price_dollars: 100.0,
                                                     shipping_dollars: 20.0)
       end.to raise_error(Taxjar::Error::BadRequest)
+    end
+
+    it "notifies error tracker for other TaxJar client errors" do
+      expect_any_instance_of(Taxjar::Client).to receive(:tax_for_order).and_raise(Taxjar::Error::Unauthorized)
+
+      expect(ErrorNotifier).to receive(:notify).exactly(:once)
+
+      expect do
+        described_class.new.calculate_tax_for_order(origin:,
+                                                    destination:,
+                                                    nexus_address:,
+                                                    quantity: 1,
+                                                    product_tax_code: nil,
+                                                    unit_price_dollars: 100.0,
+                                                    shipping_dollars: 20.0)
+      end.to raise_error(Taxjar::Error::Unauthorized)
     end
 
     it "propagates a TaxJar server error" do


### PR DESCRIPTION
## What

In `TaxjarApi#with_caching`, skip calling `ErrorNotifier.notify` for `Taxjar::Error::BadRequest` errors. Other client errors (Unauthorized, Forbidden, TooManyRequests, etc.) are still reported.

## Why

**Sentry issue:** https://gumroad-to.sentry.io/issues/7380886827/

`BadRequest` errors from TaxJar (e.g., `to_zip 60001 is not used within to_state IL`) are caused by buyer input — invalid or mismatched zip/state combos. `SalesTaxCalculator#calculate_with_taxjar` already catches all TaxJar client errors and falls back to the lookup table, so these are handled gracefully. Reporting them to Sentry creates noise without actionable signal.

## Test Results

```
8 examples, 0 failures
```

- Updated existing spec to verify `ErrorNotifier` is NOT called for `BadRequest`
- Added new spec to verify `ErrorNotifier` IS called for other client errors (`Unauthorized`)

---

AI disclosure: Implemented with Claude Opus 4.6. Prompted to fix Sentry noise from TaxJar zip/state mismatch BadRequest errors.