### PR TITLE
Fix NoMethodError: undefined method 'dig' for HTTParty::Response in SignupController#create

### DIFF
--- a/app/controllers/concerns/validate_recaptcha.rb
+++ b/app/controllers/concerns/validate_recaptcha.rb
@@ -46,6 +46,16 @@ module ValidateRecaptcha
                                }.to_json,
                                timeout: 5)
       Rails.logger.info response
-      response
+
+      parsed = response.parsed_response
+      if parsed.is_a?(Hash)
+        parsed
+      else
+        Rails.logger.error("Unexpected reCAPTCHA response format: #{response.code} #{parsed.class}")
+        {}
+      end
+    rescue StandardError => e
+      Rails.logger.error("reCAPTCHA verification request failed: #{e.message}")
+      {}
     end
 end

--- a/spec/controllers/concerns/validate_recaptcha_spec.rb
+++ b/spec/controllers/concerns/validate_recaptcha_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe ValidateRecaptcha, type: :controller do
+  controller do
+    include ValidateRecaptcha
+
+    def action
+      if valid_recaptcha_response?(site_key: "test_site_key")
+        render json: { success: true }
+      else
+        render json: { success: false, error: "captcha_failed" }, status: :unprocessable_entity
+      end
+    end
+  end
+
+  before do
+    routes.draw { post :action, to: "anonymous#action" }
+    allow(Rails).to receive(:env).and_return(ActiveSupport::EnvironmentInquirer.new("development"))
+  end
+
+  describe "#recaptcha_verification_response" do
+    it "returns parsed hash when API returns valid JSON" do
+      valid_response = { "tokenProperties" => { "valid" => true } }
+      stubbed_response = instance_double(HTTParty::Response, parsed_response: valid_response, code: 200)
+      allow(stubbed_response).to receive(:to_s).and_return(valid_response.to_json)
+      allow(HTTParty).to receive(:post).and_return(stubbed_response)
+
+      post :action, params: { "g-recaptcha-response" => "test_token" }
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)["success"]).to be true
+    end
+
+    it "returns empty hash when API returns non-JSON response (HTML error page)" do
+      stubbed_response = instance_double(HTTParty::Response, parsed_response: "<html>Error</html>", code: 502)
+      allow(stubbed_response).to receive(:to_s).and_return("<html>Error</html>")
+      allow(HTTParty).to receive(:post).and_return(stubbed_response)
+
+      post :action, params: { "g-recaptcha-response" => "test_token" }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body)["error"]).to eq("captcha_failed")
+    end
+
+    it "returns empty hash when API returns nil parsed response" do
+      stubbed_response = instance_double(HTTParty::Response, parsed_response: nil, code: 200)
+      allow(stubbed_response).to receive(:to_s).and_return("")
+      allow(HTTParty).to receive(:post).and_return(stubbed_response)
+
+      post :action, params: { "g-recaptcha-response" => "test_token" }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it "returns empty hash when HTTParty raises an error" do
+      allow(HTTParty).to receive(:post).and_raise(Net::OpenTimeout.new("execution expired"))
+
+      post :action, params: { "g-recaptcha-response" => "test_token" }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body)["error"]).to eq("captcha_failed")
+    end
+  end
+end


### PR DESCRIPTION
## What

In `ValidateRecaptcha#recaptcha_verification_response`, the method returned the raw `HTTParty::Response` object. When the Google reCAPTCHA Enterprise API returns a non-JSON response (e.g., an HTML error page during an outage or a 502), `HTTParty::Response#parsed_response` is a String, not a Hash. Calling `.dig("tokenProperties", "valid")` on it raises `NoMethodError: undefined method 'dig' for an instance of HTTParty::Response`.

Now the method:
- Extracts `parsed_response` and checks it's a Hash before returning
- Returns `{}` for non-Hash responses (so `.dig` returns `nil` → captcha treated as invalid)
- Rescues `StandardError` to handle network timeouts/connection errors gracefully

## Why

This was causing unhandled 500 errors in `SignupController#create` when the reCAPTCHA API returned unexpected responses. Returning an empty hash is the correct fallback — it treats the captcha as failed, which prompts the user to retry rather than seeing a crash.

Sentry: https://gumroad-to.sentry.io/issues/7411124264/

## Test results

Added `spec/controllers/concerns/validate_recaptcha_spec.rb` with 4 test cases:
- Valid JSON response → captcha passes
- HTML error page response → captcha fails gracefully
- Nil parsed response → captcha fails gracefully
- Network timeout → captcha fails gracefully

All 4 tests pass locally.

---

Generated with Claude Opus 4.6. Prompted to fix the Sentry issue for `NoMethodError: undefined method 'dig' for an instance of HTTParty::Response` in `SignupController#create`.