### PR TITLE
Fix squashed info icon in Wishlists Discoverable column header

### DIFF
--- a/app/javascript/pages/Wishlists/Index.tsx
+++ b/app/javascript/pages/Wishlists/Index.tsx
@@ -74,6 +74,7 @@ export default function WishlistsPage() {
                       </span>
                     }
                     position="top"
+                    className="shrink-0"
                   >
                     <InfoCircle className="size-5" />
                   </WithTooltip>


### PR DESCRIPTION
## What

The info (ⓘ) icon in the "Discoverable" column header on the Library > Wishlists page was being squashed on desktop. Adds `shrink-0` to the `WithTooltip` wrapper so the icon stays at its intended 20px size.

## Why

The `<th>` from our shared Table component wraps its children in `inline-flex items-center gap-1`. Inside the th, `<WithTooltip>` renders an outer `inline-grid` span - that's the actual flex item, not the InfoCircle SVG. With default `flex-shrink: 1`, the wrapper compressed whenever the sibling "Discoverable" text needed room, distorting the icon.

Putting `shrink-0` directly on the `<InfoCircle>` doesn't help because the SVG isn't the flex item; the WithTooltip span is. Mobile renders the same content inside a plain `<div>` (no flex), which is why the bug only showed up on desktop.

## Before
<img width="149" height="72" alt="image" src="https://github.com/user-attachments/assets/65445fa7-5067-467e-bb9b-40cc722197e3" />

## After
<img width="181" height="83" alt="image" src="https://github.com/user-attachments/assets/e0506349-5250-4683-b908-f272e337e97d" />


---

AI disclosure: Drafted with Claude Opus 4.7