### PR TITLE
Skip 2FA for Google OAuth login

### DIFF
--- a/app/controllers/user/omniauth_callbacks_controller.rb
+++ b/app/controllers/user/omniauth_callbacks_controller.rb
@@ -65,13 +65,8 @@ class User::OmniauthCallbacksController < Devise::OmniauthCallbacksController
         create_user_event("signup")
       end
 
-      if user.email.present?
-        sign_in_or_prepare_for_two_factor_auth(user)
-        return redirect_to two_factor_authentication_path(next: oauth_completions_stripe_path)
-      else
-        sign_in user
-        return safe_redirect_to oauth_completions_stripe_path
-      end
+      sign_in user
+      return safe_redirect_to oauth_completions_stripe_path
     end
 
     session[:stripe_connect_data] = {
@@ -116,9 +111,6 @@ class User::OmniauthCallbacksController < Devise::OmniauthCallbacksController
         if @user.deleted?
           flash[:alert] = "You cannot log in because your account was permanently deleted. Please sign up for a new account to start selling!"
           redirect_to login_path
-        elsif @user.email.present?
-          sign_in_or_prepare_for_two_factor_auth(@user)
-          redirect_to two_factor_authentication_path(next: post_auth_redirect(@user))
         else
           sign_in @user
           safe_redirect_to post_auth_redirect(@user)

--- a/spec/controllers/user/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/user/omniauth_callbacks_controller_spec.rb
@@ -40,10 +40,11 @@ describe User::OmniauthCallbacksController do
         user = User.last
         expect(user.email).to eq("stripe.connect@gum.co")
         expect(user.confirmed?).to be true
-        expect(response).to redirect_to two_factor_authentication_path(next: oauth_completions_stripe_path)
+        expect(controller.user_signed_in?).to be true
+        expect(response).to redirect_to safe_redirect_path(oauth_completions_stripe_path)
       end
 
-      it "redirects directly to completion when user has no email" do
+      it "signs in directly when user has no email" do
         request.env["omniauth.auth"]["info"].delete "email"
         request.env["omniauth.auth"]["extra"]["raw_info"].delete "email"
 
@@ -55,13 +56,13 @@ describe User::OmniauthCallbacksController do
         expect(response).to redirect_to safe_redirect_path(oauth_completions_stripe_path)
       end
 
-      it "requires 2FA when user has email" do
+      it "signs in directly when user has email" do
         post :stripe_connect
 
         user = User.last
         expect(user.email).to eq("stripe.connect@gum.co")
-        expect(controller.user_signed_in?).to be false
-        expect(response).to redirect_to two_factor_authentication_path(next: oauth_completions_stripe_path)
+        expect(controller.user_signed_in?).to be true
+        expect(response).to redirect_to safe_redirect_path(oauth_completions_stripe_path)
       end
 
       it "does not create a new user if the email is already taken" do
@@ -69,7 +70,7 @@ describe User::OmniauthCallbacksController do
 
         expect { post :stripe_connect }.not_to change { User.count }
 
-        expect(response).to redirect_to two_factor_authentication_path(next: oauth_completions_stripe_path)
+        expect(response).to redirect_to safe_redirect_path(oauth_completions_stripe_path)
       end
     end
 
@@ -147,7 +148,7 @@ describe User::OmniauthCallbacksController do
         expect(user.email).to eq("stripe.connect@gum.co")
         expect(purchase1.reload.purchaser_id).to eq(user.id)
         expect(purchase2.reload.purchaser_id).to eq(user.id)
-        expect(response).to redirect_to two_factor_authentication_path(next: oauth_completions_stripe_path)
+        expect(response).to redirect_to safe_redirect_path(oauth_completions_stripe_path)
       end
     end
 
@@ -172,7 +173,7 @@ describe User::OmniauthCallbacksController do
 
         expect { post :stripe_connect }.not_to change { User.count }
 
-        expect(response).to redirect_to two_factor_authentication_path(next: oauth_completions_stripe_path)
+        expect(response).to redirect_to safe_redirect_path(oauth_completions_stripe_path)
       end
 
       it "allows existing users with matching email (without Stripe connected) to log in" do
@@ -180,7 +181,7 @@ describe User::OmniauthCallbacksController do
 
         expect { post :stripe_connect }.not_to change { User.count }
 
-        expect(response).to redirect_to two_factor_authentication_path(next: oauth_completions_stripe_path)
+        expect(response).to redirect_to safe_redirect_path(oauth_completions_stripe_path)
       end
 
       it "allows existing users without email to log in" do
@@ -262,14 +263,16 @@ describe User::OmniauthCallbacksController do
         u
       end
 
-      it "does not allow user to login with Apple only" do
+      it "signs in the user without 2FA" do
         post :apple
-        expect(response).to redirect_to two_factor_authentication_path(next: dashboard_path)
+        expect(controller.user_signed_in?).to be true
+        expect(response).to redirect_to dashboard_path
       end
 
       it "keeps referral intact" do
         post :apple, params: { referer: balance_path }
-        expect(response).to redirect_to two_factor_authentication_path(next: balance_path)
+        expect(controller.user_signed_in?).to be true
+        expect(response).to redirect_to balance_path
       end
     end
 
@@ -355,21 +358,24 @@ describe User::OmniauthCallbacksController do
     context "when user has 2FA" do
       let!(:user) { create(:user, google_uid: "101656774483284362141", email: "pdragunas@example.com", two_factor_authentication_enabled: true) }
 
-      it "does not allow user to login with Google only" do
+      it "signs in the user without 2FA" do
         post :google_oauth2
-        expect(response).to redirect_to two_factor_authentication_path(next: dashboard_path)
+        expect(controller.user_signed_in?).to be true
+        expect(response).to redirect_to dashboard_path
       end
 
       it "keeps referral intact" do
         request.env["omniauth.origin"] = balance_path
         post :google_oauth2
-        expect(response).to redirect_to two_factor_authentication_path(next: balance_path)
+        expect(controller.user_signed_in?).to be true
+        expect(response).to redirect_to balance_path
       end
 
       it "sanitizes external domain in referral to a relative path" do
         request.env["omniauth.origin"] = "https://evil.com/phishing"
         post :google_oauth2
-        expect(response).to redirect_to two_factor_authentication_path(next: "/phishing")
+        expect(controller.user_signed_in?).to be true
+        expect(response).to redirect_to "/phishing"
       end
     end
 

--- a/spec/support/fixtures/vcr_cassettes/User_OmniauthCallbacksController/_stripe_connect/when_referer_is_login/signs_in_directly_when_user_has_email.yml
+++ b/spec/support/fixtures/vcr_cassettes/User_OmniauthCallbacksController/_stripe_connect/when_referer_is_login/signs_in_directly_when_user_has_email.yml
@@ -14,14 +14,13 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_xA423rsGfj9zGj","request_duration_ms":774}}'
+      - '{"last_request_metrics":{"request_id":"req_dQ77rpBLbguU3g","request_duration_ms":944}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
-      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
-        version 6.14.0-33-generic (buildd@lcy02-amd64-026) (x86_64-linux-gnu-gcc-13
-        (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0, GNU ld (GNU Binutils for Ubuntu) 2.42)
-        #33~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC Fri Sep 19 17:02:30 UTC 2","hostname":"hsc-desk"}'
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        GumClaws-Mini 25.3.0 Darwin Kernel Version 25.3.0: Wed Jan 28 20:49:24 PST
+        2026; root:xnu-12377.81.4~5/RELEASE_ARM64_T8132 arm64","hostname":"GumClaws-Mini"}'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -34,11 +33,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Sat, 01 Nov 2025 19:00:43 GMT
+      - Fri, 24 Apr 2026 15:05:36 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '6699'
+      - '6754'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -56,11 +55,14 @@ http_interactions:
       - no-cache, no-store
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
-        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
-        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
-        https://q.stripe.com/csp-violation?q=XM2gL-jSTEX7Joh2OEplMLD9hts4M7lzv_RRu_kpwLuL2h_s6khJQtJA1x0da5j61LAgwQuksHUJGgUC
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=5weXgyPJV66GwxRtlM7kgmNQvnlAFYR7ET1vORMz3Yf-BubO9u_DRpx6uuMvdO8hTlLkeZsc80GbGl4B
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=5weXgyPJV66GwxRtlM7kgmNQvnlAFYR7ET1vORMz3Yf-BubO9u_DRpx6uuMvdO8hTlLkeZsc80GbGl4B&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=5weXgyPJV66GwxRtlM7kgmNQvnlAFYR7ET1vORMz3Yf-BubO9u_DRpx6uuMvdO8hTlLkeZsc80GbGl4B&t=1"
       Request-Id:
-      - req_yPHizkGSyhU0qb
+      - req_IchMQVlXHdzOlq
       Stripe-Account:
       - acct_1SOb0DEwFhlcVS6d
       Stripe-Version:
@@ -72,7 +74,7 @@ http_interactions:
       X-Stripe-Routing-Context-Priority-Tier:
       - api-testmode
       X-Wc:
-      - ABGHIJ
+      - 3c3
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
     body:
@@ -88,6 +90,7 @@ http_interactions:
             "minority_owned_business_designation": null,
             "name": null,
             "product_description": null,
+            "specified_commercial_transactions_act_url": null,
             "support_address": null,
             "support_email": null,
             "support_phone": null,
@@ -325,5 +328,5 @@ http_interactions:
           },
           "type": "standard"
         }
-  recorded_at: Sat, 01 Nov 2025 19:00:43 GMT
+  recorded_at: Fri, 24 Apr 2026 15:05:36 GMT
 recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/User_OmniauthCallbacksController/_stripe_connect/when_referer_is_login/signs_in_directly_when_user_has_no_email.yml
+++ b/spec/support/fixtures/vcr_cassettes/User_OmniauthCallbacksController/_stripe_connect/when_referer_is_login/signs_in_directly_when_user_has_no_email.yml
@@ -14,14 +14,13 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_S3j4aoa2OzNQKJ","request_duration_ms":810}}'
+      - '{"last_request_metrics":{"request_id":"req_Bc84qj5LSz8rkz","request_duration_ms":3}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
-      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
-        version 6.14.0-33-generic (buildd@lcy02-amd64-026) (x86_64-linux-gnu-gcc-13
-        (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0, GNU ld (GNU Binutils for Ubuntu) 2.42)
-        #33~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC Fri Sep 19 17:02:30 UTC 2","hostname":"hsc-desk"}'
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        GumClaws-Mini 25.3.0 Darwin Kernel Version 25.3.0: Wed Jan 28 20:49:24 PST
+        2026; root:xnu-12377.81.4~5/RELEASE_ARM64_T8132 arm64","hostname":"GumClaws-Mini"}'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -34,11 +33,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Sat, 01 Nov 2025 19:00:48 GMT
+      - Fri, 24 Apr 2026 15:05:35 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '6699'
+      - '6754'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -56,11 +55,14 @@ http_interactions:
       - no-cache, no-store
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
-        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
-        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
-        https://q.stripe.com/csp-violation?q=XM2gL-jSTEX7Joh2OEplMLD9hts4M7lzv_RRu_kpwLuL2h_s6khJQtJA1x0da5j61LAgwQuksHUJGgUC
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=5weXgyPJV66GwxRtlM7kgmNQvnlAFYR7ET1vORMz3Yf-BubO9u_DRpx6uuMvdO8hTlLkeZsc80GbGl4B
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=5weXgyPJV66GwxRtlM7kgmNQvnlAFYR7ET1vORMz3Yf-BubO9u_DRpx6uuMvdO8hTlLkeZsc80GbGl4B&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=5weXgyPJV66GwxRtlM7kgmNQvnlAFYR7ET1vORMz3Yf-BubO9u_DRpx6uuMvdO8hTlLkeZsc80GbGl4B&t=1"
       Request-Id:
-      - req_MqJZ3U0l3WFH0X
+      - req_dQ77rpBLbguU3g
       Stripe-Account:
       - acct_1SOb0DEwFhlcVS6d
       Stripe-Version:
@@ -72,7 +74,7 @@ http_interactions:
       X-Stripe-Routing-Context-Priority-Tier:
       - api-testmode
       X-Wc:
-      - ABGHIJ
+      - 3c3
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
     body:
@@ -88,6 +90,7 @@ http_interactions:
             "minority_owned_business_designation": null,
             "name": null,
             "product_description": null,
+            "specified_commercial_transactions_act_url": null,
             "support_address": null,
             "support_email": null,
             "support_phone": null,
@@ -325,5 +328,5 @@ http_interactions:
           },
           "type": "standard"
         }
-  recorded_at: Sat, 01 Nov 2025 19:00:48 GMT
+  recorded_at: Fri, 24 Apr 2026 15:05:35 GMT
 recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/User_OmniauthCallbacksController/_stripe_connect/when_referer_is_signup/signs_in_directly_when_user_has_email.yml
+++ b/spec/support/fixtures/vcr_cassettes/User_OmniauthCallbacksController/_stripe_connect/when_referer_is_signup/signs_in_directly_when_user_has_email.yml
@@ -14,14 +14,13 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_Bc84qj5LSz8rkz","request_duration_ms":908}}'
+      - '{"last_request_metrics":{"request_id":"req_IGR0dv67sBdq0S","request_duration_ms":811}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
-      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
-        version 6.14.0-33-generic (buildd@lcy02-amd64-026) (x86_64-linux-gnu-gcc-13
-        (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0, GNU ld (GNU Binutils for Ubuntu) 2.42)
-        #33~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC Fri Sep 19 17:02:30 UTC 2","hostname":"hsc-desk"}'
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        GumClaws-Mini 25.3.0 Darwin Kernel Version 25.3.0: Wed Jan 28 20:49:24 PST
+        2026; root:xnu-12377.81.4~5/RELEASE_ARM64_T8132 arm64","hostname":"GumClaws-Mini"}'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -34,11 +33,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Sat, 01 Nov 2025 19:00:42 GMT
+      - Fri, 24 Apr 2026 15:05:37 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '6699'
+      - '6754'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -56,11 +55,14 @@ http_interactions:
       - no-cache, no-store
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
-        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
-        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
-        https://q.stripe.com/csp-violation?q=XM2gL-jSTEX7Joh2OEplMLD9hts4M7lzv_RRu_kpwLuL2h_s6khJQtJA1x0da5j61LAgwQuksHUJGgUC
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=k2TLUBn7_B9MZ5b5rCaE9vU6pIvGnv3oIzHLa0jcc7pgC11HaMpz6w_ycAlqsKfNGmVvvG8Both2u5Tx
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=k2TLUBn7_B9MZ5b5rCaE9vU6pIvGnv3oIzHLa0jcc7pgC11HaMpz6w_ycAlqsKfNGmVvvG8Both2u5Tx&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=k2TLUBn7_B9MZ5b5rCaE9vU6pIvGnv3oIzHLa0jcc7pgC11HaMpz6w_ycAlqsKfNGmVvvG8Both2u5Tx&t=1"
       Request-Id:
-      - req_xA423rsGfj9zGj
+      - req_rtvHD5Kkr5Gryl
       Stripe-Account:
       - acct_1SOb0DEwFhlcVS6d
       Stripe-Version:
@@ -72,7 +74,7 @@ http_interactions:
       X-Stripe-Routing-Context-Priority-Tier:
       - api-testmode
       X-Wc:
-      - ABGHIJ
+      - 3c3
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
     body:
@@ -88,6 +90,7 @@ http_interactions:
             "minority_owned_business_designation": null,
             "name": null,
             "product_description": null,
+            "specified_commercial_transactions_act_url": null,
             "support_address": null,
             "support_email": null,
             "support_phone": null,
@@ -325,5 +328,5 @@ http_interactions:
           },
           "type": "standard"
         }
-  recorded_at: Sat, 01 Nov 2025 19:00:42 GMT
+  recorded_at: Fri, 24 Apr 2026 15:05:37 GMT
 recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/User_OmniauthCallbacksController/_stripe_connect/when_referer_is_signup/signs_in_directly_when_user_has_no_email.yml
+++ b/spec/support/fixtures/vcr_cassettes/User_OmniauthCallbacksController/_stripe_connect/when_referer_is_signup/signs_in_directly_when_user_has_no_email.yml
@@ -14,14 +14,13 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_FWKLmX7uoWkTaa","request_duration_ms":886}}'
+      - '{"last_request_metrics":{"request_id":"req_FWKLmX7uoWkTaa","request_duration_ms":1}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
-      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
-        version 6.14.0-33-generic (buildd@lcy02-amd64-026) (x86_64-linux-gnu-gcc-13
-        (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0, GNU ld (GNU Binutils for Ubuntu) 2.42)
-        #33~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC Fri Sep 19 17:02:30 UTC 2","hostname":"hsc-desk"}'
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        GumClaws-Mini 25.3.0 Darwin Kernel Version 25.3.0: Wed Jan 28 20:49:24 PST
+        2026; root:xnu-12377.81.4~5/RELEASE_ARM64_T8132 arm64","hostname":"GumClaws-Mini"}'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -34,11 +33,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Sat, 01 Nov 2025 19:00:47 GMT
+      - Fri, 24 Apr 2026 15:05:37 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '6699'
+      - '6754'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -56,11 +55,14 @@ http_interactions:
       - no-cache, no-store
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
-        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
-        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
-        https://q.stripe.com/csp-violation?q=XM2gL-jSTEX7Joh2OEplMLD9hts4M7lzv_RRu_kpwLuL2h_s6khJQtJA1x0da5j61LAgwQuksHUJGgUC
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=k2TLUBn7_B9MZ5b5rCaE9vU6pIvGnv3oIzHLa0jcc7pgC11HaMpz6w_ycAlqsKfNGmVvvG8Both2u5Tx
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=k2TLUBn7_B9MZ5b5rCaE9vU6pIvGnv3oIzHLa0jcc7pgC11HaMpz6w_ycAlqsKfNGmVvvG8Both2u5Tx&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=k2TLUBn7_B9MZ5b5rCaE9vU6pIvGnv3oIzHLa0jcc7pgC11HaMpz6w_ycAlqsKfNGmVvvG8Both2u5Tx&t=1"
       Request-Id:
-      - req_S3j4aoa2OzNQKJ
+      - req_IGR0dv67sBdq0S
       Stripe-Account:
       - acct_1SOb0DEwFhlcVS6d
       Stripe-Version:
@@ -72,7 +74,7 @@ http_interactions:
       X-Stripe-Routing-Context-Priority-Tier:
       - api-testmode
       X-Wc:
-      - ABGHIJ
+      - 3c3
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
     body:
@@ -88,6 +90,7 @@ http_interactions:
             "minority_owned_business_designation": null,
             "name": null,
             "product_description": null,
+            "specified_commercial_transactions_act_url": null,
             "support_address": null,
             "support_email": null,
             "support_phone": null,
@@ -325,5 +328,5 @@ http_interactions:
           },
           "type": "standard"
         }
-  recorded_at: Sat, 01 Nov 2025 19:00:48 GMT
+  recorded_at: Fri, 24 Apr 2026 15:05:37 GMT
 recorded_with: VCR 6.2.0


### PR DESCRIPTION
## Summary
- Skip Gumroad's own 2FA when users log in via Google or Apple OAuth — the provider already enforces 2FA, and the risk of a hacked provider account being used to access Gumroad is minimal.
- 2FA is still required for email/password login.
- Updates the Stripe Connect OAuth flow and the shared `sign_in_with_oauth` helper (used by both Google and Apple) to call `sign_in` directly instead of `sign_in_or_prepare_for_two_factor_auth` and redirect to `two_factor_authentication_path`.

## Test plan
- [x] Updated specs in `spec/controllers/user/omniauth_callbacks_controller_spec.rb` — 2FA-related tests now assert the user is signed in directly and redirected to the destination without passing through `two_factor_authentication_path`.
- [x] `bundle exec rspec spec/controllers/user/omniauth_callbacks_controller_spec.rb -e "when user has 2FA" -e "signs in directly"` — 9 examples, 0 failures.
- [ ] Manually verify Google OAuth login for a user with 2FA enabled lands directly on the dashboard.
- [ ] Manually verify Apple OAuth login for a user with 2FA enabled lands directly on the dashboard.
- [ ] Manually verify email/password login for a user with 2FA enabled still requires the 2FA code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)