### PR TITLE
Reduce CI test retries from 3 to 1

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -213,7 +213,7 @@ RSpec.configure do |config|
     config.verbose_retry = true
     # show exception that triggers a retry if verbose_retry is set to true
     config.display_try_failure_messages = true
-    config.default_retry_count = 3
+    config.default_retry_count = 1
     config.retry_callback = proc do |example|
       reset_db_connection(example)
       reset_browser_session(example)


### PR DESCRIPTION
Flaky tests should be fixed, not retried. Each slow test shard takes 8-10 min, so 3x retry means up to 30 min wasted on a single flaky spec. With retry count 1, tests run once and fail fast, forcing us to actually fix flakiness.