### PR TITLE
Handle ResendApiResponseError in preview email flow

### DIFF
--- a/app/models/installment.rb
+++ b/app/models/installment.rb
@@ -394,7 +394,11 @@ class Installment < ApplicationRecord
     else
       recipient = { email: recipient_user.email }
       recipient[:url_redirect] = UrlRedirect.find_or_create_by!(installment: self, purchase: nil) if has_files?
-      PostEmailApi.process(post: self, recipients: [recipient], preview: true)
+      begin
+        PostEmailApi.process(post: self, recipients: [recipient], preview: true)
+      rescue ResendApiResponseError
+        raise PreviewEmailError, "Failed to send preview email. Please try again later."
+      end
     end
   end
 

--- a/spec/controllers/api/internal/installments/preview_emails_controller_spec.rb
+++ b/spec/controllers/api/internal/installments/preview_emails_controller_spec.rb
@@ -43,6 +43,15 @@ describe Api::Internal::Installments::PreviewEmailsController do
       post :create, params: { id: installment.external_id }, as: :json
     end
 
+    it "returns an error when the email service raises ResendApiResponseError" do
+      allow(PostEmailApi).to receive(:process).and_raise(ResendApiResponseError, "Application not found")
+
+      post :create, params: { id: installment.external_id }, as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body).to eq("message" => "Failed to send preview email. Please try again later.")
+    end
+
     it "returns an error while previewing an email if the logged-in user has uncofirmed email" do
       controller.logged_in_user.update_attribute(:unconfirmed_email, "john@example.com")
       expect(PostSendgridApi).to_not receive(:process)


### PR DESCRIPTION
## What

Rescue `ResendApiResponseError` in `Installment#send_preview_email` and re-raise it as `Installment::PreviewEmailError` so the controller's existing rescue handler returns a clean 422 JSON response instead of an unhandled 500.

## Why

`PostEmailApi.process` can raise `ResendApiResponseError` (e.g., when the Resend application is not found), but `PreviewEmailsController#create` only rescues `Installment::PreviewEmailError`. The unhandled error causes a 500 response and Sentry alerts.

## Test Results

All 6 specs pass in `preview_emails_controller_spec.rb`, including a new test that stubs `PostEmailApi.process` to raise `ResendApiResponseError` and verifies the controller returns 422 with a user-friendly message.

---

Generated with Claude Opus 4.6. Prompted with Sentry error context and root cause analysis for `ResendApiResponseError` in the preview email flow.