### PR TITLE
Fix Rack::Timeout on sales API page_key path by adding query timeout

### DIFF
--- a/app/controllers/api/v2/sales_controller.rb
+++ b/app/controllers/api/v2/sales_controller.rb
@@ -69,16 +69,23 @@ class Api::V2::SalesController < Api::V2::BaseController
       where_page_data = ["created_at <= ? and id < ?", last_purchase_created_at, last_purchase_id]
     end
 
-    paginated_sales = filter_sales(start_date:, end_date:, email:, product_id:, purchase_id:)
-    subquery_filters = ->(query) {
-      query.where(seller_id: current_resource_owner.id).where(where_page_data).order(created_at: :desc, id: :desc).limit(RESULTS_PER_PAGE + 1)
-    }
-    paginated_sales = paginated_sales.for_sales_api_ordered_by_date(subquery_filters)
-    paginated_sales = paginated_sales.limit(RESULTS_PER_PAGE + 1).to_a
-    has_next_page = paginated_sales.size > RESULTS_PER_PAGE
-    paginated_sales = paginated_sales.first(RESULTS_PER_PAGE)
-    additional_response = has_next_page ? pagination_info(paginated_sales.last) : {}
-    success_with_object(:sales, paginated_sales.as_json(version: 2), additional_response)
+    begin
+      timeout_s = ($redis.get(RedisKey.api_v2_sales_page_key_query_timeout) || 15).to_i
+      WithMaxExecutionTime.timeout_queries(seconds: timeout_s) do
+        paginated_sales = filter_sales(start_date:, end_date:, email:, product_id:, purchase_id:)
+        subquery_filters = ->(query) {
+          query.where(seller_id: current_resource_owner.id).where(where_page_data).order(created_at: :desc, id: :desc).limit(RESULTS_PER_PAGE + 1)
+        }
+        paginated_sales = paginated_sales.for_sales_api_ordered_by_date(subquery_filters)
+        paginated_sales = paginated_sales.limit(RESULTS_PER_PAGE + 1).to_a
+        has_next_page = paginated_sales.size > RESULTS_PER_PAGE
+        paginated_sales = paginated_sales.first(RESULTS_PER_PAGE)
+        additional_response = has_next_page ? pagination_info(paginated_sales.last) : {}
+        success_with_object(:sales, paginated_sales.as_json(version: 2), additional_response)
+      end
+    rescue WithMaxExecutionTime::QueryTimeoutError
+      error_400("Query timed out. Try narrowing your date range or filtering by product_id.")
+    end
   end
 
   def show

--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -21,6 +21,7 @@ class RedisKey
     def followers_import_limit = "followers_import:limit"
     def force_product_id_timestamp = "force_product_id_timestamp"
     def api_v2_sales_deprecated_pagination_query_timeout = "api_v2_sales_deprecated_pagination_query_timeout"
+    def api_v2_sales_page_key_query_timeout = "api_v2_sales_page_key_query_timeout"
     def free_purchases_watch_hours = "free_purchases_watch_hours"
     def max_allowed_free_purchases_of_same_product = "max_allowed_free_purchases_of_same_product"
     def ai_request_throttle(user_id) = "ai_request_throttle:#{user_id}"

--- a/spec/controllers/api/v2/sales_controller_spec.rb
+++ b/spec/controllers/api/v2/sales_controller_spec.rb
@@ -210,6 +210,17 @@ describe Api::V2::SalesController do
         }.as_json)
       end
 
+      it "returns a 400 error when page_key query times out" do
+        allow(WithMaxExecutionTime).to receive(:timeout_queries).and_raise(WithMaxExecutionTime::QueryTimeoutError)
+
+        get :index, params: @params
+        expect(response.code).to eq "400"
+        expect(response.parsed_body).to eq({
+          status: 400,
+          error: "Query timed out. Try narrowing your date range or filtering by product_id."
+        }.as_json)
+      end
+
       it "returns the correct dispute information" do
         # We have a filter in the controller so the purchases for today are not added
         @params.merge!(before: 1.day.from_now)


### PR DESCRIPTION
## Summary
- The `page_key` code path in `Api::V2::SalesController#index` had **no query timeout protection**, causing slow UNION queries from `for_sales_api_ordered_by_date` to run until Rack::Timeout killed the process at 120s
- Wrapped the `page_key` path in `WithMaxExecutionTime.timeout_queries` with a Redis-configurable timeout (default 15s, key: `api_v2_sales_page_key_query_timeout`), matching the existing pattern on the deprecated `page` path
- On timeout, returns a 400 error suggesting the user narrow their date range or filter by product_id

## Sentry
https://gumroad-to.sentry.io/issues/7404802544/

`Rack::Timeout::RequestTimeoutException` events on this endpoint. The fix converts these into graceful 400 responses with actionable guidance instead of unhandled 120s process kills.

## Test plan
- [x] Added test for timeout error returning 400 response on the page_key path
- [x] All 45 existing sales controller tests pass (no regressions)
- [ ] Verify in staging that normal page_key queries still work
- [ ] Optionally set `api_v2_sales_page_key_query_timeout` in Redis to a low value to confirm timeout behavior


🤖 Generated with [Claude Code](https://claude.com/claude-code)