### PR TITLE
Fix purchase spec: pass author_name to suspend_for_fraud

### DIFF
--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -1744,7 +1744,7 @@ describe Purchase, :vcr do
     end
 
     {
-      user_suspended: ->(u, _l) { u.suspend_for_fraud },
+      user_suspended: ->(u, _l) { u.suspend_for_fraud(author_name: "Admin") },
       link_disabled: ->(_u, l) { l.purchase_disabled_at = Time.current },
       link_deleted: ->(_u, l) { l.deleted_at = Time.current }
     }.each do |k, v|


### PR DESCRIPTION
#4364 expanded `suspend_for_fraud` to allow direct suspension from `not_reviewed`. The test calls `u.suspend_for_fraud` without arguments, which now triggers `add_user_comment` requiring `author_id` or `author_name`.

Root cause PR: [#4364](https://github.com/antiwork/gumroad/pull/4364)