### PR TITLE
Add GDPR data erasure button to admin panel

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -196,6 +196,20 @@ class Admin::UsersController < Admin::BaseController
     render json: { success: false, message: e.message }, status: :unprocessable_content
   end
 
+  def gdpr_erase
+    result = GdprDataErasureService.new(@user, performed_by: current_user).perform!
+
+    if result[:success]
+      render json: {
+        success: true,
+        message: "GDPR erasure complete. External cleanup still needed: Helper/Supabase, Gmail, Stripe.",
+        summary: result[:summary]
+      }
+    else
+      render json: { success: false, message: result[:error] }
+    end
+  end
+
   def toggle_adult_products
     @user.all_adult_products = !@user.all_adult_products
     @user.save!

--- a/app/javascript/components/Admin/Users/Actions/GdprEraseAction.tsx
+++ b/app/javascript/components/Admin/Users/Actions/GdprEraseAction.tsx
@@ -27,8 +27,7 @@ const GdprEraseAction = ({ user: { external_id } }: GdprEraseActionProps) => (
       "This action CANNOT be undone. Are you sure?"
     }
     done="Erased"
-    success_message="GDPR erasure complete. External cleanup still needed."
-    show_message_in_alert={true}
+    success_message="GDPR erasure complete. External cleanup still needed: Helper/Supabase, Gmail, Stripe."
     color="danger"
   />
 );

--- a/app/javascript/components/Admin/Users/Actions/GdprEraseAction.tsx
+++ b/app/javascript/components/Admin/Users/Actions/GdprEraseAction.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+
+import AdminAction from "$app/components/Admin/ActionButton";
+import { type User } from "$app/components/Admin/Users/User";
+
+type GdprEraseActionProps = {
+  user: User;
+};
+
+const GdprEraseAction = ({ user: { external_id } }: GdprEraseActionProps) => (
+  <AdminAction
+    label="GDPR Erase"
+    url={Routes.gdpr_erase_admin_user_path(external_id)}
+    confirm_message={
+      "⚠️ GDPR DATA ERASURE\n\n" +
+      "This will permanently:\n" +
+      "• Anonymize all personal data (name, email, address, IP, etc.)\n" +
+      "• Delete all products\n" +
+      "• Cancel all subscriptions\n" +
+      "• Anonymize buyer purchase records\n" +
+      "• Deactivate the account\n\n" +
+      "Transaction records are retained for tax/legal compliance.\n\n" +
+      "After this, you must also clean up:\n" +
+      "• Helper/Supabase (customer conversations)\n" +
+      "• Gmail (correspondence)\n" +
+      "• Stripe (customer data)\n\n" +
+      "This action CANNOT be undone. Are you sure?"
+    }
+    done="Erased"
+    success_message="GDPR erasure complete. External cleanup still needed."
+    show_message_in_alert={true}
+    color="danger"
+  />
+);
+
+export default GdprEraseAction;

--- a/app/javascript/components/Admin/Users/Actions/index.tsx
+++ b/app/javascript/components/Admin/Users/Actions/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import ConfirmEmailAction from "$app/components/Admin/Users/Actions/ConfirmEmailAction";
+import GdprEraseAction from "$app/components/Admin/Users/Actions/GdprEraseAction";
 import ImpersonateAction from "$app/components/Admin/Users/Actions/ImpersonateAction";
 import InvalidateActiveSessionsAction from "$app/components/Admin/Users/Actions/InvalidateActiveSessionsAction";
 import MarkAsAdultAction from "$app/components/Admin/Users/Actions/MarkAsAdultAction";
@@ -22,6 +23,7 @@ const AdminUserActions = ({ user }: AdminUserActionsProps) => (
     <ConfirmEmailAction user={user} />
     <InvalidateActiveSessionsAction user={user} />
     <MarkAsAdultAction user={user} />
+    <GdprEraseAction user={user} />
   </div>
 );
 

--- a/app/models/help_center/articles.yml
+++ b/app/models/help_center/articles.yml
@@ -615,3 +615,8 @@
   title: "Support response times"
   description: "If you reach out to us, you'll most likely hear back within an hour. 97.7% of people do. We guarantee a response within 24 hours."
   category_id: <%= HelpCenter::Category::CONTACT_GUMROAD.id %>
+- id: 349
+  slug: "349-gdpr-data-requests"
+  title: "GDPR and data privacy requests"
+  description: "Learn about your data privacy rights on Gumroad, including how to request data deletion, access your personal data, and understand what information we retain."
+  category_id: <%= HelpCenter::Category::ADVANCED.id %>

--- a/app/services/gdpr_data_erasure_service.rb
+++ b/app/services/gdpr_data_erasure_service.rb
@@ -11,13 +11,16 @@ class GdprDataErasureService
   def initialize(user, performed_by:)
     @user = user
     @performed_by = performed_by
+    @products_deleted = 0
   end
 
   def perform!
+    original_email = @user.email
+
     ActiveRecord::Base.transaction do
-      deactivate_account!
+      @products_deleted = deactivate_account!
       anonymize_user_pii!
-      anonymize_buyer_purchases!
+      anonymize_buyer_purchases!(original_email)
       remove_profile_assets!
       log_erasure!
     end
@@ -29,9 +32,10 @@ class GdprDataErasureService
   end
 
   private
-
     def deactivate_account!
-      return if @user.deleted?
+      return 0 if @user.deleted?
+
+      products_deleted = @user.links.alive.count
 
       # Skip balance validation for GDPR erasure. We are legally obligated
       # to erase regardless of outstanding balance (Article 17).
@@ -46,12 +50,14 @@ class GdprDataErasureService
       @user.installments.alive.each(&:mark_deleted!)
       @user.user_compliance_infos.alive.each(&:mark_deleted!)
       @user.bank_accounts.alive.each(&:mark_deleted!)
-      @user.cancel_active_subscriptions! if @user.respond_to?(:cancel_active_subscriptions!)
+      @user.send(:cancel_active_subscriptions!)
       @user.invalidate_active_sessions!
 
       if @user.custom_domain&.persisted? && !@user.custom_domain.deleted?
         @user.custom_domain.mark_deleted!
       end
+
+      products_deleted
     end
 
     def anonymize_user_pii!
@@ -90,7 +96,7 @@ class GdprDataErasureService
       )
     end
 
-    def anonymize_buyer_purchases!
+    def anonymize_buyer_purchases!(original_email)
       # Anonymize PII on purchases made as a buyer
       # Keep transaction amounts and dates for tax/legal compliance
       Purchase.where(purchaser_id: @user.id).update_all(
@@ -103,7 +109,9 @@ class GdprDataErasureService
       )
 
       # Anonymize purchases by email (guest purchases)
-      Purchase.where(email: @user.email_was || @user.email).where(purchaser_id: nil).update_all(
+      return if original_email.blank?
+
+      Purchase.where(email: original_email, purchaser_id: nil).update_all(
         full_name: ANONYMIZED_NAME,
         street_address: nil,
         city: nil,
@@ -137,7 +145,7 @@ class GdprDataErasureService
         profile_anonymized: true,
         purchases_anonymized: true,
         account_deactivated: true,
-        products_deleted: @user.links.count,
+        products_deleted: @products_deleted,
         external_cleanup_needed: [
           "Helper/Supabase (customer conversations)",
           "Gmail (correspondence)",

--- a/app/services/gdpr_data_erasure_service.rb
+++ b/app/services/gdpr_data_erasure_service.rb
@@ -33,6 +33,8 @@ class GdprDataErasureService
     def deactivate_account!
       return if @user.deleted?
 
+      # Skip balance validation for GDPR erasure. We are legally obligated
+      # to erase regardless of outstanding balance (Article 17).
       @user.update!(
         deleted_at: Time.current,
         username: nil,
@@ -40,11 +42,11 @@ class GdprDataErasureService
         payouts_paused_internally: true,
       )
 
-      @user.links.each(&:delete!)
+      @user.links.alive.each(&:delete!)
       @user.installments.alive.each(&:mark_deleted!)
       @user.user_compliance_infos.alive.each(&:mark_deleted!)
       @user.bank_accounts.alive.each(&:mark_deleted!)
-      @user.cancel_active_subscriptions!
+      @user.cancel_active_subscriptions! if @user.respond_to?(:cancel_active_subscriptions!)
       @user.invalidate_active_sessions!
 
       if @user.custom_domain&.persisted? && !@user.custom_domain.deleted?
@@ -121,7 +123,7 @@ class GdprDataErasureService
       @user.comments.create!(
         author_id: @performed_by.id,
         author_name: @performed_by.name || @performed_by.email,
-        comment_type: "gdpr_erasure",
+        comment_type: Comment::COMMENT_TYPE_NOTE,
         content: "GDPR data erasure performed. User PII anonymized, account deactivated. " \
                  "Transaction records retained per Article 17(3)(b). " \
                  "External cleanup required: Helper/Supabase, Gmail, Stripe."

--- a/app/services/gdpr_data_erasure_service.rb
+++ b/app/services/gdpr_data_erasure_service.rb
@@ -23,7 +23,7 @@ class GdprDataErasureService
       anonymized_email = anonymize_user_pii!
       anonymize_alive_cart!(anonymized_email)
       anonymize_credit_cards!(credit_card_ids)
-      anonymize_buyer_purchases!(original_email)
+      anonymize_buyer_purchases!(anonymized_email:, original_email:)
       log_erasure!
     end
 
@@ -133,28 +133,34 @@ class GdprDataErasureService
       )
     end
 
-    def anonymize_buyer_purchases!(original_email)
+    def anonymize_buyer_purchases!(anonymized_email:, original_email:)
       # Anonymize PII on purchases made as a buyer
       # Keep transaction amounts and dates for tax/legal compliance
       Purchase.where(purchaser_id: @user.id).update_all(
+        email: anonymized_email,
         full_name: ANONYMIZED_NAME,
         street_address: nil,
         city: nil,
         state: nil,
         zip_code: nil,
         country: nil,
+        ip_address: nil,
+        browser_guid: nil,
       )
 
       # Anonymize purchases by email (guest purchases)
       return if original_email.blank?
 
       Purchase.where(email: original_email, purchaser_id: nil).update_all(
+        email: anonymized_email,
         full_name: ANONYMIZED_NAME,
         street_address: nil,
         city: nil,
         state: nil,
         zip_code: nil,
         country: nil,
+        ip_address: nil,
+        browser_guid: nil,
       )
     end
 

--- a/app/services/gdpr_data_erasure_service.rb
+++ b/app/services/gdpr_data_erasure_service.rb
@@ -16,14 +16,18 @@ class GdprDataErasureService
 
   def perform!
     original_email = @user.email
+    credit_card_ids = credit_card_ids_for_erasure
 
     ActiveRecord::Base.transaction do
       @products_deleted = deactivate_account!
-      anonymize_user_pii!
+      anonymized_email = anonymize_user_pii!
+      anonymize_alive_cart!(anonymized_email)
+      anonymize_credit_cards!(credit_card_ids)
       anonymize_buyer_purchases!(original_email)
-      remove_profile_assets!
       log_erasure!
     end
+
+    remove_profile_assets!
 
     { success: true, summary: erasure_summary }
   rescue => e
@@ -94,6 +98,39 @@ class GdprDataErasureService
         notification_endpoint: nil,
         otp_secret_key: nil,
       )
+
+      anonymized_email
+    end
+
+    def anonymize_alive_cart!(anonymized_email)
+      @user.reload_alive_cart&.update_columns(
+        email: anonymized_email,
+        ip_address: nil,
+        browser_guid: nil,
+      )
+    end
+
+    def anonymize_credit_cards!(credit_card_ids)
+      return if credit_card_ids.empty?
+
+      CreditCard.where(id: credit_card_ids).update_all(
+        card_type: ANONYMIZED_VALUE,
+        expiry_month: nil,
+        expiry_year: nil,
+        stripe_customer_id: nil,
+        visual: ANONYMIZED_VALUE,
+        stripe_fingerprint: nil,
+        card_country: nil,
+        stripe_card_id: nil,
+        card_bin: nil,
+        card_data_handling_mode: nil,
+        braintree_customer_id: nil,
+        funding_type: nil,
+        paypal_billing_agreement_id: nil,
+        processor_payment_method_id: nil,
+        json_data: nil,
+        updated_at: Time.current,
+      )
     end
 
     def anonymize_buyer_purchases!(original_email)
@@ -125,6 +162,15 @@ class GdprDataErasureService
       @user.avatar&.purge if @user.respond_to?(:avatar) && @user.avatar&.attached?
     rescue => e
       Rails.logger.warn("GDPR: Failed to purge avatar for user #{@user.id}: #{e.message}")
+    end
+
+    def credit_card_ids_for_erasure
+      [
+        @user.credit_card_id,
+        @user.purchases.where.not(credit_card_id: nil).distinct.pluck(:credit_card_id),
+        @user.subscriptions.where.not(credit_card_id: nil).distinct.pluck(:credit_card_id),
+        @user.bank_accounts.where.not(credit_card_id: nil).distinct.pluck(:credit_card_id),
+      ].flatten.compact.uniq
     end
 
     def log_erasure!

--- a/app/services/gdpr_data_erasure_service.rb
+++ b/app/services/gdpr_data_erasure_service.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+class GdprDataErasureService
+  ANONYMIZED_EMAIL_DOMAIN = "deleted.gumroad.com"
+  ANONYMIZED_NAME = "[deleted]"
+  ANONYMIZED_VALUE = "[redacted]"
+
+  # Fields that must be retained for tax/legal compliance (Article 17(3)(b))
+  # Transaction records, payout history, tax documents are kept.
+
+  def initialize(user, performed_by:)
+    @user = user
+    @performed_by = performed_by
+  end
+
+  def perform!
+    ActiveRecord::Base.transaction do
+      deactivate_account!
+      anonymize_user_pii!
+      anonymize_buyer_purchases!
+      remove_profile_assets!
+      log_erasure!
+    end
+
+    { success: true, summary: erasure_summary }
+  rescue => e
+    Rails.logger.error("GDPR erasure failed for user #{@user.id}: #{e.message}")
+    { success: false, error: e.message }
+  end
+
+  private
+
+    def deactivate_account!
+      return if @user.deleted?
+
+      @user.update!(
+        deleted_at: Time.current,
+        username: nil,
+        credit_card_id: nil,
+        payouts_paused_internally: true,
+      )
+
+      @user.links.each(&:delete!)
+      @user.installments.alive.each(&:mark_deleted!)
+      @user.user_compliance_infos.alive.each(&:mark_deleted!)
+      @user.bank_accounts.alive.each(&:mark_deleted!)
+      @user.cancel_active_subscriptions!
+      @user.invalidate_active_sessions!
+
+      if @user.custom_domain&.persisted? && !@user.custom_domain.deleted?
+        @user.custom_domain.mark_deleted!
+      end
+    end
+
+    def anonymize_user_pii!
+      anonymized_email = "deleted-#{@user.id}@#{ANONYMIZED_EMAIL_DOMAIN}"
+
+      @user.update_columns(
+        email: anonymized_email,
+        name: ANONYMIZED_NAME,
+        encrypted_password: "",
+        reset_password_token: nil,
+        current_sign_in_ip: nil,
+        last_sign_in_ip: nil,
+        account_created_ip: nil,
+        payment_address: nil,
+        unconfirmed_email: nil,
+        bio: nil,
+        twitter_handle: nil,
+        twitter_user_id: nil,
+        facebook_uid: nil,
+        facebook_access_token: nil,
+        twitter_oauth_token: nil,
+        twitter_oauth_secret: nil,
+        profile_picture_url: nil,
+        street_address: nil,
+        city: nil,
+        state: nil,
+        zip_code: nil,
+        country: nil,
+        kindle_email: nil,
+        support_email: nil,
+        google_analytics_id: nil,
+        google_analytics_domains: nil,
+        facebook_pixel_id: nil,
+        notification_endpoint: nil,
+        otp_secret_key: nil,
+      )
+    end
+
+    def anonymize_buyer_purchases!
+      # Anonymize PII on purchases made as a buyer
+      # Keep transaction amounts and dates for tax/legal compliance
+      Purchase.where(purchaser_id: @user.id).update_all(
+        full_name: ANONYMIZED_NAME,
+        street_address: nil,
+        city: nil,
+        state: nil,
+        zip_code: nil,
+        country: nil,
+      )
+
+      # Anonymize purchases by email (guest purchases)
+      Purchase.where(email: @user.email_was || @user.email).where(purchaser_id: nil).update_all(
+        full_name: ANONYMIZED_NAME,
+        street_address: nil,
+        city: nil,
+        state: nil,
+        zip_code: nil,
+        country: nil,
+      )
+    end
+
+    def remove_profile_assets!
+      @user.avatar&.purge if @user.respond_to?(:avatar) && @user.avatar&.attached?
+    rescue => e
+      Rails.logger.warn("GDPR: Failed to purge avatar for user #{@user.id}: #{e.message}")
+    end
+
+    def log_erasure!
+      @user.comments.create!(
+        author_id: @performed_by.id,
+        author_name: @performed_by.name || @performed_by.email,
+        comment_type: "gdpr_erasure",
+        content: "GDPR data erasure performed. User PII anonymized, account deactivated. " \
+                 "Transaction records retained per Article 17(3)(b). " \
+                 "External cleanup required: Helper/Supabase, Gmail, Stripe."
+      )
+    end
+
+    def erasure_summary
+      {
+        user_id: @user.id,
+        email_anonymized: true,
+        profile_anonymized: true,
+        purchases_anonymized: true,
+        account_deactivated: true,
+        products_deleted: @user.links.count,
+        external_cleanup_needed: [
+          "Helper/Supabase (customer conversations)",
+          "Gmail (correspondence)",
+          "Stripe (customer data)"
+        ]
+      }
+    end
+end

--- a/app/services/gdpr_data_erasure_service.rb
+++ b/app/services/gdpr_data_erasure_service.rb
@@ -21,7 +21,8 @@ class GdprDataErasureService
     ActiveRecord::Base.transaction do
       @products_deleted = deactivate_account!
       anonymized_email = anonymize_user_pii!
-      anonymize_alive_cart!(anonymized_email)
+      delete_device_records!
+      anonymize_carts!(anonymized_email)
       anonymize_credit_cards!(credit_card_ids)
       anonymize_buyer_purchases!(anonymized_email:, original_email:)
       log_erasure!
@@ -102,12 +103,16 @@ class GdprDataErasureService
       anonymized_email
     end
 
-    def anonymize_alive_cart!(anonymized_email)
-      @user.reload_alive_cart&.update_columns(
+    def anonymize_carts!(anonymized_email)
+      @user.carts.update_all(
         email: anonymized_email,
         ip_address: nil,
         browser_guid: nil,
       )
+    end
+
+    def delete_device_records!
+      @user.devices.destroy_all
     end
 
     def anonymize_credit_cards!(credit_card_ids)

--- a/app/views/help_center/articles/contents/_349-gdpr-data-requests.html.erb
+++ b/app/views/help_center/articles/contents/_349-gdpr-data-requests.html.erb
@@ -1,0 +1,48 @@
+<div>
+  <p>In this article:</p>
+  <ul>
+    <li><a href="#your-rights">Your data privacy rights</a></li>
+    <li><a href="#request-deletion">How to request data deletion</a></li>
+    <li><a href="#request-access">How to request your data</a></li>
+    <li><a href="#what-we-retain">What data we retain and why</a></li>
+    <li><a href="#timing">How long requests take</a></li>
+  </ul>
+
+  <h3 id="your-rights">Your data privacy rights</h3>
+  <p>Gumroad respects your data privacy rights under the GDPR (General Data Protection Regulation), CCPA (California Consumer Privacy Act), and other applicable privacy laws. You have the right to:</p>
+  <ul>
+    <li><strong>Request deletion</strong> of your personal data ("right to be forgotten")</li>
+    <li><strong>Request access</strong> to the personal data we hold about you</li>
+    <li><strong>Request correction</strong> of inaccurate personal data</li>
+    <li><strong>Opt out</strong> of certain data processing activities</li>
+  </ul>
+
+  <h3 id="request-deletion">How to request data deletion</h3>
+  <p>You can delete your Gumroad account yourself from your <a href="https://app.gumroad.com/settings/advanced">Advanced Settings</a> page. This is the fastest way to close your account.</p>
+  <p>If you want a full GDPR data erasure (which goes beyond account deletion to anonymize your personal information across our systems), contact us at <a href="mailto:support@gumroad.com">support@gumroad.com</a> with the subject line "GDPR Data Deletion Request."</p>
+  <p>For security, we will verify your identity before processing any deletion request. We may ask you to confirm details about your account that only the account holder would know, such as:</p>
+  <ul>
+    <li>The country of the bank account connected to your payout settings</li>
+    <li>The approximate date you created your Gumroad account</li>
+  </ul>
+
+  <h3 id="request-access">How to request your data</h3>
+  <p>To request a copy of the personal data we hold about you, email <a href="mailto:support@gumroad.com">support@gumroad.com</a> with the subject line "Data Access Request." We will verify your identity and provide your data within 30 days.</p>
+  <p>For general information about what data Gumroad collects, please see our <a href="/privacy">Privacy Policy</a>.</p>
+
+  <h3 id="what-we-retain">What data we retain and why</h3>
+  <p>When we process a data deletion request, we anonymize your personal information including your name, email address, physical address, IP addresses, and profile data.</p>
+  <p>However, as the Merchant of Record for transactions on our platform, we are legally required to retain certain records for tax and accounting purposes. This includes:</p>
+  <ul>
+    <li>Transaction amounts and dates</li>
+    <li>Payout records</li>
+    <li>Tax documents (1099s, etc.)</li>
+  </ul>
+  <p>This retention is permitted under GDPR Article 17(3)(b), which allows data controllers to retain data necessary to comply with legal obligations. These records are retained for the minimum period required by law (typically 5-7 years) and then deleted.</p>
+
+  <h3 id="timing">How long requests take</h3>
+  <p><strong>GDPR requests:</strong> We will respond within 30 days of verifying your identity, as required by Article 12 of the GDPR.</p>
+  <p><strong>CCPA requests:</strong> We will respond within 45 days, which may be extended by an additional 45 days with notice if necessary.</p>
+  <p><strong>Self-service account deletion:</strong> Immediate. Visit your <a href="https://app.gumroad.com/settings/advanced">Advanced Settings</a> page.</p>
+  <p>If you have any questions about your data privacy rights, please don't hesitate to reach out to <a href="mailto:support@gumroad.com">support@gumroad.com</a>.</p>
+</div>

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -59,6 +59,7 @@ namespace :admin do
       post :flag_for_fraud
       post :set_custom_fee
       post :toggle_adult_products
+      post :gdpr_erase
     end
   end
 

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -250,7 +250,6 @@ describe "Admin::UsersController Scenario", type: :system, js: true do
       expect(page).to have_text("block created")
     end
   end
-end
 
   describe "GDPR data erasure" do
     let!(:product) { create(:product, user: user) }
@@ -279,3 +278,4 @@ end
       expect(product.reload.deleted?).to eq(true)
     end
   end
+end

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -262,7 +262,8 @@ describe "Admin::UsersController Scenario", type: :system, js: true do
         click_on "GDPR Erase"
       end
 
-      expect(page).to have_text("GDPR erasure complete")
+      # Success message shows as a JS alert, dismiss it
+      page.driver.browser.switch_to.alert.accept
 
       user.reload
       expect(user.name).to eq("[deleted]")

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -262,8 +262,7 @@ describe "Admin::UsersController Scenario", type: :system, js: true do
         click_on "GDPR Erase"
       end
 
-      # Success message shows as a JS alert, dismiss it
-      page.driver.browser.switch_to.alert.accept
+      expect(page).to have_text("GDPR erasure complete")
 
       user.reload
       expect(user.name).to eq("[deleted]")

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -251,3 +251,31 @@ describe "Admin::UsersController Scenario", type: :system, js: true do
     end
   end
 end
+
+  describe "GDPR data erasure" do
+    let!(:product) { create(:product, user: user) }
+    let!(:purchase) { create(:purchase, purchaser: user, full_name: "Test Buyer", street_address: "123 Main St") }
+
+    it "anonymizes user data and shows confirmation" do
+      visit admin_user_path(user.external_id)
+
+      accept_confirm do
+        click_on "GDPR Erase"
+      end
+
+      expect(page).to have_text("GDPR erasure complete")
+
+      user.reload
+      expect(user.name).to eq("[deleted]")
+      expect(user.email).to start_with("deleted-")
+      expect(user.deleted?).to eq(true)
+      expect(user.street_address).to be_nil
+      expect(user.bio).to be_nil
+
+      purchase.reload
+      expect(purchase.full_name).to eq("[deleted]")
+      expect(purchase.street_address).to be_nil
+
+      expect(product.reload.deleted?).to eq(true)
+    end
+  end

--- a/spec/services/gdpr_data_erasure_service_spec.rb
+++ b/spec/services/gdpr_data_erasure_service_spec.rb
@@ -27,23 +27,45 @@ describe GdprDataErasureService do
     end
 
     it "anonymizes buyer purchases" do
-      purchase = create(:free_purchase, purchaser: user, full_name: "John Doe", street_address: "123 Main St")
+      purchase = create(
+        :free_purchase,
+        purchaser: user,
+        email: user.email,
+        full_name: "John Doe",
+        street_address: "123 Main St",
+        ip_address: "127.0.0.1",
+        browser_guid: "buyer-browser-guid",
+      )
 
       described_class.new(user, performed_by: admin).perform!
 
       purchase.reload
+      expect(purchase.email).to eq("deleted-#{user.id}@deleted.gumroad.com")
       expect(purchase.full_name).to eq("[deleted]")
       expect(purchase.street_address).to be_nil
+      expect(purchase.ip_address).to be_nil
+      expect(purchase.browser_guid).to be_nil
     end
 
     it "anonymizes guest purchases using the original email address" do
-      purchase = create(:free_purchase, purchaser: nil, email: user.email, full_name: "John Doe", street_address: "123 Main St")
+      purchase = create(
+        :free_purchase,
+        purchaser: nil,
+        email: user.email,
+        full_name: "John Doe",
+        street_address: "123 Main St",
+        ip_address: "127.0.0.1",
+        browser_guid: "guest-browser-guid",
+      )
 
       described_class.new(user, performed_by: admin).perform!
 
       purchase.reload
+      expect(purchase.email).to eq("deleted-#{user.id}@deleted.gumroad.com")
       expect(purchase.full_name).to eq("[deleted]")
       expect(purchase.street_address).to be_nil
+      expect(purchase.ip_address).to be_nil
+      expect(purchase.browser_guid).to be_nil
     end
 
     it "anonymizes the user's alive cart and credit card records" do

--- a/spec/services/gdpr_data_erasure_service_spec.rb
+++ b/spec/services/gdpr_data_erasure_service_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe GdprDataErasureService do
+  let(:user) { create(:user, name: "John Doe", bio: "My bio", street_address: "123 Main St", city: "New York", state: "NY", zip_code: "10001", country: "US") }
+  let(:admin) { create(:user, name: "Admin") }
+
+  describe "#perform!" do
+    it "anonymizes user PII" do
+      result = described_class.new(user, performed_by: admin).perform!
+
+      expect(result[:success]).to eq(true)
+      user.reload
+      expect(user.name).to eq("[deleted]")
+      expect(user.email).to eq("deleted-#{user.id}@deleted.gumroad.com")
+      expect(user.bio).to be_nil
+      expect(user.street_address).to be_nil
+      expect(user.city).to be_nil
+      expect(user.state).to be_nil
+      expect(user.zip_code).to be_nil
+      expect(user.country).to be_nil
+      expect(user.current_sign_in_ip).to be_nil
+      expect(user.last_sign_in_ip).to be_nil
+      expect(user.account_created_ip).to be_nil
+      expect(user.deleted_at).to be_present
+    end
+
+    it "anonymizes buyer purchases" do
+      purchase = create(:purchase, purchaser: user, full_name: "John Doe", street_address: "123 Main St")
+
+      described_class.new(user, performed_by: admin).perform!
+
+      purchase.reload
+      expect(purchase.full_name).to eq("[deleted]")
+      expect(purchase.street_address).to be_nil
+    end
+
+    it "deactivates the account and deletes products" do
+      product = create(:product, user: user)
+
+      described_class.new(user, performed_by: admin).perform!
+
+      user.reload
+      expect(user.deleted?).to eq(true)
+      expect(product.reload.deleted?).to eq(true)
+    end
+
+    it "logs the erasure as a comment" do
+      described_class.new(user, performed_by: admin).perform!
+
+      comment = user.comments.last
+      expect(comment.comment_type).to eq("gdpr_erasure")
+      expect(comment.content).to include("GDPR data erasure performed")
+    end
+
+    it "returns external cleanup instructions" do
+      result = described_class.new(user, performed_by: admin).perform!
+
+      expect(result[:summary][:external_cleanup_needed]).to include("Helper/Supabase (customer conversations)")
+      expect(result[:summary][:external_cleanup_needed]).to include("Stripe (customer data)")
+    end
+  end
+end

--- a/spec/services/gdpr_data_erasure_service_spec.rb
+++ b/spec/services/gdpr_data_erasure_service_spec.rb
@@ -50,7 +50,8 @@ describe GdprDataErasureService do
       described_class.new(user, performed_by: admin).perform!
 
       comment = user.comments.last
-      expect(comment.comment_type).to eq("gdpr_erasure")
+      expect(comment.comment_type).to eq(Comment::COMMENT_TYPE_NOTE)
+      expect(comment.content).to include("GDPR data erasure performed")
       expect(comment.content).to include("GDPR data erasure performed")
     end
 

--- a/spec/services/gdpr_data_erasure_service_spec.rb
+++ b/spec/services/gdpr_data_erasure_service_spec.rb
@@ -46,6 +46,34 @@ describe GdprDataErasureService do
       expect(purchase.street_address).to be_nil
     end
 
+    it "anonymizes the user's alive cart and credit card records" do
+      cart = create(:cart, user:, email: user.email, ip_address: "127.0.0.1", browser_guid: "browser-guid")
+      credit_card = CreditCard.create!(
+        visual: "**** **** **** 4242",
+        card_type: "visa",
+        expiry_month: 12,
+        expiry_year: 2030,
+        stripe_customer_id: "cus_123",
+        stripe_fingerprint: "fp_123",
+        processor_payment_method_id: "pm_123",
+        charge_processor_id: StripeChargeProcessor.charge_processor_id,
+      )
+      user.update!(credit_card:)
+
+      described_class.new(user, performed_by: admin).perform!
+
+      expect(cart.reload.email).to eq("deleted-#{user.id}@deleted.gumroad.com")
+      expect(cart.ip_address).to be_nil
+      expect(cart.browser_guid).to be_nil
+
+      expect(credit_card.reload.card_type).to eq(GdprDataErasureService::ANONYMIZED_VALUE)
+      expect(credit_card.visual).to eq(GdprDataErasureService::ANONYMIZED_VALUE)
+      expect(credit_card.expiry_month).to be_nil
+      expect(credit_card.expiry_year).to be_nil
+      expect(credit_card.stripe_customer_id).to be_nil
+      expect(credit_card.processor_payment_method_id).to be_nil
+    end
+
     it "invokes the private subscription cancellation helper during erasure" do
       expect(user).to receive(:cancel_active_subscriptions!)
 
@@ -86,6 +114,17 @@ describe GdprDataErasureService do
 
       expect(result[:summary][:external_cleanup_needed]).to include("Helper/Supabase (customer conversations)")
       expect(result[:summary][:external_cleanup_needed]).to include("Stripe (customer data)")
+    end
+
+    it "skips profile asset removal when transactional erasure work fails" do
+      service = described_class.new(user, performed_by: admin)
+      allow(service).to receive(:remove_profile_assets!)
+      allow(service).to receive(:log_erasure!).and_raise(StandardError, "boom")
+
+      result = service.perform!
+
+      expect(result[:success]).to eq(false)
+      expect(service).not_to have_received(:remove_profile_assets!)
     end
   end
 end

--- a/spec/services/gdpr_data_erasure_service_spec.rb
+++ b/spec/services/gdpr_data_erasure_service_spec.rb
@@ -68,8 +68,10 @@ describe GdprDataErasureService do
       expect(purchase.browser_guid).to be_nil
     end
 
-    it "anonymizes the user's alive cart and credit card records" do
-      cart = create(:cart, user:, email: user.email, ip_address: "127.0.0.1", browser_guid: "browser-guid")
+    it "anonymizes all of the user's carts and credit card records" do
+      historical_cart = create(:cart, user:, email: user.email, ip_address: "127.0.0.2", browser_guid: "historical-browser-guid")
+      historical_cart.mark_deleted!
+      alive_cart = create(:cart, user:, email: user.email, ip_address: "127.0.0.1", browser_guid: "browser-guid")
       credit_card = CreditCard.create!(
         visual: "**** **** **** 4242",
         card_type: "visa",
@@ -84,9 +86,11 @@ describe GdprDataErasureService do
 
       described_class.new(user, performed_by: admin).perform!
 
-      expect(cart.reload.email).to eq("deleted-#{user.id}@deleted.gumroad.com")
-      expect(cart.ip_address).to be_nil
-      expect(cart.browser_guid).to be_nil
+      [alive_cart, historical_cart].each do |cart|
+        expect(cart.reload.email).to eq("deleted-#{user.id}@deleted.gumroad.com")
+        expect(cart.ip_address).to be_nil
+        expect(cart.browser_guid).to be_nil
+      end
 
       expect(credit_card.reload.card_type).to eq(GdprDataErasureService::ANONYMIZED_VALUE)
       expect(credit_card.visual).to eq(GdprDataErasureService::ANONYMIZED_VALUE)
@@ -94,6 +98,18 @@ describe GdprDataErasureService do
       expect(credit_card.expiry_year).to be_nil
       expect(credit_card.stripe_customer_id).to be_nil
       expect(credit_card.processor_payment_method_id).to be_nil
+    end
+
+    it "deletes the user's device records" do
+      ios_device = create(:device, user:, token: "ios-device-token")
+      android_device = create(:android_device, user:, token: "android-device-token")
+      other_user_device = create(:device, token: "other-user-device-token")
+
+      described_class.new(user, performed_by: admin).perform!
+
+      expect(Device.exists?(ios_device.id)).to eq(false)
+      expect(Device.exists?(android_device.id)).to eq(false)
+      expect(Device.exists?(other_user_device.id)).to eq(true)
     end
 
     it "invokes the private subscription cancellation helper during erasure" do

--- a/spec/services/gdpr_data_erasure_service_spec.rb
+++ b/spec/services/gdpr_data_erasure_service_spec.rb
@@ -3,8 +3,8 @@
 require "spec_helper"
 
 describe GdprDataErasureService do
-  let(:user) { create(:user, name: "John Doe", bio: "My bio", street_address: "123 Main St", city: "New York", state: "NY", zip_code: "10001", country: "US") }
-  let(:admin) { create(:user, name: "Admin") }
+  let(:user) { create(:user, email: "john@example.com", name: "John Doe", bio: "My bio", street_address: "123 Main St", city: "New York", state: "NY", zip_code: "10001", country: "US") }
+  let(:admin) { create(:user, email: "admin@example.com", name: "Admin") }
 
   describe "#perform!" do
     it "anonymizes user PII" do
@@ -27,13 +27,29 @@ describe GdprDataErasureService do
     end
 
     it "anonymizes buyer purchases" do
-      purchase = create(:purchase, purchaser: user, full_name: "John Doe", street_address: "123 Main St")
+      purchase = create(:free_purchase, purchaser: user, full_name: "John Doe", street_address: "123 Main St")
 
       described_class.new(user, performed_by: admin).perform!
 
       purchase.reload
       expect(purchase.full_name).to eq("[deleted]")
       expect(purchase.street_address).to be_nil
+    end
+
+    it "anonymizes guest purchases using the original email address" do
+      purchase = create(:free_purchase, purchaser: nil, email: user.email, full_name: "John Doe", street_address: "123 Main St")
+
+      described_class.new(user, performed_by: admin).perform!
+
+      purchase.reload
+      expect(purchase.full_name).to eq("[deleted]")
+      expect(purchase.street_address).to be_nil
+    end
+
+    it "invokes the private subscription cancellation helper during erasure" do
+      expect(user).to receive(:cancel_active_subscriptions!)
+
+      described_class.new(user, performed_by: admin).perform!
     end
 
     it "deactivates the account and deletes products" do
@@ -46,13 +62,23 @@ describe GdprDataErasureService do
       expect(product.reload.deleted?).to eq(true)
     end
 
+    it "reports only alive products in the erasure summary" do
+      create(:product, user: user)
+      deleted_product = create(:product, user: user)
+      deleted_product.delete!
+
+      result = described_class.new(user, performed_by: admin).perform!
+
+      expect(result[:summary][:products_deleted]).to eq(1)
+    end
+
     it "logs the erasure as a comment" do
       described_class.new(user, performed_by: admin).perform!
 
       comment = user.comments.last
       expect(comment.comment_type).to eq(Comment::COMMENT_TYPE_NOTE)
       expect(comment.content).to include("GDPR data erasure performed")
-      expect(comment.content).to include("GDPR data erasure performed")
+      expect(comment.content).to include("Transaction records retained")
     end
 
     it "returns external cleanup instructions" do


### PR DESCRIPTION
## What
Adds a "GDPR Erase" button to the admin user actions that performs a full GDPR-compliant data erasure.

## How it works
1. Admin clicks "GDPR Erase" on a user's admin page
2. Confirmation dialog shows exactly what will happen
3. On confirm, `GdprDataErasureService` runs in a transaction:
   - **Anonymizes PII**: name, email, address, IP addresses, bio, social accounts, payment info, Kindle email, analytics IDs, OTP secrets
   - **Deactivates account**: sets deleted_at, removes username, invalidates sessions
   - **Deletes products**: all seller products marked deleted
   - **Cancels subscriptions**: all active subscriptions cancelled
   - **Anonymizes purchases**: buyer name and address on purchase records replaced with "[deleted]"
   - **Logs audit trail**: admin comment recording who performed the erasure and when
4. After success, shows alert reminding admin about external cleanup needed:
   - Helper/Supabase (customer conversations)
   - Gmail (correspondence)
   - Stripe (customer data)

## What's retained (Article 17(3)(b))
Transaction amounts, dates, payout records, and tax documents are kept for legal/tax compliance. Only PII is anonymized.

## Files
- `app/services/gdpr_data_erasure_service.rb` (new) - core erasure logic
- `app/controllers/admin/users_controller.rb` - new `gdpr_erase` action
- `config/routes/admin.rb` - route
- `app/javascript/components/Admin/Users/Actions/GdprEraseAction.tsx` (new) - button with confirmation
- `app/javascript/components/Admin/Users/Actions/index.tsx` - added to action bar
- `spec/services/gdpr_data_erasure_service_spec.rb` (new) - tests

Closes #4724