### PR TITLE
Fix ActiveModel::RangeError in Bundles::ProductController#update

### DIFF
--- a/app/controllers/bundles/product_controller.rb
+++ b/app/controllers/bundles/product_controller.rb
@@ -53,6 +53,8 @@ class Bundles::ProductController < Bundles::BaseController
   rescue ActiveRecord::RecordNotSaved, ActiveRecord::RecordInvalid, Link::LinkInvalid => e
     error_message = @bundle.errors.full_messages.first || e.message
     redirect_to edit_bundle_product_path(@bundle.external_id), alert: error_message
+  rescue ActiveModel::RangeError
+    redirect_to edit_bundle_product_path(@bundle.external_id), alert: "The value entered is too large. Please enter a smaller number."
   end
 
   private

--- a/spec/controllers/bundles/product_controller_spec.rb
+++ b/spec/controllers/bundles/product_controller_spec.rb
@@ -350,6 +350,15 @@ describe Bundles::ProductController, inertia: true do
       end
     end
 
+    context "when price_cents exceeds integer limit" do
+      it "redirects with an error message" do
+        put :update, params: { bundle_id: bundle.external_id, price_cents: 3_000_000_000 }
+
+        expect(response).to redirect_to(edit_bundle_product_path(bundle.external_id))
+        expect(flash[:alert]).to eq("The value entered is too large. Please enter a smaller number.")
+      end
+    end
+
     context "when the bundle doesn't exist" do
       it "returns 404" do
         expect { put :update, params: { bundle_id: "" } }.to raise_error(ActiveRecord::RecordNotFound)


### PR DESCRIPTION
## What

Rescue `ActiveModel::RangeError` in `Bundles::ProductController#update` so that submitting a value exceeding the 4-byte integer limit (e.g. `price_cents` of 3,000,000,000) returns a user-friendly error instead of a 500.

## Why

When a user submits a bundle update with a numeric value that exceeds `2,147,483,647`, Rails raises `ActiveModel::RangeError` before any model validation runs. The existing rescue clause only catches `ActiveRecord::RecordNotSaved`, `ActiveRecord::RecordInvalid`, and `Link::LinkInvalid`, so this error was unhandled and reported to Sentry.

**Sentry:** https://gumroad-to.sentry.io/issues/7448623466/

This follows the same pattern already used in `CheckoutDiscountsController` and `Api::V2::LinksController`.

## Test results

Added a spec that submits `price_cents: 3_000_000_000` and asserts the redirect with the expected flash message.

---

AI Disclosure: Written with Claude Opus 4.6. Prompt: "Fix Sentry bug: ActiveModel::RangeError in Bundles::ProductController#update"