### PR TITLE
Fix NoMethodError when Discord OAuth returns non-JSON response

### DIFF
--- a/app/controllers/admin/links_controller.rb
+++ b/app/controllers/admin/links_controller.rb
@@ -126,7 +126,8 @@ class Admin::LinksController < Admin::BaseController
 
     discord_api = DiscordApi.new
     oauth_response = discord_api.oauth_token(params[:code], oauth_redirect_integrations_discord_index_url(host: DOMAIN, protocol: PROTOCOL))
-    access_token = oauth_response.parsed_response&.dig("access_token")
+    parsed = oauth_response.parsed_response
+    access_token = parsed.is_a?(Hash) ? parsed.dig("access_token") : nil
 
     return render plain: "Failed to get access token from Discord, try re-authorizing." unless oauth_response.success? && access_token.present?
 

--- a/app/controllers/integrations/discord_controller.rb
+++ b/app/controllers/integrations/discord_controller.rb
@@ -6,8 +6,10 @@ class Integrations::DiscordController < ApplicationController
   def server_info
     discord_api = DiscordApi.new
     oauth_response = discord_api.oauth_token(params[:code], oauth_redirect_integrations_discord_index_url)
-    server = oauth_response.parsed_response&.dig("guild")
-    access_token = oauth_response.parsed_response&.dig("access_token")
+    parsed = oauth_response.parsed_response
+    parsed = nil if !parsed.is_a?(Hash)
+    server = parsed&.dig("guild")
+    access_token = parsed&.dig("access_token")
     return render json: { success: false } unless oauth_response.success? && server.present? && access_token.present?
 
     begin
@@ -25,7 +27,8 @@ class Integrations::DiscordController < ApplicationController
 
     discord_api = DiscordApi.new
     oauth_response = discord_api.oauth_token(params[:code], oauth_redirect_integrations_discord_index_url(host: DOMAIN, protocol: PROTOCOL))
-    access_token = oauth_response.parsed_response&.dig("access_token")
+    parsed = oauth_response.parsed_response
+    access_token = parsed.is_a?(Hash) ? parsed.dig("access_token") : nil
 
     return render json: { success: false } unless oauth_response.success? && access_token.present?
 

--- a/spec/controllers/admin/links_controller_spec.rb
+++ b/spec/controllers/admin/links_controller_spec.rb
@@ -139,6 +139,20 @@ describe Admin::LinksController, type: :controller, inertia: true do
     end
   end
 
+  describe "GET join_discord" do
+    let(:integration) { create(:discord_integration) }
+    let(:product) { create(:product, active_integrations: [integration]) }
+
+    it "renders error when Discord returns a non-JSON response" do
+      WebMock.stub_request(:post, DISCORD_OAUTH_TOKEN_URL).
+        to_return(status: 200, body: "<html>502 Bad Gateway</html>", headers: { content_type: "text/html" })
+
+      get :join_discord, params: { external_id: product.external_id, code: "test_code" }
+
+      expect(response.body).to eq("Failed to get access token from Discord, try re-authorizing.")
+    end
+  end
+
   describe "POST is_adult" do
     it "marks the product as adult" do
       post :is_adult, params: { external_id: product.external_id, is_adult: true }

--- a/spec/controllers/integrations/discord_controller_spec.rb
+++ b/spec/controllers/integrations/discord_controller_spec.rb
@@ -111,6 +111,17 @@ describe Integrations::DiscordController do
       expect(response.status).to eq(200)
       expect(response.parsed_body).to eq({ "success" => false })
     end
+
+    it "fails if oauth token endpoint returns a non-JSON response" do
+      WebMock.stub_request(:post, DISCORD_OAUTH_TOKEN_URL).
+        with(body: oauth_request_body, headers: oauth_request_header).
+        to_return(status: 200, body: "<html>502 Bad Gateway</html>", headers: { content_type: "text/html" })
+
+      get :server_info, format: :json, params: { code: "test_code" }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq({ "success" => false })
+    end
   end
 
   describe "GET oauth_redirect" do
@@ -329,6 +340,19 @@ describe Integrations::DiscordController do
       WebMock.stub_request(:get, "#{Discordrb::API.api_base}/users/@me").
         with(headers: { "Authorization" => "Bearer test_access_token" }).
         to_return(status: 200, body: "<html>upstream connect error</html>", headers: { content_type: "text/html" })
+
+      expect do
+        get :join_server, format: :json, params: { code: "test_code", purchase_id: purchase.external_id }
+      end.not_to change { PurchaseIntegration.count }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq({ "success" => false })
+    end
+
+    it "fails if oauth token endpoint returns a non-JSON response" do
+      WebMock.stub_request(:post, DISCORD_OAUTH_TOKEN_URL).
+        with(body: oauth_request_body, headers: oauth_request_header).
+        to_return(status: 200, body: "<html>502 Bad Gateway</html>", headers: { content_type: "text/html" })
 
       expect do
         get :join_server, format: :json, params: { code: "test_code", purchase_id: purchase.external_id }


### PR DESCRIPTION
## What

Add a type guard on `parsed_response` in `Integrations::DiscordController` so `.dig` is only called when the response is a `Hash`. Applied to both `server_info` and `join_server` methods.

## Why

When the Discord API returns a non-JSON response (e.g., a 502 error page), HTTParty's `parsed_response` is a raw `String` instead of a `Hash`. The `&.` safe navigation only guards against `nil`, not `String`, so calling `.dig("access_token")` on a String raises `NoMethodError: undefined method 'dig' for an instance of String`. This was reported in Sentry.

## Test results

Added tests for both `server_info` and `join_server` that verify the controller returns `{ success: false }` when the OAuth token endpoint returns a non-JSON response.

---

AI disclosure: Implemented with Claude Opus 4.6. Prompted to fix the Sentry error `NoMethodError: undefined method 'dig' for an instance of String` in `Integrations::DiscordController#join_server`.