### PR TITLE
Skip minimum payout threshold for scheduled payouts

### DIFF
--- a/app/models/scheduled_payout.rb
+++ b/app/models/scheduled_payout.rb
@@ -62,8 +62,12 @@ class ScheduledPayout < ApplicationRecord
 
     if process_payout
       begin
-        payments = Payouts.create_payments_for_balances_up_to_date_for_users(Date.yesterday, user.current_payout_processor, [user], from_admin: true)
-        payment = payments.flatten.last
+        payments = PayoutUsersService.new(
+          date_string: Date.yesterday.to_s,
+          processor_type: user.current_payout_processor,
+          user_ids: user.id
+        ).process
+        payment = payments.last
         if payment.blank? || payment.failed?
           raise "Payout failed: #{payment&.errors&.full_messages&.first || "Payment was not sent."}"
         end

--- a/spec/models/scheduled_payout_spec.rb
+++ b/spec/models/scheduled_payout_spec.rb
@@ -125,11 +125,12 @@ describe ScheduledPayout do
     context "when action is payout" do
       let(:scheduled_payout) { create(:scheduled_payout, user: user, action: "payout", scheduled_at: 1.day.ago) }
 
-      it "calls Payouts to create payout and marks as executed" do
+      it "calls PayoutUsersService to create payout and marks as executed" do
         payment = instance_double(Payment, failed?: false)
-        expect(Payouts).to receive(:create_payments_for_balances_up_to_date_for_users)
-          .with(Date.yesterday, user.current_payout_processor, [user], from_admin: true)
-          .and_return([[payment]])
+        service = instance_double(PayoutUsersService, process: [payment])
+        expect(PayoutUsersService).to receive(:new)
+          .with(date_string: Date.yesterday.to_s, processor_type: user.current_payout_processor, user_ids: user.id)
+          .and_return(service)
 
         scheduled_payout.execute!
 
@@ -139,18 +140,20 @@ describe ScheduledPayout do
 
       it "raises if payout fails" do
         payment = instance_double(Payment, failed?: true, errors: double(full_messages: ["Stripe account not found"]))
-        allow(Payouts).to receive(:create_payments_for_balances_up_to_date_for_users)
-          .with(Date.yesterday, user.current_payout_processor, [user], from_admin: true)
-          .and_return([[payment]])
+        service = instance_double(PayoutUsersService, process: [payment])
+        allow(PayoutUsersService).to receive(:new)
+          .with(date_string: Date.yesterday.to_s, processor_type: user.current_payout_processor, user_ids: user.id)
+          .and_return(service)
 
         expect { scheduled_payout.execute! }.to raise_error(RuntimeError, /Payout failed/)
         expect(scheduled_payout.reload.status).to eq("pending")
       end
 
       it "raises if no payment is created" do
-        allow(Payouts).to receive(:create_payments_for_balances_up_to_date_for_users)
-          .with(Date.yesterday, user.current_payout_processor, [user], from_admin: true)
-          .and_return([])
+        service = instance_double(PayoutUsersService, process: [])
+        allow(PayoutUsersService).to receive(:new)
+          .with(date_string: Date.yesterday.to_s, processor_type: user.current_payout_processor, user_ids: user.id)
+          .and_return(service)
 
         expect { scheduled_payout.execute! }.to raise_error(RuntimeError, /Payment was not sent/)
         expect(scheduled_payout.reload.status).to eq("pending")
@@ -161,7 +164,7 @@ describe ScheduledPayout do
       let(:scheduled_payout) { create(:scheduled_payout, user: user, action: "payout", scheduled_at: 1.day.ago, payout_amount_cents: 150_000) }
 
       it "flags for review instead of executing" do
-        expect(Payouts).not_to receive(:create_payments_for_balances_up_to_date_for_users)
+        expect(PayoutUsersService).not_to receive(:new)
 
         scheduled_payout.execute!
 


### PR DESCRIPTION
## What

Scheduled payouts now call `PayoutUsersService` directly instead of going through `Payouts.create_payments_for_balances_up_to_date_for_users`. This bypasses the `Payouts.is_user_payable` gatekeeper — specifically the minimum payout balance check — so scheduled payouts execute regardless of whether the seller's balance meets the minimum threshold.

## Why

Scheduled payouts are explicitly initiated by admins. The minimum payout threshold is a safeguard for automated/regular payouts, not for deliberate admin-scheduled ones. When an admin schedules a payout, the intent is to pay the seller — the balance should not be blocked by the threshold.

The previous flow was: `ScheduledPayout#execute!` → `Payouts.create_payments_for_balances_up_to_date_for_users(from_admin: true)` → `Payouts.is_user_payable` (minimum balance check, only partially bypassed by `from_admin`) → `PayoutUsersService`.

The new flow is: `ScheduledPayout#execute!` → `PayoutUsersService` directly.

`PayoutUsersService` still calls `Payouts.create_payment` which guards against negative balances (`balance_cents <= 0`), so we're not paying out zero or negative amounts.

## Test results

All 32 specs in `spec/models/scheduled_payout_spec.rb` pass. Updated tests to mock `PayoutUsersService` instead of `Payouts.create_payments_for_balances_up_to_date_for_users`.

---

Generated with Claude Opus 4.6. Prompted: "let's switch to PayoutUsersService so that we will payout without looking at the minimum balance requirements when executing a scheduled payout. Create a branch and PR, update tests as needed"