### PR TITLE
Hide State field on invoice page for non-US addresses

### DIFF
--- a/app/javascript/pages/Purchases/Invoices/New.tsx
+++ b/app/javascript/pages/Purchases/Invoices/New.tsx
@@ -54,8 +54,11 @@ const PurchaseNewInvoicePage = () => {
 
   const form = useForm(form_data);
 
+  const isUsAddress = form.data.address_fields.country_code === "US";
+
   const validateFields = () =>
     Object.entries(form.data.address_fields).reduce((isValid, [key, value]) => {
+      if (key === "state" && !isUsAddress) return isValid;
       if (!value.trim()) {
         form.setError(`address_fields.${key}`, "Setting error message for highlighting the field in UI");
         return false;
@@ -122,7 +125,13 @@ const PurchaseNewInvoicePage = () => {
                   onChange={(e) => form.setData("address_fields.street_address", e.target.value)}
                 />
               </Fieldset>
-              <div style={{ display: "grid", gap: "var(--spacer-2)", gridTemplateColumns: "2fr 1fr 1fr" }}>
+              <div
+                style={{
+                  display: "grid",
+                  gap: "var(--spacer-2)",
+                  gridTemplateColumns: isUsAddress ? "2fr 1fr 1fr" : "1fr 1fr",
+                }}
+              >
                 <Fieldset state={form.errors["address_fields.city"] ? "danger" : undefined}>
                   <Label htmlFor="city">City</Label>
                   <Input
@@ -132,15 +141,17 @@ const PurchaseNewInvoicePage = () => {
                     onChange={(e) => form.setData("address_fields.city", e.target.value)}
                   />
                 </Fieldset>
-                <Fieldset state={form.errors["address_fields.state"] ? "danger" : undefined}>
-                  <Label htmlFor="state">State</Label>
-                  <Input
-                    id="state"
-                    type="text"
-                    value={form.data.address_fields.state}
-                    onChange={(e) => form.setData("address_fields.state", e.target.value)}
-                  />
-                </Fieldset>
+                {isUsAddress ? (
+                  <Fieldset state={form.errors["address_fields.state"] ? "danger" : undefined}>
+                    <Label htmlFor="state">State</Label>
+                    <Input
+                      id="state"
+                      type="text"
+                      value={form.data.address_fields.state}
+                      onChange={(e) => form.setData("address_fields.state", e.target.value)}
+                    />
+                  </Fieldset>
+                ) : null}
                 <Fieldset state={form.errors["address_fields.zip_code"] ? "danger" : undefined}>
                   <Label htmlFor="zip_code">ZIP code</Label>
                   <Input
@@ -218,13 +229,19 @@ const PurchaseNewInvoicePage = () => {
                   <span
                     style={{ opacity: form.data.address_fields.city.length ? undefined : "var(--disabled-opacity)" }}
                   >
-                    {`${form.data.address_fields.city || "San Francisco"},`}
+                    {`${form.data.address_fields.city || "San Francisco"}${isUsAddress ? "," : ""}`}
                   </span>{" "}
-                  <span
-                    style={{ opacity: form.data.address_fields.state.length ? undefined : "var(--disabled-opacity)" }}
-                  >
-                    {form.data.address_fields.state || "CA"}
-                  </span>{" "}
+                  {isUsAddress ? (
+                    <>
+                      <span
+                        style={{
+                          opacity: form.data.address_fields.state.length ? undefined : "var(--disabled-opacity)",
+                        }}
+                      >
+                        {form.data.address_fields.state || "CA"}
+                      </span>{" "}
+                    </>
+                  ) : null}
                   <span
                     style={{
                       opacity: form.data.address_fields.zip_code.length ? undefined : "var(--disabled-opacity)",

--- a/app/presenters/invoice_presenter/order_info.rb
+++ b/app/presenters/invoice_presenter/order_info.rb
@@ -77,7 +77,7 @@ class InvoicePresenter::OrderInfo
         [
           address_fields[:full_name],
           address_fields[:street_address],
-          [address_fields[:city], address_fields[:state], address_fields[:zip_code]].compact.join(", "),
+          [address_fields[:city], address_fields[:state], address_fields[:zip_code]].reject(&:blank?).join(", "),
           address_fields[:country]
         ].compact,
         tag.br

--- a/spec/requests/purchases/product/generate_invoice_spec.rb
+++ b/spec/requests/purchases/product/generate_invoice_spec.rb
@@ -896,5 +896,40 @@ describe("Generate invoice for purchase", type: :system, js: true) do
         expect(pdf_text).to have_content("Products supplied by Gumroad.")
       end
     end
+
+    it "hides the State field for non-US countries and renders a clean PDF address" do
+      purchase = create(:purchase, link: @product)
+
+      visit new_purchase_invoice_path(purchase.external_id, email: purchase.email)
+
+      fill_in("Full name", with: "Wonderful Alice")
+      fill_in("Street address", with: "Crooked St.")
+      fill_in("City", with: "Berlin")
+      fill_in("ZIP code", with: "10115")
+      select "Germany", from: "Country"
+
+      expect(page).not_to have_field("State")
+
+      click_on "Download"
+      wait_for_ajax
+
+      invoice_url = find_link("here")[:href]
+      reader = PDF::Reader.new(URI.open(invoice_url))
+      pdf_text = reader.page(1).text.squish
+
+      expect(pdf_text).to include("Wonderful Alice")
+      expect(pdf_text).to include("Berlin, 10115")
+      expect(pdf_text).to include("Germany")
+      expect(pdf_text).not_to match(/Berlin,\s+,/)
+    end
+
+    it "shows and requires the State field when country is US" do
+      purchase = create(:purchase, link: @product, country: "United States")
+
+      visit new_purchase_invoice_path(purchase.external_id, email: purchase.email)
+      select "United States", from: "Country"
+
+      expect(page).to have_field("State")
+    end
   end
 end

--- a/spec/requests/purchases/product/generate_invoice_spec.rb
+++ b/spec/requests/purchases/product/generate_invoice_spec.rb
@@ -122,7 +122,6 @@ describe("Generate invoice for purchase", type: :system, js: true) do
       fill_in("Full name", with: "Wonderful Alice")
       fill_in("Street address", with: "Crooked St.")
       fill_in("City", with: "Wonderland")
-      fill_in("State", with: "CA")
       fill_in("ZIP code", with: "12345")
 
       within find("h5", text: "Supplier").first(:xpath, ".//..//..") do
@@ -156,7 +155,6 @@ describe("Generate invoice for purchase", type: :system, js: true) do
       fill_in("Full name", with: "Wonderful Alice")
       fill_in("Street address", with: "Crooked St.")
       fill_in("City", with: "Wonderland")
-      fill_in("State", with: "CA")
       fill_in("ZIP code", with: "12345")
 
       within find("h5", text: "Supplier").first(:xpath, ".//..//..") do
@@ -191,7 +189,6 @@ describe("Generate invoice for purchase", type: :system, js: true) do
       fill_in("Full name", with: "Wonderful Alice")
       fill_in("Street address", with: "Crooked St.")
       fill_in("City", with: "Wonderland")
-      fill_in("State", with: "CA")
       fill_in("ZIP code", with: "12345")
 
       within find("h5", text: "Supplier").first(:xpath, ".//..//..") do
@@ -229,7 +226,6 @@ describe("Generate invoice for purchase", type: :system, js: true) do
       fill_in("Full name", with: "Wonderful Alice")
       fill_in("Street address", with: "Crooked St.")
       fill_in("City", with: "Wonderland")
-      fill_in("State", with: "CA")
       fill_in("ZIP code", with: "12345")
 
       within find("h5", text: "Supplier").first(:xpath, ".//..//..") do
@@ -262,7 +258,6 @@ describe("Generate invoice for purchase", type: :system, js: true) do
       fill_in("Full name", with: "Wonderful Alice")
       fill_in("Street address", with: "Crooked St.")
       fill_in("City", with: "Wonderland")
-      fill_in("State", with: "CA")
       fill_in("ZIP code", with: "12345")
 
       within find("h5", text: "Supplier").first(:xpath, ".//..//..") do
@@ -293,7 +288,6 @@ describe("Generate invoice for purchase", type: :system, js: true) do
       fill_in("Full name", with: "Wonderful Alice")
       fill_in("Street address", with: "Crooked St.")
       fill_in("City", with: "Wonderland")
-      fill_in("State", with: "CA")
       fill_in("ZIP code", with: "12345")
 
       within find("h5", text: "Supplier").first(:xpath, ".//..//..") do
@@ -324,7 +318,6 @@ describe("Generate invoice for purchase", type: :system, js: true) do
       fill_in("Full name", with: "Wonderful Alice")
       fill_in("Street address", with: "Crooked St.")
       fill_in("City", with: "Wonderland")
-      fill_in("State", with: "CA")
       fill_in("ZIP code", with: "12345")
 
       within find("h5", text: "Supplier").first(:xpath, ".//..//..") do
@@ -357,7 +350,6 @@ describe("Generate invoice for purchase", type: :system, js: true) do
       fill_in("Full name", with: "Wonderful Alice")
       fill_in("Street address", with: "Crooked St.")
       fill_in("City", with: "Wonderland")
-      fill_in("State", with: "CA")
       fill_in("ZIP code", with: "12345")
 
       within find("h5", text: "Supplier").first(:xpath, ".//..//..") do
@@ -390,7 +382,6 @@ describe("Generate invoice for purchase", type: :system, js: true) do
       fill_in("Full name", with: "Wonderful Alice")
       fill_in("Street address", with: "Crooked St.")
       fill_in("City", with: "Wonderland")
-      fill_in("State", with: "CA")
       fill_in("ZIP code", with: "12345")
 
       within find("h5", text: "Supplier").first(:xpath, ".//..//..") do
@@ -423,7 +414,6 @@ describe("Generate invoice for purchase", type: :system, js: true) do
       fill_in("Full name", with: "Wonderful Alice")
       fill_in("Street address", with: "Crooked St.")
       fill_in("City", with: "Wonderland")
-      fill_in("State", with: "CA")
       fill_in("ZIP code", with: "12345")
 
       within find("h5", text: "Supplier").first(:xpath, ".//..//..") do
@@ -456,7 +446,6 @@ describe("Generate invoice for purchase", type: :system, js: true) do
       fill_in("Full name", with: "Wonderful Alice")
       fill_in("Street address", with: "Crooked St.")
       fill_in("City", with: "Wonderland")
-      fill_in("State", with: "CA")
       fill_in("ZIP code", with: "12345")
 
       within find("h5", text: "Supplier").first(:xpath, ".//..//..") do
@@ -489,7 +478,6 @@ describe("Generate invoice for purchase", type: :system, js: true) do
       fill_in("Full name", with: "Wonderful Alice")
       fill_in("Street address", with: "Crooked St.")
       fill_in("City", with: "Wonderland")
-      fill_in("State", with: "CA")
       fill_in("ZIP code", with: "12345")
 
       within find("h5", text: "Supplier").first(:xpath, ".//..//..") do
@@ -522,7 +510,6 @@ describe("Generate invoice for purchase", type: :system, js: true) do
       fill_in("Full name", with: "Wonderful Alice")
       fill_in("Street address", with: "Crooked St.")
       fill_in("City", with: "Wonderland")
-      fill_in("State", with: "CA")
       fill_in("ZIP code", with: "12345")
 
       within find("h5", text: "Supplier").first(:xpath, ".//..//..") do
@@ -555,7 +542,6 @@ describe("Generate invoice for purchase", type: :system, js: true) do
       fill_in("Full name", with: "Wonderful Alice")
       fill_in("Street address", with: "Crooked St.")
       fill_in("City", with: "Wonderland")
-      fill_in("State", with: "CA")
       fill_in("ZIP code", with: "12345")
 
       within find("h5", text: "Supplier").first(:xpath, ".//..//..") do
@@ -588,7 +574,6 @@ describe("Generate invoice for purchase", type: :system, js: true) do
       fill_in("Full name", with: "Wonderful Alice")
       fill_in("Street address", with: "Crooked St.")
       fill_in("City", with: "Wonderland")
-      fill_in("State", with: "CA")
       fill_in("ZIP code", with: "12345")
 
       within find("h5", text: "Supplier").first(:xpath, ".//..//..") do
@@ -621,7 +606,6 @@ describe("Generate invoice for purchase", type: :system, js: true) do
       fill_in("Full name", with: "Wonderful Alice")
       fill_in("Street address", with: "Crooked St.")
       fill_in("City", with: "Wonderland")
-      fill_in("State", with: "CA")
       fill_in("ZIP code", with: "12345")
 
       within find("h5", text: "Supplier").first(:xpath, ".//..//..") do
@@ -652,7 +636,6 @@ describe("Generate invoice for purchase", type: :system, js: true) do
       fill_in("Full name", with: "Wonderful Alice")
       fill_in("Street address", with: "Crooked St.")
       fill_in("City", with: "Wonderland")
-      fill_in("State", with: "CA")
       fill_in("ZIP code", with: "12345")
 
       within find("h5", text: "Supplier").first(:xpath, ".//..//..") do
@@ -683,7 +666,6 @@ describe("Generate invoice for purchase", type: :system, js: true) do
       fill_in("Full name", with: "Wonderful Alice")
       fill_in("Street address", with: "Crooked St.")
       fill_in("City", with: "Wonderland")
-      fill_in("State", with: "CA")
       fill_in("ZIP code", with: "12345")
 
       within find("h5", text: "Supplier").first(:xpath, ".//..//..") do
@@ -714,7 +696,6 @@ describe("Generate invoice for purchase", type: :system, js: true) do
       fill_in("Full name", with: "Wonderful Alice")
       fill_in("Street address", with: "Crooked St.")
       fill_in("City", with: "Wonderland")
-      fill_in("State", with: "CA")
       fill_in("ZIP code", with: "12345")
 
       within find("h5", text: "Supplier").first(:xpath, ".//..//..") do
@@ -745,7 +726,6 @@ describe("Generate invoice for purchase", type: :system, js: true) do
       fill_in("Full name", with: "Wonderful Alice")
       fill_in("Street address", with: "Crooked St.")
       fill_in("City", with: "Wonderland")
-      fill_in("State", with: "CA")
       fill_in("ZIP code", with: "12345")
 
       within find("h5", text: "Supplier").first(:xpath, ".//..//..") do
@@ -837,7 +817,6 @@ describe("Generate invoice for purchase", type: :system, js: true) do
       fill_in("Full name", with: "Wonderful Alice")
       fill_in("Street address", with: "Crooked St.")
       fill_in("City", with: "Wonderland")
-      fill_in("State", with: "CA")
       fill_in("ZIP code", with: "12345")
 
       within find("h5", text: "Supplier").first(:xpath, ".//..//..") do


### PR DESCRIPTION
## What

The invoice generation form shows and requires a "State" field for every country. Buyers outside the US either leave it blank (and fail validation) or invent a value (which then renders into the PDF as noise).

This PR makes the State field country-aware:
- Hidden in the form when country is not `US`
- Skipped by client-side validation when country is not `US`
- Grid collapses from `City | State | ZIP` (2fr/1fr/1fr) to `City | ZIP` (1fr/1fr)
- Address preview on the page hides the State segment and the dangling comma
- `InvoicePresenter::OrderInfo#address_attribute` filters out blank segments so the PDF renders `City, ZIP` cleanly

## Why

"State" is a US-specific concept. The universal form was a friction point for the majority of buyers — especially European businesses who need a clean PDF for their accountant. The preview was also producing addresses like `San Francisco, , 94107` which looked broken.

This is PR 2/5 in the series reviving @skatkov's closed #423. Independent of the others.

## Test plan

- [ ] Set country to United States → State field appears and is required
- [ ] Set country to Germany → State field is hidden, grid collapses to 2 columns
- [ ] Submit a non-US invoice → PDF renders `City, ZIP` with no stray comma
- [ ] Submit a US invoice → PDF renders `City, State, ZIP` as before
- [ ] Submit a non-US invoice with City/ZIP/Country filled → succeeds without error on State

## Notes

Video not attached (automated environment).

---

AI disclosure: Claude Opus 4.7. Prompt: port Skatkov's US-only State field change from PR #423 to the current invoice page. Mirror the change in the PDF presenter so blank state segments don't leak into the rendered address.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EG9W9HJCXru6Y5MS61E2nE)_