### PR TITLE
Rescue Pagy::OverflowError in Checkout::DiscountsController

### DIFF
--- a/app/controllers/checkout/discounts_controller.rb
+++ b/app/controllers/checkout/discounts_controller.rb
@@ -142,8 +142,8 @@ class Checkout::DiscountsController < Sellers::BaseController
 
       begin
         pagination, offer_codes = pagy(offer_codes, page: page_num, limit: PER_PAGE)
-      rescue Pagy::OverflowError
-        pagination, offer_codes = pagy(offer_codes, page: 1, limit: PER_PAGE)
+      rescue Pagy::OverflowError => e
+        pagination, offer_codes = pagy(offer_codes, page: e.pagy.last, limit: PER_PAGE)
       end
 
       [PagyPresenter.new(pagination).props, offer_codes]

--- a/app/controllers/checkout/discounts_controller.rb
+++ b/app/controllers/checkout/discounts_controller.rb
@@ -140,7 +140,11 @@ class Checkout::DiscountsController < Sellers::BaseController
         page_num = total_pages
       end
 
-      pagination, offer_codes = pagy(offer_codes, page: page_num, limit: PER_PAGE)
+      begin
+        pagination, offer_codes = pagy(offer_codes, page: page_num, limit: PER_PAGE)
+      rescue Pagy::OverflowError
+        pagination, offer_codes = pagy(offer_codes, page: 1, limit: PER_PAGE)
+      end
 
       [PagyPresenter.new(pagination).props, offer_codes]
     end

--- a/spec/controllers/checkout/discounts_controller_spec.rb
+++ b/spec/controllers/checkout/discounts_controller_spec.rb
@@ -79,7 +79,7 @@ describe Checkout::DiscountsController do
     end
 
     context "when page exceeds available pages due to a race condition" do
-      it "returns the first page instead of raising Pagy::OverflowError" do
+      it "returns the last available page instead of raising Pagy::OverflowError" do
         call_count = 0
         allow_any_instance_of(Checkout::DiscountsController).to receive(:pagy).and_wrap_original do |method, *args, **kwargs|
           call_count += 1
@@ -89,7 +89,7 @@ describe Checkout::DiscountsController do
 
         get :paged, params: { page: 1 }
         expect(response).to be_successful
-        expect(response.parsed_body["pagination"]["page"]).to eq(1)
+        expect(response.parsed_body["pagination"]["page"]).to eq(3)
       end
     end
 

--- a/spec/controllers/checkout/discounts_controller_spec.rb
+++ b/spec/controllers/checkout/discounts_controller_spec.rb
@@ -78,6 +78,21 @@ describe Checkout::DiscountsController do
       )
     end
 
+    context "when page exceeds available pages due to a race condition" do
+      it "returns the first page instead of raising Pagy::OverflowError" do
+        call_count = 0
+        allow_any_instance_of(Checkout::DiscountsController).to receive(:pagy).and_wrap_original do |method, *args, **kwargs|
+          call_count += 1
+          kwargs[:page] = 999 if call_count == 1
+          method.call(*args, **kwargs)
+        end
+
+        get :paged, params: { page: 1 }
+        expect(response).to be_successful
+        expect(response.parsed_body["pagination"]["page"]).to eq(1)
+      end
+    end
+
     context "when `sort` is passed" do
       before do
         create(:purchase, link: create(:product, user: seller), offer_code: offer_codes.third)


### PR DESCRIPTION
## What

Rescue `Pagy::OverflowError` in `Checkout::DiscountsController#fetch_offer_codes` and fall back to the last available page (`e.pagy.last`).

## Why

`fetch_offer_codes` already clamps page numbers to valid ranges (lines 134–141), but there's a race condition: the count query and Pagy's internal count are separate SQL calls. If records are deleted between the two (e.g., a discount is removed by another request), Pagy's count can be lower than the pre-computed count, and the "clamped" page number can still exceed the actual number of pages, raising `Pagy::OverflowError`.

The rescue retries with `e.pagy.last` — the actual last page from Pagy's own count at the moment of failure. This stays consistent with the existing pre-flight clamp behavior ("user requested beyond the end → serve the end") and gives the user data near where they were browsing instead of bouncing them to page 1.

**Sentry:** https://gumroad-to.sentry.io/issues/7446409935/

## Test results

Added a spec that simulates the race condition by overriding the page number passed to `pagy` on the first call. The test confirms the controller returns a successful response with the last available page instead of raising.

---

Built with Claude Opus 4.6.