### PR TITLE
Allow suspended users to view most of the app

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,7 +33,7 @@ class ApplicationController < ActionController::Base
   before_action :redirect_to_custom_subdomain
 
   before_action :set_signup_referrer, if: -> { logged_in_user.nil? }
-  before_action :check_suspended, if: -> { logged_in_user.present? && logged_in_user.suspended? }
+  before_action :check_suspended, if: -> { logged_in_user.present? && logged_in_user.suspended? && !request.get? && !request.head? }
 
   before_action :set_gumroad_guid
 
@@ -261,7 +261,7 @@ class ApplicationController < ActionController::Base
       respond_to do |format|
         format.html do
           flash[:warning] = "You can't perform this action because your account has been suspended."
-          redirect_to root_path unless request.path == root_path
+          redirect_back fallback_location: root_path
         end
         format.json { render json: { success: false, error_message: "You can't perform this action because your account has been suspended." } }
       end

--- a/app/controllers/balance_controller.rb
+++ b/app/controllers/balance_controller.rb
@@ -2,7 +2,7 @@
 
 class BalanceController < Sellers::BaseController
   layout "inertia", only: [:index]
-  skip_before_action :check_suspended
+
 
   def index
     authorize :balance

--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -3,7 +3,7 @@
 class CustomersController < Sellers::BaseController
   include CurrencyHelper
 
-  skip_before_action :check_suspended
+
   before_action :authorize
   before_action :set_on_page_type
 

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -2,7 +2,7 @@
 
 class DashboardController < Sellers::BaseController
   include ActionView::Helpers::NumberHelper, CurrencyHelper
-  skip_before_action :check_suspended
+
   before_action :check_payment_details, only: :index
 
   layout "inertia", only: :index

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -11,7 +11,7 @@ class LinksController < ApplicationController
 
   prepend_before_action :disable_third_party_analytics!, only: :cart_items_count
 
-  skip_before_action :check_suspended, only: %i[index show edit destroy increment_views track_user_action]
+
 
   PUBLIC_ACTIONS = %i[show search increment_views track_user_action cart_items_count].freeze
   before_action :authenticate_user!, except: PUBLIC_ACTIONS

--- a/app/controllers/logins_controller.rb
+++ b/app/controllers/logins_controller.rb
@@ -5,7 +5,7 @@ class LoginsController < Devise::SessionsController
 
   include PageMeta::Base
 
-  skip_before_action :check_suspended, only: %i[create destroy]
+  skip_before_action :check_suspended
   before_action :block_json_request, only: :new
   after_action :clear_dashboard_preference, only: :destroy
   before_action :reset_impersonated_user, only: :destroy

--- a/app/controllers/payouts/exportables_controller.rb
+++ b/app/controllers/payouts/exportables_controller.rb
@@ -2,7 +2,7 @@
 
 class Payouts::ExportablesController < Sellers::BaseController
   include PayoutsHelper
-  skip_before_action :check_suspended
+
 
   before_action :load_years_with_payouts
 

--- a/app/controllers/settings/main_controller.rb
+++ b/app/controllers/settings/main_controller.rb
@@ -3,7 +3,7 @@
 class Settings::MainController < Settings::BaseController
   include ActiveSupport::NumberHelper
 
-  skip_before_action :check_suspended
+
   before_action :authorize
 
   def show

--- a/app/controllers/tax_center_controller.rb
+++ b/app/controllers/tax_center_controller.rb
@@ -2,7 +2,7 @@
 
 class TaxCenterController < Sellers::BaseController
   layout "inertia", only: [:index]
-  skip_before_action :check_suspended
+
   before_action :ensure_tax_center_enabled
 
   def index

--- a/app/controllers/url_redirects_controller.rb
+++ b/app/controllers/url_redirects_controller.rb
@@ -27,8 +27,7 @@ class UrlRedirectsController < ApplicationController
   after_action -> { create_consumption_event!(ConsumptionEvent::EVENT_TYPE_DOWNLOAD) }, only: [:show]
   after_action -> { create_download_page_view_consumption_event! }, only: [:download_page]
 
-  skip_before_action :check_suspended, only: %i[show stream confirm confirm_page download_page
-                                                download_subtitle_file download_archive download_product_files]
+  skip_before_action :check_suspended, only: %i[confirm]
   before_action :set_noindex_header, only: %i[confirm_page download_page]
 
   rescue_from ActionController::RoutingError do |exception|


### PR DESCRIPTION
## Problem

Suspended accounts see "You can't perform this action because your account has been suspended." when trying to access their payouts screen, and in fact are blocked from viewing almost everything in the app.

The current approach blocks all requests for suspended users via a blanket `before_action :check_suspended` in `ApplicationController`, then individual controllers opt out with `skip_before_action :check_suspended`. This is backwards: most of the app should be viewable by suspended users.

## Solution

Flip the approach: instead of blocking everything and adding exemptions, only block **write actions** (POST/PUT/PATCH/DELETE) for suspended users while allowing all **read-only access** (GET/HEAD).

This means suspended users can now view their dashboard, payouts, customers, tax center, products, analytics, and all other pages. They are still blocked from creating/updating/publishing products, initiating payouts, and other write operations.

### Changes

- **`ApplicationController#check_suspended`**: return early for GET/HEAD requests so suspended users can view any page
- **`ApplicationController#check_suspended`**: use `redirect_back` instead of `redirect_to root_path` for better UX when a write action is blocked
- **Remove now-redundant `skip_before_action :check_suspended`** from controllers that only had read actions: `BalanceController`, `CustomersController`, `DashboardController`, `TaxCenterController`, `Payouts::ExportablesController`, `UrlRedirectsController`
- **Narrow `LinksController` skip** to only `:destroy` (GET actions no longer need exemption)
- **Keep `skip_before_action`** for controllers where suspended users need write access: `LoginsController` (login/logout), `Settings::MainController` (update settings), `LibraryController` (manage library), `ConsumptionAnalyticsController` (tracking), `MediaLocationsController` (tracking), `Payouts::ExportsController` (export payout data), `LinksController#destroy` (delete products)

Note: Users suspended for fraud cannot log in at all, so this change only affects TOS-suspended users who can still authenticate.

Closes https://github.com/antiwork/gumroad/issues/4329