### PR TITLE
Filter archived products from checkout cart

### DIFF
--- a/app/presenters/cart_presenter.rb
+++ b/app/presenters/cart_presenter.rb
@@ -12,7 +12,7 @@ class CartPresenter
   def cart_props
     return if cart.nil?
 
-    cart_products = cart.cart_products.alive.order(created_at: :desc)
+    cart_products = cart.cart_products.alive.joins(:product).merge(Link.not_archived).order(created_at: :desc)
 
     {
       email: cart.email.presence,

--- a/spec/presenters/cart_presenter_spec.rb
+++ b/spec/presenters/cart_presenter_spec.rb
@@ -116,6 +116,36 @@ describe CartPresenter do
       end
     end
 
+    context "when the cart contains archived products" do
+      let(:cart) { create(:cart, user:) }
+      let(:archived_product) { create(:product, archived: true) }
+      let(:active_product) { create(:product) }
+
+      before do
+        create(:cart_product, cart:, product: archived_product)
+        create(:cart_product, cart:, product: active_product)
+      end
+
+      it "excludes archived products from cart items" do
+        props = presenter.cart_props
+        permalinks = props[:items].map { |item| item[:product][:permalink] }
+
+        expect(permalinks).to include(active_product.unique_permalink)
+        expect(permalinks).not_to include(archived_product.unique_permalink)
+      end
+
+      context "when all cart products are archived" do
+        before do
+          active_product.update!(archived: true)
+        end
+
+        it "returns an empty items list" do
+          props = presenter.cart_props
+          expect(props[:items]).to be_empty
+        end
+      end
+    end
+
     context "with discount codes and offers" do
       context "when the user has accepeted an upsell" do
         let(:discount_codes) do


### PR DESCRIPTION
## Summary
- Archived products were still visible and purchasable on the checkout page if added to cart before being archived
- Adds `.joins(:product).merge(Link.not_archived)` filter in `CartPresenter#cart_props` to exclude archived products
- Adds tests for mixed archived/active cart and all-archived cart edge case

## Test plan
- [ ] Add a product to cart, archive it, open checkout — archived product should not appear
- [ ] Add multiple products to cart, archive one — only non-archived products appear
- [ ] Archive all products in cart — checkout shows empty items list
- [ ] Verify `CartPresenter` spec passes: `rspec spec/presenters/cart_presenter_spec.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)