### PR TITLE
Add AI ignore files to exclude 79% of repo noise

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,24 @@
+# VCR cassettes - recorded HTTP fixtures, 202 MB / ~50M tokens
+spec/support/fixtures/vcr_cassettes/
+
+# Binary assets - images, fonts, videos
+app/assets/images/
+app/assets/fonts/
+app/assets/videos/
+
+# Generated/vendored
+public/assets/
+public/analytics/
+vendor/
+
+# Lock files
+package-lock.json
+
+# Data files
+config/zip_code_database.csv
+
+# Database migrations (historical, already applied)
+db/migrate/
+
+# Schema is auto-generated
+db/schema.rb

--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,24 @@
+# VCR cassettes - recorded HTTP fixtures, 202 MB / ~50M tokens
+spec/support/fixtures/vcr_cassettes/
+
+# Binary assets - images, fonts, videos
+app/assets/images/
+app/assets/fonts/
+app/assets/videos/
+
+# Generated/vendored
+public/assets/
+public/analytics/
+vendor/
+
+# Lock files
+package-lock.json
+
+# Data files
+config/zip_code_database.csv
+
+# Database migrations (historical, already applied)
+db/migrate/
+
+# Schema is auto-generated
+db/schema.rb

--- a/.gitattributes
+++ b/.gitattributes
@@ -6,5 +6,8 @@ db/schema.rb linguist-generated
 # Mark any vendored files as having been vendored.
 vendor/* linguist-vendored
 
+# Mark VCR cassettes as generated so AI tools and GitHub stats skip them.
+spec/support/fixtures/vcr_cassettes/** linguist-generated
+
 config/credentials/*.yml.enc diff=rails_credentials
 config/credentials.yml.enc diff=rails_credentials


### PR DESCRIPTION
Adds `.claudeignore`, `.cursorignore`, and `linguist-generated` markers in `.gitattributes` to hide non-code files from AI tool context windows.

**Before:** AI tools index 342 MB (~85M tokens)
**After:** AI tools index 72 MB (~18M tokens)
**Reduction:** 271 MB / 79% hidden

What's excluded:
- VCR cassettes: 202 MB (~50M tokens)
- Binary assets (images, fonts, videos): 64 MB
- Generated/vendored files, lock files
- Data files (`zip_code_database.csv`)
- Historical DB migrations (already applied)
- `db/schema.rb` (auto-generated)

Zero functional change. Only affects how AI tools index the repo.