### PR TITLE
Block fraud-suspended users from logging in (revert #4520)

### DIFF
--- a/app/controllers/logins_controller.rb
+++ b/app/controllers/logins_controller.rb
@@ -43,15 +43,19 @@ class LoginsController < Devise::SessionsController
 
     return redirect_with_login_error("You cannot log in because your account was permanently deleted. Please sign up for a new account to start selling!") if @user.deleted?
 
-    @user.remember_me = true # Always "remember" user sessions
+    if @user.suspended_for_fraud?
+      check_suspended
+    else
+      @user.remember_me = true # Always "remember" user sessions
 
-    sign_in_or_prepare_for_two_factor_auth(@user)
+      sign_in_or_prepare_for_two_factor_auth(@user)
 
-    if @user.respond_to?(:pwned?) && @user.pwned?
-      flash[:warning] = "Your password has previously appeared in a data breach as per haveibeenpwned.com and should never be used. We strongly recommend you change your password everywhere you have used it."
+      if @user.respond_to?(:pwned?) && @user.pwned?
+        flash[:warning] = "Your password has previously appeared in a data breach as per haveibeenpwned.com and should never be used. We strongly recommend you change your password everywhere you have used it."
+      end
+
+      redirect_to login_path_for(@user), allow_other_host: true
     end
-
-    redirect_to login_path_for(@user), allow_other_host: true
   end
 
   private

--- a/app/controllers/two_factor_authentication_controller.rb
+++ b/app/controllers/two_factor_authentication_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class TwoFactorAuthenticationController < ApplicationController
-  skip_before_action :check_suspended
   before_action :redirect_to_signed_in_path, if: -> { user_signed_in? && skip_two_factor_authentication?(logged_in_user) }
   before_action :fetch_user
   before_action :check_presence_of_user, except: :verify

--- a/spec/controllers/logins_controller_spec.rb
+++ b/spec/controllers/logins_controller_spec.rb
@@ -211,12 +211,13 @@ describe LoginsController, type: :controller, inertia: true do
         end
       end
 
-      it "allows a user suspended for fraud to log in" do
+      it "does not log in a user who is suspended for fraud" do
         user = create(:user, password: "password", user_risk_state: "suspended_for_fraud")
 
         post :create, params: { user: { login_identifier: user.email, password: "password" } }
 
-        expect(controller.user_signed_in?).to be(true)
+        expect(flash[:warning]).to eq("You can't perform this action because your account has been suspended.")
+        expect(controller.user_signed_in?).to be(false)
       end
     end
 


### PR DESCRIPTION
## What

Revert the login-gate removal from #4520. That PR let users with `user_risk_state = suspended_for_fraud` sign in and complete 2FA, turning the existing `check_suspended` global filter into the only remaining control. This PR restores the original behavior:

- `LoginsController#create` again routes `suspended_for_fraud?` users through `check_suspended` before any call to `sign_in_or_prepare_for_two_factor_auth`.
- `TwoFactorAuthenticationController` no longer calls `skip_before_action :check_suspended`, so 2FA POST cannot be used to finish signing in a suspended account.
- `spec/controllers/logins_controller_spec.rb` restores the assertion that a `suspended_for_fraud` login POST leaves `user_signed_in? == false` with the suspension warning flash.

## Why (vulnerability description and security impact)

PR #4520 justified the change by noting that the global `check_suspended` before_action still blocks suspended users on non-GET/HEAD verbs (`app/controllers/application_controller.rb:36`). That condition `!request.get? && !request.head?` leaves a large attack surface open once an authenticated session exists:

1. **GET-readable sensitive surfaces remain accessible.** `check_suspended` only runs on mutating verbs. Fraud-suspended accounts regain authenticated GET access to account, analytics, library, scheduled payouts, and buyer data pages. A suspended-for-fraud user is, by definition, the highest-risk cohort; allowing them to re-enter an authenticated session is an explicit weakening of access control.
2. **Controllers that opt out of `check_suspended` are now reachable by suspended users again.** Grep shows `skip_before_action :check_suspended` in `LibraryController`, `MediaLocationsController`, `ConsumptionAnalyticsController`, `Payouts::ExportsController`, and `UrlRedirectsController#confirm`. For those, suspension is enforced solely because the suspended account cannot log in. Removing the login gate removes the only control on those endpoints for this cohort.
3. **Doorkeeper OAuth authorization flow.** `Oauth::AuthorizationsController < Doorkeeper::AuthorizationsController` (not `ApplicationController`); the `check_suspended` filter is not applied to its inherited authorization GETs. A fraud-suspended user with a valid session can potentially step through OAuth authorize and mint access tokens to third-party apps that continue to hit Gumroad APIs.
4. **Breaks the `invalidate_active_sessions!` invariant.** The `user_risk_state` state machine (`app/models/user.rb:315`) calls `invalidate_active_sessions!` on transition into `suspended_for_fraud` / `suspended_for_tos_violation`. The intent is ''after suspension, no active sessions exist.'' Allowing a fresh POST `/login` + 2FA to create a new session after that transition silently breaks this invariant; any session-invalidation-based incident response (e.g., admin suspending an abusive account mid-incident) can be undone by the suspended user simply logging in again.
5. **2FA skip amplifies impact for accounts with 2FA enabled.** `skip_before_action :check_suspended` in `TwoFactorAuthenticationController` means the POST `create`/`verify` actions, which call `sign_in_with_two_factor_authentication` and set a full session cookie, are no longer gated — even if a future controller-level gate were reintroduced on `LoginsController`, 2FA completion would still mint a session.

Net effect: a high-risk, explicitly-suspended account regains authenticated access. Severity: high (authZ regression on a security-critical cohort; bypass of session invalidation invariant; broadens surface to every GET-readable authenticated endpoint and the OAuth flow).

## Proposed code fix

Revert the two controller changes and the test change from #4520. Diff summary:

- `app/controllers/logins_controller.rb` — restore the `if @user.suspended_for_fraud? then check_suspended` branch in `create`.
- `app/controllers/two_factor_authentication_controller.rb` — drop `skip_before_action :check_suspended`.
- `spec/controllers/logins_controller_spec.rb` — restore ''does not log in a user who is suspended for fraud''.

The user-facing motivation in #4520 (scheduled payout banner from #4397 visible to suspended users) should be delivered without granting an authenticated session to fraud-suspended accounts. Safer alternatives: email the payout status, a signed tokenized public URL scoped to the payout status page, or a separate unauthenticated ''payout status'' flow keyed off the user's email + a one-time token. Those can be scoped to `suspended_for_tos_violation` only if the product requires it, without touching `suspended_for_fraud`.

## Best-practice references

- OWASP ASVS v4.0.3, V3 Session Management — V3.3.1 / V3.3.3: the application must invalidate sessions on account termination/suspension; creating new sessions for suspended accounts violates this.
- OWASP ASVS v4.0.3, V4 Access Control — V4.1.5: access-control failures must deny by default. Relying on a per-verb filter (`!request.get? && !request.head?`) as the sole control is fail-open for the large GET surface.
- OWASP ASVS v4.0.3, V2.1.11: verify that the system enforces account lockout/disable on compromised or high-risk accounts.
- OWASP Authentication Cheat Sheet — ''Account Lockout'' and ''Session Management'': locked/suspended accounts must not be able to authenticate.
- NIST SP 800-63B §4.1.2 / §7.1: terminate and prevent re-establishment of authenticated sessions upon revocation.

## Test plan

- [ ] `bundle exec rspec spec/controllers/logins_controller_spec.rb`
- [ ] `bundle exec rspec spec/controllers/two_factor_authentication_controller_spec.rb`
- [ ] Manual: attempting POST `/login` with valid credentials for a `suspended_for_fraud` user redirects with the suspension warning and does not set a session cookie.
- [ ] Manual: a `suspended_for_fraud` user with 2FA enabled cannot complete `POST /two-factor` to establish a session.

---

Generated with Claude Opus 4.7. Prompt: security review of merged PR #4520 and implement the safest fix.