### PR TITLE
Fix ActiveRecord::InvalidForeignKey in ThumbnailsController#create

### DIFF
--- a/app/controllers/thumbnails_controller.rb
+++ b/app/controllers/thumbnails_controller.rb
@@ -22,7 +22,7 @@ class ThumbnailsController < Sellers::BaseController
     else
       render(json: { success: false, error: thumbnail.errors.any? ? thumbnail.errors.full_messages.to_sentence : "Could not process your preview, please try again." })
     end
-  rescue *INTERNET_EXCEPTIONS
+  rescue ActiveRecord::InvalidForeignKey, ActiveStorage::FileNotFoundError, *INTERNET_EXCEPTIONS
     render(json: { success: false, error: "Could not process your thumbnail, please try again." })
   end
 

--- a/spec/controllers/thumbnails_controller_spec.rb
+++ b/spec/controllers/thumbnails_controller_spec.rb
@@ -82,6 +82,30 @@ describe ThumbnailsController, :vcr do
       end
     end
 
+    it "returns an error when the file is not found in storage" do
+      allow_any_instance_of(ActiveStorage::Blob).to receive(:analyze).and_raise(ActiveStorage::FileNotFoundError)
+
+      expect do
+        post(:create, params: { link_id: product.unique_permalink, thumbnail: { signed_blob_id: blob.signed_id }, format: :json })
+      end.not_to change { Thumbnail.count }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq({ "success" => false, "error" => "Could not process your thumbnail, please try again." })
+    end
+
+    it "returns an error when the blob is purged before attach completes" do
+      allow_any_instance_of(ActiveStorage::Attached::One).to receive(:attach).and_raise(
+        ActiveRecord::InvalidForeignKey.new("Cannot add or update a child row: a foreign key constraint fails")
+      )
+
+      expect do
+        post(:create, params: { link_id: product.unique_permalink, thumbnail: { signed_blob_id: blob.signed_id }, format: :json })
+      end.not_to change { Thumbnail.count }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq({ "success" => false, "error" => "Could not process your thumbnail, please try again." })
+    end
+
     it "restores deleted thumbnail if exists" do
       product.update!(thumbnail: create(:thumbnail))
       product.thumbnail.mark_deleted!


### PR DESCRIPTION
## What

Rescues `ActiveRecord::InvalidForeignKey` (and `ActiveStorage::FileNotFoundError`, which was also unhandled) in `ThumbnailsController#create` so the controller returns a graceful JSON error instead of a 500.

## Why

When a blob is purged before the `attach` call completes (race condition), ActiveStorage tries to create records referencing a non-existent blob, causing an `InvalidForeignKey` error from the `active_storage_variant_records` foreign key constraint. This has been surfacing in production as unhandled 500s.

Related Sentry issue: https://gumroad-to.sentry.io/issues/7381706850/

## Test Results

Added two new specs:
- `returns an error when the file is not found in storage` — covers `ActiveStorage::FileNotFoundError`
- `returns an error when the blob is purged before attach completes` — covers `ActiveRecord::InvalidForeignKey`

Both verify the controller returns `{ success: false, error: "Could not process your thumbnail, please try again." }` instead of raising.

---

AI disclosure: Implemented with Claude Opus 4.6. Prompted with the bug description, Sentry error details, and instructions to add the rescue clause and corresponding tests.