### PR TITLE
Fix RequestTimeoutException in Api::V2::SalesController#index

### DIFF
--- a/app/controllers/api/v2/sales_controller.rb
+++ b/app/controllers/api/v2/sales_controller.rb
@@ -69,16 +69,23 @@ class Api::V2::SalesController < Api::V2::BaseController
       where_page_data = ["created_at <= ? and id < ?", last_purchase_created_at, last_purchase_id]
     end
 
-    paginated_sales = filter_sales(start_date:, end_date:, email:, product_id:, purchase_id:)
-    subquery_filters = ->(query) {
-      query.where(seller_id: current_resource_owner.id).where(where_page_data).order(created_at: :desc, id: :desc).limit(RESULTS_PER_PAGE + 1)
-    }
-    paginated_sales = paginated_sales.for_sales_api_ordered_by_date(subquery_filters)
-    paginated_sales = paginated_sales.limit(RESULTS_PER_PAGE + 1).to_a
-    has_next_page = paginated_sales.size > RESULTS_PER_PAGE
-    paginated_sales = paginated_sales.first(RESULTS_PER_PAGE)
-    additional_response = has_next_page ? pagination_info(paginated_sales.last) : {}
-    success_with_object(:sales, paginated_sales.as_json(version: 2), additional_response)
+    begin
+      timeout_s = ($redis.get(RedisKey.api_v2_sales_page_key_query_timeout) || 15).to_i
+      WithMaxExecutionTime.timeout_queries(seconds: timeout_s) do
+        paginated_sales = filter_sales(start_date:, end_date:, email:, product_id:, purchase_id:)
+        subquery_filters = ->(query) {
+          query.where(seller_id: current_resource_owner.id).where(where_page_data).order(created_at: :desc, id: :desc).limit(RESULTS_PER_PAGE + 1)
+        }
+        paginated_sales = paginated_sales.for_sales_api_ordered_by_date(subquery_filters)
+        paginated_sales = paginated_sales.limit(RESULTS_PER_PAGE + 1).to_a
+        has_next_page = paginated_sales.size > RESULTS_PER_PAGE
+        paginated_sales = paginated_sales.first(RESULTS_PER_PAGE)
+        additional_response = has_next_page ? pagination_info(paginated_sales.last) : {}
+        success_with_object(:sales, paginated_sales.as_json(version: 2), additional_response)
+      end
+    rescue WithMaxExecutionTime::QueryTimeoutError
+      render_response(false, message: "Request timed out. Please narrow your query with date filters or try again.")
+    end
   end
 
   def show

--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -21,6 +21,7 @@ class RedisKey
     def followers_import_limit = "followers_import:limit"
     def force_product_id_timestamp = "force_product_id_timestamp"
     def api_v2_sales_deprecated_pagination_query_timeout = "api_v2_sales_deprecated_pagination_query_timeout"
+    def api_v2_sales_page_key_query_timeout = "api_v2_sales_page_key_query_timeout"
     def free_purchases_watch_hours = "free_purchases_watch_hours"
     def max_allowed_free_purchases_of_same_product = "max_allowed_free_purchases_of_same_product"
     def ai_request_throttle(user_id) = "ai_request_throttle:#{user_id}"

--- a/spec/controllers/api/v2/sales_controller_spec.rb
+++ b/spec/controllers/api/v2/sales_controller_spec.rb
@@ -231,6 +231,17 @@ describe Api::V2::SalesController do
         sale_json = response.parsed_body["sales"].find { |s| s["id"] == @purchase.external_id }
         expect(sale_json).to include("disputed" => true, "dispute_won" => true)
       end
+
+      it "returns an error when page_key query times out" do
+        allow(WithMaxExecutionTime).to receive(:timeout_queries).and_raise(WithMaxExecutionTime::QueryTimeoutError)
+
+        get :index, params: @params
+
+        expect(response.parsed_body).to eq({
+          success: false,
+          message: "Request timed out. Please narrow your query with date filters or try again."
+        }.as_json)
+      end
     end
 
     describe "when logged in with public scope" do


### PR DESCRIPTION
## What

Wraps the `page_key` pagination path in `Api::V2::SalesController#index` with `WithMaxExecutionTime.timeout_queries`, matching the protection already present on the deprecated `page` path.

- Adds `RedisKey.api_v2_sales_page_key_query_timeout` for runtime-configurable timeout (default 15s)
- Rescues `QueryTimeoutError` and returns a user-friendly error message
- Adds test coverage for the timeout behavior

## Why

The `page_key` code path executes `for_sales_api_ordered_by_date` (a UNION subquery) without any max execution time guard. For sellers with large sales volumes, this query can run unbounded and hit the 120s Rack timeout, causing `Rack::Timeout::RequestTimeoutException`. The deprecated `page` path already had this protection — this brings the `page_key` path to parity.

## Test Results

All 45 specs in `spec/controllers/api/v2/sales_controller_spec.rb` pass, including the new timeout test.

---

Built with Claude Opus 4.6. Prompted with the bug report describing the missing timeout guard on the page_key path.