### PR TITLE
Fix dashboard timeout by fetching only overview data

### DIFF
--- a/app/presenters/creator_home_presenter.rb
+++ b/app/presenters/creator_home_presenter.rb
@@ -62,7 +62,7 @@ class CreatorHomePresenter
         "last_30" => analytics[:by_date][:totals][product.unique_permalink]&.sum || 0,
       }
     end.compact
-    balances = UserBalanceStatsService.new(user: seller).fetch[:overview]
+    balances = UserBalanceStatsService.new(user: seller).fetch_overview
 
     stripe_verification_message = nil
     if seller.stripe_account.present?

--- a/app/services/user_balance_stats_service.rb
+++ b/app/services/user_balance_stats_service.rb
@@ -19,6 +19,15 @@ class UserBalanceStatsService
     end
   end
 
+  def fetch_overview
+    if should_use_cache?
+      UpdateUserBalanceStatsCacheWorker.perform_async(user.id)
+      cached = read_cache
+      return cached[:overview] if cached
+    end
+    generate_overview
+  end
+
   def write_cache
     data = generate
     $redis.setex(cache_key, 48.hours.to_i, data.to_json)
@@ -36,6 +45,18 @@ class UserBalanceStatsService
   end
 
   private
+    def generate_overview
+      balances_by_product_service = BalancesByProductService.new(user)
+      {
+        last_payout_period_data: payout_period_data(user, user.payments.completed.last),
+        balance: user.unpaid_balance_cents(via: :elasticsearch),
+        balances_by_product: balances_by_product_service.process,
+        last_seven_days_sales_total: user.sales_cents_total(after: 7.days.ago),
+        last_28_days_sales_total: user.sales_cents_total(after: 28.days.ago),
+        sales_cents_total: user.sales_cents_total,
+      }
+    end
+
     def generate
       balances_by_product_service = BalancesByProductService.new(user)
       result = {

--- a/spec/services/user_balance_stats_service_spec.rb
+++ b/spec/services/user_balance_stats_service_spec.rb
@@ -156,6 +156,59 @@ describe UserBalanceStatsService do
     end
   end
 
+  describe "#fetch_overview" do
+    let(:fetched) { instance.fetch_overview }
+    let(:overview_values) { { balance: 100, sales_cents_total: 200 } }
+    let(:cached_data) { { overview: overview_values, payout_period_data: { 1 => "expensive" } } }
+
+    context "when value should be retrieved from the cache" do
+      before do
+        expect(instance).to receive(:should_use_cache?).and_return(true)
+      end
+
+      after do
+        expect(UpdateUserBalanceStatsCacheWorker).to have_enqueued_sidekiq_job(user.id)
+      end
+
+      context "when cached value exists" do
+        it "returns the overview from cache without generating" do
+          $redis.setex(instance.send(:cache_key), 48.hours.to_i, cached_data.to_json)
+          expect(instance).not_to receive(:generate)
+          expect(instance).not_to receive(:generate_overview)
+          expect(fetched).to eq(overview_values)
+        end
+      end
+
+      context "when cached value does not exist" do
+        it "returns generated overview without computing full stats" do
+          expect(instance).not_to receive(:generate)
+          expect(instance).to receive(:generate_overview).and_return(overview_values)
+          expect(fetched).to eq(overview_values)
+        end
+      end
+    end
+
+    context "when value should not be retrieved from the cache" do
+      before do
+        expect(instance).to receive(:should_use_cache?).and_return(false)
+      end
+
+      it "returns generated overview" do
+        expect(instance).not_to receive(:generate)
+        expect(instance).to receive(:generate_overview).and_return(overview_values)
+        expect(fetched).to eq(overview_values)
+      end
+    end
+
+    it "returns a hash with overview keys" do
+      result = instance.fetch_overview
+      expect(result).to be_a(Hash)
+      expect(result.keys).to match_array(
+        [:last_payout_period_data, :balance, :balances_by_product, :last_seven_days_sales_total, :last_28_days_sales_total, :sales_cents_total]
+      )
+    end
+  end
+
   describe "#should_use_cache?" do
     context "when user is large seller" do
       before do


### PR DESCRIPTION
## What

- Added `fetch_overview` method to `UserBalanceStatsService` that computes only the overview data (balance, sales totals, balances_by_product)
- Updated `CreatorHomePresenter#creator_home_props` to call `fetch_overview` instead of `fetch[:overview]`

## Why

The dashboard page (`DashboardController#index`) was timing out (Rack::Timeout) because `fetch[:overview]` triggers `generate`, which computes the full payout history — expensive SQL queries for every completed payment (`payout_period_data`, `paypal_sales_data_for_duration`, `sales_data_for_balance_ids`, etc.) — even though only the overview hash is needed. For non-cached users, this runs on every page load.

The new `fetch_overview` method:
1. Returns cached `:overview` if available (same cache behavior as `fetch`)
2. If not cached, computes only the overview fields directly via `generate_overview`, skipping payout_period_data, processing payouts, next payout period, and payment history

## Test Results

4 new tests for `fetch_overview` all passing:
- Returns cached overview without generating full stats
- Falls back to `generate_overview` (not `generate`) when cache misses
- Returns correct overview keys

---

Generated with Claude Opus 4.6. Prompt: Fix Rack::Timeout on DashboardController#index by adding fetch_overview to UserBalanceStatsService.