### PR TITLE
Fix StateMachines::InvalidTransition on flag_for_fraud from suspended state

### DIFF
--- a/app/models/concerns/purchase/blockable.rb
+++ b/app/models/concerns/purchase/blockable.rb
@@ -180,9 +180,10 @@ module Purchase::Blockable
       return unless failure_code == PurchaseErrorCode::CARD_DECLINED_FRAUDULENT
       return unless purchaser.present?
       return if purchaser.created_at < MAX_PURCHASER_AGE_FOR_SUSPENSION.ago
+      return if purchaser.suspended?
 
-      purchaser.flag_for_fraud!(author_name: "fraudulent_purchases_blocker")
-      purchaser.suspend_for_fraud!(author_name: "fraudulent_purchases_blocker")
+      purchaser.flag_for_fraud!(author_name: "fraudulent_purchases_blocker") if purchaser.can_flag_for_fraud?
+      purchaser.suspend_for_fraud!(author_name: "fraudulent_purchases_blocker") if purchaser.can_suspend_for_fraud?
     end
 
     def ban_card_testers!

--- a/spec/models/concerns/purchase/blockable_spec.rb
+++ b/spec/models/concerns/purchase/blockable_spec.rb
@@ -858,6 +858,39 @@ describe Purchase::Blockable do
         end
       end
     end
+
+    context "when the buyer is already suspended for fraud" do
+      before do
+        @buyer.flag_for_fraud!(author_name: "admin")
+        @buyer.suspend_for_fraud!(author_name: "admin")
+      end
+
+      it "does not attempt an invalid state transition" do
+        expect { @purchase.mark_failed! }.not_to raise_error
+        expect(@buyer.reload.suspended_for_fraud?).to be(true)
+      end
+    end
+
+    context "when the buyer is already suspended for tos violation" do
+      before do
+        @buyer.update_column(:user_risk_state, "suspended_for_tos_violation")
+      end
+
+      it "does not attempt an invalid state transition" do
+        expect { @purchase.mark_failed! }.not_to raise_error
+        expect(@buyer.reload.suspended_for_tos_violation?).to be(true)
+      end
+    end
+
+    context "when the buyer is already flagged for fraud" do
+      before do
+        @buyer.flag_for_fraud!(author_name: "admin")
+      end
+
+      it "suspends the buyer without re-flagging" do
+        expect { @purchase.mark_failed! }.to change { @buyer.reload.suspended_for_fraud? }.from(false).to(true)
+      end
+    end
   end
 
   describe "#block_buyer_based_on_chargeback_count!" do


### PR DESCRIPTION
## What

`Purchase::Blockable#suspend_buyer_on_fraudulent_card_decline!` unconditionally called `flag_for_fraud!` and `suspend_for_fraud!` on the purchaser, causing a `StateMachines::InvalidTransition` when the purchaser was already in `suspended_for_fraud`, `suspended_for_tos_violation`, or `flagged_for_fraud`.

This method runs as an `after_transition` callback when a purchase transitions to `failed`, so it fires during `OrdersController#create` whenever an existing-but-suspended user attempts a purchase that fails with `CARD_DECLINED_FRAUDULENT`.

## Why

The `user_risk_state` state machine does not define self-transitions for `flag_for_fraud` or `suspend_for_fraud`:

```ruby
event :flag_for_fraud do
  transition %i[not_reviewed compliant flagged_for_tos_violation] => :flagged_for_fraud
end

event :suspend_for_fraud do
  transition %i[not_reviewed compliant on_probation flagged_for_fraud flagged_for_tos_violation] => :suspended_for_fraud
end
```

So calling these events on an already-suspended user raises. The fix:

1. Returns early if the buyer is already suspended — there is nothing more to do for a user who is already in a terminal risk state.
2. Guards each transition with the `state_machines`-provided `can_*?` predicates so we only call the event when the transition is actually allowed (handles `flagged_for_fraud` → suspend path without re-flagging).

Sentry reported this via `StateMachines::InvalidTransition: Cannot transition user_risk_state via :flag_for_fraud from :suspended_for_fraud` on the order create endpoint.

## Test Results

Three new specs under `#suspend_buyer_on_fraudulent_card_decline!`:
- buyer already suspended for fraud — no error raised
- buyer already suspended for tos violation — no error raised
- buyer already flagged for fraud — suspends without re-flagging

All three fail on `main` with the exact `StateMachines::InvalidTransition` from Sentry, and pass with the fix applied.

---

AI disclosure: drafted with Claude Opus 4.6. Prompt: fix the Sentry issue `StateMachines::InvalidTransition: Cannot transition user_risk_state via :flag_for_fraud from :suspended_for_fraud` in `OrdersController#create`.