### PR TITLE
Fix Stripe::InvalidRequestError when syncing card bank account on charges-disabled account

### DIFF
--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -255,6 +255,10 @@ module StripeMerchantAccountManager
     stripe_account = Stripe::Account.retrieve(user.stripe_account.charge_processor_merchant_id)
     return if stripe_account["metadata"]["bank_account_id"] == bank_account.external_id
 
+    # Card bank accounts require token creation on the connected account, which fails if charges aren't enabled.
+    # The card bank account will be synced when charges become enabled via the account.updated webhook.
+    return if bank_account.is_a?(CardBankAccount) && !stripe_account["charges_enabled"]
+
     attributes = bank_account_hash(bank_account, stripe_account:, passphrase:)
     Stripe::Account.update(stripe_account.id, attributes)
 

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -9178,6 +9178,25 @@ describe StripeMerchantAccountManager, :vcr do
         expect { subject.update_bank_account(user, passphrase: "1234") }.to raise_error(MerchantRegistrationUserNotReadyError)
       end
     end
+
+    describe "card bank account with charges disabled" do
+      let(:card_bank_account) { create(:card_bank_account, user:) }
+
+      before do
+        bank_account_1.update!(deleted_at: Time.current)
+        card_bank_account
+      end
+
+      it "returns early without creating a token when charges are not enabled" do
+        expect(Stripe::Account).to receive(:retrieve).with(merchant_account.charge_processor_merchant_id).and_return(
+          { "id" => merchant_account.charge_processor_merchant_id, "charges_enabled" => false, "metadata" => {} }
+        )
+        expect(Stripe::Token).not_to receive(:create)
+        expect(Stripe::Account).not_to receive(:update)
+
+        subject.update_bank_account(user, passphrase: "1234")
+      end
+    end
   end
 
   describe ".handle_stripe_event" do


### PR DESCRIPTION
## Summary
- Adds an early return guard in `update_bank_account` when the bank account is a `CardBankAccount` and the Stripe connected account doesn't have charges enabled yet
- Card bank account token creation requires charges to be enabled on the connected account; without this guard, `Stripe::Token.create` raises `Stripe::InvalidRequestError: Your account cannot currently make live charges`
- The card bank account will be synced later when charges become enabled, handled by the `account.updated` webhook in `handle_stripe_info_requirements`

## Test plan
- [ ] Added spec: "card bank account with charges disabled" verifies early return without calling `Stripe::Token.create` or `Stripe::Account.update`
- [ ] Existing `update_bank_account` tests continue to pass
- [ ] Verify in staging that creating a merchant account with a card bank account no longer raises the error before charges are enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)