### PR TITLE
Fix StateMachines::InvalidTransition when flagging verified users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -325,7 +325,7 @@ class User < ApplicationRecord
   #
   state_machine(:user_risk_state, initial: :not_reviewed) do
     before_transition any => %i[flagged_for_fraud flagged_for_tos_violation suspended_for_fraud suspended_for_tos_violation],
-                      :do => :not_verified?
+                      :do => :remove_verified!
     after_transition any => %i[suspended_for_fraud suspended_for_tos_violation], :do => :invalidate_active_sessions!
     after_transition any => %i[suspended_for_fraud suspended_for_tos_violation], :do => :disable_links_and_tell_chat
     after_transition any => %i[on_probation compliant not_reviewed flagged_for_tos_violation flagged_for_fraud suspended_for_tos_violation suspended_for_fraud],

--- a/app/modules/user/risk.rb
+++ b/app/modules/user/risk.rb
@@ -105,6 +105,11 @@ module User::Risk
     !verified
   end
 
+  def remove_verified!
+    self.verified = false if verified?
+    true
+  end
+
   def log_suspension_time_to_mongo
     Mongoer.async_write(MongoCollections::USER_SUSPENSION_TIME, "user_id" => id, "suspended_at" => Time.current.to_s)
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1718,15 +1718,23 @@ describe User, :vcr do
       @admin_user = create(:user)
     end
 
-    it "does not suspend the user if the user is verified" do
+    it "removes verified badge when suspending a verified user" do
       @user.update_attribute(:verified, true)
-      expect(@user.suspend_for_fraud(author_id: @admin_user.id)).to be(false)
+      @user.flag_for_fraud!(author_id: @admin_user.id)
+      @user.suspend_for_fraud!(author_id: @admin_user.id)
+      expect(@user.reload.verified).to be(false)
     end
 
-    it "does not flag the user if the user is verified" do
+    it "removes verified badge when flagging a verified user" do
       @user.update_attribute(:verified, true)
-      expect(@user.flag_for_fraud(author_id: @admin_user.id)).to be(false)
-      expect(@user.flag_for_tos_violation(author_id: @admin_user.id, product_id: @product_1.id)).to be(false)
+      @user.flag_for_fraud!(author_id: @admin_user.id)
+      expect(@user.reload.verified).to be(false)
+    end
+
+    it "removes verified badge when flagging a verified user for tos violation" do
+      @user.update_attribute(:verified, true)
+      @user.flag_for_tos_violation!(author_id: @admin_user.id, product_id: @product_1.id)
+      expect(@user.reload.verified).to be(false)
     end
 
     it "suspends the user if the user is not verified, and was previously flagged for fraud" do

--- a/spec/modules/user/risk_spec.rb
+++ b/spec/modules/user/risk_spec.rb
@@ -62,4 +62,37 @@ describe User::Risk do
       end
     end
   end
+
+  describe "#remove_verified!" do
+    it "removes the verified badge when flagging a verified compliant user for tos violation" do
+      user = create(:user, verified: true)
+      user.mark_compliant!(author_name: "admin")
+      expect(user.user_risk_state).to eq("compliant")
+      expect(user.verified).to be(true)
+
+      user.flag_for_tos_violation!(author_name: "test", bulk: true)
+
+      expect(user.user_risk_state).to eq("flagged_for_tos_violation")
+      expect(user.verified).to be(false)
+    end
+
+    it "removes the verified badge when flagging a verified compliant user for fraud" do
+      user = create(:user, verified: true)
+      user.mark_compliant!(author_name: "admin")
+
+      user.flag_for_fraud!(author_name: "test")
+
+      expect(user.user_risk_state).to eq("flagged_for_fraud")
+      expect(user.verified).to be(false)
+    end
+
+    it "does not affect unverified users" do
+      user = create(:user, verified: false)
+
+      user.flag_for_tos_violation!(author_name: "test", bulk: true)
+
+      expect(user.user_risk_state).to eq("flagged_for_tos_violation")
+      expect(user.verified).to be(false)
+    end
+  end
 end


### PR DESCRIPTION
## Problem

The `before_transition` guard on `user_risk_state` used `not_verified?` as a callback, which returns `false` for verified users. In the `state_machines` gem, a `before_transition` callback returning `false` halts the transition entirely. This meant **verified users could not be flagged or suspended**, causing `StateMachines::InvalidTransition` errors in production.

**Sentry issue:** https://gumroad-to.sentry.io/issues/7393211959/

Callers like Iffy integration, Stripe risk, and admin bulk suspension were hitting this when trying to flag compliant verified users for TOS violations.

## Fix

Replace the `not_verified?` guard with `remove_verified!`, which strips the verified badge before the transition proceeds. This allows moderation to work on all users regardless of verification status, which is the correct behavior (a verified user who violates TOS should lose their badge and be flaggable).

## Changes

- `app/models/user.rb`: Changed `before_transition` callback from `:not_verified?` to `:remove_verified!`
- `app/modules/user/risk.rb`: Added `remove_verified!` method that clears the verified flag and returns `true` to avoid halting
- Updated existing tests that asserted verified users were immune to flagging/suspension
- Added new tests confirming the verified badge is removed during risk state transitions