### PR TITLE
Fix Rack::Timeout in EmailsController#edit: batch N+1 ES queries

### DIFF
--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -20,15 +20,13 @@ class UserPresenter
   end
 
   def products_for_filter_box
-    user.links.visible.includes(:alive_variants).reject do |product|
-      product.archived? && !product.has_successful_sales?
-    end
+    products = user.links.visible.includes(:alive_variants)
+    reject_archived_without_sales(products)
   end
 
   def affiliate_products_for_filter_box
-    user.links.visible.order("created_at DESC").reject do |product|
-      product.archived? && !product.has_successful_sales?
-    end
+    products = user.links.visible.order("created_at DESC")
+    reject_archived_without_sales(products)
   end
 
   def as_current_seller
@@ -60,4 +58,27 @@ class UserPresenter
       is_verified: !!user.verified,
     }
   end
+
+  private
+    def reject_archived_without_sales(products)
+      archived_products = products.select(&:archived?)
+      return products.to_a if archived_products.empty?
+
+      archived_with_sales = archived_product_ids_with_sales(archived_products)
+      products.reject do |product|
+        product.archived? && !archived_with_sales.include?(product.id)
+      end
+    end
+
+    def archived_product_ids_with_sales(archived_products)
+      return Set.new if archived_products.empty?
+
+      search_options = Purchase::ACTIVE_SALES_SEARCH_OPTIONS.merge(
+        product: archived_products,
+        size: 0,
+        aggs: { product_ids: { terms: { field: "product_id", size: archived_products.size } } },
+      )
+      result = PurchaseSearchService.search(search_options)
+      Set.new(result.aggregations.product_ids.buckets.map { |b| b["key"] })
+    end
 end


### PR DESCRIPTION
## Problem

`EmailsController#edit` was timing out (120s Rack timeout) because `products_for_filter_box` and `affiliate_products_for_filter_box` in `UserPresenter` called `has_successful_sales?` individually on each archived product. Each call makes a separate Elasticsearch query. For sellers with many archived products, this N+1 pattern easily exceeds the timeout.

**Sentry:** https://gumroad-to.sentry.io/issues/7405133169/

## Fix

Batch all archived products into a single Elasticsearch query using a `terms` aggregation on `product_id`. This reduces N Elasticsearch queries to 1, regardless of how many archived products a seller has.

## Changes

- `UserPresenter#products_for_filter_box` and `#affiliate_products_for_filter_box` now delegate to a shared `reject_archived_without_sales` method
- `archived_product_ids_with_sales` performs a single ES query with a terms aggregation to find which archived products have sales
- No behavior change: the same products are returned in the same order