### PR TITLE
Fix Rack::Timeout::RequestTimeoutException in CheckoutController#show

### DIFF
--- a/app/models/base_variant.rb
+++ b/app/models/base_variant.rb
@@ -19,6 +19,8 @@ class BaseVariant < ApplicationRecord
   has_many :live_base_variant_integrations, -> { alive }, class_name: "BaseVariantIntegration"
   has_many :active_integrations, through: :live_base_variant_integrations, source: :integration
 
+  attr_accessor :cached_sales_count_for_inventory
+
   delegate :has_stampable_pdfs?, to: :link
 
   scope :in_order, -> { order(created_at: :asc) }
@@ -141,7 +143,26 @@ class BaseVariant < ApplicationRecord
   end
 
   def sales_count_for_inventory
+    return cached_sales_count_for_inventory if cached_sales_count_for_inventory
     purchases.counts_towards_inventory.sum(:quantity)
+  end
+
+  # Batch-loads sales_count_for_inventory for a collection of variants,
+  # avoiding N+1 queries when rendering multiple variants at once.
+  def self.preload_sales_counts_for_inventory(variants)
+    variant_ids = variants.filter_map(&:id)
+    return if variant_ids.empty?
+
+    counts = Purchase
+      .joins("INNER JOIN base_variants_purchases ON base_variants_purchases.purchase_id = purchases.id")
+      .where("base_variants_purchases.base_variant_id" => variant_ids)
+      .counts_towards_inventory
+      .group("base_variants_purchases.base_variant_id")
+      .sum(:quantity)
+
+    variants.each do |variant|
+      variant.cached_sales_count_for_inventory = counts[variant.id] || 0
+    end
   end
 
   def is_downloadable?

--- a/app/presenters/checkout_presenter.rb
+++ b/app/presenters/checkout_presenter.rb
@@ -245,8 +245,14 @@ class CheckoutPresenter
       wishlist = Wishlist.alive.includes(wishlist_products: [:product, :variant]).find_by_external_id(params[:wishlist])
       return {} if wishlist.blank?
 
+      wishlist_products = wishlist.alive_wishlist_products.available_to_buy
+      products = wishlist_products.map(&:product).uniq
+      ActiveRecord::Associations::Preloader.new(records: products, associations: [:alive_variants, :skus_alive_not_default]).call
+      all_variants = products.flat_map { |p| p.alive_variants + p.skus_alive_not_default }
+      BaseVariant.preload_sales_counts_for_inventory(all_variants)
+
       {
-        add_products: wishlist.alive_wishlist_products.available_to_buy.map do |wishlist_product|
+        add_products: wishlist_products.map do |wishlist_product|
           checkout_wishlist_product(wishlist_product, params.reverse_merge(affiliate_id: wishlist_product.wishlist.user.global_affiliate.external_id_numeric.to_s))
         end
       }

--- a/spec/models/variant_spec.rb
+++ b/spec/models/variant_spec.rb
@@ -303,6 +303,35 @@ describe Variant do
     end
   end
 
+  describe ".preload_sales_counts_for_inventory" do
+    it "batch-loads sales counts and caches them on variant instances" do
+      variant_a = create(:variant)
+      variant_b = create(:variant)
+      create(:purchase, link: variant_a.link, variant_attributes: [variant_a])
+      create(:purchase, link: variant_a.link, variant_attributes: [variant_a])
+      create(:purchase, link: variant_b.link, variant_attributes: [variant_b])
+
+      BaseVariant.preload_sales_counts_for_inventory([variant_a, variant_b])
+
+      expect(variant_a.cached_sales_count_for_inventory).to eq 2
+      expect(variant_b.cached_sales_count_for_inventory).to eq 1
+      expect(variant_a.sales_count_for_inventory).to eq 2
+      expect(variant_b.sales_count_for_inventory).to eq 1
+    end
+
+    it "sets zero for variants with no purchases" do
+      variant = create(:variant)
+
+      BaseVariant.preload_sales_counts_for_inventory([variant])
+
+      expect(variant.cached_sales_count_for_inventory).to eq 0
+    end
+
+    it "handles an empty collection" do
+      expect { BaseVariant.preload_sales_counts_for_inventory([]) }.not_to raise_error
+    end
+  end
+
   describe "quantity_left" do
     describe "has max_purchase_count" do
       before do

--- a/spec/presenters/checkout_presenter_spec.rb
+++ b/spec/presenters/checkout_presenter_spec.rb
@@ -377,6 +377,32 @@ describe CheckoutPresenter do
       )
     end
 
+    it "batch-loads variant sales counts to avoid N+1 queries" do
+      wishlist = create(:wishlist)
+      products_with_variants = Array.new(3) do
+        product = create(:product_with_digital_versions)
+        create(:wishlist_product, wishlist:, product:, variant: product.alive_variants.first)
+        product
+      end
+
+      params = { wishlist: wishlist.external_id, recommended_by: "discover" }
+
+      inventory_queries = []
+      callback = lambda do |_name, _start, _finish, _id, payload|
+        inventory_queries << payload[:sql] if payload[:sql].include?("counts_towards_inventory") ||
+          (payload[:sql].include?("base_variants_purchases") && payload[:sql].include?("SUM"))
+      end
+
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        @instance.checkout_props(params:, browser_guid:)
+      end
+
+      # Should be at most 1 batch query, not N queries (one per variant)
+      total_variants = products_with_variants.sum { |p| p.alive_variants.size }
+      expect(inventory_queries.size).to be <= 1
+      expect(total_variants).to be > 1 # sanity check that we actually have multiple variants
+    end
+
     it "respects single-unit currencies in exchange_rate" do
       $currency_namespace = Redis::Namespace.new(:currencies, redis: $redis)
       $currency_namespace.set("JPY", 149)


### PR DESCRIPTION
## Summary
- `CheckoutController#show` times out on wishlists with many products/variants due to N×M individual `sales_count_for_inventory` aggregate queries (one per variant, each with a LEFT JOIN on subscriptions)
- Batch-loads all variant sales counts in a single grouped SQL query in `checkout_wishlist_props`, caching them on variant instances via `BaseVariant.preload_sales_counts_for_inventory`
- Also preloads `alive_variants` and `skus_alive_not_default` associations to ensure the `options` method uses in-memory variants (hitting the cache) instead of re-querying

## Test plan
- [ ] `bundle exec rspec spec/models/variant_spec.rb` — new specs for `BaseVariant.preload_sales_counts_for_inventory`
- [ ] `bundle exec rspec spec/presenters/checkout_presenter_spec.rb` — new spec asserting bounded query count for wishlist checkout, plus existing wishlist tests still pass
- [ ] Verify in staging with a wishlist containing 10+ products with variants — checkout page should load within normal response times

🤖 Generated with [Claude Code](https://claude.com/claude-code)