### PR TITLE
Fix ArgumentError: comparison of Integer with nil in suggested_price_greater_than_price

### DIFF
--- a/app/modules/product/prices.rb
+++ b/app/modules/product/prices.rb
@@ -143,7 +143,7 @@ module Product::Prices
   end
 
   def suggested_price_greater_than_price
-    return if suggested_price_cents.blank? || !customizable_price || suggested_price_cents >= default_price_cents
+    return if suggested_price_cents.blank? || !customizable_price || default_price_cents.nil? || suggested_price_cents >= default_price_cents
 
     errors.add(:base, "The suggested price you entered was too low.")
   end

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -336,6 +336,17 @@ describe LinksController, :vcr, inertia: true do
         let(:response_status) { 204 }
       end
 
+      it "returns the existing validation error when suggested price is set but the default price record is missing" do
+        @product.prices.destroy_all
+        @product.update_column(:customizable_price, true)
+
+        put :update, params: @params.merge(suggested_price: "10", customizable_price: true), as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body["error_message"]).to eq("Default price cents can't be blank")
+        expect(@product.reload.suggested_price_cents).to be_nil
+      end
+
       context "when user email is empty" do
         before do
           seller.email = ""

--- a/spec/modules/product/prices_spec.rb
+++ b/spec/modules/product/prices_spec.rb
@@ -37,6 +37,20 @@ describe Product::Prices do
     end
   end
 
+  describe "#suggested_price_greater_than_price" do
+    it "skips validation when the default price is missing" do
+      product = create(:product)
+      product.prices.destroy_all
+      product.reload
+      product.customizable_price = true
+      product.suggested_price_cents = 100
+
+      expect(product.default_price_cents).to be_nil
+      expect { product.valid? }.not_to raise_error
+      expect(product.errors[:base]).not_to include("The suggested price you entered was too low.")
+    end
+  end
+
   describe "#price_cents=" do
     it "writes to the price_cents column if product is not persisted" do
       product = build(:product)


### PR DESCRIPTION
## Summary
Fixes a Sentry-reported `ArgumentError: comparison of Integer with nil failed` in `Api::V2::LinksController#update`, raised from the `suggested_price_greater_than_price` validation on `Link`.

Sentry: https://gumroad-to.sentry.io/issues/7429332600/ (2 events in 7 days, 2 users affected)

## Root cause
In `app/modules/product/prices.rb`:

```ruby
def suggested_price_greater_than_price
  return if suggested_price_cents.blank? || !customizable_price || suggested_price_cents >= default_price_cents
  ...
end
```

`default_price_cents` can return `nil` when a persisted product has no alive `Price` record (via `buy_price_cents`, which returns `nil` when `default_price` is absent). Comparing `Integer >= nil` raises `ArgumentError`.

## Fix
Add a `nil` guard for `default_price_cents` so the validation is skipped when there is no price to compare against:

```ruby
return if suggested_price_cents.blank? || !customizable_price || default_price_cents.nil? || suggested_price_cents >= default_price_cents
```

## Test plan
- [x] Added a spec in `spec/modules/product/prices_spec.rb` that destroys the product's prices, sets `customizable_price = true` with a `suggested_price_cents`, and asserts `#valid?` does not raise and does not add the "suggested price too low" error.
- [x] `bundle exec rspec spec/modules/product/prices_spec.rb` — 67 examples, 0 failures.