### PR TITLE
Surface validation errors in custom fields API create action

### DIFF
--- a/app/controllers/api/v2/custom_fields_controller.rb
+++ b/app/controllers/api/v2/custom_fields_controller.rb
@@ -25,7 +25,7 @@ class Api::V2::CustomFieldsController < Api::V2::BaseController
     if field.save
       success_with_custom_field(field)
     else
-      error_with_creating_object(:custom_field)
+      error_with_creating_object(:custom_field, field)
     end
   end
 

--- a/spec/controllers/api/v2/custom_fields_controller_spec.rb
+++ b/spec/controllers/api/v2/custom_fields_controller_spec.rb
@@ -83,6 +83,28 @@ describe Api::V2::CustomFieldsController do
           custom_field: @product.reload.custom_fields.last.as_json.stringify_keys!
         }.as_json(api_scopes: ["edit_products"]))
       end
+
+      it "creates a custom field on an unpublished API-created product" do
+        api_product = create(:product, :unpublished, user: @user)
+        post @action, params: @params.merge(link_id: api_product.external_id, name: "Company", type: "text", required: "true")
+        expect(response.parsed_body["success"]).to be(true)
+        created_field = api_product.custom_fields.reload.last
+        expect(created_field.name).to eq("Company")
+        expect(created_field.field_type).to eq("text")
+        expect(created_field.required).to be(true)
+      end
+
+      it "returns validation errors when save fails" do
+        post @action, params: @params.merge(type: "invalid_type")
+        expect(response.parsed_body["success"]).to be(false)
+        expect(response.parsed_body["message"]).to include("Field type is not included in the list")
+      end
+
+      it "returns validation errors for terms field with invalid URL" do
+        post @action, params: @params.merge(name: "not-a-url", type: "terms")
+        expect(response.parsed_body["success"]).to be(false)
+        expect(response.parsed_body["message"]).to include("Please provide a valid URL for custom field of Terms type")
+      end
     end
   end
 


### PR DESCRIPTION
## What

The custom fields API create endpoint (`POST /api/v2/products/:link_id/custom_fields`) returned a generic "The custom_field was unable to be created." error when `field.save` failed, suppressing the actual validation messages. This made it impossible for API consumers to understand why their request was rejected.

The fix passes the `field` object to `error_with_creating_object`, which already supports an optional second argument to extract `field.errors.full_messages`. Every other V2 API controller already follows this pattern — custom fields was the only one not passing the object.

## Why

This was discovered during a live smoke test of CLI commands against a real Gumroad account. Creating a custom field on an API-created product returned the generic error with no indication of what went wrong. Without the actual validation messages, debugging required reading the Rails source to understand which validation failed.

The `error_with_creating_object` helper in `BaseController` already supports surfacing errors when an object is passed — this was a one-line fix to use the existing capability.

---

This PR was implemented with AI assistance using Claude Opus 4.6 and gpt‑5.4 xhigh
