### PR TITLE
Fix filter product dropdown auto-opening on sales page

### DIFF
--- a/app/javascript/components/Audience/CustomersPage.tsx
+++ b/app/javascript/components/Audience/CustomersPage.tsx
@@ -200,7 +200,10 @@ const CustomersPage = ({
                   </PopoverTrigger>
                 </WithTooltip>
               </PopoverAnchor>
-              <PopoverContent className="max-h-[calc(100vh-8rem)] overflow-y-auto p-0">
+              <PopoverContent
+                className="max-h-[calc(100vh-8rem)] overflow-y-auto p-0"
+                onOpenAutoFocus={(e) => e.preventDefault()}
+              >
                 <Card className="w-140 border-none shadow-none">
                   <CardContent>
                     <ProductSelect


### PR DESCRIPTION
## Summary

Fixes #4635.

When opening the filter panel on the sales page, the product selection dropdown was auto-opening, hiding all the other filter options beneath it. Users who wanted to filter by something other than product had to close the dropdown first.

## Root cause

The filter `Popover` uses Radix UI, which auto-focuses the first focusable element inside the content when opened. That first focusable element is the "Customers who bought" `ProductSelect` input. Our `Select` component uses `openMenuOnFocus`, so focusing the input triggers the menu to open — giving the appearance that the filter opens with the product dropdown already expanded.

## Fix

Pass `onOpenAutoFocus={(e) => e.preventDefault()}` to the filter's `PopoverContent`, which tells Radix to skip its default auto-focus behavior. The filter panel now opens with all dropdowns closed. The product dropdown still works normally when the user clicks it.

This is scoped to the filter `Popover` on `CustomersPage`; the export `Popover` is unaffected.

## Test plan

- [ ] Open the sales page and click the filter (funnel) icon — the filter panel appears with all fields visible and no dropdown auto-opened.
- [ ] Click the "Customers who bought" dropdown — it opens normally and allows selecting a product/variant.
- [ ] Click the "Customers who have not bought" dropdown — it opens normally.
- [ ] Verify the "From" country dropdown, date inputs, price inputs, and active-customers switch all still work.
- [ ] Verify the export popover still behaves as before.