### PR TITLE
Fix custom-range sales export contradicting "All Sales" export

### DIFF
--- a/app/services/exports/purchase_export_service.rb
+++ b/app/services/exports/purchase_export_service.rb
@@ -94,8 +94,8 @@ class Exports::PurchaseExportService
   def self.export(seller:, recipient:, filters: {})
     product_ids = Link.by_external_ids(filters[:product_ids]).ids if filters[:product_ids].present?
     variant_ids = BaseVariant.by_external_ids(filters[:variant_ids]).ids if filters[:variant_ids].present?
-    start_time = Date.parse(filters[:start_time]).in_time_zone(seller.timezone).beginning_of_day if filters[:start_time].present?
-    end_time = Date.parse(filters[:end_time]).in_time_zone(seller.timezone).end_of_day if filters[:end_time].present?
+    start_time = Date.parse(filters[:start_time]).in_time_zone("UTC").beginning_of_day if filters[:start_time].present?
+    end_time = Date.parse(filters[:end_time]).in_time_zone("UTC").end_of_day if filters[:end_time].present?
 
     search_service = PurchaseSearchService.new(
       seller:,

--- a/spec/controllers/purchases_controller_spec.rb
+++ b/spec/controllers/purchases_controller_spec.rb
@@ -813,19 +813,35 @@ describe PurchasesController, :vcr do
         expect(response.body).to include(free_trial_membership_purchase.external_id)
       end
 
-      it "transforms the submitted start_time / end_time in the seller's time zone" do
-        # Simulates someone's browser being in California (-07:00, ignored) while their TZ is in Japan (+09:00)
+      it "interprets the submitted start_time / end_time as UTC regardless of seller's time zone" do
         seller.update!(timezone: "Tokyo")
 
         expect(PurchaseSearchService).to receive(:new).with(
           hash_including(
-            created_on_or_after: Time.utc(2020, 7, 31, 15),
-            created_before: Time.utc(2020, 8, 31, 14).end_of_hour,
+            created_on_or_after: Time.utc(2020, 8, 1).beginning_of_day,
+            created_before: Time.utc(2020, 8, 31).end_of_day,
         )).and_call_original
 
         params[:start_time] = "2020-08-01"
         params[:end_time] = "2020-08-31"
         get :export, params:
+      end
+
+      it "includes purchases at UTC midnight boundary regardless of seller's timezone" do
+        seller.update!(timezone: "Pacific Time (US & Canada)")
+
+        at_start_boundary = create(:purchase, link: @product, seller:, created_at: Time.utc(2023, 6, 10, 3, 0, 0))
+        at_end_boundary = create(:purchase, link: @product, seller:, created_at: Time.utc(2023, 6, 20, 22, 0, 0))
+        before_range = create(:purchase, link: @product, seller:, created_at: Time.utc(2023, 6, 9, 23, 59, 59))
+        after_range = create(:purchase, link: @product, seller:, created_at: Time.utc(2023, 6, 21, 0, 0, 1))
+        index_model_records(Purchase)
+
+        get :export, params: { start_time: "2023-06-10", end_time: "2023-06-20" }
+
+        expect(response.body).to include(at_start_boundary.external_id)
+        expect(response.body).to include(at_end_boundary.external_id)
+        expect(response.body).not_to include(before_range.external_id)
+        expect(response.body).not_to include(after_range.external_id)
       end
     end
 


### PR DESCRIPTION
## What

Interpret `start_time` / `end_time` on the purchases export endpoint as UTC instead of the seller's timezone, so a custom-range export over a calendar date range returns the same set of purchases as filtering an "All Sales" export by the same calendar dates.

`app/services/exports/purchase_export_service.rb`:

```ruby
# before
start_time = Date.parse(filters[:start_time]).in_time_zone(seller.timezone).beginning_of_day if filters[:start_time].present?
end_time   = Date.parse(filters[:end_time]).in_time_zone(seller.timezone).end_of_day       if filters[:end_time].present?

# after
start_time = Date.parse(filters[:start_time]).in_time_zone("UTC").beginning_of_day if filters[:start_time].present?
end_time   = Date.parse(filters[:end_time]).in_time_zone("UTC").end_of_day         if filters[:end_time].present?
```

## Why

Purchase `created_at` timestamps are stored in UTC and the "All Sales" export applies no range at all. The custom-range export was coercing the submitted dates into the seller's timezone before serializing them into the Elasticsearch `range: { created_at: { gte/lt: ... } }` query, which shifted the boundaries by the seller's UTC offset (plus DST). Two exports over identical calendar dates returned different purchase sets, and two sellers in different timezones received different exports for otherwise-identical data.

Reported by the issue author (UTC-7): Jan 1 2022 through March 31 2022 shifted to Jan 1 2022 07:00 UTC through April 1 2022 06:59 UTC, excluding three purchases that occurred before 07:00 UTC on Jan 1 and including three that occurred before 07:00 UTC on April 1.

Interpreting the dates as UTC aligns both exports on the same boundary and removes the silent timezone shift. Chosen over "disclose the seller-timezone shift in the UI" because the "All Sales" export is already UTC-based, so matching it is the simpler contract.

## Test Results

Updated `purchases_controller_spec.rb#GET export`:

- Renamed the existing test that asserted the old seller-timezone shift, and changed its expectations to assert the new UTC boundaries — this test fails if the fix is reverted.
- Added a test that creates a Pacific-Time seller, places purchases at UTC boundaries (03:00 UTC and 22:00 UTC), and asserts boundary purchases are included and just-outside purchases are excluded — this also fails if the fix is reverted (under PST the 03:00 UTC purchase would fall outside the shifted range).

Local RSpec could not be executed in this environment (the sandbox Ruby is 3.3.6 while the Gemfile requires 3.4.3 and `bundle exec` / `bin/rspec` both failed to resolve). Syntax verified with `ruby -c` on both changed files. CI will run the full suite.

---

AI disclosure: Drafted by Claude Opus 4.7 with the prompt "https://github.com/antiwork/gumroad/issues/4545 solve this and open pr".