### PR TITLE
Fix Google OAuth signup test: remove 2FA step

### DIFF
--- a/spec/requests/signup_spec.rb
+++ b/spec/requests/signup_spec.rb
@@ -94,7 +94,6 @@ describe "Signup Feature Scenario", js: true, type: :system do
 
       expect do
         click_button "Google"
-        click_button "Login" # 2FA
         expect(page).to have_content("We're here to help you get paid for your work.")
       end.to change(User, :count).by(1)
     end


### PR DESCRIPTION
PR [#4740](https://github.com/antiwork/gumroad/pull/4740) skips 2FA for Google OAuth login, but the signup spec still clicks a `Login` button for the 2FA step that no longer exists. This fails every CI run.