### PR TITLE
Add invoice_url to Sales API response

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -686,6 +686,7 @@ class Purchase < ApplicationRecord
       can_revoke_access: pundit_user ? Pundit.policy!(pundit_user, [:audience, self]).revoke_access? : nil,
       can_undo_revoke_access: pundit_user ? Pundit.policy!(pundit_user, [:audience, self]).undo_revoke_access? : nil,
       can_update: pundit_user ? Pundit.policy!(pundit_user, [:audience, self]).update? : nil,
+      invoice_url: (invoice_url if version == 2 && has_invoice?),
       upsell: upsell_purchase&.as_json,
       paypal_refund_expired: paypal_refund_expired?
     ).delete_if { |_, v| v.nil? }

--- a/spec/controllers/api/v2/sales_controller_spec.rb
+++ b/spec/controllers/api/v2/sales_controller_spec.rb
@@ -272,6 +272,18 @@ describe Api::V2::SalesController do
         }.as_json)
       end
 
+      it "includes invoice_url in the response" do
+        get :show, params: @params
+
+        expect(response.parsed_body["sale"]["invoice_url"]).to eq(
+          Rails.application.routes.url_helpers.new_purchase_invoice_url(
+            @purchase.external_id,
+            email: @purchase.email,
+            host: UrlService.domain_with_protocol
+          )
+        )
+      end
+
       it "includes license_uses in the response for a purchase with a license key" do
         @product.update!(is_licensed: true)
         purchase_with_license = create(:purchase, :with_license, purchaser: @purchaser, link: @product)


### PR DESCRIPTION
## Summary
- add `invoice_url` to version 2 purchase JSON for sales API responses when an invoice can be generated
- add controller spec coverage for the new field on the sales show endpoint

## Testing
- `bundle exec rspec spec/controllers/api/v2/sales_controller_spec.rb` *(fails in this environment before reaching the new assertion: `create(:purchase)` raises `Validation failed: We couldn't charge your card. Try again or use a different card.`)*
- `ruby -c app/models/purchase.rb`
- `ruby -c spec/controllers/api/v2/sales_controller_spec.rb`

Refs #4667