### PR TITLE
Fix RecordInvalid exception noise in Apple OAuth for blocked emails

### DIFF
--- a/app/models/concerns/user/social_apple.rb
+++ b/app/models/concerns/user/social_apple.rb
@@ -23,7 +23,7 @@ module User::SocialApple
           user.password = Devise.friendly_token[0, 20]
           apply_apple_data(user, data, new_user: true)
 
-          if user.email.present?
+          if user.persisted? && user.email.present?
             Purchase.where(email: user.email, purchaser_id: nil).each do |past_purchase|
               past_purchase.attach_to_user_and_card(user, nil, nil)
             end
@@ -58,7 +58,11 @@ module User::SocialApple
         end
 
         user.skip_confirmation_notification!
-        user.save!
+        if new_user
+          return user unless user.save
+        else
+          user.save!
+        end
         user.confirm if user.has_unconfirmed_email?
 
         if data["uid"].present?

--- a/spec/models/concerns/user/social_apple_spec.rb
+++ b/spec/models/concerns/user/social_apple_spec.rb
@@ -79,6 +79,27 @@ describe User::SocialApple do
       end
     end
 
+    context "when a new user's email domain is blocked" do
+      before do
+        BlockedObject.block!(BLOCKED_OBJECT_TYPES[:email_domain], "example.com", nil)
+      end
+
+      it "returns an unpersisted user without raising an exception" do
+        result = User.find_or_create_for_apple_oauth(apple_data)
+
+        expect(result).to be_present
+        expect(result).not_to be_persisted
+      end
+
+      it "does not attach past purchases" do
+        purchase = create(:purchase, email: "apple-user@example.com")
+
+        User.find_or_create_for_apple_oauth(apple_data)
+
+        expect(purchase.reload.purchaser_id).to be_nil
+      end
+    end
+
     context "when name is nil" do
       it "creates a user without a name" do
         data = apple_data.merge("info" => { "email" => "apple-user@example.com", "name" => nil })


### PR DESCRIPTION
## Summary

- When a new user signs up via Apple OAuth with a blocked email domain/IP, `save!` raises `ActiveRecord::RecordInvalid` which gets reported to Sentry as noise
- Changed to use `save` (without bang) for new users so validation failures return an unpersisted user instead of raising — the controller already handles unpersisted users gracefully via `@user&.persisted?`
- Added `user.persisted?` guard before attaching past purchases, since an unsaved user can't own purchases
- Existing users still use `save!` so real errors are caught and reported

## Sentry issue

https://gumroad-to.sentry.io/issues/7403149682/

- **Occurrences:** 1 event in the last 7 days
- **Users affected:** 1
- **Estimated support tickets:** 0 (user sees a generic error and the flow works correctly for non-blocked users)

## Test plan

- [ ] New spec: blocked email domain returns unpersisted user without raising
- [ ] New spec: blocked email domain does not attach past purchases
- [ ] Existing specs continue to pass (new user creation, existing user linking, purchase attachment)
- [ ] Verify in Sentry that `RecordInvalid` noise stops for this controller action

🤖 Generated with [Claude Code](https://claude.com/claude-code)