### PR TITLE
Add timeout guards and eager loading to CheckoutController#show

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -1,14 +1,28 @@
 # frozen_string_literal: true
 
 class CheckoutController < ApplicationController
+  CHECKOUT_PROPS_TIMEOUT_SECONDS = 60
+  RECOMMENDED_PRODUCTS_TIMEOUT_SECONDS = 10
+
   layout "inertia"
 
   before_action :process_cart_id_param, only: [:show]
 
   def show
+    browser_guid = cookies[:_gumroad_guid]
+    checkout_presenter = CheckoutPresenter.new(logged_in_user:, ip: request.remote_ip)
+
     render inertia: "Checkout/Show", props: {
-      cart: -> { CartPresenter.new(logged_in_user:, ip: request.remote_ip, browser_guid: cookies[:_gumroad_guid]).cart_props },
-      checkout: -> { CheckoutPresenter.new(logged_in_user:, ip: request.remote_ip).checkout_props(params:, browser_guid: cookies[:_gumroad_guid]) },
+      cart: -> do
+        with_checkout_props_timeout(prop_name: "cart", fallback: -> { nil }) do
+          CartPresenter.new(logged_in_user:, ip: request.remote_ip, browser_guid:).cart_props
+        end
+      end,
+      checkout: -> do
+        with_checkout_props_timeout(prop_name: "checkout", fallback: -> { checkout_presenter.checkout_fallback_props }) do
+          checkout_presenter.checkout_props(params:, browser_guid:)
+        end
+      end,
       recommended_products: InertiaRails.optional { recommended_products },
     }
   end
@@ -106,8 +120,6 @@ class CheckoutController < ApplicationController
       true
     end
 
-    RECOMMENDED_PRODUCTS_TIMEOUT_SECONDS = 10
-
     def recommended_products
       args = {
         purchaser: logged_in_user,
@@ -132,6 +144,13 @@ class CheckoutController < ApplicationController
     rescue Timeout::Error
       Rails.logger.warn("[CheckoutController] Recommended products timed out after #{RECOMMENDED_PRODUCTS_TIMEOUT_SECONDS}s")
       []
+    end
+
+    def with_checkout_props_timeout(prop_name:, fallback:, &block)
+      Timeout.timeout(CHECKOUT_PROPS_TIMEOUT_SECONDS, &block)
+    rescue Timeout::Error
+      Rails.logger.warn("[CheckoutController] #{prop_name} props timed out after #{CHECKOUT_PROPS_TIMEOUT_SECONDS}s")
+      fallback.call
     end
 
     def update_permitted_params

--- a/app/presenters/cart_presenter.rb
+++ b/app/presenters/cart_presenter.rb
@@ -25,6 +25,8 @@ class CartPresenter
           :variant_categories_alive,
           :alive_variants,
           { available_upsell: :seller },
+          { available_cross_sells: [:product, :offer_code, :variant] },
+          :available_upsell_variants,
         ] }
       ).load
 

--- a/app/presenters/checkout_presenter.rb
+++ b/app/presenters/checkout_presenter.rb
@@ -47,6 +47,27 @@ class CheckoutPresenter
     }
   end
 
+  def checkout_fallback_props
+    {
+      **checkout_common,
+      country: Compliance::Countries.find_by_name(logged_in_user&.country)&.alpha2,
+      state: logged_in_user&.state,
+      address: logged_in_user ? {
+        street: logged_in_user.street_address,
+        zip: logged_in_user.zip_code,
+        city: logged_in_user.city,
+      } : nil,
+      saved_credit_card: CheckoutPresenter.saved_card(logged_in_user&.credit_card),
+      gift: nil,
+      clear_cart: false,
+      add_products: [],
+      max_allowed_cart_products: Cart::MAX_ALLOWED_CART_PRODUCTS,
+      cart_save_debounce_ms: CART_SAVE_DEBOUNCE_DURATION_IN_SECONDS.in_milliseconds,
+      tip_options: TipOptionsService.get_tip_options,
+      default_tip_option: TipOptionsService.get_default_tip_option,
+    }
+  end
+
   def checkout_product(product, cart_item, params, include_cross_sells: true)
     return unless product.present?
     upsell_variants = product.available_upsell_variants.alive.includes(:selected_variant, :offered_variant)

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -52,6 +52,28 @@ describe CheckoutController, type: :controller, inertia: true do
       )
     end
 
+    describe "timeout fallbacks" do
+      it "returns nil cart when cart props time out" do
+        allow_any_instance_of(CartPresenter).to receive(:cart_props).and_raise(Timeout::Error)
+
+        expect { get :show }.not_to raise_error
+
+        expect(response).to be_successful
+        expect(inertia.component).to eq("Checkout/Show")
+        expect(inertia.props[:cart]).to be_nil
+      end
+
+      it "returns fallback checkout props when checkout props time out" do
+        allow_any_instance_of(CheckoutPresenter).to receive(:checkout_props).and_raise(Timeout::Error)
+
+        get :show
+
+        expect(response).to be_successful
+        expect(inertia.component).to eq("Checkout/Show")
+        expect(inertia.props[:checkout]).to eq(CheckoutPresenter.new(logged_in_user: nil, ip: request.remote_ip).checkout_fallback_props)
+      end
+    end
+
     describe "process_cart_id_param check" do
       let(:user) { create(:user) }
       let(:cart) { create(:cart, user:) }


### PR DESCRIPTION
## Problem

`CheckoutController#show` was hitting Rack::Timeout (120s) and getting SIGTERMed. The `cart` and `checkout` lazy Inertia props had no timeout protection, while `recommended_products` already had a 10-second guard.

The root cause is N+1 queries in `CartPresenter#cart_props`: for each cart product, `checkout_product` loads `available_cross_sells` and `available_upsell_variants` individually. With many products and cross-sells, this cascades into hundreds of queries.

**Sentry:** https://gumroad-to.sentry.io/issues/7439778950/

## Fix

1. **Timeout guards**: Wrap `cart` and `checkout` props in 60-second `Timeout.timeout` blocks. On timeout:
   - `cart` returns `nil` (the page already handles this)
   - `checkout` returns a safe fallback payload via `checkout_fallback_props` that satisfies the Inertia page contract without expensive queries

2. **Eager loading**: Extended the cart products preload in `CartPresenter` to include `available_cross_sells` (with product, offer_code, variant) and `available_upsell_variants`, eliminating the N+1 pattern.

## Changes
- `checkout_controller.rb`: timeout wrapper around cart/checkout props
- `checkout_presenter.rb`: `checkout_fallback_props` method with safe defaults
- `cart_presenter.rb`: extended preload to cover cross-sell associations
- `checkout_controller_spec.rb`: timeout fallback tests for both props

## Note
2 existing spec failures in `checkout_controller_spec.rb` are unrelated (fail during `create(:purchase)` setup before our code runs).