### PR TITLE
Fix NoMethodError on nil flow_of_funds in OrdersController#confirm

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -2753,10 +2753,11 @@ class Purchase < ApplicationRecord
 
     def load_flow_of_funds(processor_charge)
       processor_charge.flow_of_funds ||= FlowOfFunds.build_simple_flow_of_funds(Currency::USD, self.total_transaction_cents) if StripeChargeProcessor.charge_processor_id != charge_processor_id
+      flow_of_funds = processor_charge.flow_of_funds || FlowOfFunds.build_simple_flow_of_funds(Currency::USD, self.total_transaction_cents)
       self.flow_of_funds = if is_part_of_combined_charge?
-        build_flow_of_funds_from_combined_charge(processor_charge.flow_of_funds)
+        build_flow_of_funds_from_combined_charge(flow_of_funds)
       else
-        processor_charge.flow_of_funds
+        flow_of_funds
       end
     end
 

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -5868,6 +5868,30 @@ describe Purchase, :vcr do
     end
   end
 
+  describe "#load_flow_of_funds" do
+    context "when the purchase is part of a combined charge and processor_charge.flow_of_funds is nil" do
+      it "assigns a simple flow_of_funds fallback instead of raising NoMethodError" do
+        charge = create(:charge, amount_cents: 100_00, gumroad_amount_cents: 10_00)
+        purchase = create(:purchase, total_transaction_cents: 20_00,
+                                     charge_processor_id: StripeChargeProcessor.charge_processor_id,
+                                     is_part_of_combined_charge: true)
+        purchase.update!(fee_cents: 2_00)
+        charge.purchases << purchase
+
+        processor_charge = instance_double(
+          StripeCharge,
+          charge_processor_id: StripeChargeProcessor.charge_processor_id,
+          flow_of_funds: nil
+        )
+
+        expect { purchase.send(:load_flow_of_funds, processor_charge) }.not_to raise_error
+        expect(purchase.flow_of_funds).to be_present
+        expect(purchase.flow_of_funds.issued_amount.cents).to eq(4_00)
+        expect(purchase.flow_of_funds.issued_amount.currency).to eq(Currency::USD)
+      end
+    end
+  end
+
   describe "#refunded?" do
     it "returns false when stripe_refunded is nil or false" do
       purchase = create(:purchase, stripe_refunded: nil)


### PR DESCRIPTION
## What

Fixes a `NoMethodError: undefined method 'issued_amount' for nil` raised in `Purchase#load_flow_of_funds` when a purchase is part of a combined Stripe charge and `processor_charge.flow_of_funds` is nil.

Sentry: https://gumroad-to.sentry.io/issues/7423138845/

## Why

`Purchase#load_flow_of_funds` had a fallback that built a simple `FlowOfFunds` when `processor_charge.flow_of_funds` was nil, but it only fired for non-Stripe processors:

```ruby
processor_charge.flow_of_funds ||= FlowOfFunds.build_simple_flow_of_funds(...) if StripeChargeProcessor.charge_processor_id != charge_processor_id
```

For Stripe charges, `StripeCharge#initialize` only assigns `flow_of_funds` when `stripe_charge_balance_transaction` is present. If the balance transaction hasn't materialized yet (e.g., a race in the confirm flow), `processor_charge.flow_of_funds` stays nil. The purchase was then passed that nil into `build_flow_of_funds_from_combined_charge`, which immediately calls `.issued_amount.cents` on it and blows up.

The fix extends the fallback to cover the Stripe path as well: if `processor_charge.flow_of_funds` is nil, use a simple flow of funds built from `total_transaction_cents` before branching on `is_part_of_combined_charge?`.

## Occurrences

1 event so far on Sentry.

## Estimated impact

Low volume, but the error surfaces in the checkout confirmation flow (`OrdersController#confirm`), so each occurrence is user-facing.

## Test plan

- [x] New spec `Purchase#load_flow_of_funds` reproduces the nil-flow-of-funds scenario for a combined Stripe charge; fails against `main`, passes with this fix.
- [x] Existing specs around `#save_charge_data` and `#build_flow_of_funds_from_combined_charge` still pass.
- [x] `bundle exec rubocop` clean on touched files.

---

AI disclosure: This PR was drafted with Claude Opus 4.6. Prompts included the Sentry error details, root-cause analysis, and instructions to implement the nil-guard in `load_flow_of_funds` plus a failing-first spec.