### PR TITLE
Fix CheckoutController#show timeout: eager-load cart product associations

### DIFF
--- a/app/presenters/cart_presenter.rb
+++ b/app/presenters/cart_presenter.rb
@@ -14,6 +14,23 @@ class CartPresenter
     return if cart.nil?
 
     cart_products = cart.cart_products.alive.joins(:product).merge(Link.not_archived).order(created_at: :desc)
+      .preload(
+        :option,
+        :affiliate,
+        { accepted_offer: :offer_code },
+        { product: [
+          :user,
+          :thumbnail,
+          :installment_plan,
+          :custom_fields,
+          :shipping_destinations,
+          :prices,
+          :variant_categories_alive,
+          :alive_variants,
+          { available_upsell: :seller },
+          { bundle_products: [:product, :variant] },
+        ] }
+      ).load
 
     {
       email: cart.email.presence,

--- a/app/presenters/checkout_presenter.rb
+++ b/app/presenters/checkout_presenter.rb
@@ -19,7 +19,7 @@ class CheckoutPresenter
   end
 
   def checkout_props(params:, browser_guid:)
-    geo = GeoIp.lookup(@ip)
+    geo = geo_data
     detected_country = geo.try(:country_name)
     country = logged_in_user&.country || detected_country
     detected_state = geo.try(:region_name) if [Compliance::Countries::USA, Compliance::Countries::CAN].any? { |country| country.common_name == detected_country }
@@ -95,7 +95,7 @@ class CheckoutPresenter
             }
           )
         end,
-        ppp_details: product.ppp_details(@ip),
+        ppp_details: ppp_details_for(product),
         upsell: product.available_upsell.present? ? {
           id: product.available_upsell.external_id,
           text: product.available_upsell.text,
@@ -286,6 +286,28 @@ class CheckoutPresenter
         ca_provinces: Compliance::Countries.subdivisions_for_select(Compliance::Countries::CAN.alpha2).map(&:first),
         recaptcha_key: GlobalConfig.get("RECAPTCHA_MONEY_SITE_KEY"),
         paypal_client_id: PAYPAL_PARTNER_CLIENT_ID,
+      }
+    end
+
+    def geo_data
+      return @geo if defined?(@geo)
+
+      @geo = GeoIp.lookup(@ip)
+    end
+
+    def ppp_details_for(product)
+      return unless product.purchasing_power_parity_enabled?
+
+      geo = geo_data
+      return if geo.blank?
+
+      ppp_factor = PurchasingPowerParityService.new.get_factor(geo.country_code, product.user)
+      return unless ppp_factor < 1
+
+      {
+        country: geo.country_name,
+        factor: ppp_factor,
+        minimum_price: product.currency["min_price"],
       }
     end
 

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -52,6 +52,23 @@ describe CheckoutController, type: :controller, inertia: true do
       )
     end
 
+    it "renders successfully with multiple cart products" do
+      browser_guid = SecureRandom.uuid
+      cookies[:_gumroad_guid] = browser_guid
+      cart = create(:cart, :guest, browser_guid: browser_guid)
+
+      5.times do
+        product = create(:product)
+        create(:cart_product, cart:, product:)
+      end
+
+      get :show
+
+      expect(response).to be_successful
+      expect(inertia.component).to eq("Checkout/Show")
+      expect(inertia.props.dig(:cart, :items)&.size).to eq(5)
+    end
+
     describe "process_cart_id_param check" do
       let(:user) { create(:user) }
       let(:cart) { create(:cart, user:) }

--- a/spec/presenters/cart_presenter_spec.rb
+++ b/spec/presenters/cart_presenter_spec.rb
@@ -146,6 +146,37 @@ describe CartPresenter do
       end
     end
 
+    context "with many cart items" do
+      let(:cart) { create(:cart, user:) }
+      let(:seller) { create(:user) }
+
+      def count_queries(&block)
+        queries = []
+        callback = lambda do |_name, _start, _finish, _id, payload|
+          next if payload[:cached]
+          next if payload[:name]&.match?(/SCHEMA|TRANSACTION/)
+          queries << payload[:sql] if payload[:sql].present?
+        end
+        ActiveSupport::Notifications.subscribed(callback, "sql.active_record", &block)
+        queries
+      end
+
+      def add_cart_product!
+        product = create(:product, user: seller)
+        create(:cart_product, cart:, product:)
+      end
+
+      it "keeps per-product query growth bounded" do
+        3.times { add_cart_product! }
+        baseline = count_queries { described_class.new(logged_in_user: user, ip:, browser_guid:).cart_props }.size
+
+        7.times { add_cart_product! }
+        grown = count_queries { described_class.new(logged_in_user: user, ip:, browser_guid:).cart_props }.size
+
+        expect((grown - baseline) / 7.0).to be < 15
+      end
+    end
+
     context "with discount codes and offers" do
       context "when the user has accepeted an upsell" do
         let(:discount_codes) do


### PR DESCRIPTION
## Summary
- eager-load cart product associations in `CartPresenter#cart_props` to reduce per-item checkout fan-out
- memoize the checkout GeoIP lookup so PPP details reuse the same geo result across cart items
- add regressions for cart query growth and multi-item checkout rendering

Sentry: https://gumroad-to.sentry.io/issues/7432805632/

## Testing
- `RBENV_VERSION=3.4.3 rbenv exec bundle exec rspec spec/presenters/cart_presenter_spec.rb`
- `RBENV_VERSION=3.4.3 rbenv exec bundle exec rspec spec/controllers/checkout_controller_spec.rb -e "renders successfully with multiple cart products"`