### PR TITLE
Fix NoMethodError when rich_content is passed as a string

### DIFF
--- a/app/controllers/api/v2/links_controller.rb
+++ b/app/controllers/api/v2/links_controller.rb
@@ -213,6 +213,24 @@ class Api::V2::LinksController < Api::V2::BaseController
       return render_response(false, message: "Price cannot be updated for tiered membership products. Use the variant endpoints to manage tier pricing.")
     end
 
+    if params.key?(:tags)
+      if !params[:tags].is_a?(Array) || params[:tags].any? { |t| !t.respond_to?(:to_str) }
+        return render_response(false, message: "tags must be an array of strings.")
+      end
+    end
+
+    if params.key?(:rich_content)
+      if !params[:rich_content].is_a?(Array) || params[:rich_content].any? { |p| !p.respond_to?(:key?) }
+        return render_response(false, message: "rich_content must be an array of content page objects.")
+      end
+    end
+
+    if params.key?(:files)
+      if !params[:files].is_a?(Array) || params[:files].any? { |f| !f.respond_to?(:key?) }
+        return render_response(false, message: "files must be an array of file objects.")
+      end
+    end
+
     @normalized_files = normalize_params_recursively(params[:files]) if params.key?(:files)
     @normalized_rich_content = normalize_params_recursively(params[:rich_content]) if params.key?(:rich_content)
 

--- a/spec/controllers/api/v2/links_controller_spec.rb
+++ b/spec/controllers/api/v2/links_controller_spec.rb
@@ -1279,6 +1279,54 @@ describe Api::V2::LinksController do
           expect(@product.reload.alive_rich_contents.count).to eq 1
         end
       end
+
+      it "rejects non-array tags" do
+        put @action, params: @params.merge(tags: "oops")
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to be false
+        expect(response.parsed_body["message"]).to include("tags must be an array")
+      end
+
+      it "rejects tags with non-string elements" do
+        put @action, params: @params.merge(tags: ["valid", { nested: "hash" }])
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to be false
+        expect(response.parsed_body["message"]).to include("tags must be an array of strings")
+      end
+
+      it "rejects non-array rich_content" do
+        put @action, params: @params.merge(rich_content: "oops")
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to be false
+        expect(response.parsed_body["message"]).to include("rich_content must be an array")
+      end
+
+      it "rejects rich_content with non-object elements" do
+        put @action, params: @params.merge(rich_content: ["not_an_object"])
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to be false
+        expect(response.parsed_body["message"]).to include("rich_content must be an array of content page objects")
+      end
+
+      it "rejects non-array files" do
+        put @action, params: @params.merge(files: "oops")
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to be false
+        expect(response.parsed_body["message"]).to include("files must be an array")
+      end
+
+      it "rejects files with non-object elements" do
+        put @action, params: @params.merge(files: ["not_an_object"])
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to be false
+        expect(response.parsed_body["message"]).to include("files must be an array of file objects")
+      end
     end
   end
 


### PR DESCRIPTION
## What

Adds input type validation for `rich_content`, `tags`, and `files` params in `Api::V2::LinksController#update`, matching the validation already present in `#create`.

## Why

When the API receives `rich_content` as a plain string instead of the expected array of page objects, `normalize_params_recursively` returns it as-is. Downstream methods then call `flat_map` on the string, causing `NoMethodError: undefined method 'flat_map' for an instance of String`. The `create` action already had these validations but `update` was missing them.

## Test Results

Added 6 tests covering:
- Non-array `tags`, `rich_content`, and `files` params (string input)
- Array params with wrong element types (strings instead of objects)

All new tests verify the API returns a clear error message instead of a 500.

---

AI disclosure: Implemented with Claude Opus 4.6. Prompted to fix the NoMethodError in LinksController#update where flat_map is called on a String rich_content param.

🤖 Generated with [Claude Code](https://claude.com/claude-code)