### PR TITLE
Fix sales API spec: enable licensing on product for license_uses test

### DIFF
--- a/spec/controllers/api/v2/sales_controller_spec.rb
+++ b/spec/controllers/api/v2/sales_controller_spec.rb
@@ -273,6 +273,7 @@ describe Api::V2::SalesController do
       end
 
       it "includes license_uses in the response for a purchase with a license key" do
+        @product.update!(is_licensed: true)
         purchase_with_license = create(:purchase, :with_license, purchaser: @purchaser, link: @product)
         purchase_with_license.license.update!(uses: 5)
 


### PR DESCRIPTION
The test created a purchase with a license but the product didn't have `is_licensed` set, so `license_key` returned nil and `license_uses` was missing from the response. Adds `@product.update!(is_licensed: true)` before creating the licensed purchase.

Pre-existing issue since initial commit.