### PR TITLE
Fix flaky V2 links controller tests: create S3 objects before testing file creation

### DIFF
--- a/spec/controllers/api/v2/links_controller_spec.rb
+++ b/spec/controllers/api/v2/links_controller_spec.rb
@@ -480,9 +480,12 @@ describe Api::V2::LinksController do
       end
 
       it "creates a product with files" do
+        s3_key = "attachments/#{@user.external_id}/test/original/course.pdf"
+        Aws::S3::Resource.new.bucket(S3_BUCKET).object(s3_key).put(body: "test content")
+
         files = [
           {
-            url: "#{S3_BASE_URL}attachments/#{@user.external_id}/test/original/course.pdf",
+            url: "#{S3_BASE_URL}#{s3_key}",
             display_name: "Course PDF"
           }
         ]
@@ -499,7 +502,10 @@ describe Api::V2::LinksController do
 
       it "creates a product with files and rich content referencing those files" do
         temp_id = "temp-file-1"
-        file_url = "#{S3_BASE_URL}attachments/#{@user.external_id}/test/original/doc.pdf"
+        s3_key = "attachments/#{@user.external_id}/test/original/doc.pdf"
+        Aws::S3::Resource.new.bucket(S3_BUCKET).object(s3_key).put(body: "test content")
+
+        file_url = "#{S3_BASE_URL}#{s3_key}"
         files = [{ id: temp_id, url: file_url, display_name: "Doc" }]
         rich_content = [
           {


### PR DESCRIPTION
## Problem

Two tests in `Api::V2::LinksController` are flaky, failing intermittently with `Aws::S3::Errors::NotFound`:

- `creates a product with files` (line ~482)
- `creates a product with files and rich content referencing those files` (line ~502)

**Introduced in** [#4267](https://github.com/antiwork/gumroad/pull/4267) (commit 97cb389).

**Root cause:** The tests pass S3 URLs for product files, but the objects don't actually exist in the test S3 bucket (MinIO). When the response serialization calls `obj.content_length` (in `SignedUrlHelper#minio_presigned_url`) to generate presigned URLs, it raises `Aws::S3::Errors::NotFound`.

## Fix

Upload a test object to MinIO before each test so the S3 object exists when the controller reads it during response serialization.