### PR TITLE
Fix NoMethodError when address_fields is nil in InvoicesController#create

### DIFF
--- a/app/controllers/purchases/invoices_controller.rb
+++ b/app/controllers/purchases/invoices_controller.rb
@@ -20,6 +20,8 @@ class Purchases::InvoicesController < ApplicationController
     return redirect_to new_purchase_invoice_path(@purchase.external_id, email: invoice_params[:email]), alert: "Your purchase has not been completed by PayPal yet. Please try again soon." if invoice_params["vat_id"].present? && !@purchase.successful?
 
     address_fields = invoice_params[:address_fields]
+    return redirect_to new_purchase_invoice_path(@purchase.external_id, email: invoice_params[:email]), alert: "Address information is required to generate an invoice." if address_fields.blank?
+
     address_fields[:country] = ISO3166::Country[invoice_params[:address_fields][:country_code]]&.common_name
     business_vat_id = invoice_params[:vat_id] if is_vat_id_valid?(invoice_params[:vat_id])
     invoice_presenter = InvoicePresenter.new(@chargeable, address_fields:, additional_notes: invoice_params[:additional_notes]&.strip, business_vat_id:)

--- a/spec/controllers/purchases/invoices_controller_spec.rb
+++ b/spec/controllers/purchases/invoices_controller_spec.rb
@@ -354,6 +354,15 @@ describe Purchases::InvoicesController, :vcr, type: :controller, inertia: true d
             expect(flash[:warning]).to eq("Please enter the purchase's email address to generate the invoice.")
           end
         end
+
+        context "when address_fields is missing" do
+          it "redirects with an error alert" do
+            post :create, params: payload.except(:address_fields)
+
+            expect(response).to redirect_to(new_purchase_invoice_path(purchase.external_id, email: purchase.email))
+            expect(flash[:alert]).to eq("Address information is required to generate an invoice.")
+          end
+        end
       end
 
       describe "for Charge" do


### PR DESCRIPTION
## Summary
- Adds a guard clause in `Purchases::InvoicesController#create` to handle missing `address_fields` params, preventing a `NoMethodError` on nil
- Redirects back with an alert flash ("Address information is required to generate an invoice.") instead of crashing
- Adds a controller spec for the missing address_fields scenario

## Sentry Issue
https://gumroad-to.sentry.io/issues/7402594031/

## Test plan
- [x] New spec passes: `bundle exec rspec spec/controllers/purchases/invoices_controller_spec.rb -e "when address_fields is missing"`
- [ ] Existing specs in the file still pass
- [ ] Verify on staging that submitting the invoice form without address fields shows the error flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)