### PR TITLE
Fix ArgumentError: comparison of Integer with nil in suggested_price_greater_than_price

### DIFF
--- a/app/modules/product/prices.rb
+++ b/app/modules/product/prices.rb
@@ -143,7 +143,7 @@ module Product::Prices
   end
 
   def suggested_price_greater_than_price
-    return if suggested_price_cents.blank? || !customizable_price || suggested_price_cents >= default_price_cents
+    return if suggested_price_cents.blank? || !customizable_price || default_price_cents.nil? || suggested_price_cents >= default_price_cents
 
     errors.add(:base, "The suggested price you entered was too low.")
   end

--- a/spec/modules/product/prices_spec.rb
+++ b/spec/modules/product/prices_spec.rb
@@ -37,6 +37,20 @@ describe Product::Prices do
     end
   end
 
+  describe "#suggested_price_greater_than_price" do
+    it "skips validation when the default price is missing" do
+      product = create(:product)
+      product.prices.destroy_all
+      product.reload
+      product.customizable_price = true
+      product.suggested_price_cents = 100
+
+      expect(product.default_price_cents).to be_nil
+      expect { product.valid? }.not_to raise_error
+      expect(product.errors[:base]).not_to include("The suggested price you entered was too low.")
+    end
+  end
+
   describe "#price_cents=" do
     it "writes to the price_cents column if product is not persisted" do
       product = build(:product)


### PR DESCRIPTION
## Summary
- add a nil guard in `suggested_price_greater_than_price` when `default_price_cents` is missing
- add a regression spec covering a persisted buyable product without an associated default price record

## Sentry
- Issue: https://gumroad-to.sentry.io/issues/7429332600/
- Event count: 2 events (7-day)
- Users affected: 2

## Root cause
`default_price_cents` can return `nil` via `buy_price_cents` when a buyable product has no default `Price` record. The validation compared `suggested_price_cents` against that `nil` value, which raised `ArgumentError`.

## Fix
Skip the validation when `default_price_cents` is `nil`, since there is no default price to compare against.

## Testing
- `RBENV_VERSION=3.4.3 rbenv exec bundle _2.5.10_ exec rspec spec/modules/product/prices_spec.rb`