### PR TITLE
Fix profile product total count when filtering sold-out products

### DIFF
--- a/app/presenters/profile_sections_presenter.rb
+++ b/app/presenters/profile_sections_presenter.rb
@@ -94,8 +94,9 @@ class ProfileSectionsPresenter
         cached_props[:search_results] = section_search_results(section, params:) if params.present?
         products = Link.includes(ProductPresenter::ASSOCIATIONS_FOR_CARD).includes(bundle_products: { product: :tiers, variant: [] }).find(cached_props[:search_results][:products])
         if !is_owner
+          filtered_count = products.count { |product| product.hide_sold_out_variants? && product.remaining_for_sale_count == 0 }
           products = products.reject { |product| product.hide_sold_out_variants? && product.remaining_for_sale_count == 0 }
-          cached_props[:search_results][:total] = products.size
+          cached_props[:search_results][:total] -= filtered_count
         end
         cached_props[:search_results][:products] = products.map do |product|
           ProductPresenter.card_for_web(product:, request:, recommended_by: params[:recommended_by], target: Product::Layout::PROFILE, show_seller: false, compute_description: false, compute_inventory: false)

--- a/spec/presenters/profile_sections_presenter_spec.rb
+++ b/spec/presenters/profile_sections_presenter_spec.rb
@@ -155,6 +155,24 @@ describe ProfileSectionsPresenter do
 
       expect(product_names).to include(in_stock_product.name)
     end
+
+    it "preserves correct total count when sold-out products are filtered across paginated results" do
+      extra_products = 10.times.map { |i| create(:product, user: seller, tags:, name: "Extra Product #{i}") }
+      all_shown = (products + [sold_out_product, in_stock_product] + extra_products).map(&:id)
+      products_section.update!(shown_products: all_shown)
+      Link.import(force: true, refresh: true)
+
+      result = subject.props(request:, pundit_user:, seller_custom_domain_url: nil)
+      product_section = result[:sections].find { _1[:type] == "SellerProfileProductsSection" }
+      product_names = product_section[:search_results][:products].map { _1[:name] }
+      total = product_section[:search_results][:total]
+
+      # Page size is 9, so only 9 products are loaded per page
+      # Total must NOT be replaced with page size (the bug this fixes)
+      expect(total).to be > 9
+      # Sold-out product on current page should be filtered from total
+      expect(product_names).not_to include("Sold Out Product")
+    end
   end
 
   describe "compute_description parameter" do


### PR DESCRIPTION
#4375 introduced a filter to hide sold-out products from profiles. But it replaced `total` with `products.size`, where `products` only contains the current page (up to 9 items). This made paginated profiles show '1-9 of 9 products' instead of '1-9 of 10 products'.

Fix: subtract the count of filtered products from the existing total instead of replacing it.

Root cause PR: [#4375](https://github.com/antiwork/gumroad/pull/4375)

Fixes flaky failures in:
- `product_panel_sort_filter_spec.rb:183`
- `scroll_pagination_spec.rb:60`
- `sections_spec.rb:165`