### PR TITLE
Fix mobile scroll on membership content list

### DIFF
--- a/app/javascript/components/Download/PageListLayout.tsx
+++ b/app/javascript/components/Download/PageListLayout.tsx
@@ -14,14 +14,14 @@ export const PageListLayout = React.forwardRef<
   <div
     ref={ref}
     className={classNames(
-      "flex min-h-0 flex-col gap-6 bg-background p-4 [scrollbar-gutter:stable] md:p-8 lg:flex-row lg:gap-8 lg:overflow-y-auto",
+      "flex min-h-0 flex-col gap-6 overflow-y-auto bg-background p-4 [scrollbar-gutter:stable] md:p-8 lg:flex-row lg:gap-8",
       className,
     )}
   >
     <div className="flex flex-col gap-4 [scrollbar-gutter:stable] lg:sticky lg:top-0 lg:h-full lg:max-h-[calc(100vh-184px)] lg:w-80 lg:overflow-y-auto lg:pb-8">
       {pageList}
     </div>
-    <div className="h-0 flex-1">{children}</div>
+    <div className="min-h-0 flex-1">{children}</div>
   </div>
 ));
 PageListLayout.displayName = "PageListLayout";


### PR DESCRIPTION
## What

Fixes the download page so membership content lists scroll properly on mobile. Subscribers can now access all posts, not just the first ~14.

## Why

`PageListLayout` only had `overflow-y-auto` on desktop (`lg:` breakpoint). On mobile, the container had no overflow handling. Combined with `h-0` on the content wrapper (a flex trick for desktop), content was clipped to the initial viewport height on iOS Safari and Chrome.

## Fix

Two CSS changes in `PageListLayout.tsx`:

1. `lg:overflow-y-auto` → `overflow-y-auto` — scrolling now works at all breakpoints, not just desktop
2. `h-0 flex-1` → `min-h-0 flex-1` on the content wrapper — prevents zero-height clipping while still filling available space via flex-grow

## Impact

This is priority #1. The affected creator (Sunflowers & Spirituality, $342K lifetime) has been reporting this for 7 months and is losing subscribers because members can't access content they're paying for.

Fixes [#4837](https://github.com/antiwork/gumroad/issues/4837)

---

AI disclosure: Claude Opus 4.6 via Gumclaw.