### PR TITLE
Fix Rack::Timeout in OrdersController#create by setting Stripe network timeouts

### DIFF
--- a/config/initializers/003_stripe.rb
+++ b/config/initializers/003_stripe.rb
@@ -3,6 +3,8 @@
 Stripe.api_version = Rails.env.test? ? "2023-10-16" : "2023-10-16; risk_in_requirements_beta=v1; retrieve_tax_forms_beta=v1;"
 # Ref: https://github.com/gumroad/web/issues/17770, https://stripe.com/docs/rate-limits#object-lock-timeouts
 Stripe.max_network_retries = 3
+Stripe.open_timeout = 5
+Stripe.read_timeout = 25
 if Rails.env.production?
   STRIPE_PUBLIC_KEY = GlobalConfig.get("STRIPE_PUBLIC_KEY_PROD", "pk_live_Db80xIzLPWhKo1byPrnERmym")
 else

--- a/spec/config/initializers/stripe_spec.rb
+++ b/spec/config/initializers/stripe_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Stripe configuration" do
+  it "sets network timeouts to prevent Rack::Timeout in payment flows" do
+    expect(Stripe.open_timeout).to eq(5)
+    expect(Stripe.read_timeout).to eq(25)
+  end
+
+  it "limits network retries" do
+    expect(Stripe.max_network_retries).to eq(3)
+  end
+end

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -132,6 +132,20 @@ describe OrdersController, :vcr do
         end
       end
 
+      context "when Stripe times out during charge" do
+        it "returns an error without triggering Rack::Timeout" do
+          allow(Stripe::PaymentIntent).to receive(:create).and_raise(
+            Stripe::APIConnectionError.new("Connection to Stripe timed out")
+          )
+
+          post :create, params: single_purchase_params
+
+          expect(response.parsed_body["success"]).to be(true)
+          expect(response.parsed_body["line_items"]["unique-id-0"]["success"]).to be(false)
+          expect(response.parsed_body["line_items"]["unique-id-0"]["error_message"]).to include("temporary problem")
+        end
+      end
+
       context "when gifting a subscription" do
         let(:subscription_price) { 10_00 }
         let(:product) { create(:membership_product, price_cents: subscription_price) }

--- a/spec/support/fixtures/vcr_cassettes/OrdersController/POST_create/single_purchase/when_Stripe_times_out_during_charge/returns_an_error_without_triggering_Rack_Timeout.yml
+++ b/spec/support/fixtures/vcr_cassettes/OrdersController/POST_create/single_purchase/when_Stripe_times_out_during_charge/returns_an_error_without_triggering_Rack_Timeout.yml
@@ -1,0 +1,271 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Idempotency-Key:
+      - fad44932-a191-4d2c-b6a5-86d17d56021b
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        GumClaws-Mini 25.3.0 Darwin Kernel Version 25.3.0: Wed Jan 28 20:49:24 PST
+        2026; root:xnu-12377.81.4~5/RELEASE_ARM64_T8132 arm64","hostname":"GumClaws-Mini"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 10 Apr 2026 08:20:58 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1082'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=hyoQb4ako3u5jLSY4t98pnuVXmj0n6zs0UE8tOYpPpH459SLhkJzonwyhrHgvsoFCBWWtO3ub1iRttWG
+      Idempotency-Key:
+      - fad44932-a191-4d2c-b6a5-86d17d56021b
+      Original-Request:
+      - req_g1W8FfwzDGNB70
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=hyoQb4ako3u5jLSY4t98pnuVXmj0n6zs0UE8tOYpPpH459SLhkJzonwyhrHgvsoFCBWWtO3ub1iRttWG&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=hyoQb4ako3u5jLSY4t98pnuVXmj0n6zs0UE8tOYpPpH459SLhkJzonwyhrHgvsoFCBWWtO3ub1iRttWG&t=1"
+      Request-Id:
+      - req_g1W8FfwzDGNB70
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TKaJCIBOqvOFDrfu42Aqw1M",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 4,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1775809258,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "type": "card"
+        }
+  recorded_at: Fri, 10 Apr 2026 08:20:58 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1TKaJCIBOqvOFDrfu42Aqw1M
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_g1W8FfwzDGNB70","request_duration_ms":300}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        GumClaws-Mini 25.3.0 Darwin Kernel Version 25.3.0: Wed Jan 28 20:49:24 PST
+        2026; root:xnu-12377.81.4~5/RELEASE_ARM64_T8132 arm64","hostname":"GumClaws-Mini"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 10 Apr 2026 08:20:59 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1082'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=rZ0-Xv1deUOrchLxULpjzL6Z6PEpowwMGGa26pYUlkqOuPuvTzd97NzLovkQdJt4BAdE3j3WGI4vpKEK
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=rZ0-Xv1deUOrchLxULpjzL6Z6PEpowwMGGa26pYUlkqOuPuvTzd97NzLovkQdJt4BAdE3j3WGI4vpKEK&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=rZ0-Xv1deUOrchLxULpjzL6Z6PEpowwMGGa26pYUlkqOuPuvTzd97NzLovkQdJt4BAdE3j3WGI4vpKEK&t=1"
+      Request-Id:
+      - req_H9kZeXt4qaMxO9
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TKaJCIBOqvOFDrfu42Aqw1M",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 4,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1775809258,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "type": "card"
+        }
+  recorded_at: Fri, 10 Apr 2026 08:20:59 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
## Problem

`OrdersController#create` hits `Rack::Timeout::RequestTimeoutException` (120s) when Stripe API calls are slow.

The Stripe Ruby SDK defaults to an **80s read timeout**. Combined with `max_network_retries = 3`, a single slow Stripe call can block for up to **320s** (4 attempts × 80s), far exceeding the 120s Rack::Timeout. When this happens, the request is killed mid-flight and the buyer sees a 500 error even though the charge may have already been created on Stripe's side.

## Fix

Set explicit Stripe network timeouts in the initializer:
- `open_timeout: 5s` (TCP connection establishment)
- `read_timeout: 25s` (waiting for Stripe response)

With these limits, worst case with 4 attempts + exponential backoff is ~112s, safely under the 120s Rack::Timeout. Individual Stripe calls fail fast and the existing `ChargeProcessorUnavailableError` handling returns a clean "temporary problem, please try again" message to the buyer.

## Sentry

- Issue: https://gumroad-to.sentry.io/issues/7401026187/
- Occurrences: 1 (first seen 2026-04-10)
- This is the first occurrence, but the underlying race condition (Stripe latency × retry budget > Rack::Timeout) affects all orders

## Changes

- `config/initializers/003_stripe.rb`: Add `open_timeout` and `read_timeout`
- `spec/config/initializers/stripe_spec.rb`: Verify timeout configuration
- `spec/controllers/orders_controller_spec.rb`: Test that Stripe connection timeouts are handled gracefully