### PR TITLE
Use GUMCLAW_GITHUB_PAT for Claude review requests

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -5,10 +5,6 @@ on:
     workflows: ["Tests"]
     types: [completed]
 
-permissions:
-  pull-requests: write
-  actions: read
-
 jobs:
   request-review:
     if: >-
@@ -18,6 +14,7 @@ jobs:
     steps:
       - uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.GUMCLAW_GITHUB_PAT }}
           script: |
             const REVIEW_MARKER = "<!-- claude-review-requested -->";
             const { owner, repo } = context.repo;


### PR DESCRIPTION
The `@claude review` comment was being posted as `github-actions[bot]` which Claude Code doesn't respond to. Switching to `GUMCLAW_GITHUB_PAT` so the comment comes from `gumclaw` and Claude Code treats it as a real review request.

**Setup required:** Add the PAT as a repo secret named `GUMCLAW_GITHUB_PAT` in Settings > Secrets and variables > Actions.