### PR TITLE
Implement progressive tiered fee calculation

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -26,6 +26,13 @@ class Purchase < ApplicationRecord
   GUMROAD_FLAT_FEE_PER_THOUSAND = 100
   GUMROAD_DISCOVER_FEE_PER_THOUSAND = 300
   GUMROAD_FIXED_FEE_CENTS = 50
+
+  PROGRESSIVE_FEE_TIERS = [
+    { ceiling_cents: 100_00,   per_thousand: 300 },
+    { ceiling_cents: 1_000_00, per_thousand: 125 },
+    { ceiling_cents: 5_000_00, per_thousand: 85 },
+    { ceiling_cents: nil,      per_thousand: 49 },
+  ].freeze
   PROCESSOR_FEE_PER_THOUSAND = 29
   PROCESSOR_FIXED_FEE_CENTS = 30
 
@@ -3198,7 +3205,44 @@ class Purchase < ApplicationRecord
     end
 
     def gumroad_flat_fee_per_thousand
-      seller.waive_gumroad_fee_on_new_sales? && subscription.blank? && !is_preorder_charge? ? 0 : GUMROAD_FLAT_FEE_PER_THOUSAND
+      return 0 if seller.waive_gumroad_fee_on_new_sales? && subscription.blank? && !is_preorder_charge?
+      return progressive_fee_per_thousand if Feature.active?(:progressive_fee_tiers, seller)
+
+      GUMROAD_FLAT_FEE_PER_THOUSAND
+    end
+
+    def progressive_fee_per_thousand
+      return GUMROAD_FLAT_FEE_PER_THOUSAND if price_cents.blank? || price_cents <= 0
+
+      mtd_sales_cents = seller.mtd_successful_sales_total_cents
+      remaining = price_cents
+      weighted_fee_cents = 0
+      previous_ceiling = 0
+
+      PROGRESSIVE_FEE_TIERS.each do |tier|
+        tier_ceiling = tier[:ceiling_cents]
+        tier_rate = tier[:per_thousand]
+
+        if tier_ceiling.nil?
+          weighted_fee_cents += remaining * tier_rate
+          remaining = 0
+          break
+        end
+
+        tier_space = [tier_ceiling - [mtd_sales_cents, previous_ceiling].max, 0].max
+        applied = [remaining, tier_space].min
+
+        if applied > 0
+          weighted_fee_cents += applied * tier_rate
+          remaining -= applied
+          mtd_sales_cents += applied
+        end
+
+        previous_ceiling = tier_ceiling
+        break if remaining <= 0
+      end
+
+      (weighted_fee_cents.to_f / price_cents).round
     end
 
     def calculate_taxes

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -894,6 +894,13 @@ class User < ApplicationRecord
     collaborating_products.where(id: product.id).exists?
   end
 
+  def mtd_successful_sales_total_cents
+    sales
+      .successful
+      .where(created_at: Time.current.utc.beginning_of_month..Time.current.utc)
+      .sum(:price_cents)
+  end
+
   def save_gumroad_day_timezone
     return unless waive_gumroad_fee_on_new_sales?
     return if gumroad_day_timezone.present?

--- a/spec/models/purchase/progressive_fee_spec.rb
+++ b/spec/models/purchase/progressive_fee_spec.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Purchase, "progressive fee tiers", :vcr do
+  let(:seller) { create(:named_seller) }
+  let(:product) { create(:product, user: seller, price_cents: 10_00) }
+
+  before do
+    Feature.activate_user(:progressive_fee_tiers, seller)
+    MerchantAccount.find_or_create_by!(user_id: nil, charge_processor_id: StripeChargeProcessor.charge_processor_id) do |ma|
+      ma.charge_processor_merchant_id = "gumroad_test"
+    end
+  end
+
+  def expected_fee(price_cents, progressive_per_thousand)
+    variable = (price_cents * (progressive_per_thousand + Purchase::PROCESSOR_FEE_PER_THOUSAND) / 1000.0).round
+    fixed = Purchase::GUMROAD_FIXED_FEE_CENTS + Purchase::PROCESSOR_FIXED_FEE_CENTS
+    variable + fixed
+  end
+
+  describe "#progressive_fee_per_thousand" do
+    it "returns 300 per thousand for a seller with no MTD sales" do
+      purchase = create(:purchase, link: product, price_cents: 10_00)
+
+      expect(purchase.fee_cents).to eq(expected_fee(10_00, 300))
+    end
+
+    it "applies the first tier rate for purchases within the $100 bracket" do
+      purchase = create(:purchase, link: product, price_cents: 50_00)
+
+      expect(purchase.fee_cents).to eq(expected_fee(50_00, 300))
+    end
+
+    it "splits fee across tiers when a purchase spans the $100 boundary" do
+      purchase = create(:purchase, link: product, price_cents: 200_00)
+
+      # First $100 at 300, next $100 at 125 => blended = (100*300 + 100*125) / 200 = 212.5 => 213
+      blended = (42_500_00.0 / 200_00).round
+      expect(purchase.fee_cents).to eq(expected_fee(200_00, blended))
+    end
+
+    it "applies all four tiers for a large purchase with no MTD sales" do
+      purchase = create(:purchase, link: product, price_cents: 6_000_00)
+
+      # $100 at 300, $900 at 125, $4000 at 85, $1000 at 49
+      # weighted = 100*300 + 900*125 + 4000*85 + 1000*49 = 30000+112500+340000+49000 = 531500
+      blended = (53_150_000.0 / 6_000_00).round # 88.58 => 89
+      expect(purchase.fee_cents).to eq(expected_fee(6_000_00, blended))
+    end
+
+    it "uses second tier rate when seller already has $500 MTD sales" do
+      create(:purchase, link: product, price_cents: 500_00, created_at: 1.day.ago)
+
+      purchase = create(:purchase, link: product, price_cents: 10_00)
+
+      expect(purchase.fee_cents).to eq(expected_fee(10_00, 125))
+    end
+
+    it "uses lowest tier rate when seller has over $5000 MTD sales" do
+      create(:purchase, link: product, price_cents: 6_000_00, created_at: 1.day.ago)
+
+      purchase = create(:purchase, link: product, price_cents: 10_00)
+
+      expect(purchase.fee_cents).to eq(expected_fee(10_00, 49))
+    end
+
+    it "spans tiers when purchase crosses the $1000 boundary" do
+      create(:purchase, link: product, price_cents: 900_00, created_at: 1.day.ago)
+
+      purchase = create(:purchase, link: product, price_cents: 200_00)
+
+      # MTD = $900. $100 in $100-$1000 tier at 125, $100 in $1000-$5000 tier at 85
+      blended = (21_000_00.0 / 200_00).round # 105
+      expect(purchase.fee_cents).to eq(expected_fee(200_00, blended))
+    end
+
+    it "handles exact tier boundary at $100" do
+      create(:purchase, link: product, price_cents: 100_00, created_at: 1.day.ago)
+
+      purchase = create(:purchase, link: product, price_cents: 10_00)
+
+      expect(purchase.fee_cents).to eq(expected_fee(10_00, 125))
+    end
+
+    it "handles exact tier boundary at $1000" do
+      create(:purchase, link: product, price_cents: 1_000_00, created_at: 1.day.ago)
+
+      purchase = create(:purchase, link: product, price_cents: 10_00)
+
+      expect(purchase.fee_cents).to eq(expected_fee(10_00, 85))
+    end
+
+    it "handles exact tier boundary at $5000" do
+      create(:purchase, link: product, price_cents: 5_000_00, created_at: 1.day.ago)
+
+      purchase = create(:purchase, link: product, price_cents: 10_00)
+
+      expect(purchase.fee_cents).to eq(expected_fee(10_00, 49))
+    end
+  end
+
+  describe "custom_fee_per_thousand overrides progressive pricing" do
+    it "uses the seller custom fee instead of progressive tiers" do
+      seller.update!(custom_fee_per_thousand: 50)
+
+      purchase = create(:purchase, link: product, price_cents: 10_00)
+
+      expect(purchase.fee_cents).to eq(expected_fee(10_00, 50))
+    end
+
+    it "uses the purchase custom fee instead of progressive tiers" do
+      purchase = create(:purchase, link: product, price_cents: 10_00, custom_fee_per_thousand: 75)
+
+      expect(purchase.fee_cents).to eq(expected_fee(10_00, 75))
+    end
+  end
+
+  describe "Discover fees are unaffected" do
+    it "charges the flat 30% Discover fee regardless of progressive tiers" do
+      allow_any_instance_of(Link).to receive(:recommendable?).and_return(true)
+      purchase = create(:purchase, link: product, price_cents: 10_00,
+                                   was_product_recommended: true,
+                                   recommended_by: RecommendationType::GUMROAD_SEARCH_RECOMMENDATION)
+
+      expect(purchase.was_discover_fee_charged?).to be(true)
+      expect(purchase.fee_cents).to be > 0
+    end
+  end
+
+  describe "waive_gumroad_fee_on_new_sales still works" do
+    it "waives the progressive fee for new sales" do
+      Feature.activate_user(:waive_gumroad_fee_on_new_sales, seller)
+
+      purchase = create(:purchase, link: product, price_cents: 10_00)
+
+      # Gumroad percentage waived, but fixed Gumroad fee + processor fees still apply
+      variable_processor = (10_00 * Purchase::PROCESSOR_FEE_PER_THOUSAND / 1000.0).round
+      fixed = Purchase::GUMROAD_FIXED_FEE_CENTS + Purchase::PROCESSOR_FIXED_FEE_CENTS
+      expect(purchase.fee_cents).to eq(variable_processor + fixed)
+    end
+  end
+
+  describe "MTD calculation" do
+    it "does not count failed purchases" do
+      create(:purchase, link: product, price_cents: 500_00, purchase_state: "failed", created_at: 1.day.ago)
+
+      purchase = create(:purchase, link: product, price_cents: 10_00)
+
+      expect(purchase.fee_cents).to eq(expected_fee(10_00, 300))
+    end
+
+    it "does not count purchases from previous months" do
+      create(:purchase, link: product, price_cents: 6_000_00,
+                        created_at: 1.month.ago.beginning_of_month)
+
+      purchase = create(:purchase, link: product, price_cents: 10_00)
+
+      expect(purchase.fee_cents).to eq(expected_fee(10_00, 300))
+    end
+  end
+
+  describe "feature flag disabled" do
+    it "uses the flat fee when progressive_fee_tiers is not active" do
+      Feature.deactivate_user(:progressive_fee_tiers, seller)
+
+      purchase = create(:purchase, link: product, price_cents: 10_00)
+
+      expect(purchase.fee_cents).to eq(expected_fee(10_00, Purchase::GUMROAD_FLAT_FEE_PER_THOUSAND))
+    end
+  end
+end


### PR DESCRIPTION
## What

Replace the flat 10% Gumroad fee (`GUMROAD_FLAT_FEE_PER_THOUSAND = 100`) with progressive marginal tiers based on the seller's month-to-date (MTD) sales volume:

| Monthly sales bracket | Fee rate | Per-thousand value |
|---|---|---|
| First $100 | 30% | 300 |
| $100 – $1,000 | 12.5% | 125 |
| $1,000 – $5,000 | 8.5% | 85 |
| $5,000+ | 4.9% | 49 |

Fees are **marginal** (like tax brackets) — a single purchase that spans two tiers gets a blended rate. The $0.50 fixed fee per transaction is unchanged.

**Example**: A seller at $900 MTD making a $200 sale pays: $100 at 12.5% + $100 at 8.5% = $21 (10.5% effective).

## Why

Progressive pricing rewards high-volume sellers with lower rates while maintaining healthy margins on smaller accounts. This aligns Gumroad's pricing with the value delivered — sellers who generate more volume pay less per dollar.

Gated behind the `:progressive_fee_tiers` feature flag (per seller) so it can be rolled out gradually without affecting existing sellers until enabled.

## Changes

- **`app/models/purchase.rb`**: Added `PROGRESSIVE_FEE_TIERS` constant and `progressive_fee_per_thousand` method that calculates the blended rate by walking through tiers. `gumroad_flat_fee_per_thousand` checks the feature flag and delegates accordingly.
- **`app/models/user.rb`**: Added `mtd_successful_sales_total_cents` — a single SUM query for successful purchases in the current calendar month (UTC).
- **`spec/models/purchase/progressive_fee_spec.rb`**: 17 tests covering all tiers, boundary cases, tier-spanning purchases, custom fee overrides, Discover fee isolation, waive behavior, MTD filtering (failed/previous month excluded), and feature flag toggle.

## Preserved behavior

- `custom_fee_per_thousand` on user or purchase still overrides progressive pricing
- `waive_gumroad_fee_on_new_sales?` still waives the Gumroad fee
- Discover fees (30% marketplace fee) are completely separate and unchanged
- Feature flag off = flat 10% rate (no behavior change)

## Test results

All 17 new specs pass. Existing tests unaffected (feature flag off by default).

---

Built with Claude Opus 4.6. Prompts: "Implement progressive tiered fee calculation for Gumroad" with detailed specification of tier rates, marginal calculation logic, key files, and constraints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)