### PR TITLE
Migrate CI container registry from Quay.io to AWS ECR

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,19 +35,19 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
-      - name: Login to Quay
+      - name: Login to ECR
         uses: nick-fields/retry@v3
         with:
           timeout_seconds: 120
           max_attempts: 3
           retry_wait_seconds: 10
-          command: echo "$QUAY_PASSWORD" | docker login quay.io -u "$QUAY_USERNAME" --password-stdin
+          command: aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | docker login --username AWS --password-stdin ${{ secrets.ECR_REGISTRY }}
         env:
-          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
-          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - name: Build and push base image
         env:
-          WEB_BASE_REPO: quay.io/gumroad/web_base
+          WEB_BASE_REPO: ${{ secrets.ECR_REGISTRY }}/gumroad/web_base
         run: |
           set -e
           GREEN='\033[0;32m'
@@ -55,13 +55,13 @@ jobs:
           logger() {
             echo -e "${GREEN}$(date '+%Y/%m/%d %H:%M:%S') build.sh: $1${NC}"
           }
-          logger "pulling quay.io/gumroad/ruby:$(cat .ruby-version)-slim-bullseye"
-          docker pull --quiet quay.io/gumroad/ruby:$(cat .ruby-version)-slim-bullseye
-          WEB_BASE_SHA=$(WEB_BASE_DOCKERFILE_FROM=quay.io/gumroad/ruby:$(cat .ruby-version)-slim-bullseye docker/base/generate_tag_for_web_base.sh)
+          logger "pulling ${{ secrets.ECR_REGISTRY }}/gumroad/ruby:$(cat .ruby-version)-slim-bullseye"
+          docker pull --quiet ${{ secrets.ECR_REGISTRY }}/gumroad/ruby:$(cat .ruby-version)-slim-bullseye
+          WEB_BASE_SHA=$(WEB_BASE_DOCKERFILE_FROM=${{ secrets.ECR_REGISTRY }}/gumroad/ruby:$(cat .ruby-version)-slim-bullseye docker/base/generate_tag_for_web_base.sh)
           if ! docker manifest inspect $WEB_BASE_REPO:$WEB_BASE_SHA > /dev/null 2>&1; then
             logger "Building $WEB_BASE_REPO:$WEB_BASE_SHA"
             NEW_BASE_REPO=$WEB_BASE_REPO \
-              WEB_BASE_DOCKERFILE_FROM=quay.io/gumroad/ruby:$(cat .ruby-version)-slim-bullseye \
+              WEB_BASE_DOCKERFILE_FROM=${{ secrets.ECR_REGISTRY }}/gumroad/ruby:$(cat .ruby-version)-slim-bullseye \
               BUNDLE_GEMS__CONTRIBSYS__COM=${{ secrets.BUNDLE_GEMS__CONTRIBSYS__COM }} \
               make build_base
 
@@ -83,9 +83,9 @@ jobs:
           fi
       - name: Build and push test image
         env:
-          WEB_BASE_REPO: quay.io/gumroad/web_base
-          WEB_BASE_TEST_REPO: quay.io/gumroad/web_base_test
-          WEB_REPO: quay.io/gumroad/web
+          WEB_BASE_REPO: ${{ secrets.ECR_REGISTRY }}/gumroad/web_base
+          WEB_BASE_TEST_REPO: ${{ secrets.ECR_REGISTRY }}/gumroad/web_base_test
+          WEB_REPO: ${{ secrets.ECR_REGISTRY }}/gumroad/web
           REVISION: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
         run: |
           set -e
@@ -94,8 +94,8 @@ jobs:
           logger() {
             echo -e "${GREEN}$(date '+%Y/%m/%d %H:%M:%S') build.sh: $1${NC}"
           }
-          docker pull --quiet quay.io/gumroad/ruby:$(cat .ruby-version)-slim-bullseye
-          WEB_BASE_TEST_SHA=$(WEB_BASE_DOCKERFILE_FROM=quay.io/gumroad/ruby:$(cat .ruby-version)-slim-bullseye docker/base/generate_tag_for_web_base_test.sh)
+          docker pull --quiet ${{ secrets.ECR_REGISTRY }}/gumroad/ruby:$(cat .ruby-version)-slim-bullseye
+          WEB_BASE_TEST_SHA=$(WEB_BASE_DOCKERFILE_FROM=${{ secrets.ECR_REGISTRY }}/gumroad/ruby:$(cat .ruby-version)-slim-bullseye docker/base/generate_tag_for_web_base_test.sh)
           build_and_push() {
             local repo=$1
             local tag=$2
@@ -103,7 +103,7 @@ jobs:
             if ! docker manifest inspect $repo:$tag > /dev/null 2>&1; then
               logger "building $repo:$tag"
               NEW_BASE_REPO=$WEB_BASE_REPO NEW_WEB_BASE_TEST_REPO=$WEB_BASE_TEST_REPO NEW_WEB_REPO=$WEB_REPO \
-                WEB_BASE_DOCKERFILE_FROM=quay.io/gumroad/ruby:$(cat .ruby-version)-slim-bullseye \
+                WEB_BASE_DOCKERFILE_FROM=${{ secrets.ECR_REGISTRY }}/gumroad/ruby:$(cat .ruby-version)-slim-bullseye \
                 BRANCH_CACHE_UPLOAD_ENABLED=false \
                   BRANCH_CACHE_RESTORE_ENABLED=false \
                   NEW_WEB_TAG=$REVISION \
@@ -146,16 +146,16 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
-      - name: Login to Quay
+      - name: Login to ECR
         uses: nick-fields/retry@v3
         with:
           timeout_seconds: 120
           max_attempts: 3
           retry_wait_seconds: 10
-          command: echo "$QUAY_PASSWORD" | docker login quay.io -u "$QUAY_USERNAME" --password-stdin
+          command: aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | docker login --username AWS --password-stdin ${{ secrets.ECR_REGISTRY }}
         env:
-          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
-          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - name: Start services and pull test image
         uses: nick-fields/retry@v3
         with:
@@ -172,7 +172,8 @@ jobs:
             exit $((COMPOSE_EXIT + PULL_EXIT))
         env:
           COMPOSE_HTTP_TIMEOUT: "300"
-          WEB_REPO: quay.io/gumroad/web
+          ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
+          WEB_REPO: ${{ secrets.ECR_REGISTRY }}/gumroad/web
       - name: Wait for services
         uses: nick-fields/retry@v3
         with:
@@ -187,7 +188,7 @@ jobs:
             docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh minio 9000 &
             wait
         env:
-          WEB_REPO: quay.io/gumroad/web
+          WEB_REPO: ${{ secrets.ECR_REGISTRY }}/gumroad/web
       - name: Setup test database
         uses: nick-fields/retry@v3
         with:
@@ -200,11 +201,11 @@ jobs:
               $WEB_REPO:test-${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }} \
               bundle exec rake db:prepare
         env:
-          WEB_REPO: quay.io/gumroad/web
+          WEB_REPO: ${{ secrets.ECR_REGISTRY }}/gumroad/web
 
       - name: Run tests
         env:
-          WEB_REPO: quay.io/gumroad/web
+          WEB_REPO: ${{ secrets.ECR_REGISTRY }}/gumroad/web
           KNAPSACK_PRO_BRANCH: ${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref_name }}
         run: |
           docker run --rm --entrypoint="" --network ${{ env.COMPOSE_PROJECT_NAME }}_default \
@@ -239,7 +240,7 @@ jobs:
     name: Test Slow ${{ matrix.ci_node_index }}${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository && ' (internal PR noop)' || '' }}
     env:
       COMPOSE_PROJECT_NAME: web_${{ github.run_id }}_${{ github.run_attempt }}_slow_${{ matrix.ci_node_index }}
-      WEB_REPO: quay.io/gumroad/web
+      WEB_REPO: ${{ secrets.ECR_REGISTRY }}/gumroad/web
     runs-on: ubicloud-standard-4
     needs: build
     strategy:
@@ -319,16 +320,16 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
-      - name: Login to Quay
+      - name: Login to ECR
         uses: nick-fields/retry@v3
         with:
           timeout_seconds: 120
           max_attempts: 3
           retry_wait_seconds: 10
-          command: echo "$QUAY_PASSWORD" | docker login quay.io -u "$QUAY_USERNAME" --password-stdin
+          command: aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | docker login --username AWS --password-stdin ${{ secrets.ECR_REGISTRY }}
         env:
-          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
-          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - name: Start services and pull test image
         uses: nick-fields/retry@v3
         with:
@@ -345,7 +346,8 @@ jobs:
             exit $((COMPOSE_EXIT + PULL_EXIT))
         env:
           COMPOSE_HTTP_TIMEOUT: "300"
-          WEB_REPO: quay.io/gumroad/web
+          ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
+          WEB_REPO: ${{ secrets.ECR_REGISTRY }}/gumroad/web
       - name: Wait for services
         uses: nick-fields/retry@v3
         with:
@@ -360,7 +362,7 @@ jobs:
             docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh minio 9000 &
             wait
         env:
-          WEB_REPO: quay.io/gumroad/web
+          WEB_REPO: ${{ secrets.ECR_REGISTRY }}/gumroad/web
       - name: Setup test database
         uses: nick-fields/retry@v3
         with:
@@ -373,7 +375,7 @@ jobs:
               $WEB_REPO:test-${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }} \
               bundle exec rake db:prepare
         env:
-          WEB_REPO: quay.io/gumroad/web
+          WEB_REPO: ${{ secrets.ECR_REGISTRY }}/gumroad/web
 
       - name: Run tests
         env:
@@ -392,7 +394,7 @@ jobs:
           KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
           CI: true
           IN_DOCKER: true
-          WEB_REPO: quay.io/gumroad/web
+          WEB_REPO: ${{ secrets.ECR_REGISTRY }}/gumroad/web
         run: |
           # Create local directory for artifacts
           mkdir -p ./capybara-artifacts

--- a/docker/docker-compose-test-and-ci.yml
+++ b/docker/docker-compose-test-and-ci.yml
@@ -1,6 +1,6 @@
 services:
   db_test:
-    image: quay.io/gumroad/mysql:8.0.32
+    image: ${ECR_REGISTRY}/gumroad/mysql:8.0.32
     tmpfs:
       - /var/lib/mysql:size=512M
     ports:
@@ -19,14 +19,14 @@ services:
       - "--skip-log-bin"
 
   redis:
-    image: quay.io/gumroad/redis:7.0.7
+    image: ${ECR_REGISTRY}/gumroad/redis:7.0.7
     volumes:
       - redis_data:/data
     ports:
       - "6379"
 
   mongo:
-    image: quay.io/gumroad/mongo:3.6.16
+    image: ${ECR_REGISTRY}/gumroad/mongo:3.6.16
     volumes:
       - mongo_data:/data/db
     ports:
@@ -34,7 +34,7 @@ services:
     command: "mongod --smallfiles"
 
   elasticsearch:
-    image: quay.io/gumroad/elasticsearch:7.9.3
+    image: ${ECR_REGISTRY}/gumroad/elasticsearch:7.9.3
     ports:
       - "9200"
     environment:
@@ -42,12 +42,12 @@ services:
       - "discovery.type=single-node"
 
   memcached:
-    image: quay.io/gumroad/memcached:latest
+    image: ${ECR_REGISTRY}/gumroad/memcached:latest
     ports:
       - "11211"
 
   minio:
-    image: quay.io/gumroad/minio:RELEASE.2025-09-07T16-13-09Z
+    image: ${ECR_REGISTRY}/gumroad/minio:RELEASE.2025-09-07T16-13-09Z
     ports:
       - "9000"
       - "9001"
@@ -65,7 +65,7 @@ services:
       start_period: 30s
 
   createbuckets:
-    image: quay.io/gumroad/minio-mc:RELEASE.2025-08-13T08-35-41Z
+    image: ${ECR_REGISTRY}/gumroad/minio-mc:RELEASE.2025-08-13T08-35-41Z
     depends_on:
       minio:
         condition: service_healthy
@@ -85,7 +85,7 @@ services:
       done; exit 0; "
 
   copyfixturefiles:
-    image: quay.io/gumroad/minio-mc:RELEASE.2025-08-13T08-35-41Z
+    image: ${ECR_REGISTRY}/gumroad/minio-mc:RELEASE.2025-08-13T08-35-41Z
     depends_on:
       createbuckets:
         condition: service_completed_successfully

--- a/docker/ecr-lifecycle-policy.json
+++ b/docker/ecr-lifecycle-policy.json
@@ -1,0 +1,30 @@
+{
+  "rules": [
+    {
+      "rulePriority": 1,
+      "description": "Keep last 50 images tagged with test- or web- prefix",
+      "selection": {
+        "tagStatus": "tagged",
+        "tagPrefixList": ["test-", "web-"],
+        "countType": "imageCountMoreThan",
+        "countNumber": 50
+      },
+      "action": {
+        "type": "expire"
+      }
+    },
+    {
+      "rulePriority": 2,
+      "description": "Expire untagged images older than 7 days",
+      "selection": {
+        "tagStatus": "untagged",
+        "countType": "sinceImagePushed",
+        "countUnit": "days",
+        "countNumber": 7
+      },
+      "action": {
+        "type": "expire"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## What

Migrates all CI Docker image references from Quay.io to AWS ECR, per [#4388](https://github.com/antiwork/gumroad/issues/4388).

## Changes

**`.github/workflows/tests.yml`:**
- Replaced 3x "Login to Quay" steps with "Login to ECR" using `aws ecr get-login-password`
- Auth via `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` secrets instead of `QUAY_USERNAME`/`QUAY_PASSWORD`
- All `quay.io/gumroad/` image references now use `${{ secrets.ECR_REGISTRY }}/gumroad/`

**`docker/docker-compose-test-and-ci.yml`:**
- All service images now use `${ECR_REGISTRY}` env var (passed from CI workflow)

**`docker/ecr-lifecycle-policy.json`** (new):
- Keeps last 50 `test-`/`web-` tagged images per repo
- Expires untagged images after 7 days

## Manual steps required before merging

These AWS-side changes need to happen first:

1. **Create ECR repositories** (one per image):
   - `gumroad/web`, `gumroad/web_base`, `gumroad/web_base_test`
   - `gumroad/ruby`, `gumroad/mysql`, `gumroad/redis`, `gumroad/mongo`
   - `gumroad/elasticsearch`, `gumroad/minio`, `gumroad/minio-mc`, `gumroad/memcached`

2. **Mirror existing images** from Quay.io to ECR (one-time):
   ```bash
   # For each service image, e.g.:
   docker pull quay.io/gumroad/mysql:8.0.32
   docker tag quay.io/gumroad/mysql:8.0.32 <ECR_REGISTRY>/gumroad/mysql:8.0.32
   docker push <ECR_REGISTRY>/gumroad/mysql:8.0.32
   ```

3. **Apply lifecycle policies** to each ECR repo:
   ```bash
   aws ecr put-lifecycle-policy \
     --repository-name gumroad/<repo> \
     --lifecycle-policy-text file://docker/ecr-lifecycle-policy.json
   ```

4. **Add GitHub secrets:**
   - `ECR_REGISTRY` (e.g. `123456789.dkr.ecr.us-east-1.amazonaws.com`)
   - `AWS_REGION` (e.g. `us-east-1`)
   - `AWS_ACCESS_KEY_ID` (IAM user/role with ECR push/pull permissions)
   - `AWS_SECRET_ACCESS_KEY`

5. **Test a CI run** end-to-end on this branch after secrets are configured

6. Old `QUAY_USERNAME`/`QUAY_PASSWORD` secrets can be removed after confirming everything works.

## Notes

- The Makefile already uses `ECR_REGISTRY` for production builds, so this aligns CI with the existing pattern.
- AWS CLI (`aws ecr get-login-password`) needs to be available on the Ubicloud runners. If not pre-installed, we may need to add an install step.

Closes #4388