### PR TITLE
Fix ActiveRecord::StatementInvalid when checkout params are nested

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -8,7 +8,7 @@ class CheckoutController < ApplicationController
   def show
     render inertia: "Checkout/Show", props: {
       cart: -> { CartPresenter.new(logged_in_user:, ip: request.remote_ip, browser_guid: cookies[:_gumroad_guid]).cart_props },
-      checkout: -> { CheckoutPresenter.new(logged_in_user:, ip: request.remote_ip).checkout_props(params:, browser_guid: cookies[:_gumroad_guid]) },
+      checkout: -> { CheckoutPresenter.new(logged_in_user:, ip: request.remote_ip).checkout_props(params: checkout_params, browser_guid: cookies[:_gumroad_guid]) },
       recommended_products: InertiaRails.optional { recommended_products },
     }
   end
@@ -133,6 +133,15 @@ class CheckoutController < ApplicationController
     rescue Timeout::Error
       Rails.logger.warn("[CheckoutController] Recommended products timed out after #{RECOMMENDED_PRODUCTS_TIMEOUT_SECONDS}s")
       []
+    end
+
+    def checkout_params
+      params.permit(
+        :username, :product, :wishlist, :gift_wishlist_product,
+        :accepted_offer_id, :affiliate_id, :recommended_by, :recommender_model_name,
+        :option, :rent, :recurrence, :pay_in_installments, :price, :quantity,
+        :call_start_time, :force_new_subscription
+      )
     end
 
     def update_permitted_params

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -52,6 +52,12 @@ describe CheckoutController, type: :controller, inertia: true do
       )
     end
 
+    it "does not raise when checkout params contain nested values" do
+      get :show, params: { product: { foo: "bar" }, username: { baz: "qux" }, wishlist: { id: "1" } }
+
+      expect(response).to be_successful
+    end
+
     describe "process_cart_id_param check" do
       let(:user) { create(:user) }
       let(:cart) { create(:cart, user:) }


### PR DESCRIPTION
## What

Added a `checkout_params` strong parameters method in `CheckoutController` that permits only the expected scalar parameters before passing them to `CheckoutPresenter#checkout_props`. This prevents nested `ActionController::Parameters` objects from reaching ActiveRecord finder methods.

## Why

When a malformed query string like `?product[foo]=bar` hits `CheckoutController#show`, `params[:product]` becomes an `ActionController::Parameters` object instead of a string. This value flows into `Link.find_by_unique_permalink()`, which can't quote it for SQL, raising `ActiveRecord::StatementInvalid: can't quote ActionController::Parameters`.

Sentry: https://gumroad-to.sentry.io/issues/7447859803/

Using `params.permit` is the idiomatic Rails fix — it strips any non-scalar values and returns `nil` for nested params, which the presenter already handles gracefully.

## Test results

Added a controller test that sends nested params (`product: { foo: "bar" }`) and verifies the request succeeds instead of raising.

---

AI disclosure: Built with Claude Opus 4.6. Prompted with the Sentry error details and root cause analysis, asked to implement the strong parameters fix and add a regression test.