### PR TITLE
Fix remaining unreviewed users specs for $100 threshold

### DIFF
--- a/spec/controllers/admin/unreviewed_users_controller_spec.rb
+++ b/spec/controllers/admin/unreviewed_users_controller_spec.rb
@@ -68,7 +68,7 @@ describe Admin::UnreviewedUsersController, type: :controller, inertia: true do
         end
 
         before do
-          create(:balance, user: unreviewed_user, amount_cents: 5000)
+          create(:balance, user: unreviewed_user, amount_cents: 15_000)
           Admin::UnreviewedUsersService.cache_users_data!
         end
 
@@ -89,7 +89,7 @@ describe Admin::UnreviewedUsersController, type: :controller, inertia: true do
         end
 
         before do
-          create(:balance, user:, amount_cents: 5000)
+          create(:balance, user:, amount_cents: 15_000)
           Admin::UnreviewedUsersService.cache_users_data!
           user.update!(user_risk_state: "compliant")
         end

--- a/spec/requests/admin/unreviewed_users_spec.rb
+++ b/spec/requests/admin/unreviewed_users_spec.rb
@@ -25,7 +25,7 @@ describe "Admin::UnreviewedUsersController", type: :system, js: true do
     context "when cached data exists" do
       let!(:user_with_balance) do
         user = create(:user, user_risk_state: "not_reviewed", created_at: 1.year.ago, name: "Test Creator")
-        create(:balance, user:, amount_cents: 5000)
+        create(:balance, user:, amount_cents: 15_000)
         user
       end
 
@@ -62,7 +62,7 @@ describe "Admin::UnreviewedUsersController", type: :system, js: true do
 
     context "with revenue source badges" do
       let(:user) { create(:user, user_risk_state: "not_reviewed", created_at: 1.year.ago) }
-      let!(:balance) { create(:balance, user:, amount_cents: 5000) }
+      let!(:balance) { create(:balance, user:, amount_cents: 15_000) }
 
       it "shows sales badge when user has sales" do
         product = create(:product, user:)
@@ -106,7 +106,7 @@ describe "Admin::UnreviewedUsersController", type: :system, js: true do
       end
 
       before do
-        create(:balance, user:, amount_cents: 5000)
+        create(:balance, user:, amount_cents: 15_000)
         Admin::UnreviewedUsersService.cache_users_data!
         user.update!(user_risk_state: "compliant")
       end

--- a/spec/sidekiq/cache_unreviewed_users_data_worker_spec.rb
+++ b/spec/sidekiq/cache_unreviewed_users_data_worker_spec.rb
@@ -6,7 +6,7 @@ describe CacheUnreviewedUsersDataWorker do
   describe "#perform" do
     it "caches unreviewed users data via the service" do
       user = create(:user, user_risk_state: "not_reviewed", created_at: 1.year.ago)
-      create(:balance, user:, amount_cents: 5000)
+      create(:balance, user:, amount_cents: 15_000)
 
       described_class.new.perform
 


### PR DESCRIPTION
#4393 raised the minimum balance from $10 to $100 but missed 3 spec files still using $50 balances.

✅ 7 examples, 0 failures locally.

Root cause: [#4393](https://github.com/antiwork/gumroad/pull/4393)