### PR TITLE
Handle Aws::S3::Errors::NotFound in API v2 product show

### DIFF
--- a/app/models/concerns/product/as_json.rb
+++ b/app/models/concerns/product/as_json.rb
@@ -138,15 +138,20 @@ module Product::AsJson
         json.merge!(
           "rich_content" => rich_content_json,
           "has_same_rich_content_for_all_variants" => has_same_rich_content_for_all_variants?,
-          "files" => ordered_alive_product_files.map do |f|
-            {
-              id: f.external_id,
-              name: f.display_name,
-              size: f.size,
-              url: f.signed_url,
-              filetype: f.filetype,
-              filegroup: f.filegroup,
-            }
+          "files" => ordered_alive_product_files.filter_map do |f|
+            begin
+              {
+                id: f.external_id,
+                name: f.display_name,
+                size: f.size,
+                url: f.signed_url,
+                filetype: f.filetype,
+                filegroup: f.filegroup,
+              }
+            rescue Aws::S3::Errors::NotFound => e
+              Rails.logger.warn("Skipping product file #{f.id} with missing S3 object: #{e.message}")
+              nil
+            end
           end
         )
       end

--- a/spec/controllers/api/v2/links_controller_spec.rb
+++ b/spec/controllers/api/v2/links_controller_spec.rb
@@ -748,6 +748,21 @@ describe Api::V2::LinksController do
         expect(files.first["url"]).to be_present
       end
 
+      it "gracefully skips files with missing S3 objects" do
+        good_file = create(:product_file, link: @product, url: "#{S3_BASE_URL}specs/test.pdf")
+        bad_file = create(:product_file, link: @product, url: "#{S3_BASE_URL}attachments/missing-guid/original/gone.zip")
+
+        allow_any_instance_of(ProductFile).to receive(:signed_url).and_call_original
+        allow(bad_file).to receive(:signed_url).and_raise(Aws::S3::Errors::NotFound.new(nil, "Not Found"))
+        allow(@product).to receive(:ordered_alive_product_files).and_return([good_file, bad_file])
+
+        get :show, params: @params
+        expect(response).to be_successful
+        files = response.parsed_body["product"]["files"]
+        expect(files.length).to eq(1)
+        expect(files.first["id"]).to eq(good_file.external_id)
+      end
+
       it "includes raw URL for external link files" do
         create(:product_file, link: @product, url: "https://example.com/my-file.zip", filetype: "link")
 


### PR DESCRIPTION
## Problem

The `Api::V2::LinksController#show` endpoint crashes with `Aws::S3::Errors::NotFound` when a product has a file whose S3 object has been deleted or is missing. This happens because `signed_download_url_for_s3_key_and_filename` performs a HEAD request to S3 to get the file's `content_length`, and when the object doesn't exist, the exception bubbles up and returns a 500 error.

[Sentry issue](https://gumroad-to.sentry.io/issues/7414890969/)

## Fix

In `Product::AsJson#as_json_for_api`, rescue `Aws::S3::Errors::NotFound` when serializing each product file. Files with missing S3 objects are logged as warnings and omitted from the `files` array rather than crashing the entire API response.

## Test

Added a spec that verifies the endpoint returns a successful response and only includes valid files when one file's S3 object is missing.