### PR TITLE
Fix Rack::Timeout in EmailsController#published

### DIFF
--- a/app/models/installment.rb
+++ b/app/models/installment.rb
@@ -115,11 +115,10 @@ class Installment < ApplicationRecord
     # The custom `ORDER BY` clause does the following:
     #   - Keep all unpublished updates at the top
     #   - Sort unpublished updates by `created_at DESC` and sort published updates by `published_at DESC`
-    by_seller_sql = where(seller: user).to_sql
-    by_product_sql = where(link_id: user.links.visible.select(:id)).to_sql
+    base = alive.not_workflow_installment
+    by_seller_sql = base.where(seller: user).to_sql
+    by_product_sql = base.where(link_id: user.links.visible.select(:id)).to_sql
     from("((#{by_seller_sql}) UNION (#{by_product_sql})) installments")
-      .alive
-      .not_workflow_installment
       .order(order_clause)
   }
 

--- a/app/presenters/paginated_installments_presenter.rb
+++ b/app/presenters/paginated_installments_presenter.rb
@@ -17,7 +17,7 @@ class PaginatedInstallmentsPresenter
 
   def props
     if query.blank?
-      installments = Installment.includes(:installment_rule).all
+      installments = Installment.includes(:installment_rule).preload(:link, :blasts).all
       installments = installments.ordered_updates(seller, type).public_send(type)
       installments = installments.unscope(:order).order("installment_rules.to_be_published_at ASC") if type == Installment::SCHEDULED
       pagination, installments = pagy(installments, page:, limit: PER_PAGE, overflow: :empty_page)


### PR DESCRIPTION
## Summary

- **Root cause**: The `ordered_updates` scope in `Installment` builds a UNION of two subqueries (by seller + by product), but the `alive` and `not_workflow_installment` filters were applied *after* the UNION. This meant the database materialized ALL installments into a temporary table before filtering, causing timeouts for sellers with many products/installments.
- **Fix**: Push both filters (`alive`, `not_workflow_installment`) into each UNION subquery so the database filters rows before combining them, dramatically reducing the intermediate result set.
- **Bonus**: Added `preload(:link, :blasts)` to `PaginatedInstallmentsPresenter` to avoid N+1 queries when rendering installment props.

## Test plan

- [ ] Verify existing RSpec tests pass for `spec/presenters/paginated_installments_presenter_spec.rb` and `spec/controllers/emails_controller_spec.rb`
- [ ] Verify the published emails page loads without timeout for sellers with many products
- [ ] Verify scheduled and draft tabs still work correctly
- [ ] Verify search functionality is unaffected (uses separate Elasticsearch path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)