### PR TITLE
Fix S3 NotFound test stubbing wrong instances

### DIFF
--- a/spec/controllers/api/v2/links_controller_spec.rb
+++ b/spec/controllers/api/v2/links_controller_spec.rb
@@ -752,9 +752,11 @@ describe Api::V2::LinksController do
         good_file = create(:product_file, link: @product, url: "#{S3_BASE_URL}specs/test.pdf")
         bad_file = create(:product_file, link: @product, url: "#{S3_BASE_URL}attachments/missing-guid/original/gone.zip")
 
-        allow_any_instance_of(ProductFile).to receive(:signed_url).and_call_original
-        allow(bad_file).to receive(:signed_url).and_raise(Aws::S3::Errors::NotFound.new(nil, "Not Found"))
-        allow(@product).to receive(:ordered_alive_product_files).and_return([good_file, bad_file])
+        bad_url = bad_file.url
+        allow_any_instance_of(ProductFile).to receive(:signed_url) do |product_file|
+          raise Aws::S3::Errors::NotFound.new(nil, "Not Found") if product_file.url == bad_url
+          "https://signed.example.com/test.pdf"
+        end
 
         get :show, params: @params
         expect(response).to be_successful


### PR DESCRIPTION
## What

Fixed the failing test at `links_controller_spec.rb:751` ("gracefully skips files with missing S3 objects"). The test was stubbing `signed_url` on the spec's local `bad_file` instance and `ordered_alive_product_files` on the spec's `@product`, but the controller loads its own product instance from the database — so the stubs never applied.

Replaced instance-level stubs with a single `allow_any_instance_of(ProductFile)` that conditionally raises `Aws::S3::Errors::NotFound` based on the file's URL, which works regardless of which Ruby object the controller loads.

## Why

The previous stubs targeted specific Ruby object instances created in the test, but RSpec controller tests load fresh instances from the database in the controller action. Instance-level stubs (`allow(bad_file)`, `allow(@product)`) don't carry over to those new objects, so the test always saw 2 files instead of 1.

---

This PR was implemented with AI assistance using Claude Opus 4.6.

Prompts used:

- "in a new branch, fix ./spec/controllers/api/v2/links_controller_spec.rb:751 error"
- "create a PR"