### PR TITLE
Fix DashboardController#index Rack::Timeout by limiting tax form year range

### DIFF
--- a/app/presenters/creator_home_presenter.rb
+++ b/app/presenters/creator_home_presenter.rb
@@ -78,7 +78,11 @@ class CreatorHomePresenter
       tax_forms = []
       show_1099_download_notice = seller.user_tax_forms.for_year(Time.current.prev_year.year).exists?
     else
-      tax_forms = (Time.current.year.downto(seller.created_at.year)).each_with_object({}) do |year, hash|
+      # Limit to the last 4 tax years to avoid expensive per-year eligibility
+      # queries that can cause request timeouts for long-lived accounts.
+      max_tax_form_years = 4
+      oldest_year = [seller.created_at.year, Time.current.year - max_tax_form_years + 1].max
+      tax_forms = (Time.current.year.downto(oldest_year)).each_with_object({}) do |year, hash|
         url = seller.eligible_for_1099?(year) ? seller.tax_form_1099_download_url(year: year) : nil
         hash[year] = url if url.present?
       end

--- a/spec/presenters/creator_home_presenter_spec.rb
+++ b/spec/presenters/creator_home_presenter_spec.rb
@@ -368,6 +368,16 @@ describe CreatorHomePresenter do
         expect(props[:show_1099_download_notice]).to be(true)
       end
 
+      it "limits tax form years to avoid timeouts for long-lived accounts" do
+        seller.update!(created_at: 10.years.ago)
+        allow(seller).to receive(:eligible_for_1099?).and_return(true)
+        allow(seller).to receive(:tax_form_1099_download_url).and_return(download_url)
+
+        tax_forms = presenter.creator_home_props[:tax_forms]
+        expect(tax_forms.keys.length).to be <= 4
+        expect(tax_forms.keys.min).to be >= Time.current.year - 3
+      end
+
       it "disables tax center for non-US user even with feature flag enabled" do
         create(:user_compliance_info_singapore, user: seller)
         Feature.activate_user(:tax_center, seller)


### PR DESCRIPTION
## Problem

`DashboardController#index` is hitting `Rack::Timeout::RequestTimeoutException` (120s) for some sellers.

**Root cause:** The legacy (non-tax-center) code path in `CreatorHomePresenter` iterates from the current year back to `seller.created_at.year`, running multiple expensive 1099 eligibility queries per year (`eligible_for_1099?` calls `sales_scope_for(year).sum` and `.count` multiple times). For a seller created in 2011, that's 15 years × ~5 DB queries = 75+ queries in a single request.

**Sentry:** https://gumroad-to.sentry.io/issues/7440505757/

## Fix

Limit the tax form iteration to the last 4 years (`Time.current.year - 3` to `Time.current.year`). This covers all practically relevant 1099 download periods while capping the query count to a constant ~20 regardless of account age.

Sellers on the newer `tax_center` path are unaffected (they use `user_tax_forms` records instead of the per-year loop).

## Tests

Added a test verifying long-lived accounts (10+ years) are limited to 4 years of tax form lookups. All existing tax form tests pass.