### PR TITLE
Migrate leftover BGN balances to EUR for Bulgarian Stripe accounts

### DIFF
--- a/app/services/onetime/migrate_bulgaria_bgn_balances_to_eur.rb
+++ b/app/services/onetime/migrate_bulgaria_bgn_balances_to_eur.rb
@@ -54,9 +54,14 @@ module Onetime
 
         scope.find_in_batches(batch_size: BATCH_SIZE) do |batch|
           ReplicaLagWatcher.watch
-          ids = batch.map(&:id)
-          puts "merchant_accounts batch: #{ids.first}..#{ids.last}"
-          MerchantAccount.where(id: ids).update_all(currency: Currency::EUR) unless @dry_run
+
+          batch.each do |account|
+            puts "merchant_account id=#{account.id} currency=#{account.currency} -> #{Currency::EUR}"
+          end
+
+          next if @dry_run
+
+          MerchantAccount.where(id: batch.map(&:id)).update_all(currency: Currency::EUR)
         end
       end
 
@@ -70,12 +75,15 @@ module Onetime
 
         scope.find_in_batches(batch_size: BATCH_SIZE) do |batch|
           ReplicaLagWatcher.watch
-          puts "balances batch: #{batch.first.id}..#{batch.last.id}"
-
-          next if @dry_run
 
           batch.each do |balance|
             eur_cents = (BigDecimal(balance.holding_amount_cents) / BGN_PER_EUR).round
+            puts "balance id=#{balance.id} user_id=#{balance.user_id} merchant_account_id=#{balance.merchant_account_id} " \
+                 "holding_currency=#{balance.holding_currency} -> #{Currency::EUR}, " \
+                 "holding_amount_cents=#{balance.holding_amount_cents} -> #{eur_cents}"
+
+            next if @dry_run
+
             balance.update_columns(
               holding_currency: Currency::EUR,
               holding_amount_cents: eur_cents,

--- a/app/services/onetime/migrate_bulgaria_bgn_balances_to_eur.rb
+++ b/app/services/onetime/migrate_bulgaria_bgn_balances_to_eur.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+# Migrates leftover BGN-denominated state on Bulgarian Stripe Connect accounts
+# to EUR following Bulgaria's euro adoption on 2026-01-01.
+#
+# Stripe converts pegged BGN balances to EUR at the legal fixed rate of
+# 1.95583 BGN = 1 EUR. This script brings our records in sync with what
+# Stripe holds, so `StripePayoutProcessor.is_balance_payable` (which compares
+# `Balance#holding_currency` to `MerchantAccount#currency`) stops rejecting
+# them.
+#
+# The script:
+#   1. Flips `currency` from "bgn" to "eur" on BG `merchant_accounts` (the
+#      unchecked follow-up from PR #2437).
+#   2. Converts unpaid `balances` whose `holding_currency` is "bgn" and whose
+#      merchant account is Bulgarian: divides `holding_amount_cents` by the
+#      fixed rate and sets `holding_currency` to "eur".
+#
+# Already-paid and processing balances are left untouched: they are historical
+# records of the actual settled currency at the time, and processing balances
+# are mid-payout.
+#
+# Usage:
+#   Onetime::MigrateBulgariaBgnBalancesToEur.process            # dry-run
+#   Onetime::MigrateBulgariaBgnBalancesToEur.process(dry_run: false)
+module Onetime
+  class MigrateBulgariaBgnBalancesToEur
+    BGN = "bgn"
+    BGN_PER_EUR = BigDecimal("1.95583")
+    BATCH_SIZE = 500
+
+    def self.process(dry_run: true)
+      new(dry_run:).process
+    end
+
+    def initialize(dry_run:)
+      @dry_run = dry_run
+    end
+
+    def process
+      puts "Running in #{@dry_run ? 'DRY-RUN' : 'WRITE'} mode"
+      update_merchant_accounts
+      update_unpaid_balances
+    end
+
+    private
+      def bg_alpha2
+        Compliance::Countries::BGR.alpha2
+      end
+
+      def update_merchant_accounts
+        scope = MerchantAccount.where(country: bg_alpha2, currency: BGN)
+        puts "merchant_accounts to update: #{scope.count}"
+
+        scope.find_in_batches(batch_size: BATCH_SIZE) do |batch|
+          ReplicaLagWatcher.watch
+          ids = batch.map(&:id)
+          puts "merchant_accounts batch: #{ids.first}..#{ids.last}"
+          MerchantAccount.where(id: ids).update_all(currency: Currency::EUR) unless @dry_run
+        end
+      end
+
+      def update_unpaid_balances
+        scope = Balance
+          .joins(:merchant_account)
+          .where(state: "unpaid", holding_currency: BGN)
+          .where(merchant_accounts: { country: bg_alpha2 })
+
+        puts "unpaid balances to convert: #{scope.count}"
+
+        scope.find_in_batches(batch_size: BATCH_SIZE) do |batch|
+          ReplicaLagWatcher.watch
+          puts "balances batch: #{batch.first.id}..#{batch.last.id}"
+
+          next if @dry_run
+
+          batch.each do |balance|
+            eur_cents = (BigDecimal(balance.holding_amount_cents) / BGN_PER_EUR).round
+            balance.update_columns(
+              holding_currency: Currency::EUR,
+              holding_amount_cents: eur_cents,
+            )
+          end
+        end
+      end
+  end
+end

--- a/spec/services/onetime/migrate_bulgaria_bgn_balances_to_eur_spec.rb
+++ b/spec/services/onetime/migrate_bulgaria_bgn_balances_to_eur_spec.rb
@@ -126,6 +126,19 @@ describe Onetime::MigrateBulgariaBgnBalancesToEur do
         expect(balance.holding_amount_cents).to eq(19_558)
       end
 
+      it "prints each merchant_account and balance with previous and new values" do
+        account = bg_bgn_account
+        balance = create(:balance, merchant_account: bg_eur_account, holding_currency: "bgn", holding_amount_cents: 19_558)
+
+        expect { described_class.process(dry_run: false) }.to output(
+          a_string_including(
+            "merchant_account id=#{account.id} currency=bgn -> eur",
+            "balance id=#{balance.id} user_id=#{balance.user_id} merchant_account_id=#{balance.merchant_account_id} " \
+            "holding_currency=bgn -> eur, holding_amount_cents=19558 -> 10000"
+          )
+        ).to_stdout
+      end
+
       it "is idempotent — re-running produces no further changes" do
         balance = create(:balance, merchant_account: bg_eur_account, holding_currency: "bgn", holding_amount_cents: 19_558)
 

--- a/spec/services/onetime/migrate_bulgaria_bgn_balances_to_eur_spec.rb
+++ b/spec/services/onetime/migrate_bulgaria_bgn_balances_to_eur_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Onetime::MigrateBulgariaBgnBalancesToEur do
+  let(:bg_eur_account) do
+    create(:merchant_account, country: "BG", currency: "eur")
+  end
+
+  let(:bg_bgn_account) do
+    create(:merchant_account, country: "BG", currency: "bgn")
+  end
+
+  let(:us_account) do
+    create(:merchant_account, country: "US", currency: "usd")
+  end
+
+  describe ".process" do
+    context "in dry-run mode (default)" do
+      it "does not change merchant accounts or balances" do
+        bgn_account = bg_bgn_account
+        balance = create(:balance, merchant_account: bg_eur_account, holding_currency: "bgn", holding_amount_cents: 19_558)
+
+        described_class.process
+
+        expect(bgn_account.reload.currency).to eq("bgn")
+        expect(balance.reload.holding_currency).to eq("bgn")
+        expect(balance.holding_amount_cents).to eq(19_558)
+      end
+    end
+
+    context "in write mode" do
+      it "flips currency from bgn to eur on Bulgarian merchant accounts" do
+        bgn_account = bg_bgn_account
+        eur_account = bg_eur_account
+
+        described_class.process(dry_run: false)
+
+        expect(bgn_account.reload.currency).to eq("eur")
+        expect(eur_account.reload.currency).to eq("eur")
+      end
+
+      it "leaves merchant accounts in other countries untouched" do
+        non_bg_with_bgn = create(:merchant_account, country: "DE", currency: "bgn")
+
+        described_class.process(dry_run: false)
+
+        expect(non_bg_with_bgn.reload.currency).to eq("bgn")
+      end
+
+      it "converts unpaid BGN balances on Bulgarian merchant accounts to EUR at 1.95583" do
+        balance = create(:balance, merchant_account: bg_eur_account, holding_currency: "bgn", holding_amount_cents: 19_558)
+
+        described_class.process(dry_run: false)
+
+        expect(balance.reload.holding_currency).to eq("eur")
+        expect(balance.holding_amount_cents).to eq(10_000)
+      end
+
+      it "rounds to the nearest cent when converting" do
+        balance = create(:balance, merchant_account: bg_eur_account, holding_currency: "bgn", holding_amount_cents: 100)
+
+        described_class.process(dry_run: false)
+
+        expect(balance.reload.holding_amount_cents).to eq(51)
+      end
+
+      it "leaves the issued currency and amount_cents untouched" do
+        balance = create(:balance,
+                         merchant_account: bg_eur_account,
+                         currency: "usd",
+                         amount_cents: 10_000,
+                         holding_currency: "bgn",
+                         holding_amount_cents: 19_558)
+
+        described_class.process(dry_run: false)
+
+        balance.reload
+        expect(balance.currency).to eq("usd")
+        expect(balance.amount_cents).to eq(10_000)
+      end
+
+      it "ignores BGN balances on non-Bulgarian merchant accounts" do
+        balance = create(:balance, merchant_account: us_account, holding_currency: "bgn", holding_amount_cents: 19_558)
+
+        described_class.process(dry_run: false)
+
+        expect(balance.reload.holding_currency).to eq("bgn")
+        expect(balance.holding_amount_cents).to eq(19_558)
+      end
+
+      it "ignores non-BGN balances on Bulgarian merchant accounts" do
+        balance = create(:balance, merchant_account: bg_eur_account, holding_currency: "eur", holding_amount_cents: 10_000)
+
+        described_class.process(dry_run: false)
+
+        expect(balance.reload.holding_currency).to eq("eur")
+        expect(balance.holding_amount_cents).to eq(10_000)
+      end
+
+      it "ignores already-paid balances" do
+        balance = create(:balance,
+                         merchant_account: bg_eur_account,
+                         holding_currency: "bgn",
+                         holding_amount_cents: 19_558,
+                         state: "paid")
+
+        described_class.process(dry_run: false)
+
+        balance.reload
+        expect(balance.holding_currency).to eq("bgn")
+        expect(balance.holding_amount_cents).to eq(19_558)
+      end
+
+      it "ignores processing balances" do
+        balance = create(:balance,
+                         merchant_account: bg_eur_account,
+                         holding_currency: "bgn",
+                         holding_amount_cents: 19_558,
+                         state: "processing")
+
+        described_class.process(dry_run: false)
+
+        balance.reload
+        expect(balance.holding_currency).to eq("bgn")
+        expect(balance.holding_amount_cents).to eq(19_558)
+      end
+
+      it "is idempotent — re-running produces no further changes" do
+        balance = create(:balance, merchant_account: bg_eur_account, holding_currency: "bgn", holding_amount_cents: 19_558)
+
+        described_class.process(dry_run: false)
+        first_pass_cents = balance.reload.holding_amount_cents
+        described_class.process(dry_run: false)
+
+        expect(balance.reload.holding_currency).to eq("eur")
+        expect(balance.holding_amount_cents).to eq(first_pass_cents)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds `Onetime::MigrateBulgariaBgnBalancesToEur` to bring our payout records in sync with Stripe for Bulgarian Connect accounts following the EUR adoption on 2026-01-01.

The task does two things:

1. Flips `currency` from `"bgn"` to `"eur"` on `merchant_accounts` where `country = "BG"`. This is the unchecked follow-up from #2437.
2. Converts unpaid `balances` whose `holding_currency = "bgn"` and whose merchant account is Bulgarian: divides `holding_amount_cents` by the legal fixed rate `1.95583` and sets `holding_currency = "eur"`.

`processing` and `paid` balances are left untouched — they are historical records, and processing balances are mid-payout. The task is idempotent and supports a dry-run mode (default).

## Why

Closes #4712. `StripePayoutProcessor.is_balance_payable` (`app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb:77-86`) requires `balance.holding_currency == merchant_account.currency`. Bulgarian sellers had charges that Stripe settled in BGN before the transition; #2437 then flipped our merchant account / payout currency to EUR, leaving leftover BGN-tagged balance rows that fail the equality check. Affected sellers see a balance in their dashboard but payouts skip silently with a misleading "Negative balance" log.

Stripe converts pegged BGN balances at the legal rate `1.95583 BGN = 1 EUR` (the rate fixed by the Bulgarian National Bank since 1999 and applied by the EU for euro adoption), so the same rate is used here to keep both sides consistent.

I scoped this PR to the data fix only because it directly unblocks payouts. A separate code-side change to `is_balance_payable` to handle currency-migration windows would be defensive against future cases (RON/PLN/CZK/HUF) but isn't needed to resolve this issue.

## Runbook

These are the steps for execution on production. Run from a Rails console.

```ruby
# 1. Dry run — counts and ID ranges only.
Onetime::MigrateBulgariaBgnBalancesToEur.process

# 2. Verify the printed counts look reasonable, then execute.
Onetime::MigrateBulgariaBgnBalancesToEur.process(dry_run: false)
```

To verify before running:

```sql
SELECT COUNT(*) FROM merchant_accounts WHERE country = 'BG' AND currency = 'bgn';

SELECT COUNT(*)
FROM balances b
JOIN merchant_accounts ma ON b.merchant_account_id = ma.id
WHERE b.state = 'unpaid' AND b.holding_currency = 'bgn' AND ma.country = 'BG';
```

After running, both queries should return 0. Re-running the task is safe (idempotent) — it filters by `holding_currency = 'bgn'` and `currency = 'bgn'`, so converted rows are naturally excluded.

To verify a specific affected user (e.g. user 24982534 from the issue) post-migration:

```ruby
user = User.find(24982534)
user.balances.unpaid.pluck(:id, :holding_currency, :holding_amount_cents)
# expect: holding_currency = "eur" for all unpaid rows
StripePayoutProcessor.is_balance_payable(user.balances.unpaid.first)
# expect: true
```

## Test Results

```
$ bundle exec rspec spec/services/onetime/migrate_bulgaria_bgn_balances_to_eur_spec.rb
Finished in 0.53903 seconds
11 examples, 0 failures
```

## QA / verification

- Pre-deploy: dry-run on staging with seed data.
- Post-deploy: re-run dry-run in prod, confirm counts match the queries above, then execute. Pick one affected user and verify the next scheduled payout job processes them (or trigger a manual payout via the existing flow) instead of logging "Negative balance".

---

🤖 Generated with [Claude Opus 4.7 (1M context)](https://claude.com/claude-code) via Claude Code.

Prompts given to the agent:
- "https://github.com/antiwork/gumroad/issues/4712 — how to do this?"
- "create a PR and document the steps"