### PR TITLE
Fix NoMethodError in StripeCharge#build_flow_of_funds when destination payment balance transaction is nil

### DIFF
--- a/app/business/payments/charging/implementations/stripe/stripe_charge.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge.rb
@@ -61,8 +61,8 @@ class StripeCharge < BaseProcessorCharge
 
     def build_flow_of_funds(stripe_charge, stripe_charge_balance_transaction, stripe_application_fee_balance_transaction,
                             stripe_destination_payment_balance_transaction, stripe_destination_transfer)
-      return if stripe_charge[:destination] && stripe_application_fee_balance_transaction.nil? &&
-        stripe_destination_transfer.nil?
+      return if stripe_charge[:destination] && (stripe_destination_payment_balance_transaction.nil? ||
+        (stripe_application_fee_balance_transaction.nil? && stripe_destination_transfer.nil?))
 
       issued_amount = FlowOfFunds::Amount.new(currency: stripe_charge[:currency],
                                               cents: stripe_charge[:amount])

--- a/spec/business/payments/charging/implementations/stripe/stripe_charge_spec.rb
+++ b/spec/business/payments/charging/implementations/stripe/stripe_charge_spec.rb
@@ -129,6 +129,45 @@ describe StripeCharge, :vcr do
     # zip_check_result will never be false since we do not create Charge object when an error is raised.
     # If the Stripe configuration changes in the future then a test should be added for this scenario.
 
+    describe "with a destination charge but nil destination payment balance transaction" do
+      let(:stripe_charge_hash) do
+        {
+          id: "ch_test_123",
+          status: "succeeded",
+          refunded: false,
+          dispute: nil,
+          currency: Currency::USD,
+          amount: 1_00,
+          destination: "acct_test_456",
+          payment_method_details: { card: { fingerprint: "fp_test", last4: "4242", brand: "visa", exp_month: 12, exp_year: 2030, country: "US", checks: { address_postal_code_check: nil } } },
+          billing_details: { address: { postal_code: nil } },
+          payment_method: "pm_test",
+          outcome: { risk_level: "normal" },
+        }
+      end
+
+      let(:stripe_charge_balance_transaction) do
+        {
+          currency: Currency::USD,
+          amount: 1_00,
+          fee_details: [{ type: "stripe_fee", currency: Currency::USD, amount: 30 }],
+        }
+      end
+
+      let(:stripe_destination_transfer) { { amount: 50 } }
+
+      it "returns nil flow_of_funds instead of raising NoMethodError" do
+        charge = described_class.new(
+          stripe_charge_hash,
+          stripe_charge_balance_transaction,
+          nil,
+          nil,
+          stripe_destination_transfer
+        )
+        expect(charge.flow_of_funds).to be_nil
+      end
+    end
+
     describe "with a stripe charge destined for a managed account" do
       let(:application_fee) { 50 }
 


### PR DESCRIPTION
## What

Fixes `NoMethodError: undefined method '[]' for nil` in `StripeCharge#build_flow_of_funds` when `stripe_destination_payment_balance_transaction` is nil but `stripe_charge[:destination]` and `stripe_destination_transfer` are present.

## Why

The existing guard clause only returned early when **both** `stripe_application_fee_balance_transaction` and `stripe_destination_transfer` were nil. This left a code path where `stripe_destination_payment_balance_transaction` could be nil while execution continued to lines that accessed `[:currency]`, `[:amount]`, and `[:net]` on it — causing a `NoMethodError`.

The fix adds `stripe_destination_payment_balance_transaction` to the early return guard so the method safely returns nil instead of raising.

## Test Results

- 39 examples, 0 failures
- New test verifies `NoMethodError` is not raised when `stripe_destination_payment_balance_transaction` is nil
- Test confirmed to fail when the fix is reverted

---

Built with Claude Opus 4.6. Prompt: fix the nil guard in `build_flow_of_funds`, add a regression test, verify the test fails without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)