### PR TITLE
Add retry to fast specs for flaky test resilience

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -203,30 +203,49 @@ jobs:
           WEB_REPO: gumroadteam/web
 
       - name: Run tests
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 15
+          max_attempts: 2
+          retry_wait_seconds: 10
+          command: |
+            docker run --rm --entrypoint="" --network ${{ env.COMPOSE_PROJECT_NAME }}_default \
+              -e RUBY_YJIT_ENABLE \
+              -e KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC \
+              -e KNAPSACK_PRO_CI_NODE_TOTAL \
+              -e KNAPSACK_PRO_CI_NODE_INDEX \
+              -e KNAPSACK_PRO_LOG_LEVEL \
+              -e KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES \
+              -e KNAPSACK_PRO_TEST_FILE_PATTERN \
+              -e KNAPSACK_PRO_TEST_FILE_EXCLUDE_PATTERN \
+              -e KNAPSACK_PRO_COMMIT_HASH \
+              -e KNAPSACK_PRO_BRANCH \
+              -e KNAPSACK_PRO_CI_NODE_BUILD_ID \
+              -e KNAPSACK_PRO_CI_NODE_RETRY_COUNT \
+              -e KNAPSACK_PRO_PROJECT_DIR \
+              -e KNAPSACK_PRO_FIXED_QUEUE_SPLIT \
+              -e CI \
+              -e IN_DOCKER \
+              $WEB_REPO:test-${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }} \
+              /usr/local/bin/gosu app bundle exec rake "knapsack_pro:queue:rspec[--format RSpec::Github::Formatter --tag ~skip --format progress]"
         env:
-          WEB_REPO: gumroadteam/web
+          RUBY_YJIT_ENABLE: 1
+          KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC_FAST }}
+          KNAPSACK_PRO_CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
+          KNAPSACK_PRO_CI_NODE_INDEX: ${{ matrix.ci_node_index }}
+          KNAPSACK_PRO_LOG_LEVEL: info
+          KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES: true
+          KNAPSACK_PRO_TEST_FILE_PATTERN: "spec/**/*_spec.rb"
+          KNAPSACK_PRO_TEST_FILE_EXCLUDE_PATTERN: "spec/requests/**/*_spec.rb"
+          KNAPSACK_PRO_COMMIT_HASH: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           KNAPSACK_PRO_BRANCH: ${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref_name }}
-        run: |
-          docker run --rm --entrypoint="" --network ${{ env.COMPOSE_PROJECT_NAME }}_default \
-            -e RUBY_YJIT_ENABLE=1 \
-            -e KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC_FAST }} \
-            -e KNAPSACK_PRO_CI_NODE_TOTAL=${{ matrix.ci_node_total }} \
-            -e KNAPSACK_PRO_CI_NODE_INDEX=${{ matrix.ci_node_index }} \
-            -e KNAPSACK_PRO_LOG_LEVEL=info \
-            -e KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES=true \
-            -e KNAPSACK_PRO_TEST_FILE_PATTERN="spec/**/*_spec.rb" \
-            -e KNAPSACK_PRO_TEST_FILE_EXCLUDE_PATTERN="spec/requests/**/*_spec.rb" \
-            -e KNAPSACK_PRO_COMMIT_HASH=${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }} \
-            -e KNAPSACK_PRO_BRANCH="$KNAPSACK_PRO_BRANCH" \
-            -e KNAPSACK_PRO_CI_NODE_BUILD_ID=${{ github.run_id }} \
-            -e KNAPSACK_PRO_CI_NODE_RETRY_COUNT=${{ github.run_attempt }} \
-            -e KNAPSACK_PRO_PROJECT_DIR=/app \
-            -e KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true \
-            -e CI=true \
-            -e IN_DOCKER=true \
-            $WEB_REPO:test-${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }} \
-            /usr/local/bin/gosu app bundle exec rake "knapsack_pro:queue:rspec[--format RSpec::Github::Formatter --tag ~skip --format progress]"
-        timeout-minutes: 15
+          KNAPSACK_PRO_CI_NODE_BUILD_ID: ${{ github.run_id }}
+          KNAPSACK_PRO_CI_NODE_RETRY_COUNT: ${{ github.run_attempt }}
+          KNAPSACK_PRO_PROJECT_DIR: /app
+          KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
+          CI: true
+          IN_DOCKER: true
+          WEB_REPO: gumroadteam/web
       - name: Clean up
         if: always()
         run: |


### PR DESCRIPTION
Both fast and slow test runs now retry once on failure via nick-fields/retry (max_attempts: 2). Slow specs already had this from #4808. This adds the same to fast specs, which should get most builds to green.