### PR TITLE
Remove placeholder text from labeled form inputs

### DIFF
--- a/app/javascript/components/Audience/CustomerDetailPage.tsx
+++ b/app/javascript/components/Audience/CustomerDetailPage.tsx
@@ -936,7 +936,6 @@ const AddressSection = ({
             <Input
               id={`${uid}-full-name`}
               type="text"
-              placeholder="Full name"
               value={address.full_name}
               onChange={(evt) => updateShipping({ full_name: evt.target.value })}
             />
@@ -948,7 +947,6 @@ const AddressSection = ({
             <Input
               id={`${uid}-street-address`}
               type="text"
-              placeholder="Street address"
               value={address.street_address}
               onChange={(evt) => updateShipping({ street_address: evt.target.value })}
             />
@@ -961,7 +959,6 @@ const AddressSection = ({
               <Input
                 id={`${uid}-city`}
                 type="text"
-                placeholder="City"
                 value={address.city}
                 onChange={(evt) => updateShipping({ city: evt.target.value })}
               />
@@ -973,7 +970,6 @@ const AddressSection = ({
               <Input
                 id={`${uid}-state`}
                 type="text"
-                placeholder="State"
                 value={address.state}
                 onChange={(evt) => updateShipping({ state: evt.target.value })}
               />
@@ -985,7 +981,6 @@ const AddressSection = ({
               <Input
                 id={`${uid}-zip-code`}
                 type="text"
-                placeholder="ZIP code"
                 value={address.zip_code}
                 onChange={(evt) => updateShipping({ zip_code: evt.target.value })}
               />

--- a/app/javascript/components/Checkout/PaymentForm.tsx
+++ b/app/javascript/components/Checkout/PaymentForm.tsx
@@ -162,7 +162,6 @@ const StateInput = () => {
           id={`${uid}state`}
           type="text"
           aria-invalid={errors.has("state")}
-          placeholder={stateLabel}
           disabled={isProcessing(state)}
           value={state.state}
           onChange={(e) => dispatch({ type: "set-value", state: e.target.value })}
@@ -187,7 +186,6 @@ const ZipCodeInput = () => {
         id={`${uid}zipCode`}
         type="text"
         aria-invalid={errors.has("zipCode")}
-        placeholder={label}
         value={state.zipCode}
         onChange={(e) => dispatch({ type: "set-value", zipCode: e.target.value })}
         disabled={isProcessing(state)}
@@ -344,7 +342,6 @@ const SharedInputs = ({ className }: { className?: string | undefined }) => {
                     aria-invalid={errors.has("email")}
                     value={state.email}
                     onChange={(evt) => dispatch({ type: "set-value", email: evt.target.value.toLowerCase() })}
-                    placeholder="Your email address"
                     disabled={(loggedInUser && loggedInUser.email !== null) || isProcessing(state)}
                     onBlur={checkForEmailTypos}
                   />
@@ -368,7 +365,6 @@ const SharedInputs = ({ className }: { className?: string | undefined }) => {
                 id={`${uid}fullName`}
                 type="text"
                 aria-invalid={errors.has("fullName")}
-                placeholder="Full name"
                 value={state.fullName}
                 onChange={(e) => dispatch({ type: "set-value", fullName: e.target.value })}
                 disabled={isProcessing(state)}
@@ -396,7 +392,6 @@ const SharedInputs = ({ className }: { className?: string | undefined }) => {
               <Input
                 id={`${uid}vatId`}
                 type="text"
-                placeholder={vatLabel}
                 value={state.vatId}
                 onChange={(e) => dispatch({ type: "set-value", vatId: e.target.value })}
                 disabled={isProcessing(state)}
@@ -517,7 +512,6 @@ const CustomerDetails = ({ className }: { className?: string }) => {
                   id={`${uid}fullName`}
                   type="text"
                   aria-invalid={errors.has("fullName")}
-                  placeholder="Full name"
                   disabled={isProcessing(state)}
                   value={state.fullName}
                   onChange={(e) => dispatch({ type: "set-value", fullName: e.target.value })}
@@ -531,7 +525,6 @@ const CustomerDetails = ({ className }: { className?: string }) => {
                   id={`${uid}address`}
                   type="text"
                   aria-invalid={errors.has("address")}
-                  placeholder="Street address"
                   disabled={isProcessing(state)}
                   value={state.address}
                   onChange={(e) => dispatch({ type: "set-value", address: e.target.value })}
@@ -546,7 +539,6 @@ const CustomerDetails = ({ className }: { className?: string }) => {
                     id={`${uid}city`}
                     type="text"
                     aria-invalid={errors.has("city")}
-                    placeholder="City"
                     disabled={isProcessing(state)}
                     value={state.city}
                     onChange={(e) => dispatch({ type: "set-value", city: e.target.value })}

--- a/app/javascript/components/Collaborators/Form.tsx
+++ b/app/javascript/components/Collaborators/Form.tsx
@@ -197,7 +197,6 @@ const CollaboratorForm = ({
                 id="email"
                 type="email"
                 value={form.data.email}
-                placeholder="Collaborator's Gumroad account email"
                 onChange={(evt) => {
                   form.setData("email", evt.target.value.trim());
                   form.clearErrors("email");

--- a/app/javascript/components/EmailsPage/EmailForm.tsx
+++ b/app/javascript/components/EmailsPage/EmailForm.tsx
@@ -967,7 +967,6 @@ export const EmailForm = ({ context, installment }: EmailFormProps) => {
                   </Label>
                   <TagInput
                     inputId={`${uid}-affiliated_products_dropdown`}
-                    placeholder="Select products..."
                     tagIds={affiliatedProducts}
                     tagList={selectableProductOptions(affiliateProductOptions, affiliatedProducts)}
                     onChangeTagIds={setAffiliatedProducts}
@@ -984,7 +983,6 @@ export const EmailForm = ({ context, installment }: EmailFormProps) => {
                   </FieldsetTitle>
                   <TagInput
                     inputId={`${uid}-bought`}
-                    placeholder="Any product"
                     tagIds={bought}
                     tagList={selectableProductOptions(productOptions, bought)}
                     onChangeTagIds={setBought}
@@ -1001,7 +999,6 @@ export const EmailForm = ({ context, installment }: EmailFormProps) => {
                   </FieldsetTitle>
                   <TagInput
                     inputId={`${uid}-not_bought`}
-                    placeholder="No products"
                     tagIds={notBought}
                     tagList={selectableProductOptions(productOptions, notBought)}
                     onChangeTagIds={setNotBought}

--- a/app/javascript/components/ProductEdit/ContentTab/FileEmbed.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/FileEmbed.tsx
@@ -632,7 +632,6 @@ const FileEmbedNodeView = ({ node, editor, getPos, updateAttributes }: NodeViewP
                   id={`${uid}name`}
                   value={file.display_name}
                   onChange={(evt) => updateFile({ display_name: evt.target.value })}
-                  placeholder="Name"
                 />
               </Fieldset>
 
@@ -646,7 +645,6 @@ const FileEmbedNodeView = ({ node, editor, getPos, updateAttributes }: NodeViewP
                   maxLength={65_535}
                   value={file.description ?? ""}
                   onChange={(evt) => updateFile({ description: evt.target.value })}
-                  placeholder="Description"
                 />
               </Fieldset>
 
@@ -660,7 +658,6 @@ const FileEmbedNodeView = ({ node, editor, getPos, updateAttributes }: NodeViewP
                     id={`${uid}isbn`}
                     value={file.isbn ?? ""}
                     onChange={(evt) => updateFile({ isbn: evt.target.value })}
-                    placeholder="ISBN"
                   />
                 </Fieldset>
               ) : null}

--- a/app/javascript/components/ProductEdit/ProductTab/CustomSummaryInput.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/CustomSummaryInput.tsx
@@ -18,7 +18,6 @@ export const CustomSummaryInput = ({
       <Input
         id={uid}
         type="text"
-        placeholder="You'll get..."
         value={value ?? ""}
         onChange={(evt) => onChange(evt.target.value)}
       />

--- a/app/javascript/components/ProductEdit/ProductTab/VersionsEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/VersionsEditor.tsx
@@ -162,7 +162,6 @@ const VersionEditor = ({
                   id={`${uid}-name`}
                   type="text"
                   value={version.name}
-                  placeholder="Version name"
                   onChange={(evt) => updateVersion({ name: evt.target.value })}
                 />
                 <a href={url} target="_blank" rel="noreferrer">

--- a/app/javascript/components/ProductEdit/ReceiptTab/CustomReceiptTextInput.tsx
+++ b/app/javascript/components/ProductEdit/ReceiptTab/CustomReceiptTextInput.tsx
@@ -20,7 +20,6 @@ export const CustomReceiptTextInput = ({
       <Textarea
         id={uid}
         maxLength={maxLength}
-        placeholder="Add any additional information you'd like to include on the receipt."
         value={value ?? ""}
         onChange={(evt) => onChange(evt.target.value)}
         rows={3}

--- a/app/javascript/components/ProductEdit/ReceiptTab/CustomViewContentButtonTextInput.tsx
+++ b/app/javascript/components/ProductEdit/ReceiptTab/CustomViewContentButtonTextInput.tsx
@@ -20,7 +20,6 @@ export const CustomViewContentButtonTextInput = ({
       <Input
         id={uid}
         type="text"
-        placeholder="View content"
         value={value ?? ""}
         onChange={(evt) => onChange(evt.target.value)}
         maxLength={maxLength}

--- a/app/javascript/components/Profile/EditSections.tsx
+++ b/app/javascript/components/Profile/EditSections.tsx
@@ -289,7 +289,7 @@ export const SectionLayout = ({
           <EditorSubmenu heading="Name" text={section.header}>
             <Fieldset>
               <Input
-                placeholder="Name"
+                aria-label="Name"
                 value={section.header}
                 onChange={(e) => updateSection({ header: e.target.value })}
               />
@@ -572,7 +572,6 @@ const SubscribeSectionView = ({ section }: { section: SubscribeSection }) => {
         <EditorSubmenu key="0" heading="Button Label" text={section.button_label}>
           <Input
             type="text"
-            placeholder="Subscribe"
             aria-label="Button Label"
             value={section.button_label}
             onChange={(evt) => updateSection({ button_label: evt.target.value })}

--- a/app/javascript/components/Public/LookupLayout.tsx
+++ b/app/javascript/components/Public/LookupLayout.tsx
@@ -130,7 +130,6 @@ const LookupLayout = ({ children, title, type }: {
               <Label htmlFor="email">What email address did you use?</Label>
               <Input
                 id="email"
-                placeholder="Email address"
                 type="text"
                 value={email.value}
                 onChange={(evt) => setEmail({ value: evt.target.value })}

--- a/app/javascript/components/Settings/AdvancedPage/ApplicationForm.tsx
+++ b/app/javascript/components/Settings/AdvancedPage/ApplicationForm.tsx
@@ -176,7 +176,6 @@ const ApplicationForm = ({ application }: { application?: Application }) => {
         <Input
           id={`${uid}-name`}
           ref={nameRef}
-          placeholder="Name"
           type="text"
           value={name.value}
           onChange={(e) => setName({ value: e.target.value })}

--- a/app/javascript/components/Settings/AdvancedPage/BlockEmailsSection.tsx
+++ b/app/javascript/components/Settings/AdvancedPage/BlockEmailsSection.tsx
@@ -60,7 +60,6 @@ const BlockEmailsSection = ({ blockedEmails, setBlockedEmails }: Props) => {
         </FieldsetTitle>
         <Textarea
           id={uid}
-          placeholder={["name@example.com", "name@example.net", "name@example.org"].join("\n")}
           rows={4}
           value={blockedEmails}
           onChange={(e) => setBlockedEmails(e.target.value)}

--- a/app/javascript/components/Settings/AdvancedPage/NotificationEndpointSection.tsx
+++ b/app/javascript/components/Settings/AdvancedPage/NotificationEndpointSection.tsx
@@ -69,7 +69,6 @@ const NotificationEndpointSection = ({
         </FieldsetTitle>
         <InputGroup>
           <Input
-            placeholder="Ping endpoint"
             type="url"
             id={uid}
             value={pingEndpoint}

--- a/app/javascript/components/Settings/PasswordPage/AuthenticatorSetup.tsx
+++ b/app/javascript/components/Settings/PasswordPage/AuthenticatorSetup.tsx
@@ -151,7 +151,6 @@ export const AuthenticatorSetup = ({ onCancel }: { onCancel: () => void }) => {
             inputMode="numeric"
             pattern="[0-9]*"
             maxLength={6}
-            placeholder="XXXXXX"
             value={code}
             onChange={(e) => setCode(e.target.value)}
             autoFocus

--- a/app/javascript/components/Settings/PaymentsPage/AccountDetailsSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/AccountDetailsSection.tsx
@@ -460,7 +460,6 @@ const AccountDetailsSection = ({
               </FieldsetTitle>
               <Input
                 id={`${uid}-business-legal-name`}
-                placeholder="Acme"
                 required={complianceInfo.is_business}
                 value={complianceInfo.business_name || ""}
                 disabled={isFormDisabled}
@@ -516,7 +515,6 @@ const AccountDetailsSection = ({
                 <Input
                   id={`${uid}-business-name-kanji`}
                   type="text"
-                  placeholder="Legal Business Name (Kanji)"
                   value={complianceInfo.business_name_kanji || ""}
                   disabled={isFormDisabled}
                   aria-invalid={errorFieldNames.has("business_name_kanji")}
@@ -767,7 +765,6 @@ const AccountDetailsSection = ({
             <Input
               id={`${uid}-creator-first-name`}
               type="text"
-              placeholder="First name"
               value={complianceInfo.first_name || ""}
               disabled={isFormDisabled}
               aria-invalid={errorFieldNames.has("first_name")}
@@ -783,7 +780,6 @@ const AccountDetailsSection = ({
             <Input
               id={`${uid}-creator-last-name`}
               type="text"
-              placeholder="Last name"
               value={complianceInfo.last_name || ""}
               disabled={isFormDisabled}
               aria-invalid={errorFieldNames.has("last_name")}
@@ -800,7 +796,6 @@ const AccountDetailsSection = ({
             <Input
               id={`${uid}-creator-job-title`}
               type="text"
-              placeholder="CEO"
               value={complianceInfo.job_title || ""}
               disabled={isFormDisabled}
               aria-invalid={errorFieldNames.has("job_title")}
@@ -819,7 +814,6 @@ const AccountDetailsSection = ({
                 <Input
                   id={`${uid}-creator-first-name-kanji`}
                   type="text"
-                  placeholder="First name (Kanji)"
                   value={complianceInfo.first_name_kanji || ""}
                   disabled={isFormDisabled}
                   aria-invalid={errorFieldNames.has("first_name_kanji")}
@@ -834,7 +828,6 @@ const AccountDetailsSection = ({
                 <Input
                   id={`${uid}-creator-last-name-kanji`}
                   type="text"
-                  placeholder="Last name (Kanji)"
                   value={complianceInfo.last_name_kanji || ""}
                   disabled={isFormDisabled}
                   aria-invalid={errorFieldNames.has("last_name_kanji")}
@@ -960,7 +953,6 @@ const AccountDetailsSection = ({
             <Input
               id={`${uid}-creator-street-address`}
               type="text"
-              placeholder="Street address"
               required
               value={complianceInfo.street_address || ""}
               disabled={isFormDisabled}
@@ -1031,7 +1023,6 @@ const AccountDetailsSection = ({
             <Input
               id={`${uid}-creator-city`}
               type="text"
-              placeholder="City"
               value={complianceInfo.city || ""}
               disabled={isFormDisabled}
               aria-invalid={errorFieldNames.has("city")}
@@ -1056,7 +1047,6 @@ const AccountDetailsSection = ({
             <Input
               id={`${uid}-creator-zip-code`}
               type="text"
-              placeholder={complianceInfo.country === "US" ? "ZIP code" : "Postal code"}
               value={complianceInfo.zip_code || ""}
               disabled={isFormDisabled}
               aria-invalid={errorFieldNames.has("zip_code")}
@@ -1094,7 +1084,6 @@ const AccountDetailsSection = ({
         <Input
           id={`${uid}-creator-phone`}
           type="tel"
-          placeholder="Phone number"
           value={complianceInfo.phone || ""}
           disabled={isFormDisabled}
           aria-invalid={errorFieldNames.has("phone")}

--- a/app/javascript/components/Settings/PaymentsPage/BankAccountSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/BankAccountSection.tsx
@@ -942,7 +942,6 @@ const BankAccountSection = ({
           </FieldsetTitle>
           <Input
             id={`${uid}-account-holder-full-name`}
-            placeholder="Full name of account holder"
             value={bankAccount?.account_holder_full_name || ""}
             disabled={isFormDisabled}
             aria-invalid={errorFieldNames.has("account_holder_full_name")}

--- a/app/javascript/components/Settings/PaymentsPage/PayPalEmailSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/PayPalEmailSection.tsx
@@ -52,7 +52,6 @@ const PayPalEmailSection = ({
           <Input
             type="email"
             id={`${uid}-paypal-email`}
-            placeholder="PayPal Email"
             value={paypalEmailAddress || ""}
             disabled={isFormDisabled}
             aria-invalid={errorFieldNames.has("paypal_email_address")}

--- a/app/javascript/components/UtmLinks/UtmLinkForm.tsx
+++ b/app/javascript/components/UtmLinks/UtmLinkForm.tsx
@@ -292,7 +292,6 @@ export const UtmLinkForm = (pageProps: UtmLinkFormProps | UtmLinkEditProps) => {
             <Input
               id={`title-${uid}`}
               type="text"
-              placeholder="Title"
               value={data.utm_link.title}
               ref={titleRef}
               onChange={(e) => setData("utm_link.title", e.target.value)}
@@ -308,7 +307,6 @@ export const UtmLinkForm = (pageProps: UtmLinkFormProps | UtmLinkEditProps) => {
             <Select
               inputId={`destination-${uid}`}
               instanceId={`destination-${uid}`}
-              placeholder="Select where you want to send your audience"
               options={context.destination_options}
               value={destination}
               isMulti={false}
@@ -383,7 +381,6 @@ export const UtmLinkForm = (pageProps: UtmLinkFormProps | UtmLinkEditProps) => {
               </FieldsetTitle>
               <UtmFieldSelect
                 id={`${uid}-source`}
-                placeholder="newsletter"
                 baseOptionValues={context.utm_fields_values.sources}
                 value={data.utm_link.utm_source}
                 onChange={(value) => setData("utm_link.utm_source", value)}
@@ -400,7 +397,6 @@ export const UtmLinkForm = (pageProps: UtmLinkFormProps | UtmLinkEditProps) => {
               </FieldsetTitle>
               <UtmFieldSelect
                 id={`${uid}-medium`}
-                placeholder="email"
                 baseOptionValues={context.utm_fields_values.mediums}
                 value={data.utm_link.utm_medium}
                 onChange={(value) => setData("utm_link.utm_medium", value)}
@@ -418,7 +414,6 @@ export const UtmLinkForm = (pageProps: UtmLinkFormProps | UtmLinkEditProps) => {
             </FieldsetTitle>
             <UtmFieldSelect
               id={`${uid}-campaign`}
-              placeholder="new-course-launch"
               baseOptionValues={context.utm_fields_values.campaigns}
               value={data.utm_link.utm_campaign}
               onChange={(value) => setData("utm_link.utm_campaign", value)}
@@ -435,7 +430,6 @@ export const UtmLinkForm = (pageProps: UtmLinkFormProps | UtmLinkEditProps) => {
             </FieldsetTitle>
             <UtmFieldSelect
               id={`${uid}-term`}
-              placeholder="photo-editing"
               baseOptionValues={context.utm_fields_values.terms}
               value={data.utm_link.utm_term}
               onChange={(value) => setData("utm_link.utm_term", value)}
@@ -452,7 +446,6 @@ export const UtmLinkForm = (pageProps: UtmLinkFormProps | UtmLinkEditProps) => {
             </FieldsetTitle>
             <UtmFieldSelect
               id={`${uid}-content`}
-              placeholder="video-ad"
               baseOptionValues={context.utm_fields_values.contents}
               value={data.utm_link.utm_content}
               onChange={(value) => setData("utm_link.utm_content", value)}
@@ -498,7 +491,7 @@ const UtmFieldSelect = ({
   onChange,
 }: {
   id: string;
-  placeholder: string;
+  placeholder?: string;
   baseOptionValues: string[];
   value: string | null;
   onChange: (value: string | null) => void;

--- a/app/javascript/components/Wishlist/WishlistEditor.tsx
+++ b/app/javascript/components/Wishlist/WishlistEditor.tsx
@@ -71,7 +71,6 @@ export const WishlistEditor = ({
           id={`${uid}-description`}
           type="text"
           value={newDescription}
-          placeholder="Describe your wishlist"
           onChange={(e) => setNewDescription(e.target.value)}
           onBlur={() => void update()}
         />

--- a/app/javascript/components/WorkflowsPage/WorkflowForm.tsx
+++ b/app/javascript/components/WorkflowsPage/WorkflowForm.tsx
@@ -336,7 +336,6 @@ const WorkflowForm = ({ context, workflow }: WorkflowFormProps) => {
               id="name"
               type="text"
               ref={nameInputRef}
-              placeholder="Name of workflow"
               maxLength={255}
               value={formState.name}
               onChange={(e) => updateFormState({ name: e.target.value })}
@@ -460,7 +459,6 @@ const WorkflowForm = ({ context, workflow }: WorkflowFormProps) => {
               </FieldsetTitle>
               <TagInput
                 inputId="affiliated_products"
-                placeholder="Select products..."
                 isDisabled={wasPublishedPreviously}
                 tagIds={formState.affiliatedProducts}
                 tagList={selectableProductAndVariantOptions(
@@ -508,7 +506,6 @@ const WorkflowForm = ({ context, workflow }: WorkflowFormProps) => {
               </FieldsetTitle>
               <TagInput
                 inputId="bought"
-                placeholder="Any product"
                 isDisabled={wasPublishedPreviously}
                 tagIds={formState.bought}
                 tagList={selectableProductAndVariantOptions(context.products_and_variant_options, formState.bought)}
@@ -530,7 +527,6 @@ const WorkflowForm = ({ context, workflow }: WorkflowFormProps) => {
               </FieldsetTitle>
               <TagInput
                 inputId="not_bought"
-                placeholder="No products"
                 isDisabled={wasPublishedPreviously}
                 tagIds={formState.notBought}
                 tagList={selectableProductAndVariantOptions(context.products_and_variant_options, formState.notBought)}

--- a/app/javascript/components/server-components/TaxesCollectionModal.tsx
+++ b/app/javascript/components/server-components/TaxesCollectionModal.tsx
@@ -80,7 +80,6 @@ export const TaxesCollectionModal = ({ taxesOwed, creditCreationDate, name }: Pr
                 id={`${uid}optInFullName`}
                 type="text"
                 aria-invalid={error.length !== 0}
-                placeholder="Full name"
                 disabled={saving}
                 value={signature}
                 onChange={(e) => {

--- a/app/javascript/pages/AffiliateRequests/New.tsx
+++ b/app/javascript/pages/AffiliateRequests/New.tsx
@@ -97,7 +97,6 @@ const AffiliateRequestsNew = () => {
                     id={nameUID}
                     type="text"
                     required
-                    placeholder="Name"
                     value={data.affiliate_request.name}
                     onChange={(event) => setData("affiliate_request.name", event.target.value)}
                   />
@@ -112,7 +111,6 @@ const AffiliateRequestsNew = () => {
                     id={emailUID}
                     type="email"
                     required
-                    placeholder="Email"
                     value={data.affiliate_request.email}
                     onChange={(event) => setData("affiliate_request.email", event.target.value)}
                   />

--- a/app/javascript/pages/Affiliates/Form.tsx
+++ b/app/javascript/pages/Affiliates/Form.tsx
@@ -97,7 +97,7 @@ export const AffiliateForm = ({
                     <Input
                       type="text"
                       autoComplete="off"
-                      placeholder="Commission"
+                      aria-label="Commission"
                       disabled={processing || !applyToAllProducts}
                       {...inputProps}
                     />
@@ -140,7 +140,7 @@ export const AffiliateForm = ({
                     <Input
                       type="text"
                       autoComplete="off"
-                      placeholder="Commission"
+                      aria-label="Commission"
                       disabled={processing || !product.enabled}
                       {...inputProps}
                     />

--- a/app/javascript/pages/Affiliates/Onboarding.tsx
+++ b/app/javascript/pages/Affiliates/Onboarding.tsx
@@ -277,7 +277,7 @@ const ProductRow = ({ product, disabled, onChange }: ProductRowProps) => {
                 <Input
                   type="text"
                   autoComplete="off"
-                  placeholder="Commission"
+                  aria-label="Commission"
                   disabled={disabled || !product.enabled}
                   {...inputProps}
                 />

--- a/app/javascript/pages/Products/New.tsx
+++ b/app/javascript/pages/Products/New.tsx
@@ -356,7 +356,6 @@ const NewProductPage = () => {
                 <Input
                   id={`name-${formUID}`}
                   type="text"
-                  placeholder="Name of product"
                   value={form.data.link.name}
                   onChange={(e) => form.setData("link.name", e.target.value)}
                   aria-invalid={!!errors["link.name"]}
@@ -420,7 +419,6 @@ const NewProductPage = () => {
                     type="text"
                     inputMode="decimal"
                     maxLength={10}
-                    placeholder="Price your product"
                     value={form.data.link.price_range}
                     onChange={(e) => {
                       let newValue = e.target.value;

--- a/app/javascript/pages/Public/Widgets.tsx
+++ b/app/javascript/pages/Public/Widgets.tsx
@@ -219,7 +219,6 @@ const OverlayPanel = ({ selectedProduct }: PanelProps) => {
           <Input
             id={buttonTextUID}
             type="text"
-            placeholder="Buy on"
             value={buttonText}
             onChange={(evt) => setButtonText(evt.target.value)}
           />

--- a/app/javascript/pages/Purchases/Invoices/New.tsx
+++ b/app/javascript/pages/Purchases/Invoices/New.tsx
@@ -95,7 +95,6 @@ const PurchaseNewInvoicePage = () => {
                 <Label htmlFor="full_name">Full name</Label>
                 <Input
                   id="full_name"
-                  placeholder="Full name"
                   type="text"
                   value={form.data.address_fields.full_name}
                   onChange={(e) => form.setData("address_fields.full_name", e.target.value)}
@@ -119,7 +118,6 @@ const PurchaseNewInvoicePage = () => {
                 <Input
                   id="street_address"
                   type="text"
-                  placeholder="Street address"
                   value={form.data.address_fields.street_address}
                   onChange={(e) => form.setData("address_fields.street_address", e.target.value)}
                 />
@@ -130,7 +128,6 @@ const PurchaseNewInvoicePage = () => {
                   <Input
                     id="city"
                     type="text"
-                    placeholder="City"
                     value={form.data.address_fields.city}
                     onChange={(e) => form.setData("address_fields.city", e.target.value)}
                   />
@@ -140,7 +137,6 @@ const PurchaseNewInvoicePage = () => {
                   <Input
                     id="state"
                     type="text"
-                    placeholder="State"
                     value={form.data.address_fields.state}
                     onChange={(e) => form.setData("address_fields.state", e.target.value)}
                   />
@@ -150,7 +146,6 @@ const PurchaseNewInvoicePage = () => {
                   <Input
                     id="zip_code"
                     type="text"
-                    placeholder="ZIP code"
                     value={form.data.address_fields.zip_code}
                     onChange={(e) => form.setData("address_fields.zip_code", e.target.value)}
                   />
@@ -178,7 +173,6 @@ const PurchaseNewInvoicePage = () => {
                 <Textarea
                   id="additional_notes"
                   name="additional_notes"
-                  placeholder="Enter anything else you'd like to appear on your invoice (Optional)"
                   value={form.data.additional_notes}
                   onChange={(e) => form.setData("additional_notes", e.target.value)}
                 />

--- a/app/javascript/pages/Settings/Main/Show.tsx
+++ b/app/javascript/pages/Settings/Main/Show.tsx
@@ -362,7 +362,6 @@ export default function MainPage() {
                       maxLength={3000}
                       rows={10}
                       value={form.data.user.seller_refund_policy.fine_print || ""}
-                      placeholder="Describe your refund policy"
                       disabled={isFormDisabled}
                       onChange={(e) =>
                         updateUserSettings({

--- a/app/javascript/pages/Settings/Team/Show.tsx
+++ b/app/javascript/pages/Settings/Team/Show.tsx
@@ -159,7 +159,6 @@ const AddTeamMembersSection = ({
             id={emailUID}
             type="text"
             ref={emailFieldRef}
-            placeholder="Team member's email"
             className="required"
             value={teamInvitation.email}
             onChange={(evt) => {
@@ -179,7 +178,6 @@ const AddTeamMembersSection = ({
             options={options.filter((o) => o.id !== "owner")}
             isMulti={false}
             isClearable={false}
-            placeholder="Choose a role"
             value={options.find((o) => o.id === teamInvitation.role) ?? null}
             onChange={(evt) => {
               if (evt !== null) {

--- a/app/javascript/pages/Settings/ThirdPartyAnalytics/Show.tsx
+++ b/app/javascript/pages/Settings/ThirdPartyAnalytics/Show.tsx
@@ -337,7 +337,6 @@ const SnippetRow = ({
             <Label htmlFor={`${uid}code`}>Code</Label>
             <Textarea
               id={`${uid}code`}
-              placeholder="Enter your analytics code"
               value={snippet.code}
               onChange={(evt) => updateSnippet({ code: evt.target.value })}
             />

--- a/app/javascript/pages/User/Passwords/Edit.tsx
+++ b/app/javascript/pages/User/Passwords/Edit.tsx
@@ -42,7 +42,6 @@ function PasswordReset() {
               id={`${uid}-password`}
               value={form.data.user.password}
               onChange={(e) => form.setData("user.password", e.target.value)}
-              placeholder="Password"
               required
               autoFocus
               autoComplete="new-password"
@@ -56,7 +55,6 @@ function PasswordReset() {
               id={`${uid}-password-confirmation`}
               value={form.data.user.password_confirmation}
               onChange={(e) => form.setData("user.password_confirmation", e.target.value)}
-              placeholder="Password (to confirm)"
               required
               autoComplete="new-password"
             />

--- a/spec/requests/affiliates_spec.rb
+++ b/spec/requests/affiliates_spec.rb
@@ -17,7 +17,7 @@ describe "Affiliates", type: :system, js: true do
     expect(page).to have_selector("[role='status']", text: "$20 off will be applied at checkout (Code FREE)")
     expect(page).to have_selector("[itemprop='price']", text: "$20 $0")
     click_on "I want this!"
-    fill_in("Your email address", with: "test@gumroad.com")
+    fill_in("Email address", with: "test@gumroad.com")
     click_on "Get"
     expect(page).to have_alert(text: "Your purchase was successful!")
   end

--- a/spec/requests/products/edit/digital_versions_spec.rb
+++ b/spec/requests/products/edit/digital_versions_spec.rb
@@ -77,7 +77,7 @@ describe("Product Edit Digital Versions", type: :system, js: true) do
       click_on "Add version"
       within version_rows[0] do
         within version_option_rows[2] do
-          fill_in "Version name", with: "Second version"
+          fill_in "Name", with: "Second version"
         end
 
         # Fix flaky spec when the banner component is present.

--- a/spec/requests/products/edit/integrations/circle_integrations_spec.rb
+++ b/spec/requests/products/edit/integrations/circle_integrations_spec.rb
@@ -125,12 +125,14 @@ describe("Product Edit Integrations edit - Circle", :without_circle_rate_limit, 
               select("Tests", from: "Select a space group")
 
               click_on("Add version")
-              fill_in "Version name", with: "Files"
+              within version_rows.last do
+                fill_in "Name", with: "Files"
+              end
 
               click_on("Add version")
               within version_rows[0] do
                 within version_option_rows[0] do
-                  fill_in "Version name", with: "New Version"
+                  fill_in "Name", with: "New Version"
                   check "Enable access to Circle community", allow_label_click: true
                 end
               end

--- a/spec/requests/products/edit/integrations/discord_integrations_spec.rb
+++ b/spec/requests/products/edit/integrations/discord_integrations_spec.rb
@@ -169,12 +169,14 @@ describe("Product Edit Integrations edit - Discord", type: :system, js: true) do
           expect(page).to have_button "Disconnect Discord"
 
           click_on "Add version"
-          fill_in "Version name", with: "Files"
+          within version_rows.last do
+            fill_in "Name", with: "Files"
+          end
 
           click_on "Add version"
           within version_rows[0] do
             within version_option_rows[0] do
-              fill_in "Version name", with: "New Version"
+              fill_in "Name", with: "New Version"
               check "Enable access to Discord server", allow_label_click: true
             end
           end

--- a/spec/requests/products/edit/options_spec.rb
+++ b/spec/requests/products/edit/options_spec.rb
@@ -33,7 +33,7 @@ describe("ProductMoreOptionScenario", type: :system, js: true) do
 
       click_on "Add version"
       within version_rows.last do
-        fill_in "Version name", with: "M"
+        fill_in "Name", with: "M"
       end
 
       expect do
@@ -65,7 +65,7 @@ describe("ProductMoreOptionScenario", type: :system, js: true) do
 
       click_on "Add version"
       within version_rows.last do
-        fill_in "Version name", with: "99%"
+        fill_in "Name", with: "99%"
       end
 
       save_change

--- a/spec/requests/products/edit/preview_spec.rb
+++ b/spec/requests/products/edit/preview_spec.rb
@@ -20,7 +20,7 @@ describe("Product Edit Previews", type: :system, js: true) do
   it "opens the full-screen preview only after the changes have been saved" do
     visit edit_link_path(product.unique_permalink)
 
-    fill_in("You'll get...", with: "This should be saved automatically")
+    fill_in("Summary", with: "This should be saved automatically")
 
     new_window = window_opened_by do
       click_on "Preview"
@@ -63,13 +63,13 @@ describe("Product Edit Previews", type: :system, js: true) do
 
     click_on "Add version"
     within version_rows[0] do
-      fill_in "Version name", with: "Version 1"
+      fill_in "Name", with: "Version 1"
     end
 
     click_on "Add version"
     within version_rows[0] do
       within version_option_rows[1] do
-        fill_in "Version name", with: "Version 2"
+        fill_in "Name", with: "Version 2"
         fill_in "Maximum number of purchases", with: 0
       end
     end

--- a/spec/requests/purchases/product/payment_errors_spec.rb
+++ b/spec/requests/purchases/product/payment_errors_spec.rb
@@ -125,9 +125,9 @@ describe("Purchase from a product page", type: :system, js: true) do
 
     fill_in_credit_card
     click_on "Pay"
-    expect_focused find_field("Your email address")
+    expect_focused find_field("Email address")
 
-    fill_in "Your email address", with: "gumroad@example.com"
+    fill_in "Email address", with: "gumroad@example.com"
     click_on "Pay"
     expect_focused find_field("Full name")
 

--- a/spec/requests/purchases/product/taxes_spec.rb
+++ b/spec/requests/purchases/product/taxes_spec.rb
@@ -3910,7 +3910,7 @@ describe("Product Page - Tax Scenarios", type: :system, js: true) do
 
       expect(page).to have_select("Country", selected: "Austria")
 
-      fill_in("Your email address", with: "test@test.com")
+      fill_in("Email address", with: "test@test.com")
       fill_in_credit_card
 
       fill_in("Business VAT ID (optional)", with: "NL860999063B01\t")

--- a/spec/requests/settings/payments_spec.rb
+++ b/spec/requests/settings/payments_spec.rb
@@ -657,12 +657,12 @@ describe("Payments Settings Scenario", type: :system, js: true) do
         visit settings_payments_path
 
         choose "Individual"
-        fill_in "Street address", with: "P.O. Box 123, Smith street"
+        find_field("Address", match: :first).set("P.O. Box 123, Smith street")
         expect do
           click_on "Update settings"
           expect(page).to have_status(text: "We require a valid physical US address. We cannot accept a P.O. Box as a valid address.")
         end.to_not change { @user.alive_user_compliance_info.reload.street_address }
-        fill_in "Street address", with: "123, Smith street"
+        find_field("Address", match: :first).set("123, Smith street")
         expect do
           click_on "Update settings"
           wait_for_ajax
@@ -689,7 +689,7 @@ describe("Payments Settings Scenario", type: :system, js: true) do
           expect(page).to have_alert(text: "Thanks! You're all set.")
           sleep 0.5 # Since the previous Alerts takes time to disappear, checking alert returns early before the api call is complete
         end.to change { @user.alive_user_compliance_info.reload.business_street_address }.to("123 North street")
-        fill_in "Street address", with: "po box 123 smith street"
+        find(:css, "input[id$='creator-street-address']").set("po box 123 smith street")
         expect do
           click_on "Update settings"
           expect(page).to have_status(text: "We require a valid physical US address. We cannot accept a P.O. Box as a valid address.")

--- a/spec/requests/settings/payments_spec.rb
+++ b/spec/requests/settings/payments_spec.rb
@@ -6276,7 +6276,7 @@ describe("Payments Settings Scenario", type: :system, js: true) do
 
           click_on "Opt-in to backtaxes collection"
 
-          expect(page).to have_field("Type your full name to opt-in", placeholder: "Full name")
+          expect(page).to have_field("Type your full name to opt-in")
         end
       end
     end


### PR DESCRIPTION
Remove placeholder attributes from inputs that already have visible labels, since they are redundant and can cause Capybara ambiguity in tests.

Update specs to use `find_field` with `match: :first` or CSS selectors instead of matching on removed placeholder text.

Replaces #4641 with a clean branch (no unrelated commits in diff).