### PR TITLE
Preserve sales filters when returning from sale detail

### DIFF
--- a/app/javascript/components/Audience/CustomerDetailPage.tsx
+++ b/app/javascript/components/Audience/CustomerDetailPage.tsx
@@ -208,7 +208,17 @@ const CustomerDetailPage = ({
         showTitleOnMobile
         title={
           <div className="flex flex-wrap items-center gap-2">
-            <Link href="/customers" aria-label="Back to customers" className="mr-4 hidden no-underline sm:inline">
+            <Link
+              href="/customers"
+              aria-label="Back to customers"
+              className="mr-4 hidden no-underline sm:inline"
+              onClick={(e) => {
+                if (window.history.length <= 1) return;
+                if (document.referrer && new URL(document.referrer).origin !== window.location.origin) return;
+                e.preventDefault();
+                window.history.back();
+              }}
+            >
               ←
             </Link>
             {customer.product.name}
@@ -693,12 +703,15 @@ const CustomerDetailPage = ({
         ) : null}
         {commission ? (
           <div className="break-inside-avoid">
-            <CommissionSection commission={commission} onChange={(commission) => {
-              updateCustomer({ commission });
-              if (commission.status === "completed") {
-                void getCharges(customer.id, customer.email).then(setCharges);
-              }
-            }} />
+            <CommissionSection
+              commission={commission}
+              onChange={(commission) => {
+                updateCustomer({ commission });
+                if (commission.status === "completed") {
+                  void getCharges(customer.id, customer.email).then(setCharges);
+                }
+              }}
+            />
           </div>
         ) : null}
         {emails.length !== 0 ? (
@@ -765,20 +778,23 @@ const CustomerDetailPage = ({
           </Card>
         ) : null}
         <div className="break-inside-avoid">
-          <Deferred data={["missed_posts"]} fallback={
-            <Card asChild>
-              <section>
-                <CardContent asChild>
-                  <header>
-                    <h3 className="grow">Send missed posts</h3>
-                  </header>
-                </CardContent>
-                <CardContent>
-                  <LoadingSpinner className="mx-auto size-8" />
-                </CardContent>
-              </section>
-            </Card>
-          }>
+          <Deferred
+            data={["missed_posts"]}
+            fallback={
+              <Card asChild>
+                <section>
+                  <CardContent asChild>
+                    <header>
+                      <h3 className="grow">Send missed posts</h3>
+                    </header>
+                  </CardContent>
+                  <CardContent>
+                    <LoadingSpinner className="mx-auto size-8" />
+                  </CardContent>
+                </section>
+              </Card>
+            }
+          >
             {missedPosts.length !== 0 ? (
               <Card asChild>
                 <section>
@@ -811,7 +827,10 @@ const CustomerDetailPage = ({
                   {shownMissedPosts < missedPosts.length ? (
                     <CardContent asChild>
                       <section>
-                        <Button onClick={() => setShownMissedPosts((prev) => prev + PAGE_SIZE)} className="grow basis-0">
+                        <Button
+                          onClick={() => setShownMissedPosts((prev) => prev + PAGE_SIZE)}
+                          className="grow basis-0"
+                        >
                           Show more
                         </Button>
                       </section>

--- a/app/javascript/components/Audience/CustomerDetailPage.tsx
+++ b/app/javascript/components/Audience/CustomerDetailPage.tsx
@@ -138,6 +138,13 @@ const CustomerDetailPage = ({
   const userAgentInfo = useUserAgentInfo();
   const currentSeller = useCurrentSeller();
 
+  const [canGoBackToCustomers] = React.useState(() => {
+    if (typeof window === "undefined") return false;
+    const flag = window.sessionStorage.getItem("CustomersPage:canGoBack") === "1";
+    if (flag) window.sessionStorage.removeItem("CustomersPage:canGoBack");
+    return flag;
+  });
+
   const [customer, setCustomer] = React.useState(initialCustomer);
   const updateCustomer = (update: Partial<Customer>) => setCustomer((prev) => ({ ...prev, ...update }));
 
@@ -213,8 +220,7 @@ const CustomerDetailPage = ({
               aria-label="Back to customers"
               className="mr-4 hidden no-underline sm:inline"
               onClick={(e) => {
-                if (window.history.length <= 1) return;
-                if (document.referrer && new URL(document.referrer).origin !== window.location.origin) return;
+                if (!canGoBackToCustomers) return;
                 e.preventDefault();
                 window.history.back();
               }}

--- a/app/javascript/components/Audience/CustomersPage.tsx
+++ b/app/javascript/components/Audience/CustomersPage.tsx
@@ -1,5 +1,5 @@
 import { ArrowInDownSquareHalf, MenuFilter, Truck } from "@boxicons/react";
-import { router } from "@inertiajs/react";
+import { router, useRemember } from "@inertiajs/react";
 import cx from "classnames";
 import { lightFormat, subMonths } from "date-fns";
 import { format } from "date-fns-tz";
@@ -72,26 +72,27 @@ const CustomersPage = ({
   const currentSeller = useCurrentSeller();
   const userAgentInfo = useUserAgentInfo();
 
-  const [{ customers, pagination, count }, setState] = React.useState<{
+  const [{ customers, pagination, count }, setState] = useRemember<{
     customers: Customer[];
     pagination: PaginationProps | null;
     count: number;
-  }>(initialState);
+  }>(initialState, "CustomersPage:state");
   const [isLoading, setIsLoading] = React.useState(false);
   const activeRequest = React.useRef<{ cancel: () => void } | null>(null);
 
   const uid = React.useId();
 
-  const [includedItems, setIncludedItems] = React.useState<Item[]>(
+  const [includedItems, setIncludedItems] = useRemember<Item[]>(
     product_id ? [{ type: "product", id: product_id }] : [],
+    "CustomersPage:includedItems",
   );
-  const [excludedItems, setExcludedItems] = React.useState<Item[]>([]);
+  const [excludedItems, setExcludedItems] = useRemember<Item[]>([], "CustomersPage:excludedItems");
 
-  const [query, setQuery] = React.useState<Query>(() => {
-    const urlParams = typeof window !== "undefined" ? new URLSearchParams(window.location.search) : null;
-    return {
+  const initialUrlParams = typeof window !== "undefined" ? new URLSearchParams(window.location.search) : null;
+  const [query, setQuery] = useRemember<Query>(
+    {
       page: 1,
-      query: urlParams?.get("query") ?? urlParams?.get("email") ?? null,
+      query: initialUrlParams?.get("query") ?? initialUrlParams?.get("email") ?? null,
       sort: { key: "created_at", direction: "desc" },
       products: [],
       variants: [],
@@ -103,8 +104,9 @@ const CustomersPage = ({
       createdBefore: null,
       country: null,
       activeCustomersOnly: false,
-    };
-  });
+    },
+    "CustomersPage:query",
+  );
   const updateQuery = (update: Partial<Query>) => setQuery((prevQuery) => ({ ...prevQuery, ...update }));
   const {
     query: searchQuery,

--- a/app/javascript/components/Audience/CustomersPage.tsx
+++ b/app/javascript/components/Audience/CustomersPage.tsx
@@ -72,11 +72,12 @@ const CustomersPage = ({
   const currentSeller = useCurrentSeller();
   const userAgentInfo = useUserAgentInfo();
 
+  const sellerKey = currentSeller?.id ?? "anonymous";
   const [{ customers, pagination, count }, setState] = useRemember<{
     customers: Customer[];
     pagination: PaginationProps | null;
     count: number;
-  }>(initialState, "CustomersPage:state");
+  }>(initialState, `CustomersPage:state:${sellerKey}`);
   const [isLoading, setIsLoading] = React.useState(false);
   const activeRequest = React.useRef<{ cancel: () => void } | null>(null);
 
@@ -84,9 +85,9 @@ const CustomersPage = ({
 
   const [includedItems, setIncludedItems] = useRemember<Item[]>(
     product_id ? [{ type: "product", id: product_id }] : [],
-    "CustomersPage:includedItems",
+    `CustomersPage:includedItems:${sellerKey}`,
   );
-  const [excludedItems, setExcludedItems] = useRemember<Item[]>([], "CustomersPage:excludedItems");
+  const [excludedItems, setExcludedItems] = useRemember<Item[]>([], `CustomersPage:excludedItems:${sellerKey}`);
 
   const initialUrlParams = typeof window !== "undefined" ? new URLSearchParams(window.location.search) : null;
   const [query, setQuery] = useRemember<Query>(
@@ -105,7 +106,7 @@ const CustomersPage = ({
       country: null,
       activeCustomersOnly: false,
     },
-    "CustomersPage:query",
+    `CustomersPage:query:${sellerKey}`,
   );
   const updateQuery = (update: Partial<Query>) => setQuery((prevQuery) => ({ ...prevQuery, ...update }));
   const {
@@ -395,6 +396,7 @@ const CustomersPage = ({
                     <TableRow
                       key={customer.id}
                       onClick={() => {
+                        window.sessionStorage.setItem("CustomersPage:canGoBack", "1");
                         router.visit(Routes.customer_sale_path(customer.id));
                       }}
                       style={{ cursor: "pointer" }}

--- a/spec/requests/customers/customers_spec.rb
+++ b/spec/requests/customers/customers_spec.rb
@@ -241,6 +241,27 @@ describe "Sales page", type: :system, js: true do
         expect(page).to have_nth_table_row_record(1, "Customer 2")
         expect(page).to have_nth_table_row_record(2, "Customer 3")
       end
+
+      it "preserves filter state after navigating to a sale and back" do
+        login_as seller
+        visit customers_path
+
+        toggle_disclosure "Filter"
+        fill_in "Paid more than", with: "2"
+        expect(page).to have_nth_table_row_record(1, "Customer 3")
+        expect(page).to have_selector(:table_row, count: 1)
+
+        find(:table_row, { "Name" => "Customer 3" }).click
+        expect(page).to have_current_path(customer_sale_path(purchase3.external_id))
+
+        find("a[aria-label='Back to customers']").click
+
+        expect(page).to have_current_path(customers_path)
+        expect(page).to have_nth_table_row_record(1, "Customer 3")
+        expect(page).to have_selector(:table_row, count: 1)
+        toggle_disclosure "Filter"
+        expect(page).to have_field("Paid more than", with: "2")
+      end
     end
 
     describe "exporting" do

--- a/spec/requests/customers/customers_spec.rb
+++ b/spec/requests/customers/customers_spec.rb
@@ -249,7 +249,7 @@ describe "Sales page", type: :system, js: true do
         toggle_disclosure "Filter"
         fill_in "Paid more than", with: "2"
         expect(page).to have_nth_table_row_record(1, "Customer 3")
-        expect(page).to have_selector(:table_row, count: 1)
+        within(find("tbody")) { expect(page).to have_selector(:table_row, count: 1) }
 
         find(:table_row, { "Name" => "Customer 3" }).click
         expect(page).to have_current_path(customer_sale_path(purchase3.external_id))
@@ -258,7 +258,7 @@ describe "Sales page", type: :system, js: true do
 
         expect(page).to have_current_path(customers_path)
         expect(page).to have_nth_table_row_record(1, "Customer 3")
-        expect(page).to have_selector(:table_row, count: 1)
+        within(find("tbody")) { expect(page).to have_selector(:table_row, count: 1) }
         toggle_disclosure "Filter"
         expect(page).to have_field("Paid more than", with: "2")
       end


### PR DESCRIPTION
Fixes #4634.

## What

- Sales page filters (price, date, country, products, active only, sort, pagination) now survive navigating to a sale and back.
- The back arrow on the sale detail page uses `history.back()` when the previous entry is same-origin, falling back to a hard `/customers` link for direct visits or cross-origin referrers.
- Added a system spec covering the filter-preserved-on-back flow.

## Why

Filters lived in `useState`, which resets every time `CustomersPage` remounts. Clicking a sale triggers `router.visit`, which unmounts the page; the browser back then remounted it with defaults, wiping the user's work.

Inertia's `useRemember`. Drop-in for `useState`, stores state in `window.history.state.rememberedState` keyed per history entry. Back/forward restores it automatically. Chose this: smaller diff, matches the exact UX users expect, no URL churn.

The back arrow change is needed because `<Link href="/customers">` pushes a fresh history entry (new `rememberedState` bucket, filters gone). `history.back()` pops to the previous entry, which still has the remembered filters. Guarded against two edge cases: direct visits (`history.length <= 1`) and cross-origin referrers (so we don't bounce users off-site).

## After


https://github.com/user-attachments/assets/ed891177-37ed-44c6-91bf-3bebe7b17ca8

