### PR TITLE
Stop v2 product update from silently deleting files when only the file id is sent

### DIFF
--- a/app/controllers/api/v2/links_controller.rb
+++ b/app/controllers/api/v2/links_controller.rb
@@ -245,6 +245,7 @@ class Api::V2::LinksController < Api::V2::BaseController
       existing_files_by_id = @product.product_files.alive.index_by(&:external_id)
       new_files = []
       params[:files].each do |f|
+        f.delete(:modified) if f.respond_to?(:delete)
         existing = f[:id].present? ? existing_files_by_id[f[:id]] : nil
         if existing
           if f[:url].blank?
@@ -322,7 +323,7 @@ class Api::V2::LinksController < Api::V2::BaseController
         unless @normalized_files.nil?
           keep_only_ids = @normalized_files.filter_map { |f| f[:id] if f[:modified].to_s == "false" }
           if keep_only_ids.any?
-            missing_ids = keep_only_ids - @product.alive_product_files.map(&:external_id)
+            missing_ids = keep_only_ids - @product.product_files.alive.map(&:external_id)
             raise Link::LinkInvalid, "Cannot keep file(s) #{missing_ids.join(', ')}: they were deleted concurrently. Retry with the current file list." if missing_ids.any?
           end
 
@@ -458,7 +459,7 @@ class Api::V2::LinksController < Api::V2::BaseController
         if action_name == "create"
           presign_flow
         else
-          "#{presign_flow} Note: files is a full replacement — to keep an existing file, include its id and its original canonical url (not the signed URL returned by GET /v2/products/:id); files missing from the array are removed."
+          "#{presign_flow} Note: files is a full replacement — to keep an existing file, include an entry with its id; files missing from the array are removed."
         end
       when :preview
         if action_name == "create"

--- a/app/controllers/api/v2/links_controller.rb
+++ b/app/controllers/api/v2/links_controller.rb
@@ -242,10 +242,12 @@ class Api::V2::LinksController < Api::V2::BaseController
       if !params[:files].is_a?(Array) || params[:files].any? { |f| !f.respond_to?(:key?) }
         return render_response(false, message: "files must be an array of file objects.")
       end
+      if params[:files].any? { |f| f.key?(:modified) }
+        return render_response(false, message: "'modified' is not an accepted parameter on files[]; it is an internal save-path flag.")
+      end
       existing_files_by_id = @product.product_files.alive.index_by(&:external_id)
       new_files = []
       params[:files].each do |f|
-        f.delete(:modified) if f.respond_to?(:delete)
         existing = f[:id].present? ? existing_files_by_id[f[:id]] : nil
         if existing
           if f[:url].blank?
@@ -321,11 +323,11 @@ class Api::V2::LinksController < Api::V2::BaseController
         flag_changed = @product.has_same_rich_content_for_all_variants? != rich_content_flag_was
 
         unless @normalized_files.nil?
-          keep_only_ids = @normalized_files.filter_map { |f| f[:id] if f[:modified].to_s == "false" }
-          if keep_only_ids.any?
+          referenced_existing_ids = @normalized_files.filter_map { |f| f[:id] if f[:id].present? }
+          if referenced_existing_ids.any?
             locked_alive_ids = @product.product_files.alive.lock.map(&:external_id)
-            missing_ids = keep_only_ids - locked_alive_ids
-            raise Link::LinkInvalid, "Cannot keep file(s) #{missing_ids.join(', ')}: they were deleted concurrently. Retry with the current file list." if missing_ids.any?
+            missing_ids = referenced_existing_ids - locked_alive_ids
+            raise Link::LinkInvalid, "File(s) #{missing_ids.join(', ')} no longer exist; they may have been deleted by a concurrent request. Retry with the current file list." if missing_ids.any?
           end
 
           validate_file_embed_conflicts!(skip_variant_embeds: flag_changed && @product.has_same_rich_content_for_all_variants? && !@normalized_rich_content.nil?)

--- a/app/controllers/api/v2/links_controller.rb
+++ b/app/controllers/api/v2/links_controller.rb
@@ -323,7 +323,8 @@ class Api::V2::LinksController < Api::V2::BaseController
         unless @normalized_files.nil?
           keep_only_ids = @normalized_files.filter_map { |f| f[:id] if f[:modified].to_s == "false" }
           if keep_only_ids.any?
-            missing_ids = keep_only_ids - @product.product_files.alive.map(&:external_id)
+            locked_alive_ids = @product.product_files.alive.lock.map(&:external_id)
+            missing_ids = keep_only_ids - locked_alive_ids
             raise Link::LinkInvalid, "Cannot keep file(s) #{missing_ids.join(', ')}: they were deleted concurrently. Retry with the current file list." if missing_ids.any?
           end
 

--- a/app/controllers/api/v2/links_controller.rb
+++ b/app/controllers/api/v2/links_controller.rb
@@ -242,14 +242,23 @@ class Api::V2::LinksController < Api::V2::BaseController
       if !params[:files].is_a?(Array) || params[:files].any? { |f| !f.respond_to?(:key?) }
         return render_response(false, message: "files must be an array of file objects.")
       end
-      existing_files_by_id = @product.alive_product_files.index_by(&:external_id)
+      existing_files_by_id = @product.product_files.alive.index_by(&:external_id)
       new_files = []
       params[:files].each do |f|
         existing = f[:id].present? ? existing_files_by_id[f[:id]] : nil
         if existing
-          if f[:url].present? && f[:url] != existing.url
+          if f[:url].blank?
+            if (f.keys.map(&:to_s) - %w[id]).empty?
+              f[:url] = existing.url
+              f[:modified] = "false"
+            else
+              return render_response(false, message: "Include the canonical url returned by POST /v2/files/complete when updating fields on an existing file; an entry with only id keeps the file unchanged.")
+            end
+          elsif f[:url] != existing.url
             return render_response(false, message: "File URLs must reference your own uploaded files. Use the presigned upload endpoint to upload files first.")
           end
+        elsif f[:url].blank?
+          return render_response(false, message: "Each files entry must reference an existing file by id or include a url for a new file uploaded via POST /v2/files/complete.")
         else
           new_files << f
         end
@@ -311,6 +320,12 @@ class Api::V2::LinksController < Api::V2::BaseController
         flag_changed = @product.has_same_rich_content_for_all_variants? != rich_content_flag_was
 
         unless @normalized_files.nil?
+          keep_only_ids = @normalized_files.filter_map { |f| f[:id] if f[:modified].to_s == "false" }
+          if keep_only_ids.any?
+            missing_ids = keep_only_ids - @product.alive_product_files.map(&:external_id)
+            raise Link::LinkInvalid, "Cannot keep file(s) #{missing_ids.join(', ')}: they were deleted concurrently. Retry with the current file list." if missing_ids.any?
+          end
+
           validate_file_embed_conflicts!(skip_variant_embeds: flag_changed && @product.has_same_rich_content_for_all_variants? && !@normalized_rich_content.nil?)
 
           rich_content_params = build_rich_content_params

--- a/spec/controllers/api/v2/links_controller_spec.rb
+++ b/spec/controllers/api/v2/links_controller_spec.rb
@@ -1153,9 +1153,8 @@ describe Api::V2::LinksController do
           expect(message).to include("POST /v2/files/complete")
           expect(message).to include("files[][url]")
           expect(message).to include("full replacement")
-          expect(message).to include("id")
-          expect(message).to include("canonical url")
-          expect(message).to include("not the signed URL")
+          expect(message).to include("include an entry with its id")
+          expect(message).to include("files missing from the array are removed")
         end
 
         it "points preview rejections to the covers endpoint rather than presign" do
@@ -1389,6 +1388,18 @@ describe Api::V2::LinksController do
         expect(file.reload.display_name).to eq("Old")
       end
 
+      it "ignores client-supplied modified flag so partial updates with a canonical url still apply" do
+        existing_file = create(:product_file, link: @product, display_name: "Old")
+        Aws::S3::Resource.new.bucket(S3_BUCKET).object(existing_file.s3_key).put(body: "test content")
+
+        put @action, params: @params.merge(files: [
+                                             { id: existing_file.external_id, url: existing_file.url, modified: "false", display_name: "New" }
+                                           ]), as: :json
+
+        expect(response.parsed_body["success"]).to be(true)
+        expect(existing_file.reload.display_name).to eq("New")
+      end
+
       it "preserves existing subtitle tracks when id-only files[] entry keeps a video file unchanged" do
         video = create(:streamable_video, link: @product)
         subtitle = create(:subtitle_file, product_file: video)
@@ -1405,7 +1416,7 @@ describe Api::V2::LinksController do
         original_external_id = file.external_id
 
         stubbed_once = false
-        allow_any_instance_of(Link).to receive(:alive_product_files).and_wrap_original do |m, *args|
+        allow_any_instance_of(Link).to receive(:assign_attributes).and_wrap_original do |m, *args|
           unless stubbed_once
             stubbed_once = true
             file.mark_deleted!

--- a/spec/controllers/api/v2/links_controller_spec.rb
+++ b/spec/controllers/api/v2/links_controller_spec.rb
@@ -1388,16 +1388,16 @@ describe Api::V2::LinksController do
         expect(file.reload.display_name).to eq("Old")
       end
 
-      it "ignores client-supplied modified flag so partial updates with a canonical url still apply" do
+      it "rejects client-supplied modified flag on files[] entries" do
         existing_file = create(:product_file, link: @product, display_name: "Old")
-        Aws::S3::Resource.new.bucket(S3_BUCKET).object(existing_file.s3_key).put(body: "test content")
 
         put @action, params: @params.merge(files: [
                                              { id: existing_file.external_id, url: existing_file.url, modified: "false", display_name: "New" }
                                            ]), as: :json
 
-        expect(response.parsed_body["success"]).to be(true)
-        expect(existing_file.reload.display_name).to eq("New")
+        expect(response.parsed_body["success"]).to be(false)
+        expect(response.parsed_body["message"]).to include("modified")
+        expect(existing_file.reload.display_name).to eq("Old")
       end
 
       it "preserves existing subtitle tracks when id-only files[] entry keeps a video file unchanged" do
@@ -1411,7 +1411,7 @@ describe Api::V2::LinksController do
         expect(subtitle.reload.alive?).to be(true)
       end
 
-      it "fails id-only keep requests if the file was deleted concurrently instead of resurrecting it" do
+      it "fails requests that reference a file deleted concurrently instead of resurrecting it" do
         file = create(:product_file, link: @product)
         original_external_id = file.external_id
 
@@ -1427,7 +1427,7 @@ describe Api::V2::LinksController do
         put @action, params: @params.merge(files: [{ id: original_external_id }]), as: :json
 
         expect(response.parsed_body["success"]).to be(false)
-        expect(response.parsed_body["message"]).to include("deleted concurrently")
+        expect(response.parsed_body["message"]).to include("no longer exist")
         expect(ProductFile.where(link: @product).count).to eq(1)
       end
 

--- a/spec/controllers/api/v2/links_controller_spec.rb
+++ b/spec/controllers/api/v2/links_controller_spec.rb
@@ -1055,12 +1055,12 @@ describe Api::V2::LinksController do
         expect(response.parsed_body["message"]).to include("files must be an array of file objects")
       end
 
-      it "rejects file objects missing url" do
+      it "rejects file objects missing url when no existing file id is provided" do
         put @action, params: @params.merge(files: [{ display_name: "No URL" }])
 
         expect(response).to be_successful
         expect(response.parsed_body["success"]).to be false
-        expect(response.parsed_body["message"]).to include("must include a url string")
+        expect(response.parsed_body["message"]).to include("must reference an existing file by id or include a url")
       end
 
       it "rejects file urls that are not the seller's S3 path" do
@@ -1210,7 +1210,7 @@ describe Api::V2::LinksController do
 
         expect(response).to be_successful
         expect(response.parsed_body["success"]).to be false
-        expect(response.parsed_body["message"]).to include("must include a url string")
+        expect(response.parsed_body["message"]).to include("must reference an existing file by id or include a url")
       end
 
       it "rejects rich_content when numeric-keyed params normalize into non-hash elements" do
@@ -1354,6 +1354,84 @@ describe Api::V2::LinksController do
         ), as: :json
         expect(response.parsed_body["success"]).to be(true)
         expect(file.reload.alive?).to be(false)
+      end
+
+      it "treats id-only files[] entries as keep-unchanged for existing files" do
+        file = create(:product_file, link: @product, display_name: "Keep me")
+
+        put @action, params: @params.merge(files: [{ id: file.external_id }]), as: :json
+
+        expect(response.parsed_body["success"]).to be(true)
+        expect(file.reload.alive?).to be(true)
+        expect(file.display_name).to eq("Keep me")
+      end
+
+      it "preserves rich-content embeds when id-only files[] entries match existing files" do
+        file = create(:product_file, link: @product)
+        rc = create(:rich_content, entity: @product, title: "Page", description: [
+                      { "type" => "fileEmbed", "attrs" => { "id" => file.external_id, "uid" => SecureRandom.uuid } }
+                    ], position: 0)
+
+        put @action, params: @params.merge(files: [{ id: file.external_id }]), as: :json
+
+        expect(response.parsed_body["success"]).to be(true)
+        expect(file.reload.alive?).to be(true)
+        expect(rc.reload.description.first.dig("attrs", "id")).to eq(file.external_id)
+      end
+
+      it "rejects partial updates to an existing file that omit the canonical url" do
+        file = create(:product_file, link: @product, display_name: "Old")
+
+        put @action, params: @params.merge(files: [{ id: file.external_id, display_name: "New" }]), as: :json
+
+        expect(response.parsed_body["success"]).to be(false)
+        expect(response.parsed_body["message"]).to include("canonical url")
+        expect(file.reload.display_name).to eq("Old")
+      end
+
+      it "preserves existing subtitle tracks when id-only files[] entry keeps a video file unchanged" do
+        video = create(:streamable_video, link: @product)
+        subtitle = create(:subtitle_file, product_file: video)
+
+        put @action, params: @params.merge(files: [{ id: video.external_id }]), as: :json
+
+        expect(response.parsed_body["success"]).to be(true)
+        expect(video.reload.alive?).to be(true)
+        expect(subtitle.reload.alive?).to be(true)
+      end
+
+      it "fails id-only keep requests if the file was deleted concurrently instead of resurrecting it" do
+        file = create(:product_file, link: @product)
+        original_external_id = file.external_id
+
+        stubbed_once = false
+        allow_any_instance_of(Link).to receive(:alive_product_files).and_wrap_original do |m, *args|
+          unless stubbed_once
+            stubbed_once = true
+            file.mark_deleted!
+          end
+          m.call(*args)
+        end
+
+        put @action, params: @params.merge(files: [{ id: original_external_id }]), as: :json
+
+        expect(response.parsed_body["success"]).to be(false)
+        expect(response.parsed_body["message"]).to include("deleted concurrently")
+        expect(ProductFile.where(link: @product).count).to eq(1)
+      end
+
+      it "supports round-tripping serialized file entries back through PUT using id only" do
+        file = create(:product_file, link: @product, display_name: "Round Trip")
+        serialized_files = JSON.parse(@product.as_json(api_scopes: ["view_public", "edit_products"]).to_json)["files"]
+        expect(serialized_files.first["id"]).to eq(file.external_id)
+
+        put @action, params: @params.merge(
+          files: serialized_files.map { |f| { id: f["id"] } }
+        ), as: :json
+
+        expect(response.parsed_body["success"]).to be(true)
+        expect(file.reload.alive?).to be(true)
+        expect(file.display_name).to eq("Round Trip")
       end
 
       it "reorders covers via cover_ids" do


### PR DESCRIPTION
## What

Before this PR, calling `PUT /v2/products/:id` with a file entry like `{ id: "..." }` silently deleted that file from the product — and left any rich-content references to it pointing at nothing. Now, sending just the file id means "keep this file unchanged." The file stays, its subtitles and thumbnail stay, and any text content referencing it stays valid.

If a client sends the id with other fields but no url, the request is rejected with a clear message instead of quietly destroying the file.

## Why

`files[]` on product update is a full replacement: anything you don't send is removed. The only way to say "keep this file" used to be to echo back its original upload url — but clients that only had the file id (e.g. from the product's GET response) were unknowingly deleting their own files. This is a data-loss bug. Accepting the id alone as "keep this" matches what clients reasonably expect.

---

This PR was implemented with AI assistance using Claude Opus 4.7 and gpt‑5.4 xhigh