### PR TITLE
[codex] Fix presign file_size handling for multipart uploads

### DIFF
--- a/app/controllers/api/v2/files_controller.rb
+++ b/app/controllers/api/v2/files_controller.rb
@@ -12,7 +12,7 @@ class Api::V2::FilesController < Api::V2::BaseController
     filename = ActiveStorage::Filename.new(params[:filename].to_s).sanitized
     return error_400("filename is required") if filename.blank?
 
-    file_size = params[:file_size].to_i
+    file_size = params[:file_size].to_s.to_i
     return error_400("file_size is required") if file_size <= 0
     return error_400("file_size exceeds the #{MAX_FILE_SIZE_GB} GB maximum") if file_size > MAX_FILE_SIZE
 

--- a/spec/controllers/api/v2/files_controller_spec.rb
+++ b/spec/controllers/api/v2/files_controller_spec.rb
@@ -85,10 +85,10 @@ describe Api::V2::FilesController do
         expect(response.parsed_body["error"]).to be_present
       end
 
-      it "returns 400 when file_size is not a valid number" do
-        post action, params: params.merge(file_size: "not_a_number")
+      it "returns 400 when file_size is sent as a file upload" do
+        post action, params: params.merge(file_size: fixture_file_upload("blah.txt", "text/plain"))
         expect(response.status).to eq(400)
-        expect(response.parsed_body["error"]).to be_present
+        expect(response.parsed_body["error"]).to eq("file_size is required")
       end
 
       it "returns 400 when S3 raises a service error" do

--- a/spec/controllers/api/v2/files_controller_spec.rb
+++ b/spec/controllers/api/v2/files_controller_spec.rb
@@ -85,6 +85,12 @@ describe Api::V2::FilesController do
         expect(response.parsed_body["error"]).to be_present
       end
 
+      it "returns 400 when file_size is not a valid number" do
+        post action, params: params.merge(file_size: "not_a_number")
+        expect(response.status).to eq(400)
+        expect(response.parsed_body["error"]).to be_present
+      end
+
       it "returns 400 when S3 raises a service error" do
         allow_any_instance_of(Aws::S3::Client).to receive(:create_multipart_upload)
           .and_raise(Aws::S3::Errors::ServiceError.new(nil, "S3 unavailable"))


### PR DESCRIPTION
Supersedes closed PR #4580 so CI can run on a fresh branch.

## Summary

- keep the `Api::V2::FilesController#presign` fix that coerces `file_size` through `to_s.to_i`
- replace the invalid regression spec with one that sends `file_size` as an uploaded file
- assert the existing `400` validation path instead of allowing a `NoMethodError` crash

## Root cause

Some multipart API clients can send `file_size` as an `ActionDispatch::Http::UploadedFile` instead of a scalar param. The old code called `to_i` directly on that object and raised `NoMethodError`.

The original PR's spec used a plain string value, which never covered the failure because Ruby already returns `0` for `"not_a_number".to_i`. This PR updates the spec to exercise the actual crash path.

## Impact

API clients now receive the existing `400` error response when `file_size` is sent as a non-scalar multipart value, and CI covers the real regression path.

## Validation

- `ruby -c app/controllers/api/v2/files_controller.rb`
- `ruby -c spec/controllers/api/v2/files_controller_spec.rb`
- `bundle exec rspec spec/controllers/api/v2/files_controller_spec.rb` *(blocked in this environment because MySQL at `127.0.0.1:3306` and MongoDB at `localhost:27017` were unavailable)*

## AI disclosure

Used Codex to inspect the closed PR, correct the regression spec, and prepare this replacement PR.