### PR TITLE
Fix link spec nesting

### DIFF
--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -98,7 +98,6 @@ describe Link, :vcr do
           .to_not raise_error(ActiveRecord::RecordInvalid)
       end
     end
-  end
 
     it "adds an error for unsupported currency type" do
       link = build(:product, price_currency_type: "xyz", price_cents: 100)


### PR DESCRIPTION
Ref #4841

## What

Fixes the main CI failure caused by the unsupported-currency spec in the Link model being placed outside its intended validation group. The spec now loads correctly while preserving the model and controller coverage added by the original change.

## Why

PR #4841 added the right regression coverage, but one extra `end` left `spec/models/link_spec.rb` syntactically invalid. Moving the example into the existing price validation group is the smallest fix because it corrects the test structure without changing product behavior.

---

This PR was implemented with AI assistance using gpt-5.5 xhigh.