### PR TITLE
Fix: Skip Brazilian Stripe validation when soft-deleting affiliates

### DIFF
--- a/app/models/affiliate.rb
+++ b/app/models/affiliate.rb
@@ -123,6 +123,7 @@ class Affiliate < ApplicationRecord
     end
 
     def eligible_for_stripe_payments
+      return if being_marked_as_deleted?
       errors.add(:base, "This user cannot be added as #{collaborator? ? "a collaborator" : "an affiliate"} because they use a Brazilian Stripe account.") if affiliate_user&.has_brazilian_stripe_connect_account?
     end
 end

--- a/app/models/collaborator.rb
+++ b/app/models/collaborator.rb
@@ -60,6 +60,7 @@ class Collaborator < Affiliate
     end
 
     def eligible_for_stripe_payments
+      return if being_marked_as_deleted?
       super
       return unless seller.present? && seller.has_brazilian_stripe_connect_account?
       errors.add(:base, "You cannot add a collaborator because you are using a Brazilian Stripe account.")

--- a/app/models/direct_affiliate.rb
+++ b/app/models/direct_affiliate.rb
@@ -137,6 +137,7 @@ class DirectAffiliate < Affiliate
     end
 
     def eligible_for_stripe_payments
+      return if being_marked_as_deleted?
       super
       return unless seller.present? && seller.has_brazilian_stripe_connect_account?
       errors.add(:base, "You cannot add an affiliate because you are using a Brazilian Stripe account.")

--- a/spec/controllers/affiliates_controller_spec.rb
+++ b/spec/controllers/affiliates_controller_spec.rb
@@ -201,6 +201,16 @@ describe AffiliatesController, type: :controller, inertia: true do
       it "returns 404 for non-existent affiliate" do
         expect { delete :destroy, params: { id: "nonexistent" } }.to raise_error(ActionController::RoutingError)
       end
+
+      it "deletes the affiliate even when the affiliate user has a Brazilian Stripe account" do
+        allow(affiliate.affiliate_user).to receive(:has_brazilian_stripe_connect_account?).and_return(true)
+
+        delete :destroy, params: { id: affiliate.external_id }
+
+        expect(response).to redirect_to(affiliates_path)
+        expect(flash[:notice]).to eq("Affiliate deleted successfully")
+        expect(affiliate.reload).to be_deleted
+      end
     end
 
     describe "GET export" do

--- a/spec/models/direct_affiliate_spec.rb
+++ b/spec/models/direct_affiliate_spec.rb
@@ -58,6 +58,19 @@ describe DirectAffiliate do
           expect(direct_affiliate).to be_valid
         end
       end
+
+      context "when soft-deleting an affiliate whose user has a Brazilian Stripe account" do
+        let(:direct_affiliate) { create(:direct_affiliate, seller:, affiliate_user:) }
+
+        it "allows soft deletion" do
+          direct_affiliate # force creation before stubbing
+          allow(affiliate_user).to receive(:has_brazilian_stripe_connect_account?).and_return(true)
+          allow(seller).to receive(:has_brazilian_stripe_connect_account?).and_return(false)
+
+          expect { direct_affiliate.mark_deleted! }.not_to raise_error
+          expect(direct_affiliate.reload).to be_deleted
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Problem

`AffiliatesController#destroy` calls `mark_deleted!` which triggers `save!`, running all validations. The `eligible_for_stripe_payments` validation on `Affiliate`, `DirectAffiliate`, and `Collaborator` raises `ActiveRecord::RecordInvalid` when the affiliate user has a Brazilian Stripe account, preventing sellers from removing these affiliates.

**Sentry:** https://gumroad-to.sentry.io/issues/7402678326/

## Root Cause

`mark_deleted!` (from `Deletable`) sets `deleted_at` and calls `save!`, which runs all validations including `eligible_for_stripe_payments`. This validation was designed to prevent *adding* affiliates with Brazilian Stripe accounts, but it also blocks *removing* them.

## Fix

Added an early return (`return if being_marked_as_deleted?`) at the top of `eligible_for_stripe_payments` in:
- `Affiliate` (base class)
- `DirectAffiliate`
- `Collaborator`

This skips the Brazilian Stripe check when the record is being soft-deleted, since the restriction only matters for creating/updating active affiliates.

## Tests

- Controller test: verifies `DELETE destroy` succeeds when affiliate user has a Brazilian Stripe account
- Model test: verifies `mark_deleted!` succeeds on a `DirectAffiliate` with a Brazilian Stripe affiliate user