### PR TITLE
Apply seller custom fee to subscription renewals

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -3379,7 +3379,8 @@ class Purchase < ApplicationRecord
 
       if is_recurring_subscription_charge || is_updated_original_subscription_purchase
         original_purchase = subscription.original_purchase
-        self.custom_fee_per_thousand = original_purchase.custom_fee_per_thousand if original_purchase&.custom_fee_per_thousand.present?
+        fee = original_purchase&.custom_fee_per_thousand.presence || seller.custom_fee_per_thousand
+        self.custom_fee_per_thousand = fee if fee.present?
       elsif is_preorder_charge?
         self.custom_fee_per_thousand = preorder.authorization_purchase.custom_fee_per_thousand if preorder.authorization_purchase.custom_fee_per_thousand.present?
       elsif seller.custom_fee_per_thousand.present?

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -6318,10 +6318,22 @@ describe Purchase, :vcr do
         end
       end
 
-      context "when original subscription purchase did not have a custom fee" do
-        it "does not set a custom fee" do
-          original_subscription_purchase.seller.update!(custom_fee_per_thousand: 75)
+      context "when original subscription purchase did not have a custom fee but the seller has one set" do
+        it "falls back to the seller's custom fee" do
+          recurring_purchase = create(:purchase, subscription:, is_original_subscription_purchase: false)
+          recurring_purchase.seller.update!(custom_fee_per_thousand: 75)
           expect(original_subscription_purchase.custom_fee_per_thousand).to be_nil
+          expect(recurring_purchase.reload.custom_fee_per_thousand).to be_nil
+
+          recurring_purchase.send(:calculate_custom_fee_per_thousand)
+          expect(recurring_purchase.custom_fee_per_thousand).to eq(75)
+        end
+      end
+
+      context "when neither the original subscription purchase nor the seller has a custom fee" do
+        it "does not set a custom fee" do
+          expect(original_subscription_purchase.custom_fee_per_thousand).to be_nil
+          expect(original_subscription_purchase.seller.custom_fee_per_thousand).to be_nil
 
           recurring_purchase = create(:purchase, subscription:, is_original_subscription_purchase: false)
           expect(recurring_purchase.reload.custom_fee_per_thousand).to be_nil

--- a/spec/requests/purchases/product/subscription_purchases_spec.rb
+++ b/spec/requests/purchases/product/subscription_purchases_spec.rb
@@ -70,8 +70,8 @@ describe("Subscription Purchases from the product page", type: :system, js: true
 
         recurring_charge = purchase.subscription.purchases.successful.last
         expect(purchase.subscription.purchases.successful.count).to eq(2)
-        expect(recurring_charge.custom_fee_per_thousand).to be_nil
-        expect(recurring_charge.fee_cents).to eq(261)
+        expect(recurring_charge.custom_fee_per_thousand).to eq(25)
+        expect(recurring_charge.fee_cents).to eq(156) # 2.5% of $14 + 50c + 2.9% of $14 + 30c
       end
 
       it "charges custom Gumroad fee if custom fee is set for the seller" do


### PR DESCRIPTION
## What

`Purchase#calculate_custom_fee_per_thousand` now falls back to `seller.custom_fee_per_thousand` when the subscription's `original_purchase.custom_fee_per_thousand` is `nil`. Previously, recurring subscription charges only consulted the value frozen on the original purchase and ignored the seller-level override entirely.

## Why

Reported in https://github.com/antiwork/gumroad-private/issues/319.

A creator had `custom_fee_per_thousand = 50` (5%) set on their User account but their subscription renewals continued to charge 10%. After investigation:

- `User#custom_fee_per_thousand` only applies to **new direct sales**.
- For recurring charges, `calculate_custom_fee_per_thousand` reads from `subscription.original_purchase.custom_fee_per_thousand`. If that field was nil at renewal time (which it is for any subscription created before the seller's custom fee was set), the renewal falls back to the 10% flat rate.
- The manual fix support ran (writing the value onto each original_purchase) was incomplete — many active subs on this seller's product were missed, and they continue to overcharge on every renewal.

The same bug affects other custom-fee sellers, totaling tens of thousands of active subscriptions that should be charged the negotiated rate but are charged 10%. A code-level fallback is more durable than per-seller backfills, which have already proven to miss subs in practice.

Scope kept narrow: the `is_preorder_charge?` branch has the same shape and same latent issue but is out of scope for the reported bug.

## Before/After

**Before:** Renewals on subscriptions whose `original_purchase.custom_fee_per_thousand` was nil charged the 10% flat fee, regardless of the seller's `custom_fee_per_thousand`.

**After:** Same renewals fall back to the seller's value. When both the original purchase and the seller have a value, the original purchase still wins (preserving frozen historical rates).

This is a backend fee-calculation change; no UI surface. I do not have a way to record a video of fee math evaluation against a real subscription, so the verification is via unit tests below.

## Test Results

```
$ bundle exec rspec spec/models/purchase_spec.rb -e "calculate_custom_fee_per_thousand"
...........
Finished in 1.81 seconds (files took 3.5 seconds to load)
11 examples, 0 failures
```

Updated test that previously asserted the broken behavior (`when original subscription purchase did not have a custom fee` → `does not set a custom fee`) to assert the new fallback behavior, and added a third case for `when neither the original subscription purchase nor the seller has a custom fee` to keep coverage of the no-op path.

## Follow-up (not in this PR)

- Credit the reporter for the remaining overcharge beyond what was already applied.
- Decide whether to retroactively credit the other affected custom-fee sellers.

---

🤖 Generated with [Claude Opus 4.7](https://claude.com/claude-code).

