### PR TITLE
Fix NoMethodError on nil gifter_purchase in vague_error_message

### DIFF
--- a/app/modules/purchase/risk.rb
+++ b/app/modules/purchase/risk.rb
@@ -37,7 +37,11 @@ module Purchase::Risk
 
   private
     def vague_error_message
-      record = is_gift_receiver_purchase ? gift_received.gifter_purchase : self
+      record = if is_gift_receiver_purchase
+        gift_received&.gifter_purchase || self
+      else
+        self
+      end
       if record.free_purchase?
         "The transaction could not complete."
       else

--- a/spec/modules/purchase/risk_spec.rb
+++ b/spec/modules/purchase/risk_spec.rb
@@ -336,6 +336,17 @@ describe Purchase::Risk do
             end.to change { gifter_purchase.error_code }.from(nil).to(PurchaseErrorCode::BLOCKED_EMAIL_DOMAIN)
              .and change { gifter_purchase.errors.full_messages.to_sentence }.from("").to(vague_purchase_error_notice)
           end
+
+          it "returns error without raising when gifter_purchase is not yet persisted on the gift" do
+            gift.update_column(:gifter_purchase_id, nil)
+            gift.reload
+            BlockedObject.block!(BLOCKED_OBJECT_TYPES[:email_domain], "giftee.com", nil)
+
+            expect do
+              giftee_purchase.check_for_fraud
+            end.to change { giftee_purchase.error_code }.from(nil).to(PurchaseErrorCode::BLOCKED_EMAIL_DOMAIN)
+             .and change { giftee_purchase.errors.full_messages.to_sentence }.from("").to("The transaction could not complete.")
+          end
         end
       end
 


### PR DESCRIPTION
## What

Fixes `NoMethodError: undefined method 'free_purchase?' for nil` in `Purchase::Risk#vague_error_message` by handling the case where `gift_received.gifter_purchase` is nil.

## Why

During gift checkout, the giftee purchase's fraud check (`check_for_fraud`) can run before the `gifter_purchase_id` is persisted on the `Gift` record. The flow is:

1. A `Gift` record is created with `gifter_purchase_id = NULL`
2. The gifter purchase is built with `gift_given: gift` (in-memory only)
3. `create_giftee_purchase` creates the giftee purchase and calls `process!`
4. During fraud check, `vague_error_message` calls `gift_received.gifter_purchase` which loads from DB where `gifter_purchase_id` is still NULL → returns `nil`
5. `nil.free_purchase?` → **NoMethodError**

The fix falls back to `self` (the giftee purchase) when the gifter purchase association isn't available yet. This is safe because giftee purchases always have `perceived_price_cents: 0` (free), and the error message is just a user-facing string for fraud rejection.

Sentry: https://gumroad-to.sentry.io/issues/7442204831/ (1 occurrence so far, affects gift purchases where the giftee's email hits a fraud check)

---

AI disclosure: Claude Opus 4.6. Prompted to fix the Sentry bug with provided root cause analysis and fix approach.