### PR TITLE
Remove stale X/Twitter reference from help center profile article

### DIFF
--- a/app/views/help_center/articles/contents/_124-your-gumroad-profile-page.html.erb
+++ b/app/views/help_center/articles/contents/_124-your-gumroad-profile-page.html.erb
@@ -28,7 +28,6 @@
   <h3 id="setup">Set up your profile</h3>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/63ff2813b7da6b15a7ea212e/file-Yc0TiiOjTZ.png" %></figure>
   <p>Go to the <a href="https://gumroad.com/settings/profile" target="_blank">profile settings</a> to update the public-facing information for your customers to read, including a short bio (we’ve found that a sentence or two works best rather than overly-long descriptions of your entire career path).</p>
-  <p>You can also connect your X/Twitter account which will be linked with an icon on the profile page.</p>
   <h3 id="font-and-colors">Customize fonts and colors</h3>
   <p>Choose from different font styles, accents, and background colors from your <a href="https://gumroad.com/settings/profile" target="_self">profile settings</a>. The custom fonts and colors will apply to your profile, product, posts, and emails; but not to your product’s content.</p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/63ff28543c396c395ec0f4c3/file-O2U84Acgi2.png" %></figure>


### PR DESCRIPTION
## What

Removes a stale sentence from the help center article for "Your Gumroad Profile Page" that told users they could connect their X/Twitter account and have it linked with an icon on their profile page.

## Why

That functionality no longer exists:

- #4055 removed the "Connect to X" OAuth flow.
- #4592 removed the `twitter_handle` column and the X icon from public profiles.

The help article was left referencing the removed feature, so users reading it would be misled. This addresses the review comment at https://github.com/antiwork/gumroad/pull/4592#discussion_r3111640053.

---

AI disclosure: Drafted with Claude Opus 4.6. Prompt: remove the stale X/Twitter sentence from `app/views/help_center/articles/contents/_124-your-gumroad-profile-page.html.erb` and open a PR referencing the review comment on #4592.