### PR TITLE
Fix ActiveRecord::Deadlocked in Google OAuth2 sign-in with retry logic

### DIFF
--- a/app/models/concerns/user/social_google.rb
+++ b/app/models/concerns/user/social_google.rb
@@ -41,36 +41,47 @@ module User::SocialGoogle
 
   class_methods do
     def find_or_create_for_google_oauth2(data)
-      if data["uid"].blank?
-        ErrorNotifier.notify("Google OAuth2 data is missing a uid")
-        return nil
-      end
+      retries = 0
 
-      user = User.where(google_uid: data["uid"]).first
+      begin
+        if data["uid"].blank?
+          ErrorNotifier.notify("Google OAuth2 data is missing a uid")
+          return nil
+        end
 
-      if user.nil?
-        email = data["info"]["email"] || data["extra"]["raw_info"]["email"]
-        user = User.where(email:).first if EmailFormatValidator.valid?(email)
+        user = User.where(google_uid: data["uid"]).first
 
         if user.nil?
-          user = User.new
-          user.provider = :google_oauth2
-          user.password = Devise.friendly_token[0, 20]
-          query_google(user, data, new_user: true)
+          email = data["info"]["email"] || data["extra"]["raw_info"]["email"]
+          user = User.where(email:).first if EmailFormatValidator.valid?(email)
 
-          if user.email.present?
-            Purchase.where(email: user.email, purchaser_id: nil).each do |past_purchase|
-              past_purchase.attach_to_user_and_card(user, nil, nil)
+          if user.nil?
+            user = User.new
+            user.provider = :google_oauth2
+            user.password = Devise.friendly_token[0, 20]
+            query_google(user, data, new_user: true)
+
+            if user.email.present?
+              Purchase.where(email: user.email, purchaser_id: nil).each do |past_purchase|
+                past_purchase.attach_to_user_and_card(user, nil, nil)
+              end
             end
+          else
+            query_google(user, data)
           end
         else
           query_google(user, data)
         end
-      else
-        query_google(user, data)
-      end
 
-      user
+        user
+      rescue ActiveRecord::Deadlocked => e
+        retries += 1
+        retry if retries <= 2
+
+        logger.error("Deadlock finding or creating user via Google OAuth2 after #{retries} retries: #{e.message}")
+        ErrorNotifier.notify(e)
+        nil
+      end
     rescue ActiveRecord::RecordInvalid => e
       logger.error("Error finding or creating user via Google OAuth2: #{e.message}")
       ErrorNotifier.notify(e)

--- a/spec/modules/user/social_google_spec.rb
+++ b/spec/modules/user/social_google_spec.rb
@@ -56,6 +56,45 @@ describe User::SocialGoogle do
       expect(user).to be_valid
       expect(user.name).to eq("Test User")
     end
+
+    it "retries after a deadlock and returns the created user" do
+      deadlock_data = @data.deep_dup
+      deadlock_data["uid"] = "google-deadlock-retry-uid"
+      deadlock_data["info"]["email"] = "google-deadlock-retry@example.com"
+      deadlock_data["extra"]["raw_info"]["email"] = "google-deadlock-retry@example.com"
+
+      allow_any_instance_of(User).to receive(:google_picture_url).and_return(nil)
+
+      save_attempts = 0
+      allow_any_instance_of(User).to receive(:save!).and_wrap_original do |original, *args|
+        save_attempts += 1
+        raise ActiveRecord::Deadlocked, "Deadlock found when trying to get lock" if save_attempts == 1
+
+        original.call(*args)
+      end
+
+      result = User.find_or_create_for_google_oauth2(deadlock_data)
+
+      expect(result).to be_persisted
+      expect(result).to be_valid
+      expect(result.google_uid).to eq(deadlock_data["uid"])
+      expect(save_attempts).to be >= 2
+    end
+
+    it "returns nil and notifies after exhausting deadlock retries" do
+      deadlock_data = @data.deep_dup
+      deadlock_data["uid"] = "google-deadlock-failure-uid"
+      deadlock_data["info"]["email"] = "google-deadlock-failure@example.com"
+      deadlock_data["extra"]["raw_info"]["email"] = "google-deadlock-failure@example.com"
+
+      allow_any_instance_of(User).to receive(:google_picture_url).and_return(nil)
+      allow_any_instance_of(User).to receive(:save!).and_raise(ActiveRecord::Deadlocked, "Deadlock found when trying to get lock")
+      expect(ErrorNotifier).to receive(:notify).with(instance_of(ActiveRecord::Deadlocked))
+
+      result = User.find_or_create_for_google_oauth2(deadlock_data)
+
+      expect(result).to be_nil
+    end
   end
 
   describe ".google_picture_url", :vcr do


### PR DESCRIPTION
Sentry: https://gumroad-to.sentry.io/issues/7434404347/

## Summary
- add retry handling for `ActiveRecord::Deadlocked` in `User::SocialGoogle.find_or_create_for_google_oauth2`
- retry the full find-or-create flow up to 2 times so a concurrent successful request can create the user first
- add regression specs for a successful retry and exhausted retries

## Root cause
Two concurrent Google OAuth2 sign-in requests for the same user can both miss the initial lookup and race into user creation. When both requests try to persist the same logical user, MySQL can deadlock before the loser request gets a chance to observe the newly-created record.

## Occurrences
- 1 (first seen)

## Estimated impact
- Low frequency but blocks user login when it occurs
