### PR TITLE
Fix Ghana P.O. box payout validation

### DIFF
--- a/app/javascript/pages/Settings/Payments/Show.tsx
+++ b/app/javascript/pages/Settings/Payments/Show.tsx
@@ -216,19 +216,34 @@ export default function PaymentsPage() {
   }, [errors, clientErrorMessage]);
 
   const isStreetAddressPOBox = (input: string) => {
-    const countryCode: CountryCode = cast(props.user.country_code);
+    return input
+      // Removes all non-alphanumeric characters (excluding underscores).
+      // The 'g' flag allows to match globally and the 'u' flag treats
+      // the pattern as a sequence of Unicode code points (as mandated by
+      // the 'require-unicode-regexp' ESLint rule).
+      .replace(/[^\w]*/gu, "")
+      .toLocaleLowerCase()
+      .includes("pobox");
+  };
 
-    return (
-      countryCode === "US" &&
-      input
-        // Removes all non-alphanumeric characters (excluding underscores).
-        // The 'g' flag allows to match globally and the 'u' flag treats
-        // the pattern as a sequence of Unicode code points (as mandated by
-        // the 'require-unicode-regexp' ESLint rule).
-        .replace(/[^\w]*/gu, "")
-        .toLocaleLowerCase()
-        .includes("pobox")
-    );
+  const poBoxAddressErrorMessage = (countryCode: CountryCode) => {
+    if (countryCode === "US") {
+      return "We require a valid physical US address. We cannot accept a P.O. Box as a valid address.";
+    }
+
+    if (countryCode === "GH") {
+      return "We require a valid physical address in Ghana. We cannot accept a P.O. Box as a valid address.";
+    }
+
+    return "We require a valid physical address. We cannot accept a P.O. Box as a valid address.";
+  };
+
+  const countryRequiresPhysicalAddress = (countryCode: CountryCode) => {
+    return ["US", "GH"].includes(countryCode);
+  };
+
+  const isPhysicalAddressRequiredAndPOBox = (countryCode: CountryCode, input: string) => {
+    return countryRequiresPhysicalAddress(countryCode) && isStreetAddressPOBox(input);
   };
 
   const validatePhoneNumber = (input: string | null, country_code: string | null) => {
@@ -571,12 +586,13 @@ export default function PaymentsPage() {
       );
     } else if (
       !form.data.user.street_address ||
-      (form.data.user.country === "US" && isStreetAddressPOBox(form.data.user.street_address))
+      (form.data.user.country !== null &&
+        isPhysicalAddressRequiredAndPOBox(cast(form.data.user.country), form.data.user.street_address))
     ) {
       markFieldInvalid("street_address");
       if (form.data.user.street_address) {
         setClientErrorMessage({
-          message: "We require a valid physical US address. We cannot accept a P.O. Box as a valid address.",
+          message: poBoxAddressErrorMessage(cast(form.data.user.country)),
         });
       }
     }
@@ -681,12 +697,13 @@ export default function PaymentsPage() {
         }
       } else if (
         !form.data.user.business_street_address ||
-        (form.data.user.business_country === "US" && isStreetAddressPOBox(form.data.user.business_street_address))
+        (form.data.user.business_country !== null &&
+          isPhysicalAddressRequiredAndPOBox(cast(form.data.user.business_country), form.data.user.business_street_address))
       ) {
         markFieldInvalid("business_street_address");
         if (form.data.user.business_street_address) {
           setClientErrorMessage({
-            message: "We require a valid physical US address. We cannot accept a P.O. Box as a valid address.",
+            message: poBoxAddressErrorMessage(cast(form.data.user.business_country)),
           });
         }
       }

--- a/app/javascript/pages/Settings/Payments/Show.tsx
+++ b/app/javascript/pages/Settings/Payments/Show.tsx
@@ -529,6 +529,15 @@ export default function PaymentsPage() {
   };
 
   const validateComplianceInfoFields = () => {
+    const streetAddressValidationContextChanged =
+      form.data.user.street_address !== props.compliance_info.street_address ||
+      form.data.user.country !== props.compliance_info.country ||
+      form.data.user.is_business !== props.compliance_info.is_business;
+    const businessStreetAddressValidationContextChanged =
+      form.data.user.business_street_address !== props.compliance_info.business_street_address ||
+      form.data.user.business_country !== props.compliance_info.business_country ||
+      form.data.user.is_business !== props.compliance_info.is_business;
+
     if (!form.data.user.first_name) {
       markFieldInvalid("first_name");
     }
@@ -582,7 +591,8 @@ export default function PaymentsPage() {
       );
     } else if (
       !form.data.user.street_address ||
-      (form.data.user.country !== null &&
+      (streetAddressValidationContextChanged &&
+        form.data.user.country !== null &&
         isPhysicalAddressRequiredAndPOBox(cast(form.data.user.country), form.data.user.street_address))
     ) {
       markFieldInvalid("street_address");
@@ -693,7 +703,8 @@ export default function PaymentsPage() {
         }
       } else if (
         !form.data.user.business_street_address ||
-        (form.data.user.business_country !== null &&
+        (businessStreetAddressValidationContextChanged &&
+          form.data.user.business_country !== null &&
           isPhysicalAddressRequiredAndPOBox(cast(form.data.user.business_country), form.data.user.business_street_address))
       ) {
         markFieldInvalid("business_street_address");

--- a/app/javascript/pages/Settings/Payments/Show.tsx
+++ b/app/javascript/pages/Settings/Payments/Show.tsx
@@ -217,10 +217,6 @@ export default function PaymentsPage() {
 
   const isStreetAddressPOBox = (input: string) => {
     return input
-      // Removes all non-alphanumeric characters (excluding underscores).
-      // The 'g' flag allows to match globally and the 'u' flag treats
-      // the pattern as a sequence of Unicode code points (as mandated by
-      // the 'require-unicode-regexp' ESLint rule).
       .replace(/[^\w]*/gu, "")
       .toLocaleLowerCase()
       .includes("pobox");

--- a/app/services/update_user_compliance_info.rb
+++ b/app/services/update_user_compliance_info.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 class UpdateUserComplianceInfo
+  COUNTRIES_REQUIRING_PHYSICAL_ADDRESS = {
+    "US" => "We require a valid physical US address. We cannot accept a P.O. Box as a valid address.",
+    "GH" => "We require a valid physical address in Ghana. We cannot accept a P.O. Box as a valid address.",
+  }.freeze
+
   attr_reader :compliance_params, :user
 
   def initialize(compliance_params:, user:)
@@ -10,6 +15,9 @@ class UpdateUserComplianceInfo
 
   def process
     if compliance_params.present?
+      po_box_error = po_box_error_message
+      return { success: false, error_message: po_box_error } if po_box_error.present?
+
       old_compliance_info = user.fetch_or_build_user_compliance_info
       saved, new_compliance_info = old_compliance_info.dup_and_save do |new_compliance_info|
         # if the following fields are submitted and are blank, we don't clear the field for the user
@@ -76,4 +84,45 @@ class UpdateUserComplianceInfo
 
     { success: true }
   end
+
+  private
+    def po_box_error_message
+      country_code = address_country_code
+      return if country_code.blank?
+
+      address = if business_account?
+        submitted_or_existing_field(:business_street_address)
+      else
+        submitted_or_existing_field(:street_address)
+      end
+      return if address.blank?
+      return unless COUNTRIES_REQUIRING_PHYSICAL_ADDRESS.key?(country_code)
+      return unless po_box_address?(address)
+
+      COUNTRIES_REQUIRING_PHYSICAL_ADDRESS.fetch(country_code)
+    end
+
+    def address_country_code
+      if business_account?
+        country = submitted_or_existing_field(:business_country) || submitted_or_existing_field(:country)
+        Compliance::Countries.find_by_name(country)&.alpha2 || country
+      else
+        country = submitted_or_existing_field(:country)
+        Compliance::Countries.find_by_name(country)&.alpha2 || country
+      end
+    end
+
+    def business_account?
+      return user.fetch_or_build_user_compliance_info.is_business? if compliance_params[:is_business].nil?
+
+      ActiveModel::Type::Boolean.new.cast(compliance_params[:is_business])
+    end
+
+    def submitted_or_existing_field(field)
+      compliance_params[field].presence || user.fetch_or_build_user_compliance_info.public_send(field)
+    end
+
+    def po_box_address?(address)
+      address.gsub(/[^\w]/, "").downcase.include?("pobox")
+    end
 end

--- a/app/services/update_user_compliance_info.rb
+++ b/app/services/update_user_compliance_info.rb
@@ -94,7 +94,7 @@ class UpdateUserComplianceInfo
       ADDRESS_FIELDS_AND_COUNTRY_FALLBACKS.each_key do |address_field|
         next unless should_validate_po_box_for?(address_field)
 
-        address = compliance_params[address_field].presence
+        address = address_for_validation(address_field)
         next unless po_box_address?(address)
 
         country_code = effective_country_code_for(address_field)
@@ -108,19 +108,35 @@ class UpdateUserComplianceInfo
     end
 
     def should_validate_po_box_for?(address_field)
-      address = compliance_params[address_field].presence
+      address = address_for_validation(address_field)
       return false if address.blank?
-      return false unless address_field_active?(address_field)
 
-      address_changed?(address_field) || country_changed_for?(address_field) || business_mode_changed?
+      address_changed?(address_field) || validation_context_changed_for?(address_field)
     end
 
-    def address_field_active?(address_field)
-      address_field == :street_address || effective_is_business?
+    def address_for_validation(address_field)
+      compliance_params[address_field].presence || stored_address_for_validation(address_field)
     end
 
     def address_changed?(address_field)
-      compliance_params[address_field].to_s != current_compliance_info.public_send(address_field).to_s
+      compliance_params[address_field].present? &&
+        compliance_params[address_field].to_s != current_compliance_info.public_send(address_field).to_s
+    end
+
+    def stored_address_for_validation(address_field)
+      return unless validation_context_changed_for?(address_field)
+
+      current_compliance_info.public_send(address_field).presence
+    end
+
+    def validation_context_changed_for?(address_field)
+      country_changed_for?(address_field) || business_mode_changed_for?(address_field)
+    end
+
+    def business_mode_changed_for?(address_field)
+      return business_mode_changed? if address_field == :street_address
+
+      business_mode_activating? if address_field == :business_street_address
     end
 
     def country_changed_for?(address_field)
@@ -158,6 +174,10 @@ class UpdateUserComplianceInfo
 
     def business_mode_changed?
       effective_is_business? != current_compliance_info.is_business?
+    end
+
+    def business_mode_activating?
+      !current_compliance_info.is_business? && effective_is_business?
     end
 
     def effective_is_business?

--- a/app/services/update_user_compliance_info.rb
+++ b/app/services/update_user_compliance_info.rb
@@ -91,14 +91,15 @@ class UpdateUserComplianceInfo
 
   private
     def po_box_error_message
-      ADDRESS_FIELDS_AND_COUNTRY_FALLBACKS.each do |address_field, country_fields|
-        address = compliance_params[address_field].presence
-        next if address.blank?
+      ADDRESS_FIELDS_AND_COUNTRY_FALLBACKS.each_key do |address_field|
+        next unless should_validate_po_box_for?(address_field)
 
-        country_code = country_code_for(*country_fields)
+        address = compliance_params[address_field].presence
+        next unless po_box_address?(address)
+
+        country_code = effective_country_code_for(address_field)
         next if country_code.blank?
         next unless COUNTRIES_REQUIRING_PHYSICAL_ADDRESS.key?(country_code)
-        next unless po_box_address?(address)
 
         return COUNTRIES_REQUIRING_PHYSICAL_ADDRESS.fetch(country_code)
       end
@@ -106,19 +107,66 @@ class UpdateUserComplianceInfo
       nil
     end
 
-    def country_code_for(*fields)
-      country = fields.filter_map { |field| submitted_or_existing_field(field) }.first
+    def should_validate_po_box_for?(address_field)
+      address = compliance_params[address_field].presence
+      return false if address.blank?
+      return false unless address_field_active?(address_field)
+
+      address_changed?(address_field) || country_changed_for?(address_field) || business_mode_changed?
+    end
+
+    def address_field_active?(address_field)
+      address_field == :street_address || effective_is_business?
+    end
+
+    def address_changed?(address_field)
+      compliance_params[address_field].to_s != current_compliance_info.public_send(address_field).to_s
+    end
+
+    def country_changed_for?(address_field)
+      effective_country_code_for(address_field) != current_country_code_for(address_field)
+    end
+
+    def effective_country_code_for(address_field)
+      country_code_for(
+        ADDRESS_FIELDS_AND_COUNTRY_FALLBACKS.fetch(address_field).filter_map { |field| effective_country_value_for(field) }.first
+      )
+    end
+
+    def current_country_code_for(address_field)
+      country_code_for(
+        ADDRESS_FIELDS_AND_COUNTRY_FALLBACKS.fetch(address_field).filter_map { |field| current_compliance_info.public_send(field) }.first
+      )
+    end
+
+    def country_code_for(country)
       return if country.blank?
 
       Compliance::Countries.find_by_name(country)&.alpha2 || country
     end
 
-    def submitted_or_existing_field(field)
-      compliance_params[field].presence || current_compliance_info.public_send(field)
+    def effective_country_value_for(field)
+      if field == :country && compliance_params[:country].present? && effective_is_business?
+        Compliance::Countries.mapping[compliance_params[:country]]
+      elsif field == :business_country && compliance_params[:business_country].present? && effective_is_business?
+        Compliance::Countries.mapping[compliance_params[:business_country]]
+      else
+        current_compliance_info.public_send(field)
+      end
     end
 
     def po_box_address?(address)
       address.gsub(/[^\w]/, "").downcase.include?("pobox")
+    end
+
+    def business_mode_changed?
+      effective_is_business? != current_compliance_info.is_business?
+    end
+
+    def effective_is_business?
+      return current_compliance_info.is_business? if compliance_params[:is_business].nil?
+
+      ActiveModel::Type::Boolean.new.cast(compliance_params[:is_business])
     end
 
     def current_compliance_info

--- a/app/services/update_user_compliance_info.rb
+++ b/app/services/update_user_compliance_info.rb
@@ -146,13 +146,10 @@ class UpdateUserComplianceInfo
     end
 
     def effective_country_value_for(field)
-      if field == :country && compliance_params[:country].present? && effective_is_business?
-        Compliance::Countries.mapping[compliance_params[:country]]
-      elsif field == :business_country && compliance_params[:business_country].present? && effective_is_business?
-        Compliance::Countries.mapping[compliance_params[:business_country]]
-      else
-        current_compliance_info.public_send(field)
-      end
+      current_country = current_compliance_info.public_send(field)
+      return current_country unless submitted_country_will_be_persisted?(field)
+
+      Compliance::Countries.mapping[compliance_params[field]].presence || current_country
     end
 
     def po_box_address?(address)
@@ -171,5 +168,9 @@ class UpdateUserComplianceInfo
 
     def current_compliance_info
       @current_compliance_info ||= user.fetch_or_build_user_compliance_info
+    end
+
+    def submitted_country_will_be_persisted?(field)
+      compliance_params[field].present? && compliance_params[:is_business]
     end
 end

--- a/app/services/update_user_compliance_info.rb
+++ b/app/services/update_user_compliance_info.rb
@@ -5,6 +5,10 @@ class UpdateUserComplianceInfo
     "US" => "We require a valid physical US address. We cannot accept a P.O. Box as a valid address.",
     "GH" => "We require a valid physical address in Ghana. We cannot accept a P.O. Box as a valid address.",
   }.freeze
+  ADDRESS_FIELDS_AND_COUNTRY_FALLBACKS = {
+    street_address: [:country],
+    business_street_address: [:business_country, :country],
+  }.freeze
 
   attr_reader :compliance_params, :user
 
@@ -18,7 +22,7 @@ class UpdateUserComplianceInfo
       po_box_error = po_box_error_message
       return { success: false, error_message: po_box_error } if po_box_error.present?
 
-      old_compliance_info = user.fetch_or_build_user_compliance_info
+      old_compliance_info = current_compliance_info
       saved, new_compliance_info = old_compliance_info.dup_and_save do |new_compliance_info|
         # if the following fields are submitted and are blank, we don't clear the field for the user
         new_compliance_info.first_name =              compliance_params[:first_name]              if compliance_params[:first_name].present?
@@ -87,42 +91,37 @@ class UpdateUserComplianceInfo
 
   private
     def po_box_error_message
-      country_code = address_country_code
-      return if country_code.blank?
+      ADDRESS_FIELDS_AND_COUNTRY_FALLBACKS.each do |address_field, country_fields|
+        address = compliance_params[address_field].presence
+        next if address.blank?
 
-      address = if business_account?
-        submitted_or_existing_field(:business_street_address)
-      else
-        submitted_or_existing_field(:street_address)
+        country_code = country_code_for(*country_fields)
+        next if country_code.blank?
+        next unless COUNTRIES_REQUIRING_PHYSICAL_ADDRESS.key?(country_code)
+        next unless po_box_address?(address)
+
+        return COUNTRIES_REQUIRING_PHYSICAL_ADDRESS.fetch(country_code)
       end
-      return if address.blank?
-      return unless COUNTRIES_REQUIRING_PHYSICAL_ADDRESS.key?(country_code)
-      return unless po_box_address?(address)
 
-      COUNTRIES_REQUIRING_PHYSICAL_ADDRESS.fetch(country_code)
+      nil
     end
 
-    def address_country_code
-      if business_account?
-        country = submitted_or_existing_field(:business_country) || submitted_or_existing_field(:country)
-        Compliance::Countries.find_by_name(country)&.alpha2 || country
-      else
-        country = submitted_or_existing_field(:country)
-        Compliance::Countries.find_by_name(country)&.alpha2 || country
-      end
-    end
+    def country_code_for(*fields)
+      country = fields.filter_map { |field| submitted_or_existing_field(field) }.first
+      return if country.blank?
 
-    def business_account?
-      return user.fetch_or_build_user_compliance_info.is_business? if compliance_params[:is_business].nil?
-
-      ActiveModel::Type::Boolean.new.cast(compliance_params[:is_business])
+      Compliance::Countries.find_by_name(country)&.alpha2 || country
     end
 
     def submitted_or_existing_field(field)
-      compliance_params[field].presence || user.fetch_or_build_user_compliance_info.public_send(field)
+      compliance_params[field].presence || current_compliance_info.public_send(field)
     end
 
     def po_box_address?(address)
       address.gsub(/[^\w]/, "").downcase.include?("pobox")
+    end
+
+    def current_compliance_info
+      @current_compliance_info ||= user.fetch_or_build_user_compliance_info
     end
 end

--- a/spec/controllers/settings/payments_controller_spec.rb
+++ b/spec/controllers/settings/payments_controller_spec.rb
@@ -893,6 +893,46 @@ describe Settings::PaymentsController, :vcr, type: :controller, inertia: true do
         expect(response).to have_http_status :found
         expect(session[:inertia_errors][:base]).to include("We require a valid physical address in Ghana. We cannot accept a P.O. Box as a valid address.")
       end
+
+      it "rejects toggling business mode on when a legacy Ghana beneficiary P.O. Box remains on file" do
+        user.alive_user_compliance_info.dup_and_save! do |new_compliance_info|
+          new_compliance_info.street_address = "PO Box 11, Accra"
+        end
+
+        expect do
+          put :update, params: { user: { is_business: "on" } }
+        end.to_not change { user.reload.alive_user_compliance_info.is_business }
+
+        expect(user.reload.alive_user_compliance_info.street_address).to eq("PO Box 11, Accra")
+        expect(response).to redirect_to(settings_payments_path)
+        expect(response).to have_http_status :found
+        expect(session[:inertia_errors][:base]).to include("We require a valid physical address in Ghana. We cannot accept a P.O. Box as a valid address.")
+      end
+
+      it "rejects planting a Ghana business P.O. Box while business mode is off" do
+        expect do
+          put :update, params: { user: { is_business: false, business_street_address: "PO Box 1" } }
+        end.to_not change { user.reload.alive_user_compliance_info.business_street_address }
+
+        expect(response).to redirect_to(settings_payments_path)
+        expect(response).to have_http_status :found
+        expect(session[:inertia_errors][:base]).to include("We require a valid physical address in Ghana. We cannot accept a P.O. Box as a valid address.")
+      end
+
+      it "rejects toggling business mode on when a dormant Ghana business P.O. Box remains on file" do
+        user.alive_user_compliance_info.dup_and_save! do |new_compliance_info|
+          new_compliance_info.business_street_address = "PO Box 22, Accra"
+        end
+
+        expect do
+          put :update, params: { user: { is_business: "on" } }
+        end.to_not change { user.reload.alive_user_compliance_info.is_business }
+
+        expect(user.reload.alive_user_compliance_info.business_street_address).to eq("PO Box 22, Accra")
+        expect(response).to redirect_to(settings_payments_path)
+        expect(response).to have_http_status :found
+        expect(session[:inertia_errors][:base]).to include("We require a valid physical address in Ghana. We cannot accept a P.O. Box as a valid address.")
+      end
     end
 
     describe "ach account" do

--- a/spec/controllers/settings/payments_controller_spec.rb
+++ b/spec/controllers/settings/payments_controller_spec.rb
@@ -749,6 +749,46 @@ describe Settings::PaymentsController, :vcr, type: :controller, inertia: true do
       end
     end
 
+    describe "P.O. Box validation" do
+      before do
+        compliance_info = user.alive_user_compliance_info
+        compliance_info.dup_and_save! do |new_compliance_info|
+          new_compliance_info.country = "Ghana"
+        end
+      end
+
+      it "rejects an individual Ghana address that uses a P.O. Box" do
+        expect do
+          put :update, params: { user: params.merge(street_address: "P.O. Box 123, High street") }
+        end.to_not change { user.reload.alive_user_compliance_info.street_address }
+
+        expect(response).to redirect_to(settings_payments_path)
+        expect(response).to have_http_status :found
+        expect(session[:inertia_errors][:base]).to include("We require a valid physical address in Ghana. We cannot accept a P.O. Box as a valid address.")
+      end
+
+      it "rejects a business Ghana address that uses a P.O. Box" do
+        expect do
+          put :update, params: {
+            user: params.merge(
+              is_business: "on",
+              business_country: "Ghana",
+              business_street_address: "PO Box 456",
+              business_city: "Accra",
+              business_state: "",
+              business_zip_code: "00233",
+              business_type: UserComplianceInfo::BusinessTypes::LLC,
+              business_tax_id: "123-123-123"
+            )
+          }
+        end.to_not change { user.reload.alive_user_compliance_info.business_street_address }
+
+        expect(response).to redirect_to(settings_payments_path)
+        expect(response).to have_http_status :found
+        expect(session[:inertia_errors][:base]).to include("We require a valid physical address in Ghana. We cannot accept a P.O. Box as a valid address.")
+      end
+    end
+
     describe "ach account" do
       let(:user) { create(:user) }
       before do

--- a/spec/controllers/settings/payments_controller_spec.rb
+++ b/spec/controllers/settings/payments_controller_spec.rb
@@ -869,6 +869,30 @@ describe Settings::PaymentsController, :vcr, type: :controller, inertia: true do
         expect(response).to have_http_status :found
         expect(session[:inertia_errors][:base]).to include("We require a valid physical address in Ghana. We cannot accept a P.O. Box as a valid address.")
       end
+
+      it "rejects a Ghana beneficiary P.O. Box when the submitted country cannot be mapped" do
+        expect do
+          put :update, params: { user: { is_business: "on", country: "Ghana", street_address: "PO Box 999" } }
+        end.to_not change { user.reload.alive_user_compliance_info.street_address }
+
+        expect(response).to redirect_to(settings_payments_path)
+        expect(response).to have_http_status :found
+        expect(session[:inertia_errors][:base]).to include("We require a valid physical address in Ghana. We cannot accept a P.O. Box as a valid address.")
+      end
+
+      it "rejects a Ghana business beneficiary P.O. Box when is_business is omitted" do
+        user.alive_user_compliance_info.dup_and_save! do |new_compliance_info|
+          new_compliance_info.is_business = true
+        end
+
+        expect do
+          put :update, params: { user: { country: "FR", street_address: "PO Box 5" } }
+        end.to_not change { user.reload.alive_user_compliance_info.street_address }
+
+        expect(response).to redirect_to(settings_payments_path)
+        expect(response).to have_http_status :found
+        expect(session[:inertia_errors][:base]).to include("We require a valid physical address in Ghana. We cannot accept a P.O. Box as a valid address.")
+      end
     end
 
     describe "ach account" do

--- a/spec/controllers/settings/payments_controller_spec.rb
+++ b/spec/controllers/settings/payments_controller_spec.rb
@@ -767,17 +767,50 @@ describe Settings::PaymentsController, :vcr, type: :controller, inertia: true do
         expect(session[:inertia_errors][:base]).to include("We require a valid physical address in Ghana. We cannot accept a P.O. Box as a valid address.")
       end
 
-      it "allows unrelated partial updates when a legacy Ghana P.O. Box address already exists" do
+      it "allows unrelated full-form updates when a legacy Ghana P.O. Box address is unchanged" do
         user.alive_user_compliance_info.dup_and_save! do |new_compliance_info|
           new_compliance_info.street_address = "PO Box 99, Accra"
         end
 
         expect do
-          put :update, params: { user: { first_name: "newfirst", last_name: "newlast" } }
+          put :update, params: {
+            user: params.merge(
+              first_name: "newfirst",
+              last_name: "newlast",
+              is_business: false,
+              country: "GH",
+              street_address: "PO Box 99, Accra"
+            )
+          }
         end.to change { user.reload.alive_user_compliance_info.first_name }.to("newfirst")
 
         expect(user.reload.alive_user_compliance_info.last_name).to eq("newlast")
         expect(user.alive_user_compliance_info.street_address).to eq("PO Box 99, Accra")
+        expect(response).to redirect_to(settings_payments_path)
+        expect(response).to have_http_status :see_other
+        expect(flash[:notice]).to eq("Thanks! You're all set.")
+      end
+
+      it "allows unrelated full-form updates when a hidden legacy Ghana business P.O. Box is unchanged for an individual" do
+        user.alive_user_compliance_info.dup_and_save! do |new_compliance_info|
+          new_compliance_info.business_street_address = "PO Box 77, Accra"
+        end
+
+        expect do
+          put :update, params: {
+            user: params.merge(
+              first_name: "newfirst",
+              last_name: "newlast",
+              is_business: false,
+              country: "GH",
+              business_street_address: "PO Box 77, Accra",
+              business_country: "GH"
+            )
+          }
+        end.to change { user.reload.alive_user_compliance_info.first_name }.to("newfirst")
+
+        expect(user.reload.alive_user_compliance_info.last_name).to eq("newlast")
+        expect(user.alive_user_compliance_info.business_street_address).to eq("PO Box 77, Accra")
         expect(response).to redirect_to(settings_payments_path)
         expect(response).to have_http_status :see_other
         expect(flash[:notice]).to eq("Thanks! You're all set.")
@@ -822,6 +855,16 @@ describe Settings::PaymentsController, :vcr, type: :controller, inertia: true do
         end.to_not change { user.reload.alive_user_compliance_info.street_address }
 
         expect(user.reload.alive_user_compliance_info.business_street_address).to be_nil
+        expect(response).to redirect_to(settings_payments_path)
+        expect(response).to have_http_status :found
+        expect(session[:inertia_errors][:base]).to include("We require a valid physical address in Ghana. We cannot accept a P.O. Box as a valid address.")
+      end
+
+      it "rejects a Ghana beneficiary P.O. Box when the submitted country would not be persisted" do
+        expect do
+          put :update, params: { user: { country: "FR", street_address: "PO Box 999" } }
+        end.to_not change { user.reload.alive_user_compliance_info.street_address }
+
         expect(response).to redirect_to(settings_payments_path)
         expect(response).to have_http_status :found
         expect(session[:inertia_errors][:base]).to include("We require a valid physical address in Ghana. We cannot accept a P.O. Box as a valid address.")

--- a/spec/controllers/settings/payments_controller_spec.rb
+++ b/spec/controllers/settings/payments_controller_spec.rb
@@ -767,6 +767,22 @@ describe Settings::PaymentsController, :vcr, type: :controller, inertia: true do
         expect(session[:inertia_errors][:base]).to include("We require a valid physical address in Ghana. We cannot accept a P.O. Box as a valid address.")
       end
 
+      it "allows unrelated partial updates when a legacy Ghana P.O. Box address already exists" do
+        user.alive_user_compliance_info.dup_and_save! do |new_compliance_info|
+          new_compliance_info.street_address = "PO Box 99, Accra"
+        end
+
+        expect do
+          put :update, params: { user: { first_name: "newfirst", last_name: "newlast" } }
+        end.to change { user.reload.alive_user_compliance_info.first_name }.to("newfirst")
+
+        expect(user.reload.alive_user_compliance_info.last_name).to eq("newlast")
+        expect(user.alive_user_compliance_info.street_address).to eq("PO Box 99, Accra")
+        expect(response).to redirect_to(settings_payments_path)
+        expect(response).to have_http_status :see_other
+        expect(flash[:notice]).to eq("Thanks! You're all set.")
+      end
+
       it "rejects a business Ghana address that uses a P.O. Box" do
         expect do
           put :update, params: {
@@ -783,6 +799,29 @@ describe Settings::PaymentsController, :vcr, type: :controller, inertia: true do
           }
         end.to_not change { user.reload.alive_user_compliance_info.business_street_address }
 
+        expect(response).to redirect_to(settings_payments_path)
+        expect(response).to have_http_status :found
+        expect(session[:inertia_errors][:base]).to include("We require a valid physical address in Ghana. We cannot accept a P.O. Box as a valid address.")
+      end
+
+      it "rejects a submitted beneficiary Ghana P.O. Box even when the business address is valid" do
+        expect do
+          put :update, params: {
+            user: params.merge(
+              is_business: "on",
+              street_address: "PO Box 789",
+              business_country: "Ghana",
+              business_street_address: "12 Independence Ave",
+              business_city: "Accra",
+              business_state: "",
+              business_zip_code: "00233",
+              business_type: UserComplianceInfo::BusinessTypes::LLC,
+              business_tax_id: "123-123-123"
+            )
+          }
+        end.to_not change { user.reload.alive_user_compliance_info.street_address }
+
+        expect(user.reload.alive_user_compliance_info.business_street_address).to be_nil
         expect(response).to redirect_to(settings_payments_path)
         expect(response).to have_http_status :found
         expect(session[:inertia_errors][:base]).to include("We require a valid physical address in Ghana. We cannot accept a P.O. Box as a valid address.")

--- a/spec/requests/settings/payments_spec.rb
+++ b/spec/requests/settings/payments_spec.rb
@@ -4197,6 +4197,7 @@ describe("Payments Settings Scenario", type: :system, js: true) do
         visit settings_payments_path
 
         choose "Individual"
+        fill_in("Phone number", with: "302213850")
 
         find_field("Address", match: :first).set("P.O. Box 123, High street")
 

--- a/spec/requests/settings/payments_spec.rb
+++ b/spec/requests/settings/payments_spec.rb
@@ -4192,6 +4192,17 @@ describe("Payments Settings Scenario", type: :system, js: true) do
         expect(@user.reload.active_bank_account.routing_number).to eq("022112")
         expect(@user.reload.active_bank_account.send(:account_number_decrypted)).to eq("000123456789")
       end
+
+      it "does not allow saving a P.O. Box address" do
+        visit settings_payments_path
+
+        find_field("Address", match: :first).set("P.O. Box 123, High street")
+
+        expect do
+          click_on "Update settings"
+          expect(page).to have_status(text: "We require a valid physical address in Ghana. We cannot accept a P.O. Box as a valid address.")
+        end.to_not change { @user.alive_user_compliance_info.reload.street_address }
+      end
     end
 
     describe "Jamaican creator" do

--- a/spec/requests/settings/payments_spec.rb
+++ b/spec/requests/settings/payments_spec.rb
@@ -4193,6 +4193,53 @@ describe("Payments Settings Scenario", type: :system, js: true) do
         expect(@user.reload.active_bank_account.send(:account_number_decrypted)).to eq("000123456789")
       end
 
+      it "allows saving unrelated changes when a legacy individual P.O. Box address is unchanged" do
+        allow_any_instance_of(User).to receive(:can_setup_paypal_payouts?).and_return(true)
+        @user.update!(payment_address: "ghanaian@example.com")
+        @user.alive_user_compliance_info.dup_and_save! do |new_compliance_info|
+          new_compliance_info.first_name = "ghanaian"
+          new_compliance_info.last_name = "creator"
+          new_compliance_info.street_address = "PO Box 99, Accra"
+          new_compliance_info.city = "Accra"
+          new_compliance_info.phone = "+233302213850"
+          new_compliance_info.zip_code = "00233"
+          new_compliance_info.birthday = Date.new(1980, 1, 1)
+        end
+
+        visit settings_payments_path
+
+        fill_in("First name", with: "newfirst")
+        click_on("Update settings")
+
+        expect(page).to have_alert(text: "Thanks! You're all set.")
+        expect(@user.reload.alive_user_compliance_info.first_name).to eq("newfirst")
+        expect(@user.alive_user_compliance_info.street_address).to eq("PO Box 99, Accra")
+      end
+
+      it "allows saving unrelated changes when a hidden legacy business P.O. Box address is unchanged for an individual" do
+        allow_any_instance_of(User).to receive(:can_setup_paypal_payouts?).and_return(true)
+        @user.update!(payment_address: "ghanaian@example.com")
+        @user.alive_user_compliance_info.dup_and_save! do |new_compliance_info|
+          new_compliance_info.first_name = "ghanaian"
+          new_compliance_info.last_name = "creator"
+          new_compliance_info.street_address = "address_full_match"
+          new_compliance_info.business_street_address = "PO Box 77, Accra"
+          new_compliance_info.city = "Accra"
+          new_compliance_info.phone = "+233302213850"
+          new_compliance_info.zip_code = "00233"
+          new_compliance_info.birthday = Date.new(1980, 1, 1)
+        end
+
+        visit settings_payments_path
+
+        fill_in("First name", with: "newfirst")
+        click_on("Update settings")
+
+        expect(page).to have_alert(text: "Thanks! You're all set.")
+        expect(@user.reload.alive_user_compliance_info.first_name).to eq("newfirst")
+        expect(@user.alive_user_compliance_info.business_street_address).to eq("PO Box 77, Accra")
+      end
+
       it "does not allow saving an individual P.O. Box address" do
         visit settings_payments_path
 

--- a/spec/requests/settings/payments_spec.rb
+++ b/spec/requests/settings/payments_spec.rb
@@ -4193,8 +4193,10 @@ describe("Payments Settings Scenario", type: :system, js: true) do
         expect(@user.reload.active_bank_account.send(:account_number_decrypted)).to eq("000123456789")
       end
 
-      it "does not allow saving a P.O. Box address" do
+      it "does not allow saving an individual P.O. Box address" do
         visit settings_payments_path
+
+        choose "Individual"
 
         find_field("Address", match: :first).set("P.O. Box 123, High street")
 
@@ -4202,6 +4204,41 @@ describe("Payments Settings Scenario", type: :system, js: true) do
           click_on "Update settings"
           expect(page).to have_status(text: "We require a valid physical address in Ghana. We cannot accept a P.O. Box as a valid address.")
         end.to_not change { @user.alive_user_compliance_info.reload.street_address }
+      end
+
+      it "does not allow saving a business P.O. Box address" do
+        visit settings_payments_path
+
+        fill_in("First name", with: "ghanaian")
+        fill_in("Last name", with: "creator")
+        fill_in("Address", with: "address_full_match")
+        fill_in("City", with: "Accra")
+        fill_in("Phone number", with: "302213850")
+        fill_in("Postal code", with: "00233")
+
+        select("1", from: "Day")
+        select("January", from: "Month")
+        select("1980", from: "Year")
+
+        choose "Business"
+
+        fill_in "Legal business name", with: "Acme"
+        select("LLC", from: "Type")
+        find_field("Address", match: :first).set("PO Box 123 High street")
+        find_field("City", match: :first).set("Accra")
+        find_field("Postal code", match: :first).set("00233")
+        fill_in "Business phone number", with: "302213850"
+        fill_in "Company tax ID", with: "000000000"
+
+        fill_in("Pay to the order of", with: "ghanaian creator")
+        fill_in("Bank code", with: "022112")
+        fill_in("Account #", with: "000123456789")
+        fill_in("Confirm account #", with: "000123456789")
+
+        expect do
+          click_on "Update settings"
+          expect(page).to have_status(text: "We require a valid physical address in Ghana. We cannot accept a P.O. Box as a valid address.")
+        end.to_not change { @user.alive_user_compliance_info.reload.business_street_address }
       end
     end
 


### PR DESCRIPTION
## What
- Reject P.O. box payout addresses for Ghana sellers in the payments form and on the server.
- Keep the existing US protection in place while extending the same validation to Ghana.
- Add coverage for both the direct update path and the browser flow.

## Why
- Stripe’s upcoming Ghana update requires a real beneficiary address, so we need to stop bad addresses before they reach Stripe.
- Adding the check server-side avoids gaps if a request bypasses the UI.

---

This PR was implemented with AI assistance using GPT-5.4.