### PR TITLE
Pass PKCE params through OAuth consent form

### DIFF
--- a/app/views/doorkeeper/authorizations/new.html.erb
+++ b/app/views/doorkeeper/authorizations/new.html.erb
@@ -45,6 +45,8 @@
       <%= hidden_field_tag :state, @pre_auth.state %>
       <%= hidden_field_tag :response_type, @pre_auth.response_type %>
       <%= hidden_field_tag :scope, @pre_auth.scope %>
+      <%= hidden_field_tag :code_challenge, @pre_auth.code_challenge %>
+      <%= hidden_field_tag :code_challenge_method, @pre_auth.code_challenge_method %>
       <%= button_tag "Authorize", class: "inline-flex items-center justify-center gap-2 cursor-pointer border border-border rounded font-[inherit] no-underline transition-transform hover:-translate-1 hover:shadow active:translate-0 active:shadow-none disabled:opacity-30 disabled:hover:translate-0 disabled:hover:shadow-none bg-accent text-accent-foreground px-4 py-3 text-base leading-snug" %>
     <% end %>
     <%= form_tag oauth_authorization_path, method: :delete, style: "display: contents" do %>
@@ -53,6 +55,8 @@
       <%= hidden_field_tag :state, @pre_auth.state %>
       <%= hidden_field_tag :response_type, @pre_auth.response_type %>
       <%= hidden_field_tag :scope, @pre_auth.scope %>
+      <%= hidden_field_tag :code_challenge, @pre_auth.code_challenge %>
+      <%= hidden_field_tag :code_challenge_method, @pre_auth.code_challenge_method %>
       <%= button_tag "Deny", class: "inline-flex items-center justify-center gap-2 cursor-pointer border border-border rounded font-[inherit] no-underline transition-transform hover:-translate-1 hover:shadow active:translate-0 active:shadow-none disabled:opacity-30 disabled:hover:translate-0 disabled:hover:shadow-none bg-white text-black hover:bg-pink hover:text-black px-4 py-3 text-base leading-snug" %>
     <% end %>
   </footer>

--- a/spec/requests/oauth_authorizations_spec.rb
+++ b/spec/requests/oauth_authorizations_spec.rb
@@ -51,4 +51,17 @@ describe Oauth::AuthorizationsController, type: :system do
     visit "/oauth/authorize?response_type=code&client_id=#{@app.uid + 'invalid'}&redirect_uri=#{Addressable::URI.escape(@app.redirect_uri)}&scope=mobile_api"
     expect(page).to have_content("Client authentication failed due to unknown client")
   end
+
+  it "preserves PKCE params through the consent form" do
+    stub_const("OauthApplication::MOBILE_API_OAUTH_APPLICATION_UID", @internal_app.uid)
+    code_challenge = Base64.urlsafe_encode64(Digest::SHA256.digest("test-verifier"), padding: false)
+
+    visit "/oauth/authorize?response_type=code&client_id=#{@app.uid}&redirect_uri=#{Addressable::URI.escape(@app.redirect_uri)}&scope=edit_products&code_challenge=#{code_challenge}&code_challenge_method=S256"
+    expect(page).to have_content("Authorize")
+    click_button "Authorize"
+
+    grant = @app.access_grants.last
+    expect(grant.code_challenge).to eq(code_challenge)
+    expect(grant.code_challenge_method).to eq("S256")
+  end
 end


### PR DESCRIPTION
## What

Adds `code_challenge` and `code_challenge_method` hidden fields to both the authorize and deny forms in the Doorkeeper consent view. Without these fields, PKCE parameters sent in the initial authorization request are silently dropped when the user submits the consent form, causing the token exchange to fail with `invalid_grant`.

## Why

PR #4447 added the PKCE migration (`code_challenge` column on `oauth_access_grants`), which activates Doorkeeper 5.7.1's built-in PKCE support. However, our custom consent form (`app/views/doorkeeper/authorizations/new.html.erb`) only passes through `client_id`, `redirect_uri`, `state`, `response_type`, and `scope`. The PKCE params get lost on form submission, so the access grant is always created without a challenge, making the code verifier check fail at token exchange.

This is needed for CLI OAuth login, where the CLI is a public client that relies on PKCE for security (it can't keep a client secret). Existing OAuth apps that don't send PKCE params are unaffected. The fields render as empty values, which Doorkeeper treats as a non-PKCE flow.

---

This PR was written with AI assistance using Claude Opus 4.6 and gpt‑5.4 xhigh
