### PR TITLE
Allow admin to impersonate suspended users

### DIFF
--- a/app/controllers/concerns/impersonate.rb
+++ b/app/controllers/concerns/impersonate.rb
@@ -34,8 +34,7 @@ module Impersonate
     impersonated_user_id = $redis.get(RedisKey.impersonated_user(current_user_from_api_or_web.id))
     return if impersonated_user_id.nil?
 
-    user = User.alive.find(impersonated_user_id)
-    user if user.account_active?
+    User.alive.find(impersonated_user_id)
   rescue ActiveRecord::RecordNotFound
     nil
   end

--- a/spec/controllers/concerns/impersonate_spec.rb
+++ b/spec/controllers/concerns/impersonate_spec.rb
@@ -143,9 +143,9 @@ describe Impersonate, type: :controller do
               user.suspend_for_fraud!(author_id: admin.id)
             end
 
-            it "returns nil" do
+            it "returns the user" do
               get :action
-              expect(controller.impersonated_user).to be(nil)
+              expect(controller.impersonated_user).to eq(user)
             end
           end
 
@@ -155,9 +155,9 @@ describe Impersonate, type: :controller do
               user.suspend_for_tos_violation!(author_id: admin.id)
             end
 
-            it "returns nil" do
+            it "returns the user" do
               get :action
-              expect(controller.impersonated_user).to be(nil)
+              expect(controller.impersonated_user).to eq(user)
             end
           end
         end


### PR DESCRIPTION
## What

Admins can now impersonate suspended users. Previously, `find_impersonated_user_from_redis` checked `account_active?`, which requires the user to not be suspended. This removed that check while keeping the `User.alive` scope to still block impersonating deleted users.

## Why

Suspended users need admin support for things like accessing 1099 tax forms. Admins couldn't impersonate them to investigate or assist, forcing workarounds.