### PR TITLE
Restore per-spec rspec-retry (3 attempts)

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -213,7 +213,7 @@ RSpec.configure do |config|
     config.verbose_retry = true
     # show exception that triggers a retry if verbose_retry is set to true
     config.display_try_failure_messages = true
-    config.default_retry_count = 1
+    config.default_retry_count = 3
     config.retry_callback = proc do |example|
       reset_db_connection(example)
       reset_browser_session(example)


### PR DESCRIPTION
Restores `config.default_retry_count = 3` in spec_helper.rb (was reduced to 1 in #4729).

Per-spec retry is much more efficient than job-level retry (nick-fields/retry) because it only reruns the individual failing example, not the entire 8-10 min test shard. A flaky Capybara spec takes ~10s to retry vs ~10min to restart the whole job.