### PR TITLE
Redirect /users/sign_in and /users/sign_up to custom auth routes

### DIFF
--- a/app/javascript/components/Home/Shared/Nav.tsx
+++ b/app/javascript/components/Home/Shared/Nav.tsx
@@ -121,10 +121,10 @@ const AuthButtons = ({
 
   return (
     <>
-      <NavButton href={Routes.new_user_session_path()} {...(onClick && { onClick })}>
+      <NavButton href={Routes.login_path()} {...(onClick && { onClick })}>
         Log in
       </NavButton>
-      <NavButton href={Routes.new_user_registration_path()} context="primary" {...(onClick && { onClick })}>
+      <NavButton href={Routes.signup_path()} context="primary" {...(onClick && { onClick })}>
         Start selling
       </NavButton>
     </>

--- a/app/views/home/about.html.erb
+++ b/app/views/home/about.html.erb
@@ -6,7 +6,7 @@
         <div class="text-xl max-w-md lg:text-2xl lg:max-w-3xl">Anyone can earn their first dollar online. Just start with what you know, see what sticks, and get paid. It's that easy.</div>
         <div class="mt-2 flex flex-col sm:flex-row items-center justify-center gap-3 sm:gap-4 w-full max-w-[384px] sm:max-w-none sm:w-auto mx-auto">
           <div class="w-full sm:w-auto [&>div]:block!">
-            <%= render "home/shared/button", text: "Start selling", url: new_user_registration_path %>
+            <%= render "home/shared/button", text: "Start selling", url: signup_path %>
           </div>
           <form action="<%= discover_path %>" method="get" class="relative w-full sm:w-auto">
             <label for="marketplace-search" class="sr-only">Search marketplace</label>
@@ -310,7 +310,7 @@
   <div class="px-8 py-16 lg:px-[4vw] lg:py-24">
     <div class="flex flex-col lg:flex-col gap-8 lg:gap-16 max-w-5xl mx-auto lg:items-center">
       <h1 class="font-medium text-4xl sm:text-5xl lg:text-7xl text-center"> Share your work. <br> Someone out there needs it.</h1>
-      <%= render "home/shared/button", text: "Start selling", url: new_user_registration_path %>
+      <%= render "home/shared/button", text: "Start selling", url: signup_path %>
     </div>
   </div>
 

--- a/app/views/home/shared/_nav.html.erb
+++ b/app/views/home/shared/_nav.html.erb
@@ -68,8 +68,8 @@
       if signed_in?
         nav_link("Dashboard", dashboard_url(host: DOMAIN), category: "button", context: "primary")
       else
-        nav_link("Log in", new_user_session_path, category: "button") +
-        nav_link("Start selling", new_user_registration_path, category: "button", context: "primary")
+        nav_link("Log in", login_path, category: "button") +
+        nav_link("Start selling", signup_path, category: "button", context: "primary")
       end
     end
   end

--- a/app/views/home/shared/_section_cta.html.erb
+++ b/app/views/home/shared/_section_cta.html.erb
@@ -2,5 +2,5 @@
   <h2 class="text-4xl font-medium sm:text-5xl lg:text-7xl">
     Share your work. <br> Someone out there needs it.
   </h2>
-  <%= render "home/shared/button", text: "Start selling", url: new_user_registration_path %>
+  <%= render "home/shared/button", text: "Start selling", url: signup_path %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -343,6 +343,12 @@ Rails.application.routes.draw do
     # /robots.txt
     get "/robots.:format" => "robots#index"
 
+    # Redirect Devise's default auth paths to our custom routes.
+    # Must be defined before devise_for so they match first, preventing Devise's
+    # require_no_authentication filter from showing "You are already signed in." flash.
+    get "/users/sign_in", to: redirect("/login")
+    get "/users/sign_up", to: redirect("/signup")
+
     # users (logins/signups and other goodies)
     devise_for(:users,
                controllers: {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -346,8 +346,8 @@ Rails.application.routes.draw do
     # Redirect Devise's default auth paths to our custom routes.
     # Must be defined before devise_for so they match first, preventing Devise's
     # require_no_authentication filter from showing "You are already signed in." flash.
-    get "/users/sign_in", to: redirect("/login")
-    get "/users/sign_up", to: redirect("/signup")
+    get "/users/sign_in", to: redirect { |_p, req| "/login#{req.query_string.present? ? "?#{req.query_string}" : ""}" }
+    get "/users/sign_up", to: redirect { |_p, req| "/signup#{req.query_string.present? ? "?#{req.query_string}" : ""}" }
 
     # users (logins/signups and other goodies)
     devise_for(:users,

--- a/spec/requests/devise_auth_redirects_spec.rb
+++ b/spec/requests/devise_auth_redirects_spec.rb
@@ -15,6 +15,16 @@ describe "Devise auth path redirects", type: :request do
       expect(response).to redirect_to("/login")
     end
 
+    it "preserves query string when redirecting" do
+      get "/users/sign_in?next=/dashboard"
+      expect(response).to redirect_to("/login?next=/dashboard")
+    end
+
+    it "preserves multiple query parameters" do
+      get "/users/sign_in?next=/checkout&email=test%40example.com"
+      expect(response).to redirect_to("/login?next=/checkout&email=test%40example.com")
+    end
+
     context "when user is already signed in" do
       let(:user) { create(:user) }
 
@@ -32,6 +42,16 @@ describe "Devise auth path redirects", type: :request do
     it "redirects to /signup" do
       get "/users/sign_up"
       expect(response).to redirect_to("/signup")
+    end
+
+    it "preserves query string when redirecting" do
+      get "/users/sign_up?referrer=alice"
+      expect(response).to redirect_to("/signup?referrer=alice")
+    end
+
+    it "preserves multiple query parameters" do
+      get "/users/sign_up?referrer=alice&email=test%40example.com"
+      expect(response).to redirect_to("/signup?referrer=alice&email=test%40example.com")
     end
   end
 end

--- a/spec/requests/devise_auth_redirects_spec.rb
+++ b/spec/requests/devise_auth_redirects_spec.rb
@@ -3,6 +3,12 @@
 require "spec_helper"
 
 describe "Devise auth path redirects", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  before do
+    allow_any_instance_of(ActionDispatch::Request).to receive(:host).and_return(VALID_REQUEST_HOSTS.first)
+  end
+
   describe "GET /users/sign_in" do
     it "redirects to /login" do
       get "/users/sign_in"

--- a/spec/requests/devise_auth_redirects_spec.rb
+++ b/spec/requests/devise_auth_redirects_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Devise auth path redirects", type: :request do
+  describe "GET /users/sign_in" do
+    it "redirects to /login" do
+      get "/users/sign_in"
+      expect(response).to redirect_to("/login")
+    end
+
+    context "when user is already signed in" do
+      let(:user) { create(:user) }
+
+      before { sign_in user }
+
+      it "redirects to /login without 'already signed in' flash" do
+        get "/users/sign_in"
+        expect(response).to redirect_to("/login")
+        expect(flash[:alert]).to be_nil
+      end
+    end
+  end
+
+  describe "GET /users/sign_up" do
+    it "redirects to /signup" do
+      get "/users/sign_up"
+      expect(response).to redirect_to("/signup")
+    end
+  end
+end


### PR DESCRIPTION
## Problem
Visiting `/users/sign_in` while logged in shows a "You are already signed in." popup (Devise flash), while `/login` does not. The Devise-generated routes at `/users/sign_in` and `/users/sign_up` go through Devise's `require_no_authentication` filter which sets this flash message, but our custom `/login` and `/signup` routes handle authenticated users gracefully.

## Fix
1. Added redirect routes for `/users/sign_in` → `/login` and `/users/sign_up` → `/signup` before `devise_for`, so they match first and bypass Devise's session/registration controllers entirely
2. Updated all references from `new_user_session_path` to `login_path` and `new_user_registration_path` to `signup_path` in ERBs and TSX
3. Added request specs verifying the redirects work and no flash message appears

Fixes https://github.com/antiwork/gumroad/issues/4770