### PR TITLE
Add /jobs → /careers redirect

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -302,6 +302,7 @@ Rails.application.routes.draw do
     get "/about", to: "home#about"
     get "/careers", to: "careers#index"
     get "/careers/:slug", to: "careers#show", as: :career
+    get "/jobs", to: redirect("/careers")
     get "/features", to: "home#features"
     get "/features.md", to: "home#features_md"
     get "/pricing", to: "home#pricing"


### PR DESCRIPTION
Adds a 301 redirect from `/jobs` to `/careers` so both URLs work.

The hiring tweet links to gumroad.com/jobs but the actual page is at /careers.