### PR TITLE
Fix NoMethodError on nil in receipt refund_policy_attribute

### DIFF
--- a/app/presenters/receipt_presenter/item_info.rb
+++ b/app/presenters/receipt_presenter/item_info.rb
@@ -219,8 +219,8 @@ class ReceiptPresenter::ItemInfo
       # Bundle product purchases' refund policy is on the bundle purchase, not the individual product purchases.
       with_refund_policy = purchase.is_bundle_product_purchase ? purchase.bundle_purchase : purchase
       # Gift purchases' refund policy is on the gift sender's purchase, not the giftee's purchase.
-      with_refund_policy = with_refund_policy.is_gift_receiver_purchase ? with_refund_policy.gift.gifter_purchase : with_refund_policy
-      refund_policy = with_refund_policy.purchase_refund_policy
+      with_refund_policy = with_refund_policy&.is_gift_receiver_purchase ? with_refund_policy.gift&.gifter_purchase : with_refund_policy
+      refund_policy = with_refund_policy&.purchase_refund_policy
 
       return unless refund_policy.present?
 

--- a/spec/presenters/receipt_presenter/item_info_spec.rb
+++ b/spec/presenters/receipt_presenter/item_info_spec.rb
@@ -525,6 +525,23 @@ describe ReceiptPresenter::ItemInfo do
         end
       end
 
+      context "when the purchase is a gift receiver purchase with no gifter purchase" do
+        let(:gift) { create(:gift, gift_note: "Hope you like it!", giftee_email: "giftee@example.com") }
+        let(:purchase) { create(:purchase, link: gift.link, gift_received: gift, is_gift_receiver_purchase: true) }
+
+        before do
+          gift.update_column(:gifter_purchase_id, nil)
+        end
+
+        it "does not raise an error" do
+          expect(props[:general_attributes]).to eq(
+            [
+              { label: "Product price", value: "$1" },
+            ]
+          )
+        end
+      end
+
       context "when the purchase is a bundle product purchase" do
         let(:bundle) { create(:product, user: seller, is_bundle: true, name: "Bundle product") }
         let(:purchase) { create(:purchase, link: bundle, seller:) }


### PR DESCRIPTION
## What

Adds safe navigation operators in `ReceiptPresenter::ItemInfo#refund_policy_attribute` to handle nil values when resolving the purchase that holds the refund policy.

## Why

The method chains through `bundle_purchase`, `gift`, and `gifter_purchase` to find the correct purchase holding the refund policy. Any of these can return nil (e.g., a gift receiver purchase where the gifter purchase record is missing), causing `ActionView::Template::Error: undefined method 'purchase_refund_policy' for nil` on the receipt page.

Sentry: https://gumroad-to.sentry.io/issues/7409107216/

## Test Results

Added a test for the nil gifter_purchase case. All 9 `refund_policy_attribute` tests pass:

```
9 examples, 0 failures
```

---

AI disclosure: This fix was implemented with Claude Opus 4.6. Prompted with the Sentry error details and root cause analysis for the nil chain in `refund_policy_attribute`.