### PR TITLE
Accept 8-character SWIFT/BIC codes for Moldova bank accounts

### DIFF
--- a/app/models/moldova_bank_account.rb
+++ b/app/models/moldova_bank_account.rb
@@ -3,7 +3,7 @@
 class MoldovaBankAccount < BankAccount
   BANK_ACCOUNT_TYPE = "MD"
 
-  BANK_CODE_FORMAT_REGEX = /^[A-Z0-9]{4}MD[A-Z0-9]{5}$/
+  BANK_CODE_FORMAT_REGEX = /^[A-Z0-9]{4}MD[A-Z0-9]{2}([A-Z0-9]{3})?$/
   ACCOUNT_NUMBER_FORMAT_REGEX = /^MD\d{2}[A-Z0-9]{20}$/
   private_constant :BANK_CODE_FORMAT_REGEX, :ACCOUNT_NUMBER_FORMAT_REGEX
 

--- a/spec/models/moldova_bank_account_spec.rb
+++ b/spec/models/moldova_bank_account_spec.rb
@@ -36,12 +36,20 @@ describe MoldovaBankAccount do
   end
 
   describe "#validate_bank_code" do
-    it "allows only 8-11 characters in the correct format" do
+    it "allows 8 or 11 character SWIFT/BIC codes with MD country code" do
+      # Valid 11-character codes
       expect(build(:moldova_bank_account, bank_code: "AAAAMDMDXXX")).to be_valid
       expect(build(:moldova_bank_account, bank_code: "BBBBMDMDYYY")).to be_valid
       expect(build(:moldova_bank_account, bank_code: "AGRNMD2XZZZ")).to be_valid
+      # Valid 8-character codes (no branch suffix)
+      expect(build(:moldova_bank_account, bank_code: "AGROMDMD")).to be_valid
+      expect(build(:moldova_bank_account, bank_code: "AGRLMDMM")).to be_valid
+      # Invalid: 9 or 10 characters
       expect(build(:moldova_bank_account, bank_code: "AGRNMD2ZZ")).not_to be_valid
+      expect(build(:moldova_bank_account, bank_code: "AGRNMD2ZZX")).not_to be_valid
+      # Invalid: wrong country code position
       expect(build(:moldova_bank_account, bank_code: "AGRNMM2XZZZ")).not_to be_valid
+      # Invalid: too long or too short
       expect(build(:moldova_bank_account, bank_code: "AGRNMD2XZZZZ")).not_to be_valid
       expect(build(:moldova_bank_account, bank_code: "AAAMDMDXXX")).not_to be_valid
       expect(build(:moldova_bank_account, bank_code: "AAAAMDMDXXXX")).not_to be_valid


### PR DESCRIPTION
The SWIFT/BIC standard allows both 8-character codes (without branch suffix) and 11-character codes. Moldova's `BANK_CODE_FORMAT_REGEX` only accepted 11-character codes, causing valid 8-character SWIFT codes to be rejected with "The bank code is invalid."

**Before:** `/^[A-Z0-9]{4}MD[A-Z0-9]{5}$/` (11 chars only)
**After:** `/^[A-Z0-9]{4}MD[A-Z0-9]{2}([A-Z0-9]{3})?$/` (8 or 11 chars)

Fixes https://github.com/antiwork/gumroad/issues/4586