### PR TITLE
Add Helper SendGrid email suppression endpoints

### DIFF
--- a/app/controllers/api/internal/helper/sendgrid_emails_controller.rb
+++ b/app/controllers/api/internal/helper/sendgrid_emails_controller.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class Api::Internal::Helper::SendgridEmailsController < Api::Internal::Helper::BaseController
+  SUPPORTED_LISTS = %w[bounces blocks spam_reports invalid_emails].freeze
+
+  def check_status
+    return render json: { success: false, message: "'email' parameter is required" }, status: :bad_request if params[:email].blank?
+
+    sendgrid_status = EmailSuppressionManager.new(params[:email]).detailed_status
+
+    render json: {
+      success: true,
+      email: params[:email],
+      suppressed: sendgrid_status.values.any?(&:present?),
+      sendgrid: sendgrid_status,
+    }
+  end
+
+  def remove_suppression
+    return render json: { success: false, message: "'email' parameter is required" }, status: :bad_request if params[:email].blank?
+
+    requested = params[:list].blank? || params[:list] == "all" ? SUPPORTED_LISTS : Array(params[:list])
+    invalid = requested - SUPPORTED_LISTS
+    if invalid.present?
+      return render json: { success: false, message: "Unsupported list(s): #{invalid.join(", ")}" }, status: :bad_request
+    end
+
+    removed_from = EmailSuppressionManager.new(params[:email]).remove_from_lists(requested.map(&:to_sym))
+
+    render json: {
+      success: true,
+      email: params[:email],
+      removed_from:,
+    }
+  end
+end

--- a/app/services/email_suppression_manager.rb
+++ b/app/services/email_suppression_manager.rb
@@ -2,6 +2,7 @@
 
 class EmailSuppressionManager
   SUPPRESSION_LISTS = [:bounces, :spam_reports]
+  ALL_SUPPRESSION_LISTS = [:bounces, :blocks, :spam_reports, :invalid_emails].freeze
   private_constant :SUPPRESSION_LISTS
 
   def initialize(email)
@@ -14,6 +15,40 @@ class EmailSuppressionManager
       supression_reasons = email_suppression_reasons(api_key)
       reasons[subuser] = supression_reasons if supression_reasons.present?
       reasons
+    end
+  end
+
+  def detailed_status(lists: ALL_SUPPRESSION_LISTS)
+    sendgrid_subusers.each_with_object(lists.index_with { [] }) do |(subuser, api_key), result|
+      suppression = sendgrid(api_key).client.suppression
+      lists.each do |list|
+        parsed_body = suppression.public_send(list)._(email).get.parsed_body
+        next if parsed_body.blank?
+        raise "Unexpected SendGrid response shape: #{parsed_body.inspect}" unless parsed_body.is_a?(Array)
+
+        parsed_body.each do |entry|
+          raise "Unexpected SendGrid entry shape: #{entry.inspect}" unless entry.is_a?(Hash)
+          result[list] << {
+            subuser:,
+            reason: entry[:reason],
+            created_at: entry[:created] ? Time.zone.at(entry[:created]).iso8601 : nil,
+          }
+        end
+      rescue => e
+        ErrorNotifier.notify(e)
+        Rails.logger.info "[EmailSuppressionManager] Error parsing SendGrid #{list} response for #{subuser}: #{e.message}"
+      end
+    end
+  end
+
+  def remove_from_lists(lists)
+    lists = Array(lists).map(&:to_sym)
+    sendgrid_subusers.each_with_object(lists.index_with { [] }) do |(subuser, api_key), result|
+      suppression = sendgrid(api_key).client.suppression
+      lists.each do |list|
+        next unless successful_response?(suppression.public_send(list)._(email).delete.status_code)
+        result[list] << subuser
+      end
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -285,6 +285,13 @@ Rails.application.routes.draw do
 
           resources :payouts, only: [:index, :create]
           resources :instant_payouts, only: [:index, :create]
+
+          resources :sendgrid_emails, only: [] do
+            collection do
+              post :check_status
+              post :remove_suppression
+            end
+          end
         end
 
         namespace :admin do

--- a/spec/controllers/api/internal/helper/sendgrid_emails_controller_spec.rb
+++ b/spec/controllers/api/internal/helper/sendgrid_emails_controller_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "shared_examples/authorized_helper_api_method"
+
+describe Api::Internal::Helper::SendgridEmailsController do
+  let(:email) { "buyer@example.com" }
+  let(:suppression_manager) { instance_double(EmailSuppressionManager) }
+
+  before do
+    request.headers["Authorization"] = "Bearer #{GlobalConfig.get("HELPER_TOOLS_TOKEN")}"
+    allow(EmailSuppressionManager).to receive(:new).with(email).and_return(suppression_manager)
+  end
+
+  it "inherits from Api::Internal::Helper::BaseController" do
+    expect(described_class.superclass).to eq(Api::Internal::Helper::BaseController)
+  end
+
+  describe "POST check_status" do
+    include_examples "helper api authorization required", :post, :check_status
+
+    context "when email parameter is missing" do
+      it "returns 400" do
+        post :check_status
+        expect(response).to have_http_status(:bad_request)
+        expect(response.parsed_body).to eq("success" => false, "message" => "'email' parameter is required")
+      end
+    end
+
+    context "when email is not suppressed" do
+      before do
+        allow(suppression_manager).to receive(:detailed_status).and_return(
+          bounces: [], blocks: [], spam_reports: [], invalid_emails: []
+        )
+      end
+
+      it "returns suppressed: false with empty SendGrid buckets" do
+        post :check_status, params: { email: }
+
+        expect(response).to be_successful
+        body = response.parsed_body
+        expect(body["success"]).to eq(true)
+        expect(body["email"]).to eq(email)
+        expect(body["suppressed"]).to eq(false)
+        expect(body["sendgrid"]).to eq(
+          "bounces" => [],
+          "blocks" => [],
+          "spam_reports" => [],
+          "invalid_emails" => []
+        )
+      end
+    end
+
+    context "when email is suppressed in some lists" do
+      before do
+        allow(suppression_manager).to receive(:detailed_status).and_return(
+          bounces: [{ subuser: :gumroad, reason: "550 5.1.1 mailbox does not exist", created_at: "2025-01-15T00:00:00Z" }],
+          blocks: [],
+          spam_reports: [{ subuser: :creators, reason: "user marked as spam", created_at: "2025-01-15T00:00:00Z" }],
+          invalid_emails: [],
+        )
+      end
+
+      it "returns suppressed: true with details" do
+        post :check_status, params: { email: }
+
+        expect(response).to be_successful
+        body = response.parsed_body
+        expect(body["success"]).to eq(true)
+        expect(body["suppressed"]).to eq(true)
+        expect(body["sendgrid"]["bounces"].first["subuser"]).to eq("gumroad")
+        expect(body["sendgrid"]["spam_reports"].first["subuser"]).to eq("creators")
+      end
+    end
+  end
+
+  describe "POST remove_suppression" do
+    include_examples "helper api authorization required", :post, :remove_suppression
+
+    context "when email parameter is missing" do
+      it "returns 400" do
+        post :remove_suppression
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+
+    context "when list is invalid" do
+      it "returns 400" do
+        post :remove_suppression, params: { email:, list: "garbage" }
+
+        expect(response).to have_http_status(:bad_request)
+        expect(response.parsed_body["message"]).to include("Unsupported list(s): garbage")
+      end
+    end
+
+    context "when list is omitted (defaults to all)" do
+      it "removes from every supported list" do
+        expected_lists = [:bounces, :blocks, :spam_reports, :invalid_emails]
+        expect(suppression_manager).to receive(:remove_from_lists).with(expected_lists).and_return(
+          bounces: [:gumroad], blocks: [], spam_reports: [:creators], invalid_emails: []
+        )
+
+        post :remove_suppression, params: { email: }
+
+        expect(response).to be_successful
+        body = response.parsed_body
+        expect(body["success"]).to eq(true)
+        expect(body["removed_from"]).to eq(
+          "bounces" => ["gumroad"],
+          "blocks" => [],
+          "spam_reports" => ["creators"],
+          "invalid_emails" => []
+        )
+      end
+    end
+
+    context "when list is a single value" do
+      it "removes from only that list" do
+        expect(suppression_manager).to receive(:remove_from_lists).with([:bounces]).and_return(bounces: [:gumroad])
+
+        post :remove_suppression, params: { email:, list: "bounces" }
+
+        expect(response).to be_successful
+        expect(response.parsed_body["removed_from"]).to eq("bounces" => ["gumroad"])
+      end
+    end
+
+    context "when list is 'all'" do
+      it "removes from every supported list" do
+        expected_lists = [:bounces, :blocks, :spam_reports, :invalid_emails]
+        expect(suppression_manager).to receive(:remove_from_lists).with(expected_lists).and_return(
+          bounces: [], blocks: [], spam_reports: [], invalid_emails: []
+        )
+
+        post :remove_suppression, params: { email:, list: "all" }
+
+        expect(response).to be_successful
+      end
+    end
+  end
+end

--- a/spec/services/email_suppression_manager_spec.rb
+++ b/spec/services/email_suppression_manager_spec.rb
@@ -57,4 +57,66 @@ describe EmailSuppressionManager, :vcr do
       end
     end
   end
+
+  describe "#detailed_status" do
+    def stub_list(list, body)
+      allow_any_instance_of(SendGrid::Client).to receive_message_chain(list, :_, :get, :parsed_body).and_return(body)
+    end
+
+    it "returns an empty bucket for every list when nothing is suppressed" do
+      [:bounces, :blocks, :spam_reports, :invalid_emails].each { |list| stub_list(list, []) }
+
+      result = described_class.new(email).detailed_status
+
+      expect(result.keys).to match_array([:bounces, :blocks, :spam_reports, :invalid_emails])
+      expect(result.values).to all(eq([]))
+    end
+
+    it "returns subuser-tagged entries for each suppression hit" do
+      bounce_entry = { created: 1683811050, email:, reason: "550 5.1.1 mailbox does not exist", status: "5.1.1" }
+      block_entry  = { created: 1683811060, email:, reason: "blocked by recipient mailserver", status: "5.7.1" }
+      stub_list(:bounces, [bounce_entry])
+      stub_list(:blocks, [block_entry])
+      stub_list(:spam_reports, [])
+      stub_list(:invalid_emails, [])
+
+      result = described_class.new(email).detailed_status
+
+      expect(result[:bounces]).to be_present
+      expect(result[:bounces].first).to include(reason: "550 5.1.1 mailbox does not exist", subuser: :gumroad)
+      expect(result[:bounces].first[:created_at]).to eq(Time.zone.at(1683811050).iso8601)
+      expect(result[:blocks]).to be_present
+    end
+
+    it "swallows and reports parsing errors per list without aborting the scan" do
+      stub_list(:bounces, "garbage")
+      stub_list(:blocks, [])
+      stub_list(:spam_reports, [])
+      stub_list(:invalid_emails, [])
+      expect(ErrorNotifier).to receive(:notify).at_least(:once)
+
+      expect { described_class.new(email).detailed_status }.not_to raise_error
+    end
+  end
+
+  describe "#remove_from_lists" do
+    it "deletes only the requested lists across every subuser" do
+      list_chain = double(_: double(delete: double(status_code: 204)))
+      allow_any_instance_of(SendGrid::Client).to receive(:bounces).and_return(list_chain)
+
+      result = described_class.new(email).remove_from_lists([:bounces])
+
+      expect(result.keys).to eq([:bounces])
+      expect(result[:bounces]).to match_array([:gumroad, :followers, :creators, :customers_level_1, :customers_level_2])
+    end
+
+    it "skips subusers whose deletion call returns a non-success status" do
+      list_chain = double(_: double(delete: double(status_code: 404)))
+      allow_any_instance_of(SendGrid::Client).to receive(:bounces).and_return(list_chain)
+
+      result = described_class.new(email).remove_from_lists([:bounces])
+
+      expect(result[:bounces]).to eq([])
+    end
+  end
 end


### PR DESCRIPTION
## What

- Add `POST /internal/helper/sendgrid_emails/check_status` - returns per-subuser SendGrid suppression entries (subuser, reason, created_at) for an email across the four lists: `bounces`, `blocks`, `spam_reports`, `invalid_emails`.
- Add `POST /internal/helper/sendgrid_emails/remove_suppression` - deletes the email from the requested list (or all four when `list` is omitted or `"all"`) across every SendGrid subuser; returns the subusers from which each list deletion succeeded.
- Extend `EmailSuppressionManager` with two new methods backing those endpoints:
  - `#detailed_status(lists:)` aggregates suppression hits per `{subuser, reason, created_at}` and swallows per-list parse errors via `ErrorNotifier` so one bad subuser response cannot abort the scan.
  - `#remove_from_lists(lists)` issues per-subuser DELETE requests and returns only the subusers that responded 2xx.
- Both controller actions inherit bearer-token auth from `Api::Internal::Helper::BaseController` and validate `email` / `list` inputs.
- Add two manual end-to-end scripts (`script/manual_test_helper_sendgrid_emails.sh` rails-runner variant, `..._curl.sh` server variant) for verifying the endpoints against live SendGrid before deploy.

## Why

Surfacing this as authenticated Helper endpoints lets an agent resolve those tickets without human involvement, while keeping the same auth surface as the rest of `Api::Internal::Helper`.

---

AI disclosure: drafted with Claude Opus 4.7