### PR TITLE
Add test confidence score (0-100) to CI

### DIFF
--- a/.github/scripts/test-confidence.sh
+++ b/.github/scripts/test-confidence.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# Test Confidence Score Calculator
+#
+# Computes a 0-100 confidence score based on test shard results.
+# 0-98  = FAILING (not enough shards passed)
+# 99    = NEUTRAL (high pass rate but not perfect)
+# 100   = PASSING (all shards passed)
+#
+# The score is a weighted combination of:
+# - Fast test pass rate (unit/controller tests, lower weight)
+# - Slow test pass rate (E2E/system tests, higher weight because they catch integration issues)
+#
+# Usage: test-confidence.sh <fast_total> <fast_passed> <slow_total> <slow_passed>
+
+set -euo pipefail
+
+FAST_TOTAL="${1:?Usage: test-confidence.sh <fast_total> <fast_passed> <slow_total> <slow_passed>}"
+FAST_PASSED="${2:?}"
+SLOW_TOTAL="${3:?}"
+SLOW_PASSED="${4:?}"
+
+TOTAL=$((FAST_TOTAL + SLOW_TOTAL))
+PASSED=$((FAST_PASSED + SLOW_PASSED))
+FAILED=$((TOTAL - PASSED))
+
+FAST_FAILED=$((FAST_TOTAL - FAST_PASSED))
+SLOW_FAILED=$((SLOW_TOTAL - SLOW_PASSED))
+
+# Perfect score: all shards passed
+if [ "$FAILED" -eq 0 ]; then
+  echo "100"
+  exit 0
+fi
+
+# Calculate weighted confidence
+# Fast tests: 30% weight (unit tests, less integration signal)
+# Slow tests: 70% weight (E2E tests, high integration signal)
+python3 << PYEOF
+import math
+
+fast_total = $FAST_TOTAL
+fast_passed = $FAST_PASSED
+slow_total = $SLOW_TOTAL
+slow_passed = $SLOW_PASSED
+
+fast_rate = fast_passed / fast_total if fast_total > 0 else 1.0
+slow_rate = slow_passed / slow_total if slow_total > 0 else 1.0
+
+# Weighted pass rate
+weighted_rate = 0.3 * fast_rate + 0.7 * slow_rate
+
+# Map to 0-98 range (since 99=neutral, 100=passing)
+# Use a curve that penalizes failures heavily
+# Any failure drops us below 99
+if weighted_rate == 1.0:
+    score = 100
+elif weighted_rate >= 0.99:
+    score = 99  # neutral: very close but not perfect
+else:
+    # Scale 0-0.99 to 0-98
+    # Apply a curve that makes low pass rates score very low
+    score = int(weighted_rate * 98)
+
+# Additional penalty: each slow test failure is more costly
+slow_failed = slow_total - slow_passed
+fast_failed = fast_total - fast_passed
+
+if slow_failed > 0:
+    # Each slow test failure costs more confidence
+    penalty = min(slow_failed * 3, 30)
+    score = max(0, score - penalty)
+
+if fast_failed > 0:
+    penalty = min(fast_failed * 1, 10)
+    score = max(0, score - penalty)
+
+print(score)
+PYEOF

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -446,6 +446,103 @@ jobs:
           docker volume rm $(docker volume ls -q -f name=${{ env.COMPOSE_PROJECT_NAME }}) 2>/dev/null || true
           docker network rm ${{ env.COMPOSE_PROJECT_NAME }}_default 2>/dev/null || true
 
+  test_confidence:
+    name: Test Confidence
+    runs-on: ubicloud-standard-2
+    needs: [test_fast, test_slow]
+    if: always() && (github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name != github.repository)
+    outputs:
+      score: ${{ steps.score.outputs.confidence }}
+      status: ${{ steps.score.outputs.status }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/scripts
+
+      - name: Compute confidence score
+        id: score
+        env:
+          FAST_TOTAL: 20
+          SLOW_TOTAL: 65
+        run: |
+          chmod +x .github/scripts/test-confidence.sh
+
+          # Count passed shards from job outcomes
+          FAST_PASSED=0
+          SLOW_PASSED=0
+
+          # Parse needs context for pass/fail counts
+          FAST_RESULT="${{ needs.test_fast.result }}"
+          SLOW_RESULT="${{ needs.test_slow.result }}"
+
+          if [ "$FAST_RESULT" = "success" ]; then
+            FAST_PASSED=$FAST_TOTAL
+          else
+            # When the matrix partially fails, the job result is 'failure'
+            # but individual shards may have passed. We count all as failed
+            # for simplicity since GitHub doesn't expose per-matrix outcomes.
+            FAST_PASSED=0
+          fi
+
+          if [ "$SLOW_RESULT" = "success" ]; then
+            SLOW_PASSED=$SLOW_TOTAL
+          else
+            SLOW_PASSED=0
+          fi
+
+          SCORE=$(bash .github/scripts/test-confidence.sh $FAST_TOTAL $FAST_PASSED $SLOW_TOTAL $SLOW_PASSED)
+
+          if [ "$SCORE" -eq 100 ]; then
+            STATUS="passing"
+          elif [ "$SCORE" -eq 99 ]; then
+            STATUS="neutral"
+          else
+            STATUS="failing"
+          fi
+
+          echo "confidence=$SCORE" >> $GITHUB_OUTPUT
+          echo "status=$STATUS" >> $GITHUB_OUTPUT
+          echo "🎯 Test Confidence: $SCORE% ($STATUS)"
+          echo "   Fast tests: $FAST_RESULT ($FAST_PASSED/$FAST_TOTAL passed)"
+          echo "   Slow tests: $SLOW_RESULT ($SLOW_PASSED/$SLOW_TOTAL passed)"
+
+      - name: Post confidence to PR
+        if: github.event_name == 'pull_request_target'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const score = '${{ steps.score.outputs.confidence }}';
+            const status = '${{ steps.score.outputs.status }}';
+            const emoji = score == '100' ? '🟢' : score == '99' ? '🟡' : '🔴';
+            const body = `## ${emoji} Test Confidence: ${score}%\n\n` +
+              `**Status:** ${status}\n` +
+              `- Fast tests: ${{ needs.test_fast.result }}\n` +
+              `- Slow tests: ${{ needs.test_slow.result }}\n\n` +
+              (score == '100' ? '✅ All test shards passed.' :
+               score == '99' ? '⚠️ Very close to passing. Minor issues detected.' :
+               `❌ Confidence below threshold. Score: ${score}/100.`);
+
+            // Find and update existing comment or create new one
+            const { data: comments } = await github.rest.issues.listComments({
+              ...context.repo,
+              issue_number: context.payload.pull_request.number,
+            });
+            const botComment = comments.find(c => c.body.includes('Test Confidence:'));
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                ...context.repo,
+                comment_id: botComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: context.payload.pull_request.number,
+                body,
+              });
+            }
+
   unblock_deployment_from_buildkite:
     name: Unblock deployment from Buildkite
     runs-on: ubicloud-standard-2


### PR DESCRIPTION
## What

Adds a **Test Confidence** score (0-100) to every CI run:

- **100** = 🟢 PASSING (all 85 test shards green)
- **99** = 🟡 NEUTRAL (very close but not perfect)
- **0-98** = 🔴 FAILING (confidence score based on weighted pass rates)

Posts a confidence comment on PRs with the score and breakdown.

## How it works

After all test shards complete, a new `test_confidence` job:
1. Collects pass/fail results from fast (20 shards) and slow (65 shards) test jobs
2. Computes a weighted confidence score (slow/E2E tests weighted 70%, fast/unit tests 30%)
3. Applies penalties per failure (slow: -3pts each, fast: -1pt each)
4. Posts a comment on the PR with the score and status

## Why

Foundation for Predictive Test Selection (PTS). Instead of binary pass/fail, CI now produces a confidence metric that can drive:
- Adaptive test streaming (run waves, stop when confidence crosses threshold)
- Per-path thresholds (`app/billing/**` → 99.999%, `docs/**` → 90%)
- LLM-powered diff analysis to predict which tests matter most

## Future

This PR is step 1. Next steps:
- Per-matrix shard outcome tracking (currently GitHub doesn't expose individual matrix job results cleanly)
- Historical confidence tracking in Metabase
- Adaptive stopping rule (Sequential Probability Ratio Test)
- Per-path confidence thresholds in a config file