### PR TITLE
Fix 'Show active customers only' filter to exclude all inactive subscriptions

### DIFF
--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -129,6 +129,8 @@ class CustomersController < Sellers::BaseController
 
       if active_customers_only
         search_options[:exclude_deactivated_subscriptions] = true
+        search_options[:exclude_cancelled_or_pending_cancellation_subscriptions] = true
+        search_options[:exclude_pending_failure_subscriptions] = true
         search_options[:exclude_refunded_except_subscriptions] = true
         search_options[:exclude_unreversed_chargedback] = true
       end

--- a/app/models/concerns/purchase/searchable.rb
+++ b/app/models/concerns/purchase/searchable.rb
@@ -111,6 +111,7 @@ module Purchase::Searchable
       indexes :subscription_id, type: :long
       indexes :subscription_cancelled_at, type: :date
       indexes :subscription_deactivated_at, type: :date
+      indexes :subscription_pending_failure, type: :boolean
       indexes :taxonomy_id, type: :long
     end
 
@@ -197,6 +198,8 @@ module Purchase::Searchable
         purchaser.attributes[$LAST_MATCH_INFO[1]] if purchaser.present?
       when /\Asubscription_(id|cancelled_at|deactivated_at)\z/
         subscription.attributes[$LAST_MATCH_INFO[1]] if subscription.present?
+      when "subscription_pending_failure"
+        subscription&.pending_failure? || false
       when "taxonomy_id"
         link.taxonomy_id
       when "variant_ids"
@@ -243,12 +246,18 @@ module Purchase::Searchable
     def update_purchase_index
       tracked_columns = %w[cancelled_at deactivated_at]
       changed_tracked_columns = attributes_committed & tracked_columns
-      if changed_tracked_columns.present?
+      pending_failure_changed = (attributes_committed & %w[failed_at ended_at cancelled_at]).present?
+
+      if changed_tracked_columns.present? || pending_failure_changed
+        fields = changed_tracked_columns.map { |name| "subscription_#{name}" }
+        fields << "subscription_pending_failure" if pending_failure_changed
+        fields.uniq!
+
         purchases.select(:id).find_each do |purchase|
           options = {
             "record_id" => purchase.id,
             "class_name" => "Purchase",
-            "fields" => changed_tracked_columns.map { |name| ["subscription_#{name}"] }.flatten
+            "fields" => fields,
           }
           ElasticsearchIndexerWorker.perform_in(2.seconds, "update", options)
         end
@@ -294,18 +303,17 @@ module Purchase::Searchable
       end
 
       def update_same_purchaser_subscription_purchase_documents
-        should_update = successful?
-        should_update &= previous_changes.key?(:purchase_state)
-        should_update &= !is_original_subscription_purchase?
-        should_update &= subscription.present? && subscription.original_purchase.present?
-        return unless should_update
+        return unless previous_changes.key?(:purchase_state)
+        return if is_original_subscription_purchase?
+        return unless subscription.present? && subscription.original_purchase.present?
+
+        fields = ["subscription_pending_failure"]
+        fields << "latest_charge_date" if successful?
 
         options = {
           "record_id" => subscription.original_purchase.id,
           "class_name" => "Purchase",
-          "fields" => [
-            "latest_charge_date",
-          ]
+          "fields" => fields,
         }
         ElasticsearchIndexerWorker.perform_in(2.seconds, "update", options)
       end

--- a/app/services/purchase_search_service.rb
+++ b/app/services/purchase_search_service.rb
@@ -22,6 +22,7 @@ class PurchaseSearchService
     exclude_non_original_subscription_purchases: false,
     exclude_deactivated_subscriptions: false,
     exclude_cancelled_or_pending_cancellation_subscriptions: false,
+    exclude_pending_failure_subscriptions: false,
     exclude_refunded: false,
     exclude_refunded_except_subscriptions: false,
     exclude_unreversed_chargedback: false,
@@ -125,6 +126,7 @@ class PurchaseSearchService
       build_body_exclude_not_charged_non_free_trial_purchases
       build_body_exclude_deactivated_subscriptions
       build_body_exclude_cancelled_or_pending_cancellation_subscriptions
+      build_body_exclude_pending_failure_subscriptions
       build_body_exclude_cant_contact
       build_body_exclude_giftees
       build_body_exclude_gifters
@@ -316,6 +318,11 @@ class PurchaseSearchService
     def build_body_exclude_cancelled_or_pending_cancellation_subscriptions
       return unless @options[:exclude_cancelled_or_pending_cancellation_subscriptions]
       @body[:query][:bool][:must_not] << { exists: { field: "subscription_cancelled_at" } }
+    end
+
+    def build_body_exclude_pending_failure_subscriptions
+      return unless @options[:exclude_pending_failure_subscriptions]
+      @body[:query][:bool][:must_not] << { term: { "subscription_pending_failure" => true } }
     end
 
     def build_body_exclude_cant_contact

--- a/spec/controllers/customers_controller_spec.rb
+++ b/spec/controllers/customers_controller_spec.rb
@@ -142,6 +142,41 @@ describe CustomersController, :vcr, type: :controller, inertia: true do
     end
   end
 
+  describe "GET paged with active_customers_only filter" do
+    let(:product) { create(:product, user: seller, name: "Product 1", price_cents: 100) }
+    let(:customer_ids) { ->(res) { res.parsed_body.deep_symbolize_keys[:customers].map { _1[:id] } } }
+
+    it "excludes customers with deactivated, cancelled, or pending failure subscriptions" do
+      active_purchase = create(:membership_purchase, seller:, link: product)
+      deactivated_purchase = create(:membership_purchase, seller:, link: product)
+      deactivated_purchase.subscription.deactivate!
+      cancelled_purchase = create(:membership_purchase, seller:, link: product)
+      cancelled_purchase.subscription.update!(cancelled_at: 2.days.ago)
+      pending_cancellation_purchase = create(:membership_purchase, seller:, link: product)
+      pending_cancellation_purchase.subscription.update!(cancelled_at: 2.days.from_now)
+      pending_failure_purchase = create(:membership_purchase, seller:, link: product)
+      create(:purchase, subscription: pending_failure_purchase.subscription, purchase_state: "failed", created_at: 1.day.from_now)
+      index_model_records(Purchase)
+
+      get :paged, params: { page: 1, active_customers_only: true }
+      expect(response).to be_successful
+      expect(customer_ids[response]).to match_array([active_purchase.external_id])
+    end
+
+    it "returns all customers when filter is not active" do
+      active_purchase = create(:membership_purchase, seller:, link: product)
+      cancelled_purchase = create(:membership_purchase, seller:, link: product)
+      cancelled_purchase.subscription.update!(cancelled_at: 2.days.ago)
+      pending_failure_purchase = create(:membership_purchase, seller:, link: product)
+      create(:purchase, subscription: pending_failure_purchase.subscription, purchase_state: "failed", created_at: 1.day.from_now)
+      index_model_records(Purchase)
+
+      get :paged, params: { page: 1, active_customers_only: false }
+      expect(response).to be_successful
+      expect(customer_ids[response]).to match_array([active_purchase.external_id, cancelled_purchase.external_id, pending_failure_purchase.external_id])
+    end
+  end
+
   describe "GET paged when Elasticsearch times out" do
     it "returns 504" do
       allow(PurchaseSearchService).to receive(:search).and_raise(Faraday::TimeoutError)

--- a/spec/services/purchase_search_service_spec.rb
+++ b/spec/services/purchase_search_service_spec.rb
@@ -195,6 +195,15 @@ describe PurchaseSearchService do
       expect(get_records(exclude_cancelled_or_pending_cancellation_subscriptions: true)).to match_array([purchase_1])
     end
 
+    it "can exclude pending failure subscriptions" do
+      purchase_1 = create(:membership_purchase)
+      purchase_2 = create(:membership_purchase, is_original_subscription_purchase: true)
+      create(:purchase, subscription: purchase_2.subscription, purchase_state: "failed", created_at: 1.day.from_now)
+      index_model_records(Purchase)
+
+      expect(get_records(exclude_pending_failure_subscriptions: true)).to match_array([purchase_1])
+    end
+
     it "can exclude refunded" do
       purchase_1 = create(:purchase, stripe_refunded: nil)
       purchase_2 = create(:purchase, stripe_refunded: false)


### PR DESCRIPTION
## What

The "Show active customers only" toggle on the Customers dashboard was not filtering out all inactive customers. Two categories of inactive subscriptions were slipping through:

1. **Cancelled/pending-cancellation subscriptions** — `exclude_cancelled_or_pending_cancellation_subscriptions` was never passed to the search service when the filter was active
2. **Pending-failure subscriptions** — subscriptions where the last charge failed but the subscription hasn't been formally deactivated yet had no exclusion mechanism at all

## Why

The root cause was twofold:

- The controller's `active_customers_only` block was missing `exclude_cancelled_or_pending_cancellation_subscriptions: true`, so cancelled and pending-cancellation subscriptions were never excluded.
- The `pending_failure` subscription state (where `Subscription#alive?` is true but the latest charge purchase has `purchase_state: "failed"`) had no corresponding Elasticsearch field or filter. The frontend correctly shows these as "Inactive" (via `subscription.status !== "alive"`), but the backend had no way to exclude them.

The fix adds a new `subscription_pending_failure` boolean field to the Elasticsearch purchase index, along with the necessary indexing logic, reindex callbacks (when charge purchases fail/succeed and when subscription state changes), and a new `exclude_pending_failure_subscriptions` filter in `PurchaseSearchService`.

Fixes https://github.com/antiwork/gumroad/issues/4853

---

_Generated with Claude Opus 4.6. Prompts: "Fix GitHub issue #4853 - Show active customers only filter does not hide inactive customers"_