### PR TITLE
Fall back to seller_purchases in ensure block for cleanup when non_free_seller_purchases is nil

### DIFF
--- a/app/services/order/charge_service.rb
+++ b/app/services/order/charge_service.rb
@@ -76,8 +76,11 @@ class Order::ChargeService
       Rails.logger.error("Error charging order (#{order.id}):: #{e.class} => #{e.message} => #{e.backtrace}")
     ensure
       # Ensure all purchases of the charge are transitioned to a terminal state
-      # and each line item has a response
-      ensure_all_purchases_processed(non_free_seller_purchases)
+      # and each line item has a response.
+      # Fall back to seller_purchases if non_free_seller_purchases was not yet assigned
+      # (e.g. an exception occurred before that line), so cleanup still runs.
+      purchases_to_process = non_free_seller_purchases || seller_purchases.select(&:in_progress?)
+      ensure_all_purchases_processed(purchases_to_process)
     end
 
     charge_responses

--- a/spec/services/order/charge_service_spec.rb
+++ b/spec/services/order/charge_service_spec.rb
@@ -734,6 +734,38 @@ describe Order::ChargeService, :vcr do
       expect { service.send(:ensure_all_purchases_processed, nil) }.not_to raise_error
     end
 
+    it "falls back to seller_purchases to process in-progress purchases when non_free_seller_purchases is not assigned" do
+      seller = create(:user)
+      product = create(:product, user: seller, price_cents: 10_00)
+      line_items = {
+        line_items: [
+          { uid: "uid-1", permalink: product.unique_permalink, perceived_price_cents: product.price_cents, quantity: 1 }
+        ]
+      }
+      params = line_items.merge(
+        email: "buyer@example.com",
+        cc_zipcode: "12345",
+        purchase: { full_name: "Test Buyer", street_address: "123 Test St", country: "US", state: "CA", city: "San Francisco", zip_code: "94117" },
+        browser_guid: SecureRandom.uuid,
+        ip_address: "0.0.0.0",
+        session_id: SecureRandom.hex,
+        is_mobile: false,
+      )
+
+      order, _ = Order::CreateService.new(params:).perform
+
+      # Force an error before non_free_seller_purchases is assigned
+      allow(order.charges).to receive(:create!).and_raise(ActiveRecord::RecordInvalid)
+
+      Order::ChargeService.new(order:, params:).perform
+
+      # The ensure block should still process purchases via the fallback,
+      # so no purchases should remain stranded in in_progress state
+      order.purchases.reload.each do |purchase|
+        expect(purchase).not_to be_in_progress
+      end
+    end
+
     it "does not raise NoMethodError when an error occurs before non_free_seller_purchases is assigned" do
       seller = create(:user)
       product = create(:product, user: seller, price_cents: 10_00)


### PR DESCRIPTION
## Problem

After [#4163](https://github.com/antiwork/gumroad/pull/4163) added a nil guard to `ensure_all_purchases_processed`, the ensure block in `ChargeService#perform` silently skips cleanup when `non_free_seller_purchases` was never assigned (e.g., an exception occurs before that line). This means purchases that were partially set up can remain stranded in `in_progress` state.

## Solution

Fall back to `seller_purchases.select(&:in_progress?)` in the ensure block so that cleanup (marking purchases as failed, scheduling abandonment checks) still runs even when `non_free_seller_purchases` was never assigned.

```ruby
# Before
ensure_all_purchases_processed(non_free_seller_purchases)

# After
purchases_to_process = non_free_seller_purchases || seller_purchases.select(&:in_progress?)
ensure_all_purchases_processed(purchases_to_process)
```

## Tests

Added an integration test that verifies in-progress purchases are marked as failed when an exception occurs before `non_free_seller_purchases` is assigned.

Follow-up to [#4163](https://github.com/antiwork/gumroad/pull/4163), as discussed in [#4126 (comment)](https://github.com/antiwork/gumroad/pull/4126#issuecomment-4193921666).