### PR TITLE
Fix NoMethodError in Api::V2::FilesController#complete when part params are arrays

### DIFF
--- a/app/controllers/api/v2/files_controller.rb
+++ b/app/controllers/api/v2/files_controller.rb
@@ -53,7 +53,12 @@ class Api::V2::FilesController < Api::V2::BaseController
 
     return error_400("invalid key") unless key.start_with?(s3_key_prefix)
 
-    parts = Array(params[:parts]).map { |p| { part_number: p[:part_number].to_i, etag: p[:etag].to_s } }
+    raw_parts = Array(params[:parts])
+    unless raw_parts.all? { |p| p.respond_to?(:[]) && !p[:part_number].is_a?(Array) && !p[:etag].is_a?(Array) }
+      return error_400("each part must have scalar part_number and etag values")
+    end
+
+    parts = raw_parts.map { |p| { part_number: p[:part_number].to_i, etag: p[:etag].to_s } }
 
     Aws::S3::Client.new.complete_multipart_upload(
       bucket: S3_BUCKET,

--- a/spec/controllers/api/v2/files_controller_spec.rb
+++ b/spec/controllers/api/v2/files_controller_spec.rb
@@ -179,6 +179,18 @@ describe Api::V2::FilesController do
         expect(response.parsed_body["error"]).to include("boom")
       end
 
+      it "returns 400 when part_number is an array instead of a scalar" do
+        post action, params: params.merge(parts: [{ part_number: [1], etag: '"etag-abc"' }])
+        expect(response.status).to eq(400)
+        expect(response.parsed_body["error"]).to eq("each part must have scalar part_number and etag values")
+      end
+
+      it "returns 400 when etag is an array instead of a scalar" do
+        post action, params: params.merge(parts: [{ part_number: 1, etag: ['"etag-abc"'] }])
+        expect(response.status).to eq(400)
+        expect(response.parsed_body["error"]).to eq("each part must have scalar part_number and etag values")
+      end
+
       it "returns 400 with the S3 error message when the upload_id no longer exists" do
         allow_any_instance_of(Aws::S3::Client).to receive(:complete_multipart_upload)
           .and_raise(Aws::S3::Errors::NoSuchUpload.new(nil, "The specified upload does not exist."))


### PR DESCRIPTION
## What

Validates that `part_number` and `etag` values in the `parts` array parameter are scalar values (not arrays) before calling `.to_i`/`.to_s` on them in the `complete` action. Returns a 400 error for malformed input instead of raising a 500.

## Why

Sentry reports `NoMethodError: undefined method 'to_i' for an instance of Array` when clients send malformed params like `parts[][part_number][]=1` instead of `parts[][part_number]=1`. The root cause is that Rails parses nested array brackets into an Array, and calling `.to_i` on an Array raises NoMethodError. Adding input validation at the boundary converts this into a clean 400 response.

[Sentry issue](https://gumroad-to.sentry.io/issues/7442735191/)

## Test results

```
33 examples, 0 failures
```

Two new test cases added:
- `returns 400 when part_number is an array instead of a scalar`
- `returns 400 when etag is an array instead of a scalar`

---

AI disclosure: This fix was implemented with Claude Opus 4.6. Prompt: fix Sentry bug for NoMethodError on Array#to_i in FilesController#complete by validating scalar part params.