### PR TITLE
Fix NoMethodError on nil flow_of_funds in OrdersController#confirm

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -2753,10 +2753,11 @@ class Purchase < ApplicationRecord
 
     def load_flow_of_funds(processor_charge)
       processor_charge.flow_of_funds ||= FlowOfFunds.build_simple_flow_of_funds(Currency::USD, self.total_transaction_cents) if StripeChargeProcessor.charge_processor_id != charge_processor_id
+      flow_of_funds = processor_charge.flow_of_funds || FlowOfFunds.build_simple_flow_of_funds(Currency::USD, self.total_transaction_cents)
       self.flow_of_funds = if is_part_of_combined_charge?
-        build_flow_of_funds_from_combined_charge(processor_charge.flow_of_funds)
+        build_flow_of_funds_from_combined_charge(flow_of_funds)
       else
-        processor_charge.flow_of_funds
+        flow_of_funds
       end
     end
 

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -5868,6 +5868,30 @@ describe Purchase, :vcr do
     end
   end
 
+  describe "#load_flow_of_funds" do
+    context "when the purchase is part of a combined charge and processor_charge.flow_of_funds is nil" do
+      it "assigns a simple flow_of_funds fallback instead of raising NoMethodError" do
+        charge = create(:charge, amount_cents: 20_00, gumroad_amount_cents: 2_00)
+        purchase = create(:purchase, total_transaction_cents: 20_00,
+                                     charge_processor_id: StripeChargeProcessor.charge_processor_id,
+                                     is_part_of_combined_charge: true)
+        purchase.update!(fee_cents: 2_00)
+        charge.purchases << purchase
+
+        processor_charge = instance_double(
+          StripeCharge,
+          charge_processor_id: StripeChargeProcessor.charge_processor_id,
+          flow_of_funds: nil
+        )
+
+        expect { purchase.send(:load_flow_of_funds, processor_charge) }.not_to raise_error
+        expect(purchase.flow_of_funds).to be_present
+        expect(purchase.flow_of_funds.issued_amount.cents).to eq(20_00)
+        expect(purchase.flow_of_funds.issued_amount.currency).to eq(Currency::USD)
+      end
+    end
+  end
+
   describe "#refunded?" do
     it "returns false when stripe_refunded is nil or false" do
       purchase = create(:purchase, stripe_refunded: nil)


### PR DESCRIPTION
## Summary
- Sentry: https://gumroad-to.sentry.io/issues/7423138845/
- Occurrences: 1 event so far
- Estimated impact: Low volume but affects checkout confirmation flow

## Root cause
`Purchase#load_flow_of_funds` only built a fallback `FlowOfFunds` for non-Stripe charges. During checkout confirmation, a Stripe combined charge can still have `processor_charge.flow_of_funds == nil` when the Stripe balance transaction has not materialized yet. In that case, `nil` was passed into `build_flow_of_funds_from_combined_charge`, which calls `issued_amount` and raised `NoMethodError`.

## Fix
Always derive a local fallback `FlowOfFunds.build_simple_flow_of_funds(Currency::USD, total_transaction_cents)` when `processor_charge.flow_of_funds` is nil, then use that fallback for both combined-charge and non-combined-charge paths.

## Testing
- `bundle _2.5.10_ exec rspec spec/models/purchase_spec.rb:5463 spec/models/purchase_spec.rb:5871`