### PR TITLE
Add minimum license uses filter to sales page

### DIFF
--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -60,6 +60,7 @@ class CustomersController < Sellers::BaseController
       created_before: params[:created_before],
       country: params[:country],
       active_customers_only: ActiveModel::Type::Boolean.new.cast(params[:active_customers_only]),
+      minimum_license_uses: params[:minimum_license_uses],
     )
     customers_presenter = CustomersPresenter.new(
       pundit_user:,
@@ -94,7 +95,7 @@ class CustomersController < Sellers::BaseController
   end
 
   private
-    def fetch_sales(query: nil, sort: nil, products: nil, variants: nil, excluded_products: nil, excluded_variants: nil, minimum_amount_cents: nil, maximum_amount_cents: nil, created_after: nil, created_before: nil, country: nil, active_customers_only: false)
+    def fetch_sales(query: nil, sort: nil, products: nil, variants: nil, excluded_products: nil, excluded_variants: nil, minimum_amount_cents: nil, maximum_amount_cents: nil, created_after: nil, created_before: nil, country: nil, active_customers_only: false, minimum_license_uses: nil)
       search_options = {
         seller: current_seller,
         country: Compliance::Countries.historical_names(country || params[:bought_from]).presence,
@@ -124,6 +125,16 @@ class CustomersController < Sellers::BaseController
 
       search_options[:price_greater_than] = get_usd_cents(current_seller.currency_type, minimum_amount_cents) if minimum_amount_cents.present?
       search_options[:price_less_than] = get_usd_cents(current_seller.currency_type, maximum_amount_cents) if maximum_amount_cents.present?
+
+      if minimum_license_uses.present? && minimum_license_uses.to_i > 0
+        threshold = minimum_license_uses.to_i
+        matching_ids = current_seller.sales
+          .joins(:license)
+          .where("licenses.uses >= ?", threshold)
+          .pluck(:id)
+        # When empty, use a sentinel id that matches nothing so results are empty rather than unfiltered.
+        search_options[:id] = matching_ids.presence || [0]
+      end
 
       if created_after || created_before
         timezone = ActiveSupport::TimeZone[current_seller.timezone]

--- a/app/javascript/components/Audience/CustomersPage.tsx
+++ b/app/javascript/components/Audience/CustomersPage.tsx
@@ -103,6 +103,7 @@ const CustomersPage = ({
       createdBefore: null,
       country: null,
       activeCustomersOnly: false,
+      minimumLicenseUses: null,
     };
   });
   const updateQuery = (update: Partial<Query>) => setQuery((prevQuery) => ({ ...prevQuery, ...update }));
@@ -115,6 +116,7 @@ const CustomersPage = ({
     createdBefore,
     country,
     activeCustomersOnly,
+    minimumLicenseUses,
   } = query;
 
   const thProps = useSortingTableDriver<SortKey>(sort, (sort) => updateQuery({ sort }));
@@ -307,6 +309,27 @@ const CustomersPage = ({
                           </option>
                         ))}
                       </FormSelect>
+                    </Fieldset>
+                  </CardContent>
+                  <CardContent>
+                    <Fieldset className="grow basis-0">
+                      <Label htmlFor={`${uid}-minimum-license-uses`}>Minimum license uses</Label>
+                      <input
+                        id={`${uid}-minimum-license-uses`}
+                        type="number"
+                        min="0"
+                        step="1"
+                        placeholder="0"
+                        value={minimumLicenseUses ?? ""}
+                        onChange={(e) => {
+                          const value = e.target.value;
+                          const parsed = value === "" ? null : Number.parseInt(value, 10);
+                          updateQuery({ minimumLicenseUses: Number.isFinite(parsed) ? parsed : null });
+                        }}
+                      />
+                      <FieldsetDescription>
+                        Only show sales whose license has been used at least this many times.
+                      </FieldsetDescription>
                     </Fieldset>
                   </CardContent>
                   <CardContent>

--- a/app/javascript/data/customers.ts
+++ b/app/javascript/data/customers.ts
@@ -142,6 +142,7 @@ export type Query = {
   createdBefore: Date | null;
   country: string | null;
   activeCustomersOnly: boolean;
+  minimumLicenseUses: number | null;
 };
 
 export const getPagedCustomers = ({
@@ -158,6 +159,7 @@ export const getPagedCustomers = ({
   createdBefore,
   country,
   activeCustomersOnly,
+  minimumLicenseUses,
 }: Query) => {
   const abort = new AbortController();
   const response = request({
@@ -177,6 +179,7 @@ export const getPagedCustomers = ({
       created_before: createdBefore,
       country,
       active_customers_only: activeCustomersOnly,
+      minimum_license_uses: minimumLicenseUses,
     }),
     abortSignal: abort.signal,
   })

--- a/spec/controllers/customers_controller_spec.rb
+++ b/spec/controllers/customers_controller_spec.rb
@@ -103,6 +103,25 @@ describe CustomersController, :vcr, type: :controller, inertia: true do
       expect(response).to be_successful
       expect(customer_ids[response]).to match_array([purchases.third.external_id, purchases.fourth.external_id])
     end
+
+    it "filters by minimum license uses" do
+      customer_ids = -> (res) { res.parsed_body.deep_symbolize_keys[:customers].map { _1[:id] } }
+      purchases.first.license.update!(uses: 10)
+      purchases.second.license.update!(uses: 5)
+      purchases.third.license.update!(uses: 1)
+
+      get :paged, params: { page: 1, minimum_license_uses: 5 }
+      expect(response).to be_successful
+      expect(customer_ids[response]).to match_array([purchases.first.external_id, purchases.second.external_id])
+
+      get :paged, params: { page: 1, minimum_license_uses: 10 }
+      expect(response).to be_successful
+      expect(customer_ids[response]).to eq([purchases.first.external_id])
+
+      get :paged, params: { page: 1, minimum_license_uses: 1000 }
+      expect(response).to be_successful
+      expect(customer_ids[response]).to eq([])
+    end
   end
 
   describe "GET charges" do


### PR DESCRIPTION
## Summary

Adds a "Minimum license uses" numeric filter to the Sales page so that sellers can narrow the list down to purchases whose license has been activated (used) at least N times.

Closes #4633

### What's new

- **Frontend** — new numeric input in the Sales filter popover (`CustomersPage.tsx`) bound to a new `minimumLicenseUses` field on the customer `Query`.
- **API** — `GET /customers/paged` now accepts a `minimum_license_uses` query parameter.
- **Backend** — when the filter is provided, `CustomersController#fetch_sales` pre-computes purchase IDs from SQL (`current_seller.sales.joins(:license).where("licenses.uses >= ?", threshold)`) and passes them as an `id:` filter to `PurchaseSearchService`. This keeps pagination/count correct without requiring a new Elasticsearch index field or a reindex.

### Why SQL pre-filter rather than ES

License `uses` changes frequently (every license activation). Adding it to the purchase ES mapping would introduce churn on every activation event. Pre-computing the matching IDs per-seller keeps the change minimal and avoids an index/reindex migration, at the cost of an extra SQL query when this filter is active.

## Test plan

- [x] Added `spec/controllers/customers_controller_spec.rb` case covering `minimum_license_uses` with three thresholds (5, 10, 1000).
- [ ] Manually verify the input appears under the Filter popover on the Sales page.
- [ ] Manually verify purchases without a license are excluded when the filter is active.
- [ ] Verify pagination/count remain correct when the filter narrows results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)