### PR TITLE
Name accepted types in cover upload error message

### DIFF
--- a/app/models/asset_preview.rb
+++ b/app/models/asset_preview.rb
@@ -221,7 +221,7 @@ class AssetPreview < ApplicationRecord
     def url_or_file
       return if deleted?
 
-      errors.add(:base, "Could not process your preview, please try again.") unless valid_file_type?
+      errors.add(:base, "Cover must be an image (JPEG, PNG, GIF) or a video.") unless valid_file_type?
     end
 
     def max_preview_count

--- a/spec/controllers/api/v2/covers_controller_spec.rb
+++ b/spec/controllers/api/v2/covers_controller_spec.rb
@@ -62,6 +62,20 @@ describe Api::V2::CoversController do
         expect(body["message"]).to eq("The signed_blob_id is invalid or expired.")
       end
 
+      it "returns a descriptive error for an unsupported file type" do
+        blob = ActiveStorage::Blob.create_and_upload!(
+          io: Rack::Test::UploadedFile.new(Rails.root.join("spec", "support", "fixtures", "webp_image.webp"), "image/webp"),
+          filename: "webp_image.webp"
+        )
+        blob.analyze
+
+        post @action, params: @params.merge(signed_blob_id: blob.signed_id)
+
+        body = response.parsed_body
+        expect(body["success"]).to be(false)
+        expect(body["message"]).to eq("Cover must be an image (JPEG, PNG, GIF) or a video.")
+      end
+
       it "returns the correct main_cover_id when covers already exist" do
         existing_cover = create(:asset_preview, link: @product)
 

--- a/spec/models/asset_preview_spec.rb
+++ b/spec/models/asset_preview_spec.rb
@@ -40,7 +40,7 @@ describe AssetPreview, :vcr do
       asset_preview = create(:asset_preview)
       asset_preview.file.attach Rack::Test::UploadedFile.new(Rails.root.join("spec", "support", "fixtures", "test.zip"), "application/octet-stream")
       expect(asset_preview.save).to eq(false)
-      expect(asset_preview.errors.full_messages).to eq(["Could not process your preview, please try again."])
+      expect(asset_preview.errors.full_messages).to eq(["Cover must be an image (JPEG, PNG, GIF) or a video."])
     end
 
     describe "#analyze_file" do
@@ -59,7 +59,7 @@ describe AssetPreview, :vcr do
         blob.analyze
         asset_preview.file.attach(blob)
         expect(asset_preview.save).to eq(false)
-        expect(asset_preview.errors.full_messages).to include("Could not process your preview, please try again.")
+        expect(asset_preview.errors.full_messages).to include("Cover must be an image (JPEG, PNG, GIF) or a video.")
       end
 
       it "fails with an image which cannot be analyzed" do
@@ -76,7 +76,7 @@ describe AssetPreview, :vcr do
       asset_preview = create(:asset_preview)
       asset_preview.file.attach(Rack::Test::UploadedFile.new(Rails.root.join("spec", "support", "fixtures", "webp_image.webp"), "image/webp"))
       expect(asset_preview.save).to eq(false)
-      expect(asset_preview.errors.full_messages).to eq(["Could not process your preview, please try again."])
+      expect(asset_preview.errors.full_messages).to eq(["Cover must be an image (JPEG, PNG, GIF) or a video."])
     end
 
     context "deleted" do

--- a/spec/requests/products/edit/covers_spec.rb
+++ b/spec/requests/products/edit/covers_spec.rb
@@ -58,14 +58,14 @@ describe "Product Edit Covers", type: :system, js: true do
     visit edit_link_path(product.unique_permalink)
     upload_image(["disguised_html_script.png"])
     allow_any_instance_of(ActiveStorage::Blob).to receive(:purge).and_return(nil)
-    expect(page).to have_alert(text: "Could not process your preview, please try again.")
+    expect(page).to have_alert(text: "Cover must be an image (JPEG, PNG, GIF) or a video.")
   end
 
   it "allows uploading valid image after trying an invalid one" do
     visit edit_link_path(product.unique_permalink)
     upload_image(["disguised_html_script.png"])
     allow_any_instance_of(ActiveStorage::Blob).to receive(:purge).and_return(nil)
-    expect(page).to have_alert(text: "Could not process your preview, please try again.")
+    expect(page).to have_alert(text: "Cover must be an image (JPEG, PNG, GIF) or a video.")
     upload_image(["test-small.jpg"])
     wait_for_ajax
     within "[role=tablist][aria-label='Product covers']" do


### PR DESCRIPTION
Ref #4477

## What

Change the `AssetPreview` validation error from `"Could not process your preview, please try again."` to `"Cover must be an image (JPEG, PNG, GIF) or a video."` Surfaces in the product-edit cover upload and `POST /api/v2/products/:id/covers`.

The generic fallbacks for network errors and empty-error save failures are left alone.

## Why

An integrator in #4477 sent a PDF to the covers endpoint and got the generic error, with no way to self-diagnose. Naming the accepted types turns a dead end into actionable feedback for both sellers and API clients.

---

This PR was implemented with AI assistance using Claude Opus 4.7 and gpt‑5.4 xhigh