### PR TITLE
Fix RecurringChargeWorker enqueue timestamp off-by-1 flaky test

### DIFF
--- a/spec/models/purchase/purchase_subscription_spec.rb
+++ b/spec/models/purchase/purchase_subscription_spec.rb
@@ -48,7 +48,7 @@ describe "PurchaseSubscription", :vcr do
             freeze_time do
               @purchase.update_balance_and_mark_successful!
 
-              expect(RecurringChargeWorker).to have_enqueued_sidekiq_job(@subscription.id).at(1.month.from_now)
+              expect(RecurringChargeWorker).to have_enqueued_sidekiq_job(@subscription.id).at(@subscription.reload.end_time_of_subscription)
             end
           end
 


### PR DESCRIPTION
Same pattern as [#4771](https://github.com/antiwork/gumroad/pull/4771): the test computes `1.month.from_now` independently but the subscription's `end_time_of_subscription` was set before `freeze_time`, so they can differ by 1 second.

Fix: use `@subscription.reload.end_time_of_subscription` (the actual value the app uses) instead of recalculating.