### PR TITLE
Redesign test-confidence: 99% as the goal, not a spectrum

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -14,7 +14,7 @@ Create a commit for the current changes.
 1. Run `git status` (without `-uall`) to see untracked and modified files.
 2. Run `git diff` and `git diff --cached` to understand staged and unstaged changes.
 3. Run `git log --oneline -5` to see recent commit style.
-4. **Run `/test-confidence` to verify your changes don't break anything.** Wait for confidence to meet the threshold before proceeding. If any test fails, fix it first.
+4. **Run `bin/test-confidence` to verify your changes don't break anything.** Opus analyzes your diff and runs the right tests. Wait for 99% confidence (green bar) before proceeding. If any test fails, fix it first.
 5. **Run linters on changed files before staging:**
    - Ruby files: `bundle exec rubocop --force-exclusion -a <files>`
    - JS/TS files: `npm run lint-fast -- --max-warnings 0 --fix --no-warn-ignored <files>`

--- a/.claude/skills/test-confidence/SKILL.md
+++ b/.claude/skills/test-confidence/SKILL.md
@@ -1,40 +1,34 @@
 ---
 name: test-confidence
-description: Run tests ranked by relevance to your diff. Confidence climbs continuously from 0% to 100%. Stop when you're confident enough.
-argument-hint: [threshold, e.g. 0.99]
+description: AI-driven test execution. Opus decides what to run and how confident to be, based on your diff.
+argument-hint: [--full to run to 100%, --no-ai for convention fallback]
 allowed-tools: Bash(git *), Bash(bundle exec rspec *), Bash(cat *), Bash(find *), Bash(wc *), Bash(head *), Bash(tail *), Bash(grep *), Bash(bin/test-confidence *)
 ---
 
 # Test Confidence
 
-Run `bin/test-confidence` to execute tests ranked by relevance to your diff. Confidence climbs continuously from 0% to 100% as each test passes. No waves, no stages. Just a stream of tests, most important first.
+Run `bin/test-confidence` to have Opus 4.7 analyze your diff, decide the risk level, plan which tests to run and in what order, and set confidence milestones. The AI decides the shape of the curve based on this specific diff.
 
 ## Usage
 
 ```bash
-bin/test-confidence              # Stop at 99%
-bin/test-confidence 0.95         # Stop at 95% (quick sanity check)
-bin/test-confidence 1.0          # Run everything
-bin/test-confidence --no-ai      # Convention mapping only
+bin/test-confidence          # Run to 99%, stop
+bin/test-confidence --full   # Run to 100%
+bin/test-confidence --no-ai  # Convention fallback, no API call
 ```
 
-If `$ARGUMENTS` provides a number, pass it through: `bin/test-confidence $ARGUMENTS`
+If `$ARGUMENTS` is provided, pass it through: `bin/test-confidence $ARGUMENTS`
 
 ## How it works
 
-1. Finds changed files: branch diff vs main (for PR branches), local uncommitted changes, or both
-2. Builds a single ordered queue: direct specs first, then specs referencing your classes, then same-directory specs, then everything else
-3. Optionally calls Sonnet to reorder by likelihood of catching a regression
-4. Runs tests one at a time. After each pass, confidence updates on a Pareto curve (early tests contribute more since they're the most relevant)
-5. Stops the moment confidence crosses the threshold
+1. Finds changed files (branch diff vs main for PR branches, local diff on main)
+2. Sends the diff + full spec file list to Opus 4.7 in one call
+3. Opus returns a plan: risk level, ordered test list, confidence milestones
+4. Script executes the plan, showing yellow progress bar toward 99%
+5. At 99%, bar turns green. Safe to commit.
+6. With `--full`, continues running remaining tests toward 100%
 
-The confidence model:
-- 10% of tests (most relevant) → ~70% confidence
-- 30% of tests → ~92% confidence  
-- 50% of tests → ~98% confidence
-- 100% of tests → 100% confidence
-
-If any test fails, it stops immediately and reports the failure.
+The key insight: Opus decides ad hoc how many tests are needed for each confidence level. A comment-only change might need 2 tests for 99%. A payment model refactor might need 100.
 
 ## When to use
 

--- a/.claude/skills/test-confidence/SKILL.md
+++ b/.claude/skills/test-confidence/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: test-confidence
 description: AI-driven test execution. Opus decides what to run and how confident to be, based on your diff.
-argument-hint: [--full to run to 100%, --no-ai for convention fallback]
+argument-hint: [--full to run to 100%]
 allowed-tools: Bash(git *), Bash(bundle exec rspec *), Bash(cat *), Bash(find *), Bash(wc *), Bash(head *), Bash(tail *), Bash(grep *), Bash(bin/test-confidence *)
 ---
 
@@ -14,8 +14,9 @@ Run `bin/test-confidence` to have Opus 4.7 analyze your diff, decide the risk le
 ```bash
 bin/test-confidence          # Run to 99%, stop
 bin/test-confidence --full   # Run to 100%
-bin/test-confidence --no-ai  # Convention fallback, no API call
 ```
+
+Requires `ANTHROPIC_API_KEY` in your environment.
 
 If `$ARGUMENTS` is provided, pass it through: `bin/test-confidence $ARGUMENTS`
 

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ test-branch-creation.log
 .claude/worktrees/
 autoresearch.*
 .codex/
+.test-confidence-history.json

--- a/.gitignore
+++ b/.gitignore
@@ -66,4 +66,3 @@ test-branch-creation.log
 .claude/worktrees/
 autoresearch.*
 .codex/
-.test-confidence-history.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,15 +56,16 @@ Use the latest and greatest state-of-the-art models from American AI companies l
 Run **test-confidence** before every commit:
 
 ```bash
-bin/test-confidence          # Stop at 99%
-bin/test-confidence 0.95     # Quick sanity check
-bin/test-confidence 1.0      # Run the full suite
-bin/test-confidence --no-ai  # No API key needed
+bin/test-confidence          # Run to 99%, stop
+bin/test-confidence --full   # Run to 100%
+bin/test-confidence --no-ai  # Convention fallback, no API key needed
 ```
 
-It ranks every spec by relevance to your diff and runs them in order. Confidence climbs from 0% to 100% in real-time as each test passes. Most relevant tests run first, so confidence front-loads fast. For payment/billing changes it auto-raises the threshold to 100%.
+Opus 4.7 analyzes your diff in one call: decides the risk level, picks which tests to run, sets the order, and determines how many tests are needed for each confidence milestone. A comment-only change might need 2 tests for 99%. A payment model refactor might need 100. The AI decides the curve shape ad hoc per diff.
 
-Set `ANTHROPIC_API_KEY` for AI-powered reordering (falls back to convention mapping without it). Also works as a Claude Code skill: `/test-confidence`
+The bar is yellow while running toward 99%, then turns green. At green, safe to commit.
+
+Set `ANTHROPIC_API_KEY` for AI mode (falls back to convention mapping without it). Also works as a Claude Code skill: `/test-confidence`
 
 Also lint before committing:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,14 +58,11 @@ Run **test-confidence** before every commit:
 ```bash
 bin/test-confidence          # Run to 99%, stop
 bin/test-confidence --full   # Run to 100%
-bin/test-confidence --no-ai  # Convention fallback, no API key needed
 ```
 
-Opus 4.7 analyzes your diff in one call: decides the risk level, picks which tests to run, sets the order, and determines how many tests are needed for each confidence milestone. A comment-only change might need 2 tests for 99%. A payment model refactor might need 100. The AI decides the curve shape ad hoc per diff.
+Requires `ANTHROPIC_API_KEY`. Opus 4.7 analyzes your diff in one call: decides the risk level, picks which tests to run, sets the order, and determines how many tests are needed for each confidence milestone. A comment-only change might need 2 tests for 99%. A payment model refactor might need 100. The AI decides the curve shape ad hoc per diff.
 
-The bar is yellow while running toward 99%, then turns green. At green, safe to commit.
-
-Set `ANTHROPIC_API_KEY` for AI mode (falls back to convention mapping without it). Also works as a Claude Code skill: `/test-confidence`
+The bar is yellow while running toward 99%, then turns green. At green, safe to commit. Also works as a Claude Code skill: `/test-confidence`
 
 Also lint before committing:
 

--- a/bin/test-confidence
+++ b/bin/test-confidence
@@ -1,16 +1,13 @@
 #!/usr/bin/env bash
 #
-# bin/test-confidence — Run the tests that matter, fast.
-#
-# Finds the minimal set of tests needed for 99% confidence based on your
-# diff, runs them, then optionally continues toward 100%.
+# bin/test-confidence — AI-driven test execution. Opus decides what to run and how confident to be.
 #
 # Usage:
 #   bin/test-confidence          # Run to 99%, stop
 #   bin/test-confidence --full   # Run to 100%
-#   bin/test-confidence --no-ai  # Skip AI reranking
+#   bin/test-confidence --no-ai  # Convention mapping, no AI (deterministic fallback)
 #
-# Set ANTHROPIC_API_KEY for AI-powered ranking. Falls back to convention without it.
+# Requires: ANTHROPIC_API_KEY for AI mode. Falls back to convention without it.
 #
 set -euo pipefail
 
@@ -57,134 +54,82 @@ else
   echo "  📂 $FILE_COUNT files changed (local)"
 fi
 
-# ── Build the critical set (tests needed for 99%) ──
+# ── Get the diff ──
 
-CRITICAL=$(mktemp)
-REMAINING=$(mktemp)
-SEEN=$(mktemp)
+if [[ -n "$LOCAL_CHANGED" ]]; then
+  DIFF_TEXT=$(git diff HEAD -- $(echo "$LOCAL_CHANGED" | head -20) 2>/dev/null | head -500)
+elif [[ -n "$MERGE_BASE" ]]; then
+  DIFF_TEXT=$(git diff "$MERGE_BASE"...HEAD -- $(echo "$BRANCH_CHANGED" | head -20) 2>/dev/null | head -500)
+else
+  DIFF_TEXT=$(git diff HEAD -- $(echo "$CHANGED" | head -20) 2>/dev/null | head -500)
+fi
 
-add_critical() {
-  local f="$1"
-  [[ -f "$f" ]] || return 0
-  grep -qxF "$f" "$SEEN" 2>/dev/null && return 0
-  echo "$f" >> "$CRITICAL"
-  echo "$f" >> "$SEEN"
-}
+# ── Get all spec files ──
 
-add_remaining() {
-  local f="$1"
-  [[ -f "$f" ]] || return 0
-  grep -qxF "$f" "$SEEN" 2>/dev/null && return 0
-  echo "$f" >> "$REMAINING"
-  echo "$f" >> "$SEEN"
-}
+ALL_SPECS=$(find spec -name "*_spec.rb" -type f 2>/dev/null | sort)
+TOTAL_SPECS=$(echo "$ALL_SPECS" | wc -l | tr -d ' ')
 
-# Critical: direct specs for changed files
-while IFS= read -r file; do
-  [[ -z "$file" ]] && continue
-  spec=$(echo "$file" | sed 's|^app/|spec/|; s|\.rb$|_spec.rb|')
-  add_critical "$spec"
-  if [[ "$file" == app/controllers/* ]]; then
-    add_critical "$(echo "$file" | sed 's|^app/controllers/|spec/requests/|; s|_controller\.rb$|_spec.rb|')"
-  fi
-done <<< "$CHANGED"
+# ── AI planning: one call, Opus decides everything ──
 
-# Critical: specs that reference changed classes
-while IFS= read -r file; do
-  [[ -z "$file" || "$file" != *.rb ]] && continue
-  classname=$(basename "$file" .rb | sed -E 's/(^|_)([a-z])/\U\2/g')
-  [[ -z "$classname" ]] && continue
-  grep -rl --include="*.rb" "$classname" spec/ 2>/dev/null | sort | while IFS= read -r spec; do
-    add_critical "$spec"
-  done
-done <<< "$CHANGED"
+PLAN_FILE=$(mktemp)
+AI_PLANNED=false
 
-# Critical: same-directory specs
-while IFS= read -r file; do
-  [[ -z "$file" ]] && continue
-  dir=$(echo "$file" | sed 's|^app/|spec/|; s|/[^/]*$||')
-  [[ -d "$dir" ]] || continue
-  find "$dir" -maxdepth 1 -name "*_spec.rb" -type f 2>/dev/null | sort | while IFS= read -r spec; do
-    add_critical "$spec"
-  done
-done <<< "$CHANGED"
+if [[ "$USE_AI" == true && -n "${ANTHROPIC_API_KEY:-}" ]]; then
+  # Group specs by directory for compact listing
+  SPEC_TREE=$(echo "$ALL_SPECS" | awk -F/ '{dir=""; for(i=1;i<NF;i++) dir=dir"/"$i; dirs[dir]=dirs[dir]" "$NF} END {for(d in dirs) print d": "dirs[d]}' | sort | head -200)
 
-CRITICAL_COUNT=$(wc -l < "$CRITICAL" | tr -d ' ')
+  PROMPT="You are a senior Rails engineer planning test execution for a code change.
 
-# Remaining: everything else, ordered by info gain per second.
-# Ranking: specs closer to changed code first, weighted by file size (smaller = faster).
-#   Tier A: specs in parent directories of changed files (broader integration tests)
-#   Tier B: request/feature specs (end-to-end coverage)
-#   Tier C: everything else, smallest files first (fastest gain per second)
+Your job: given this diff, return an ordered list of test files to run, grouped into confidence milestones. YOU decide how many tests are needed for each confidence level based on the risk profile of this specific diff.
 
-REMAINING_A=$(mktemp)
-REMAINING_B=$(mktemp)
-REMAINING_C=$(mktemp)
+A trivial change (typo fix, comment update, rescue clause) might need 2 tests for 99%.
+A core model change might need 50 tests for 99%.
+A payment flow change might need 100 tests for 99%.
 
-# Tier A: parent/sibling directory specs of changed files
-while IFS= read -r file; do
-  [[ -z "$file" ]] && continue
-  parent=$(echo "$file" | sed 's|^app/|spec/|; s|/[^/]*/[^/]*$||')
-  [[ -d "$parent" ]] || continue
-  find "$parent" -name "*_spec.rb" -type f 2>/dev/null | while IFS= read -r spec; do
-    grep -qxF "$spec" "$SEEN" 2>/dev/null && continue
-    echo "$spec"
-  done
-done <<< "$CHANGED" | sort -u >> "$REMAINING_A"
+Think about:
+- What code paths does this diff touch?
+- What could break that isn't obvious?
+- What are the transitive dependencies?
+- How risky is this change?
 
-# Tier B: request and feature specs (broad integration)
-find spec/requests spec/features -name "*_spec.rb" -type f 2>/dev/null | while IFS= read -r spec; do
-  grep -qxF "$spec" "$SEEN" 2>/dev/null && continue
-  grep -qxF "$spec" "$REMAINING_A" 2>/dev/null && continue
-  echo "$spec"
-done | sort >> "$REMAINING_B"
-
-# Tier C: everything else, smallest first (fastest info gain per second)
-find spec -name "*_spec.rb" -type f 2>/dev/null | xargs wc -l 2>/dev/null | grep -v total | sort -n | awk '{print $2}' | while IFS= read -r spec; do
-  grep -qxF "$spec" "$SEEN" 2>/dev/null && continue
-  grep -qxF "$spec" "$REMAINING_A" 2>/dev/null && continue
-  grep -qxF "$spec" "$REMAINING_B" 2>/dev/null && continue
-  echo "$spec"
-done >> "$REMAINING_C"
-
-# Combine tiers into remaining queue
-while IFS= read -r spec; do add_remaining "$spec"; done < "$REMAINING_A"
-while IFS= read -r spec; do add_remaining "$spec"; done < "$REMAINING_B"
-while IFS= read -r spec; do add_remaining "$spec"; done < "$REMAINING_C"
-rm -f "$REMAINING_A" "$REMAINING_B" "$REMAINING_C"
-
-REMAINING_COUNT=$(wc -l < "$REMAINING" | tr -d ' ')
-TOTAL_SPECS=$(( CRITICAL_COUNT + REMAINING_COUNT ))
-
-# ── AI reranking of critical set ──
-
-if [[ "$USE_AI" == true && -n "${ANTHROPIC_API_KEY:-}" && "$CRITICAL_COUNT" -gt 0 ]]; then
-  if [[ -n "$LOCAL_CHANGED" ]]; then
-    DIFF_TEXT=$(git diff HEAD -- $(echo "$LOCAL_CHANGED" | head -20) 2>/dev/null | head -400)
-  elif [[ -n "$MERGE_BASE" ]]; then
-    DIFF_TEXT=$(git diff "$MERGE_BASE"...HEAD -- $(echo "$BRANCH_CHANGED" | head -20) 2>/dev/null | head -400)
-  else
-    DIFF_TEXT=$(git diff HEAD -- $(echo "$CHANGED" | head -20) 2>/dev/null | head -400)
-  fi
-
-  SPEC_LIST=$(cat "$CRITICAL")
-
-  PROMPT="You are a senior Rails engineer. Given this diff, reorder these test files from MOST to LEAST likely to catch a regression. Return ONLY the reordered file paths, one per line, no numbering, no explanation.
-
-Diff:
+## Diff:
 ${DIFF_TEXT}
 
-Test files to reorder:
-${SPEC_LIST}"
+## Test files (${TOTAL_SPECS} total):
+${SPEC_TREE}
+
+Return a JSON object with this exact structure:
+{
+  \"risk\": \"low|medium|high|critical\",
+  \"reason\": \"one sentence explaining the risk level\",
+  \"milestones\": [
+    {\"confidence\": 80, \"tests\": [\"spec/models/foo_spec.rb\"]},
+    {\"confidence\": 95, \"tests\": [\"spec/requests/bar_spec.rb\"]},
+    {\"confidence\": 99, \"tests\": [\"spec/features/baz_spec.rb\"]},
+    {\"confidence\": 100, \"tests\": [\"ALL_REMAINING\"]}
+  ]
+}
+
+Rules:
+- Each milestone's tests are ADDITIONAL, not cumulative.
+- Use exact file paths from the spec tree.
+- The last milestone can use \"ALL_REMAINING\" to mean everything else.
+- Confidence values must be strictly increasing.
+- You MUST include a 99 milestone and a 100 milestone.
+- Be aggressive early: put the highest-value tests first.
+- For low-risk changes, the 99 milestone might only need 2-5 tests.
+- For critical changes, the 99 milestone might need 50+ tests.
+
+Return ONLY the JSON object. No markdown, no explanation outside the JSON."
 
   PAYLOAD=$(jq -n \
     --arg model "claude-opus-4-7" \
     --arg prompt "$PROMPT" \
-    '{model: $model, max_tokens: 8192, messages: [{role: "user", content: $prompt}]}')
+    '{model: $model, max_tokens: 16384, messages: [{role: "user", content: $prompt}]}')
 
-  printf "  🧠 AI reordering %d critical tests..." "$CRITICAL_COUNT"
+  printf "  🧠 Opus planning test execution..."
 
-  RESPONSE=$(curl -s --max-time 30 \
+  RESPONSE=$(curl -s --max-time 60 \
     -H "Content-Type: application/json" \
     -H "x-api-key: ${ANTHROPIC_API_KEY}" \
     -H "anthropic-version: 2023-06-01" \
@@ -194,27 +139,116 @@ ${SPEC_LIST}"
   AI_TEXT=$(echo "$RESPONSE" | jq -r '.content[0].text // empty' 2>/dev/null || true)
 
   if [[ -n "$AI_TEXT" ]]; then
-    AI_QUEUE=$(mktemp)
-    AI_SEEN=$(mktemp)
-    echo "$AI_TEXT" | grep -E '^spec/.*_spec\.rb$' | while IFS= read -r spec; do
-      [[ -f "$spec" ]] || continue
-      grep -qxF "$spec" "$AI_SEEN" 2>/dev/null && continue
-      echo "$spec" >> "$AI_QUEUE"
-      echo "$spec" >> "$AI_SEEN"
-    done
-    while IFS= read -r spec; do
-      grep -qxF "$spec" "$AI_SEEN" 2>/dev/null && continue
-      echo "$spec" >> "$AI_QUEUE"
-      echo "$spec" >> "$AI_SEEN"
-    done < "$CRITICAL"
-    mv "$AI_QUEUE" "$CRITICAL"
-    rm -f "$AI_SEEN"
-    echo " done"
+    # Extract JSON
+    AI_JSON=$(echo "$AI_TEXT" | python3 -c "
+import sys, json, re
+text = sys.stdin.read()
+m = re.search(r'\{[\s\S]*\}', text)
+if m:
+    try:
+        obj = json.loads(m.group())
+        print(json.dumps(obj))
+    except:
+        pass
+" 2>/dev/null || true)
+
+    if [[ -n "$AI_JSON" ]]; then
+      echo "$AI_JSON" > "$PLAN_FILE"
+      RISK=$(echo "$AI_JSON" | jq -r '.risk // "unknown"')
+      REASON=$(echo "$AI_JSON" | jq -r '.reason // ""')
+      echo " done"
+      echo "  ⚡ Risk: $RISK — $REASON"
+      AI_PLANNED=true
+    else
+      echo " failed to parse, using convention"
+    fi
   else
-    echo " skipped"
+    echo " no response, using convention"
   fi
 fi
 
+# ── Convention fallback: build plan without AI ──
+
+if [[ "$AI_PLANNED" != true ]]; then
+  echo "  📁 Convention-based test mapping"
+
+  SEEN=$(mktemp)
+  T99=$(mktemp)
+  T100=$(mktemp)
+
+  add_once() {
+    local f="$1" dest="$2"
+    [[ -f "$f" ]] || return 0
+    grep -qxF "$f" "$SEEN" 2>/dev/null && return 0
+    echo "$f" >> "$dest"
+    echo "$f" >> "$SEEN"
+  }
+
+  # 99%: direct specs, class references, same-directory
+  while IFS= read -r file; do
+    [[ -z "$file" ]] && continue
+    spec=$(echo "$file" | sed 's|^app/|spec/|; s|\.rb$|_spec.rb|')
+    add_once "$spec" "$T99"
+    if [[ "$file" == app/controllers/* ]]; then
+      add_once "$(echo "$file" | sed 's|^app/controllers/|spec/requests/|; s|_controller\.rb$|_spec.rb|')" "$T99"
+    fi
+  done <<< "$CHANGED"
+
+  while IFS= read -r file; do
+    [[ -z "$file" || "$file" != *.rb ]] && continue
+    classname=$(basename "$file" .rb | sed -E 's/(^|_)([a-z])/\U\2/g')
+    [[ -z "$classname" ]] && continue
+    grep -rl --include="*.rb" "$classname" spec/ 2>/dev/null | sort | while IFS= read -r spec; do
+      add_once "$spec" "$T99"
+    done
+  done <<< "$CHANGED"
+
+  while IFS= read -r file; do
+    [[ -z "$file" ]] && continue
+    dir=$(echo "$file" | sed 's|^app/|spec/|; s|/[^/]*$||')
+    [[ -d "$dir" ]] || continue
+    find "$dir" -maxdepth 1 -name "*_spec.rb" -type f 2>/dev/null | sort | while IFS= read -r spec; do
+      add_once "$spec" "$T99"
+    done
+  done <<< "$CHANGED"
+
+  # 100%: everything else
+  echo "$ALL_SPECS" | while IFS= read -r spec; do
+    add_once "$spec" "$T100"
+  done
+
+  T99_LIST=$(cat "$T99" | jq -R . | jq -s .)
+  T100_LIST=$(cat "$T100" | jq -R . | jq -s .)
+
+  echo "{\"risk\":\"unknown\",\"reason\":\"convention mapping (no AI)\",\"milestones\":[{\"confidence\":99,\"tests\":$T99_LIST},{\"confidence\":100,\"tests\":$T100_LIST}]}" > "$PLAN_FILE"
+
+  rm -f "$SEEN" "$T99" "$T100"
+fi
+
+# ── Parse plan and execute ──
+
+MILESTONES=$(jq '.milestones | length' "$PLAN_FILE")
+TOTAL_PLANNED=0
+
+# Count total tests across milestones
+for (( m=0; m<MILESTONES; m++ )); do
+  TESTS_JSON=$(jq -r ".milestones[$m].tests[]" "$PLAN_FILE" 2>/dev/null)
+  if echo "$TESTS_JSON" | grep -q "ALL_REMAINING"; then
+    # Count remaining
+    PLANNED_SEEN=$(mktemp)
+    for (( p=0; p<m; p++ )); do
+      jq -r ".milestones[$p].tests[]" "$PLAN_FILE" 2>/dev/null >> "$PLANNED_SEEN"
+    done
+    REMAINING_N=$(echo "$ALL_SPECS" | while IFS= read -r s; do
+      grep -qxF "$s" "$PLANNED_SEEN" 2>/dev/null || echo "$s"
+    done | wc -l | tr -d ' ')
+    TOTAL_PLANNED=$(( TOTAL_PLANNED + REMAINING_N ))
+    rm -f "$PLANNED_SEEN"
+  else
+    N=$(echo "$TESTS_JSON" | grep -c "spec/" || true)
+    TOTAL_PLANNED=$(( TOTAL_PLANNED + N ))
+  fi
+done
 
 # ── Header ──
 
@@ -222,211 +256,137 @@ echo ""
 echo "  ═══════════════════════════════════════════════════"
 echo "    TEST CONFIDENCE"
 echo "  ───────────────────────────────────────────────────"
-echo "    99%  ←  $CRITICAL_COUNT tests"
-echo "   100%  ←  $TOTAL_SPECS tests"
+for (( m=0; m<MILESTONES; m++ )); do
+  CONF=$(jq -r ".milestones[$m].confidence" "$PLAN_FILE")
+  TESTS_JSON=$(jq -r ".milestones[$m].tests[]" "$PLAN_FILE" 2>/dev/null)
+  if echo "$TESTS_JSON" | grep -q "ALL_REMAINING"; then
+    echo "   ${CONF}%  ←  remaining tests"
+  else
+    N=$(echo "$TESTS_JSON" | grep -c "spec/" || true)
+    echo "   ${CONF}%  ←  $N tests"
+  fi
+done
 echo "  ═══════════════════════════════════════════════════"
 echo ""
 
-
-# ── Run critical tests (the 99% set) ──
+# ── Run ──
 
 START=$(date +%s)
 PASSED=0
 FAILED=0
+SEEN_RUN=$(mktemp)
+CURRENT_CONFIDENCE=0
 
 draw_bar() {
   local passed=$1 total=$2 phase=$3
   local width=40
   local filled=0
-  if [[ "$total" -gt 0 ]]; then
-    filled=$(( passed * width / total ))
-  fi
+  [[ "$total" -gt 0 ]] && filled=$(( passed * width / total ))
   [[ $filled -gt $width ]] && filled=$width
   local empty=$(( width - filled ))
   local bar=""
-  # Yellow while running critical, green once 99% reached
   for (( j=0; j<filled; j++ )); do
-    if [[ "$phase" == "green" ]]; then
-      bar+="🟩"
-    else
-      bar+="🟨"
-    fi
+    [[ "$phase" == "green" ]] && bar+="🟩" || bar+="🟨"
   done
   for (( j=0; j<empty; j++ )); do bar+="⬜"; done
   echo "$bar"
 }
 
-echo "  ── 99% confidence (critical tests) ──"
-echo ""
+for (( m=0; m<MILESTONES; m++ )); do
+  CONF=$(jq -r ".milestones[$m].confidence" "$PLAN_FILE")
+  TESTS_JSON=$(jq -r ".milestones[$m].tests[]" "$PLAN_FILE" 2>/dev/null)
 
-mapfile -t CRITICAL_TESTS < "$CRITICAL"
-
-for spec in "${CRITICAL_TESTS[@]}"; do
-  [[ -z "$spec" ]] && continue
-
-  if output=$(bundle exec rspec --format progress --no-color "$spec" 2>&1); then
-    PASSED=$((PASSED + 1))
-    elapsed=$(( $(date +%s) - START ))
-    bar=$(draw_bar "$PASSED" "$CRITICAL_COUNT" "neutral")
-    printf "\r  %s  %d/%d  %ds" "$bar" "$PASSED" "$CRITICAL_COUNT" "$elapsed"
+  # Resolve ALL_REMAINING
+  if echo "$TESTS_JSON" | grep -q "ALL_REMAINING"; then
+    MILESTONE_TESTS=$(echo "$ALL_SPECS" | while IFS= read -r s; do
+      grep -qxF "$s" "$SEEN_RUN" 2>/dev/null || echo "$s"
+    done)
   else
-    FAILED=$((FAILED + 1))
-    echo ""
-    echo ""
-    echo "  ═══════════════════════════════════════════════════"
-    echo "    ❌ FAILED — $spec"
-    echo "  ═══════════════════════════════════════════════════"
-    echo ""
-    echo "$output" | tail -20 | sed 's/^/    /'
-    echo ""
-    echo "  Fix this before committing."
-    echo ""
-
-    # Save timing data
-    elapsed=$(( $(date +%s) - START ))
-    exit 1
+    MILESTONE_TESTS=$(echo "$TESTS_JSON" | while IFS= read -r s; do
+      [[ -f "$s" ]] && ! grep -qxF "$s" "$SEEN_RUN" 2>/dev/null && echo "$s"
+    done)
   fi
-done
 
-CRITICAL_ELAPSED=$(( $(date +%s) - START ))
+  MILESTONE_COUNT=$(echo "$MILESTONE_TESTS" | grep -c "spec/" 2>/dev/null || echo 0)
+  [[ "$MILESTONE_COUNT" -eq 0 ]] && continue
 
-# ── 99% reached ──
-
-echo ""
-echo ""
-bar=$(draw_bar "$CRITICAL_COUNT" "$CRITICAL_COUNT" "green")
-echo "  $bar"
-echo ""
-echo "  ✅ 99% confidence — $CRITICAL_COUNT tests passed in ${CRITICAL_ELAPSED}s"
-echo "     Safe to commit."
-echo ""
-
-# ── Continue to 100% if requested ──
-
-if [[ "$RUN_FULL" != true ]]; then
-  if [[ "$REMAINING_COUNT" -gt 0 ]]; then
-    echo "  $REMAINING_COUNT more tests for 100%. Run with --full to continue."
-    echo ""
+  # Skip milestones past 99 unless --full
+  if [[ "$RUN_FULL" != true && "$CURRENT_CONFIDENCE" -ge 99 ]]; then
+    echo "  ${CONF}%  ←  $MILESTONE_COUNT tests ⬜ skipped"
+    continue
   fi
-  exit 0
-fi
 
-echo "  ── 99% → 100% (remaining suite, AI-scored) ──"
-echo ""
+  PHASE="neutral"
+  [[ "$CURRENT_CONFIDENCE" -ge 99 ]] && PHASE="green"
 
-mapfile -t REMAINING_TESTS < "$REMAINING"
-REM_PASSED=0
-PASSED_REMAINING_LIST=$(mktemp)
-LAST_CONFIDENCE="99.0"
+  MILESTONE_PASSED=0
 
-# Get the diff for AI context
-if [[ -n "$LOCAL_CHANGED" ]]; then
-  FULL_DIFF=$(git diff HEAD -- $(echo "$LOCAL_CHANGED" | head -20) 2>/dev/null | head -300)
-elif [[ -n "$MERGE_BASE" ]]; then
-  FULL_DIFF=$(git diff "$MERGE_BASE"...HEAD -- $(echo "$BRANCH_CHANGED" | head -20) 2>/dev/null | head -300)
-else
-  FULL_DIFF=$(git diff HEAD -- $(echo "$CHANGED" | head -20) 2>/dev/null | head -300)
-fi
+  while IFS= read -r spec; do
+    [[ -z "$spec" ]] && continue
+    echo "$spec" >> "$SEEN_RUN"
 
-# Ask AI for confidence after every batch of tests
-ai_confidence() {
-  local passed_list=$1 remaining_count=$2
-  [[ -z "${ANTHROPIC_API_KEY:-}" ]] && { echo "$LAST_CONFIDENCE"; return; }
-
-  local passed_specs
-  passed_specs=$(cat "$passed_list" | tail -20)
-  local critical_specs
-  critical_specs=$(cat "$CRITICAL" | head -10)
-
-  local prompt="You are evaluating regression risk for a code change.
-
-Diff summary:
-${FULL_DIFF}
-
-Critical tests (all passed):
-${critical_specs}
-...(${CRITICAL_COUNT} total, all green)
-
-Additional tests passed since:
-${passed_specs}
-
-Remaining untested: ${remaining_count} spec files
-
-Given this diff and what has passed, what is your confidence (99.0-100.0) that there is NO regression? Consider:
-- How risky is this diff?
-- Do the passed tests cover the important code paths?
-- What could the remaining untested specs catch that hasn't been tested?
-
-Return ONLY a number between 99.0 and 100.0, nothing else."
-
-  local payload
-  payload=$(jq -n \
-    --arg model "claude-opus-4-7" \
-    --arg prompt "$prompt" \
-    '{model: $model, max_tokens: 16, messages: [{role: "user", content: $prompt}]}')
-
-  local response
-  response=$(curl -s --max-time 10 \
-    -H "Content-Type: application/json" \
-    -H "x-api-key: ${ANTHROPIC_API_KEY}" \
-    -H "anthropic-version: 2023-06-01" \
-    -d "$payload" \
-    "https://api.anthropic.com/v1/messages" 2>/dev/null) || { echo "$LAST_CONFIDENCE"; return; }
-
-  local text
-  text=$(echo "$response" | jq -r '.content[0].text // empty' 2>/dev/null || true)
-  # Extract number
-  local num
-  num=$(echo "$text" | grep -oE '[0-9]{2,3}\.[0-9]' | head -1)
-  if [[ -n "$num" ]]; then
-    echo "$num"
-  else
-    echo "$LAST_CONFIDENCE"
-  fi
-}
-
-# How often to ask AI (every N tests)
-AI_BATCH_SIZE=20
-
-for spec in "${REMAINING_TESTS[@]}"; do
-  [[ -z "$spec" ]] && continue
-
-  if output=$(bundle exec rspec --format progress --no-color "$spec" 2>&1); then
-    REM_PASSED=$((REM_PASSED + 1))
-    echo "$spec" >> "$PASSED_REMAINING_LIST"
-    FULL_PASSED=$((PASSED + REM_PASSED))
-    elapsed=$(( $(date +%s) - START ))
-    remaining_left=$(( REMAINING_COUNT - REM_PASSED ))
-
-    # Ask AI for updated confidence every AI_BATCH_SIZE tests
-    if [[ $(( REM_PASSED % AI_BATCH_SIZE )) -eq 0 ]] || [[ $remaining_left -eq 0 ]]; then
-      LAST_CONFIDENCE=$(ai_confidence "$PASSED_REMAINING_LIST" "$remaining_left")
+    if output=$(bundle exec rspec --format progress --no-color "$spec" 2>&1); then
+      PASSED=$((PASSED + 1))
+      MILESTONE_PASSED=$((MILESTONE_PASSED + 1))
+      elapsed=$(( $(date +%s) - START ))
+      bar=$(draw_bar "$MILESTONE_PASSED" "$MILESTONE_COUNT" "$PHASE")
+      printf "\r  %s  →%s%%  %d/%d  %ds" "$bar" "$CONF" "$MILESTONE_PASSED" "$MILESTONE_COUNT" "$elapsed"
+    else
+      FAILED=$((FAILED + 1))
+      echo ""
+      echo ""
+      echo "  ═══════════════════════════════════════════════════"
+      echo "    ❌ FAILED — $spec"
+      echo "  ═══════════════════════════════════════════════════"
+      echo ""
+      echo "$output" | tail -20 | sed 's/^/    /'
+      echo ""
+      echo "  Fix this before committing."
+      echo ""
+      rm -f "$PLAN_FILE" "$SEEN_RUN"
+      exit 1
     fi
+  done <<< "$MILESTONE_TESTS"
 
-    bar=$(draw_bar "$FULL_PASSED" "$TOTAL_SPECS" "green")
-    printf "\r  %s  %s%%  %d/%d  %ds" "$bar" "$LAST_CONFIDENCE" "$FULL_PASSED" "$TOTAL_SPECS" "$elapsed"
+  CURRENT_CONFIDENCE=$CONF
+  elapsed=$(( $(date +%s) - START ))
+
+  # Milestone complete
+  echo ""
+  if [[ "$CURRENT_CONFIDENCE" -ge 99 && "$PHASE" != "green" ]]; then
+    echo ""
+    bar=$(draw_bar "$MILESTONE_COUNT" "$MILESTONE_COUNT" "green")
+    echo "  $bar"
+    echo ""
+    echo "  ✅ ${CURRENT_CONFIDENCE}% confidence — $PASSED tests passed in ${elapsed}s"
+    echo "     Safe to commit."
+    echo ""
   else
-    FAILED=$((FAILED + 1))
-    echo ""
-    echo ""
-    echo "  ═══════════════════════════════════════════════════"
-    echo "    ❌ FAILED at ${LAST_CONFIDENCE}% — $spec"
-    echo "  ═══════════════════════════════════════════════════"
-    echo ""
-    echo "$output" | tail -20 | sed 's/^/    /'
-    echo ""
-    exit 1
+    echo "  ✅ ${CURRENT_CONFIDENCE}% — $MILESTONE_PASSED tests — ${elapsed}s"
   fi
 done
 
-rm -f "$PASSED_REMAINING_LIST"
-FULL_ELAPSED=$(( $(date +%s) - START ))
+# ── Done ──
 
-echo ""
-echo ""
-echo "  ═══════════════════════════════════════════════════"
-echo "    ✅ 100% confidence — $((PASSED + REM_PASSED)) tests in ${FULL_ELAPSED}s"
-echo "  ═══════════════════════════════════════════════════"
-echo ""
+elapsed=$(( $(date +%s) - START ))
 
+if [[ "$CURRENT_CONFIDENCE" -ge 100 ]]; then
+  echo ""
+  echo "  ═══════════════════════════════════════════════════"
+  echo "    ✅ 100% confidence — $PASSED tests in ${elapsed}s"
+  echo "  ═══════════════════════════════════════════════════"
+  echo ""
+elif [[ "$CURRENT_CONFIDENCE" -lt 99 ]]; then
+  echo ""
+  echo "  ⚠️  Only reached ${CURRENT_CONFIDENCE}% — $PASSED tests in ${elapsed}s"
+  echo ""
+fi
 
+if [[ "$RUN_FULL" != true && "$CURRENT_CONFIDENCE" -ge 99 && "$CURRENT_CONFIDENCE" -lt 100 ]]; then
+  remaining=$(( TOTAL_SPECS - PASSED ))
+  echo "  $remaining more tests for 100%. Run with --full to continue."
+  echo ""
+fi
+
+rm -f "$PLAN_FILE" "$SEEN_RUN"
+[[ "$CURRENT_CONFIDENCE" -ge 99 ]]

--- a/bin/test-confidence
+++ b/bin/test-confidence
@@ -5,21 +5,25 @@
 # Usage:
 #   bin/test-confidence          # Run to 99%, stop
 #   bin/test-confidence --full   # Run to 100%
-#   bin/test-confidence --no-ai  # Convention mapping, no AI (deterministic fallback)
 #
-# Requires: ANTHROPIC_API_KEY for AI mode. Falls back to convention without it.
+# Requires: ANTHROPIC_API_KEY
 #
 set -euo pipefail
 
 RUN_FULL=false
-USE_AI=true
 
 for arg in "$@"; do
   case "$arg" in
     --full) RUN_FULL=true ;;
-    --no-ai) USE_AI=false ;;
   esac
 done
+
+if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
+  echo ""
+  echo "  ❌ ANTHROPIC_API_KEY is required. Set it in your environment."
+  echo ""
+  exit 1
+fi
 
 # ── Changed files ──
 
@@ -72,13 +76,11 @@ TOTAL_SPECS=$(echo "$ALL_SPECS" | wc -l | tr -d ' ')
 # ── AI planning: one call, Opus decides everything ──
 
 PLAN_FILE=$(mktemp)
-AI_PLANNED=false
 
-if [[ "$USE_AI" == true && -n "${ANTHROPIC_API_KEY:-}" ]]; then
-  # Group specs by directory for compact listing
-  SPEC_TREE=$(echo "$ALL_SPECS" | awk -F/ '{dir=""; for(i=1;i<NF;i++) dir=dir"/"$i; dirs[dir]=dirs[dir]" "$NF} END {for(d in dirs) print d": "dirs[d]}' | sort | head -200)
+# Group specs by directory for compact listing
+SPEC_TREE=$(echo "$ALL_SPECS" | awk -F/ '{dir=""; for(i=1;i<NF;i++) dir=dir"/"$i; dirs[dir]=dirs[dir]" "$NF} END {for(d in dirs) print d": "dirs[d]}' | sort | head -200)
 
-  PROMPT="You are a senior Rails engineer planning test execution for a code change.
+PROMPT="You are a senior Rails engineer planning test execution for a code change.
 
 Your job: given this diff, return an ordered list of test files to run, grouped into confidence milestones. YOU decide how many tests are needed for each confidence level based on the risk profile of this specific diff.
 
@@ -122,25 +124,35 @@ Rules:
 
 Return ONLY the JSON object. No markdown, no explanation outside the JSON."
 
-  PAYLOAD=$(jq -n \
-    --arg model "claude-opus-4-7" \
-    --arg prompt "$PROMPT" \
-    '{model: $model, max_tokens: 16384, messages: [{role: "user", content: $prompt}]}')
+PAYLOAD=$(jq -n \
+  --arg model "claude-opus-4-7" \
+  --arg prompt "$PROMPT" \
+  '{model: $model, max_tokens: 16384, messages: [{role: "user", content: $prompt}]}')
 
-  printf "  🧠 Opus planning test execution..."
+printf "  🧠 Opus planning test execution..."
 
-  RESPONSE=$(curl -s --max-time 60 \
-    -H "Content-Type: application/json" \
-    -H "x-api-key: ${ANTHROPIC_API_KEY}" \
-    -H "anthropic-version: 2023-06-01" \
-    -d "$PAYLOAD" \
-    "https://api.anthropic.com/v1/messages" 2>/dev/null) || RESPONSE=""
+RESPONSE=$(curl -s --max-time 60 \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: ${ANTHROPIC_API_KEY}" \
+  -H "anthropic-version: 2023-06-01" \
+  -d "$PAYLOAD" \
+  "https://api.anthropic.com/v1/messages" 2>/dev/null)
 
-  AI_TEXT=$(echo "$RESPONSE" | jq -r '.content[0].text // empty' 2>/dev/null || true)
+if [[ -z "$RESPONSE" ]]; then
+  echo " failed (no response)"
+  exit 1
+fi
 
-  if [[ -n "$AI_TEXT" ]]; then
-    # Extract JSON
-    AI_JSON=$(echo "$AI_TEXT" | python3 -c "
+AI_TEXT=$(echo "$RESPONSE" | jq -r '.content[0].text // empty' 2>/dev/null || true)
+
+if [[ -z "$AI_TEXT" ]]; then
+  echo " failed (empty response)"
+  echo "  Response: $(echo "$RESPONSE" | jq -r '.error.message // "unknown error"' 2>/dev/null)"
+  exit 1
+fi
+
+# Extract JSON
+AI_JSON=$(echo "$AI_TEXT" | python3 -c "
 import sys, json, re
 text = sys.stdin.read()
 m = re.search(r'\{[\s\S]*\}', text)
@@ -152,78 +164,16 @@ if m:
         pass
 " 2>/dev/null || true)
 
-    if [[ -n "$AI_JSON" ]]; then
-      echo "$AI_JSON" > "$PLAN_FILE"
-      RISK=$(echo "$AI_JSON" | jq -r '.risk // "unknown"')
-      REASON=$(echo "$AI_JSON" | jq -r '.reason // ""')
-      echo " done"
-      echo "  ⚡ Risk: $RISK — $REASON"
-      AI_PLANNED=true
-    else
-      echo " failed to parse, using convention"
-    fi
-  else
-    echo " no response, using convention"
-  fi
+if [[ -z "$AI_JSON" ]]; then
+  echo " failed to parse AI response"
+  exit 1
 fi
 
-# ── Convention fallback: build plan without AI ──
-
-if [[ "$AI_PLANNED" != true ]]; then
-  echo "  📁 Convention-based test mapping"
-
-  SEEN=$(mktemp)
-  T99=$(mktemp)
-  T100=$(mktemp)
-
-  add_once() {
-    local f="$1" dest="$2"
-    [[ -f "$f" ]] || return 0
-    grep -qxF "$f" "$SEEN" 2>/dev/null && return 0
-    echo "$f" >> "$dest"
-    echo "$f" >> "$SEEN"
-  }
-
-  # 99%: direct specs, class references, same-directory
-  while IFS= read -r file; do
-    [[ -z "$file" ]] && continue
-    spec=$(echo "$file" | sed 's|^app/|spec/|; s|\.rb$|_spec.rb|')
-    add_once "$spec" "$T99"
-    if [[ "$file" == app/controllers/* ]]; then
-      add_once "$(echo "$file" | sed 's|^app/controllers/|spec/requests/|; s|_controller\.rb$|_spec.rb|')" "$T99"
-    fi
-  done <<< "$CHANGED"
-
-  while IFS= read -r file; do
-    [[ -z "$file" || "$file" != *.rb ]] && continue
-    classname=$(basename "$file" .rb | ruby -e 'puts STDIN.read.strip.split("_").map(&:capitalize).join' 2>/dev/null)
-    [[ -z "$classname" ]] && continue
-    grep -rl --include="*.rb" "$classname" spec/ 2>/dev/null | sort | while IFS= read -r spec; do
-      add_once "$spec" "$T99"
-    done
-  done <<< "$CHANGED"
-
-  while IFS= read -r file; do
-    [[ -z "$file" ]] && continue
-    dir=$(echo "$file" | sed 's|^app/|spec/|; s|/[^/]*$||')
-    [[ -d "$dir" ]] || continue
-    find "$dir" -maxdepth 1 -name "*_spec.rb" -type f 2>/dev/null | sort | while IFS= read -r spec; do
-      add_once "$spec" "$T99"
-    done
-  done <<< "$CHANGED"
-
-  # 100%: everything else
-  echo "$ALL_SPECS" | while IFS= read -r spec; do
-    add_once "$spec" "$T100"
-  done
-
-  T99_LIST=$(cat "$T99" | jq -R . | jq -s .)
-  T100_LIST=$(cat "$T100" | jq -R . | jq -s .)
-
-  echo "{\"risk\":\"unknown\",\"reason\":\"convention mapping (no AI)\",\"milestones\":[{\"confidence\":99,\"tests\":$T99_LIST},{\"confidence\":100,\"tests\":$T100_LIST}]}" > "$PLAN_FILE"
-
-  rm -f "$SEEN" "$T99" "$T100"
-fi
+echo "$AI_JSON" > "$PLAN_FILE"
+RISK=$(echo "$AI_JSON" | jq -r '.risk // "unknown"')
+REASON=$(echo "$AI_JSON" | jq -r '.reason // ""')
+echo " done"
+echo "  ⚡ Risk: $RISK — $REASON"
 
 # ── Parse plan and execute ──
 
@@ -234,7 +184,6 @@ TOTAL_PLANNED=0
 for (( m=0; m<MILESTONES; m++ )); do
   TESTS_JSON=$(jq -r ".milestones[$m].tests[]" "$PLAN_FILE" 2>/dev/null)
   if echo "$TESTS_JSON" | grep -q "ALL_REMAINING"; then
-    # Count remaining
     PLANNED_SEEN=$(mktemp)
     for (( p=0; p<m; p++ )); do
       jq -r ".milestones[$p].tests[]" "$PLAN_FILE" 2>/dev/null >> "$PLANNED_SEEN"

--- a/bin/test-confidence
+++ b/bin/test-confidence
@@ -60,13 +60,16 @@ fi
 
 # ── Get the diff ──
 
+# Build diff text: include both local changes AND branch commits when both exist
+DIFF_PARTS=""
 if [[ -n "$LOCAL_CHANGED" ]]; then
-  DIFF_TEXT=$(git diff HEAD -- $(echo "$LOCAL_CHANGED" | head -20) 2>/dev/null | head -500)
-elif [[ -n "$MERGE_BASE" ]]; then
-  DIFF_TEXT=$(git diff "$MERGE_BASE"...HEAD -- $(echo "$BRANCH_CHANGED" | head -20) 2>/dev/null | head -500)
-else
-  DIFF_TEXT=$(git diff HEAD -- $(echo "$CHANGED" | head -20) 2>/dev/null | head -500)
+  DIFF_PARTS+=$(git diff HEAD -- $(echo "$LOCAL_CHANGED" | head -20) 2>/dev/null)
+  DIFF_PARTS+=$'\n'
 fi
+if [[ -n "$MERGE_BASE" && -n "$BRANCH_CHANGED" ]]; then
+  DIFF_PARTS+=$(git diff "$MERGE_BASE"...HEAD -- $(echo "$BRANCH_CHANGED" | head -20) 2>/dev/null)
+fi
+DIFF_TEXT=$(echo "$DIFF_PARTS" | head -500)
 
 # ── Get all spec files ──
 
@@ -78,7 +81,7 @@ TOTAL_SPECS=$(echo "$ALL_SPECS" | wc -l | tr -d ' ')
 PLAN_FILE=$(mktemp)
 
 # Group specs by directory for compact listing
-SPEC_TREE=$(echo "$ALL_SPECS" | awk -F/ '{dir=""; for(i=1;i<NF;i++) dir=dir"/"$i; dirs[dir]=dirs[dir]" "$NF} END {for(d in dirs) print d": "dirs[d]}' | sort | head -200)
+SPEC_TREE=$(echo "$ALL_SPECS" | awk -F/ '{dir=$1; for(i=2;i<NF;i++) dir=dir"/"$i; dirs[dir]=dirs[dir]" "$NF} END {for(d in dirs) print d": "dirs[d]}' | sort)
 
 PROMPT="You are a senior Rails engineer planning test execution for a code change.
 
@@ -248,7 +251,10 @@ for (( m=0; m<MILESTONES; m++ )); do
   fi
 
   MILESTONE_COUNT=$(echo "$MILESTONE_TESTS" | grep -c "spec/" 2>/dev/null || true)
-  [[ -z "$MILESTONE_COUNT" || "$MILESTONE_COUNT" -eq 0 ]] && continue
+  if [[ -z "$MILESTONE_COUNT" || "$MILESTONE_COUNT" -eq 0 ]]; then
+    CURRENT_CONFIDENCE=$CONF
+    continue
+  fi
 
   # Skip milestones past 99 unless --full
   if [[ "$RUN_FULL" != true && "$CURRENT_CONFIDENCE" -ge 99 ]]; then

--- a/bin/test-confidence
+++ b/bin/test-confidence
@@ -196,7 +196,7 @@ if [[ "$AI_PLANNED" != true ]]; then
 
   while IFS= read -r file; do
     [[ -z "$file" || "$file" != *.rb ]] && continue
-    classname=$(basename "$file" .rb | sed -E 's/(^|_)([a-z])/\U\2/g')
+    classname=$(basename "$file" .rb | ruby -e 'puts STDIN.read.strip.split("_").map(&:capitalize).join' 2>/dev/null)
     [[ -z "$classname" ]] && continue
     grep -rl --include="*.rb" "$classname" spec/ 2>/dev/null | sort | while IFS= read -r spec; do
       add_once "$spec" "$T99"

--- a/bin/test-confidence
+++ b/bin/test-confidence
@@ -179,6 +179,13 @@ echo "  ⚡ Risk: $RISK — $REASON"
 
 MILESTONES=$(jq '.milestones | length' "$PLAN_FILE")
 
+# ── Helpers ──
+
+pluralize() {
+  local n=$1 word=$2
+  if [[ $n -eq 1 ]]; then echo "$n $word"; else echo "$n ${word}s"; fi
+}
+
 # ── Header ──
 
 echo ""
@@ -191,8 +198,12 @@ for (( m=0; m<MILESTONES; m++ )); do
   if echo "$TESTS_JSON" | grep -q "ALL_REMAINING"; then
     echo "   ${CONF}%  ←  remaining tests"
   else
-    N=$(echo "$TESTS_JSON" | grep -c "spec/" || true)
-    echo "   ${CONF}%  ←  $N tests"
+    NAMES=$(echo "$TESTS_JSON" | grep "spec/")
+    N=$(echo "$NAMES" | wc -l | tr -d ' ')
+    echo "   ${CONF}%  ←  $(pluralize $N test)"
+    echo "$NAMES" | while IFS= read -r name; do
+      echo "          $(basename "$name")"
+    done
   fi
 done
 echo "  ═══════════════════════════════════════════════════"
@@ -241,7 +252,7 @@ for (( m=0; m<MILESTONES; m++ )); do
 
   # Skip milestones past 99 unless --full
   if [[ "$RUN_FULL" != true && "$CURRENT_CONFIDENCE" -ge 99 ]]; then
-    echo "  ${CONF}%  ←  $MILESTONE_COUNT tests ⬜ skipped"
+    echo "  ${CONF}%  ←  $(pluralize $MILESTONE_COUNT test) ⬜ skipped"
     continue
   fi
 
@@ -287,11 +298,11 @@ for (( m=0; m<MILESTONES; m++ )); do
     bar=$(draw_bar "$MILESTONE_COUNT" "$MILESTONE_COUNT" "green")
     echo "  $bar"
     echo ""
-    echo "  ✅ ${CURRENT_CONFIDENCE}% confidence — $PASSED tests passed in ${elapsed}s"
+    echo "  ✅ ${CURRENT_CONFIDENCE}% confidence — $(pluralize $PASSED test) passed in ${elapsed}s"
     echo "     Safe to commit."
     echo ""
   else
-    echo "  ✅ ${CURRENT_CONFIDENCE}% — $MILESTONE_PASSED tests — ${elapsed}s"
+    echo "  ✅ ${CURRENT_CONFIDENCE}% — $(pluralize $MILESTONE_PASSED test) — ${elapsed}s"
   fi
 done
 
@@ -302,18 +313,18 @@ elapsed=$(( $(date +%s) - START ))
 if [[ "$CURRENT_CONFIDENCE" -ge 100 ]]; then
   echo ""
   echo "  ═══════════════════════════════════════════════════"
-  echo "    ✅ 100% confidence — $PASSED tests in ${elapsed}s"
+  echo "    ✅ 100% confidence — $(pluralize $PASSED test) in ${elapsed}s"
   echo "  ═══════════════════════════════════════════════════"
   echo ""
 elif [[ "$CURRENT_CONFIDENCE" -lt 99 ]]; then
   echo ""
-  echo "  ⚠️  Only reached ${CURRENT_CONFIDENCE}% — $PASSED tests in ${elapsed}s"
+  echo "  ⚠️  Only reached ${CURRENT_CONFIDENCE}% — $(pluralize $PASSED test) in ${elapsed}s"
   echo ""
 fi
 
 if [[ "$RUN_FULL" != true && "$CURRENT_CONFIDENCE" -ge 99 && "$CURRENT_CONFIDENCE" -lt 100 ]]; then
   remaining=$(( TOTAL_SPECS - PASSED ))
-  echo "  $remaining more tests for 100%. Run with --full to continue."
+  echo "  $(pluralize $remaining test) more for 100%. Run with --full to continue."
   echo ""
 fi
 

--- a/bin/test-confidence
+++ b/bin/test-confidence
@@ -311,44 +311,106 @@ if [[ "$RUN_FULL" != true ]]; then
   exit 0
 fi
 
-echo "  ── 99% → 100% (remaining suite, Pareto-ordered) ──"
+echo "  ── 99% → 100% (remaining suite, AI-scored) ──"
 echo ""
 
 mapfile -t REMAINING_TESTS < "$REMAINING"
 REM_PASSED=0
+PASSED_REMAINING_LIST=$(mktemp)
+LAST_CONFIDENCE="99.0"
 
-# Pareto confidence: 99% + (1% * (1 - (1 - passed/remaining)^2.5))
-# Early tests in the ranked remaining set contribute more info gain.
-calc_full_confidence() {
-  local rem_passed=$1 rem_total=$2
-  python3 -c "
-passed, total = $rem_passed, $rem_total
-if total == 0:
-    print('100.0')
-else:
-    frac = passed / total
-    gain = 1.0 - (1.0 - frac) ** 2.5
-    conf = 99.0 + gain * 1.0
-    print(f'{conf:.1f}')
-" 2>/dev/null
+# Get the diff for AI context
+if [[ -n "$LOCAL_CHANGED" ]]; then
+  FULL_DIFF=$(git diff HEAD -- $(echo "$LOCAL_CHANGED" | head -20) 2>/dev/null | head -300)
+elif [[ -n "$MERGE_BASE" ]]; then
+  FULL_DIFF=$(git diff "$MERGE_BASE"...HEAD -- $(echo "$BRANCH_CHANGED" | head -20) 2>/dev/null | head -300)
+else
+  FULL_DIFF=$(git diff HEAD -- $(echo "$CHANGED" | head -20) 2>/dev/null | head -300)
+fi
+
+# Ask AI for confidence after every batch of tests
+ai_confidence() {
+  local passed_list=$1 remaining_count=$2
+  [[ -z "${ANTHROPIC_API_KEY:-}" ]] && { echo "$LAST_CONFIDENCE"; return; }
+
+  local passed_specs
+  passed_specs=$(cat "$passed_list" | tail -20)
+  local critical_specs
+  critical_specs=$(cat "$CRITICAL" | head -10)
+
+  local prompt="You are evaluating regression risk for a code change.
+
+Diff summary:
+${FULL_DIFF}
+
+Critical tests (all passed):
+${critical_specs}
+...(${CRITICAL_COUNT} total, all green)
+
+Additional tests passed since:
+${passed_specs}
+
+Remaining untested: ${remaining_count} spec files
+
+Given this diff and what has passed, what is your confidence (99.0-100.0) that there is NO regression? Consider:
+- How risky is this diff?
+- Do the passed tests cover the important code paths?
+- What could the remaining untested specs catch that hasn't been tested?
+
+Return ONLY a number between 99.0 and 100.0, nothing else."
+
+  local payload
+  payload=$(jq -n \
+    --arg model "claude-sonnet-4-6" \
+    --arg prompt "$prompt" \
+    '{model: $model, max_tokens: 16, messages: [{role: "user", content: $prompt}]}')
+
+  local response
+  response=$(curl -s --max-time 10 \
+    -H "Content-Type: application/json" \
+    -H "x-api-key: ${ANTHROPIC_API_KEY}" \
+    -H "anthropic-version: 2023-06-01" \
+    -d "$payload" \
+    "https://api.anthropic.com/v1/messages" 2>/dev/null) || { echo "$LAST_CONFIDENCE"; return; }
+
+  local text
+  text=$(echo "$response" | jq -r '.content[0].text // empty' 2>/dev/null || true)
+  # Extract number
+  local num
+  num=$(echo "$text" | grep -oE '[0-9]{2,3}\.[0-9]' | head -1)
+  if [[ -n "$num" ]]; then
+    echo "$num"
+  else
+    echo "$LAST_CONFIDENCE"
+  fi
 }
+
+# How often to ask AI (every N tests)
+AI_BATCH_SIZE=20
 
 for spec in "${REMAINING_TESTS[@]}"; do
   [[ -z "$spec" ]] && continue
 
   if output=$(bundle exec rspec --format progress --no-color "$spec" 2>&1); then
     REM_PASSED=$((REM_PASSED + 1))
+    echo "$spec" >> "$PASSED_REMAINING_LIST"
     FULL_PASSED=$((PASSED + REM_PASSED))
     elapsed=$(( $(date +%s) - START ))
-    conf=$(calc_full_confidence "$REM_PASSED" "$REMAINING_COUNT")
+    remaining_left=$(( REMAINING_COUNT - REM_PASSED ))
+
+    # Ask AI for updated confidence every AI_BATCH_SIZE tests
+    if [[ $(( REM_PASSED % AI_BATCH_SIZE )) -eq 0 ]] || [[ $remaining_left -eq 0 ]]; then
+      LAST_CONFIDENCE=$(ai_confidence "$PASSED_REMAINING_LIST" "$remaining_left")
+    fi
+
     bar=$(draw_bar "$FULL_PASSED" "$TOTAL_SPECS" "green")
-    printf "\r  %s  %s%%  %d/%d  %ds" "$bar" "$conf" "$FULL_PASSED" "$TOTAL_SPECS" "$elapsed"
+    printf "\r  %s  %s%%  %d/%d  %ds" "$bar" "$LAST_CONFIDENCE" "$FULL_PASSED" "$TOTAL_SPECS" "$elapsed"
   else
     FAILED=$((FAILED + 1))
     echo ""
     echo ""
     echo "  ═══════════════════════════════════════════════════"
-    echo "    ❌ FAILED at ${conf}% — $spec"
+    echo "    ❌ FAILED at ${LAST_CONFIDENCE}% — $spec"
     echo "  ═══════════════════════════════════════════════════"
     echo ""
     echo "$output" | tail -20 | sed 's/^/    /'
@@ -357,6 +419,7 @@ for spec in "${REMAINING_TESTS[@]}"; do
   fi
 done
 
+rm -f "$PASSED_REMAINING_LIST"
 FULL_ELAPSED=$(( $(date +%s) - START ))
 
 echo ""

--- a/bin/test-confidence
+++ b/bin/test-confidence
@@ -113,10 +113,47 @@ done <<< "$CHANGED"
 
 CRITICAL_COUNT=$(wc -l < "$CRITICAL" | tr -d ' ')
 
-# Remaining: everything else (for --full or continuing past 99%)
-find spec -name "*_spec.rb" -type f 2>/dev/null | sort -R | while IFS= read -r spec; do
-  add_remaining "$spec"
-done
+# Remaining: everything else, ordered by info gain per second.
+# Ranking: specs closer to changed code first, weighted by file size (smaller = faster).
+#   Tier A: specs in parent directories of changed files (broader integration tests)
+#   Tier B: request/feature specs (end-to-end coverage)
+#   Tier C: everything else, smallest files first (fastest gain per second)
+
+REMAINING_A=$(mktemp)
+REMAINING_B=$(mktemp)
+REMAINING_C=$(mktemp)
+
+# Tier A: parent/sibling directory specs of changed files
+while IFS= read -r file; do
+  [[ -z "$file" ]] && continue
+  parent=$(echo "$file" | sed 's|^app/|spec/|; s|/[^/]*/[^/]*$||')
+  [[ -d "$parent" ]] || continue
+  find "$parent" -name "*_spec.rb" -type f 2>/dev/null | while IFS= read -r spec; do
+    grep -qxF "$spec" "$SEEN" 2>/dev/null && continue
+    echo "$spec"
+  done
+done <<< "$CHANGED" | sort -u >> "$REMAINING_A"
+
+# Tier B: request and feature specs (broad integration)
+find spec/requests spec/features -name "*_spec.rb" -type f 2>/dev/null | while IFS= read -r spec; do
+  grep -qxF "$spec" "$SEEN" 2>/dev/null && continue
+  grep -qxF "$spec" "$REMAINING_A" 2>/dev/null && continue
+  echo "$spec"
+done | sort >> "$REMAINING_B"
+
+# Tier C: everything else, smallest first (fastest info gain per second)
+find spec -name "*_spec.rb" -type f 2>/dev/null | xargs wc -l 2>/dev/null | grep -v total | sort -n | awk '{print $2}' | while IFS= read -r spec; do
+  grep -qxF "$spec" "$SEEN" 2>/dev/null && continue
+  grep -qxF "$spec" "$REMAINING_A" 2>/dev/null && continue
+  grep -qxF "$spec" "$REMAINING_B" 2>/dev/null && continue
+  echo "$spec"
+done >> "$REMAINING_C"
+
+# Combine tiers into remaining queue
+while IFS= read -r spec; do add_remaining "$spec"; done < "$REMAINING_A"
+while IFS= read -r spec; do add_remaining "$spec"; done < "$REMAINING_B"
+while IFS= read -r spec; do add_remaining "$spec"; done < "$REMAINING_C"
+rm -f "$REMAINING_A" "$REMAINING_B" "$REMAINING_C"
 
 REMAINING_COUNT=$(wc -l < "$REMAINING" | tr -d ' ')
 TOTAL_SPECS=$(( CRITICAL_COUNT + REMAINING_COUNT ))
@@ -342,28 +379,44 @@ if [[ "$RUN_FULL" != true ]]; then
   exit 0
 fi
 
-echo "  ── 100% confidence (full suite) ──"
+echo "  ── 99% → 100% (remaining suite, Pareto-ordered) ──"
 echo ""
 
 mapfile -t REMAINING_TESTS < "$REMAINING"
-FULL_PASSED=$PASSED
-FULL_START=$(date +%s)
+REM_PASSED=0
+
+# Pareto confidence: 99% + (1% * (1 - (1 - passed/remaining)^2.5))
+# Early tests in the ranked remaining set contribute more info gain.
+calc_full_confidence() {
+  local rem_passed=$1 rem_total=$2
+  python3 -c "
+passed, total = $rem_passed, $rem_total
+if total == 0:
+    print('100.0')
+else:
+    frac = passed / total
+    gain = 1.0 - (1.0 - frac) ** 2.5
+    conf = 99.0 + gain * 1.0
+    print(f'{conf:.1f}')
+" 2>/dev/null
+}
 
 for spec in "${REMAINING_TESTS[@]}"; do
   [[ -z "$spec" ]] && continue
 
   if output=$(bundle exec rspec --format progress --no-color "$spec" 2>&1); then
-    FULL_PASSED=$((FULL_PASSED + 1))
+    REM_PASSED=$((REM_PASSED + 1))
+    FULL_PASSED=$((PASSED + REM_PASSED))
     elapsed=$(( $(date +%s) - START ))
-    pct=$(( FULL_PASSED * 100 / TOTAL_SPECS ))
+    conf=$(calc_full_confidence "$REM_PASSED" "$REMAINING_COUNT")
     bar=$(draw_bar "$FULL_PASSED" "$TOTAL_SPECS" "green")
-    printf "\r  %s  %d/%d  %d%%  %ds" "$bar" "$FULL_PASSED" "$TOTAL_SPECS" "$pct" "$elapsed"
+    printf "\r  %s  %s%%  %d/%d  %ds" "$bar" "$conf" "$FULL_PASSED" "$TOTAL_SPECS" "$elapsed"
   else
     FAILED=$((FAILED + 1))
     echo ""
     echo ""
     echo "  ═══════════════════════════════════════════════════"
-    echo "    ❌ FAILED — $spec"
+    echo "    ❌ FAILED at ${conf}% — $spec"
     echo "  ═══════════════════════════════════════════════════"
     echo ""
     echo "$output" | tail -20 | sed 's/^/    /'
@@ -377,8 +430,8 @@ FULL_ELAPSED=$(( $(date +%s) - START ))
 echo ""
 echo ""
 echo "  ═══════════════════════════════════════════════════"
-echo "    ✅ 100% confidence — $FULL_PASSED tests in ${FULL_ELAPSED}s"
+echo "    ✅ 100% confidence — $((PASSED + REM_PASSED)) tests in ${FULL_ELAPSED}s"
 echo "  ═══════════════════════════════════════════════════"
 echo ""
 
-save_history "$FULL_PASSED" "$FULL_ELAPSED" "passed_100"
+save_history "$((PASSED + REM_PASSED))" "$FULL_ELAPSED" "passed_100"

--- a/bin/test-confidence
+++ b/bin/test-confidence
@@ -1,40 +1,39 @@
 #!/usr/bin/env bash
 #
-# bin/test-confidence — Run tests in order of relevance. Confidence climbs from 0% to 100%.
+# bin/test-confidence — Run the tests that matter, fast.
+#
+# Finds the minimal set of tests needed for 99% confidence based on your
+# diff, runs them, then optionally continues toward 100%. Shows ETA based
+# on the last green CI build on main.
 #
 # Usage:
-#   bin/test-confidence              # Stop at 99%
-#   bin/test-confidence 0.95         # Stop at 95%
-#   bin/test-confidence 1.0          # Run everything (100%)
-#   bin/test-confidence --no-ai      # Convention mapping only, no API call
+#   bin/test-confidence          # Run to 99%, stop
+#   bin/test-confidence --full   # Run to 100%
+#   bin/test-confidence --no-ai  # Skip AI reranking
 #
 # Set ANTHROPIC_API_KEY for AI-powered ranking. Falls back to convention without it.
 #
 set -euo pipefail
 
-THRESHOLD=99
+RUN_FULL=false
 USE_AI=true
+HISTORY_FILE=".test-confidence-history.json"
 
 for arg in "$@"; do
   case "$arg" in
+    --full) RUN_FULL=true ;;
     --no-ai) USE_AI=false ;;
-    0.*|1|1.0|1.00) THRESHOLD=$(printf '%.0f' "$(echo "$arg * 100" | bc)") ;;
   esac
 done
 
 # ── Changed files ──
-# Priority:
-#   1. Uncommitted local changes (git diff HEAD + staged)
-#   2. Branch diff vs main (for PR branches with committed changes)
-#   3. If on main with no local changes, nothing to test
 
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "main")
+MERGE_BASE=""
 
-# Local uncommitted + staged changes
 LOCAL_CHANGED=$({ git diff --name-only HEAD 2>/dev/null; git diff --name-only --cached 2>/dev/null; } \
   | sort -u | grep -E '\.(rb|ts|tsx|js|jsx)$' || true)
 
-# Branch diff vs main (what the PR introduces)
 BRANCH_CHANGED=""
 if [[ "$CURRENT_BRANCH" != "main" ]]; then
   MERGE_BASE=$(git merge-base origin/main HEAD 2>/dev/null || echo "")
@@ -44,7 +43,6 @@ if [[ "$CURRENT_BRANCH" != "main" ]]; then
   fi
 fi
 
-# Combine: local changes + branch diff (local first for priority)
 CHANGED=$(printf '%s\n%s' "$LOCAL_CHANGED" "$BRANCH_CHANGED" | sort -u | grep -v '^$' || true)
 
 if [[ -z "$CHANGED" ]]; then
@@ -54,80 +52,78 @@ if [[ -z "$CHANGED" ]]; then
   exit 0
 fi
 
-# Show diff source
-if [[ -n "$LOCAL_CHANGED" && -n "$BRANCH_CHANGED" ]]; then
-  echo "  📂 Uncommitted changes + branch diff vs main"
-elif [[ -n "$BRANCH_CHANGED" ]]; then
-  echo "  📂 Branch diff: $CURRENT_BRANCH vs main"
+FILE_COUNT=$(echo "$CHANGED" | wc -l | tr -d ' ')
+if [[ -n "$BRANCH_CHANGED" ]]; then
+  echo "  📂 $FILE_COUNT files changed ($CURRENT_BRANCH vs main)"
 else
-  echo "  📂 Uncommitted local changes"
+  echo "  📂 $FILE_COUNT files changed (local)"
 fi
 
-# Auto-raise for payment code
-if echo "$CHANGED" | grep -qE '^(app/billing/|app/payments/|app/models/purchase\.rb)'; then
-  [[ "$THRESHOLD" -lt 100 ]] && THRESHOLD=100
-  echo "  ⚠ Payment/billing code — threshold raised to 100%"
-fi
+# ── Build the critical set (tests needed for 99%) ──
 
-TOTAL_SPECS=$(find spec -name "*_spec.rb" -type f 2>/dev/null | wc -l | tr -d ' ')
-
-# ── Build a single ordered list: most relevant first, least relevant last ──
-
-QUEUE=$(mktemp)
+CRITICAL=$(mktemp)
+REMAINING=$(mktemp)
 SEEN=$(mktemp)
 
-add_if_new() {
+add_critical() {
   local f="$1"
   [[ -f "$f" ]] || return 0
   grep -qxF "$f" "$SEEN" 2>/dev/null && return 0
-  echo "$f" >> "$QUEUE"
+  echo "$f" >> "$CRITICAL"
   echo "$f" >> "$SEEN"
 }
 
-# --- Tier 1: Direct spec for each changed file ---
+add_remaining() {
+  local f="$1"
+  [[ -f "$f" ]] || return 0
+  grep -qxF "$f" "$SEEN" 2>/dev/null && return 0
+  echo "$f" >> "$REMAINING"
+  echo "$f" >> "$SEEN"
+}
+
+# Critical: direct specs for changed files
 while IFS= read -r file; do
   [[ -z "$file" ]] && continue
   spec=$(echo "$file" | sed 's|^app/|spec/|; s|\.rb$|_spec.rb|')
-  add_if_new "$spec"
-  # Controller → request spec
+  add_critical "$spec"
   if [[ "$file" == app/controllers/* ]]; then
-    add_if_new "$(echo "$file" | sed 's|^app/controllers/|spec/requests/|; s|_controller\.rb$|_spec.rb|')"
+    add_critical "$(echo "$file" | sed 's|^app/controllers/|spec/requests/|; s|_controller\.rb$|_spec.rb|')"
   fi
 done <<< "$CHANGED"
 
-# --- Tier 2: Specs that reference changed classes ---
+# Critical: specs that reference changed classes
 while IFS= read -r file; do
   [[ -z "$file" || "$file" != *.rb ]] && continue
   classname=$(basename "$file" .rb | sed -E 's/(^|_)([a-z])/\U\2/g')
   [[ -z "$classname" ]] && continue
   grep -rl --include="*.rb" "$classname" spec/ 2>/dev/null | sort | while IFS= read -r spec; do
-    add_if_new "$spec"
+    add_critical "$spec"
   done
 done <<< "$CHANGED"
 
-# --- Tier 3: Same-directory specs ---
+# Critical: same-directory specs
 while IFS= read -r file; do
   [[ -z "$file" ]] && continue
   dir=$(echo "$file" | sed 's|^app/|spec/|; s|/[^/]*$||')
   [[ -d "$dir" ]] || continue
   find "$dir" -maxdepth 1 -name "*_spec.rb" -type f 2>/dev/null | sort | while IFS= read -r spec; do
-    add_if_new "$spec"
+    add_critical "$spec"
   done
 done <<< "$CHANGED"
 
-RANKED_COUNT=$(wc -l < "$QUEUE" | tr -d ' ')
+CRITICAL_COUNT=$(wc -l < "$CRITICAL" | tr -d ' ')
 
-# --- Tier 4: Everything else (shuffled so it's not always alphabetical) ---
+# Remaining: everything else (for --full or continuing past 99%)
 find spec -name "*_spec.rb" -type f 2>/dev/null | sort -R | while IFS= read -r spec; do
-  add_if_new "$spec"
+  add_remaining "$spec"
 done
 
-TOTAL_QUEUED=$(wc -l < "$QUEUE" | tr -d ' ')
+REMAINING_COUNT=$(wc -l < "$REMAINING" | tr -d ' ')
+TOTAL_SPECS=$(( CRITICAL_COUNT + REMAINING_COUNT ))
 
-# ── Optional: AI re-ranks the queue ──
+# ── AI reranking of critical set ──
 
-if [[ "$USE_AI" == true && -n "${ANTHROPIC_API_KEY:-}" && "$RANKED_COUNT" -gt 0 ]]; then
-  # Get diff text: prefer local changes, fall back to branch diff vs main
+if [[ "$USE_AI" == true && -n "${ANTHROPIC_API_KEY:-}" && "$CRITICAL_COUNT" -gt 0 ]]; then
   if [[ -n "$LOCAL_CHANGED" ]]; then
     DIFF_TEXT=$(git diff HEAD -- $(echo "$LOCAL_CHANGED" | head -20) 2>/dev/null | head -400)
   elif [[ -n "$MERGE_BASE" ]]; then
@@ -135,7 +131,8 @@ if [[ "$USE_AI" == true && -n "${ANTHROPIC_API_KEY:-}" && "$RANKED_COUNT" -gt 0 
   else
     DIFF_TEXT=$(git diff HEAD -- $(echo "$CHANGED" | head -20) 2>/dev/null | head -400)
   fi
-  SPEC_LIST=$(cat "$QUEUE" | head -200)
+
+  SPEC_LIST=$(cat "$CRITICAL")
 
   PROMPT="You are a senior Rails engineer. Given this diff, reorder these test files from MOST to LEAST likely to catch a regression. Return ONLY the reordered file paths, one per line, no numbering, no explanation.
 
@@ -150,7 +147,7 @@ ${SPEC_LIST}"
     --arg prompt "$PROMPT" \
     '{model: $model, max_tokens: 8192, messages: [{role: "user", content: $prompt}]}')
 
-  printf "  🧠 AI reordering %d tests..." "$RANKED_COUNT"
+  printf "  🧠 AI reordering %d critical tests..." "$CRITICAL_COUNT"
 
   RESPONSE=$(curl -s --max-time 30 \
     -H "Content-Type: application/json" \
@@ -164,124 +161,142 @@ ${SPEC_LIST}"
   if [[ -n "$AI_TEXT" ]]; then
     AI_QUEUE=$(mktemp)
     AI_SEEN=$(mktemp)
-    # Add AI-ordered files first
     echo "$AI_TEXT" | grep -E '^spec/.*_spec\.rb$' | while IFS= read -r spec; do
       [[ -f "$spec" ]] || continue
       grep -qxF "$spec" "$AI_SEEN" 2>/dev/null && continue
       echo "$spec" >> "$AI_QUEUE"
       echo "$spec" >> "$AI_SEEN"
     done
-    # Then everything else from original queue that AI didn't mention
     while IFS= read -r spec; do
       grep -qxF "$spec" "$AI_SEEN" 2>/dev/null && continue
       echo "$spec" >> "$AI_QUEUE"
       echo "$spec" >> "$AI_SEEN"
-    done < "$QUEUE"
-    mv "$AI_QUEUE" "$QUEUE"
+    done < "$CRITICAL"
+    mv "$AI_QUEUE" "$CRITICAL"
     rm -f "$AI_SEEN"
     echo " done"
   else
-    echo " skipped (using convention order)"
+    echo " skipped"
   fi
 fi
 
-# ── Run tests one by one, confidence climbing continuously ──
+# ── Estimate time from CI history ──
 
-fmt_threshold() {
-  [[ "$THRESHOLD" -ge 100 ]] && echo "100%" || echo "${THRESHOLD}%"
+estimate_time() {
+  local count=$1
+  # Check for last green main CI run timing
+  local avg_per_spec=""
+  if [[ -f "$HISTORY_FILE" ]]; then
+    avg_per_spec=$(python3 -c "
+import json
+try:
+    h = json.load(open('$HISTORY_FILE'))
+    runs = h.get('runs', [])
+    if runs:
+        last = runs[-1]
+        avg = last['elapsed_seconds'] / max(last['specs_run'], 1)
+        print(f'{avg:.1f}')
+except: pass
+" 2>/dev/null || true)
+  fi
+
+  # Fallback: estimate from last green CI on GitHub
+  if [[ -z "$avg_per_spec" ]]; then
+    local ci_seconds
+    ci_seconds=$(gh run list -b main -s success -w "Tests" -L 1 --json updatedAt,createdAt \
+      --jq '.[0] | (((.updatedAt | fromdateiso8601) - (.createdAt | fromdateiso8601)))' 2>/dev/null || true)
+    if [[ -n "$ci_seconds" && "$ci_seconds" -gt 0 ]]; then
+      # CI runs ~1300 specs across ~30 parallel nodes
+      avg_per_spec=$(python3 -c "print(f'{$ci_seconds / 30 / 43:.1f}')" 2>/dev/null || true)
+    fi
+  fi
+
+  if [[ -n "$avg_per_spec" ]]; then
+    python3 -c "print(int($count * $avg_per_spec))" 2>/dev/null || echo ""
+  fi
 }
 
+ETA_CRITICAL=$(estimate_time "$CRITICAL_COUNT")
+ETA_FULL=$(estimate_time "$TOTAL_SPECS")
+
+# ── Header ──
+
 echo ""
 echo "  ═══════════════════════════════════════════════════"
-echo "    TEST CONFIDENCE  →  $(fmt_threshold)"
-echo "    $TOTAL_QUEUED tests queued ($RANKED_COUNT prioritized)"
+echo "    TEST CONFIDENCE"
+echo "  ───────────────────────────────────────────────────"
+printf "    99%%  ←  %d tests" "$CRITICAL_COUNT"
+[[ -n "$ETA_CRITICAL" ]] && printf "  (~%ds)" "$ETA_CRITICAL"
+echo ""
+printf "   100%%  ←  %d tests" "$TOTAL_SPECS"
+[[ -n "$ETA_FULL" ]] && printf "  (~%ds)" "$ETA_FULL"
+echo ""
 echo "  ═══════════════════════════════════════════════════"
 echo ""
+
+# ── History tracking ──
+
+save_history() {
+  local specs=$1 elapsed=$2 result=$3
+  python3 -c "
+import json, time, os
+path = '$HISTORY_FILE'
+try:
+    h = json.load(open(path)) if os.path.exists(path) else {'runs': []}
+except: h = {'runs': []}
+h['runs'].append({
+    'timestamp': int(time.time()),
+    'branch': '$CURRENT_BRANCH',
+    'specs_run': $specs,
+    'elapsed_seconds': $elapsed,
+    'result': '$result'
+})
+h['runs'] = h['runs'][-50:]  # keep last 50
+json.dump(h, open(path, 'w'), indent=2)
+" 2>/dev/null || true
+}
+
+# ── Run critical tests (the 99% set) ──
 
 START=$(date +%s)
 PASSED=0
 FAILED=0
-CONFIDENCE=0
-
-# Confidence model:
-#   Each passing test adds to confidence proportional to total suite size.
-#   Early (high-relevance) tests contribute more via a Pareto curve.
-#
-#   confidence = 1 - (1 - passed/total)^k
-#     where k = 2.5 for ranked tests (front-loaded confidence)
-#     and   k = 1.0 for unranked tests (linear)
-#
-#   This means:
-#     10% of tests (most relevant) → ~70% confidence
-#     30% of tests                 → ~92% confidence
-#     50% of tests                 → ~98% confidence
-#     100% of tests                → 100% confidence
-
-calc_confidence() {
-  local passed=$1 total=$2 ranked=$3
-  python3 -c "
-import math
-passed, total, ranked = $passed, $total, $ranked
-if total == 0:
-    print(0)
-else:
-    frac = passed / total
-    # Pareto curve: front-loaded if we're still in ranked territory
-    if passed <= ranked:
-        k = 2.5
-    else:
-        # Blend: once past ranked tests, curve flattens toward linear
-        ranked_frac = ranked / total if total > 0 else 0
-        k = 2.5 - 1.5 * min(1, (frac - ranked_frac) / max(0.01, 1 - ranked_frac))
-    c = 1.0 - (1.0 - frac) ** k
-    print(int(c * 10000))  # basis points for integer math
-" 2>/dev/null
-}
 
 draw_bar() {
-  local bps=$1  # basis points (0-10000)
+  local passed=$1 total=$2 phase=$3
   local width=40
-  local filled=$(( bps * width / 10000 ))
+  local filled=0
+  if [[ "$total" -gt 0 ]]; then
+    filled=$(( passed * width / total ))
+  fi
   [[ $filled -gt $width ]] && filled=$width
   local empty=$(( width - filled ))
   local bar=""
-  for (( j=0; j<filled; j++ )); do bar+="▓"; done
-  for (( j=0; j<empty; j++ )); do bar+="░"; done
+  # Yellow while running critical, green once 99% reached
+  for (( j=0; j<filled; j++ )); do
+    if [[ "$phase" == "green" ]]; then
+      bar+="🟩"
+    else
+      bar+="🟨"
+    fi
+  done
+  for (( j=0; j<empty; j++ )); do bar+="⬜"; done
   echo "$bar"
 }
 
-fmt_confidence() {
-  local bps=$1
-  if [[ $bps -ge 10000 ]]; then echo "100"
-  elif [[ $bps -ge 9990 ]]; then echo "99.9"
-  elif [[ $bps -ge 1000 ]]; then echo "$(( bps / 100 )).$(( bps % 100 / 10 ))"
-  elif [[ $bps -ge 100 ]]; then echo "$(( bps / 100 )).$(( bps % 100 ))"
-  else echo "0.$(printf '%02d' $bps)"
-  fi
-}
+echo "  ── 99% confidence (critical tests) ──"
+echo ""
 
-THRESHOLD_BPS=$(( THRESHOLD * 100 ))
+mapfile -t CRITICAL_TESTS < "$CRITICAL"
 
-mapfile -t ALL_TESTS < "$QUEUE"
-
-for spec in "${ALL_TESTS[@]}"; do
+for spec in "${CRITICAL_TESTS[@]}"; do
   [[ -z "$spec" ]] && continue
 
-  # Run single test file
   if output=$(bundle exec rspec --format progress --no-color "$spec" 2>&1); then
     PASSED=$((PASSED + 1))
-    CONFIDENCE=$(calc_confidence $PASSED $TOTAL_QUEUED $RANKED_COUNT)
-
     elapsed=$(( $(date +%s) - START ))
-    bar=$(draw_bar "$CONFIDENCE")
-    conf_str=$(fmt_confidence "$CONFIDENCE")
-    printf "\r  %s  %5s%%  %d/%d passed  %ds  " "$bar" "$conf_str" "$PASSED" "$TOTAL_QUEUED" "$elapsed"
-
-    # Stop if we've hit the threshold
-    if [[ "$CONFIDENCE" -ge "$THRESHOLD_BPS" ]]; then
-      echo ""
-      break
-    fi
+    bar=$(draw_bar "$PASSED" "$CRITICAL_COUNT" "neutral")
+    printf "\r  %s  %d/%d  %ds" "$bar" "$PASSED" "$CRITICAL_COUNT" "$elapsed"
   else
     FAILED=$((FAILED + 1))
     echo ""
@@ -294,25 +309,76 @@ for spec in "${ALL_TESTS[@]}"; do
     echo ""
     echo "  Fix this before committing."
     echo ""
+
+    # Save timing data
+    elapsed=$(( $(date +%s) - START ))
+    save_history "$PASSED" "$elapsed" "failed"
     exit 1
   fi
 done
 
-# ── Done ──
+CRITICAL_ELAPSED=$(( $(date +%s) - START ))
 
-elapsed=$(( $(date +%s) - START ))
-conf_str=$(fmt_confidence "$CONFIDENCE")
+# ── 99% reached ──
 
 echo ""
-echo "  ═══════════════════════════════════════════════════"
-if [[ "$CONFIDENCE" -ge "$THRESHOLD_BPS" ]]; then
-  echo "    ✅  ${conf_str}% confidence  (threshold: $(fmt_threshold))"
-else
-  echo "    ⚠️   ${conf_str}% confidence  (threshold: $(fmt_threshold))"
+echo ""
+bar=$(draw_bar "$CRITICAL_COUNT" "$CRITICAL_COUNT" "green")
+echo "  $bar"
+echo ""
+echo "  ✅ 99% confidence — $CRITICAL_COUNT tests passed in ${CRITICAL_ELAPSED}s"
+echo "     Safe to commit."
+echo ""
+
+save_history "$PASSED" "$CRITICAL_ELAPSED" "passed_99"
+
+# ── Continue to 100% if requested ──
+
+if [[ "$RUN_FULL" != true ]]; then
+  if [[ "$REMAINING_COUNT" -gt 0 ]]; then
+    echo "  $REMAINING_COUNT more tests for 100%. Run with --full to continue."
+    echo ""
+  fi
+  exit 0
 fi
-echo "  ═══════════════════════════════════════════════════"
-echo ""
-echo "  $PASSED passed in ${elapsed}s  ·  $TOTAL_QUEUED in repo"
+
+echo "  ── 100% confidence (full suite) ──"
 echo ""
 
-[[ "$CONFIDENCE" -ge "$THRESHOLD_BPS" ]]
+mapfile -t REMAINING_TESTS < "$REMAINING"
+FULL_PASSED=$PASSED
+FULL_START=$(date +%s)
+
+for spec in "${REMAINING_TESTS[@]}"; do
+  [[ -z "$spec" ]] && continue
+
+  if output=$(bundle exec rspec --format progress --no-color "$spec" 2>&1); then
+    FULL_PASSED=$((FULL_PASSED + 1))
+    elapsed=$(( $(date +%s) - START ))
+    pct=$(( FULL_PASSED * 100 / TOTAL_SPECS ))
+    bar=$(draw_bar "$FULL_PASSED" "$TOTAL_SPECS" "green")
+    printf "\r  %s  %d/%d  %d%%  %ds" "$bar" "$FULL_PASSED" "$TOTAL_SPECS" "$pct" "$elapsed"
+  else
+    FAILED=$((FAILED + 1))
+    echo ""
+    echo ""
+    echo "  ═══════════════════════════════════════════════════"
+    echo "    ❌ FAILED — $spec"
+    echo "  ═══════════════════════════════════════════════════"
+    echo ""
+    echo "$output" | tail -20 | sed 's/^/    /'
+    echo ""
+    exit 1
+  fi
+done
+
+FULL_ELAPSED=$(( $(date +%s) - START ))
+
+echo ""
+echo ""
+echo "  ═══════════════════════════════════════════════════"
+echo "    ✅ 100% confidence — $FULL_PASSED tests in ${FULL_ELAPSED}s"
+echo "  ═══════════════════════════════════════════════════"
+echo ""
+
+save_history "$FULL_PASSED" "$FULL_ELAPSED" "passed_100"

--- a/bin/test-confidence
+++ b/bin/test-confidence
@@ -178,7 +178,7 @@ Test files to reorder:
 ${SPEC_LIST}"
 
   PAYLOAD=$(jq -n \
-    --arg model "claude-sonnet-4-6" \
+    --arg model "claude-opus-4-7" \
     --arg prompt "$PROMPT" \
     '{model: $model, max_tokens: 8192, messages: [{role: "user", content: $prompt}]}')
 
@@ -361,7 +361,7 @@ Return ONLY a number between 99.0 and 100.0, nothing else."
 
   local payload
   payload=$(jq -n \
-    --arg model "claude-sonnet-4-6" \
+    --arg model "claude-opus-4-7" \
     --arg prompt "$prompt" \
     '{model: $model, max_tokens: 16, messages: [{role: "user", content: $prompt}]}')
 

--- a/bin/test-confidence
+++ b/bin/test-confidence
@@ -3,8 +3,7 @@
 # bin/test-confidence — Run the tests that matter, fast.
 #
 # Finds the minimal set of tests needed for 99% confidence based on your
-# diff, runs them, then optionally continues toward 100%. Shows ETA based
-# on the last green CI build on main.
+# diff, runs them, then optionally continues toward 100%.
 #
 # Usage:
 #   bin/test-confidence          # Run to 99%, stop
@@ -17,7 +16,6 @@ set -euo pipefail
 
 RUN_FULL=false
 USE_AI=true
-HISTORY_FILE=".test-confidence-history.json"
 
 for arg in "$@"; do
   case "$arg" in
@@ -217,44 +215,6 @@ ${SPEC_LIST}"
   fi
 fi
 
-# ── Estimate time from CI history ──
-
-estimate_time() {
-  local count=$1
-  # Check for last green main CI run timing
-  local avg_per_spec=""
-  if [[ -f "$HISTORY_FILE" ]]; then
-    avg_per_spec=$(python3 -c "
-import json
-try:
-    h = json.load(open('$HISTORY_FILE'))
-    runs = h.get('runs', [])
-    if runs:
-        last = runs[-1]
-        avg = last['elapsed_seconds'] / max(last['specs_run'], 1)
-        print(f'{avg:.1f}')
-except: pass
-" 2>/dev/null || true)
-  fi
-
-  # Fallback: estimate from last green CI on GitHub
-  if [[ -z "$avg_per_spec" ]]; then
-    local ci_seconds
-    ci_seconds=$(gh run list -b main -s success -w "Tests" -L 1 --json updatedAt,createdAt \
-      --jq '.[0] | (((.updatedAt | fromdateiso8601) - (.createdAt | fromdateiso8601)))' 2>/dev/null || true)
-    if [[ -n "$ci_seconds" && "$ci_seconds" -gt 0 ]]; then
-      # CI runs ~1300 specs across ~30 parallel nodes
-      avg_per_spec=$(python3 -c "print(f'{$ci_seconds / 30 / 43:.1f}')" 2>/dev/null || true)
-    fi
-  fi
-
-  if [[ -n "$avg_per_spec" ]]; then
-    python3 -c "print(int($count * $avg_per_spec))" 2>/dev/null || echo ""
-  fi
-}
-
-ETA_CRITICAL=$(estimate_time "$CRITICAL_COUNT")
-ETA_FULL=$(estimate_time "$TOTAL_SPECS")
 
 # ── Header ──
 
@@ -262,36 +222,11 @@ echo ""
 echo "  ═══════════════════════════════════════════════════"
 echo "    TEST CONFIDENCE"
 echo "  ───────────────────────────────────────────────────"
-printf "    99%%  ←  %d tests" "$CRITICAL_COUNT"
-[[ -n "$ETA_CRITICAL" ]] && printf "  (~%ds)" "$ETA_CRITICAL"
-echo ""
-printf "   100%%  ←  %d tests" "$TOTAL_SPECS"
-[[ -n "$ETA_FULL" ]] && printf "  (~%ds)" "$ETA_FULL"
-echo ""
+echo "    99%  ←  $CRITICAL_COUNT tests"
+echo "   100%  ←  $TOTAL_SPECS tests"
 echo "  ═══════════════════════════════════════════════════"
 echo ""
 
-# ── History tracking ──
-
-save_history() {
-  local specs=$1 elapsed=$2 result=$3
-  python3 -c "
-import json, time, os
-path = '$HISTORY_FILE'
-try:
-    h = json.load(open(path)) if os.path.exists(path) else {'runs': []}
-except: h = {'runs': []}
-h['runs'].append({
-    'timestamp': int(time.time()),
-    'branch': '$CURRENT_BRANCH',
-    'specs_run': $specs,
-    'elapsed_seconds': $elapsed,
-    'result': '$result'
-})
-h['runs'] = h['runs'][-50:]  # keep last 50
-json.dump(h, open(path, 'w'), indent=2)
-" 2>/dev/null || true
-}
 
 # ── Run critical tests (the 99% set) ──
 
@@ -349,7 +284,6 @@ for spec in "${CRITICAL_TESTS[@]}"; do
 
     # Save timing data
     elapsed=$(( $(date +%s) - START ))
-    save_history "$PASSED" "$elapsed" "failed"
     exit 1
   fi
 done
@@ -366,8 +300,6 @@ echo ""
 echo "  ✅ 99% confidence — $CRITICAL_COUNT tests passed in ${CRITICAL_ELAPSED}s"
 echo "     Safe to commit."
 echo ""
-
-save_history "$PASSED" "$CRITICAL_ELAPSED" "passed_99"
 
 # ── Continue to 100% if requested ──
 
@@ -434,4 +366,4 @@ echo "    ✅ 100% confidence — $((PASSED + REM_PASSED)) tests in ${FULL_ELAPS
 echo "  ═══════════════════════════════════════════════════"
 echo ""
 
-save_history "$((PASSED + REM_PASSED))" "$FULL_ELAPSED" "passed_100"
+

--- a/bin/test-confidence
+++ b/bin/test-confidence
@@ -178,26 +178,6 @@ echo "  ⚡ Risk: $RISK — $REASON"
 # ── Parse plan and execute ──
 
 MILESTONES=$(jq '.milestones | length' "$PLAN_FILE")
-TOTAL_PLANNED=0
-
-# Count total tests across milestones
-for (( m=0; m<MILESTONES; m++ )); do
-  TESTS_JSON=$(jq -r ".milestones[$m].tests[]" "$PLAN_FILE" 2>/dev/null)
-  if echo "$TESTS_JSON" | grep -q "ALL_REMAINING"; then
-    PLANNED_SEEN=$(mktemp)
-    for (( p=0; p<m; p++ )); do
-      jq -r ".milestones[$p].tests[]" "$PLAN_FILE" 2>/dev/null >> "$PLANNED_SEEN"
-    done
-    REMAINING_N=$(echo "$ALL_SPECS" | while IFS= read -r s; do
-      grep -qxF "$s" "$PLANNED_SEEN" 2>/dev/null || echo "$s"
-    done | wc -l | tr -d ' ')
-    TOTAL_PLANNED=$(( TOTAL_PLANNED + REMAINING_N ))
-    rm -f "$PLANNED_SEEN"
-  else
-    N=$(echo "$TESTS_JSON" | grep -c "spec/" || true)
-    TOTAL_PLANNED=$(( TOTAL_PLANNED + N ))
-  fi
-done
 
 # ── Header ──
 
@@ -256,8 +236,8 @@ for (( m=0; m<MILESTONES; m++ )); do
     done)
   fi
 
-  MILESTONE_COUNT=$(echo "$MILESTONE_TESTS" | grep -c "spec/" 2>/dev/null || echo 0)
-  [[ "$MILESTONE_COUNT" -eq 0 ]] && continue
+  MILESTONE_COUNT=$(echo "$MILESTONE_TESTS" | grep -c "spec/" 2>/dev/null || true)
+  [[ -z "$MILESTONE_COUNT" || "$MILESTONE_COUNT" -eq 0 ]] && continue
 
   # Skip milestones past 99 unless --full
   if [[ "$RUN_FULL" != true && "$CURRENT_CONFIDENCE" -ge 99 ]]; then


### PR DESCRIPTION
## What

Rewrites `bin/test-confidence` so Opus 4.7 decides everything: which tests to run, in what order, how many are needed for each confidence level, and what the risk is. No formulas, no convention mapping, no fallback. The AI is the only path.

## Why

The previous version used fixed formulas (Pareto curves) and deterministic file mapping (grep for class names, same-directory specs) to decide which tests to run. This produced bad results:

- A one-line comment change mapped to 277 tests via grep
- The same change with Opus mapped to 4 tests
- The curve shape was identical regardless of whether you changed a comment or a payment model

Different diffs have fundamentally different risk profiles. The AI should decide the shape of the curve ad hoc, not a formula.

## How it works

1. Detects changed files (branch diff vs main for PR branches, local diff on main)
2. Sends the diff + full spec file tree to **Opus 4.7** in one API call
3. Opus returns a JSON plan with risk level, ordered tests, and confidence milestones
4. Script executes the plan milestone by milestone
5. Yellow bar while running toward 99%, green when reached
6. Stops at 99% by default. `--full` continues to 100%.

## Tested locally

Comment-only change to `offer_code.rb`:

```
  📂 1 files changed (local)
  🧠 Opus planning test execution... done
  ⚡ Risk: low — The diff only adds a trailing comment line with no functional code change.

  ═══════════════════════════════════════════════════
    TEST CONFIDENCE
  ───────────────────────────────────────────────────
   80%  ←  1 test
          offer_code_spec.rb
   95%  ←  1 test
          create_service_spec.rb
   99%  ←  2 tests
          offer_codes_spec.rb
          purchase_spec.rb
  100%  ←  remaining tests
  ═══════════════════════════════════════════════════

  🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨  →80%  1/1  22s
  ✅ 80% — 1 test — 22s
  🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨  →95%  1/1  30s
  ✅ 95% — 1 test — 30s
  🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜  →99%  1/2  37s

  🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩

  ✅ 99% confidence — 4 tests passed in 45s
     Safe to commit.

  1263 tests more for 100%. Run with --full to continue.
```

Convention mapping (old behavior) wanted 277 tests for the same change.

## Changes

| File | What changed |
|------|-------------|
| `bin/test-confidence` | Complete rewrite. Single Opus 4.7 call plans everything. No convention mapping. Requires `ANTHROPIC_API_KEY`. Shows test file names per milestone. Proper pluralization. |
| `CONTRIBUTING.md` | Updated "Before pushing" section. |
| `.claude/skills/test-confidence/SKILL.md` | Updated to describe Opus-driven flow. |
| `.claude/skills/commit/SKILL.md` | References `bin/test-confidence` and green bar. |

## Design decisions

- **Opus 4.7** — best agentic coding model (87.6% SWE-bench, 5+ points ahead of #2)
- **No fallback** — convention mapping produced bad results. If you're writing code, you have an API key.
- **One call** — single planning call up front, not repeated scoring during execution
- **Ad hoc milestones** — the AI decides confidence levels and test counts per diff
- **Branch-aware** — diffs against main on PR branches, local changes on main

## Claude Code Review findings (all addressed)

- 🔴 `MILESTONE_COUNT` producing "0\n0" on empty → fixed
- 🟡 `TOTAL_PLANNED` dead code → removed
- 🔴 Convention mapping bugs (Tier A regex, AI rerank merge, unanchored grep) → all removed with convention mapping

---

AI disclosure: Claude Opus 4.6 via Gumclaw. Iterated through ~10 rounds of feedback from Sahil.