### PR TITLE
Fix ActiveRecord::Deadlocked in LinksController#update

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -300,6 +300,7 @@ class LinksController < ApplicationController
 
   def update
     authorize @product
+    deadlock_retries = 0
     begin
       ActiveRecord::Base.transaction do
         @product.assign_attributes(product_permitted_params.except(
@@ -393,6 +394,11 @@ class LinksController < ApplicationController
         toggle_community_chat!(product_permitted_params[:community_chat_enabled])
         @product.generate_product_files_archives!
       end
+    rescue ActiveRecord::Deadlocked => e
+      deadlock_retries += 1
+      retry if deadlock_retries <= 2
+      ErrorNotifier.notify(e)
+      return render json: { error_message: "Your changes couldn't be saved due to a temporary conflict. Please try again." }, status: :service_unavailable
     rescue ActiveRecord::RecordNotSaved, ActiveRecord::RecordInvalid, Link::LinkInvalid => e
       if @product.errors.details[:custom_fields].present?
         error_message = "You must add titles to all of your inputs"

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -336,6 +336,32 @@ describe LinksController, :vcr, inertia: true do
         let(:response_status) { 204 }
       end
 
+      context "when ActiveRecord::Deadlocked is raised" do
+        it "retries and succeeds" do
+          call_count = 0
+          allow_any_instance_of(Link).to receive(:save!).and_wrap_original do |original, *args|
+            call_count += 1
+            raise ActiveRecord::Deadlocked if call_count == 1
+            original.call(*args)
+          end
+
+          put :update, params: @params, as: :json
+
+          expect(response).to have_http_status(:no_content)
+          expect(call_count).to eq(2)
+        end
+
+        it "returns 503 after exhausting retries" do
+          allow_any_instance_of(Link).to receive(:save!).and_raise(ActiveRecord::Deadlocked)
+          expect(ErrorNotifier).to receive(:notify).with(instance_of(ActiveRecord::Deadlocked))
+
+          put :update, params: @params, as: :json
+
+          expect(response).to have_http_status(:service_unavailable)
+          expect(response.parsed_body["error_message"]).to eq("Your changes couldn't be saved due to a temporary conflict. Please try again.")
+        end
+      end
+
       it "returns the existing validation error when suggested price is set but the default price record is missing" do
         @product.prices.destroy_all
         @product.update_column(:customizable_price, true)


### PR DESCRIPTION
## What

Adds retry logic for `ActiveRecord::Deadlocked` in `LinksController#update`. When a deadlock occurs, the transaction is retried up to 2 times before returning a 503 with a user-friendly message.

## Why

Concurrent product update requests can cause MySQL deadlocks within the transaction block. Without handling, this bubbles up as a 500 error. The codebase already uses this retry pattern in `User::SocialGoogle` and `CheckoutController`.

Sentry: https://gumroad-to.sentry.io/issues/7445395533/

## Test results

```
2 examples, 0 failures
```

- Verifies the transaction retries on deadlock and succeeds
- Verifies 503 is returned with error message after exhausting retries

---

AI disclosure: Built with Claude Opus 4.6. Prompted to fix the Sentry `ActiveRecord::Deadlocked` issue in `LinksController#update` by adding retry logic following the existing codebase pattern.