### PR TITLE
Fix ArgumentError when invalid purchase_type is submitted

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -223,6 +223,12 @@ class Link < ApplicationRecord
 
   enum subscription_duration: %i[monthly yearly quarterly biannually every_two_years]
   enum purchase_type: %i[buy_only rent_only buy_and_rent] # Indicates whether this product can be bought or rented or both.
+
+  def purchase_type=(value)
+    super(value)
+  rescue ArgumentError
+    super(:buy_only)
+  end
   enum free_trial_duration_unit: %i[week month]
 
   attr_json_data_accessor :excluded_sales_tax_regions, default: -> { [] }

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -474,6 +474,29 @@ describe Link, :vcr do
     end
 
 
+    describe "#purchase_type=" do
+      it "accepts valid purchase_type values" do
+        link.purchase_type = :buy_only
+        expect(link.purchase_type).to eq("buy_only")
+
+        link.purchase_type = :rent_only
+        expect(link.purchase_type).to eq("rent_only")
+
+        link.purchase_type = :buy_and_rent
+        expect(link.purchase_type).to eq("buy_and_rent")
+      end
+
+      it "defaults to buy_only when given an invalid value" do
+        link.purchase_type = "buy"
+        expect(link.purchase_type).to eq("buy_only")
+      end
+
+      it "does not raise ArgumentError for invalid values" do
+        expect { link.purchase_type = "invalid" }.not_to raise_error
+        expect(link.purchase_type).to eq("buy_only")
+      end
+    end
+
     describe "delete_unused_prices" do
       let!(:product) { create(:product, purchase_type: :buy_and_rent, price_cents: 500, rental_price_cents: 100) }
       let(:buy_price) { product.prices.is_buy.first }


### PR DESCRIPTION
## Summary
- Override `purchase_type=` setter on `Link` model to rescue `ArgumentError` from invalid enum values and default to `:buy_only`
- Rails enums raise `ArgumentError` on assignment of invalid values before validation runs, causing 500 errors when users submit values like `"buy"` instead of `"buy_only"`
- Fixes 4 occurrences seen in Sentry

## Test plan
- [x] Added spec confirming valid purchase_type values still work
- [x] Added spec confirming invalid values default to `buy_only` without raising
- [x] All 3 new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)