### PR TITLE
Handle ActiveRecord::Deadlocked in LinksController#update

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -298,8 +298,11 @@ class LinksController < ApplicationController
     render inertia: "Products/Edit", props: presenter.edit_props
   end
 
+  DEADLOCK_MAX_RETRIES = 2
+
   def update
     authorize @product
+    deadlock_retries = 0
     begin
       ActiveRecord::Base.transaction do
         @product.assign_attributes(product_permitted_params.except(
@@ -393,6 +396,14 @@ class LinksController < ApplicationController
         toggle_community_chat!(product_permitted_params[:community_chat_enabled])
         @product.generate_product_files_archives!
       end
+    rescue ActiveRecord::Deadlocked => e
+      deadlock_retries += 1
+      if deadlock_retries <= DEADLOCK_MAX_RETRIES
+        @product.reload
+        retry
+      end
+      ErrorNotifier.notify(e)
+      return render json: { error_message: "Sorry, something went wrong. Please try again." }, status: :conflict
     rescue ActiveRecord::RecordNotSaved, ActiveRecord::RecordInvalid, Link::LinkInvalid => e
       if @product.errors.details[:custom_fields].present?
         error_message = "You must add titles to all of your inputs"

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -455,6 +455,35 @@ describe LinksController, :vcr, inertia: true do
         end
       end
 
+      context "when a deadlock occurs" do
+        it "retries and succeeds" do
+          call_count = 0
+          allow(ActiveRecord::Base).to receive(:transaction).and_wrap_original do |method, **args, &block|
+            call_count += 1
+            if call_count == 1
+              raise ActiveRecord::Deadlocked.new("Deadlock found when trying to get lock; try restarting transaction")
+            end
+            method.call(**args, &block)
+          end
+
+          put :update, params: @params, as: :json
+
+          expect(response).to have_http_status(:no_content)
+          expect(call_count).to eq(2)
+        end
+
+        it "returns conflict after exhausting retries" do
+          allow(ActiveRecord::Base).to receive(:transaction).and_raise(
+            ActiveRecord::Deadlocked.new("Deadlock found when trying to get lock; try restarting transaction")
+          )
+
+          put :update, params: @params, as: :json
+
+          expect(response).to have_http_status(:conflict)
+          expect(response.parsed_body["error_message"]).to eq("Sorry, something went wrong. Please try again.")
+        end
+      end
+
       it "updates the product" do
         expect(SaveContentUpsellsService).to receive(:new).with(
           seller: @product.user,


### PR DESCRIPTION
## Problem

`LinksController#update` wraps many database operations in a single transaction but does not handle `ActiveRecord::Deadlocked`. When concurrent requests modify overlapping rows (e.g., two saves on the same product), MySQL raises a deadlock exception that bubbles up as an unhandled 500 error.

**Sentry:** https://gumroad-to.sentry.io/issues/7445268383/

**Occurrences (7-day):** 1 (first seen)
**Occurrences (14-day):** 1
**Estimated users affected/month:** Low (intermittent concurrency issue)
**Estimated support tickets/month:** ~0 (users can retry, but poor UX)

## Fix

Add retry logic (up to 2 retries with `@product.reload`) before the transaction, consistent with existing patterns in:
- `CheckoutController` (rescues `ActiveRecord::Deadlocked`)
- `User::SocialGoogle` (retries up to 2 times on deadlock)

After exhausting retries, returns **409 Conflict** with a user-friendly error message and notifies Sentry.

## Changes

- `app/controllers/links_controller.rb`: Added `ActiveRecord::Deadlocked` rescue with retry loop
- `spec/controllers/links_controller_spec.rb`: Added tests for successful retry and exhausted retries scenarios