### PR TITLE
Fix Rack::Timeout in AssetPreview retina variant processing

### DIFF
--- a/app/models/asset_preview.rb
+++ b/app/models/asset_preview.rb
@@ -79,9 +79,13 @@ class AssetPreview < ApplicationRecord
     oembed && oembed["info"]["height"].to_i
   end
 
+  IMAGE_PROCESSING_TIMEOUT_SECONDS = 30
+
   def retina_variant
     return unless file.attached?
-    file.variant(resize_to_limit: [retina_width, nil]).processed
+    Timeout.timeout(IMAGE_PROCESSING_TIMEOUT_SECONDS) do
+      file.variant(resize_to_limit: [retina_width, nil]).processed
+    end
   end
 
   def display_type

--- a/spec/models/asset_preview_spec.rb
+++ b/spec/models/asset_preview_spec.rb
@@ -272,6 +272,14 @@ describe AssetPreview, :vcr do
         expect(asset_preview.display_height).to eq(210)
       end
 
+      describe "#retina_variant" do
+        it "falls back to original file URL when image processing times out" do
+          allow(asset_preview.file).to receive(:variant).and_raise(Timeout::Error)
+
+          expect(asset_preview.url_from_file(style: :retina)).to eq(asset_preview.file.url)
+        end
+      end
+
       describe "#url" do
         it "returns retina variant" do
           expect(asset_preview.url).to match(asset_preview.retina_variant.key)


### PR DESCRIPTION
## What

Adds a 30-second `Timeout.timeout` guard around MiniMagick image processing in `AssetPreview#retina_variant`. When an oversized or complex image causes ImageMagick to hang, the timeout fires and the existing `rescue` in `url_from_file` falls back to serving the original file URL.

## Why

`LinksController#show` was hitting `Rack::Timeout::RequestTimeoutException` (120s) because `retina_variant` calls `.processed`, which synchronously runs ImageMagick via MiniMagick. For certain large/complex images, ImageMagick hangs indefinitely. By the time the Rack timeout kills the request, the rescue block never runs. A shorter, in-process timeout ensures the rescue path is reached and the user gets the original image instead of a 500 error.

## Test Results

New spec confirms that when `variant` raises `Timeout::Error`, `url_from_file` falls back to the original file URL. All existing `asset_preview_spec` tests continue to pass (2 pre-existing failures unrelated to this change).

---

AI Disclosure: Implemented with Claude Opus 4.6. Prompted with the Sentry issue context, root cause analysis, and specific fix instructions for adding a timeout guard around MiniMagick processing in `AssetPreview#retina_variant`.