### PR TITLE
Add missing DialogTitle to discover mobile menu sidebar

### DIFF
--- a/app/javascript/components/NestedMenu.tsx
+++ b/app/javascript/components/NestedMenu.tsx
@@ -334,6 +334,7 @@ const OverlayMenu = ({
         modal
         className="w-[calc(20rem+3rem)] bg-transparent p-0 pr-12 md:left-0 md:border-l-0"
       >
+        <Dialog.Title className="sr-only">{buttonLabel ?? "Categories"}</Dialog.Title>
         <Dialog.Close
           className="absolute top-4 right-4 z-40 cursor-pointer bg-transparent all-unset"
           aria-label="Close Menu"


### PR DESCRIPTION
Opening the categories sidebar on mobile at `/discover` logs a console error:

> DialogContent requires a DialogTitle for the component to be accessible for screen reader users.

The `OverlayMenu` in `NestedMenu.tsx` uses a Radix `Dialog` (via `Sheet`) but was missing the required `Dialog.Title`. Added a visually hidden (`sr-only`) title using the button label ("Categories").