### PR TITLE
Fix NameError: uninitialized constant Faker in test factories

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ require "capybara/rspec"
 require "rspec/rails"
 require "paper_trail/frameworks/rspec"
 require "pundit/rspec"
+require "faker"
 Dir.glob(Rails.root.join("spec", "support", "**", "*.rb")).each { |f| require f }
 
 JsonMatchers.schema_root = "spec/support/schemas"


### PR DESCRIPTION
## Problem

Sentry reported a `NameError: uninitialized constant Faker` in `spec/support/factories/users.rb` ([Sentry issue](https://gumroad-to.sentry.io/issues/7430939043/)).

The `faker` gem is in the `:test` Gemfile group so Bundler auto-requires it, but factory definitions can be evaluated before Faker is available in certain load-order scenarios (parallel test runners via knapsack_pro, Spring preloader).

## Fix

Add an explicit `require "faker"` in `spec/spec_helper.rb` before the `Dir.glob` that loads all support files (including factories). This guarantees Faker is available when FactoryBot evaluates factory definitions that reference `Faker::Internet`, `Faker::Lorem`, etc.

## Testing

Single line change. No behavior change to production code, just ensures test infrastructure loads correctly.