### PR TITLE
Remove the migration

### DIFF
--- a/db/migrate/20261122000000_remove_twitter_handle_from_users.rb
+++ b/db/migrate/20261122000000_remove_twitter_handle_from_users.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class RemoveTwitterHandleFromUsers < ActiveRecord::Migration[7.1]
-  def change
-    remove_column :users, :twitter_handle, :string
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_11_22_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_11_21_000000) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -2578,6 +2578,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_11_22_000000) do
     t.string "google_uid"
     t.integer "purchasing_power_parity_limit"
     t.string "tiktok_pixel_id"
+    t.string "twitter_handle"
     t.index ["account_created_ip"], name: "index_users_on_account_created_ip"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", length: 191
     t.index ["created_at"], name: "index_users_on_created_at"


### PR DESCRIPTION
We can keep the `users.twitter_handle` column.