### PR TITLE
Add marketing page slugs to username DENYLIST

### DIFF
--- a/config/initializers/004_constants.rb
+++ b/config/initializers/004_constants.rb
@@ -42,17 +42,17 @@ DENYLIST = %w[ a about account activate add admin administrator api app apps
                cart challenge changelog checkout codereview community compare config configuration
                connect contact create delete direct_messages discover documentation
                download downloads edit email employment enterprise facebook
-               faq favorites feed feedback feeds fleet fleets follow
-               followers following friend friends group groups gist help
+               faq favorites features feed feedback feeds fleet fleets follow
+               followers following friend friends group groups gist hackathon help
                home hosting hostmaster idea ideas index info invitations
                invite is it json job jobs lists login logout logs mail map
                maps mine mis news oauth oauth_clients offers openid order
-               orders organizations plans popular privacy projects put post
-               read recruitment register remove replies root rss sales save
+               orders organizations plans popular pricing privacy prohibited projects put post
+               read recruitment register remove replies root rss saas sales save
                search security sessions settings shop signup sitemap ssl
                ssladmin ssladministrator sslwebmaster status stories stream
                styleguide subscribe subscriptions support sysadmin
-               sysadministrator terms tour translations trends twitter
+               sysadministrator taxes terms tour translations trends twitter
                twittr update unfollow unsubscribe url user weather widget
                widgets wiki ww www wwww xfn xml xmpp yml yaml ladygaga
                kanye kanyewest randyjackson mariahcarey atrak deadmau5


### PR DESCRIPTION
## What

Adds `features`, `hackathon`, `pricing`, `prohibited`, `saas`, and `taxes` to the username `DENYLIST` so creators can't claim usernames that collide with existing marketing-page slugs.

## Why

After [#4833](https://github.com/antiwork/gumroad/pull/4833) added a `/saas` marketing page, I noticed `gumroad.com/saas` 301-redirects to `saas.gumroad.com`. A creator already owns the `saas` username and the request hits the `/:username` catch-all instead of `home#saas`. Every other marketing slug we have (`features`, `pricing`, etc.) is also claimable as a username, which lets creators take over the matching subdomain.

---

This PR was implemented with AI assistance using Claude Opus 4.7.