### PR TITLE
Fix ActionView::Template::Error in AffiliateMailer when destination_url is nil

### DIFF
--- a/app/mailers/affiliate_mailer.rb
+++ b/app/mailers/affiliate_mailer.rb
@@ -23,7 +23,7 @@ class AffiliateMailer < ApplicationMailer
       "#{product[:fee_percent]}%"
     end
     @affiliate_referral_url = affiliate_referral_url
-    @final_destination_url = @products.one? ? product[:destination_url] : @direct_affiliate.final_destination_url
+    @final_destination_url = @direct_affiliate.final_destination_url
 
     @subject = "#{@seller_name} has added you as an affiliate."
     params = {

--- a/spec/mailers/affiliate_mailer_spec.rb
+++ b/spec/mailers/affiliate_mailer_spec.rb
@@ -196,6 +196,19 @@ describe AffiliateMailer do
           expect(mail.body.encoded).to_not include("— after they click, we'll redirect them to")
         end
       end
+
+      context "when affiliate has a destination URL but product affiliate does not" do
+        it "uses the model fallback URL instead of nil" do
+          direct_affiliate = create(:direct_affiliate, seller:, destination_url: "https://example.com")
+          create(:product_affiliate, product:, affiliate: direct_affiliate, destination_url: nil)
+
+          mail = AffiliateMailer.direct_affiliate_invitation(direct_affiliate.id)
+          expect(mail.to).to eq([direct_affiliate.affiliate_user.form_email])
+          expect(mail.body.encoded).to include("— after they click, we'll redirect them to")
+          final_url = direct_affiliate.final_destination_url
+          expect(mail.body.encoded.squish).to include(%(href="#{final_url}">#{final_url}</a>))
+        end
+      end
     end
 
     context "when affiliate has multiple products" do


### PR DESCRIPTION
## What

Fixes `ActionView::Template::Error: No route matches {}` in `AffiliateMailer#direct_affiliate_invitation`.

When a direct affiliate has a single product whose `product_affiliate` has no `destination_url`, the mailer assigned `nil` to `@final_destination_url`. The email template then called `link_to nil`, which Rails resolved as `url_for({})`, raising `No route matches {}`.

Replaced the ternary with `DirectAffiliate#final_destination_url`, which already handles all fallback cases (product destination → affiliate destination → product long_url → seller subdomain).

## Why

The previous code bypassed the model's fallback logic for single-product affiliates, directly reading `product[:destination_url]` from the `enabled_products` hash. This is nil when the `ProductAffiliate` record has no custom destination URL. The `DirectAffiliate#final_destination_url` method already exists specifically to handle these edge cases.

## Test results

Added a test that reproduces the exact Sentry error — creating a direct affiliate with a destination URL but whose product affiliate has `destination_url: nil`. Confirmed the test raises `ActionView::Template::Error: No route matches {}` without the fix and passes with it.

```
27 examples, 0 failures
```

---

AI disclosure: This fix was implemented with Claude Opus 4.6. Prompted with the Sentry error details and root cause analysis pointing to the nil destination_url edge case in `AffiliateMailer#direct_affiliate_invitation`.