### PR TITLE
Handle Faraday::ConnectionFailed in content moderation ClassifierStrategy

### DIFF
--- a/app/services/content_moderation/strategies/classifier_strategy.rb
+++ b/app/services/content_moderation/strategies/classifier_strategy.rb
@@ -91,7 +91,7 @@ class ContentModeration::Strategies::ClassifierStrategy
         attempts += 1
         response = @client.moderations(parameters: { model: "omni-moderation-latest", input: input })
         response.dig("results", 0, "category_scores") || {}
-      rescue Faraday::TimeoutError, Faraday::ParsingError, Faraday::ServerError => e
+      rescue Faraday::TimeoutError, Faraday::ConnectionFailed, Faraday::ParsingError, Faraday::ServerError => e
         if attempts < MAX_MODERATION_ATTEMPTS
           Rails.logger.warn("ContentModeration::ClassifierStrategy #{e.class.name.demodulize} on attempt #{attempts}/#{MAX_MODERATION_ATTEMPTS}, retrying: #{e.message}")
           retry

--- a/spec/services/content_moderation/strategies/classifier_strategy_spec.rb
+++ b/spec/services/content_moderation/strategies/classifier_strategy_spec.rb
@@ -259,6 +259,39 @@ RSpec.describe ContentModeration::Strategies::ClassifierStrategy, :vcr do
     )
   end
 
+  it "retries on Faraday::ConnectionFailed and succeeds when a subsequent attempt returns" do
+    call_count = 0
+    allow(client).to receive(:moderations) do
+      call_count += 1
+      raise Faraday::ConnectionFailed, "Failed to open TCP connection" if call_count < 3
+      { "results" => [{ "category_scores" => {} }] }
+    end
+
+    result = described_class.new(text:, image_urls: []).perform
+
+    expect(result.status).to eq("compliant")
+    expect(call_count).to eq(3)
+    expect(Rails.logger).to have_received(:warn).with(/ConnectionFailed on attempt 1\/3, retrying/).once
+    expect(Rails.logger).to have_received(:warn).with(/ConnectionFailed on attempt 2\/3, retrying/).once
+  end
+
+  it "returns flagged with unavailable reason after MAX_MODERATION_ATTEMPTS connection failures" do
+    allow(client).to receive(:moderations).and_raise(Faraday::ConnectionFailed, "Failed to open TCP connection")
+    allow(ErrorNotifier).to receive(:notify)
+
+    result = described_class.new(text:, image_urls: []).perform
+
+    expect(result.status).to eq("flagged")
+    expect(result.reasoning).to eq([described_class::UNAVAILABLE_REASON])
+    expect(client).to have_received(:moderations).exactly(described_class::MAX_MODERATION_ATTEMPTS).times
+    expect(ErrorNotifier).to have_received(:notify).with(
+      instance_of(Faraday::ConnectionFailed),
+      attempts: described_class::MAX_MODERATION_ATTEMPTS,
+      input_type: "text",
+      skip_url: nil,
+    )
+  end
+
   it "retries on Faraday::ServerError and succeeds when a subsequent attempt returns" do
     call_count = 0
     allow(client).to receive(:moderations) do


### PR DESCRIPTION
## Problem

`LinksController#update` crashes with `Faraday::ConnectionFailed: Failed to open TCP connection to api.openai.com:443 (getaddrinfo(3): Temporary failure in name resolution)` when DNS resolution transiently fails during content moderation.

**Sentry:** https://gumroad-to.sentry.io/issues/7445499982/

## Root Cause

When a published product's name or description is updated, the `content_moderation_check` validation runs, which calls `ClassifierStrategy#moderate`. That method retries on `Faraday::TimeoutError`, `Faraday::ParsingError`, and `Faraday::ServerError` but **not** `Faraday::ConnectionFailed`.

The sister class `PromptStrategy` already handles `ConnectionFailed` correctly at every level. `ClassifierStrategy` was the only gap.

## Fix

Add `Faraday::ConnectionFailed` to the rescue clause in `ClassifierStrategy#moderate`. On transient connection failures, the strategy now retries up to `MAX_MODERATION_ATTEMPTS` and then returns the unavailable result instead of crashing the request.

## Tests

Added two specs:
- Retries on `ConnectionFailed` and succeeds when a subsequent attempt returns
- Returns flagged with unavailable reason after `MAX_MODERATION_ATTEMPTS` connection failures