### PR TITLE
Center gift and trash icons in wishlist product card footer

### DIFF
--- a/app/javascript/components/Wishlist/index.tsx
+++ b/app/javascript/components/Wishlist/index.tsx
@@ -118,7 +118,7 @@ const WishlistItemCard = ({
       footerAction={
         <>
           {canEdit ? (
-            <div style={{ padding: 0, display: "grid" }}>
+            <div style={{ padding: 0, display: "grid", placeItems: "center" }}>
               <WithTooltip position="top" tip="Remove this product">
                 <button
                   disabled={isDeleting}
@@ -132,7 +132,7 @@ const WishlistItemCard = ({
             </div>
           ) : null}
           {item.purchasable && item.giftable ? (
-            <div style={{ padding: 0, display: "grid" }}>
+            <div style={{ padding: 0, display: "grid", placeItems: "center" }}>
               <WithTooltip position="top" tip="Gift this product">
                 <a
                   aria-label="Gift this product"


### PR DESCRIPTION
The gift and trash icons in wishlist product card footers were not vertically centered. When the price section is taller than the icon cell, the icons sat at the top instead of being centered.

Added `placeItems: 'center'` to the grid containers wrapping both the gift and trash buttons.