### PR TITLE
Remove twitter_handle and X icon from public profiles

### DIFF
--- a/app/controllers/concerns/page_meta/product.rb
+++ b/app/controllers/concerns/page_meta/product.rb
@@ -88,9 +88,5 @@ module PageMeta::Product
       end
       description = description.length > 200 ? "#{description[0, 197]}..." : description
       set_meta_tag(property: "twitter:description", value: description)
-
-      if product.user&.twitter_handle?
-        set_meta_tag(property: "twitter:creator", value: "@#{product.user.twitter_handle}")
-      end
     end
 end

--- a/app/javascript/components/ApiDocumentation/Endpoints/User.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/User.tsx
@@ -25,7 +25,6 @@ export const GetUser = () => (
   "user": {
     "bio": "a sailor, a tailor",
     "name": "John Smith",
-    "twitter_handle": null,
     "user_id": "G_-mnBf9b1j9A7a4ub4nFQ==",
     "email": "johnsmith@gumroad.com", # available with the 'view_sales' scope
     "url": "https://gumroad.com/sailorjohn", # only if username is set

--- a/app/javascript/components/ApiDocumentation/responseFieldDefinitions.ts
+++ b/app/javascript/components/ApiDocumentation/responseFieldDefinitions.ts
@@ -515,7 +515,6 @@ export const PAYOUT_DETAIL_FIELDS: FieldDefinition[] = [
 export const USER_FIELDS: FieldDefinition[] = [
   { name: "bio", type: "string | null", description: "User's bio" },
   { name: "name", type: "string", description: "User's display name" },
-  { name: "twitter_handle", type: "string | null", description: "User's Twitter handle" },
   { name: "id", type: "string", description: "Unique identifier for the user" },
   { name: "user_id", type: "string", description: "Alternate user ID, not currently used" },
   {

--- a/app/javascript/components/ProductEdit/ProductPreview.tsx
+++ b/app/javascript/components/ProductEdit/ProductPreview.tsx
@@ -162,7 +162,6 @@ export const ProductPreview = ({ showRefundPolicyModal }: { showRefundPolicyModa
         avatar_url: currentSeller.avatarUrl,
         name: currentSeller.name ?? "",
         subdomain: currentSeller.subdomain,
-        twitter_handle: "",
         is_verified: seller.is_verified,
       }}
       hideFollowForm

--- a/app/javascript/components/Profile/Layout.tsx
+++ b/app/javascript/components/Profile/Layout.tsx
@@ -1,4 +1,3 @@
-import { TwitterX } from "@boxicons/react";
 import * as React from "react";
 
 import { CreatorProfile } from "$app/parsers/profile";
@@ -25,17 +24,11 @@ export const Layout = ({ creatorProfile, hideFollowForm, children }: LayoutProps
   const loggedInUser = useLoggedInUser();
   const isDesktop = useIsAboveBreakpoint("lg");
 
-  const headerButtons =
-    creatorProfile.twitter_handle || cartItemsCount ? (
-      <div className="ml-auto flex items-center gap-3">
-        {creatorProfile.twitter_handle ? (
-          <NavigationButton outline href={`https://twitter.com/${creatorProfile.twitter_handle}`} target="_blank">
-            <TwitterX pack="brands" className="size-5" />
-          </NavigationButton>
-        ) : null}
-        <CartNavigationButton />
-      </div>
-    ) : null;
+  const headerButtons = cartItemsCount ? (
+    <div className="ml-auto flex items-center gap-3">
+      <CartNavigationButton />
+    </div>
+  ) : null;
 
   return (
     <div className="flex min-h-screen flex-col">

--- a/app/javascript/parsers/profile.ts
+++ b/app/javascript/parsers/profile.ts
@@ -2,7 +2,6 @@ export type CreatorProfile = {
   external_id: string;
   avatar_url: string;
   name: string;
-  twitter_handle: string | null;
   subdomain: string | null;
   is_verified: boolean;
 };

--- a/app/models/concerns/user/as_json.rb
+++ b/app/models/concerns/user/as_json.rb
@@ -6,11 +6,11 @@ module User::AsJson
   def as_json(options = {})
     result =
       if options[:internal_use] || valid_api_scope?(options)
-        super(only: %i[name bio twitter_handle currency_type], methods: options[:methods], include: options[:include])
+        super(only: %i[name bio currency_type], methods: options[:methods], include: options[:include])
           .merge(common_fields_for_as_json)
           .merge(profile_url: avatar_url, email: form_email)
       else
-        super(only: %i[name bio twitter_handle])
+        super(only: %i[name bio])
           .compact
           .merge(common_fields_for_as_json)
       end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -556,15 +556,9 @@ class Link < ApplicationRecord
   end
 
   def social_share_text
-    if user.twitter_handle.present?
-      return "I pre-ordered #{name} from @#{user.twitter_handle} on @Gumroad" if is_in_preorder_state
+    return "I pre-ordered #{name} on @Gumroad" if is_in_preorder_state
 
-      "I got #{name} from @#{user.twitter_handle} on @Gumroad"
-    else
-      return "I pre-ordered #{name} on @Gumroad" if is_in_preorder_state
-
-      "I got #{name} on @Gumroad"
-    end
+    "I got #{name} on @Gumroad"
   end
 
   def self.human_attribute_name(attr, _)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -294,7 +294,7 @@ class User < ApplicationRecord
             :flag_query_mode => :bit_operator,
             check_for_column: false
 
-  LINK_PROPERTIES = %w[username twitter_handle bio name google_analytics_id flags
+  LINK_PROPERTIES = %w[username bio name google_analytics_id flags
                        facebook_pixel_id tiktok_pixel_id skip_free_sale_analytics disable_third_party_analytics].freeze
 
   after_update :clear_products_cache, if: -> (user) { (User::LINK_PROPERTIES & user.saved_changes.keys).present? || user.tiktok_pixel_id_changed_in_json_data? || (%w[font background_color highlight_color] & user.seller_profile&.saved_changes&.keys).present? }

--- a/app/presenters/profile_presenter.rb
+++ b/app/presenters/profile_presenter.rb
@@ -15,7 +15,6 @@ class ProfilePresenter
       external_id: seller.external_id,
       avatar_url: seller.avatar_url,
       name: seller.name || seller.username,
-      twitter_handle: seller.twitter_handle,
       subdomain: seller.subdomain,
       is_verified: !!seller.verified,
     }

--- a/db/migrate/20261122000000_remove_twitter_handle_from_users.rb
+++ b/db/migrate/20261122000000_remove_twitter_handle_from_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveTwitterHandleFromUsers < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :users, :twitter_handle, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_11_21_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_11_22_000000) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -2538,7 +2538,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_11_21_000000) do
     t.boolean "payment_notification", default: true
     t.string "currency_type", default: "usd"
     t.text "bio", size: :medium
-    t.string "twitter_handle"
     t.string "username"
     t.bigint "credit_card_id"
     t.string "profile_picture_url"

--- a/spec/models/concerns/user/as_json_spec.rb
+++ b/spec/models/concerns/user/as_json_spec.rb
@@ -59,30 +59,22 @@ describe User::AsJson do
       subject(:returned_keys) { as_json.keys.collect(&:to_s) }
 
       let(:options) { {} }
-      let(:common_keys) { %w[name bio twitter_handle id user_id url profile_picture_url links] }
+      let(:common_keys) { %w[name bio id user_id url profile_picture_url links] }
       let(:api_scope_keys) { %w[currency_type profile_url email] }
       let(:internal_use_keys) { %w[created_at sign_in_count current_sign_in_at last_sign_in_at current_sign_in_ip last_sign_in_ip purchases_count successful_purchases_count] }
 
       context "when no options are provided" do
-        context "when the bio and twitter_handle are NOT set" do
+        context "when the bio is NOT set" do
           it "returns common values" do
-            expect(returned_keys).to contain_exactly(*common_keys - %w[bio twitter_handle])
+            expect(returned_keys).to contain_exactly(*common_keys - %w[bio])
           end
         end
 
         context "when the bio is set" do
           let(:user_traits) { [:with_bio] }
 
-          it "returns common values expect twitter_handle" do
-            expect(returned_keys).to contain_exactly(*common_keys - %w[twitter_handle])
-          end
-        end
-
-        context "when the twitter_handle is set" do
-          let(:user_traits) { [:with_twitter_handle] }
-
-          it "returns common values expect bio" do
-            expect(returned_keys).to contain_exactly(*common_keys - %w[bio])
+          it "returns common values" do
+            expect(returned_keys).to contain_exactly(*common_keys)
           end
         end
       end

--- a/spec/presenters/profile_presenter_spec.rb
+++ b/spec/presenters/profile_presenter_spec.rb
@@ -39,7 +39,6 @@ describe ProfilePresenter do
           avatar_url: ActionController::Base.helpers.asset_url("gumroad-default-avatar-5.png"),
           external_id: seller.external_id,
           name: seller.name,
-          twitter_handle: nil,
           subdomain: seller.subdomain,
           is_verified: false,
         }

--- a/spec/support/factories/users.rb
+++ b/spec/support/factories/users.rb
@@ -169,10 +169,6 @@ FactoryBot.define do
       bio { Faker::Lorem.sentence }
     end
 
-    trait :with_twitter_handle do
-      twitter_handle { Faker::Lorem.word }
-    end
-
     trait :deleted do
       deleted_at { Time.current }
     end


### PR DESCRIPTION
## What

- Remove the `twitter_handle` column from the `users` table (migration)
- Remove the X icon from public profile pages
- Remove the `twitter:creator` meta tag from product pages
- Drop `twitter_handle` from the `/user` API response (and the ApiDocumentation example)
- Drop `twitter_handle` from the `CreatorProfile` parser/presenter props
- Drop the `@handle` mention from `Link#social_share_text`
- Update tests and factory (remove `:with_twitter_handle` trait)

## Why

PR #4055 removed the "Connect to X" OAuth flow, but the `twitter_handle` column and the X icon on public profiles were left behind, so pre-#4055 users are stuck with a handle they can't edit or clear. This retires the column and the public-facing UI/API to match #4055's intent, as agreed on the issue.

Fixes #4585.

## Test Results

Ran the affected specs locally:

```
bundle exec rspec spec/models/concerns/user/as_json_spec.rb \
                  spec/presenters/profile_presenter_spec.rb \
                  spec/models/link_spec.rb -e "twitter_share_url"
# 24 examples, 0 failures
```

## QA steps

1. Visit a public creator profile (`/<username>`) that previously had a `twitter_handle` value — the X icon no longer appears in the header.
2. View a product page source — `twitter:creator` meta tag is no longer emitted.
3. Hit `/v2/user` via API — response no longer includes `twitter_handle`.
4. Run `bin/rails db:migrate` — `twitter_handle` column is removed from `users`.

---

Built with Claude Opus 4.6. Prompts:
- "Remove the X icon and retire the `twitter_handle` column from the Gumroad codebase (issue #4585)"