### PR TITLE
Make Business/VAT ID label on invoice form country-aware

### DIFF
--- a/app/javascript/pages/Purchases/Invoices/New.tsx
+++ b/app/javascript/pages/Purchases/Invoices/New.tsx
@@ -30,6 +30,7 @@ type NewInvoicePageProps = {
     heading: string;
     display_vat_id: boolean;
     vat_id_label: string;
+    business_id_labels: Record<string, string>;
     supplier_info: {
       heading: string;
       attributes: { label: string | null; value: string }[];
@@ -53,6 +54,9 @@ const PurchaseNewInvoicePage = () => {
   const { supplier_info, seller_info, order_info, countries } = form_metadata;
 
   const form = useForm(form_data);
+
+  const businessIdLabel =
+    form_metadata.business_id_labels[form.data.address_fields.country_code] ?? form_metadata.vat_id_label;
 
   const validateFields = () =>
     Object.entries(form.data.address_fields).reduce((isValid, [key, value]) => {
@@ -103,7 +107,7 @@ const PurchaseNewInvoicePage = () => {
               {form_metadata.display_vat_id ? (
                 <Fieldset className="flex-1">
                   <FieldsetTitle>
-                    <Label htmlFor="chargeable_vat_id">{form_metadata.vat_id_label}</Label>
+                    <Label htmlFor="chargeable_vat_id">{businessIdLabel}</Label>
                   </FieldsetTitle>
                   <Input
                     id="chargeable_vat_id"

--- a/app/presenters/invoice_presenter.rb
+++ b/app/presenters/invoice_presenter.rb
@@ -17,6 +17,7 @@ class InvoicePresenter
       heading: form_info.heading,
       display_vat_id: form_info.display_vat_id?,
       vat_id_label: form_info.vat_id_label,
+      business_id_labels: form_info.business_id_labels,
       supplier_info: { heading: supplier_info.heading, attributes: supplier_info.attributes },
       seller_info: { heading: seller_info.heading, attributes: seller_info.attributes },
       order_info: { heading: order_info.heading, form_attributes: order_info.form_attributes, invoice_date_attribute: order_info.invoice_date_attribute },

--- a/app/presenters/invoice_presenter/form_info.rb
+++ b/app/presenters/invoice_presenter/form_info.rb
@@ -1,6 +1,28 @@
 # frozen_string_literal: true
 
 class InvoicePresenter::FormInfo
+  BUSINESS_ID_LABELS = {
+    "AT" => "VAT ID", "BE" => "VAT ID", "BG" => "VAT ID", "HR" => "VAT ID", "CY" => "VAT ID",
+    "CZ" => "VAT ID", "DK" => "VAT ID", "EE" => "VAT ID", "FI" => "VAT ID", "FR" => "VAT ID",
+    "DE" => "VAT ID", "GR" => "VAT ID", "HU" => "VAT ID", "IE" => "VAT ID", "IT" => "VAT ID",
+    "LV" => "VAT ID", "LT" => "VAT ID", "LU" => "VAT ID", "MT" => "VAT ID", "NL" => "VAT ID",
+    "PL" => "VAT ID", "PT" => "VAT ID", "RO" => "VAT ID", "SK" => "VAT ID", "SI" => "VAT ID",
+    "ES" => "VAT ID", "SE" => "VAT ID",
+    "GB" => "GB VAT",
+    "NO" => "MVA",
+    "CH" => "MWST/TVA",
+    "IS" => "VSK",
+    "CA" => "GST/HST",
+    "AU" => "ABN",
+    "NZ" => "GST",
+    "ZA" => "VAT vendor",
+    "JP" => "Consumption tax",
+    "KR" => "VAT registration",
+    "IN" => "GST",
+    "BR" => "CNPJ",
+    "MX" => "RFC",
+  }.freeze
+
   def initialize(chargeable)
     @chargeable = chargeable
   end
@@ -11,6 +33,10 @@ class InvoicePresenter::FormInfo
 
   def display_vat_id?
     chargeable.taxed_by_gumroad? && !chargeable.purchase_sales_tax_info&.business_vat_id
+  end
+
+  def business_id_labels
+    BUSINESS_ID_LABELS
   end
 
   def vat_id_label

--- a/spec/presenters/invoice_presenter/form_info_spec.rb
+++ b/spec/presenters/invoice_presenter/form_info_spec.rb
@@ -107,6 +107,29 @@ describe InvoicePresenter::FormInfo do
       end
     end
 
+    describe "#business_id_labels" do
+      it "maps EU member states to 'VAT ID'" do
+        labels = presenter.business_id_labels
+        %w[DE FR IT ES NL BE IE].each do |code|
+          expect(labels[code]).to eq("VAT ID")
+        end
+      end
+
+      it "maps non-EU jurisdictions to their local label" do
+        labels = presenter.business_id_labels
+        expect(labels["GB"]).to eq("GB VAT")
+        expect(labels["AU"]).to eq("ABN")
+        expect(labels["BR"]).to eq("CNPJ")
+        expect(labels["MX"]).to eq("RFC")
+        expect(labels["JP"]).to eq("Consumption tax")
+        expect(labels["CA"]).to eq("GST/HST")
+      end
+
+      it "does not include countries outside the business-ID scope" do
+        expect(presenter.business_id_labels).not_to have_key("US")
+      end
+    end
+
     describe "#data" do
       let(:product) { create(:physical_product, user: seller) }
       let(:address_fields) do

--- a/spec/presenters/invoice_presenter_spec.rb
+++ b/spec/presenters/invoice_presenter_spec.rb
@@ -121,6 +121,7 @@ describe InvoicePresenter do
           heading: be_a(String),
           display_vat_id: be_in([true, false]),
           vat_id_label: be_a(String),
+          business_id_labels: be_a(Hash),
           supplier_info: be_a(Hash),
           seller_info: be_a(Hash),
           order_info: be_a(Hash),
@@ -128,6 +129,8 @@ describe InvoicePresenter do
         )
 
         expect(props[:countries]).to eq(Compliance::Countries.for_select.to_h)
+        expect(props[:business_id_labels]["DE"]).to eq("VAT ID")
+        expect(props[:business_id_labels]["BR"]).to eq("CNPJ")
       end
     end
   end
@@ -239,6 +242,7 @@ describe InvoicePresenter do
           heading: be_a(String),
           display_vat_id: be_in([true, false]),
           vat_id_label: be_a(String),
+          business_id_labels: be_a(Hash),
           supplier_info: be_a(Hash),
           seller_info: be_a(Hash),
           order_info: be_a(Hash),
@@ -246,6 +250,8 @@ describe InvoicePresenter do
         )
 
         expect(props[:countries]).to eq(Compliance::Countries.for_select.to_h)
+        expect(props[:business_id_labels]["DE"]).to eq("VAT ID")
+        expect(props[:business_id_labels]["BR"]).to eq("CNPJ")
       end
     end
   end

--- a/spec/requests/purchases/product/generate_invoice_spec.rb
+++ b/spec/requests/purchases/product/generate_invoice_spec.rb
@@ -896,5 +896,30 @@ describe("Generate invoice for purchase", type: :system, js: true) do
         expect(pdf_text).to have_content("Products supplied by Gumroad.")
       end
     end
+
+    it "updates the Business/VAT ID field label based on the selected invoice country" do
+      purchase = create(
+        :purchase,
+        link: @product,
+        country: "Australia",
+        gumroad_tax_cents: 100,
+        was_purchase_taxable: true
+      )
+      purchase.create_purchase_sales_tax_info!(country_code: Compliance::Countries::AUS.alpha2)
+
+      visit new_purchase_invoice_path(purchase.external_id, email: purchase.email)
+
+      expect(page).to have_field("Business ABN ID (Optional)")
+
+      select "Germany", from: "Country"
+      expect(page).to have_field("VAT ID")
+      expect(page).not_to have_field("Business ABN ID (Optional)")
+
+      select "Brazil", from: "Country"
+      expect(page).to have_field("CNPJ")
+
+      select "Canada", from: "Country"
+      expect(page).to have_field("GST/HST")
+    end
   end
 end


### PR DESCRIPTION
## What

Adds `InvoicePresenter::FormInfo::BUSINESS_ID_LABELS` — a country-code → local-label map — and wires the invoice form to pick the label based on the **selected** address country instead of the charge's original country.

Label map:
- EU-27: `VAT ID`
- UK: `GB VAT` · Norway: `MVA` · Switzerland: `MWST/TVA` · Iceland: `VSK`
- Canada: `GST/HST` · Australia: `ABN` · New Zealand: `GST` · South Africa: `VAT vendor`
- Japan: `Consumption tax` · South Korea: `VAT registration` · India: `GST` · Brazil: `CNPJ` · Mexico: `RFC`

Fallback: when the selected country isn't in the map, the form falls back to the existing `form_metadata.vat_id_label` from `InvoicePresenter::FormInfo#vat_id_label`, so nothing changes for the original charge-country path.

## Why

The current form resolves the Business/VAT ID label from `purchase_sales_tax_info.country_code` (the charge's country), server-side, once. If the buyer then edits their invoice address to a different country in the form, the label stays stuck on the original — e.g., an AU-taxed charge invoiced to a German billing address shows "Business ABN ID (Optional)", which the German buyer's bookkeeper will reject.

The buyer cares about their own jurisdiction's conventional label. The frontend already has the selected country — this PR gives it the map to look up the right label.

This is PR 5/5 reviving @skatkov's closed #423. It composes with the earlier PR in the series that broadens the set of countries for which the field is visible, but is useful on its own for today's `display_vat_id` path.

## Test plan

- [ ] Purchase taxed in AU, buyer changes invoice country to Germany → label shows `VAT ID`, not `Business ABN ID (Optional)`
- [ ] Purchase taxed in AU, buyer keeps country as Australia → label shows `ABN`
- [ ] Purchase taxed in Singapore (SGP not in the map) → falls back to `Business GST ID (Optional)` (current behavior preserved)
- [ ] Purchase with no Gumroad tax → field is hidden regardless (unaffected — field visibility is a separate concern)

```bash
bundle exec rspec spec/presenters/invoice_presenter/form_info_spec.rb
```

## Notes

Video not attached (automated environment). The label mapping intentionally lives in the presenter (server-side constant) rather than the React component so the list has one source of truth for both the UI label and future back-end consumers.

---

AI disclosure: Claude Opus 4.7. Prompt: port Skatkov's country-aware Business ID label from the closed PR #423 to the current invoice form, keeping the logic server-side as a map consumed by the React form with a fallback to the existing charge-country label.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EG9W9HJCXru6Y5MS61E2nE)_