### PR TITLE
Fix ActiveRecord::RecordInvalid not rescued in Api::V2::LinksController#enable

### DIFF
--- a/app/controllers/api/v2/links_controller.rb
+++ b/app/controllers/api/v2/links_controller.rb
@@ -46,7 +46,7 @@ class Api::V2::LinksController < Api::V2::BaseController
 
     begin
       @product.publish!
-    rescue Link::LinkInvalid
+    rescue Link::LinkInvalid, ActiveRecord::RecordInvalid
       return error_with_product(@product)
     rescue => e
       ErrorNotifier.notify(e)

--- a/spec/controllers/api/v2/links_controller_spec.rb
+++ b/spec/controllers/api/v2/links_controller_spec.rb
@@ -350,6 +350,24 @@ describe Api::V2::LinksController do
           expect(@product.purchase_disabled_at).to_not be_nil
         end
       end
+
+      context "when a variant category has no alive variants" do
+        before do
+          @product.update!(purchase_disabled_at: 1.day.ago)
+          category = create(:variant_category, link: @product)
+          variant = create(:variant, variant_category: category)
+          variant.update!(deleted_at: Time.current)
+        end
+
+        it "returns a validation error instead of notifying error tracker" do
+          expect(ErrorNotifier).not_to receive(:notify)
+
+          put @action, params: @params
+
+          expect(response.parsed_body["success"]).to eq(false)
+          expect(response.parsed_body["message"]).to include("product versions must have at least one option")
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## What

Rescue `ActiveRecord::RecordInvalid` alongside `Link::LinkInvalid` in the `Api::V2::LinksController#enable` action, so validation errors are returned to the API caller instead of triggering Sentry alerts.

## Why

The `alive_category_variants_presence` validation on `Link` adds an error to the model, but `publish!` calls `save!`, which raises `ActiveRecord::RecordInvalid` — not `Link::LinkInvalid`. This exception was falling through to the generic `rescue => e` handler, which notified Sentry and returned a generic error message to the caller. The fix ensures these validation errors are handled the same way as `Link::LinkInvalid`: the product's error messages are returned in the API response.

Related Sentry issue: https://gumroad-to.sentry.io/issues/7384239150/

## Test Results

Added a test that creates a product with a variant category whose only variant is deleted (triggering `alive_category_variants_presence`), calls the enable endpoint, and asserts:
- `ErrorNotifier` is not called
- The response includes `success: false` with the validation message

The test fails when the controller fix is reverted, confirming it covers the bug.

---

AI disclosure: Implemented with Claude Opus 4.6. Prompted with the Sentry issue context, root cause analysis, and fix instructions.