### PR TITLE
Fix dark mode text in search dropdown on discovery category pages

### DIFF
--- a/app/javascript/components/ComboBox.tsx
+++ b/app/javascript/components/ComboBox.tsx
@@ -122,7 +122,7 @@ export const ComboBox = <Option extends unknown>({
           aria-multiselectable={multiple}
           style={maxHeight ? { maxHeight } : undefined}
           className={classNames(
-            "absolute top-full left-0 z-10 block w-full overflow-auto rounded-b border border-t-0 border-border bg-background py-2 shadow",
+            "absolute top-full left-0 z-10 block w-full overflow-auto rounded-b border border-t-0 border-border bg-background py-2 text-foreground shadow [--color:var(--contrast-filled)]",
           )}
         >
           {options.map((item, index) => (

--- a/app/javascript/components/Select.tsx
+++ b/app/javascript/components/Select.tsx
@@ -216,7 +216,7 @@ const MenuList = <IsMulti extends boolean>(props: MenuListProps<Option, IsMulti>
       style={{ maxHeight: props.maxHeight }}
       id={menuListId ?? undefined}
       className={classNames(
-        "absolute top-full left-0 z-10 block w-full overflow-auto rounded-b border border-border bg-background py-2 shadow",
+        "absolute top-full left-0 z-10 block w-full overflow-auto rounded-b border border-border bg-background py-2 text-foreground shadow [--color:var(--contrast-filled)]",
       )}
     >
       {props.children}


### PR DESCRIPTION
On discovery category pages like `/3d`, the header overrides `--color` to force black text for readability on the bright colored background. The search dropdown inherits this override, causing black-on-black text in dark mode.

## Fix

Reset `--color` inside the dropdown container using `[--color:var(--contrast-filled)]` and apply it with `text-foreground`. This insulates the dropdown from the parent's theme override while staying consistent with the design system.

- `[--color:var(--contrast-filled)]` — resets the CSS variable so it contrasts against `bg-background` in both light and dark mode
- `text-foreground` — explicitly applies the reset `--color` as the text color on the element

Fixes https://github.com/antiwork/gumroad/issues/4546