### PR TITLE
Fix menu item alignment in discover mobile menu

### DIFF
--- a/app/javascript/components/NestedMenu.tsx
+++ b/app/javascript/components/NestedMenu.tsx
@@ -439,7 +439,7 @@ const MenuItemLink = ({
     {...props}
     href={props.href ?? "#"}
     className={classNames(
-      "shrink-0 justify-between gap-2 overflow-visible! p-4! whitespace-normal! hover:bg-primary! hover:text-background!",
+      "flex shrink-0 justify-between gap-2 overflow-visible! p-4! whitespace-normal! hover:bg-primary! hover:text-background!",
       className,
     )}
     role="menuitem"

--- a/app/javascript/components/NestedMenu.tsx
+++ b/app/javascript/components/NestedMenu.tsx
@@ -391,6 +391,7 @@ const ItemsList = ({
         <MenuItemLink
           key={`back${displayedItem.key}`}
           href={displayedItem.parent?.href ?? "#"}
+          className="justify-start"
           onClick={(e) => {
             if (e.ctrlKey || e.shiftKey) return;
             setDisplayedItem(displayedItem.parent ?? initialMenuItem);


### PR DESCRIPTION
On the discover page mobile menu, items without children (like 'All' and 'Other') had no top margin and appeared inline instead of as full-width rows.

**Root cause:** `MenuItemLink` is an `<a>` element which is inline by default. Items with children already got `flex!` via their className prop, but items without children stayed inline. On inline elements, vertical padding doesn't affect layout flow, so the spacing was broken.

**Fix:** Add `flex` to the base `MenuItemLink` classes so all menu items are block-level. This ensures proper padding behavior and makes every item take a full row in the menu.

**Before:** 'All' and 'Other' appear on the same line with no top margin
**After:** All items are properly spaced as full-width rows