### PR TITLE
Fix unstyled Insert menu items in rich text editor toolbar

### DIFF
--- a/app/javascript/components/TiptapExtensions/Link.tsx
+++ b/app/javascript/components/TiptapExtensions/Link.tsx
@@ -13,6 +13,7 @@ import { Button, buttonVariants } from "$app/components/Button";
 import { Modal } from "$app/components/Modal";
 import { Popover, PopoverContent, PopoverTrigger } from "$app/components/Popover";
 import { MenuItem, validateUrl } from "$app/components/RichTextEditor";
+import { MenuItem as MenuListItem } from "$app/components/ui/Menu";
 import { showAlert } from "$app/components/server-components/Alert";
 import { Fieldset } from "$app/components/ui/Fieldset";
 import { Input } from "$app/components/ui/Input";
@@ -301,10 +302,10 @@ const TiptapButton = Node.create({
   submenu: {
     menu: "insert",
     item: (_editor, onOpen) => (
-      <div role="menuitem" onClick={onOpen}>
+      <MenuListItem onClick={onOpen}>
         <CursorClick className="size-5" />
         <span>Button</span>
-      </div>
+      </MenuListItem>
     ),
   },
 });

--- a/app/javascript/components/TiptapExtensions/MediaEmbed.tsx
+++ b/app/javascript/components/TiptapExtensions/MediaEmbed.tsx
@@ -11,6 +11,7 @@ import { sanitizeHtml } from "$app/utils/sanitize";
 
 import { Button } from "$app/components/Button";
 import { MenuItem } from "$app/components/RichTextEditor";
+import { MenuItem as MenuListItem } from "$app/components/ui/Menu";
 import { showAlert } from "$app/components/server-components/Alert";
 import { createInsertCommand } from "$app/components/TiptapExtensions/utils";
 import { Fieldset, FieldsetTitle } from "$app/components/ui/Fieldset";
@@ -84,10 +85,10 @@ export const Raw = TiptapNode.create({
   submenu: {
     menu: "insert",
     item: (_editor, onOpen) => (
-      <div role="menuitem" onClick={onOpen}>
+      <MenuListItem onClick={onOpen}>
         <TwitterX pack="brands" className="size-5" />
         <span>X post</span>
-      </div>
+      </MenuListItem>
     ),
   },
   addCommands() {


### PR DESCRIPTION
## What
Replace unstyled `<div role="menuitem">` elements with the MenuItem component from the Menu UI for the "Button" and "X post" items in the Insert dropdown of the rich text editor toolbar.

## Why
When the rich text editor was migrated to Tailwind (#3849), the "Button" and "X post" submenu items in the Insert dropdown were left as plain `<div>` elements with no styling classes. Other items in the same dropdown (Divider, Upsell, Reviews) correctly use the `MenuItem` component, which provides `flex items-center gap-2`, padding, and hover styles. This caused the first two items to appear visually broken - missing padding, alignment, and hover feedback.

## Before
<img width="219" height="292" alt="image" src="https://github.com/user-attachments/assets/161db4de-409a-4c20-88a4-5f9e5c413f65" />


## After

<img width="233" height="316" alt="image" src="https://github.com/user-attachments/assets/dfff6ac1-13d0-4b56-b607-c238ec8c3c9f" />
