### PR TITLE
P0 Fix: gracefully handle content moderation API failures

### DIFF
--- a/app/services/content_moderation/moderate_record_service.rb
+++ b/app/services/content_moderation/moderate_record_service.rb
@@ -71,7 +71,13 @@ class ContentModeration::ModerateRecordService
         end
       end
 
-      threads.map(&:value)
+      threads.map do |t|
+        t.value
+      rescue StandardError => e
+        Rails.logger.error("ContentModeration strategy thread error: #{e.class}: #{e.message}")
+        ErrorNotifier.notify(e)
+        ContentModeration::Strategies::ClassifierStrategy::Result.new(status: "compliant", reasoning: [])
+      end
     end
 
     def leave_admin_comment(reasons)

--- a/app/services/content_moderation/strategies/classifier_strategy.rb
+++ b/app/services/content_moderation/strategies/classifier_strategy.rb
@@ -60,9 +60,10 @@ class ContentModeration::Strategies::ClassifierStrategy
     else
       Result.new(status: "compliant", reasoning: [])
     end
-  rescue StandardError => e
-    Rails.logger.error("ContentModeration::ClassifierStrategy error: #{e.message}")
-    raise
+  rescue Faraday::Error, Net::OpenTimeout, Net::ReadTimeout, OpenAI::Error => e
+    Rails.logger.error("ContentModeration::ClassifierStrategy error: #{e.class}: #{e.message}")
+    ErrorNotifier.notify(e)
+    Result.new(status: "compliant", reasoning: [])
   end
 
   private

--- a/app/services/content_moderation/strategies/prompt_strategy.rb
+++ b/app/services/content_moderation/strategies/prompt_strategy.rb
@@ -65,9 +65,10 @@ class ContentModeration::Strategies::PromptStrategy
     else
       Result.new(status: "compliant", reasoning: [])
     end
-  rescue StandardError => e
-    Rails.logger.error("ContentModeration::PromptStrategy error: #{e.message}")
-    raise
+  rescue Faraday::Error, Net::OpenTimeout, Net::ReadTimeout, OpenAI::Error => e
+    Rails.logger.error("ContentModeration::PromptStrategy error: #{e.class}: #{e.message}")
+    ErrorNotifier.notify(e)
+    Result.new(status: "compliant", reasoning: [])
   end
 
   private

--- a/spec/services/content_moderation/moderate_record_service_spec.rb
+++ b/spec/services/content_moderation/moderate_record_service_spec.rb
@@ -130,12 +130,14 @@ RSpec.describe ContentModeration::ModerateRecordService, :vcr do
       end
     end
 
-    it "propagates errors raised by AI strategies" do
+    it "returns compliant when AI strategies raise errors" do
       classifier = instance_double(ContentModeration::Strategies::ClassifierStrategy)
       allow(classifier).to receive(:perform).and_raise(StandardError, "OpenAI down")
       allow(ContentModeration::Strategies::ClassifierStrategy).to receive(:new).and_return(classifier)
 
-      expect { described_class.check(product, :product) }.to raise_error(StandardError, "OpenAI down")
+      result = described_class.check(product, :product)
+
+      expect(result.passed).to be true
     end
 
     context "for posts" do

--- a/spec/services/content_moderation/strategies/classifier_strategy_spec.rb
+++ b/spec/services/content_moderation/strategies/classifier_strategy_spec.rb
@@ -54,10 +54,13 @@ RSpec.describe ContentModeration::Strategies::ClassifierStrategy, :vcr do
     expect(result.reasoning).to eq([])
   end
 
-  it "logs and re-raises when the OpenAI request fails" do
-    allow(client).to receive(:moderations).and_raise(StandardError, "API failure")
+  it "returns compliant when the OpenAI request fails with a network error" do
+    allow(client).to receive(:moderations).and_raise(Faraday::BadRequestError.new(nil, { status: 400 }))
 
-    expect { described_class.new(text:, image_urls:).perform }.to raise_error(StandardError, "API failure")
-    expect(Rails.logger).to have_received(:error).with("ContentModeration::ClassifierStrategy error: API failure")
+    result = described_class.new(text:, image_urls:).perform
+
+    expect(result.status).to eq("compliant")
+    expect(result.reasoning).to be_empty
+    expect(Rails.logger).to have_received(:error).with(/ContentModeration::ClassifierStrategy error/)
   end
 end


### PR DESCRIPTION
## Problem

Product publishing and saving has been broken platform-wide since ~3 PM ET on April 22. 25+ support tickets, 14,800+ Sentry events (`GUMROAD-HX`).

The OpenAI moderation API (`omni-moderation-latest`) started returning 400 errors. The `ClassifierStrategy` and `PromptStrategy` caught the error but re-raised it, which caused the entire publish/save to fail with "Something broke."

## Fix

On API errors (Faraday::Error, timeouts, OpenAI::Error), return a compliant result instead of crashing. Content moderation is a best-effort check. Products should still be publishable when the moderation API is down.

**Changes:**
- `ClassifierStrategy`: catch network/API errors, return compliant, notify Sentry
- `PromptStrategy`: same
- `ModerateRecordService`: safety net in `run_ai_strategies` for any uncaught thread errors
- Updated specs to match new graceful degradation behavior

All 33 content moderation specs pass.

Fixes antiwork/gumroad-private#310