### PR TITLE
Add 1 retry to slow specs for flaky test resilience

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -376,6 +376,39 @@ jobs:
           WEB_REPO: gumroadteam/web
 
       - name: Run tests
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 20
+          max_attempts: 2
+          retry_wait_seconds: 10
+          command: |
+            # Create local directory for artifacts
+            mkdir -p ./capybara-artifacts
+            chmod 777 ./capybara-artifacts
+            mkdir -p ./test-logs
+            chmod 777 ./test-logs
+
+            # Run tests with volume mount to capture capybara artifacts and test logs
+            docker run --rm --entrypoint="" --network ${{ env.COMPOSE_PROJECT_NAME }}_default \
+              -v "$(pwd)/capybara-artifacts:/app/tmp/capybara" \
+              -v "$(pwd)/test-logs:/app/log" \
+              -e RUBY_YJIT_ENABLE \
+              -e KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC \
+              -e KNAPSACK_PRO_CI_NODE_TOTAL \
+              -e KNAPSACK_PRO_CI_NODE_INDEX \
+              -e KNAPSACK_PRO_LOG_LEVEL \
+              -e KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES \
+              -e KNAPSACK_PRO_TEST_FILE_PATTERN \
+              -e KNAPSACK_PRO_COMMIT_HASH \
+              -e KNAPSACK_PRO_BRANCH \
+              -e KNAPSACK_PRO_CI_NODE_BUILD_ID \
+              -e KNAPSACK_PRO_CI_NODE_RETRY_COUNT \
+              -e KNAPSACK_PRO_PROJECT_DIR \
+              -e KNAPSACK_PRO_FIXED_QUEUE_SPLIT \
+              -e CI \
+              -e IN_DOCKER \
+              $WEB_REPO:test-${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }} \
+              /usr/local/bin/gosu app bundle exec rake "knapsack_pro:queue:rspec[--format RSpec::Github::Formatter --tag ~skip --format progress]"
         env:
           RUBY_YJIT_ENABLE: 1
           KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC_FAST }}
@@ -393,35 +426,6 @@ jobs:
           CI: true
           IN_DOCKER: true
           WEB_REPO: gumroadteam/web
-        run: |
-          # Create local directory for artifacts
-          mkdir -p ./capybara-artifacts
-          chmod 777 ./capybara-artifacts
-          mkdir -p ./test-logs
-          chmod 777 ./test-logs
-
-          # Run tests with volume mount to capture capybara artifacts and test logs
-          docker run --rm --entrypoint="" --network ${{ env.COMPOSE_PROJECT_NAME }}_default \
-            -v "$(pwd)/capybara-artifacts:/app/tmp/capybara" \
-            -v "$(pwd)/test-logs:/app/log" \
-            -e RUBY_YJIT_ENABLE \
-            -e KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC \
-            -e KNAPSACK_PRO_CI_NODE_TOTAL \
-            -e KNAPSACK_PRO_CI_NODE_INDEX \
-            -e KNAPSACK_PRO_LOG_LEVEL \
-            -e KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES \
-            -e KNAPSACK_PRO_TEST_FILE_PATTERN \
-            -e KNAPSACK_PRO_COMMIT_HASH \
-            -e KNAPSACK_PRO_BRANCH \
-            -e KNAPSACK_PRO_CI_NODE_BUILD_ID \
-            -e KNAPSACK_PRO_CI_NODE_RETRY_COUNT \
-            -e KNAPSACK_PRO_PROJECT_DIR \
-            -e KNAPSACK_PRO_FIXED_QUEUE_SPLIT \
-            -e CI \
-            -e IN_DOCKER \
-            $WEB_REPO:test-${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }} \
-            /usr/local/bin/gosu app bundle exec rake "knapsack_pro:queue:rspec[--format RSpec::Github::Formatter --tag ~skip --format progress]"
-        timeout-minutes: 20
       - name: Archive capybara artifacts
         if: failure()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Wraps the slow test run step with nick-fields/retry (max_attempts: 2) so a single flaky test failure doesn't block the entire build. Fast specs are unchanged.