### PR TITLE
Fix RuntimeError in PaymentsController#update for unsupported bank account types

### DIFF
--- a/app/services/update_payout_method.rb
+++ b/app/services/update_payout_method.rb
@@ -140,7 +140,7 @@ class UpdatePayoutMethod
       params[:bank_account][:type].present? &&
       (params[:bank_account][:account_holder_full_name].present? || params[:bank_account][:account_number].present?)
 
-      raise unless params[:bank_account][:type].in?(BANK_ACCOUNT_TYPES)
+      return { error: :bank_account_error, data: "Unsupported bank account type." } unless params[:bank_account][:type].in?(BANK_ACCOUNT_TYPES)
 
       if params[:bank_account][:account_number].present?
         bank_account_account_number = params[:bank_account][:account_number].delete("-").strip

--- a/spec/controllers/settings/payments_controller_spec.rb
+++ b/spec/controllers/settings/payments_controller_spec.rb
@@ -245,6 +245,23 @@ describe Settings::PaymentsController, :vcr, type: :controller, inertia: true do
       end
     end
 
+    describe "unsupported bank account type" do
+      it "returns an error instead of raising" do
+        put :update, params: {
+          bank_account: {
+            type: "UnsupportedBankAccount",
+            account_number: "000123456789",
+            account_number_confirmation: "000123456789",
+            account_holder_full_name: "gumbot"
+          }
+        }
+
+        expect(response).to redirect_to(settings_payments_path)
+        expect(response).to have_http_status :found
+        expect(session[:inertia_errors][:base]).to include("Unsupported bank account type.")
+      end
+    end
+
     describe "individual" do
       let(:all_params) do { user: params }.merge!(
         bank_account: {


### PR DESCRIPTION
## What

Replace bare `raise` in `UpdatePayoutMethod#process` with a graceful error return when the submitted bank account type is not in `BANK_ACCOUNT_TYPES`. Add a controller spec covering this case.

## Why

The bare `raise` produces a `RuntimeError` with the default message "unhandled exception", which crashes the request and surfaces in Sentry. This can happen when a user submits a malformed or unsupported bank account type. The fix uses the existing `:bank_account_error` pattern already handled by the controller, returning a user-friendly error message instead.

## Test Results

Added a test in `spec/controllers/settings/payments_controller_spec.rb` that submits an unsupported bank account type and verifies the error is returned gracefully.

---

AI disclosure: Implemented with Claude Opus 4.6. Prompted to fix the Sentry issue for the `RuntimeError` "unhandled exception" in `Settings::PaymentsController#update` caused by a bare `raise` on unsupported bank account types.