### PR TITLE
Fix Elasticsearch index_not_found_exception crash on payments settings page

### DIFF
--- a/app/modules/user/stats.rb
+++ b/app/modules/user/stats.rb
@@ -787,6 +787,9 @@ module User::Stats
       total -= result.aggregations.affiliate_credit_amount_cents_total.value
       total += result.aggregations.affiliate_credit_amount_partially_refunded_cents_total.value
       total.to_i
+    rescue Elasticsearch::Transport::Transport::Error => e
+      ErrorNotifier.notify(e)
+      0
     end
 
     def revenue_as_affiliate(after: nil)
@@ -810,6 +813,9 @@ module User::Stats
       total += result.aggregations.affiliate_credit_amount_cents_total.value
       total -= result.aggregations.affiliate_credit_amount_partially_refunded_cents_total.value
       total.to_i
+    rescue Elasticsearch::Transport::Transport::Error => e
+      ErrorNotifier.notify(e)
+      0
     end
 
     def page_basis_points_floor(page_number:, total_page_count:)

--- a/spec/modules/user/stats_spec.rb
+++ b/spec/modules/user/stats_spec.rb
@@ -1054,6 +1054,18 @@ describe User::Stats, :vcr do
         expect(@user.sales_cents_total).to eq(expected_total)
       end
     end
+
+    context "when Elasticsearch is unavailable" do
+      it "returns 0 and notifies the error" do
+        allow(PurchaseSearchService).to receive(:search).and_raise(
+          Elasticsearch::Transport::Transport::Errors::NotFound.new("[404] index_not_found_exception")
+        )
+
+        expect(ErrorNotifier).to receive(:notify).twice
+
+        expect(@user.sales_cents_total).to eq(0)
+      end
+    end
   end
 
   describe "#gross_sales_cents_total_as_seller", :sidekiq_inline, :elasticsearch_wait_for_refresh do


### PR DESCRIPTION
## What

Added rescue clauses for `Elasticsearch::Transport::Transport::Error` in `revenue_as_seller` and `revenue_as_affiliate` methods in `app/modules/user/stats.rb`. When the Elasticsearch "purchases" index is missing or ES is unavailable, these methods now return 0 instead of letting the exception propagate.

## Why

The `Settings::PaymentsController#show` page crashes with an unrescued `Elasticsearch::Transport::Transport::Errors::NotFound` when the ES "purchases" index doesn't exist. The call chain is: `payments_props` → `paypal_connect` → `paypal_connect_allowed?` → `sales_cents_total` → `revenue_as_seller` → `PurchaseSearchService.search`.

Returning 0 is a safe fallback — it means `paypal_connect_allowed?` returns false, and the page loads gracefully. The error is still reported to Sentry via `ErrorNotifier.notify`.

This follows the existing pattern used in `unpaid_balance_cents` in `app/modules/user/money_balance.rb`.

Fixes: https://gumroad-to.sentry.io/issues/7383088074/

## Test Results

- `spec/modules/user/stats_spec.rb` — 1 new test, 0 failures
- `spec/controllers/settings/payments_controller_spec.rb` — 97 examples, 0 failures

---

AI disclosure: Implementation by Claude Opus 4.6 based on a detailed prompt specifying the root cause, fix approach, and existing codebase patterns.