### PR TITLE
Document POST and DELETE /v2/products/:id/covers in API docs

### DIFF
--- a/app/javascript/components/ApiDocumentation/Endpoints/Covers.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/Covers.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+
+import CodeSnippet from "$app/components/ui/CodeSnippet";
+
+import { ApiEndpoint } from "../ApiEndpoint";
+import { ApiParameter, ApiParameters } from "../ApiParameters";
+import { ApiResponseFields, renderFields } from "../ApiResponseFields";
+import { COVER_FIELDS } from "../responseFieldDefinitions";
+
+const CoversResponseFields = () => (
+  <ApiResponseFields>
+    {renderFields([
+      { name: "success", type: "boolean", description: "Whether the request succeeded" },
+      {
+        name: "covers",
+        type: "array",
+        description: "Covers for the product, in display order",
+        children: COVER_FIELDS,
+      },
+      {
+        name: "main_cover_id",
+        type: "string | null",
+        description: "ID of the first cover in display order; null when the product has no covers",
+      },
+    ])}
+  </ApiResponseFields>
+);
+
+export const CreateCover = () => (
+  <ApiEndpoint
+    method="post"
+    path="/products/:product_id/covers"
+    description={
+      <>
+        Add a cover to a product from a publicly accessible URL. The server fetches the URL and stores a copy, so the
+        URL must be reachable over HTTP(S) and cannot be a private or pre-signed upload URL. Accepts image (JPEG, PNG,
+        GIF) and video URLs, as well as YouTube and Vimeo URLs. Requires the <code>edit_products</code> scope.
+      </>
+    }
+  >
+    <ApiParameters>
+      <ApiParameter
+        name="url"
+        description="(required; a publicly accessible image/video URL, or a YouTube/Vimeo URL)"
+      />
+    </ApiParameters>
+    <CoversResponseFields />
+    <CodeSnippet caption="cURL example">
+      {`curl https://api.gumroad.com/v2/products/A-m3CDDC5dlrSdKZp0RFhA==/covers \\
+  -d "access_token=ACCESS_TOKEN" \\
+  -d "url=https://www.youtube.com/watch?v=qKebcV1jv3A" \\
+  -X POST`}
+    </CodeSnippet>
+    <CodeSnippet caption="Example response:">
+      {`{
+  "success": true,
+  "covers": [{
+    "id": "abc123",
+    "url": "https://www.youtube.com/embed/qKebcV1jv3A?feature=oembed&enablejsapi=1",
+    "original_url": "https://www.youtube.com/embed/qKebcV1jv3A?feature=oembed&enablejsapi=1",
+    "thumbnail": "https://i.ytimg.com/vi/qKebcV1jv3A/hqdefault.jpg",
+    "type": "oembed",
+    "filetype": null,
+    "width": 670,
+    "height": 377,
+    "native_width": 1280,
+    "native_height": 720
+  }],
+  "main_cover_id": "abc123"
+}`}
+    </CodeSnippet>
+  </ApiEndpoint>
+);
+
+export const DeleteCover = () => (
+  <ApiEndpoint
+    method="delete"
+    path="/products/:product_id/covers/:id"
+    description={
+      <>
+        Delete a cover from a product. Requires the <code>edit_products</code> scope.
+      </>
+    }
+  >
+    <CoversResponseFields />
+    <CodeSnippet caption="cURL example">
+      {`curl https://api.gumroad.com/v2/products/A-m3CDDC5dlrSdKZp0RFhA==/covers/abc123 \\
+  -d "access_token=ACCESS_TOKEN" \\
+  -X DELETE`}
+    </CodeSnippet>
+    <CodeSnippet caption="Example response:">
+      {`{
+  "success": true,
+  "covers": [],
+  "main_cover_id": null
+}`}
+    </CodeSnippet>
+  </ApiEndpoint>
+);

--- a/app/javascript/components/ApiDocumentation/Navigation.tsx
+++ b/app/javascript/components/ApiDocumentation/Navigation.tsx
@@ -29,6 +29,9 @@ export const Navigation = () => (
             <a href="#files">Files</a>
           </li>
           <li>
+            <a href="#covers">Covers</a>
+          </li>
+          <li>
             <a href="#variant-categories">Variant categories</a>
           </li>
           <li>

--- a/app/javascript/components/ApiDocumentation/responseFieldDefinitions.ts
+++ b/app/javascript/components/ApiDocumentation/responseFieldDefinitions.ts
@@ -1,5 +1,26 @@
 import { FieldDefinition } from "./ApiResponseFields";
 
+export const COVER_FIELDS: FieldDefinition[] = [
+  { name: "id", type: "string", description: "Unique identifier for the cover" },
+  {
+    name: "url",
+    type: "string",
+    description: "Display URL (retina variant for non-GIF images; original URL for GIFs, videos, and oEmbed covers)",
+  },
+  { name: "original_url", type: "string", description: "URL of the original uploaded asset" },
+  {
+    name: "thumbnail",
+    type: "string | null",
+    description: "Thumbnail URL for oEmbed covers; null otherwise",
+  },
+  { name: "type", type: "string", description: 'One of "image", "video", "oembed", or "unsplash"' },
+  { name: "filetype", type: "string | null", description: "File extension; null when no file is attached" },
+  { name: "width", type: "number", description: "Display width in pixels" },
+  { name: "height", type: "number", description: "Display height in pixels" },
+  { name: "native_width", type: "number", description: "Intrinsic width of the source asset in pixels" },
+  { name: "native_height", type: "number", description: "Intrinsic height of the source asset in pixels" },
+];
+
 const PRODUCT_VARIANT_FIELDS: FieldDefinition[] = [
   { name: "title", type: "string", description: 'Variant category title (e.g. "Tier")' },
   {
@@ -86,6 +107,17 @@ const SHARED_PRODUCT_FIELDS: FieldDefinition[] = [
   { name: "currency", type: "string", description: 'ISO currency code (e.g. "usd")' },
   { name: "short_url", type: "string", description: "Short Gumroad URL for the product" },
   { name: "thumbnail_url", type: "string | null", description: "URL of the product thumbnail image" },
+  {
+    name: "covers",
+    type: "array",
+    description: "Covers for the product, in display order",
+    children: COVER_FIELDS,
+  },
+  {
+    name: "main_cover_id",
+    type: "string | null",
+    description: "ID of the first cover in display order; null when the product has no covers",
+  },
   { name: "tags", type: "array", description: "Tags associated with the product" },
   { name: "formatted_price", type: "string", description: "Human-readable formatted price" },
   {
@@ -94,12 +126,6 @@ const SHARED_PRODUCT_FIELDS: FieldDefinition[] = [
     description:
       'Legacy single-file metadata; returns {} for products with 0 or 2+ files. For complete file state, fetch the product via GET /v2/products/:id and read the "files" array (not returned by GET /v2/products).',
   },
-  {
-    name: "covers",
-    type: "array",
-    description: "Cover images and videos attached to the product",
-  },
-  { name: "main_cover_id", type: "string | null", description: "GUID of the cover shown first" },
   {
     name: "bundle_products",
     type: "array",

--- a/app/javascript/pages/Public/Api.tsx
+++ b/app/javascript/pages/Public/Api.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import { ApiResource } from "$app/components/ApiDocumentation/ApiResource";
 import { Authentication } from "$app/components/ApiDocumentation/Authentication";
+import { CreateCover, DeleteCover } from "$app/components/ApiDocumentation/Endpoints/Covers";
 import {
   GetCustomFields,
   CreateCustomField,
@@ -108,6 +109,11 @@ export default function Api() {
                 <PresignFile />
                 <CompleteFile />
                 <AttachFile />
+              </ApiResource>
+
+              <ApiResource name="Covers" id="covers">
+                <CreateCover />
+                <DeleteCover />
               </ApiResource>
 
               <ApiResource name="Variant categories" id="variant-categories">


### PR DESCRIPTION
Closes #4477

## What

Adds public API documentation for the covers endpoint. Also extracts a shared `COVER_FIELDS` definition and wires it into the product schema so the Products docs and the new Covers docs describe cover state consistently.

## Why

The covers endpoint shipped without docs, which was one of the reasons users kept getting stuck trying to attach cover images via the API. This is the next PR in the docs and UX series for #4477, following the upload flow docs (#4557), legacy field rejection (#4559), and products create/update docs (#4565).

---

This PR was implemented with AI assistance using Claude Opus 4.7 and gpt‑5.4 xhigh