### PR TITLE
Fix ArgumentError: string contains null byte in LoginsController#create

### DIFF
--- a/app/controllers/logins_controller.rb
+++ b/app/controllers/logins_controller.rb
@@ -34,8 +34,8 @@ class LoginsController < Devise::SessionsController
     end
 
     if params["user"].instance_of?(ActionController::Parameters)
-      login_identifier = params["user"]["login_identifier"]
-      password = params["user"]["password"]
+      login_identifier = params["user"]["login_identifier"]&.delete("\0")
+      password = params["user"]["password"]&.delete("\0")
       @user = User.where(email: login_identifier).first || User.where(username: login_identifier).first if login_identifier.present?
     end
 

--- a/spec/controllers/logins_controller_spec.rb
+++ b/spec/controllers/logins_controller_spec.rb
@@ -127,6 +127,18 @@ describe LoginsController, type: :controller, inertia: true do
       expect(flash[:warning]).to eq("An account does not exist with that email.")
     end
 
+    it "handles null bytes in login_identifier without raising" do
+      post "create", params: { user: { login_identifier: "test\0@example.com", password: "password" } }
+      expect(response).to redirect_to(login_path)
+      expect(flash[:warning]).to eq("An account does not exist with that email.")
+    end
+
+    it "handles null bytes in password without raising" do
+      post "create", params: { user: { login_identifier: @user.email, password: "wrong\0pass" } }
+      expect(response).to redirect_to(login_path)
+      expect(flash[:warning]).to eq("Please try another password. The one you entered was incorrect.")
+    end
+
     it "returns an error with no params" do
       post "create"
       expect(response).to redirect_to(login_path)


### PR DESCRIPTION
## Problem

`LoginsController#create` crashes with `ArgumentError: string contains null byte` when a login request includes null bytes (`\x00`) in the `login_identifier` or `password` parameters. PostgreSQL rejects strings containing null bytes, causing an unhandled exception.

**Sentry:** https://gumroad-to.sentry.io/issues/7445875963/

## Fix

Strip null bytes from `login_identifier` and `password` using `String#delete` before they reach any database query. This is a no-op for normal input and silently removes the problematic bytes from malformed requests.

## Tests

Added two specs confirming null bytes in both `login_identifier` and `password` are handled gracefully without raising.