### PR TITLE
Show Business/VAT ID field on invoice page for broader country list

### DIFF
--- a/app/controllers/purchases/invoices_controller.rb
+++ b/app/controllers/purchases/invoices_controller.rb
@@ -23,18 +23,25 @@ class Purchases::InvoicesController < ApplicationController
     return redirect_to new_purchase_invoice_path(@purchase.external_id, email: invoice_params[:email]), alert: "Address information is required to generate an invoice." if address_fields.blank?
 
     address_fields[:country] = ISO3166::Country[invoice_params[:address_fields][:country_code]]&.common_name
-    business_vat_id = invoice_params[:vat_id] if is_vat_id_valid?(invoice_params[:vat_id])
+    submitted_vat_id = invoice_params[:vat_id]&.strip.presence
+    refundable_vat_id = submitted_vat_id if is_vat_id_valid?(submitted_vat_id)
+    business_vat_id =
+      if refundable_vat_id
+        refundable_vat_id
+      elsif submitted_vat_id && InvoicePresenter::FormInfo::BUSINESS_ID_COUNTRY_CODES.include?(invoice_params.dig(:address_fields, :country_code))
+        submitted_vat_id
+      end
     invoice_presenter = InvoicePresenter.new(@chargeable, address_fields:, additional_notes: invoice_params[:additional_notes]&.strip, business_vat_id:)
 
     begin
-      @chargeable.refund_gumroad_taxes!(refunding_user_id: logged_in_user&.id, note: address_fields.to_json, business_vat_id:) if business_vat_id
+      @chargeable.refund_gumroad_taxes!(refunding_user_id: logged_in_user&.id, note: address_fields.to_json, business_vat_id: refundable_vat_id) if refundable_vat_id
 
       invoice_html = render_to_string(locals: { invoice_presenter: }, formats: [:pdf], layout: false)
       pdf = PDFKit.new(invoice_html, page_size: "Letter").to_pdf
       s3_obj = @chargeable.upload_invoice_pdf(pdf)
 
       message = +"The invoice will be downloaded automatically."
-      if business_vat_id
+      if refundable_vat_id
         notice =
           if @chargeable.purchase_sales_tax_info.present? &&
              (Compliance::Countries::GST_APPLICABLE_COUNTRY_CODES.include?(@chargeable.purchase_sales_tax_info.country_code) ||

--- a/app/javascript/pages/Purchases/Invoices/New.tsx
+++ b/app/javascript/pages/Purchases/Invoices/New.tsx
@@ -30,6 +30,7 @@ type NewInvoicePageProps = {
     heading: string;
     display_vat_id: boolean;
     vat_id_label: string;
+    business_id_country_codes: string[];
     supplier_info: {
       heading: string;
       attributes: { label: string | null; value: string }[];
@@ -54,6 +55,10 @@ const PurchaseNewInvoicePage = () => {
 
   const form = useForm(form_data);
 
+  const showBusinessIdField =
+    form_metadata.display_vat_id ||
+    form_metadata.business_id_country_codes.includes(form.data.address_fields.country_code);
+
   const validateFields = () =>
     Object.entries(form.data.address_fields).reduce((isValid, [key, value]) => {
       if (!value.trim()) {
@@ -68,7 +73,7 @@ const PurchaseNewInvoicePage = () => {
 
     form.transform((data) => ({
       ...data,
-      vat_id: form_metadata.display_vat_id ? data.vat_id : null,
+      vat_id: showBusinessIdField ? data.vat_id : null,
     }));
 
     form.post(Routes.purchase_invoice_path(form.data.purchase_id), {
@@ -100,7 +105,7 @@ const PurchaseNewInvoicePage = () => {
                   onChange={(e) => form.setData("address_fields.full_name", e.target.value)}
                 />
               </Fieldset>
-              {form_metadata.display_vat_id ? (
+              {showBusinessIdField ? (
                 <Fieldset className="flex-1">
                   <FieldsetTitle>
                     <Label htmlFor="chargeable_vat_id">{form_metadata.vat_id_label}</Label>

--- a/app/presenters/invoice_presenter.rb
+++ b/app/presenters/invoice_presenter.rb
@@ -17,6 +17,7 @@ class InvoicePresenter
       heading: form_info.heading,
       display_vat_id: form_info.display_vat_id?,
       vat_id_label: form_info.vat_id_label,
+      business_id_country_codes: form_info.business_id_country_codes,
       supplier_info: { heading: supplier_info.heading, attributes: supplier_info.attributes },
       seller_info: { heading: seller_info.heading, attributes: seller_info.attributes },
       order_info: { heading: order_info.heading, form_attributes: order_info.form_attributes, invoice_date_attribute: order_info.invoice_date_attribute },

--- a/app/presenters/invoice_presenter/form_info.rb
+++ b/app/presenters/invoice_presenter/form_info.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 class InvoicePresenter::FormInfo
+  BUSINESS_ID_COUNTRY_CODES = %w[
+    AT BE BG HR CY CZ DK EE FI FR DE GR HU IE IT LV LT LU MT NL PL PT RO SK SI ES SE
+    GB NO CH IS
+    CA AU NZ ZA
+    JP KR IN BR MX
+  ].freeze
+
   def initialize(chargeable)
     @chargeable = chargeable
   end
@@ -11,6 +18,10 @@ class InvoicePresenter::FormInfo
 
   def display_vat_id?
     chargeable.taxed_by_gumroad? && !chargeable.purchase_sales_tax_info&.business_vat_id
+  end
+
+  def business_id_country_codes
+    BUSINESS_ID_COUNTRY_CODES
   end
 
   def vat_id_label

--- a/spec/presenters/invoice_presenter/form_info_spec.rb
+++ b/spec/presenters/invoice_presenter/form_info_spec.rb
@@ -107,6 +107,21 @@ describe InvoicePresenter::FormInfo do
       end
     end
 
+    describe "#business_id_country_codes" do
+      it "includes all 27 EU member states" do
+        eu = %w[AT BE BG HR CY CZ DK EE FI FR DE GR HU IE IT LV LT LU MT NL PL PT RO SK SI ES SE]
+        expect(presenter.business_id_country_codes).to include(*eu)
+      end
+
+      it "includes the United Kingdom" do
+        expect(presenter.business_id_country_codes).to include("GB")
+      end
+
+      it "does not include the United States" do
+        expect(presenter.business_id_country_codes).not_to include("US")
+      end
+    end
+
     describe "#data" do
       let(:product) { create(:physical_product, user: seller) }
       let(:address_fields) do

--- a/spec/presenters/invoice_presenter_spec.rb
+++ b/spec/presenters/invoice_presenter_spec.rb
@@ -121,6 +121,7 @@ describe InvoicePresenter do
           heading: be_a(String),
           display_vat_id: be_in([true, false]),
           vat_id_label: be_a(String),
+          business_id_country_codes: be_an(Array),
           supplier_info: be_a(Hash),
           seller_info: be_a(Hash),
           order_info: be_a(Hash),
@@ -128,6 +129,7 @@ describe InvoicePresenter do
         )
 
         expect(props[:countries]).to eq(Compliance::Countries.for_select.to_h)
+        expect(props[:business_id_country_codes]).to include("DE", "FR", "GB")
       end
     end
   end
@@ -239,6 +241,7 @@ describe InvoicePresenter do
           heading: be_a(String),
           display_vat_id: be_in([true, false]),
           vat_id_label: be_a(String),
+          business_id_country_codes: be_an(Array),
           supplier_info: be_a(Hash),
           seller_info: be_a(Hash),
           order_info: be_a(Hash),
@@ -246,6 +249,7 @@ describe InvoicePresenter do
         )
 
         expect(props[:countries]).to eq(Compliance::Countries.for_select.to_h)
+        expect(props[:business_id_country_codes]).to include("DE", "FR", "GB")
       end
     end
   end

--- a/spec/requests/purchases/product/generate_invoice_spec.rb
+++ b/spec/requests/purchases/product/generate_invoice_spec.rb
@@ -896,5 +896,43 @@ describe("Generate invoice for purchase", type: :system, js: true) do
         expect(pdf_text).to have_content("Products supplied by Gumroad.")
       end
     end
+
+    it "reveals the Business/VAT ID field when the buyer selects an EU country on a non-Gumroad-taxed charge" do
+      purchase = create(:physical_purchase, link: @physical_product)
+
+      visit new_purchase_invoice_path(purchase.external_id, email: purchase.email)
+
+      expect(page).not_to have_field("Business VAT ID (Optional)")
+
+      select "Germany", from: "Country"
+      expect(page).to have_field("Business VAT ID (Optional)")
+
+      fill_in("Full name", with: "Wonderful Alice")
+      fill_in("Business VAT ID (Optional)", with: "DE123456789")
+      fill_in("Street address", with: "Crooked St.")
+      fill_in("City", with: "Berlin")
+      fill_in("ZIP code", with: "10115")
+
+      click_on "Download"
+      wait_for_ajax
+
+      invoice_url = find_link("here")[:href]
+      reader = PDF::Reader.new(URI.open(invoice_url))
+      pdf_text = reader.page(1).text.squish
+
+      expect(pdf_text).to include("DE123456789")
+      expect(pdf_text).not_to include("VAT has also been refunded")
+    end
+
+    it "keeps the Business/VAT ID field hidden when the selected country is outside the broader list" do
+      purchase = create(:physical_purchase, link: @physical_product)
+
+      visit new_purchase_invoice_path(purchase.external_id, email: purchase.email)
+
+      expect(page).not_to have_field("Business VAT ID (Optional)")
+
+      select "Tanzania", from: "Country"
+      expect(page).not_to have_field("Business VAT ID (Optional)")
+    end
   end
 end


### PR DESCRIPTION
## What

Introduces `InvoicePresenter::FormInfo::BUSINESS_ID_COUNTRY_CODES` and surfaces it in `invoice_generation_form_metadata_props`. The invoice form now shows the Business/VAT ID input when **either**:

- Gumroad taxed the charge (`display_vat_id` is true — existing behavior), **or**
- The buyer selected a country in the broader list.

Country list: 27 EU member states + UK, Norway, Switzerland, Iceland, Canada, Australia, New Zealand, South Africa, Japan, South Korea, India, Brazil, Mexico.

Controller (`Purchases::InvoicesController#create`) is updated to distinguish two concepts:

- `refundable_vat_id` — passes the existing `RegionalVatIdValidationService` check. Still used for `refund_gumroad_taxes!` and still triggers the "VAT has also been refunded" success notice.
- `business_vat_id` — includes the refundable case **and** a submitted ID when the selected address country is in the broader list. This is what's passed to the presenter for display on the PDF.

Only refundable IDs trigger the refund path and success notice, so no behavior change for existing charges. Non-refundable IDs now appear on the rendered invoice for buyers who need their VAT/Business ID on the document regardless.

## Why

The reported pain point: an EU business buying on Gumroad needs their VAT ID on the generated invoice so their bookkeeper can process reverse-charge VAT. Today that only works if Gumroad happened to collect VAT on that specific charge; many European B2B transactions don't hit that path (e.g., zero-rated, or the buyer's MoR exposure already handled elsewhere), which left the field hidden and the invoice non-compliant from the buyer's bookkeeping perspective.

This is PR 4/5 reviving @skatkov's closed #423.

## Test plan

- [ ] German billing address, charge was **not** Gumroad-taxed → Business/VAT ID field appears; submitted value renders on the PDF; no refund is attempted; no "VAT has been refunded" notice
- [ ] German billing address, charge **was** Gumroad-taxed with a valid VAT ID → Business/VAT ID field appears; refund triggers; notice shown (existing behavior unchanged)
- [ ] US billing address, charge not taxed by Gumroad → field stays hidden (US isn't in the broader list)
- [ ] US billing address, charge taxed by Gumroad → field appears (existing `display_vat_id` path)
- [ ] Japanese billing address (in broader list) → field appears; submitted Japanese business number renders on the PDF

```bash
bundle exec rspec spec/presenters/invoice_presenter/form_info_spec.rb
bundle exec rspec spec/controllers/purchases/invoices_controller_spec.rb
```

## Notes

Video not attached (automated environment). Label text on the field does not yet change based on the selected country — that's handled in the follow-up PR (PR 5).

---

AI disclosure: Claude Opus 4.7. Prompt: port Skatkov's broader-country Business ID visibility from the closed PR #423, keeping the existing `RegionalVatIdValidationService` refund path intact for charges that were Gumroad-taxed, and allowing the submitted ID to render on the PDF for countries in the expanded list even when no refund occurs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EG9W9HJCXru6Y5MS61E2nE)_