### PR TITLE
Fix Link::LinkInvalid when deleting tiered memberships

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1327,6 +1327,7 @@ class Link < ApplicationRecord
     end
 
     def valid_tier_version_structure
+      return if deleted_at.present?
       return if archived?
 
       if variant_categories.alive.size != 1

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -2801,6 +2801,15 @@ describe Link, :vcr do
       expect(public_file2.scheduled_for_deletion_at).to be_within(5.seconds).of(10.minutes.from_now)
       expect(_another_product_public_file.reload.scheduled_for_deletion_at).to be_nil
     end
+
+    it "deletes a tiered membership even when tier categories are in an inconsistent state" do
+      product = create(:membership_product_with_preset_tiered_pricing)
+      product.tier_category.mark_deleted!
+      product.reload
+
+      expect { product.delete! }.not_to raise_error
+      expect(product.reload.deleted?).to be(true)
+    end
   end
 
   describe "#ordered_by_ids" do


### PR DESCRIPTION
## Problem

Deleting a tiered membership product raises `Link::LinkInvalid: Memberships should only have one Tier version category` when the product's tier variant categories are in an inconsistent state (e.g., the tier category was already soft-deleted).

This happens because `valid_tier_version_structure` runs during the `save!` call inside `mark_deleted!`, and it only skips for `archived?` products, not for products being soft-deleted.

**Sentry:** https://gumroad-to.sentry.io/issues/7392092392/

## Fix

Added `return if deleted_at.present?` to the `valid_tier_version_structure` validation, matching the existing pattern in `alive_category_variants_presence` which already handles this case correctly.

## Changes

- `app/models/link.rb`: Skip tier structure validation when the product is being deleted
- `spec/models/link_spec.rb`: Added test confirming deletion works for memberships with inconsistent tier categories

## Impact
- **Sentry events**: 23 total
- **Users affected**: ~20
- **Estimated support tickets**: ~1-2/month
- First seen: 2026-04-07T05:55:01Z