### PR TITLE
Fix TypeError string params validation (Claude)

### DIFF
--- a/app/controllers/api/v2/links_controller.rb
+++ b/app/controllers/api/v2/links_controller.rb
@@ -76,6 +76,13 @@ class Api::V2::LinksController < Api::V2::BaseController
       end
     end
 
+    [:name, :custom_permalink, :description, :custom_receipt, :custom_summary, :price_currency_type].each do |key|
+      next if !params.key?(key)
+      if params[key].respond_to?(:key?) || params[key].is_a?(Array)
+        return render_response(false, message: "#{key} must be a string value.")
+      end
+    end
+
     currency = params[:price_currency_type].presence || current_resource_owner.currency_type
     if !CURRENCY_CHOICES.key?(currency)
       return render_response(false, message: "'#{currency}' is not a supported currency.")
@@ -206,6 +213,13 @@ class Api::V2::LinksController < Api::V2::BaseController
   def update
     if @product.is_tiered_membership && params.key?(:price)
       return render_response(false, message: "Price cannot be updated for tiered membership products. Use the variant endpoints to manage tier pricing.")
+    end
+
+    [:name, :custom_permalink, :description, :custom_receipt, :custom_summary, :price_currency_type].each do |key|
+      next if !params.key?(key)
+      if params[key].respond_to?(:key?) || params[key].is_a?(Array)
+        return render_response(false, message: "#{key} must be a string value.")
+      end
     end
 
     if params.key?(:tags)

--- a/app/controllers/api/v2/links_controller.rb
+++ b/app/controllers/api/v2/links_controller.rb
@@ -76,7 +76,7 @@ class Api::V2::LinksController < Api::V2::BaseController
       end
     end
 
-    [:name, :custom_permalink, :description, :custom_receipt, :custom_summary, :price_currency_type].each do |key|
+    [:name, :custom_permalink, :description, :custom_summary, :price_currency_type].each do |key|
       next if !params.key?(key)
       if params[key].respond_to?(:key?) || params[key].is_a?(Array)
         return render_response(false, message: "#{key} must be a string value.")

--- a/spec/controllers/api/v2/links_controller_spec.rb
+++ b/spec/controllers/api/v2/links_controller_spec.rb
@@ -353,6 +353,24 @@ describe Api::V2::LinksController do
         expect(@user.links.last.tags.pluck(:name)).to eq(["valid-tag"])
       end
 
+      %i[name custom_permalink description custom_receipt custom_summary price_currency_type].each do |field|
+        it "rejects a nested object for #{field}" do
+          post @action, params: @params.merge(field => { foo: "bar" })
+
+          expect(response).to be_successful
+          expect(response.parsed_body["success"]).to be false
+          expect(response.parsed_body["message"]).to eq("#{field} must be a string value.")
+        end
+
+        it "rejects an array for #{field}" do
+          post @action, params: @params.merge(field => ["a", "b"])
+
+          expect(response).to be_successful
+          expect(response.parsed_body["success"]).to be false
+          expect(response.parsed_body["message"]).to eq("#{field} must be a string value.")
+        end
+      end
+
       it "rejects non-array tags" do
         post @action, params: @params.merge(tags: "oops")
 
@@ -897,6 +915,24 @@ describe Api::V2::LinksController do
         put @action, params: @params.merge(tags: ["ruby"])
         expect(response.parsed_body["success"]).to be(true)
         expect(@product.reload.tags.pluck(:name)).to match_array(["ruby"])
+      end
+
+      %i[name custom_permalink description custom_receipt custom_summary price_currency_type].each do |field|
+        it "rejects a nested object for #{field}" do
+          put @action, params: @params.merge(field => { foo: "bar" })
+
+          expect(response).to be_successful
+          expect(response.parsed_body["success"]).to be false
+          expect(response.parsed_body["message"]).to eq("#{field} must be a string value.")
+        end
+
+        it "rejects an array for #{field}" do
+          put @action, params: @params.merge(field => ["a", "b"])
+
+          expect(response).to be_successful
+          expect(response.parsed_body["success"]).to be false
+          expect(response.parsed_body["message"]).to eq("#{field} must be a string value.")
+        end
       end
 
       it "rejects non-array tags" do


### PR DESCRIPTION
Race branch (Claude Code). Fixes #4527 review comment: removed custom_receipt from create validation since it's never saved on create. custom_summary kept (it IS saved via json_data).