### PR TITLE
Fix URI::InvalidURIError in GlobalAffiliates::ProductEligibilityController

### DIFF
--- a/app/controllers/global_affiliates/product_eligibility_controller.rb
+++ b/app/controllers/global_affiliates/product_eligibility_controller.rb
@@ -11,7 +11,7 @@ class GlobalAffiliates::ProductEligibilityController < Sellers::BaseController
 
     product_data = fetch_and_parse_product_data
     render json: { success: true, product: product_data }
-  rescue InvalidUrl
+  rescue InvalidUrl, URI::InvalidURIError, Addressable::URI::InvalidURIError
     render json: { success: false, error: "Please provide a valid Gumroad product URL" }
   end
 

--- a/spec/controllers/global_affiliates/product_eligibility_controller_spec.rb
+++ b/spec/controllers/global_affiliates/product_eligibility_controller_spec.rb
@@ -30,5 +30,17 @@ describe GlobalAffiliates::ProductEligibilityController do
         expect(response.parsed_body["error"]).to eq("Please provide a valid Gumroad product URL")
       end
     end
+
+    context "with non-ASCII characters in URL" do
+      let(:url) { "https://gumroad.com/discover.json?a=123\u201D" }
+
+      it "returns an error instead of raising URI::InvalidURIError" do
+        get :show, format: :json, params: { url: }
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to be(false)
+        expect(response.parsed_body["error"]).to eq("Please provide a valid Gumroad product URL")
+      end
+    end
   end
 end


### PR DESCRIPTION
## Problem

URLs containing non-ASCII characters (e.g. Unicode smart quotes from copy-paste) cause an unhandled `URI::InvalidURIError` in `GlobalAffiliates::ProductEligibilityController#show`.

`Addressable::URI.parse` handles Unicode fine, but when `HTTParty.get` internally calls Ruby's `URI.parse`, it rejects non-ASCII characters and raises `URI::InvalidURIError`.

Sentry: https://gumroad-to.sentry.io/issues/7411267971/

## Fix

Rescue `URI::InvalidURIError` and `Addressable::URI::InvalidURIError` alongside `InvalidUrl` so these requests return a user-friendly JSON error instead of a 500.

## Test

Added test case for URLs with non-ASCII characters to verify the error is handled gracefully.