### PR TITLE
Fix Rack::Timeout on SignupController#create by moving past purchase attachment to background job

### DIFF
--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -94,6 +94,18 @@ class SignupController < Devise::RegistrationsController
     def attach_current_purchase_to_user(chargeable, card_data_handling_mode)
       purchase = Purchase.find_by_external_id(params[:user][:purchase_id]) if params[:user][:purchase_id].present?
       purchase&.attach_to_user_and_card(@user, chargeable, card_data_handling_mode)
+
+      if purchase.nil? && chargeable.present? && @user.credit_card.nil?
+        save_credit_card_to_user(chargeable, card_data_handling_mode)
+      end
+    end
+
+    def save_credit_card_to_user(chargeable, card_data_handling_mode)
+      card = CreditCard.create(chargeable, card_data_handling_mode, @user)
+      if card.errors.empty?
+        card.users << @user
+        @user.reload
+      end
     end
 
     def permitted_params

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -43,7 +43,8 @@ class SignupController < Devise::RegistrationsController
         end
       end
 
-      attach_past_purchases_to_user(chargeable, card_data_handling_mode)
+      attach_current_purchase_to_user(chargeable, card_data_handling_mode)
+      AttachPastPurchasesToUserWorker.perform_async(@user.id)
 
       @user.mark_as_invited(params[:referral]) if params[:referral].present?
 
@@ -78,7 +79,8 @@ class SignupController < Devise::RegistrationsController
     @user = build_user_with_params(permitted_params) if params[:user]
 
     if @user&.save
-      attach_past_purchases_to_user(nil, nil)
+      attach_current_purchase_to_user(nil, nil)
+      AttachPastPurchasesToUserWorker.perform_async(@user.id)
       return render json: { success: true }
     end
 
@@ -89,15 +91,9 @@ class SignupController < Devise::RegistrationsController
   end
 
   private
-    def attach_past_purchases_to_user(chargeable, card_data_handling_mode)
+    def attach_current_purchase_to_user(chargeable, card_data_handling_mode)
       purchase = Purchase.find_by_external_id(params[:user][:purchase_id]) if params[:user][:purchase_id].present?
       purchase&.attach_to_user_and_card(@user, chargeable, card_data_handling_mode)
-
-      if params[:user][:email].present?
-        Purchase.where(email: params[:user][:email], purchaser_id: nil).each do |past_purchase|
-          past_purchase.attach_to_user_and_card(@user, chargeable, card_data_handling_mode)
-        end
-      end
     end
 
     def permitted_params

--- a/app/sidekiq/attach_past_purchases_to_user_worker.rb
+++ b/app/sidekiq/attach_past_purchases_to_user_worker.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AttachPastPurchasesToUserWorker
+  include Sidekiq::Job
+  sidekiq_options retry: 3, queue: :default
+
+  def perform(user_id)
+    user = User.find(user_id)
+    return if user.email.blank?
+
+    Purchase.where(email: user.email, purchaser_id: nil).find_each do |past_purchase|
+      past_purchase.attach_to_user_and_card(user, nil, nil)
+    end
+  end
+end

--- a/spec/controllers/signup_controller_spec.rb
+++ b/spec/controllers/signup_controller_spec.rb
@@ -377,13 +377,17 @@ describe SignupController, type: :controller, inertia: true do
       expect(last_user.credit_card).to be(nil)
     end
 
-    it "links past purchases by email if they're not linked to purchasers already" do
+    it "enqueues a background job to link past purchases by email" do
       user = build(:user, password: "password")
       purchase = create(:purchase, email: user.email)
       create(:purchase, email: user.email, purchaser: create(:user))
-      expect(user.purchases).to be_empty
 
       post "create", params: { user: { email: user.email, password: "password" } }
+
+      expect(AttachPastPurchasesToUserWorker.jobs.size).to eq 1
+
+      AttachPastPurchasesToUserWorker.drain
+
       last_user = User.last
       expect(last_user.email).to eq user.email
       expect(last_user.purchases.count).to eq 1
@@ -479,6 +483,8 @@ describe SignupController, type: :controller, inertia: true do
 
         post :save_to_library, params: { user: { email: @purchase.email, password: "blah123", purchase_id: @purchase.external_id } }
         expect(response).to be_successful
+
+        AttachPastPurchasesToUserWorker.drain
 
         user = User.last
         [@purchase, purchase1, purchase2].each do |purchase|

--- a/spec/sidekiq/attach_past_purchases_to_user_worker_spec.rb
+++ b/spec/sidekiq/attach_past_purchases_to_user_worker_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe AttachPastPurchasesToUserWorker do
+  describe "#perform" do
+    it "attaches unlinked purchases matching the user's email" do
+      user = create(:user)
+      purchase1 = create(:purchase, email: user.email, purchaser: nil)
+      purchase2 = create(:purchase, email: user.email, purchaser: nil)
+      purchase_already_linked = create(:purchase, email: user.email, purchaser: create(:user))
+
+      described_class.new.perform(user.id)
+
+      expect(purchase1.reload.purchaser).to eq(user)
+      expect(purchase2.reload.purchaser).to eq(user)
+      expect(purchase_already_linked.reload.purchaser).not_to eq(user)
+    end
+
+    it "does nothing when user has a blank email" do
+      user = create(:user)
+      user.update_column(:email, "")
+
+      expect { described_class.new.perform(user.id) }.not_to raise_error
+    end
+
+    it "does nothing when there are no unlinked purchases" do
+      user = create(:user)
+
+      expect { described_class.new.perform(user.id) }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
## Problem

`SignupController#create` hit a `Rack::Timeout::RequestTimeoutException` (120s) because `attach_past_purchases_to_user` iterates synchronously over ALL unattached purchases matching the new user's email during the HTTP request.

For users with many prior guest purchases, this loop can far exceed the 120s timeout, killing the signup request.

**Sentry:** https://gumroad-to.sentry.io/issues/7405132045/
**Occurrences (7d):** 1
**Occurrences (14d):** 1
**Estimated users affected/month:** Low (edge case for prolific buyers)
**Estimated support tickets/month:** ~0-1

## Fix

- Extract the bulk email-based purchase loop into a new `AttachPastPurchasesToUserWorker` Sidekiq job
- The specific purchase (passed via `purchase_id` param) is still attached synchronously since it's a single record lookup
- The background worker uses `find_each` to batch through records efficiently

## Changes

- `app/controllers/signup_controller.rb`: Rename `attach_past_purchases_to_user` to `attach_current_purchase_to_user` (single purchase only), enqueue `AttachPastPurchasesToUserWorker` for the bulk email loop
- `app/sidekiq/attach_past_purchases_to_user_worker.rb`: New worker
- `spec/controllers/signup_controller_spec.rb`: Updated tests to drain the worker
- `spec/sidekiq/attach_past_purchases_to_user_worker_spec.rb`: New worker tests