### PR TITLE
Fix race condition in Taxonomy find_or_create_by causing RecordNotUnique

### DIFF
--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -7,4 +7,18 @@ class Taxonomy < ApplicationRecord
   has_one :taxonomy_stat, dependent: :destroy
 
   validates :slug, presence: true, uniqueness: { scope: :parent_id }
+
+  def self.find_or_create_by!(attributes, &block)
+    super
+  rescue ActiveRecord::RecordNotUnique
+    ActiveRecord::Base.connection.stick_to_primary!
+    find_by!(attributes)
+  end
+
+  def self.find_or_create_by(attributes, &block)
+    super
+  rescue ActiveRecord::RecordNotUnique
+    ActiveRecord::Base.connection.stick_to_primary!
+    find_by(attributes)
+  end
 end

--- a/spec/models/taxonomy_spec.rb
+++ b/spec/models/taxonomy_spec.rb
@@ -59,4 +59,80 @@ describe Taxonomy do
       end
     end
   end
+
+  describe ".find_or_create_by!" do
+    let!(:parent) { Taxonomy.create!(slug: "parent-slug") }
+
+    it "creates the taxonomy when none exists" do
+      result = Taxonomy.find_or_create_by!(slug: "brand-new-slug", parent:)
+      expect(result).to be_persisted
+      expect(result.slug).to eq("brand-new-slug")
+      expect(result.parent).to eq(parent)
+    end
+
+    it "returns the existing taxonomy without creating a duplicate" do
+      existing = Taxonomy.create!(slug: "already-there", parent:)
+      expect do
+        result = Taxonomy.find_or_create_by!(slug: "already-there", parent:)
+        expect(result).to eq(existing)
+      end.not_to change { Taxonomy.count }
+    end
+
+    it "handles concurrent creation for the same slug and parent" do
+      ready = Queue.new
+      start = Queue.new
+      taxonomies = []
+      errors = []
+      mutex = Mutex.new
+
+      threads = 2.times.map do
+        Thread.new do
+          Taxonomy.connection_pool.with_connection do
+            ready << true
+            start.pop
+            taxonomy = Taxonomy.find_or_create_by!(slug: "race-slug", parent:)
+
+            mutex.synchronize do
+              taxonomies << taxonomy
+            end
+          end
+        rescue StandardError => e
+          mutex.synchronize do
+            errors << e
+          end
+        end
+      end
+
+      2.times { ready.pop }
+      2.times { start << true }
+      threads.each(&:join)
+
+      expect(errors).to be_empty
+      expect(taxonomies.map(&:id).uniq.size).to eq(1)
+
+      taxonomy = Taxonomy.find_by!(slug: "race-slug", parent:)
+
+      expect(Taxonomy.where(slug: "race-slug", parent:).count).to eq(1)
+      expect(taxonomy.parent).to eq(parent)
+      expect(taxonomy.self_and_ancestors.map(&:id)).to match_array([parent.id, taxonomy.id])
+    end
+  end
+
+  describe ".find_or_create_by" do
+    let!(:parent) { Taxonomy.create!(slug: "parent-slug") }
+
+    it "recovers from a RecordNotUnique race by returning the existing record" do
+      existing = Taxonomy.create!(slug: "race-slug-nonbang", parent:)
+
+      allow(Taxonomy).to receive(:create_or_find_by).and_raise(ActiveRecord::RecordNotUnique)
+      allow(ActiveRecord::Base.connection).to receive(:stick_to_primary!)
+
+      result = nil
+      expect do
+        result = Taxonomy.find_or_create_by(slug: "race-slug-nonbang", parent:)
+      end.not_to raise_error
+
+      expect(result).to eq(existing)
+    end
+  end
 end

--- a/spec/models/taxonomy_spec.rb
+++ b/spec/models/taxonomy_spec.rb
@@ -61,7 +61,7 @@ describe Taxonomy do
   end
 
   describe ".find_or_create_by!" do
-    let!(:parent) { Taxonomy.create!(slug: "parent-slug") }
+    let!(:parent) { create(:taxonomy, slug: "parent-slug") }
 
     it "creates the taxonomy when none exists" do
       result = Taxonomy.find_or_create_by!(slug: "brand-new-slug", parent:)
@@ -71,7 +71,7 @@ describe Taxonomy do
     end
 
     it "returns the existing taxonomy without creating a duplicate" do
-      existing = Taxonomy.create!(slug: "already-there", parent:)
+      existing = create(:taxonomy, slug: "already-there", parent:)
       expect do
         result = Taxonomy.find_or_create_by!(slug: "already-there", parent:)
         expect(result).to eq(existing)
@@ -119,20 +119,46 @@ describe Taxonomy do
   end
 
   describe ".find_or_create_by" do
-    let!(:parent) { Taxonomy.create!(slug: "parent-slug") }
+    let!(:parent) { create(:taxonomy, slug: "parent-slug") }
 
-    it "recovers from a RecordNotUnique race by returning the existing record" do
-      existing = Taxonomy.create!(slug: "race-slug-nonbang", parent:)
+    it "handles concurrent creation for the same slug and parent" do
+      ready = Queue.new
+      start = Queue.new
+      taxonomies = []
+      errors = []
+      mutex = Mutex.new
 
-      allow(Taxonomy).to receive(:create_or_find_by).and_raise(ActiveRecord::RecordNotUnique)
-      allow(ActiveRecord::Base.connection).to receive(:stick_to_primary!)
+      threads = 2.times.map do
+        Thread.new do
+          Taxonomy.connection_pool.with_connection do
+            ready << true
+            start.pop
+            taxonomy = Taxonomy.find_or_create_by(slug: "race-slug-nonbang", parent:)
 
-      result = nil
-      expect do
-        result = Taxonomy.find_or_create_by(slug: "race-slug-nonbang", parent:)
-      end.not_to raise_error
+            mutex.synchronize do
+              taxonomies << taxonomy
+            end
+          end
+        rescue StandardError => e
+          mutex.synchronize do
+            errors << e
+          end
+        end
+      end
 
-      expect(result).to eq(existing)
+      2.times { ready.pop }
+      2.times { start << true }
+      threads.each(&:join)
+
+      expect(errors).to be_empty
+      expect(taxonomies).to all(be_a(Taxonomy))
+      expect(taxonomies.map(&:id).uniq.size).to eq(1)
+
+      taxonomy = Taxonomy.find_by!(slug: "race-slug-nonbang", parent:)
+
+      expect(Taxonomy.where(slug: "race-slug-nonbang", parent:).count).to eq(1)
+      expect(taxonomy.parent).to eq(parent)
+      expect(taxonomies).to all(eq(taxonomy))
     end
   end
 end


### PR DESCRIPTION
## Summary
- make `Taxonomy.find_or_create_by` and `Taxonomy.find_or_create_by!` retry safely after `ActiveRecord::RecordNotUnique`
- add a concurrent spec covering two threads creating the same taxonomy under the same parent
- keep the fix in the model so callers like seeds and `Onetime::AddNewVrTaxonomies` inherit the protection automatically

## Context
- Sentry issue: https://gumroad-to.sentry.io/issues/7428194352/
- observed once so far (first seen 2026-04-20), but this is a race condition that can affect any concurrent taxonomy creation
- avoids including any PII, user data, or database identifiers

## Testing
- bundle exec rspec spec/models/taxonomy_spec.rb