### PR TITLE
Fix invoice page footer appearing mid-page in Firefox

### DIFF
--- a/app/javascript/pages/Purchases/Invoices/New.tsx
+++ b/app/javascript/pages/Purchases/Invoices/New.tsx
@@ -84,7 +84,7 @@ const PurchaseNewInvoicePage = () => {
     <>
       <div>
         <Card asChild>
-          <main className="mx-auto my-4 h-min max-w-md [&>*]:flex-col [&>*]:items-stretch">
+          <main className="mx-auto my-4 max-w-md [&>*]:flex-col [&>*]:items-stretch">
             <CardContent asChild>
               <header className="text-center">
                 <h4 className="grow font-bold">{form_metadata.heading}</h4>


### PR DESCRIPTION
## What

Removes `h-min` from the invoice page's `main` element. `h-min` compiles to `height: min-content`, which Firefox honors by shrinking the main region to its content height. On shorter invoices that pushes the "Powered by" footer up into the middle of the viewport instead of sitting at the bottom.

## Why

An EU business buyer generating a VAT invoice on Firefox sees a visibly broken page — the footer lands next to the form fields. The constraint isn't needed for the layout to work; dropping it lets `main` fill the available vertical space and keeps the footer pinned to the bottom across Chrome and Firefox.

This is the first of five atomic PRs reviving the invoice-page improvements originally contributed by @skatkov in #423, which also identified and fixed this exact bug (at the time the styling lived in `_stack.scss` as `height: min-content` on `main.stack`; the codebase has since migrated to Tailwind but the same property was carried over as `h-min`).

Companion PRs in this series:
1. This PR — Firefox footer fix
2. Show State field only for US addresses
3. Optional Business name field
4. Show Business/VAT ID field for broader country list
5. Country-aware Business ID label on the form

A sixth PR revives #504 (BillingDetails model + auto-email invoice).

## Test plan

- [ ] Open a generated invoice page in Firefox → footer sits at the bottom of the viewport, not mid-page
- [ ] Same page in Chrome → no regression, footer still at the bottom
- [ ] Long invoices (lots of items) — page scrolls normally and footer appears after content
- [ ] Short invoices — footer sits at the bottom of the visible area rather than floating up

## Notes

Video not attached (automated environment). The fix is a one-line CSS class removal and the rendered layout can be QA'd on any branch preview.

---

AI disclosure: Claude Opus 4.7. Prompt: port Skatkov's Firefox footer fix from the closed PR #423 to the current invoice page at `app/javascript/pages/Purchases/Invoices/New.tsx` as an atomic PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EG9W9HJCXru6Y5MS61E2nE)_