### PR TITLE
Fix mobile table of contents popover scroll on download page

### DIFF
--- a/app/javascript/components/DownloadPage/WithContent.tsx
+++ b/app/javascript/components/DownloadPage/WithContent.tsx
@@ -320,7 +320,10 @@ export const WithContent = ({
                   </Button>
                 </PopoverTrigger>
               </PopoverAnchor>
-              <PopoverContent sideOffset={4} className="border-0 p-0 shadow-none">
+              <PopoverContent
+                sideOffset={4}
+                className="max-h-[var(--radix-popover-content-available-height,80vh)] overflow-auto border-0 p-0 shadow-none"
+              >
                 <Menu>
                   {pages.map((page, index) => (
                     <PopoverClose key={page.page_id} asChild>


### PR DESCRIPTION
Fixes https://github.com/antiwork/gumroad/issues/4837

## What

Caps the mobile "Table of Contents" popover at the available viewport height and enables internal scrolling, so subscribers can reach every post in memberships with many pages.

## Why

The page list is inside a Radix `PopoverContent` in `WithContent.tsx`. With no `max-height` or `overflow` set, items past the viewport were clipped with no way to scroll the menu, so affected subscribers could still only see the first ~14 posts.

## After

https://github.com/user-attachments/assets/1a82e669-9b08-4232-82a2-b8e4d1482b62

AI disclosure: Claude Opus 4.7.
