### PR TITLE
Restrict Sentry event reporting to production and staging environments

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -2,6 +2,7 @@
 
 Sentry.init do |config|
   config.dsn = GlobalConfig.get("SENTRY_DSN")
+  config.enabled_environments = %w[production staging]
   config.breadcrumbs_logger = [:active_support_logger, :http_logger]
   config.send_default_pii = true
   config.traces_sample_rate = 0.01

--- a/spec/config/initializers/sentry_spec.rb
+++ b/spec/config/initializers/sentry_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Sentry configuration" do
+  it "is not enabled in the test environment" do
+    expect(Sentry.configuration.enabled_in_current_env?).to eq(false)
+  end
+
+  it "only enables production and staging environments" do
+    expect(Sentry.configuration.enabled_environments).to eq(%w[production staging])
+  end
+end


### PR DESCRIPTION
## What

Adds `config.enabled_environments = %w[production staging]` to the Sentry initializer so only production and staging environments send error events to Sentry.

## Why

When developers have `SENTRY_DSN` configured locally, test errors leak to Sentry as real issues. A spec in `PayoutUsersService` that deliberately raises `StandardError` was captured by `ErrorNotifier.notify` and sent to Sentry from the test environment on a developer's machine.

Sentry issue: https://gumroad-to.sentry.io/issues/7444930640/

This was a single occurrence from the test environment — no production impact.

## Changes

- `config/initializers/sentry.rb`: Added `enabled_environments` config restricting Sentry to production and staging
- `spec/config/initializers/sentry_spec.rb`: Verifies Sentry is not enabled in the test environment

---

Built with Claude Opus 4.6. Prompt: fix Sentry config to restrict enabled environments to production and staging.