### PR TITLE
Fix NoMethodError when ids param is a String in search_options

### DIFF
--- a/app/controllers/concerns/search_products.rb
+++ b/app/controllers/concerns/search_products.rb
@@ -28,6 +28,10 @@ module SearchProducts
         params[:filetypes] = params[:filetypes].split(",").map { |f| f.squish.downcase }
       end
 
+      if params[:ids].is_a?(String)
+        params[:ids] = params[:ids].split(",").map(&:strip)
+      end
+
       params[:offer_code] = "__no_match__" if params[:offer_code].present? && !offer_codes_search_feature_active?(params)
 
       if params[:size].is_a?(String)

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -184,6 +184,7 @@ class LinksController < ApplicationController
   end
 
   def search
+    format_search_params!
     search_params = params
     in_section = search_params[:user_id].present?
     if in_section

--- a/app/modules/product/searchable.rb
+++ b/app/modules/product/searchable.rb
@@ -366,7 +366,7 @@ module Product::Searchable
       search_options[:query][:bool][:must] << params[:search] if params[:search]
 
       if (params[:ids].present? || params[:section].is_a?(SellerProfileSection)) && params[:sort] == ProductSortKey::PAGE_LAYOUT
-        product_ids = params[:ids] || params[:section].shown_products
+        product_ids = Array(params[:ids] || params[:section].shown_products)
         search_options[:query][:bool][:should] ||= []
         product_ids.each_with_index do |id, i|
           search_options[:query][:bool][:should] << { term: { _id: { value: id, boost: product_ids.size - i } } }

--- a/spec/controllers/concerns/search_products_spec.rb
+++ b/spec/controllers/concerns/search_products_spec.rb
@@ -105,6 +105,11 @@ describe SearchProducts do
         expect(JSON.parse(response.body)["filetypes"]).to eq(["pdf", "video"])
       end
 
+      it "parses ids from string" do
+        get :index, params: { ids: "abc,def, ghi" }
+        expect(JSON.parse(response.body)["ids"]).to eq(["abc", "def", "ghi"])
+      end
+
       it "converts size to integer" do
         get :index, params: { size: "20" }
         expect(JSON.parse(response.body)["size"]).to eq(20)

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -4281,6 +4281,28 @@ describe LinksController, :vcr, inertia: true do
         ProductPresenter.card_for_web(product:, request: @request, recommended_by: @recommended_by, show_seller: !@on_profile, target:, query:).as_json
       end
 
+      it "accepts a string ids param when searching by user" do
+        Link.__elasticsearch__.create_index!(force: true)
+        creator = create(:compliant_user, username: "creatordudey", name: "Creator Dudey")
+        section = create(:seller_profile_products_section, seller: creator)
+        product = create(:product, name: "Top quality weasel", user: creator)
+        other_product = create(:product, name: "First product", user: creator)
+        section.update!(shown_products: [other_product, product].map { _1.id })
+        Link.import(force: true, refresh: true)
+
+        @recommended_by = nil
+        @on_profile = true
+
+        get :search, params: {
+          user_id: creator.external_id,
+          section_id: section.external_id,
+          ids: product.external_id
+        }
+
+        expect(response).to be_successful
+        expect(response.parsed_body["products"]).to eq([product_json(product, "profile")])
+      end
+
       describe "Setting and ordering" do
         before do
           Link.__elasticsearch__.create_index!(force: true)

--- a/spec/modules/product/searchable/search_spec.rb
+++ b/spec/modules/product/searchable/search_spec.rb
@@ -420,6 +420,14 @@ describe "Product::Searchable - Search scenarios" do
       end
     end
 
+    describe "search_options with String ids param" do
+      it "does not raise NoMethodError when ids is a String" do
+        expect do
+          Link.search_options({ ids: "some-id", sort: "page_layout" })
+        end.not_to raise_error
+      end
+    end
+
     describe "on indexed products with reviews" do
       before do
         creator = create(:compliant_user, username: "username")


### PR DESCRIPTION
## Summary
- Production Sentry error: `NoMethodError: undefined method 'each_with_index' for an instance of String` in `UsersController#show`.
- When a request includes `?ids=some_string`, `params[:ids]` arrives as a `String`, and `Product::Searchable#search_options` called `each_with_index` on it.
- Wrap `product_ids` with `Array()` in `searchable.rb` so the enumeration is always safe, and normalize `String` ids to an `Array` in `SearchProducts#format_search_params!` alongside the existing `tags`/`filetypes` handling.

## Test plan
- [x] Added `spec/controllers/concerns/search_products_spec.rb` test for parsing `ids` from a comma-separated string.
- [x] Added `spec/modules/product/searchable/search_spec.rb` test ensuring `Link.search_options` does not raise when `ids` is a `String`.
- [x] `bundle exec rspec spec/controllers/concerns/search_products_spec.rb` passes (12 examples, 0 failures).
- [x] New searchable spec passes.

Sentry: https://gumroad-to.sentry.io/issues/7428447017/

🤖 Generated with [Claude Code](https://claude.com/claude-code)