### PR TITLE
Fix warning alert icon missing exclamation mark

### DIFF
--- a/app/javascript/components/Admin/Purchases/RefundPolicy.tsx
+++ b/app/javascript/components/Admin/Purchases/RefundPolicy.tsx
@@ -1,4 +1,4 @@
-import { Shield } from "@boxicons/react";
+import { AlertShield } from "@boxicons/react";
 import React from "react";
 
 import { WithTooltip } from "$app/components/WithTooltip";
@@ -13,7 +13,7 @@ export const RefundPolicyTitle = ({ refundPolicy }: { refundPolicy: RefundPolicy
     Refund policy: {refundPolicy.title}{" "}
     {refundPolicy.current_refund_policy ? (
       <WithTooltip tip={`Current refund policy: ${refundPolicy.current_refund_policy}`}>
-        <Shield pack="filled" className="size-5 text-warning" />
+        <AlertShield pack="filled" className="size-5 text-warning" />
       </WithTooltip>
     ) : null}
   </>

--- a/app/javascript/components/Admin/Users/BlockedUserTooltip.tsx
+++ b/app/javascript/components/Admin/Users/BlockedUserTooltip.tsx
@@ -1,4 +1,4 @@
-import { Shield } from "@boxicons/react";
+import { AlertShield } from "@boxicons/react";
 import React from "react";
 
 import { formatDate } from "$app/utils/date";
@@ -34,7 +34,7 @@ const BlockedUserTooltip = ({ user, position = "bottom" }: Props) => {
 
   return (
     <WithTooltip tip={content()} position={position}>
-      <Shield pack="filled" className="size-5 text-warning" aria-label="Blocked User" />
+      <AlertShield pack="filled" className="size-5 text-warning" aria-label="Blocked User" />
     </WithTooltip>
   );
 };

--- a/app/javascript/components/ui/Alert.tsx
+++ b/app/javascript/components/ui/Alert.tsx
@@ -1,4 +1,4 @@
-import { CheckCircle, InfoCircle, Shield, XCircle, type BoxIconProps } from "@boxicons/react";
+import { AlertShield, CheckCircle, InfoCircle, XCircle, type BoxIconProps } from "@boxicons/react";
 import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
@@ -21,7 +21,7 @@ type AlertVariant = NonNullable<VariantProps<typeof alertVariants>["variant"]>;
 const alertIcons = {
   success: CheckCircle,
   danger: XCircle,
-  warning: Shield,
+  warning: AlertShield,
   info: InfoCircle,
 } satisfies Record<Exclude<AlertVariant, "accent">, React.ComponentType<BoxIconProps>>;
 

--- a/app/javascript/pages/Collaborators/Index.tsx
+++ b/app/javascript/pages/Collaborators/Index.tsx
@@ -1,4 +1,4 @@
-import { Pencil, Shield, Trash } from "@boxicons/react";
+import { AlertShield, Pencil, Trash } from "@boxicons/react";
 import { useForm, usePage } from "@inertiajs/react";
 import * as React from "react";
 import { cast } from "ts-safe-cast";
@@ -99,7 +99,7 @@ const CollaboratorsPage = () => {
                         </div>
                         {collaborator.setup_incomplete ? (
                           <WithTooltip tip="Not receiving payouts" position="top">
-                            <Shield
+                            <AlertShield
                               pack="filled"
                               style={{ color: "rgb(var(--warning))" }}
                               aria-label="Not receiving payouts"

--- a/app/javascript/pages/Settings/Team/Show.tsx
+++ b/app/javascript/pages/Settings/Team/Show.tsx
@@ -1,4 +1,4 @@
-import { Shield } from "@boxicons/react";
+import { AlertShield } from "@boxicons/react";
 import { usePage, router } from "@inertiajs/react";
 import * as React from "react";
 import { GroupBase, SelectInstance } from "react-select";
@@ -321,7 +321,7 @@ const TeamMembersSection = ({
                         tip="Invitation has expired. You can resend the invitation from the member's menu options."
                         position="top"
                       >
-                        <Shield
+                        <AlertShield
                           pack="filled"
                           style={{ color: "rgb(var(--warning))" }}
                           aria-label="Invitation has expired. You can resend the invitation from the member's menu options."


### PR DESCRIPTION
## What

Replace Shield with AlertShield in the warning Alert component. The Boxicons migration (#3803) replaced the old solid-shield-exclamation icon (a shield with an exclamation mark) with a plain Shield (empty shield with no inner detail).

## Why

The warning badge on product pages (e.g. "This product is not currently for sale.") lost the exclamation mark inside the shield, making it look incomplete. AlertShield is the correct Boxicons equivalent.

## Before
<img width="74" height="70" alt="image" src="https://github.com/user-attachments/assets/80fdab12-0d41-4187-b733-c8448166a28f" />

## After
<img width="86" height="70" alt="image" src="https://github.com/user-attachments/assets/4d77a10f-263a-4afd-800a-95a5aac0d5db" />
