### PR TITLE
Fix flaky account switching in shared test context

### DIFF
--- a/spec/shared_examples/authorize_called.rb
+++ b/spec/shared_examples/authorize_called.rb
@@ -95,8 +95,9 @@ RSpec.shared_context "with switching account to user with given role for seller"
     login_as user_with_role_for_seller
     visit(options[:host] ? settings_main_url(host: options[:host]) : settings_main_path)
     within "nav[aria-label='Main']" do
-      toggle_disclosure(user_with_role_for_seller.name)
-      choose(seller.display_name)
+      select_disclosure(user_with_role_for_seller.name) do
+        choose(seller.display_name)
+      end
     end
 
     wait_for_ajax


### PR DESCRIPTION
## Problem

The shared context `with switching account to user with given role for seller` intermittently fails with:

```
Capybara::ElementNotFound: Unable to find radio_button "Seller"
  within #<Capybara::Node::Element tag="nav" ...>
```

This affected tests like:
- "File embeds in product content editor with video when uploading a valid subtitle file type"
- "Checkout form page custom fields allows managing custom fields"
- "Churn analytics" tests

## Root cause

`toggle_disclosure` clicks the disclosure button and returns immediately without waiting for the disclosure content to render. The subsequent `choose(seller.display_name)` then fails because the radio buttons haven't appeared in the DOM yet.

## Fix

Replace `toggle_disclosure` + `choose` with `select_disclosure` block:

- `select_disclosure` opens the disclosure and waits for its content element to be present before running the block
- The existing Radix re-render retry logic in `_run_in_disclosure` handles stale elements from popover repositioning
- `choose` inside the block now runs only after the disclosure content is confirmed ready

## Verification

Ran 12 CI builds (3x parallel x 4 rounds). Zero account-switch radio_button failures with the fix, vs ~2/5 baseline failure rate.