### PR TITLE
Defer missed posts on sale detail page

### DIFF
--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -39,7 +39,7 @@ class CustomersController < Sellers::BaseController
              can_ping: current_seller.urls_for_ping_notification(ResourceSubscription::SALE_RESOURCE_NAME).size > 0,
              show_refund_fee_notice: current_seller.show_refund_fee_notice?,
              emails: build_customer_emails(purchase),
-             missed_posts: presenter.missed_posts,
+             missed_posts: InertiaRails.defer { presenter.missed_posts },
              charges: build_charges(purchase),
              product_purchases: purchase.is_bundle_purchase ? purchase.product_purchases.map { CustomerPresenter.new(purchase: _1).customer(pundit_user:) } : [],
            }

--- a/app/javascript/components/Audience/CustomerDetailPage.tsx
+++ b/app/javascript/components/Audience/CustomerDetailPage.tsx
@@ -1,5 +1,5 @@
 import { ArrowDown, ArrowUpRightSquare, Paperclip, Trash } from "@boxicons/react";
-import { Link } from "@inertiajs/react";
+import { Deferred, Link } from "@inertiajs/react";
 import { Blob, DirectUpload } from "@rails/activestorage";
 import * as React from "react";
 
@@ -86,7 +86,7 @@ export type CustomerDetailPageProps = {
   can_ping: boolean;
   show_refund_fee_notice: boolean;
   emails: CustomerEmail[];
-  missed_posts: MissedPost[];
+  missed_posts?: MissedPost[];
   charges: Charge[];
   product_purchases: Customer[];
 };
@@ -142,7 +142,7 @@ const CustomerDetailPage = ({
   const updateCustomer = (update: Partial<Customer>) => setCustomer((prev) => ({ ...prev, ...update }));
 
   const [loadingId, setLoadingId] = React.useState<string | null>(null);
-  const missedPosts = initialMissedPosts;
+  const missedPosts = initialMissedPosts ?? [];
   const [shownMissedPosts, setShownMissedPosts] = React.useState(PAGE_SIZE);
   const emails = initialEmails;
   const [shownEmails, setShownEmails] = React.useState(PAGE_SIZE);
@@ -764,47 +764,64 @@ const CustomerDetailPage = ({
             </section>
           </Card>
         ) : null}
-        {missedPosts.length !== 0 ? (
-          <Card asChild>
-            <section className="break-inside-avoid">
-              <CardContent asChild>
-                <header>
-                  <h3 className="grow">Send missed posts</h3>
-                </header>
-              </CardContent>
-              {missedPosts.slice(0, shownMissedPosts).map((post) => (
-                <CardContent asChild key={post.id}>
-                  <section>
-                    <div className="grow">
-                      <h5 className="font-bold">
-                        <a href={post.url} target="_blank" rel="noreferrer">
-                          {post.name}
-                        </a>
-                      </h5>
-                      <small className="block text-muted">{`Originally sent on ${formatDateWithoutTime(new Date(post.published_at))}`}</small>
-                    </div>
-                    <Button
-                      color="primary"
-                      disabled={!!loadingId || sentEmailIds.current.has(post.id)}
-                      onClick={() => void onSend(post.id, "post")}
-                    >
-                      {sentEmailIds.current.has(post.id) ? "Sent" : loadingId === post.id ? "Sending..." : "Send"}
-                    </Button>
-                  </section>
-                </CardContent>
-              ))}
-              {shownMissedPosts < missedPosts.length ? (
+        <div className="break-inside-avoid">
+          <Deferred data={["missed_posts"]} fallback={
+            <Card asChild>
+              <section>
                 <CardContent asChild>
-                  <section>
-                    <Button onClick={() => setShownMissedPosts((prev) => prev + PAGE_SIZE)} className="grow basis-0">
-                      Show more
-                    </Button>
-                  </section>
+                  <header>
+                    <h3 className="grow">Send missed posts</h3>
+                  </header>
                 </CardContent>
-              ) : null}
-            </section>
-          </Card>
-        ) : null}
+                <CardContent>
+                  <LoadingSpinner className="mx-auto size-8" />
+                </CardContent>
+              </section>
+            </Card>
+          }>
+            {missedPosts.length !== 0 ? (
+              <Card asChild>
+                <section>
+                  <CardContent asChild>
+                    <header>
+                      <h3 className="grow">Send missed posts</h3>
+                    </header>
+                  </CardContent>
+                  {missedPosts.slice(0, shownMissedPosts).map((post) => (
+                    <CardContent asChild key={post.id}>
+                      <section>
+                        <div className="grow">
+                          <h5 className="font-bold">
+                            <a href={post.url} target="_blank" rel="noreferrer">
+                              {post.name}
+                            </a>
+                          </h5>
+                          <small className="block text-muted">{`Originally sent on ${formatDateWithoutTime(new Date(post.published_at))}`}</small>
+                        </div>
+                        <Button
+                          color="primary"
+                          disabled={!!loadingId || sentEmailIds.current.has(post.id)}
+                          onClick={() => void onSend(post.id, "post")}
+                        >
+                          {sentEmailIds.current.has(post.id) ? "Sent" : loadingId === post.id ? "Sending..." : "Send"}
+                        </Button>
+                      </section>
+                    </CardContent>
+                  ))}
+                  {shownMissedPosts < missedPosts.length ? (
+                    <CardContent asChild>
+                      <section>
+                        <Button onClick={() => setShownMissedPosts((prev) => prev + PAGE_SIZE)} className="grow basis-0">
+                          Show more
+                        </Button>
+                      </section>
+                    </CardContent>
+                  ) : null}
+                </section>
+              </Card>
+            ) : null}
+          </Deferred>
+        </div>
       </ColumnLayout>
     </div>
   );


### PR DESCRIPTION
## What

Defer the `missed_posts` prop on the customer sale detail page using `InertiaRails.defer`, so the page renders instantly while missed posts load in the background.
Show a loading spinner in the "Send missed posts" section while data loads.
Wrap the deferred section in a `<div>` inside `ColumnLayout` so column distribution stays stable.

## Why

The `Installment.missed_for_purchase` query is expensive for sellers with many published posts - it iterates through every installment in Ruby and runs per-installment exclusion filter queries against the sales table. For a seller like MacWhisper (900k sales, 99 published installments), this takes 11+ seconds, blocking the entire page load.

Every other prop on this page loads in under 200ms. Deferring just this one prop makes the page render instantly for all sellers.

