### PR TITLE
Fix Resend::Error::InvalidRequestError for single-recipient email sends

### DIFF
--- a/app/services/post_resend_api.rb
+++ b/app/services/post_resend_api.rb
@@ -29,7 +29,11 @@ class PostResendApi
     if Rails.application.config.action_mailer.perform_deliveries != false && !Rails.env.test?
       Resend.api_key = GlobalConfig.get("RESEND_CREATORS_API_KEY")
       duration = Benchmark.realtime do
-        response = Resend::Batch.send(emails)
+        if emails.size == 1
+          response = Resend::Emails.send(emails.first)
+        else
+          response = Resend::Batch.send(emails)
+        end
         unless response.success?
           raise ResendApiResponseError.new(response.body)
         end

--- a/spec/services/post_resend_api_spec.rb
+++ b/spec/services/post_resend_api_spec.rb
@@ -361,6 +361,34 @@ describe PostResendApi, :freeze_time do
     expect(node.text).to include("Powered by")
   end
 
+  describe "Resend API dispatch" do
+    before do
+      allow(Rails.env).to receive(:test?).and_return(false)
+      allow(Rails.application.config.action_mailer).to receive(:perform_deliveries).and_return(true)
+      allow(GlobalConfig).to receive(:get).and_call_original
+      allow(GlobalConfig).to receive(:get).with("RESEND_CREATORS_API_KEY").and_return("test-api-key")
+    end
+
+    it "uses Resend::Emails.send for a single recipient" do
+      response = instance_double("Response", success?: true)
+      expect(Resend::Emails).to receive(:send).with(a_hash_including(to: ["c1@example.com"])).and_return(response)
+      expect(Resend::Batch).not_to receive(:send)
+
+      send_emails(recipients: [{ email: "c1@example.com" }])
+    end
+
+    it "uses Resend::Batch.send for multiple recipients" do
+      response = instance_double("Response", success?: true)
+      expect(Resend::Batch).to receive(:send).with(an_instance_of(Array)).and_return(response)
+      expect(Resend::Emails).not_to receive(:send)
+
+      send_emails(recipients: [
+                    { email: "c1@example.com" },
+                    { email: "c2@example.com" }
+                  ])
+    end
+  end
+
   describe "Cache" do
     it "prevents the template from being rendered several times for the same post, across multiple calls" do
       cache = {}


### PR DESCRIPTION
## Summary
- **Root cause**: `PostResendApi#send_emails` always used `Resend::Batch.send`, but the `RESEND_CREATORS_API_KEY` only has permissions for the single-email endpoint (`Resend::Emails.send`), not the batch endpoint. This caused `Resend::Error::InvalidRequestError` for single-recipient flows like `send_for_purchase`.
- **Fix**: When there is only 1 email, use `Resend::Emails.send(emails.first)` instead of `Resend::Batch.send(emails)`. Batch send is still used for multiple recipients.
- Added tests verifying the correct Resend API method is called for single vs multiple recipients.

**Sentry issue**: https://gumroad-to.sentry.io/issues/7401455580/

## Test plan
- [x] Existing `PostResendApi` tests pass (33 examples, 0 failures)
- [x] New tests confirm `Resend::Emails.send` is called for single recipient
- [x] New tests confirm `Resend::Batch.send` is still called for multiple recipients
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)