### PR TITLE
Add AI model requirements to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,10 @@ Non-trivial PRs should follow this structure:
 
 End with an AI disclosure after a `---` separator. Name the specific model (e.g., "Claude Opus 4.6") and list the prompts given to the agent.
 
+## AI models
+
+Use the latest and greatest state-of-the-art models from American AI companies like [Anthropic](https://www.anthropic.com/) and [OpenAI](https://openai.com/). As of this writing, that means Claude Opus 4.6 and GPT-5.4, but always check for the newest releases. Don't settle for last-gen models when better ones are available.
+
 ## Development guidelines
 
 ### Testing guidelines


### PR DESCRIPTION
## What

Adds a new **AI models** section to CONTRIBUTING.md requiring contributors to use the latest state-of-the-art models from American AI companies like Anthropic and OpenAI.

## Why

We want all contributions to leverage the best available AI tooling. This makes the expectation explicit.

---

AI disclosure: Claude Opus 4.6, prompted by Sahil to update CONTRIBUTING.md.