### PR TITLE
feat: mobile filter bar for Discover page

### DIFF
--- a/app/javascript/components/Discover/Layout.tsx
+++ b/app/javascript/components/Discover/Layout.tsx
@@ -110,6 +110,7 @@ export const Layout: React.FC<{
   className?: string;
   children: React.ReactNode;
   forceDomain?: boolean;
+  stickyBar?: React.ReactNode;
 }> = ({
   taxonomiesForNav,
   taxonomyPath,
@@ -120,6 +121,7 @@ export const Layout: React.FC<{
   className,
   children,
   forceDomain = false,
+  stickyBar,
 }) => {
   const { discoverDomain, appDomain } = useDomains();
   const isDesktop = useIsAboveBreakpoint("lg");
@@ -187,7 +189,7 @@ export const Layout: React.FC<{
   return (
     <div className={className}>
       <header
-        className="hero relative z-20 border-t-0 border-b border-border bg-body px-4 py-8 lg:ps-16 lg:pe-16"
+        className={classNames("hero relative z-20 border-t-0 bg-body px-4 pt-8 lg:ps-16 lg:pe-16", stickyBar ? "pb-2" : "border-b border-border pb-8")}
         style={showTaxonomy && rootTaxonomy ? getRootTaxonomyCss(rootTaxonomy) : undefined}
       >
         <div className="flex w-full flex-col gap-4">
@@ -206,8 +208,34 @@ export const Layout: React.FC<{
           />
         ) : null}
       </header>
+      {stickyBar ? <StickyBar>{stickyBar}</StickyBar> : null}
       {children}
     </div>
+  );
+};
+
+const StickyBar = ({ children }: { children: React.ReactNode }) => {
+  const sentinelRef = React.useRef<HTMLDivElement>(null);
+  const [isStuck, setIsStuck] = React.useState(false);
+
+  React.useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => { if (entry) setIsStuck(!entry.isIntersecting); },
+      { threshold: 0 },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <>
+      <div ref={sentinelRef} className="h-0" />
+      <div className={classNames("sticky top-0 z-10 bg-body py-2", isStuck && "border-b border-border")}>
+        {children}
+      </div>
+    </>
   );
 };
 

--- a/app/javascript/components/Discover/MobileFilterBar.tsx
+++ b/app/javascript/components/Discover/MobileFilterBar.tsx
@@ -1,0 +1,282 @@
+import { ChevronDown } from "@boxicons/react";
+import * as React from "react";
+
+import { SearchRequest } from "$app/data/search";
+import { SORT_KEYS } from "$app/parsers/product";
+import { CurrencyCode, getShortCurrencySymbol } from "$app/utils/currency";
+
+import { NumberInput } from "$app/components/NumberInput";
+import { Action, FilterCheckboxes, RatingFilterOptions, SORT_BY_LABELS, State } from "$app/components/Product/CardGrid";
+import { showAlert } from "$app/components/server-components/Alert";
+import { BottomSheet, BottomSheetFooter, BottomSheetHeader } from "$app/components/ui/BottomSheet";
+import { Checkbox } from "$app/components/ui/Checkbox";
+import { Fieldset, FieldsetTitle } from "$app/components/ui/Fieldset";
+import { Input } from "$app/components/ui/Input";
+import { InputGroup } from "$app/components/ui/InputGroup";
+import { Label } from "$app/components/ui/Label";
+import { Pill } from "$app/components/ui/Pill";
+import { Radio } from "$app/components/ui/Radio";
+import { useDebouncedCallback } from "$app/components/useDebouncedCallback";
+import { useOnChange } from "$app/components/useOnChange";
+
+type FilterKey = "sort" | "tags" | "contains" | "price" | "rating";
+
+type MobileFilterBarProps = {
+  state: State;
+  dispatchAction: React.Dispatch<Action>;
+  defaults: SearchRequest;
+  currencyCode: CurrencyCode;
+  hideSort?: boolean;
+  hasOfferCode?: boolean;
+};
+
+export const MobileFilterBar = ({
+  state,
+  dispatchAction,
+  defaults,
+  currencyCode,
+  hideSort,
+  hasOfferCode,
+}: MobileFilterBarProps) => {
+  const currencySymbol = getShortCurrencySymbol(currencyCode);
+  const [openFilter, setOpenFilter] = React.useState<FilterKey | null>(null);
+
+  const { params: searchParams } = state;
+  const lastResultsRef = React.useRef(state.results);
+  if (state.results != null) lastResultsRef.current = state.results;
+  const results = state.results ?? lastResultsRef.current;
+
+  const updateParams = (newParams: Partial<SearchRequest>) => {
+    const { from: _, ...params } = searchParams;
+    dispatchAction({ type: "set-params", params: { ...params, ...newParams } });
+  };
+
+  const [enteredMinPrice, setEnteredMinPrice] = React.useState(searchParams.min_price ?? null);
+  const [enteredMaxPrice, setEnteredMaxPrice] = React.useState(searchParams.max_price ?? null);
+
+  useOnChange(() => {
+    setEnteredMinPrice(searchParams.min_price ?? null);
+    setEnteredMaxPrice(searchParams.max_price ?? null);
+  }, [searchParams]);
+
+  const debouncedTrySetPrice = useDebouncedCallback((minPrice: number | null, maxPrice: number | null) => {
+    trySetPrice(minPrice, maxPrice);
+  }, 500);
+
+  const trySetPrice = (minPrice: number | null, maxPrice: number | null) => {
+    if (minPrice == null || maxPrice == null || maxPrice > minPrice) {
+      updateParams({ min_price: minPrice ?? undefined, max_price: maxPrice ?? undefined });
+    } else showAlert("Please set the price minimum to be lower than the maximum.", "error");
+  };
+
+  const hasActiveFilters = Object.keys(searchParams).some(
+    (key) =>
+      !["from", "curated_product_ids"].includes(key) &&
+      searchParams[key] != null &&
+      searchParams[key] !== defaults[key],
+  );
+
+  const uid = React.useId();
+  const minPriceUid = React.useId();
+  const maxPriceUid = React.useId();
+
+  const concatFoundAndNotFound = (
+    resultsData: { key: string; doc_count: number }[] | undefined,
+    searchedKeys: string[] | undefined,
+  ) => {
+    const foundData = resultsData ?? [];
+    const notFoundKeys = searchedKeys?.filter((s) => !foundData.some((f) => f.key === s)) ?? [];
+    return notFoundKeys.map((key) => ({ key, doc_count: 0 })).concat(foundData);
+  };
+
+  const filters: { key: FilterKey; label: string; title: string; active: boolean; visible: boolean; content: React.ReactNode }[] = [
+    {
+      key: "sort",
+      title: "Sort by",
+      label: searchParams.sort !== defaults.sort && searchParams.sort != null
+        ? `Sort: ${SORT_BY_LABELS[searchParams.sort as keyof typeof SORT_BY_LABELS]}`
+        : "Sort by",
+      active: searchParams.sort !== defaults.sort && searchParams.sort != null,
+      visible: !hideSort,
+      content: (
+        <Fieldset role="group">
+          {SORT_KEYS.map((key) => (
+            <Label key={key} className="w-full">
+              {SORT_BY_LABELS[key]}
+              <Radio
+                wrapperClassName="ml-auto"
+                name={`${uid}-mobile-sortBy`}
+                checked={(searchParams.sort ?? defaults.sort) === key}
+                onChange={() => updateParams({ sort: key })}
+              />
+            </Label>
+          ))}
+        </Fieldset>
+      ),
+    },
+    {
+      key: "tags",
+      title: "Tags",
+      label: (searchParams.tags?.length ?? 0) > 0 ? `Tags (${searchParams.tags!.length})` : "Tags",
+      active: (searchParams.tags?.length ?? 0) > 0,
+      visible: (results?.tags_data?.length ?? 0) > 0 || (searchParams.tags?.length ?? 0) > 0,
+      content: (
+        <Fieldset role="group">
+          <Label className="w-full">
+            All Products
+            <Checkbox
+              wrapperClassName="ml-auto"
+              checked={!searchParams.tags?.length}
+              disabled={!searchParams.tags?.length}
+              onChange={() => updateParams({ tags: undefined })}
+            />
+          </Label>
+          {results ? (
+            <FilterCheckboxes
+              filters={concatFoundAndNotFound(results.tags_data, searchParams.tags)}
+              selection={searchParams.tags ?? []}
+              setSelection={(tags) => updateParams({ tags })}
+              disabled={false}
+            />
+          ) : null}
+        </Fieldset>
+      ),
+    },
+    {
+      key: "contains",
+      title: "Contains",
+      label: (searchParams.filetypes?.length ?? 0) > 0 ? `Contains (${searchParams.filetypes!.length})` : "Contains",
+      active: (searchParams.filetypes?.length ?? 0) > 0,
+      visible: (results?.filetypes_data?.length ?? 0) > 0 || (searchParams.filetypes?.length ?? 0) > 0,
+      content: (
+        <Fieldset role="group">
+          {results ? (
+            <FilterCheckboxes
+              filters={concatFoundAndNotFound(results.filetypes_data, searchParams.filetypes)}
+              selection={searchParams.filetypes ?? []}
+              setSelection={(filetypes) => updateParams({ filetypes })}
+              disabled={false}
+            />
+          ) : null}
+        </Fieldset>
+      ),
+    },
+    {
+      key: "price",
+      title: "Price",
+      label: (() => {
+        const minSet = searchParams.min_price != null;
+        const maxSet = searchParams.max_price != null;
+        if (minSet && maxSet) return `${currencySymbol}${searchParams.min_price}\u2013${currencySymbol}${searchParams.max_price}`;
+        if (minSet) return `${currencySymbol}${searchParams.min_price}+`;
+        if (maxSet) return `Up to ${currencySymbol}${searchParams.max_price}`;
+        return "Price";
+      })(),
+      active: searchParams.min_price != null || searchParams.max_price != null,
+      visible: true,
+      content: (
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(var(--dynamic-grid), 1fr))",
+            gridAutoFlow: "row",
+            gap: "var(--spacer-3)",
+          }}
+        >
+          <Fieldset>
+            <FieldsetTitle>
+              <Label htmlFor={minPriceUid}>Minimum price</Label>
+            </FieldsetTitle>
+            <InputGroup>
+              <Pill className="-ml-2 shrink-0">{currencySymbol}</Pill>
+              <NumberInput
+                onChange={(value) => {
+                  setEnteredMinPrice(value);
+                  debouncedTrySetPrice(value, enteredMaxPrice);
+                }}
+                value={enteredMinPrice ?? null}
+              >
+                {(props) => <Input id={minPriceUid} placeholder="0" {...props} />}
+              </NumberInput>
+            </InputGroup>
+          </Fieldset>
+          <Fieldset>
+            <FieldsetTitle>
+              <Label htmlFor={maxPriceUid}>Maximum price</Label>
+            </FieldsetTitle>
+            <InputGroup>
+              <Pill className="-ml-2 shrink-0">{currencySymbol}</Pill>
+              <NumberInput
+                onChange={(value) => {
+                  setEnteredMaxPrice(value);
+                  debouncedTrySetPrice(enteredMinPrice, value);
+                }}
+                value={enteredMaxPrice ?? null}
+              >
+                {(props) => <Input id={maxPriceUid} placeholder="∞" {...props} />}
+              </NumberInput>
+            </InputGroup>
+          </Fieldset>
+        </div>
+      ),
+    },
+    {
+      key: "rating",
+      title: "Rating",
+      label: searchParams.rating != null ? `${searchParams.rating}+ stars` : "Rating",
+      active: searchParams.rating != null,
+      visible: true,
+      content: (
+        <RatingFilterOptions
+          rating={searchParams.rating}
+          onRatingChange={(rating) => updateParams({ rating })}
+        />
+      ),
+    },
+  ];
+
+  const visibleFilters = filters.filter((f) => f.visible);
+
+  return (
+    <>
+      <div
+        role="toolbar"
+        aria-label="Filters"
+        className="flex overflow-x-auto gap-2 px-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+      >
+        {visibleFilters.map((filter) => (
+          <Pill key={filter.key} asChild className={`shrink-0 cursor-pointer ${filter.active ? "bg-accent/20 border-foreground" : "bg-transparent"}`}>
+            <button onClick={() => setOpenFilter(filter.key)} aria-haspopup="dialog" className="inline-flex items-center gap-1">
+              {filter.label}
+              <ChevronDown className="size-4" />
+            </button>
+          </Pill>
+        ))}
+        {hasOfferCode ? (
+          <Pill asChild color="primary" className="shrink-0 cursor-pointer">
+            <button onClick={() => updateParams({ offer_code: undefined })}>
+              {searchParams.offer_code}
+            </button>
+          </Pill>
+        ) : null}
+        {hasActiveFilters ? (
+          <Pill asChild className="shrink-0 cursor-pointer bg-transparent">
+            <button onClick={() => dispatchAction({ type: "set-params", params: defaults })}>Clear all</button>
+          </Pill>
+        ) : null}
+      </div>
+
+      {filters.map((filter) => (
+        <BottomSheet
+          key={filter.key}
+          open={openFilter === filter.key}
+          onOpenChange={(open) => { if (!open) setOpenFilter(null); }}
+        >
+          <BottomSheetHeader>{filter.title}</BottomSheetHeader>
+          {filter.content}
+          <BottomSheetFooter />
+        </BottomSheet>
+      ))}
+    </>
+  );
+};

--- a/app/javascript/components/Product/CardGrid.tsx
+++ b/app/javascript/components/Product/CardGrid.tsx
@@ -1,4 +1,5 @@
 import { Archive } from "@boxicons/react";
+import { range } from "lodash-es";
 import * as React from "react";
 
 import { getSearchResults, ProductFilter, SearchRequest, SearchResults } from "$app/data/search";
@@ -10,6 +11,7 @@ import { AbortError, assertResponseError } from "$app/utils/request";
 
 import { Button } from "$app/components/Button";
 import { NumberInput } from "$app/components/NumberInput";
+import { RatingStars } from "$app/components/RatingStars";
 import { showAlert } from "$app/components/server-components/Alert";
 import { Skeleton } from "$app/components/Skeleton";
 import { CardContent, Card as UICard } from "$app/components/ui/Card";
@@ -121,7 +123,7 @@ type Props = {
   pagination?: "scroll" | "button";
 };
 
-const FilterCheckboxes = ({
+export const FilterCheckboxes = ({
   selection,
   setSelection,
   filters,
@@ -160,6 +162,33 @@ const FilterCheckboxes = ({
     </>
   );
 };
+
+export const RatingFilterOptions = ({
+  rating,
+  onRatingChange,
+}: {
+  rating: number | undefined;
+  onRatingChange: (rating: number | undefined) => void;
+}) => (
+  <Fieldset role="group">
+    {range(4, 0).map((number) => (
+      <Label key={number} className="w-full">
+        <span className="flex shrink-0 items-center gap-1">
+          <RatingStars rating={number} />
+          and up
+        </span>
+        <Radio
+          wrapperClassName="ml-auto"
+          value={number}
+          aria-label={`${number} ${number === 1 ? "star" : "stars"} and up`}
+          checked={number === rating}
+          readOnly
+          onClick={() => onRatingChange(rating === number ? undefined : number)}
+        />
+      </Label>
+    ))}
+  </Fieldset>
+);
 
 export const CardGrid = ({
   state,

--- a/app/javascript/components/ui/BottomSheet.tsx
+++ b/app/javascript/components/ui/BottomSheet.tsx
@@ -1,0 +1,34 @@
+import { X } from "@boxicons/react";
+import * as Dialog from "@radix-ui/react-dialog";
+import * as React from "react";
+
+import { Button } from "$app/components/Button";
+
+export const BottomSheet = ({ children, ...props }: React.ComponentProps<typeof Dialog.Root>) => (
+  <Dialog.Root {...props} modal>
+    <Dialog.Portal>
+      <Dialog.Overlay className="fixed inset-0 z-40 bg-black/80" />
+      <Dialog.Content aria-describedby={undefined} className="fixed inset-x-0 bottom-0 z-40 flex max-h-[85vh] flex-col gap-4 overflow-auto rounded-t border-t border-border bg-background p-6">
+        {children}
+      </Dialog.Content>
+    </Dialog.Portal>
+  </Dialog.Root>
+);
+
+export const BottomSheetHeader = ({ children }: { children: React.ReactNode }) => (
+  <div className="flex items-center gap-4">
+    <Dialog.Title>{children}</Dialog.Title>
+    <Dialog.Close className="ml-auto cursor-pointer all-unset" aria-label="Close">
+      <X className="size-5" />
+    </Dialog.Close>
+  </div>
+);
+
+export const BottomSheetFooter = ({ children }: { children?: React.ReactNode }) => (
+  <div className="flex items-center justify-end gap-4 pt-2">
+    {children}
+    <Dialog.Close asChild>
+      <Button color="primary">Done</Button>
+    </Dialog.Close>
+  </div>
+);

--- a/app/javascript/pages/Discover/Index.tsx
+++ b/app/javascript/pages/Discover/Index.tsx
@@ -1,6 +1,5 @@
 import { ArrowLeft, ArrowRight, X } from "@boxicons/react";
 import { Deferred, Link, router, usePage } from "@inertiajs/react";
-import { range } from "lodash-es";
 import * as React from "react";
 import { cast, is } from "ts-safe-cast";
 
@@ -12,19 +11,17 @@ import { classNames } from "$app/utils/classNames";
 import { CurrencyCode, formatPriceCentsWithCurrencySymbol } from "$app/utils/currency";
 import { discoverTitleGenerator, Taxonomy } from "$app/utils/discover";
 
+import { MobileFilterBar } from "$app/components/Discover/MobileFilterBar";
 import { Layout } from "$app/components/Discover/Layout";
 import { RecommendedWishlists } from "$app/components/Discover/RecommendedWishlists";
 import { HomeFooter } from "$app/components/Home/Shared/Footer";
 import { HorizontalCard } from "$app/components/Product/Card";
-import { CardGrid, useSearchReducer } from "$app/components/Product/CardGrid";
-import { RatingStars } from "$app/components/RatingStars";
+import { CardGrid, RatingFilterOptions, useSearchReducer } from "$app/components/Product/CardGrid";
 import { Skeleton } from "$app/components/Skeleton";
 import { CardContent } from "$app/components/ui/Card";
 import { Details, DetailsToggle } from "$app/components/ui/Details";
-import { Fieldset } from "$app/components/ui/Fieldset";
-import { Label } from "$app/components/ui/Label";
-import { Radio } from "$app/components/ui/Radio";
 import { Tab, Tabs } from "$app/components/ui/Tabs";
+import { useIsAboveBreakpoint } from "$app/components/useIsAboveBreakpoint";
 import { useScrollableCarousel } from "$app/components/useScrollableCarousel";
 import { CardWishlist } from "$app/components/Wishlist/Card";
 
@@ -325,6 +322,13 @@ function DiscoverIndex() {
     dispatch({ type: "set-params", params: { ...state.params, from: undefined, ...newParams } });
 
   const hasOfferCode = !!state.params.offer_code;
+  const isDesktop = useIsAboveBreakpoint("lg");
+
+  const filterDefaults: SearchRequest = {
+    taxonomy: state.params.taxonomy,
+    query: state.params.query,
+    sort: state.params.query || hasOfferCode ? "default" : state.params.sort,
+  };
 
   const recommendedProducts = props.recommended_products ?? [];
   const isCuratedProducts = (() => {
@@ -363,6 +367,18 @@ function DiscoverIndex() {
         onTaxonomyChange={handleTaxonomyChange}
         query={state.params.query}
         setQuery={(query) => dispatch({ type: "set-params", params: { query, taxonomy: taxonomyPath } })}
+        stickyBar={
+          !isDesktop ? (
+            <MobileFilterBar
+              state={state}
+              dispatchAction={dispatch}
+              defaults={filterDefaults}
+              currencyCode={props.currency_code}
+              hideSort={!state.params.query && !hasOfferCode}
+              hasOfferCode={hasOfferCode}
+            />
+          ) : undefined
+        }
       >
         {showBlackFridayHero ? (
           <header className="relative flex flex-col items-center justify-center">
@@ -413,7 +429,7 @@ function DiscoverIndex() {
             </div>
           </header>
         ) : null}
-        <div className="grid gap-16! px-4 py-16 lg:ps-16 lg:pe-16">
+        <div className="grid gap-16! px-4 pt-2 pb-16 lg:pt-16 lg:ps-16 lg:pe-16">
           {showRecommendationSections ? (
             <Deferred data={["recommended_products"]} fallback={<ProductsCarouselSkeleton />}>
               {recommendedProducts.length ? (
@@ -475,63 +491,44 @@ function DiscoverIndex() {
               state={state}
               dispatchAction={dispatch}
               currencyCode={props.currency_code}
+              hideFilters={!isDesktop}
               hideSort={!state.params.query && !hasOfferCode}
-              defaults={{
-                taxonomy: state.params.taxonomy,
-                query: state.params.query,
-                sort: state.params.query || hasOfferCode ? "default" : state.params.sort,
-              }}
+              defaults={filterDefaults}
               appendFilters={
-                <>
-                  <CardContent asChild details>
-                    <Details>
-                      <DetailsToggle chevronPosition="right" className="grow">
-                        Rating
-                      </DetailsToggle>
-                      <Fieldset role="group">
-                        {range(4, 0).map((number) => (
-                          <Label key={number} className="w-full">
-                            <span className="flex shrink-0 items-center gap-1">
-                              <RatingStars rating={number} />
-                              and up
-                            </span>
-                            <Radio
-                              wrapperClassName="ml-auto"
-                              value={number}
-                              aria-label={`${number} ${number === 1 ? "star" : "stars"} and up`}
-                              checked={number === state.params.rating}
-                              readOnly
-                              onClick={() =>
-                                updateParams(
-                                  state.params.rating === number ? { rating: undefined } : { rating: number },
-                                )
-                              }
-                            />
-                          </Label>
-                        ))}
-                      </Fieldset>
-                    </Details>
-                  </CardContent>
-                  {hasOfferCode ? (
+                isDesktop ? (
+                  <>
                     <CardContent asChild details>
-                      <Details open>
+                      <Details>
                         <DetailsToggle chevronPosition="right" className="grow">
-                          Offer code
+                          Rating
                         </DetailsToggle>
-                        <div className="flex items-center justify-between gap-2 py-1">
-                          <span>{props.black_friday_offer_code}</span>
-                          <button
-                            onClick={() => updateParams({ offer_code: undefined })}
-                            className="flex cursor-pointer items-center justify-center all-unset"
-                            aria-label="Remove offer code filter"
-                          >
-                            <X className="size-4" />
-                          </button>
-                        </div>
+                        <RatingFilterOptions
+                          rating={state.params.rating}
+                          onRatingChange={(rating) => updateParams({ rating })}
+                        />
                       </Details>
                     </CardContent>
-                  ) : null}
-                </>
+                    {hasOfferCode ? (
+                      <CardContent asChild details>
+                        <Details open>
+                          <DetailsToggle chevronPosition="right" className="grow">
+                            Offer code
+                          </DetailsToggle>
+                          <div className="flex items-center justify-between gap-2 py-1">
+                            <span>{props.black_friday_offer_code}</span>
+                            <button
+                              onClick={() => updateParams({ offer_code: undefined })}
+                              className="flex cursor-pointer items-center justify-center all-unset"
+                              aria-label="Remove offer code filter"
+                            >
+                              <X className="size-4" />
+                            </button>
+                          </div>
+                        </Details>
+                      </CardContent>
+                    ) : null}
+                  </>
+                ) : undefined
               }
               pagination="button"
             />


### PR DESCRIPTION
## What

Added a mobile filter bar to the Discover page. On screens below the `lg` breakpoint, a horizontally scrollable pill bar replaces the desktop sidebar filters. Each pill opens a bottom sheet for filter selection. The bar sticks to the top of the viewport on scroll, with a border that appears only when scrolled.

Concrete changes:
- New `StickyBar` component in Layout using IntersectionObserver to detect scroll state
- `BottomSheetFooter` component with a Done button using the existing `Button` component
- Active filter pills styled with `bg-accent/20` and `border-foreground` (light pink tint, dark border)
- Stale results caching via ref to prevent content flash when toggling filters mid-search
- Extracted `RatingFilterOptions` and exported `FilterCheckboxes` from CardGrid as shared components used by both mobile and desktop
- `aria-describedby={undefined}` on BottomSheet to suppress Radix console warning
- Deduplicated `filterDefaults` in Discover Index
- Renamed `headerBottom` prop to `stickyBar`

## Why

On Gumroad's mobile site, the filters panel takes up a lot of space above the fold, degrading the customer experience. Anytime a customer performs a search, they have to scroll past a big filter block to see results. This fixes it with a horizontally scrollable pill bar + bottom sheets.

## Test results

42/45 discover specs passing (`discover_mobile_spec.rb`, `filtering_spec.rb`, `discover_spec.rb`)

3 pre-existing failures (verified by reproducing on `main`):
- `discover_spec.rb:388` — relies on subdomain resolution (local hosts config)
- `discover_spec.rb:657` — relies on subdomain resolution (local hosts config)
- `discover_spec.rb:177` — wishlist element not found (unrelated to filter changes)

---

Based on https://github.com/aaronw122/gumroad/pull/1 by @aaronw122.

AI Disclosure: Claude Opus 4.6 was used to review the original PR and import the changes.