### PR TITLE
Filter unsupported image formats in ContentModeration::PromptStrategy

### DIFF
--- a/app/services/content_moderation/strategies/prompt_strategy.rb
+++ b/app/services/content_moderation/strategies/prompt_strategy.rb
@@ -32,6 +32,7 @@ class ContentModeration::Strategies::PromptStrategy
 
   MODEL = "gpt-4o-mini"
   JUDGE_MODEL = "gpt-4o-mini"
+  SUPPORTED_IMAGE_EXTENSIONS = %w[.png .jpg .jpeg .gif .webp].freeze
 
   def initialize(text:, image_urls: [])
     @text = text
@@ -153,12 +154,26 @@ class ContentModeration::Strategies::PromptStrategy
       )
     end
 
+    def supported_image_url?(url)
+      path = URI.parse(url).path.to_s
+      ext = File.extname(path).downcase
+      SUPPORTED_IMAGE_EXTENSIONS.include?(ext)
+    rescue URI::InvalidURIError
+      false
+    end
+
     def build_messages(rules, skip_images: false)
       user_content = []
       user_content << { type: "text", text: "Content to evaluate:\n\n#{@text.presence || '[no text provided]'}" }
 
       if !skip_images && @image_urls.present?
-        @image_urls.sample(3).each do |url|
+        supported_urls = @image_urls.select { |url| supported_image_url?(url) }
+        if supported_urls.empty? && @image_urls.any?
+          Rails.logger.warn(
+            "ContentModeration::PromptStrategy filtered out all #{@image_urls.size} image URLs (unsupported formats)"
+          )
+        end
+        supported_urls.sample(3).each do |url|
           user_content << { type: "image_url", image_url: { url: url } }
         end
       end

--- a/spec/services/content_moderation/strategies/prompt_strategy_spec.rb
+++ b/spec/services/content_moderation/strategies/prompt_strategy_spec.rb
@@ -143,6 +143,67 @@ RSpec.describe ContentModeration::Strategies::PromptStrategy, :vcr do
     end
   end
 
+  context "when image URLs have unsupported formats" do
+    it "filters out unsupported image formats before sending to OpenAI" do
+      allow(client).to receive(:chat).and_return(
+        json_chat_response(flagged: false, reasoning: ""),
+        json_chat_response(flagged: false, reasoning: "")
+      )
+
+      described_class.new(
+        text: "test",
+        image_urls: ["https://cdn.example.com/photo.png", "https://cdn.example.com/design.psd", "https://cdn.example.com/logo.svg"]
+      ).perform
+
+      adult_call = client.as_null_object
+      expect(client).to have_received(:chat).with(
+        parameters: hash_including(
+          messages: [
+            anything,
+            {
+              role: "user",
+              content: [
+                { type: "text", text: anything },
+                { type: "image_url", image_url: { url: "https://cdn.example.com/photo.png" } },
+              ],
+            },
+          ]
+        )
+      ).at_least(:once)
+    end
+
+    it "evaluates text-only when all image URLs are unsupported" do
+      allow(client).to receive(:chat).and_return(
+        json_chat_response(flagged: false, reasoning: ""),
+        json_chat_response(flagged: false, reasoning: "")
+      )
+
+      result = described_class.new(
+        text: "test",
+        image_urls: ["https://cdn.example.com/design.psd", "https://cdn.example.com/file.ai", "https://cdn.example.com/photo.tiff"]
+      ).perform
+
+      expect(result.status).to eq("compliant")
+      expect(Rails.logger).to have_received(:warn).with(
+        /filtered out all 3 image URLs \(unsupported formats\)/
+      )
+    end
+
+    it "passes through supported formats normally" do
+      allow(client).to receive(:chat).and_return(
+        json_chat_response(flagged: false, reasoning: ""),
+        json_chat_response(flagged: false, reasoning: "")
+      )
+
+      described_class.new(
+        text: "test",
+        image_urls: ["https://cdn.example.com/a.jpg", "https://cdn.example.com/b.jpeg", "https://cdn.example.com/c.gif", "https://cdn.example.com/d.webp"]
+      ).perform
+
+      expect(client).to have_received(:chat).at_least(:once)
+    end
+  end
+
   def json_chat_response(payload)
     { "choices" => [{ "message" => { "content" => payload.to_json } }] }
   end


### PR DESCRIPTION
## Problem

`PromptStrategy#build_messages` sends image URLs directly to OpenAI's chat API without checking if the format is supported. When unsupported formats like `.psd` are included, OpenAI returns a 400 `invalid_image_url` error. Since all images are batched in one request, one bad URL fails the entire moderation call and generates unnecessary Sentry noise.

**Sentry:** https://gumroad-to.sentry.io/issues/7439574034/

## Fix

Pre-filter image URLs to only include OpenAI-supported formats (PNG, JPEG, GIF, WebP) before sampling and sending. If all URLs are filtered out, logs a warning and proceeds with text-only evaluation.

## Changes
- `prompt_strategy.rb`: add `SUPPORTED_IMAGE_EXTENSIONS` constant and `supported_image_url?` method, filter URLs in `build_messages`
- `prompt_strategy_spec.rb`: three new tests for unsupported format filtering, all-filtered warning, and supported format passthrough