### PR TITLE
Fix Elasticsearch BadRequest when browser_guid is nil in autocomplete

### DIFF
--- a/app/presenters/discover/autocomplete_presenter.rb
+++ b/app/presenters/discover/autocomplete_presenter.rb
@@ -20,6 +20,8 @@ class Discover::AutocompletePresenter
     def product_results
       return { products: search_results(Link.partial_search_options(query:, size: PRODUCT_RESULT_COUNT)) } if query.present?
 
+      return { products: search_results(Link.search_options(size: PRODUCT_RESULT_COUNT)), viewed: false } if user.blank? && browser_guid.blank?
+
       recently_viewed_ids = ProductPageView.search(
         query: {
           bool: user.present? ? {

--- a/spec/presenters/discover/autocomplete_presenter_spec.rb
+++ b/spec/presenters/discover/autocomplete_presenter_spec.rb
@@ -147,6 +147,24 @@ describe Discover::AutocompletePresenter do
       expect(result[:recent_searches]).to eq(["user search"])
     end
 
+    context "when both user and browser_guid are nil" do
+      let(:query) { "" }
+
+      it "returns top products without querying page views" do
+        result = described_class.new(query:, user: nil, browser_guid: nil).props
+
+        expect(result[:products]).to contain_exactly(
+          {
+            name: "Test Product",
+            url: a_string_matching(/\/#{product.unique_permalink}\?autocomplete=true&layout=discover&recommended_by=search/),
+            seller_name: "gumbo",
+            thumbnail_url: nil,
+          },
+        )
+        expect(result[:viewed]).to be(false)
+      end
+    end
+
     it "finds searches by browser_guid when user is nil" do
       other_guid = SecureRandom.uuid
       create(:discover_search_suggestion, discover_search: create(:discover_search, user: nil, browser_guid:, query: "browser search"))


### PR DESCRIPTION
## Problem

`LinksController#show` raises `Elasticsearch::Transport::Transport::Errors::BadRequest` when a visitor without cookies hits the discover autocomplete endpoint (`layout=discover` with `X-Inertia-Partial-Data=autocomplete_results`).

The `Discover::AutocompletePresenter` builds a `ProductPageView` ES query using `browser_guid` from cookies. When both `user` and `browser_guid` are nil, the query sends `{ term: { browser_guid: null } }` which ES rejects as a malformed query.

**Sentry:** https://gumroad-to.sentry.io/issues/7430176655/

## Fix

Short-circuit early when neither `user` nor `browser_guid` is available — return the default top products (same as the fallback when no page views are found). This avoids sending the malformed ES query entirely.

## Test

Added a spec for the nil user + nil browser_guid case confirming it returns top products with `viewed: false` without raising.