### PR TITLE
Add top margin to referrers table Show more button

### DIFF
--- a/app/javascript/components/Analytics/ReferrersTable.tsx
+++ b/app/javascript/components/Analytics/ReferrersTable.tsx
@@ -71,7 +71,7 @@ export const ReferrersTable = ({ data }: { data: AnalyticsReferrerTotals }) => {
         </TableBody>
       </Table>
       {items.length > maxRowsShown && (
-        <Button onClick={() => setMaxRowsShown(maxRowsShown + ROWS_PER_PAGE)} className="flex">
+        <Button onClick={() => setMaxRowsShown(maxRowsShown + ROWS_PER_PAGE)} className="mt-4 flex">
           Show more
         </Button>
       )}


### PR DESCRIPTION
## What

Add `mt-4` to the "Show more" button on the analytics referrers table so it no longer sits flush against the table above it.

## Why

The button had no top margin, making it visually cramped against the bottom of the table. Adding `mt-4` gives it proper breathing room consistent with other spacing in the analytics UI.

---

AI disclosure: Generated with Claude Opus 4.6. Prompt: add top margin to the "Show more" button on the sales/analytics referrers table by changing the Button's className from `"flex"` to `"mt-4 flex"`.