### PR TITLE
Fix ActiveRecord::RecordInvalid when referrer/url_parameters are nil in checkout update

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -48,8 +48,8 @@ class CheckoutController < ApplicationController
         cart_product.recurrence = item[:recurrence]
         cart_product.recommended_by = item[:recommended_by]
         cart_product.rent = item[:rent]
-        cart_product.url_parameters = item[:url_parameters]
-        cart_product.referrer = item[:referrer]
+        cart_product.url_parameters = item[:url_parameters] || cart_product.url_parameters
+        cart_product.referrer = item[:referrer] || cart_product.referrer
         cart_product.recommender_model_name = item[:recommender_model_name]
         cart_product.call_start_time = item[:call_start_time].present? ? Time.zone.parse(item[:call_start_time]) : nil
         cart_product.pay_in_installments = !!item[:pay_in_installments] && product.allow_installment_plan?

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -466,6 +466,57 @@ describe CheckoutController, type: :controller, inertia: true do
         expect(flash[:alert]).to eq("Sorry, something went wrong. Please try again.")
       end
 
+      it "preserves default referrer and url_parameters when not provided in params" do
+        product = create(:product)
+
+        patch :update, params: {
+          cart: {
+            items: [{
+              product: { id: product.external_id },
+              price: product.price_cents,
+              quantity: 1,
+              rent: false
+            }],
+            discountCodes: []
+          }
+        }, as: :json
+
+        expect(response).to have_http_status(:see_other)
+        expect(response).to redirect_to(checkout_path)
+
+        cart = controller.logged_in_user.alive_cart
+        cart_product = cart.cart_products.sole
+        expect(cart_product.referrer).to be_present
+        expect(cart_product.url_parameters).to eq({})
+      end
+
+      it "does not overwrite existing referrer and url_parameters with nil on update" do
+        product = create(:product)
+        cart = create(:cart, user: controller.logged_in_user)
+        create(:cart_product, cart: cart, product: product, referrer: "google.com", url_parameters: { "utm_source" => "google" })
+
+        patch :update, params: {
+          cart: {
+            items: [{
+              product: { id: product.external_id },
+              price: product.price_cents,
+              quantity: 1,
+              rent: false,
+              referrer: nil,
+              url_parameters: nil
+            }],
+            discountCodes: []
+          }
+        }, as: :json
+
+        expect(response).to have_http_status(:see_other)
+        expect(response).to redirect_to(checkout_path)
+
+        cart_product = cart.reload.cart_products.alive.sole
+        expect(cart_product.referrer).to eq("google.com")
+        expect(cart_product.url_parameters).to eq("utm_source" => "google")
+      end
+
       it "returns an error when cart contains more than allowed number of cart products" do
         items = (Cart::MAX_ALLOWED_CART_PRODUCTS + 1).times.map { { product: { id: _1 + 1 } }  }
         patch :update, params: { cart: { items: } }, as: :json


### PR DESCRIPTION
## What

Preserves existing/default values for `referrer` and `url_parameters` on cart products when the client omits these fields or sends null in `CheckoutController#update`.

Changed:
```ruby
cart_product.url_parameters = item[:url_parameters] || cart_product.url_parameters
cart_product.referrer = item[:referrer] || cart_product.referrer
```

## Why

When the client sends a checkout update request without `referrer` or `url_parameters` (or sends null), the controller unconditionally overwrites them with nil. This causes:
1. `referrer` fails `validates :referrer, presence: true`
2. `url_parameters` fails JSON schema validation (expects object, gets null)

This results in `ActiveRecord::RecordInvalid` — "Validation failed: Referrer can't be blank, Url parameters The property '#/' of type null did not match the following type: object"

Sentry: https://gumroad-to.sentry.io/issues/7381083685/

## Test Results

Added two test cases:
- Cart product saves when `referrer` and `url_parameters` are omitted from params
- Existing `referrer` and `url_parameters` are not overwritten when nil is sent

---

AI disclosure: Built with Claude Opus 4.6. Prompted with the Sentry error details, root cause analysis, and fix instructions.