### PR TITLE
Fix NoMethodError in build_flow_of_funds_from_combined_charge when flow_of_funds is nil

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -2594,6 +2594,8 @@ class Purchase < ApplicationRecord
   end
 
   def build_flow_of_funds_from_combined_charge(combined_flow_of_funds)
+    return if combined_flow_of_funds.nil?
+
     total_issued_amount_cents = combined_flow_of_funds.issued_amount.cents
     purchase_portion = total_transaction_cents * 1.0 / charge.amount_cents
     purchase_gumroad_amount_portion = if charge.gumroad_amount_cents == 0

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -5626,6 +5626,10 @@ describe Purchase, :vcr do
       expect(flow_of_funds.merchant_account_net_amount.cents).to eq(-31_25)
       expect(flow_of_funds.merchant_account_net_amount.currency).to eq(Currency::CAD)
     end
+
+    it "returns nil when combined_flow_of_funds is nil" do
+      expect(@purchase1.build_flow_of_funds_from_combined_charge(nil)).to be_nil
+    end
   end
 
   describe "#mandate_options_for_stripe" do


### PR DESCRIPTION
## Problem

`Purchase#build_flow_of_funds_from_combined_charge` raises `NoMethodError: undefined method 'issued_amount' for nil (NoMethodError)` when called with a nil `combined_flow_of_funds` argument.

This happens when processor charges, events, or refunds don't have `flow_of_funds` set — the method is called from multiple places (`load_flow_of_funds`, `Charge::Disputable`, `Charge::Refundable`, `ChargeEventsHandler`, `SyncStatusWithChargeProcessorService`) and any of them can pass nil.

Sentry: https://gumroad-to.sentry.io/issues/7423689333/

## Fix

Add a nil guard at the top of `build_flow_of_funds_from_combined_charge` that returns nil early, consistent with how the non-combined-charge code path already handles missing flow_of_funds.

## Test

Added a test confirming that passing nil returns nil instead of raising.