### PR TITLE
Fix test-subset workflow Docker networking

### DIFF
--- a/.github/workflows/test-subset.yml
+++ b/.github/workflows/test-subset.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubicloud-standard-4
     needs: build
     env:
-      COMPOSE_PROJECT_NAME: web_${{ github.run_id }}_subset
+      COMPOSE_PROJECT_NAME: web_${{ github.run_id }}_${{ github.run_attempt }}_subset
       WEB_REPO: gumroadteam/web
     steps:
       - uses: actions/checkout@v4
@@ -74,44 +74,62 @@ jobs:
           max_attempts: 3
           retry_wait_seconds: 5
           command: |
+            docker pull --quiet $WEB_REPO:test-${{ github.sha }} &
+            PULL_PID=$!
             docker compose -f docker/docker-compose-test-and-ci.yml up -d
-            docker pull "$WEB_REPO:test-${{ github.sha }}"
+            COMPOSE_EXIT=$?
+            wait $PULL_PID
+            PULL_EXIT=$?
+            exit $((COMPOSE_EXIT + PULL_EXIT))
+        env:
+          COMPOSE_HTTP_TIMEOUT: "300"
 
       - name: Wait for services
-        run: |
-          docker compose -f docker/docker-compose-test-and-ci.yml exec -T db mysqladmin ping --wait=30 -uroot -ppassword || true
-          sleep 5
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 5
+          command: |
+            IMG=$WEB_REPO:test-${{ github.sha }}
+            NET=${{ env.COMPOSE_PROJECT_NAME }}_default
+            docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh db_test 3306 &
+            docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh elasticsearch 9200 &
+            docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh minio 9000 &
+            wait
+
+      - name: Setup test database
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 10
+          command: |
+            docker run --rm --entrypoint="" --network ${{ env.COMPOSE_PROJECT_NAME }}_default \
+              -e RAILS_ENV=test \
+              $WEB_REPO:test-${{ github.sha }} \
+              bundle exec rake db:prepare
 
       - name: Run test subset
         run: |
           TEST_FILES="${{ inputs.test_files }}"
-          # Convert comma-separated to space-separated for rspec
+          # Convert comma-separated to space-separated
           TEST_FILES_SPACED=$(echo "$TEST_FILES" | tr ',' ' ')
 
-          docker run --rm \
-            --network ${COMPOSE_PROJECT_NAME}_default \
-            -e RAILS_ENV=test \
+          docker run --rm --entrypoint="" --network ${{ env.COMPOSE_PROJECT_NAME }}_default \
+            -e RUBY_YJIT_ENABLE=1 \
             -e CI=true \
-            -e DATABASE_HOST=db \
-            -e REDIS_URL=redis://redis:6379/0 \
-            -e MEMCACHE_SERVERS=memcached:11211 \
-            -e ELASTICSEARCH_URL=http://opensearch:9200 \
-            "$WEB_REPO:test-${{ github.sha }}" \
+            -e IN_DOCKER=true \
+            $WEB_REPO:test-${{ github.sha }} \
             /usr/local/bin/gosu app bundle exec rspec \
-              --format json --out /tmp/test-results.json \
               --format progress \
+              --tag ~skip \
               $TEST_FILES_SPACED
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-confidence-results
-          path: /tmp/test-results.json
-          if-no-files-found: ignore
+        timeout-minutes: 15
 
       - name: Clean up
         if: always()
         run: |
           docker compose -f docker/docker-compose-test-and-ci.yml down -v 2>/dev/null || true
           docker rm -f $(docker ps -aq -f name=${{ env.COMPOSE_PROJECT_NAME }}) 2>/dev/null || true
+          docker volume rm $(docker volume ls -q -f name=${{ env.COMPOSE_PROJECT_NAME }}) 2>/dev/null || true


### PR DESCRIPTION
The test-subset workflow was failing because it used wrong service hostnames and missing db setup. Now matches the main CI workflow:

- `db_test` instead of `db` for MySQL
- `wait_on_connection.sh` for service readiness checks
- `db:prepare` step before running tests
- Proper `entrypoint` and `gosu` patterns