### PR TITLE
Fix ArgumentError in Rack::Attack: use RedisProxy instead of RedisStoreProxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ test-branch-creation.log
 .vercel
 .claude/worktrees/
 autoresearch.*
+.codex/

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -3,7 +3,7 @@
 class Rack::Attack
   redis_url    = ENV.fetch("RACK_ATTACK_REDIS_HOST")
   redis_client = Redis.new(url: "redis://#{redis_url}")
-  Rack::Attack.cache.store = Rack::Attack::StoreProxy::RedisStoreProxy.new(redis_client)
+  Rack::Attack.cache.store = Rack::Attack::StoreProxy::RedisProxy.new(redis_client)
 
   class Request < ::Rack::Request
     # When the server is behind a load balancer


### PR DESCRIPTION
## Problem

`Rack::Attack` was crashing with `ArgumentError: wrong number of arguments (given 4, expected 3)` because it used `RedisStoreProxy` with a plain `Redis` client.

`RedisStoreProxy.setex` passes `raw: true` as a 4th argument, but the plain `redis` gem (5.x) `setex(key, ttl, value)` only accepts 3 positional args.

## Fix

One-line change: `RedisStoreProxy` → `RedisProxy`, which is designed for plain `Redis` clients and doesn't pass the extra `raw:` kwarg.

Also added `.codex/` to `.gitignore` to prevent codex worktree directories from being committed.