### PR TITLE
Fix ScheduledPayout#execute! to surface meaningful error messages

### DIFF
--- a/app/models/scheduled_payout.rb
+++ b/app/models/scheduled_payout.rb
@@ -66,14 +66,26 @@ class ScheduledPayout < ApplicationRecord
 
     if process_payout
       begin
-        payments = PayoutUsersService.new(
-          date_string: Date.yesterday.to_s,
-          processor_type: user.current_payout_processor,
-          user_ids: user.id
-        ).process
-        payment = payments.last
-        if payment.blank? || payment.failed?
-          raise "Payout failed: #{payment&.errors&.full_messages&.first || "Payment was not sent."}"
+        payment, payment_errors = Payouts.create_payment(
+          Date.yesterday.to_s,
+          user.current_payout_processor,
+          user
+        )
+
+        if payment.blank?
+          error_detail = if payment_errors.present?
+            payment_errors.join(", ")
+          else
+            "No payable balance available"
+          end
+          raise "Payout failed: #{error_detail}"
+        end
+
+        payout_processor = PayoutProcessorType.get(user.current_payout_processor)
+        payout_processor.process_payments([payment])
+
+        if payment.reload.failed?
+          raise "Payout failed: #{payment.errors.full_messages.first || "Payment processing failed"}"
         end
       rescue => e
         update!(status: "pending", executed_at: nil)

--- a/spec/models/scheduled_payout_spec.rb
+++ b/spec/models/scheduled_payout_spec.rb
@@ -171,12 +171,15 @@ describe ScheduledPayout do
     context "when action is payout" do
       let(:scheduled_payout) { create(:scheduled_payout, user: user, action: "payout", scheduled_at: 1.day.ago) }
 
-      it "calls PayoutUsersService to create payout and marks as executed" do
-        payment = instance_double(Payment, failed?: false)
-        service = instance_double(PayoutUsersService, process: [payment])
-        expect(PayoutUsersService).to receive(:new)
-          .with(date_string: Date.yesterday.to_s, processor_type: user.current_payout_processor, user_ids: user.id)
-          .and_return(service)
+      it "creates a payment via Payouts.create_payment and marks as executed" do
+        payment = instance_double(Payment, failed?: false, reload: nil)
+        allow(payment).to receive(:reload).and_return(payment)
+        processor = class_double(StripePayoutProcessor, process_payments: nil)
+        expect(Payouts).to receive(:create_payment)
+          .with(Date.yesterday.to_s, user.current_payout_processor, user)
+          .and_return([payment, nil])
+        expect(PayoutProcessorType).to receive(:get).with(user.current_payout_processor).and_return(processor)
+        expect(processor).to receive(:process_payments).with([payment])
 
         scheduled_payout.execute!
 
@@ -186,22 +189,32 @@ describe ScheduledPayout do
 
       it "raises if payout fails" do
         payment = instance_double(Payment, failed?: true, errors: double(full_messages: ["Stripe account not found"]))
-        service = instance_double(PayoutUsersService, process: [payment])
-        allow(PayoutUsersService).to receive(:new)
-          .with(date_string: Date.yesterday.to_s, processor_type: user.current_payout_processor, user_ids: user.id)
-          .and_return(service)
+        allow(payment).to receive(:reload).and_return(payment)
+        processor = class_double(StripePayoutProcessor, process_payments: nil)
+        allow(Payouts).to receive(:create_payment)
+          .with(Date.yesterday.to_s, user.current_payout_processor, user)
+          .and_return([payment, nil])
+        allow(PayoutProcessorType).to receive(:get).with(user.current_payout_processor).and_return(processor)
 
-        expect { scheduled_payout.execute! }.to raise_error(RuntimeError, /Payout failed/)
+        expect { scheduled_payout.execute! }.to raise_error(RuntimeError, /Payout failed: Stripe account not found/)
         expect(scheduled_payout.reload.status).to eq("pending")
       end
 
       it "raises if no payment is created" do
-        service = instance_double(PayoutUsersService, process: [])
-        allow(PayoutUsersService).to receive(:new)
-          .with(date_string: Date.yesterday.to_s, processor_type: user.current_payout_processor, user_ids: user.id)
-          .and_return(service)
+        allow(Payouts).to receive(:create_payment)
+          .with(Date.yesterday.to_s, user.current_payout_processor, user)
+          .and_return([nil, nil])
 
-        expect { scheduled_payout.execute! }.to raise_error(RuntimeError, /Payment was not sent/)
+        expect { scheduled_payout.execute! }.to raise_error(RuntimeError, /Payout failed: No payable balance available/)
+        expect(scheduled_payout.reload.status).to eq("pending")
+      end
+
+      it "raises with payment errors when create_payment returns errors" do
+        allow(Payouts).to receive(:create_payment)
+          .with(Date.yesterday.to_s, user.current_payout_processor, user)
+          .and_return([nil, ["Stripe account not connected"]])
+
+        expect { scheduled_payout.execute! }.to raise_error(RuntimeError, /Payout failed: Stripe account not connected/)
         expect(scheduled_payout.reload.status).to eq("pending")
       end
     end
@@ -210,7 +223,7 @@ describe ScheduledPayout do
       let(:scheduled_payout) { create(:scheduled_payout, user: user, action: "payout", scheduled_at: 1.day.ago, payout_amount_cents: 150_000) }
 
       it "flags for review instead of executing" do
-        expect(PayoutUsersService).not_to receive(:new)
+        expect(Payouts).not_to receive(:create_payment)
 
         scheduled_payout.execute!
 


### PR DESCRIPTION
## Problem

`ScheduledPayout#execute!` was using the batch `PayoutUsersService` which swallowed individual errors, making it hard to diagnose why a scheduled payout failed.

## Fix

Replaced the batch call with direct calls to `Payouts.create_payment` and `PayoutProcessorType.get(...).process_payments`, so errors now surface with meaningful detail:
- Payment-creation errors
- "No payable balance available"
- Processor failure messages

## Tests

- Updated 3 existing tests and added a new test for `create_payment` errors
- All 41 specs in `scheduled_payout_spec.rb` pass
- Rubocop clean