### PR TITLE
Fix Pundit::AuthorizationNotPerformedError in AudienceCountsController

### DIFF
--- a/app/controllers/api/internal/installments/audience_counts_controller.rb
+++ b/app/controllers/api/internal/installments/audience_counts_controller.rb
@@ -6,7 +6,7 @@ class Api::Internal::Installments::AudienceCountsController < Api::Internal::Bas
 
   def show
     installment = current_seller.installments.alive.find_by_external_id(params[:id])
-    return e404_json unless installment
+    return (skip_authorization and e404_json) unless installment
     authorize installment, :updated_audience_count?
 
     render json: { count: installment.audience_members_count }

--- a/spec/controllers/api/internal/installments/audience_counts_controller_spec.rb
+++ b/spec/controllers/api/internal/installments/audience_counts_controller_spec.rb
@@ -30,6 +30,11 @@ describe Api::Internal::Installments::AudienceCountsController do
       let(:request_params) { { id: record.external_id } }
     end
 
+    it "returns 404 when installment is not found" do
+      get :show, params: { id: "nonexistent" }
+      expect(response).to have_http_status(:not_found)
+    end
+
     it "returns audience count" do
       get :show, params: { id: create(:audience_post, seller:).external_id }
       expect(response).to be_successful


### PR DESCRIPTION
## What

Adds `skip_authorization` before the early `e404_json` return in `Api::Internal::Installments::AudienceCountsController#show` when the installment is not found.

## Why

The `show` action has `after_action :verify_authorized`, but when the installment lookup returns nil, the early `return e404_json` exits before `authorize` is called. This causes `Pundit::AuthorizationNotPerformedError` on every 404 response from this endpoint.

The fix calls `skip_authorization` before returning, which satisfies `verify_authorized` for the not-found case where there is no record to authorize against.

## Test Results

Added a test that requests the show action with a nonexistent installment ID and expects a 404 response. This test would have raised `Pundit::AuthorizationNotPerformedError` before the fix.

---

Generated with Claude Opus 4.6. Prompt: fix Pundit::AuthorizationNotPerformedError in AudienceCountsController by adding skip_authorization before e404_json early return, add test for 404 case.