### PR TITLE
Fix restart checkout card reuse

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -112,7 +112,7 @@ class OrdersController < ApplicationController
         :friend, :locale, :plugins, :save_card, :card_data_handling_mode, :card_data_handling_error,
         :card_country, :card_country_source, :wallet_type, :cc_zipcode, :vat_id, :email, :tax_country_election,
         :save_shipping_address, :card_expiry_month, :card_expiry_year, :stripe_status, :visual,
-        :billing_agreement_id, :paypal_order_id, :stripe_payment_method_id, :stripe_customer_id, :stripe_error,
+        :billing_agreement_id, :paypal_order_id, :stripe_payment_method_id, :stripe_customer_id, :stripe_setup_intent_id, :stripe_error,
         :braintree_transient_customer_store_key, :braintree_device_data, :use_existing_card, :paymentToken,
         :url_parameters, :is_gift, :giftee_email, :giftee_id, :gift_note, :referrer,
         purchase: [:full_name, :street_address, :city, :state, :zip_code, :country],

--- a/app/services/subscription/restart_at_checkout_service.rb
+++ b/app/services/subscription/restart_at_checkout_service.rb
@@ -53,8 +53,17 @@ class Subscription::RestartAtCheckoutService
     end
 
     def use_existing_card?
+      return false if new_payment_method_params_present?
+
       card_data_handling_mode = CardParamsHelper.get_card_data_handling_mode(params)
       card_data_handling_mode.blank? || card_data_handling_mode == :reuse
+    end
+
+    def new_payment_method_params_present?
+      params[:stripe_payment_method_id].present? ||
+        params[:stripe_customer_id].present? ||
+        params[:stripe_setup_intent_id].present? ||
+        params[:paypal_order_id].present?
     end
 
     def adapt_result(result)

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -747,6 +747,41 @@ describe OrdersController, :vcr do
         end
       end
 
+      describe "strong params for reusable Stripe payments" do
+        it "passes stripe_setup_intent_id through to order creation" do
+          order_purchases = double("order_purchases", successful: [])
+          allow(order_purchases).to receive(:each).and_return([])
+          order = double("order", persisted?: false, purchases: order_purchases, send_charge_receipts: nil)
+          create_service = instance_double(Order::CreateService, perform: [order, {}, {}])
+          charge_service = instance_double(Order::ChargeService, perform: {})
+
+          expect(Order::CreateService).to receive(:new).with(
+            buyer: nil,
+            params: hash_including(
+              stripe_payment_method_id: "pm_123",
+              stripe_customer_id: "cus_123",
+              stripe_setup_intent_id: "seti_123"
+            )
+          ).and_return(create_service)
+          allow(Order::ChargeService).to receive(:new).and_return(charge_service)
+
+          post :create, params: {
+            email: "buyer@example.com",
+            stripe_payment_method_id: "pm_123",
+            stripe_customer_id: "cus_123",
+            stripe_setup_intent_id: "seti_123",
+            line_items: [{
+              uid: "unique-id-0",
+              permalink: product_1.unique_permalink,
+              perceived_price_cents: price_1,
+              quantity: 1
+            }]
+          }
+
+          expect(response.parsed_body["success"]).to be(true)
+        end
+      end
+
       describe "single item purchases that require SCA" do
         let(:price) { 10_00 }
         let(:multiple_purchase_params_with_sca) do

--- a/spec/services/order/create_service_spec.rb
+++ b/spec/services/order/create_service_spec.rb
@@ -237,11 +237,7 @@ describe Order::CreateService, :vcr do
         }.merge(common_order_params_without_payment)
       end
 
-      it "passes stripe_customer_id and stripe_setup_intent_id through to the subscription restart in a multi-seller cart" do
-        # In a multi-seller cart, prepareFutureCharges() creates a SetupIntent and the
-        # customer completes SCA upfront. The resulting stripe_customer_id and
-        # stripe_setup_intent_id must reach UpdaterService so the restart charge can
-        # reference the prior authentication and avoid a second SCA prompt.
+      it "treats submitted checkout payment data as a new card during subscription restart in a multi-seller cart" do
         multi_seller_params = {
           line_items: [
             {
@@ -260,14 +256,14 @@ describe Order::CreateService, :vcr do
           ],
           stripe_payment_method_id: "pm_123",
           stripe_customer_id: "cus_123",
-          stripe_setup_intent_id: "seti_123",
-          card_data_handling_mode: "stripe_elements"
+          stripe_setup_intent_id: "seti_123"
         }.merge(common_order_params_without_payment)
 
         updater_service = instance_double(Subscription::UpdaterService)
         expect(Subscription::UpdaterService).to receive(:new).with(
           subscription: subscription,
           params: hash_including(
+            use_existing_card: false,
             stripe_customer_id: "cus_123",
             stripe_setup_intent_id: "seti_123",
             stripe_payment_method_id: "pm_123"

--- a/spec/services/subscription/restart_at_checkout_service_spec.rb
+++ b/spec/services/subscription/restart_at_checkout_service_spec.rb
@@ -91,12 +91,11 @@ describe Subscription::RestartAtCheckoutService do
         expect(transformed_params[:use_existing_card]).to be true
       end
 
-      it "forwards stripe_customer_id and stripe_setup_intent_id to UpdaterService" do
+      it "treats submitted checkout payment data as a new card" do
         params_with_stripe = base_params.merge(
           stripe_payment_method_id: "pm_123",
           stripe_customer_id: "cus_123",
-          stripe_setup_intent_id: "seti_123",
-          card_data_handling_mode: "stripe_elements"
+          stripe_setup_intent_id: "seti_123"
         )
 
         service = described_class.new(
@@ -111,6 +110,7 @@ describe Subscription::RestartAtCheckoutService do
         expect(transformed_params[:stripe_customer_id]).to eq("cus_123")
         expect(transformed_params[:stripe_setup_intent_id]).to eq("seti_123")
         expect(transformed_params[:stripe_payment_method_id]).to eq("pm_123")
+        expect(transformed_params[:use_existing_card]).to be false
       end
 
       it "uses default variants when not provided in params" do


### PR DESCRIPTION
## What

Fixes transparent subscription restarts so checkout honors a newly submitted payment method instead of silently falling back to the saved card on the old subscription.

When restart checkout sends Stripe payment-method data, we now treat that as "use the new card" even if `card_data_handling_mode` is missing. The regression tests cover both the restart adapter and the order creation flow using the same payload shape the checkout frontend sends today.

## Why

Expired subscription restarts go through the normal checkout flow, but the restart adapter was deciding whether to reuse the saved card from `card_data_handling_mode`. The frontend does not rely on that field for this path. It sends the new card through Stripe payment-method IDs instead.

That mismatch made it possible for a restart to authenticate and charge the previously saved card even after a buyer entered a different one. This keeps restart checkout aligned with the actual request payload and prevents us from reusing the old card when a new payment method was submitted.

---

This PR was implemented with AI assistance using gpt‑5.4 xhigh
