### PR TITLE
Add /install-cli.sh route for Gumroad CLI installer

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -968,7 +968,7 @@ Rails.application.routes.draw do
     get "/paypal_charge_data", to: "public#paypal_charge_data", as: :paypal_charge_data
     get "/CHARGE" => redirect("/charge")
 
-    get "/install-cli.sh", to: redirect("https://raw.githubusercontent.com/antiwork/gumroad-cli/main/script/install.sh")
+    get "/install-cli.sh", to: redirect("https://raw.githubusercontent.com/antiwork/gumroad-cli/refs/heads/main/script/install.sh")
 
     # discover
     get "/blackfriday", to: redirect("/discover?offer_code=BLACKFRIDAY2025"), as: :blackfriday

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -968,6 +968,8 @@ Rails.application.routes.draw do
     get "/paypal_charge_data", to: "public#paypal_charge_data", as: :paypal_charge_data
     get "/CHARGE" => redirect("/charge")
 
+    get "/install-cli.sh", to: redirect("https://raw.githubusercontent.com/antiwork/gumroad-cli/main/script/install.sh")
+
     # discover
     get "/blackfriday", to: redirect("/discover?offer_code=BLACKFRIDAY2025"), as: :blackfriday
     get "/discover", to: "discover#index"

--- a/spec/requests/install_cli_spec.rb
+++ b/spec/requests/install_cli_spec.rb
@@ -1,0 +1,10 @@
+require "spec_helper"
+
+describe "GET /install-cli.sh" do
+  it "redirects to the Gumroad CLI install script on GitHub" do
+    get "/install-cli.sh", headers: { "HOST" => DOMAIN }
+
+    expect(response).to have_http_status(:redirect)
+    expect(response.location).to eq("https://raw.githubusercontent.com/antiwork/gumroad-cli/main/script/install.sh")
+  end
+end

--- a/spec/requests/install_cli_spec.rb
+++ b/spec/requests/install_cli_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe "GET /install-cli.sh" do

--- a/spec/requests/install_cli_spec.rb
+++ b/spec/requests/install_cli_spec.rb
@@ -7,6 +7,6 @@ describe "GET /install-cli.sh" do
     get "/install-cli.sh", headers: { "HOST" => DOMAIN }
 
     expect(response).to have_http_status(:redirect)
-    expect(response.location).to eq("https://raw.githubusercontent.com/antiwork/gumroad-cli/main/script/install.sh")
+    expect(response.location).to eq("https://raw.githubusercontent.com/antiwork/gumroad-cli/refs/heads/main/script/install.sh")
   end
 end


### PR DESCRIPTION
## What

Adds a `GET /install-cli.sh` route that 302 redirects to `https://raw.githubusercontent.com/antiwork/gumroad-cli/main/script/install.sh`.

This enables the standard CLI install pattern:

```
curl -fsSL https://gumroad.com/install-cli.sh | bash
```

## Why

Provides a clean, memorable install URL for the Gumroad CLI, following the same pattern used by other CLIs (e.g., `curl -fsSL https://claude.ai/install.sh | bash`).

## Test results

- `GET /install-cli.sh` returns 302 redirect to the GitHub-hosted install script
- Request spec passes locally

---

AI disclosure: Built with Claude Opus 4.6. Prompted to create a redirect route for `/install-cli.sh` pointing to the Gumroad CLI installer on GitHub, with request specs.