### PR TITLE
Show license use count on sales detail page

### DIFF
--- a/app/javascript/components/Audience/CustomerDetailPage.tsx
+++ b/app/javascript/components/Audience/CustomerDetailPage.tsx
@@ -1467,6 +1467,10 @@ const LicenseSection = ({ license, onSave }: { license: License; onSave: (enable
           </pre>
         </CardContent>
         <CardContent>
+          <h5 className="grow font-bold">Uses</h5>
+          {license.uses}
+        </CardContent>
+        <CardContent>
           {license.enabled ? (
             <Button color="danger" disabled={isLoading} onClick={() => void handleSave(false)} className="grow basis-0">
               Disable

--- a/app/javascript/data/customers.ts
+++ b/app/javascript/data/customers.ts
@@ -14,7 +14,7 @@ export type Discount = ({ type: "fixed"; cents: number } | { type: "percent"; pe
   code: string | null;
 };
 
-export type License = { id: string; key: string; enabled: boolean };
+export type License = { id: string; key: string; enabled: boolean; uses: number };
 export type Address = {
   full_name: string;
   street_address: string;

--- a/app/presenters/customer_presenter.rb
+++ b/app/presenters/customer_presenter.rb
@@ -95,6 +95,7 @@ class CustomerPresenter
           id: purchase.linked_license.external_id,
           key: purchase.linked_license.serial,
           enabled: !purchase.linked_license.disabled?,
+          uses: purchase.linked_license.uses,
         } : nil,
       review: review.present? ?
         {

--- a/spec/presenters/customer_presenter_spec.rb
+++ b/spec/presenters/customer_presenter_spec.rb
@@ -174,6 +174,7 @@ describe CustomerPresenter do
             id: purchase2.license.external_id,
             enabled: true,
             key: purchase2.license.serial,
+            uses: purchase2.license.uses,
           },
           call: nil,
           commission: nil,


### PR DESCRIPTION
## Summary

- Adds the license `uses` count to the license section on the sales detail page (customer detail), so sellers can see activation usage without leaving the dashboard.
- Exposes `uses` from `CustomerPresenter#customer_props` and renders it in the `LicenseSection` component alongside the license key.

Closes #4631

## Test plan

- [ ] Visit a sale detail page for a purchase of a product with a license key; confirm the "Uses" count is shown in the License card.
- [ ] Confirm non-licensed purchases do not render the License section (unchanged behavior).
- [ ] Run `bundle exec rspec spec/presenters/customer_presenter_spec.rb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)