### PR TITLE
Fix false positive Sentry error when disabling membership price propagation

### DIFF
--- a/app/services/product/variant_category_updater_service.rb
+++ b/app/services/product/variant_category_updater_service.rb
@@ -100,7 +100,7 @@ class Product::VariantCategoryUpdaterService
 
       if notify_members_of_price_change
         ScheduleMembershipPriceUpdatesJob.perform_async(variant.id)
-      elsif variant.flags_previously_changed? || variant.subscription_price_change_effective_date_previously_changed?
+      elsif variant.apply_price_changes_to_existing_memberships? && (variant.flags_previously_changed? || variant.subscription_price_change_effective_date_previously_changed?)
         ErrorNotifier.notify("Not notifying subscribers of membership price change - tier: #{variant.id}; apply_price_changes_to_existing_memberships: #{variant.apply_price_changes_to_existing_memberships?}; subscription_price_change_effective_date: #{variant.subscription_price_change_effective_date}")
       end
 

--- a/spec/services/product/variant_category_updater_service_spec.rb
+++ b/spec/services/product/variant_category_updater_service_spec.rb
@@ -76,8 +76,8 @@ describe Product::VariantCategoryUpdaterService do
         end
 
         context "when the flags previously changed" do
-          it "notifies error tracker" do
-            expect(ErrorNotifier).to receive(:notify).with("Not notifying subscribers of membership price change - tier: #{variant.id}; apply_price_changes_to_existing_memberships: false; subscription_price_change_effective_date: #{was_subscription_price_change_effective_date}")
+          it "does not notify error tracker" do
+            expect(ErrorNotifier).not_to receive(:notify)
 
             Product::VariantCategoryUpdaterService.new(product: product, category_params: variant_category_params).perform
           end
@@ -89,11 +89,23 @@ describe Product::VariantCategoryUpdaterService do
           let(:was_subscription_price_change_effective_date) { 7.days.from_now.to_date }
           let(:subscription_price_change_effective_date) { 10.days.from_now.to_date }
 
-          it "notifies error tracker" do
-            expect(ErrorNotifier).to receive(:notify).with("Not notifying subscribers of membership price change - tier: #{variant.id}; apply_price_changes_to_existing_memberships: false; subscription_price_change_effective_date: #{subscription_price_change_effective_date}")
+          it "does not notify error tracker" do
+            expect(ErrorNotifier).not_to receive(:notify)
 
             Product::VariantCategoryUpdaterService.new(product: product, category_params: variant_category_params).perform
           end
+        end
+      end
+
+      context "when apply_price_changes_to_existing_memberships is enabled but effective date did not change" do
+        let(:was_applying_price_changes_to_existing_memberships) { false }
+        let(:apply_price_changes_to_existing_memberships) { true }
+        let(:subscription_price_change_effective_date) { was_subscription_price_change_effective_date }
+
+        it "notifies error tracker" do
+          expect(ErrorNotifier).to receive(:notify).with(/Not notifying subscribers of membership price change/)
+
+          Product::VariantCategoryUpdaterService.new(product: product, category_params: variant_category_params).perform
         end
       end
 


### PR DESCRIPTION
## What

Added `variant.apply_price_changes_to_existing_memberships?` guard to the `elsif` condition in `Product::VariantCategoryUpdaterService#create_or_update_variant!` that triggers `ErrorNotifier`.

## Why

The `elsif` condition `variant.flags_previously_changed? || variant.subscription_price_change_effective_date_previously_changed?` was too broad. When a seller **disables** "apply price changes to existing memberships", the `flags` integer column changes, causing `flags_previously_changed?` to be true. Since the feature is now off, `notify_members_of_price_change` is false, and we fall into the elsif branch — firing a false positive Sentry error.

The fix ensures the ErrorNotifier only fires when the feature is **enabled** but notifications weren't sent (genuinely unexpected), not when the feature is being turned off (expected behavior).

## Test results

24 examples, 0 failures — updated existing tests to match corrected behavior and added a new test for the case where the feature is enabled but the effective date didn't change.

---

AI disclosure: Claude Opus 4.6 — prompted with the Sentry error context, root cause analysis, and fix instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)