### PR TITLE
Fix Referrer link on sales dashboard to point to correct help article section

### DIFF
--- a/app/javascript/components/Analytics/ReferrersTable.tsx
+++ b/app/javascript/components/Analytics/ReferrersTable.tsx
@@ -37,7 +37,7 @@ export const ReferrersTable = ({ data }: { data: AnalyticsReferrerTotals }) => {
     <section>
       <Table>
         <TableCaption>
-          <a href="/help/article/74-the-analytics-dashboard" target="_blank" rel="noreferrer">
+          <a href="/help/article/74-the-analytics-dashboard#Referrers-WBsBP" target="_blank" rel="noreferrer">
             Referrer
           </a>
         </TableCaption>


### PR DESCRIPTION
The 'Referrer' link in the analytics dashboard table caption (`ReferrersTable.tsx`) was pointing to the general analytics help article at `/help/article/74-the-analytics-dashboard`.

Updated it to link directly to the Referrers section: `/help/article/74-the-analytics-dashboard#Referrers-WBsBP`