### PR TITLE
Fix lottie-player CSP console error

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -88,6 +88,9 @@ SecureHeaders::Configuration.default do |config|
 
       # helper widget
       "help.gumroad.com",
+
+      # lottie - homepage
+      "unpkg.com/@lottiefiles/lottie-player@latest/",
     ],
     script_src: [
       "'self'",


### PR DESCRIPTION
The browser blocks the lottie-player source map fetch because `unpkg.com` is in `script_src` but not `connect_src`. Add it to `connect_src` to resolve the console error on the homepage.