### PR TITLE
Fix 3 broken/flaky specs from content moderation PR

### DIFF
--- a/spec/requests/embed_spec.rb
+++ b/spec/requests/embed_spec.rb
@@ -161,6 +161,7 @@ describe "Embed scenario", type: :system, js: true, mock_easypost: true do
     visit(embed_page_url)
 
     within_frame do
+      wait_for_ajax
       expect(page).to have_radio_button("Blue - Extra Large - Polo", checked: true)
       expect(page).to have_field("Quantity", with: 2)
       expect(page).to have_field("Name a fair price", with: 3)

--- a/spec/services/content_moderation/content_extractor_spec.rb
+++ b/spec/services/content_moderation/content_extractor_spec.rb
@@ -60,8 +60,9 @@ RSpec.describe ContentModeration::ContentExtractor do
       expect(result.image_urls).to include("https://cdn.example.com/valid.png")
       expect(result.image_urls).not_to include(nil)
       expect(result.image_urls).not_to include("")
+    end
 
-context "when a product file's S3 object is missing" do
+    context "when a product file's S3 object is missing" do
       before do
         missing_file = double(s3_key: "images/missing.png", s3_filename: "missing.png")
         valid_file = double(s3_key: "images/file.png", s3_filename: "file.png")

--- a/spec/services/content_moderation/strategies/classifier_strategy_spec.rb
+++ b/spec/services/content_moderation/strategies/classifier_strategy_spec.rb
@@ -275,10 +275,20 @@ RSpec.describe ContentModeration::Strategies::ClassifierStrategy, :vcr do
     expect(Rails.logger).to have_received(:warn).with(/ServerError on attempt 2\/3, retrying/).once
   end
 
-  it "gives up after MAX_MODERATION_ATTEMPTS server errors and re-raises" do
+  it "returns flagged with unavailable reason after MAX_MODERATION_ATTEMPTS server errors" do
     allow(client).to receive(:moderations).and_raise(Faraday::ServerError, "500 Internal Server Error")
+    allow(ErrorNotifier).to receive(:notify)
 
-    expect { described_class.new(text:, image_urls: []).perform }.to raise_error(Faraday::ServerError)
+    result = described_class.new(text:, image_urls: []).perform
+
+    expect(result.status).to eq("flagged")
+    expect(result.reasoning).to eq([described_class::UNAVAILABLE_REASON])
     expect(client).to have_received(:moderations).exactly(described_class::MAX_MODERATION_ATTEMPTS).times
+    expect(ErrorNotifier).to have_received(:notify).with(
+      instance_of(Faraday::ServerError),
+      attempts: described_class::MAX_MODERATION_ATTEMPTS,
+      input_type: "text",
+      skip_url: nil,
+    )
   end
 end


### PR DESCRIPTION
## What

Fixes 3 spec failures that appeared in CI after the content moderation PR (fc58e8da):

1. **`content_extractor_spec.rb`** — Missing `end` keyword + wrong indentation caused a `SyntaxError` when loading the file, failing the entire shard
2. **`classifier_strategy_spec.rb`** — Test expected `raise_error(Faraday::ServerError)` but fc58e8da changed behavior to return a flagged result with `UNAVAILABLE_REASON` instead of re-raising. Updated test to match
3. **`embed_spec.rb:144`** — Capybara timing flake when checking pre-filled variant options. Added `wait_for_ajax` before assertions

## Why

These 3 failures caused 3 failed CI shards on the latest main build. The first two are deterministic failures (not flaky) introduced by fc58e8da. The third is a recurring Capybara timing issue.

## Test results

Changes are spec-only — the fixes align tests with existing application behavior.

---

AI disclosure: Claude Opus 4.6 — prompted to investigate and fix CI failures from the latest main build.