### PR TITLE
Fix reviews not rendering on product-level custom domains

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1041,6 +1041,20 @@ Rails.application.routes.draw do
   constraints ProductCustomDomainConstraint do
     get "/.well-known/acme-challenge/:token", to: "acme_challenges#show"
     product_tracking_routes(named_routes: false)
+
+    put "/product_reviews/set", to: "product_reviews#set", format: :json
+    resources :product_reviews, only: [:index, :show]
+    resources :product_review_responses, only: [:update, :destroy], format: :json
+    resources :product_review_videos, only: [] do
+      scope module: :product_review_videos do
+        resource :stream, only: [:show]
+        resources :streaming_urls, only: [:index]
+      end
+    end
+    namespace :product_review_videos do
+      resource :upload_context, only: [:show]
+    end
+
     get "/", to: "links#show", defaults: { format: "html" }
     get "/l/:id", to: "links#show", defaults: { format: "html" }
     get "/l/:id/:code", to: "links#show", defaults: { format: "html" }

--- a/spec/requests/product_custom_domain_spec.rb
+++ b/spec/requests/product_custom_domain_spec.rb
@@ -51,6 +51,17 @@ describe "ProductCustomDomainScenario", type: :system, js: true do
     end
   end
 
+  context "when the product has reviews" do
+    let!(:purchase) { create(:purchase, link: product) }
+    let!(:review) { create(:product_review, purchase:, rating: 5, message: "Great product!") }
+
+    it "displays reviews on the product custom domain page" do
+      visit "http://#{custom_domain.domain}:#{port}/"
+      expect(page).to have_text("Ratings")
+      expect(page).to have_text("Great product!")
+    end
+  end
+
   context "when buyer is logged in" do
     let(:buyer) { create(:user) }
     before do


### PR DESCRIPTION
## Problem
Reviews/ratings do not render on product pages accessed via a product-level custom domain, even though the data is present in the server response. The client-side JS fetches `/product_reviews` expecting JSON, but the product custom domain returns HTML because the review routes aren't defined inside the `ProductCustomDomainConstraint` block.

## Root cause
[PR #4727](https://github.com/antiwork/gumroad/pull/4727) added review routes to the `UserCustomDomainConstraint` block (profile-level custom domains) but missed the `ProductCustomDomainConstraint` block (product-level custom domains). The `product_reviews`, `product_review_responses`, and `product_review_videos` routes were only available for profile-level custom domains and `*.gumroad.com` requests.

## Fix
Added the same review routes inside the `ProductCustomDomainConstraint` block, placed before the catch-all product routes so they match before falling through to the HTML shell.

Also added a system test to verify reviews render correctly on product-level custom domains.

Fixes #4781