### PR TITLE
Fix Rack::Timeout in Products::AffiliatedController#index

### DIFF
--- a/app/models/affiliate.rb
+++ b/app/models/affiliate.rb
@@ -110,7 +110,7 @@ class Affiliate < ApplicationRecord
   end
 
   def total_cents_earned
-    purchases.paid.not_chargedback_or_chargedback_reversed.sum(:affiliate_credit_cents)
+    affiliate_credits.paid.sum(:amount_cents)
   end
 
   def eligible_for_credit?

--- a/spec/models/affiliate_spec.rb
+++ b/spec/models/affiliate_spec.rb
@@ -139,19 +139,19 @@ describe Affiliate do
 
   describe "#total_cents_earned" do
     let(:affiliate) { create(:direct_affiliate, affiliate_basis_points: 1000) }
+    let(:balance) { create(:balance, user: affiliate.seller) }
 
-    it "sums the affiliate credits earned for all successful, paid purchases" do
-      create(:purchase, affiliate:, purchase_state: "successful", price_cents: 100)
-      create(:purchase, affiliate:, purchase_state: "failed", price_cents: 150)
-      create(:purchase, affiliate:, purchase_state: "successful", price_cents: 0).update!(affiliate_credit_cents: 8) # should not have affiliate credits > 0 - just for testing purposes
-      create(:purchase, affiliate:, purchase_state: "successful", price_cents: 1399)
+    it "sums paid affiliate credits" do
+      create(:affiliate_credit, affiliate:, affiliate_user: affiliate.affiliate_user, amount_cents: 50, affiliate_credit_success_balance: balance)
+      create(:affiliate_credit, affiliate:, affiliate_user: affiliate.affiliate_user, amount_cents: 63, affiliate_credit_success_balance: balance)
 
       expect(affiliate.total_cents_earned).to eq 113
     end
 
-    it "excludes refunded or chargedback purchases" do
-      create(:purchase, affiliate:, purchase_state: "successful", price_cents: 100, chargeback_date: 1.day.ago)
-      create(:purchase, affiliate:, purchase_state: "successful", price_cents: 150, stripe_refunded: true)
+    it "excludes refunded or chargedback credits" do
+      create(:affiliate_credit, affiliate:, affiliate_user: affiliate.affiliate_user, amount_cents: 50, affiliate_credit_success_balance: balance, affiliate_credit_chargeback_balance: balance)
+      create(:affiliate_credit, affiliate:, affiliate_user: affiliate.affiliate_user, amount_cents: 63, affiliate_credit_success_balance: balance, affiliate_credit_refund_balance: balance)
+      create(:affiliate_credit, affiliate:, affiliate_user: affiliate.affiliate_user, amount_cents: 10)
 
       expect(affiliate.total_cents_earned).to eq 0
     end
@@ -160,8 +160,9 @@ describe Affiliate do
   describe "#total_cents_earned_formatted" do
     it "returns the formatted amount earned" do
       affiliate = create(:direct_affiliate, affiliate_basis_points: 1000)
-      create(:purchase, affiliate:, purchase_state: "successful", price_cents: 100)
-      create(:purchase, affiliate:, purchase_state: "successful", price_cents: 1399)
+      balance = create(:balance, user: affiliate.seller)
+      create(:affiliate_credit, affiliate:, affiliate_user: affiliate.affiliate_user, amount_cents: 50, affiliate_credit_success_balance: balance)
+      create(:affiliate_credit, affiliate:, affiliate_user: affiliate.affiliate_user, amount_cents: 63, affiliate_credit_success_balance: balance)
 
       expect(affiliate.total_cents_earned_formatted).to eq "$1.13"
     end


### PR DESCRIPTION
## What

`Affiliate#total_cents_earned` now queries the `affiliate_credits` table instead of the `purchases` table.

**Before:** `purchases.paid.not_chargedback_or_chargedback_reversed.sum(:affiliate_credit_cents)` — unbounded SUM across all purchases for a global affiliate.

**After:** `affiliate_credits.paid.sum(:amount_cents)` — SUM on the indexed `affiliate_credits` table (has `index_affiliate_credits_on_affiliate_id`).

## Why

Sentry issue: `Rack::Timeout::RequestTimeoutException` (120s) on `Products::AffiliatedController#index`. The stacktrace shows `Affiliate#total_cents_earned` running a slow SUM query across the purchases table. For global affiliates with many purchases, this query exceeds the 120s timeout.

The `affiliate_credits` table already stores the same credit amounts (set from `purchase.affiliate_credit_cents` at creation time) and has an index on `affiliate_id`. The `AffiliateCredit.paid` scope excludes refunded and chargedback credits, matching the previous query semantics. This same pattern is already used by `User#affiliate_credits_sum_total` in the same presenter.

## Test Results

All 23 affiliate model tests pass. Updated tests to directly create `AffiliateCredit` records to match the new query path.

---

Generated with Claude Opus 4.6. Prompted to fix Rack::Timeout in `Products::AffiliatedController#index` caused by slow `total_cents_earned` query on the purchases table.