### PR TITLE
Fix ProductDuplicatorService failing on effective date validation

### DIFF
--- a/app/services/product_duplicator_service.rb
+++ b/app/services/product_duplicator_service.rb
@@ -236,6 +236,9 @@ class ProductDuplicatorService
         variant_category.variants.each do |variant|
           new_variant = variant.dup
           new_variant.variant_category = new_variant_category
+          new_variant.apply_price_changes_to_existing_memberships = false
+          new_variant.subscription_price_change_effective_date = nil
+          new_variant.subscription_price_change_message = nil
           duplicate_variant_product_files(original_variant: variant, duplicate_variant: new_variant)
           variant.skus.each do |sku|
             new_sku = duplicated_product.skus.where(name: sku.name).first
@@ -252,6 +255,9 @@ class ProductDuplicatorService
       product.skus.each do |sku|
         new_sku = sku.dup
         new_sku.link = duplicated_product
+        new_sku.apply_price_changes_to_existing_memberships = false
+        new_sku.subscription_price_change_effective_date = nil
+        new_sku.subscription_price_change_message = nil
         duplicate_variant_product_files(original_variant: sku, duplicate_variant: new_sku)
         new_sku.save!
       end

--- a/spec/services/product_duplicator_service_spec.rb
+++ b/spec/services/product_duplicator_service_spec.rb
@@ -199,6 +199,23 @@ describe ProductDuplicatorService do
     end
   end
 
+  it "duplicates a product whose variant has a membership price change effective date in the past" do
+    variant_category = create(:variant_category, title: "Tier", link: product)
+    variant = create(:variant, variant_category:, name: "Premium")
+    variant.apply_price_changes_to_existing_memberships = true
+    variant.subscription_price_change_effective_date = 3.days.ago.to_date
+    variant.subscription_price_change_message = "Price is going up"
+    variant.save!(validate: false)
+
+    duplicate_product = ProductDuplicatorService.new(product.id).duplicate
+
+    duplicated_variant = duplicate_product.variant_categories.alive.first.variants.first
+    expect(duplicated_variant.name).to eq("Premium")
+    expect(duplicated_variant.apply_price_changes_to_existing_memberships).to eq(false)
+    expect(duplicated_variant.subscription_price_change_effective_date).to be_nil
+    expect(duplicated_variant.subscription_price_change_message).to be_nil
+  end
+
   describe "prices" do
     it "handles products with rental prices" do
       product.is_recurring_billing = false


### PR DESCRIPTION
## Summary
- Reset membership price change fields (`apply_price_changes_to_existing_memberships`, `subscription_price_change_effective_date`, `subscription_price_change_message`) on duplicated variants and SKUs in `ProductDuplicatorService`
- When duplicating a product, `.dup` marks all attributes as changed, causing the effective date validation to fire and fail if the original date is in the past or less than 7 days away
- These fields are irrelevant for duplicated draft products anyway

## Test plan
- [x] Added test that duplicates a product whose variant has `apply_price_changes_to_existing_memberships: true` and a `subscription_price_change_effective_date` in the past, verifying duplication succeeds and fields are reset
- [x] All existing `ProductDuplicatorService` tests pass (17 examples, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)