### PR TITLE
Fix NoMethodError when checkout update receives nil items

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -14,7 +14,10 @@ class CheckoutController < ApplicationController
   end
 
   def update
-    if update_permitted_params[:items].length > Cart::MAX_ALLOWED_CART_PRODUCTS
+    items = Array(update_permitted_params[:items])
+    discount_codes = Array(update_permitted_params[:discountCodes])
+
+    if items.length > Cart::MAX_ALLOWED_CART_PRODUCTS
       return redirect_to checkout_path, alert: "You cannot add more than #{Cart::MAX_ALLOWED_CART_PRODUCTS} products to the cart."
     end
 
@@ -26,10 +29,10 @@ class CheckoutController < ApplicationController
       cart.email = update_permitted_params[:email].presence || logged_in_user&.email
       cart.return_url = update_permitted_params[:returnUrl]
       cart.reject_ppp_discount = update_permitted_params[:rejectPppDiscount] || false
-      cart.discount_codes = update_permitted_params[:discountCodes].map { { code: _1[:code], fromUrl: _1[:fromUrl] } }
+      cart.discount_codes = discount_codes.map { { code: _1[:code], fromUrl: _1[:fromUrl] } }
       cart.save!
 
-      updated_cart_products = update_permitted_params[:items].map do |item|
+      updated_cart_products = items.map do |item|
         product = Link.find_by_external_id!(item[:product][:id])
         option = item[:option_id].present? ? BaseVariant.find_by_external_id(item[:option_id]) : nil
 
@@ -128,7 +131,10 @@ class CheckoutController < ApplicationController
     end
 
     def update_permitted_params
-      @_update_permitted_params ||= params.require(:cart).permit(
+      cart_params = params.require(:cart)
+      raise ActionController::BadRequest, "cart param is invalid" unless cart_params.is_a?(ActionController::Parameters)
+
+      @_update_permitted_params ||= cart_params.permit(
         :email, :returnUrl, :rejectPppDiscount,
         discountCodes: [:code, :fromUrl],
         items: [

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -476,6 +476,20 @@ describe CheckoutController, type: :controller, inertia: true do
         expect(flash[:alert]).to eq("Sorry, something went wrong. Please try again.")
       end
 
+      it "does not crash when `items` and `discountCodes` are omitted" do
+        expect do
+          patch :update, params: { cart: { email: "john@example.com" } }, as: :json
+        end.to change(Cart, :count).by(1)
+
+        expect(response).to have_http_status(:see_other)
+        expect(response).to redirect_to(checkout_path)
+
+        cart = controller.logged_in_user.alive_cart
+        expect(cart.email).to eq("john@example.com")
+        expect(cart.alive_cart_products).to be_empty
+        expect(cart.discount_codes).to eq([])
+      end
+
       it "returns an error when cart contains more than allowed number of cart products" do
         items = (Cart::MAX_ALLOWED_CART_PRODUCTS + 1).times.map { { product: { id: _1 + 1 } }  }
         patch :update, params: { cart: { items: } }, as: :json


### PR DESCRIPTION
## Summary
- guard checkout update against missing `items` and `discountCodes` params
- preserve the existing 400 response for malformed non-hash `cart` params
- add a controller spec covering checkout updates with omitted `items`

## Context
- Sentry issue: https://gumroad-to.sentry.io/issues/7426826658/
- Event count: 1 occurrence
- First seen: new issue
