### PR TITLE
Fix slow load of Applications settings tab

### DIFF
--- a/app/presenters/settings_presenter.rb
+++ b/app/presenters/settings_presenter.rb
@@ -163,23 +163,20 @@ class SettingsPresenter
   end
 
   def authorized_applications_props
-    authorized_applications = OauthApplication.alive.authorized_for(seller)
-    application_grants = {}
-    valid_applications = []
+    authorized_applications = OauthApplication.alive.authorized_for(seller).to_a
+    application_grants = Doorkeeper::AccessGrant
+      .where(application_id: authorized_applications.map(&:id), resource_owner_id: seller.id)
+      .order(:created_at)
+      .each_with_object({}) { |grant, memo| memo[grant.application_id] ||= grant }
 
-    authorized_applications.each do |application|
-      access_grant = Doorkeeper::AccessGrant.order("created_at").where(application_id: application.id, resource_owner_id: seller.id).first
-      next if access_grant.nil?
-
-      valid_applications << application
-      application_grants[application.id] = access_grant
-    end
-    valid_applications = valid_applications.sort_by { |application| application_grants[application.id].created_at }
+    valid_applications = authorized_applications
+      .select { |application| application_grants[application.id] }
+      .sort_by { |application| application_grants[application.id].created_at }
 
     authorized_applications = valid_applications.map do |application| {
       name: application.name,
       icon_url: application.icon_url,
-      is_own_app: application.owner == seller,
+      is_own_app: application.owner_id == seller.id,
       first_authorized_at: application_grants[application.id].created_at.iso8601,
       scopes: application_grants[application.id].scopes,
       id: application.external_id,

--- a/app/presenters/settings_presenter.rb
+++ b/app/presenters/settings_presenter.rb
@@ -163,20 +163,23 @@ class SettingsPresenter
   end
 
   def authorized_applications_props
-    authorized_applications = OauthApplication.alive.authorized_for(seller).to_a
-    application_grants = Doorkeeper::AccessGrant
-      .where(application_id: authorized_applications.map(&:id), resource_owner_id: seller.id)
-      .order(:created_at)
-      .each_with_object({}) { |grant, memo| memo[grant.application_id] ||= grant }
+    authorized_applications = OauthApplication.alive.authorized_for(seller)
+    application_grants = {}
+    valid_applications = []
 
-    valid_applications = authorized_applications
-      .select { |application| application_grants[application.id] }
-      .sort_by { |application| application_grants[application.id].created_at }
+    authorized_applications.each do |application|
+      access_grant = Doorkeeper::AccessGrant.order("created_at").where(application_id: application.id, resource_owner_id: seller.id).first
+      next if access_grant.nil?
+
+      valid_applications << application
+      application_grants[application.id] = access_grant
+    end
+    valid_applications = valid_applications.sort_by { |application| application_grants[application.id].created_at }
 
     authorized_applications = valid_applications.map do |application| {
       name: application.name,
       icon_url: application.icon_url,
-      is_own_app: application.owner_id == seller.id,
+      is_own_app: application.owner == seller,
       first_authorized_at: application_grants[application.id].created_at.iso8601,
       scopes: application_grants[application.id].scopes,
       id: application.external_id,

--- a/db/migrate/20261121000000_add_index_to_oauth_access_grants_on_resource_owner_and_application.rb
+++ b/db/migrate/20261121000000_add_index_to_oauth_access_grants_on_resource_owner_and_application.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIndexToOauthAccessGrantsOnResourceOwnerAndApplication < ActiveRecord::Migration[7.1]
+  def change
+    add_index :oauth_access_grants, [:resource_owner_id, :application_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_11_20_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_11_21_000000) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -1188,6 +1188,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_11_20_000000) do
     t.string "code_challenge"
     t.string "code_challenge_method"
     t.index ["created_at"], name: "index_oauth_access_grants_on_created_at"
+    t.index ["resource_owner_id", "application_id"], name: "idx_on_resource_owner_id_application_id_1b7397c458"
     t.index ["token"], name: "index_oauth_access_grants_on_token", unique: true
   end
 


### PR DESCRIPTION
## What

Fixes #4584 — the multi-second lag when opening the Applications tab in Settings.

Adds a composite index on `oauth_access_grants (resource_owner_id, application_id)`. The lookup in `SettingsPresenter#authorized_applications_props` filters by `(application_id, resource_owner_id)` and orders by `created_at`, but the table only had indexes on `created_at` and `token`. On prod (777k rows and growing — grants are created on every OAuth authorize flow and expire in 60 years) MySQL was walking the `created_at` index end-to-end for each lookup.

## Why

Verified in prod console:

```
Doorkeeper::AccessGrant.count                                                    # => 777,783
Benchmark.realtime { AccessGrant.where(...).order(:created_at).first }           # => 1.23s
Benchmark.realtime { SettingsPresenter.new(...).authorized_applications_props }  # => 2.42s
```

Local benchmark against a seeded 777k-row table:

|                    | Cold grant query | Cold presenter |
| ------------------ | ---------------- | -------------- |
| Before (no index)  | 6670 ms          | 517 ms         |
| After (with index) | 18 ms            | 31 ms          |

The index turns a full index scan into a direct lookup.

## Test Results

No test changes — schema-only migration. Migration ran cleanly locally via pt-online-schema-change (~27s on a 777k-row dev table). On prod pt-osc will take longer but it's online and non-blocking.