### PR TITLE
Document frozen schema rule for users and purchases tables

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,7 @@ Do not push code with failing tests. CI is not a substitute for local verificati
 
 - When creating financial records (receipts, sales), copy the specific values (amount, currency, percentage) at the time of purchase instead of referencing mutable data like a `DiscountCode` ID. This ensures historical records remain accurate if the original object is edited or deleted.
 - Do not use database-level foreign key constraints (`add_foreign_key`). Avoiding hard constraints simplifies data migration and sharding operations at scale.
+- **Do not add, remove, or rename columns on the `users` or `purchases` tables.** These tables are too large for schema changes. Migrations that alter their schema will block deployments. If you need new data associated with users or purchases, create a new table and reference it. This also applies to adding or removing indexes on these tables.
 - Do not use dynamic string interpolation for Tailwind class names (e.g., `` `text-${color}` ``). Tailwind scanners cannot detect these during build. Use full class names or a lookup map.
 - Prefer re-using deprecated boolean flags (https://github.com/pboling/flag_shih_tzu) instead of creating new ones. Deprecated flags are named `DEPRECATED_<something>`. To re-use this flag you'll first need to reset the values for it on staging and production and then rename the flag to the new name. You can reset the flag like this:
   ```ruby

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -2,7 +2,7 @@
 
 ## Frozen tables
 
-**Do not write migrations that alter the schema of `users` or `purchases`.** These tables are too large for online schema changes. Even with PT-OSC, column additions/removals/renames block deployments and can cause extended downtime.
+**Do not write migrations that alter the schema of `users` or `purchases`.** These tables are too large for online schema changes. Even with PT-OSC, column additions/removals/renames block deployments.
 
 If you need new data associated with users or purchases, create a separate table (e.g., `user_settings`, `purchase_metadata`) and join to it.
 

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -1,5 +1,20 @@
 (Gumroad-specific, go crazy with the other repos)
 
+## Frozen tables
+
+**Do not write migrations that alter the schema of `users` or `purchases`.** These tables are too large for online schema changes. Even with PT-OSC, column additions/removals/renames block deployments and can cause extended downtime.
+
+If you need new data associated with users or purchases, create a separate table (e.g., `user_settings`, `purchase_metadata`) and join to it.
+
+This includes:
+- Adding columns
+- Removing columns
+- Renaming columns
+- Adding or removing indexes
+- Any `ALTER TABLE` operation
+
+## General rules
+
 1. Submit migrations in separate PRs, except for:
    - Creating new tables
    - Adding columns/indexes to normal tables


### PR DESCRIPTION
The `users` and `purchases` tables are too large for online schema changes. Migrations that alter their schema block deployments (e.g., `remove_column :users, :twitter_handle` blocked a deploy).

**Rule: Do not add, remove, or rename columns (or indexes) on `users` or `purchases`. Use new tables instead.**

Added to:
- **CONTRIBUTING.md**: explicit rule in the database section so all contributors and AI agents see it
- **docs/migrations.md**: new "Frozen tables" section at the top with full explanation

Since `CLAUDE.md` references `CONTRIBUTING.md`, coding agents (Codex, Claude Code, etc.) will also pick this up.