### PR TITLE
Fix: Skip Sentry notification for postal_code_invalid Stripe errors during merchant account creation

### DIFF
--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -114,7 +114,7 @@ module StripeMerchantAccountManager
     merchant_account
   rescue Stripe::StripeError => e
     cleanup_failed_merchant_account(merchant_account) if merchant_account.present?
-    ErrorNotifier.notify(e)
+    ErrorNotifier.notify(e) unless e.is_a?(Stripe::InvalidRequestError) && e.code == "postal_code_invalid"
     raise
   end
 

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -128,6 +128,26 @@ describe StripeMerchantAccountManager, :vcr do
         end.to raise_error(Stripe::InvalidRequestError)
       end
 
+      context "when Stripe raises postal_code_invalid error" do
+        let(:error) { Stripe::InvalidRequestError.new("The postal code you entered is not valid.", nil, code: "postal_code_invalid") }
+
+        before do
+          allow(Stripe::Account).to receive(:create).and_raise(error)
+        end
+
+        it "does not notify Sentry" do
+          expect(ErrorNotifier).not_to receive(:notify)
+          expect { subject.create_account(user, passphrase: "1234") }.to raise_error(Stripe::InvalidRequestError)
+        end
+
+        it "still cleans up the merchant account" do
+          merchant_account = create(:merchant_account, user:, charge_processor: MerchantRegistration::STRIPE)
+          allow(MerchantAccount).to receive(:create!).and_return(merchant_account)
+          expect(described_class).to receive(:cleanup_failed_merchant_account).with(merchant_account)
+          expect { subject.create_account(user, passphrase: "1234") }.to raise_error(Stripe::InvalidRequestError)
+        end
+      end
+
       context "when user compliance info contains whitespaces" do
         let(:user_compliance_info) do
           create(:user_compliance_info,


### PR DESCRIPTION
## What

Skip `ErrorNotifier.notify` in `StripeMerchantAccountManager.create_account` when the error is a `Stripe::InvalidRequestError` with code `postal_code_invalid`.

## Why

The `postal_code_invalid` error is a normal user-input validation error that the controller (`Settings::PaymentsController#update`) already handles gracefully with a user-facing redirect. The unconditional `ErrorNotifier.notify(e)` in the rescue block was creating Sentry noise ([Sentry issue](https://gumroad-to.sentry.io/issues/7444954257/)) for an error that doesn't indicate a system problem.

The fix adds a targeted exclusion: only `postal_code_invalid` errors skip notification — all other `Stripe::StripeError` subclasses continue to notify Sentry as before. Cleanup and re-raise behavior are preserved.

## Test results

Added tests verifying:
- `ErrorNotifier.notify` is **not** called for `postal_code_invalid` errors
- The error is still re-raised
- Merchant account cleanup still runs

Note: existing tests in this spec file fail locally due to factory/environment setup requirements (the `user` factory requires a pre-existing merchant account), but pass in CI. The new tests follow the same patterns as the existing `"raises the Stripe::InvalidRequestError"` test.

---

AI disclosure: implemented with Claude Opus 4.6. Prompt: fix Sentry noise from `postal_code_invalid` Stripe errors in `StripeMerchantAccountManager.create_account`.