### PR TITLE
Handle Stripe::APIError in Settings::PaymentsController#update

### DIFF
--- a/app/controllers/settings/payments_controller.rb
+++ b/app/controllers/settings/payments_controller.rb
@@ -211,6 +211,9 @@ class Settings::PaymentsController < Settings::BaseController
 
       redirect_with_error(error_message)
       false
+    rescue Stripe::APIError => e
+      redirect_with_error(e.message.presence || "Something went wrong. Please try again.")
+      false
     end
 
     def update_user_compliance_info

--- a/spec/controllers/settings/payments_controller_spec.rb
+++ b/spec/controllers/settings/payments_controller_spec.rb
@@ -865,6 +865,23 @@ describe Settings::PaymentsController, :vcr, type: :controller, inertia: true do
         end
       end
 
+      describe "when Stripe raises an API error while updating the payout method" do
+        let(:params) { { card: { token: "tok_123" } } }
+
+        before do
+          allow(ChargeProcessor).to receive(:get_chargeable_for_params).and_return(double("chargeable"))
+          allow(CreditCard).to receive(:create).and_raise(Stripe::APIError.new("An unknown error occurred"))
+        end
+
+        it "redirects with the Stripe error instead of raising" do
+          put :update, params: params
+
+          expect(response).to redirect_to(settings_payments_path)
+          expect(response).to have_http_status :found
+          expect(session[:inertia_errors][:base]).to eq(["An unknown error occurred"])
+        end
+      end
+
       describe "account number and repeated account number don't match" do
         let(:params) do
           {


### PR DESCRIPTION
## What
- Rescue `Stripe::APIError` inside `Settings::PaymentsController#update_payout_method` so Stripe failures raised during payout-method preparation redirect back with a user-facing error instead of bubbling up as a 500.
- Add a controller spec that stubs the card payout flow to raise `Stripe::APIError.new("An unknown error occurred")` and verifies the request redirects with the expected error.

## Why
`Settings::PaymentsController#update` already rescues `Stripe::StripeError` around `StripeMerchantAccountManager.create_account`, but payout-method changes can reach Stripe earlier through `UpdatePayoutMethod#process`.

In the debit-card flow, `update_payout_method` calls `UpdatePayoutMethod#process`, which reaches `prepare_credit_card`, `ChargeProcessor.get_chargeable_for_params`, and `CreditCard.create`. When Stripe raises `Stripe::APIError` there, the exception bypasses the existing rescue and returns a 500 from Rails. Rescuing `Stripe::APIError` in `update_payout_method` fixes the actual unhandled path and keeps the controller response consistent with the rest of the action.

Sentry issue: https://gumroad-to.sentry.io/issues/7435732699/
Sentry event count: 1 occurrence so far (new issue)

## Before/After
- Before: a Stripe API failure during payout-method preparation could raise out of `update_payout_method` and produce a 500 in `Settings::PaymentsController#update`.
- After: the controller catches that Stripe API error, redirects back to settings payments, and shows the Stripe message (or a fallback message).
- Video: not included; this is a non-user-facing controller error-handling change.

## Test Results
- `bundle _2.5.10_ exec rspec spec/controllers/settings/payments_controller_spec.rb`
- Result: `106 examples, 0 failures`

## QA steps
- Submit a payout-method update that triggers a Stripe API error during card preparation.
- Confirm the request redirects back to `Settings > Payments` instead of rendering a 500.
- Confirm the flash/inertia base error shows the Stripe message.

---
AI disclosure: This PR was prepared with OpenAI GPT-5 via Codex CLI.
Prompts provided to the agent:
1. "[Thu 2026-04-23 03:18 EDT] Fix a Sentry bug: `Stripe::APIError: An unknown error occurred` in `Settings::PaymentsController#update`."
