### PR TITLE
Fix Stripe::InvalidRequestError by sanitizing US tax IDs (Codex)

### DIFF
--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -529,7 +529,7 @@ module StripeMerchantAccountManager
     return unless user_compliance_info.present?
 
     business_tax_id = user_compliance_info.business_tax_id.decrypt(passphrase)
-    business_tax_id = sanitize_tax_id(business_tax_id) if user_compliance_info.country_code == Compliance::Countries::USA.alpha2
+    business_tax_id = sanitize_tax_id(business_tax_id) if user_compliance_info.legal_entity_country_code == Compliance::Countries::USA.alpha2
     hash = {
       company: {
         name: user_compliance_info.business_name.presence,

--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -392,6 +392,11 @@ module StripeMerchantAccountManager
   end
 
   private_class_method
+  def self.sanitize_tax_id(tax_id)
+    tax_id&.gsub(/\D/, "")
+  end
+
+  private_class_method
   def self.bank_account_hash(bank_account, stripe_account: {}, passphrase:)
     country_code = bank_account.user.alive_user_compliance_info.legal_entity_country_code
     cross_border_payouts_only = Country.new(country_code).supports_stripe_cross_border_payouts?
@@ -444,6 +449,7 @@ module StripeMerchantAccountManager
   def self.person_hash(user_compliance_info, passphrase)
     if user_compliance_info
       personal_tax_id = user_compliance_info.individual_tax_id.decrypt(passphrase)
+      personal_tax_id = sanitize_tax_id(personal_tax_id) if user_compliance_info.country_code == Compliance::Countries::USA.alpha2
 
       hash = {
         first_name: user_compliance_info.first_name,
@@ -523,6 +529,7 @@ module StripeMerchantAccountManager
     return unless user_compliance_info.present?
 
     business_tax_id = user_compliance_info.business_tax_id.decrypt(passphrase)
+    business_tax_id = sanitize_tax_id(business_tax_id) if user_compliance_info.country_code == Compliance::Countries::USA.alpha2
     hash = {
       company: {
         name: user_compliance_info.business_name.presence,

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -9,6 +9,35 @@ describe StripeMerchantAccountManager, :vcr do
 
   let(:user) { create(:user, unpaid_balance_cents: 10, email: "chuck@gum.com", username: "chuck") }
 
+  describe "tax ID sanitization" do
+    let(:user) { create(:user, email: "chuck@gum.com", username: "chuck") }
+
+    it "strips non-digits from a US individual's SSN before building Stripe params" do
+      user_compliance_info = create(:user_compliance_info, user:, individual_tax_id: "123-45-6789")
+
+      person_hash = described_class.send(:person_hash, user_compliance_info, "1234")
+
+      expect(person_hash[:id_number]).to eq("123456789")
+      expect(person_hash).not_to have_key(:ssn_last_4)
+    end
+
+    it "strips non-digits from a US business's EIN before building Stripe params" do
+      user_compliance_info = create(:user_compliance_info_business, user:, business_tax_id: "12-3456789")
+
+      company_hash = described_class.send(:company_hash, user_compliance_info, "1234")
+
+      expect(company_hash.dig(:company, :tax_id)).to eq("123456789")
+    end
+
+    it "preserves non-US alphanumeric tax IDs" do
+      user_compliance_info = create(:user_compliance_info_singapore, user:, individual_tax_id: "S1234567D")
+
+      person_hash = described_class.send(:person_hash, user_compliance_info, "1234")
+
+      expect(person_hash[:id_number]).to eq("S1234567D")
+    end
+  end
+
   describe "#create_account" do
     describe "all info provided of an individual" do
       let(:user_compliance_info) { create(:user_compliance_info, user:) }

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -36,6 +36,18 @@ describe StripeMerchantAccountManager, :vcr do
 
       expect(person_hash[:id_number]).to eq("S1234567D")
     end
+    it "does not sanitize a non-US business tax ID for a US resident" do
+      user_compliance_info = create(:user_compliance_info_business,
+                                    user:,
+                                    country: "United States",
+                                    business_country: "Singapore",
+                                    business_tax_id: "200309485K")
+
+      company_hash = described_class.send(:company_hash, user_compliance_info, "1234")
+
+      expect(company_hash.dig(:company, :tax_id)).to eq("200309485K")
+    end
+
   end
 
   describe "#create_account" do


### PR DESCRIPTION
Race branch (Codex GPT-5.4 xhigh). Strips non-digit chars from US SSN/EIN only, preserves alphanumeric IDs for other countries (e.g. Singapore NRIC). Specs verified locally.