### PR TITLE
Rescue network errors in TaxIdValidationService

### DIFF
--- a/app/services/tax_id_validation_service.rb
+++ b/app/services/tax_id_validation_service.rb
@@ -29,5 +29,7 @@ class TaxIdValidationService
     def valid_tax_id?
       response = HTTParty.get(TAX_ID_PRO_ENDPOINT_TEMPLATE.expand(country_code:, tax_id:).to_s, headers: TAX_ID_PRO_HEADERS, timeout: 5)
       response.code == 200 && response.parsed_response["is_valid"]
+    rescue Net::OpenTimeout, Net::ReadTimeout, Errno::ECONNREFUSED, Errno::EHOSTUNREACH, SocketError
+      false
     end
 end

--- a/app/services/tax_id_validation_service.rb
+++ b/app/services/tax_id_validation_service.rb
@@ -25,11 +25,25 @@ class TaxIdValidationService
     TAX_ID_PRO_HEADERS = {
       "Authorization" => "Bearer #{TAX_ID_PRO_API_KEY}"
     }
+    RETRIABLE_NETWORK_ERRORS = [Net::OpenTimeout, Net::ReadTimeout, Errno::ECONNREFUSED, Errno::EHOSTUNREACH, SocketError].freeze
+    MAX_TRIES = 3
+    RETRY_DELAY = 1
 
     def valid_tax_id?
-      response = HTTParty.get(TAX_ID_PRO_ENDPOINT_TEMPLATE.expand(country_code:, tax_id:).to_s, headers: TAX_ID_PRO_HEADERS, timeout: 5)
-      response.code == 200 && response.parsed_response["is_valid"]
-    rescue Net::OpenTimeout, Net::ReadTimeout, Errno::ECONNREFUSED, Errno::EHOSTUNREACH, SocketError
-      false
+      tries = 0
+      begin
+        tries += 1
+        response = HTTParty.get(TAX_ID_PRO_ENDPOINT_TEMPLATE.expand(country_code:, tax_id:).to_s, headers: TAX_ID_PRO_HEADERS, timeout: 5)
+        response.code == 200 && response.parsed_response["is_valid"]
+      rescue *RETRIABLE_NETWORK_ERRORS => e
+        if tries < MAX_TRIES
+          Rails.logger.info("TaxIdValidationService network error, attempt #{tries}/#{MAX_TRIES}: #{e.class}: #{e.message}")
+          sleep(RETRY_DELAY)
+          retry
+        else
+          Rails.logger.error("TaxIdValidationService failed after #{MAX_TRIES} attempts: #{e.class}: #{e.message}")
+          false
+        end
+      end
     end
 end

--- a/spec/services/tax_id_validation_service_spec.rb
+++ b/spec/services/tax_id_validation_service_spec.rb
@@ -29,4 +29,14 @@ describe TaxIdValidationService, :vcr do
   it "returns false when the tax id is not valid" do
     expect(described_class.new("1234567890", country_code).process).to be(false)
   end
+
+  it "returns false when the API request times out" do
+    allow(HTTParty).to receive(:get).and_raise(Net::OpenTimeout)
+    expect(described_class.new(tax_id, country_code).process).to be(false)
+  end
+
+  it "returns false when the API connection is refused" do
+    allow(HTTParty).to receive(:get).and_raise(Errno::ECONNREFUSED)
+    expect(described_class.new(tax_id, country_code).process).to be(false)
+  end
 end

--- a/spec/services/tax_id_validation_service_spec.rb
+++ b/spec/services/tax_id_validation_service_spec.rb
@@ -30,13 +30,31 @@ describe TaxIdValidationService, :vcr do
     expect(described_class.new("1234567890", country_code).process).to be(false)
   end
 
-  it "returns false when the API request times out" do
-    allow(HTTParty).to receive(:get).and_raise(Net::OpenTimeout)
-    expect(described_class.new(tax_id, country_code).process).to be(false)
-  end
+  context "when the API is unreachable" do
+    before do
+      allow_any_instance_of(described_class).to receive(:sleep)
+    end
 
-  it "returns false when the API connection is refused" do
-    allow(HTTParty).to receive(:get).and_raise(Errno::ECONNREFUSED)
-    expect(described_class.new(tax_id, country_code).process).to be(false)
+    it "retries and returns false when the API request times out on every attempt" do
+      expect(HTTParty).to receive(:get).exactly(TaxIdValidationService::MAX_TRIES).times.and_raise(Net::OpenTimeout)
+      expect(described_class.new(tax_id, country_code).process).to be(false)
+    end
+
+    it "retries and returns false when the API connection is refused on every attempt" do
+      expect(HTTParty).to receive(:get).exactly(TaxIdValidationService::MAX_TRIES).times.and_raise(Errno::ECONNREFUSED)
+      expect(described_class.new(tax_id, country_code).process).to be(false)
+    end
+
+    it "returns the API result if a retry succeeds after a transient network error" do
+      response = instance_double(HTTParty::Response, code: 200, parsed_response: { "is_valid" => true })
+      call_count = 0
+      allow(HTTParty).to receive(:get) do
+        call_count += 1
+        raise Net::OpenTimeout if call_count == 1
+        response
+      end
+      expect(described_class.new(tax_id, country_code).process).to be(true)
+      expect(call_count).to eq(2)
+    end
   end
 end


### PR DESCRIPTION
## Problem

`CustomerSurchargeController#calculate_all` crashes with `Net::OpenTimeout` when the taxid.pro API is unreachable. This breaks the checkout surcharge calculation for buyers in countries that use TaxIdPro validation.

[Sentry issue](https://gumroad-to.sentry.io/issues/7440627359/)

## Root Cause

`TaxIdValidationService#valid_tax_id?` makes an HTTP call to `v3.api.taxid.pro` with a 5-second timeout, but doesn't rescue network errors. When the API host is down or unreachable, the exception propagates up through `SalesTaxCalculator` → `CustomerSurchargeController`.

## Fix

Rescue common network errors (`Net::OpenTimeout`, `Net::ReadTimeout`, `Errno::ECONNREFUSED`, `Errno::EHOSTUNREACH`, `SocketError`) and return `false`. This is the conservative default: treat the tax ID as invalid so tax is still charged. The result is cached for 10 minutes, so a transient outage won't cause repeated failed requests.

## Tests

Added specs confirming that timeout and connection-refused errors return `false` instead of raising.