### PR TITLE
Remove job-level retry, rely on per-spec rspec-retry

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -203,45 +203,30 @@ jobs:
           WEB_REPO: gumroadteam/web
 
       - name: Run tests
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 15
-          max_attempts: 2
-          retry_wait_seconds: 10
-          command: |
-            docker run --rm --entrypoint="" --network ${{ env.COMPOSE_PROJECT_NAME }}_default \
-              -e RUBY_YJIT_ENABLE \
-              -e KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC \
-              -e KNAPSACK_PRO_CI_NODE_TOTAL \
-              -e KNAPSACK_PRO_CI_NODE_INDEX \
-              -e KNAPSACK_PRO_LOG_LEVEL \
-              -e KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES \
-              -e KNAPSACK_PRO_TEST_FILE_PATTERN \
-              -e KNAPSACK_PRO_TEST_FILE_EXCLUDE_PATTERN \
-              -e KNAPSACK_PRO_COMMIT_HASH \
-              -e KNAPSACK_PRO_BRANCH \
-              -e KNAPSACK_PRO_CI_NODE_BUILD_ID \
-              -e KNAPSACK_PRO_CI_NODE_RETRY_COUNT \
-              -e KNAPSACK_PRO_PROJECT_DIR \
-              -e KNAPSACK_PRO_FIXED_QUEUE_SPLIT \
-              -e CI \
-              -e IN_DOCKER \
-              $WEB_REPO:test-${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }} \
-              /usr/local/bin/gosu app bundle exec rake "knapsack_pro:queue:rspec[--format RSpec::Github::Formatter --tag ~skip --format progress]"
         env:
-          RUBY_YJIT_ENABLE: 1
-          KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC_FAST }}
-          KNAPSACK_PRO_CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
-          KNAPSACK_PRO_CI_NODE_INDEX: ${{ matrix.ci_node_index }}
-          KNAPSACK_PRO_LOG_LEVEL: info
-          KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES: true
-          KNAPSACK_PRO_TEST_FILE_PATTERN: "spec/**/*_spec.rb"
-          KNAPSACK_PRO_TEST_FILE_EXCLUDE_PATTERN: "spec/requests/**/*_spec.rb"
-          KNAPSACK_PRO_COMMIT_HASH: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          WEB_REPO: gumroadteam/web
           KNAPSACK_PRO_BRANCH: ${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref_name }}
-          KNAPSACK_PRO_CI_NODE_BUILD_ID: ${{ github.run_id }}
-          KNAPSACK_PRO_CI_NODE_RETRY_COUNT: ${{ github.run_attempt }}
-          KNAPSACK_PRO_PROJECT_DIR: /app
+        run: |
+          docker run --rm --entrypoint="" --network ${{ env.COMPOSE_PROJECT_NAME }}_default \
+            -e RUBY_YJIT_ENABLE=1 \
+            -e KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC_FAST }} \
+            -e KNAPSACK_PRO_CI_NODE_TOTAL=${{ matrix.ci_node_total }} \
+            -e KNAPSACK_PRO_CI_NODE_INDEX=${{ matrix.ci_node_index }} \
+            -e KNAPSACK_PRO_LOG_LEVEL=info \
+            -e KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES=true \
+            -e KNAPSACK_PRO_TEST_FILE_PATTERN="spec/**/*_spec.rb" \
+            -e KNAPSACK_PRO_TEST_FILE_EXCLUDE_PATTERN="spec/requests/**/*_spec.rb" \
+            -e KNAPSACK_PRO_COMMIT_HASH=${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }} \
+            -e KNAPSACK_PRO_BRANCH="$KNAPSACK_PRO_BRANCH" \
+            -e KNAPSACK_PRO_CI_NODE_BUILD_ID=${{ github.run_id }} \
+            -e KNAPSACK_PRO_CI_NODE_RETRY_COUNT=${{ github.run_attempt }} \
+            -e KNAPSACK_PRO_PROJECT_DIR=/app \
+            -e KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true \
+            -e CI=true \
+            -e IN_DOCKER=true \
+            $WEB_REPO:test-${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }} \
+            /usr/local/bin/gosu app bundle exec rake "knapsack_pro:queue:rspec[--format RSpec::Github::Formatter --tag ~skip --format progress]"
+        timeout-minutes: 15
           KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
           CI: true
           IN_DOCKER: true
@@ -395,39 +380,6 @@ jobs:
           WEB_REPO: gumroadteam/web
 
       - name: Run tests
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 20
-          max_attempts: 2
-          retry_wait_seconds: 10
-          command: |
-            # Create local directory for artifacts
-            mkdir -p ./capybara-artifacts
-            chmod 777 ./capybara-artifacts
-            mkdir -p ./test-logs
-            chmod 777 ./test-logs
-
-            # Run tests with volume mount to capture capybara artifacts and test logs
-            docker run --rm --entrypoint="" --network ${{ env.COMPOSE_PROJECT_NAME }}_default \
-              -v "$(pwd)/capybara-artifacts:/app/tmp/capybara" \
-              -v "$(pwd)/test-logs:/app/log" \
-              -e RUBY_YJIT_ENABLE \
-              -e KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC \
-              -e KNAPSACK_PRO_CI_NODE_TOTAL \
-              -e KNAPSACK_PRO_CI_NODE_INDEX \
-              -e KNAPSACK_PRO_LOG_LEVEL \
-              -e KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES \
-              -e KNAPSACK_PRO_TEST_FILE_PATTERN \
-              -e KNAPSACK_PRO_COMMIT_HASH \
-              -e KNAPSACK_PRO_BRANCH \
-              -e KNAPSACK_PRO_CI_NODE_BUILD_ID \
-              -e KNAPSACK_PRO_CI_NODE_RETRY_COUNT \
-              -e KNAPSACK_PRO_PROJECT_DIR \
-              -e KNAPSACK_PRO_FIXED_QUEUE_SPLIT \
-              -e CI \
-              -e IN_DOCKER \
-              $WEB_REPO:test-${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }} \
-              /usr/local/bin/gosu app bundle exec rake "knapsack_pro:queue:rspec[--format RSpec::Github::Formatter --tag ~skip --format progress]"
         env:
           RUBY_YJIT_ENABLE: 1
           KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC_FAST }}
@@ -445,6 +397,35 @@ jobs:
           CI: true
           IN_DOCKER: true
           WEB_REPO: gumroadteam/web
+        run: |
+          # Create local directory for artifacts
+          mkdir -p ./capybara-artifacts
+          chmod 777 ./capybara-artifacts
+          mkdir -p ./test-logs
+          chmod 777 ./test-logs
+
+          # Run tests with volume mount to capture capybara artifacts and test logs
+          docker run --rm --entrypoint="" --network ${{ env.COMPOSE_PROJECT_NAME }}_default \
+            -v "$(pwd)/capybara-artifacts:/app/tmp/capybara" \
+            -v "$(pwd)/test-logs:/app/log" \
+            -e RUBY_YJIT_ENABLE=1 \
+            -e KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC_FAST }} \
+            -e KNAPSACK_PRO_CI_NODE_TOTAL=${{ matrix.ci_node_total }} \
+            -e KNAPSACK_PRO_CI_NODE_INDEX=${{ matrix.ci_node_index }} \
+            -e KNAPSACK_PRO_LOG_LEVEL=info \
+            -e KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES=true \
+            -e KNAPSACK_PRO_TEST_FILE_PATTERN="spec/requests/**/*_spec.rb" \
+            -e KNAPSACK_PRO_COMMIT_HASH=${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }} \
+            -e KNAPSACK_PRO_BRANCH="$KNAPSACK_PRO_BRANCH" \
+            -e KNAPSACK_PRO_CI_NODE_BUILD_ID=${{ github.run_id }} \
+            -e KNAPSACK_PRO_CI_NODE_RETRY_COUNT=${{ github.run_attempt }} \
+            -e KNAPSACK_PRO_PROJECT_DIR=/app \
+            -e KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true \
+            -e CI=true \
+            -e IN_DOCKER=true \
+            $WEB_REPO:test-${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }} \
+            /usr/local/bin/gosu app bundle exec rake "knapsack_pro:queue:rspec[--format RSpec::Github::Formatter --tag ~skip --format progress]"
+        timeout-minutes: 20
       - name: Archive capybara artifacts
         if: failure()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Removes nick-fields/retry wrapping the 'Run tests' step for both fast and slow specs. Per-spec retry via rspec-retry (default_retry_count=3, restored in #4820) handles flaky tests much more efficiently: ~10s to retry one spec vs ~10min to restart the entire shard.