### PR TITLE
Fix TypeError in FilesController#complete when parts contains non-hash elements

### DIFF
--- a/app/controllers/api/v2/files_controller.rb
+++ b/app/controllers/api/v2/files_controller.rb
@@ -54,7 +54,7 @@ class Api::V2::FilesController < Api::V2::BaseController
     return error_400("invalid key") unless key.start_with?(s3_key_prefix)
 
     raw_parts = Array(params[:parts])
-    unless raw_parts.all? { |p| p.respond_to?(:[]) && !p[:part_number].is_a?(Array) && !p[:etag].is_a?(Array) }
+    unless raw_parts.all? { |p| p.respond_to?(:key?) && !p[:part_number].is_a?(Array) && !p[:etag].is_a?(Array) }
       return error_400("each part must have scalar part_number and etag values")
     end
 

--- a/spec/controllers/api/v2/files_controller_spec.rb
+++ b/spec/controllers/api/v2/files_controller_spec.rb
@@ -191,6 +191,12 @@ describe Api::V2::FilesController do
         expect(response.parsed_body["error"]).to eq("each part must have scalar part_number and etag values")
       end
 
+      it "returns 400 when parts contains a non-hash element" do
+        post action, params: params.merge(parts: ["not-a-hash"])
+        expect(response.status).to eq(400)
+        expect(response.parsed_body["error"]).to eq("each part must have scalar part_number and etag values")
+      end
+
       it "returns 400 with the S3 error message when the upload_id no longer exists" do
         allow_any_instance_of(Aws::S3::Client).to receive(:complete_multipart_upload)
           .and_raise(Aws::S3::Errors::NoSuchUpload.new(nil, "The specified upload does not exist."))


### PR DESCRIPTION
## What

Fixes `TypeError: no implicit conversion of Symbol into Integer` in `Api::V2::FilesController#complete` when `params[:parts]` contains non-hash elements.

**Sentry**: https://gumroad-to.sentry.io/issues/7446471950/

## Why

The validation guard on line 57 used `p.respond_to?(:[])` to check whether each element in `parts` is a hash-like object. However, Arrays and Strings also respond to `[]` — but their `[]` expects an Integer index, not a Symbol key. When a non-hash element (e.g. a plain string) passes this check, the subsequent `p[:part_number]` call raises `TypeError: no implicit conversion of Symbol into Integer`.

The fix replaces `p.respond_to?(:[])` with `p.respond_to?(:key?)`, which is true for Hash and ActionController::Parameters but false for Array, String, Integer, etc. Non-hash elements are now correctly rejected with a 400 error before any Symbol-keyed access is attempted.

## Test results

Added a test that sends `parts: ["not-a-hash"]` and verifies a 400 response. Unable to run tests locally (Ruby 3.4.3 not installed on this machine) — CI will validate.

---

AI disclosure: This fix was implemented with Claude Opus 4.6. Prompt: "Fix TypeError in FilesController#complete when parts contains non-hash elements — replace `respond_to?(:[])` with `respond_to?(:key?)` and add test for non-hash parts element."