### PR TITLE
Fix Rack::Timeout in checkout upsells (Codex)

### DIFF
--- a/app/controllers/checkout/upsells/products_controller.rb
+++ b/app/controllers/checkout/upsells/products_controller.rb
@@ -3,34 +3,51 @@
 class Checkout::Upsells::ProductsController < ApplicationController
   include CustomDomainConfig
 
-  MAX_PRODUCTS = 50
+  MAX_PRODUCTS = 25
+
+  QUERY_TIMEOUT_MS = 10_000
 
   PRODUCT_INCLUDES = [
     :skus_alive_not_default,
     :variant_categories_alive,
     :product_review_stat,
     { alive_variants: { variant_category: :link },
-      thumbnail_alive: { file_attachment: { blob: { variant_records: { image_attachment: :blob } } } },
-      display_asset_previews: { file_attachment: { blob: { variant_records: { image_attachment: :blob } } } } },
+      thumbnail_alive: { file_attachment: :blob },
+      display_asset_previews: { file_attachment: :blob } },
   ].freeze
 
   def index
     seller = user_by_domain(request.host) || current_seller
     return render json: [] unless seller
 
-    products = seller.products
-      .eligible_for_content_upsells
-      .includes(*PRODUCT_INCLUDES)
-      .order(created_at: :desc, id: :desc)
-      .limit(MAX_PRODUCTS)
+    products = with_query_timeout do
+      seller.products
+        .eligible_for_content_upsells
+        .includes(*PRODUCT_INCLUDES)
+        .order(created_at: :desc, id: :desc)
+        .limit(MAX_PRODUCTS)
+        .to_a
+    end
     render json: products.map { |product| Checkout::Upsells::ProductPresenter.new(product).product_props }
   end
 
   def show
-    product = Link.eligible_for_content_upsells
-                  .includes(*PRODUCT_INCLUDES)
-                  .find_by_external_id!(params[:id])
+    product = with_query_timeout do
+      Link.eligible_for_content_upsells
+          .includes(*PRODUCT_INCLUDES)
+          .find_by_external_id!(params[:id])
+    end
 
     render json: Checkout::Upsells::ProductPresenter.new(product).product_props
+  end
+
+  private
+
+  def with_query_timeout
+    previous_timeout = ActiveRecord::Base.connection.execute("SELECT @@SESSION.max_execution_time AS t").first.first
+    ActiveRecord::Base.connection.execute("SET SESSION max_execution_time = #{QUERY_TIMEOUT_MS}")
+    yield
+  ensure
+    ActiveRecord::Base.connection.execute("SET SESSION max_execution_time = #{previous_timeout || 0}")
   end
 end

--- a/app/controllers/checkout/upsells/products_controller.rb
+++ b/app/controllers/checkout/upsells/products_controller.rb
@@ -5,8 +5,6 @@ class Checkout::Upsells::ProductsController < ApplicationController
 
   MAX_PRODUCTS = 25
 
-  QUERY_TIMEOUT_MS = 10_000
-
   PRODUCT_INCLUDES = [
     :skus_alive_not_default,
     :variant_categories_alive,
@@ -20,7 +18,7 @@ class Checkout::Upsells::ProductsController < ApplicationController
     seller = user_by_domain(request.host) || current_seller
     return render json: [] unless seller
 
-    products = with_query_timeout do
+    products = WithMaxExecutionTime.timeout_queries(seconds: 10) do
       seller.products
         .eligible_for_content_upsells
         .includes(*PRODUCT_INCLUDES)
@@ -29,25 +27,19 @@ class Checkout::Upsells::ProductsController < ApplicationController
         .to_a
     end
     render json: products.map { |product| Checkout::Upsells::ProductPresenter.new(product).product_props }
+  rescue WithMaxExecutionTime::QueryTimeoutError
+    render json: []
   end
 
   def show
-    product = with_query_timeout do
+    product = WithMaxExecutionTime.timeout_queries(seconds: 10) do
       Link.eligible_for_content_upsells
           .includes(*PRODUCT_INCLUDES)
           .find_by_external_id!(params[:id])
     end
 
     render json: Checkout::Upsells::ProductPresenter.new(product).product_props
-  end
-
-  private
-
-  def with_query_timeout
-    previous_timeout = ActiveRecord::Base.connection.execute("SELECT @@SESSION.max_execution_time AS t").first.first
-    ActiveRecord::Base.connection.execute("SET SESSION max_execution_time = #{QUERY_TIMEOUT_MS}")
-    yield
-  ensure
-    ActiveRecord::Base.connection.execute("SET SESSION max_execution_time = #{previous_timeout || 0}")
+  rescue WithMaxExecutionTime::QueryTimeoutError
+    render json: { error: "Request timed out" }, status: :gateway_timeout
   end
 end

--- a/spec/controllers/checkout/upsells/products_controller_spec.rb
+++ b/spec/controllers/checkout/upsells/products_controller_spec.rb
@@ -171,6 +171,17 @@ describe Checkout::Upsells::ProductsController do
         )
       end
     end
+
+    it "returns an empty array when the query times out" do
+      sign_in seller
+      allow(WithMaxExecutionTime).to receive(:timeout_queries).with(seconds: 10)
+        .and_raise(WithMaxExecutionTime::QueryTimeoutError.new("maximum statement execution time exceeded"))
+
+      get :index
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq([])
+    end
   end
 
   describe "GET #show" do
@@ -216,6 +227,17 @@ describe Checkout::Upsells::ProductsController do
       expect do
         get :show, params: { id: "non_existent_id" }
       end.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "returns a timeout error when the query times out" do
+      sign_in seller
+      allow(WithMaxExecutionTime).to receive(:timeout_queries).with(seconds: 10)
+        .and_raise(WithMaxExecutionTime::QueryTimeoutError.new("maximum statement execution time exceeded"))
+
+      get :show, params: { id: product1.external_id }
+
+      expect(response).to have_http_status(:gateway_timeout)
+      expect(response.parsed_body).to eq("error" => "Request timed out")
     end
   end
 end


### PR DESCRIPTION
Race branch (Codex GPT-5.4 xhigh). Fixes #4506 review comment: replaced custom with_query_timeout with WithMaxExecutionTime.timeout_queries, added QueryTimeoutError rescue in both actions, added tests.