### PR TITLE
Fix ActiveModel::UnknownAttributeError for 'name' in ProductFile

### DIFF
--- a/app/services/save_files_service.rb
+++ b/app/services/save_files_service.rb
@@ -57,6 +57,10 @@ class SaveFilesService
       all_file_params = all_file_params.is_a?(Array) ? all_file_params : all_file_params.values
       all_file_params.each do |file_params|
         file_params[:filetype] = "link" if file_params.delete(:extension) == "URL"
+        if file_params.key?(:name)
+          file_params[:display_name] ||= file_params[:name]
+          file_params.delete(:name)
+        end
       end
     end
 end

--- a/spec/services/save_files_service_spec.rb
+++ b/spec/services/save_files_service_spec.rb
@@ -127,6 +127,37 @@ describe SaveFilesService do
       expect(video_2_subtitles.first.language).to eq("new-language2")
     end
 
+    it "maps 'name' param to 'display_name' for product files" do
+      file = create(:product_file, link: @product, url: "#{AWS_S3_ENDPOINT}/#{S3_BUCKET}/attachment/pencil.png")
+      @product.product_files << file
+
+      service.perform(@product, {
+                        files: [{
+                          external_id: file.external_id,
+                          url: file.url,
+                          name: "renamed file",
+                        }]
+                      })
+
+      expect(file.reload.display_name).to eq("renamed file")
+    end
+
+    it "prefers 'display_name' over 'name' when both are provided" do
+      file = create(:product_file, link: @product, url: "#{AWS_S3_ENDPOINT}/#{S3_BUCKET}/attachment/pencil.png")
+      @product.product_files << file
+
+      service.perform(@product, {
+                        files: [{
+                          external_id: file.external_id,
+                          url: file.url,
+                          name: "from name",
+                          display_name: "from display_name",
+                        }]
+                      })
+
+      expect(file.reload.display_name).to eq("from display_name")
+    end
+
     it "supports `files` param as an array" do
       installment = create(:installment, workflow: create(:workflow))
       file1 = create(:product_file, installment:, url: "#{AWS_S3_ENDPOINT}/#{S3_BUCKET}/attachment/pencil.png")


### PR DESCRIPTION
## Problem

The V2 Links API `update` action raises `ActiveModel::UnknownAttributeError: unknown attribute 'name' for ProductFile` when an API consumer includes a `name` field in the file params.

**Sentry:** https://gumroad-to.sentry.io/issues/7412532248/

**Culprit:** `Api::V2::LinksController#update`

## Root Cause

The `create` action properly uses `permit` to filter file params to a known allowlist (`[:id, :url, :display_name, :extension, ...]`). The `update` action passes file params through `normalize_params_recursively` without any strong-params filtering, so arbitrary attributes flow through to `product_file.update!`.

Since the API response returns `file_name` (via `name_displayable`), it's reasonable for API consumers to send `name` when updating a file. But the actual column is `display_name`, causing the error.

## Fix

Map `name` → `display_name` in `SaveFilesService#updated_file_params`, consistent with how `extension` is already mapped to `filetype` in the same method. If both `name` and `display_name` are provided, `display_name` takes precedence.

## Tests

- Added test: maps `name` param to `display_name`
- Added test: prefers `display_name` over `name` when both are provided
- All 6 `save_files_service_spec` tests pass