### PR TITLE
Guard WithMaxExecutionTime ensure block against broken connections

### DIFF
--- a/lib/utilities/with_max_execution_time.rb
+++ b/lib/utilities/with_max_execution_time.rb
@@ -18,6 +18,10 @@ module WithMaxExecutionTime
       raise
     end
   ensure
-    connection.execute("set max_execution_time = #{previous_max_execution_time}")
+    begin
+      connection.execute("set max_execution_time = #{previous_max_execution_time}")
+    rescue ActiveRecord::StatementInvalid, Mysql2::Error => e
+      Rails.logger.error("[WithMaxExecutionTime] Failed to restore max_execution_time: #{e.message}")
+    end
   end
 end

--- a/spec/lib/utilities/with_max_execution_time_spec.rb
+++ b/spec/lib/utilities/with_max_execution_time_spec.rb
@@ -22,5 +22,51 @@ describe WithMaxExecutionTime do
       end
       expect(returned_value).to eq(:foo)
     end
+
+    context "when restoring max_execution_time fails" do
+      it "does not mask QueryTimeoutError from the caller" do
+        connection = ActiveRecord::Base.connection
+        original_execute = connection.method(:execute)
+        call_count = 0
+
+        allow(connection).to receive(:execute).and_wrap_original do |_original, sql, *args|
+          call_count += 1
+          if call_count > 2 && sql.match?(/\Aset max_execution_time/)
+            raise Mysql2::Error, "MySQL server has gone away"
+          else
+            original_execute.call(sql, *args)
+          end
+        end
+
+        expect do
+          described_class.timeout_queries(seconds: 0.001) do
+            raise ActiveRecord::StatementInvalid.new("Mysql2::Error: Query execution was interrupted, maximum statement execution time exceeded")
+          end
+        end.to raise_error(described_class::QueryTimeoutError)
+      end
+
+      it "logs the restoration failure" do
+        connection = ActiveRecord::Base.connection
+        original_execute = connection.method(:execute)
+        call_count = 0
+
+        allow(connection).to receive(:execute).and_wrap_original do |_original, sql, *args|
+          call_count += 1
+          if call_count > 2 && sql.match?(/\Aset max_execution_time/)
+            raise Mysql2::Error, "MySQL server has gone away"
+          else
+            original_execute.call(sql, *args)
+          end
+        end
+
+        expect(Rails.logger).to receive(:error).with(/\[WithMaxExecutionTime\] Failed to restore max_execution_time.*MySQL server has gone away/)
+
+        expect do
+          described_class.timeout_queries(seconds: 0.001) do
+            raise ActiveRecord::StatementInvalid.new("Mysql2::Error: Query execution was interrupted, maximum statement execution time exceeded")
+          end
+        end.to raise_error(described_class::QueryTimeoutError)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Problem

When a query wrapped in `WithMaxExecutionTime.timeout_queries` exceeds its time limit and the MySQL connection is left in a bad state, the `ensure` block attempts to restore `max_execution_time` on a broken connection. This raises a **new** exception that **masks the original `QueryTimeoutError`**, making production debugging significantly harder.

## Fix

Wrap the `ensure` block in `begin/rescue` to catch `ActiveRecord::StatementInvalid` and `Mysql2::Error`, logging the failure instead of letting it propagate and mask the real error.

## Tests

Added two specs:
- Verifies `QueryTimeoutError` propagates to the caller even when the ensure block fails
- Verifies the restoration failure is logged via `Rails.logger.error`

## Impact

- **Sentry events (7d):** 1
- **Sentry events (14d):** 1  
- **Estimated affected users/month:** Low (transient, but when it does happen the masked error makes debugging much harder)
- **Estimated support tickets/month:** 0 (background job context)

Sentry: https://gumroad-to.sentry.io/issues/7445166358/