### PR TITLE
Fix flaky Elasticsearch search spec ordering assertion

### DIFF
--- a/spec/modules/product/searchable/search_spec.rb
+++ b/spec/modules/product/searchable/search_spec.rb
@@ -658,7 +658,7 @@ describe "Product::Searchable - Search scenarios" do
       end
 
       it "returns products from both users" do
-        expect(Link.search(Link.search_options(user_id: [product1.user_id, product2.user_id])).records.map(&:id)).to eq([product1.id, product2.id])
+        expect(Link.search(Link.search_options(user_id: [product1.user_id, product2.user_id])).records.map(&:id)).to match_array([product1.id, product2.id])
       end
     end
   end


### PR DESCRIPTION
## What

Changes `eq` to `match_array` in `search_spec.rb:660` for the "searching by multiple user IDs" test.

## Why

Elasticsearch does not guarantee result order when relevance scores are equal. The test expected `[450, 451]` but got `[451, 450]`, causing a flaky failure in Test Fast 15. Using `match_array` asserts the correct records are returned without requiring a specific order.

## Test results

One-line change in spec file only. The fix is a standard RSpec pattern for unordered collection assertions.

---

AI disclosure: Claude Opus 4.6 — prompted to fix CI flaky test identified in autoresearch loop.