### PR TITLE
Fix NoMethodError in Api::V2::LinksController#update for unsupported currency

### DIFF
--- a/app/controllers/api/v2/links_controller.rb
+++ b/app/controllers/api/v2/links_controller.rb
@@ -210,6 +210,10 @@ class Api::V2::LinksController < Api::V2::BaseController
       return render_response(false, message: "Price cannot be updated for tiered membership products. Use the variant endpoints to manage tier pricing.")
     end
 
+    if params.key?(:price_currency_type) && !CURRENCY_CHOICES.key?(params[:price_currency_type])
+      return render_response(false, message: "'#{params[:price_currency_type]}' is not a supported currency.")
+    end
+
     if params.key?(:tags)
       if !params[:tags].is_a?(Array) || params[:tags].any? { |t| !t.respond_to?(:to_str) }
         return render_response(false, message: "tags must be an array of strings.")

--- a/app/modules/base_price/shared.rb
+++ b/app/modules/base_price/shared.rb
@@ -48,7 +48,12 @@ module BasePrice::Shared
   end
 
   def price_must_be_within_range
-    min_price = CURRENCY_CHOICES[price_currency_type]["min_price"]
+    currency_config = CURRENCY_CHOICES[price_currency_type]
+    unless currency_config
+      errors.add(:base, "'#{price_currency_type}' is not a supported currency.")
+      return
+    end
+    min_price = currency_config["min_price"]
 
     prices_to_validate.compact.each do |price_cents_to_validate|
       next if price_cents_to_validate == 0

--- a/spec/controllers/api/v2/links_controller_spec.rb
+++ b/spec/controllers/api/v2/links_controller_spec.rb
@@ -970,6 +970,12 @@ describe Api::V2::LinksController do
         expect(response.parsed_body["message"]).to include("tiered membership")
       end
 
+      it "rejects unsupported price_currency_type" do
+        put @action, params: @params.merge(price_currency_type: "xyz")
+        expect(response.parsed_body["success"]).to be(false)
+        expect(response.parsed_body["message"]).to include("not a supported currency")
+      end
+
       it "processes description through SaveContentUpsellsService" do
         expect_any_instance_of(SaveContentUpsellsService).to receive(:from_html).and_call_original
         put @action, params: @params.merge(description: "<p>test</p>")

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -100,6 +100,13 @@ describe Link, :vcr do
     end
   end
 
+    it "adds an error for unsupported currency type" do
+      link = build(:product, price_currency_type: "xyz", price_cents: 100)
+      expect(link).not_to be_valid
+      expect(link.errors.full_messages).to include("'xyz' is not a supported currency.")
+    end
+  end
+
   describe "native_type inclusion validation" do
     it "fails if native_type is nil" do
       link = build(:product, native_type: nil)


### PR DESCRIPTION
## Problem

`PUT /v2/products/:id` accepts `price_currency_type` without validating it against `CURRENCY_CHOICES`. When an unsupported currency is passed, the `price_must_be_within_range` model validation calls `[]` on `nil`, raising:

```
NoMethodError: undefined method '[]' for nil (NoMethodError)
    min_price = CURRENCY_CHOICES[price_currency_type]["min_price"]
```

**Sentry:** https://gumroad-to.sentry.io/issues/7447533354/
**Occurrences:** 1 (first seen 2026-04-28)
**Users affected:** ~1/month (low volume, but returns a 500 to API consumers)
**Estimated support tickets:** minimal

## Fix

1. **Controller validation** — Added the same `CURRENCY_CHOICES.key?` check to the `update` action that `create` already has. Returns a clear 200 error response instead of a 500.
2. **Model defense-in-depth** — Added a nil guard in `price_must_be_within_range` so even if an unsupported currency slips through, the model adds a validation error instead of raising `NoMethodError`.

## Tests

- Controller spec: verifies update rejects unsupported `price_currency_type` with a friendly message
- Model spec: verifies `price_must_be_within_range` adds an error for unknown currencies