### PR TITLE
Fix flaky tests exposed by retry reduction

### DIFF
--- a/spec/controllers/purchases_controller_spec.rb
+++ b/spec/controllers/purchases_controller_spec.rb
@@ -665,14 +665,19 @@ describe PurchasesController, :vcr do
         index_model_records(Purchase)
       end
 
+      def csv_safe(value)
+        # CSV 3.3+ prepends ' to values starting with =, +, -, @ to prevent formula injection
+        value&.match?(/\A[=+\-@]/) ? "'#{value}" : value
+      end
+
       def expect_correct_csv(csv_string)
         csv = CSV.parse(csv_string)
         expect(csv.size).to eq(5)
         expect(csv[0]).to eq(Exports::PurchaseExportService::PURCHASE_FIELDS + ["Age", "Height", "Citizenship"])
         # Test the correct purchase is listed with the expected custom fields values.
-        expect([csv[1].first] + csv[1].last(3)).to eq([@purchase_1.external_id, "25", nil, nil])
-        expect([csv[2].first] + csv[2].last(3)).to eq([@purchase_2.external_id, nil, nil, "Japan"])
-        expect([csv[3].first] + csv[3].last(3)).to eq([@purchase_3.external_id, nil, nil, nil])
+        expect([csv[1].first] + csv[1].last(3)).to eq([csv_safe(@purchase_1.external_id), "25", nil, nil])
+        expect([csv[2].first] + csv[2].last(3)).to eq([csv_safe(@purchase_2.external_id), nil, nil, "Japan"])
+        expect([csv[3].first] + csv[3].last(3)).to eq([csv_safe(@purchase_3.external_id), nil, nil, nil])
         expect([csv[4].first] + csv[4].last(3)).to eq(["Totals", nil, nil, nil])
       end
 

--- a/spec/presenters/product_presenter_spec.rb
+++ b/spec/presenters/product_presenter_spec.rb
@@ -794,7 +794,7 @@ describe ProductPresenter do
       let(:new_product) { create(:product, name: "Product", description: "Boring") }
       let(:presenter) { described_class.new(product: new_product, request:) }
 
-      it "returns the properties for the product edit page" do
+      it "returns the properties for the product edit page", :freeze_time do
         expect(presenter.edit_props).to eq(
           {
             product: {

--- a/spec/services/payout_users_service_spec.rb
+++ b/spec/services/payout_users_service_spec.rb
@@ -127,7 +127,7 @@ describe PayoutUsersService, :vcr do
 
     include_examples "PayoutUsersService#process specs"
 
-    it "does not process cross-border payouts immediately and schedules for 25 hours later" do
+    it "does not process cross-border payouts immediately and schedules for 25 hours later", :freeze_time do
       allow_any_instance_of(UserComplianceInfo).to receive(:legal_entity_country_code).and_return("TH")
       expect(StripePayoutProcessor).not_to receive(:process_payments)
 

--- a/spec/support/checkout_helpers.rb
+++ b/spec/support/checkout_helpers.rb
@@ -172,11 +172,11 @@ module CheckoutHelpers
       else
         if gift.present? || product.is_in_preorder_state
           # Specific cases where we show the receipt instead of the product content
-          expect(page).to have_text("Your purchase was successful!")
+          expect(page).to have_text("Your purchase was successful!", wait: 60)
           expect(page).to have_text(logged_in_user&.email&.downcase || email&.downcase)
         else
           # The alert show/hide timing can cause specs to be flaky
-          expect(page).to have_alert(text: "Your purchase was successful! We sent a receipt to #{logged_in_user&.email&.downcase || email&.downcase}", visible: :all)
+          expect(page).to have_alert(text: "Your purchase was successful! We sent a receipt to #{logged_in_user&.email&.downcase || email&.downcase}", visible: :all, wait: 60)
         end
 
         expect(page).to have_text("You bought this for #{gift[:email] || gift[:name]}") if gift&.dig(:email).present? || gift&.dig(:name).present?


### PR DESCRIPTION
After reducing retries from 3 to 1 in #4729 (commit 9dd34bb), 17 tests failed on the first CI run. These were always flaky but masked by retries.

## Fixes

### E2E checkout tests (14 tests)
Increased wait time for 'Your purchase was successful!' assertion from 25s → 60s in the shared `check_out` helper. Stripe test card processing on CI can be slow.

### CSV export test  
CSV gem 3.3 adds formula injection prevention, prepending `'` to values starting with `-`, `+`, `=`, `@`. The test now accounts for this behavior.

### ProductPresenter test
Added `:freeze_time` tag. The `earliest_membership_price_change_date` uses `.from_now` which is non-deterministic without frozen time.

### PayoutUsersService test
Added `:freeze_time` tag. The `.in(25.hours)` Sidekiq matcher is sensitive to time drift between job scheduling and assertion.