### PR TITLE
Add ModerateProductsJob for bulk content moderation

### DIFF
--- a/app/sidekiq/moderate_products_job.rb
+++ b/app/sidekiq/moderate_products_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class ModerateProductsJob
+  include Sidekiq::Job
+  sidekiq_options queue: :low, retry: 3
+
+  def perform(product_ids)
+    Link.where(id: product_ids).find_each do |product|
+      ContentModeration::ModerateRecordService.check(product, :product)
+    rescue StandardError => e
+      ErrorNotifier.notify(e, context: { product_id: product.id })
+      Rails.logger.error("ModerateProductsJob: moderation failed for product ##{product.id}: #{e.class}: #{e.message}")
+    end
+  end
+end

--- a/spec/sidekiq/moderate_products_job_spec.rb
+++ b/spec/sidekiq/moderate_products_job_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe ModerateProductsJob do
+  let(:product1) { create(:product) }
+  let(:product2) { create(:product) }
+  let(:passed_result) { ContentModeration::ModerateRecordService::CheckResult.new(passed: true, reasons: []) }
+
+  before do
+    allow(ContentModeration::ModerateRecordService).to receive(:check).and_return(passed_result)
+  end
+
+  it "runs moderation for each product in the given ids" do
+    described_class.new.perform([product1.id, product2.id])
+
+    expect(ContentModeration::ModerateRecordService).to have_received(:check).with(have_attributes(id: product1.id), :product)
+    expect(ContentModeration::ModerateRecordService).to have_received(:check).with(have_attributes(id: product2.id), :product)
+  end
+
+  it "skips ids that no longer exist without raising" do
+    missing_id = Link.maximum(:id).to_i + 10_000
+
+    expect do
+      described_class.new.perform([product1.id, missing_id])
+    end.not_to raise_error
+
+    expect(ContentModeration::ModerateRecordService).to have_received(:check).once
+  end
+
+  it "reports errors for individual products and continues processing the rest" do
+    allow(ContentModeration::ModerateRecordService).to receive(:check).with(have_attributes(id: product1.id), :product)
+      .and_raise(Faraday::TimeoutError, "Net::ReadTimeout")
+    allow(ContentModeration::ModerateRecordService).to receive(:check).with(have_attributes(id: product2.id), :product)
+      .and_return(passed_result)
+    allow(ErrorNotifier).to receive(:notify)
+    allow(Rails.logger).to receive(:error)
+
+    described_class.new.perform([product1.id, product2.id])
+
+    expect(ErrorNotifier).to have_received(:notify).with(instance_of(Faraday::TimeoutError), context: { product_id: product1.id })
+    expect(ContentModeration::ModerateRecordService).to have_received(:check).with(have_attributes(id: product2.id), :product)
+  end
+
+  it "enqueues to the low queue" do
+    expect(described_class.sidekiq_options["queue"]).to eq(:low)
+  end
+end


### PR DESCRIPTION
## What

Adds `ModerateProductsJob`, a Sidekiq job that runs `ContentModeration::ModerateRecordService` against a list of product IDs.

- `app/sidekiq/moderate_products_job.rb` — new job on the `low` queue, `retry: 3`
- Iterates `Link.where(id: product_ids).find_each`, calls `ContentModeration::ModerateRecordService.check(product, :product)` per product
- Missing IDs are silently skipped (they don't appear in the scan)
- Per-product errors are rescued, reported via `ErrorNotifier.notify`, and logged — one failing product doesn't abort the batch

Invoke with `ModerateProductsJob.perform_async([id1, id2, ...])`.

## Why

We need a way to re-run moderation over existing products in bulk (e.g., backfilling after a threshold change, re-checking after a false-positive fix, or moderating a targeted set flagged by ops). Inline moderation happens in `Link#save`, but there was no async path to moderate arbitrary batches without touching the records themselves.

The per-product rescue is intentional: content moderation hits external APIs (OpenAI) which can have transient failures. Aborting a 1k-product batch because one call timed out would be wasteful, and Sidekiq's default retry would redo the already-processed products. Reporting + continuing gives us visibility without losing work.

Queue choice: `low` per the CLAUDE.md guidance — bulk moderation is not time-sensitive.

## Before/After

Non-user-facing. Walkthrough video TODO — this job has no UI; invocation is console-driven for ops.

## Test Results

```
$ bundle exec rspec spec/sidekiq/moderate_products_job_spec.rb
....
4 examples, 0 failures
```

Specs cover: running moderation for each id, skipping missing ids, rescuing per-product errors and continuing, and queue name.

---

AI disclosure: Written with Claude Opus 4.7. Prompt: "add sidekiq job to run moderations for the given list of product ids".

🤖 Generated with [Claude Code](https://claude.com/claude-code)