### PR TITLE
Fix tip field autofill: add name attribute to prevent phone number fill

### DIFF
--- a/app/javascript/components/Checkout/index.tsx
+++ b/app/javascript/components/Checkout/index.tsx
@@ -466,6 +466,7 @@ const TipSelector = () => {
             }}
             placeholder="Custom tip"
             disabled={isProcessing(state)}
+            name="tip_amount"
           />
         </Fieldset>
       </div>

--- a/app/javascript/components/PriceInput.tsx
+++ b/app/javascript/components/PriceInput.tsx
@@ -21,6 +21,7 @@ export const PriceInput = React.forwardRef<
     cents: number | null;
     onChange?: (cents: number | null) => void;
     id?: string;
+    name?: string;
     placeholder?: string;
     hasError?: boolean;
     ariaLabel?: string;
@@ -36,6 +37,7 @@ export const PriceInput = React.forwardRef<
       cents,
       onChange,
       id,
+      name,
       placeholder,
       hasError,
       ariaLabel,
@@ -85,6 +87,7 @@ export const PriceInput = React.forwardRef<
           type="text"
           inputMode="decimal"
           id={id}
+          name={name}
           value={value}
           onChange={(evt) => handleChange(evt.target.value)}
           maxLength={10}


### PR DESCRIPTION
## What

Adds a `name` prop to `PriceInput` and sets `name="tip_amount"` on the checkout tip field.

## Why

Browser autofill was entering users' phone numbers into the tip field (see screenshot in #4576). The input had no `name` attribute, so browsers guessed from context/placeholder and matched it to phone number autofill patterns. Setting an explicit name that doesn't match any standard autofill token prevents this.

The existing `autoComplete="off"` on PriceInput is kept but modern browsers frequently ignore it. The `name` attribute is the more reliable signal.

Closes #4576