### PR TITLE
Fix Resend API key restriction error for preview emails

### DIFF
--- a/app/services/post_resend_api.rb
+++ b/app/services/post_resend_api.rb
@@ -29,7 +29,11 @@ class PostResendApi
     if Rails.application.config.action_mailer.perform_deliveries != false && !Rails.env.test?
       Resend.api_key = GlobalConfig.get("RESEND_CREATORS_API_KEY")
       duration = Benchmark.realtime do
-        response = Resend::Batch.send(emails)
+        response = if emails.size == 1
+          Resend::Emails.send(emails.first)
+        else
+          Resend::Batch.send(emails)
+        end
         unless response.success?
           raise ResendApiResponseError.new(response.body)
         end

--- a/spec/services/post_resend_api_spec.rb
+++ b/spec/services/post_resend_api_spec.rb
@@ -354,6 +354,31 @@ describe PostResendApi, :freeze_time do
     end
   end
 
+  describe "Resend API routing" do
+    before do
+      allow(Rails.application.config.action_mailer).to receive(:perform_deliveries).and_return(true)
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("production"))
+      allow(GlobalConfig).to receive(:get).and_call_original
+      allow(GlobalConfig).to receive(:get).with("RESEND_CREATORS_API_KEY").and_return("test_key")
+    end
+
+    it "uses Resend::Emails.send for a single recipient" do
+      response = double(success?: true)
+      expect(Resend::Emails).to receive(:send).with(a_hash_including(to: ["c1@example.com"])).and_return(response)
+      expect(Resend::Batch).not_to receive(:send)
+
+      send_emails(recipients: [{ email: "c1@example.com" }])
+    end
+
+    it "uses Resend::Batch.send for multiple recipients" do
+      response = double(success?: true)
+      expect(Resend::Batch).to receive(:send).with(an_instance_of(Array)).and_return(response)
+      expect(Resend::Emails).not_to receive(:send)
+
+      send_emails(recipients: [{ email: "c1@example.com" }, { email: "c2@example.com" }])
+    end
+  end
+
   it "includes a link to Gumroad" do
     send_default_email
     node = html_doc(sent_email_content).at_xpath(%(//div[contains(@class, 'footer')]/a[@href="#{root_url}"]))


### PR DESCRIPTION
## What

When sending preview emails, `PostResendApi` was using `Resend::Batch.send` (`POST /emails/batch`) even for a single recipient. The `RESEND_CREATORS_API_KEY` only has "sending access" permission, which allows `POST /emails` but not `POST /emails/batch`, causing `Resend::Error::InvalidRequestError: This API key is restricted to only send emails`.

This PR routes single-recipient sends through `Resend::Emails.send` (`POST /emails`) and keeps `Resend::Batch.send` for multiple recipients.

## Why

Preview emails always have exactly one recipient, so the batch endpoint is unnecessary. Using the single-email endpoint avoids the API key permission restriction while keeping batch sends for actual post deliveries with multiple recipients.

## Test results

```
33 examples, 0 failures  (spec/services/post_resend_api_spec.rb)
5 examples, 0 failures   (spec/controllers/api/internal/installments/preview_emails_controller_spec.rb)
```

---

AI disclosure: Claude Opus 4.6 — prompted with Sentry error details, root cause analysis, and implementation plan for fixing the Resend API key restriction error on preview emails.