### PR TITLE
Fix RequestTimeoutException in UsersController#show by clamping search size

### DIFF
--- a/app/controllers/concerns/search_products.rb
+++ b/app/controllers/concerns/search_products.rb
@@ -3,6 +3,7 @@
 module SearchProducts
   BLACK_FRIDAY_CODE = "BLACKFRIDAY2025"
   ALLOWED_OFFER_CODES = [BLACK_FRIDAY_CODE].freeze
+  MAX_SEARCH_SIZE = 100
 
   private
     def search_products(params)
@@ -30,8 +31,8 @@ module SearchProducts
 
       params[:offer_code] = "__no_match__" if params[:offer_code].present? && !offer_codes_search_feature_active?(params)
 
-      if params[:size].is_a?(String)
-        params[:size] = params[:size].to_i
+      if params[:size].present?
+        params[:size] = [[params[:size].to_i, 1].max, MAX_SEARCH_SIZE].min
       end
 
       params.delete(:search) unless params[:search].is_a?(Hash)

--- a/spec/controllers/concerns/search_products_spec.rb
+++ b/spec/controllers/concerns/search_products_spec.rb
@@ -109,6 +109,21 @@ describe SearchProducts do
         get :index, params: { size: "20" }
         expect(JSON.parse(response.body)["size"]).to eq(20)
       end
+
+      it "clamps size to MAX_SEARCH_SIZE when exceeding limit" do
+        get :index, params: { size: "10000" }
+        expect(JSON.parse(response.body)["size"]).to eq(SearchProducts::MAX_SEARCH_SIZE)
+      end
+
+      it "clamps size to minimum of 1" do
+        get :index, params: { size: "0" }
+        expect(JSON.parse(response.body)["size"]).to eq(1)
+      end
+
+      it "clamps negative size to 1" do
+        get :index, params: { size: "-5" }
+        expect(JSON.parse(response.body)["size"]).to eq(1)
+      end
     end
   end
 end


### PR DESCRIPTION
## Problem

`UsersController#show` was hitting `Rack::Timeout::RequestTimeoutException` (120s timeout) when the `size` query parameter was large or unbounded.

The `size` parameter from the URL query string flows through `format_search_params!` → `search_products` → `Link.search_options` → Elasticsearch's `size` option, controlling how many product IDs are returned. Those IDs are then loaded via `Link.includes(ASSOCIATIONS_FOR_CARD).includes(bundle_products: ...)`.find(ids)`, which with thousands of products and heavy eager loading easily exceeds the 120s timeout.

The frontend never sends a `size` parameter (it only uses `from` for pagination), so this only affects external or crafted requests.

**Sentry:** https://gumroad-to.sentry.io/issues/7410129219/

## Fix

Clamp the `size` parameter in `format_search_params!` to `[1, MAX_SEARCH_SIZE]` where `MAX_SEARCH_SIZE = 100`. This follows the existing pattern in `api/mobile/purchases_controller.rb` which uses `MAX_PER_PAGE = 100` with the same clamping approach.

## Changes

- `app/controllers/concerns/search_products.rb`: Added `MAX_SEARCH_SIZE = 100` constant and clamp logic
- `spec/controllers/concerns/search_products_spec.rb`: Added tests for clamping to max, min of 1, and negative values

## Tests

All 14 specs pass (11 existing + 3 new).