### PR TITLE
Handle stale Stripe account IDs in account session creation

### DIFF
--- a/app/controllers/stripe_account_sessions_controller.rb
+++ b/app/controllers/stripe_account_sessions_controller.rb
@@ -23,6 +23,13 @@ class StripeAccountSessionsController < Sellers::BaseController
       )
 
       render json: { success: true, client_secret: session.client_secret }
+    rescue Stripe::InvalidRequestError => e
+      if e.message.include?("No such account")
+        render json: { success: false, error_message: "Your Stripe account is no longer active. Please reconnect your Stripe account." }
+      else
+        ErrorNotifier.notify("Failed to create stripe account session for user #{current_seller.id}: #{e.message}")
+        render json: { success: false, error_message: "Failed to create stripe account session" }
+      end
     rescue => e
       ErrorNotifier.notify("Failed to create stripe account session for user #{current_seller.id}: #{e.message}")
       render json: { success: false, error_message: "Failed to create stripe account session" }

--- a/spec/controllers/stripe_account_sessions_controller_spec.rb
+++ b/spec/controllers/stripe_account_sessions_controller_spec.rb
@@ -44,7 +44,19 @@ RSpec.describe StripeAccountSessionsController do
         )
       end
 
-      it "handles stripe errors" do
+      it "handles 'No such account' error without notifying Sentry" do
+        expect(Stripe::AccountSession).to receive(:create).and_raise(Stripe::InvalidRequestError.new("No such account: acct_123", "account"))
+        expect(ErrorNotifier).not_to receive(:notify)
+
+        post :create
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to eq(
+          "success" => false,
+          "error_message" => "Your Stripe account is no longer active. Please reconnect your Stripe account."
+        )
+      end
+
+      it "handles unexpected Stripe errors" do
         expect(Stripe::AccountSession).to receive(:create).and_raise(StandardError.new("Stripe error"))
         expect(ErrorNotifier).to receive(:notify).with("Failed to create stripe account session for user #{seller.id}: Stripe error")
 


### PR DESCRIPTION
## What

- Catch `Stripe::InvalidRequestError` with "No such account" separately from unexpected errors in `StripeAccountSessionsController#create`
- Return a user-facing message ("Your Stripe account is no longer active. Please reconnect your Stripe account.") instead of a generic error
- Skip `ErrorNotifier.notify` for this expected edge case to reduce Sentry noise

## Why

When a Stripe account is deleted or deactivated, the stored `charge_processor_merchant_id` becomes stale. The resulting "No such account" error is expected, not a bug. Reporting it to Sentry creates noise and obscures real issues.

## Test results

- Added test for "No such account" `Stripe::InvalidRequestError` — verifies `ErrorNotifier` is NOT called and the appropriate user-facing error is returned
- Renamed existing error test to "handles unexpected Stripe errors" to clarify its purpose

---

AI disclosure: Built with Claude Opus 4.6. Prompt: Fix Sentry noise from "No such account" errors in StripeAccountSessionsController by catching the expected Stripe::InvalidRequestError separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)