### PR TITLE
Fix ActiveRecord::StatementInvalid for custom_fee_per_thousand json_data field

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -190,7 +190,8 @@ class Admin::UsersController < Admin::BaseController
 
   def set_custom_fee
     custom_fee_per_thousand = params[:custom_fee_percent].present? ? (params[:custom_fee_percent].to_f * 10).round : nil
-    @user.update!(custom_fee_per_thousand:)
+    @user.custom_fee_per_thousand = custom_fee_per_thousand
+    @user.save!
     render json: { success: true }
   rescue ActiveRecord::RecordInvalid => e
     render json: { success: false, message: e.message }, status: :unprocessable_content

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -275,7 +275,8 @@ describe Admin::UsersController, type: :controller, inertia: true do
     end
 
     it "updates the existing custom fee" do
-      user.update!(custom_fee_per_thousand: 75)
+      user.custom_fee_per_thousand = 75
+      user.save!
       expect(user.reload.custom_fee_per_thousand).to eq 75
 
       post :set_custom_fee, params: { external_id: user.external_id, custom_fee_percent: "5" }


### PR DESCRIPTION
## Problem

The `set_custom_fee` admin action calls `@user.update!(custom_fee_per_thousand:)`, but `custom_fee_per_thousand` is a `json_data` accessor (via `attr_json_data_accessor`), not a real database column. This causes ActiveRecord to generate SQL referencing a non-existent column:

```
ActiveRecord::StatementInvalid: Mysql2::Error: Unknown column 'custom_fee_per_thousand' in 'field list'
```

**Sentry:** https://gumroad-to.sentry.io/issues/7447586023/
**Occurrences (7-day):** 1
**Occurrences (14-day):** 1
**Estimated users affected/month:** Low (admin-only action, triggered when setting custom fees for sellers)
**Estimated support tickets/month:** 0 (internal admin action)

## Fix

Use the json_data accessor setter (`@user.custom_fee_per_thousand = value`) followed by `save!` instead of `update!`. This correctly writes to the `json_data` JSON column.

## Changes

- `app/controllers/admin/users_controller.rb`: Replace `update!` with accessor + `save!`
- `spec/controllers/admin/users_controller_spec.rb`: Same fix in test setup