### PR TITLE
Fix InvalidPromptError when sanitized prompt is blank

### DIFF
--- a/app/controllers/api/internal/ai_product_details_generations_controller.rb
+++ b/app/controllers/api/internal/ai_product_details_generations_controller.rb
@@ -14,7 +14,7 @@ class Api::Internal::AiProductDetailsGenerationsController < Api::Internal::Base
   def create
     authorize current_seller, :generate_product_details_with_ai?
 
-    prompt = params[:prompt]
+    prompt = sanitize_prompt(params[:prompt].to_s)
 
     if prompt.blank?
       render json: { error: "Prompt is required" }, status: :bad_request
@@ -23,7 +23,7 @@ class Api::Internal::AiProductDetailsGenerationsController < Api::Internal::Base
 
     begin
       service = ::Ai::ProductDetailsGeneratorService.new(current_seller: current_seller)
-      result = service.generate_product_details(prompt: sanitize_prompt(prompt))
+      result = service.generate_product_details(prompt: prompt)
 
       render json: {
         success: true,

--- a/spec/controllers/api/internal/ai_product_details_generations_controller_spec.rb
+++ b/spec/controllers/api/internal/ai_product_details_generations_controller_spec.rb
@@ -94,6 +94,13 @@ describe Api::Internal::AiProductDetailsGenerationsController do
         expect(response.parsed_body).to eq({ "error" => "Prompt is required" })
       end
 
+      it "returns error when prompt contains only characters removed by sanitization" do
+        post :create, params: { prompt: "\u{1F3A8}\u{1F3B5}\u{1F3AD}" }, format: :json
+
+        expect(response).to have_http_status(:bad_request)
+        expect(response.parsed_body).to eq({ "error" => "Prompt is required" })
+      end
+
       it "returns error when prompt is missing" do
         post :create, params: {}, format: :json
 


### PR DESCRIPTION
## What

Moves the blank-prompt check in `AiProductDetailsGenerationsController#create` to **after** sanitization instead of before. Previously, a prompt like "🎨🎵🎭" passed the initial `blank?` check but was stripped to an empty string by `sanitize_prompt`, causing `Ai::ProductDetailsGeneratorService` to raise `InvalidPromptError` — an unhandled 500.

## Why

This was surfacing as a Sentry error: `Ai::ProductDetailsGeneratorService::InvalidPromptError: Prompt cannot be blank`. The fix ensures prompts that sanitize to empty return a clean 400 (`"Prompt is required"`) instead of a 500.

Sentry issue: https://gumroad-to.sentry.io/issues/7448556296/

## Test results

```
8 examples, 0 failures  (controller spec)
9 examples, 0 failures  (service spec)
```

Added a test that sends a prompt of only emoji characters and asserts a 400 response.

---

Built with Claude Opus 4.6. Prompt: fix Sentry InvalidPromptError by moving blank check after sanitization, add test for emoji-only prompt.