### PR TITLE
Retry balance_transaction retrieval for destination payments

### DIFF
--- a/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
+++ b/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
@@ -162,14 +162,19 @@ class StripePayoutProcessor
                                                          # 1 key (`payment`) already added above so allow max - 1 more keys
                                                          max_key_length: StripeMetadata::STRIPE_METADATA_MAX_KEYS_LENGTH - 1))
       )
-      destination_payment = Stripe::Charge.retrieve(
-        {
-          id: internal_transfer.destination_payment,
-          expand: %w[balance_transaction]
-        },
-        { stripe_account: payment.stripe_connect_account_id }
-      )
-      raise "Balance transaction not yet available for destination payment #{destination_payment.id}" if destination_payment.balance_transaction.nil?
+      destination_payment = nil
+      3.times do |attempt|
+        destination_payment = Stripe::Charge.retrieve(
+          {
+            id: internal_transfer.destination_payment,
+            expand: %w[balance_transaction]
+          },
+          { stripe_account: payment.stripe_connect_account_id }
+        )
+        break if destination_payment.balance_transaction.present?
+        raise "Balance transaction not yet available for destination payment #{destination_payment.id}" if attempt == 2
+        sleep(2)
+      end
       payment.amount_cents += destination_payment.balance_transaction.amount
       payment.stripe_internal_transfer_id = internal_transfer.id
     end

--- a/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
+++ b/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
@@ -302,10 +302,23 @@ describe StripePayoutProcessor, :vcr do
       transfer
     end
 
-    let(:destination_payment) do
+    let(:destination_payment_nil_bt) do
       dest = double
       allow(dest).to receive(:id).and_return("py_1234")
       allow(dest).to receive(:balance_transaction).and_return(nil)
+      dest
+    end
+
+    let(:balance_transaction) do
+      bt = double
+      allow(bt).to receive(:amount).and_return(10_00)
+      bt
+    end
+
+    let(:destination_payment_with_bt) do
+      dest = double
+      allow(dest).to receive(:id).and_return("py_1234")
+      allow(dest).to receive(:balance_transaction).and_return(balance_transaction)
       dest
     end
 
@@ -313,15 +326,31 @@ describe StripePayoutProcessor, :vcr do
       merchant_account
       user.reload
       allow(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account).and_return(internal_transfer)
-      allow(Stripe::Charge).to receive(:retrieve).and_return(destination_payment)
+      allow(described_class).to receive(:sleep)
     end
 
-    it "raises an error and marks the payment as failed" do
+    it "raises an error after retries and marks the payment as failed" do
+      allow(Stripe::Charge).to receive(:retrieve).and_return(destination_payment_nil_bt)
+
       expect do
         described_class.prepare_payment_and_set_amount(payment, payment.balances.to_a)
       end.to raise_error(RuntimeError, /Balance transaction not yet available/)
+
+      expect(Stripe::Charge).to have_received(:retrieve).exactly(3).times
+      expect(described_class).to have_received(:sleep).with(2).twice
       payment.reload
       expect(payment.state).to eq("failed")
+    end
+
+    it "succeeds when balance_transaction becomes available on retry" do
+      allow(Stripe::Charge).to receive(:retrieve).and_return(destination_payment_nil_bt, destination_payment_with_bt)
+
+      errors = described_class.prepare_payment_and_set_amount(payment, payment.balances.to_a)
+
+      expect(errors).to eq([])
+      expect(Stripe::Charge).to have_received(:retrieve).twice
+      expect(described_class).to have_received(:sleep).with(2).once
+      expect(payment.amount_cents).to eq(10_00)
     end
   end
 


### PR DESCRIPTION
## What

Adds a retry mechanism (3 attempts, 2-second delay) when retrieving a destination payment's `balance_transaction` after an internal Stripe transfer. Previously, a `RuntimeError` was raised immediately if `balance_transaction` was nil.

## Why

Stripe doesn't always have the `balance_transaction` available immediately after creating a transfer. This is a transient timing issue causing `RuntimeError: Balance transaction not yet available for destination payment` errors in Sentry. A short retry loop resolves the race condition without any broader changes.

## Test Results

Updated existing test to verify 3 retry attempts and 2 sleeps before raising. Added new test confirming success when `balance_transaction` becomes available on the second attempt.

```
2 examples, 0 failures
```

---

AI disclosure: Built with Claude Opus 4.6. Prompted with the Sentry error context and fix strategy.