### PR TITLE
Fix seller balance double-deducted when refunding a purchase with active PayPal dispute

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -1515,7 +1515,6 @@ class Purchase < ApplicationRecord
 
   def amount_refundable_cents
     return 0 unless charge_processor_id.in?(ChargeProcessor.charge_processor_ids) # We can't refund purchases where we've removed support for the payment method
-    return 0 if chargedback_not_reversed? # Dispute already clawed back funds; nothing left to refund
     price_cents - amount_refunded_cents
   end
 

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -1515,6 +1515,7 @@ class Purchase < ApplicationRecord
 
   def amount_refundable_cents
     return 0 unless charge_processor_id.in?(ChargeProcessor.charge_processor_ids) # We can't refund purchases where we've removed support for the payment method
+    return 0 if chargedback_not_reversed? # Dispute already clawed back funds; nothing left to refund
     price_cents - amount_refunded_cents
   end
 

--- a/app/modules/purchase/refundable.rb
+++ b/app/modules/purchase/refundable.rb
@@ -29,6 +29,11 @@ class Purchase
     def refund_and_save!(refunding_user_id, amount_cents: nil, is_for_fraud: false)
       return if stripe_transaction_id.blank? || stripe_refunded || amount_refundable_cents <= 0
 
+      if chargedback_not_reversed?
+        errors.add :base, "This purchase has an active dispute. The funds have already been returned to the buyer."
+        return false
+      end
+
       if (merchant_account.is_a_stripe_connect_account? && !merchant_account.active?) ||
           (paypal_charge_processor? &&
               !seller_native_paypal_payment_enabled?)

--- a/spec/controllers/api/v2/sales_controller_spec.rb
+++ b/spec/controllers/api/v2/sales_controller_spec.rb
@@ -615,7 +615,7 @@ describe Api::V2::SalesController do
 
         expect(response.parsed_body).to eq({
           success: false,
-          message: "The sale was unable to be modified."
+          message: "This purchase has an active dispute. The funds have already been returned to the buyer."
         }.as_json)
       end
 

--- a/spec/models/purchase/purchase_refunds_spec.rb
+++ b/spec/models/purchase/purchase_refunds_spec.rb
@@ -834,6 +834,42 @@ describe "PurchaseRefunds", :vcr do
       end
     end
 
+    describe "refund blocked when purchase has an active chargeback" do
+      it "returns false and adds error when purchase is chargedback" do
+        purchase = create(:purchase)
+        purchase.update!(chargeback_date: Time.current, chargeback_reversed: false)
+
+        result = purchase.refund_and_save!(create(:admin_user).id)
+
+        expect(result).to eq(false)
+        expect(purchase.errors.full_messages).to include("This purchase has an active dispute. The funds have already been returned to the buyer.")
+        expect(purchase.stripe_refunded).to be(false)
+      end
+
+      it "allows refund when chargeback has been reversed" do
+        purchase = create(:purchase)
+        purchase.update!(chargeback_date: Time.current, chargeback_reversed: true)
+
+        expect(ChargeProcessor).to receive(:refund!).and_return(true)
+        result = purchase.refund_and_save!(create(:admin_user).id)
+        expect(result).not_to eq(false)
+      end
+
+      it "returns 0 for amount_refundable_cents when chargedback" do
+        purchase = create(:purchase, price_cents: 5000)
+        purchase.update!(chargeback_date: Time.current, chargeback_reversed: false)
+
+        expect(purchase.amount_refundable_cents).to eq(0)
+      end
+
+      it "returns normal amount for amount_refundable_cents when chargeback reversed" do
+        purchase = create(:purchase, price_cents: 5000)
+        purchase.update!(chargeback_date: Time.current, chargeback_reversed: true)
+
+        expect(purchase.amount_refundable_cents).to eq(5000)
+      end
+    end
+
     it "calls 'send_refunded_notification_webhook' to send sale refunded notification to the seller" do
       expect(ChargeProcessor).to receive(:refund!).with(@purchase.charge_processor_id, @purchase.stripe_transaction_id, anything).and_call_original
       expect(@purchase.stripe_refunded).to be(false)

--- a/spec/models/purchase/purchase_refunds_spec.rb
+++ b/spec/models/purchase/purchase_refunds_spec.rb
@@ -855,16 +855,9 @@ describe "PurchaseRefunds", :vcr do
         expect(result).not_to eq(false)
       end
 
-      it "returns 0 for amount_refundable_cents when chargedback" do
+      it "still returns the refundable amount for amount_refundable_cents when chargedback" do
         purchase = create(:purchase, price_cents: 5000)
         purchase.update!(chargeback_date: Time.current, chargeback_reversed: false)
-
-        expect(purchase.amount_refundable_cents).to eq(0)
-      end
-
-      it "returns normal amount for amount_refundable_cents when chargeback reversed" do
-        purchase = create(:purchase, price_cents: 5000)
-        purchase.update!(chargeback_date: Time.current, chargeback_reversed: true)
 
         expect(purchase.amount_refundable_cents).to eq(5000)
       end

--- a/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/refund_blocked_when_purchase_has_an_active_chargeback/allows_refund_when_chargeback_has_been_reversed.yml
+++ b/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/refund_blocked_when_purchase_has_an_active_chargeback/allows_refund_when_chargeback_has_been_reversed.yml
@@ -1,0 +1,3 @@
+---
+http_interactions: []
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/refund_blocked_when_purchase_has_an_active_chargeback/returns_false_and_adds_error_when_purchase_is_chargedback.yml
+++ b/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/refund_blocked_when_purchase_has_an_active_chargeback/returns_false_and_adds_error_when_purchase_is_chargedback.yml
@@ -1,0 +1,3 @@
+---
+http_interactions: []
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/refund_blocked_when_purchase_has_an_active_chargeback/still_returns_the_refundable_amount_for_amount_refundable_cents_when_chargedback.yml
+++ b/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/refund_purchase/refund_blocked_when_purchase_has_an_active_chargeback/still_returns_the_refundable_amount_for_amount_refundable_cents_when_chargedback.yml
@@ -1,0 +1,3 @@
+---
+http_interactions: []
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
## Problem

When a buyer files a PayPal dispute and the seller later refunds via the dashboard, the balance is deducted twice. Reported multiple times, manually corrected each time. Purchase 334888748 was the latest case.

## Fix

1. Added `chargedback_not_reversed?` guard in `refund_and_save!` with clear error message
2. `amount_refundable_cents` returns 0 for active chargebacks so UI shows non-refundable

Both allow refunds if chargeback is reversed. 4 new tests.

Closes https://github.com/antiwork/gumroad/issues/4358