### PR TITLE
Fix flaky ProductPresenter test: freeze time for edit_props

### DIFF
--- a/spec/presenters/product_presenter_spec.rb
+++ b/spec/presenters/product_presenter_spec.rb
@@ -794,7 +794,7 @@ describe ProductPresenter do
       let(:new_product) { create(:product, name: "Product", description: "Boring") }
       let(:presenter) { described_class.new(product: new_product, request:) }
 
-      it "returns the properties for the product edit page" do
+      it "returns the properties for the product edit page", :freeze_time do
         expect(presenter.edit_props).to eq(
           {
             product: {


### PR DESCRIPTION
`earliest_membership_price_change_date` uses `.from_now` making the hash comparison non-deterministic. Adding `:freeze_time` makes it reliable.