### PR TITLE
Fix Rack::Timeout in cart_items_count: replace full cart serialization with COUNT query

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -177,8 +177,9 @@ class LinksController < ApplicationController
   end
 
   def cart_items_count
+    cart = Cart.fetch_by(user: logged_in_user, browser_guid: cookies[:_gumroad_guid])
     render inertia: "Products/CartItemsCount", props: {
-      cart: CartPresenter.new(logged_in_user:, ip: request.remote_ip, browser_guid: cookies[:_gumroad_guid]).cart_props
+      cart_items_count: cart&.cart_products&.alive&.count || 0
     }
   end
 

--- a/app/javascript/pages/Products/CartItemsCount.tsx
+++ b/app/javascript/pages/Products/CartItemsCount.tsx
@@ -2,23 +2,21 @@ import { usePage } from "@inertiajs/react";
 import * as React from "react";
 import { cast } from "ts-safe-cast";
 
-import { CartState, newCartState } from "$app/components/Checkout/cartState";
-
 type Props = {
-  cart: CartState | null;
+  cart_items_count: number;
 };
 
 const CartItemsCount = () => {
-  const { cart } = cast<Props>(usePage().props);
+  const { cart_items_count } = cast<Props>(usePage().props);
 
   React.useEffect(() => {
     void document.hasStorageAccess().then((hasAccess) =>
       window.parent.postMessage({
         type: "cart-items-count",
-        cartItemsCount: hasAccess ? (cart ?? newCartState()).items.length : "not-available",
+        cartItemsCount: hasAccess ? cart_items_count : "not-available",
       }),
     );
-  }, [cart]);
+  }, [cart_items_count]);
 
   return null;
 };

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -3982,11 +3982,11 @@ describe LinksController, :vcr, inertia: true do
     end
 
     describe "GET cart_items_count" do
-      it "renders the Inertia page" do
+      it "returns 0 when no cart exists" do
         get :cart_items_count
 
         expect(inertia.component).to eq("Products/CartItemsCount")
-        expect(inertia.props[:cart]).to be_nil
+        expect(inertia.props[:cart_items_count]).to eq(0)
 
         html = Nokogiri::HTML.parse(response.body)
         [
@@ -3998,7 +3998,7 @@ describe LinksController, :vcr, inertia: true do
         end
       end
 
-      it "returns cart props when the user has a cart with items" do
+      it "returns the count of alive cart products" do
         sign_in @user
         product = create(:product)
         cart = create(:cart, user: @user, email: @user.email)
@@ -4007,18 +4007,19 @@ describe LinksController, :vcr, inertia: true do
         get :cart_items_count
 
         expect(inertia.component).to eq("Products/CartItemsCount")
-        expect(inertia.props[:cart]).to match(
-          email: @user.email,
-          returnUrl: "",
-          rejectPppDiscount: false,
-          discountCodes: [],
-          items: [
-            a_hash_including(
-              product: a_hash_including(permalink: product.unique_permalink),
-              quantity: 1,
-            ),
-          ],
-        )
+        expect(inertia.props[:cart_items_count]).to eq(1)
+      end
+
+      it "does not count deleted cart products" do
+        sign_in @user
+        product = create(:product)
+        cart = create(:cart, user: @user, email: @user.email)
+        create(:cart_product, cart:, product:)
+        create(:cart_product, cart:, product: create(:product), deleted_at: Time.current)
+
+        get :cart_items_count
+
+        expect(inertia.props[:cart_items_count]).to eq(1)
       end
     end
 


### PR DESCRIPTION
## What

Replace expensive `CartPresenter#cart_props` serialization in `LinksController#cart_items_count` with a simple `Cart.fetch_by` + `alive.count` query. Update the React component to accept a `cart_items_count` number prop instead of a full `CartState` object.

## Why

The `cart_items_count` endpoint was timing out (Rack::Timeout::RequestTimeoutException after 120s) because it built full cart props — serializing every cart product with all checkout details (upsells, bundles, discount codes, PPP, etc.) — when the frontend only needed `cart.items.length` to get a count. This replaces an O(n × expensive) serialization with a single COUNT query.

**Sentry issue:** https://gumroad-to.sentry.io/issues/7383431971/

## Test Results

Tests updated to verify the new `cart_items_count` prop:
- Returns 0 when no cart exists
- Returns correct count of alive cart products
- Excludes deleted cart products from count

Tests could not run locally due to missing webpack test manifest (`public/packs-test/manifest.json`), but the changes are straightforward: controller returns a count integer, frontend renders it.

---

AI disclosure: Claude Opus 4.6 was used to implement this fix, prompted with the Sentry error details and root cause analysis.

## Impact
- **Sentry events**: 11 total
- **Users affected**: ~10
- **Estimated support tickets**: <1/month
- First seen: 2026-04-02T19:22:33Z