### PR TITLE
Fix restart checkout card params from orders

### DIFF
--- a/app/services/order/create_service.rb
+++ b/app/services/order/create_service.rb
@@ -58,7 +58,7 @@ class Order::CreateService
         card_params = common_params.slice(
           :card_data_handling_mode, :stripe_payment_method_id, :paypal_order_id,
           :stripe_customer_id, :stripe_setup_intent_id
-        ).compact
+        ).to_h.symbolize_keys.compact
 
         purchase, error, sca_response = Purchase::CreateService.new(
           product:,

--- a/app/services/subscription/restart_at_checkout_service.rb
+++ b/app/services/subscription/restart_at_checkout_service.rb
@@ -6,7 +6,7 @@ class Subscription::RestartAtCheckoutService
   def initialize(subscription:, product:, params:, buyer: nil)
     @subscription = subscription
     @product = product
-    @params = params
+    @params = normalize_params(params)
     @buyer = buyer
   end
 
@@ -23,6 +23,13 @@ class Subscription::RestartAtCheckoutService
   end
 
   private
+    def normalize_params(params)
+      return params.to_unsafe_h.with_indifferent_access if params.respond_to?(:to_unsafe_h)
+      return params.to_h.with_indifferent_access if params.respond_to?(:to_h)
+
+      params.with_indifferent_access
+    end
+
     def updater_service_params
       perceived_price_cents = params.dig(:purchase, :perceived_price_cents)&.to_i ||
                               subscription.current_subscription_price_cents

--- a/spec/services/order/create_service_spec.rb
+++ b/spec/services/order/create_service_spec.rb
@@ -274,7 +274,10 @@ describe Order::CreateService, :vcr do
         ).and_return(updater_service)
         allow(updater_service).to receive(:perform).and_return({ success: true, success_message: "Membership restarted" })
 
-        order, purchase_responses, _ = Order::CreateService.new(params: multi_seller_params, buyer:).perform
+        order, purchase_responses, _ = Order::CreateService.new(
+          params: ActionController::Parameters.new(multi_seller_params).permit!,
+          buyer:
+        ).perform
 
         expect(purchase_responses["unique-id-0"]).to include(success: true)
         # The regular product from seller_2 should still be in the order

--- a/spec/services/subscription/restart_at_checkout_service_spec.rb
+++ b/spec/services/subscription/restart_at_checkout_service_spec.rb
@@ -92,11 +92,14 @@ describe Subscription::RestartAtCheckoutService do
       end
 
       it "treats submitted checkout payment data as a new card" do
-        params_with_stripe = base_params.merge(
-          stripe_payment_method_id: "pm_123",
-          stripe_customer_id: "cus_123",
-          stripe_setup_intent_id: "seti_123"
+        params_with_stripe = ActionController::Parameters.new(
+          base_params.deep_stringify_keys.merge(
+            "stripe_payment_method_id" => "pm_123",
+            "stripe_customer_id" => "cus_123",
+            "stripe_setup_intent_id" => "seti_123"
+          )
         )
+        params_with_stripe.permit!
 
         service = described_class.new(
           subscription: subscription,


### PR DESCRIPTION
## What

Fix the expired subscription restart checkout path so a newly entered card is still recognized when `/orders` passes checkout params through controller strong params. `Order::CreateService` now normalizes the extracted card params before handing them to the restart flow, and `RestartAtCheckoutService` accepts indifferent-access params before deciding whether to reuse the saved card. The regression specs now exercise the real strong-params shape that hit production.

## Why

This follows up on [#4697](https://github.com/antiwork/gumroad/pull/4697). That first restart-card fix handled symbol-keyed params, but the real browser/controller path can send these fields as string-keyed `ActionController::Parameters`. In that case the restart flow treated the request as if no new card had been entered and silently reused the saved card, which matches the support report. Normalizing the params at the boundary fixes the bug without changing the rest of the restart logic.

---

This PR was implemented with AI assistance using gpt‑5.5 xhigh