### PR TITLE
Fix scheduled payout banner messages for sellers

### DIFF
--- a/app/controllers/balance_controller.rb
+++ b/app/controllers/balance_controller.rb
@@ -30,7 +30,7 @@ class BalanceController < Sellers::BaseController
     def scheduled_payout_props
       return nil if !current_seller.suspended?
 
-      sp = current_seller.scheduled_payouts.where(status: %w[pending flagged held]).order(id: :desc).first
+      sp = current_seller.scheduled_payouts.where(status: %w[pending flagged held executed]).order(id: :desc).first
       return nil if sp.nil?
 
       {

--- a/app/javascript/components/Payouts/index.tsx
+++ b/app/javascript/components/Payouts/index.tsx
@@ -281,7 +281,7 @@ export type PayoutsProps = {
   tax_center_enabled: boolean;
   scheduled_payout: {
     action: "refund" | "payout" | "hold";
-    status: "pending" | "flagged" | "held";
+    status: "pending" | "flagged" | "held" | "executed";
     scheduled_at: string;
     payout_amount_cents: number | null;
   } | null;

--- a/app/javascript/pages/Payouts/Index.tsx
+++ b/app/javascript/pages/Payouts/Index.tsx
@@ -538,21 +538,35 @@ export default function PayoutsIndex() {
           <Alert variant="info" role="status">
             <p>
               {scheduled_payout.action === "payout" ? (
-                <>
-                  Your balance
-                  {scheduled_payout.payout_amount_cents != null
-                    ? ` of ${formatPriceCentsWithCurrencySymbol("usd", scheduled_payout.payout_amount_cents, { symbolFormat: "short", noCentsIfWhole: false })}`
-                    : ""}{" "}
-                  is scheduled for payout on{" "}
-                  <strong>{new Date(scheduled_payout.scheduled_at).toLocaleDateString()}</strong>.
-                  {scheduled_payout.status === "flagged" &&
-                    " Your payout is under review. Please contact support for details."}
-                </>
+                scheduled_payout.status === "executed" ? (
+                  <>
+                    Your balance
+                    {scheduled_payout.payout_amount_cents != null
+                      ? ` of ${formatPriceCentsWithCurrencySymbol("usd", scheduled_payout.payout_amount_cents, { symbolFormat: "short", noCentsIfWhole: false })}`
+                      : ""}{" "}
+                    has been paid out.
+                  </>
+                ) : (
+                  <>
+                    Your balance
+                    {scheduled_payout.payout_amount_cents != null
+                      ? ` of ${formatPriceCentsWithCurrencySymbol("usd", scheduled_payout.payout_amount_cents, { symbolFormat: "short", noCentsIfWhole: false })}`
+                      : ""}{" "}
+                    is scheduled for payout on{" "}
+                    <strong>{new Date(scheduled_payout.scheduled_at).toLocaleDateString()}</strong>.
+                    {scheduled_payout.status === "flagged" &&
+                      " Your payout is under review. Please contact support for details."}
+                  </>
+                )
               ) : scheduled_payout.action === "refund" ? (
-                <>
-                  Your purchases are scheduled to be refunded on{" "}
-                  <strong>{new Date(scheduled_payout.scheduled_at).toLocaleDateString()}</strong>.
-                </>
+                scheduled_payout.status === "executed" ? (
+                  <>Your unpaid sales have been refunded to buyers.</>
+                ) : (
+                  <>
+                    Your balance will not be paid out. Unpaid sales are scheduled to be refunded to buyers on{" "}
+                    <strong>{new Date(scheduled_payout.scheduled_at).toLocaleDateString()}</strong>.
+                  </>
+                )
               ) : (
                 <>
                   Your balance is on hold. Please <a href={Routes.support_index_path()}>contact support</a> for details.

--- a/spec/controllers/balance_controller_spec.rb
+++ b/spec/controllers/balance_controller_spec.rb
@@ -40,6 +40,66 @@ describe BalanceController, type: :controller, inertia: true do
       expect(inertia.props[:pagination]).to be_present
     end
 
+    context "with scheduled payout" do
+      it "returns nil when seller is not suspended" do
+        create(:scheduled_payout, user: seller, action: "payout", status: "pending")
+
+        get :index
+
+        expect(inertia.props[:scheduled_payout]).to be_nil
+      end
+
+      context "when seller is suspended" do
+        before do
+          seller.update!(user_risk_state: "suspended_for_fraud")
+        end
+
+        it "returns pending payout props" do
+          sp = create(:scheduled_payout, user: seller, action: "payout", status: "pending", payout_amount_cents: 50_000)
+
+          get :index
+
+          expect(inertia.props[:scheduled_payout]).to eq({
+            action: "payout",
+            status: "pending",
+            scheduled_at: sp.scheduled_at,
+            payout_amount_cents: 50_000
+          })
+        end
+
+        it "returns executed payout props" do
+          sp = create(:scheduled_payout, user: seller, action: "refund", status: "executed", executed_at: Time.current, payout_amount_cents: 30_000)
+
+          get :index
+
+          expect(inertia.props[:scheduled_payout]).to eq({
+            action: "refund",
+            status: "executed",
+            scheduled_at: sp.scheduled_at,
+            payout_amount_cents: 30_000
+          })
+        end
+
+        it "returns the most recent scheduled payout" do
+          create(:scheduled_payout, user: seller, action: "refund", status: "pending")
+          sp = create(:scheduled_payout, user: seller, action: "payout", status: "pending", payout_amount_cents: 75_000)
+
+          get :index
+
+          expect(inertia.props[:scheduled_payout][:action]).to eq("payout")
+          expect(inertia.props[:scheduled_payout][:payout_amount_cents]).to eq(75_000)
+        end
+
+        it "returns nil when no active scheduled payout exists" do
+          create(:scheduled_payout, user: seller, action: "payout", status: "cancelled")
+
+          get :index
+
+          expect(inertia.props[:scheduled_payout]).to be_nil
+        end
+      end
+    end
+
     context "with pagination" do
       let(:payments_per_page) { 2 }
 

--- a/spec/controllers/balance_controller_spec.rb
+++ b/spec/controllers/balance_controller_spec.rb
@@ -82,7 +82,7 @@ describe BalanceController, type: :controller, inertia: true do
 
         it "returns the most recent scheduled payout" do
           create(:scheduled_payout, user: seller, action: "refund", status: "pending")
-          sp = create(:scheduled_payout, user: seller, action: "payout", status: "pending", payout_amount_cents: 75_000)
+          create(:scheduled_payout, user: seller, action: "payout", status: "pending", payout_amount_cents: 75_000)
 
           get :index
 

--- a/spec/requests/balance_pages_spec.rb
+++ b/spec/requests/balance_pages_spec.rb
@@ -903,6 +903,70 @@ describe "Balance Pages Scenario", js: true, type: :system do
       end
     end
 
+    describe "scheduled payout banner" do
+      context "when seller is suspended with a pending payout" do
+        let(:seller) { create(:named_seller, user_risk_state: "suspended_for_fraud") }
+
+        it "displays payout scheduled message" do
+          create(:scheduled_payout, user: seller, action: "payout", status: "pending", payout_amount_cents: 50_000, scheduled_at: 21.days.from_now)
+
+          visit balance_path
+
+          expect(page).to have_status(text: /Your balance of \$500\.00 is scheduled for payout on/)
+        end
+
+        it "displays flagged payout message" do
+          create(:scheduled_payout, user: seller, action: "payout", status: "flagged", payout_amount_cents: 50_000, scheduled_at: 21.days.from_now)
+
+          visit balance_path
+
+          expect(page).to have_status(text: /Your payout is under review/)
+        end
+
+        it "displays refund scheduled message" do
+          create(:scheduled_payout, user: seller, action: "refund", status: "pending", payout_amount_cents: 50_000, scheduled_at: 21.days.from_now)
+
+          visit balance_path
+
+          expect(page).to have_status(text: /Your balance will not be paid out. Unpaid sales are scheduled to be refunded to buyers on/)
+        end
+
+        it "displays hold message" do
+          create(:scheduled_payout, user: seller, action: "hold", status: "held", payout_amount_cents: 50_000)
+
+          visit balance_path
+
+          expect(page).to have_status(text: "Your balance is on hold. Please contact support for details.")
+        end
+
+        it "displays executed payout message" do
+          create(:scheduled_payout, user: seller, action: "payout", status: "executed", executed_at: Time.current, payout_amount_cents: 50_000)
+
+          visit balance_path
+
+          expect(page).to have_status(text: /Your balance of \$500\.00 has been paid out\./)
+        end
+
+        it "displays executed refund message" do
+          create(:scheduled_payout, user: seller, action: "refund", status: "executed", executed_at: Time.current, payout_amount_cents: 50_000)
+
+          visit balance_path
+
+          expect(page).to have_status(text: "Your unpaid sales have been refunded to buyers.")
+        end
+      end
+
+      context "when seller is not suspended" do
+        it "does not display the banner" do
+          create(:scheduled_payout, user: seller, action: "payout", status: "pending", payout_amount_cents: 50_000)
+
+          visit balance_path
+
+          expect(page).not_to have_text("is scheduled for payout on")
+        end
+      end
+    end
+
     describe "past payouts" do
       let!(:now) { Time.current }
       let!(:payout_date) { 1.week.ago }

--- a/spec/requests/balance_pages_spec.rb
+++ b/spec/requests/balance_pages_spec.rb
@@ -906,29 +906,31 @@ describe "Balance Pages Scenario", js: true, type: :system do
     describe "scheduled payout banner" do
       context "when seller is suspended with a pending payout" do
         let(:seller) { create(:named_seller, user_risk_state: "suspended_for_fraud") }
+        let(:scheduled_date) { 21.days.from_now }
+        let(:formatted_date) { scheduled_date.strftime("%-m/%-d/%Y") }
 
         it "displays payout scheduled message" do
-          create(:scheduled_payout, user: seller, action: "payout", status: "pending", payout_amount_cents: 50_000, scheduled_at: 21.days.from_now)
+          create(:scheduled_payout, user: seller, action: "payout", status: "pending", payout_amount_cents: 50_000, scheduled_at: scheduled_date)
 
           visit balance_path
 
-          expect(page).to have_status(text: /Your balance of \$500\.00 is scheduled for payout on/)
+          expect(page).to have_status(text: "Your balance of $500.00 is scheduled for payout on #{formatted_date}.")
         end
 
         it "displays flagged payout message" do
-          create(:scheduled_payout, user: seller, action: "payout", status: "flagged", payout_amount_cents: 50_000, scheduled_at: 21.days.from_now)
+          create(:scheduled_payout, user: seller, action: "payout", status: "flagged", payout_amount_cents: 50_000, scheduled_at: scheduled_date)
 
           visit balance_path
 
-          expect(page).to have_status(text: /Your payout is under review/)
+          expect(page).to have_status(text: "Your balance of $500.00 is scheduled for payout on #{formatted_date}. Your payout is under review. Please contact support for details.")
         end
 
         it "displays refund scheduled message" do
-          create(:scheduled_payout, user: seller, action: "refund", status: "pending", payout_amount_cents: 50_000, scheduled_at: 21.days.from_now)
+          create(:scheduled_payout, user: seller, action: "refund", status: "pending", payout_amount_cents: 50_000, scheduled_at: scheduled_date)
 
           visit balance_path
 
-          expect(page).to have_status(text: /Your balance will not be paid out. Unpaid sales are scheduled to be refunded to buyers on/)
+          expect(page).to have_status(text: "Your balance will not be paid out. Unpaid sales are scheduled to be refunded to buyers on #{formatted_date}.")
         end
 
         it "displays hold message" do
@@ -944,7 +946,7 @@ describe "Balance Pages Scenario", js: true, type: :system do
 
           visit balance_path
 
-          expect(page).to have_status(text: /Your balance of \$500\.00 has been paid out\./)
+          expect(page).to have_status(text: "Your balance of $500.00 has been paid out.")
         end
 
         it "displays executed refund message" do


### PR DESCRIPTION
## What

- Refund banner now uses seller-perspective language instead of buyer-perspective
- Banner persists after execution with past-tense confirmation messages
- Controller includes `executed` status in the query

## Why

The refund message said "Your purchases are scheduled to be refunded" — but this is a seller-facing page. Sellers have sales, not purchases. The message also didn't clarify that the seller's balance won't be paid out. Additionally, the banner disappeared after execution, leaving the seller with no confirmation.

## Banner messages

| Action | Pending/Flagged | Executed |
|--------|----------------|----------|
| Payout | Your balance of $500.00 is scheduled for payout on **5/6/2026**. | Your balance of $500.00 has been paid out. |
| Payout (flagged) | Your balance of $500.00 is scheduled for payout on **5/6/2026**. Your payout is under review. Please contact support for details. | — |
| Refund | Your balance will not be paid out. Unpaid sales are scheduled to be refunded to buyers on **5/6/2026**. | Your unpaid sales have been refunded to buyers. |
| Hold | Your balance is on hold. Please contact support for details. | — |

## Test plan
- [ ] As a suspended seller with a pending payout, verify banner shows future-tense message
- [ ] As a suspended seller with a pending refund, verify "Your balance will not be paid out. Unpaid sales are scheduled to be refunded to buyers"
- [ ] As a suspended seller with an executed payout, verify "has been paid out"
- [ ] As a suspended seller with an executed refund, verify "have been refunded to buyers"
- [ ] As a suspended seller with a hold, verify hold message

---

Generated with Claude Opus 4.6. Prompted: "fix the banner messages — refund message should reference unpaid sales not purchases, handle executed state"