### PR TITLE
Treat OpenAI 400s as compliant in PromptStrategy, report to Sentry

### DIFF
--- a/app/services/content_moderation/strategies/prompt_strategy.rb
+++ b/app/services/content_moderation/strategies/prompt_strategy.rb
@@ -90,6 +90,9 @@ class ContentModeration::Strategies::PromptStrategy
         status: parsed["flagged"] ? "flagged" : "compliant",
         reasoning: parsed["reasoning"].to_s,
       }
+    rescue Faraday::BadRequestError => e
+      notify_openai_rejection(e, stage: "preset:#{preset[:name]}", images_sent: !preset[:skip_images])
+      { status: "compliant", reasoning: "" }
     rescue StandardError => e
       Rails.logger.error("ContentModeration::PromptStrategy preset evaluation error: #{e.message}")
       raise
@@ -118,9 +121,36 @@ class ContentModeration::Strategies::PromptStrategy
       parsed = JSON.parse(content)
 
       !parsed["uncertain"]
+    rescue Faraday::BadRequestError => e
+      notify_openai_rejection(e, stage: "uncertainty_check", images_sent: false)
+      false
     rescue StandardError => e
       Rails.logger.error("ContentModeration::PromptStrategy uncertainty check error: #{e.message}")
       raise
+    end
+
+    def notify_openai_rejection(error, stage:, images_sent:)
+      body = error.response&.dig(:body)
+      error_payload = body.is_a?(Hash) ? body["error"] : nil
+      error_message = error_payload.is_a?(Hash) ? error_payload["message"].to_s : body.to_s
+      error_code    = error_payload.is_a?(Hash) ? error_payload["code"] : nil
+      error_param   = error_payload.is_a?(Hash) ? error_payload["param"] : nil
+
+      Rails.logger.warn(
+        "ContentModeration::PromptStrategy OpenAI 400 on #{stage} (code=#{error_code}): #{error_message[0, 500]}"
+      )
+
+      ErrorNotifier.notify(
+        "ContentModeration::PromptStrategy OpenAI rejected input",
+        stage: stage,
+        model: MODEL,
+        openai_error_code: error_code,
+        openai_error_param: error_param,
+        openai_error_message: error_message[0, 1000],
+        text_length: @text.to_s.length,
+        image_url_count: @image_urls.size,
+        image_urls_sent: images_sent ? @image_urls.first(20) : [],
+      )
     end
 
     def build_messages(rules, skip_images: false)

--- a/spec/services/content_moderation/strategies/prompt_strategy_spec.rb
+++ b/spec/services/content_moderation/strategies/prompt_strategy_spec.rb
@@ -75,6 +75,74 @@ RSpec.describe ContentModeration::Strategies::PromptStrategy, :vcr do
     expect(Rails.logger).to have_received(:error).with("ContentModeration::PromptStrategy preset evaluation error: API failure").at_least(:once)
   end
 
+  context "when OpenAI rejects the request with a 400" do
+    let(:bad_request_response) do
+      {
+        status: 400,
+        body: {
+          "error" => {
+            "message" => "Error while downloading https://files.gumroad.com/bad.psd.",
+            "type" => "invalid_request_error",
+            "param" => nil,
+            "code" => "invalid_image_url",
+          }
+        },
+      }
+    end
+    let(:bad_request_error) { Faraday::BadRequestError.new("bad request", bad_request_response) }
+
+    it "treats both presets as compliant and reports each rejection to Sentry" do
+      allow(client).to receive(:chat).and_raise(bad_request_error)
+      allow(ErrorNotifier).to receive(:notify)
+
+      result = described_class.new(
+        text: "moderate me",
+        image_urls: ["https://files.gumroad.com/bad.psd", "https://cdn.example.com/ok.png"]
+      ).perform
+
+      expect(result.status).to eq("compliant")
+      expect(result.reasoning).to eq([])
+
+      expect(ErrorNotifier).to have_received(:notify).with(
+        "ContentModeration::PromptStrategy OpenAI rejected input",
+        hash_including(
+          stage: "preset:adult_content",
+          model: described_class::MODEL,
+          openai_error_code: "invalid_image_url",
+          openai_error_message: a_string_including("Error while downloading"),
+          text_length: "moderate me".length,
+          image_url_count: 2,
+          image_urls_sent: ["https://files.gumroad.com/bad.psd", "https://cdn.example.com/ok.png"],
+        )
+      )
+      expect(ErrorNotifier).to have_received(:notify).with(
+        "ContentModeration::PromptStrategy OpenAI rejected input",
+        hash_including(stage: "preset:spam", image_urls_sent: [])
+      )
+    end
+
+    it "skips the uncertainty flag and reports when the judge call is rejected" do
+      call_count = 0
+      allow(client).to receive(:chat) do |_kwargs|
+        call_count += 1
+        case call_count
+        when 1 then json_chat_response(flagged: true, reasoning: "looks explicit")
+        when 2 then raise bad_request_error
+        else json_chat_response(flagged: false, reasoning: "")
+        end
+      end
+      allow(ErrorNotifier).to receive(:notify)
+
+      result = described_class.new(text: "moderate me").perform
+
+      expect(result.status).to eq("compliant")
+      expect(ErrorNotifier).to have_received(:notify).with(
+        "ContentModeration::PromptStrategy OpenAI rejected input",
+        hash_including(stage: "uncertainty_check", openai_error_code: "invalid_image_url")
+      )
+    end
+  end
+
   def json_chat_response(payload)
     { "choices" => [{ "message" => { "content" => payload.to_json } }] }
   end


### PR DESCRIPTION
## What

Rescue `Faraday::BadRequestError` inside `ContentModeration::Strategies::PromptStrategy#evaluate_preset` and `#passes_uncertainty_check?`. When OpenAI returns a 400, the offending stage short-circuits to compliant and the whole event is reported to Sentry via `ErrorNotifier.notify` with:

- `stage` (`preset:adult_content`, `preset:spam`, or `uncertainty_check`)
- `model`
- `openai_error_code` / `openai_error_param` / `openai_error_message`
- `text_length`, `image_url_count`
- `image_urls_sent` (only populated for the stage that actually sent images)

Non-400 errors still raise, matching existing behavior.

## Why

Production is seeing a cluster of moderation failures, all from OpenAI's `gpt-4o-mini` chat completions returning `invalid_request_error / invalid_image_url` ("Error while downloading …"). Investigation traced the rejections to inputs the extractor shouldn't be sending in the first place:

- Unsupported formats (e.g. `.psd`, MIME `image/vnd.adobe.photoshop`)
- Files over OpenAI's 20 MB per-image limit
- Images over the 20 MP pixel-dimension limit
- `blob:` URLs scraped from description HTML (only valid in the browser session that created them)

The root cause is under-filtering in `ContentExtractor#product_image_urls` — only `cover_image_urls` MIME-filters blobs; `thumbnail_image_urls`, `product_description_image_urls`, `rich_content_file_image_urls` (`filegroup: "image"` is a UI category, not a MIME filter), and `rich_content_embedded_image_urls` don't. Any single bad image in the `sample(3)` draw makes OpenAI reject the whole request, which today propagates out of `ModerateRecordService` and blocks publish/update.

This PR is the short-term mitigation: unblock creators while we gather high-signal data (including the failing URLs) in Sentry to drive the proper extractor fix. `ClassifierStrategy` already uses the same pattern (`Faraday::BadRequestError` rescue + `ErrorNotifier.notify`), so this keeps the two strategies aligned.

## Before/After

Not a user-facing UI change — rendering a video here isn't meaningful. The behavior difference is:

- **Before:** OpenAI 400 → `evaluate_preset` / `passes_uncertainty_check?` log and re-raise → `ModerateRecordService#check` raises → `LinksController#update` / `#publish` errors and the save is blocked.
- **After:** OpenAI 400 → that stage returns compliant, the other preset still runs, `ModerateRecordService#check` returns normally, and an `ErrorNotifier.notify` event fires with all the context needed to investigate.

## Test Results

\`\`\`
$ bundle exec rspec spec/services/content_moderation/
43 examples, 0 failures
\`\`\`

New specs:
- `when OpenAI rejects the request with a 400 › treats both presets as compliant and reports each rejection to Sentry`
- `when OpenAI rejects the request with a 400 › skips the uncertainty flag and reports when the judge call is rejected`

---

Authored with Claude Opus 4.7 (1M context). Prompts given:

1. "check in read-only production console why these moderations failed, do not update the product." (plus an internal list of affected products)
2. "configure to report to sentry with detailed info when these error occur. For now, when OpenAI rejects the input, treat as pass but make sure it's reported to sentry"
3. "and send a PR"