### PR TITLE
Switch CI container registry from Quay.io to Docker Hub

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,19 +35,19 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
-      - name: Login to Quay
+      - name: Login to Docker Hub
         uses: nick-fields/retry@v3
         with:
           timeout_seconds: 120
           max_attempts: 3
           retry_wait_seconds: 10
-          command: echo "$QUAY_PASSWORD" | docker login quay.io -u "$QUAY_USERNAME" --password-stdin
+          command: echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
         env:
-          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
-          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Build and push base image
         env:
-          WEB_BASE_REPO: quay.io/gumroad/web_base
+          WEB_BASE_REPO: gumroadteam/web_base
         run: |
           set -e
           GREEN='\033[0;32m'
@@ -55,13 +55,13 @@ jobs:
           logger() {
             echo -e "${GREEN}$(date '+%Y/%m/%d %H:%M:%S') build.sh: $1${NC}"
           }
-          logger "pulling quay.io/gumroad/ruby:$(cat .ruby-version)-slim-bullseye"
-          docker pull --quiet quay.io/gumroad/ruby:$(cat .ruby-version)-slim-bullseye
-          WEB_BASE_SHA=$(WEB_BASE_DOCKERFILE_FROM=quay.io/gumroad/ruby:$(cat .ruby-version)-slim-bullseye docker/base/generate_tag_for_web_base.sh)
+          logger "pulling ruby:$(cat .ruby-version)-slim-bullseye"
+          docker pull --quiet ruby:$(cat .ruby-version)-slim-bullseye
+          WEB_BASE_SHA=$(WEB_BASE_DOCKERFILE_FROM=ruby:$(cat .ruby-version)-slim-bullseye docker/base/generate_tag_for_web_base.sh)
           if ! docker manifest inspect $WEB_BASE_REPO:$WEB_BASE_SHA > /dev/null 2>&1; then
             logger "Building $WEB_BASE_REPO:$WEB_BASE_SHA"
             NEW_BASE_REPO=$WEB_BASE_REPO \
-              WEB_BASE_DOCKERFILE_FROM=quay.io/gumroad/ruby:$(cat .ruby-version)-slim-bullseye \
+              WEB_BASE_DOCKERFILE_FROM=ruby:$(cat .ruby-version)-slim-bullseye \
               BUNDLE_GEMS__CONTRIBSYS__COM=${{ secrets.BUNDLE_GEMS__CONTRIBSYS__COM }} \
               make build_base
 
@@ -83,9 +83,9 @@ jobs:
           fi
       - name: Build and push test image
         env:
-          WEB_BASE_REPO: quay.io/gumroad/web_base
-          WEB_BASE_TEST_REPO: quay.io/gumroad/web_base_test
-          WEB_REPO: quay.io/gumroad/web
+          WEB_BASE_REPO: gumroadteam/web_base
+          WEB_BASE_TEST_REPO: gumroadteam/web_base_test
+          WEB_REPO: gumroadteam/web
           REVISION: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
         run: |
           set -e
@@ -94,8 +94,8 @@ jobs:
           logger() {
             echo -e "${GREEN}$(date '+%Y/%m/%d %H:%M:%S') build.sh: $1${NC}"
           }
-          docker pull --quiet quay.io/gumroad/ruby:$(cat .ruby-version)-slim-bullseye
-          WEB_BASE_TEST_SHA=$(WEB_BASE_DOCKERFILE_FROM=quay.io/gumroad/ruby:$(cat .ruby-version)-slim-bullseye docker/base/generate_tag_for_web_base_test.sh)
+          docker pull --quiet ruby:$(cat .ruby-version)-slim-bullseye
+          WEB_BASE_TEST_SHA=$(WEB_BASE_DOCKERFILE_FROM=ruby:$(cat .ruby-version)-slim-bullseye docker/base/generate_tag_for_web_base_test.sh)
           build_and_push() {
             local repo=$1
             local tag=$2
@@ -103,7 +103,7 @@ jobs:
             if ! docker manifest inspect $repo:$tag > /dev/null 2>&1; then
               logger "building $repo:$tag"
               NEW_BASE_REPO=$WEB_BASE_REPO NEW_WEB_BASE_TEST_REPO=$WEB_BASE_TEST_REPO NEW_WEB_REPO=$WEB_REPO \
-                WEB_BASE_DOCKERFILE_FROM=quay.io/gumroad/ruby:$(cat .ruby-version)-slim-bullseye \
+                WEB_BASE_DOCKERFILE_FROM=ruby:$(cat .ruby-version)-slim-bullseye \
                 BRANCH_CACHE_UPLOAD_ENABLED=false \
                   BRANCH_CACHE_RESTORE_ENABLED=false \
                   NEW_WEB_TAG=$REVISION \
@@ -146,16 +146,16 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
-      - name: Login to Quay
+      - name: Login to Docker Hub
         uses: nick-fields/retry@v3
         with:
           timeout_seconds: 120
           max_attempts: 3
           retry_wait_seconds: 10
-          command: echo "$QUAY_PASSWORD" | docker login quay.io -u "$QUAY_USERNAME" --password-stdin
+          command: echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
         env:
-          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
-          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Start services and pull test image
         uses: nick-fields/retry@v3
         with:
@@ -172,7 +172,7 @@ jobs:
             exit $((COMPOSE_EXIT + PULL_EXIT))
         env:
           COMPOSE_HTTP_TIMEOUT: "300"
-          WEB_REPO: quay.io/gumroad/web
+          WEB_REPO: gumroadteam/web
       - name: Wait for services
         uses: nick-fields/retry@v3
         with:
@@ -187,7 +187,7 @@ jobs:
             docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh minio 9000 &
             wait
         env:
-          WEB_REPO: quay.io/gumroad/web
+          WEB_REPO: gumroadteam/web
       - name: Setup test database
         uses: nick-fields/retry@v3
         with:
@@ -200,11 +200,11 @@ jobs:
               $WEB_REPO:test-${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }} \
               bundle exec rake db:prepare
         env:
-          WEB_REPO: quay.io/gumroad/web
+          WEB_REPO: gumroadteam/web
 
       - name: Run tests
         env:
-          WEB_REPO: quay.io/gumroad/web
+          WEB_REPO: gumroadteam/web
           KNAPSACK_PRO_BRANCH: ${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref_name }}
         run: |
           docker run --rm --entrypoint="" --network ${{ env.COMPOSE_PROJECT_NAME }}_default \
@@ -239,7 +239,7 @@ jobs:
     name: Test Slow ${{ matrix.ci_node_index }}${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository && ' (internal PR noop)' || '' }}
     env:
       COMPOSE_PROJECT_NAME: web_${{ github.run_id }}_${{ github.run_attempt }}_slow_${{ matrix.ci_node_index }}
-      WEB_REPO: quay.io/gumroad/web
+      WEB_REPO: gumroadteam/web
     runs-on: ubicloud-standard-4
     needs: build
     strategy:
@@ -319,16 +319,16 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
-      - name: Login to Quay
+      - name: Login to Docker Hub
         uses: nick-fields/retry@v3
         with:
           timeout_seconds: 120
           max_attempts: 3
           retry_wait_seconds: 10
-          command: echo "$QUAY_PASSWORD" | docker login quay.io -u "$QUAY_USERNAME" --password-stdin
+          command: echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
         env:
-          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
-          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Start services and pull test image
         uses: nick-fields/retry@v3
         with:
@@ -345,7 +345,7 @@ jobs:
             exit $((COMPOSE_EXIT + PULL_EXIT))
         env:
           COMPOSE_HTTP_TIMEOUT: "300"
-          WEB_REPO: quay.io/gumroad/web
+          WEB_REPO: gumroadteam/web
       - name: Wait for services
         uses: nick-fields/retry@v3
         with:
@@ -360,7 +360,7 @@ jobs:
             docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh minio 9000 &
             wait
         env:
-          WEB_REPO: quay.io/gumroad/web
+          WEB_REPO: gumroadteam/web
       - name: Setup test database
         uses: nick-fields/retry@v3
         with:
@@ -373,7 +373,7 @@ jobs:
               $WEB_REPO:test-${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }} \
               bundle exec rake db:prepare
         env:
-          WEB_REPO: quay.io/gumroad/web
+          WEB_REPO: gumroadteam/web
 
       - name: Run tests
         env:
@@ -392,7 +392,7 @@ jobs:
           KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
           CI: true
           IN_DOCKER: true
-          WEB_REPO: quay.io/gumroad/web
+          WEB_REPO: gumroadteam/web
         run: |
           # Create local directory for artifacts
           mkdir -p ./capybara-artifacts

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ build_base:
 			--cache-from $(NEW_BASE_REPO):latest \
 			--compress . \
 		&& ./generate_tag_for_web_base.sh | xargs -I{} $(DOCKER_CMD) tag $(NEW_BASE_REPO):latest $(NEW_BASE_REPO):{} \
-		&& rm -f Gemfile* .ruby-version Dockerfile
+		&& rm -f Gemfile* .ruby-version
 
 build_base_test:
 	rm -f docker/base/Gemfile* docker/base/.ruby-version

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -7,8 +7,6 @@
 ARG WEB_BASE_DOCKERFILE_FROM
 FROM ${WEB_BASE_DOCKERFILE_FROM}
 
-# Expire Docker images after 6 months in Quay
-LABEL quay.expires-after=6M
 
 ENV BUNDLE_PATH=/bundle_path \
   APP_DIR=/app

--- a/docker/base/Dockerfile.test
+++ b/docker/base/Dockerfile.test
@@ -1,8 +1,6 @@
 ARG WEB_BASE_DOCKERFILE_FROM
 FROM ${WEB_BASE_DOCKERFILE_FROM}
 
-# Expire Docker images after 6 months in Quay
-LABEL quay.expires-after=6M
 
 # Customizations copied from:
 # https://github.com/circleci/circleci-images/blob/master/shared/images/Dockerfile-basic.template

--- a/docker/branch_app_nginx/Dockerfile
+++ b/docker/branch_app_nginx/Dockerfile
@@ -1,7 +1,5 @@
 FROM openresty/openresty:alpine-fat
 
-# Expire Docker images after 1 week in Quay
-LABEL quay.expires-after=1w
 
 RUN luarocks install luasocket
 RUN luarocks install lua_json

--- a/docker/docker-compose-test-and-ci.yml
+++ b/docker/docker-compose-test-and-ci.yml
@@ -1,6 +1,6 @@
 services:
   db_test:
-    image: quay.io/gumroad/mysql:8.0.32
+    image: mysql:8.0.32
     tmpfs:
       - /var/lib/mysql:size=512M
     ports:
@@ -19,14 +19,14 @@ services:
       - "--skip-log-bin"
 
   redis:
-    image: quay.io/gumroad/redis:7.0.7
+    image: redis:7.0.7
     volumes:
       - redis_data:/data
     ports:
       - "6379"
 
   mongo:
-    image: quay.io/gumroad/mongo:3.6.16
+    image: mongo:3.6.16
     volumes:
       - mongo_data:/data/db
     ports:
@@ -34,7 +34,7 @@ services:
     command: "mongod --smallfiles"
 
   elasticsearch:
-    image: quay.io/gumroad/elasticsearch:7.9.3
+    image: elasticsearch:7.9.3
     ports:
       - "9200"
     environment:
@@ -42,12 +42,12 @@ services:
       - "discovery.type=single-node"
 
   memcached:
-    image: quay.io/gumroad/memcached:latest
+    image: memcached:latest
     ports:
       - "11211"
 
   minio:
-    image: quay.io/gumroad/minio:RELEASE.2025-09-07T16-13-09Z
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     ports:
       - "9000"
       - "9001"
@@ -65,7 +65,7 @@ services:
       start_period: 30s
 
   createbuckets:
-    image: quay.io/gumroad/minio-mc:RELEASE.2025-08-13T08-35-41Z
+    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
     depends_on:
       minio:
         condition: service_healthy
@@ -85,7 +85,7 @@ services:
       done; exit 0; "
 
   copyfixturefiles:
-    image: quay.io/gumroad/minio-mc:RELEASE.2025-08-13T08-35-41Z
+    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
     depends_on:
       createbuckets:
         condition: service_completed_successfully

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,7 +1,5 @@
 FROM nginx:1.23.4
 
-# Expire Docker images after 1 week in Quay
-LABEL quay.expires-after=1w
 
 COPY public /public
 COPY docker/nginx/nginx.conf /nginx.conf

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -2,8 +2,6 @@
 ARG WEB_DOCKERFILE_FROM
 FROM ${WEB_DOCKERFILE_FROM}
 
-# Expire Docker images after 1 week in Quay
-LABEL quay.expires-after=1w
 
 ENV BUNDLE_PATH=/bundle_path
 ENV APP_DIR=/app

--- a/docker/web/Dockerfile.test
+++ b/docker/web/Dockerfile.test
@@ -4,8 +4,6 @@ ARG WEB_BASE_TEST_DOCKERFILE_FROM
 FROM ${WEB_DOCKERFILE_FROM}
 FROM ${WEB_BASE_TEST_DOCKERFILE_FROM}
 
-# Expire Docker images after 1 week in Quay
-LABEL quay.expires-after=1w
 
 COPY --from=0 /bundle_path /bundle_path
 COPY --from=0 /usr/local/bin /usr/local/bin


### PR DESCRIPTION
## What

Migrates all CI Docker image references from Quay.io to Docker Hub.

- **`.github/workflows/tests.yml`**: Login steps switched from Quay to Docker Hub (`DOCKERHUB_USERNAME`/`DOCKERHUB_PASSWORD` secrets). All `quay.io/gumroad/` image references updated to `gumroadteam/` (custom images) or official Docker Hub images (service images).
- **`docker/docker-compose-test-and-ci.yml`**: Service images now pull directly from Docker Hub — `mysql:8.0.32`, `redis:7.0.7`, `mongo:3.6.16`, `elasticsearch:7.9.3`, `memcached:latest`, `minio/minio:...`, `minio/mc:...`.

## Why

Quay.io has been unreliable, causing CI failures. Docker Hub is the most battle-tested container registry with no per-GB egress charges (flat monthly fee), unlike ECR which would cost ~$19/CI run (~$11k+/month) in egress fees since our Ubicloud runners are outside AWS.

## Manual steps before merging

1. Add GitHub secrets: `DOCKERHUB_USERNAME` and `DOCKERHUB_PASSWORD`
2. Push existing `web_base`, `web_base_test`, and `web` images from Quay to Docker Hub (`gumroadteam/` namespace)
3. Docker Hub repos already created: `gumroadteam/web`, `gumroadteam/web_base`, `gumroadteam/web_base_test`

---

Built with Claude Opus 4.6. Prompts: review PR #4476 for ECR migration, calculate ECR egress costs, evaluate alternative registries, switch to Docker Hub.