### PR TITLE
Fix reviews not loading on custom domains

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1146,6 +1146,19 @@ Rails.application.routes.draw do
 
     resources :profile_sections, only: [:create, :update, :destroy]
 
+    put "/product_reviews/set", to: "product_reviews#set", format: :json
+    resources :product_reviews, only: [:index, :show]
+    resources :product_review_responses, only: [:update, :destroy], format: :json
+    resources :product_review_videos, only: [] do
+      scope module: :product_review_videos do
+        resource :stream, only: [:show]
+        resources :streaming_urls, only: [:index]
+      end
+    end
+    namespace :product_review_videos do
+      resource :upload_context, only: [:show]
+    end
+
     get "/", to: "users#show"
   end
 


### PR DESCRIPTION
## Problem
Product reviews fail to load on custom domains. The client-side JS fetches `/product_reviews` expecting JSON, but the custom domain proxy returns HTML because the route isn't matched inside the `UserCustomDomainConstraint` block.

## Root cause
The `product_reviews`, `product_review_responses`, and `product_review_videos` routes were only defined outside the custom domain constraint block in `config/routes.rb`. On a custom domain, the request hits the constraint block first, doesn't find a matching route, falls through to the catch-all, and returns the HTML shell.

## Fix
Added the review routes inside the `UserCustomDomainConstraint` block so they're properly matched for custom domain requests. The existing routes outside the block are kept for `*.gumroad.com` requests.

Fixes #4718