### PR TITLE
Fix LockWaitTimeout in OauthApplication#mark_deleted!

### DIFF
--- a/app/models/oauth_application.rb
+++ b/app/models/oauth_application.rb
@@ -32,7 +32,7 @@ class OauthApplication < Doorkeeper::Application
     transaction do
       access_grants.where(revoked_at: nil).update_all(revoked_at: Time.current)
       access_tokens.where(revoked_at: nil).update_all(revoked_at: Time.current)
-      resource_subscriptions.alive.each(&:mark_deleted!)
+      resource_subscriptions.alive.update_all(deleted_at: Time.current)
       update!(deleted_at: Time.current)
     end
   end
@@ -68,7 +68,7 @@ class OauthApplication < Doorkeeper::Application
 
   def revoke_access_for(user)
     Doorkeeper::AccessToken.revoke_all_for(id, user)
-    resource_subscriptions.where(user:).alive.each(&:mark_deleted!)
+    resource_subscriptions.where(user:).alive.update_all(deleted_at: Time.current)
   end
 
   def icon_url

--- a/spec/models/oauth_application_spec.rb
+++ b/spec/models/oauth_application_spec.rb
@@ -181,6 +181,18 @@ describe OauthApplication do
       expect(@oauth_application.access_grants).to all be_revoked
     end
 
+    it "marks multiple resource subscriptions as deleted in bulk" do
+      create_list(:resource_subscription, 3, oauth_application: @oauth_application)
+
+      expect do
+        @oauth_application.mark_deleted!
+      end.to change { @oauth_application.resource_subscriptions.alive.count }.from(4).to(0)
+
+      @oauth_application.resource_subscriptions.each do |rs|
+        expect(rs.deleted_at).to be_present
+      end
+    end
+
     it "revokes access tokens" do
       expect do
         @oauth_application.mark_deleted!


### PR DESCRIPTION
## What

Replace `each(&:mark_deleted!)` with `update_all` for resource_subscriptions in `OauthApplication#mark_deleted!` and `#revoke_access_for`.

## Why

The `mark_deleted!` method iterates resource_subscriptions one-by-one, each performing an individual `save!` inside a transaction. This holds row locks longer than necessary, causing `ActiveRecord::LockWaitTimeout` under contention when destroying OAuth applications.

The fix uses `update_all` — matching the existing pattern already used for `access_grants` and `access_tokens` in the same transaction — to set `deleted_at` in a single query, minimizing lock hold time.

## Test Results

All existing tests for `#mark_deleted!` and `#revoke_access_for` pass. Added a new test verifying bulk deletion of multiple resource subscriptions.

---

AI disclosure: Implemented with Claude Opus 4.6. Prompted to fix LockWaitTimeout in OauthApplication#mark_deleted! by using update_all for resource_subscriptions.