### PR TITLE
Fix deadlock in CheckoutController#update by locking cart row

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -35,6 +35,7 @@ class CheckoutController < ApplicationController
       cart.reject_ppp_discount = update_permitted_params[:rejectPppDiscount] || false
       cart.discount_codes = update_permitted_params[:discountCodes].to_a.map { { code: _1[:code], fromUrl: _1[:fromUrl] } }
       cart.save!
+      cart.lock!
 
       updated_cart_products = items.map do |item|
         product = Link.find_by_external_id!(item[:product][:id])
@@ -68,7 +69,7 @@ class CheckoutController < ApplicationController
     end
 
     redirect_to checkout_path, status: :see_other
-  rescue ActiveRecord::RecordInvalid => e
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::Deadlocked => e
     ErrorNotifier.notify(e)
     Rails.logger.error(e.full_message) if Rails.env.development?
     redirect_to checkout_path, alert: "Sorry, something went wrong. Please try again."

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -504,6 +504,28 @@ describe CheckoutController, type: :controller, inertia: true do
         expect(Cart.last.discount_codes).to eq([])
       end
 
+      it "acquires a row lock on the cart to prevent deadlocks" do
+        cart = create(:cart, user: seller)
+
+        expect_any_instance_of(Cart).to receive(:lock!).and_call_original
+
+        patch :update, params: { cart: { items: [], discountCodes: [] } }, as: :json
+
+        expect(response).to have_http_status(:see_other)
+      end
+
+      it "rescues ActiveRecord::Deadlocked and redirects with an error" do
+        allow_any_instance_of(Cart).to receive(:lock!).and_raise(
+          ActiveRecord::Deadlocked.new("Deadlock found when trying to get lock")
+        )
+
+        patch :update, params: { cart: { items: [], discountCodes: [] } }, as: :json
+
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to(checkout_path)
+        expect(flash[:alert]).to eq("Sorry, something went wrong. Please try again.")
+      end
+
       it "returns an error when the `cart` param is not a Hash" do
         expect do
           patch :update, params: { cart: "foo" }, as: :json


### PR DESCRIPTION
## What

Adds a `SELECT ... FOR UPDATE` row lock on the `Cart` record inside `CheckoutController#update`'s transaction, and rescues `ActiveRecord::Deadlocked` with a friendly redirect.

## Why

Two concurrent `PATCH /checkout` requests for the same cart can interleave their INSERT/UPDATE statements on `cart_products`, causing MySQL gap-lock deadlocks ([Sentry issue](https://gumroad-to.sentry.io/issues/7441623745/)). The transaction fetches/creates a Cart and iterates over cart products without holding a row lock, so concurrent requests aren't serialized.

`cart.lock!` after `cart.save!` acquires a `FOR UPDATE` lock that serializes concurrent updates to the same cart row. The `ActiveRecord::Deadlocked` rescue is a safety net so any remaining edge-case deadlock returns a redirect instead of a 500.

## Changes

- `app/controllers/checkout_controller.rb`: Added `cart.lock!` after `cart.save!` (line 38). Combined `ActiveRecord::Deadlocked` into the existing rescue clause.
- `spec/controllers/checkout_controller_spec.rb`: Two new tests — one verifying the lock is acquired, one verifying the deadlock rescue path redirects gracefully.

## Test results

Tests cannot run locally outside Docker. The two new specs verify:
1. `cart.lock!` is called during update
2. `ActiveRecord::Deadlocked` is rescued and redirects with an alert

---

Built with Claude Opus 4.6. Prompts: "Fix a MySQL deadlock in CheckoutController#update by adding cart.lock! and rescuing ActiveRecord::Deadlocked."