### PR TITLE
Fix NoMethodError when account_number_confirmation is nil in payments update

### DIFF
--- a/app/services/update_payout_method.rb
+++ b/app/services/update_payout_method.rb
@@ -195,7 +195,7 @@ class UpdatePayoutMethod
 
     def process_full_bank_account_replacement
       account_number = params[:bank_account][:account_number].delete("-").strip
-      account_number_confirmation = params[:bank_account][:account_number_confirmation].delete("-").strip
+      account_number_confirmation = params[:bank_account][:account_number_confirmation].to_s.delete("-").strip
       return { error: :account_number_does_not_match } if account_number != account_number_confirmation
       return { error: :bank_account_error, data: "Account number is too long" } if account_number.length > MAX_ENCRYPTED_FIELD_LENGTH
 

--- a/spec/controllers/settings/payments_controller_spec.rb
+++ b/spec/controllers/settings/payments_controller_spec.rb
@@ -1106,6 +1106,26 @@ describe Settings::PaymentsController, :vcr, type: :controller, inertia: true do
         end
       end
 
+      describe "account_number_confirmation is nil" do
+        let(:params) do
+          {
+            bank_account: {
+              type: AchAccount.name,
+              account_number: "000123456789",
+              routing_number: "110000000",
+              account_holder_full_name: "gumbot"
+            }
+          }
+        end
+
+        it "returns a validation error instead of raising NoMethodError" do
+          put(:update, params:)
+          expect(response).to redirect_to(settings_payments_path)
+          expect(response).to have_http_status :found
+          expect(session[:inertia_errors][:base]).to include("The account numbers do not match.")
+        end
+      end
+
       describe "canadian bank account" do
         let(:user) { create(:user) }
 


### PR DESCRIPTION
## Problem

`NoMethodError: undefined method 'delete' for nil (NoMethodError)` in `Settings::PaymentsController#update` when a user submits bank account details without the `account_number_confirmation` parameter.

**Sentry:** https://gumroad-to.sentry.io/issues/7449304887/
- **7-day events:** 1
- **14-day events:** 1
- **Users affected:** 1
- **Estimated support tickets/month:** ~0 (new issue, first seen today)

## Root Cause

In `UpdatePayoutMethod#process_full_bank_account_replacement`, line 198 calls `.delete("-")` directly on `params[:bank_account][:account_number_confirmation]` without handling the case where it's `nil`. This happens when the form is submitted without the confirmation field.

## Fix

Added `.to_s` before `.delete("-")` so that `nil` becomes an empty string. The existing comparison on the next line then correctly returns the `:account_number_does_not_match` error, giving the user a proper validation message instead of a 500.

## Test

Added a spec that submits bank account params without `account_number_confirmation` and asserts the validation error is returned.