### PR TITLE
Fix ActiveRecord::ConfigurationError in BaseVariant#mark_deleted when deleting Skus

### DIFF
--- a/app/models/base_variant.rb
+++ b/app/models/base_variant.rb
@@ -42,8 +42,8 @@ class BaseVariant < ApplicationRecord
 
   def mark_deleted
     super
-    DeleteProductRichContentWorker.perform_async(variant_category.link_id, id)
-    DeleteProductFilesArchivesWorker.perform_async(variant_category.link_id, id)
+    DeleteProductRichContentWorker.perform_async(link.id, id)
+    DeleteProductFilesArchivesWorker.perform_async(link.id, id)
   end
 
   def price_difference_in_currency_units

--- a/spec/models/sku_spec.rb
+++ b/spec/models/sku_spec.rb
@@ -78,6 +78,22 @@ describe Sku do
     end
   end
 
+  describe "#mark_deleted" do
+    it "marks the sku deleted and enqueues deletion for rich content and product file archives" do
+      product = create(:product)
+      sku = create(:sku, link: product)
+
+      freeze_time do
+        expect do
+          sku.mark_deleted
+        end.to change { sku.reload.deleted_at }.from(nil).to(Time.current)
+
+        expect(DeleteProductRichContentWorker).to have_enqueued_sidekiq_job(product.id, sku.id)
+        expect(DeleteProductFilesArchivesWorker).to have_enqueued_sidekiq_job(product.id, sku.id)
+      end
+    end
+  end
+
   describe "updating price_difference_cents" do
     let(:product) { create(:product) }
     let!(:sku) { create(:sku, link: product, custom_sku: "customSKU", price_difference_cents: 20) }


### PR DESCRIPTION
## What

`BaseVariant#mark_deleted` now uses `link.id` instead of `variant_category.link_id` when enqueueing `DeleteProductRichContentWorker` and `DeleteProductFilesArchivesWorker`. Added a spec covering `Sku#mark_deleted`.

## Why

Sentry was reporting `ActiveRecord::ConfigurationError: Can't join 'BaseVariant' to association named 'variant_category'` whenever a `Sku` was soft-deleted.

Root cause: `BaseVariant#mark_deleted` called `variant_category.link_id`, but the `variant_category` `belongs_to` association is only defined on the `Variant` subclass — not on `BaseVariant` itself, and not on `Sku`. `Sku` defines its own `belongs_to :link` directly, so calling `variant_category` on a `Sku` instance blew up.

Both subclasses already respond to `link` (`Variant` delegates `link` to `variant_category`; `Sku` has `belongs_to :link`), so `link.id` produces the same value for `Variant` and also works for `Sku`. The existing `Variant#mark_deleted` behavior is unchanged.

## Before / After

Before: calling `Sku#mark_deleted` raised `ActiveRecord::ConfigurationError`.
After: `Sku#mark_deleted` soft-deletes the record and enqueues the cleanup workers with the product id, matching the behavior already covered for `Variant`.

## Test results

```
bundle exec rspec spec/models/sku_spec.rb -e "mark_deleted" spec/models/variant_spec.rb -e "mark_deleted"
# 3 examples, 0 failures
```

Confirmed the new `Sku#mark_deleted` spec fails when the fix is reverted.

---

AI disclosure: Drafted by Claude Opus 4.6 based on a prompt describing the Sentry error, root cause, and fix approach (swap `variant_category.link_id` for `link.id` in `BaseVariant#mark_deleted` and add a `Sku#mark_deleted` spec mirroring the existing `Variant#mark_deleted` test).