### PR TITLE
Handle EncodingError in SecureExternalId#decrypt_id

### DIFF
--- a/app/models/concerns/secure_external_id.rb
+++ b/app/models/concerns/secure_external_id.rb
@@ -101,7 +101,7 @@ module SecureExternalId
       return nil if inner_payload[:exp] && Time.current.to_i > inner_payload[:exp]
 
       inner_payload[:id]
-    rescue JSON::ParserError, ArgumentError, ActiveSupport::MessageEncryptor::InvalidMessage => e
+    rescue JSON::ParserError, ArgumentError, EncodingError, ActiveSupport::MessageEncryptor::InvalidMessage => e
       Rails.logger.error "SecureExternalId decryption failed: #{e.class}"
       nil
     end

--- a/spec/models/concerns/secure_external_id_spec.rb
+++ b/spec/models/concerns/secure_external_id_spec.rb
@@ -77,6 +77,12 @@ RSpec.describe SecureExternalId do
       expect(test_class.find_by_secure_external_id("invalid base64!", scope: "test")).to be_nil
     end
 
+    it "returns nil for tokens with invalid UTF-8 encoding" do
+      # Simulate a token that decodes to bytes with invalid UTF-8 sequences
+      invalid_utf8_token = Base64.urlsafe_encode64("{\"v\":\"1\",\"d\":\"|Y\xB8\"}")
+      expect(test_class.find_by_secure_external_id(invalid_utf8_token, scope: "test")).to be_nil
+    end
+
     it "returns nil for wrong model name" do
       other_class = Class.new do
         include SecureExternalId


### PR DESCRIPTION
## Problem

`PurchasesController#unsubscribe` raises an unhandled `EncodingError` when a token contains invalid UTF-8 byte sequences. The `SecureExternalId#decrypt_id` method rescues `JSON::ParserError`, `ArgumentError`, and `ActiveSupport::MessageEncryptor::InvalidMessage`, but not `EncodingError`, which can be raised during Base64 decoding or JSON parsing of malformed tokens.

**Sentry:** https://gumroad-to.sentry.io/issues/7430960659/

## Fix

Add `EncodingError` to the rescue clause in `SecureExternalId#decrypt_id` so malformed tokens return `nil` instead of raising a 500 error.

## Test

Added a test confirming that tokens with invalid UTF-8 encoding return `nil` gracefully.