### PR TITLE
Fix removeChild crash caused by browser translation extensions

### DIFF
--- a/app/javascript/packs/inertia.js
+++ b/app/javascript/packs/inertia.js
@@ -5,6 +5,27 @@ import { createRoot } from "react-dom/client";
 import AppWrapper from "../inertia/app_wrapper.tsx";
 import Layout, { PublicLayout, LoggedInUserLayout } from "../inertia/layout.tsx";
 
+// Prevent "Failed to execute 'removeChild' on 'Node'" errors caused by
+// browser translation extensions (e.g. Google Translate) relocating DOM nodes.
+// See https://github.com/facebook/react/issues/11538
+if (typeof Node !== "undefined") {
+  const originalRemoveChild = Node.prototype.removeChild;
+  Node.prototype.removeChild = function (child) {
+    if (child.parentNode !== this) {
+      return child;
+    }
+    return originalRemoveChild.apply(this, arguments);
+  };
+
+  const originalInsertBefore = Node.prototype.insertBefore;
+  Node.prototype.insertBefore = function (newNode, referenceNode) {
+    if (referenceNode && referenceNode.parentNode !== this) {
+      return newNode;
+    }
+    return originalInsertBefore.apply(this, arguments);
+  };
+}
+
 router.on("start", (event) => {
   if (event.detail.visit.prefetch) return;
   window.__activeRequests = (window.__activeRequests || 0) + 1;


### PR DESCRIPTION
Fixes https://github.com/antiwork/gumroad/issues/4483

## What

Patches `Node.prototype.removeChild` and `Node.prototype.insertBefore` in the Inertia entry point to gracefully handle DOM nodes that have been relocated by browser translation tools (e.g. Google Translate). When the patched methods detect a parent-child mismatch, they return early instead of crashing.

## Why

Users with non-English browsers who rely on Chrome's built-in translation encounter a fatal "Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node" error, most commonly when uploading cover images. Google Translate wraps and relocates text nodes in the DOM, and when React later tries to reconcile those nodes, it fails because they are no longer where React expects them.

This is a known React issue (https://github.com/facebook/react/issues/11538) and the monkey-patch is the standard workaround used across large React codebases.

Reported across 9+ issues from users in Spanish, Turkish, Italian, French, and Russian locales:
- #4483, #4310, #3740, #3742, #3741, #3168, #3322, #3016, #3478, #2330

## How to test

1. Open Chrome Settings > Languages, add Spanish (or another non-English language) and move it above English
2. Navigate to a product edit page with at least one cover image
3. Let Chrome translate the page
4. Upload a cover image via the "+" button
5. Verify no crash occurs

## Before

https://github.com/user-attachments/assets/5030e783-2111-4364-a809-bfcea393a98c

## After

https://github.com/user-attachments/assets/5e403a52-4e53-4bca-bb1f-2341b0ee49db

