### PR TITLE
Fix NoMethodError when discountCodes is nil in CheckoutController#update

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -26,7 +26,7 @@ class CheckoutController < ApplicationController
       cart.email = update_permitted_params[:email].presence || logged_in_user&.email
       cart.return_url = update_permitted_params[:returnUrl]
       cart.reject_ppp_discount = update_permitted_params[:rejectPppDiscount] || false
-      cart.discount_codes = update_permitted_params[:discountCodes].map { { code: _1[:code], fromUrl: _1[:fromUrl] } }
+      cart.discount_codes = (update_permitted_params[:discountCodes] || []).map { { code: _1[:code], fromUrl: _1[:fromUrl] } }
       cart.save!
 
       updated_cart_products = update_permitted_params[:items].map do |item|

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -261,6 +261,18 @@ describe CheckoutController, type: :controller, inertia: true do
         expect(controller.logged_in_user.carts.alive).to be_present
       end
 
+      it "does not raise when `discountCodes` is omitted" do
+        expect do
+          patch :update, params: { cart: { items: [] } }, as: :json
+        end.to change(Cart, :count).by(1)
+
+        expect(response).to have_http_status(:see_other)
+        expect(response).to redirect_to(checkout_path)
+
+        cart = controller.logged_in_user.alive_cart
+        expect(cart.discount_codes).to eq([])
+      end
+
       it "creates and populates a cart" do
         product = create(:product)
         call_start_time = Time.current.round


### PR DESCRIPTION
## Summary
- Guard against `nil` when mapping `discountCodes` in `CheckoutController#update`. When the request omits `discountCodes`, `update_permitted_params[:discountCodes]` is `nil`, causing `NoMethodError: undefined method 'map' for nil`.
- Default to `[]` so the update proceeds normally with no discount codes.

Sentry: https://gumroad-to.sentry.io/issues/7426826495/

## Test plan
- [x] Added a controller spec covering a `PATCH /checkout` request that omits `discountCodes` and verifies the cart is created with `discount_codes == []`.
- [x] New and adjacent specs pass locally (`bundle exec rspec spec/controllers/checkout_controller_spec.rb`).