### PR TITLE
Fix ProductPresenter timestamp off-by-1 flaky test

### DIFF
--- a/spec/presenters/product_presenter_spec.rb
+++ b/spec/presenters/product_presenter_spec.rb
@@ -284,7 +284,7 @@ describe ProductPresenter do
       product.user.reload
     end
 
-    it "returns the properties for the product edit page" do
+    it "returns the properties for the product edit page", :freeze_time do
       expect(presenter.edit_props).to eq(
         {
           product: {
@@ -535,7 +535,7 @@ describe ProductPresenter do
         Feature.activate_user(:cancellation_discounts, membership.user)
       end
 
-      it "returns the properties for the product edit page" do
+      it "returns the properties for the product edit page", :freeze_time do
         expect(presenter.edit_props).to eq(
           {
             product: {


### PR DESCRIPTION
Add `:freeze_time` to the two `edit_props` tests that compare `earliest_membership_price_change_date` without frozen time. The third instance at line 797 already had it.

Without `freeze_time`, `BaseVariant::MINIMUM_DAYS_TIL_EXISTING_MEMBERSHIP_PRICE_CHANGE.days.from_now` can differ by 1 second between the presenter computing it and the test asserting it.