### PR TITLE
Document POST and PUT /v2/products in API docs

### DIFF
--- a/app/javascript/components/ApiDocumentation/ApiParameters.tsx
+++ b/app/javascript/components/ApiDocumentation/ApiParameters.tsx
@@ -7,7 +7,7 @@ export const ApiParameters = ({ children }: { children: React.ReactNode }) => (
   </div>
 );
 
-export const ApiParameter = ({ name, description }: { name: string; description?: string }) => (
+export const ApiParameter = ({ name, description }: { name: string; description?: React.ReactNode }) => (
   <p>
     <strong>{name}</strong> {description}
   </p>

--- a/app/javascript/components/ApiDocumentation/Endpoints/Products.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/Products.tsx
@@ -215,7 +215,11 @@ export const CreateProduct = () => (
   <ApiEndpoint
     method="post"
     path="/products"
-    description="Create a new product (as a draft). Requires the edit_products or account scope."
+    description={
+      <>
+        Create a new product (as a draft). Requires the <code>edit_products</code> or <code>account</code> scope.
+      </>
+    }
   >
     <ApiParameters>
       <ApiParameter
@@ -281,7 +285,7 @@ export const CreateProduct = () => (
     "main_cover_id": null,
     "rich_content": [],
     "has_same_rich_content_for_all_variants": true
-    // ...remaining product fields
+# ...remaining product fields
   }
 }`}
     </CodeSnippet>
@@ -361,7 +365,7 @@ export const UpdateProduct = () => (
         "filegroup": "image"
       }
     ]
-    // ...remaining product fields
+# ...remaining product fields
   }
 }`}
     </CodeSnippet>

--- a/app/javascript/components/ApiDocumentation/Endpoints/Products.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/Products.tsx
@@ -3,14 +3,27 @@ import React from "react";
 import CodeSnippet from "$app/components/ui/CodeSnippet";
 
 import { ApiEndpoint } from "../ApiEndpoint";
+import { ApiParameter, ApiParameters } from "../ApiParameters";
 import { ApiResponseFields, renderFields } from "../ApiResponseFields";
-import { PRODUCT_FIELDS } from "../responseFieldDefinitions";
+import { PRODUCT_FIELDS, PRODUCT_LIST_FIELDS } from "../responseFieldDefinitions";
 
 const ProductResponseFields = () => (
   <ApiResponseFields>
     {renderFields([
       { name: "success", type: "boolean", description: "Whether the request succeeded" },
-      { name: "products", type: "array", description: "Array of product objects", children: PRODUCT_FIELDS },
+      { name: "products", type: "array", description: "Array of product objects", children: PRODUCT_LIST_FIELDS },
+      {
+        name: "next_page_key",
+        type: "string",
+        description: "Opaque cursor to pass as page_key to fetch the next page",
+        condition: "present when more results follow",
+      },
+      {
+        name: "next_page_url",
+        type: "string",
+        description: "Path-relative URL (with query string) for the next page of results",
+        condition: "present when more results follow",
+      },
     ])}
   </ApiResponseFields>
 );
@@ -20,6 +33,22 @@ const SingleProductResponseFields = () => (
     {renderFields([
       { name: "success", type: "boolean", description: "Whether the request succeeded" },
       { name: "product", type: "object", description: "The product object", children: PRODUCT_FIELDS },
+    ])}
+  </ApiResponseFields>
+);
+
+const UpdateProductResponseFields = () => (
+  <ApiResponseFields>
+    {renderFields([
+      { name: "success", type: "boolean", description: "Whether the request succeeded" },
+      { name: "product", type: "object", description: "The product object", children: PRODUCT_FIELDS },
+      {
+        name: "warning",
+        type: "string",
+        description:
+          "Warning about offer codes that became invalid for the product (currency mismatch or below minimum price).",
+        condition: "present when at least one offer code is invalid after the update",
+      },
     ])}
   </ApiResponseFields>
 );
@@ -53,7 +82,7 @@ export const GetProducts = () => (
     "require_shipping": false,
     "subscription_duration": null,
     "published": true,
-    "url": "http://sahillavingia.com/pencil.psd",
+    "url": null, # Deprecated, always null
     "id": "A-m3CDDC5dlrSdKZp0RFhA==",
     "price": 100,
     "purchasing_power_parity_prices": {
@@ -67,8 +96,8 @@ export const GetProducts = () => (
     "tags": ["pencil", "icon"],
     "formatted_price": "$1",
     "file_info": {},
-    "sales_count": "0", # available with the 'view_sales' scope
-    "sales_usd_cents": "0", # available with the 'view_sales' scope
+    "sales_count": 0, # available with the 'view_sales' or 'account' scope
+    "sales_usd_cents": 0, # available with the 'view_sales' or 'account' scope
     "is_tiered_membership": true,
     "recurrences": ["monthly"], # if is_tiered_membership is true, renders list of available subscription durations; otherwise null
     "variants": [
@@ -77,8 +106,8 @@ export const GetProducts = () => (
         "options": [
           {
             "name": "First Tier",
-            "price_difference": 0, # set for non-membership product options
-            "purchasing_power_parity_prices": { # set for non-membership product options
+            "price_difference": 0, # 0 for tiered membership options; non-zero for non-membership options with a price bump
+            "purchasing_power_parity_prices": { # present when PPP is enabled for the seller and the product has not opted out; null when price_difference is null
               "US": 200,
               "IN": 100,
               "EC": 50
@@ -130,7 +159,7 @@ export const GetProduct = () => (
     "require_shipping": false,
     "subscription_duration": null,
     "published": true,
-    "url": "http://sahillavingia.com/pencil.psd",
+    "url": null, # Deprecated, always null
     "id": "A-m3CDDC5dlrSdKZp0RFhA==",
     "price": 100,
     "purchasing_power_parity_prices": {
@@ -144,8 +173,8 @@ export const GetProduct = () => (
     "tags": ["pencil", "icon"],
     "formatted_price": "$1",
     "file_info": {},
-    "sales_count": "0", # available with the 'view_sales' scope
-    "sales_usd_cents": "0", # available with the 'view_sales' scope
+    "sales_count": 0, # available with the 'view_sales' or 'account' scope
+    "sales_usd_cents": 0, # available with the 'view_sales' or 'account' scope
     "is_tiered_membership": true,
     "recurrences": ["monthly"], # if is_tiered_membership is true, renders list of available subscription durations; otherwise null
     "variants": [
@@ -154,8 +183,8 @@ export const GetProduct = () => (
         "options": [
           {
             "name": "First Tier",
-            "price_difference": 0, # set for non-membership product options
-            "purchasing_power_parity_prices": { # set for non-membership product options
+            "price_difference": 0, # 0 for tiered membership options; non-zero for non-membership options with a price bump
+            "purchasing_power_parity_prices": { # present when PPP is enabled for the seller and the product has not opted out; null when price_difference is null
               "US": 200,
               "IN": 100,
               "EC": 50
@@ -176,6 +205,163 @@ export const GetProduct = () => (
         ]
       }
     ]
+  }
+}`}
+    </CodeSnippet>
+  </ApiEndpoint>
+);
+
+export const CreateProduct = () => (
+  <ApiEndpoint
+    method="post"
+    path="/products"
+    description="Create a new product (as a draft). Requires the edit_products or account scope."
+  >
+    <ApiParameters>
+      <ApiParameter
+        name="native_type"
+        description='(optional, "digital" (default), "course", "ebook", "membership", "bundle", "coffee", "call", or "commission") cannot be changed later'
+      />
+      <ApiParameter name="name" description="(required)" />
+      <ApiParameter name="description" description="(optional) HTML" />
+      <ApiParameter name="custom_permalink" description="(optional)" />
+      <ApiParameter name="price" description="(required) in the smallest currency unit (e.g. cents)" />
+      <ApiParameter
+        name="price_currency_type"
+        description="(optional) ISO currency code; defaults to your account currency"
+      />
+      <ApiParameter
+        name="subscription_duration"
+        description='(optional, membership only, "monthly", "quarterly", "biannually", "yearly", or "every_two_years")'
+      />
+      <ApiParameter name="customizable_price" description="(optional, true or false) pay-what-you-want" />
+      <ApiParameter name="suggested_price_cents" description="(optional)" />
+      <ApiParameter name="max_purchase_count" description="(optional)" />
+      <ApiParameter name="taxonomy_id" description="(optional)" />
+      <ApiParameter name="tags" description="(optional) array of tag strings" />
+      <ApiParameter name="custom_summary" description="(optional)" />
+      <ApiParameter
+        name="rich_content"
+        description="(optional) array of { id, title, description } pages; description is a ProseMirror doc"
+      />
+      <ApiParameter
+        name="files"
+        description={
+          <>
+            (optional) array of files to attach — see <a href="#attach-file">Attaching to a product</a>
+          </>
+        }
+      />
+    </ApiParameters>
+    <p>
+      Cover images and thumbnails are attached separately via <code>POST /v2/products/:id/covers</code> and{" "}
+      <code>POST /v2/products/:id/thumbnail</code>.
+    </p>
+    <SingleProductResponseFields />
+    <CodeSnippet caption="cURL example">
+      {`curl https://api.gumroad.com/v2/products \\
+  -d "access_token=ACCESS_TOKEN" \\
+  -d "native_type=digital" \\
+  -d "name=Pencil Icon PSD" \\
+  -d "price=100" \\
+  -d "price_currency_type=usd" \\
+  -X POST`}
+    </CodeSnippet>
+    <CodeSnippet caption="Example response:">
+      {`{
+  "success": true,
+  "product": {
+    "id": "A-m3CDDC5dlrSdKZp0RFhA==",
+    "name": "Pencil Icon PSD",
+    "price": 100,
+    "currency": "usd",
+    "published": false,
+    "files": [],
+    "covers": [],
+    "main_cover_id": null,
+    "rich_content": [],
+    "has_same_rich_content_for_all_variants": true
+    // ...remaining product fields
+  }
+}`}
+    </CodeSnippet>
+  </ApiEndpoint>
+);
+
+export const UpdateProduct = () => (
+  <ApiEndpoint
+    method="put"
+    path="/products/:id"
+    description={
+      <>
+        Update an existing product. Send only the fields you want to change. Sending <code>files</code>,{" "}
+        <code>tags</code>, or <code>rich_content</code> replaces the entire collection. Requires the{" "}
+        <code>edit_products</code> or <code>account</code> scope.
+      </>
+    }
+  >
+    <ApiParameters>
+      <ApiParameter name="name" description="(optional)" />
+      <ApiParameter name="description" description="(optional) HTML" />
+      <ApiParameter name="custom_permalink" description="(optional)" />
+      <ApiParameter
+        name="price"
+        description="(optional) in the smallest currency unit; not allowed for tiered memberships — use the variant endpoints to manage tier pricing"
+      />
+      <ApiParameter name="price_currency_type" description="(optional) ISO currency code" />
+      <ApiParameter name="customizable_price" description="(optional, true or false)" />
+      <ApiParameter name="suggested_price_cents" description="(optional)" />
+      <ApiParameter name="max_purchase_count" description="(optional)" />
+      <ApiParameter name="quantity_enabled" description="(optional, true or false)" />
+      <ApiParameter name="is_adult" description="(optional, true or false)" />
+      <ApiParameter name="display_product_reviews" description="(optional, true or false)" />
+      <ApiParameter name="should_show_sales_count" description="(optional, true or false)" />
+      <ApiParameter name="taxonomy_id" description="(optional)" />
+      <ApiParameter name="tags" description="(optional) array of tag strings; full replacement" />
+      <ApiParameter name="custom_receipt" description="(optional)" />
+      <ApiParameter name="custom_summary" description="(optional)" />
+      <ApiParameter name="cover_ids" description="(optional) array of cover GUIDs in display order" />
+      <ApiParameter name="rich_content" description="(optional) array of pages; full replacement" />
+      <ApiParameter
+        name="has_same_rich_content_for_all_variants"
+        description="(optional, true or false) switches between product-level and per-variant rich content"
+      />
+      <ApiParameter
+        name="files"
+        description={
+          <>
+            (optional) array of files; full replacement — see <a href="#attach-file">Attaching to a product</a> for how
+            to keep existing files
+          </>
+        }
+      />
+    </ApiParameters>
+    <UpdateProductResponseFields />
+    <CodeSnippet caption="cURL example">
+      {`curl https://api.gumroad.com/v2/products/A-m3CDDC5dlrSdKZp0RFhA== \\
+  -d "access_token=ACCESS_TOKEN" \\
+  -d "name=Pencil Icon PSD v2" \\
+  -d "max_purchase_count=100" \\
+  -X PUT`}
+    </CodeSnippet>
+    <CodeSnippet caption="Example response:">
+      {`{
+  "success": true,
+  "product": {
+    "id": "A-m3CDDC5dlrSdKZp0RFhA==",
+    "name": "Pencil Icon PSD v2",
+    "max_purchase_count": 100,
+    "files": [
+      {
+        "id": "K7QmZw==",
+        "name": "Pencil Icon",
+        "size": 102400,
+        "url": "https://api.gumroad.com/r/...signed...",
+        "filetype": "psd",
+        "filegroup": "image"
+      }
+    ]
+    // ...remaining product fields
   }
 }`}
     </CodeSnippet>
@@ -223,7 +409,7 @@ export const EnableProduct = () => (
     "require_shipping": false,
     "subscription_duration": null,
     "published": true,
-    "url": "http://sahillavingia.com/pencil.psd",
+    "url": null, # Deprecated, always null
     "id": "A-m3CDDC5dlrSdKZp0RFhA==",
     "price": 100,
     "purchasing_power_parity_prices": {
@@ -237,8 +423,8 @@ export const EnableProduct = () => (
     "tags": ["pencil", "icon"],
     "formatted_price": "$1",
     "file_info": {},
-    "sales_count": "0", # available with the 'view_sales' scope
-    "sales_usd_cents": "0", # available with the 'view_sales' scope
+    "sales_count": 0, # available with the 'view_sales' or 'account' scope
+    "sales_usd_cents": 0, # available with the 'view_sales' or 'account' scope
     "is_tiered_membership": true,
     "recurrences": ["monthly"], # if is_tiered_membership is true, renders list of available subscription durations; otherwise null
     "variants": [
@@ -247,8 +433,8 @@ export const EnableProduct = () => (
         "options": [
           {
             "name": "First Tier",
-            "price_difference": 0, # set for non-membership product options
-            "purchasing_power_parity_prices": { # set for non-membership product options
+            "price_difference": 0, # 0 for tiered membership options; non-zero for non-membership options with a price bump
+            "purchasing_power_parity_prices": { # present when PPP is enabled for the seller and the product has not opted out; null when price_difference is null
               "US": 200,
               "IN": 100,
               "EC": 50
@@ -300,7 +486,7 @@ export const DisableProduct = () => (
     "require_shipping": false,
     "subscription_duration": null,
     "published": false,
-    "url": "http://sahillavingia.com/pencil.psd",
+    "url": null, # Deprecated, always null
     "id": "A-m3CDDC5dlrSdKZp0RFhA==",
     "price": 100,
     "currency": "usd",
@@ -309,9 +495,8 @@ export const DisableProduct = () => (
     "tags": ["pencil", "icon"],
     "formatted_price": "$1",
     "file_info": {},
-    "view_count": "0", # available with the 'view_sales' scope
-    "sales_count": "0", # available with the 'view_sales' scope
-    "sales_usd_cents": "0", # available with the 'view_sales' scope
+    "sales_count": 0, # available with the 'view_sales' or 'account' scope
+    "sales_usd_cents": 0, # available with the 'view_sales' or 'account' scope
     "is_tiered_membership": true,
     "recurrences": ["monthly"], # if is_tiered_membership is true, renders list of available subscription durations; otherwise null
     "variants": [
@@ -320,7 +505,7 @@ export const DisableProduct = () => (
         "options": [
           {
             "name": "First Tier",
-            "price_difference": 0, # set for non-membership product options
+            "price_difference": 0, # 0 for tiered membership options; non-zero for non-membership options with a price bump
             "is_pay_what_you_want": false,
             "recurrence_prices": { # present for membership products; otherwise null
               "monthly": {

--- a/app/javascript/components/ApiDocumentation/responseFieldDefinitions.ts
+++ b/app/javascript/components/ApiDocumentation/responseFieldDefinitions.ts
@@ -1,11 +1,71 @@
 import { FieldDefinition } from "./ApiResponseFields";
 
-export const PRODUCT_FIELDS: FieldDefinition[] = [
+const PRODUCT_VARIANT_FIELDS: FieldDefinition[] = [
+  { name: "title", type: "string", description: 'Variant category title (e.g. "Tier")' },
+  {
+    name: "options",
+    type: "array",
+    description: "Options within this variant category",
+    children: [
+      { name: "name", type: "string", description: "Option name" },
+      {
+        name: "price_difference",
+        type: "number | null",
+        description: "Price difference in cents from the base price (0 for membership tiers, whose prices are set via recurrence_prices)",
+      },
+      {
+        name: "purchasing_power_parity_prices",
+        type: "object | null",
+        description:
+          "PPP-adjusted prices for this option, computed from the base price plus price_difference; null for options whose price_difference is null",
+        condition:
+          "present when the seller has purchasing power parity enabled and the product has not opted out",
+      },
+      { name: "is_pay_what_you_want", type: "boolean", description: "Whether this option is pay-what-you-want" },
+      { name: "url", type: "null", description: "Deprecated, always null" },
+      {
+        name: "recurrence_prices",
+        type: "object | null",
+        description: "Prices per recurrence interval",
+        condition: "present for membership products; otherwise null",
+        children: [
+          { name: "price_cents", type: "number", description: "Price in cents for this recurrence" },
+          {
+            name: "suggested_price_cents",
+            type: "number | null",
+            description: "Suggested price in cents",
+            condition: "may return a number if is_pay_what_you_want is true",
+          },
+          {
+            name: "purchasing_power_parity_prices",
+            type: "object",
+            description: "PPP-adjusted prices for this recurrence",
+            condition:
+              "present when the seller has purchasing power parity enabled and the product has not opted out",
+          },
+        ],
+      },
+      {
+        name: "rich_content",
+        type: "array",
+        description: "Per-variant rich content pages",
+        condition: "omitted from GET /v2/products list responses",
+      },
+    ],
+  },
+];
+
+const SHARED_PRODUCT_FIELDS: FieldDefinition[] = [
   { name: "custom_permalink", type: "string | null", description: "Custom URL slug for the product" },
   { name: "custom_receipt", type: "string | null", description: "Custom receipt text" },
   { name: "custom_summary", type: "string | null", description: "Custom summary shown to buyers" },
-  { name: "custom_fields", type: "array", description: "Custom fields defined on the product" },
-  { name: "customizable_price", type: "number | null", description: "Minimum price if pay-what-you-want is enabled" },
+  {
+    name: "custom_fields",
+    type: "array",
+    description:
+      "Combined list of the seller's global checkout custom fields and the product's own custom fields",
+  },
+  { name: "customizable_price", type: "boolean | null", description: "Whether pay-what-you-want pricing is enabled" },
   { name: "description", type: "string | null", description: "Product description" },
   { name: "deleted", type: "boolean", description: "Whether the product has been deleted" },
   { name: "max_purchase_count", type: "number | null", description: "Maximum number of purchases allowed" },
@@ -21,24 +81,47 @@ export const PRODUCT_FIELDS: FieldDefinition[] = [
     name: "purchasing_power_parity_prices",
     type: "object",
     description: "Country-code-keyed prices adjusted for purchasing power parity",
+    condition: "present when the seller has purchasing power parity enabled and the product has not opted out",
   },
   { name: "currency", type: "string", description: 'ISO currency code (e.g. "usd")' },
   { name: "short_url", type: "string", description: "Short Gumroad URL for the product" },
   { name: "thumbnail_url", type: "string | null", description: "URL of the product thumbnail image" },
   { name: "tags", type: "array", description: "Tags associated with the product" },
   { name: "formatted_price", type: "string", description: "Human-readable formatted price" },
-  { name: "file_info", type: "object", description: "Information about attached files" },
+  {
+    name: "file_info",
+    type: "object",
+    description:
+      'Legacy single-file metadata; returns {} for products with 0 or 2+ files. For complete file state, fetch the product via GET /v2/products/:id and read the "files" array (not returned by GET /v2/products).',
+  },
+  {
+    name: "covers",
+    type: "array",
+    description: "Cover images and videos attached to the product",
+  },
+  { name: "main_cover_id", type: "string | null", description: "GUID of the cover shown first" },
+  {
+    name: "bundle_products",
+    type: "array",
+    description: "Items contained in a bundle product; empty for non-bundle products",
+    children: [
+      { name: "product_id", type: "string", description: "External ID of the included product" },
+      { name: "variant_id", type: "string | null", description: "External ID of the selected variant, if any" },
+      { name: "quantity", type: "number", description: "Quantity of this item in the bundle" },
+      { name: "position", type: "number", description: "Order of this item within the bundle" },
+    ],
+  },
   {
     name: "sales_count",
-    type: "string",
+    type: "number",
     description: "Total number of sales",
-    condition: "available with the 'view_sales' scope",
+    condition: "available with the 'view_sales' or 'account' scope",
   },
   {
     name: "sales_usd_cents",
-    type: "string",
+    type: "number",
     description: "Total revenue in USD cents",
-    condition: "available with the 'view_sales' scope",
+    condition: "available with the 'view_sales' or 'account' scope",
   },
   { name: "is_tiered_membership", type: "boolean", description: "Whether this is a tiered membership product" },
   {
@@ -48,54 +131,63 @@ export const PRODUCT_FIELDS: FieldDefinition[] = [
     condition: "present when is_tiered_membership is true; otherwise null",
   },
   {
-    name: "variants",
+    name: "is_preorder",
+    type: "boolean",
+    description: "Whether the product is a preorder",
+    condition: "present only for preorder products",
+  },
+  {
+    name: "is_in_preorder_state",
+    type: "boolean",
+    description: "Whether the preorder has not yet been released",
+    condition: "present only for preorder products",
+  },
+  {
+    name: "release_at",
+    type: "string",
+    description: "Preorder release timestamp",
+    condition: "present only for preorder products",
+  },
+  {
+    name: "custom_delivery_url",
+    type: "null",
+    description: "Deprecated, always null",
+    condition: "present only with the 'view_sales' or 'account' scope",
+  },
+];
+
+export const PRODUCT_LIST_FIELDS: FieldDefinition[] = [
+  ...SHARED_PRODUCT_FIELDS,
+  { name: "variants", type: "array", description: "Variant categories and their options", children: PRODUCT_VARIANT_FIELDS },
+];
+
+export const PRODUCT_FIELDS: FieldDefinition[] = [
+  ...SHARED_PRODUCT_FIELDS,
+  { name: "rich_content", type: "array", description: "Product-level rich content pages" },
+  {
+    name: "has_same_rich_content_for_all_variants",
+    type: "boolean",
+    description: "Whether all variants share the product-level rich content",
+  },
+  {
+    name: "files",
     type: "array",
-    description: "Variant categories and their options",
+    description:
+      "Files attached to the product. Files whose backing S3 object is missing are omitted from the response.",
     children: [
-      { name: "title", type: "string", description: 'Variant category title (e.g. "Tier")' },
+      { name: "id", type: "string", description: "External ID of the file" },
+      { name: "name", type: "string | null", description: "Display name of the file" },
+      { name: "size", type: "number | null", description: "File size in bytes" },
       {
-        name: "options",
-        type: "array",
-        description: "Options within this variant category",
-        children: [
-          { name: "name", type: "string", description: "Option name" },
-          {
-            name: "price_difference",
-            type: "number",
-            description: "Price difference in cents from the base price",
-            condition: "set for non-membership product options",
-          },
-          {
-            name: "purchasing_power_parity_prices",
-            type: "object",
-            description: "PPP-adjusted prices for this option",
-            condition: "set for non-membership product options",
-          },
-          { name: "is_pay_what_you_want", type: "boolean", description: "Whether this option is pay-what-you-want" },
-          {
-            name: "recurrence_prices",
-            type: "object | null",
-            description: "Prices per recurrence interval",
-            condition: "present for membership products; otherwise null",
-            children: [
-              { name: "price_cents", type: "number", description: "Price in cents for this recurrence" },
-              {
-                name: "suggested_price_cents",
-                type: "number | null",
-                description: "Suggested price in cents",
-                condition: "may return a number if is_pay_what_you_want is true",
-              },
-              {
-                name: "purchasing_power_parity_prices",
-                type: "object",
-                description: "PPP-adjusted prices for this recurrence",
-              },
-            ],
-          },
-        ],
+        name: "url",
+        type: "string",
+        description: "Signed download URL for uploaded files; raw URL for external-link files (filetype: \"link\")",
       },
+      { name: "filetype", type: "string", description: 'File extension (e.g. "pdf") or "link" for external URLs' },
+      { name: "filegroup", type: "string", description: 'Group classification (e.g. "audio", "video", "document")' },
     ],
   },
+  { name: "variants", type: "array", description: "Variant categories and their options", children: PRODUCT_VARIANT_FIELDS },
 ];
 
 export const SALE_FIELDS: FieldDefinition[] = [

--- a/app/javascript/pages/Public/Api.tsx
+++ b/app/javascript/pages/Public/Api.tsx
@@ -27,6 +27,8 @@ import {GetPayouts, GetPayout, GetUpcomingPayouts} from "$app/components/ApiDocu
 import {
   GetProducts,
   GetProduct,
+  CreateProduct,
+  UpdateProduct,
   DeleteProduct,
   EnableProduct,
   DisableProduct,
@@ -94,6 +96,8 @@ export default function Api() {
               <ApiResource name="Products" id="products">
                 <GetProducts />
                 <GetProduct />
+                <CreateProduct />
+                <UpdateProduct />
                 <DeleteProduct />
                 <EnableProduct />
                 <DisableProduct />

--- a/gh-pr-draft.md
+++ b/gh-pr-draft.md
@@ -1,0 +1,24 @@
+Fixes #4477
+
+## What
+
+Adds public API documentation for creating and updating products (`POST /v2/products` and `PUT /v2/products/:id`).
+
+The new sections list every supported field, the response shape, and the follow-up endpoints for files, covers, and thumbnails. They also flag a few non-obvious behaviors that tripped the issue reporter — notably that updating the `files` list replaces it entirely, and that keeping an existing file requires sending it back with the URL from the upload flow, not the one returned by `GET`.
+
+## Why
+
+The create and update endpoints shipped without docs, so users had to guess the request shape and kept hitting silent failures. This closes that gap.
+
+Scope is docs-only. The related upload-flow docs (#4557) and stricter input validation (#4559) already shipped.
+
+---
+
+This PR was implemented with AI assistance using Claude Opus 4.7 (1M context).
+
+Prompts used:
+
+- "implement PR 3 from the plan at .context/attachments/api-docs-and-ux-fixes-plan.md"
+- "validate with /codex:adversarial-review and address findings if any, and repeat this loop in sequence until no worthy findings remain"
+- "pull main latest, rebase main, then squash commits and push"
+- "pr should be more concise and high level, avoid jargon"


### PR DESCRIPTION
Ref #4477

## What

Adds public API documentation for creating and updating products (`POST /v2/products` and `PUT /v2/products/:id`).

The new sections list every supported field, the response shape, and the follow-up endpoints for files, covers, and thumbnails. They also flag a few non-obvious behaviors that tripped the issue reporter — notably that updating the `files` list replaces it entirely, and that keeping an existing file requires sending it back with the URL from the upload flow, not the one returned by `GET`.

## Why

The create and update endpoints shipped without docs, so users had to guess the request shape and kept hitting silent failures.

Scope is docs-only. The related upload-flow docs (#4557) and stricter input validation (#4559) already shipped.

---

This PR was implemented with AI assistance using Claude Opus 4.7 and gpt‑5.4 xhigh