### PR TITLE
Fix: Handle deleted Stripe bank accounts in instant payout check

### DIFF
--- a/app/models/bank_account.rb
+++ b/app/models/bank_account.rb
@@ -84,6 +84,9 @@ class BankAccount < ApplicationRecord
       )
 
       external_account.available_payout_methods.include?("instant")
+    rescue Stripe::InvalidRequestError => e
+      ErrorNotifier.notify(e) unless e.message.include?("has been deleted")
+      false
     rescue Stripe::StripeError => e
       ErrorNotifier.notify(e)
       false

--- a/spec/models/bank_account_spec.rb
+++ b/spec/models/bank_account_spec.rb
@@ -60,7 +60,23 @@ describe BankAccount do
             .and_raise(Stripe::StripeError.new)
         end
 
-        it "returns false" do
+        it "returns false and notifies error" do
+          expect(ErrorNotifier).to receive(:notify)
+          expect(bank_account.supports_instant_payouts?).to be false
+        end
+      end
+
+      context "when the bank account has been deleted on Stripe" do
+        before do
+          allow(Stripe::Account).to receive(:retrieve_external_account)
+            .and_raise(Stripe::InvalidRequestError.new(
+              "The bank account ba_xxx has been deleted and can no longer be used.",
+              :bank_account
+            ))
+        end
+
+        it "returns false without notifying Sentry" do
+          expect(ErrorNotifier).not_to receive(:notify)
           expect(bank_account.supports_instant_payouts?).to be false
         end
       end


### PR DESCRIPTION
## Summary

When a Stripe bank account is deleted externally but still referenced in our DB, `supports_instant_payouts?` raises a `Stripe::InvalidRequestError` on every payments settings page load. This gets reported to Sentry as noise — it's an expected condition, not a bug.

- Catch the specific "has been deleted" `InvalidRequestError` and return `false` silently
- Continue reporting other Stripe errors normally
- Added test coverage for the deleted bank account case

## Test plan

- [ ] `bundle exec rspec spec/models/bank_account_spec.rb` passes
- [ ] Verify payments settings page loads without Sentry noise for users with deleted Stripe bank accounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)