### PR TITLE
fix(security): pass explicit scheduled_payout_id to suspension email

### DIFF
--- a/app/mailers/contacting_creator_mailer.rb
+++ b/app/mailers/contacting_creator_mailer.rb
@@ -371,10 +371,10 @@ class ContactingCreatorMailer < ApplicationMailer
     @subject = "Your account has been suspended for being high risk"
   end
 
-  def account_suspended(user_id)
+  def account_suspended(user_id, scheduled_payout_id = nil)
     @seller = User.find(user_id)
     @subject = "Your Gumroad account has been suspended"
-    @scheduled_payout = @seller.scheduled_payouts.pending.last
+    @scheduled_payout = @seller.scheduled_payouts.find_by(id: scheduled_payout_id) if scheduled_payout_id
     @payout_amount = formatted_dollar_amount(@scheduled_payout.payout_amount_cents) if @scheduled_payout
   end
 

--- a/app/modules/user/risk.rb
+++ b/app/modules/user/risk.rb
@@ -105,10 +105,11 @@ module User::Risk
   end
 
   def send_suspension_email(transition)
-    return if transition.args.first&.dig(:skip_generic_suspension_email)
+    args = transition.args.first || {}
+    return if args[:skip_generic_suspension_email]
     return unless Feature.active?(:account_suspended_email)
 
-    ContactingCreatorMailer.account_suspended(id).deliver_later
+    ContactingCreatorMailer.account_suspended(id, args[:scheduled_payout_id]).deliver_later
   end
 
   def log_suspension_time_to_mongo

--- a/app/sidekiq/suspend_users_worker.rb
+++ b/app/sidekiq/suspend_users_worker.rb
@@ -13,13 +13,15 @@ class SuspendUsersWorker
       was_suspended = user.suspended?
       content = "Suspended for a policy violation by #{author_name} on #{Time.current.to_fs(:formatted_date_full_month)} as part of mass suspension. Reason: #{reason}."
       content += "\nAdditional notes: #{additional_notes}" if additional_notes.present?
-      user.suspend_for_tos_violation(author_id:, content:)
 
-      next if was_suspended || !user.suspended?
-      next if scheduled_payout.blank? || scheduled_payout["action"].blank?
-      next if user.unpaid_balance_cents.to_i <= 0
+      scheduled_payout_record = nil
+      if !was_suspended &&
+         scheduled_payout.present? && scheduled_payout["action"].present? &&
+         user.unpaid_balance_cents.to_i > 0
+        scheduled_payout_record = create_scheduled_payout(user, author, scheduled_payout)
+      end
 
-      create_scheduled_payout(user, author, scheduled_payout)
+      user.suspend_for_tos_violation(author_id:, content:, scheduled_payout_id: scheduled_payout_record&.id)
     end
   end
 
@@ -38,5 +40,7 @@ class SuspendUsersWorker
         comment_type: Comment::COMMENT_TYPE_PAYOUT_NOTE,
         content: "Scheduled #{record.action} for #{record.scheduled_at.to_fs(:formatted_date_full_month)} (#{record.delay_days} day delay)"
       )
+
+      record
     end
 end

--- a/spec/mailers/contacting_creator_mailer_spec.rb
+++ b/spec/mailers/contacting_creator_mailer_spec.rb
@@ -1995,22 +1995,22 @@ describe ContactingCreatorMailer do
       expect(mail.body.encoded).to include("The Gumroad team")
     end
 
-    context "when the seller has a pending scheduled payout" do
+    context "when passed a scheduled payout id for a payout" do
       it "includes scheduled payout amount and chargeback disclaimer" do
-        create(:scheduled_payout, user: seller, action: "payout", scheduled_at: Date.parse("2025-06-15"), payout_amount_cents: 150_00)
+        scheduled_payout = create(:scheduled_payout, user: seller, action: "payout", scheduled_at: Date.parse("2025-06-15"), payout_amount_cents: 150_00)
 
-        mail = ContactingCreatorMailer.account_suspended(seller.id)
+        mail = ContactingCreatorMailer.account_suspended(seller.id, scheduled_payout.id)
 
         expect(mail.body.encoded).to include("You have a scheduled payout ($150) set for June 15, 2025.")
         expect(mail.body.encoded).to include("If chargebacks are filed against any of your sales, your payout will be held for review and the amount may be reduced.")
       end
     end
 
-    context "when the seller has a pending scheduled refund" do
+    context "when passed a scheduled payout id for a refund" do
       it "includes refund amount" do
-        create(:scheduled_payout, user: seller, action: "refund", scheduled_at: Date.parse("2025-06-15"), payout_amount_cents: 75_50)
+        scheduled_payout = create(:scheduled_payout, user: seller, action: "refund", scheduled_at: Date.parse("2025-06-15"), payout_amount_cents: 75_50)
 
-        mail = ContactingCreatorMailer.account_suspended(seller.id)
+        mail = ContactingCreatorMailer.account_suspended(seller.id, scheduled_payout.id)
 
         expect(mail.body.encoded).to include("Your unpaid balance ($75.50) will be refunded back to your customers.")
         expect(mail.body.encoded).to include("This is scheduled for June 15, 2025.")
@@ -2018,20 +2018,45 @@ describe ContactingCreatorMailer do
       end
     end
 
-    context "when the seller has a pending scheduled hold" do
+    context "when passed a scheduled payout id for a hold" do
       it "includes hold amount" do
-        create(:scheduled_payout, user: seller, action: "hold", scheduled_at: Date.parse("2025-06-15"), payout_amount_cents: 200_00)
+        scheduled_payout = create(:scheduled_payout, user: seller, action: "hold", scheduled_at: Date.parse("2025-06-15"), payout_amount_cents: 200_00)
 
-        mail = ContactingCreatorMailer.account_suspended(seller.id)
+        mail = ContactingCreatorMailer.account_suspended(seller.id, scheduled_payout.id)
 
         expect(mail.body.encoded).to include("Your unpaid balance ($200) is under review and will not be paid out at this time.")
         expect(mail.body.encoded).not_to include("chargeback")
       end
     end
 
-    context "when the seller has no scheduled payout" do
-      it "does not include payout information or chargeback disclaimer" do
+    context "when no scheduled payout id is passed" do
+      it "does not include payout information or chargeback disclaimer even if a stale pending payout exists" do
+        create(:scheduled_payout, user: seller, action: "payout", scheduled_at: Date.parse("2025-06-15"), payout_amount_cents: 999_99)
+
         mail = ContactingCreatorMailer.account_suspended(seller.id)
+
+        expect(mail.body.encoded).not_to include("scheduled payout")
+        expect(mail.body.encoded).not_to include("refunded back")
+        expect(mail.body.encoded).not_to include("chargeback")
+        expect(mail.body.encoded).not_to include("$999.99")
+      end
+    end
+
+    context "when passed a scheduled payout id that does not belong to the seller" do
+      it "does not include payout information" do
+        other_seller = create(:user)
+        other_payout = create(:scheduled_payout, user: other_seller, action: "payout", payout_amount_cents: 500_00)
+
+        mail = ContactingCreatorMailer.account_suspended(seller.id, other_payout.id)
+
+        expect(mail.body.encoded).not_to include("scheduled payout")
+        expect(mail.body.encoded).not_to include("$500")
+      end
+    end
+
+    context "when passed a scheduled payout id that does not exist" do
+      it "does not include payout information" do
+        mail = ContactingCreatorMailer.account_suspended(seller.id, 0)
 
         expect(mail.body.encoded).not_to include("scheduled payout")
         expect(mail.body.encoded).not_to include("refunded back")

--- a/spec/modules/user/risk_spec.rb
+++ b/spec/modules/user/risk_spec.rb
@@ -23,7 +23,7 @@ describe User::Risk do
 
       expect do
         user.suspend_for_tos_violation!(author_name: "admin")
-      end.to have_enqueued_mail(ContactingCreatorMailer, :account_suspended).with(user.id)
+      end.to have_enqueued_mail(ContactingCreatorMailer, :account_suspended).with(user.id, nil)
     end
 
     it "sends suspension email when suspended for fraud" do
@@ -32,7 +32,17 @@ describe User::Risk do
 
       expect do
         user.suspend_for_fraud!(author_name: "admin")
-      end.to have_enqueued_mail(ContactingCreatorMailer, :account_suspended).with(user.id)
+      end.to have_enqueued_mail(ContactingCreatorMailer, :account_suspended).with(user.id, nil)
+    end
+
+    it "passes scheduled_payout_id from transition args through to the mailer" do
+      user = create(:user)
+      user.flag_for_tos_violation!(author_name: "admin", bulk: true)
+      scheduled_payout = create(:scheduled_payout, user: user)
+
+      expect do
+        user.suspend_for_tos_violation!(author_name: "admin", scheduled_payout_id: scheduled_payout.id)
+      end.to have_enqueued_mail(ContactingCreatorMailer, :account_suspended).with(user.id, scheduled_payout.id)
     end
 
     it "skips the generic suspension email when called with skip_generic_suspension_email" do

--- a/spec/sidekiq/suspend_users_worker_spec.rb
+++ b/spec/sidekiq/suspend_users_worker_spec.rb
@@ -70,6 +70,36 @@ describe SuspendUsersWorker do
         end
       end
 
+      it "passes the scheduled_payout_id through to the suspension email so the mailer uses the correct record" do
+        Feature.activate(:account_suspended_email)
+        user_id = not_reviewed_user.id
+
+        expect do
+          described_class.new.perform(admin_user.id, [user_id], reason, additional_notes, scheduled_payout)
+        end.to have_enqueued_mail(ContactingCreatorMailer, :account_suspended).with { [user_id, ScheduledPayout.where(user_id: user_id).last.id] }
+      end
+
+      it "does not reuse a stale pending scheduled payout from a previous suspension" do
+        Feature.activate(:account_suspended_email)
+        stale_payout = create(:scheduled_payout, user: not_reviewed_user, action: "payout", payout_amount_cents: 999_99)
+        user_id = not_reviewed_user.id
+
+        expect do
+          described_class.new.perform(admin_user.id, [user_id], reason, additional_notes, scheduled_payout)
+        end.to have_enqueued_mail(ContactingCreatorMailer, :account_suspended).with { [user_id, ScheduledPayout.where(user_id: user_id).order(:id).last.id] }
+
+        new_payout = not_reviewed_user.reload.scheduled_payouts.order(:id).last
+        expect(new_payout.id).not_to eq(stale_payout.id)
+      end
+
+      it "passes a nil scheduled_payout_id when no scheduled payout is created" do
+        Feature.activate(:account_suspended_email)
+
+        expect do
+          described_class.new.perform(admin_user.id, [not_reviewed_user.id], reason, additional_notes, nil)
+        end.to have_enqueued_mail(ContactingCreatorMailer, :account_suspended).with(not_reviewed_user.id, nil)
+      end
+
       it "does not create a scheduled payout for users who were already suspended" do
         described_class.new.perform(admin_user.id, user_ids_to_suspend, reason, additional_notes, scheduled_payout)
 


### PR DESCRIPTION
## What

The `account_suspended` mailer added in #4543 resolves scheduled payout details by querying `@seller.scheduled_payouts.pending.last` at render time. Because the suspension email is enqueued from a `state_machine` `after_transition` callback, and `SuspendUsersWorker` currently creates the scheduled payout *after* the suspension transition fires, the mailer can pick up either:

- a stale pending payout from a prior suspension of the same seller, or
- any pending `ScheduledPayout` on that user that is unrelated to the triggering suspension event.

This risks disclosing the wrong payout/refund/hold amount in the suspension email — a user-facing privacy bug for a sensitive, high-trust communication.

This PR threads an explicit `scheduled_payout_id` end-to-end:

1. `SuspendUsersWorker#perform` creates the scheduled payout *before* calling `suspend_for_tos_violation`, then passes the newly-created record's id through the transition args.
2. `User::Risk#send_suspension_email(transition)` reads `scheduled_payout_id` from `transition.args.first` and forwards it to the mailer.
3. `ContactingCreatorMailer.account_suspended(user_id, scheduled_payout_id = nil)` now looks up the payout via `@seller.scheduled_payouts.find_by(id: scheduled_payout_id)` — scoped to the seller (so a bad/tampered id can never surface another user's payout) and exact (so stale pending payouts are not reused). The existing `if @scheduled_payout` guard in the view handles the missing case cleanly.

## Why

**Vulnerability class:** information disclosure / wrong-record exposure in user notifications.

**Impact:**
- Suspended sellers could see incorrect scheduled payout amounts, dates, or actions (payout vs refund vs hold) in the suspension email.
- The prior query (`pending.last`) has no filter that ties the record to the triggering suspension — any pending `ScheduledPayout` row the seller ever accumulated (e.g. from an earlier suspension cycle) could surface.
- Because `deliver_later` enqueues the mail before the worker creates the new payout, the render-time query is non-deterministic with respect to the current suspension event.

**Root cause:** the mailer was inferring context (`.pending.last`) instead of being given context. The fix removes the inference.

**Why this approach:**
- Keeps the state machine callback as the single dispatch point for suspension emails (no duplication across call sites).
- `transition.args` is the idiomatic way to pass per-transition context into `state_machine` callbacks, and `send_suspension_email` already reads `skip_generic_suspension_email` from there — so `scheduled_payout_id` rides along the same channel.
- Scoping the lookup to `@seller.scheduled_payouts` is defense-in-depth: even if a caller passes a wrong or malicious id in the future, the mailer cannot leak another user's record.
- Other suspension paths (`Iffy::User::BanService`, `suspend_due_to_stripe_risk`) are unaffected — they either `skip_generic_suspension_email` or send their own specific mailer.

## Best practices reinforced

- Emails about specific financial records should be addressed by id, not by "last matching row" heuristics.
- Background jobs should pass explicit record ids, not re-query for "current" state at render time (render time is arbitrarily far from event time).
- Lookups in mailers should be scoped to the recipient (`user.association.find_by(id:)`) rather than global (`Model.find_by(id:)`) to prevent cross-tenant disclosure if an id is wrong.

## Test plan

Updated / added tests:

- `spec/mailers/contacting_creator_mailer_spec.rb`
  - Passing a `scheduled_payout_id` for each action (`payout` / `refund` / `hold`) renders the correct amount and copy.
  - With no `scheduled_payout_id`, payout details are omitted **even if a stale pending payout exists** on the seller (regression test for the bug).
  - Passing a `scheduled_payout_id` belonging to another user does not surface that payout's amount.
  - Passing a non-existent `scheduled_payout_id` renders the plain suspension email.

- `spec/modules/user/risk_spec.rb`
  - `send_suspension_email` callback forwards `scheduled_payout_id` from transition args to `ContactingCreatorMailer.account_suspended`.
  - Existing skip / feature-flag paths continue to behave correctly.

- `spec/sidekiq/suspend_users_worker_spec.rb`
  - Worker enqueues the mail with the exact id of the payout it just created.
  - A pre-existing stale pending payout on the user is **not** used; the newly-created id is used instead.
  - Worker passes `nil` when no scheduled payout is configured for this mass-suspension run.

Local test results:

```
bundle exec rspec \
  spec/modules/user/risk_spec.rb \
  spec/sidekiq/suspend_users_worker_spec.rb \
  spec/services/iffy/user/ban_service_spec.rb \
  spec/mailers/contacting_creator_mailer_spec.rb -e account_suspended
# 31 examples, 0 failures
```

```
bundle exec rubocop -a app/mailers/contacting_creator_mailer.rb \
  app/modules/user/risk.rb app/sidekiq/suspend_users_worker.rb \
  spec/mailers/contacting_creator_mailer_spec.rb \
  spec/modules/user/risk_spec.rb \
  spec/sidekiq/suspend_users_worker_spec.rb
# no offenses detected
```

## Checklist for reviewers

- [ ] Verify no other call site of `suspend_for_tos_violation` / `suspend_for_fraud` expects `pending.last` behavior (none found).
- [ ] Confirm scoping `@seller.scheduled_payouts.find_by(id: ...)` is acceptable as a defense-in-depth tightening.
- [ ] Consider a follow-up to audit other mailers for similar `last` / `pending.last` inference patterns.

---

This PR was implemented with AI assistance using Claude Opus 4.6.

Prompt given to the agent: "Create a security fix PR addressing the privacy bug introduced by merged PR #4543 where `account_suspended(user_id)` picks up whatever pending scheduled payout happens to be last, risking disclosure of wrong payout/refund/hold amounts. Thread an explicit `scheduled_payout_id` through the `send_suspension_email` callback into the mailer so the mailer uses the exact record rather than guessing."