### PR TITLE
Fix RequestTimeoutException in LinksController#show from synchronous image processing in preload tags

### DIFF
--- a/app/controllers/concerns/page_meta/product.rb
+++ b/app/controllers/concerns/page_meta/product.rb
@@ -20,7 +20,7 @@ module PageMeta::Product
       set_twitter_meta(product, product_description:)
 
       product.display_asset_previews.select { |asset| asset.file.image? }.each do |asset|
-        set_meta_tag(tag_name: "link", rel: "preload", as: "image", href: asset.url)
+        set_meta_tag(tag_name: "link", rel: "preload", as: "image", href: asset.url(style: :original))
       end
 
       set_meta_tag(tag_name: "link", rel: "canonical", href: product.long_url, head_key: "canonical")

--- a/spec/controllers/concerns/page_meta/product_spec.rb
+++ b/spec/controllers/concerns/page_meta/product_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "inertia_rails/rspec"
+
+describe PageMeta::Product, type: :controller do
+  controller(ApplicationController) do
+    include PageMeta::Product
+
+    def action
+      set_product_page_meta(Link.find(params[:id]))
+      render inertia: "Anonymous"
+    end
+  end
+
+  before do
+    routes.draw { get :action, to: "anonymous#action" }
+  end
+
+  describe "image preload meta tags", inertia: true do
+    let(:product) { create(:product) }
+    let(:file_double) { double("attached_file", image?: true).as_null_object }
+    let(:asset_preview) { double("AssetPreview", file: file_double).as_null_object }
+
+    before do
+      allow(asset_preview).to receive(:url).with(no_args).and_return("https://cdn.example.com/retina-url.png")
+      allow(asset_preview).to receive(:url).with(style: :original).and_return("https://cdn.example.com/original-url.png")
+      allow_any_instance_of(Link).to receive(:display_asset_previews).and_return([asset_preview])
+    end
+
+    it "does not trigger image processing by avoiding the default (retina) style URL" do
+      expect(asset_preview).not_to receive(:url).with(no_args)
+      expect(asset_preview).to receive(:url).with(style: :original).at_least(:once).and_return("https://cdn.example.com/original-url.png")
+
+      get :action, params: { id: product.id }
+
+      expect(response).to be_successful
+    end
+
+    it "adds a preload link tag pointing at the original asset URL" do
+      get :action, params: { id: product.id }
+
+      preload_tag = inertia.props[:_inertia_meta].find do |tag|
+        tag[:rel] == "preload" && tag[:as] == "image"
+      end
+
+      expect(preload_tag).to be_present
+      expect(preload_tag[:href]).to eq("https://cdn.example.com/original-url.png")
+    end
+  end
+end


### PR DESCRIPTION
## What

`PageMeta::Product#set_product_page_meta` iterates over a product's image asset previews and emits `<link rel=\"preload\" as=\"image\">` tags. It was calling `AssetPreview#url` with no arguments, which defaults to `:retina` and triggers `AssetPreview#retina_variant`. That method runs a synchronous ImageMagick resize with a 30s timeout per image. Products with several image previews could exhaust the 120s Rack timeout on first load, raising `Rack::Timeout::RequestTimeoutException`.

Pass `style: :original` to the preload URLs so the direct file URL is used and no image processing is triggered during meta tag setup. Product rendering still uses retina URLs via `ProductPresenter`, which memoize through `Rails.cache.fetch(\"attachment_#{file.id}_#{style}_url\")` for later requests.

Sentry: https://gumroad-to.sentry.io/issues/7437281722/

## Why

Preload hints are a browser optimization and do not need the retina variant; they exist to start the fetch early. Synchronous image processing inside a request-path concern is the wrong place to do work that can block for tens of seconds. Moving to the original URL eliminates cold-start timeouts without changing the rendered output.

## Before/After

_Non-user-facing fix — no visual change. The `<link rel=\"preload\">` URLs now use the original asset URL. On first request for a product with several image previews, page load no longer blocks on ImageMagick resizes._

## Test Results

New concern spec verifies:

1. `AssetPreview#url` is not called with the default style (which would trigger `retina_variant`).
2. `AssetPreview#url(style: :original)` is used and the preload link tag points at the original URL.

Both specs fail on `main` (before the fix) and pass with the patch applied.

```
$ bundle exec rspec spec/controllers/concerns/page_meta/product_spec.rb
..
Finished in 2.03 seconds (files took 5.48 seconds to load)
2 examples, 0 failures
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) using Claude Opus 4.6.

Prompt: Investigate the Sentry error (link above) showing Rack::Timeout in `LinksController#show` where `set_product_page_meta` triggers synchronous image processing via `AssetPreview#retina_variant` for `<link rel=\"preload\">` tags. Fix by passing `style: :original` to avoid image processing for preload hints. Add a spec.