### PR TITLE
Fix NoMethodError on nil URL in content moderation extractor

### DIFF
--- a/app/services/content_moderation/content_extractor.rb
+++ b/app/services/content_moderation/content_extractor.rb
@@ -50,7 +50,7 @@ class ContentModeration::ContentExtractor
         product_description_image_urls +
         rich_content_file_image_urls +
         rich_content_embedded_image_urls
-      ).reject(&:empty?)
+      ).compact_blank
     end
 
     def rich_content_text(rich_contents)

--- a/spec/services/content_moderation/content_extractor_spec.rb
+++ b/spec/services/content_moderation/content_extractor_spec.rb
@@ -48,6 +48,18 @@ RSpec.describe ContentModeration::ContentExtractor do
       expect(result.image_urls).to include("https://signed.example.com/file.png")
       expect(result.image_urls).to include("https://cdn.example.com/rich-content.png")
     end
+
+    it "handles nil URLs from cover image previews without raising" do
+      allow(product.display_asset_previews).to receive(:joins).and_return(
+        double(where: double(map: [nil, "https://cdn.example.com/valid.png", ""]))
+      )
+
+      result = extractor.extract_from_product(product)
+
+      expect(result.image_urls).to include("https://cdn.example.com/valid.png")
+      expect(result.image_urls).not_to include(nil)
+      expect(result.image_urls).not_to include("")
+    end
   end
 
   describe "#extract_from_post" do


### PR DESCRIPTION
## What

Replace `.reject(&:empty?)` with `.compact_blank` in `ContentModeration::ContentExtractor#product_image_urls` to handle `nil` values in the URL array.

## Why

The `product_image_urls` method concatenates several URL arrays (cover images, thumbnails, description images, rich content files, embedded images) and calls `.reject(&:empty?)`. Some of these sources can produce `nil` values — for example, `cover_image_urls` from `.map(&:url)` can return `nil` when a preview has no URL. Calling `.empty?` on `nil` raises `NoMethodError`.

`.compact_blank` (Rails) removes both `nil` and empty string values, which is the intended behavior.

**Sentry issue**: https://gumroad-to.sentry.io/issues/7441561882/
- 3 events (new issue, first seen today)
- ~1 user affected

## Test results

Added a test that verifies `nil` URLs in cover image previews are handled without raising. Docker environment not available locally for test execution — CI will verify.

---

AI disclosure: This fix was implemented with Claude Opus 4.6. Prompts: fix Sentry NoMethodError on nil URL in content moderation extractor, write regression test.