### PR TITLE
Handle missing S3 objects in ProductFile#signed_url

### DIFF
--- a/app/models/product_file.rb
+++ b/app/models/product_file.rb
@@ -167,6 +167,8 @@ class ProductFile < ApplicationRecord
     return url if external_link?
 
     signed_download_url_for_s3_key_and_filename(s3_key, s3_filename, is_video: streamable?)
+  rescue Aws::S3::Errors::NotFound
+    nil
   end
 
   def readable?

--- a/spec/models/product_file_spec.rb
+++ b/spec/models/product_file_spec.rb
@@ -1034,4 +1034,20 @@ describe ProductFile do
       end
     end
   end
+
+  describe "#signed_url" do
+    let(:product_file) { create(:product_file) }
+
+    it "returns nil when the S3 object does not exist" do
+      allow_any_instance_of(SignedUrlHelper).to receive(:signed_download_url_for_s3_key_and_filename)
+        .and_raise(Aws::S3::Errors::NotFound.new(nil, "Not Found"))
+
+      expect(product_file.signed_url).to be_nil
+    end
+
+    it "returns the url for external links" do
+      product_file.update!(filetype: "link", url: "https://example.com/file.zip")
+      expect(product_file.signed_url).to eq("https://example.com/file.zip")
+    end
+  end
 end


### PR DESCRIPTION
## Problem

`Api::V2::LinksController#update` raises an unhandled `Aws::S3::Errors::NotFound` when a product's file references an S3 key that no longer exists. The error occurs during response serialization: `as_json_for_api` iterates product files and calls `signed_url`, which calls `signed_download_url_for_s3_key_and_filename` in `SignedUrlHelper`. That method does `obj.content_length` on the S3 object and re-raises `NotFound` if the object is missing.

This causes a 500 error for the API caller even though the product update itself succeeded.

Sentry: https://gumroad-to.sentry.io/issues/7414876722/

## Fix

Rescue `Aws::S3::Errors::NotFound` in `ProductFile#signed_url` and return `nil` instead. The API response will include `null` for that file's URL rather than blowing up. The file's S3 object being missing is a data integrity issue that should be handled separately, not crash the update response.

## Tests

Added tests for `ProductFile#signed_url`:
- Returns `nil` when S3 object is not found
- Returns the URL directly for external links