### PR TITLE
Fix ActiveModel::RangeError in DiscountsController for out-of-range integers

### DIFF
--- a/app/controllers/checkout/discounts_controller.rb
+++ b/app/controllers/checkout/discounts_controller.rb
@@ -5,6 +5,8 @@ class Checkout::DiscountsController < Sellers::BaseController
 
   PER_PAGE = 10
 
+  rescue_from ActiveModel::RangeError, with: :handle_range_error
+
   before_action :clean_params, only: [:create, :update]
 
   layout "inertia", only: [:index]
@@ -111,6 +113,10 @@ class Checkout::DiscountsController < Sellers::BaseController
     def parse_date_times
       offer_code_params[:valid_at] = Time.zone.parse(offer_code_params[:valid_at]) if offer_code_params[:valid_at].present?
       offer_code_params[:expires_at] = Time.zone.parse(offer_code_params[:expires_at]) if offer_code_params[:expires_at].present?
+    end
+
+    def handle_range_error
+      render json: { success: false, error_message: "The value entered is too large. Please enter a smaller number." }, status: :unprocessable_entity
     end
 
     def fetch_offer_codes

--- a/spec/controllers/checkout/discounts_controller_spec.rb
+++ b/spec/controllers/checkout/discounts_controller_spec.rb
@@ -258,6 +258,26 @@ describe Checkout::DiscountsController do
       end
     end
 
+    context "when an integer parameter exceeds the 4-byte limit" do
+      it "returns an error instead of raising" do
+        expect do
+          post :create, params: {
+            name: "Black Friday",
+            code: "bfy2k",
+            max_purchase_count: 2,
+            amount_cents: 20_000_000_000,
+            currency_type: "usd",
+            universal: true,
+            selected_product_ids: [],
+          }, as: :json
+        end.not_to change { seller.offer_codes.count }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body["success"]).to eq(false)
+        expect(response.parsed_body["error_message"]).to eq("The value entered is too large. Please enter a smaller number.")
+      end
+    end
+
     context "when the offer code's code is taken" do
       before do
         create(:offer_code, code: "code", user: seller)


### PR DESCRIPTION
## Problem

When a user submits a discount with an integer value exceeding the 4-byte column limit (e.g. `amount_cents=20000000000`), ActiveRecord raises `ActiveModel::RangeError` before model validations run, resulting in an unhandled 500 error.

**Sentry:** https://gumroad-to.sentry.io/issues/7437458663/

## Fix

Added `rescue_from ActiveModel::RangeError` to `Checkout::DiscountsController` that returns a friendly JSON validation error (`422`) instead of letting it bubble up as a 500. This handles all integer columns at once without requiring schema changes.

## Impact

1 occurrence so far, low impact but unhandled 500 error that returns no useful feedback to the user.