### PR TITLE
Fix ActiveRecord::RecordNotUnique on avatar attachment in profile update

### DIFF
--- a/app/controllers/settings/profile_controller.rb
+++ b/app/controllers/settings/profile_controller.rb
@@ -16,7 +16,11 @@ class Settings::ProfileController < Settings::BaseController
 
     if permitted_params[:profile_picture_blob_id].present?
       return respond_error("The logo is already removed. Please refresh the page and try again.") if ActiveStorage::Blob.find_signed(permitted_params[:profile_picture_blob_id]) .nil?
-      current_seller.avatar.attach permitted_params[:profile_picture_blob_id]
+      begin
+        current_seller.avatar.attach permitted_params[:profile_picture_blob_id]
+      rescue ActiveRecord::RecordNotUnique
+        current_seller.avatar.reload
+      end
     elsif permitted_params.has_key?(:profile_picture_blob_id) && current_seller.avatar.attached?
       current_seller.avatar.purge
     end

--- a/spec/controllers/settings/profile_controller_spec.rb
+++ b/spec/controllers/settings/profile_controller_spec.rb
@@ -112,6 +112,36 @@ describe Settings::ProfileController, :vcr, type: :controller, inertia: true do
       expect(flash[:alert]).to eq("The logo is already removed. Please refresh the page and try again.")
     end
 
+    it "handles duplicate attachment gracefully when avatar is already attached with the same blob" do
+      blob = ActiveStorage::Blob.create_and_upload!(
+        io: fixture_file_upload("smilie.png"),
+        filename: "smilie.png",
+      )
+      seller.avatar.attach(blob)
+
+      put :update, params: { profile_picture_blob_id: blob.signed_id }
+
+      expect(response).to redirect_to(settings_profile_path)
+      expect(response).to have_http_status :see_other
+      expect(flash[:notice]).to eq("Changes saved!")
+      expect(seller.avatar.attached?).to be(true)
+    end
+
+    it "handles concurrent avatar attachment race condition" do
+      blob = ActiveStorage::Blob.create_and_upload!(
+        io: fixture_file_upload("smilie.png"),
+        filename: "smilie.png",
+      )
+
+      allow_any_instance_of(ActiveStorage::Attached::One).to receive(:attach).and_raise(ActiveRecord::RecordNotUnique)
+
+      put :update, params: { profile_picture_blob_id: blob.signed_id }
+
+      expect(response).to redirect_to(settings_profile_path)
+      expect(response).to have_http_status :see_other
+      expect(flash[:notice]).to eq("Changes saved!")
+    end
+
     it "regenerates the subscribe preview when the avatar changes" do
       allow_any_instance_of(User).to receive(:generate_subscribe_preview).and_call_original
 


### PR DESCRIPTION
## What

Rescue `ActiveRecord::RecordNotUnique` when attaching an avatar in `Settings::ProfileController#update`. When the error occurs, the attachment association is reloaded since the desired state (blob attached) already exists.

## Why

The `index_active_storage_attachments_uniqueness` index enforces uniqueness on `(record_type, record_id, name, blob_id)`. When concurrent requests both attempt to attach an avatar, or a user re-submits the same avatar blob, the second insert violates this constraint and raises `ActiveRecord::RecordNotUnique`, causing a 500 error.

Rescuing this specific exception is safe because the uniqueness violation means the exact attachment already exists — the operation the user requested has already succeeded.

Sentry: https://gumroad-to.sentry.io/issues/7381735635/

## Test Results

Added two tests:
- Verifies attaching the same blob that's already attached succeeds gracefully
- Verifies a simulated race condition (stubbed `RecordNotUnique`) completes without error

---

Generated with Claude Opus 4.6. Prompt: fix the Sentry `ActiveRecord::RecordNotUnique` error on `Settings::ProfileController#update` avatar attachment.