### PR TITLE
Fix confusing business checkbox on payments onboarding

### DIFF
--- a/app/javascript/components/CountrySelectionModal.tsx
+++ b/app/javascript/components/CountrySelectionModal.tsx
@@ -24,7 +24,7 @@ export const CountrySelectionModal = ({ country: initialCountry, countries }: Pr
   const checkboxes = [
     "I have a valid, government-issued photo ID",
     "I have proof of residence within this country",
-    "If I am signing up as a business, it is registered in the country above",
+    "I am signing up as an individual, or my business is registered in the country above",
   ];
   const [checked, setChecked] = React.useState<number[]>([]);
   const [error, setError] = React.useState("");

--- a/spec/requests/settings/payments_spec.rb
+++ b/spec/requests/settings/payments_spec.rb
@@ -6257,7 +6257,7 @@ describe("Payments Settings Scenario", type: :system, js: true) do
           select "United States", from: "Country"
           check "I have a valid, government-issued photo ID"
           check "I have proof of residence within this country"
-          check "If I am signing up as a business, it is registered in the country above"
+          check "I am signing up as an individual, or my business is registered in the country above"
           click_on "Save"
           wait_for_ajax
         end


### PR DESCRIPTION
## What

Changes the third checkbox on the payments onboarding country selection modal from:

> If I am signing up as a business, it is registered in the country above

To:

> I am signing up as an individual, or my business is registered in the country above

## Why

This is a recurring support ticket pattern. Individual sellers (especially non-native English speakers) read "If I am signing up as a business" as a declaration that they ARE signing up as a business, not a conditional. They refuse to check the box because they're individuals, and get stuck on the onboarding page.

The new wording makes both paths explicit: you're either an individual (check it) or a business registered in the selected country (check it). No ambiguity.

Fixes [#4834](https://github.com/antiwork/gumroad/issues/4834)

---

AI disclosure: Claude Opus 4.6 via Gumclaw.