### PR TITLE
Fix NameError: undefined local variable 'account_params' in StripeMerchantAccountManager.create_minimal_account

### DIFF
--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -3,6 +3,7 @@
 module StripeMerchantAccountManager
   REQUESTED_CAPABILITIES = %w(card_payments transfers)
   CROSS_BORDER_PAYOUTS_ONLY_CAPABILITIES = %w(transfers)
+  STRIPE_EMBEDDED_ONBOARDING_COUNTRIES = %w[AZ].freeze
   COUNTRIES_SUPPORTED_BY_STRIPE_CONNECT = ["Australia", "Austria", "Belgium", "Brazil", "Bulgaria", "Canada", "Croatia",
                                            "Cyprus", "Czechia", "Denmark", "Estonia", "Finland", "France",
                                            "Germany", "Gibraltar", "Greece", "Hong Kong", "Hungary", "Ireland", "Italy",

--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -112,6 +112,57 @@ module StripeMerchantAccountManager
     raise
   end
 
+  def self.create_minimal_account(user)
+    merchant_account = nil
+
+    ActiveRecord::Base.connection.stick_to_primary!
+    user.with_lock do
+      raise MerchantRegistrationUserNotReadyError.new(user.id, "is not supported yet") if !user.native_payouts_supported?
+      raise MerchantRegistrationUserAlreadyHasAccountError.new(user.id, StripeChargeProcessor.charge_processor_id) if user.merchant_accounts.alive.stripe.any?
+
+      user_compliance_info = user.alive_user_compliance_info
+      country_code = user_compliance_info.legal_entity_country_code
+      raise MerchantRegistrationUserNotReadyError.new(user.id, "does not have a legal entity country") if country_code.blank?
+
+      country = Country.new(country_code)
+      currency = country.payout_currency
+      raise MerchantRegistrationUserNotReadyError.new(user.id, "has no default currency defined for its legal entity's country") if currency.blank?
+
+      capabilities = country.stripe_capabilities
+
+      account_params = {
+        type: "custom",
+        country: country_code,
+        capabilities: capabilities.index_with { |c| { requested: true } },
+        business_profile: { url: user.business_profile_url },
+        metadata: { user_id: user.external_id },
+        controller: {
+          losses: { payments: "application" },
+          fees: { payer: "application" },
+          stripe_dashboard: { type: "none" },
+          requirement_collection: "stripe"
+        }
+      }
+
+      merchant_account = MerchantAccount.create!(
+        user:,
+        country: country_code,
+        currency:,
+        charge_processor_id: StripeChargeProcessor.charge_processor_id
+      )
+    end
+
+    stripe_account = Stripe::Account.create(account_params)
+    merchant_account.charge_processor_merchant_id = stripe_account.id
+    merchant_account.charge_processor_alive_at = Time.current
+    merchant_account.save!
+    merchant_account
+  rescue Stripe::StripeError => e
+    cleanup_failed_merchant_account(merchant_account) if merchant_account.present?
+    ErrorNotifier.notify(e)
+    raise
+  end
+
   def self.delete_account(merchant_account)
     stripe_account = Stripe::Account.retrieve(merchant_account.charge_processor_merchant_id)
     result = stripe_account.delete

--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -130,7 +130,7 @@ module StripeMerchantAccountManager
 
       capabilities = country.stripe_capabilities
 
-      account_params = {
+      {
         type: "custom",
         country: country_code,
         capabilities: capabilities.index_with { |c| { requested: true } },

--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -114,6 +114,7 @@ module StripeMerchantAccountManager
 
   def self.create_minimal_account(user)
     merchant_account = nil
+    account_params = {}
 
     ActiveRecord::Base.connection.stick_to_primary!
     user.with_lock do
@@ -130,7 +131,7 @@ module StripeMerchantAccountManager
 
       capabilities = country.stripe_capabilities
 
-      {
+      account_params = {
         type: "custom",
         country: country_code,
         capabilities: capabilities.index_with { |c| { requested: true } },

--- a/app/controllers/settings/payments_controller.rb
+++ b/app/controllers/settings/payments_controller.rb
@@ -113,6 +113,10 @@ class Settings::PaymentsController < Settings::BaseController
         current_seller.save!
       end
     end
+
+    if current_seller.reload.stripe_embedded_onboarding_enabled? && current_seller.merchant_accounts.stripe.alive.empty?
+      StripeMerchantAccountManager.create_minimal_account(current_seller)
+    end
   end
 
   def opt_in_to_au_backtax_collection

--- a/app/controllers/stripe_account_sessions_controller.rb
+++ b/app/controllers/stripe_account_sessions_controller.rb
@@ -10,15 +10,24 @@ class StripeAccountSessionsController < Sellers::BaseController
     end
 
     begin
+      components = {
+        notification_banner: {
+          enabled: true,
+          features: { external_account_collection: true }
+        }
+      }
+
+      if current_seller.stripe_embedded_onboarding_enabled?
+        components[:account_onboarding] = {
+          enabled: true,
+          features: { external_account_collection: true }
+        }
+      end
+
       session = Stripe::AccountSession.create(
         {
           account: connected_account_id,
-          components: {
-            notification_banner: {
-              enabled: true,
-              features: { external_account_collection: true }
-            }
-          }
+          components:
         }
       )
 

--- a/app/javascript/components/Settings/PaymentsPage/StripeConnectEmbeddedOnboarding.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/StripeConnectEmbeddedOnboarding.tsx
@@ -1,0 +1,38 @@
+import { StripeConnectInstance } from "@stripe/connect-js";
+import { ConnectAccountOnboarding, ConnectComponentsProvider } from "@stripe/react-connect-js";
+import * as React from "react";
+
+import { getStripeConnectInstance } from "$app/utils/stripe_loader";
+
+import { Skeleton } from "$app/components/Skeleton";
+import { useRunOnce } from "$app/components/useRunOnce";
+
+export const StripeConnectEmbeddedOnboarding = ({ onExit }: { onExit: () => void }) => {
+  const [connectInstance, setConnectInstance] = React.useState<null | StripeConnectInstance>(null);
+  const [isLoading, setIsLoading] = React.useState(true);
+
+  useRunOnce(() => {
+    setConnectInstance(getStripeConnectInstance());
+  });
+
+  const loader = <Skeleton className="h-96" />;
+
+  return (
+    <section>
+      {connectInstance ? (
+        <ConnectComponentsProvider connectInstance={connectInstance}>
+          <ConnectAccountOnboarding
+            onExit={() => {
+              setIsLoading(false);
+              onExit();
+            }}
+            onLoadError={() => setIsLoading(false)}
+          />
+          {isLoading ? loader : null}
+        </ConnectComponentsProvider>
+      ) : (
+        loader
+      )}
+    </section>
+  );
+};

--- a/app/javascript/pages/Settings/Payments/Show.tsx
+++ b/app/javascript/pages/Settings/Payments/Show.tsx
@@ -27,6 +27,7 @@ import BankAccountSection, {
 import DebitCardSection from "$app/components/Settings/PaymentsPage/DebitCardSection";
 import PayPalConnectSection, { PayPalConnect } from "$app/components/Settings/PaymentsPage/PayPalConnectSection";
 import PayPalEmailSection from "$app/components/Settings/PaymentsPage/PayPalEmailSection";
+import { StripeConnectEmbeddedOnboarding } from "$app/components/Settings/PaymentsPage/StripeConnectEmbeddedOnboarding";
 import StripeConnectSection, { StripeConnect } from "$app/components/Settings/PaymentsPage/StripeConnectSection";
 import { TypeSafeOptionSelect } from "$app/components/TypeSafeOptionSelect";
 import { Alert } from "$app/components/ui/Alert";
@@ -100,6 +101,8 @@ type PaymentsPageProps = {
   payout_country_name: string | null;
   payout_frequency: PayoutFrequency;
   payout_frequency_daily_supported: boolean;
+  use_stripe_embedded_onboarding: boolean;
+  stripe_onboarding_complete: boolean;
   errors?: {
     base?: string[];
   };
@@ -1035,147 +1038,173 @@ export default function PaymentsPage() {
           </section>
         </FormSection>
 
-        <FormSection
-          header={
-            <>
-              <h2>Payout method</h2>
-              <div>
-                <a href="/help/article/260-your-payout-settings-page" target="_blank" rel="noreferrer">
-                  Any questions about these payout settings?
-                </a>
-              </div>
-            </>
-          }
-        >
-          <section className="grid gap-8">
-            <Tabs variant="buttons" className="gap-4" role="radiogroup">
-              {props.bank_account_details.show_bank_account ? (
-                <>
-                  <Tab key="bank" isSelected={selectedPayoutMethod === "bank"} asChild>
-                    <Button
-                      role="radio"
-                      aria-checked={selectedPayoutMethod === "bank"}
-                      onClick={() => updatePayoutMethod("bank")}
-                      disabled={props.is_form_disabled}
-                      className="items-start justify-start text-left"
-                    >
-                      <Bank className="size-5" />
-                      <div>
-                        <h4 className="font-bold">Bank Account</h4>
-                      </div>
-                    </Button>
-                  </Tab>
-                  {props.user.country_code === "US" ? (
-                    <Tab key="card" isSelected={selectedPayoutMethod === "card"} asChild>
+        {props.use_stripe_embedded_onboarding ? (
+          <FormSection
+            header={
+              <>
+                <h2>Payout method</h2>
+                <div>
+                  <a href="/help/article/260-your-payout-settings-page" target="_blank" rel="noreferrer">
+                    Any questions about these payout settings?
+                  </a>
+                </div>
+              </>
+            }
+          >
+            {props.stripe_onboarding_complete ? (
+              <section className="flex flex-col gap-4">
+                <Alert role="status" variant="success">
+                  Your payouts are set up through Stripe.
+                </Alert>
+                <StripeConnectEmbeddedNotificationBanner />
+              </section>
+            ) : (
+              <StripeConnectEmbeddedOnboarding onExit={() => window.location.reload()} />
+            )}
+          </FormSection>
+        ) : (
+          <FormSection
+            header={
+              <>
+                <h2>Payout method</h2>
+                <div>
+                  <a href="/help/article/260-your-payout-settings-page" target="_blank" rel="noreferrer">
+                    Any questions about these payout settings?
+                  </a>
+                </div>
+              </>
+            }
+          >
+            <section className="grid gap-8">
+              <Tabs variant="buttons" className="gap-4" role="radiogroup">
+                {props.bank_account_details.show_bank_account ? (
+                  <>
+                    <Tab key="bank" isSelected={selectedPayoutMethod === "bank"} asChild>
                       <Button
                         role="radio"
-                        aria-checked={selectedPayoutMethod === "card"}
-                        onClick={() => updatePayoutMethod("card")}
+                        aria-checked={selectedPayoutMethod === "bank"}
+                        onClick={() => updatePayoutMethod("bank")}
                         disabled={props.is_form_disabled}
                         className="items-start justify-start text-left"
                       >
-                        <CreditCard className="size-5" />
+                        <Bank className="size-5" />
                         <div>
-                          <h4 className="font-bold">Debit Card</h4>
+                          <h4 className="font-bold">Bank Account</h4>
                         </div>
                       </Button>
                     </Tab>
-                  ) : null}
-                </>
+                    {props.user.country_code === "US" ? (
+                      <Tab key="card" isSelected={selectedPayoutMethod === "card"} asChild>
+                        <Button
+                          role="radio"
+                          aria-checked={selectedPayoutMethod === "card"}
+                          onClick={() => updatePayoutMethod("card")}
+                          disabled={props.is_form_disabled}
+                          className="items-start justify-start text-left"
+                        >
+                          <CreditCard className="size-5" />
+                          <div>
+                            <h4 className="font-bold">Debit Card</h4>
+                          </div>
+                        </Button>
+                      </Tab>
+                    ) : null}
+                  </>
+                ) : null}
+                {props.bank_account_details.show_paypal ? (
+                  <Tab key="paypal" isSelected={selectedPayoutMethod === "paypal"} asChild>
+                    <Button
+                      role="radio"
+                      aria-checked={selectedPayoutMethod === "paypal"}
+                      onClick={() => updatePayoutMethod("paypal")}
+                      disabled={props.is_form_disabled}
+                      className="items-start justify-start text-left"
+                    >
+                      <Paypal pack="brands" className="size-5" />
+                      <div>
+                        <h4 className="font-bold">PayPal</h4>
+                      </div>
+                    </Button>
+                  </Tab>
+                ) : null}
+                {props.user.country_code === "BR" ||
+                props.user.can_connect_stripe ||
+                props.stripe_connect.has_connected_stripe ? (
+                  <Tab key="stripe" isSelected={selectedPayoutMethod === "stripe"} asChild>
+                    <Button
+                      role="radio"
+                      aria-checked={selectedPayoutMethod === "stripe"}
+                      onClick={() => updatePayoutMethod("stripe")}
+                      disabled={props.is_form_disabled}
+                      className="items-start justify-start text-left"
+                    >
+                      <Stripe pack="brands" className="size-5" />
+                      <div>
+                        <h4 className="font-bold">Connect to Stripe</h4>
+                      </div>
+                    </Button>
+                  </Tab>
+                ) : null}
+              </Tabs>
+              {selectedPayoutMethod === "bank" ? (
+                <BankAccountSection
+                  bankAccountDetails={props.bank_account_details}
+                  bankAccount={form.data.bank_account}
+                  updateBankAccount={updateBankAccount}
+                  hasConnectedStripe={props.stripe_connect.has_connected_stripe}
+                  user={props.user}
+                  isFormDisabled={props.is_form_disabled}
+                  feeInfoText={props.fee_info.card_fee_info_text}
+                  showNewBankAccount={showNewBankAccount}
+                  setShowNewBankAccount={setShowNewBankAccount}
+                  errorFieldNames={errorFieldNames}
+                />
+              ) : selectedPayoutMethod === "card" ? (
+                <DebitCardSection
+                  isFormDisabled={props.is_form_disabled}
+                  hasConnectedStripe={props.stripe_connect.has_connected_stripe}
+                  feeInfoText={props.fee_info.card_fee_info_text}
+                  savedCard={props.bank_account_details.card}
+                  setDebitCard={setDebitCard}
+                />
+              ) : selectedPayoutMethod === "paypal" ? (
+                <PayPalEmailSection
+                  countrySupportsNativePayouts={props.user.country_supports_native_payouts}
+                  showPayPalPayoutsFeeNote={props.user.is_charged_paypal_payout_fee}
+                  isFormDisabled={props.is_form_disabled}
+                  paypalEmailAddress={form.data.payment_address}
+                  setPaypalEmailAddress={(value) => form.setData("payment_address", value)}
+                  hasConnectedStripe={props.stripe_connect.has_connected_stripe}
+                  feeInfoText={props.fee_info.paypal_fee_info_text}
+                  updatePayoutMethod={updatePayoutMethod}
+                  errorFieldNames={errorFieldNames}
+                  user={props.user}
+                />
               ) : null}
-              {props.bank_account_details.show_paypal ? (
-                <Tab key="paypal" isSelected={selectedPayoutMethod === "paypal"} asChild>
-                  <Button
-                    role="radio"
-                    aria-checked={selectedPayoutMethod === "paypal"}
-                    onClick={() => updatePayoutMethod("paypal")}
-                    disabled={props.is_form_disabled}
-                    className="items-start justify-start text-left"
-                  >
-                    <Paypal pack="brands" className="size-5" />
-                    <div>
-                      <h4 className="font-bold">PayPal</h4>
-                    </div>
-                  </Button>
-                </Tab>
-              ) : null}
-              {props.user.country_code === "BR" ||
-              props.user.can_connect_stripe ||
-              props.stripe_connect.has_connected_stripe ? (
-                <Tab key="stripe" isSelected={selectedPayoutMethod === "stripe"} asChild>
-                  <Button
-                    role="radio"
-                    aria-checked={selectedPayoutMethod === "stripe"}
-                    onClick={() => updatePayoutMethod("stripe")}
-                    disabled={props.is_form_disabled}
-                    className="items-start justify-start text-left"
-                  >
-                    <Stripe pack="brands" className="size-5" />
-                    <div>
-                      <h4 className="font-bold">Connect to Stripe</h4>
-                    </div>
-                  </Button>
-                </Tab>
-              ) : null}
-            </Tabs>
-            {selectedPayoutMethod === "bank" ? (
-              <BankAccountSection
-                bankAccountDetails={props.bank_account_details}
-                bankAccount={form.data.bank_account}
-                updateBankAccount={updateBankAccount}
-                hasConnectedStripe={props.stripe_connect.has_connected_stripe}
-                user={props.user}
-                isFormDisabled={props.is_form_disabled}
-                feeInfoText={props.fee_info.card_fee_info_text}
-                showNewBankAccount={showNewBankAccount}
-                setShowNewBankAccount={setShowNewBankAccount}
-                errorFieldNames={errorFieldNames}
-              />
-            ) : selectedPayoutMethod === "card" ? (
-              <DebitCardSection
-                isFormDisabled={props.is_form_disabled}
-                hasConnectedStripe={props.stripe_connect.has_connected_stripe}
-                feeInfoText={props.fee_info.card_fee_info_text}
-                savedCard={props.bank_account_details.card}
-                setDebitCard={setDebitCard}
-              />
-            ) : selectedPayoutMethod === "paypal" ? (
-              <PayPalEmailSection
-                countrySupportsNativePayouts={props.user.country_supports_native_payouts}
-                showPayPalPayoutsFeeNote={props.user.is_charged_paypal_payout_fee}
-                isFormDisabled={props.is_form_disabled}
-                paypalEmailAddress={form.data.payment_address}
-                setPaypalEmailAddress={(value) => form.setData("payment_address", value)}
-                hasConnectedStripe={props.stripe_connect.has_connected_stripe}
-                feeInfoText={props.fee_info.paypal_fee_info_text}
-                updatePayoutMethod={updatePayoutMethod}
-                errorFieldNames={errorFieldNames}
-                user={props.user}
-              />
-            ) : null}
-            {selectedPayoutMethod !== "stripe" ? (
-              <AccountDetailsSection
-                user={props.user}
-                complianceInfo={form.data.user}
-                updateComplianceInfo={updateComplianceInfo}
-                minDobYear={props.min_dob_year}
-                isFormDisabled={props.is_form_disabled}
-                countries={props.countries}
-                uaeBusinessTypes={props.uae_business_types}
-                indiaBusinessTypes={props.india_business_types}
-                canadaBusinessTypes={props.canada_business_types}
-                states={props.states}
-                errorFieldNames={errorFieldNames}
-              />
-            ) : (
-              <StripeConnectSection
-                stripeConnect={props.stripe_connect}
-                isFormDisabled={props.is_form_disabled}
-                connectAccountFeeInfoText={props.fee_info.connect_account_fee_info_text}
-              />
-            )}
-          </section>
-        </FormSection>
+              {selectedPayoutMethod !== "stripe" ? (
+                <AccountDetailsSection
+                  user={props.user}
+                  complianceInfo={form.data.user}
+                  updateComplianceInfo={updateComplianceInfo}
+                  minDobYear={props.min_dob_year}
+                  isFormDisabled={props.is_form_disabled}
+                  countries={props.countries}
+                  uaeBusinessTypes={props.uae_business_types}
+                  indiaBusinessTypes={props.india_business_types}
+                  canadaBusinessTypes={props.canada_business_types}
+                  states={props.states}
+                  errorFieldNames={errorFieldNames}
+                />
+              ) : (
+                <StripeConnectSection
+                  stripeConnect={props.stripe_connect}
+                  isFormDisabled={props.is_form_disabled}
+                  connectAccountFeeInfoText={props.fee_info.connect_account_fee_info_text}
+                />
+              )}
+            </section>
+          </FormSection>
+        )}
         {props.paypal_connect.show_paypal_connect ? (
           <PayPalConnectSection
             paypalConnect={props.paypal_connect}

--- a/app/modules/user/feature_status.rb
+++ b/app/modules/user/feature_status.rb
@@ -6,6 +6,13 @@
 
 class User
   module FeatureStatus
+    def stripe_embedded_onboarding_enabled?
+      Feature.active?(:stripe_embedded_onboarding, self) &&
+        StripeMerchantAccountManager::STRIPE_EMBEDDED_ONBOARDING_COUNTRIES.include?(
+          ::Compliance::Countries.find_by_name(alive_user_compliance_info&.country)&.alpha2
+        )
+    end
+
     def merchant_migration_enabled?
       check_merchant_account_is_linked || (Feature.active?(:merchant_migration, self) &&
           StripeMerchantAccountManager::COUNTRIES_SUPPORTED_BY_STRIPE_CONNECT.include?(::Compliance::Countries.find_by_name(alive_user_compliance_info&.country)&.alpha2))

--- a/app/presenters/settings_presenter.rb
+++ b/app/presenters/settings_presenter.rb
@@ -225,6 +225,8 @@ class SettingsPresenter
       payout_country_name: Compliance::Countries.for_select.to_h[seller.alive_user_compliance_info&.legal_entity_country_code],
       payout_frequency: seller.payout_frequency,
       payout_frequency_daily_supported: seller.instant_payouts_supported?,
+      use_stripe_embedded_onboarding: seller.stripe_embedded_onboarding_enabled? && seller.stripe_account.present?,
+      stripe_onboarding_complete: seller.stripe_embedded_onboarding_enabled? && seller.stripe_account&.charge_processor_verified?,
     }
   end
 

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -8601,6 +8601,104 @@ describe StripeMerchantAccountManager, :vcr do
     end
   end
 
+  describe ".create_minimal_account" do
+    describe "with valid setup for an embedded-onboarding country" do
+      let(:user_compliance_info) do
+        create(:user_compliance_info, user:, city: "Baku", street_address: "address_full_match",
+                                      state: nil, zip_code: "43200", country: "Azerbaijan", individual_tax_id: nil)
+      end
+      let(:fake_stripe_account) { Stripe::Account.construct_from(id: "acct_fake_minimal_123", object: "account") }
+
+      before do
+        user_compliance_info
+        Feature.activate_user(:stripe_embedded_onboarding, user)
+        allow(Stripe::Account).to receive(:create).and_return(fake_stripe_account)
+      end
+
+      it "creates a merchant account and calls Stripe with the correct params" do
+        merchant_account = subject.create_minimal_account(user)
+
+        expect(Stripe::Account).to have_received(:create).with(
+          type: "custom",
+          country: "AZ",
+          capabilities: { "transfers" => { requested: true } },
+          business_profile: { url: user.business_profile_url },
+          metadata: { user_id: user.external_id },
+          controller: {
+            losses: { payments: "application" },
+            fees: { payer: "application" },
+            stripe_dashboard: { type: "none" },
+            requirement_collection: "stripe"
+          }
+        )
+
+        expect(merchant_account).to be_persisted
+        expect(merchant_account.charge_processor_id).to eq(StripeChargeProcessor.charge_processor_id)
+        expect(merchant_account.charge_processor_merchant_id).to eq("acct_fake_minimal_123")
+        expect(merchant_account.charge_processor_alive_at).to be_present
+        expect(merchant_account.country).to eq("AZ")
+        expect(merchant_account.currency).to eq("azn")
+      end
+    end
+
+    describe "when user is not payouts-supported" do
+      it "raises a user not ready error" do
+        expect { subject.create_minimal_account(user) }.to raise_error(MerchantRegistrationUserNotReadyError)
+      end
+    end
+
+    describe "when user already has a stripe merchant account" do
+      let(:user_compliance_info) do
+        create(:user_compliance_info, user:, city: "Baku", street_address: "address_full_match",
+                                      state: nil, zip_code: "43200", country: "Azerbaijan", individual_tax_id: nil)
+      end
+      let(:fake_stripe_account) { Stripe::Account.construct_from(id: "acct_fake_minimal_456", object: "account") }
+
+      before do
+        user_compliance_info
+        Feature.activate_user(:stripe_embedded_onboarding, user)
+        allow(Stripe::Account).to receive(:create).and_return(fake_stripe_account)
+        subject.create_minimal_account(user)
+      end
+
+      it "raises an already has account error" do
+        expect { subject.create_minimal_account(user) }.to raise_error(MerchantRegistrationUserAlreadyHasAccountError)
+      end
+    end
+
+    describe "when user does not have a country" do
+      let(:user_compliance_info) { create(:user_compliance_info_empty, user:) }
+
+      before do
+        user_compliance_info
+      end
+
+      it "raises a user not ready error" do
+        expect { subject.create_minimal_account(user) }.to raise_error(MerchantRegistrationUserNotReadyError)
+      end
+    end
+
+    describe "when Stripe returns an error" do
+      let(:user_compliance_info) do
+        create(:user_compliance_info, user:, city: "Baku", street_address: "address_full_match",
+                                      state: nil, zip_code: "43200", country: "Azerbaijan", individual_tax_id: nil)
+      end
+
+      before do
+        user_compliance_info
+        Feature.activate_user(:stripe_embedded_onboarding, user)
+        allow(Stripe::Account).to receive(:create).and_raise(Stripe::InvalidRequestError.new("Invalid request", "param"))
+      end
+
+      it "cleans up the merchant account and re-raises" do
+        expect do
+          subject.create_minimal_account(user)
+        end.to raise_error(Stripe::InvalidRequestError)
+        expect(user.merchant_accounts.alive.count).to eq(0)
+      end
+    end
+  end
+
   describe "#update_account" do
     describe "all info provided" do
       let(:user_compliance_info_1) { create(:user_compliance_info, user:) }

--- a/spec/modules/user/feature_status_spec.rb
+++ b/spec/modules/user/feature_status_spec.rb
@@ -3,6 +3,53 @@
 require "spec_helper"
 
 describe User::FeatureStatus do
+  describe "#stripe_embedded_onboarding_enabled?" do
+    it "returns false when feature flag is not enabled" do
+      seller = create(:user)
+      create(:user_compliance_info, user: seller, country: "Azerbaijan")
+
+      expect(seller.stripe_embedded_onboarding_enabled?).to eq false
+    end
+
+    it "returns true when feature flag is enabled and country is in the allowlist" do
+      seller = create(:user)
+      create(:user_compliance_info, user: seller, country: "Azerbaijan")
+
+      Feature.activate_user(:stripe_embedded_onboarding, seller)
+
+      expect(seller.stripe_embedded_onboarding_enabled?).to eq true
+    end
+
+    it "returns false when feature flag is enabled but country is not in the allowlist" do
+      seller = create(:user)
+      create(:user_compliance_info, user: seller, country: "United States")
+
+      Feature.activate_user(:stripe_embedded_onboarding, seller)
+
+      expect(seller.stripe_embedded_onboarding_enabled?).to eq false
+    end
+
+    it "returns false when user has no compliance info" do
+      seller = create(:user)
+
+      Feature.activate_user(:stripe_embedded_onboarding, seller)
+
+      expect(seller.stripe_embedded_onboarding_enabled?).to eq false
+    end
+
+    it "returns true for all countries in the allowlist" do
+      StripeMerchantAccountManager::STRIPE_EMBEDDED_ONBOARDING_COUNTRIES.each do |country_code|
+        seller = create(:user)
+        country_name = ISO3166::Country[country_code].common_name
+        create(:user_compliance_info, user: seller, country: country_name)
+
+        Feature.activate_user(:stripe_embedded_onboarding, seller)
+
+        expect(seller.stripe_embedded_onboarding_enabled?).to eq(true), "Expected true for #{country_name} (#{country_code})"
+      end
+    end
+  end
+
   describe "#merchant_migration_enabled?" do
     it "returns true if either feature flag is enabled of else false" do
       creator = create(:user)

--- a/spec/presenters/settings_presenter_spec.rb
+++ b/spec/presenters/settings_presenter_spec.rb
@@ -576,6 +576,8 @@ describe SettingsPresenter do
         payout_country_name: nil,
         payout_frequency: User::PayoutSchedule::WEEKLY,
         payout_frequency_daily_supported: false,
+        use_stripe_embedded_onboarding: false,
+        stripe_onboarding_complete: false,
       }
     end
 


### PR DESCRIPTION
## What

Fixes `NameError: undefined local variable or method 'account_params'` in `StripeMerchantAccountManager.create_minimal_account`.

The hash literal building the Stripe account params was a standalone expression — not assigned to any variable. When `Stripe::Account.create(account_params)` was called after the `with_lock` block, `account_params` was undefined.

## Why

This caused a runtime crash whenever `create_minimal_account` was called for users in embedded-onboarding countries (e.g. AZ). The fix assigns the hash to `account_params` before and inside the `with_lock` block, matching the existing pattern in `create_account`.

Sentry: https://gumroad-to.sentry.io/issues/7383606547/

## Test Results

Added tests for `create_minimal_account` covering:
- Successful account creation with correct Stripe params
- Error when user is not payouts-supported
- Error when user already has a merchant account
- Error when user has no country
- Stripe error cleanup

All 5 new tests pass. Existing `set_country` controller tests also pass.

---

Generated with Claude Opus 4.6. Prompted to fix the undefined variable bug and write tests for `create_minimal_account`.