### PR TITLE
Fix test-subset: build image when Docker pull fails

### DIFF
--- a/.github/workflows/test-subset.yml
+++ b/.github/workflows/test-subset.yml
@@ -48,13 +48,18 @@ jobs:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      - name: Pull test image
+      - name: Pull or build test image
         uses: nick-fields/retry@v3
         with:
-          timeout_minutes: 5
-          max_attempts: 3
-          retry_wait_seconds: 5
-          command: docker pull "gumroadteam/web:test-${{ env.TEST_SHA }}"
+          timeout_minutes: 10
+          max_attempts: 1
+          command: |
+            if docker pull "gumroadteam/web:test-${{ env.TEST_SHA }}" 2>/dev/null; then
+              echo "Pulled existing image"
+            else
+              echo "Image not found, building locally..."
+              docker build -f docker/Dockerfile -t "gumroadteam/web:test-${{ env.TEST_SHA }}" --target test .
+            fi
 
   test:
     name: ${{ inputs.run_name || format('tc-pr-{0}', inputs.pr_number) }}


### PR DESCRIPTION
The test-subset workflow (used by test-confidence) fails when the Docker image for the PR commit SHA doesn't exist on Docker Hub (e.g., after rebase). This causes Test Confidence checks to stay stuck as 'in_progress' forever.

Now falls back to building the image locally instead of failing. The pull-first approach is still preferred for speed.