### PR TITLE
Skip unmoderatable image URLs in moderation classifier

### DIFF
--- a/app/services/content_moderation/strategies/classifier_strategy.rb
+++ b/app/services/content_moderation/strategies/classifier_strategy.rb
@@ -3,7 +3,7 @@
 class ContentModeration::Strategies::ClassifierStrategy
   Result = Struct.new(:status, :reasoning, keyword_init: true)
   OPENAI_REQUEST_TIMEOUT_IN_SECONDS = 10
-  MAX_IMAGES_PER_REQUEST = 1
+  MAX_IMAGES_TO_MODERATE = 5
 
   DEFAULT_THRESHOLDS = {
     "harassment" => 0.8,
@@ -32,31 +32,31 @@ class ContentModeration::Strategies::ClassifierStrategy
     api_key = GlobalConfig.get("OPENAI_ACCESS_TOKEN")
     return Result.new(status: "compliant", reasoning: []) if api_key.blank?
 
-    client = OpenAI::Client.new(access_token: api_key, request_timeout: OPENAI_REQUEST_TIMEOUT_IN_SECONDS)
-
-    input = build_input
-    response = client.moderations(parameters: { model: "omni-moderation-latest", input: input })
-
-    result = response.dig("results", 0)
-    return Result.new(status: "compliant", reasoning: []) if result.nil?
-
+    @client = OpenAI::Client.new(access_token: api_key, request_timeout: OPENAI_REQUEST_TIMEOUT_IN_SECONDS)
     thresholds = load_thresholds
-    category_scores = result["category_scores"] || {}
+
     flagged_categories = []
 
-    category_scores.each do |category, score|
-      threshold = thresholds[category]
-      next if threshold.nil?
+    if @text.present?
+      scores = moderate([{ type: "text", text: @text }])
+      flagged_categories.concat(collect_flagged(scores, thresholds)) if scores
+    end
 
-      if score >= threshold
-        flagged_categories << "#{category} (score: #{score.round(3)}, threshold: #{threshold})"
-      end
+    moderated_count = 0
+    @image_urls.shuffle.each do |url|
+      break if moderated_count >= MAX_IMAGES_TO_MODERATE
+
+      scores = moderate([{ type: "image_url", image_url: { url: url } }], skip_url: url)
+      next if scores.nil?
+
+      moderated_count += 1
+      flagged_categories.concat(collect_flagged(scores, thresholds))
     end
 
     if flagged_categories.any?
       Result.new(
         status: "flagged",
-        reasoning: flagged_categories.map { |cat| "OpenAI moderation flagged: #{cat}" }
+        reasoning: flagged_categories.uniq.map { |cat| "OpenAI moderation flagged: #{cat}" }
       )
     else
       Result.new(status: "compliant", reasoning: [])
@@ -67,13 +67,24 @@ class ContentModeration::Strategies::ClassifierStrategy
   end
 
   private
-    def build_input
-      parts = []
-      parts << { type: "text", text: @text } if @text.present?
-      @image_urls.sample(MAX_IMAGES_PER_REQUEST).each do |url|
-        parts << { type: "image_url", image_url: { url: url } }
+    def moderate(input, skip_url: nil)
+      response = @client.moderations(parameters: { model: "omni-moderation-latest", input: input })
+      response.dig("results", 0, "category_scores") || {}
+    rescue Faraday::BadRequestError => e
+      raise if skip_url.nil?
+      body = e.response&.dig(:body).to_s
+      Rails.logger.warn("ContentModeration::ClassifierStrategy skipping unmoderatable image URL=#{skip_url} error=#{body[0..500]}")
+      nil
+    end
+
+    def collect_flagged(category_scores, thresholds)
+      category_scores.filter_map do |category, score|
+        threshold = thresholds[category]
+        next if threshold.nil?
+        next unless score >= threshold
+
+        "#{category} (score: #{score.round(3)}, threshold: #{threshold})"
       end
-      parts
     end
 
     def load_thresholds

--- a/app/services/content_moderation/strategies/classifier_strategy.rb
+++ b/app/services/content_moderation/strategies/classifier_strategy.rb
@@ -4,6 +4,7 @@ class ContentModeration::Strategies::ClassifierStrategy
   Result = Struct.new(:status, :reasoning, keyword_init: true)
   OPENAI_REQUEST_TIMEOUT_IN_SECONDS = 10
   MAX_IMAGES_TO_MODERATE = 5
+  UNAVAILABLE_REASON = "We cannot moderate the content at this time, please try again later or update the content."
 
   DEFAULT_THRESHOLDS = {
     "harassment" => 0.8,
@@ -43,14 +44,27 @@ class ContentModeration::Strategies::ClassifierStrategy
     end
 
     moderated_count = 0
+    skipped_urls = []
     @image_urls.shuffle.each do |url|
       break if moderated_count >= MAX_IMAGES_TO_MODERATE
 
       scores = moderate([{ type: "image_url", image_url: { url: url } }], skip_url: url)
-      next if scores.nil?
+      if scores.nil?
+        skipped_urls << url
+        next
+      end
 
       moderated_count += 1
       flagged_categories.concat(collect_flagged(scores, thresholds))
+    end
+
+    if @image_urls.any? && moderated_count == 0
+      ErrorNotifier.notify(
+        "ContentModeration::ClassifierStrategy could not moderate any image",
+        image_url_count: @image_urls.size,
+        skipped_urls: skipped_urls,
+      )
+      return Result.new(status: "flagged", reasoning: [UNAVAILABLE_REASON])
     end
 
     if flagged_categories.any?

--- a/spec/services/content_moderation/strategies/classifier_strategy_spec.rb
+++ b/spec/services/content_moderation/strategies/classifier_strategy_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe ContentModeration::Strategies::ClassifierStrategy, :vcr do
     allow(GlobalConfig).to receive(:get).with("CONTENT_MODERATION_CLASSIFIER_THRESHOLDS").and_return(nil)
     allow(Rails.logger).to receive(:error)
     allow(Rails.logger).to receive(:warn)
+    allow(ErrorNotifier).to receive(:notify)
     allow(OpenAI::Client).to receive(:new).with(access_token: "test-key", request_timeout: 10).and_return(client)
   end
 
@@ -145,6 +146,45 @@ RSpec.describe ContentModeration::Strategies::ClassifierStrategy, :vcr do
 
     expect(result.status).to eq("flagged")
     expect(result.reasoning).to eq(["OpenAI moderation flagged: violence (score: 0.95, threshold: 0.8)"])
+  end
+
+  it "returns flagged with a retry reason and notifies Sentry when every image URL fails" do
+    image_urls = [
+      "blob:https://gumroad.com/bad-1",
+      "https://cdn.example.com/bad-2.png",
+      "https://cdn.example.com/bad-3.png",
+    ]
+    bad_response = instance_double(Faraday::Response, status: 400, body: "", headers: {})
+    bad_error = Faraday::BadRequestError.new(
+      { status: 400, body: { "error" => { "code" => "image_url_unavailable" } } },
+      bad_response
+    )
+    allow(client).to receive(:moderations) do |parameters:|
+      part = parameters[:input].first
+      raise bad_error if part[:type] == "image_url"
+      { "results" => [{ "category_scores" => {} }] }
+    end
+
+    result = described_class.new(text: "some text", image_urls:).perform
+
+    expect(result.status).to eq("flagged")
+    expect(result.reasoning).to eq([described_class::UNAVAILABLE_REASON])
+    expect(ErrorNotifier).to have_received(:notify).with(
+      "ContentModeration::ClassifierStrategy could not moderate any image",
+      image_url_count: 3,
+      skipped_urls: match_array(image_urls),
+    )
+  end
+
+  it "does not flag unavailability when text exists and image_urls is empty" do
+    allow(client).to receive(:moderations).and_return(
+      "results" => [{ "category_scores" => {} }]
+    )
+
+    result = described_class.new(text: "some text", image_urls: []).perform
+
+    expect(result.status).to eq("compliant")
+    expect(ErrorNotifier).not_to have_received(:notify)
   end
 
   it "logs and re-raises non-image OpenAI errors" do

--- a/spec/services/content_moderation/strategies/classifier_strategy_spec.rb
+++ b/spec/services/content_moderation/strategies/classifier_strategy_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe ContentModeration::Strategies::ClassifierStrategy, :vcr do
     allow(GlobalConfig).to receive(:get).with("OPENAI_ACCESS_TOKEN").and_return("test-key")
     allow(GlobalConfig).to receive(:get).with("CONTENT_MODERATION_CLASSIFIER_THRESHOLDS").and_return(nil)
     allow(Rails.logger).to receive(:error)
+    allow(Rails.logger).to receive(:warn)
     allow(OpenAI::Client).to receive(:new).with(access_token: "test-key", request_timeout: 10).and_return(client)
   end
 
@@ -54,26 +55,99 @@ RSpec.describe ContentModeration::Strategies::ClassifierStrategy, :vcr do
     expect(result.reasoning).to eq([])
   end
 
-  it "sends at most one image to the OpenAI moderation API" do
+  it "sends one image per moderation request" do
     many_image_urls = [
       "https://cdn.example.com/1.png",
       "https://cdn.example.com/2.png",
       "https://cdn.example.com/3.png",
     ]
-    captured_parameters = nil
+    captured_inputs = []
     allow(client).to receive(:moderations) do |parameters:|
-      captured_parameters = parameters
+      captured_inputs << parameters[:input]
       { "results" => [{ "category_scores" => {} }] }
     end
 
     described_class.new(text:, image_urls: many_image_urls).perform
 
-    image_parts = captured_parameters[:input].select { |part| part[:type] == "image_url" }
-    expect(image_parts.size).to eq(1)
-    expect(many_image_urls).to include(image_parts.first[:image_url][:url])
+    captured_inputs.each do |input|
+      image_parts = input.select { |part| part[:type] == "image_url" }
+      expect(image_parts.size).to be <= 1
+    end
   end
 
-  it "logs and re-raises when the OpenAI request fails" do
+  it "moderates text and every image (up to the cap) in separate requests" do
+    image_urls = 7.times.map { |i| "https://cdn.example.com/#{i}.png" }
+    captured_inputs = []
+    allow(client).to receive(:moderations) do |parameters:|
+      captured_inputs << parameters[:input]
+      { "results" => [{ "category_scores" => {} }] }
+    end
+
+    described_class.new(text:, image_urls:).perform
+
+    expect(captured_inputs.size).to eq(1 + described_class::MAX_IMAGES_TO_MODERATE)
+    expect(captured_inputs.first).to eq([{ type: "text", text: }])
+    image_calls = captured_inputs.drop(1)
+    expect(image_calls).to all(satisfy { |input| input.size == 1 && input.first[:type] == "image_url" })
+    tested_urls = image_calls.map { |input| input.first[:image_url][:url] }
+    expect(tested_urls).to all(satisfy { |u| image_urls.include?(u) })
+    expect(tested_urls.uniq.size).to eq(described_class::MAX_IMAGES_TO_MODERATE)
+  end
+
+  it "skips image URLs that OpenAI rejects as bad requests and continues with remaining images" do
+    image_urls = [
+      "blob:https://gumroad.com/bad-1",
+      "https://cdn.example.com/good-1.png",
+      "https://cdn.example.com/good-2.png",
+    ]
+    bad_response = instance_double(
+      Faraday::Response,
+      status: 400,
+      body: '{"error":{"code":"image_url_unavailable","message":"Could not download"}}',
+      headers: {},
+    )
+    bad_error = Faraday::BadRequestError.new(
+      { status: 400, body: { "error" => { "code" => "image_url_unavailable" } } },
+      bad_response
+    )
+
+    call_inputs = []
+    allow(client).to receive(:moderations) do |parameters:|
+      call_inputs << parameters[:input]
+      part = parameters[:input].first
+      if part[:type] == "image_url" && part[:image_url][:url].start_with?("blob:")
+        raise bad_error
+      end
+      { "results" => [{ "category_scores" => {} }] }
+    end
+
+    result = described_class.new(text: "", image_urls:).perform
+
+    expect(result.status).to eq("compliant")
+    expect(call_inputs.size).to eq(3)
+    expect(Rails.logger).to have_received(:warn).with(/skipping unmoderatable image URL=blob:https:\/\/gumroad\.com\/bad-1/).once
+  end
+
+  it "still flags content based on successful image moderations after skipping a bad URL" do
+    image_urls = ["blob:https://gumroad.com/bad", "https://cdn.example.com/good.png"]
+    bad_response = instance_double(Faraday::Response, status: 400, body: "", headers: {})
+    bad_error = Faraday::BadRequestError.new({ status: 400, body: {} }, bad_response)
+
+    allow(client).to receive(:moderations) do |parameters:|
+      part = parameters[:input].first
+      if part[:type] == "image_url" && part[:image_url][:url].start_with?("blob:")
+        raise bad_error
+      end
+      { "results" => [{ "category_scores" => { "violence" => 0.95 } }] }
+    end
+
+    result = described_class.new(text: "", image_urls:).perform
+
+    expect(result.status).to eq("flagged")
+    expect(result.reasoning).to eq(["OpenAI moderation flagged: violence (score: 0.95, threshold: 0.8)"])
+  end
+
+  it "logs and re-raises non-image OpenAI errors" do
     allow(client).to receive(:moderations).and_raise(StandardError, "API failure")
 
     expect { described_class.new(text:, image_urls:).perform }.to raise_error(StandardError, "API failure")


### PR DESCRIPTION
## What

- Change `ContentModeration::Strategies::ClassifierStrategy#perform` to moderate text and each image in separate OpenAI `moderations` calls.
- Replace `MAX_IMAGES_PER_REQUEST = 1` with `MAX_IMAGES_TO_MODERATE = 5` — the cap on *successful* image moderations per product/post.
- On `Faraday::BadRequestError` for a single image, log `ContentModeration::ClassifierStrategy skipping unmoderatable image URL=… error=…` and skip that URL without consuming cap budget.
- Aggregate `category_scores` across text + all successful image calls, so a real policy violation on any valid image still fails the publish.
- If images exist but every URL is rejected by OpenAI, return `flagged` with the user-facing reason `We cannot moderate the content at this time, please try again later or update the content.` and call `ErrorNotifier.notify` so the all-broken-URLs case pages in Sentry.
- Non-400 errors (timeouts, 5xx, auth, etc.) still bubble up through the existing top-level rescue.
- Spec updates: new coverage for skip-bad-continue-good, flagging-still-works-after-skip, all-images-rejected → flagged + Sentry notify, and one-image-per-request.

## Why

Investigating recent Sentry events for `Faraday::BadRequestError` at `classifier_strategy.rb:38` surfaced two deterministic failure modes that the 1-image cap from #4709 does not solve:

1. **`blob:` URLs in description HTML.** `ContentExtractor#product_image_urls` does not filter non-HTTP schemes, so a browser Object URL saved into a product description (e.g. a paste from an editor with an unresolved upload) leaks through. OpenAI returns `400 Failed to download image`. With many image URLs extracted, there is still a chance per attempt of sampling the bad URL and failing the whole moderation.

2. **Signed attachment URLs from rich-content product files.** `rich_content_file_image_urls` uses `signed_download_url_for_s3_key_and_filename`, which serves content with `Content-Disposition: attachment` and a custom `verify`/`cache_key` scheme. HEAD from our network returns `200 image/png`, but OpenAI's image fetcher returns `400 image_url_unavailable` (intermittent-to-persistent).

Rather than special-casing hosts or rewriting the extractor, this PR makes the classifier robust to any URL OpenAI cannot fetch: skip + log and keep scanning the remaining images until we have 5 successful moderations (or exhaust the list). Moderation decisions remain correct because flagged categories aggregate across all calls that did succeed.

If every image URL is rejected we do *not* silently return compliant — that would be a safety bypass (upload only unreachable images, skip image moderation entirely). Instead we flag with a retry-later message the creator can act on, and raise a Sentry error so we catch patterns of broken URL generation on our side.

Tradeoff: up to 6 API calls per check (1 text + 5 image) instead of 1, and the latency is sequential. Acceptable because moderation already runs in a thread alongside `PromptStrategy`, and the cost per call is low.

## Before/After

N/A — non-user-facing internal service change. Before: any single bad URL sampled from the image set aborted moderation with a 500 and blocked publish. After: bad URLs are logged and skipped; moderation still completes, still flags real violations, and only blocks publish (with a retry message) when *every* image URL is unreachable to OpenAI. I'll record a short walkthrough of the publish path before this merges.

## Test Results

`bundle exec rspec spec/services/content_moderation/strategies/classifier_strategy_spec.rb` — 11 examples, 0 failures.

`bundle exec rspec spec/services/content_moderation/moderate_record_service_spec.rb spec/services/content_moderation/content_extractor_spec.rb` — 16 examples, 0 failures.

`bundle exec rubocop app/services/content_moderation/strategies/classifier_strategy.rb spec/services/content_moderation/strategies/classifier_strategy_spec.rb` — clean.

---

AI disclosure: Written with Claude Opus 4.7 (1M context). Prompts: (1) investigate recent `classifier_strategy.rb:38` 400s via the read-only production console and list the failure categories; (2) change the classifier to skip-and-log URLs that OpenAI rejects and keep scanning up to 5 successful image moderations, failing the check if any valid image is flagged; (3) require at least one successful image moderation when images exist, otherwise return a retry-later user message and notify Sentry as an error; (4) open this PR.