### PR TITLE
Fix customer email not reverting on cancel

### DIFF
--- a/app/javascript/components/Audience/CustomerDetailPage.tsx
+++ b/app/javascript/components/Audience/CustomerDetailPage.tsx
@@ -1152,7 +1152,7 @@ const EmailSection = ({
                 className="grow"
               />
               <div className="flex w-full gap-2">
-                <Button onClick={() => setIsEditing(false)} disabled={isLoading} className="flex-1">
+                <Button onClick={() => { setEmail(currentEmail); setIsEditing(false); }} disabled={isLoading} className="flex-1">
                   Cancel
                 </Button>
                 <Button color="primary" onClick={() => void handleSave()} disabled={isLoading} className="flex-1">


### PR DESCRIPTION
## Bug

When editing a customer's email on the customer detail page:

1. Navigate to /customers
2. Click on a customer
3. Click "Edit" on customer email
4. Change the email value
5. Click "Cancel"
6. Click "Edit" again on the same customer
7. The email field still shows the modified (unsaved) value instead of reverting to the original

## Fix

In the `EmailSection` component, the Cancel button only called `setIsEditing(false)` without resetting the `email` state back to `currentEmail`. Added `setEmail(currentEmail)` to the Cancel handler so the email input reverts to the original saved value.

## Change

One-line fix in `app/javascript/components/Audience/CustomerDetailPage.tsx`.