### PR TITLE
Add auto Claude review for bot PRs after CI passes

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,64 @@
+name: Request Claude review
+
+on:
+  workflow_run:
+    workflows: ["Tests"]
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  actions: read
+
+jobs:
+  request-review:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const BOT_AUTHORS = ["gumclaw"];
+            const REVIEW_MARKER = "<!-- claude-review-requested -->";
+            const { owner, repo } = context.repo;
+
+            const headBranch = context.payload.workflow_run.head_branch;
+
+            if (headBranch === "main") {
+              core.info("Skipping main branch");
+              return;
+            }
+
+            const { data: prs } = await github.rest.pulls.list({
+              owner, repo, state: "open", head: `${owner}:${headBranch}`
+            });
+
+            if (prs.length === 0) {
+              core.info(`No open PR found for branch ${headBranch}`);
+              return;
+            }
+
+            const pr = prs[0];
+
+            if (!BOT_AUTHORS.includes(pr.user.login)) {
+              core.info(`Skipping PR #${pr.number} — author ${pr.user.login} not in bot list`);
+              return;
+            }
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner, repo, issue_number: pr.number, per_page: 100
+            });
+
+            const alreadyRequested = comments.some(c => c.body.includes(REVIEW_MARKER));
+            if (alreadyRequested) {
+              core.info(`PR #${pr.number} — Claude review already requested`);
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner, repo, issue_number: pr.number,
+              body: `${REVIEW_MARKER}\n@claude review`
+            });
+
+            core.info(`PR #${pr.number} — requested Claude review`);


### PR DESCRIPTION
Adds a GitHub Action that automatically comments `@claude review` on gumclaw PRs after CI passes.

**How it works:**
- Triggers when the Tests workflow completes successfully
- Only targets PRs authored by `gumclaw` (our AI bot)
- Checks for an existing review request to avoid duplicates
- Comments `@claude review` to trigger Claude Code review

This ensures all automated PRs (Sentry fixes, feature work, etc.) get a Claude Code review before merging, without spamming human PRs.