### PR TITLE
Fix Errno::ENOENT from temp file cleanup during image variant processing

### DIFF
--- a/app/models/thumbnail.rb
+++ b/app/models/thumbnail.rb
@@ -52,7 +52,7 @@ class Thumbnail < ApplicationRecord
     else
       cdn_url_for(file.url)
     end
-  rescue MiniMagick::Error, ActiveStorage::Error => e
+  rescue MiniMagick::Error, ActiveStorage::Error, Errno::ENOENT => e
     Rails.logger.warn("Thumbnail#url error (#{id}): #{e.class} => #{e.message}")
     cdn_url_for(file.url)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -414,7 +414,7 @@ class User < ApplicationRecord
   def resized_avatar_url(size:)
     return ActionController::Base.helpers.asset_url("gumroad-default-avatar-5.png") unless avatar.attached?
     cdn_url_for(avatar.variant(resize_to_limit: [size, size]).processed.url)
-  rescue ActiveStorage::FileNotFoundError => e
+  rescue ActiveStorage::FileNotFoundError, Errno::ENOENT => e
     Rails.logger.warn("User#resized_avatar_url error (#{id}): #{e.class} => #{e.message}")
     ActionController::Base.helpers.asset_url("gumroad-default-avatar-5.png")
   end

--- a/spec/models/thumbnail_spec.rb
+++ b/spec/models/thumbnail_spec.rb
@@ -123,5 +123,16 @@ describe Thumbnail do
       allow(thumbnail).to receive(:thumbnail_variant).and_raise(ActiveStorage::Error, "processing failed")
       expect(thumbnail.url).to match(PUBLIC_STORAGE_S3_BUCKET)
     end
+
+    it "falls back to original file URL when Errno::ENOENT is raised" do
+      thumbnail = Thumbnail.new(product: @product)
+      blob = ActiveStorage::Blob.create_and_upload!(io: fixture_file_upload("smilie.png"), filename: "smilie.png")
+      blob.analyze
+      thumbnail.file.attach(blob)
+      thumbnail.save!
+
+      allow(thumbnail).to receive(:thumbnail_variant).and_raise(Errno::ENOENT, "/tmp/image_processing.png")
+      expect(thumbnail.url).to match(PUBLIC_STORAGE_S3_BUCKET)
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1321,6 +1321,15 @@ describe User, :vcr do
           expect(@user.resized_avatar_url(size: 256)).to eq(ActionController::Base.helpers.asset_url("gumroad-default-avatar-5.png"))
         end
       end
+
+      context "when temp file is deleted during variant processing" do
+        it "returns URL to default avatar" do
+          allow(@user.avatar).to receive(:attached?).and_return(true)
+          allow(@user.avatar).to receive(:variant).and_raise(Errno::ENOENT, "/tmp/image_processing.png")
+
+          expect(@user.resized_avatar_url(size: 256)).to eq(ActionController::Base.helpers.asset_url("gumroad-default-avatar-5.png"))
+        end
+      end
     end
 
     describe "avatar_url" do


### PR DESCRIPTION
## What

Add `Errno::ENOENT` to rescue clauses in `Thumbnail#url` and `User#resized_avatar_url` so they gracefully handle temp file race conditions during ActiveStorage variant processing.

## Why

[Sentry issue](https://gumroad-to.sentry.io/issues/7441441718/): The `image_processing` gem creates temp files in `/tmp/` during `.variant(...).processed` calls. A race condition can occur when a temp file is cleaned up (by GC, OS tmpwatch, or concurrent processing) before `File.size` reads it, raising `Errno::ENOENT`. This error was not caught by existing rescue clauses that only handled `MiniMagick::Error`, `ActiveStorage::Error`, and `ActiveStorage::FileNotFoundError`.

The fix adds `Errno::ENOENT` to the rescue clauses so both methods fall back to their safe defaults (original file URL for thumbnails, default avatar for users), matching the existing error-handling behavior.

### Changes
- `Thumbnail#url`: rescue `Errno::ENOENT` alongside `MiniMagick::Error` and `ActiveStorage::Error`
- `User#resized_avatar_url`: rescue `Errno::ENOENT` alongside `ActiveStorage::FileNotFoundError`
- Added specs for both methods verifying the fallback behavior

## Test results

New specs follow the same pattern as the existing error-handling specs (stub the variant call to raise the error, assert the fallback URL is returned).

---

AI disclosure: This PR was authored with Claude Opus 4.6. Prompted to fix the Sentry issue by adding `Errno::ENOENT` to rescue clauses in variant processing methods and adding corresponding specs.