### PR TITLE
Fix ActiveRecord::StatementTimeout in CustomerMailer#grouped_receipt

### DIFF
--- a/app/mailers/customer_mailer.rb
+++ b/app/mailers/customer_mailer.rb
@@ -10,7 +10,7 @@ class CustomerMailer < ApplicationMailer
   layout "layouts/email", except: :send_to_kindle
 
   def grouped_receipt(purchase_ids)
-    @chargeables = Purchase.where(id: purchase_ids).map { Charge::Chargeable.find_by_purchase_or_charge!(purchase: _1) }.uniq
+    @chargeables = Purchase.where(id: purchase_ids).includes(charge: :order).map { Charge::Chargeable.find_by_purchase_or_charge!(purchase: _1) }.uniq
     last_chargeable = @chargeables.last
 
     mail(

--- a/spec/mailers/customer_mailer_spec.rb
+++ b/spec/mailers/customer_mailer_spec.rb
@@ -1244,6 +1244,30 @@ describe CustomerMailer do
       expect(mail.to).to eq([purchases.last.email])
       expect(mail.subject).to eq("Receipts for Purchases")
     end
+
+    it "eager loads charges and orders to avoid N+1 queries" do
+      purchases_with_charges = Array.new(3) do
+        purchase = create(:purchase, link: product, seller:)
+        charge = create(:charge, seller:)
+        charge.purchases << purchase
+        charge.order.purchases << purchase
+        purchase
+      end
+
+      queries = []
+      callback = lambda { |_name, _start, _finish, _id, payload|
+        queries << payload[:sql] if payload[:sql] && !payload[:name]&.match?(/SCHEMA|TRANSACTION/)
+      }
+
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        CustomerMailer.grouped_receipt(purchases_with_charges.map(&:id)).message
+      end
+
+      charge_queries = queries.select { |sql| sql.match?(/FROM `charges`/i) }
+      order_queries = queries.select { |sql| sql.match?(/FROM `orders`/i) }
+      expect(charge_queries.size).to be <= 2
+      expect(order_queries.size).to be <= 2
+    end
   end
 
   describe "#refund" do


### PR DESCRIPTION
## Summary
- eager load `charge` and `order` when building grouped receipt chargeables
- add a mailer spec that guards against repeated charge/order lookups for grouped receipts
- keep the change small and focused on the Sentry timeout regression

## Context
- Sentry: https://gumroad-to.sentry.io/issues/7420629584/
- 7-day events: 1
- 14-day events: 1
- Users affected: ~0 (first occurrence)
- Estimated support tickets: 0

## Root cause
N+1 queries in `CustomerMailer#grouped_receipt` caused repeated `purchase.charge` and `charge.order` lookups while resolving charge receipts for large purchase sets.