### PR TITLE
Fix: Truncate UTM params exceeding max length during auto-creation

### DIFF
--- a/app/controllers/concerns/utm_link_tracking.rb
+++ b/app/controllers/concerns/utm_link_tracking.rb
@@ -29,7 +29,7 @@ module UtmLinkTracking
       target_resource_type, target_resource_id = determine_utm_link_target_resource(seller)
       return if target_resource_type.blank?
 
-      utm_params = required_params.merge(optional_params).transform_values { _1.to_s.strip.downcase.gsub(/[^a-z0-9\-_]/u, "-").presence }
+      utm_params = required_params.merge(optional_params).transform_values { _1.to_s.strip.downcase.gsub(/[^a-z0-9\-_]/u, "-").first(UtmLink::MAX_UTM_PARAM_LENGTH).presence }
 
       ActiveRecord::Base.transaction do
         utm_link = UtmLink.active.find_or_initialize_by(utm_params.merge(target_resource_type:, target_resource_id:))

--- a/spec/controllers/concerns/utm_link_tracking_spec.rb
+++ b/spec/controllers/concerns/utm_link_tracking_spec.rb
@@ -290,6 +290,20 @@ describe UtmLinkTracking, type: :controller do
       end
     end
 
+    it "truncates UTM params that exceed the maximum length", :sidekiq_inline do
+      long_source = "a" * 300
+      request.host = "#{seller.subdomain}"
+      request.path = "/"
+      allow(controller).to receive(:root_path).and_return("/")
+
+      expect do
+        get :action, params: utm_params.merge(utm_source: long_source)
+      end.to change(UtmLink, :count).by(1)
+
+      utm_link = UtmLink.last
+      expect(utm_link.utm_source.length).to eq(UtmLink::MAX_UTM_PARAM_LENGTH)
+    end
+
     it "does not auto-create UTM link when feature is disabled" do
       Feature.deactivate_user(:utm_links, seller)
       request.host = "#{seller.subdomain}"


### PR DESCRIPTION
## Problem

`LinksController#show` raises `ActiveRecord::RecordInvalid: Validation failed: Utm source is too long (maximum is 200 characters)` when visitors arrive with UTM parameters longer than 200 characters.

**Sentry:** https://gumroad-to.sentry.io/issues/7422994411/ (22 occurrences)

## Root Cause

The `track_utm_link_visit` concern auto-creates `UtmLink` records from incoming query parameters. While it sanitizes the values (lowercase, replace special chars with hyphens), it doesn't truncate them. The sanitization regex can even expand multi-byte characters into longer ASCII sequences. When the sanitized value exceeds 200 characters, the model validation rejects it and the unrescued exception crashes the page.

## Fix

Add `.first(UtmLink::MAX_UTM_PARAM_LENGTH)` to the sanitization chain in `track_utm_link_visit`, truncating values before they reach the model.

## Test

Added a spec that sends a 300-character `utm_source` and verifies the created `UtmLink` has its value truncated to the max length (200 chars).