### PR TITLE
Fix Elasticsearch BadRequest from non-Hash search param in profile pages

### DIFF
--- a/app/controllers/concerns/search_products.rb
+++ b/app/controllers/concerns/search_products.rb
@@ -33,6 +33,8 @@ module SearchProducts
       if params[:size].is_a?(String)
         params[:size] = params[:size].to_i
       end
+
+      params.delete(:search) unless params[:search].is_a?(Hash)
     end
 
     def offer_codes_search_feature_active?(params)

--- a/app/modules/product/searchable.rb
+++ b/app/modules/product/searchable.rb
@@ -363,7 +363,7 @@ module Product::Searchable
       end
 
       search_options = search_options.to_hash
-      search_options[:query][:bool][:must] << params[:search] if params[:search].is_a?(Hash)
+      search_options[:query][:bool][:must] << params[:search] if params[:search]
 
       if (params[:ids].present? || params[:section].is_a?(SellerProfileSection)) && params[:sort] == ProductSortKey::PAGE_LAYOUT
         product_ids = params[:ids] || params[:section].shown_products


### PR DESCRIPTION
## What
Only append `params[:search]` to the ES `bool.must` array when it's a Hash.

## Why
The `search_options` method in `Product::Searchable` appends `params[:search]` directly to the ES `must` clause. When a user visits a profile page with `?search=some_string`, this string gets injected into `must`, which expects objects. Elasticsearch returns a 400: `parsing_exception: query malformed, must start with start_object`.

The `search` param is designed for internal use (passing a pre-built ES query hash). String values from URL params should be ignored.

Fixes https://gumroad-to.sentry.io/issues/7366918596/

## Impact
- **Sentry events**:  total
- **Users affected**: ~
- **Estimated support tickets**: <1/month
- First seen: 