### PR TITLE
Add 60s timeout to AssetPreviewsController#create to prevent Rack::Timeout

### DIFF
--- a/app/controllers/asset_previews_controller.rb
+++ b/app/controllers/asset_previews_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AssetPreviewsController < ApplicationController
+  PREVIEW_PROCESSING_TIMEOUT_SECONDS = 60
+
   before_action :find_product
   after_action :verify_authorized
 
@@ -9,13 +11,15 @@ class AssetPreviewsController < ApplicationController
 
     asset_preview = @product.asset_previews.build
 
-    if permitted_params[:signed_blob_id].present?
-      asset_preview.file.attach(permitted_params[:signed_blob_id])
-    else
-      asset_preview.url = permitted_params[:url]
-    end
+    Timeout.timeout(PREVIEW_PROCESSING_TIMEOUT_SECONDS) do
+      if permitted_params[:signed_blob_id].present?
+        asset_preview.file.attach(permitted_params[:signed_blob_id])
+      else
+        asset_preview.url = permitted_params[:url]
+      end
 
-    asset_preview.analyze_file
+      asset_preview.analyze_file
+    end
 
     if asset_preview.save
       render(json: { success: true, asset_previews: @product.display_asset_previews, active_preview_id: asset_preview.guid })

--- a/spec/controllers/asset_previews_controller_spec.rb
+++ b/spec/controllers/asset_previews_controller_spec.rb
@@ -47,6 +47,15 @@ describe AssetPreviewsController do
       expect(response.parsed_body["error"]).to eq("Could not process your preview, please try again.")
     end
 
+    it "returns a graceful error when preview processing times out" do
+      stub_const("AssetPreviewsController::PREVIEW_PROCESSING_TIMEOUT_SECONDS", 0.001)
+      allow(SsrfFilter).to receive(:get) { sleep 1 }
+      post(:create, params: { link_id: product.unique_permalink, asset_preview: { url: "https://slow-server.example/image.png" }, format: :json })
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["success"]).to eq(false)
+      expect(response.parsed_body["error"]).to eq("Could not process your preview, please try again.")
+    end
+
     it "doesn't add a preview if there are too many previews" do
       stub_const("Link::MAX_PREVIEW_COUNT", 1)
       allow_any_instance_of(AssetPreview).to receive(:analyze_file).and_return(nil)


### PR DESCRIPTION
## Problem

`AssetPreviewsController#create` processes file uploads and URL fetches synchronously with no timeout protection. When a remote server is slow or a file is very large, the request can exceed Rack::Timeout's 120s limit, resulting in a `Rack::Timeout::RequestTimeoutException` that sends SIGTERM to the worker process.

`Rack::Timeout::RequestTimeoutException` is not included in `INTERNET_EXCEPTIONS`, so it bypasses the graceful error handling.

[Sentry issue](https://gumroad-to.sentry.io/issues/7435425003/)

## Fix

Wraps the file attachment, URL fetch, and analysis steps in a `Timeout.timeout(60)` block. This raises `Timeout::Error` (already caught by `INTERNET_EXCEPTIONS`) well before Rack::Timeout's 120s limit, returning a clean JSON error to the user instead of killing the process.

## Changes

- **`app/controllers/asset_previews_controller.rb`**: Added `PREVIEW_PROCESSING_TIMEOUT_SECONDS = 60` and wrapped the create action's processing in `Timeout.timeout`
- **`spec/controllers/asset_previews_controller_spec.rb`**: Added test verifying timeout returns a graceful error response