### PR TITLE
Remove Mexico VAT collection on digital products

### DIFF
--- a/lib/utilities/compliance.rb
+++ b/lib/utilities/compliance.rb
@@ -266,7 +266,6 @@ module Compliance
       Compliance::Countries::GEO.alpha2, # Georgia
       Compliance::Countries::KAZ.alpha2, # Kazakhstan
       Compliance::Countries::MYS.alpha2, # Malaysia
-      Compliance::Countries::MEX.alpha2, # Mexico
       Compliance::Countries::MDA.alpha2, # Moldova
       Compliance::Countries::MAR.alpha2, # Morocco
       Compliance::Countries::RUS.alpha2, # Russia

--- a/spec/business/sales_tax/sales_tax_calculator_spec.rb
+++ b/spec/business/sales_tax/sales_tax_calculator_spec.rb
@@ -1298,67 +1298,17 @@ describe SalesTaxCalculator do
     end
 
     describe "Mexico VAT" do
-      let!(:standard_tax_rate) { create(:zip_tax_rate, country: "MX", state: nil, zip_code: nil, combined_rate: 0.16, is_seller_responsible: false) }
-      let!(:epublication_tax_rate) { create(:zip_tax_rate, country: "MX", state: nil, zip_code: nil, combined_rate: 0.00, is_seller_responsible: false, is_epublication_rate: true) }
+      it "does not assess VAT in Mexico" do
+        create(:zip_tax_rate, country: "MX", state: nil, zip_code: nil, combined_rate: 0.16, is_seller_responsible: false)
+        product = create(:product, user: @seller)
 
-      context "when collect_tax_mx feature flag is off" do
-        it "does not assess VAT in Mexico" do
-          product = create(:product, user: @seller)
+        expected_sales_tax = SalesTaxCalculation.zero_tax(100)
 
-          expected_sales_tax = SalesTaxCalculation.zero_tax(100)
+        actual_sales_tax = SalesTaxCalculator.new(product:,
+                                                  price_cents: 100,
+                                                  buyer_location: { country: "MX" }).calculate
 
-          actual_sales_tax = SalesTaxCalculator.new(product:,
-                                                    price_cents: 100,
-                                                    buyer_location: { country: "MX" }).calculate
-
-          compare_calculations(expected: expected_sales_tax, actual: actual_sales_tax)
-        end
-      end
-
-      context "when collect_tax_mx feature flag is on" do
-        before do
-          Feature.activate(:collect_tax_mx)
-        end
-
-        it "assesses VAT in Mexico" do
-          product = create(:product, user: @seller)
-
-          expected_sales_tax = SalesTaxCalculation.new(price_cents: 100,
-                                                       tax_cents: 16,
-                                                       zip_tax_rate: standard_tax_rate)
-
-          actual_sales_tax = SalesTaxCalculator.new(product:,
-                                                    price_cents: 100,
-                                                    buyer_location: { country: "MX" }).calculate
-
-          compare_calculations(expected: expected_sales_tax, actual: actual_sales_tax)
-        end
-
-        it "applies zero rate for e-publications" do
-          product = create(:product, user: @seller, is_epublication: true)
-
-          expected_sales_tax = SalesTaxCalculation.new(price_cents: 100,
-                                                       tax_cents: 0,
-                                                       zip_tax_rate: epublication_tax_rate)
-
-          actual_sales_tax = SalesTaxCalculator.new(product:,
-                                                    price_cents: 100,
-                                                    buyer_location: { country: "MX" }).calculate
-
-          compare_calculations(expected: expected_sales_tax, actual: actual_sales_tax)
-        end
-
-        it "does not assess VAT for physical products" do
-          product = create(:physical_product, user: @seller)
-
-          expected_sales_tax = SalesTaxCalculation.zero_tax(100)
-
-          actual_sales_tax = SalesTaxCalculator.new(product:,
-                                                    price_cents: 100,
-                                                    buyer_location: { country: "MX" }).calculate
-
-          compare_calculations(expected: expected_sales_tax, actual: actual_sales_tax)
-        end
+        compare_calculations(expected: expected_sales_tax, actual: actual_sales_tax)
       end
     end
 

--- a/spec/requests/purchases/product/taxes_spec.rb
+++ b/spec/requests/purchases/product/taxes_spec.rb
@@ -2336,7 +2336,6 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
       Capybara.current_session.driver.browser.manage.delete_all_cookies
 
       create(:zip_tax_rate, country: "MX", state: nil, zip_code: nil, combined_rate: 0.16, is_seller_responsible: false)
-      create(:zip_tax_rate, country: "MX", state: nil, zip_code: nil, combined_rate: 0.00, is_seller_responsible: false, is_epublication_rate: true)
       allow_any_instance_of(ActionDispatch::Request).to receive(:remote_ip).and_return("187.189.0.1") # Mexico
 
       @product = create(:product, price_cents: 100_00)
@@ -2348,97 +2347,19 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
       @product.save!
     end
 
-    context "when collect_tax_mx feature flag is off" do
-      it "does not apply tax in Mexico" do
-        visit "/l/#{@product.unique_permalink}"
-        expect(page).to have_text("$100")
-        add_to_cart(@product)
+    it "does not apply tax in Mexico" do
+      visit "/l/#{@product.unique_permalink}"
+      expect(page).to have_text("$100")
+      add_to_cart(@product)
 
-        check_out(@product, zip_code: nil, credit_card: { number: "4000000360000006" })
+      check_out(@product, zip_code: nil, credit_card: { number: "4000000360000006" })
 
-        purchase = Purchase.last
-        expect(purchase.total_transaction_cents).to eq(100_00)
-        expect(purchase.price_cents).to eq(100_00)
-        expect(purchase.tax_cents).to eq(0)
-        expect(purchase.gumroad_tax_cents).to eq(0)
-        expect(purchase.was_purchase_taxable).to be(false)
-      end
-    end
-
-    context "when collect_tax_mx feature flag is on" do
-      before do
-        Feature.activate(:collect_tax_mx)
-      end
-
-      it "applies tax in Mexico" do
-        visit "/l/#{@product.unique_permalink}"
-        expect(page).to have_text("$100")
-        add_to_cart(@product)
-
-        check_out(@product, zip_code: nil, credit_card: { number: "4000000360000006" })
-
-        purchase = Purchase.last
-        expect(purchase.total_transaction_cents).to eq(116_00)
-        expect(purchase.price_cents).to eq(100_00)
-        expect(purchase.tax_cents).to eq(0)
-        expect(purchase.gumroad_tax_cents).to eq(16_00)
-        expect(purchase.was_purchase_taxable).to be(true)
-      end
-
-      it "applies the epublication tax rate for epublications in Mexico" do
-        @product.update!(is_epublication: true)
-
-        visit "/l/#{@product.unique_permalink}"
-        expect(page).to have_text("$100")
-        add_to_cart(@product)
-
-        check_out(@product, zip_code: nil, credit_card: { number: "4000000360000006" })
-
-        purchase = Purchase.last
-        expect(purchase.total_transaction_cents).to eq(100_00)
-        expect(purchase.price_cents).to eq(100_00)
-        expect(purchase.tax_cents).to eq(0)
-        expect(purchase.gumroad_tax_cents).to eq(0)
-        expect(purchase.was_purchase_taxable).to be(false)
-      end
-
-      it "does not apply tax for physical products", :mock_easypost do
-        physical_product = create(:physical_product, price_cents: 100_00)
-
-        visit "/l/#{physical_product.unique_permalink}"
-        expect(page).to have_text("$100")
-        add_to_cart(physical_product)
-
-        check_out(physical_product, address: { street: "Building 1234, Road 123, Block 123", city: "Mexico City", zip_code: "01000", state: "DF", country: "MX" }, credit_card: { number: "4000000360000006" }, should_verify_address: true)
-
-        purchase = Purchase.last
-        expect(purchase.total_transaction_cents).to eq(100_00)
-        expect(purchase.price_cents).to eq(100_00)
-        expect(purchase.tax_cents).to eq(0)
-        expect(purchase.gumroad_tax_cents).to eq(0)
-        expect(purchase.was_purchase_taxable).to be(false)
-      end
-
-      it "allows entry of the Tax ID and doesn't charge tax", :stub_tax_id_validation do
-        visit "/l/#{@product.unique_permalink}"
-        expect(page).to have_text("$100")
-        add_to_cart(@product)
-
-        check_out(@product, zip_code: nil, credit_card: { number: "4000000360000006" }, rfc_id: "RTL-630713-7M9")
-
-        purchase = Purchase.last
-        expect(purchase.total_transaction_cents).to eq(100_00)
-        expect(purchase.price_cents).to eq(100_00)
-        expect(purchase.tax_cents).to eq(0)
-        expect(purchase.gumroad_tax_cents).to eq(0)
-        expect(purchase.was_purchase_taxable).to be(false)
-
-        # Check Tax ID is present on the invoice as well
-
-        visit purchase.receipt_url
-        click_on("Generate")
-        expect(page).to(have_text("RTL-630713-7M9"))
-      end
+      purchase = Purchase.last
+      expect(purchase.total_transaction_cents).to eq(100_00)
+      expect(purchase.price_cents).to eq(100_00)
+      expect(purchase.tax_cents).to eq(0)
+      expect(purchase.gumroad_tax_cents).to eq(0)
+      expect(purchase.was_purchase_taxable).to be(false)
     end
   end
 


### PR DESCRIPTION
Removes Mexico from the list of countries where Gumroad collects VAT on digital products.

**Change:** Remove `Compliance::Countries::MEX` from `COUNTRIES_THAT_COLLECT_TAX_ON_DIGITAL_PRODUCTS_WITH_TAX_ID_PRO_VALIDATION` in `lib/utilities/compliance.rb`.

This also makes the `collect_tax_mx` Flipper flag irrelevant (it will no longer gate anything).