### PR TITLE
Fix flaky tests: timing waits and deterministic interactions

### DIFF
--- a/spec/requests/embed_spec.rb
+++ b/spec/requests/embed_spec.rb
@@ -90,6 +90,7 @@ describe "Embed scenario", type: :system, js: true, mock_easypost: true do
       visit(create_embed_page(product, url: "#{product.long_url}/#{offer_code.code}", outbound: false))
 
       within_frame do
+        wait_for_ajax
         expect(page).to have_status(text: "$1 off will be applied at checkout (Code SXSW)")
         click_on "Add to cart"
       end

--- a/spec/requests/products/edit/edit_spec.rb
+++ b/spec/requests/products/edit/edit_spec.rb
@@ -681,6 +681,7 @@ describe("Product Edit Scenario", type: :system, js: true) do
     it "shows eligibility notice until dismissed and success notice if recommendable product" do
       expect(product.recommendable?).to be(false)
       visit edit_link_path(product.unique_permalink) + "/share"
+      expect(page).to have_status(text: "To appear on Gumroad Discover, make sure to meet all the")
       expect(page).not_to have_status(text: "#{product.name} is listed on Gumroad Discover.")
 
       click_on "Close"

--- a/spec/requests/products/edit/rich_text_editor_spec.rb
+++ b/spec/requests/products/edit/rich_text_editor_spec.rb
@@ -170,12 +170,11 @@ describe("Product Edit Rich Text Editor", type: :system, js: true) do
     click_on "Insert link"
     within_modal do
       fill_in "Enter URL", with: "https://example.com/link2"
-      send_keys :enter
+      click_on "Add link"
     end
 
     expect(rich_text_editor_input).to have_link("https://example.com/link1", href: "https://example.com/link1")
     expect(rich_text_editor_input).to have_link("https://example.com/link2", href: "https://example.com/link2")
-    sleep 1
     save_change
     expect(@product.reload.description).to have_link("https://example.com/link1", href: "https://example.com/link1")
     expect(@product.description).to have_link("https://example.com/link2", href: "https://example.com/link2")
@@ -317,6 +316,7 @@ describe("Product Edit Rich Text Editor", type: :system, js: true) do
     visit("/products/#{@product.unique_permalink}/edit")
 
     within("[aria-label='Description']") do
+      expect(page).to have_link("Gumroad")
       # Need to double click in order to ensure we have the editor input focused first
       find("a").double_click
     end

--- a/spec/requests/subscription/tiered_membership_offer_codes_spec.rb
+++ b/spec/requests/subscription/tiered_membership_offer_codes_spec.rb
@@ -326,6 +326,7 @@ describe "Tiered Membership Offer code Spec", type: :system, js: true do
           visit "/subscriptions/#{@subscription.external_id}/manage?token=#{@subscription.token}"
 
           choose "Second Tier"
+          wait_for_ajax
 
           # shows the prorated price to be charged today
           expect(page).to have_text "You'll be charged US$6.82"


### PR DESCRIPTION
Fixes 4+ flaky tests that have been causing intermittent CI failures on main:

**embed_spec.rb:89** — discount code in URL test. Added `wait_for_ajax` inside iframe before asserting discount status text. The iframe's JS needs time to process the offer code from the URL.

**rich_text_editor_spec.rb:159** — external links test. Replaced `send_keys :enter` with `click_on "Add link"` for reliable modal submission. Removed unnecessary `sleep 1`.

**rich_text_editor_spec.rb:314** — external link click test. Added `have_link` wait to ensure editor content is rendered before double-clicking.

**tiered_membership_offer_codes_spec.rb:323** — offer code update test. Added `wait_for_ajax` after tier selection so the prorated price calculation completes before assertion.

**edit_spec.rb:681** — discover notices test. Added positive assertion that eligibility notice is present before clicking Close, preventing race where Close is clicked before notice renders.

All changes are test-only. No retries added, no tests skipped, net +3 lines.