### PR TITLE
Fix flaky email edit spec missing clear option

### DIFF
--- a/spec/requests/emails/edit_spec.rb
+++ b/spec/requests/emails/edit_spec.rb
@@ -444,7 +444,7 @@ describe("Email Editing Flow", :js, :elasticsearch_wait_for_refresh, type: :syst
     find(:table_row, { "Subject" => "Updated original email - scheduled" }).click
     click_on "Edit"
     check "Send email"
-    fill_in "Title", with: "Updated original email - scheduled - edit 2"
+    fill_in "Title", with: "Updated original email - scheduled - edit 2", fill_options: { clear: :backspace }
     select_disclosure "Preview" do
       click_on "Preview Email"
     end


### PR DESCRIPTION
The `fill_in "Title"` on line 447 of `spec/requests/emails/edit_spec.rb` was missing `fill_options: { clear: :backspace }`, causing Capybara to type over existing text without clearing it first. This resulted in mangled text like `"Updat 2"` instead of the expected `"Updated original email - scheduled - edit 2"`.

Every other `fill_in "Title"` call in the same test flow already uses `fill_options: { clear: :backspace }`; this was the only one missing it.

This was causing [the latest main build to fail](https://github.com/antiwork/gumroad/actions/runs/24372973674).