### PR TITLE
Fix missing spacing between recap options in community notification settings

### DIFF
--- a/app/javascript/pages/Communities/Index.tsx
+++ b/app/javascript/pages/Communities/Index.tsx
@@ -725,7 +725,7 @@ const NotificationsSettingsModal = ({
         value={form.data.recap_frequency !== null}
         onChange={(newValue) => form.setData("recap_frequency", newValue ? "weekly" : null)}
         dropdown={
-          <div className="radio-buttons flex! flex-col!" role="radiogroup">
+          <div className="radio-buttons flex! flex-col! gap-2" role="radiogroup">
             <Button
               role="radio"
               aria-checked={form.data.recap_frequency === "daily"}


### PR DESCRIPTION
The Daily and Weekly recap frequency options in community notification settings had no spacing between them.

Added `gap-2` to the radio button flex container in `Communities/Index.tsx`, consistent with the parent `Dropdown` component's grid gap.