### PR TITLE
Enforce offer code usage limit across cart line items

### DIFF
--- a/app/models/concerns/purchase/blockable.rb
+++ b/app/models/concerns/purchase/blockable.rb
@@ -39,7 +39,8 @@ module Purchase::Blockable
                          PurchaseErrorCode::TEMPORARILY_BLOCKED_PRODUCT,
                          PurchaseErrorCode::BLOCKED_CHARGE_PROCESSOR_FINGERPRINT,
                          PurchaseErrorCode::BLOCKED_CUSTOMER_EMAIL_ADDRESS,
-                         PurchaseErrorCode::BLOCKED_CUSTOMER_CHARGE_PROCESSOR_FINGERPRINT]
+                         PurchaseErrorCode::BLOCKED_CUSTOMER_CHARGE_PROCESSOR_FINGERPRINT,
+                         PurchaseErrorCode::EXCEEDING_OFFER_CODE_QUANTITY]
   private_constant :IGNORED_ERROR_CODES
 
   MAX_BUYER_CHARGEBACKS_BEFORE_BLOCK = 5

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -903,7 +903,10 @@ class Purchase < ApplicationRecord
   # Fails line items in a cart that individually pass `validate_offer_code` but
   # collectively exceed the same offer code's `max_purchase_count`. Single-line carts
   # are skipped because `before_create :validate_offer_code` already handles them.
+  # Returns the array of purchases it marked failed so the caller can route error
+  # responses for them through `Order::ChargeService#ensure_all_purchases_processed`.
   def self.validate_offer_code_usage_across_line_items(purchases)
+    rejected = []
     purchases
       .select { |p| p.offer_code_id && p.in_progress? && p.errors.empty? }
       .group_by(&:offer_code_id)
@@ -917,8 +920,10 @@ class Purchase < ApplicationRecord
           purchase.error_code = PurchaseErrorCode::EXCEEDING_OFFER_CODE_QUANTITY
           Purchase::MarkFailedService.new(purchase).perform
           purchase.errors.add(:base, "Sorry, the discount code you are using is invalid for the quantity you have selected.")
+          rejected << purchase
         end
       end
+    rejected
   end
 
   def self.purchase_response(url_redirect, link, purchase = nil)

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -900,6 +900,27 @@ class Purchase < ApplicationRecord
     self.class.purchase_info(url_redirect, link, self).merge!(variants_displayable: variants_list)
   end
 
+  # Fails line items in a cart that individually pass `validate_offer_code` but
+  # collectively exceed the same offer code's `max_purchase_count`. Single-line carts
+  # are skipped because `before_create :validate_offer_code` already handles them.
+  def self.validate_offer_code_usage_across_line_items(purchases)
+    purchases
+      .select { |p| p.offer_code_id && p.in_progress? && p.errors.empty? }
+      .group_by(&:offer_code_id)
+      .each do |_, code_purchases|
+        next if code_purchases.size < 2
+        offer_code = code_purchases.first.offer_code
+        next if offer_code&.max_purchase_count.nil?
+        next if code_purchases.sum(&:quantity) <= offer_code.quantity_left
+
+        code_purchases.each do |purchase|
+          purchase.error_code = PurchaseErrorCode::EXCEEDING_OFFER_CODE_QUANTITY
+          Purchase::MarkFailedService.new(purchase).perform
+          purchase.errors.add(:base, "Sorry, the discount code you are using is invalid for the quantity you have selected.")
+        end
+      end
+  end
+
   def self.purchase_response(url_redirect, link, purchase = nil)
     extra_purchase_notice = nil
     if link.is_in_preorder_state

--- a/app/services/order/charge_service.rb
+++ b/app/services/order/charge_service.rb
@@ -12,7 +12,7 @@ class Order::ChargeService
   end
 
   def perform
-    Purchase.validate_offer_code_usage_across_line_items(order.purchases)
+    rejected_by_offer_code_limit = Purchase.validate_offer_code_usage_across_line_items(order.purchases)
 
     # We need to make off session charges if there are products from more than one seller
     # In such case we create a reusable payment method before initiating the order from front-end
@@ -28,18 +28,11 @@ class Order::ChargeService
     purchases_by_seller.each do |seller_id, seller_purchases|
       self.charge_intent = nil
       self.setup_intent = nil
-
-      # Every purchase in this seller group has already reached a terminal state
-      # (e.g. pre-failed by `validate_offer_code_usage_across_line_items`) — skip
-      # creating a Charge record that would have no Stripe activity attached.
-      next if seller_purchases.none?(&:in_progress?)
-
       charge = order.charges.create!(seller_id:)
       seller_purchases.each do |purchase|
-        # Skip purchases already failed before the loop (e.g. rejected by
-        # `validate_offer_code_usage_across_line_items`). Running save! would
-        # clear the in-memory errors we need for the line item response.
-        next if purchase.failed?
+        # Skip purchases rejected by `Purchase.validate_offer_code_usage_across_line_items`.
+        # Re-saving would clear the in-memory errors we need for the line item response.
+        next if rejected_by_offer_code_limit.include?(purchase)
         purchase.charge = charge
         purchase.save!
         # Mark free or test purchase as successful as it does not require any further processing
@@ -90,11 +83,10 @@ class Order::ChargeService
       Rails.logger.error("Error charging order (#{order.id}):: #{e.class} => #{e.message} => #{e.backtrace}")
     ensure
       # Ensure all purchases of the charge are transitioned to a terminal state
-      # and each line item has a response. Pass the full seller group so pre-failed
-      # line items (e.g. rejected by `validate_offer_code_usage_across_line_items`)
-      # also get an error response in `charge_responses`. Already-processed line
-      # items are skipped via the `charge_responses[uid].present?` guard inside.
-      ensure_all_purchases_processed(seller_purchases)
+      # and each line item has a response. Include purchases rejected by
+      # `Purchase.validate_offer_code_usage_across_line_items` so their line items
+      # get an error response in `charge_responses`.
+      ensure_all_purchases_processed((non_free_seller_purchases || seller_purchases.select(&:in_progress?)) + (seller_purchases & rejected_by_offer_code_limit))
     end
 
     charge_responses

--- a/app/services/order/charge_service.rb
+++ b/app/services/order/charge_service.rb
@@ -12,8 +12,6 @@ class Order::ChargeService
   end
 
   def perform
-    rejected_by_offer_code_limit = Purchase.validate_offer_code_usage_across_line_items(order.purchases)
-
     # We need to make off session charges if there are products from more than one seller
     # In such case we create a reusable payment method before initiating the order from front-end
     off_session = order.purchases.non_free.pluck(:seller_id).uniq.count > 1
@@ -23,11 +21,19 @@ class Order::ChargeService
     # i.e. one charge per seller
     # Exclude purchases that already have a payment intent (e.g. subscription restarts
     # requiring SCA — they are confirmed later via Order::ConfirmService)
-    purchases_by_seller = order.purchases.reject { _1.processor_payment_intent.present? }.group_by(&:seller_id)
+    chargeable_purchases = order.purchases.reject { _1.processor_payment_intent.present? }
+    rejected_by_offer_code_limit = Purchase.validate_offer_code_usage_across_line_items(chargeable_purchases)
+    purchases_by_seller = chargeable_purchases.group_by(&:seller_id)
 
     purchases_by_seller.each do |seller_id, seller_purchases|
       self.charge_intent = nil
       self.setup_intent = nil
+
+      # Every purchase in this seller group has already reached a terminal state
+      # (e.g. rejected by `validate_offer_code_usage_across_line_items`) — skip
+      # creating a Charge record that would have no Stripe activity attached.
+      next if seller_purchases.none?(&:in_progress?)
+
       charge = order.charges.create!(seller_id:)
       seller_purchases.each do |purchase|
         # Skip purchases rejected by `Purchase.validate_offer_code_usage_across_line_items`.

--- a/app/services/order/charge_service.rb
+++ b/app/services/order/charge_service.rb
@@ -14,6 +14,20 @@ class Order::ChargeService
   def perform
     Purchase.validate_offer_code_usage_across_line_items(order.purchases)
 
+    # Build charge_responses for purchases already failed before the seller loop
+    # (e.g. rejected by `validate_offer_code_usage_across_line_items`) so they get
+    # a per-line-item error response even when the ensure block filters them out.
+    order.purchases.select(&:failed?).each do |purchase|
+      line_item = params[:line_items].find do |li|
+        purchase.link.unique_permalink == li[:permalink] &&
+          (li[:variants].blank? || purchase.variant_attributes.first&.external_id == li[:variants]&.first)
+      end
+      next if line_item.nil?
+      line_item_uid = line_item[:uid]
+      next if charge_responses[line_item_uid].present?
+      charge_responses[line_item_uid] = error_response(purchase.errors.first&.message || "Sorry, something went wrong. Please try again.", purchase:)
+    end
+
     # We need to make off session charges if there are products from more than one seller
     # In such case we create a reusable payment method before initiating the order from front-end
     off_session = order.purchases.non_free.pluck(:seller_id).uniq.count > 1
@@ -90,11 +104,12 @@ class Order::ChargeService
       Rails.logger.error("Error charging order (#{order.id}):: #{e.class} => #{e.message} => #{e.backtrace}")
     ensure
       # Ensure all purchases of the charge are transitioned to a terminal state
-      # and each line item has a response. Pass the full seller group so pre-failed
-      # line items (e.g. rejected by `validate_offer_code_usage_across_line_items`)
-      # also get an error response in `charge_responses`. Already-processed line
-      # items are skipped via the `charge_responses[uid].present?` guard inside.
-      ensure_all_purchases_processed(seller_purchases)
+      # and each line item has a response. Pre-failed purchases (e.g. rejected by
+      # `validate_offer_code_usage_across_line_items`) already have responses built
+      # upfront, so filter to in-progress purchases here to avoid re-matching line
+      # items for already-processed purchases whose variant attributes may have
+      # been mutated during processing.
+      ensure_all_purchases_processed(non_free_seller_purchases || seller_purchases.select(&:in_progress?))
     end
 
     charge_responses

--- a/app/services/order/charge_service.rb
+++ b/app/services/order/charge_service.rb
@@ -12,6 +12,8 @@ class Order::ChargeService
   end
 
   def perform
+    Purchase.validate_offer_code_usage_across_line_items(order.purchases)
+
     # We need to make off session charges if there are products from more than one seller
     # In such case we create a reusable payment method before initiating the order from front-end
     off_session = order.purchases.non_free.pluck(:seller_id).uniq.count > 1

--- a/app/services/order/charge_service.rb
+++ b/app/services/order/charge_service.rb
@@ -14,20 +14,6 @@ class Order::ChargeService
   def perform
     Purchase.validate_offer_code_usage_across_line_items(order.purchases)
 
-    # Build charge_responses for purchases already failed before the seller loop
-    # (e.g. rejected by `validate_offer_code_usage_across_line_items`) so they get
-    # a per-line-item error response even when the ensure block filters them out.
-    order.purchases.select(&:failed?).each do |purchase|
-      line_item = params[:line_items].find do |li|
-        purchase.link.unique_permalink == li[:permalink] &&
-          (li[:variants].blank? || purchase.variant_attributes.first&.external_id == li[:variants]&.first)
-      end
-      next if line_item.nil?
-      line_item_uid = line_item[:uid]
-      next if charge_responses[line_item_uid].present?
-      charge_responses[line_item_uid] = error_response(purchase.errors.first&.message || "Sorry, something went wrong. Please try again.", purchase:)
-    end
-
     # We need to make off session charges if there are products from more than one seller
     # In such case we create a reusable payment method before initiating the order from front-end
     off_session = order.purchases.non_free.pluck(:seller_id).uniq.count > 1
@@ -104,12 +90,11 @@ class Order::ChargeService
       Rails.logger.error("Error charging order (#{order.id}):: #{e.class} => #{e.message} => #{e.backtrace}")
     ensure
       # Ensure all purchases of the charge are transitioned to a terminal state
-      # and each line item has a response. Pre-failed purchases (e.g. rejected by
-      # `validate_offer_code_usage_across_line_items`) already have responses built
-      # upfront, so filter to in-progress purchases here to avoid re-matching line
-      # items for already-processed purchases whose variant attributes may have
-      # been mutated during processing.
-      ensure_all_purchases_processed(non_free_seller_purchases || seller_purchases.select(&:in_progress?))
+      # and each line item has a response. Pass the full seller group so pre-failed
+      # line items (e.g. rejected by `validate_offer_code_usage_across_line_items`)
+      # also get an error response in `charge_responses`. Already-processed line
+      # items are skipped via the `charge_responses[uid].present?` guard inside.
+      ensure_all_purchases_processed(seller_purchases)
     end
 
     charge_responses

--- a/app/services/order/charge_service.rb
+++ b/app/services/order/charge_service.rb
@@ -30,6 +30,10 @@ class Order::ChargeService
       self.setup_intent = nil
       charge = order.charges.create!(seller_id:)
       seller_purchases.each do |purchase|
+        # Skip purchases already failed before the loop (e.g. rejected by
+        # `validate_offer_code_usage_across_line_items`). Running save! would
+        # clear the in-memory errors we need for the line item response.
+        next if purchase.failed?
         purchase.charge = charge
         purchase.save!
         # Mark free or test purchase as successful as it does not require any further processing
@@ -80,8 +84,10 @@ class Order::ChargeService
       Rails.logger.error("Error charging order (#{order.id}):: #{e.class} => #{e.message} => #{e.backtrace}")
     ensure
       # Ensure all purchases of the charge are transitioned to a terminal state
-      # and each line item has a response
-      ensure_all_purchases_processed(non_free_seller_purchases || seller_purchases.select(&:in_progress?))
+      # and each line item has a response. Include failed purchases so pre-failed
+      # line items (e.g. rejected by `validate_offer_code_usage_across_line_items`)
+      # also get an error response in `charge_responses`.
+      ensure_all_purchases_processed((non_free_seller_purchases || seller_purchases.select(&:in_progress?)) + seller_purchases.select(&:failed?))
     end
 
     charge_responses

--- a/app/services/order/charge_service.rb
+++ b/app/services/order/charge_service.rb
@@ -28,6 +28,12 @@ class Order::ChargeService
     purchases_by_seller.each do |seller_id, seller_purchases|
       self.charge_intent = nil
       self.setup_intent = nil
+
+      # Every purchase in this seller group has already reached a terminal state
+      # (e.g. pre-failed by `validate_offer_code_usage_across_line_items`) — skip
+      # creating a Charge record that would have no Stripe activity attached.
+      next if seller_purchases.none?(&:in_progress?)
+
       charge = order.charges.create!(seller_id:)
       seller_purchases.each do |purchase|
         # Skip purchases already failed before the loop (e.g. rejected by
@@ -84,10 +90,11 @@ class Order::ChargeService
       Rails.logger.error("Error charging order (#{order.id}):: #{e.class} => #{e.message} => #{e.backtrace}")
     ensure
       # Ensure all purchases of the charge are transitioned to a terminal state
-      # and each line item has a response. Include failed purchases so pre-failed
+      # and each line item has a response. Pass the full seller group so pre-failed
       # line items (e.g. rejected by `validate_offer_code_usage_across_line_items`)
-      # also get an error response in `charge_responses`.
-      ensure_all_purchases_processed((non_free_seller_purchases || seller_purchases.select(&:in_progress?)) + seller_purchases.select(&:failed?))
+      # also get an error response in `charge_responses`. Already-processed line
+      # items are skipped via the `charge_responses[uid].present?` guard inside.
+      ensure_all_purchases_processed(seller_purchases)
     end
 
     charge_responses

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -6428,4 +6428,49 @@ describe Purchase, :vcr do
       end
     end
   end
+
+  describe ".validate_offer_code_usage_across_line_items" do
+    let(:seller) { create(:user) }
+    let(:product) { create(:product, user: seller, price_cents: 1_000) }
+
+    def build_in_progress_purchase(offer_code:)
+      purchase = build(:purchase_in_progress, link: product, seller:, offer_code:, quantity: 1)
+      purchase.save(validate: false)
+      purchase
+    end
+
+    it "fails every line item when the cart collectively exceeds max_purchase_count" do
+      offer_code = create(:offer_code, products: [product], code: "once", amount_cents: 100, max_purchase_count: 1)
+      purchases = [build_in_progress_purchase(offer_code:), build_in_progress_purchase(offer_code:)]
+
+      Purchase.validate_offer_code_usage_across_line_items(purchases)
+
+      purchases.each do |purchase|
+        expect(purchase.reload.purchase_state).to eq "failed"
+        expect(purchase.error_code).to eq PurchaseErrorCode::EXCEEDING_OFFER_CODE_QUANTITY
+        expect(purchase.errors[:base].first).to match(/quantity you have selected/)
+      end
+    end
+
+    it "leaves line items alone when the cart fits within max_purchase_count" do
+      offer_code = create(:offer_code, products: [product], code: "plenty", amount_cents: 100, max_purchase_count: 5)
+      purchases = [build_in_progress_purchase(offer_code:), build_in_progress_purchase(offer_code:)]
+
+      Purchase.validate_offer_code_usage_across_line_items(purchases)
+
+      purchases.each do |purchase|
+        expect(purchase.reload.purchase_state).to eq "in_progress"
+        expect(purchase.error_code).to be_nil
+      end
+    end
+
+    it "skips single-line carts (already handled by per-purchase validation)" do
+      offer_code = create(:offer_code, products: [product], code: "single", amount_cents: 100, max_purchase_count: 1)
+      purchase = build_in_progress_purchase(offer_code:)
+
+      Purchase.validate_offer_code_usage_across_line_items([purchase])
+
+      expect(purchase.reload.purchase_state).to eq "in_progress"
+    end
+  end
 end

--- a/spec/services/order/charge_service_spec.rb
+++ b/spec/services/order/charge_service_spec.rb
@@ -904,22 +904,20 @@ describe Order::ChargeService, :vcr do
     end
   end
 
-  describe "#perform with purchases already failed before the loop" do
-    it "returns an error response per failed line item and skips Stripe" do
+  describe "#perform rejecting a cart that overruns an offer code limit" do
+    it "fails the offending line items, skips Stripe, and returns an error response per line item" do
       seller = create(:user)
       product = create(:product, user: seller, price_cents: 1_000)
       category = create(:variant_category, title: "Tier", link: product)
       variant_a = create(:variant, name: "A", variant_category: category)
       variant_b = create(:variant, name: "B", variant_category: category)
+      offer_code = create(:offer_code, products: [product], code: "once", amount_cents: 100, max_purchase_count: 1)
 
       order = create(:order)
       [variant_a, variant_b].each do |variant|
-        purchase = build(:purchase_in_progress, link: product, seller:, quantity: 1)
+        purchase = build(:purchase_in_progress, link: product, seller:, offer_code:, quantity: 1)
         purchase.variant_attributes << variant
         purchase.save(validate: false)
-        purchase.error_code = PurchaseErrorCode::EXCEEDING_OFFER_CODE_QUANTITY
-        Purchase::MarkFailedService.new(purchase).perform
-        purchase.errors.add(:base, "Sorry, the discount code you are using is invalid for the quantity you have selected.")
         order.purchases << purchase
       end
 
@@ -934,7 +932,6 @@ describe Order::ChargeService, :vcr do
 
       charge_responses = Order::ChargeService.new(order:, params:).perform
 
-      expect(order.charges.count).to eq(0), "no phantom Charge should be created for an all-failed seller group"
       expect(order.purchases.reload.map(&:purchase_state).uniq).to eq(["failed"])
       expect(charge_responses.keys).to contain_exactly("uid-a", "uid-b")
       charge_responses.each_value do |response|

--- a/spec/services/order/charge_service_spec.rb
+++ b/spec/services/order/charge_service_spec.rb
@@ -903,4 +903,45 @@ describe Order::ChargeService, :vcr do
       expect(mandate_options[:payment_method_options][:card][:mandate_options][:amount_type]).to eq("maximum")
     end
   end
+
+  describe "#perform with purchases already failed before the loop" do
+    it "returns an error response per failed line item and skips Stripe" do
+      seller = create(:user)
+      product = create(:product, user: seller, price_cents: 1_000)
+      category = create(:variant_category, title: "Tier", link: product)
+      variant_a = create(:variant, name: "A", variant_category: category)
+      variant_b = create(:variant, name: "B", variant_category: category)
+
+      order = create(:order)
+      [variant_a, variant_b].each do |variant|
+        purchase = build(:purchase_in_progress, link: product, seller:, quantity: 1)
+        purchase.variant_attributes << variant
+        purchase.save(validate: false)
+        purchase.error_code = PurchaseErrorCode::EXCEEDING_OFFER_CODE_QUANTITY
+        Purchase::MarkFailedService.new(purchase).perform
+        purchase.errors.add(:base, "Sorry, the discount code you are using is invalid for the quantity you have selected.")
+        order.purchases << purchase
+      end
+
+      params = {
+        line_items: [
+          { uid: "uid-a", permalink: product.unique_permalink, variants: [variant_a.external_id] },
+          { uid: "uid-b", permalink: product.unique_permalink, variants: [variant_b.external_id] },
+        ]
+      }
+
+      expect(Stripe::PaymentIntent).not_to receive(:create)
+
+      charge_responses = Order::ChargeService.new(order:, params:).perform
+
+      expect(order.charges.count).to eq(0), "no phantom Charge should be created for an all-failed seller group"
+      expect(order.purchases.reload.map(&:purchase_state).uniq).to eq(["failed"])
+      expect(charge_responses.keys).to contain_exactly("uid-a", "uid-b")
+      charge_responses.each_value do |response|
+        expect(response[:success]).to eq(false)
+        expect(response[:error_message]).to match(/quantity you have selected/)
+        expect(response[:error_code]).to eq(PurchaseErrorCode::EXCEEDING_OFFER_CODE_QUANTITY)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/antiwork/gumroad/issues/4664

## What

`Order::ChargeService#perform` now validates offer code usage across all cart line items before creating a Stripe charge. When a cart would collectively consume an offer code beyond its `max_purchase_count`, every line item using that code is transitioned to `failed` state with `EXCEEDING_OFFER_CODE_QUANTITY` — before any money moves.

- New class method: `Purchase.validate_offer_code_usage_across_line_items(purchases)`
- Called from `Order::ChargeService#perform` at the top, before charge assembly
- Uses `Purchase::MarkFailedService` so the failed state is persisted and survives downstream saves

## Why

Reported in antiwork/gumroad#4664: an offer code with `max_purchase_count: 1` was used twice on a single order. Investigation of the live data showed:

- Same buyer, same session, same Order (`id=103876238`), same Charge (`ch_2TOv8k9e1RjUNIyY0VZ0CbnH`)
- Two Purchase rows: one for variant "MacWhisper Free" (price 0), one for "MacWhisper Pro" (paid $48 after 25% off)
- Both Purchase rows referenced the same `offer_code_id`
- Created 0ms apart (same checkout, one user action)

Root cause: `Purchase#validate_offer_code` runs in `before_create`, per Purchase, so each line item sees `times_used = 0` during its own validation and passes. There was no aggregate check once all cart line items existed. This PR adds that aggregate check in the single window where it's possible — after `Order::CreateService` returns, before `Charge::CreateService` is called.

Single-line carts are skipped because the per-Purchase validator already handles them.

## After

https://github.com/user-attachments/assets/8996f841-72be-4fc9-80a1-ba63f276601d

Generated with assistance from Claude Opus 4.7

