### PR TITLE
Fix Rack::Timeout in checkout upsells products endpoint

### DIFF
--- a/app/controllers/checkout/upsells/products_controller.rb
+++ b/app/controllers/checkout/upsells/products_controller.rb
@@ -3,34 +3,51 @@
 class Checkout::Upsells::ProductsController < ApplicationController
   include CustomDomainConfig
 
-  MAX_PRODUCTS = 50
+  MAX_PRODUCTS = 25
+
+  QUERY_TIMEOUT_MS = 10_000
 
   PRODUCT_INCLUDES = [
     :skus_alive_not_default,
     :variant_categories_alive,
     :product_review_stat,
     { alive_variants: { variant_category: :link },
-      thumbnail_alive: { file_attachment: { blob: { variant_records: { image_attachment: :blob } } } },
-      display_asset_previews: { file_attachment: { blob: { variant_records: { image_attachment: :blob } } } } },
+      thumbnail_alive: { file_attachment: :blob },
+      display_asset_previews: { file_attachment: :blob } },
   ].freeze
 
   def index
     seller = user_by_domain(request.host) || current_seller
     return render json: [] unless seller
 
-    products = seller.products
-      .eligible_for_content_upsells
-      .includes(*PRODUCT_INCLUDES)
-      .order(created_at: :desc, id: :desc)
-      .limit(MAX_PRODUCTS)
+    products = with_query_timeout do
+      seller.products
+        .eligible_for_content_upsells
+        .includes(*PRODUCT_INCLUDES)
+        .order(created_at: :desc, id: :desc)
+        .limit(MAX_PRODUCTS)
+        .to_a
+    end
     render json: products.map { |product| Checkout::Upsells::ProductPresenter.new(product).product_props }
   end
 
   def show
-    product = Link.eligible_for_content_upsells
-                  .includes(*PRODUCT_INCLUDES)
-                  .find_by_external_id!(params[:id])
+    product = with_query_timeout do
+      Link.eligible_for_content_upsells
+          .includes(*PRODUCT_INCLUDES)
+          .find_by_external_id!(params[:id])
+    end
 
     render json: Checkout::Upsells::ProductPresenter.new(product).product_props
+  end
+
+  private
+
+  def with_query_timeout
+    previous_timeout = ActiveRecord::Base.connection.execute("SELECT @@SESSION.max_execution_time AS t").first.first
+    ActiveRecord::Base.connection.execute("SET SESSION max_execution_time = #{QUERY_TIMEOUT_MS}")
+    yield
+  ensure
+    ActiveRecord::Base.connection.execute("SET SESSION max_execution_time = #{previous_timeout || 0}")
   end
 end


### PR DESCRIPTION
## Summary
- **Add 10s MySQL query timeout** (`max_execution_time`) to both `index` and `show` actions to prevent the full 120s Rack timeout from being hit
- **Remove unnecessary eager loading** of `variant_records: { image_attachment: :blob }` — Active Storage variants are generated at runtime via `file.variant().processed`, not pre-loaded from the database
- **Reduce `MAX_PRODUCTS` from 50 to 25** to limit query complexity for sellers with many products

Fixes a `Rack::Timeout::RequestTimeoutException` (120s) in `Checkout::Upsells::ProductsController#index`.

## Test plan
- [x] `bundle exec rspec spec/controllers/checkout/upsells/products_controller_spec.rb` — 8 examples, 0 failures
- [ ] Verify checkout upsell products load correctly in staging
- [ ] Confirm thumbnail URLs still render for products with thumbnails and display asset previews

🤖 Generated with [Claude Code](https://claude.com/claude-code)