### PR TITLE
Fix cart button never showing on profile pages

### DIFF
--- a/app/javascript/pages/Products/CartItemsCount.tsx
+++ b/app/javascript/pages/Products/CartItemsCount.tsx
@@ -11,10 +11,13 @@ const CartItemsCount = () => {
 
   React.useEffect(() => {
     void document.hasStorageAccess().then((hasAccess) =>
-      window.parent.postMessage({
-        type: "cart-items-count",
-        cartItemsCount: hasAccess ? cart_items_count : "not-available",
-      }),
+      window.parent.postMessage(
+        {
+          type: "cart-items-count",
+          cartItemsCount: hasAccess ? cart_items_count : "not-available",
+        },
+        "*",
+      ),
     );
   }, [cart_items_count]);
 


### PR DESCRIPTION
## Problem

The cart button never appears on profile pages (both `gumroad.com/username` and custom domain profile pages).

## Root Cause

In `CartItemsCount.tsx`, the iframe component calls `window.parent.postMessage()` **without a `targetOrigin` argument**:

```tsx
window.parent.postMessage({
  type: "cart-items-count",
  cartItemsCount: hasAccess ? cart_items_count : "not-available",
});
```

When `postMessage` is called with only one argument, the second parameter (`targetOrigin`) is `undefined`. The browser requires a valid origin string or `"*"` — passing `undefined` means the message is silently dropped and never delivered to the parent window.

The parent's `loadCartItemsCount` (in `cart.ts`) sets up a message listener and waits for this message, but it never arrives. The cart items count stays `null`, and since `CartNavigationButton` only renders when `cartItemsCount` is truthy, the button never shows.

This affects **all** profile pages, not just custom domains.

## Fix

Add `"*"` as the `targetOrigin` argument. This is safe because:

1. The data is just a cart item count (not sensitive)
2. The receiver in `loadCartItemsCount` already validates `evt.origin` and `evt.source` before processing the message
3. This also fixes the cross-origin case where profile pages are served from custom domains (iframe loads from gumroad.com, parent is on the custom domain)