### PR TITLE
Fix Stripe::InvalidRequestError by stripping non-digit characters from US tax IDs

### DIFF
--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -450,7 +450,7 @@ module StripeMerchantAccountManager
   def self.person_hash(user_compliance_info, passphrase)
     if user_compliance_info
       personal_tax_id = user_compliance_info.individual_tax_id.decrypt(passphrase)
-      personal_tax_id = sanitize_tax_id(personal_tax_id) if personal_tax_id.present?
+      personal_tax_id = sanitize_tax_id(personal_tax_id) if personal_tax_id.present? && user_compliance_info.country_code == Compliance::Countries::USA.alpha2
 
       hash = {
         first_name: user_compliance_info.first_name,

--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -530,7 +530,7 @@ module StripeMerchantAccountManager
     return unless user_compliance_info.present?
 
     business_tax_id = user_compliance_info.business_tax_id.decrypt(passphrase)
-    business_tax_id = sanitize_tax_id(business_tax_id) if business_tax_id.present?
+    business_tax_id = sanitize_tax_id(business_tax_id) if business_tax_id.present? && user_compliance_info.legal_entity_country_code == Compliance::Countries::USA.alpha2
     hash = {
       company: {
         name: user_compliance_info.business_name.presence,

--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -441,9 +441,16 @@ module StripeMerchantAccountManager
   end
 
   private_class_method
+  def self.sanitize_tax_id(tax_id)
+    return tax_id unless tax_id.is_a?(String)
+    tax_id.gsub(/\D/, "")
+  end
+
+  private_class_method
   def self.person_hash(user_compliance_info, passphrase)
     if user_compliance_info
       personal_tax_id = user_compliance_info.individual_tax_id.decrypt(passphrase)
+      personal_tax_id = sanitize_tax_id(personal_tax_id) if personal_tax_id.present?
 
       hash = {
         first_name: user_compliance_info.first_name,
@@ -523,6 +530,7 @@ module StripeMerchantAccountManager
     return unless user_compliance_info.present?
 
     business_tax_id = user_compliance_info.business_tax_id.decrypt(passphrase)
+    business_tax_id = sanitize_tax_id(business_tax_id) if business_tax_id.present?
     hash = {
       company: {
         name: user_compliance_info.business_name.presence,

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -147,7 +147,7 @@ describe StripeMerchantAccountManager, :vcr do
         end
       end
 
-      context "when individual tax ID contains non-digit characters" do
+      context "when US individual tax ID contains non-digit characters" do
         before do
           user_compliance_info.individual_tax_id = "123-45-6789"
           user_compliance_info.save!
@@ -156,6 +156,22 @@ describe StripeMerchantAccountManager, :vcr do
         it "strips non-digit characters before sending to Stripe" do
           expect(Stripe::Account).to receive(:create).with(hash_including(
             individual: hash_including(id_number: "123456789")
+          )).and_call_original
+          subject.create_account(user, passphrase: "1234")
+        end
+      end
+
+      context "when non-US individual tax ID contains letters" do
+        let(:user_compliance_info) { create(:user_compliance_info_singapore, user:) }
+
+        before do
+          user_compliance_info.individual_tax_id = "S1234567D"
+          user_compliance_info.save!
+        end
+
+        it "preserves alphanumeric characters" do
+          expect(Stripe::Account).to receive(:create).with(hash_including(
+            individual: hash_including(id_number: "S1234567D")
           )).and_call_original
           subject.create_account(user, passphrase: "1234")
         end

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -147,6 +147,20 @@ describe StripeMerchantAccountManager, :vcr do
         end
       end
 
+      context "when individual tax ID contains non-digit characters" do
+        before do
+          user_compliance_info.individual_tax_id = "123-45-6789"
+          user_compliance_info.save!
+        end
+
+        it "strips non-digit characters before sending to Stripe" do
+          expect(Stripe::Account).to receive(:create).with(hash_including(
+            individual: hash_including(id_number: "123456789")
+          )).and_call_original
+          subject.create_account(user, passphrase: "1234")
+        end
+      end
+
       context "with stripe connect account" do
         before do
           allow_any_instance_of(MerchantAccount).to receive(:is_a_stripe_connect_account?).and_return(true)
@@ -478,6 +492,21 @@ describe StripeMerchantAccountManager, :vcr do
         merchant_account = subject.create_account(user, passphrase: "1234")
         expect(merchant_account.charge_processor_id).to eq(StripeChargeProcessor.charge_processor_id)
         expect(merchant_account.charge_processor_merchant_id).to be_present
+      end
+
+      context "when business tax ID contains non-digit characters" do
+        before do
+          user_compliance_info.business_tax_id = "12-3456789"
+          user_compliance_info.save!
+        end
+
+        it "strips non-digit characters before sending to Stripe" do
+          expect(Stripe::Account).to receive(:create).with(hash_including(
+            company: hash_including(tax_id: "123456789")
+          )).and_call_original
+          allow(Stripe::Account).to receive(:create_person).and_call_original
+          subject.create_account(user, passphrase: "1234")
+        end
       end
     end
 

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -524,6 +524,25 @@ describe StripeMerchantAccountManager, :vcr do
           subject.create_account(user, passphrase: "1234")
         end
       end
+
+      context "when non-US business is owned by a US resident" do
+        let(:user_compliance_info) do
+          create(:user_compliance_info_business, user:,
+                                                 business_country: "Singapore",
+                                                 business_city: "Singapore",
+                                                 business_state: nil,
+                                                 business_zip_code: "546080",
+                                                 business_tax_id: "200309485K")
+        end
+
+        it "does not strip non-digit characters from the business tax ID" do
+          expect(Stripe::Account).to receive(:create).with(hash_including(
+            company: hash_including(tax_id: "200309485K")
+          )).and_call_original
+          allow(Stripe::Account).to receive(:create_person).and_call_original
+          subject.create_account(user, passphrase: "1234")
+        end
+      end
     end
 
     describe "all info provided of an individual (non-US)" do


### PR DESCRIPTION
## Summary
- Strips non-digit characters (dashes, spaces) from individual and business tax IDs before sending to Stripe API
- Adds `sanitize_tax_id` helper that removes all non-digit characters from tax ID strings
- Applies sanitization in both `person_hash` (SSN/individual tax ID → `id_number`) and `company_hash` (EIN/business tax ID → `company.tax_id`)

## Context
Sentry: https://gumroad-to.sentry.io/issues/7415911249/

Users entering tax IDs with dashes (e.g., "123-45-6789" for SSN, "12-3456789" for EIN) pass our length checks but Stripe rejects them with `Stripe::InvalidRequestError: US tax IDs must have 9 digits` because the string contains non-digit characters.

## Test plan
- [ ] Verify existing US individual account creation tests pass
- [ ] Verify existing US business account creation tests pass
- [ ] New test: US individual with hyphenated SSN sends digits-only to Stripe
- [ ] New test: US business with hyphenated EIN sends digits-only to Stripe
- [ ] Verify non-US account creation is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)