### PR TITLE
Request Claude review on all PRs, not just bot PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -19,7 +19,6 @@ jobs:
       - uses: actions/github-script@v7
         with:
           script: |
-            const BOT_AUTHORS = ["gumclaw"];
             const REVIEW_MARKER = "<!-- claude-review-requested -->";
             const { owner, repo } = context.repo;
 
@@ -41,8 +40,8 @@ jobs:
 
             const pr = prs[0];
 
-            if (!BOT_AUTHORS.includes(pr.user.login)) {
-              core.info(`Skipping PR #${pr.number} — author ${pr.user.login} not in bot list`);
+            if (pr.draft) {
+              core.info(`Skipping PR #${pr.number} — draft`);
               return;
             }
 


### PR DESCRIPTION
Updates the Claude review workflow to request `@claude review` on **all** PRs after CI passes, not just gumclaw PRs.

Changes:
- Removed bot-author filter
- Added draft PR skip (no point reviewing drafts)
- Still skips if review was already requested (dedup marker)