### PR TITLE
Fix ActiveRecord::RecordInvalid in team invitation restore

### DIFF
--- a/app/controllers/settings/team/invitations_controller.rb
+++ b/app/controllers/settings/team/invitations_controller.rb
@@ -37,8 +37,12 @@ class Settings::Team::InvitationsController < Sellers::BaseController
   def restore
     authorize [:settings, :team, @team_invitation]
 
-    @team_invitation.update_as_not_deleted!
-    render json: { success: true }
+    @team_invitation.deleted_at = nil
+    if @team_invitation.save
+      render json: { success: true }
+    else
+      render json: { success: false, error_message: @team_invitation.errors.full_messages.to_sentence }
+    end
   end
 
   def accept

--- a/spec/controllers/settings/team/invitations_controller_spec.rb
+++ b/spec/controllers/settings/team/invitations_controller_spec.rb
@@ -133,6 +133,22 @@ describe Settings::Team::InvitationsController do
       expect(team_invitation.reload.deleted?).to eq(false)
     end
 
+    context "when the email is associated with an existing team member" do
+      before do
+        member = create(:user, email: team_invitation.email)
+        member.create_owner_membership_if_needed!
+        create(:team_membership, seller: seller, user: member)
+      end
+
+      it "returns an error" do
+        put :restore, params: { id: team_invitation.external_id }, as: :json
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to eq(false)
+        expect(response.parsed_body["error_message"]).to include("existing team member")
+        expect(team_invitation.reload.deleted?).to eq(true)
+      end
+    end
+
     context "with record belonging to other seller" do
       let(:team_invitation) { create(:team_invitation) }
 


### PR DESCRIPTION
## Problem

The `restore` action on `Settings::Team::InvitationsController` calls `update_as_not_deleted!` which uses `update!` internally. When the invited email now belongs to an existing team member (added while the invitation was deleted), the `email_cannot_belong_to_existing_member` validation fires and raises `ActiveRecord::RecordInvalid`, resulting in a 500 error.

[Sentry issue](https://gumroad-to.sentry.io/issues/7427691565/)

## Fix

Replace the bang method with `save` and return a JSON error response (matching the pattern used in `create`), so the user sees a clear validation message instead of an unhandled exception.

## Test

Added a spec for restoring an invitation when the email is already associated with a team member.