### PR TITLE
Skip Sentry notification for Stripe::InvalidRequestError in create_account

### DIFF
--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -105,6 +105,9 @@ module StripeMerchantAccountManager
     end
 
     merchant_account
+  rescue Stripe::InvalidRequestError => e
+    cleanup_failed_merchant_account(merchant_account) if merchant_account.present?
+    raise
   rescue Stripe::StripeError => e
     cleanup_failed_merchant_account(merchant_account) if merchant_account.present?
     ErrorNotifier.notify(e)

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -120,12 +120,23 @@ describe StripeMerchantAccountManager, :vcr do
         expect(bank_account.reload.stripe_fingerprint).to match(/[a-zA-Z0-9]+/)
       end
 
-      it "raises the Stripe::InvalidRequestError" do
+      it "raises the Stripe::InvalidRequestError without notifying Sentry" do
         error_message = "Invalid account number: must contain only digits, and be at most 12 digits long"
         allow(Stripe::Account).to receive(:create).and_raise(Stripe::InvalidRequestError.new(error_message, nil))
+        allow(ErrorNotifier).to receive(:notify)
         expect do
           subject.create_account(user, passphrase: "1234")
         end.to raise_error(Stripe::InvalidRequestError)
+        expect(ErrorNotifier).not_to have_received(:notify)
+      end
+
+      it "raises and notifies Sentry for non-InvalidRequestError Stripe errors" do
+        allow(Stripe::Account).to receive(:create).and_raise(Stripe::APIError.new("Internal server error"))
+        allow(ErrorNotifier).to receive(:notify)
+        expect do
+          subject.create_account(user, passphrase: "1234")
+        end.to raise_error(Stripe::APIError)
+        expect(ErrorNotifier).to have_received(:notify).with(instance_of(Stripe::APIError))
       end
 
       context "when user compliance info contains whitespaces" do
@@ -8528,6 +8539,7 @@ describe StripeMerchantAccountManager, :vcr do
           subject.create_account(user, passphrase: "1234")
         end.to raise_error(Stripe::InvalidRequestError)
         expect(user.merchant_accounts.alive.count).to eq(0)
+        expect(ErrorNotifier).not_to have_received(:notify)
       end
 
       it "still marks the merchant account as deleted when Stripe account deletion fails" do
@@ -8537,7 +8549,7 @@ describe StripeMerchantAccountManager, :vcr do
           subject.create_account(user, passphrase: "1234")
         end.to raise_error(Stripe::InvalidRequestError)
         expect(user.merchant_accounts.alive.count).to eq(0)
-        expect(ErrorNotifier).to have_received(:notify).at_least(:twice)
+        expect(ErrorNotifier).to have_received(:notify).at_least(:once)
       end
     end
 


### PR DESCRIPTION
## Problem

The `create_account` method in `StripeMerchantAccountManager` catches all `Stripe::StripeError` and reports them to Sentry via `ErrorNotifier.notify`. However, `Stripe::InvalidRequestError` represents user-input validation issues (invalid tax ID format, invalid account numbers, etc.) that the controller already handles gracefully by rendering a JSON error response. Reporting these to Sentry creates noise without actionable signal.

## Fix

Split the rescue block so:
- `Stripe::InvalidRequestError` — cleans up but does **not** notify Sentry, then re-raises (the controller handles the user-facing response)
- Other `Stripe::StripeError` subclasses (API errors, auth errors, connection errors) — still notify Sentry as before

## Tests

- Updated existing `InvalidRequestError` test to verify `ErrorNotifier` is NOT called
- Added new test confirming `Stripe::APIError` still triggers `ErrorNotifier.notify`
- Updated cleanup tests to reflect that `InvalidRequestError` from `create_person` no longer triggers Sentry