### PR TITLE
Show username when name is missing on admin product seller link

### DIFF
--- a/app/javascript/components/Admin/Products/Header.tsx
+++ b/app/javascript/components/Admin/Products/Header.tsx
@@ -46,7 +46,7 @@ const AdminUsersProductsHeader = ({ product, isCurrentUrl }: Props) => (
               <DateTimeWithRelativeTooltip date={product.created_at} utc />
             </li>
             <li>
-              <Link href={Routes.admin_user_path(product.user.external_id)}>{product.user.name}</Link>
+              <Link href={Routes.admin_user_path(product.user.external_id)}>{product.user.name || product.user.username}</Link>
             </li>
             <AdminProductStats product_external_id={product.external_id} />
           </InlineList>

--- a/app/javascript/components/Admin/Products/Header.tsx
+++ b/app/javascript/components/Admin/Products/Header.tsx
@@ -46,7 +46,7 @@ const AdminUsersProductsHeader = ({ product, isCurrentUrl }: Props) => (
               <DateTimeWithRelativeTooltip date={product.created_at} utc />
             </li>
             <li>
-              <Link href={Routes.admin_user_path(product.user.external_id)}>{product.user.name || product.user.username}</Link>
+              <Link href={Routes.admin_user_path(product.user.external_id)}>{product.user.display_name}</Link>
             </li>
             <AdminProductStats product_external_id={product.external_id} />
           </InlineList>

--- a/app/javascript/components/Admin/Products/Product.tsx
+++ b/app/javascript/components/Admin/Products/Product.tsx
@@ -25,6 +25,7 @@ export type ActiveIntegration = {
 export type ProductUser = {
   external_id: string;
   name: string | null;
+  username: string;
   suspended: boolean;
   flagged_for_tos_violation: boolean;
 };

--- a/app/javascript/components/Admin/Products/Product.tsx
+++ b/app/javascript/components/Admin/Products/Product.tsx
@@ -25,7 +25,7 @@ export type ActiveIntegration = {
 export type ProductUser = {
   external_id: string;
   name: string | null;
-  username: string;
+  display_name: string;
   suspended: boolean;
   flagged_for_tos_violation: boolean;
 };

--- a/app/presenters/admin/product_presenter/card.rb
+++ b/app/presenters/admin/product_presenter/card.rb
@@ -24,7 +24,7 @@ class Admin::ProductPresenter::Card
       user: {
         external_id: product.user.external_id,
         name: product.user.name,
-        username: product.user.username,
+        display_name: product.user.display_name,
         suspended: product.user.suspended?,
         flagged_for_tos_violation: product.user.flagged_for_tos_violation?
       },

--- a/app/presenters/admin/product_presenter/card.rb
+++ b/app/presenters/admin/product_presenter/card.rb
@@ -24,6 +24,7 @@ class Admin::ProductPresenter::Card
       user: {
         external_id: product.user.external_id,
         name: product.user.name,
+        username: product.user.username,
         suspended: product.user.suspended?,
         flagged_for_tos_violation: product.user.flagged_for_tos_violation?
       },

--- a/spec/presenters/admin/product_presenter/card_spec.rb
+++ b/spec/presenters/admin/product_presenter/card_spec.rb
@@ -27,7 +27,7 @@ describe Admin::ProductPresenter::Card do
           user: {
             external_id: product.user.external_id,
             name: product.user.name,
-            username: product.user.username,
+            display_name: product.user.display_name,
             suspended: false,
             flagged_for_tos_violation: false
           },

--- a/spec/presenters/admin/product_presenter/card_spec.rb
+++ b/spec/presenters/admin/product_presenter/card_spec.rb
@@ -27,6 +27,7 @@ describe Admin::ProductPresenter::Card do
           user: {
             external_id: product.user.external_id,
             name: product.user.name,
+            username: product.user.username,
             suspended: false,
             flagged_for_tos_violation: false
           },


### PR DESCRIPTION
When a user has no name set (only a username), the seller link in the admin product header was invisible because `product.user.name` is `null` and the `<Link>` rendered with empty content.

**Fix:** Add `username` to the admin product user payload and fall back to it in the header: `product.user.name || product.user.username`. The `username` method on User already falls back to `external_id`, so the link always has visible text.

**Changes:**
- `app/presenters/admin/product_presenter/card.rb` — include `username` in user hash
- `app/javascript/components/Admin/Products/Product.tsx` — add `username` to `ProductUser` type
- `app/javascript/components/Admin/Products/Header.tsx` — fall back to `username` when `name` is null
- `spec/presenters/admin/product_presenter/card_spec.rb` — update expected user hash