### PR TITLE
Fix ActiveRecord::LockWaitTimeout in OAuth access token creation

### DIFF
--- a/app/models/oauth_application.rb
+++ b/app/models/oauth_application.rb
@@ -61,9 +61,10 @@ class OauthApplication < Doorkeeper::Application
   # Returns an existing active access token or creates one if none exist
   def get_or_generate_access_token
     ensure_access_grant_exists
-    access_tokens.where(resource_owner_id: owner.id,
-                        revoked_at: nil,
-                        scopes: Doorkeeper.configuration.public_scopes.join(" ")).first_or_create!
+    attrs = { resource_owner_id: owner.id,
+              revoked_at: nil,
+              scopes: Doorkeeper.configuration.public_scopes.join(" ") }
+    find_or_create_concurrency_safe(access_tokens, attrs)
   end
 
   def revoke_access_for(user)
@@ -78,10 +79,33 @@ class OauthApplication < Doorkeeper::Application
   end
 
   private
+    CONCURRENCY_RETRY_LIMIT = 3
+    CONCURRENCY_RETRY_BACKOFF = 0.1
+
     def ensure_access_grant_exists
-      access_grants.where(resource_owner_id: owner.id,
-                          scopes: Doorkeeper.configuration.public_scopes.join(" "),
-                          redirect_uri:).first_or_create! { |access_grant| access_grant.expires_in = 60.years }
+      attrs = { resource_owner_id: owner.id,
+                scopes: Doorkeeper.configuration.public_scopes.join(" "),
+                redirect_uri: }
+      find_or_create_concurrency_safe(access_grants, attrs) do |access_grant|
+        access_grant.expires_in = 60.years
+      end
+    end
+
+    def find_or_create_concurrency_safe(relation, attrs, &block)
+      attempts = 0
+      begin
+        record = relation.find_by(attrs)
+        return record if record
+
+        relation.create!(attrs, &block)
+      rescue ActiveRecord::RecordNotUnique
+        relation.find_by!(attrs)
+      rescue ActiveRecord::LockWaitTimeout
+        attempts += 1
+        raise if attempts >= CONCURRENCY_RETRY_LIMIT
+        sleep(CONCURRENCY_RETRY_BACKOFF * attempts)
+        retry
+      end
     end
 
     def set_default_scopes

--- a/spec/models/oauth_application_spec.rb
+++ b/spec/models/oauth_application_spec.rb
@@ -156,6 +156,85 @@ describe OauthApplication do
         end.to_not change(Doorkeeper::AccessGrant, :count)
       end
     end
+
+    describe "concurrency safety" do
+      let(:relation) { @oauth_application.access_tokens }
+      let(:attrs) do
+        { resource_owner_id: @oauth_application.owner.id,
+          revoked_at: nil,
+          scopes: Doorkeeper.configuration.public_scopes.join(" ") }
+      end
+
+      it "returns the existing record when RecordNotUnique is raised during create!" do
+        existing_token = Doorkeeper::AccessToken.create!(
+          application: @oauth_application,
+          resource_owner_id: @oauth_application.owner.id,
+          scopes: Doorkeeper.configuration.public_scopes.join(" ")
+        )
+
+        find_call = 0
+        allow(relation).to receive(:find_by).and_wrap_original do |original, *args|
+          find_call += 1
+          find_call == 1 ? nil : original.call(*args)
+        end
+        allow(relation).to receive(:create!).and_raise(ActiveRecord::RecordNotUnique.new("duplicate"))
+
+        result = @oauth_application.send(:find_or_create_concurrency_safe, relation, attrs)
+        expect(result).to eq(existing_token)
+      end
+
+      it "retries and succeeds when LockWaitTimeout is raised once" do
+        attempts = 0
+        allow(relation).to receive(:find_by).and_return(nil)
+        allow(relation).to receive(:create!).and_wrap_original do |original, *args|
+          attempts += 1
+          raise ActiveRecord::LockWaitTimeout.new("Lock wait timeout exceeded") if attempts == 1
+          original.call(*args)
+        end
+        allow(@oauth_application).to receive(:sleep)
+
+        result = @oauth_application.send(:find_or_create_concurrency_safe, relation, attrs)
+        expect(result).to be_a(Doorkeeper::AccessToken)
+        expect(attempts).to eq(2)
+      end
+
+      it "re-raises LockWaitTimeout after exhausting retries" do
+        allow(relation).to receive(:find_by).and_return(nil)
+        allow(relation).to receive(:create!).and_raise(ActiveRecord::LockWaitTimeout.new("Lock wait timeout exceeded"))
+        allow(@oauth_application).to receive(:sleep)
+
+        expect do
+          @oauth_application.send(:find_or_create_concurrency_safe, relation, attrs)
+        end.to raise_error(ActiveRecord::LockWaitTimeout)
+      end
+
+      it "does not raise RecordNotUnique from get_or_generate_access_token under a concurrent create" do
+        @oauth_application.send(:ensure_access_grant_exists)
+
+        existing_token = nil
+        raised = false
+        access_tokens_relation = @oauth_application.access_tokens
+        allow(@oauth_application).to receive(:access_tokens).and_return(access_tokens_relation)
+        allow(access_tokens_relation).to receive(:create!).and_wrap_original do |original, *args|
+          if raised
+            original.call(*args)
+          else
+            raised = true
+            existing_token = Doorkeeper::AccessToken.create!(
+              application: @oauth_application,
+              resource_owner_id: @oauth_application.owner.id,
+              scopes: Doorkeeper.configuration.public_scopes.join(" ")
+            )
+            raise ActiveRecord::RecordNotUnique.new("duplicate")
+          end
+        end
+
+        expect do
+          result = @oauth_application.get_or_generate_access_token
+          expect(result).to eq(existing_token)
+        end.not_to raise_error
+      end
+    end
   end
 
   describe "#mark_deleted!" do


### PR DESCRIPTION
## What

`OauthApplication#get_or_generate_access_token` and `ensure_access_grant_exists` used `first_or_create!`, which is not safe under concurrent requests. When two requests arrive simultaneously for the same application/owner, they contend on the same rows and occasionally surface as `ActiveRecord::LockWaitTimeout` from `Oauth::AccessTokensController#create`.

This PR replaces `first_or_create!` with a concurrency-safe helper that:

- looks up the record with `find_by`
- attempts `create!` if none is found
- rescues `ActiveRecord::RecordNotUnique` and re-reads the record created by the concurrent request
- rescues `ActiveRecord::LockWaitTimeout` with a bounded retry + small backoff, then re-raises

## Why

Sentry has been reporting `ActiveRecord::LockWaitTimeout` errors from `Oauth::AccessTokensController#create`. The cause is two concurrent requests racing through `first_or_create!` for the same `access_token`/`access_grant` row: both miss the `first`, both attempt to insert, one blocks on row locks, and the slower one times out. Handling the race explicitly eliminates the timeout and also correctly handles `RecordNotUnique` in case the duplicate slips past MySQL's lock wait.

Sentry: https://gumroad-to.sentry.io/issues/7437171528/

## Before/After

No user-facing change — this is a concurrency bug fix in an internal OAuth code path. A walkthrough of the existing OAuth token flow and the updated method behavior will be attached in a follow-up comment.

## Test Results

Ran the affected spec locally:

```
bundle exec rspec spec/models/oauth_application_spec.rb
```

The pre-existing unrelated S3 test (`#validate_file saves with a valid icon type attached`) fails on `main` as well due to local S3 bucket configuration; it is not affected by this change. All other tests — including 4 new concurrency tests — pass.

---

🤖 AI disclosure: drafted with Claude Opus 4.6. Prompt: fix the Sentry `ActiveRecord::LockWaitTimeout` in `Oauth::AccessTokensController#create`, make `get_or_generate_access_token`/`ensure_access_grant_exists` concurrency-safe, add tests, and open a PR.