### PR TITLE
Fix NoMethodError on pluck for ActionController::Parameters in workflow emails

### DIFF
--- a/app/services/workflow/save_installments_service.rb
+++ b/app/services/workflow/save_installments_service.rb
@@ -21,7 +21,9 @@ class Workflow::SaveInstallmentsService
       return [false, errors]
     end
 
-    if workflow.abandoned_cart_type? && params[:installments].size != 1
+    @installments_array = params[:installments].is_a?(ActionController::Parameters) ? params[:installments].values : Array(params[:installments])
+
+    if workflow.abandoned_cart_type? && @installments_array.size != 1
       workflow.errors.add(:base, "An abandoned cart workflow can only have one email.")
       @errors = workflow.errors
       return [false, errors]
@@ -35,7 +37,7 @@ class Workflow::SaveInstallmentsService
 
         delete_removed_installments
 
-        params[:installments].each do |installment_params|
+        @installments_array.each do |installment_params|
           installment = workflow.installments.alive.find_by_external_id(installment_params[:id]) || workflow.installments.build
           installment.name = installment_params[:name]
           installment.message = installment_params[:message]
@@ -73,7 +75,7 @@ class Workflow::SaveInstallmentsService
     attr_reader :params, :seller, :workflow, :preview_email_recipient
 
     def delete_removed_installments
-      deleted_external_ids = workflow.installments.alive.map(&:external_id) - params[:installments].pluck(:id)
+      deleted_external_ids = workflow.installments.alive.map(&:external_id) - @installments_array.map { |i| i[:id] }
       workflow.installments.by_external_ids(deleted_external_ids).find_each do |installment|
         installment.mark_deleted!
         installment.installment_rule&.mark_deleted!

--- a/spec/services/workflow/save_installments_service_spec.rb
+++ b/spec/services/workflow/save_installments_service_spec.rb
@@ -331,6 +331,22 @@ describe Workflow::SaveInstallmentsService do
       )
     end
 
+    it "handles installments passed as ActionController::Parameters (hash-like)" do
+      installment = create(:installment, workflow:, name: "Installment 1", message: "Message 1")
+      hash_params = ActionController::Parameters.new(
+        "0" => { id: installment.external_id, name: "Updated name", message: "Updated message", time_duration: 1, time_period: "hour", send_preview_email: false, files: [] }
+      )
+      params[:installments] = hash_params
+
+      service = described_class.new(seller:, params:, workflow:, preview_email_recipient:)
+      success, errors = service.process
+
+      expect(success).to be(true)
+      expect(errors).to be_nil
+      expect(installment.reload.name).to eq("Updated name")
+      expect(installment.message).to eq("Updated message")
+    end
+
     it "does not save installments if there are errors" do
       params[:installments] = [default_installment_params.merge(id: SecureRandom.uuid, message: "")]
       service = described_class.new(seller:, params:, workflow:, preview_email_recipient:)


### PR DESCRIPTION
## What

Fixes `NoMethodError: undefined method 'pluck' for an instance of ActionController::Parameters` in `Workflows::EmailsController#update` (Sentry).

In `Workflow::SaveInstallmentsService#delete_removed_installments`, `params[:installments].pluck(:id)` assumed `params[:installments]` is always an Array. When the frontend submits installments as an object with numeric string keys (e.g. `{"0" => {...}, "1" => {...}}`), Rails parses it as an `ActionController::Parameters` instance (hash-like), which doesn't respond to `pluck`.

## Why

`ActionController::Parameters` doesn't have `pluck` (that's an ActiveRecord method). The same hash-like params also broke `.each` iteration (yielding key-value pairs instead of just values) and `.size` semantics.

The fix normalizes `params[:installments]` to an array once at the top of `process`:
- If it's an `ActionController::Parameters` (hash-like): call `.values` to extract the array of installment param objects
- Otherwise: wrap with `Array()` for safety

All three call sites (`.size`, `.each`, `.map { |i| i[:id] }`) now use the normalized `@installments_array`.

## Test results

Added a spec that passes installments as hash-like `ActionController::Parameters` to confirm the fix.

---

AI disclosure: Implemented with Claude Opus 4.6. Prompt: fix the Sentry NoMethodError on pluck in workflow emails controller, with root cause analysis and fix strategy provided.