### PR TITLE
Track CLI users via bit flag (no migration)

### DIFF
--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -65,6 +65,17 @@ class Api::V2::BaseController < ApplicationController
       return unless doorkeeper_token.present?
 
       Rails.logger.info("api v2 user:#{current_resource_owner.id} token:#{doorkeeper_token.id} in #{params[:controller]}##{params[:action]}")
+
+      mark_cli_user
+    end
+
+    def mark_cli_user
+      return unless request.user_agent&.match?(/gumroad-cli/i)
+      return if current_resource_owner.has_used_cli?
+
+      current_resource_owner.update_column(:flags, current_resource_owner.flags | User.flag_mapping["flags"][:has_used_cli])
+    rescue => e
+      Rails.logger.error("Failed to mark CLI user: #{e.message}")
     end
 
     def next_page_url(page_key)

--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -80,7 +80,7 @@ class Api::V2::BaseController < ApplicationController
     end
 
     def request_from_cli?
-      request.user_agent&.match?(/gumroad-cli/i)
+      request.user_agent&.match?(/\Agumroad-cli\//i)
     end
 
     def next_page_url(page_key)

--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -70,12 +70,16 @@ class Api::V2::BaseController < ApplicationController
     end
 
     def mark_cli_user
-      return unless request.user_agent&.match?(/gumroad-cli/i)
+      return unless request_from_cli?
       return if current_resource_owner.has_used_cli?
 
       current_resource_owner.update_column(:flags, current_resource_owner.flags | User.flag_mapping["flags"][:has_used_cli])
     rescue => e
       Rails.logger.error("Failed to mark CLI user: #{e.message}")
+    end
+
+    def request_from_cli?
+      request.user_agent&.match?(/gumroad-cli/i)
     end
 
     def next_page_url(page_key)

--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -73,7 +73,8 @@ class Api::V2::BaseController < ApplicationController
       return unless request_from_cli?
       return if current_resource_owner.has_used_cli?
 
-      current_resource_owner.update_column(:flags, current_resource_owner.flags | User.flag_mapping["flags"][:has_used_cli])
+      mask = User.flag_mapping["flags"][:has_used_cli]
+      User.where(id: current_resource_owner.id).where("flags & ? = 0", mask).update_all(["flags = flags | ?", mask])
     rescue => e
       Rails.logger.error("Failed to mark CLI user: #{e.message}")
     end

--- a/app/controllers/api/v2/links_controller.rb
+++ b/app/controllers/api/v2/links_controller.rb
@@ -151,6 +151,8 @@ class Api::V2::LinksController < Api::V2::BaseController
       @product.json_data["custom_summary"] = params[:custom_summary]
     end
 
+    @product.created_via_cli = true if request_from_cli?
+
     ActiveRecord::Base.transaction do
       @product.save!
       @product.set_template_properties_if_needed

--- a/app/controllers/api/v2/offer_codes_controller.rb
+++ b/app/controllers/api/v2/offer_codes_controller.rb
@@ -28,6 +28,7 @@ class Api::V2::OfferCodesController < Api::V2::BaseController
 
     offer_code.user = @product.user
     offer_code.products << @product unless params[:universal] == "true"
+    offer_code.created_via_cli = true if request_from_cli?
 
     if offer_code.save
       success_with_offer_code(offer_code)

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -37,7 +37,7 @@ class Link < ApplicationRecord
             28 => :is_collab,
             29 => :is_unpublished_by_admin,
             30 => :community_chat_enabled,
-            31 => :DEPRECATED_excluded_from_mobile_app_discover,
+            31 => :created_via_cli,
             32 => :DEPRECATED_moderated_by_iffy,
             33 => :hide_sold_out_variants,
             :column => "flags",

--- a/app/models/offer_code.rb
+++ b/app/models/offer_code.rb
@@ -11,6 +11,7 @@ class OfferCode < ApplicationRecord
   include OfferCode::Sorting
 
   has_flags 1 => :is_cancellation_discount,
+            2 => :created_via_cli,
             :column => "flags",
             :flag_query_mode => :bit_operator,
             check_for_column: false

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -267,7 +267,7 @@ class User < ApplicationRecord
             27 => :is_eu_vat_exclusive,
             28 => :is_team_member,
             29 => :has_dismissed_getting_started_checklist,
-            30 => :DEPRECATED_has_risk_privilege,
+            30 => :has_used_cli,
             31 => :disable_paypal_sales,
             32 => :all_adult_products,
             33 => :enable_free_downloads_email,

--- a/spec/controllers/api/v2/links_controller_spec.rb
+++ b/spec/controllers/api/v2/links_controller_spec.rb
@@ -195,7 +195,9 @@ describe Api::V2::LinksController do
 
       it "marks products created from the CLI and marks the user without dropping other flags" do
         request.user_agent = "gumroad-cli/1.0"
+        stale_user = @user.reload
         other_flag_mask = User.flag_mapping["flags"][:disable_paypal_sales]
+        allow(controller).to receive(:current_resource_owner).and_return(stale_user)
 
         allow(controller).to receive(:mark_cli_user).and_wrap_original do |original, *args|
           User.where(id: @user.id).update_all(["flags = flags | ?", other_flag_mask])

--- a/spec/controllers/api/v2/links_controller_spec.rb
+++ b/spec/controllers/api/v2/links_controller_spec.rb
@@ -193,6 +193,24 @@ describe Api::V2::LinksController do
         expect(product.display_product_reviews).to be true
       end
 
+      it "marks products created from the CLI and marks the user without dropping other flags" do
+        request.user_agent = "gumroad-cli/1.0"
+        other_flag_mask = User.flag_mapping["flags"][:disable_paypal_sales]
+
+        allow(controller).to receive(:mark_cli_user).and_wrap_original do |original, *args|
+          User.where(id: @user.id).update_all(["flags = flags | ?", other_flag_mask])
+          original.call(*args)
+        end
+
+        post @action, params: @params
+
+        product = @user.links.last
+        @user.reload
+        expect(product.created_via_cli?).to be true
+        expect(@user.has_used_cli?).to be true
+        expect(@user.disable_paypal_sales?).to be true
+      end
+
       it "creates a product with all optional params" do
         post @action, params: @params.merge(
           description: "<p>A great product</p>",

--- a/spec/controllers/api/v2/offer_codes_controller_spec.rb
+++ b/spec/controllers/api/v2/offer_codes_controller_spec.rb
@@ -88,6 +88,15 @@ describe Api::V2::OfferCodesController do
         expect(offer_code.products).to match_array(@product)
       end
 
+      it "marks offer codes created from the CLI" do
+        request.user_agent = "gumroad-cli/1.0"
+
+        post @action, params: @params.merge(offer_type: "cents")
+
+        expect(@product.reload.offer_codes.alive.count).to eq 1
+        expect(@product.offer_codes.alive.first.created_via_cli?).to be true
+      end
+
       it "creates a new percent offer code" do
         post @action, params: @params.merge(offer_type: "percent")
 


### PR DESCRIPTION
## What
Tracks CLI usage across users, products, and offer codes via bit flags. No new tables, no migrations.

## Flags added
| Model | Flag | Bit | Repurposed from |
|-------|------|-----|-----------------|
| User | `has_used_cli` | 30 | `DEPRECATED_has_risk_privilege` |
| Link | `created_via_cli` | 31 | `DEPRECATED_excluded_from_mobile_app_discover` |
| OfferCode | `created_via_cli` | 2 | (new, unused slot) |

## How it works
- `Api::V2::BaseController` detects `gumroad-cli` in User-Agent via `request_from_cli?` helper
- **User flag**: set once on first CLI API call (idempotent, skips if already set)
- **Product flag**: set during `LinksController#create` before save
- **Offer code flag**: set during `OfferCodesController#create` before save
- All fire-and-forget (rescued on failure)

## Query in Metabase
```sql
-- CLI users
SELECT COUNT(*) FROM users WHERE flags & (1 << 29) != 0;

-- Products created via CLI
SELECT COUNT(*) FROM links WHERE flags & (1 << 30) != 0;

-- Offer codes created via CLI
SELECT COUNT(*) FROM offer_codes WHERE flags & (1 << 1) != 0;
```

## TODO for Gianfranco
- [x] Ensure the Gumroad CLI sends User-Agent `gumroad-cli/VERSION`
- [x] Add tests for flag setting in controller specs

Refs #4676