### PR TITLE
Fix StateMachines::InvalidTransition race condition in mark_balances_processing

### DIFF
--- a/app/business/payments/payouts/payouts.rb
+++ b/app/business/payments/payouts/payouts.rb
@@ -192,9 +192,11 @@ class Payouts
       next if !::PayoutProcessorType.get(processor_type).is_balance_payable(balance)
 
       balance.with_lock do
-        balance.mark_processing!
+        if balance.unpaid?
+          balance.mark_processing!
+          true
+        end
       end
-      true
     end
   end
   private_class_method :mark_balances_processing

--- a/spec/business/payments/payouts/payouts_spec.rb
+++ b/spec/business/payments/payouts/payouts_spec.rb
@@ -658,6 +658,25 @@ describe Payouts do
       end
     end
 
+    describe "when a balance is already processing due to a concurrent payout" do
+      let(:payout_date) { Date.today - 1 }
+      let(:payout_processor_type) { PayoutProcessorType::PAYPAL }
+      let(:seller) { create(:compliant_user, payment_address: "seller@example.com") }
+
+      before do
+        create(:balance, user: seller, date: payout_date - 3, amount_cents: 10_00, state: "processing")
+        create(:balance, user: seller, date: payout_date - 2, amount_cents: 20_00)
+      end
+
+      it "skips the already-processing balance without raising an error" do
+        allow(Payouts).to receive(:is_user_payable).and_return(true)
+
+        expect do
+          described_class.create_payments_for_balances_up_to_date_for_users(payout_date, payout_processor_type, [seller])
+        end.not_to raise_error
+      end
+    end
+
     describe "a user is payable but balances are changed (e.g. by a chargeback) and will make for a negative payment" do
       let(:payout_date) { Date.today - 1 }
       let(:payout_processor_type) { PayoutProcessorType::PAYPAL }


### PR DESCRIPTION
## Problem

`StateMachines::InvalidTransition: Cannot transition state via :mark_processing from :processing` is raised in `Api::Internal::Helper::PayoutsController#create`.

**Sentry:** https://gumroad-to.sentry.io/issues/7401210834/

## Root Cause

Race condition in `Payouts.mark_balances_processing`. When two payout processes run concurrently for the same user (e.g., the regular batch payout job and the Helper API payout endpoint), both load the user's unpaid balances. Both then attempt to transition those balances to `processing`.

The `with_lock` call acquires a row lock and reloads the record, but the code didn't check the balance's state after reloading. When the second process acquires the lock, the balance is already `processing` (transitioned by the first process), and `mark_processing!` raises because the state machine only allows `unpaid -> processing`.

## Fix

After acquiring the row lock (which reloads the record), check that the balance is still `unpaid` before calling `mark_processing!`. If another process already transitioned it, skip it gracefully. The return value is also moved inside the `with_lock` block so skipped balances are properly excluded from the collection.

## Impact

- **Occurrences:** 1 (first seen today)
- **Users affected:** Low (requires concurrent payout triggers for the same user)
- **Support tickets:** Likely minimal, but the error prevents manual payouts via Helper when it occurs