### PR TITLE
Fix country change failing due to kana validation on soft-deleted compliance info

### DIFF
--- a/app/services/update_user_country.rb
+++ b/app/services/update_user_country.rb
@@ -24,7 +24,7 @@ class UpdateUserCountry
     @user.active_bank_account.try(:mark_deleted!)
     @user.user_compliance_info_requests.requested.find_each(&:mark_provided!)
 
-    @user.alive_user_compliance_info.mark_deleted!
+    @user.alive_user_compliance_info.mark_deleted(validate: false)
     @user.user_compliance_infos.build.tap do |new_user_compliance_info|
       new_user_compliance_info.country = Compliance::Countries.mapping[@new_country_code]
       new_user_compliance_info.json_data = {}

--- a/spec/services/update_user_country_spec.rb
+++ b/spec/services/update_user_country_spec.rb
@@ -66,6 +66,35 @@ describe UpdateUserCountry do
       end
     end
 
+    context "when changing from Japan with invalid kana data" do
+      before do
+        @user.alive_user_compliance_info.mark_deleted(validate: false)
+        jp_compliance = @user.user_compliance_infos.build(
+          country: "Japan",
+          first_name: "Taro",
+          last_name: "Yamada",
+          street_address: "address_full_match",
+          city: "Tokyo",
+          state: "Tokyo",
+          zip_code: "1000001"
+        )
+        jp_compliance.street_address_kana = "123 Main St"
+        jp_compliance.save!(validate: false)
+        @user.reload
+      end
+
+      it "soft-deletes old compliance info without raising validation errors" do
+        old_compliance_info = @user.alive_user_compliance_info
+        expect(old_compliance_info.country).to eq("Japan")
+
+        expect {
+          UpdateUserCountry.new(new_country_code: "GB", user: @user).process
+        }.not_to raise_error
+
+        expect(old_compliance_info.reload.deleted?).to eq(true)
+      end
+    end
+
     context "when user has balance" do
       before do
         stub_const("GUMROAD_ADMIN_ID", create(:admin_user).id) # For negative credits


### PR DESCRIPTION
## Problem

When a user changes their country from Japan to another country, `UpdateUserCountry#process` calls `mark_deleted!` on the old compliance info record. This triggers `save!` with full validations, including kana field validations. If the old Japanese record has kana data that doesn't pass current validations (e.g., `street_address_kana` without katakana characters), the soft-delete fails and the entire country change is blocked.

Sentry: https://gumroad-to.sentry.io/issues/7449665467/

## Fix

Changed `mark_deleted!` to `mark_deleted(validate: false)` when soft-deleting the old compliance info during country change. This is consistent with how `Immutable#dup_and_save` already handles soft-deletion of the old record.

## Test

Added a test that creates a Japanese compliance info record with invalid kana data (latin-only `street_address_kana`) and verifies the country change to GB succeeds without validation errors.