### PR TITLE
Fix Elasticsearch::Transport::Transport::Errors::NotFound in LinksController#index

### DIFF
--- a/app/modules/product/caching.rb
+++ b/app/modules/product/caching.rb
@@ -55,7 +55,7 @@ module Product::Caching
     collection.map do |product|
       cache_or_product = cached_values.find { |cached_value| cached_value.product_id == product.id } || product
       if block_given?
-        yield(product).merge(
+        stats = begin
           {
             "successful_sales_count" => cache_or_product.successful_sales_count,
             "remaining_for_sale_count" => cache_or_product.remaining_for_sale_count,
@@ -63,7 +63,17 @@ module Product::Caching
             "revenue_pending" => cache_or_product.revenue_pending.to_f,
             "total_usd_cents" => cache_or_product.total_usd_cents.to_f,
           }
-        )
+        rescue Elasticsearch::Transport::Transport::Errors::NotFound, Faraday::ConnectionFailed, Faraday::TimeoutError => e
+          Rails.logger.warn("[Product::Caching] Elasticsearch unavailable for product #{product.id}: #{e.class}")
+          {
+            "successful_sales_count" => 0,
+            "remaining_for_sale_count" => product.remaining_for_sale_count,
+            "monthly_recurring_revenue" => 0.0,
+            "revenue_pending" => 0.0,
+            "total_usd_cents" => 0.0,
+          }
+        end
+        yield(product).merge(stats)
       else
         cache_or_product
       end

--- a/app/modules/product/caching.rb
+++ b/app/modules/product/caching.rb
@@ -63,13 +63,13 @@ module Product::Caching
             "revenue_pending" => cache_or_product.revenue_pending.to_f,
             "total_usd_cents" => cache_or_product.total_usd_cents.to_f,
           }
-        rescue Elasticsearch::Transport::Transport::Errors::NotFound, Faraday::ConnectionFailed, Faraday::TimeoutError => e
+        rescue Elasticsearch::Transport::Transport::Error, Faraday::ConnectionFailed, Faraday::TimeoutError => e
           Rails.logger.warn("[Product::Caching] Elasticsearch unavailable for product #{product.id}: #{e.class}")
           {
             "successful_sales_count" => 0,
             "remaining_for_sale_count" => product.remaining_for_sale_count,
             "monthly_recurring_revenue" => 0.0,
-            "revenue_pending" => 0.0,
+            "revenue_pending" => product.revenue_pending.to_f,
             "total_usd_cents" => 0.0,
           }
         end

--- a/spec/modules/product/caching_spec.rb
+++ b/spec/modules/product/caching_spec.rb
@@ -272,7 +272,7 @@ describe Product::Caching do
                                                 "id" => product.id,
                                                 "monthly_recurring_revenue" => 0.0,
                                                 "remaining_for_sale_count" => 100,
-                                                "revenue_pending" => 0.0,
+                                                "revenue_pending" => product.revenue_pending.to_f,
                                                 "successful_sales_count" => 0,
                                                 "total_usd_cents" => 0.0,
                                               })

--- a/spec/modules/product/caching_spec.rb
+++ b/spec/modules/product/caching_spec.rb
@@ -259,6 +259,25 @@ describe Product::Caching do
             expect(CacheProductDataWorker).to have_enqueued_sidekiq_job(product.id)
           end
         end
+
+        context "when Elasticsearch is unavailable" do
+          it "returns default values instead of raising" do
+            allow(product).to receive(:successful_sales_count).and_raise(
+              Elasticsearch::Transport::Transport::Errors::NotFound.new("[404] no such index [purchases]")
+            )
+
+            result = described_class.dashboard_collection_data([product], cache: true) { |p| { "id" => p.id } }
+
+            expect(result).to contain_exactly({
+                                                "id" => product.id,
+                                                "monthly_recurring_revenue" => 0.0,
+                                                "remaining_for_sale_count" => 100,
+                                                "revenue_pending" => 0.0,
+                                                "successful_sales_count" => 0,
+                                                "total_usd_cents" => 0.0,
+                                              })
+          end
+        end
       end
 
       context "when multiple products exist" do


### PR DESCRIPTION
## Summary
- When the `purchases` Elasticsearch index is missing/unavailable, `Product::Caching.dashboard_collection_data` now rescues the error and returns zero/default values for uncached products instead of crashing `LinksController#index`
- Handles `Elasticsearch::Transport::Transport::Errors::NotFound`, `Faraday::ConnectionFailed`, and `Faraday::TimeoutError`
- `remaining_for_sale_count` is still computed from the database since it doesn't depend on ES

Sentry: https://gumroad-to.sentry.io/issues/7412103003/

## Test plan
- [ ] Verify existing `Product::Caching` specs pass
- [ ] New spec confirms default values are returned when ES raises `NotFound`
- [ ] Confirm dashboard page loads when ES `purchases` index is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)