### PR TITLE
Remove forfeit balance warning from country selection modal

### DIFF
--- a/app/javascript/components/CountrySelectionModal.tsx
+++ b/app/javascript/components/CountrySelectionModal.tsx
@@ -96,7 +96,6 @@ export const CountrySelectionModal = ({ country: initialCountry, countries }: Pr
               </Label>
             ))}
           </Fieldset>
-          <h4>You may have to forfeit your balance if you want to change your country in the future.</h4>
         </div>
       </Modal>
     </div>

--- a/spec/requests/settings/payments_spec.rb
+++ b/spec/requests/settings/payments_spec.rb
@@ -6251,7 +6251,6 @@ describe("Payments Settings Scenario", type: :system, js: true) do
         visit settings_payments_path
         within_modal do
           expect(page).to have_content "Where are you located?"
-          expect(page).to have_content "You may have to forfeit your balance if you want to change your country in the future."
           expect(page).to have_button "Save", disabled: true
           expect(find(:select, "Country")).to have_selector(:option, "Somalia (not supported)", disabled: true)
           select "United States", from: "Country"


### PR DESCRIPTION
## What

Removes "You may have to forfeit your balance if you want to change your country in the future." from the payments onboarding country selection modal.

## Why

Scary language on an onboarding screen. New sellers haven't earned anything yet and they're already being warned about forfeiting balances. It adds friction to a flow that should be as smooth as possible.

---

AI disclosure: Claude Opus 4.6 via Gumclaw.