### PR TITLE
Fix NoMethodError in InstallmentRule#displayable_time_duration for nil delayed_delivery_time

### DIFF
--- a/app/models/installment_rule.rb
+++ b/app/models/installment_rule.rb
@@ -47,6 +47,7 @@ class InstallmentRule < ApplicationRecord
     when MONTH
       period = 1.month
     end
+    return 0 if delayed_delivery_time.nil? || period.nil?
     (delayed_delivery_time / period).to_i
   end
 

--- a/spec/models/installment_rule_spec.rb
+++ b/spec/models/installment_rule_spec.rb
@@ -60,6 +60,16 @@ describe InstallmentRule do
       @post_rule.update(delayed_delivery_time: 1.month, time_period: "month")
       expect(@post_rule.displayable_time_duration).to eq(1)
     end
+
+    it "returns 0 when delayed_delivery_time is nil" do
+      @post_rule.update_columns(delayed_delivery_time: nil)
+      expect(@post_rule.reload.displayable_time_duration).to eq(0)
+    end
+
+    it "returns 0 when time_period is nil" do
+      @post_rule.update_columns(time_period: nil)
+      expect(@post_rule.reload.displayable_time_duration).to eq(0)
+    end
   end
 
   describe "validations" do


### PR DESCRIPTION
## What

Adds a nil guard in `InstallmentRule#displayable_time_duration` so it returns `0` instead of raising `NoMethodError` when `delayed_delivery_time` or `time_period` is nil.

## Why

Production Sentry error: https://gumroad-to.sentry.io/issues/7441359590/

`WorkflowsController#edit` crashes with `NoMethodError: undefined method '/' for nil (NoMethodError)` when rendering the workflow edit page for an installment rule that has a nil `delayed_delivery_time` or `time_period`. Both columns are nullable in the database, but the method assumed they were always present.

The call chain is: `WorkflowsController#edit` → `WorkflowPresenter#workflow_props` → `InstallmentPresenter#props` → `installment.installment_rule.displayable_time_duration`.

## Fix

Added `return 0 if delayed_delivery_time.nil? || period.nil?` before the division on line 50 of `installment_rule.rb`.

## Test results

Added two specs covering:
- `delayed_delivery_time` is nil → returns 0
- `time_period` is nil (so `period` is never assigned) → returns 0

---

Built with Claude Opus 4.6. Prompt: fix the Sentry NoMethodError in InstallmentRule#displayable_time_duration, add nil guard, write tests, push and open PR.