### PR TITLE
Fix Elasticsearch parse error for timezones with DST gap at midnight

### DIFF
--- a/app/services/creator_analytics/churn/date_window.rb
+++ b/app/services/creator_analytics/churn/date_window.rb
@@ -22,10 +22,6 @@ class CreatorAnalytics::Churn::DateWindow
     seller.timezone_id
   end
 
-  def timezone_formatted_offset
-    seller.timezone_formatted_offset
-  end
-
   def daily_dates
     @daily_dates ||= (start_date..end_date).to_a
   end

--- a/app/services/creator_analytics/churn/date_window.rb
+++ b/app/services/creator_analytics/churn/date_window.rb
@@ -22,6 +22,10 @@ class CreatorAnalytics::Churn::DateWindow
     seller.timezone_id
   end
 
+  def timezone_formatted_offset
+    seller.timezone_formatted_offset
+  end
+
   def daily_dates
     @daily_dates ||= (start_date..end_date).to_a
   end

--- a/app/services/creator_analytics/churn/elasticsearch_fetcher.rb
+++ b/app/services/creator_analytics/churn/elasticsearch_fetcher.rb
@@ -22,7 +22,7 @@ class CreatorAnalytics::Churn::ElasticsearchFetcher
     query[:bool][:filter] << {
       range: {
         subscription_cancelled_at: {
-          time_zone: date_window.timezone_id,
+          time_zone: date_window.timezone_formatted_offset,
           gte: date_window.start_date.to_s,
           lte: date_window.end_date.to_s
         }
@@ -54,7 +54,7 @@ class CreatorAnalytics::Churn::ElasticsearchFetcher
     query[:bool][:filter] << {
       range: {
         created_at: {
-          time_zone: date_window.timezone_id,
+          time_zone: date_window.timezone_formatted_offset,
           gte: date_window.start_date.to_s,
           lte: date_window.end_date.to_s
         }
@@ -80,10 +80,10 @@ class CreatorAnalytics::Churn::ElasticsearchFetcher
 
     query = base_query
     start_boundary = date_window.start_date.to_s
-    query[:bool][:filter] << { range: { created_at: { lt: start_boundary, time_zone: date_window.timezone_id } } }
+    query[:bool][:filter] << { range: { created_at: { lt: start_boundary, time_zone: date_window.timezone_formatted_offset } } }
     query[:bool][:should] ||= []
     query[:bool][:should] << { bool: { must_not: { exists: { field: "subscription_deactivated_at" } } } }
-    query[:bool][:should] << { range: { subscription_deactivated_at: { time_zone: date_window.timezone_id, gt: start_boundary } } }
+    query[:bool][:should] << { range: { subscription_deactivated_at: { time_zone: date_window.timezone_formatted_offset, gt: start_boundary } } }
     query[:bool][:minimum_should_match] = 1
 
     sources = [

--- a/app/services/creator_analytics/churn/elasticsearch_fetcher.rb
+++ b/app/services/creator_analytics/churn/elasticsearch_fetcher.rb
@@ -19,15 +19,12 @@ class CreatorAnalytics::Churn::ElasticsearchFetcher
 
     query = base_query
     query[:bool][:must] << { exists: { field: "subscription_cancelled_at" } }
-    query[:bool][:filter] << {
-      range: {
-        subscription_cancelled_at: {
-          time_zone: date_window.timezone_formatted_offset,
-          gte: date_window.start_date.to_s,
-          lte: date_window.end_date.to_s
-        }
-      }
-    }
+    query[:bool][:filter] << CreatorAnalytics::DateQuery.day_range(
+      field: :subscription_cancelled_at,
+      start_date: date_window.start_date,
+      end_date: date_window.end_date,
+      timezone: seller.timezone
+    )
 
     sources = composite_sources(field: "subscription_cancelled_at")
     aggs = {
@@ -51,15 +48,12 @@ class CreatorAnalytics::Churn::ElasticsearchFetcher
     return {} if product_ids.empty?
 
     query = base_query
-    query[:bool][:filter] << {
-      range: {
-        created_at: {
-          time_zone: date_window.timezone_formatted_offset,
-          gte: date_window.start_date.to_s,
-          lte: date_window.end_date.to_s
-        }
-      }
-    }
+    query[:bool][:filter] << CreatorAnalytics::DateQuery.day_range(
+      field: :created_at,
+      start_date: date_window.start_date,
+      end_date: date_window.end_date,
+      timezone: seller.timezone
+    )
 
     sources = composite_sources(field: "created_at")
     aggs = {
@@ -79,11 +73,11 @@ class CreatorAnalytics::Churn::ElasticsearchFetcher
     return {} if product_ids.empty?
 
     query = base_query
-    start_boundary = date_window.start_date.to_s
-    query[:bool][:filter] << { range: { created_at: { lt: start_boundary, time_zone: date_window.timezone_formatted_offset } } }
+    start_boundary = CreatorAnalytics::DateQuery.day_start(date_window.start_date, timezone: seller.timezone).iso8601
+    query[:bool][:filter] << { range: { created_at: { lt: start_boundary } } }
     query[:bool][:should] ||= []
     query[:bool][:should] << { bool: { must_not: { exists: { field: "subscription_deactivated_at" } } } }
-    query[:bool][:should] << { range: { subscription_deactivated_at: { time_zone: date_window.timezone_formatted_offset, gt: start_boundary } } }
+    query[:bool][:should] << { range: { subscription_deactivated_at: { gt: start_boundary } } }
     query[:bool][:minimum_should_match] = 1
 
     sources = [

--- a/app/services/creator_analytics/date_query.rb
+++ b/app/services/creator_analytics/date_query.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class CreatorAnalytics::DateQuery
+  class << self
+    def day_range(field:, start_date:, end_date:, timezone:)
+      {
+        range: {
+          field => {
+            gte: day_start(start_date, timezone:).iso8601,
+            lt: day_start(end_date + 1.day, timezone:).iso8601,
+          }
+        }
+      }
+    end
+
+    def before_day(field:, date:, timezone:)
+      {
+        range: {
+          field => {
+            lt: day_start(date, timezone:).iso8601,
+          }
+        }
+      }
+    end
+
+    def day_start(date, timezone:)
+      date.in_time_zone(timezone)
+    end
+  end
+end

--- a/app/services/creator_analytics/following.rb
+++ b/app/services/creator_analytics/following.rb
@@ -28,7 +28,7 @@ class CreatorAnalytics::Following
   # This method is used for displaying the running total of followers.
   # net_total = added - removed
   def net_total(before_date: nil)
-    must = [{ range: { timestamp: { time_zone: user.timezone_id, lt: before_date.to_s } } }] if before_date
+    must = [{ range: { timestamp: { time_zone: user.timezone_formatted_offset, lt: before_date.to_s } } }] if before_date
     aggs = ADDED_AND_REMOVED.index_with do |name|
       { filter: { term: { name: } }, aggs: { count: { value_count: { field: "name" } } } }
     end
@@ -68,7 +68,7 @@ class CreatorAnalytics::Following
         query: {
           bool: {
             filter: [{ term: { followed_user_id: user.id } }],
-            must: [{ range: { timestamp: { time_zone: user.timezone_id, gte: start_date.to_s, lte: end_date.to_s } } }]
+            must: [{ range: { timestamp: { time_zone: user.timezone_formatted_offset, gte: start_date.to_s, lte: end_date.to_s } } }]
           }
         },
         aggs: {

--- a/app/services/creator_analytics/following.rb
+++ b/app/services/creator_analytics/following.rb
@@ -28,7 +28,7 @@ class CreatorAnalytics::Following
   # This method is used for displaying the running total of followers.
   # net_total = added - removed
   def net_total(before_date: nil)
-    must = [{ range: { timestamp: { time_zone: user.timezone_formatted_offset, lt: before_date.to_s } } }] if before_date
+    must = [CreatorAnalytics::DateQuery.before_day(field: :timestamp, date: before_date, timezone: user.timezone)] if before_date
     aggs = ADDED_AND_REMOVED.index_with do |name|
       { filter: { term: { name: } }, aggs: { count: { value_count: { field: "name" } } } }
     end
@@ -68,7 +68,7 @@ class CreatorAnalytics::Following
         query: {
           bool: {
             filter: [{ term: { followed_user_id: user.id } }],
-            must: [{ range: { timestamp: { time_zone: user.timezone_formatted_offset, gte: start_date.to_s, lte: end_date.to_s } } }]
+            must: [CreatorAnalytics::DateQuery.day_range(field: :timestamp, start_date:, end_date:, timezone: user.timezone)]
           }
         },
         aggs: {

--- a/app/services/creator_analytics/product_page_views.rb
+++ b/app/services/creator_analytics/product_page_views.rb
@@ -8,7 +8,7 @@ class CreatorAnalytics::ProductPageViews
     @query = {
       bool: {
         filter: [{ terms: { product_id: @products.map(&:id) } }],
-        must: [{ range: { timestamp: { time_zone: @user.timezone_formatted_offset, gte: @dates.first.to_s, lte: @dates.last.to_s } } }]
+        must: [CreatorAnalytics::DateQuery.day_range(field: :timestamp, start_date: @dates.first, end_date: @dates.last, timezone: @user.timezone)]
       }
     }
   end

--- a/app/services/creator_analytics/product_page_views.rb
+++ b/app/services/creator_analytics/product_page_views.rb
@@ -8,7 +8,7 @@ class CreatorAnalytics::ProductPageViews
     @query = {
       bool: {
         filter: [{ terms: { product_id: @products.map(&:id) } }],
-        must: [{ range: { timestamp: { time_zone: @user.timezone_id, gte: @dates.first.to_s, lte: @dates.last.to_s } } }]
+        must: [{ range: { timestamp: { time_zone: @user.timezone_formatted_offset, gte: @dates.first.to_s, lte: @dates.last.to_s } } }]
       }
     }
   end

--- a/app/services/creator_analytics/sales.rb
+++ b/app/services/creator_analytics/sales.rb
@@ -12,7 +12,7 @@ class CreatorAnalytics::Sales
     @dates = dates
     @query = PurchaseSearchService.new(SEARCH_OPTIONS).body[:query]
     @query[:bool][:filter] << { terms: { product_id: @products.map(&:id) } }
-    @query[:bool][:must] << { range: { created_at: { time_zone: @user.timezone_formatted_offset, gte: @dates.first.to_s, lte: @dates.last.to_s } } }
+    @query[:bool][:must] << CreatorAnalytics::DateQuery.day_range(field: :created_at, start_date: @dates.first, end_date: @dates.last, timezone: @user.timezone)
   end
 
   def by_product_and_date

--- a/app/services/creator_analytics/sales.rb
+++ b/app/services/creator_analytics/sales.rb
@@ -12,7 +12,7 @@ class CreatorAnalytics::Sales
     @dates = dates
     @query = PurchaseSearchService.new(SEARCH_OPTIONS).body[:query]
     @query[:bool][:filter] << { terms: { product_id: @products.map(&:id) } }
-    @query[:bool][:must] << { range: { created_at: { time_zone: @user.timezone_id, gte: @dates.first.to_s, lte: @dates.last.to_s } } }
+    @query[:bool][:must] << { range: { created_at: { time_zone: @user.timezone_formatted_offset, gte: @dates.first.to_s, lte: @dates.last.to_s } } }
   end
 
   def by_product_and_date

--- a/spec/services/creator_analytics/date_query_spec.rb
+++ b/spec/services/creator_analytics/date_query_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe CreatorAnalytics::DateQuery do
+  describe ".day_range" do
+    it "builds explicit datetime bounds for dates with a midnight DST gap" do
+      result = described_class.day_range(
+        field: :timestamp,
+        start_date: Date.new(2026, 3, 22),
+        end_date: Date.new(2026, 3, 22),
+        timezone: "Tehran"
+      )
+
+      expect(result).to eq(
+        range: {
+          timestamp: {
+            gte: Date.new(2026, 3, 22).in_time_zone("Tehran").iso8601,
+            lt: Date.new(2026, 3, 23).in_time_zone("Tehran").iso8601,
+          }
+        }
+      )
+      expect(result.dig(:range, :timestamp)).not_to have_key(:time_zone)
+    end
+  end
+
+  describe ".before_day" do
+    it "builds an explicit start-of-day instant for exclusive upper bounds" do
+      result = described_class.before_day(field: :created_at, date: Date.new(2026, 3, 22), timezone: "Tehran")
+
+      expect(result).to eq(
+        range: {
+          created_at: {
+            lt: Date.new(2026, 3, 22).in_time_zone("Tehran").iso8601,
+          }
+        }
+      )
+    end
+  end
+end

--- a/spec/services/creator_analytics/product_page_views_spec.rb
+++ b/spec/services/creator_analytics/product_page_views_spec.rb
@@ -227,5 +227,30 @@ describe CreatorAnalytics::ProductPageViews do
         expect(result[[product.id, "2025-03-10"]]).to eq(1)
       end
     end
+
+    context "when the boundary date skips midnight" do
+      let(:user_timezone) { "Tehran" }
+
+      it "filters and buckets page views consistently on March 22, 2026" do
+        user = create(:user, timezone: user_timezone)
+        product = create(:product, user: user)
+
+        Time.use_zone(user_timezone) do
+          add_page_view(product, Time.zone.parse("2026-03-21 23:30:00").utc, referrer_domain: "google.com")
+          add_page_view(product, Time.zone.parse("2026-03-22 01:15:00").utc, referrer_domain: "google.com")
+          add_page_view(product, Time.zone.parse("2026-03-23 00:15:00").utc, referrer_domain: "t.co")
+        end
+        ProductPageView.__elasticsearch__.refresh_index!
+
+        service = described_class.new(
+          user: user,
+          products: [product],
+          dates: [Date.new(2026, 3, 22)]
+        )
+
+        expect(service.by_product_and_date).to eq({ [product.id, "2026-03-22"] => 1 })
+        expect(service.by_product_and_referrer_and_date).to eq({ [product.id, "google.com", "2026-03-22"] => 1 })
+      end
+    end
   end
 end

--- a/spec/services/creator_analytics/sales_spec.rb
+++ b/spec/services/creator_analytics/sales_spec.rb
@@ -167,6 +167,29 @@ describe CreatorAnalytics::Sales do
   end
 end
 
+describe CreatorAnalytics::Sales, "timezone with DST gap at midnight" do
+  context "when user timezone has a DST transition at midnight (e.g. Tehran)" do
+    it "does not raise an Elasticsearch parse error" do
+      # Iran DST: on 2026-03-22 at 00:00, clocks jump to 01:00.
+      # Passing 'Asia/Tehran' as time_zone to ES with a date-only string causes a
+      # parse_exception because midnight on that date is an illegal instant.
+      # Using a fixed UTC offset for range queries avoids the problem.
+      user = create(:user, timezone: "Tehran")
+      product = create(:product, user: user)
+      create(:free_purchase, link: product, created_at: Time.utc(2026, 3, 21, 12, 0))
+      index_model_records(Purchase)
+
+      service = described_class.new(
+        user: user,
+        products: [product],
+        dates: (Date.new(2026, 3, 20)..Date.new(2026, 3, 23)).to_a
+      )
+
+      expect { service.by_product_and_date }.not_to raise_error
+    end
+  end
+end
+
 describe CreatorAnalytics::Sales, "DST handling" do
   context "when sale occurs near midnight during DST" do
     it "correctly attributes sale to the right day" do

--- a/spec/services/creator_analytics/sales_spec.rb
+++ b/spec/services/creator_analytics/sales_spec.rb
@@ -169,23 +169,25 @@ end
 
 describe CreatorAnalytics::Sales, "timezone with DST gap at midnight" do
   context "when user timezone has a DST transition at midnight (e.g. Tehran)" do
-    it "does not raise an Elasticsearch parse error" do
-      # Iran DST: on 2026-03-22 at 00:00, clocks jump to 01:00.
-      # Passing 'Asia/Tehran' as time_zone to ES with a date-only string causes a
-      # parse_exception because midnight on that date is an illegal instant.
-      # Using a fixed UTC offset for range queries avoids the problem.
+    it "filters and buckets sales consistently on March 22, 2026" do
       user = create(:user, timezone: "Tehran")
       product = create(:product, user: user)
-      create(:free_purchase, link: product, created_at: Time.utc(2026, 3, 21, 12, 0))
+
+      Time.use_zone(user.timezone) do
+        create(:free_purchase, link: product, created_at: Time.zone.parse("2026-03-21 23:30:00").utc, referrer: "https://google.com")
+        create(:free_purchase, link: product, created_at: Time.zone.parse("2026-03-22 01:15:00").utc, referrer: "https://google.com")
+        create(:free_purchase, link: product, created_at: Time.zone.parse("2026-03-23 00:15:00").utc, referrer: "https://t.co")
+      end
       index_model_records(Purchase)
 
       service = described_class.new(
         user: user,
         products: [product],
-        dates: (Date.new(2026, 3, 20)..Date.new(2026, 3, 23)).to_a
+        dates: [Date.new(2026, 3, 22)]
       )
 
-      expect { service.by_product_and_date }.not_to raise_error
+      expect(service.by_product_and_date).to eq({ [product.id, "2026-03-22"] => { count: 1, total: 0 } })
+      expect(service.by_product_and_referrer_and_date).to eq({ [product.id, "google.com", "2026-03-22"] => { count: 1, total: 0 } })
     end
   end
 end

--- a/spec/services/creator_analytics/web_spec.rb
+++ b/spec/services/creator_analytics/web_spec.rb
@@ -132,5 +132,29 @@ describe CreatorAnalytics::Web do
 
       expect(@service.by_referral).to eq(expected_result)
     end
+
+    it "keeps filters aligned with histogram buckets when midnight is skipped" do
+      user = create(:user, timezone: "Tehran")
+      product = create(:product, user: user)
+      service = described_class.new(user: user, dates: [Date.new(2026, 3, 22)])
+
+      Time.use_zone(user.timezone) do
+        add_page_view(product, Time.zone.parse("2026-03-22 01:15:00").utc, referrer_domain: "google.com")
+        add_page_view(product, Time.zone.parse("2026-03-23 00:15:00").utc, referrer_domain: "t.co")
+        create(:free_purchase, link: product, created_at: Time.zone.parse("2026-03-22 01:15:00").utc, referrer: "https://google.com")
+        create(:free_purchase, link: product, created_at: Time.zone.parse("2026-03-23 00:15:00").utc, referrer: "https://t.co")
+      end
+      ProductPageView.__elasticsearch__.refresh_index!
+      index_model_records(Purchase)
+
+      expect { service.by_referral }.not_to raise_error
+      expect(service.by_referral).to include(
+        by_referral: {
+          views: { product.unique_permalink => { "Google" => [1] } },
+          sales: { product.unique_permalink => { "Google" => [1] } },
+          totals: { product.unique_permalink => { "Google" => [0] } }
+        }
+      )
+    end
   end
 end


### PR DESCRIPTION
## Problem

Sentry issue: https://gumroad-to.sentry.io/issues/7428332845/

`DashboardController#index` crashes with `Elasticsearch::Transport::Transport::Errors::BadRequest` for users whose timezone has a DST transition at midnight.

The root cause: when Elasticsearch receives a date-only string (e.g. `2026-03-22`) with `time_zone: 'Asia/Tehran'`, it tries to resolve `2026-03-22T00:00:00` in that timezone. But on that date, Iran observes DST — clocks skip from 00:00 to 01:00, so midnight doesn't exist. ES throws:

> `Cannot parse "2026-03-22": Illegal instant due to time zone offset transition (Asia/Tehran)`

## Fix

Use `timezone_formatted_offset` (a fixed UTC offset like `+03:30`) for ES **range query filters** instead of `timezone_id` (like `Asia/Tehran`). Fixed offsets always resolve cleanly since they don't have DST transitions.

**Date histogram aggregations** still use `timezone_id` so records are bucketed into the correct local day with DST awareness.

This matches the existing pattern documented on `User#timezone_formatted_offset`, which was specifically designed for resolving TZ database inconsistencies between Rails, Elasticsearch, and MySQL.

## Trade-off

Range boundaries may be off by up to ~1 hour around DST transitions (same trade-off already documented in `CachingProxy` and `User#timezone_formatted_offset`). This is acceptable since day bucketing remains DST-aware.

## Files changed

- `app/services/creator_analytics/sales.rb` — range filter
- `app/services/creator_analytics/product_page_views.rb` — range filter
- `app/services/creator_analytics/following.rb` — range filters
- `app/services/creator_analytics/churn/elasticsearch_fetcher.rb` — range filters
- `app/services/creator_analytics/churn/date_window.rb` — expose `timezone_formatted_offset`
- `spec/services/creator_analytics/sales_spec.rb` — regression test for Tehran DST gap