### PR TITLE
Fix ArgumentError when asset preview URL has no host

### DIFF
--- a/app/models/asset_preview.rb
+++ b/app/models/asset_preview.rb
@@ -176,6 +176,7 @@ class AssetPreview < ApplicationRecord
     new_url = Addressable::URI.escape(new_url) unless URI::ABS_URI.match?(new_url)
     new_uri = URI.parse(new_url)
     raise URI::InvalidURIError.new("URL '#{new_url}' is not a web url") unless new_uri.scheme.in?(["http", "https"])
+    raise URI::InvalidURIError.new("URL must include a valid host") if new_uri.host.blank?
     new_url = new_uri.to_s
     embeddable = OEmbedFinder.embeddable_from_url(new_url)
 

--- a/spec/controllers/asset_previews_controller_spec.rb
+++ b/spec/controllers/asset_previews_controller_spec.rb
@@ -33,6 +33,12 @@ describe AssetPreviewsController do
       end.to change { product.asset_previews.alive.count }.by(1)
     end
 
+    it "returns an error for a URL without a host" do
+      post(:create, params: { link_id: product.unique_permalink, asset_preview: { url: "https:///path" }, format: :json })
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["success"]).to eq(false)
+    end
+
     it "doesn't add a preview if there are too many previews" do
       stub_const("Link::MAX_PREVIEW_COUNT", 1)
       allow_any_instance_of(AssetPreview).to receive(:analyze_file).and_return(nil)

--- a/spec/models/asset_preview_spec.rb
+++ b/spec/models/asset_preview_spec.rb
@@ -169,6 +169,12 @@ describe AssetPreview, :vcr do
       end.to raise_error(URI::InvalidURIError, /not a web url/)
     end
 
+    it "rejects URLs without a host" do
+      expect do
+        asset_preview.url = "https:///path"
+      end.to raise_error(URI::InvalidURIError, /valid host/)
+    end
+
     it "blocks SSRF attempts to localhost", :skip_ssrf_stub do
       expect do
         asset_preview.url = "http://127.0.0.1:6379/"


### PR DESCRIPTION
## What

Adds host presence validation in `AssetPreview#url=` to reject URLs like `https:///path` that have a valid scheme but no host.

## Why

URLs without a host pass the existing scheme check but cause `SsrfFilter.get` to call DNS resolution on `nil`, raising `ArgumentError: cannot interpret as DNS name: nil`. Since `ArgumentError` isn't in `INTERNET_EXCEPTIONS`, this results in an unhandled 500 error.

The fix raises `URI::InvalidURIError` (which is in `INTERNET_EXCEPTIONS`) when the host is blank, so the controller's existing rescue returns a proper JSON error response.

Sentry: https://gumroad-to.sentry.io/issues/7384175159/

## Test plan

- [ ] `bundle exec rspec spec/models/asset_preview_spec.rb` — new test verifies `URI::InvalidURIError` is raised for hostless URLs
- [ ] `bundle exec rspec spec/controllers/asset_previews_controller_spec.rb` — new test verifies the controller returns a JSON error (not a 500)

---

Generated with Claude Opus 4.6. Prompt: fix the ArgumentError from nil DNS name in AssetPreviewsController#create by validating host presence in AssetPreview#url=.