### PR TITLE
Remove email signoffs from mailer templates

### DIFF
--- a/app/services/onetime/deactivate_affiliates_for_stripe_connect_brazil.rb
+++ b/app/services/onetime/deactivate_affiliates_for_stripe_connect_brazil.rb
@@ -43,9 +43,6 @@ module Onetime::DeactivateAffiliatesForStripeConnectBrazil
             Unfortunately, recent changes made by Stripe have required us to suspend our affiliate and collaborator programs for Brazilian creators. Going forward, your affiliates and collaborators will be disabled and will no longer receive payments for purchases made through them, including for pre-existing membership subscriptions. They will be separately notified of this change.
 
             We apologize for the inconvenience.
-
-            Best,
-            Sahil and the Gumroad Team.
           BODY
           OneOffMailer.email(user_id: seller.id, subject:, body:)
 
@@ -62,9 +59,6 @@ module Onetime::DeactivateAffiliatesForStripeConnectBrazil
               Unfortunately, recent changes made by Stripe have required us to suspend our #{affiliate_type} program for Brazilian creators. Going forward, you will no longer receive affiliate payments for purchases made through these creators, including for pre-existing membership subscriptions. Non-Brazil-based creators are not affected by this change, and you will continue to receive #{affiliate_type} payments as usual for those creators.
 
               We apologize for the inconvenience.
-
-              Best,
-              Sahil and the Gumroad Team.
             BODY
             OneOffMailer.email(user_id: affiliate.affiliate_user_id, subject:, body:)
             affiliate.mark_deleted!

--- a/app/services/onetime/notify_sellers_about_legacy_fee_migration.rb
+++ b/app/services/onetime/notify_sellers_about_legacy_fee_migration.rb
@@ -8,7 +8,6 @@ class Onetime::NotifySellersAboutLegacyFeeMigration < Onetime::Base
     <p>Starting today, those memberships will move to the same pricing as everything else on Gumroad.</p>
     <p>You can see the full details at <a href="https://gumroad.com/pricing">gumroad.com/pricing</a>.</p>
     <p>If you have any questions, just reply to this email.</p>
-    <p>The Gumroad Team</p>
   HTML
 
   attr_reader :seller_ids, :emailed_user_ids

--- a/app/views/contacting_creator_mailer/account_suspended.html.erb
+++ b/app/views/contacting_creator_mailer/account_suspended.html.erb
@@ -12,5 +12,4 @@
     <% end %>
   <% end %>
   <p>If you believe this suspension was made in error, please <a href="<%= support_index_url %>">contact our support team</a> or reply to this email.</p>
-  <p>The Gumroad team</p>
 </div>

--- a/app/views/contacting_creator_mailer/flagged_for_explicit_nsfw_tos_violation.html.erb
+++ b/app/views/contacting_creator_mailer/flagged_for_explicit_nsfw_tos_violation.html.erb
@@ -8,5 +8,4 @@
   </p>
   <p>Of course, we will pay you out your remaining balance. Your existing customers' purchases will not be affected by this.</p>
   <p>We're super sorry about the inconvenience!</p>
-  <p>Sahil and the Gumroad team</p>
 </div>

--- a/app/views/contacting_creator_mailer/paypal_suspension_notification.html.erb
+++ b/app/views/contacting_creator_mailer/paypal_suspension_notification.html.erb
@@ -16,9 +16,4 @@
   <p>We apologize for any inconvenience this may cause. Our team is working diligently to ensure smooth payouts for all our creators.</p>
   <p>If you have any questions or need assistance, please don't hesitate to contact our support team.</p>
   <p>Thank you for your understanding and continued support.</p>
-  <p>
-    Best regards,
-    <br>
-    The Gumroad Team
-  </p>
 </div>

--- a/app/views/contacting_creator_mailer/product_level_refund_policies_reverted.html.erb
+++ b/app/views/contacting_creator_mailer/product_level_refund_policies_reverted.html.erb
@@ -28,8 +28,4 @@
   <p>
     More questions? Just reply to this email.
   </p>
-  <p>
-    Best,<br>
-    The Gumroad Team
-  </p>
 </div>

--- a/app/views/contacting_creator_mailer/refund_policy_enabled_email.html.erb
+++ b/app/views/contacting_creator_mailer/refund_policy_enabled_email.html.erb
@@ -51,8 +51,4 @@
   <p>
     More questions? Just reply to this email.
   </p>
-  <p>
-    Best,<br>
-    The Gumroad Team
-  </p>
 </div>

--- a/app/views/contacting_creator_mailer/suspended_due_to_stripe_risk.html.erb
+++ b/app/views/contacting_creator_mailer/suspended_due_to_stripe_risk.html.erb
@@ -6,5 +6,4 @@
   <p>Of course, we will pay you out your remaining balance. Your existing customers' purchases will not be affected by this.</p>
   <p>And you can contact our support team to get your account reviewed again.</p>
   <p>We're super sorry about the inconvenience!</p>
-  <p>Sahil and the Gumroad team</p>
 </div>

--- a/app/views/contacting_creator_mailer/upcoming_refund_policy_change.html.erb
+++ b/app/views/contacting_creator_mailer/upcoming_refund_policy_change.html.erb
@@ -39,8 +39,4 @@
   <p>
     More questions? Just reply to this email.
   </p>
-  <p>
-    Best,<br>
-    The Gumroad Team
-  </p>
 </div>

--- a/app/views/creator_mailer/gumroad_day_fee_saved.html.erb
+++ b/app/views/creator_mailer/gumroad_day_fee_saved.html.erb
@@ -11,7 +11,5 @@
 
   <p>See you next year!</p>
 
-  <p>Best, <br />Sahil and the Gumroad team</p>
-
   <p>PS. View the #GumroadDay2024 hashtag on <%= link_to "Twitter", "https://twitter.com/hashtag/GumroadDay2024/" %> and <%= link_to "Instagram", "https://www.instagram.com/explore/tags/gumroadday2024/" %> for inspiration for next year.</p>
 </div>

--- a/app/views/creator_mailer/scheduled_payout_chargeback_hold.html.erb
+++ b/app/views/creator_mailer/scheduled_payout_chargeback_hold.html.erb
@@ -4,6 +4,4 @@
   <p>Your scheduled payout has been delayed due to a chargeback on your account.</p>
 
   <p>We are holding the funds until the chargeback is resolved. Please <a href="<%= support_index_url %>">contact our support team</a> to discuss next steps.</p>
-
-  <p>The Gumroad Team</p>
 </div>

--- a/app/views/creator_mailer/top_creator_announcement.html.erb
+++ b/app/views/creator_mailer/top_creator_announcement.html.erb
@@ -8,6 +8,4 @@
   <p>You just earned the Top Creator badge on Gumroad.</p>
 
   <p>It's now live on your profile and everywhere your products appear, so buyers always know they're getting something from one of Gumroad's best. No action needed. You've already done the hard part.</p>
-
-  <p>Keep creating,<br />The Gumroad Team</p>
 </div>

--- a/spec/mailers/contacting_creator_mailer_spec.rb
+++ b/spec/mailers/contacting_creator_mailer_spec.rb
@@ -1900,7 +1900,6 @@ describe ContactingCreatorMailer do
         expect(mail.body.encoded).to include("Of course, we will pay you out your remaining balance. Your existing customers' purchases will not be affected by this.")
         expect(mail.body.encoded).to include("And you can contact our support team to get your account reviewed again.")
         expect(mail.body.encoded).to include("We're super sorry about the inconvenience!")
-        expect(mail.body.encoded).to include("Sahil and the Gumroad team")
       end
     end
   end
@@ -1992,7 +1991,6 @@ describe ContactingCreatorMailer do
       expect(mail.body.encoded).to include("Your Gumroad account has been suspended for a policy violation.")
       expect(mail.body.encoded).to include("contact our support team")
       expect(mail.body.encoded).to include("reply to this email")
-      expect(mail.body.encoded).to include("The Gumroad team")
     end
 
     context "when the seller has a pending scheduled payout" do
@@ -2058,7 +2056,6 @@ describe ContactingCreatorMailer do
         expect(mail.body.encoded).to include("Your account will be permanently suspended in 10 days, on 7 April, if your storefront is not updated to be compliant by then.")
         expect(mail.body.encoded).to include("Of course, we will pay you out your remaining balance. Your existing customers' purchases will not be affected by this.")
         expect(mail.body.encoded).to include("We're super sorry about the inconvenience!")
-        expect(mail.body.encoded).to include("Sahil and the Gumroad team")
       end
     end
   end

--- a/spec/mailers/creator_mailer/top_creator_announcement_spec.rb
+++ b/spec/mailers/creator_mailer/top_creator_announcement_spec.rb
@@ -42,7 +42,6 @@ describe CreatorMailer do
       body = mail.body.encoded
       expect(body).to include("top_creator_badge")
       expect(body).to include("You just earned the Top Creator badge on Gumroad.")
-      expect(body).to include("The Gumroad Team")
     end
   end
 end

--- a/spec/mailers/creator_mailer_spec.rb
+++ b/spec/mailers/creator_mailer_spec.rb
@@ -21,8 +21,6 @@ describe CreatorMailer do
       expect(body).to have_text("Thanks for being a part of #GumroadDay2024!")
       expect(body).to have_text("As a reminder, April 4, 2024 was Gumroad's 13th birthday and we celebrated by lowering Gumroad fees to 0% flat, saving you a total of $40.62 in Gumroad fees.")
       expect(body).to have_text("See you next year!")
-      expect(body).to have_text("Best,")
-      expect(body).to have_text("Sahil and the Gumroad team")
       expect(body).to have_text("PS. View the #GumroadDay2024 hashtag on Twitter and Instagram for inspiration for next year.")
     end
   end


### PR DESCRIPTION
## What

Removes closing signatures (e.g. "The Gumroad Team", "Best, Sahil and the Gumroad team", "Best regards, The Gumroad Team") from all transactional/notification mailers:

- `account_suspended`
- `flagged_for_explicit_nsfw_tos_violation`
- `paypal_suspension_notification`
- `product_level_refund_policies_reverted`
- `refund_policy_enabled_email`
- `suspended_due_to_stripe_risk`
- `upcoming_refund_policy_change`
- `gumroad_day_fee_saved`
- `scheduled_payout_chargeback_hold`
- `top_creator_announcement`

Also drops signoffs from the two onetime notification services (`notify_sellers_about_legacy_fee_migration`, `deactivate_affiliates_for_stripe_connect_brazil`) and updates the mailer specs to stop asserting the removed copy.

## Why

Keeps emails more efficient — the sender is already clear from the `From:` line and the content; the signature adds length without information. Body-copy mentions of the Gumroad team (e.g. Sahil's self-intro in `paypal_purchase_failed`) are intentionally preserved since they're part of the message, not a closer.

## Test Results

`bundle exec rubocop -a` on changed Ruby files: clean (5 files, no offenses).

---

AI disclosure: generated with Claude Opus 4.7 (1M context). Prompt: "remove this and Best, The Gumroad team etc from all of our emails. keeps them more efficient".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
