### PR TITLE
Add retry: 2 to embed_spec for iframe loading flakes

### DIFF
--- a/spec/requests/embed_spec.rb
+++ b/spec/requests/embed_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe "Embed scenario", type: :system, js: true, mock_easypost: true do
+describe "Embed scenario", type: :system, js: true, mock_easypost: true, retry: 2 do
   include EmbedHelpers
 
   after(:all) { cleanup_embed_artifacts }


### PR DESCRIPTION
## What

Adds `retry: 2` to the `embed_spec.rb` describe block, giving each embed example up to 3 attempts before failing.

## Why

Embed tests load products inside dynamically-created iframes. The iframe creation (via `gumroad-embed.js`) and React app mounting can intermittently exceed Capybara's 25s wait timeout on slow CI runners. This causes "Unable to find command 'Add to cart'" failures that aren't deterministic — they pass on retry.

In the latest CI run on main (after #4812), 1 shard failed solely due to embed_spec lines 76 and 115 hitting this iframe timing issue. The tests themselves are correct; they just need more tolerance for slow iframe loading.

## Test results

Change is metadata-only (1 line). No application behavior affected.

---

AI disclosure: Claude Opus 4.6 — prompted to fix flaky CI embed tests identified from CI run analysis.