### PR TITLE
Fix Faraday::BadRequestError crashing LinksController#publish

### DIFF
--- a/app/services/content_moderation/strategies/prompt_strategy.rb
+++ b/app/services/content_moderation/strategies/prompt_strategy.rb
@@ -65,6 +65,9 @@ class ContentModeration::Strategies::PromptStrategy
     else
       Result.new(status: "compliant", reasoning: [])
     end
+  rescue Faraday::ClientError => e
+    Rails.logger.error("ContentModeration::PromptStrategy client error (failing open): #{e.message}")
+    Result.new(status: "compliant", reasoning: [])
   rescue StandardError => e
     Rails.logger.error("ContentModeration::PromptStrategy error: #{e.message}")
     raise
@@ -90,6 +93,9 @@ class ContentModeration::Strategies::PromptStrategy
         status: parsed["flagged"] ? "flagged" : "compliant",
         reasoning: parsed["reasoning"].to_s,
       }
+    rescue Faraday::ClientError => e
+      Rails.logger.error("ContentModeration::PromptStrategy preset evaluation client error (failing open): #{e.message}")
+      { status: "compliant", reasoning: "" }
     rescue StandardError => e
       Rails.logger.error("ContentModeration::PromptStrategy preset evaluation error: #{e.message}")
       raise
@@ -118,6 +124,9 @@ class ContentModeration::Strategies::PromptStrategy
       parsed = JSON.parse(content)
 
       !parsed["uncertain"]
+    rescue Faraday::ClientError => e
+      Rails.logger.error("ContentModeration::PromptStrategy uncertainty check client error (failing open): #{e.message}")
+      false
     rescue StandardError => e
       Rails.logger.error("ContentModeration::PromptStrategy uncertainty check error: #{e.message}")
       raise

--- a/spec/services/content_moderation/strategies/prompt_strategy_spec.rb
+++ b/spec/services/content_moderation/strategies/prompt_strategy_spec.rb
@@ -75,6 +75,36 @@ RSpec.describe ContentModeration::Strategies::PromptStrategy, :vcr do
     expect(Rails.logger).to have_received(:error).with("ContentModeration::PromptStrategy preset evaluation error: API failure").at_least(:once)
   end
 
+  it "fails open when the OpenAI request returns a 400 Bad Request" do
+    allow(client).to receive(:chat).and_raise(Faraday::BadRequestError.new("the server responded with status 400"))
+
+    result = described_class.new(text: "moderate me", image_urls: ["https://cdn.example.com/1.png"]).perform
+
+    expect(result.status).to eq("compliant")
+    expect(result.reasoning).to eq([])
+    expect(Rails.logger).to have_received(:error).with(/ContentModeration::PromptStrategy preset evaluation client error \(failing open\):/).at_least(:once)
+  end
+
+  it "fails open when the uncertainty check returns a 400 Bad Request" do
+    call_count = 0
+    allow(client).to receive(:chat) do |_kwargs|
+      call_count += 1
+
+      case call_count
+      when 1
+        json_chat_response(flagged: true, reasoning: "clear adult content")
+      else
+        raise Faraday::BadRequestError.new("the server responded with status 400")
+      end
+    end
+
+    result = described_class.new(text: "moderate me").perform
+
+    expect(result.status).to eq("compliant")
+    expect(result.reasoning).to eq([])
+    expect(Rails.logger).to have_received(:error).with(/ContentModeration::PromptStrategy uncertainty check client error \(failing open\):/).at_least(:once)
+  end
+
   def json_chat_response(payload)
     { "choices" => [{ "message" => { "content" => payload.to_json } }] }
   end


### PR DESCRIPTION
## What

Rescue `Faraday::ClientError` in `ContentModeration::Strategies::PromptStrategy` at all three OpenAI call sites (`perform`, `evaluate_preset`, `passes_uncertainty_check?`) and fail open — return a compliant result / treat the reasoning as uncertain — instead of re-raising.

## Why

Sentry issue: `Faraday::BadRequestError: the server responded with status 400` in `LinksController#publish` ([link](https://gumroad-to.sentry.io/issues/7436982838/)).

Root cause: `ModerateRecordService#run_ai_strategies` runs `PromptStrategy#perform` inside `Thread.new { ... }` and then calls `Thread#value`, which re-raises any exception to the caller. `PromptStrategy` sends product text and image URLs to OpenAI's chat completions API. When an image URL is invalid, expired, or otherwise inaccessible to OpenAI, the API returns HTTP 400 which `ruby-openai` surfaces as `Faraday::BadRequestError` (a subclass of `Faraday::ClientError`). The existing `rescue StandardError` only logged and re-raised, so the error propagated up through the thread and crashed the publish action.

Content moderation is meant to be best-effort: a 4xx from the moderation API is not a signal that the content is unsafe, and shouldn't prevent a creator from publishing. Fail-open is the correct behavior here — the same principle as the existing early return when `OPENAI_ACCESS_TOKEN` is blank.

Scope: narrowed to `Faraday::ClientError` so genuine bugs (JSON parse errors, nil dereferences, etc.) still re-raise and remain visible in Sentry. Server-side Faraday errors (5xx → `Faraday::ServerError`) are not silenced by this change; only client errors are.

## Changes

- `perform`: rescue `Faraday::ClientError` → return `Result.new(status: "compliant", reasoning: [])`
- `evaluate_preset`: rescue `Faraday::ClientError` → return `{ status: "compliant", reasoning: "" }` so the outer loop treats that preset as non-flagged
- `passes_uncertainty_check?`: rescue `Faraday::ClientError` → return `false` (treat as uncertain, which prevents adding to `all_reasoning`), matching the stated fail-open intent
- Each rescue logs a distinct `(failing open)` message so these remain observable without paging

## Test Results

Added two specs that raise `Faraday::BadRequestError` from the stubbed OpenAI client and assert `perform` returns compliant:

```
$ bundle exec rspec spec/services/content_moderation/strategies/prompt_strategy_spec.rb
7 examples, 0 failures
```

Rubocop clean on both modified files.

## AI disclosure

Generated with Claude Opus 4.6 via Claude Code. Prompt: fix the Sentry `Faraday::BadRequestError` in `LinksController#publish`, rescue `Faraday::ClientError` in `PromptStrategy` and fail open, add a spec covering the new path.