### PR TITLE
Fix Learn more links on third-party analytics settings to point to specific sections

### DIFF
--- a/app/javascript/pages/Settings/ThirdPartyAnalytics/Show.tsx
+++ b/app/javascript/pages/Settings/ThirdPartyAnalytics/Show.tsx
@@ -114,7 +114,7 @@ export default function ThirdPartyAnalyticsPage() {
               <Fieldset>
                 <FieldsetTitle>
                   <Label htmlFor={`${uid}googleAnalyticsId`}>Google Analytics Property ID</Label>
-                  <a href="/help/article/174-third-party-analytics" target="_blank" rel="noreferrer">
+                  <a href="/help/article/174-third-party-analytics#Google-Analytics-Ib1dB" target="_blank" rel="noreferrer">
                     Learn more
                   </a>
                 </FieldsetTitle>
@@ -129,7 +129,7 @@ export default function ThirdPartyAnalyticsPage() {
               <Fieldset>
                 <FieldsetTitle>
                   <Label htmlFor={`${uid}facebookPixel`}>Facebook Pixel</Label>
-                  <a href="/help/article/174-third-party-analytics" target="_blank" rel="noreferrer">
+                  <a href="/help/article/174-third-party-analytics#Meta-Pixel-Yisi6" target="_blank" rel="noreferrer">
                     Learn more
                   </a>
                 </FieldsetTitle>
@@ -144,7 +144,7 @@ export default function ThirdPartyAnalyticsPage() {
               <Fieldset>
                 <FieldsetTitle>
                   <Label htmlFor={`${uid}tiktokPixel`}>TikTok Pixel</Label>
-                  <a href="/help/article/174-third-party-analytics" target="_blank" rel="noreferrer">
+                  <a href="/help/article/174-third-party-analytics#TikTok-Pixel-zK9mP" target="_blank" rel="noreferrer">
                     Learn more
                   </a>
                 </FieldsetTitle>
@@ -203,7 +203,7 @@ export default function ThirdPartyAnalyticsPage() {
             <>
               <h2>Snippets</h2>
               <div>Add custom JavaScript to pages in the checkout flow.</div>
-              <a href="/help/article/174-third-party-analytics" target="_blank" rel="noreferrer">
+              <a href="/help/article/174-third-party-analytics#Snippets-j1elc" target="_blank" rel="noreferrer">
                 Learn more
               </a>
             </>


### PR DESCRIPTION
## What

The "Learn more" links for Google Analytics, Facebook Pixel, TikTok Pixel, and Snippets on the third-party analytics settings page all pointed to the same generic help article URL. Each link now points to its specific section within the article using anchor fragments.

## Why

Clicking "Learn more" next to a specific field should take the user directly to the relevant documentation for that field, not the top of a general article.

- Google Analytics -> `#Google-Analytics-Ib1dB`
- Facebook Pixel -> `#Meta-Pixel-Yisi6`
- TikTok Pixel -> `#TikTok-Pixel-zK9mP`
- Snippets -> `#Snippets-j1elc`