### PR TITLE
Allow suspended users to log in

### DIFF
--- a/app/controllers/logins_controller.rb
+++ b/app/controllers/logins_controller.rb
@@ -43,19 +43,15 @@ class LoginsController < Devise::SessionsController
 
     return redirect_with_login_error("You cannot log in because your account was permanently deleted. Please sign up for a new account to start selling!") if @user.deleted?
 
-    if @user.suspended_for_fraud?
-      check_suspended
-    else
-      @user.remember_me = true # Always "remember" user sessions
+    @user.remember_me = true # Always "remember" user sessions
 
-      sign_in_or_prepare_for_two_factor_auth(@user)
+    sign_in_or_prepare_for_two_factor_auth(@user)
 
-      if @user.respond_to?(:pwned?) && @user.pwned?
-        flash[:warning] = "Your password has previously appeared in a data breach as per haveibeenpwned.com and should never be used. We strongly recommend you change your password everywhere you have used it."
-      end
-
-      redirect_to login_path_for(@user), allow_other_host: true
+    if @user.respond_to?(:pwned?) && @user.pwned?
+      flash[:warning] = "Your password has previously appeared in a data breach as per haveibeenpwned.com and should never be used. We strongly recommend you change your password everywhere you have used it."
     end
+
+    redirect_to login_path_for(@user), allow_other_host: true
   end
 
   private

--- a/app/controllers/two_factor_authentication_controller.rb
+++ b/app/controllers/two_factor_authentication_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class TwoFactorAuthenticationController < ApplicationController
+  skip_before_action :check_suspended
   before_action :redirect_to_signed_in_path, if: -> { user_signed_in? && skip_two_factor_authentication?(logged_in_user) }
   before_action :fetch_user
   before_action :check_presence_of_user, except: :verify

--- a/spec/controllers/logins_controller_spec.rb
+++ b/spec/controllers/logins_controller_spec.rb
@@ -211,13 +211,12 @@ describe LoginsController, type: :controller, inertia: true do
         end
       end
 
-      it "does not log in a user who is suspended for fraud" do
+      it "allows a user suspended for fraud to log in" do
         user = create(:user, password: "password", user_risk_state: "suspended_for_fraud")
 
         post :create, params: { user: { login_identifier: user.email, password: "password" } }
 
-        expect(flash[:warning]).to eq("You can't perform this action because your account has been suspended.")
-        expect(controller.user_signed_in?).to be(false)
+        expect(controller.user_signed_in?).to be(true)
       end
     end
 


### PR DESCRIPTION
## What

Suspended-for-fraud users can now log in to their account. Previously, `LoginsController#create` explicitly called `check_suspended` for these users, blocking the login POST. This also blocked 2FA completion since `TwoFactorAuthenticationController` didn't skip the global `check_suspended` filter.

- Remove the explicit `check_suspended` gate in `LoginsController#create`
- Add `skip_before_action :check_suspended` to `TwoFactorAuthenticationController`

## Why

Suspended users need to access their account to view their payouts page, which now shows a scheduled payout status banner (PR #4397). The global `check_suspended` before_action already prevents suspended users from performing non-GET actions (POST/PUT/PATCH/DELETE) across the app, so blocking login itself is redundant — they can view pages but can't take destructive actions.

## Test plan
- [x] Existing login specs pass (suspended user test updated to expect successful login)
- [x] 2FA controller specs pass
- [ ] Log in as a suspended user, verify access to payouts page
- [ ] Verify suspended user still cannot perform non-GET actions (e.g. updating settings)

---

Generated with Claude Opus 4.6. Prompted: "in a branch from origin/main, fix the login issue - suspended users should be able to login, include 2FA"