### PR TITLE
Fix Rack::Timeout in LibraryController#index by capping library purchases

### DIFF
--- a/app/presenters/library_presenter.rb
+++ b/app/presenters/library_presenter.rb
@@ -3,6 +3,8 @@
 class LibraryPresenter
   include Rails.application.routes.url_helpers
 
+  MAX_LIBRARY_PURCHASES = 5000
+
   attr_reader :logged_in_user
 
   def initialize(logged_in_user)
@@ -26,7 +28,8 @@ class LibraryPresenter
           user: { avatar_attachment: :blob }
         }
       )
-      .find_each(batch_size: 3000, order: :desc) # required to avoid full table scans. See https://github.com/gumroad/web/pull/25970
+      .order(id: :desc)
+      .limit(MAX_LIBRARY_PURCHASES)
       .to_a
 
     user_ids = purchases.map { |p| p.link.user_id }.uniq

--- a/spec/presenters/library_presenter_spec.rb
+++ b/spec/presenters/library_presenter_spec.rb
@@ -203,6 +203,17 @@ describe LibraryPresenter do
       end
     end
 
+    it "caps the number of purchases returned" do
+      stub_const("LibraryPresenter::MAX_LIBRARY_PURCHASES", 1)
+
+      other_product = create(:product, user: creator)
+      create(:purchase, link: other_product, purchaser: buyer).tap { _1.create_url_redirect! }
+
+      purchases, _ = described_class.new(buyer).library_cards
+
+      expect(purchases.size).to eq(1)
+    end
+
     describe "has_third_party_analytics" do
       it "detects product-level receipt analytics" do
         create(:third_party_analytic, user: creator, link: product, location: "receipt", analytics_code: "<script>test</script>")


### PR DESCRIPTION
## What

Cap the number of purchases loaded in `LibraryPresenter#library_cards` to 5,000 by replacing the unbounded `find_each(batch_size: 3000).to_a` with `order(id: :desc).limit(5000).to_a`.

## Why

For users with many thousands of purchases, `library_cards` loads every purchase into memory with heavy eager loading. This causes requests to exceed the 120s Rack::Timeout, resulting in `Rack::Timeout::RequestTimeoutException` errors in production ([Sentry #7410238907](https://gumroad-to.sentry.io/issues/7410238907/)).

The previous `find_each` approach didn't help here because `.to_a` was called immediately after, so all records were loaded into memory regardless — `find_each` only batched the SQL, not the memory usage. Switching to `order(id: :desc).limit(N)` lets the SQL planner use the primary key index efficiently and caps total memory usage.

A limit of 5,000 covers the vast majority of users while preventing pathological cases from timing out.

## Test Results

All 19 specs pass in `spec/presenters/library_presenter_spec.rb`, including a new test that verifies the limit is applied.

---

AI disclosure: Implemented with Claude Opus 4.6. Prompted with the Sentry error details, root cause analysis, and fix strategy.