### PR TITLE
Speed up Tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,11 +25,13 @@ jobs:
 
   build:
     name: Build images${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository && ' (internal PR noop)' || '' }}
-    runs-on: ubicloud-standard-4
+    runs-on: ubicloud-standard-8
     needs: ci_gate
     if: ${{ github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name != github.repository }}
     env:
       DOCKER_BUILDKIT: 1
+    outputs:
+      test_image_tag: ${{ steps.test_image_tag.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -81,12 +83,23 @@ jobs:
           else
             logger "$WEB_BASE_REPO:$WEB_BASE_SHA already exists"
           fi
+      - name: Compute content-addressed test image tag
+        id: test_image_tag
+        env:
+          WEB_BASE_REPO: gumroadteam/web_base
+        run: |
+          set -e
+          # Resolve the base test SHA (used as a hash input).
+          WEB_BASE_TEST_SHA=$(WEB_BASE_DOCKERFILE_FROM=ruby:$(cat .ruby-version)-slim-bullseye docker/base/generate_tag_for_web_base_test.sh)
+          TAG=test-$(BASE_TEST_SHA=$WEB_BASE_TEST_SHA docker/base/generate_tag_for_test_image.sh)
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "Computed test image tag: $TAG"
       - name: Build and push test image
         env:
           WEB_BASE_REPO: gumroadteam/web_base
           WEB_BASE_TEST_REPO: gumroadteam/web_base_test
           WEB_REPO: gumroadteam/web
-          REVISION: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          TEST_IMAGE_TAG: ${{ steps.test_image_tag.outputs.tag }}
         run: |
           set -e
           GREEN='\033[0;32m'
@@ -96,6 +109,16 @@ jobs:
           }
           docker pull --quiet ruby:$(cat .ruby-version)-slim-bullseye
           WEB_BASE_TEST_SHA=$(WEB_BASE_DOCKERFILE_FROM=ruby:$(cat .ruby-version)-slim-bullseye docker/base/generate_tag_for_web_base_test.sh)
+          # Only pull/push test-cache when we're actually going to build.
+          # On a manifest-inspect HIT (e.g. doc-only PR, re-run), skip the
+          # cache pull entirely — it's ~2m wasted otherwise.
+          if docker manifest inspect $WEB_REPO:$TEST_IMAGE_TAG > /dev/null 2>&1; then
+            TEST_IMAGE_NEEDS_BUILD=false
+            logger "$WEB_REPO:$TEST_IMAGE_TAG already exists; skipping test-cache pull"
+          else
+            TEST_IMAGE_NEEDS_BUILD=true
+            docker pull --quiet $WEB_REPO:test-cache 2>/dev/null || logger "$WEB_REPO:test-cache not yet available; building without registry cache"
+          fi
           build_and_push() {
             local repo=$1
             local tag=$2
@@ -106,7 +129,7 @@ jobs:
                 WEB_BASE_DOCKERFILE_FROM=ruby:$(cat .ruby-version)-slim-bullseye \
                 BRANCH_CACHE_UPLOAD_ENABLED=false \
                   BRANCH_CACHE_RESTORE_ENABLED=false \
-                  NEW_WEB_TAG=$REVISION \
+                  NEW_WEB_TAG=${TEST_IMAGE_TAG#test-} \
                   COMPOSE_PROJECT_NAME=web_${{ github.run_id }}_${{ github.run_attempt }} \
                   make $make_target
               logger "pushing $repo:$tag"
@@ -128,7 +151,25 @@ jobs:
           }
 
           build_and_push $WEB_BASE_TEST_REPO $WEB_BASE_TEST_SHA build_base_test
-          build_and_push $WEB_REPO test-$REVISION build_test
+          build_and_push $WEB_REPO $TEST_IMAGE_TAG build_test
+
+          # Only update the floating :test-cache tag when we actually built
+          # the test image this run. On manifest-inspect hits the existing
+          # test-cache is already correct (or close enough), so we skip the
+          # ~30s of retag/push and avoid an unnecessary docker pull.
+          if [ "$TEST_IMAGE_NEEDS_BUILD" = "true" ]; then
+            docker tag $WEB_REPO:$TEST_IMAGE_TAG $WEB_REPO:test-cache
+            for i in {1..3}; do
+              if docker push --quiet $WEB_REPO:test-cache; then
+                logger "Pushed $WEB_REPO:test-cache"
+                break
+              elif [ $i -eq 3 ]; then
+                logger "Failed to push $WEB_REPO:test-cache (non-fatal, build still succeeds)"
+              else
+                sleep 5
+              fi
+            done
+          fi
 
   test_fast:
     name: Test Fast ${{ matrix.ci_node_index }}${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository && ' (internal PR noop)' || '' }}
@@ -139,8 +180,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ci_node_total: [20]
-        ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
+        ci_node_total: [28]
+        ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -163,7 +204,7 @@ jobs:
           max_attempts: 3
           retry_wait_seconds: 5
           command: |
-            docker pull --quiet $WEB_REPO:test-${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }} &
+            docker pull --quiet $WEB_REPO:${{ needs.build.outputs.test_image_tag }} &
             PULL_PID=$!
             docker compose -f docker/docker-compose-test-and-ci.yml up -d
             COMPOSE_EXIT=$?
@@ -173,32 +214,28 @@ jobs:
         env:
           COMPOSE_HTTP_TIMEOUT: "300"
           WEB_REPO: gumroadteam/web
-      - name: Wait for services
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 5
-          max_attempts: 3
-          retry_wait_seconds: 5
-          command: |
-            IMG=$WEB_REPO:test-${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
-            NET=${{ env.COMPOSE_PROJECT_NAME }}_default
-            docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh db_test 3306 &
-            docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh elasticsearch 9200 &
-            docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh minio 9000 &
-            wait
-        env:
-          WEB_REPO: gumroadteam/web
-      - name: Setup test database
+      - name: Wait for services and prepare test database
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 5
           max_attempts: 3
           retry_wait_seconds: 10
           command: |
-            docker run --rm --entrypoint="" --network ${{ env.COMPOSE_PROJECT_NAME }}_default \
-              -e RAILS_ENV=test \
-              $WEB_REPO:test-${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }} \
-              bundle exec rake db:prepare
+            IMG=$WEB_REPO:${{ needs.build.outputs.test_image_tag }}
+            NET=${{ env.COMPOSE_PROJECT_NAME }}_default
+            # db:prepare only needs db_test; ES/minio waits run in parallel.
+            (
+              docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh db_test 3306 \
+                && docker run --rm --entrypoint="" --network $NET -e RAILS_ENV=test $IMG bundle exec rake db:prepare
+            ) &
+            DB_PID=$!
+            docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh elasticsearch 9200 &
+            ES_PID=$!
+            docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh minio 9000 &
+            MINIO_PID=$!
+            wait $DB_PID || exit 1
+            wait $ES_PID || exit 1
+            wait $MINIO_PID || exit 1
         env:
           WEB_REPO: gumroadteam/web
 
@@ -226,7 +263,7 @@ jobs:
               -e KNAPSACK_PRO_FIXED_QUEUE_SPLIT \
               -e CI \
               -e IN_DOCKER \
-              $WEB_REPO:test-${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }} \
+              $WEB_REPO:${{ needs.build.outputs.test_image_tag }} \
               /usr/local/bin/gosu app bundle exec rake "knapsack_pro:queue:rspec[--format RSpec::Github::Formatter --tag ~skip --format progress]"
         env:
           RUBY_YJIT_ENABLE: 1
@@ -264,7 +301,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ci_node_total: [65]
+        ci_node_total: [72]
         ci_node_index:
           [
             0,
@@ -332,6 +369,13 @@ jobs:
             62,
             63,
             64,
+            65,
+            66,
+            67,
+            68,
+            69,
+            70,
+            71,
           ]
     steps:
       - uses: actions/checkout@v4
@@ -355,7 +399,7 @@ jobs:
           max_attempts: 3
           retry_wait_seconds: 5
           command: |
-            docker pull --quiet $WEB_REPO:test-${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }} &
+            docker pull --quiet $WEB_REPO:${{ needs.build.outputs.test_image_tag }} &
             PULL_PID=$!
             docker compose -f docker/docker-compose-test-and-ci.yml up -d
             COMPOSE_EXIT=$?
@@ -365,32 +409,28 @@ jobs:
         env:
           COMPOSE_HTTP_TIMEOUT: "300"
           WEB_REPO: gumroadteam/web
-      - name: Wait for services
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 5
-          max_attempts: 3
-          retry_wait_seconds: 5
-          command: |
-            IMG=$WEB_REPO:test-${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
-            NET=${{ env.COMPOSE_PROJECT_NAME }}_default
-            docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh db_test 3306 &
-            docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh elasticsearch 9200 &
-            docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh minio 9000 &
-            wait
-        env:
-          WEB_REPO: gumroadteam/web
-      - name: Setup test database
+      - name: Wait for services and prepare test database
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 5
           max_attempts: 3
           retry_wait_seconds: 10
           command: |
-            docker run --rm --entrypoint="" --network ${{ env.COMPOSE_PROJECT_NAME }}_default \
-              -e RAILS_ENV=test \
-              $WEB_REPO:test-${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }} \
-              bundle exec rake db:prepare
+            IMG=$WEB_REPO:${{ needs.build.outputs.test_image_tag }}
+            NET=${{ env.COMPOSE_PROJECT_NAME }}_default
+            # db:prepare only needs db_test; ES/minio waits run in parallel.
+            (
+              docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh db_test 3306 \
+                && docker run --rm --entrypoint="" --network $NET -e RAILS_ENV=test $IMG bundle exec rake db:prepare
+            ) &
+            DB_PID=$!
+            docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh elasticsearch 9200 &
+            ES_PID=$!
+            docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh minio 9000 &
+            MINIO_PID=$!
+            wait $DB_PID || exit 1
+            wait $ES_PID || exit 1
+            wait $MINIO_PID || exit 1
         env:
           WEB_REPO: gumroadteam/web
 
@@ -426,7 +466,7 @@ jobs:
               -e KNAPSACK_PRO_FIXED_QUEUE_SPLIT \
               -e CI \
               -e IN_DOCKER \
-              $WEB_REPO:test-${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }} \
+              $WEB_REPO:${{ needs.build.outputs.test_image_tag }} \
               /usr/local/bin/gosu app bundle exec rake "knapsack_pro:queue:rspec[--format RSpec::Github::Formatter --tag ~skip --format progress]"
         env:
           RUBY_YJIT_ENABLE: 1

--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,10 @@ build_test:
 		--cache-from $(NEW_BASE_REPO):$(shell ./docker/base/generate_tag_for_web_base.sh) \
 		--cache-from $(NEW_WEB_BASE_TEST_REPO):$(shell ./docker/base/generate_tag_for_web_base_test.sh) \
 		--cache-from $(NEW_WEB_REPO):test-$(NEW_WEB_TAG) \
+		--cache-from $(NEW_WEB_REPO):test-cache \
 		--build-arg WEB_DOCKERFILE_FROM \
 		--build-arg WEB_BASE_TEST_DOCKERFILE_FROM \
+		--build-arg BUILDKIT_INLINE_CACHE=1 \
 		--file docker/web/Dockerfile.test \
 		--compress .
 	COMPOSE_PROJECT_NAME=$(COMPOSE_PROJECT_NAME) \
@@ -97,7 +99,7 @@ build_test:
 		--name worker_$(COMPOSE_PROJECT_NAME) \
 		-v $${PWD}:/mnt/host \
 		$(NEW_WEB_REPO):test-$(NEW_WEB_TAG) \
-		bash -c "su -c \"[[ -e /mnt/host/$$CACHE_TAR_FILE ]] && tar -xf /mnt/host/$$CACHE_TAR_FILE -C . || true; npm ci && npm run setup && bundle exec rake db:setup assets:precompile --trace\" app; exit_status=$$?; [[ $$BRANCH_CACHE_UPLOAD_ENABLED == 'true' ]] && tar -cf /mnt/host/$$CACHE_TAR_FILE node_modules public/assets public/packs-test tmp/cache/assets tmp/shakapacker || true; [[ $$BRANCH_CACHE_RESTORE_ENABLED == 'true' ]] && rm -rf node_modules public/assets tmp/cache/assets tmp/shakapacker || true; exit $$exit_status"
+		bash -c "su -c \"[[ -e /mnt/host/$$CACHE_TAR_FILE ]] && tar -xf /mnt/host/$$CACHE_TAR_FILE -C . || true; npm run setup && bundle exec rake db:setup assets:precompile --trace\" app; exit_status=$$?; [[ $$BRANCH_CACHE_UPLOAD_ENABLED == 'true' ]] && tar -cf /mnt/host/$$CACHE_TAR_FILE node_modules public/assets public/packs-test tmp/cache/assets tmp/shakapacker || true; [[ $$BRANCH_CACHE_RESTORE_ENABLED == 'true' ]] && rm -rf node_modules public/assets tmp/cache/assets tmp/shakapacker || true; exit $$exit_status"
 	$(DOCKER_CMD) ps -lq --filter='label=routes_compiled=true' --filter='exited=0' --filter='name=worker_$(COMPOSE_PROJECT_NAME)' | xargs -I{} $(DOCKER_CMD) commit {} $(NEW_WEB_REPO):test-$(NEW_WEB_TAG)
 	COMPOSE_PROJECT_NAME=$(COMPOSE_PROJECT_NAME) \
 		$(DOCKER_COMPOSE_CMD) -f docker/docker-compose-test-and-ci.yml down

--- a/docker/base/generate_tag_for_test_image.sh
+++ b/docker/base/generate_tag_for_test_image.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -e
+
+# Compute a content-addressed tag for the web test image.
+#
+# Inputs (env):
+#   BASE_TEST_SHA   Required. The content-addressed tag of web_base_test for
+#                   this build (output of generate_tag_for_web_base_test.sh).
+#
+# The previous scheme used the commit SHA (`test-$REVISION`), forcing a
+# rebuild on every commit even when the changes had no effect on the test
+# image (e.g. doc-only or workflow-only commits). Here we hash only the
+# files that actually contribute to the test image content, so identical
+# content reuses the previously-pushed image via `docker manifest inspect`.
+#
+# Excluded paths (don't affect the test image content):
+#   - .github/        workflow changes
+#   - docs/           documentation
+#   - autoresearch.*  autoresearch session files at repo root
+#   - *.md            any markdown file (verified: no specs read .md fixtures,
+#                     no app templates have .md extension; .md.erb still hashed)
+#
+# Inputs to the hash:
+#   1. BASE_TEST_SHA — already content-addressed across base layer + Gemfile.lock
+#   2. docker/web/Dockerfile.test — controls the build steps
+#   3. The git tree listing (file paths + blob shas) for non-excluded paths,
+#      which fingerprints all source code copied into the image (`COPY .`).
+
+if [ -z "$BASE_TEST_SHA" ]; then
+  echo "BASE_TEST_SHA is required" >&2
+  exit 1
+fi
+
+dockerfile_sha=$(sha1sum docker/web/Dockerfile.test | cut -d " " -f1)
+
+# Each `git ls-tree -r HEAD` entry is "<mode> blob <sha>\t<path>". The blob
+# sha changes whenever a file's content changes, so hashing the filtered list
+# fingerprints the relevant subset of the tree exactly.
+tree_sha=$(git ls-tree -r HEAD \
+  | awk -F'\t' '{
+      path=$2
+      if (path ~ /^\.github\//) next
+      if (path ~ /^docs\//) next
+      if (path ~ /^autoresearch\./) next
+      if (path ~ /\.md$/) next
+      print
+    }' \
+  | sha1sum | cut -d " " -f1)
+
+echo "$BASE_TEST_SHA $dockerfile_sha $tree_sha" | sha1sum | cut -d " " -f1

--- a/docker/web/Dockerfile.test
+++ b/docker/web/Dockerfile.test
@@ -14,22 +14,39 @@ ENV BUNDLE_PATH=/bundle_path \
 # Use unicode
 ENV LANG=C.UTF-8
 
-# setup app user, directories
+# setup app user, directories. Combined with the chmod/chown so dir ownership
+# and modes are baked into one small layer (avoids a later recursive chown
+# layer that would duplicate node_modules into a fat layer).
 RUN useradd -ms /bin/bash app \
   && mkdir -p $APP_DIR \
   && mkdir -p $BUNDLE_PATH \
   && mkdir -p $APP_DIR/log \
-  && mkdir -p $APP_DIR/tmp
+  && mkdir -p $APP_DIR/tmp \
+  && chmod -R 755 $BUNDLE_PATH \
+  && chmod 755 $APP_DIR \
+  && chmod 770 $APP_DIR/tmp \
+  && chmod 770 $APP_DIR/log \
+  && chown -R root:app $BUNDLE_PATH \
+  && chown app:app $APP_DIR $APP_DIR/tmp $APP_DIR/log
 
-COPY . $APP_DIR/
+WORKDIR $APP_DIR
+USER app
 
-# TODO: look into solutions that prevent image bloating and/or avoids --squash
-RUN chmod -R 755 $BUNDLE_PATH \
-  && chmod -R 755 $APP_DIR \
-  && chmod -R 770 $APP_DIR/tmp \
-  && chmod -R 770 $APP_DIR/log \
-  && chown -R app:app $APP_DIR \
-  && chown -R root:app $BUNDLE_PATH
+# Cacheable npm dependencies layer keyed only on package-lock.json + patches/.
+# Most PRs don't change these — BuildKit reuses this layer (~1m npm ci) on
+# subsequent builds via `--cache-from $REPO:test-cache`.
+COPY --chown=app:app package.json package-lock.json ./
+COPY --chown=app:app patches ./patches
+RUN npm ci
+
+# Application source. COPY --chown sets ownership inline, so we no longer
+# need a recursive `chown -R app:app $APP_DIR` step (which previously
+# duplicated all of $APP_DIR — including node_modules — into a new layer).
+COPY --chown=app:app . ./
+
+# Switch back so subsequent ImageMagick edits and the worker step's `su -c
+# ... app` pattern work correctly.
+USER root
 
 # Update ImageMagick configuration
 # Set memory limit to 1GiB


### PR DESCRIPTION
## What

This PR makes five infra changes to speed up `Tests` without changing coverage:

1. Use `ubicloud-standard-8` for `Build images`, which blocks every test shard.
2. Run `db:prepare` in parallel with Elasticsearch and MinIO waits.
3. Reuse the test image when the relevant tree is unchanged, even across different commit SHAs.
4. Cache `npm ci` in the Docker build via ordered `COPY`s and `:test-cache`.
5. Increase shards: Test Fast 20 → 28, Test Slow 65 → 72.

Before vs. after:

| Scenario | Before | After | Reduction |
|---|---:|---:|---:|
| Typical PR (`app/`, `spec/`, `lib/`, etc.) | ~22m | ~14m | -36% |
| Same-SHA re-run | ~17m¹ | ~9m | -47% |
| Different SHA, identical relevant tree | ~22m | ~9m | -59% |

¹ `main` already skipped the ~5m build on same-SHA re-runs via `docker manifest inspect $WEB_REPO:test-$github.sha`, so this baseline is estimated as 22m - 5m. No recent same-SHA `main` re-runs were available to measure directly.

## Why

`Tests` runs 60+ jobs per PR, retry, and merge-queue gate. The critical bottlenecks were:

- the build job blocks every shard
- the slowest shard sets the wall-clock floor
- new SHAs rebuilt the test image even when relevant files were unchanged

This PR targets those bottlenecks while keeping the existing test coverage and example-level knapsack splitting.

## Evidence

Measured across 58 probes against `antiwork/gumroad`'s `Tests` workflow on a branch synced to `origin/main`. Kept results had 0 failed shards. Wall clock is `min(started_at) → max(completed_at)` across all jobs.

| Metric | Before typical PR | After typical PR | After cache-hit re-run |
|---|---:|---:|---:|
| Wall | 22m | 13m | 8m |
| Build | 5m | 3m | 0m |
| Slowest shard | 14m | 9m | 7m |
| Slowest RSpec | ~870s | ~389s | 297s |
| Median RSpec | — | 292s | 234s |
| Median per-shard setup | — | 223s | 124s |

Per-change attribution:

| Change | Evidence |
|---|---|
| Bigger build runner | Saves ~30-60s on the critical-path build. |
| Parallel `db:prepare` + service waits | Median setup fell from 226s to 186-189s in two probes. |
| Content-addressed test image tag | Build fell from ~5m to 0m when the relevant tree was unchanged. |
| Cached `npm ci` layer | Cache-miss build fell from ~6m to ~3m. |
| 28 + 72 shards | Median RSpec fell from 286s to 259s; slowest shard fell from 8-9m to 7m, reproduced 4x. |

Rejected alternatives:

- Bigger test runners exhausted Ubicloud capacity at 85+ shards: 77/88 shards timed out in [run 25072355587](https://github.com/antiwork/gumroad/actions/runs/25072355587).
- Test Slow 80/85 increased setup overhead faster than it improved distribution; max test time rose from 7m to 8m.
- `KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES=false` put one long spec file on a single shard, timing out at 43m in [run 25113028448](https://github.com/antiwork/gumroad/actions/runs/25113028448).
- Slimming the image with `rm -rf tmp/cache` had no measurable pull-time effect.
- Removing `needs: build` made re-runs 33% slower by serializing compose-up and docker pull.
- Dropping `rake db:setup` from build caused MySQL query timeouts because shards rely on Rails' `schema_cache.yml`.

Reference green runs:

- [25082244310](https://github.com/antiwork/gumroad/actions/runs/25082244310): first cache-miss content-addressed build, wall=16m, build=6m, 88/88 green.
- [25082824242](https://github.com/antiwork/gumroad/actions/runs/25082824242): first confirmed image reuse, wall=10m, build=28s, 88/88 green.
- [25090013446](https://github.com/antiwork/gumroad/actions/runs/25090013446): best end-state, wall=8m48s, build=28s, 103/103 green.

---

This PR was implemented with AI assistance using Claude Sonnet 4.7 driving an autoresearch loop: 58 probes, 5 kept, 53 discarded. Decisions were gated on 0 failed shards plus queue-immune step-level metrics.