### PR TITLE
Fix Rack::Timeout in ThumbnailsController#create with 30s analyze guard

### DIFF
--- a/app/controllers/thumbnails_controller.rb
+++ b/app/controllers/thumbnails_controller.rb
@@ -14,7 +14,7 @@ class ThumbnailsController < Sellers::BaseController
 
     if permitted_params[:signed_blob_id].present?
       thumbnail.file.attach(permitted_params[:signed_blob_id])
-      thumbnail.file.analyze
+      Timeout.timeout(30) { thumbnail.file.analyze }
       thumbnail.unsplash_url = nil
     end
 
@@ -26,6 +26,8 @@ class ThumbnailsController < Sellers::BaseController
     else
       render(json: { success: false, error: thumbnail.errors.any? ? thumbnail.errors.full_messages.to_sentence : "Could not process your preview, please try again." })
     end
+  rescue Timeout::Error
+    render(json: { success: false, error: "Thumbnail processing took too long, please try again with a smaller image." })
   rescue ActiveRecord::InvalidForeignKey, ActiveStorage::FileNotFoundError, *INTERNET_EXCEPTIONS
     render(json: { success: false, error: "Could not process your thumbnail, please try again." })
   end

--- a/spec/controllers/thumbnails_controller_spec.rb
+++ b/spec/controllers/thumbnails_controller_spec.rb
@@ -91,6 +91,17 @@ describe ThumbnailsController, :vcr do
       end
     end
 
+    it "returns an error when thumbnail analysis times out" do
+      allow_any_instance_of(ActiveStorage::Blob).to receive(:analyze).and_raise(Timeout::Error)
+
+      expect do
+        post(:create, params: { link_id: product.unique_permalink, thumbnail: { signed_blob_id: blob.signed_id }, format: :json })
+      end.not_to change { Thumbnail.count }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq({ "success" => false, "error" => "Thumbnail processing took too long, please try again with a smaller image." })
+    end
+
     it "returns an error when the file is not found in storage" do
       allow_any_instance_of(ActiveStorage::Blob).to receive(:analyze).and_raise(ActiveStorage::FileNotFoundError)
 


### PR DESCRIPTION
## Problem

`ThumbnailsController#create` calls `thumbnail.file.analyze` synchronously during the request. This downloads the blob from storage and runs image analysis (ImageMagick/MiniMagick). For large uploads or when storage is slow, this easily exceeds the 120-second Rack::Timeout, which sends SIGTERM and kills the entire worker process.

[Sentry issue](https://gumroad-to.sentry.io/issues/7441113843/)

## Fix

Wrap the `analyze` call in a 30-second `Timeout.timeout` block. If analysis takes too long, the request returns a user-friendly JSON error instead of timing out and killing the process.

The 30s limit is generous for image analysis (typically <5s) but well within the 120s Rack::Timeout, leaving headroom for the rest of the request lifecycle.

## Changes

- `app/controllers/thumbnails_controller.rb`: Wrap `analyze` in `Timeout.timeout(30)`, add `rescue Timeout::Error` handler
- `spec/controllers/thumbnails_controller_spec.rb`: Add test for timeout scenario