### PR TITLE
Fix Faraday::ParsingError in content moderation classifier retries

### DIFF
--- a/app/services/content_moderation/strategies/classifier_strategy.rb
+++ b/app/services/content_moderation/strategies/classifier_strategy.rb
@@ -88,9 +88,9 @@ class ContentModeration::Strategies::ClassifierStrategy
         attempts += 1
         response = @client.moderations(parameters: { model: "omni-moderation-latest", input: input })
         response.dig("results", 0, "category_scores") || {}
-      rescue Faraday::TimeoutError => e
+      rescue Faraday::TimeoutError, Faraday::ParsingError => e
         if attempts < MAX_MODERATION_ATTEMPTS
-          Rails.logger.warn("ContentModeration::ClassifierStrategy timeout on attempt #{attempts}/#{MAX_MODERATION_ATTEMPTS}, retrying: #{e.message}")
+          Rails.logger.warn("ContentModeration::ClassifierStrategy error on attempt #{attempts}/#{MAX_MODERATION_ATTEMPTS}, retrying: #{e.message}")
           retry
         end
         raise

--- a/spec/services/content_moderation/strategies/classifier_strategy_spec.rb
+++ b/spec/services/content_moderation/strategies/classifier_strategy_spec.rb
@@ -206,14 +206,36 @@ RSpec.describe ContentModeration::Strategies::ClassifierStrategy, :vcr do
 
     expect(result.status).to eq("compliant")
     expect(call_count).to eq(3)
-    expect(Rails.logger).to have_received(:warn).with(/timeout on attempt 1\/3, retrying/).once
-    expect(Rails.logger).to have_received(:warn).with(/timeout on attempt 2\/3, retrying/).once
+    expect(Rails.logger).to have_received(:warn).with(/error on attempt 1\/3, retrying/).once
+    expect(Rails.logger).to have_received(:warn).with(/error on attempt 2\/3, retrying/).once
   end
 
   it "gives up after MAX_MODERATION_ATTEMPTS timeouts and re-raises" do
     allow(client).to receive(:moderations).and_raise(Faraday::TimeoutError, "Net::ReadTimeout")
 
     expect { described_class.new(text:, image_urls: []).perform }.to raise_error(Faraday::TimeoutError)
+    expect(client).to have_received(:moderations).exactly(described_class::MAX_MODERATION_ATTEMPTS).times
+  end
+
+  it "retries on Faraday::ParsingError and succeeds when a subsequent attempt returns valid JSON" do
+    call_count = 0
+    allow(client).to receive(:moderations) do
+      call_count += 1
+      raise Faraday::ParsingError, "unexpected character: 'upstream' at line 1 column 1" if call_count == 1
+      { "results" => [{ "category_scores" => {} }] }
+    end
+
+    result = described_class.new(text:, image_urls: []).perform
+
+    expect(result.status).to eq("compliant")
+    expect(call_count).to eq(2)
+    expect(Rails.logger).to have_received(:warn).with(/error on attempt 1\/3, retrying/).once
+  end
+
+  it "gives up after MAX_MODERATION_ATTEMPTS parsing errors and re-raises" do
+    allow(client).to receive(:moderations).and_raise(Faraday::ParsingError, "unexpected character: 'upstream' at line 1 column 1")
+
+    expect { described_class.new(text:, image_urls: []).perform }.to raise_error(Faraday::ParsingError)
     expect(client).to have_received(:moderations).exactly(described_class::MAX_MODERATION_ATTEMPTS).times
   end
 end


### PR DESCRIPTION
## Problem

When OpenAI's moderation API returns a non-JSON response (e.g., an upstream error page), Faraday's JSON parser raises `Faraday::ParsingError`. This exception was unhandled in `ClassifierStrategy#moderate`, causing `LinksController#publish` to crash.

**Sentry:** https://gumroad-to.sentry.io/issues/7444490016/
**Events (7d):** 1 | **Events (14d):** 1 | **Users affected:** ~1/month
**Estimated support tickets:** 0 (transient upstream error, user can retry)

## Fix

Added `Faraday::ParsingError` to the existing retry rescue clause alongside `Faraday::TimeoutError`. Non-JSON responses from OpenAI are transient upstream errors that should be retried, not fatal crashes.

Also updated the log message from "timeout" to "error" since the rescue now covers more than just timeouts.

## Tests

- Added spec: retries on `ParsingError` and succeeds when a subsequent attempt returns valid JSON
- Added spec: re-raises after exhausting all retry attempts with `ParsingError`
- Updated existing timeout specs to match the new log message wording