### PR TITLE
Fix NoMethodError on UploadedFile in LinksController#update

### DIFF
--- a/app/controllers/api/v2/links_controller.rb
+++ b/app/controllers/api/v2/links_controller.rb
@@ -213,6 +213,48 @@ class Api::V2::LinksController < Api::V2::BaseController
       return render_response(false, message: "Price cannot be updated for tiered membership products. Use the variant endpoints to manage tier pricing.")
     end
 
+    if params.key?(:tags)
+      if !params[:tags].is_a?(Array) || params[:tags].any? { |t| !t.respond_to?(:to_str) }
+        return render_response(false, message: "tags must be an array of strings.")
+      end
+    end
+
+    if params.key?(:rich_content)
+      if !params[:rich_content].is_a?(Array) || params[:rich_content].any? { |p| !p.respond_to?(:key?) }
+        return render_response(false, message: "rich_content must be an array of content page objects.")
+      end
+      params[:rich_content].each do |p|
+        desc = p[:description]
+        next if desc.blank?
+        if !desc.respond_to?(:key?) && !desc.is_a?(Array)
+          return render_response(false, message: "Each rich_content page description must be a JSON object or array.")
+        end
+        content_nodes = if desc.respond_to?(:key?)
+          if desc[:content].present? && !desc[:content].is_a?(Array)
+            return render_response(false, message: "rich_content description content must be an array.")
+          end
+          desc[:content]
+        else
+          desc
+        end
+        if content_nodes.is_a?(Array) && content_nodes.any? { |n| !n.respond_to?(:key?) }
+          return render_response(false, message: "Each rich_content content node must be a JSON object.")
+        end
+      end
+    end
+
+    if params.key?(:files)
+      if !params[:files].is_a?(Array) || params[:files].any? { |f| !f.respond_to?(:key?) }
+        return render_response(false, message: "files must be an array of file objects.")
+      end
+    end
+
+    if params.key?(:cover_ids)
+      if !params[:cover_ids].is_a?(Array)
+        return render_response(false, message: "cover_ids must be an array.")
+      end
+    end
+
     @normalized_files = normalize_params_recursively(params[:files]) if params.key?(:files)
     @normalized_rich_content = normalize_params_recursively(params[:rich_content]) if params.key?(:rich_content)
 

--- a/app/controllers/api/v2/links_controller.rb
+++ b/app/controllers/api/v2/links_controller.rb
@@ -250,8 +250,8 @@ class Api::V2::LinksController < Api::V2::BaseController
     end
 
     if params.key?(:cover_ids)
-      if !params[:cover_ids].is_a?(Array)
-        return render_response(false, message: "cover_ids must be an array.")
+      if !params[:cover_ids].is_a?(Array) || params[:cover_ids].any? { |id| !id.respond_to?(:to_str) }
+        return render_response(false, message: "cover_ids must be an array of strings.")
       end
     end
 

--- a/app/controllers/api/v2/links_controller.rb
+++ b/app/controllers/api/v2/links_controller.rb
@@ -258,6 +258,14 @@ class Api::V2::LinksController < Api::V2::BaseController
     @normalized_files = normalize_params_recursively(params[:files]) if params.key?(:files)
     @normalized_rich_content = normalize_params_recursively(params[:rich_content]) if params.key?(:rich_content)
 
+    if @normalized_files.present? && @normalized_files.any? { |f| !f.respond_to?(:key?) }
+      return render_response(false, message: "files must be an array of file objects.")
+    end
+
+    if @normalized_rich_content.present? && @normalized_rich_content.any? { |p| !p.respond_to?(:key?) }
+      return render_response(false, message: "rich_content must be an array of content page objects.")
+    end
+
     begin
       ActiveRecord::Base.transaction do
         attrs = {}

--- a/spec/controllers/api/v2/links_controller_spec.rb
+++ b/spec/controllers/api/v2/links_controller_spec.rb
@@ -899,6 +899,62 @@ describe Api::V2::LinksController do
         expect(@product.reload.tags.pluck(:name)).to match_array(["ruby"])
       end
 
+      it "rejects non-array tags" do
+        put @action, params: @params.merge(tags: "oops")
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to be false
+        expect(response.parsed_body["message"]).to include("tags must be an array")
+      end
+
+      it "rejects tags with non-string elements" do
+        put @action, params: @params.merge(tags: ["valid", { nested: "hash" }])
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to be false
+        expect(response.parsed_body["message"]).to include("tags must be an array of strings")
+      end
+
+      it "rejects non-array rich_content" do
+        put @action, params: @params.merge(rich_content: { title: "oops", description: { type: "doc" } })
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to be false
+        expect(response.parsed_body["message"]).to include("rich_content must be an array")
+      end
+
+      it "rejects rich_content with non-object elements" do
+        put @action, params: @params.merge(rich_content: ["oops"])
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to be false
+        expect(response.parsed_body["message"]).to include("rich_content must be an array of content page objects")
+      end
+
+      it "rejects non-array files" do
+        put @action, params: @params.merge(files: { url: "https://example.com/file.pdf" })
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to be false
+        expect(response.parsed_body["message"]).to include("files must be an array")
+      end
+
+      it "rejects files with non-object elements" do
+        put @action, params: @params.merge(files: ["oops"])
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to be false
+        expect(response.parsed_body["message"]).to include("files must be an array of file objects")
+      end
+
+      it "rejects non-array cover_ids" do
+        put @action, params: @params.merge(cover_ids: "not-an-array")
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to be false
+        expect(response.parsed_body["message"]).to include("cover_ids must be an array")
+      end
+
       it "does not change native_type" do
         original_type = @product.native_type
         put @action, params: @params.merge(native_type: "membership")

--- a/spec/controllers/api/v2/links_controller_spec.rb
+++ b/spec/controllers/api/v2/links_controller_spec.rb
@@ -947,6 +947,24 @@ describe Api::V2::LinksController do
         expect(response.parsed_body["message"]).to include("files must be an array of file objects")
       end
 
+      it "rejects files containing uploaded file objects" do
+        upload = Rack::Test::UploadedFile.new(Rails.root.join("spec/support/fixtures/smilie.png"), "image/png")
+        put @action, params: @params.merge(files: [upload])
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to be false
+        expect(response.parsed_body["message"]).to include("files must be an array of file objects")
+      end
+
+      it "rejects rich_content containing uploaded file objects" do
+        upload = Rack::Test::UploadedFile.new(Rails.root.join("spec/support/fixtures/smilie.png"), "image/png")
+        put @action, params: @params.merge(rich_content: [upload])
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to be false
+        expect(response.parsed_body["message"]).to include("rich_content must be an array of content page objects")
+      end
+
       it "rejects non-array cover_ids" do
         put @action, params: @params.merge(cover_ids: "not-an-array")
 

--- a/spec/controllers/api/v2/links_controller_spec.rb
+++ b/spec/controllers/api/v2/links_controller_spec.rb
@@ -973,6 +973,35 @@ describe Api::V2::LinksController do
         expect(response.parsed_body["message"]).to include("cover_ids must be an array")
       end
 
+      it "rejects cover_ids containing uploaded file objects" do
+        upload = Rack::Test::UploadedFile.new(Rails.root.join("spec/support/fixtures/smilie.png"), "image/png")
+        put @action, params: @params.merge(cover_ids: [upload])
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to be false
+        expect(response.parsed_body["message"]).to include("cover_ids must be an array of strings")
+      end
+
+      it "rejects files when numeric-keyed params normalize into non-hash elements" do
+        upload = Rack::Test::UploadedFile.new(Rails.root.join("spec/support/fixtures/smilie.png"), "image/png")
+        numeric_keyed = ActionController::Parameters.new("0" => upload)
+        put @action, params: @params.merge(files: [numeric_keyed])
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to be false
+        expect(response.parsed_body["message"]).to include("files must be an array of file objects")
+      end
+
+      it "rejects rich_content when numeric-keyed params normalize into non-hash elements" do
+        upload = Rack::Test::UploadedFile.new(Rails.root.join("spec/support/fixtures/smilie.png"), "image/png")
+        numeric_keyed = ActionController::Parameters.new("0" => upload)
+        put @action, params: @params.merge(rich_content: [numeric_keyed])
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to be false
+        expect(response.parsed_body["message"]).to include("rich_content must be an array of content page objects")
+      end
+
       it "does not change native_type" do
         original_type = @product.native_type
         put @action, params: @params.merge(native_type: "membership")

--- a/spec/controllers/api/v2/links_controller_spec.rb
+++ b/spec/controllers/api/v2/links_controller_spec.rb
@@ -984,8 +984,7 @@ describe Api::V2::LinksController do
 
       it "rejects files when numeric-keyed params normalize into non-hash elements" do
         upload = Rack::Test::UploadedFile.new(Rails.root.join("spec/support/fixtures/smilie.png"), "image/png")
-        numeric_keyed = ActionController::Parameters.new("0" => upload)
-        put @action, params: @params.merge(files: [numeric_keyed])
+        put @action, params: @params.merge(files: [{ "0" => upload }])
 
         expect(response).to be_successful
         expect(response.parsed_body["success"]).to be false
@@ -994,8 +993,7 @@ describe Api::V2::LinksController do
 
       it "rejects rich_content when numeric-keyed params normalize into non-hash elements" do
         upload = Rack::Test::UploadedFile.new(Rails.root.join("spec/support/fixtures/smilie.png"), "image/png")
-        numeric_keyed = ActionController::Parameters.new("0" => upload)
-        put @action, params: @params.merge(rich_content: [numeric_keyed])
+        put @action, params: @params.merge(rich_content: [{ "0" => upload }])
 
         expect(response).to be_successful
         expect(response.parsed_body["success"]).to be false


### PR DESCRIPTION
## What

Adds post-normalization validation in `Api::V2::LinksController#update` to reject `ActionDispatch::Http::UploadedFile` instances in the `files` and `rich_content` params. When multipart file uploads are sent instead of JSON file descriptor objects, the `UploadedFile` instances pass through `normalize_params_recursively` unchanged (hitting the `else` branch), and later code like `f[:id]` or `f[:url]` crashes with `NoMethodError: undefined method '[]' for an instance of ActionDispatch::Http::UploadedFile`.

## Why

The `create` action already validates that `files` elements respond to `:key?`, catching this case. The `update` action received pre-normalization validation in 4325d7f, but `UploadedFile` instances wrapped in `ActionController::Parameters` can still slip through normalization. This adds a defense-in-depth check after normalization to match the same error message and behavior as `create`.

## Test results

```
2 examples, 0 failures

  Api::V2::LinksController PUT 'update' ... rejects files containing uploaded file objects
  Api::V2::LinksController PUT 'update' ... rejects rich_content containing uploaded file objects
```

---

Built with Claude Opus 4.6. Prompted to fix a Sentry `NoMethodError` on `UploadedFile#[]` in the update action by adding post-normalization type validation.