### PR TITLE
Fix Rack::Timeout in LibraryController#index

### DIFF
--- a/app/presenters/library_presenter.rb
+++ b/app/presenters/library_presenter.rb
@@ -20,8 +20,8 @@ class LibraryPresenter
         :variant_attributes,
         :bundle_purchase,
         link: {
-          display_asset_previews: { file_attachment: :blob },
-          thumbnail_alive: { file_attachment: :blob },
+          display_asset_previews: { file_attachment: { blob: { variant_records: { image_attachment: :blob } } } },
+          thumbnail_alive: { file_attachment: { blob: { variant_records: { image_attachment: :blob } } } },
           user: { avatar_attachment: :blob }
         }
       )


### PR DESCRIPTION
## What

Eager-load `ActiveStorage::VariantRecord` associations for `thumbnail_alive` and `display_asset_previews` in `LibraryPresenter#library_cards`.

## Why

`library_cards` iterates every purchase and calls `thumbnail_or_cover_url` on each product. This calls `Thumbnail#thumbnail_variant` (`.variant(...).processed`) and `AssetPreview#retina_variant` (`.variant(...).processed`), each of which queries for `ActiveStorage::VariantRecord` individually. For users with large libraries, these N+1 queries accumulate past the 120s Rack::Timeout threshold.

The existing includes already eager-loaded `file_attachment` and `blob`, but not the `variant_records` association that `.processed` checks. Adding `variant_records: { image_attachment: :blob }` to the includes lets `.processed` use preloaded data instead of issuing per-record queries.

## Test results

Unable to run tests locally (Ruby/Bundler version mismatch). CI will validate.

---

AI disclosure: Implemented with Claude Opus 4.6. Prompted with the Sentry error details, stacktrace analysis, and root cause identification pointing to N+1 variant record queries in library_cards.