### PR TITLE
Block suspended users from editing reviews via email digest auth

### DIFF
--- a/app/controllers/product_reviews_controller.rb
+++ b/app/controllers/product_reviews_controller.rb
@@ -56,6 +56,11 @@ class ProductReviewsController < ApplicationController
         return
       end
 
+      if purchase.purchaser&.suspended?
+        render json: { success: false, message: "Sorry, you are not authorized to review this product." }
+        return
+      end
+
       if purchase.created_at < 1.year.ago && @product.user.disable_reviews_after_year?
         render json: { success: false, message: "Sorry, something went wrong." }
         return

--- a/spec/controllers/product_reviews_controller_spec.rb
+++ b/spec/controllers/product_reviews_controller_spec.rb
@@ -128,6 +128,49 @@ describe ProductReviewsController do
       end
     end
 
+    context "when purchaser is suspended" do
+      it "rejects review creation from a suspended user" do
+        purchaser.update!(user_risk_state: "suspended_for_fraud")
+        put :set, params: valid_params
+
+        expect(response.parsed_body["success"]).to eq(false)
+        expect(response.parsed_body["message"]).to eq("Sorry, you are not authorized to review this product.")
+        expect(purchase.reload.product_review).to be_nil
+      end
+
+      it "rejects review edits from a suspended user" do
+        review = create(:product_review, purchase: purchase, rating: 3)
+        purchaser.update!(user_risk_state: "suspended_for_tos_violation")
+        put :set, params: valid_params.merge(rating: 1)
+
+        expect(response.parsed_body["success"]).to eq(false)
+        expect(review.reload.rating).to eq(3)
+      end
+
+      it "allows review creation after user is unsuspended" do
+        purchaser.update!(user_risk_state: "suspended_for_fraud")
+        purchaser.update!(user_risk_state: "compliant")
+        put :set, params: valid_params
+
+        expect(response.parsed_body["success"]).to eq(true)
+        expect(purchase.reload.product_review.rating).to eq(4)
+      end
+
+      it "allows reviews from guest purchases with no linked user" do
+        guest_purchase = create(:purchase, link: product, purchaser: nil, created_at: 2.years.ago)
+        put :set, params: {
+          link_id: product.unique_permalink,
+          purchase_id: guest_purchase.external_id,
+          purchase_email_digest: guest_purchase.email_digest,
+          rating: 5,
+          message: "Guest review"
+        }
+
+        expect(response.parsed_body["success"]).to eq(true)
+        expect(guest_purchase.reload.product_review.rating).to eq(5)
+      end
+    end
+
     context "when seller has reviews disabled after 1 year" do
       before { product.user.update!(disable_reviews_after_year: true) }
 


### PR DESCRIPTION
## Problem
Suspended users could still modify their product reviews through the download page linked in receipt emails. The download page uses HMAC-based `email_digest` auth (not sessions), so the `check_suspended` gate in ApplicationController never fires.

## Fix
Adds a suspension check in `ProductReviewsController#set` after the email_digest verification:

```ruby
if purchase.purchaser&.suspended?
  render json: { success: false, message: "Sorry, you are not authorized to review this product." }
  return
end
```

## Edge cases covered
- **Guest purchases** (`purchaser` is nil): unaffected, reviews still work
- **Unsuspended users**: reads live state, so they can edit again naturally
- **Both suspension types**: `suspended_for_fraud` and `suspended_for_tos_violation`

## Tests added
- Rejects review creation from suspended user
- Rejects review edits from suspended user  
- Allows reviews after unsuspension
- Allows guest purchase reviews (no linked user)

Closes https://github.com/antiwork/gumroad-private/issues/311