### PR TITLE
Fix NoMethodError in CurrencyHelper#symbol_for for unknown currency types

### DIFF
--- a/app/helpers/currency_helper.rb
+++ b/app/helpers/currency_helper.rb
@@ -10,11 +10,13 @@ module CurrencyHelper
   end
 
   def symbol_for(type = :usd)
-    CURRENCY_CHOICES[type.to_sym][:symbol]
+    currency = CURRENCY_CHOICES[type.to_sym] || CURRENCY_CHOICES[:usd]
+    currency[:symbol]
   end
 
   def min_price_for(type = :usd)
-    CURRENCY_CHOICES[type.to_sym][:min_price]
+    currency = CURRENCY_CHOICES[type.to_sym] || CURRENCY_CHOICES[:usd]
+    currency[:min_price]
   end
 
   def currency_choices

--- a/spec/helpers/currency_helper_spec.rb
+++ b/spec/helpers/currency_helper_spec.rb
@@ -29,12 +29,20 @@ describe CurrencyHelper do
       expect(symbol_for(:usd)).to eq "$"
       expect(symbol_for(:gbp)).to eq "£"
     end
+
+    it "falls back to USD for unknown currency types" do
+      expect(symbol_for(:xyz)).to eq "$"
+    end
   end
 
   describe "#min_price_for" do
     it "returns the correct value" do
       expect(min_price_for(:usd)).to eq 99
       expect(min_price_for(:gbp)).to eq 59
+    end
+
+    it "falls back to USD for unknown currency types" do
+      expect(min_price_for(:xyz)).to eq 99
     end
   end
 


### PR DESCRIPTION
## What

`symbol_for` and `min_price_for` in `CurrencyHelper` raise `NoMethodError` when called with a currency type not present in `CURRENCY_CHOICES`, because the hash lookup returns `nil` and then `[:symbol]` is called on `nil`.

This was triggered in production via `Api::Mobile::PurchasesController#index` → `Purchase#json_data_for_mobile`.

## Why

Fall back to USD when the currency type is not found in `CURRENCY_CHOICES`, matching the existing pattern in `get_currency_by_type`.

## Test results

Added tests for `symbol_for` and `min_price_for` with unknown currency types to verify USD fallback.

---

Generated with Claude Opus 4.6. Prompt: fix NoMethodError in CurrencyHelper#symbol_for by adding USD fallback for unknown currency types.