### PR TITLE
Handle Faraday::TimeoutError in content moderation PromptStrategy

### DIFF
--- a/app/services/content_moderation/strategies/prompt_strategy.rb
+++ b/app/services/content_moderation/strategies/prompt_strategy.rb
@@ -66,6 +66,9 @@ class ContentModeration::Strategies::PromptStrategy
     else
       Result.new(status: "compliant", reasoning: [])
     end
+  rescue Faraday::TimeoutError, Faraday::ConnectionFailed, Net::ReadTimeout => e
+    Rails.logger.warn("ContentModeration::PromptStrategy timeout: #{e.class} - #{e.message}")
+    Result.new(status: "compliant", reasoning: [])
   rescue StandardError => e
     Rails.logger.error("ContentModeration::PromptStrategy error: #{e.message}")
     raise
@@ -93,6 +96,9 @@ class ContentModeration::Strategies::PromptStrategy
       }
     rescue Faraday::BadRequestError => e
       notify_openai_rejection(e, stage: "preset:#{preset[:name]}", images_sent: !preset[:skip_images])
+      { status: "compliant", reasoning: "" }
+    rescue Faraday::TimeoutError, Faraday::ConnectionFailed, Net::ReadTimeout => e
+      Rails.logger.warn("ContentModeration::PromptStrategy preset timeout on #{preset[:name]}: #{e.class} - #{e.message}")
       { status: "compliant", reasoning: "" }
     rescue StandardError => e
       Rails.logger.error("ContentModeration::PromptStrategy preset evaluation error: #{e.message}")
@@ -124,6 +130,9 @@ class ContentModeration::Strategies::PromptStrategy
       !parsed["uncertain"]
     rescue Faraday::BadRequestError => e
       notify_openai_rejection(e, stage: "uncertainty_check", images_sent: false)
+      false
+    rescue Faraday::TimeoutError, Faraday::ConnectionFailed, Net::ReadTimeout => e
+      Rails.logger.warn("ContentModeration::PromptStrategy uncertainty check timeout: #{e.class} - #{e.message}")
       false
     rescue StandardError => e
       Rails.logger.error("ContentModeration::PromptStrategy uncertainty check error: #{e.message}")

--- a/spec/services/content_moderation/strategies/prompt_strategy_spec.rb
+++ b/spec/services/content_moderation/strategies/prompt_strategy_spec.rb
@@ -204,6 +204,54 @@ RSpec.describe ContentModeration::Strategies::PromptStrategy, :vcr do
     end
   end
 
+  context "when OpenAI times out" do
+    it "returns compliant when a preset evaluation times out" do
+      allow(client).to receive(:chat).and_raise(Faraday::TimeoutError)
+
+      result = described_class.new(text: "moderate me", image_urls: ["https://cdn.example.com/1.png"]).perform
+
+      expect(result.status).to eq("compliant")
+      expect(result.reasoning).to eq([])
+      expect(Rails.logger).to have_received(:warn).with(/preset timeout on adult_content.*Faraday::TimeoutError/)
+    end
+
+    it "returns compliant when a Net::ReadTimeout occurs" do
+      allow(client).to receive(:chat).and_raise(Net::ReadTimeout)
+
+      result = described_class.new(text: "moderate me").perform
+
+      expect(result.status).to eq("compliant")
+      expect(result.reasoning).to eq([])
+      expect(Rails.logger).to have_received(:warn).with(/preset timeout on adult_content.*Net::ReadTimeout/)
+    end
+
+    it "skips the flagged result when the uncertainty check times out" do
+      call_count = 0
+      allow(client).to receive(:chat) do |_kwargs|
+        call_count += 1
+        case call_count
+        when 1 then json_chat_response(flagged: true, reasoning: "looks explicit")
+        when 2 then raise Faraday::TimeoutError
+        else json_chat_response(flagged: false, reasoning: "")
+        end
+      end
+
+      result = described_class.new(text: "moderate me").perform
+
+      expect(result.status).to eq("compliant")
+      expect(Rails.logger).to have_received(:warn).with(/uncertainty check timeout.*Faraday::TimeoutError/)
+    end
+
+    it "returns compliant when a Faraday::ConnectionFailed occurs" do
+      allow(client).to receive(:chat).and_raise(Faraday::ConnectionFailed, "connection refused")
+
+      result = described_class.new(text: "moderate me").perform
+
+      expect(result.status).to eq("compliant")
+      expect(result.reasoning).to eq([])
+    end
+  end
+
   def json_chat_response(payload)
     { "choices" => [{ "message" => { "content" => payload.to_json } }] }
   end


### PR DESCRIPTION
## Problem

`LinksController#publish` was crashing with `Faraday::TimeoutError: Net::ReadTimeout` when OpenAI API calls in the content moderation `PromptStrategy` timed out. The timeout propagated through the validation layer and killed the publish action, preventing creators from publishing their products.

**Sentry:** https://gumroad-to.sentry.io/issues/7439854354/

## Fix

Added rescue clauses for `Faraday::TimeoutError`, `Faraday::ConnectionFailed`, and `Net::ReadTimeout` at all three levels in `PromptStrategy`:

1. **`perform`**: Returns compliant on timeout (fail open)
2. **`evaluate_preset`**: Returns compliant for the preset on timeout (matches existing `BadRequestError` behavior)
3. **`passes_uncertainty_check?`**: Returns `false` on timeout (skips the flagged result, matches existing `BadRequestError` behavior)

Content moderation should never block a creator from publishing due to a transient API timeout.

## Tests

Added 4 tests covering timeout/connection-failure scenarios at all three levels. All 11 tests pass.