### PR TITLE
Fix Faraday::ServerError crash in content moderation prompt strategy

### DIFF
--- a/app/services/content_moderation/strategies/prompt_strategy.rb
+++ b/app/services/content_moderation/strategies/prompt_strategy.rb
@@ -94,7 +94,7 @@ class ContentModeration::Strategies::PromptStrategy
     else
       Result.new(status: "compliant", reasoning: [])
     end
-  rescue Faraday::TimeoutError, Faraday::ConnectionFailed, Net::ReadTimeout => e
+  rescue Faraday::TimeoutError, Faraday::ConnectionFailed, Faraday::ServerError, Net::ReadTimeout => e
     Rails.logger.warn("ContentModeration::PromptStrategy timeout: #{e.class} - #{e.message}")
     Result.new(status: "compliant", reasoning: [])
   rescue StandardError => e
@@ -125,7 +125,7 @@ class ContentModeration::Strategies::PromptStrategy
     rescue Faraday::BadRequestError => e
       notify_openai_rejection(e, stage: "preset:#{preset[:name]}", images_sent: !preset[:skip_images])
       { status: "compliant", reasoning: "" }
-    rescue Faraday::TimeoutError, Faraday::ConnectionFailed, Net::ReadTimeout => e
+    rescue Faraday::TimeoutError, Faraday::ConnectionFailed, Faraday::ServerError, Net::ReadTimeout => e
       Rails.logger.warn("ContentModeration::PromptStrategy preset timeout on #{preset[:name]}: #{e.class} - #{e.message}")
       { status: "compliant", reasoning: "" }
     rescue StandardError => e
@@ -159,7 +159,7 @@ class ContentModeration::Strategies::PromptStrategy
     rescue Faraday::BadRequestError => e
       notify_openai_rejection(e, stage: "uncertainty_check", images_sent: false)
       false
-    rescue Faraday::TimeoutError, Faraday::ConnectionFailed, Net::ReadTimeout => e
+    rescue Faraday::TimeoutError, Faraday::ConnectionFailed, Faraday::ServerError, Net::ReadTimeout => e
       Rails.logger.warn("ContentModeration::PromptStrategy uncertainty check timeout: #{e.class} - #{e.message}")
       false
     rescue StandardError => e

--- a/spec/services/content_moderation/strategies/prompt_strategy_spec.rb
+++ b/spec/services/content_moderation/strategies/prompt_strategy_spec.rb
@@ -250,6 +250,33 @@ RSpec.describe ContentModeration::Strategies::PromptStrategy, :vcr do
       expect(result.status).to eq("compliant")
       expect(result.reasoning).to eq([])
     end
+
+    it "returns compliant when OpenAI returns a 500 server error" do
+      allow(client).to receive(:chat).and_raise(Faraday::ServerError, "the server responded with status 500")
+
+      result = described_class.new(text: "moderate me").perform
+
+      expect(result.status).to eq("compliant")
+      expect(result.reasoning).to eq([])
+      expect(Rails.logger).to have_received(:warn).with(/preset timeout on adult_content.*Faraday::ServerError/)
+    end
+
+    it "skips the flagged result when the uncertainty check gets a 500 server error" do
+      call_count = 0
+      allow(client).to receive(:chat) do |_kwargs|
+        call_count += 1
+        case call_count
+        when 1 then json_chat_response(flagged: true, reasoning: "looks explicit")
+        when 2 then raise Faraday::ServerError, "the server responded with status 500"
+        else json_chat_response(flagged: false, reasoning: "")
+        end
+      end
+
+      result = described_class.new(text: "moderate me").perform
+
+      expect(result.status).to eq("compliant")
+      expect(Rails.logger).to have_received(:warn).with(/uncertainty check timeout.*Faraday::ServerError/)
+    end
   end
 
   def json_chat_response(payload)


### PR DESCRIPTION
## What

Adds `Faraday::ServerError` to the three rescue blocks in `ContentModeration::Strategies::PromptStrategy` that already handle `Faraday::TimeoutError`, `Faraday::ConnectionFailed`, and `Net::ReadTimeout`. When OpenAI returns a 500, the strategy now defaults to compliant/false instead of letting the error propagate up and crash `LinksController#update`.

## Why

Sentry issue: https://gumroad-to.sentry.io/issues/7448459601/

OpenAI occasionally returns 500 server errors. These are transient and should be treated the same as timeouts — log a warning and default to compliant. Without this fix, the error propagates through the thread in `ModerateRecordService#run_ai_strategies` and crashes the controller action.

## Test results

```
16 examples, 0 failures
```

Two new specs added covering `Faraday::ServerError` in both preset evaluation and uncertainty check paths.

---

AI disclosure: Fixed with Claude Opus 4.6. Prompted to add `Faraday::ServerError` to rescue blocks in `prompt_strategy.rb` and add corresponding test coverage.