### PR TITLE
Fix TypeError in LinksController#update when params are not arrays

### DIFF
--- a/app/controllers/api/v2/links_controller.rb
+++ b/app/controllers/api/v2/links_controller.rb
@@ -213,6 +213,48 @@ class Api::V2::LinksController < Api::V2::BaseController
       return render_response(false, message: "Price cannot be updated for tiered membership products. Use the variant endpoints to manage tier pricing.")
     end
 
+    if params.key?(:tags)
+      if !params[:tags].is_a?(Array) || params[:tags].any? { |t| !t.respond_to?(:to_str) }
+        return render_response(false, message: "tags must be an array of strings.")
+      end
+    end
+
+    if params.key?(:rich_content)
+      if !params[:rich_content].is_a?(Array) || params[:rich_content].any? { |p| !p.respond_to?(:key?) }
+        return render_response(false, message: "rich_content must be an array of content page objects.")
+      end
+      params[:rich_content].each do |p|
+        desc = p[:description]
+        next if desc.blank?
+        if !desc.respond_to?(:key?) && !desc.is_a?(Array)
+          return render_response(false, message: "Each rich_content page description must be a JSON object or array.")
+        end
+        content_nodes = if desc.respond_to?(:key?)
+          if desc[:content].present? && !desc[:content].is_a?(Array)
+            return render_response(false, message: "rich_content description content must be an array.")
+          end
+          desc[:content]
+        else
+          desc
+        end
+        if content_nodes.is_a?(Array) && content_nodes.any? { |n| !n.respond_to?(:key?) }
+          return render_response(false, message: "Each rich_content content node must be a JSON object.")
+        end
+      end
+    end
+
+    if params.key?(:files)
+      if !params[:files].is_a?(Array) || params[:files].any? { |f| !f.respond_to?(:key?) }
+        return render_response(false, message: "files must be an array of file objects.")
+      end
+    end
+
+    if params.key?(:cover_ids)
+      if !params[:cover_ids].is_a?(Array)
+        return render_response(false, message: "cover_ids must be an array.")
+      end
+    end
+
     @normalized_files = normalize_params_recursively(params[:files]) if params.key?(:files)
     @normalized_rich_content = normalize_params_recursively(params[:rich_content]) if params.key?(:rich_content)
 

--- a/spec/controllers/api/v2/links_controller_spec.rb
+++ b/spec/controllers/api/v2/links_controller_spec.rb
@@ -899,6 +899,62 @@ describe Api::V2::LinksController do
         expect(@product.reload.tags.pluck(:name)).to match_array(["ruby"])
       end
 
+      it "rejects non-array tags" do
+        put @action, params: @params.merge(tags: "oops")
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to be false
+        expect(response.parsed_body["message"]).to include("tags must be an array")
+      end
+
+      it "rejects tags with non-string elements" do
+        put @action, params: @params.merge(tags: ["valid", { nested: "hash" }])
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to be false
+        expect(response.parsed_body["message"]).to include("tags must be an array of strings")
+      end
+
+      it "rejects non-array rich_content" do
+        put @action, params: @params.merge(rich_content: { title: "oops", description: { type: "doc" } })
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to be false
+        expect(response.parsed_body["message"]).to include("rich_content must be an array")
+      end
+
+      it "rejects rich_content with non-object elements" do
+        put @action, params: @params.merge(rich_content: ["oops"])
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to be false
+        expect(response.parsed_body["message"]).to include("rich_content must be an array of content page objects")
+      end
+
+      it "rejects non-array files" do
+        put @action, params: @params.merge(files: { url: "https://example.com/file.pdf" })
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to be false
+        expect(response.parsed_body["message"]).to include("files must be an array")
+      end
+
+      it "rejects files with non-object elements" do
+        put @action, params: @params.merge(files: ["oops"])
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to be false
+        expect(response.parsed_body["message"]).to include("files must be an array of file objects")
+      end
+
+      it "rejects non-array cover_ids" do
+        put @action, params: @params.merge(cover_ids: "not-an-array")
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to be false
+        expect(response.parsed_body["message"]).to include("cover_ids must be an array")
+      end
+
       it "does not change native_type" do
         original_type = @product.native_type
         put @action, params: @params.merge(native_type: "membership")


### PR DESCRIPTION
## What

Add type validation for `rich_content`, `files`, `tags`, and `cover_ids` params in the `Api::V2::LinksController#update` action, matching existing validations already present in `create`.

## Why

When a user sends a single object instead of an array (e.g. `"rich_content": {"title": "..."}` instead of `"rich_content": [{"title": "..."}]`), `normalize_params_recursively` returns a Hash. Then `save_rich_content!` iterates with `.each.with_index`, yielding `[key, value]` pairs instead of Hash pages. Accessing `page[:description]` on an Array raises `TypeError: no implicit conversion of Symbol into Integer`.

The `create` action already validates these param types but `update` was missing the same checks. This mirrors the create validations exactly.

Sentry: https://gumroad-to.sentry.io/issues/7410838011/ (1 occurrence, first seen today)

## Test results

All 140 controller specs pass, including 7 new tests covering each invalid param type for the update action.

---

AI disclosure: Implemented with Claude Opus 4.6. Prompted with the Sentry error details, root cause analysis, and instructions to add matching validations from create to update.