### PR TITLE
Fix NoMethodError when default_tier is nil in API product show

### DIFF
--- a/app/modules/product/prices.rb
+++ b/app/modules/product/prices.rb
@@ -297,7 +297,7 @@ module Product::Prices
       # 1. there are multiple tiers, or
       # 2. any tiers have PWYW enabled, or
       # 3. there's only 1 tier but it has multiple prices
-      tiers.size > 1 || tiers.where(customizable_price: true).exists? || default_tier.prices.alive.is_buy.size > 1
+      tiers.size > 1 || tiers.where(customizable_price: true).exists? || (default_tier.present? && default_tier.prices.alive.is_buy.size > 1)
     end
 
     def lowest_tier_price(for_default_duration: false)
@@ -306,7 +306,8 @@ module Product::Prices
       prices = VariantPrice.where(variant_id: tiers.map(&:id)).alive.is_buy
       prices = prices.where(recurrence: subscription_duration) if for_default_duration
       prices.order("price_cents asc").take ||
-        default_tier.prices.is_buy.build(price_cents: 0, recurrence: subscription_duration)
+        default_tier&.prices&.is_buy&.build(price_cents: 0, recurrence: subscription_duration) ||
+        VariantPrice.new(price_cents: 0, recurrence: subscription_duration)
     end
 
     def lowest_variant_price_difference_cents

--- a/spec/controllers/api/v2/links_controller_spec.rb
+++ b/spec/controllers/api/v2/links_controller_spec.rb
@@ -767,6 +767,24 @@ describe Api::V2::LinksController do
       expect(response).to be_successful
       expect(response.parsed_body["product"]).to have_key("sales_count")
     end
+
+    context "when product is a tiered membership with no default tier" do
+      before do
+        token = create("doorkeeper/access_token", application: @app, resource_owner_id: @user.id, scopes: "view_public")
+        @product = create(:membership_product, user: @user)
+        @product.tier_category.tiers.each { |tier| tier.update_columns(deleted_at: Time.current) }
+        @product.reload
+        @params = { id: @product.external_id, access_token: token.token }
+      end
+
+      it "returns product data without raising an error" do
+        get :show, params: @params
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to be true
+        expect(response.parsed_body["product"]).to be_present
+      end
+    end
   end
 
   describe "PUT 'update'" do


### PR DESCRIPTION
## What

Adds nil guards for `default_tier` in two methods in `Product::Prices`:

- **`show_customizable_price_indicator?`** — wraps `default_tier.prices.alive.is_buy.size > 1` with a `default_tier.present?` check so it short-circuits to `false` when `default_tier` is nil.
- **`lowest_tier_price`** — uses safe navigation (`&.`) on `default_tier` and adds a fallback `VariantPrice.new(price_cents: 0, ...)` when both the query and `default_tier` return nil.

## Why

When a tiered membership product has data inconsistency (e.g. its tier category's variants have been soft-deleted), `default_tier` returns `nil`. The API v2 `LinksController#show` endpoint serializes the product via `as_json_for_api` → `price_formatted` → `display_price_cents` → `lowest_tier_price`, which calls `default_tier.prices` and raises `NoMethodError: undefined method 'prices' for nil`.

The fix handles the nil case gracefully instead of crashing, returning safe defaults (false for the indicator, zero-price for the tier price).

Sentry issue: https://gumroad-to.sentry.io/issues/7392220002/

## Test results

Added a test that creates a tiered membership product, soft-deletes all tiers to simulate the data inconsistency, and verifies the API show endpoint returns successfully. The test fails when the fix is reverted.

---

Generated with Claude Opus 4.6. Prompts: fix Sentry NoMethodError on nil default_tier in API product show, add nil guards and test.

## Impact
- **Sentry events**:  total
- **Users affected**: ~
- **Estimated support tickets**: <1/month
- First seen: 