### PR TITLE
Reject legacy file/preview/thumbnail fields on v2 product create/update

### DIFF
--- a/app/controllers/api/v2/links_controller.rb
+++ b/app/controllers/api/v2/links_controller.rb
@@ -21,7 +21,7 @@ class Api::V2::LinksController < Api::V2::BaseController
 
   before_action(only: [:show, :index]) { doorkeeper_authorize!(*Doorkeeper.configuration.public_scopes.concat([:view_public])) }
   before_action(only: [:create, :update, :disable, :enable, :destroy]) { doorkeeper_authorize! :edit_products }
-  before_action :check_types_of_file_objects, only: [:update, :create]
+  before_action :reject_unsupported_upload_fields, only: [:update, :create]
   before_action :set_link_id_to_id, only: [:show, :update, :disable, :enable, :destroy]
   before_action :fetch_product, only: [:show, :update, :disable, :enable, :destroy]
 
@@ -409,11 +409,55 @@ class Api::V2::LinksController < Api::V2::BaseController
       error_with_object(:product, product)
     end
 
-    def check_types_of_file_objects
-      return if params[:file].class != String && params[:preview].class != String
+    UNSUPPORTED_UPLOAD_FIELDS = %i[file preview thumbnail].freeze
 
-      render_response(false, message: "You entered the name of the file to be uploaded incorrectly. Please refer to " \
-                                      "https://gumroad.com/api#methods for the correct syntax.")
+    def reject_unsupported_upload_fields
+      rejected_field = UNSUPPORTED_UPLOAD_FIELDS.find { |key| legacy_upload_present?(params[key]) }
+      return unless rejected_field
+
+      render_response(false, message: unsupported_upload_field_message(rejected_field))
+    end
+
+    def legacy_upload_present?(value)
+      return false if value.blank?
+
+      case value
+      when ActionController::Parameters, Hash
+        value.each_value.any? { |v| legacy_upload_present?(v) }
+      when Array
+        value.any? { |v| legacy_upload_present?(v) }
+      else
+        true
+      end
+    end
+
+    def unsupported_upload_field_message(field)
+      verb_path = action_name == "create" ? "POST /v2/products" : "PUT /v2/products/:id"
+      "'#{field}' is not an accepted parameter on #{verb_path}. #{upload_field_guidance(field)}"
+    end
+
+    def upload_field_guidance(field)
+      case field
+      when :file
+        presign_flow = "Upload files with the presign flow (POST /v2/files/presign, upload parts to the returned S3 URLs, then POST /v2/files/complete), then attach them by including the returned URLs in files[][url]."
+        if action_name == "create"
+          presign_flow
+        else
+          "#{presign_flow} Note: files is a full replacement — to keep an existing file, include its id and its original canonical url (not the signed URL returned by GET /v2/products/:id); files missing from the array are removed."
+        end
+      when :preview
+        if action_name == "create"
+          "Covers can only be added after the product is created. Create the product first, then POST to /v2/products/:id/covers with a url or signed_blob_id."
+        else
+          "Use POST /v2/products/:id/covers with a url or signed_blob_id to add a cover."
+        end
+      when :thumbnail
+        if action_name == "create"
+          "Thumbnails can only be set after the product is created. Create the product first, then POST to /v2/products/:id/thumbnail with a signed_blob_id."
+        else
+          "Use POST /v2/products/:id/thumbnail with a signed_blob_id to set the thumbnail."
+        end
+      end
     end
 
     def validate_file_urls(files)

--- a/spec/controllers/api/v2/links_controller_spec.rb
+++ b/spec/controllers/api/v2/links_controller_spec.rb
@@ -474,6 +474,65 @@ describe Api::V2::LinksController do
         expect(response.parsed_body["message"]).to include("files must be an array of file objects")
       end
 
+      describe "rejecting legacy upload fields" do
+        %i[file preview thumbnail].each do |field|
+          it "rejects #{field} sent as a string" do
+            post @action, params: @params.merge(field => "something.pdf")
+
+            expect(response).to be_successful
+            expect(response.parsed_body["success"]).to be false
+            expect(response.parsed_body["message"]).to start_with("'#{field}' is not an accepted parameter on POST /v2/products.")
+          end
+
+          it "rejects #{field} sent as a multipart upload" do
+            upload = Rack::Test::UploadedFile.new(Rails.root.join("spec/support/fixtures/smilie.png"), "image/png")
+            post @action, params: @params.merge(field => upload)
+
+            expect(response).to be_successful
+            expect(response.parsed_body["success"]).to be false
+            expect(response.parsed_body["message"]).to start_with("'#{field}' is not an accepted parameter on POST /v2/products.")
+          end
+        end
+
+        it "points file rejections to the full presign and complete flow" do
+          post @action, params: @params.merge(file: "something.pdf")
+
+          message = response.parsed_body["message"]
+          expect(message).to include("POST /v2/files/presign")
+          expect(message).to include("POST /v2/files/complete")
+          expect(message).to include("files[][url]")
+        end
+
+        it "points preview rejections to the covers endpoint rather than presign" do
+          post @action, params: @params.merge(preview: "cover.png")
+
+          message = response.parsed_body["message"]
+          expect(message).to include("/v2/products/:id/covers")
+          expect(message).to include("Create the product first")
+          expect(message).not_to include("POST /v2/files/presign")
+        end
+
+        it "points thumbnail rejections to the thumbnail endpoint rather than presign" do
+          post @action, params: @params.merge(thumbnail: "thumb.png")
+
+          message = response.parsed_body["message"]
+          expect(message).to include("/v2/products/:id/thumbnail")
+          expect(message).to include("Create the product first")
+          expect(message).not_to include("POST /v2/files/presign")
+        end
+
+        %i[file preview thumbnail].each do |field|
+          [nil, "", {}, { url: "" }, { signed_blob_id: "" }, { nested: { key: "" } }, [nil, ""]].each do |blank_value|
+            it "ignores #{field} when sent as #{blank_value.inspect}" do
+              post @action, params: @params.merge(field => blank_value)
+
+              expect(response).to be_successful
+              expect(response.parsed_body["success"]).to be true
+            end
+          end
+        end
+      end
+
       it "defaults taxonomy to 'other' when not specified" do
         post @action, params: @params
 
@@ -1064,6 +1123,68 @@ describe Api::V2::LinksController do
         expect(response).to be_successful
         expect(response.parsed_body["success"]).to be false
         expect(response.parsed_body["message"]).to include("rich_content must be an array of content page objects")
+      end
+
+      describe "rejecting legacy upload fields" do
+        %i[file preview thumbnail].each do |field|
+          it "rejects #{field} sent as a string" do
+            put @action, params: @params.merge(field => "something.pdf")
+
+            expect(response).to be_successful
+            expect(response.parsed_body["success"]).to be false
+            expect(response.parsed_body["message"]).to start_with("'#{field}' is not an accepted parameter on PUT /v2/products/:id.")
+          end
+
+          it "rejects #{field} sent as a multipart upload" do
+            upload = Rack::Test::UploadedFile.new(Rails.root.join("spec/support/fixtures/smilie.png"), "image/png")
+            put @action, params: @params.merge(field => upload)
+
+            expect(response).to be_successful
+            expect(response.parsed_body["success"]).to be false
+            expect(response.parsed_body["message"]).to start_with("'#{field}' is not an accepted parameter on PUT /v2/products/:id.")
+          end
+        end
+
+        it "points file rejections to the full presign and complete flow and describes the preservation contract" do
+          put @action, params: @params.merge(file: "something.pdf")
+
+          message = response.parsed_body["message"]
+          expect(message).to include("POST /v2/files/presign")
+          expect(message).to include("POST /v2/files/complete")
+          expect(message).to include("files[][url]")
+          expect(message).to include("full replacement")
+          expect(message).to include("id")
+          expect(message).to include("canonical url")
+          expect(message).to include("not the signed URL")
+        end
+
+        it "points preview rejections to the covers endpoint rather than presign" do
+          put @action, params: @params.merge(preview: "cover.png")
+
+          message = response.parsed_body["message"]
+          expect(message).to include("POST /v2/products/:id/covers")
+          expect(message).not_to include("POST /v2/files/presign")
+        end
+
+        it "points thumbnail rejections to the thumbnail endpoint rather than presign" do
+          put @action, params: @params.merge(thumbnail: "thumb.png")
+
+          message = response.parsed_body["message"]
+          expect(message).to include("POST /v2/products/:id/thumbnail")
+          expect(message).not_to include("POST /v2/files/presign")
+        end
+
+        %i[file preview thumbnail].each do |field|
+          [nil, "", {}, { url: "" }, { signed_blob_id: "" }, { nested: { key: "" } }, [nil, ""]].each do |blank_value|
+            it "ignores #{field} when sent as #{blank_value.inspect}" do
+              put @action, params: @params.merge(field => blank_value, name: "Updated")
+
+              expect(response).to be_successful
+              expect(response.parsed_body["success"]).to be true
+              expect(@product.reload.name).to eq("Updated")
+            end
+          end
+        end
       end
 
       it "rejects non-array cover_ids" do


### PR DESCRIPTION
Ref #4477

## What

Reject `file`, `preview`, and `thumbnail` on `POST /v2/products` and `PUT /v2/products/:id`. These fields aren't wired into v2 product create/update. Previously, the endpoint accepted them and returned `success: true` without saving anything.

Each rejection now names the right endpoint to use instead:

- `file` → upload via the presign flow, then attach with `files[][url]`. On update, the message also warns that `files` fully replaces the existing list.
- `preview` → `POST /v2/products/:id/covers`. On create, tells the caller to create the product first.
- `thumbnail` → `POST /v2/products/:id/thumbnail`. Same "create first" note on create.

Empty values (`nil`, `""`, `{}`, all-blank nested hashes) are ignored so callers that happen to send a blank field keep working.

## Why

A seller reported in #4477 that five of their products shipped with no files, covers, or thumbnails because the API silently dropped their uploads. The old guard only caught bare strings and pointed at a docs page that no longer described the upload flow. Failing with a pointer to the correct endpoint saves anyone else from the same debugging loop.

---

This PR was implemented with AI assistance using Claude Opus 4.7 and gpt‑5.4 xhigh