### PR TITLE
Fix N+1 ES queries causing timeout in LinksController#index

### DIFF
--- a/app/controllers/api/v2/links_controller.rb
+++ b/app/controllers/api/v2/links_controller.rb
@@ -18,6 +18,11 @@ class Api::V2::LinksController < Api::V2::BaseController
       preloaded_ppp_factors: PurchasingPowerParityService.new.get_all_countries_factors(current_resource_owner)
     }
 
+    if (doorkeeper_token.scopes & %w[view_sales account]).present?
+      as_json_options[:preloaded_sales_counts] = Link.batch_successful_sales_counts(products: products)
+      as_json_options[:preloaded_total_usd_cents] = Link.batch_total_usd_cents(products: products)
+    end
+
     products_as_json = products.as_json(as_json_options)
 
     render json: { success: true, products: products_as_json }

--- a/app/models/concerns/product/as_json.rb
+++ b/app/models/concerns/product/as_json.rb
@@ -135,8 +135,8 @@ module Product::AsJson
 
       if (options[:api_scopes] & %w[view_sales account]).present?
         json["custom_delivery_url"] = nil # Deprecated
-        json["sales_count"] = successful_sales_count
-        json["sales_usd_cents"] = total_usd_cents
+        json["sales_count"] = options[:preloaded_sales_counts]&.fetch(id, 0) || successful_sales_count
+        json["sales_usd_cents"] = options[:preloaded_total_usd_cents]&.fetch(id, 0) || total_usd_cents
       end
 
       json

--- a/app/modules/product/stats.rb
+++ b/app/modules/product/stats.rb
@@ -19,6 +19,46 @@ module Product::Stats
       PurchaseSearchService.search(search_options).results.total
     end
 
+    def batch_successful_sales_counts(products:)
+      return {} if products.blank?
+
+      search_options = Purchase::ACTIVE_SALES_SEARCH_OPTIONS.merge(
+        product: products,
+        size: 0,
+        aggs: {
+          per_product: {
+            terms: { field: "product_id", size: Array.wrap(products).size }
+          }
+        }
+      )
+      result = PurchaseSearchService.search(search_options)
+      result.aggregations.per_product.buckets.each_with_object({}) do |bucket, hash|
+        hash[bucket[:key]] = bucket[:doc_count]
+      end
+    end
+
+    def batch_total_usd_cents(products:)
+      return {} if products.blank?
+
+      search_options = Purchase::CHARGED_SALES_SEARCH_OPTIONS.merge(
+        product: products,
+        size: 0,
+        aggs: {
+          per_product: {
+            terms: { field: "product_id", size: Array.wrap(products).size },
+            aggs: {
+              price_cents_total: { sum: { field: "price_cents" } },
+              amount_refunded_cents_total: { sum: { field: "amount_refunded_cents" } },
+            }
+          }
+        }
+      )
+      result = PurchaseSearchService.search(search_options)
+      result.aggregations.per_product.buckets.each_with_object({}) do |bucket, hash|
+        hash[bucket[:key]] = bucket.dig(:price_cents_total, :value) - bucket.dig(:amount_refunded_cents_total, :value)
+      end
+    end
+
     def monthly_recurring_revenue(products:)
       return 0 if products.blank?
 

--- a/spec/controllers/api/v2/links_controller_spec.rb
+++ b/spec/controllers/api/v2/links_controller_spec.rb
@@ -47,6 +47,13 @@ describe Api::V2::LinksController do
         @product2.reload
         expect(response.parsed_body).to eq({ success: true, products: [@product2, @product1] }.as_json(api_scopes: ["view_sales"]))
       end
+
+      it "batch preloads sales stats instead of querying per product" do
+        expect(Link).to receive(:batch_successful_sales_counts).once.and_return({})
+        expect(Link).to receive(:batch_total_usd_cents).once.and_return({})
+        get @action, params: @params
+        expect(response).to be_successful
+      end
     end
 
     it "grants access with the account scope" do

--- a/spec/models/concerns/product/as_json_spec.rb
+++ b/spec/models/concerns/product/as_json_spec.rb
@@ -204,6 +204,18 @@ describe Product::AsJson, :vcr do
           expect(result["sales_count"]).to eq(1)
           expect(result["sales_usd_cents"]).to eq(100)
         end
+
+        it "uses preloaded sales data when provided" do
+          product = create(:product)
+
+          result = product.as_json(
+            api_scopes: %w[view_sales],
+            preloaded_sales_counts: { product.id => 42 },
+            preloaded_total_usd_cents: { product.id => 9900 }
+          )
+          expect(result["sales_count"]).to eq(42)
+          expect(result["sales_usd_cents"]).to eq(9900)
+        end
       end
     end
 

--- a/spec/modules/product/stats_spec.rb
+++ b/spec/modules/product/stats_spec.rb
@@ -56,6 +56,42 @@ describe Product::Stats do
     end
   end
 
+  describe ".batch_successful_sales_counts", :sidekiq_inline, :elasticsearch_wait_for_refresh do
+    it "returns per-product sales counts in a single query" do
+      product1 = create(:product, price_cents: 500)
+      product2 = create(:product, price_cents: 500)
+      create_list(:purchase, 2, link: product1)
+      create(:purchase, link: product1, stripe_refunded: true)
+      create(:purchase, link: product2)
+
+      counts = Link.batch_successful_sales_counts(products: [product1, product2])
+      expect(counts[product1.id]).to eq(2)
+      expect(counts[product2.id]).to eq(1)
+    end
+
+    it "returns an empty hash when products is blank" do
+      expect(Link.batch_successful_sales_counts(products: [])).to eq({})
+    end
+  end
+
+  describe ".batch_total_usd_cents", :sidekiq_inline, :elasticsearch_wait_for_refresh do
+    it "returns per-product net revenue in a single query" do
+      product1 = create(:product, price_cents: 500)
+      product2 = create(:product, price_cents: 300)
+      create_list(:purchase, 2, link: product1)
+      create(:purchase, link: product1, stripe_refunded: true)
+      create(:purchase, link: product2)
+
+      totals = Link.batch_total_usd_cents(products: [product1, product2])
+      expect(totals[product1.id]).to eq(1000)
+      expect(totals[product2.id]).to eq(300)
+    end
+
+    it "returns an empty hash when products is blank" do
+      expect(Link.batch_total_usd_cents(products: [])).to eq({})
+    end
+  end
+
   describe "#total_usd_cents", :sidekiq_inline, :elasticsearch_wait_for_refresh do
     it "returns net revenue" do
       product = create(:product)


### PR DESCRIPTION
## What

Batch Elasticsearch queries for `sales_count` and `sales_usd_cents` in `Api::V2::LinksController#index` to eliminate N+1 query pattern.

- Add `batch_successful_sales_counts` and `batch_total_usd_cents` class methods to `Product::Stats` using ES `terms` aggregation on `product_id`
- Preload batched stats in `LinksController#index` when scopes include `view_sales` or `account`
- Use preloaded values in `as_json_for_api` with fallback to individual queries for backward compatibility

## Why

The `index` action was calling `successful_sales_count` and `total_usd_cents` individually on each product (2 ES queries per product). For users with many products, this caused `Rack::Timeout::RequestTimeoutException` after 120s. This change reduces 2N ES queries to just 2 total queries using per-product `terms` aggregation.

## Test Results

Added tests for:
- `batch_successful_sales_counts` returns correct per-product counts
- `batch_total_usd_cents` returns correct per-product net revenue
- `as_json_for_api` uses preloaded data when provided
- `LinksController#index` calls batch methods instead of per-product queries

---

AI disclosure: Built with Claude Opus 4.6. Prompted to fix the N+1 ES query pattern in `Api::V2::LinksController#index` that was causing `Rack::Timeout::RequestTimeoutException`.