### PR TITLE
Fix embed_spec flake: wait for React mount before asserting radio buttons

### DIFF
--- a/spec/requests/embed_spec.rb
+++ b/spec/requests/embed_spec.rb
@@ -163,6 +163,7 @@ describe "Embed scenario", type: :system, js: true, mock_easypost: true, retry: 
     visit(embed_page_url)
 
     within_frame do
+      wait_for_embed_react_mount
       expect(page).to have_radio_button("Blue - Extra Large - Polo", checked: true)
       expect(page).to have_field("Quantity", with: 2)
       expect(page).to have_field("Name a fair price", with: 3)

--- a/spec/support/embed_helpers.rb
+++ b/spec/support/embed_helpers.rb
@@ -5,6 +5,19 @@ module EmbedHelpers
     Dir.glob(Rails.root.join("public", "embed_spec_page_*.html")).each { |f| File.delete(f) }
   end
 
+  # Wait for React to mount inside an embed iframe. Call this inside a
+  # `within_frame` block before asserting on React-rendered elements like
+  # radio buttons or number inputs. Without this, Capybara can check for
+  # elements before React has hydrated the component tree, causing flakes.
+  def wait_for_embed_react_mount
+    Timeout.timeout(Capybara.default_max_wait_time) do
+      loop until page.evaluate_script("document.readyState") == "complete"
+    end
+    Timeout.timeout(Capybara.default_max_wait_time) do
+      loop until page.evaluate_script("document.querySelectorAll('button, input[type=radio], input[type=number]').length > 0")
+    end
+  end
+
   def create_embed_page(product, template_name: "embed_page.html.erb", url: nil, gumroad_params: nil, outbound: true, insert_anchor_tag: true, custom_domain_base_uri: nil, query_params: {})
     template = Rails.root.join("spec", "support", "fixtures", template_name)
     filename = Rails.root.join("public", "embed_spec_page_#{product.unique_permalink}.html")


### PR DESCRIPTION
## Problem

The embed_spec test "prefills the values for quantity, variant, price, and custom fields from the URL" intermittently fails in CI with:

```
expected to find radio_button "Blue - Extra Large - Polo" but there were no matches
```

**Root cause**: `within_frame` enters the iframe as soon as it exists, but React hasn't mounted yet. The radio buttons are rendered by React, so there's a race between when Capybara looks for them and when React hydrates the component tree.

## Fix

Added a `wait_for_embed_react_mount` helper to `EmbedHelpers` that:
1. Waits for `document.readyState == "complete"` (page load)
2. Polls for the presence of React-rendered form elements (`button`, `input[type=radio]`, `input[type=number]`) before yielding to test assertions

The helper is called in the flaky test's `within_frame` block, right before the radio button assertion.

## Validation

This fix was tested on the `autoresearch/ci-probe` branch with **2 consecutive green CI runs**. The one failure during testing was an infrastructure-level issue (80+ jobs failed across the board, zero embed_spec mentions).

## Changes

- `spec/support/embed_helpers.rb`: Add `wait_for_embed_react_mount` helper
- `spec/requests/embed_spec.rb`: Use the helper in the flaky test