### PR TITLE
Fix filter panel auto-opening product dropdown

### DIFF
--- a/app/javascript/components/Audience/CustomersPage.tsx
+++ b/app/javascript/components/Audience/CustomersPage.tsx
@@ -200,7 +200,10 @@ const CustomersPage = ({
                   </PopoverTrigger>
                 </WithTooltip>
               </PopoverAnchor>
-              <PopoverContent className="max-h-[calc(100vh-8rem)] overflow-y-auto p-0">
+              <PopoverContent
+                className="max-h-[calc(100vh-8rem)] overflow-y-auto p-0"
+                onOpenAutoFocus={(e) => e.preventDefault()}
+              >
                 <Card className="w-140 border-none shadow-none">
                   <CardContent>
                     <ProductSelect


### PR DESCRIPTION
## Summary

Fixes #4635 — when clicking the filter icon on the Sales page, the product selection dropdown would immediately pop open, which is unexpected behavior.

## Root cause

Radix's `Popover` auto-focuses the first focusable element inside `PopoverContent` when it opens. The first focusable element in the filter panel is the "Customers who bought" product `Select` input. The shared `Select` component uses `openMenuOnFocus`, so focusing the input immediately opens the dropdown menu.

## Fix

Add `onOpenAutoFocus={(e) => e.preventDefault()}` to the filter's `PopoverContent` so the popover opens without stealing focus. All dropdowns remain closed until the user interacts with them directly.

This is scoped to the filter popover only — other usages of `Select` and `Popover` are unaffected.

## Test plan

- [ ] Navigate to the Sales page
- [ ] Click the filter icon
- [ ] Verify the filter panel opens with the "Customers who bought" and "Customers who have not bought" product dropdowns both closed
- [ ] Click each product select and verify its dropdown still opens normally
- [ ] Verify filtering still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)