### PR TITLE
Auto-delete single-use discount codes after use

### DIFF
--- a/app/models/offer_code.rb
+++ b/app/models/offer_code.rb
@@ -156,6 +156,14 @@ class OfferCode < ApplicationRecord
     purchases.counts_towards_offer_code_uses.sum(:quantity)
   end
 
+  def auto_delete_if_single_use_exhausted!
+    return unless max_purchase_count == 1
+    return if deleted?
+    return if quantity_left > 0
+
+    mark_deleted!
+  end
+
   def time_fields
     attributes.keys.keep_if { |key| key.include?("_at") && send(key) }
   end

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -363,6 +363,7 @@ class Purchase < ApplicationRecord
   after_commit :sync_inventory_counter_caches_on_create, on: :create
   after_commit :sync_inventory_counter_cache_for_state_change, on: :update
   after_commit :sync_inventory_counter_cache_for_destroy, on: :destroy
+  after_commit :auto_delete_single_use_offer_code, on: :create, if: -> { successful? && offer_code.present? }
   after_rollback :reset_inventory_pre_save_snapshot
   after_rollback :clear_inventory_pending_create_commit_id
   before_destroy :capture_inventory_state_before_destroy
@@ -2847,6 +2848,12 @@ class Purchase < ApplicationRecord
   end
 
   private
+    def auto_delete_single_use_offer_code
+      offer_code.auto_delete_if_single_use_exhausted!
+    rescue => e
+      Rails.logger.warn("Failed to auto-delete single-use offer code #{offer_code.id}: #{e.message}")
+    end
+
     def offer_amount_off(purchase_min_price)
       # For commissions, apply deposit purchase's offer code to its completion
       # purchase even if it has been soft deleted.

--- a/spec/models/offer_code_spec.rb
+++ b/spec/models/offer_code_spec.rb
@@ -818,4 +818,44 @@ describe OfferCode do
       expect(codes.size).to eq(2)
     end
   end
+
+  describe "#auto_delete_if_single_use_exhausted!" do
+    it "soft-deletes a single-use code that has been fully used" do
+      offer_code = create(:offer_code, products: [@product], max_purchase_count: 1)
+      # Stub the after_commit hook so the purchase doesn't auto-delete the code
+      allow_any_instance_of(Purchase).to receive(:auto_delete_single_use_offer_code)
+      create(:purchase, offer_code:, link: @product, seller: @product.user, price_cents: @product.price_cents)
+
+      expect { offer_code.auto_delete_if_single_use_exhausted! }.to change { offer_code.reload.deleted? }.from(false).to(true)
+    end
+
+    it "does not delete a single-use code that still has quantity left" do
+      offer_code = create(:offer_code, products: [@product], max_purchase_count: 1)
+
+      expect { offer_code.auto_delete_if_single_use_exhausted! }.not_to change { offer_code.reload.deleted? }
+    end
+
+    it "does not delete a multi-use code even when fully used" do
+      offer_code = create(:offer_code, products: [@product], max_purchase_count: 5)
+      5.times { create(:purchase, offer_code:, link: @product, seller: @product.user, price_cents: @product.price_cents) }
+
+      expect { offer_code.auto_delete_if_single_use_exhausted! }.not_to change { offer_code.reload.deleted? }
+    end
+
+    it "does not delete an unlimited-use code" do
+      offer_code = create(:offer_code, products: [@product], max_purchase_count: nil)
+
+      expect { offer_code.auto_delete_if_single_use_exhausted! }.not_to change { offer_code.reload.deleted? }
+    end
+
+    it "does not delete a code that is already deleted" do
+      offer_code = create(:offer_code, products: [@product], max_purchase_count: 1)
+      allow_any_instance_of(Purchase).to receive(:auto_delete_single_use_offer_code)
+      create(:purchase, offer_code:, link: @product, seller: @product.user, price_cents: @product.price_cents)
+      offer_code.mark_deleted!
+
+      expect { offer_code.auto_delete_if_single_use_exhausted! }.not_to change { offer_code.reload.deleted_at }
+    end
+  end
+
 end

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -6473,4 +6473,49 @@ describe Purchase, :vcr do
       expect(purchase.reload.purchase_state).to eq "in_progress"
     end
   end
+
+  describe "#auto_delete_single_use_offer_code" do
+    before do
+      @user = create(:user)
+      @product = create(:product, user: @user, price_cents: 1000)
+    end
+
+    it "auto-deletes a single-use offer code after a successful purchase" do
+      offer_code = create(:offer_code, products: [@product], max_purchase_count: 1)
+      create(:purchase, offer_code:, link: @product, seller: @user, price_cents: @product.price_cents)
+
+      expect(offer_code.reload).to be_deleted
+    end
+
+    it "does not auto-delete offer codes for non-successful purchases" do
+      offer_code = create(:offer_code, products: [@product], max_purchase_count: 1)
+      create(:failed_purchase, offer_code:, link: @product, seller: @user, price_cents: @product.price_cents)
+
+      expect(offer_code.reload).not_to be_deleted
+    end
+
+    it "does not auto-delete when the purchase has no offer code" do
+      purchase = create(:purchase, link: @product, seller: @user, price_cents: @product.price_cents)
+
+      expect(purchase).to be_persisted
+    end
+
+    it "does not auto-delete multi-use offer codes" do
+      offer_code = create(:offer_code, products: [@product], max_purchase_count: 3)
+      create(:purchase, offer_code:, link: @product, seller: @user, price_cents: @product.price_cents)
+
+      expect(offer_code.reload).not_to be_deleted
+    end
+
+    it "does not break the purchase flow if auto-delete raises an error" do
+      offer_code = create(:offer_code, products: [@product], max_purchase_count: 1)
+      allow_any_instance_of(OfferCode).to receive(:auto_delete_if_single_use_exhausted!).and_raise(StandardError, "unexpected error")
+
+      purchase = create(:purchase, offer_code:, link: @product, seller: @user, price_cents: @product.price_cents)
+
+      expect(purchase).to be_persisted
+      expect(offer_code.reload).not_to be_deleted
+    end
+  end
+
 end


### PR DESCRIPTION
When a discount code with `max_purchase_count=1` gets used, automatically soft-delete it. Creators who generate lots of unique single-use codes no longer need to manually clean them up.

- Adds `auto_delete_if_single_use_exhausted!` to `OfferCode`
- Hooks into `Purchase` via `after_commit` on successful purchases with offer codes
- Only affects single-use codes (`max_purchase_count == 1`), multi-use and unlimited codes are not touched
- Uses existing `mark_deleted!` (soft delete), so codes can be restored if needed
- Wrapped in rescue to never break the purchase flow