### PR TITLE
Fix NoMethodError on nil seller in upsells products index

### DIFF
--- a/app/controllers/checkout/upsells/products_controller.rb
+++ b/app/controllers/checkout/upsells/products_controller.rb
@@ -16,6 +16,8 @@ class Checkout::Upsells::ProductsController < ApplicationController
 
   def index
     seller = user_by_domain(request.host) || current_seller
+    return render json: [] unless seller
+
     products = seller.products
       .eligible_for_content_upsells
       .includes(*PRODUCT_INCLUDES)

--- a/spec/controllers/checkout/upsells/products_controller_spec.rb
+++ b/spec/controllers/checkout/upsells/products_controller_spec.rb
@@ -89,6 +89,15 @@ describe Checkout::Upsells::ProductsController do
       expect(response.parsed_body.length).to eq(2)
     end
 
+    context "when no seller is found" do
+      it "returns an empty array" do
+        get :index
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to eq([])
+      end
+    end
+
     context "with custom domain" do
       before do
         @request.host = "example.com"


### PR DESCRIPTION
## Summary
- Fixes `NoMethodError: undefined method 'products' for nil` in `Checkout::Upsells::ProductsController#index` ([Sentry issue](https://gumroad-to.sentry.io/issues/7408788373/))
- When neither `user_by_domain` nor `current_seller` returns a seller (e.g., unauthenticated request to a non-custom-domain host), `seller` is nil and `.products` crashes
- Added an early return rendering an empty JSON array when no seller is found
- Added test covering the nil seller case

## Test plan
- [ ] Verify new test passes: `bundle exec rspec spec/controllers/checkout/upsells/products_controller_spec.rb`
- [ ] Confirm Sentry error stops recurring after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)