### PR TITLE
Fix coffee product limit bypassed by unarchiving

### DIFF
--- a/app/controllers/products/archived_controller.rb
+++ b/app/controllers/products/archived_controller.rb
@@ -31,8 +31,11 @@ class Products::ArchivedController < Sellers::BaseController
   def destroy
     authorize [:products, :archived, @product]
 
-    @product.update!(archived: false)
-    render json: { success: true, archived_products_count: current_seller.archived_products_count }
+    if @product.update(archived: false)
+      render json: { success: true, archived_products_count: current_seller.archived_products_count }
+    else
+      render json: { success: false, errors: @product.errors.full_messages }, status: :unprocessable_entity
+    end
   end
 
   private

--- a/app/javascript/data/product_dashboard.ts
+++ b/app/javascript/data/product_dashboard.ts
@@ -32,10 +32,10 @@ export async function unarchiveProduct(permalink: string) {
     accept: "json",
   });
 
-  const json = cast<{ success: true; archived_products_count: number } | { success: false; error: string }>(
+  const json = cast<{ success: true; archived_products_count: number } | { success: false; errors: string[] }>(
     await response.json(),
   );
-  if (!json.success) throw new ResponseError("Failed to unarchive product");
+  if (!json.success) throw new ResponseError(json.errors[0] || "Failed to unarchive product");
   return json.archived_products_count;
 }
 

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -205,7 +205,7 @@ class Link < ApplicationRecord
   validate :published_bundle_must_have_at_least_one_product, on: :update
   validate :user_is_eligible_for_service_products, on: :create, if: :is_service?
   validate :commission_price_is_valid, if: -> { native_type == Link::NATIVE_TYPE_COMMISSION }
-  validate :one_coffee_per_user, on: :create, if: -> { native_type == Link::NATIVE_TYPE_COFFEE }
+  validate :one_coffee_per_user, if: -> { native_type == Link::NATIVE_TYPE_COFFEE && (new_record? || (archived_changed? && !archived?)) }
   validate :quantity_enabled_state_is_allowed
   validate :default_offer_code_must_be_valid
   validate :content_moderation_check, if: -> { publishing? || (persisted? && published? && (name_changed? || description_changed?)) }

--- a/app/services/product_duplicator_service.rb
+++ b/app/services/product_duplicator_service.rb
@@ -35,6 +35,7 @@ class ProductDuplicatorService
       duplicated_product.is_collab = false
       mark_duplicate_product_as_draft
       duplicated_product.is_duplicating = false
+      enforce_one_coffee_per_user!
       duplicated_product.save!(validate: false) # Skip validations since the duplicated product may have invalid state (e.g. missing required fields) that will be fixed by subsequent duplication steps
 
       duplicate_prices
@@ -88,6 +89,15 @@ class ProductDuplicatorService
     def mark_duplicate_product_as_draft
       duplicated_product.draft = true
       duplicated_product.purchase_disabled_at = Time.current
+    end
+
+    def enforce_one_coffee_per_user!
+      return unless duplicated_product.native_type == Link::NATIVE_TYPE_COFFEE
+      return if duplicated_product.archived? || duplicated_product.deleted_at.present?
+      return unless product.user.links.visible_and_not_archived.where(native_type: Link::NATIVE_TYPE_COFFEE).exists?
+
+      duplicated_product.errors.add(:base, "You can only have one coffee product.")
+      raise ActiveRecord::RecordInvalid.new(duplicated_product)
     end
 
     def duplicate_prices

--- a/spec/controllers/products/archived_controller_spec.rb
+++ b/spec/controllers/products/archived_controller_spec.rb
@@ -149,5 +149,23 @@ describe Products::ArchivedController, inertia: true do
       expect(response.parsed_body).to eq({ "success" => true, "archived_products_count" => seller.archived_products_count })
       expect(membership.reload.archived?).to be(false)
     end
+
+    context "when unarchiving would violate validation" do
+      let(:eligible_seller) { create(:user, :eligible_for_service_products) }
+      let!(:archived_coffee) { create(:product, user: eligible_seller, native_type: Link::NATIVE_TYPE_COFFEE, archived: true) }
+      let!(:active_coffee) { create(:product, user: eligible_seller, native_type: Link::NATIVE_TYPE_COFFEE) }
+
+      before do
+        sign_in eligible_seller
+      end
+
+      it "returns validation error" do
+        delete :destroy, params: { id: archived_coffee.unique_permalink }, as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body).to eq({ "success" => false, "errors" => ["You can only have one coffee product."] })
+        expect(archived_coffee.reload.archived?).to be(true)
+      end
+    end
   end
 end

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -4659,6 +4659,26 @@ describe Link, :vcr do
       end
     end
 
+    context "unarchiving coffee product when another coffee product exists" do
+      let!(:coffee_a) { create(:product, user: seller, native_type: Link::NATIVE_TYPE_COFFEE, archived: true) }
+      let!(:coffee_b) { create(:product, user: seller, native_type: Link::NATIVE_TYPE_COFFEE) }
+
+      it "prevents unarchiving" do
+        coffee_a.archived = false
+        expect(coffee_a).to_not be_valid
+        expect(coffee_a.errors.full_messages.first).to eq("You can only have one coffee product.")
+      end
+    end
+
+    context "unarchiving coffee product when no other coffee product exists" do
+      let!(:coffee_a) { create(:product, user: seller, native_type: Link::NATIVE_TYPE_COFFEE, archived: true) }
+
+      it "allows unarchiving" do
+        coffee_a.archived = false
+        expect(coffee_a).to be_valid
+      end
+    end
+
     context "with zero price" do
       let(:coffee) { create(:product, user: seller, native_type: Link::NATIVE_TYPE_COFFEE) }
       let(:variant_category) { create(:variant_category, link: coffee) }

--- a/spec/services/product_duplicator_service_spec.rb
+++ b/spec/services/product_duplicator_service_spec.rb
@@ -199,6 +199,35 @@ describe ProductDuplicatorService do
     end
   end
 
+  context "duplicating a coffee product" do
+    let(:coffee_seller) { create(:user, :eligible_for_service_products) }
+    let(:coffee_product) { create(:product, user: coffee_seller, native_type: Link::NATIVE_TYPE_COFFEE) }
+
+    it "raises a validation error when an active coffee product already exists" do
+      expect do
+        ProductDuplicatorService.new(coffee_product.id).duplicate
+      end.to raise_error(ActiveRecord::RecordInvalid, /You can only have one coffee product/)
+
+      expect(coffee_seller.links.where(native_type: Link::NATIVE_TYPE_COFFEE).count).to eq(1)
+    end
+
+    it "stores the validation message so the dashboard can surface it" do
+      service = ProductDuplicatorService.new(coffee_product.id)
+      expect { service.duplicate }.to raise_error(ActiveRecord::RecordInvalid)
+      expect(service.recently_failed_error_message).to eq("You can only have one coffee product.")
+    end
+
+    it "allows duplicating an archived coffee when no active coffee exists" do
+      coffee_product.update!(archived: true)
+
+      duplicate_product = ProductDuplicatorService.new(coffee_product.id).duplicate
+
+      expect(duplicate_product).to be_persisted
+      expect(duplicate_product.native_type).to eq(Link::NATIVE_TYPE_COFFEE)
+      expect(coffee_seller.links.where(native_type: Link::NATIVE_TYPE_COFFEE).count).to eq(2)
+    end
+  end
+
   it "duplicates a product whose variant has a membership price change effective date in the past" do
     variant_category = create(:variant_category, title: "Tier", link: product)
     variant = create(:variant, variant_category:, name: "Premium")


### PR DESCRIPTION
## What

Fixes a bug where sellers could have more than one active coffee product by archiving the original, creating a new one, then unarchiving the original.

- Run `one_coffee_per_user` validation on unarchive, not just on create
- Return 422 with validation messages from the unarchive endpoint
- Surface the actual error in the products dashboard alert

## Why

The `one_coffee_per_user` validation was scoped to `on: :create`, so the limit was only enforced at creation time. Unarchiving used `update!`, which skipped the check entirely and crashed with a 500 if it had been enforced.

The validation now also runs when `archived_changed? && !archived?`. The guard is intentionally narrow so unrelated updates (price, name, description) on a coffee product don't re-run the check.

## After

https://github.com/user-attachments/assets/fe317637-45be-4368-92e9-404349a255bc

## QA steps

1. Sign in as a seller eligible for service products
2. Create a coffee product (Coffee A)
3. Archive Coffee A from the products dashboard
4. Create a second coffee product (Coffee B)
5. Go to the archived products page and try to unarchive Coffee A
6. Confirm an error toast appears with "You can only have one coffee product." and Coffee A remains archived
7. Delete Coffee B, then unarchive Coffee A — should succeed

---

AI disclosure: drafted with Claude Opus 4.7