### PR TITLE
Allow admins to login with Google, Apple, and Stripe OAuth

### DIFF
--- a/app/controllers/user/omniauth_callbacks_controller.rb
+++ b/app/controllers/user/omniauth_callbacks_controller.rb
@@ -50,9 +50,6 @@ class User::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       if user.nil?
         flash[:alert] = "An account already exists with this email."
         return safe_redirect_to referer
-      elsif user.is_team_member?
-        flash[:alert] = "You're an admin, you can't login with Stripe."
-        return safe_redirect_to referer
       elsif user.deleted?
         flash[:alert] = "You cannot log in because your account was permanently deleted. Please sign up for a new account to start selling!"
         return safe_redirect_to referer
@@ -116,10 +113,7 @@ class User::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
     def sign_in_with_oauth(provider_name)
       if @user&.persisted?
-        if @user.is_team_member?
-          flash[:alert] = "You're an admin, you can't login with #{provider_name}."
-          redirect_to login_path
-        elsif @user.deleted?
+        if @user.deleted?
           flash[:alert] = "You cannot log in because your account was permanently deleted. Please sign up for a new account to start selling!"
           redirect_to login_path
         elsif @user.email.present?

--- a/spec/controllers/user/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/user/omniauth_callbacks_controller_spec.rb
@@ -109,13 +109,13 @@ describe User::OmniauthCallbacksController do
 
       include_examples "stripe connect user creation"
 
-      it "does not log in admin user" do
-        create(:merchant_account_stripe_connect, user: create(:admin_user), charge_processor_merchant_id: stripe_uid)
+      it "allows admin user to log in" do
+        admin = create(:admin_user)
+        create(:merchant_account_stripe_connect, user: admin, charge_processor_merchant_id: stripe_uid)
 
         post :stripe_connect
 
-        expect(flash[:alert]).to eq "You're an admin, you can't login with Stripe."
-        expect(response).to redirect_to login_url
+        expect(flash[:alert]).to be_nil
       end
 
       it "does not allow user to login if the account is deleted" do
@@ -230,13 +230,13 @@ describe User::OmniauthCallbacksController do
     end
 
     context "when user is admin" do
-      it "does not allow user to login" do
-        allow(User).to receive(:new).and_return(create(:admin_user))
+      it "allows admin user to log in with Apple" do
+        admin = create(:admin_user)
+        allow(User).to receive(:find_or_create_for_apple_oauth).and_return(admin)
 
         post :apple
 
-        expect(flash[:alert]).to eq "You're an admin, you can't login with Apple."
-        expect(response).to redirect_to login_path
+        expect(flash[:alert]).to be_nil
       end
     end
 
@@ -331,13 +331,13 @@ describe User::OmniauthCallbacksController do
     end
 
     context "when user is admin" do
-      it "does not allow user to login" do
-        allow(User).to receive(:new).and_return(create(:admin_user))
+      it "allows admin user to log in with Google" do
+        admin = create(:admin_user)
+        allow(User).to receive(:find_or_create_for_google_oauth2).and_return(admin)
 
         post :google_oauth2
 
-        expect(flash[:alert]).to eq "You're an admin, you can't login with Google."
-        expect(response).to redirect_to login_path
+        expect(flash[:alert]).to be_nil
       end
     end
 

--- a/spec/controllers/user/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/user/omniauth_callbacks_controller_spec.rb
@@ -112,6 +112,8 @@ describe User::OmniauthCallbacksController do
       it "allows admin user to log in" do
         admin = create(:admin_user)
         create(:merchant_account_stripe_connect, user: admin, charge_processor_merchant_id: stripe_uid)
+        stripe_account = Stripe::Account.construct_from(id: stripe_uid, country: "US", object: "account")
+        allow(Stripe::Account).to receive(:retrieve).with(stripe_uid).and_return(stripe_account)
 
         post :stripe_connect
 

--- a/spec/controllers/user/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/user/omniauth_callbacks_controller_spec.rb
@@ -112,8 +112,6 @@ describe User::OmniauthCallbacksController do
       it "allows admin user to log in" do
         admin = create(:admin_user)
         create(:merchant_account_stripe_connect, user: admin, charge_processor_merchant_id: stripe_uid)
-        stripe_account = Stripe::Account.construct_from(id: stripe_uid, country: "US", object: "account")
-        allow(Stripe::Account).to receive(:retrieve).with(stripe_uid).and_return(stripe_account)
 
         post :stripe_connect
 

--- a/spec/support/fixtures/vcr_cassettes/User_OmniauthCallbacksController/_stripe_connect/when_referer_is_login/allows_admin_user_to_log_in.yml
+++ b/spec/support/fixtures/vcr_cassettes/User_OmniauthCallbacksController/_stripe_connect/when_referer_is_login/allows_admin_user_to_log_in.yml
@@ -1,0 +1,332 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/accounts/acct_1SOb0DEwFhlcVS6d
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_3n9jPr3YQi6E1S","request_duration_ms":2}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        GumClaws-Mini 25.3.0 Darwin Kernel Version 25.3.0: Wed Jan 28 20:49:24 PST
+        2026; root:xnu-12377.81.4~5/RELEASE_ARM64_T8132 arm64","hostname":"GumClaws-Mini"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 22 Apr 2026 18:12:21 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '6754'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=gaI-uMiNnS8hbmwQz1XO5XkX4vfEdlT9JlZiDBM7klNG8QXytLUxxK-4C_OuuoYt8R63Z7I1qSFGKsgM
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=gaI-uMiNnS8hbmwQz1XO5XkX4vfEdlT9JlZiDBM7klNG8QXytLUxxK-4C_OuuoYt8R63Z7I1qSFGKsgM&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=gaI-uMiNnS8hbmwQz1XO5XkX4vfEdlT9JlZiDBM7klNG8QXytLUxxK-4C_OuuoYt8R63Z7I1qSFGKsgM&t=1"
+      Request-Id:
+      - req_oYRqdpiWs5pOUG
+      Stripe-Account:
+      - acct_1SOb0DEwFhlcVS6d
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1SOb0DEwFhlcVS6d",
+          "object": "account",
+          "business_profile": {
+            "annual_revenue": null,
+            "estimated_worker_count": null,
+            "mcc": null,
+            "minority_owned_business_designation": null,
+            "name": null,
+            "product_description": null,
+            "specified_commercial_transactions_act_url": null,
+            "support_address": null,
+            "support_email": null,
+            "support_phone": null,
+            "support_url": null,
+            "url": null
+          },
+          "business_type": "individual",
+          "capabilities": {
+            "acss_debit_payments": "inactive",
+            "affirm_payments": "inactive",
+            "afterpay_clearpay_payments": "inactive",
+            "amazon_pay_payments": "inactive",
+            "bancontact_payments": "inactive",
+            "card_payments": "inactive",
+            "cartes_bancaires_payments": "inactive",
+            "cashapp_payments": "inactive",
+            "eps_payments": "inactive",
+            "giropay_payments": "inactive",
+            "ideal_payments": "inactive",
+            "kakao_pay_payments": "inactive",
+            "klarna_payments": "inactive",
+            "kr_card_payments": "inactive",
+            "link_payments": "inactive",
+            "mb_way_payments": "inactive",
+            "multibanco_payments": "inactive",
+            "naver_pay_payments": "inactive",
+            "p24_payments": "inactive",
+            "payco_payments": "inactive",
+            "pix_payments": "inactive",
+            "samsung_pay_payments": "inactive",
+            "sepa_bank_transfer_payments": "inactive",
+            "sepa_debit_payments": "inactive",
+            "sofort_payments": "inactive",
+            "tax_reporting_us_1099_k": "active",
+            "tax_reporting_us_1099_misc": "active",
+            "transfers": "inactive",
+            "us_bank_account_ach_payments": "inactive",
+            "us_bank_transfer_payments": "inactive",
+            "zip_payments": "inactive"
+          },
+          "charges_enabled": false,
+          "company": {
+            "address": {
+              "city": null,
+              "country": "US",
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "directors_provided": true,
+            "executives_provided": true,
+            "name": null,
+            "owners_provided": true,
+            "tax_id_provided": false,
+            "verification": {
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              }
+            }
+          },
+          "controller": {
+            "fees": {
+              "payer": "account"
+            },
+            "is_controller": true,
+            "losses": {
+              "payments": "stripe"
+            },
+            "requirement_collection": "stripe",
+            "stripe_dashboard": {
+              "type": "full"
+            },
+            "type": "application"
+          },
+          "country": "US",
+          "created": 1761988902,
+          "default_currency": "usd",
+          "details_submitted": false,
+          "email": null,
+          "external_accounts": {
+            "object": "list",
+            "data": [],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/accounts/acct_1SOb0DEwFhlcVS6d/external_accounts"
+          },
+          "future_requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [],
+            "disabled_reason": null,
+            "errors": [],
+            "eventually_due": [],
+            "past_due": [],
+            "pending_verification": []
+          },
+          "metadata": {},
+          "payouts_enabled": false,
+          "requirements": {
+            "alternatives": [],
+            "current_deadline": 1763208247,
+            "currently_due": [
+              "business_profile.mcc",
+              "business_profile.product_description",
+              "business_profile.support_email",
+              "business_profile.support_phone",
+              "business_profile.url",
+              "external_account",
+              "individual.address.city",
+              "individual.address.line1",
+              "individual.address.postal_code",
+              "individual.address.state",
+              "individual.dob.day",
+              "individual.dob.month",
+              "individual.dob.year",
+              "individual.email",
+              "individual.first_name",
+              "individual.last_name",
+              "individual.phone",
+              "individual.ssn_last_4",
+              "individual.verification.proof_of_liveness",
+              "settings.payments.statement_descriptor",
+              "tos_acceptance.date",
+              "tos_acceptance.ip"
+            ],
+            "disabled_reason": "requirements.past_due",
+            "errors": [],
+            "eventually_due": [
+              "business_profile.mcc",
+              "business_profile.product_description",
+              "business_profile.support_email",
+              "business_profile.support_phone",
+              "business_profile.url",
+              "external_account",
+              "individual.address.city",
+              "individual.address.line1",
+              "individual.address.postal_code",
+              "individual.address.state",
+              "individual.dob.day",
+              "individual.dob.month",
+              "individual.dob.year",
+              "individual.email",
+              "individual.first_name",
+              "individual.last_name",
+              "individual.phone",
+              "individual.ssn_last_4",
+              "individual.verification.proof_of_liveness",
+              "settings.payments.statement_descriptor",
+              "tos_acceptance.date",
+              "tos_acceptance.ip"
+            ],
+            "past_due": [
+              "business_profile.mcc",
+              "business_profile.product_description",
+              "business_profile.support_email",
+              "business_profile.support_phone",
+              "business_profile.url",
+              "external_account",
+              "individual.address.city",
+              "individual.address.line1",
+              "individual.address.postal_code",
+              "individual.address.state",
+              "individual.dob.day",
+              "individual.dob.month",
+              "individual.dob.year",
+              "individual.email",
+              "individual.first_name",
+              "individual.last_name",
+              "individual.phone",
+              "individual.ssn_last_4",
+              "individual.verification.proof_of_liveness",
+              "settings.payments.statement_descriptor",
+              "tos_acceptance.date",
+              "tos_acceptance.ip"
+            ],
+            "pending_verification": []
+          },
+          "settings": {
+            "bacs_debit_payments": {
+              "display_name": null,
+              "service_user_number": null
+            },
+            "branding": {
+              "icon": null,
+              "logo": null,
+              "primary_color": null,
+              "secondary_color": null
+            },
+            "card_issuing": {
+              "tos_acceptance": {
+                "date": null,
+                "ip": null
+              }
+            },
+            "card_payments": {
+              "decline_on": {
+                "avs_failure": false,
+                "cvc_failure": false
+              },
+              "statement_descriptor_prefix": null,
+              "statement_descriptor_prefix_kana": null,
+              "statement_descriptor_prefix_kanji": null
+            },
+            "dashboard": {
+              "display_name": null,
+              "timezone": "Etc/UTC"
+            },
+            "invoices": {
+              "default_account_tax_ids": null,
+              "hosted_payment_method_save": "offer"
+            },
+            "payments": {
+              "statement_descriptor": null,
+              "statement_descriptor_kana": null,
+              "statement_descriptor_kanji": null
+            },
+            "payouts": {
+              "debit_negative_balances": true,
+              "schedule": {
+                "delay_days": 2,
+                "interval": "daily"
+              },
+              "statement_descriptor": null
+            },
+            "sepa_debit_payments": {}
+          },
+          "tos_acceptance": {
+            "date": null,
+            "ip": null,
+            "user_agent": null
+          },
+          "type": "standard"
+        }
+  recorded_at: Wed, 22 Apr 2026 18:12:21 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
Admins were explicitly blocked from OAuth login with a flash message: "You're an admin, you can't login with [provider]."

This removes that restriction so team members can use Google, Apple, and Stripe Connect OAuth like everyone else. The admin check (`is_team_member?`) in `sign_in_with_oauth` and the Stripe Connect callback now falls through to normal login flow instead of rejecting.

Specs updated to expect successful admin login.