### PR TITLE
Fix NoMethodError on nil global_affiliate in Products::AffiliatedController#index

### DIFF
--- a/app/javascript/components/AffiliatedPage.tsx
+++ b/app/javascript/components/AffiliatedPage.tsx
@@ -48,8 +48,8 @@ export type AffiliatedPageProps = {
   affiliated_products: AffiliatedProduct[];
   stats: Stats;
   global_affiliates_data: {
-    global_affiliate_id: number;
-    global_affiliate_sales: string;
+    global_affiliate_id: number | null;
+    global_affiliate_sales: string | null;
     cookie_expiry_days: number;
     affiliate_query_param: string;
   };
@@ -260,10 +260,10 @@ const AffiliatedPage = ({
       }
       archivedTabVisible={archivedTabVisible}
     >
-      {isShowingGlobalAffiliates ? (
+      {isShowingGlobalAffiliates && globalAffiliatesData.global_affiliate_id != null ? (
         <GlobalAffiliates
           globalAffiliateId={globalAffiliatesData.global_affiliate_id}
-          totalSales={globalAffiliatesData.global_affiliate_sales}
+          totalSales={globalAffiliatesData.global_affiliate_sales ?? "$0"}
           cookieExpiryDays={globalAffiliatesData.cookie_expiry_days}
           affiliateQueryParam={globalAffiliatesData.affiliate_query_param}
         />

--- a/app/presenters/affiliated_products_presenter.rb
+++ b/app/presenters/affiliated_products_presenter.rb
@@ -56,9 +56,10 @@ class AffiliatedProductsPresenter
     end
 
     def global_affiliates_data
+      global_affiliate = user.global_affiliate
       {
-        global_affiliate_id: user.global_affiliate.external_id_numeric,
-        global_affiliate_sales: user.global_affiliate.total_cents_earned_formatted,
+        global_affiliate_id: global_affiliate&.external_id_numeric,
+        global_affiliate_sales: global_affiliate&.total_cents_earned_formatted,
         cookie_expiry_days: GlobalAffiliate::AFFILIATE_COOKIE_LIFETIME_DAYS,
         affiliate_query_param: Affiliate::SHORT_QUERY_PARAM,
       }

--- a/spec/presenters/affiliated_products_presenter_spec.rb
+++ b/spec/presenters/affiliated_products_presenter_spec.rb
@@ -186,21 +186,6 @@ describe AffiliatedProductsPresenter do
       expect(props[:affiliates_disabled_reason]).to be nil
     end
 
-    context "when the global affiliate has been deleted" do
-      before do
-        global_affiliate.update!(deleted_at: Time.current)
-        affiliate_user.reload
-      end
-
-      it "returns nil for global affiliate fields without raising" do
-        props = described_class.new(affiliate_user).affiliated_products_page_props
-        expect(props[:global_affiliates_data][:global_affiliate_id]).to be_nil
-        expect(props[:global_affiliates_data][:global_affiliate_sales]).to be_nil
-        expect(props[:global_affiliates_data][:cookie_expiry_days]).to eq GlobalAffiliate::AFFILIATE_COOKIE_LIFETIME_DAYS
-        expect(props[:global_affiliates_data][:affiliate_query_param]).to eq Affiliate::SHORT_QUERY_PARAM
-      end
-    end
-
     it "returns affiliates_disabled_reason if using Brazilian Stripe Connect account" do
       brazilian_stripe_account = create(:merchant_account_stripe_connect, user: affiliate_user, country: "BR")
       affiliate_user.update!(check_merchant_account_is_linked: true)
@@ -537,6 +522,21 @@ describe AffiliatedProductsPresenter do
                                                                  url: direct_affiliate_one.referral_url_for_product(creator_one_product_two)
                                                                })
       end
+    end
+  end
+
+  describe "#affiliated_products_page_props when the global affiliate has been deleted" do
+    it "returns nil for global affiliate fields without raising" do
+      user = create(:affiliate_user)
+      user.global_affiliate.update!(deleted_at: Time.current)
+      user.reload
+
+      props = described_class.new(user).affiliated_products_page_props
+
+      expect(props[:global_affiliates_data][:global_affiliate_id]).to be_nil
+      expect(props[:global_affiliates_data][:global_affiliate_sales]).to be_nil
+      expect(props[:global_affiliates_data][:cookie_expiry_days]).to eq GlobalAffiliate::AFFILIATE_COOKIE_LIFETIME_DAYS
+      expect(props[:global_affiliates_data][:affiliate_query_param]).to eq Affiliate::SHORT_QUERY_PARAM
     end
   end
 

--- a/spec/presenters/affiliated_products_presenter_spec.rb
+++ b/spec/presenters/affiliated_products_presenter_spec.rb
@@ -186,6 +186,21 @@ describe AffiliatedProductsPresenter do
       expect(props[:affiliates_disabled_reason]).to be nil
     end
 
+    context "when the global affiliate has been deleted" do
+      before do
+        global_affiliate.update!(deleted_at: Time.current)
+        affiliate_user.reload
+      end
+
+      it "returns nil for global affiliate fields without raising" do
+        props = described_class.new(affiliate_user).affiliated_products_page_props
+        expect(props[:global_affiliates_data][:global_affiliate_id]).to be_nil
+        expect(props[:global_affiliates_data][:global_affiliate_sales]).to be_nil
+        expect(props[:global_affiliates_data][:cookie_expiry_days]).to eq GlobalAffiliate::AFFILIATE_COOKIE_LIFETIME_DAYS
+        expect(props[:global_affiliates_data][:affiliate_query_param]).to eq Affiliate::SHORT_QUERY_PARAM
+      end
+    end
+
     it "returns affiliates_disabled_reason if using Brazilian Stripe Connect account" do
       brazilian_stripe_account = create(:merchant_account_stripe_connect, user: affiliate_user, country: "BR")
       affiliate_user.update!(check_merchant_account_is_linked: true)


### PR DESCRIPTION
## Problem

`Products::AffiliatedController#index` raises `NoMethodError: undefined method 'external_id_numeric' for nil` when a user's global affiliate has been soft-deleted.

The `has_one :global_affiliate, -> { alive }` association returns `nil` when the global affiliate record has `deleted_at` set, but `AffiliatedProductsPresenter#global_affiliates_data` calls methods on it unconditionally.

**Sentry:** https://gumroad-to.sentry.io/issues/7425676680/

## Fix

- Use safe navigation (`&.`) on `user.global_affiliate` in the presenter so nil values are returned instead of raising
- Update the TypeScript type to allow `null` for `global_affiliate_id` and `global_affiliate_sales`
- Guard the `GlobalAffiliates` component rendering so it only mounts when `global_affiliate_id` is present
- Add a test for the deleted global affiliate scenario