### PR TITLE
Add PKCE support to Doorkeeper and CLI OAuth app seed

### DIFF
--- a/db/migrate/20261119011939_add_pkce_to_doorkeeper.rb
+++ b/db/migrate/20261119011939_add_pkce_to_doorkeeper.rb
@@ -2,7 +2,9 @@
 
 class AddPkceToDoorkeeper < ActiveRecord::Migration[7.1]
   def change
-    add_column :oauth_access_grants, :code_challenge, :string, null: true
-    add_column :oauth_access_grants, :code_challenge_method, :string, null: true
+    change_table :oauth_access_grants, bulk: true do |t|
+      t.string :code_challenge
+      t.string :code_challenge_method
+    end
   end
 end

--- a/db/migrate/20261119011939_add_pkce_to_doorkeeper.rb
+++ b/db/migrate/20261119011939_add_pkce_to_doorkeeper.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddPkceToDoorkeeper < ActiveRecord::Migration[7.1]
+  def change
+    add_column :oauth_access_grants, :code_challenge, :string, null: true
+    add_column :oauth_access_grants, :code_challenge_method, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_11_19_011938) do
+ActiveRecord::Schema[7.1].define(version: 2026_11_19_011939) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -1185,6 +1185,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_11_19_011938) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "revoked_at", precision: nil
     t.string "scopes", default: "", null: false
+    t.string "code_challenge"
+    t.string "code_challenge_method"
     t.index ["created_at"], name: "index_oauth_access_grants_on_created_at"
     t.index ["token"], name: "index_oauth_access_grants_on_token", unique: true
   end

--- a/db/seeds/030_development/cli_oauth_application.rb
+++ b/db/seeds/030_development/cli_oauth_application.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+cli_oauth_app = OauthApplication.find_or_initialize_by(uid: "CLI_DEVELOPMENT_CLIENT_pkce_auth")
+
+cli_oauth_app.owner = User.find_by(email: "seller@gumroad.com")
+cli_oauth_app.scopes = "edit_products view_sales mark_sales_as_shipped edit_sales view_payouts view_profile account"
+cli_oauth_app.redirect_uri = "http://127.0.0.1/callback"
+cli_oauth_app.name = "Gumroad CLI"
+cli_oauth_app.confidential = false
+cli_oauth_app.save!


### PR DESCRIPTION
Ref #4405

## What

Enables PKCE (Proof Key for Code Exchange) support in Doorkeeper by adding `code_challenge` and `code_challenge_method` columns to `oauth_access_grants`. Also adds a development seed for a non-confidential CLI OAuth application configured for loopback redirect (`http://127.0.0.1/callback`).

## Why

This is the server-side foundation for browser-based OAuth login in the Gumroad CLI (`gumroad auth login`). PKCE protects public clients (like CLIs that can't keep a secret) against authorization code interception attacks. Doorkeeper 5.7.1 has built-in PKCE support that auto-activates once the columns exist. Existing OAuth flows unaffected.

The CLI app is seeded as `confidential: false` (public client per RFC 8252) and does not use `skip_authorization`, so users always see a consent screen. The client_id will be embedded in an open-source binary, and the consent screen prevents silent token theft if an attacker reuses it.

---

This PR was implemented with AI assistance using Claude Opus 4.6 and gpt‑5.4 xhigh