### PR TITLE
Add confirmation dialog for unusually large tips at checkout

### DIFF
--- a/app/javascript/components/Checkout/payment.ts
+++ b/app/javascript/components/Checkout/payment.ts
@@ -165,6 +165,15 @@ export function isTippingEnabled(state: State) {
   );
 }
 
+const LARGE_TIP_THRESHOLD_CENTS = 10000;
+
+export function isTipSuspiciouslyLarge(state: State): boolean {
+  const tipCents = computeTip(state);
+  if (tipCents === 0) return false;
+  const productTotal = getTotalPriceFromProducts(state);
+  return tipCents > LARGE_TIP_THRESHOLD_CENTS && tipCents > productTotal;
+}
+
 export function computeTip(state: State) {
   if (!isTippingEnabled(state)) return 0;
   if (state.tip.type === "fixed") {

--- a/app/javascript/pages/Checkout/Show.tsx
+++ b/app/javascript/pages/Checkout/Show.tsx
@@ -10,12 +10,13 @@ import { type SavedCreditCard } from "$app/parsers/card";
 import { type CardProduct, COMMISSION_DEPOSIT_PROPORTION, type CustomFieldDescriptor } from "$app/parsers/product";
 import { isOpenTuple } from "$app/utils/array";
 import { assert } from "$app/utils/assert";
-import { getIsSingleUnitCurrency } from "$app/utils/currency";
+import { formatPriceCentsWithCurrencySymbol, getIsSingleUnitCurrency } from "$app/utils/currency";
 import { isValidEmail } from "$app/utils/email";
 import { calculateFirstInstallmentPaymentPriceCents } from "$app/utils/price";
 import { assertResponseError } from "$app/utils/request";
 import { startTrackingForSeller, trackProductEvent } from "$app/utils/user_analytics";
 
+import { Button } from "$app/components/Button";
 import { Checkout } from "$app/components/Checkout";
 import {
   type CartItem,
@@ -30,10 +31,13 @@ import {
 } from "$app/components/Checkout/cartState";
 import { CrossSellModal } from "$app/components/Checkout/CrossSellModal";
 import {
+  computeTip,
   computeTipForPrice,
   createReducer,
   getCustomFieldKey,
+  getTotalPriceFromProducts,
   type Gift,
+  isTipSuspiciouslyLarge,
   loadSurcharges,
   type Product,
   requiresReusablePaymentMethod,
@@ -358,8 +362,15 @@ const CheckoutIndexPage = () => {
     });
   }
 
+  const [showLargeTipConfirmation, setShowLargeTipConfirmation] = React.useState(false);
+  const largeTipConfirmedRef = React.useRef(false);
+
   async function pay() {
     if (state.status.type !== "finished") return;
+    if (isTipSuspiciouslyLarge(state) && !largeTipConfirmedRef.current) {
+      setShowLargeTipConfirmation(true);
+      return;
+    }
     try {
       await trackUserActionEvent("process_payment");
       if (user) {
@@ -560,6 +571,12 @@ const CheckoutIndexPage = () => {
     }
   }
   React.useEffect(() => void pay(), [state.status]);
+  React.useEffect(() => {
+    if (largeTipConfirmedRef.current && state.status.type === "finished") void pay();
+  }, [showLargeTipConfirmation]);
+  React.useEffect(() => {
+    largeTipConfirmedRef.current = false;
+  }, [state.tip]);
 
   const debouncedSaveCartState = useDebouncedCallback(() => {
     cartForm.patch(Routes.checkout_path(), {
@@ -676,6 +693,49 @@ const CheckoutIndexPage = () => {
           )}
         </Modal>
       ) : null}
+      <Modal
+        open={showLargeTipConfirmation}
+        onClose={() => {
+          setShowLargeTipConfirmation(false);
+          dispatch({ type: "cancel" });
+        }}
+        title="Confirm tip amount"
+        footer={
+          <>
+            <Button
+              onClick={() => {
+                setShowLargeTipConfirmation(false);
+                dispatch({ type: "cancel" });
+              }}
+            >
+              Edit tip
+            </Button>
+            <Button
+              color="primary"
+              onClick={() => {
+                largeTipConfirmedRef.current = true;
+                setShowLargeTipConfirmation(false);
+              }}
+            >
+              Yes, leave tip
+            </Button>
+          </>
+        }
+      >
+        <p>
+          You're about to leave a tip of{" "}
+          {formatPriceCentsWithCurrencySymbol("usd", computeTip(state), {
+            symbolFormat: "short",
+            noCentsIfWhole: true,
+          })}{" "}
+          on a{" "}
+          {formatPriceCentsWithCurrencySymbol("usd", getTotalPriceFromProducts(state), {
+            symbolFormat: "short",
+            noCentsIfWhole: true,
+          })}{" "}
+          purchase. Are you sure?
+        </p>
+      </Modal>
     </StateContext.Provider>
   );
 };

--- a/spec/requests/purchases/tipping_spec.rb
+++ b/spec/requests/purchases/tipping_spec.rb
@@ -290,6 +290,80 @@ describe("Product checkout with tipping", type: :system, js: true) do
     end
   end
 
+  context "when the tip is suspiciously large" do
+    let(:product) { create(:product, user: seller, price_cents: 500) }
+
+    it "shows a confirmation dialog and proceeds when confirmed" do
+      visit product.long_url
+      add_to_cart(product)
+      fill_checkout_form(product)
+
+      fill_in "Custom tip", with: 200
+
+      expect(page).to have_text("Add a tip? US$200", normalize_ws: true)
+
+      click_on "Pay"
+
+      expect(page).to have_text("Confirm tip amount")
+      expect(page).to have_text("You're about to leave a tip of $200 on a $5 purchase. Are you sure?")
+      expect(page).to have_button("Yes, leave tip")
+      expect(page).to have_button("Edit tip")
+
+      click_on "Yes, leave tip"
+
+      expect(page).to have_alert(text: "Your purchase was successful! We sent a receipt to test@gumroad.com.")
+
+      purchase = Purchase.last
+      expect(purchase).to be_successful
+      expect(purchase.tip.value_cents).to eq(20_000)
+    end
+
+    it "dismisses the dialog and returns to editing when 'Edit tip' is clicked" do
+      visit product.long_url
+      add_to_cart(product)
+      fill_checkout_form(product)
+
+      fill_in "Custom tip", with: 200
+
+      click_on "Pay"
+
+      expect(page).to have_text("Confirm tip amount")
+
+      click_on "Edit tip"
+
+      expect(page).not_to have_text("Confirm tip amount")
+      expect(page).to have_field("Custom tip", with: "200")
+    end
+
+    it "does not show the dialog when the tip is under $100" do
+      visit product.long_url
+      add_to_cart(product)
+      fill_checkout_form(product)
+
+      fill_in "Custom tip", with: 50
+
+      click_on "Pay"
+
+      expect(page).not_to have_text("Confirm tip amount")
+      expect(page).to have_alert(text: "Your purchase was successful! We sent a receipt to test@gumroad.com.")
+    end
+
+    it "does not show the dialog when the tip does not exceed the product price" do
+      expensive_product = create(:product, user: seller, price_cents: 50_000)
+
+      visit expensive_product.long_url
+      add_to_cart(expensive_product)
+      fill_checkout_form(expensive_product)
+
+      fill_in "Custom tip", with: 200
+
+      click_on "Pay"
+
+      expect(page).not_to have_text("Confirm tip amount")
+      expect(page).to have_alert(text: "Your purchase was successful! We sent a receipt to test@gumroad.com.")
+    end
+  end
+
   context "when there is no tip" do
     it "doesn't create a tip record" do
       visit product1.long_url


### PR DESCRIPTION
Fixes #4457

A buyer accidentally left a €5,450 tip on a €64 product. This adds a confirmation modal before payment when a tip is suspiciously large.

**Trigger conditions (both must be true):**
- Tip exceeds $100
- Tip exceeds 100% of the product price

**Changes:**
- `payment.ts`: Added `isTipSuspiciouslyLarge()` validation function
- `Show.tsx`: Added confirmation modal that intercepts payment flow when tip is suspicious. Uses a ref to track confirmation state so the payment effect can re-trigger after user confirms.
- `tipping_spec.rb`: Added system tests for the confirmation dialog

Frontend-only change, no backend modifications.