### PR TITLE
Handle Stripe::PermissionError in Admin::MerchantAccountsController#show

### DIFF
--- a/app/presenters/admin/merchant_account_presenter.rb
+++ b/app/presenters/admin/merchant_account_presenter.rb
@@ -44,13 +44,17 @@ class Admin::MerchantAccountPresenter
       return unless merchant_account.charge_processor_merchant_id.present?
 
       if merchant_account.stripe_charge_processor?
-        stripe_account = Stripe::Account.retrieve(merchant_account.charge_processor_merchant_id)
-        [
-          { label: "Charges enabled", value: stripe_account.charges_enabled },
-          { label: "Payout enabled", value: stripe_account.payouts_enabled },
-          { label: "Disabled reason", value: stripe_account.requirements.disabled_reason },
-          { label: "Fields needed", value: stripe_account.requirements.as_json }
-        ]
+        begin
+          stripe_account = Stripe::Account.retrieve(merchant_account.charge_processor_merchant_id)
+          [
+            { label: "Charges enabled", value: stripe_account.charges_enabled },
+            { label: "Payout enabled", value: stripe_account.payouts_enabled },
+            { label: "Disabled reason", value: stripe_account.requirements.disabled_reason },
+            { label: "Fields needed", value: stripe_account.requirements.as_json }
+          ]
+        rescue Stripe::PermissionError
+          [{ label: "Error", value: "Stripe account access has been revoked or the account no longer exists" }]
+        end
       elsif merchant_account.paypal_charge_processor?
         paypal_account_details = merchant_account.paypal_account_details
         if paypal_account_details.present?

--- a/spec/presenters/admin/merchant_account_presenter_spec.rb
+++ b/spec/presenters/admin/merchant_account_presenter_spec.rb
@@ -102,6 +102,24 @@ describe Admin::MerchantAccountPresenter do
         end
       end
 
+      context "when Stripe account access has been revoked" do
+        let(:merchant_account) do
+          create(:merchant_account, charge_processor_merchant_id: "acct_revoked123")
+        end
+
+        before do
+          allow(Stripe::Account).to receive(:retrieve).with("acct_revoked123").and_raise(
+            Stripe::PermissionError.new("The provided key does not have access to account 'acct_revoked123'")
+          )
+        end
+
+        it "returns an error message instead of raising" do
+          expect(props[:live_attributes]).to eq(
+            [{ label: "Error", value: "Stripe account access has been revoked or the account no longer exists" }]
+          )
+        end
+      end
+
       context "for PayPal merchant accounts", :vcr do
         let(:merchant_account) do
           create(:merchant_account_paypal, charge_processor_merchant_id: "B66YJBBNCRW6L")


### PR DESCRIPTION
## What

When an admin views a merchant account whose Stripe connected account access has been revoked (or the account no longer exists), `Stripe::Account.retrieve` in `Admin::MerchantAccountPresenter#live_attributes` raises an unhandled `Stripe::PermissionError`, resulting in a 500 error.

This PR rescues `Stripe::PermissionError` in the `live_attributes` method and returns a descriptive error message instead of crashing.

## Why

This was reported via Sentry ([issue 7443752566](https://gumroad-to.sentry.io/issues/7443752566/)). When a Stripe connected account is deauthorized or deleted, the API returns a permission error. The admin page should handle this gracefully rather than showing an error page.

## Changes

- `app/presenters/admin/merchant_account_presenter.rb` — Wrapped `Stripe::Account.retrieve` in a `rescue Stripe::PermissionError` block that returns `[{ label: "Error", value: "Stripe account access has been revoked or the account no longer exists" }]`
- `spec/presenters/admin/merchant_account_presenter_spec.rb` — Added test for the revoked access scenario

## Test results

New spec stubs `Stripe::Account.retrieve` to raise `Stripe::PermissionError` and asserts the error message is returned in `live_attributes`.

---

Built with Claude Opus 4.6. Prompt: fix the Sentry issue for Stripe::PermissionError in admin merchant account show, add rescue handling and test.