### PR TITLE
Add autofill suggestion chips for suspend users notes

### DIFF
--- a/app/javascript/pages/Admin/SuspendUsers/Show.tsx
+++ b/app/javascript/pages/Admin/SuspendUsers/Show.tsx
@@ -18,6 +18,10 @@ const DEFAULT_SCHEDULED_PAYOUT_DELAY_DAYS = "21";
 
 const NOTES_SUGGESTIONS = [
   "Adult (18+) content",
+  "Stripe reported high risk",
+  "Intellectual property infringement",
+  "General non-compliance",
+  "Credit repair services",
   "Pirated/unauthorized software or content",
   "Counterfeit or copied products from another creator",
   "DMCA/copyright infringement",
@@ -28,11 +32,6 @@ const NOTES_SUGGESTIONS = [
   "Spam or SEO manipulation",
   "Phishing or scam products",
   "Physical goods only (not permitted)",
-  "Consulting/services (not permitted)",
-  "Pharmaceutical products",
-  "Financial instruments or advice",
-  "Sexually explicit or fetish-related content",
-  "Stripe reported high risk",
   "Negative balance over 3 months",
   "No products / empty storefront with balance",
 ];

--- a/app/javascript/pages/Admin/SuspendUsers/Show.tsx
+++ b/app/javascript/pages/Admin/SuspendUsers/Show.tsx
@@ -16,6 +16,27 @@ type PageProps = {
 
 const DEFAULT_SCHEDULED_PAYOUT_DELAY_DAYS = "21";
 
+const NOTES_SUGGESTIONS = [
+  "Adult (18+) content",
+  "Pirated/unauthorized software or content",
+  "Counterfeit or copied products from another creator",
+  "DMCA/copyright infringement",
+  "Card testing or fraudulent transactions",
+  "High chargeback rate",
+  "Shared bank account with previously suspended user",
+  "Unauthorized resale of third-party products",
+  "Spam or SEO manipulation",
+  "Phishing or scam products",
+  "Physical goods only (not permitted)",
+  "Consulting/services (not permitted)",
+  "Pharmaceutical products",
+  "Financial instruments or advice",
+  "Sexually explicit or fetish-related content",
+  "Stripe reported high risk",
+  "Negative balance over 3 months",
+  "No products / empty storefront with balance",
+];
+
 const SuspendUsers = () => {
   const { authenticity_token: authenticityToken, suspend_reasons: suspendReasons } = usePage<PageProps>().props;
 
@@ -108,6 +129,22 @@ const SuspendUsers = () => {
         </Select>
 
         <Label htmlFor="additionalNotes">Notes</Label>
+        <div className="flex flex-wrap gap-1 mb-2">
+          {NOTES_SUGGESTIONS.map((suggestion) => (
+            <button
+              key={suggestion}
+              type="button"
+              className="rounded-full border px-2.5 py-0.5 text-xs hover:bg-black hover:text-white transition-colors"
+              onClick={() => {
+                const current = form.data.suspend_users.additional_notes;
+                const sep = current && !current.endsWith("\n") ? "\n" : "";
+                form.setData("suspend_users.additional_notes", current + sep + suggestion);
+              }}
+            >
+              {suggestion}
+            </button>
+          ))}
+        </div>
         <Textarea
           id="additionalNotes"
           name="suspend_users[additional_notes]"


### PR DESCRIPTION
Adds clickable suggestion chips above the Notes textarea on the suspend users page. Clicking a chip appends the reason to the notes field, so reviewers can build detailed suspension notes without typing.

## 18 suggestions based on production data

Derived from historical `tos_violation_reason` data (2.8M+ suspended accounts):

- Adult (18+) content (30K+)
- Pirated/unauthorized software or content
- Counterfeit or copied products from another creator
- DMCA/copyright infringement
- Card testing or fraudulent transactions
- High chargeback rate
- Shared bank account with previously suspended user
- Unauthorized resale of third-party products
- Spam or SEO manipulation
- Phishing or scam products
- Physical goods only (not permitted)
- Consulting/services (not permitted)
- Pharmaceutical products
- Financial instruments or advice
- Sexually explicit or fetish-related content
- Stripe reported high risk
- Negative balance over 3 months
- No products / empty storefront with balance

## How it works

Chips are rendered as rounded pill buttons above the notes textarea. Clicking one appends the text (with newline separator if notes already have content). Multiple chips can be clicked to build a compound reason.

Per Sahil: reduce typing friction for common suspension reasons.