### PR TITLE
Fix NoMethodError: undefined method 'permit' for String in CheckoutController#update

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -14,6 +14,8 @@ class CheckoutController < ApplicationController
   end
 
   def update
+    return head :bad_request unless params[:cart].is_a?(ActionController::Parameters)
+
     if update_permitted_params[:items].length > Cart::MAX_ALLOWED_CART_PRODUCTS
       return redirect_to checkout_path, alert: "You cannot add more than #{Cart::MAX_ALLOWED_CART_PRODUCTS} products to the cart."
     end

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -250,6 +250,12 @@ describe CheckoutController, type: :controller, inertia: true do
         sign_in(seller)
       end
 
+      it "returns a 400 when cart param is not a hash" do
+        patch :update, params: { cart: "invalid_string" }, as: :json
+
+        expect(response).to have_http_status(:bad_request)
+      end
+
       it "creates an empty cart" do
         expect do
           patch :update, params: { cart: { items: [], discountCodes: [] } }, as: :json


### PR DESCRIPTION
## Problem

A malformed request to `CheckoutController#update` sends the `cart` parameter as a plain string instead of a nested hash. When this happens, `params.require(:cart)` returns a `String`, and calling `.permit` on it raises:

```
NoMethodError: undefined method 'permit' for an instance of String
```

**Sentry:** https://gumroad-to.sentry.io/issues/7426826751/

## Fix

Add an early guard at the top of the `update` action that returns `400 Bad Request` when `params[:cart]` is not an `ActionController::Parameters` instance. This prevents the malformed data from reaching `update_permitted_params`.

## Test

Added a spec confirming that sending `cart` as a string returns a 400 status.