### PR TITLE
Cap moderation classifier to 1 image per request

### DIFF
--- a/app/services/content_moderation/strategies/classifier_strategy.rb
+++ b/app/services/content_moderation/strategies/classifier_strategy.rb
@@ -3,6 +3,7 @@
 class ContentModeration::Strategies::ClassifierStrategy
   Result = Struct.new(:status, :reasoning, keyword_init: true)
   OPENAI_REQUEST_TIMEOUT_IN_SECONDS = 10
+  MAX_IMAGES_PER_REQUEST = 1
 
   DEFAULT_THRESHOLDS = {
     "harassment" => 0.8,
@@ -69,7 +70,7 @@ class ContentModeration::Strategies::ClassifierStrategy
     def build_input
       parts = []
       parts << { type: "text", text: @text } if @text.present?
-      @image_urls.sample(5).each do |url|
+      @image_urls.sample(MAX_IMAGES_PER_REQUEST).each do |url|
         parts << { type: "image_url", image_url: { url: url } }
       end
       parts

--- a/spec/services/content_moderation/strategies/classifier_strategy_spec.rb
+++ b/spec/services/content_moderation/strategies/classifier_strategy_spec.rb
@@ -54,6 +54,25 @@ RSpec.describe ContentModeration::Strategies::ClassifierStrategy, :vcr do
     expect(result.reasoning).to eq([])
   end
 
+  it "sends at most one image to the OpenAI moderation API" do
+    many_image_urls = [
+      "https://cdn.example.com/1.png",
+      "https://cdn.example.com/2.png",
+      "https://cdn.example.com/3.png",
+    ]
+    captured_parameters = nil
+    allow(client).to receive(:moderations) do |parameters:|
+      captured_parameters = parameters
+      { "results" => [{ "category_scores" => {} }] }
+    end
+
+    described_class.new(text:, image_urls: many_image_urls).perform
+
+    image_parts = captured_parameters[:input].select { |part| part[:type] == "image_url" }
+    expect(image_parts.size).to eq(1)
+    expect(many_image_urls).to include(image_parts.first[:image_url][:url])
+  end
+
   it "logs and re-raises when the OpenAI request fails" do
     allow(client).to receive(:moderations).and_raise(StandardError, "API failure")
 


### PR DESCRIPTION
## What

- Change `ContentModeration::Strategies::ClassifierStrategy#build_input` to sample a single random image (`MAX_IMAGES_PER_REQUEST = 1`) instead of up to 5, matching what the OpenAI moderation endpoint accepts.
- Add a spec covering the cap: when multiple image URLs are supplied, exactly one `image_url` part is sent to `client.moderations`.

## Why

OpenAI's `omni-moderation-latest` endpoint only accepts 1 image per request. Any product or post with 2+ images produced:

```
Faraday::BadRequestError: the server responded with status 400
{"error": {"message": "Number of images (2) exceeds maximum of 1",
           "type": "invalid_request_error",
           "param": "input",
           "code": "too_many_images"}}
```

Reproduced against a live production product (2 images) by running the strategy directly through the read-only production console. With 1 image the same call returned `compliant`. Capping to 1 image is the minimal fix; a future change can fan out per image and merge `category_scores` if broader image coverage is needed.

## Before/After

N/A — non-user-facing internal service change. Previous behavior crashed the moderation check on any multi-image product; new behavior completes normally. I'll add a short walkthrough video before this merges.

## Test Results

`bundle exec rspec spec/services/content_moderation/strategies/classifier_strategy_spec.rb` — 6 examples, 0 failures. The new spec was confirmed to fail when the fix is reverted (reports 3 image parts vs. expected 1).

---

AI disclosure: Written with Claude Opus 4.7 (1M context). Prompts: (1) reproduce the Sentry `Faraday::BadRequestError` at `classifier_strategy.rb:37` without modifying the live product, using the read-only production console; (2) confirm whether the same call succeeds with 1 image; (3) apply the "use a random image instead of the first image" fix on a new branch and open this PR.