### PR TITLE
Fix: preserve existing triggers in Alterity pt-online-schema-change

### DIFF
--- a/config/initializers/alterity.rb
+++ b/config/initializers/alterity.rb
@@ -13,6 +13,7 @@ Alterity.configure do |config|
       --critical-load Threads_running=1000
       --max-load Threads_running=200
       --set-vars lock_wait_timeout=1
+      --preserve-triggers
       --recursion-method 'dsn=D=#{config.replicas_dsns_database},t=#{config.replicas_dsns_table}'
       --execute
       --no-check-alter

--- a/spec/config/initializers/alterity_spec.rb
+++ b/spec/config/initializers/alterity_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Alterity configuration" do
+  describe "command template" do
+    let(:command) { Alterity.config.command.call("users", "DROP COLUMN twitter_handle") }
+
+    it "includes --preserve-triggers so migrations succeed on tables with existing triggers" do
+      expect(command).to include("--preserve-triggers")
+    end
+
+    it "includes the altered table and alter argument" do
+      expect(command).to include("t=users")
+      expect(command).to include("--alter DROP COLUMN twitter_handle")
+    end
+  end
+end


### PR DESCRIPTION
## What

Add `--preserve-triggers` to the `pt-online-schema-change` command template used by Alterity in `config/initializers/alterity.rb`.

## Why

`pt-online-schema-change` refuses to alter a table that already has triggers unless `--preserve-triggers` is explicitly passed. This caused `db:migrate` to fail on tables with existing triggers (e.g. `users`) with:

```
[Alterity] Command failed. Full output:
The table `gumroad_production`.`users` has triggers but --preserve-triggers was not specified.
Please read the documentation for --preserve-triggers.
```

Because `ActiveRecord::Migrator` aborts on the first failing migration, all later migrations were cancelled as well, blocking deploys.

`--preserve-triggers` is the recommended flag for MySQL 5.7+ / 8.0+ with `pt-online-schema-change` 3.3.0+: pt-osc copies the existing triggers onto the new table at swap time, so the table keeps behaving identically after the schema change.

Sentry: https://gumroad-to.sentry.io/issues/7430925236/

## Test

Added `spec/config/initializers/alterity_spec.rb` which renders the configured command and asserts `--preserve-triggers` is present. Verified the spec fails when the flag is removed and passes with it included.

```
$ bundle exec rspec spec/config/initializers/alterity_spec.rb
..
Finished in 0.17454 seconds (files took 2.09 seconds to load)
2 examples, 0 failures
```

---

AI disclosure: written with Claude Opus 4.6. Prompt: fix the Sentry error "StandardError: An error has occurred, all later migrations canceled" caused by Alterity missing `--preserve-triggers`, add a test that verifies the flag is included in the generated command, and open a PR.