### PR TITLE
Fix search filter not preserved when navigating back from sale detail

### DIFF
--- a/app/javascript/components/Search.tsx
+++ b/app/javascript/components/Search.tsx
@@ -12,8 +12,12 @@ type SearchProps = {
   placeholder?: string;
 };
 
-export const Search = ({ onSearch, value: initialValue, placeholder = "Search" }: SearchProps) => {
-  const [searchQuery, setSearchQuery] = React.useState(initialValue);
+export const Search = ({ onSearch, value, placeholder = "Search" }: SearchProps) => {
+  const [searchQuery, setSearchQuery] = React.useState(value);
+
+  React.useEffect(() => {
+    setSearchQuery(value);
+  }, [value]);
 
   return (
     <Popover>

--- a/spec/requests/customers/customers_spec.rb
+++ b/spec/requests/customers/customers_spec.rb
@@ -262,6 +262,30 @@ describe "Sales page", type: :system, js: true do
         toggle_disclosure "Filter"
         expect(page).to have_field("Paid more than", with: "2")
       end
+
+      it "preserves search query after navigating to a sale and back" do
+        login_as seller
+        visit customers_path
+
+        select_disclosure "Toggle Search" do
+          fill_in "Search sales", with: purchase1.email
+        end
+        wait_for_ajax
+        expect(page).to have_nth_table_row_record(1, "Customer 1")
+        within(find("tbody")) { expect(page).to have_selector(:table_row, count: 1) }
+
+        find(:table_row, { "Name" => "Customer 1" }).click
+        expect(page).to have_current_path(customer_sale_path(purchase1.external_id))
+
+        find("a[aria-label='Back to customers']").click
+
+        expect(page).to have_current_path(customers_path)
+        expect(page).to have_nth_table_row_record(1, "Customer 1")
+        within(find("tbody")) { expect(page).to have_selector(:table_row, count: 1) }
+        select_disclosure "Toggle Search" do
+          expect(page).to have_field("Search sales", with: purchase1.email)
+        end
+      end
     end
 
     describe "exporting" do


### PR DESCRIPTION
## Problem
On `/customers`, typing a search query and clicking a sale row opens the detail page. Clicking back clears the search field, even though other filters (price, date, country, etc.) persist correctly.

## Root cause
The `Search` component uses `useState(value)` for its internal state, which only reads the prop on first mount. When the component remounts after back navigation with a restored value from `useRemember`, `useState` ignores the updated prop and the search field renders empty.

## Fix
Added a `useEffect` that syncs the internal `searchQuery` state whenever the `value` prop changes:

```tsx
React.useEffect(() => {
  setSearchQuery(value);
}, [value]);
```

This is a generic fix in the `Search` component, so it benefits all consumers (customers page, products page, emails page, affiliates page). During normal typing, the `value` prop and `searchQuery` are already in sync, so the effect is a no-op.

## Test added
System spec: type email in search, click a sale row, click back, assert search field value and filtered results are restored.

Fixes #4711