### PR TITLE
Fix blank referrer validation error in cross-sell checkout

### DIFF
--- a/app/javascript/components/Checkout/CrossSellModal.tsx
+++ b/app/javascript/components/Checkout/CrossSellModal.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+import { getReferrer } from "$app/data/user_action_event";
 import { formatOrderOfMagnitude } from "$app/utils/formatOrderOfMagnitude";
 
 import { Button } from "$app/components/Button";
@@ -28,7 +29,7 @@ export const CrossSellModal = ({
     ...crossSell.offered_product,
     quantity: crossSell.offered_product.quantity || 1,
     url_parameters: {},
-    referrer: "",
+    referrer: getReferrer(),
     recommender_model_name: null,
     accepted_offer: crossSell.discount ? { id: crossSell.id, discount: crossSell.discount } : null,
   };

--- a/spec/models/cart_product_spec.rb
+++ b/spec/models/cart_product_spec.rb
@@ -41,6 +41,23 @@ describe CartProduct do
       end
     end
 
+    describe "referrer" do
+      context "when referrer is blank" do
+        it "marks the cart product as invalid" do
+          cart_product = build(:cart_product, referrer: "")
+          expect(cart_product).to be_invalid
+          expect(cart_product.errors[:referrer]).to include("can't be blank")
+        end
+      end
+
+      context "when referrer is present" do
+        it "marks the cart product as valid" do
+          cart_product = build(:cart_product, referrer: "direct")
+          expect(cart_product).to be_valid
+        end
+      end
+    end
+
     describe "accepted offer details" do
       context "when accepted offer details is empty" do
         it "marks the cart product as valid" do


### PR DESCRIPTION
## What

`CrossSellModal.tsx` was setting `referrer: ""` when building a cross-sell cart item. The `CartProduct` model validates referrer presence (`validates :referrer, presence: true`), so an empty string caused `ActiveRecord::RecordInvalid: Validation failed: Referrer can't be blank` during `CheckoutController#update`.

## Why

This was a Sentry production error. The fix uses `getReferrer()` from `$app/data/user_action_event` — the same utility used everywhere else in the codebase — which returns the URL `referrer` param, `document.referrer`, or `"direct"` as a fallback.

## Changes

- **`app/javascript/components/Checkout/CrossSellModal.tsx`**: Import `getReferrer` and use it instead of `""` for the cross-sell cart item referrer field.
- **`spec/models/cart_product_spec.rb`**: Added referrer validation tests confirming blank referrer is invalid and present referrer is valid.

## Test results

- ESLint passes on the changed file
- New spec tests validate the referrer presence constraint on `CartProduct`

---

Built with Claude Opus 4.6. Prompt: "Fix Sentry bug: ActiveRecord::RecordInvalid for blank referrer in CrossSellModal cross-sell checkout flow."