### PR TITLE
Admin: replace 'Flag for Fraud' with 'Suspend for Fraud' button

### DIFF
--- a/app/javascript/components/Admin/Users/PermissionRisk/FlagForFraud.tsx
+++ b/app/javascript/components/Admin/Users/PermissionRisk/FlagForFraud.tsx
@@ -1,12 +1,7 @@
 import * as React from "react";
 
-import { Form } from "$app/components/Admin/Form";
 import type { User } from "$app/components/Admin/Users/User";
-import { Button } from "$app/components/Button";
-import { showAlert } from "$app/components/server-components/Alert";
-import { Details, DetailsToggle } from "$app/components/ui/Details";
-import { Fieldset } from "$app/components/ui/Fieldset";
-import { Textarea } from "$app/components/ui/Textarea";
+import { NavigationButton } from "$app/components/Button";
 
 type FlagForFraudProps = {
   user: User;
@@ -15,37 +10,15 @@ type FlagForFraudProps = {
 const FlagForFraud = ({ user }: FlagForFraudProps) => {
   const hide = user.flagged_for_fraud || user.on_probation || user.suspended;
 
+  const suspendUrl = `${Routes.admin_suspend_users_url()}?identifiers=${encodeURIComponent(user.external_id)}`;
+
   return (
     !hide && (
       <>
         <hr />
-        <Details>
-          <DetailsToggle>
-            <h3>Flag for fraud</h3>
-          </DetailsToggle>
-          <Form
-            url={Routes.flag_for_fraud_admin_user_path(user.external_id)}
-            method="POST"
-            confirmMessage={`Are you sure you want to flag user ${user.external_id} for fraud?`}
-            onSuccess={() => showAlert("Flagged.", "success")}
-          >
-            {(isLoading) => (
-              <Fieldset>
-                <div className="flex items-start gap-2">
-                  <Textarea
-                    name="flag_for_fraud[flag_note]"
-                    className="flex-1"
-                    rows={3}
-                    placeholder="Add flag note (optional)"
-                  />
-                  <Button type="submit" disabled={isLoading}>
-                    {isLoading ? "Submitting..." : "Submit"}
-                  </Button>
-                </div>
-              </Fieldset>
-            )}
-          </Form>
-        </Details>
+        <NavigationButton color="danger" href={suspendUrl}>
+          Suspend for fraud
+        </NavigationButton>
       </>
     )
   );

--- a/app/javascript/pages/Admin/SuspendUsers/Show.tsx
+++ b/app/javascript/pages/Admin/SuspendUsers/Show.tsx
@@ -19,10 +19,12 @@ const DEFAULT_SCHEDULED_PAYOUT_DELAY_DAYS = "21";
 const SuspendUsers = () => {
   const { authenticity_token: authenticityToken, suspend_reasons: suspendReasons } = usePage<PageProps>().props;
 
+  const initialIdentifiers = new URLSearchParams(window.location.search).get("identifiers") ?? "";
+
   const form = useForm({
     authenticity_token: authenticityToken,
     suspend_users: {
-      identifiers: "",
+      identifiers: initialIdentifiers,
       reason: "",
       additional_notes: "",
     },

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -283,4 +283,46 @@ describe "Admin::UsersController Scenario", type: :system, js: true do
       expect(product.reload.deleted?).to eq(true)
     end
   end
+
+  describe "Suspend for fraud button" do
+    it "links to the suspend users page with the user ID pre-filled" do
+      visit admin_user_path(user.external_id)
+
+      click_on "Permissions & Risk"
+
+      expect(page).to have_link("Suspend for fraud")
+      suspend_link = find_link("Suspend for fraud")
+      expect(suspend_link[:href]).to include(admin_suspend_users_path)
+      expect(suspend_link[:href]).to include("identifiers=#{user.external_id}")
+    end
+
+    it "is hidden when user is already flagged for fraud" do
+      user.flag_for_fraud!(author_id: admin.id)
+
+      visit admin_user_path(user.external_id)
+
+      click_on "Permissions & Risk"
+
+      expect(page).not_to have_link("Suspend for fraud")
+    end
+
+    it "is hidden when user is already suspended" do
+      user.flag_for_fraud!(author_id: admin.id)
+      user.suspend_for_fraud(author_id: admin.id)
+
+      visit admin_user_path(user.external_id)
+
+      click_on "Permissions & Risk"
+
+      expect(page).not_to have_link("Suspend for fraud")
+    end
+  end
+
+  describe "Suspend users page pre-fill" do
+    it "pre-fills identifiers from query parameter" do
+      visit "#{admin_suspend_users_path}?identifiers=#{user.external_id}"
+
+      expect(page).to have_field("identifiers", with: user.external_id)
+    end
+  end
 end

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -288,8 +288,6 @@ describe "Admin::UsersController Scenario", type: :system, js: true do
     it "links to the suspend users page with the user ID pre-filled" do
       visit admin_user_path(user.external_id)
 
-      click_on "Permissions & Risk"
-
       expect(page).to have_link("Suspend for fraud")
       suspend_link = find_link("Suspend for fraud")
       expect(suspend_link[:href]).to include(admin_suspend_users_path)
@@ -301,8 +299,6 @@ describe "Admin::UsersController Scenario", type: :system, js: true do
 
       visit admin_user_path(user.external_id)
 
-      click_on "Permissions & Risk"
-
       expect(page).not_to have_link("Suspend for fraud")
     end
 
@@ -311,8 +307,6 @@ describe "Admin::UsersController Scenario", type: :system, js: true do
       user.suspend_for_fraud(author_id: admin.id)
 
       visit admin_user_path(user.external_id)
-
-      click_on "Permissions & Risk"
 
       expect(page).not_to have_link("Suspend for fraud")
     end


### PR DESCRIPTION
Replaces the "Flag for Fraud" expandable form on admin user pages with a single "Suspend for Fraud" button that links directly to the suspend users page with the user's ID pre-filled.

**FlagForFraud.tsx**: Removed the expandable form. Replaced with a red NavigationButton linking to `/admin/suspend_users?identifiers={external_id}`.

**SuspendUsers/Show.tsx**: Reads `?identifiers=` from the URL on mount to pre-fill the identifiers textarea.

One click to a pre-filled suspend page instead of flag then navigate then type ID then suspend.

Closes #4867