### PR TITLE
Fix unhandled Stripe::APIError in Settings::PaymentsController#update

### DIFF
--- a/app/controllers/settings/payments_controller.rb
+++ b/app/controllers/settings/payments_controller.rb
@@ -81,14 +81,11 @@ class Settings::PaymentsController < Settings::BaseController
     if current_seller.active_bank_account && current_seller.merchant_accounts.stripe.alive.empty? && current_seller.native_payouts_supported?
       begin
         StripeMerchantAccountManager.create_account(current_seller, passphrase: GlobalConfig.get("STRONGBOX_GENERAL_PASSWORD"))
-      rescue Stripe::InvalidRequestError => e
-        if e.code == "postal_code_invalid"
+      rescue Stripe::StripeError => e
+        if e.is_a?(Stripe::InvalidRequestError) && e.code == "postal_code_invalid"
           country = current_seller.fetch_or_build_user_compliance_info.legal_entity_country
-          redirect_with_error("The postal code you entered is not valid for #{country}.")
-        else
-          redirect_with_error(e.try(:message) || "Something went wrong.")
+          return redirect_with_error("The postal code you entered is not valid for #{country}.")
         end
-        return
         return redirect_with_error(e.try(:message) || "Something went wrong.")
       end
     end

--- a/spec/controllers/settings/payments_controller_spec.rb
+++ b/spec/controllers/settings/payments_controller_spec.rb
@@ -327,6 +327,26 @@ describe Settings::PaymentsController, :vcr, type: :controller, inertia: true do
             expect(response).to have_http_status :found
             expect(session[:inertia_errors][:base]).to include("You must use a test bank account number in test mode. Try 000123456789 or see more options at https://stripe.com/docs/connect/testing#account-numbers.")
           end
+
+          it "handles Stripe::APIError gracefully instead of raising a 500" do
+            all_params.merge!(
+              bank_account: {
+                type: AchAccount.name,
+                account_number: "000123456789",
+                account_number_confirmation: "000123456789",
+                routing_number: "110000000",
+                account_holder_full_name: "gumbot"
+              }
+            )
+
+            expect(StripeMerchantAccountManager).to receive(:create_account).and_raise(Stripe::APIError.new("An unknown error occurred"))
+
+            put :update, params: all_params
+
+            expect(response).to redirect_to(settings_payments_path)
+            expect(response).to have_http_status :found
+            expect(session[:inertia_errors][:base]).to eq(["An unknown error occurred"])
+          end
         end
       end
 


### PR DESCRIPTION
## What

Rescue `Stripe::StripeError` instead of only `Stripe::InvalidRequestError` in `Settings::PaymentsController#update` when creating a Stripe merchant account. Also removes unreachable dead code (duplicate return statement on line 92).

## Why

`Stripe::APIError` inherits from `Stripe::StripeError`, not `Stripe::InvalidRequestError`. When Stripe returns an unknown API error during account creation, it was unhandled and caused a 500. Broadening the rescue to `Stripe::StripeError` catches all Stripe errors while preserving the special `postal_code_invalid` handling.

## Test Results

All 98 tests in `spec/controllers/settings/payments_controller_spec.rb` pass, including a new test confirming `Stripe::APIError` is handled gracefully (user gets redirected with error message instead of 500).

---

Generated with Claude Opus 4.6. Prompt: fix Sentry issue for unhandled `Stripe::APIError` in `Settings::PaymentsController#update`.