### PR TITLE
Fix unreviewed users spec assertion ($50 → $150)

### DIFF
--- a/spec/requests/admin/unreviewed_users_spec.rb
+++ b/spec/requests/admin/unreviewed_users_spec.rb
@@ -44,7 +44,7 @@ describe "Admin::UnreviewedUsersController", type: :system, js: true do
 
         expect(page).to have_text(user_with_balance.external_id)
         expect(page).to have_text(user_with_balance.email)
-        expect(page).to have_text("$50")
+        expect(page).to have_text("$150")
       end
 
       it "links to the user's admin page" do


### PR DESCRIPTION
## What

Fixes the balance assertion in `spec/requests/admin/unreviewed_users_spec.rb` from `$50` to `$150`.

## Why

Commit 528c575 (PR #4403) updated the test balance from `5_000` to `15_000` cents on line 28, but missed updating the corresponding assertion on line 47 from `"$50"` to `"$150"`. This causes the spec to fail since 15,000 cents = $150, not $50.

---

Generated with Claude Opus 4.6.