### PR TITLE
Track CLI users via API event logging

### DIFF
--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -65,6 +65,24 @@ class Api::V2::BaseController < ApplicationController
       return unless doorkeeper_token.present?
 
       Rails.logger.info("api v2 user:#{current_resource_owner.id} token:#{doorkeeper_token.id} in #{params[:controller]}##{params[:action]}")
+
+      track_api_event
+    end
+
+    def track_api_event
+      source = ApiEvent.detect_source(request.user_agent)
+      cli_version = request.user_agent&.match(/gumroad-cli\/(\S+)/i)&.captures&.first
+
+      ApiEvent.create(
+        user: current_resource_owner,
+        oauth_application: doorkeeper_token.application,
+        event_type: "api_call",
+        source:,
+        source_version: cli_version,
+        controller_action: "#{params[:controller]}##{params[:action]}"
+      )
+    rescue => e
+      Rails.logger.error("Failed to track API event: #{e.message}")
     end
 
     def next_page_url(page_key)

--- a/app/models/api_event.rb
+++ b/app/models/api_event.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class ApiEvent < ApplicationRecord
+  belongs_to :user
+  belongs_to :oauth_application, optional: true
+
+  validates :event_type, :source, :controller_action, presence: true
+
+  SOURCES = %w[cli api mobile].freeze
+  validates :source, inclusion: { in: SOURCES }
+
+  scope :from_cli, -> { where(source: "cli") }
+  scope :from_api, -> { where(source: "api") }
+  scope :recent, -> { where("created_at > ?", 30.days.ago) }
+
+  # Determine source from User-Agent header
+  def self.detect_source(user_agent)
+    return "cli" if user_agent&.match?(/gumroad-cli/i)
+    return "mobile" if user_agent&.match?(/GumroadMobile|Gumroad iOS|Gumroad Android/i)
+
+    "api"
+  end
+end

--- a/db/migrate/20261122000000_create_api_events.rb
+++ b/db/migrate/20261122000000_create_api_events.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreateApiEvents < ActiveRecord::Migration[7.1]
+  def change
+    create_table :api_events do |t|
+      t.references :user, null: false, index: true
+      t.references :oauth_application, null: true, index: true
+      t.string :event_type, null: false
+      t.string :source, null: false # "cli", "api", "mobile"
+      t.string :source_version # CLI version string, e.g. "1.2.3"
+      t.string :controller_action, null: false # e.g. "links#create"
+      t.json :metadata # flexible bag for additional context
+      t.timestamps
+    end
+
+    add_index :api_events, [:user_id, :source, :created_at]
+    add_index :api_events, [:source, :created_at]
+  end
+end


### PR DESCRIPTION
## What
Starter implementation for tracking CLI usage ([#4676](https://github.com/antiwork/gumroad/issues/4676)).

## How it works
- New `api_events` table logs every API v2 request with source detection (`cli`, `api`, `mobile`)
- Source is detected via User-Agent header matching `gumroad-cli`
- CLI version is extracted when present (`gumroad-cli/1.2.3`)
- Instrumented in `Api::V2::BaseController#log_method_use` so all endpoints are tracked
- Fire-and-forget (rescued on failure) to avoid impacting API latency

## Schema
```
api_events: user_id, oauth_application_id, event_type, source, source_version, controller_action, metadata (json), timestamps
```

## TODO (for Gianfranco to complete)
- [ ] Ensure the Gumroad CLI sends a User-Agent header with `gumroad-cli/VERSION`
- [ ] Move event tracking to a Sidekiq job to avoid write latency in API responses
- [ ] Build Metabase dashboard for CLI adoption metrics (DAU, commands, retention)
- [ ] Consider opt-out mechanism and privacy policy update
- [ ] Add data retention policy (auto-purge events older than N days)
- [ ] Add tests for ApiEvent model and source detection

Refs #4676