### PR TITLE
Preserve triggers in Alterity pt-online-schema-change

### DIFF
--- a/config/initializers/alterity.rb
+++ b/config/initializers/alterity.rb
@@ -16,6 +16,7 @@ Alterity.configure do |config|
       --recursion-method 'dsn=D=#{config.replicas_dsns_database},t=#{config.replicas_dsns_table}'
       --execute
       --no-check-alter
+      --preserve-triggers
       D=#{config.database},t=#{altered_table}
       --alter #{alter_argument}
     SHELL

--- a/spec/config/initializers/alterity_spec.rb
+++ b/spec/config/initializers/alterity_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Alterity initializer" do
+  it "includes --preserve-triggers in the generated command" do
+    config = Alterity.config
+
+    allow(config).to receive_messages(
+      host: "db.example.com",
+      port: 3306,
+      username: "gumroad",
+      password: "secret",
+      replicas_dsns_database: "percona",
+      replicas_dsns_table: "replicas_dsns",
+      database: "gumroad_test"
+    )
+
+    command = config.command.call("users", "DROP COLUMN twitter_handle")
+
+    expect(command).to include("--preserve-triggers")
+  end
+end


### PR DESCRIPTION
## Summary
- add `--preserve-triggers` to the Alterity `pt-online-schema-change` command template
- add a focused initializer spec that verifies the generated command includes the flag

## Testing
- `bundle exec rspec spec/config/initializers/alterity_spec.rb`

## Context
- Sentry issue: https://gumroad-to.sentry.io/issues/7430925236/