### PR TITLE
Fix Elasticsearch NotFound crash on dashboard when product_page_views index is missing

### DIFF
--- a/app/services/creator_analytics/product_page_views.rb
+++ b/app/services/creator_analytics/product_page_views.rb
@@ -72,6 +72,8 @@ class CreatorAnalytics::ProductPageViews
         after_key = response_agg["after_key"]
       end
       buckets
+    rescue Elasticsearch::Transport::Transport::Errors::NotFound
+      []
     end
 
     def build_body(sources)

--- a/spec/services/creator_analytics/product_page_views_spec.rb
+++ b/spec/services/creator_analytics/product_page_views_spec.rb
@@ -159,6 +159,24 @@ describe CreatorAnalytics::ProductPageViews do
     end
   end
 
+  context "when the product_page_views Elasticsearch index does not exist" do
+    before do
+      allow(ProductPageView).to receive(:search).and_raise(Elasticsearch::Transport::Transport::Errors::NotFound)
+    end
+
+    it "by_product_and_date returns an empty hash" do
+      expect(@service.by_product_and_date).to eq({})
+    end
+
+    it "by_product_and_country_and_state returns an empty hash" do
+      expect(@service.by_product_and_country_and_state).to eq({})
+    end
+
+    it "by_product_and_referrer_and_date returns an empty hash" do
+      expect(@service.by_product_and_referrer_and_date).to eq({})
+    end
+  end
+
   describe "DST handling" do
     context "when page view occurs near midnight during DST" do
       let(:user_timezone) { "Pacific Time (US & Canada)" }


### PR DESCRIPTION
## What

Rescue `Elasticsearch::Transport::Transport::Errors::NotFound` in `CreatorAnalytics::ProductPageViews#paginate` so the seller dashboard returns zero views instead of 500ing when the `product_page_views` index doesn't exist.

## Why

When the ES index is missing (not yet created or cleaned up), `ProductPageView.search` raises `NotFound`, which bubbles up through `CreatorAnalytics::CachingProxy#data_for_dates` → `CreatorHomePresenter` → `DashboardController#index` and crashes the entire dashboard.

Sentry: https://gumroad-to.sentry.io/issues/7414621359/

## Test plan

- [ ] `bundle exec rspec spec/services/creator_analytics/product_page_views_spec.rb` passes
- [ ] New specs verify all three public methods (`by_product_and_date`, `by_product_and_country_and_state`, `by_product_and_referrer_and_date`) return empty hashes when `ProductPageView.search` raises `NotFound`
- [ ] Revert the rescue in `paginate` and confirm the new tests fail

---

AI disclosure: implemented with Claude Opus 4.6. Prompt: fix Sentry issue for missing `product_page_views` ES index crashing `DashboardController#index`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)