### PR TITLE
Pin lottie-player to an immutable version + add SRI (remove @latest CSP risk from #4619)

### DIFF
--- a/app/views/home/shared/_scripts.html.erb
+++ b/app/views/home/shared/_scripts.html.erb
@@ -96,4 +96,4 @@
   }
 <% end %>
 
-<script src="https://unpkg.com/@lottiefiles/lottie-player@latest/dist/lottie-player.js"></script>
+<script src="https://unpkg.com/@lottiefiles/lottie-player@2.0.12/dist/lottie-player.js" integrity="sha384-i8zT4p4C0XG4mPhfz0zuffZpppP8NjlttNsP6srEdEBatwZkcYUBoQtAW7sfKEp2" crossorigin="anonymous"></script>

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -89,8 +89,8 @@ SecureHeaders::Configuration.default do |config|
       # helper widget
       "help.gumroad.com",
 
-      # lottie - homepage
-      "unpkg.com/@lottiefiles/lottie-player@latest/",
+      # lottie - homepage (pinned version; no @latest)
+      "unpkg.com/@lottiefiles/lottie-player@2.0.12/",
     ],
     script_src: [
       "'self'",
@@ -158,8 +158,8 @@ SecureHeaders::Configuration.default do |config|
       # helper widget
       "help.gumroad.com",
 
-      # lottie - homepage
-      "unpkg.com/@lottiefiles/lottie-player@latest/"
+      # lottie - homepage (pinned version; no @latest)
+      "unpkg.com/@lottiefiles/lottie-player@2.0.12/"
     ],
     style_src: [
       "'self'",


### PR DESCRIPTION
## Summary

PR #4619 added a Content Security Policy allowlist entry (and a homepage `<script>` tag) that references the **versionless** URL `unpkg.com/@lottiefiles/lottie-player@latest/`. This change pins that dependency to a specific immutable version (`@2.0.12`) and adds Subresource Integrity (SRI) on the script tag so the browser rejects any modified payload.

## Vulnerability

`config/initializers/secure_headers.rb` currently includes, in both `connect-src` and `script-src`:

```
unpkg.com/@lottiefiles/lottie-player@latest/
```

and `app/views/home/shared/_scripts.html.erb` loads:

```html
<script src="https://unpkg.com/@lottiefiles/lottie-player@latest/dist/lottie-player.js"></script>
```

`@latest` is a mutable tag: every time upstream publishes a new version of `@lottiefiles/lottie-player`, that new code is served to every visitor of Gumroad's homepage with **no code review, no CI run, and no deploy** on our side. The CSP entry explicitly allows it, so it will not even raise a warning.

## Security impact

- **Supply-chain compromise risk.** If the `@lottiefiles/lottie-player` package (or the account publishing it, or the unpkg CDN surface serving `@latest`) is compromised or an upstream bug is introduced, attacker-controlled JavaScript executes on `gumroad.com` homepage contexts.
- **Scope of execution.** The script is loaded on the public homepage (`app/views/home/about.html.erb`). It runs in the same origin as Gumroad's main site and inherits the trust of any first-party context, including access to cookies/localStorage subject to their own flags.
- **CSP bypass potential.** Because CSP whitelists the versionless path, an attacker who can cause upstream to publish new code under `@latest` effectively gets a pre-approved script-src. SRI is not currently enforced on this tag, so no integrity check catches a modified payload.
- **Auditability loss.** Because the bytes served change outside our repository, post-incident forensics cannot rely on git history to know what JavaScript was shipped at any given moment.

## Proposed code fix

Minimal, atomic change in two files:

1. `config/initializers/secure_headers.rb` — replace both `@latest` entries (in `connect-src` and `script-src`) with the immutable pinned path:
   ```
   unpkg.com/@lottiefiles/lottie-player@2.0.12/
   ```
2. `app/views/home/shared/_scripts.html.erb` — pin the script URL to the same version and add Subresource Integrity:
   ```html
   <script
     src=\"https://unpkg.com/@lottiefiles/lottie-player@2.0.12/dist/lottie-player.js\"
     integrity=\"sha384-i8zT4p4C0XG4mPhfz0zuffZpppP8NjlttNsP6srEdEBatwZkcYUBoQtAW7sfKEp2\"
     crossorigin=\"anonymous\"></script>
   ```

unpkg serves `@<exact-version>` paths as immutable artifacts, so combined with SRI the browser will refuse to execute any script whose bytes differ from what was audited when this PR was merged. Any future upgrade now requires a deliberate PR that updates both the CSP allowlist, the version, and the SRI hash — restoring code review to the supply chain.

A stronger long-term option is to self-host the script via Shakapacker (remove `unpkg.com` from CSP entirely). That requires adding `@lottiefiles/lottie-player` to `package.json` and importing it from the homepage pack; it was intentionally left out of this PR to keep the fix atomic and low-risk. Happy to follow up with that if preferred.

## References / best practices

- OWASP — Third-Party JavaScript Management Cheat Sheet: https://cheatsheetseries.owasp.org/cheatsheets/Third_Party_Javascript_Management_Cheat_Sheet.html
- MDN — Subresource Integrity: https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity
- MDN — CSP `script-src`: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src
- OWASP — Content Security Policy Cheat Sheet (avoid broad/versionless hosts): https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html
- npm docs — Why not to depend on `latest` / floating tags: https://docs.npmjs.com/cli/v10/commands/npm-dist-tag
- Google web.dev — Pin and verify third-party scripts with SRI: https://web.dev/articles/subresource-integrity

## Test plan

- [ ] CI green on this branch.
- [ ] Manually verify `https://gumroad.com/about` loads without CSP console errors and the Lottie animation still plays.
- [ ] Confirm the `integrity` check passes (no `Failed to find a valid digest` console error in a modern browser).