### PR TITLE
Add feature flag to disable reCAPTCHA on login

### DIFF
--- a/app/controllers/logins_controller.rb
+++ b/app/controllers/logins_controller.rb
@@ -26,9 +26,11 @@ class LoginsController < Devise::SessionsController
   end
 
   def create
-    site_key = GlobalConfig.get("RECAPTCHA_LOGIN_SITE_KEY")
-    if !(Rails.env.development? && site_key.blank?) && !valid_recaptcha_response?(site_key: site_key)
-      return redirect_with_login_error("Sorry, we could not verify the CAPTCHA. Please try again.")
+    unless Feature.active?(:disable_login_recaptcha)
+      site_key = GlobalConfig.get("RECAPTCHA_LOGIN_SITE_KEY")
+      if !(Rails.env.development? && site_key.blank?) && !valid_recaptcha_response?(site_key: site_key)
+        return redirect_with_login_error("Sorry, we could not verify the CAPTCHA. Please try again.")
+      end
     end
 
     if params["user"].instance_of?(ActionController::Parameters)

--- a/app/presenters/auth_presenter.rb
+++ b/app/presenters/auth_presenter.rb
@@ -12,7 +12,7 @@ class AuthPresenter
     {
       email: params[:email] || retrieve_team_invitation_email(params[:next]),
       application_name: application&.name,
-      recaptcha_site_key: GlobalConfig.get("RECAPTCHA_LOGIN_SITE_KEY"),
+      recaptcha_site_key: Feature.active?(:disable_login_recaptcha) ? nil : GlobalConfig.get("RECAPTCHA_LOGIN_SITE_KEY"),
     }
   end
 

--- a/spec/controllers/logins_controller_spec.rb
+++ b/spec/controllers/logins_controller_spec.rb
@@ -24,6 +24,17 @@ describe LoginsController, type: :controller, inertia: true do
       expect(inertia.props[:recaptcha_site_key]).to eq(GlobalConfig.get("RECAPTCHA_LOGIN_SITE_KEY"))
     end
 
+    context "when disable_login_recaptcha feature flag is active" do
+      before { Feature.activate(:disable_login_recaptcha) }
+      after { Feature.deactivate(:disable_login_recaptcha) }
+
+      it "does not pass reCAPTCHA site key" do
+        get :new
+
+        expect(inertia.props[:recaptcha_site_key]).to be_nil
+      end
+    end
+
     context "with an email in the query parameters" do
       it "renders successfully" do
         get :new, params: { email: "test@example.com" }
@@ -164,6 +175,20 @@ describe LoginsController, type: :controller, inertia: true do
 
       expect(response).to redirect_to(dashboard_path)
       expect(controller.user_signed_in?).to be(true)
+    end
+
+    context "when disable_login_recaptcha feature flag is active" do
+      before { Feature.activate(:disable_login_recaptcha) }
+      after { Feature.deactivate(:disable_login_recaptcha) }
+
+      it "skips reCAPTCHA validation and logs in the user" do
+        allow(controller).to receive(:valid_recaptcha_response?).and_return(false)
+
+        post :create, params: { user: { login_identifier: @user.email, password: "password" } }
+
+        expect(response).to redirect_to(dashboard_path)
+        expect(controller.user_signed_in?).to be(true)
+      end
     end
 
     it "logs in a user when reCAPTCHA site key is not set in development environment" do


### PR DESCRIPTION
Adds a `:disable_login_recaptcha` Flipper feature flag. When enabled:

- **Backend**: Skips reCAPTCHA validation in `LoginsController#create`
- **Frontend**: Receives `null` for `recaptcha_site_key`, so no reCAPTCHA widget is rendered or executed

**Rollout**: Enable `:disable_login_recaptcha` in Flipper (supports percentage rollout)
**Rollback**: Disable the flag, reCAPTCHA returns immediately

**Tests added:**
- Login page does not pass reCAPTCHA site key when flag is active
- Login succeeds even when reCAPTCHA would have failed, when flag is active