### PR TITLE
Fix Faraday::ServerError crash in content moderation classifier

### DIFF
--- a/app/services/content_moderation/strategies/classifier_strategy.rb
+++ b/app/services/content_moderation/strategies/classifier_strategy.rb
@@ -88,9 +88,9 @@ class ContentModeration::Strategies::ClassifierStrategy
         attempts += 1
         response = @client.moderations(parameters: { model: "omni-moderation-latest", input: input })
         response.dig("results", 0, "category_scores") || {}
-      rescue Faraday::TimeoutError, Faraday::ParsingError => e
+      rescue Faraday::TimeoutError, Faraday::ParsingError, Faraday::ServerError => e
         if attempts < MAX_MODERATION_ATTEMPTS
-          Rails.logger.warn("ContentModeration::ClassifierStrategy error on attempt #{attempts}/#{MAX_MODERATION_ATTEMPTS}, retrying: #{e.message}")
+          Rails.logger.warn("ContentModeration::ClassifierStrategy #{e.class.name.demodulize} on attempt #{attempts}/#{MAX_MODERATION_ATTEMPTS}, retrying: #{e.message}")
           retry
         end
         raise

--- a/spec/services/content_moderation/strategies/classifier_strategy_spec.rb
+++ b/spec/services/content_moderation/strategies/classifier_strategy_spec.rb
@@ -206,8 +206,8 @@ RSpec.describe ContentModeration::Strategies::ClassifierStrategy, :vcr do
 
     expect(result.status).to eq("compliant")
     expect(call_count).to eq(3)
-    expect(Rails.logger).to have_received(:warn).with(/error on attempt 1\/3, retrying/).once
-    expect(Rails.logger).to have_received(:warn).with(/error on attempt 2\/3, retrying/).once
+    expect(Rails.logger).to have_received(:warn).with(/TimeoutError on attempt 1\/3, retrying/).once
+    expect(Rails.logger).to have_received(:warn).with(/TimeoutError on attempt 2\/3, retrying/).once
   end
 
   it "gives up after MAX_MODERATION_ATTEMPTS timeouts and re-raises" do
@@ -229,13 +229,36 @@ RSpec.describe ContentModeration::Strategies::ClassifierStrategy, :vcr do
 
     expect(result.status).to eq("compliant")
     expect(call_count).to eq(2)
-    expect(Rails.logger).to have_received(:warn).with(/error on attempt 1\/3, retrying/).once
+    expect(Rails.logger).to have_received(:warn).with(/ParsingError on attempt 1\/3, retrying/).once
   end
 
   it "gives up after MAX_MODERATION_ATTEMPTS parsing errors and re-raises" do
     allow(client).to receive(:moderations).and_raise(Faraday::ParsingError, "unexpected character: 'upstream' at line 1 column 1")
 
     expect { described_class.new(text:, image_urls: []).perform }.to raise_error(Faraday::ParsingError)
+    expect(client).to have_received(:moderations).exactly(described_class::MAX_MODERATION_ATTEMPTS).times
+  end
+
+  it "retries on Faraday::ServerError and succeeds when a subsequent attempt returns" do
+    call_count = 0
+    allow(client).to receive(:moderations) do
+      call_count += 1
+      raise Faraday::ServerError, "500 Internal Server Error" if call_count < 3
+      { "results" => [{ "category_scores" => {} }] }
+    end
+
+    result = described_class.new(text:, image_urls: []).perform
+
+    expect(result.status).to eq("compliant")
+    expect(call_count).to eq(3)
+    expect(Rails.logger).to have_received(:warn).with(/ServerError on attempt 1\/3, retrying/).once
+    expect(Rails.logger).to have_received(:warn).with(/ServerError on attempt 2\/3, retrying/).once
+  end
+
+  it "gives up after MAX_MODERATION_ATTEMPTS server errors and re-raises" do
+    allow(client).to receive(:moderations).and_raise(Faraday::ServerError, "500 Internal Server Error")
+
+    expect { described_class.new(text:, image_urls: []).perform }.to raise_error(Faraday::ServerError)
     expect(client).to have_received(:moderations).exactly(described_class::MAX_MODERATION_ATTEMPTS).times
   end
 end


### PR DESCRIPTION
## Problem

`ClassifierStrategy#moderate` rescues `Faraday::TimeoutError` (with retry) and `Faraday::BadRequestError` (skip for images), but not `Faraday::ServerError`. When OpenAI's moderation API returns HTTP 500, the exception propagates all the way up through `ModerateRecordService` to `LinksController#publish`, crashing the publish action.

**Sentry:** https://gumroad-to.sentry.io/issues/7439774968/

## Fix

Add `Faraday::ServerError` to the same rescue clause as `Faraday::TimeoutError`. Both now retry up to `MAX_MODERATION_ATTEMPTS` (3) times before re-raising. The log message uses `e.class.name.demodulize` to distinguish between error types.

## Changes
- `classifier_strategy.rb`: rescue `Faraday::ServerError` alongside `TimeoutError` 
- `classifier_strategy_spec.rb`: two new tests for ServerError retry + exhaustion, updated existing timeout test expectation for the new log format