### PR TITLE
Add POST /v2/files/abort for multipart uploads

### DIFF
--- a/app/controllers/api/v2/files_controller.rb
+++ b/app/controllers/api/v2/files_controller.rb
@@ -67,6 +67,23 @@ class Api::V2::FilesController < Api::V2::BaseController
     error_400(e.message)
   end
 
+  def abort
+    upload_id = params[:upload_id].to_s
+    key = params[:key].to_s
+
+    return error_400("upload_id is required") if upload_id.blank?
+    return error_400("key is required") if key.blank?
+    return error_400("invalid key") unless key.start_with?(s3_key_prefix)
+
+    Aws::S3::Client.new.abort_multipart_upload(bucket: S3_BUCKET, key:, upload_id:)
+
+    render json: { success: true, status: "accepted" }
+  rescue Aws::S3::Errors::NoSuchUpload
+    render json: { success: true, status: "already_gone" }
+  rescue Aws::S3::Errors::ServiceError => e
+    error_400(e.message)
+  end
+
   private
     def s3_key_prefix
       "attachments/#{current_resource_owner.external_id}/"

--- a/app/javascript/components/ApiDocumentation/Endpoints/Files.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/Files.tsx
@@ -27,6 +27,13 @@ export const FilesOverview = () => (
           <code>PUT /v2/products/:id</code>.
         </li>
       </ol>
+      <p>
+        If an upload fails partway through, call <a href="#post-/files/abort">/v2/files/abort</a> to cancel it. Abort
+        responses include a <code>status</code> field: <code>accepted</code> means S3 took the cancellation but parts
+        still in flight may finish seconds later, and <code>already_gone</code> means S3 has no multipart session for
+        this <code>upload_id</code>. Call abort again while you see <code>accepted</code>; stop when you see{" "}
+        <code>already_gone</code>.
+      </p>
     </div>
   </CardContent>
 );
@@ -124,6 +131,54 @@ export const CompleteFile = () => (
   "file_url": "https://gumroad-specials.s3.amazonaws.com/attachments/A-m3CDDC5dlrSdKZp0RFhA==/9f2c1b7d6e4a/original/course.pdf"
 }`}
     </CodeSnippet>
+    <p>
+      <strong>Don't retry this call.</strong> The <code>upload_id</code> works only once. If you lose the response,
+      start a fresh upload with <code>/v2/files/presign</code> and use the new <code>file_url</code>.
+    </p>
+  </ApiEndpoint>
+);
+
+export const AbortFile = () => (
+  <ApiEndpoint
+    method="post"
+    path="/files/abort"
+    description="Cancel a multipart upload started by /v2/files/presign. Requires the edit_products scope."
+  >
+    <ApiParameters>
+      <ApiParameter name="upload_id" description="(returned by /files/presign)" />
+      <ApiParameter name="key" description="(returned by /files/presign)" />
+    </ApiParameters>
+    <ApiResponseFields>
+      {renderFields([
+        { name: "success", type: "boolean", description: "Whether the request succeeded" },
+        {
+          name: "status",
+          type: "string",
+          description:
+            "accepted if S3 took the cancellation on this call (parts still in flight may finish seconds later); already_gone if S3 has no multipart session for this upload_id",
+        },
+      ])}
+    </ApiResponseFields>
+    <CodeSnippet caption="cURL example">
+      {`curl https://api.gumroad.com/v2/files/abort \\
+  -d "access_token=ACCESS_TOKEN" \\
+  -d "upload_id=ibZBv_75gd9o.uPYmGbJ5JjxqK4_VsP3..." \\
+  -d "key=attachments/A-m3CDDC5dlrSdKZp0RFhA==/9f2c1b7d6e4a/original/course.pdf" \\
+  -X POST`}
+    </CodeSnippet>
+    <CodeSnippet caption="Example response:">
+      {`{
+  "success": true,
+  "status": "accepted"
+}`}
+    </CodeSnippet>
+    <p>
+      Loop on <code>status</code>: while it's <code>accepted</code>, keep calling abort; when it's{" "}
+      <code>already_gone</code>, stop. <code>already_gone</code> only tells you S3 has no multipart session for this{" "}
+      <code>upload_id</code> — it does not distinguish "fully cancelled" from "finalized by a racing{" "}
+      <code>/v2/files/complete</code>". To avoid ambiguity, don't issue abort and complete for the same upload
+      concurrently.
+    </p>
   </ApiEndpoint>
 );
 

--- a/app/javascript/pages/Public/Api.tsx
+++ b/app/javascript/pages/Public/Api.tsx
@@ -8,7 +8,7 @@ import {
   UpdateCustomField,
   DeleteCustomField,
 } from "$app/components/ApiDocumentation/Endpoints/CustomFields";
-import { FilesOverview, PresignFile, CompleteFile, AttachFile } from "$app/components/ApiDocumentation/Endpoints/Files";
+import { FilesOverview, PresignFile, CompleteFile, AbortFile, AttachFile } from "$app/components/ApiDocumentation/Endpoints/Files";
 import {
   VerifyLicense,
   EnableLicense,
@@ -107,6 +107,7 @@ export default function Api() {
                 <FilesOverview />
                 <PresignFile />
                 <CompleteFile />
+                <AbortFile />
                 <AttachFile />
               </ApiResource>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,7 @@ Rails.application.routes.draw do
     scope "v2", module: "v2", as: "v2" do
       post "files/presign", to: "files#presign"
       post "files/complete", to: "files#complete"
+      post "files/abort", to: "files#abort"
       resources :licenses, only: [] do
         collection do
           post :verify

--- a/spec/controllers/api/v2/files_controller_spec.rb
+++ b/spec/controllers/api/v2/files_controller_spec.rb
@@ -167,10 +167,18 @@ describe Api::V2::FilesController do
 
       it "returns 400 when S3 raises a service error" do
         allow_any_instance_of(Aws::S3::Client).to receive(:complete_multipart_upload)
-          .and_raise(Aws::S3::Errors::ServiceError.new(nil, "NoSuchUpload"))
+          .and_raise(Aws::S3::Errors::ServiceError.new(nil, "boom"))
         post action, params: params
         expect(response.status).to eq(400)
-        expect(response.parsed_body["error"]).to include("NoSuchUpload")
+        expect(response.parsed_body["error"]).to include("boom")
+      end
+
+      it "returns 400 with the S3 error message when the upload_id no longer exists" do
+        allow_any_instance_of(Aws::S3::Client).to receive(:complete_multipart_upload)
+          .and_raise(Aws::S3::Errors::NoSuchUpload.new(nil, "The specified upload does not exist."))
+        post action, params: params
+        expect(response.status).to eq(400)
+        expect(response.parsed_body["error"]).to include("does not exist")
       end
     end
 
@@ -182,6 +190,95 @@ describe Api::V2::FilesController do
         post action, params: params
         expect(response.parsed_body["success"]).to be true
         expect(response.parsed_body["file_url"]).to be_present
+      end
+    end
+  end
+
+  describe "POST 'abort'" do
+    let(:key) { "attachments/#{user.external_id}/abc123hex/original/course.pdf" }
+    let(:action) { :abort }
+    let(:params) { { upload_id: "test-upload-id", key: key } }
+
+    before do
+      allow_any_instance_of(Aws::S3::Client).to receive(:abort_multipart_upload)
+    end
+
+    context "without a token" do
+      it "returns 401" do
+        post action, params: params
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context "with a token missing edit_products scope" do
+      let(:token) { create("doorkeeper/access_token", application: app, resource_owner_id: user.id, scopes: "view_public view_sales") }
+      let(:params) { super().merge(access_token: token.token) }
+
+      it "returns 403" do
+        post action, params: params
+        expect(response.status).to eq(403)
+      end
+    end
+
+    context "with edit_products scope" do
+      let(:token) { create("doorkeeper/access_token", application: app, resource_owner_id: user.id, scopes: "edit_products") }
+      let(:params) { super().merge(access_token: token.token) }
+
+      it "aborts the multipart upload and returns status=accepted" do
+        expect_any_instance_of(Aws::S3::Client).to receive(:abort_multipart_upload)
+          .with(bucket: S3_BUCKET, key: key, upload_id: "test-upload-id")
+        post action, params: params
+        body = response.parsed_body
+        expect(response.status).to eq(200)
+        expect(body["success"]).to be true
+        expect(body["status"]).to eq("accepted")
+      end
+
+      it "returns 400 when upload_id is missing" do
+        post action, params: params.except(:upload_id)
+        expect(response.status).to eq(400)
+        expect(response.parsed_body["error"]).to include("upload_id")
+      end
+
+      it "returns 400 when key is missing" do
+        post action, params: params.except(:key)
+        expect(response.status).to eq(400)
+        expect(response.parsed_body["error"]).to include("key")
+      end
+
+      it "returns 400 for a key scoped to a different user" do
+        post action, params: params.merge(key: "attachments/other-user-id/abc/original/file.pdf")
+        expect(response.status).to eq(400)
+        expect(response.parsed_body["error"]).to eq("invalid key")
+      end
+
+      it "returns 400 when S3 raises a service error" do
+        allow_any_instance_of(Aws::S3::Client).to receive(:abort_multipart_upload)
+          .and_raise(Aws::S3::Errors::ServiceError.new(nil, "boom"))
+        post action, params: params
+        expect(response.status).to eq(400)
+        expect(response.parsed_body["error"]).to include("boom")
+      end
+
+      it "returns 200 with status=already_gone when S3 reports NoSuchUpload" do
+        allow_any_instance_of(Aws::S3::Client).to receive(:abort_multipart_upload)
+          .and_raise(Aws::S3::Errors::NoSuchUpload.new(nil, "The specified upload does not exist."))
+        post action, params: params
+        body = response.parsed_body
+        expect(response.status).to eq(200)
+        expect(body["success"]).to be true
+        expect(body["status"]).to eq("already_gone")
+      end
+    end
+
+    context "with account scope" do
+      let(:token) { create("doorkeeper/access_token", application: app, resource_owner_id: user.id, scopes: "account") }
+      let(:params) { super().merge(access_token: token.token) }
+
+      it "returns success with status=accepted" do
+        post action, params: params
+        expect(response.parsed_body["success"]).to be true
+        expect(response.parsed_body["status"]).to eq("accepted")
       end
     end
   end


### PR DESCRIPTION
## What

Adds `POST /v2/files/abort` so API clients can cancel a file upload that was started but never finished, and updates the docs to cover when to use it.

## Why

Without an abort endpoint, clients had no clean way to recover from an upload that failed partway through. The only backstop was the bucket's garbage-collection rule, which is slow and offers no explicit signal. Abort is a conventional companion to the existing presign/complete flow.

The docs add a note about `/v2/files/complete`: retrying it blindly after a lost response doesn't work today, so clients should treat the response as terminal and start a fresh upload if they're unsure.

---

This PR was implemented with AI assistance using Claude Opus 4.7 and gpt‑5.4 xhigh