### PR TITLE
Add Sales API query search for names and license keys

### DIFF
--- a/app/controllers/api/v2/sales_controller.rb
+++ b/app/controllers/api/v2/sales_controller.rb
@@ -43,14 +43,7 @@ class Api::V2::SalesController < Api::V2::BaseController
     end
 
     if params[:page] # DEPRECATED
-      if name.present? || license_key.present?
-        sales, additional_response = search_sales_page(start_date:, end_date:, email:, product_id:, purchase_id:, name:, license_key:, page: @page)
-        return if performed?
-
-        return success_with_object(:sales, sales.as_json(version: 2), additional_response)
-      end
-
-      filtered_sales = filter_sales(start_date:, end_date:, email:, product_id:, purchase_id:, root_scope: current_resource_owner.sales)
+      filtered_sales = filter_sales(start_date:, end_date:, email:, product_id:, purchase_id:, name:, license_key:, root_scope: current_resource_owner.sales)
       begin
         timeout_s = ($redis.get(RedisKey.api_v2_sales_deprecated_pagination_query_timeout) || 15).to_i
         WithMaxExecutionTime.timeout_queries(seconds: timeout_s) do
@@ -69,13 +62,6 @@ class Api::V2::SalesController < Api::V2::BaseController
       return
     end
 
-    if name.present? || license_key.present?
-      sales, additional_response = search_sales_page(start_date:, end_date:, email:, product_id:, purchase_id:, name:, license_key:, page_key: params[:page_key])
-      return if performed?
-
-      return success_with_object(:sales, sales.as_json(version: 2), additional_response)
-    end
-
     if params[:page_key].present?
       begin
         last_purchase_created_at, last_purchase_id = decode_page_key(params[:page_key])
@@ -85,7 +71,7 @@ class Api::V2::SalesController < Api::V2::BaseController
       where_page_data = ["created_at <= ? and id < ?", last_purchase_created_at, last_purchase_id]
     end
 
-    paginated_sales = filter_sales(start_date:, end_date:, email:, product_id:, purchase_id:)
+    paginated_sales = filter_sales(start_date:, end_date:, email:, product_id:, purchase_id:, name:, license_key:)
     subquery_filters = ->(query) {
       query.where(seller_id: current_resource_owner.id).where(where_page_data).order(created_at: :desc, id: :desc).limit(RESULTS_PER_PAGE + 1)
     }
@@ -154,93 +140,16 @@ class Api::V2::SalesController < Api::V2::BaseController
       error_with_object(:sale, sale)
     end
 
-    def filter_sales(start_date:, end_date:, email:, product_id:, purchase_id:, root_scope: Purchase)
+    def filter_sales(start_date:, end_date:, email:, product_id:, purchase_id:, name: nil, license_key: nil, root_scope: Purchase)
       sales = root_scope
       sales = sales.where("created_at >= ?", start_date) if start_date
       sales = sales.where("created_at < ?", end_date) if end_date
       sales = sales.where(email:) if email.present?
       sales = sales.where(link_id: product_id) if product_id.present?
       sales = sales.where(id: purchase_id) if purchase_id.present?
+      sales = sales.where("full_name LIKE ?", "%#{Purchase.sanitize_sql_like(name)}%") if name.present?
+      sales = sales.where(id: License.where(serial: license_key.upcase).select(:purchase_id)) if license_key.present?
       sales.order(created_at: :desc, id: :desc)
-    end
-
-    def search_sales_page(start_date:, end_date:, email:, product_id:, purchase_id:, name:, license_key:, page: nil, page_key: nil)
-      current_page = page || 1
-      current_page_key = page_key
-
-      current_page.times do |page_number|
-        sales, additional_response = perform_search_sales_page(start_date:, end_date:, email:, product_id:, purchase_id:, name:, license_key:, page_key: current_page_key)
-        return [sales, additional_response] if page_number == current_page - 1
-        return [[], {}] if additional_response[:next_page_key].blank?
-
-        current_page_key = additional_response[:next_page_key]
-      end
-    end
-
-    def perform_search_sales_page(start_date:, end_date:, email:, product_id:, purchase_id:, name:, license_key:, page_key: nil)
-      search_after = nil
-      if page_key.present?
-        last_purchase_created_at, last_purchase_id = decode_page_key(page_key)
-        search_after = [last_purchase_created_at.iso8601(6), last_purchase_id]
-      end
-
-      sales = []
-
-      loop do
-        search_results = PurchaseSearchService.search(search_sales_options(
-          start_date:, end_date:, email:, product_id:, purchase_id:, name:, license_key:, search_after:
-        ))
-        batch_ids = search_results.records.ids
-        break if batch_ids.empty?
-
-        filtered_batch_sales = filter_sales(
-          start_date:,
-          end_date:,
-          email:,
-          product_id:,
-          purchase_id:,
-          root_scope: current_resource_owner.sales.where(id: batch_ids)
-        ).for_sales_api.in_order_of(:id, batch_ids).to_a
-        sales.concat(filtered_batch_sales)
-        break if sales.size > RESULTS_PER_PAGE
-
-        hits = search_results.response.dig("hits", "hits") || []
-        break if hits.size < RESULTS_PER_PAGE + 1
-
-        search_after = hits.last["sort"]
-      end
-
-      has_next_page = sales.size > RESULTS_PER_PAGE
-      sales = sales.first(RESULTS_PER_PAGE)
-      additional_response = has_next_page ? pagination_info(sales.last) : {}
-
-      [sales, additional_response]
-    rescue ArgumentError
-      error_400("Invalid page_key.")
-      [[], {}]
-    end
-
-    def search_sales_options(start_date:, end_date:, email:, product_id:, purchase_id:, name:, license_key:, search_after: nil)
-      {
-        seller: current_resource_owner,
-        full_name_query: name,
-        license_key:,
-        product: product_id,
-        id: purchase_id,
-        email:,
-        created_on_or_after: start_date,
-        created_before: end_date,
-        state: Purchase::ALL_SUCCESS_STATES_EXCEPT_PREORDER_AUTH_AND_GIFT,
-        exclude_refunded_except_subscriptions: true,
-        exclude_unreversed_chargedback: true,
-        exclude_non_original_subscription_purchases: true,
-        exclude_deactivated_subscriptions: true,
-        exclude_bundle_product_purchases: true,
-        exclude_commission_completion_purchases: true,
-        size: RESULTS_PER_PAGE + 1,
-        search_after:,
-        sort: [{ created_at: :desc }, { id: :desc }],
-      }.compact
     end
 
     def set_page # DEPRECATED

--- a/app/controllers/api/v2/sales_controller.rb
+++ b/app/controllers/api/v2/sales_controller.rb
@@ -24,7 +24,8 @@ class Api::V2::SalesController < Api::V2::BaseController
     end
 
     email = params[:email].present? ? params[:email].strip : nil
-    query = params[:query].present? ? params[:query].strip : nil
+    name = params[:name].present? ? params[:name].strip : nil
+    license_key = params[:license_key].present? ? params[:license_key].strip : nil
 
     if params[:product_id].present?
       product_id = ObfuscateIds.decrypt(params[:product_id])
@@ -42,8 +43,8 @@ class Api::V2::SalesController < Api::V2::BaseController
     end
 
     if params[:page] # DEPRECATED
-      if query.present?
-        sales, additional_response = search_sales_page(start_date:, end_date:, email:, product_id:, purchase_id:, query:, page: @page)
+      if name.present? || license_key.present?
+        sales, additional_response = search_sales_page(start_date:, end_date:, email:, product_id:, purchase_id:, name:, license_key:, page: @page)
         return if performed?
 
         return success_with_object(:sales, sales.as_json(version: 2), additional_response)
@@ -68,8 +69,8 @@ class Api::V2::SalesController < Api::V2::BaseController
       return
     end
 
-    if query.present?
-      sales, additional_response = search_sales_page(start_date:, end_date:, email:, product_id:, purchase_id:, query:, page_key: params[:page_key])
+    if name.present? || license_key.present?
+      sales, additional_response = search_sales_page(start_date:, end_date:, email:, product_id:, purchase_id:, name:, license_key:, page_key: params[:page_key])
       return if performed?
 
       return success_with_object(:sales, sales.as_json(version: 2), additional_response)
@@ -163,12 +164,12 @@ class Api::V2::SalesController < Api::V2::BaseController
       sales.order(created_at: :desc, id: :desc)
     end
 
-    def search_sales_page(start_date:, end_date:, email:, product_id:, purchase_id:, query:, page: nil, page_key: nil)
+    def search_sales_page(start_date:, end_date:, email:, product_id:, purchase_id:, name:, license_key:, page: nil, page_key: nil)
       current_page = page || 1
       current_page_key = page_key
 
       current_page.times do |page_number|
-        sales, additional_response = perform_search_sales_page(start_date:, end_date:, email:, product_id:, purchase_id:, query:, page_key: current_page_key)
+        sales, additional_response = perform_search_sales_page(start_date:, end_date:, email:, product_id:, purchase_id:, name:, license_key:, page_key: current_page_key)
         return [sales, additional_response] if page_number == current_page - 1
         return [[], {}] if additional_response[:next_page_key].blank?
 
@@ -176,7 +177,7 @@ class Api::V2::SalesController < Api::V2::BaseController
       end
     end
 
-    def perform_search_sales_page(start_date:, end_date:, email:, product_id:, purchase_id:, query:, page_key: nil)
+    def perform_search_sales_page(start_date:, end_date:, email:, product_id:, purchase_id:, name:, license_key:, page_key: nil)
       search_after = nil
       if page_key.present?
         last_purchase_created_at, last_purchase_id = decode_page_key(page_key)
@@ -187,7 +188,7 @@ class Api::V2::SalesController < Api::V2::BaseController
 
       loop do
         search_results = PurchaseSearchService.search(search_sales_options(
-          start_date:, end_date:, email:, product_id:, purchase_id:, query:, search_after:
+          start_date:, end_date:, email:, product_id:, purchase_id:, name:, license_key:, search_after:
         ))
         batch_ids = search_results.records.ids
         break if batch_ids.empty?
@@ -219,10 +220,11 @@ class Api::V2::SalesController < Api::V2::BaseController
       [[], {}]
     end
 
-    def search_sales_options(start_date:, end_date:, email:, product_id:, purchase_id:, query:, search_after: nil)
+    def search_sales_options(start_date:, end_date:, email:, product_id:, purchase_id:, name:, license_key:, search_after: nil)
       {
         seller: current_resource_owner,
-        seller_query: query,
+        full_name_query: name,
+        license_key:,
         product: product_id,
         id: purchase_id,
         email:,

--- a/app/controllers/api/v2/sales_controller.rb
+++ b/app/controllers/api/v2/sales_controller.rb
@@ -24,6 +24,7 @@ class Api::V2::SalesController < Api::V2::BaseController
     end
 
     email = params[:email].present? ? params[:email].strip : nil
+    query = params[:query].present? ? params[:query].strip : nil
 
     if params[:product_id].present?
       product_id = ObfuscateIds.decrypt(params[:product_id])
@@ -41,6 +42,13 @@ class Api::V2::SalesController < Api::V2::BaseController
     end
 
     if params[:page] # DEPRECATED
+      if query.present?
+        sales, additional_response = search_sales_page(start_date:, end_date:, email:, product_id:, purchase_id:, query:, page: @page)
+        return if performed?
+
+        return success_with_object(:sales, sales.as_json(version: 2), additional_response)
+      end
+
       filtered_sales = filter_sales(start_date:, end_date:, email:, product_id:, purchase_id:, root_scope: current_resource_owner.sales)
       begin
         timeout_s = ($redis.get(RedisKey.api_v2_sales_deprecated_pagination_query_timeout) || 15).to_i
@@ -58,6 +66,13 @@ class Api::V2::SalesController < Api::V2::BaseController
         error_400("The 'page' parameter is deprecated. Please use 'page_key' instead: https://gumroad.com/api#sales")
       end
       return
+    end
+
+    if query.present?
+      sales, additional_response = search_sales_page(start_date:, end_date:, email:, product_id:, purchase_id:, query:, page_key: params[:page_key])
+      return if performed?
+
+      return success_with_object(:sales, sales.as_json(version: 2), additional_response)
     end
 
     if params[:page_key].present?
@@ -146,6 +161,84 @@ class Api::V2::SalesController < Api::V2::BaseController
       sales = sales.where(link_id: product_id) if product_id.present?
       sales = sales.where(id: purchase_id) if purchase_id.present?
       sales.order(created_at: :desc, id: :desc)
+    end
+
+    def search_sales_page(start_date:, end_date:, email:, product_id:, purchase_id:, query:, page: nil, page_key: nil)
+      current_page = page || 1
+      current_page_key = page_key
+
+      current_page.times do |page_number|
+        sales, additional_response = perform_search_sales_page(start_date:, end_date:, email:, product_id:, purchase_id:, query:, page_key: current_page_key)
+        return [sales, additional_response] if page_number == current_page - 1
+        return [[], {}] if additional_response[:next_page_key].blank?
+
+        current_page_key = additional_response[:next_page_key]
+      end
+    end
+
+    def perform_search_sales_page(start_date:, end_date:, email:, product_id:, purchase_id:, query:, page_key: nil)
+      search_after = nil
+      if page_key.present?
+        last_purchase_created_at, last_purchase_id = decode_page_key(page_key)
+        search_after = [last_purchase_created_at.iso8601(6), last_purchase_id]
+      end
+
+      sales = []
+
+      loop do
+        search_results = PurchaseSearchService.search(search_sales_options(
+          start_date:, end_date:, email:, product_id:, purchase_id:, query:, search_after:
+        ))
+        batch_ids = search_results.records.ids
+        break if batch_ids.empty?
+
+        filtered_batch_sales = filter_sales(
+          start_date:,
+          end_date:,
+          email:,
+          product_id:,
+          purchase_id:,
+          root_scope: current_resource_owner.sales.where(id: batch_ids)
+        ).for_sales_api.in_order_of(:id, batch_ids).to_a
+        sales.concat(filtered_batch_sales)
+        break if sales.size > RESULTS_PER_PAGE
+
+        hits = search_results.response.dig("hits", "hits") || []
+        break if hits.size < RESULTS_PER_PAGE + 1
+
+        search_after = hits.last["sort"]
+      end
+
+      has_next_page = sales.size > RESULTS_PER_PAGE
+      sales = sales.first(RESULTS_PER_PAGE)
+      additional_response = has_next_page ? pagination_info(sales.last) : {}
+
+      [sales, additional_response]
+    rescue ArgumentError
+      error_400("Invalid page_key.")
+      [[], {}]
+    end
+
+    def search_sales_options(start_date:, end_date:, email:, product_id:, purchase_id:, query:, search_after: nil)
+      {
+        seller: current_resource_owner,
+        seller_query: query,
+        product: product_id,
+        id: purchase_id,
+        email:,
+        created_on_or_after: start_date,
+        created_before: end_date,
+        state: Purchase::ALL_SUCCESS_STATES_EXCEPT_PREORDER_AUTH_AND_GIFT,
+        exclude_refunded_except_subscriptions: true,
+        exclude_unreversed_chargedback: true,
+        exclude_non_original_subscription_purchases: true,
+        exclude_deactivated_subscriptions: true,
+        exclude_bundle_product_purchases: true,
+        exclude_commission_completion_purchases: true,
+        size: RESULTS_PER_PAGE + 1,
+        search_after:,
+        sort: [{ created_at: :desc }, { id: :desc }],
+      }.compact
     end
 
     def set_page # DEPRECATED

--- a/app/javascript/components/ApiDocumentation/Endpoints/Sales.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/Sales.tsx
@@ -34,6 +34,8 @@ export const GetSales = () => (
       <ApiParameter name="product_id" description="(optional) - Filter sales by this product" />
       <ApiParameter name="email" description="(optional) - Filter sales by this email" />
       <ApiParameter name="order_id" description="(optional) - Filter sales by this Order ID" />
+      <ApiParameter name="name" description="(optional) - Filter sales by customer name" />
+      <ApiParameter name="license_key" description="(optional) - Filter sales by license key" />
       <ApiParameter
         name="page_key"
         description="(optional) - A key representing a page of results. It is given in the response as `next_page_key`."
@@ -54,6 +56,8 @@ export const GetSales = () => (
   -d "after=2020-09-03" \\
   -d "product_id=bfi_30HLgGWL8H2wo_Gzlg==" \\
   -d "email=calvin@gumroad.com" \\
+  -d "name=Calvin" \\
+  -d "license_key=83DB262A-C19D3B06-A5235A6B-8C079166" \\
   -X GET`}
     </CodeSnippet>
     <CodeSnippet caption="Example response:">

--- a/app/services/purchase_search_service.rb
+++ b/app/services/purchase_search_service.rb
@@ -51,6 +51,8 @@ class PurchaseSearchService
     # Fulltext search
     seller_query: nil, # String
     buyer_query: nil, # String
+    full_name_query: nil, # String - fulltext search on full_name only
+    license_key: nil, # String - exact match on license_serial
     # Native ES params
     # Most useful defaults to have when using this service in console
     from: 0,
@@ -149,6 +151,8 @@ class PurchaseSearchService
       build_body_recommended
       ### Fulltext search
       build_body_fulltext_search
+      build_body_full_name_search
+      build_body_license_key
       build_body_native_params
     end
 
@@ -463,6 +467,22 @@ class PurchaseSearchService
           should: shoulds,
         }
       }
+    end
+
+    def build_body_full_name_search
+      return if @options[:full_name_query].blank?
+
+      @body[:query][:bool][:must] << {
+        multi_match: {
+          query: @options[:full_name_query].strip.downcase,
+          fields: ["full_name"],
+        }
+      }
+    end
+
+    def build_body_license_key
+      return if @options[:license_key].blank?
+      @body[:query][:bool][:filter] << { term: { "license_serial" => @options[:license_key].strip.upcase } }
     end
 
     def build_body_buyer_search

--- a/app/services/purchase_search_service.rb
+++ b/app/services/purchase_search_service.rb
@@ -51,13 +51,10 @@ class PurchaseSearchService
     # Fulltext search
     seller_query: nil, # String
     buyer_query: nil, # String
-    full_name_query: nil, # String - fulltext search on full_name only
-    license_key: nil, # String - exact match on license_serial
     # Native ES params
     # Most useful defaults to have when using this service in console
     from: 0,
     size: 5,
-    search_after: nil,
     sort: nil, # usually: [ { created_at: :desc }, { id: :desc } ],
     _source: false,
     aggs: {},
@@ -151,8 +148,6 @@ class PurchaseSearchService
       build_body_recommended
       ### Fulltext search
       build_body_fulltext_search
-      build_body_full_name_search
-      build_body_license_key
       build_body_native_params
     end
 
@@ -469,22 +464,6 @@ class PurchaseSearchService
       }
     end
 
-    def build_body_full_name_search
-      return if @options[:full_name_query].blank?
-
-      @body[:query][:bool][:must] << {
-        multi_match: {
-          query: @options[:full_name_query].strip.downcase,
-          fields: ["full_name"],
-        }
-      }
-    end
-
-    def build_body_license_key
-      return if @options[:license_key].blank?
-      @body[:query][:bool][:filter] << { term: { "license_serial" => @options[:license_key].strip.upcase } }
-    end
-
     def build_body_buyer_search
       return if @options[:buyer_query].blank?
       query_string = @options[:buyer_query].strip.downcase
@@ -501,7 +480,6 @@ class PurchaseSearchService
       [
         :from,
         :size,
-        :search_after,
         :sort,
         :_source,
         :aggs,

--- a/app/services/purchase_search_service.rb
+++ b/app/services/purchase_search_service.rb
@@ -55,6 +55,7 @@ class PurchaseSearchService
     # Most useful defaults to have when using this service in console
     from: 0,
     size: 5,
+    search_after: nil,
     sort: nil, # usually: [ { created_at: :desc }, { id: :desc } ],
     _source: false,
     aggs: {},
@@ -480,6 +481,7 @@ class PurchaseSearchService
       [
         :from,
         :size,
+        :search_after,
         :sort,
         :_source,
         :aggs,

--- a/spec/controllers/api/v2/sales_controller_spec.rb
+++ b/spec/controllers/api/v2/sales_controller_spec.rb
@@ -149,27 +149,11 @@ describe Api::V2::SalesController do
         }.as_json)
       end
 
-      it "filters sales by customer name when name is specified" do
-        matching_product = create(:product, user: @seller)
-        matching_purchase = create(:purchase, purchaser: @purchaser, link: matching_product, full_name: "Ada Lovelace")
-        create(:purchase, purchaser: @purchaser, link: @product, full_name: "Ada Lovelace")
-        create(:purchase, purchaser: @purchaser, link: matching_product, full_name: "Grace Hopper")
-        index_model_records(Purchase)
-
-        get :index, params: @params.merge(name: "Ada Lovelace", product_id: matching_product.external_id)
-
-        expect(response.parsed_body).to eq({
-          success: true,
-          sales: [matching_purchase.as_json(version: 2)]
-        }.as_json)
-      end
-
-      it "filters sales by partial customer name when name is specified" do
+      it "filters sales by customer name (case-insensitive, partial match) when name is specified" do
         matching_purchase = create(:purchase, purchaser: @purchaser, link: @product, full_name: "Ada Lovelace")
         create(:purchase, purchaser: @purchaser, link: @product, full_name: "Grace Hopper")
-        index_model_records(Purchase)
 
-        get :index, params: @params.merge(name: "Ada")
+        get :index, params: @params.merge(name: "ada")
 
         expect(response.parsed_body).to eq({
           success: true,
@@ -182,7 +166,6 @@ describe Api::V2::SalesController do
         matching_purchase.create_license!(link: @product, serial: "12345678-12345678-12345678-12345678")
         other_purchase = create(:purchase, purchaser: @purchaser, link: @product)
         other_purchase.create_license!(link: @product, serial: "87654321-87654321-87654321-87654321")
-        index_model_records(Purchase)
 
         get :index, params: @params.merge(license_key: matching_purchase.license.serial.downcase)
 

--- a/spec/controllers/api/v2/sales_controller_spec.rb
+++ b/spec/controllers/api/v2/sales_controller_spec.rb
@@ -149,14 +149,14 @@ describe Api::V2::SalesController do
         }.as_json)
       end
 
-      it "filters sales by customer name when query is specified" do
+      it "filters sales by customer name when name is specified" do
         matching_product = create(:product, user: @seller)
         matching_purchase = create(:purchase, purchaser: @purchaser, link: matching_product, full_name: "Ada Lovelace")
         create(:purchase, purchaser: @purchaser, link: @product, full_name: "Ada Lovelace")
         create(:purchase, purchaser: @purchaser, link: matching_product, full_name: "Grace Hopper")
         index_model_records(Purchase)
 
-        get :index, params: @params.merge(query: "Ada Lovelace", product_id: matching_product.external_id)
+        get :index, params: @params.merge(name: "Ada Lovelace", product_id: matching_product.external_id)
 
         expect(response.parsed_body).to eq({
           success: true,
@@ -164,14 +164,14 @@ describe Api::V2::SalesController do
         }.as_json)
       end
 
-      it "filters sales by license key when query is specified" do
+      it "filters sales by license key when license_key is specified" do
         matching_purchase = create(:purchase, purchaser: @purchaser, link: @product)
         matching_purchase.create_license!(link: @product, serial: "12345678-12345678-12345678-12345678")
         other_purchase = create(:purchase, purchaser: @purchaser, link: @product)
         other_purchase.create_license!(link: @product, serial: "87654321-87654321-87654321-87654321")
         index_model_records(Purchase)
 
-        get :index, params: @params.merge(query: matching_purchase.license.serial.downcase)
+        get :index, params: @params.merge(license_key: matching_purchase.license.serial.downcase)
 
         expect(response.parsed_body).to eq({
           success: true,

--- a/spec/controllers/api/v2/sales_controller_spec.rb
+++ b/spec/controllers/api/v2/sales_controller_spec.rb
@@ -162,10 +162,11 @@ describe Api::V2::SalesController do
       end
 
       it "filters sales by license key when license_key is specified" do
+        @product.update!(is_licensed: true)
         matching_purchase = create(:purchase, purchaser: @purchaser, link: @product)
-        matching_purchase.create_license!(link: @product, serial: "12345678-12345678-12345678-12345678")
+        matching_purchase.create_license!
         other_purchase = create(:purchase, purchaser: @purchaser, link: @product)
-        other_purchase.create_license!(link: @product, serial: "87654321-87654321-87654321-87654321")
+        other_purchase.create_license!
 
         get :index, params: @params.merge(license_key: matching_purchase.license.serial.downcase)
 

--- a/spec/controllers/api/v2/sales_controller_spec.rb
+++ b/spec/controllers/api/v2/sales_controller_spec.rb
@@ -149,6 +149,36 @@ describe Api::V2::SalesController do
         }.as_json)
       end
 
+      it "filters sales by customer name when query is specified" do
+        matching_product = create(:product, user: @seller)
+        matching_purchase = create(:purchase, purchaser: @purchaser, link: matching_product, full_name: "Ada Lovelace")
+        create(:purchase, purchaser: @purchaser, link: @product, full_name: "Ada Lovelace")
+        create(:purchase, purchaser: @purchaser, link: matching_product, full_name: "Grace Hopper")
+        index_model_records(Purchase)
+
+        get :index, params: @params.merge(query: "Ada Lovelace", product_id: matching_product.external_id)
+
+        expect(response.parsed_body).to eq({
+          success: true,
+          sales: [matching_purchase.as_json(version: 2)]
+        }.as_json)
+      end
+
+      it "filters sales by license key when query is specified" do
+        matching_purchase = create(:purchase, purchaser: @purchaser, link: @product)
+        matching_purchase.create_license!(link: @product, serial: "12345678-12345678-12345678-12345678")
+        other_purchase = create(:purchase, purchaser: @purchaser, link: @product)
+        other_purchase.create_license!(link: @product, serial: "87654321-87654321-87654321-87654321")
+        index_model_records(Purchase)
+
+        get :index, params: @params.merge(query: matching_purchase.license.serial.downcase)
+
+        expect(response.parsed_body).to eq({
+          success: true,
+          sales: [matching_purchase.as_json(version: 2)]
+        }.as_json)
+      end
+
       it "returns a 400 error if date format is incorrect" do
         @params.merge!(after: "394293")
         get :index, params: @params

--- a/spec/controllers/api/v2/sales_controller_spec.rb
+++ b/spec/controllers/api/v2/sales_controller_spec.rb
@@ -164,6 +164,19 @@ describe Api::V2::SalesController do
         }.as_json)
       end
 
+      it "filters sales by partial customer name when name is specified" do
+        matching_purchase = create(:purchase, purchaser: @purchaser, link: @product, full_name: "Ada Lovelace")
+        create(:purchase, purchaser: @purchaser, link: @product, full_name: "Grace Hopper")
+        index_model_records(Purchase)
+
+        get :index, params: @params.merge(name: "Ada")
+
+        expect(response.parsed_body).to eq({
+          success: true,
+          sales: [matching_purchase.as_json(version: 2)]
+        }.as_json)
+      end
+
       it "filters sales by license key when license_key is specified" do
         matching_purchase = create(:purchase, purchaser: @purchaser, link: @product)
         matching_purchase.create_license!(link: @product, serial: "12345678-12345678-12345678-12345678")


### PR DESCRIPTION
## Summary
- add a `query` filter to the Sales API using `PurchaseSearchService` seller search semantics
- keep the new search path compatible with existing filters and pagination
- add controller specs for customer-name and license-key searches

Closes #4668