### PR TITLE
Fix unhandled Faraday::TimeoutError in CustomersController#paged

### DIFF
--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -3,6 +3,8 @@
 class CustomersController < Sellers::BaseController
   include CurrencyHelper
 
+  rescue_from Faraday::TimeoutError, with: :handle_search_timeout
+
 
   before_action :authorize
   before_action :set_on_page_type
@@ -91,6 +93,14 @@ class CustomersController < Sellers::BaseController
     purchase = current_seller.sales.find_by_external_id!(params[:purchase_id]) if params[:purchase_id].present?
 
     render json: purchase.product_purchases.map { CustomerPresenter.new(purchase: _1).customer(pundit_user:) }
+  end
+
+  def handle_search_timeout
+    if action_name == "paged"
+      render json: { success: false, error: "request timed out" }, status: :gateway_timeout
+    else
+      redirect_back fallback_location: root_path, warning: "Request timed out. Please try again.", status: :see_other
+    end
   end
 
   private

--- a/spec/controllers/customers_controller_spec.rb
+++ b/spec/controllers/customers_controller_spec.rb
@@ -103,6 +103,18 @@ describe CustomersController, :vcr, type: :controller, inertia: true do
       expect(response).to be_successful
       expect(customer_ids[response]).to match_array([purchases.third.external_id, purchases.fourth.external_id])
     end
+
+  end
+
+  describe "GET paged when Elasticsearch times out" do
+    it "returns 504" do
+      allow(PurchaseSearchService).to receive(:search).and_raise(Faraday::TimeoutError)
+
+      get :paged, params: { page: 1 }
+
+      expect(response).to have_http_status(:gateway_timeout)
+      expect(response.parsed_body).to eq("success" => false, "error" => "request timed out")
+    end
   end
 
   describe "GET charges" do


### PR DESCRIPTION
Sentry link: https://gumroad-to.sentry.io/issues/7435116971/

## What
- Elasticsearch timeout in `CustomersController#paged` causes a 500

## Why
- `CustomersController` does not rescue `Faraday::TimeoutError`
- `Api::Mobile::AnalyticsController` already handles this case gracefully

## Fix
- Add `rescue_from Faraday::TimeoutError` in `CustomersController`
- Return `{ success: false, error: "request timed out" }` with `504 Gateway Timeout` for `paged`
- Redirect Inertia actions back with a warning for a simpler graceful failure path
- Add a controller spec covering the timeout response

## Notes
- 1 occurrence so far
- Low volume, but this should still be handled gracefully