### PR TITLE
Remove 'Report a bug' GitHub issue button from help center

### DIFF
--- a/app/javascript/components/server-components/support/Header.tsx
+++ b/app/javascript/components/server-components/support/Header.tsx
@@ -1,8 +1,8 @@
-import { Github, Search } from "@boxicons/react";
+import { Search } from "@boxicons/react";
 import { HelperClientProvider } from "@helperai/react";
 import React from "react";
 
-import { Button, NavigationButton } from "$app/components/Button";
+import { Button } from "$app/components/Button";
 import { UnauthenticatedNewTicketModal } from "$app/components/support/UnauthenticatedNewTicketModal";
 import { UnreadTicketsBadge } from "$app/components/support/UnreadTicketsBadge";
 import { PageHeader } from "$app/components/ui/PageHeader";
@@ -51,39 +51,13 @@ export function SupportHeader({
               </a>
             </Button>
           ) : isAnonymousUserOnHelpCenter ? (
-            <>
-              <NavigationButton
-                color="accent"
-                outline
-                href="https://github.com/antiwork/gumroad/issues/new"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center gap-2"
-              >
-                <Github pack="brands" className="size-5" />
-                Report a bug
-              </NavigationButton>
               <Button color="accent" onClick={() => setIsUnauthenticatedNewTicketOpen(true)}>
                 Contact support
               </Button>
-            </>
           ) : hasHelperSession ? (
-            <>
-              <NavigationButton
-                color="accent"
-                outline
-                href="https://github.com/antiwork/gumroad/issues/new"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center gap-2"
-              >
-                <Github pack="brands" className="size-5" />
-                Report a bug
-              </NavigationButton>
               <Button color="accent" onClick={onOpenNewTicket}>
                 New ticket
               </Button>
-            </>
           ) : null
         }
       >

--- a/app/javascript/pages/HelpCenter/Layout.tsx
+++ b/app/javascript/pages/HelpCenter/Layout.tsx
@@ -1,9 +1,9 @@
-import { Github, Search } from "@boxicons/react";
+import { Search } from "@boxicons/react";
 import { HelperClientProvider } from "@helperai/react";
 import { Link, router, usePage } from "@inertiajs/react";
 import * as React from "react";
 
-import { Button, NavigationButton } from "$app/components/Button";
+import { Button } from "$app/components/Button";
 import { NewTicketModal } from "$app/components/support/NewTicketModal";
 import { UnauthenticatedNewTicketModal } from "$app/components/support/UnauthenticatedNewTicketModal";
 import { UnreadTicketsBadge } from "$app/components/support/UnreadTicketsBadge";
@@ -27,22 +27,6 @@ type HelpCenterLayoutProps = {
   children: React.ReactNode;
   showSearchButton?: boolean;
 };
-
-function ReportBugButton() {
-  return (
-    <NavigationButton
-      color="accent"
-      outline
-      href="https://github.com/antiwork/gumroad/issues/new"
-      target="_blank"
-      rel="noopener noreferrer"
-      className="flex items-center gap-2"
-    >
-      <Github pack="brands" className="size-5" />
-      Report a bug
-    </NavigationButton>
-  );
-}
 
 function HelpCenterHeader({
   hasHelperSession,
@@ -102,23 +86,17 @@ function HelpCenterHeader({
 
     if (isAnonymousUserOnHelpCenter) {
       return (
-        <>
-          <ReportBugButton />
-          <Button color="accent" onClick={() => setIsUnauthenticatedNewTicketOpen(true)}>
-            Contact support
-          </Button>
-        </>
+        <Button color="accent" onClick={() => setIsUnauthenticatedNewTicketOpen(true)}>
+          Contact support
+        </Button>
       );
     }
 
     if (hasHelperSession) {
       return (
-        <>
-          <ReportBugButton />
-          <Button color="accent" onClick={() => onOpenNewTicket?.()}>
-            New ticket
-          </Button>
-        </>
+        <Button color="accent" onClick={() => onOpenNewTicket?.()}>
+          New ticket
+        </Button>
       );
     }
 

--- a/spec/requests/help_center_spec.rb
+++ b/spec/requests/help_center_spec.rb
@@ -38,7 +38,7 @@ describe "Help Center", type: :system, js: true do
       visit "/help"
 
       expect(page).to have_button("Contact support")
-      expect(page).to have_link("Report a bug", href: "https://github.com/antiwork/gumroad/issues/new")
+      expect(page).not_to have_link("Report a bug")
 
       click_on "Contact support"
 
@@ -77,11 +77,11 @@ describe "Help Center", type: :system, js: true do
       sign_in seller
     end
 
-    it "shows the new ticket button and report a bug link" do
+    it "shows the new ticket button" do
       visit "/help"
 
       expect(page).to have_button("New ticket")
-      expect(page).to have_link("Report a bug", href: "https://github.com/antiwork/gumroad/issues/new")
+      expect(page).not_to have_link("Report a bug")
     end
 
     it "opens the new ticket modal when the new ticket parameter is present" do


### PR DESCRIPTION
Removes the 'Report a bug' button that linked to `github.com/antiwork/gumroad/issues/new` from:

- **Support Header** (`components/server-components/support/Header.tsx`) — both anonymous and authenticated views
- **HelpCenter Layout** (`pages/HelpCenter/Layout.tsx`) — `ReportBugButton` component and all usages

Cleans up unused imports (`Github` icon, `NavigationButton`).