### PR TITLE
Let buyers pause memberships instead of cancelling

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -3,13 +3,13 @@
 class SubscriptionsController < ApplicationController
   include PageMeta::Product
 
-  PUBLIC_ACTIONS = %i[manage unsubscribe_by_user].freeze
+  PUBLIC_ACTIONS = %i[manage unsubscribe_by_user pause_by_user].freeze
   before_action :authenticate_user!, except: PUBLIC_ACTIONS
   after_action :verify_authorized, except: PUBLIC_ACTIONS
 
-  before_action :fetch_subscription, only: %i[unsubscribe_by_seller unsubscribe_by_user]
+  before_action :fetch_subscription, only: %i[unsubscribe_by_seller unsubscribe_by_user pause_by_user]
   before_action :set_noindex_header, only: [:manage]
-  before_action :check_can_manage, only: [:manage, :unsubscribe_by_user]
+  before_action :check_can_manage, only: [:manage, :unsubscribe_by_user, :pause_by_user]
 
   layout "inertia", only: [:manage]
 
@@ -28,6 +28,16 @@ class SubscriptionsController < ApplicationController
     redirect_to manage_subscription_path(@subscription.external_id), notice: "Your #{subscription_entity} has been cancelled."
   rescue ActiveRecord::RecordInvalid => e
     redirect_to manage_subscription_path(@subscription.external_id), alert: e.message
+  end
+
+  def pause_by_user
+    cycles = params[:cycles].to_i
+    @subscription.pause!(cycles: cycles)
+    redirect_to manage_subscription_path(@subscription.external_id),
+                notice: "Your membership is paused until #{@subscription.paused_until.to_date.to_fs(:long)}."
+  rescue ArgumentError, Subscription::CannotBePaused, ActiveRecord::RecordInvalid => e
+    redirect_to manage_subscription_path(@subscription.external_id),
+                alert: e.is_a?(Subscription::CannotBePaused) ? "This membership cannot be paused." : e.message
   end
 
   def manage

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -33,6 +33,7 @@ class SubscriptionsController < ApplicationController
   def pause_by_user
     cycles = params[:cycles].to_i
     @subscription.pause!(cycles: cycles)
+    CustomerLowPriorityMailer.subscription_paused(@subscription.id).deliver_later(queue: "low")
     redirect_to manage_subscription_path(@subscription.external_id),
                 notice: "Your membership is paused until #{@subscription.paused_until.to_date.to_fs(:long)}."
   rescue ArgumentError, Subscription::CannotBePaused, ActiveRecord::RecordInvalid => e

--- a/app/javascript/components/Subscriptions/PauseDeflectionModal.tsx
+++ b/app/javascript/components/Subscriptions/PauseDeflectionModal.tsx
@@ -1,0 +1,68 @@
+import { router } from "@inertiajs/react";
+import * as React from "react";
+
+import * as Routes from "$app/utils/routes";
+
+import { Button } from "$app/components/Button";
+import { Modal } from "$app/components/Modal";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  subscriptionId: string;
+  canBePaused: boolean;
+};
+
+export const PauseDeflectionModal = ({ open, onClose, subscriptionId, canBePaused }: Props) => {
+  const [submitting, setSubmitting] = React.useState(false);
+
+  const submitPause = (cycles: 1 | 3) => {
+    setSubmitting(true);
+    router.post(
+      Routes.pause_by_user_subscription_path(subscriptionId),
+      { cycles },
+      { onFinish: () => setSubmitting(false) },
+    );
+  };
+
+  const submitCancel = () => {
+    setSubmitting(true);
+    router.post(
+      Routes.unsubscribe_by_user_subscription_path(subscriptionId),
+      {},
+      { onFinish: () => setSubmitting(false) },
+    );
+  };
+
+  return (
+    <Modal
+      open={open}
+      title="Need a break?"
+      onClose={onClose}
+      footer={
+        <Button color="danger" onClick={submitCancel} disabled={submitting}>
+          Cancel anyway
+        </Button>
+      }
+    >
+      {canBePaused ? (
+        <>
+          <p>
+            You can pause your membership instead of cancelling. Your access lapses while paused, and the next charge
+            happens automatically when the pause ends.
+          </p>
+          <div className="grid gap-2 sm:flex">
+            <Button color="primary" onClick={() => submitPause(1)} disabled={submitting}>
+              Pause for 1 month
+            </Button>
+            <Button color="primary" onClick={() => submitPause(3)} disabled={submitting}>
+              Pause for 3 months
+            </Button>
+          </div>
+        </>
+      ) : (
+        <p>Pause is not available for this membership.</p>
+      )}
+    </Modal>
+  );
+};

--- a/app/javascript/pages/Subscriptions/Manage.tsx
+++ b/app/javascript/pages/Subscriptions/Manage.tsx
@@ -335,6 +335,14 @@ export default function SubscriptionsManage() {
       ? `Your first charge will be on ${formattedSubscriptionEndDate}.`
       : null;
 
+  const pausedUntilDate = subscription.paused_until ? parseISO(subscription.paused_until) : null;
+  const isPaused = pausedUntilDate !== null && pausedUntilDate > new Date();
+  const formattedPausedUntilDate = pausedUntilDate?.toLocaleDateString(undefined, {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+
   return (
     <Card className="input-group mx-auto my-8 max-w-2xl">
       <CardContent asChild>
@@ -343,6 +351,15 @@ export default function SubscriptionsManage() {
           <h2 className="grow">{product.name}</h2>
         </header>
       </CardContent>
+
+      {isPaused ? (
+        <CardContent>
+          <Alert variant="info" className="grow">
+            Your {subscriptionEntity} is paused until {formattedPausedUntilDate}. It will resume automatically on the
+            next charge.
+          </Alert>
+        </CardContent>
+      ) : null}
 
       {!hasSavedCard && subscription.is_gift ? (
         <CardContent>
@@ -380,7 +397,7 @@ export default function SubscriptionsManage() {
         </CardContent>
       </StateContext.Provider>
 
-      {!restartable && !subscription.is_installment_plan ? (
+      {!restartable && !subscription.is_installment_plan && !isPaused ? (
         <CardContent>
           <Button
             color="danger"

--- a/app/javascript/pages/Subscriptions/Manage.tsx
+++ b/app/javascript/pages/Subscriptions/Manage.tsx
@@ -34,6 +34,7 @@ import {
   applySelection,
 } from "$app/components/Product/ConfigurationSelector";
 import { showAlert } from "$app/components/server-components/Alert";
+import { PauseDeflectionModal } from "$app/components/Subscriptions/PauseDeflectionModal";
 import { Alert } from "$app/components/ui/Alert";
 import { Card, CardContent } from "$app/components/ui/Card";
 import { useOnChangeSync } from "$app/components/useOnChange";
@@ -77,6 +78,8 @@ type Props = {
     is_overdue_for_charge: boolean;
     is_gift: boolean;
     is_installment_plan: boolean;
+    paused_until: string | null;
+    can_be_paused: boolean;
   };
   contact_info: {
     email: string;
@@ -310,6 +313,15 @@ export default function SubscriptionsManage() {
     });
   };
 
+  const [showPauseModal, setShowPauseModal] = React.useState(false);
+  const handleCancelClick = () => {
+    if (subscription.can_be_paused) {
+      setShowPauseModal(true);
+    } else {
+      unsubscribe();
+    }
+  };
+
   const hasSavedCard = state.savedCreditCard != null;
   const isPendingFirstGifteePayment = subscription.is_gift && subscription.successful_purchases_count === 1;
   const formattedSubscriptionEndDate = parseISO(subscription.end_time_of_subscription).toLocaleDateString(undefined, {
@@ -373,7 +385,7 @@ export default function SubscriptionsManage() {
           <Button
             color="danger"
             outline
-            onClick={unsubscribe}
+            onClick={handleCancelClick}
             disabled={cancelForm.processing}
             className="grow basis-0"
           >
@@ -381,6 +393,13 @@ export default function SubscriptionsManage() {
           </Button>
         </CardContent>
       ) : null}
+
+      <PauseDeflectionModal
+        open={showPauseModal}
+        onClose={() => setShowPauseModal(false)}
+        subscriptionId={subscription.id}
+        canBePaused={subscription.can_be_paused}
+      />
     </Card>
   );
 }

--- a/app/mailers/customer_low_priority_mailer.rb
+++ b/app/mailers/customer_low_priority_mailer.rb
@@ -12,7 +12,7 @@ class CustomerLowPriorityMailer < ApplicationMailer
                                                      subscription_charge_failed subscription_product_deleted subscription_renewal_reminder
                                                      subscription_price_change_notification subscription_ended free_trial_expiring_soon
                                                      credit_card_expiring_membership subscription_early_fraud_warning_notification
-                                                     subscription_giftee_added_card]
+                                                     subscription_giftee_added_card subscription_paused]
 
   layout "layouts/email"
 
@@ -79,6 +79,11 @@ class CustomerLowPriorityMailer < ApplicationMailer
   def subscription_cancelled(subscription_id)
     @subscription = Subscription.find(subscription_id)
     @subject = "Your subscription has been canceled."
+  end
+
+  def subscription_paused(subscription_id)
+    @subscription = Subscription.find(subscription_id)
+    @subject = "Your membership is paused."
   end
 
   def subscription_cancelled_by_seller(subscription_id)

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -8,6 +8,9 @@ class Subscription < ApplicationRecord
   end
 
   class UpdateFailed < StandardError; end
+  class CannotBePaused < StandardError; end
+
+  PAUSE_CYCLES_ALLOWED = [1, 3].freeze
 
   has_paper_trail
   include ExternalId
@@ -64,6 +67,7 @@ class Subscription < ApplicationRecord
 
   validate :must_have_payment_option
   validate :installment_plans_cannot_be_cancelled_by_buyer
+  validate :installment_plans_cannot_be_paused_by_buyer
 
   before_create :enable_mor_fee
   after_create :update_last_payment_option
@@ -447,6 +451,33 @@ class Subscription < ApplicationRecord
 
       CustomerLowPriorityMailer.subscription_ended(id).deliver_later(queue: "low")
       ContactingCreatorMailer.subscription_ended(id).deliver_later(queue: "critical") if seller.enable_payment_email?
+    end
+  end
+
+  def paused?
+    paused_until.present? && paused_until.future?
+  end
+
+  def can_be_paused_by_buyer?
+    return false if is_installment_plan?
+    return false if is_test_subscription
+    return false if in_free_trial?
+    return false unless alive?(include_pending_cancellation: false)
+    return false if cancelled_at.present?
+    return false if paused?
+    return false if has_fixed_length? && remaining_charges_count <= 1
+
+    true
+  end
+
+  def pause!(cycles:)
+    raise ArgumentError, "cycles must be one of #{PAUSE_CYCLES_ALLOWED}" unless PAUSE_CYCLES_ALLOWED.include?(cycles)
+
+    with_lock do
+      raise CannotBePaused unless can_be_paused_by_buyer?
+
+      self.paused_until = end_time_of_last_paid_period + cycles * period
+      save!
     end
   end
 
@@ -928,6 +959,13 @@ class Subscription < ApplicationRecord
       return unless cancelled_at_changed?(from: nil)
 
       errors.add(:base, "Installment plans cannot be cancelled by the customer") if cancelled_by_buyer?
+    end
+
+    def installment_plans_cannot_be_paused_by_buyer
+      return unless is_installment_plan?
+      return unless paused_until_changed?(from: nil) && paused_until.present?
+
+      errors.add(:base, "Installment plans cannot be paused")
     end
 
     def must_have_payment_option

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -486,6 +486,7 @@ class Subscription < ApplicationRecord
   def update_current_plan!(new_variants:, new_price:, new_quantity: nil, perceived_price_cents: nil, is_applying_plan_change: false, skip_preparing_for_charge: false, offer_code: nil, clear_discount: false)
     raise Subscription::UpdateFailed, "Installment plans cannot be updated." if is_installment_plan?
     raise Subscription::UpdateFailed, "Changing plans for fixed-length subscriptions is not currently supported." if has_fixed_length?
+    raise Subscription::UpdateFailed, "Resume your membership to change tier or plan." if paused?
 
     ActiveRecord::Base.transaction do
       payment_option = last_payment_option

--- a/app/presenters/checkout_presenter.rb
+++ b/app/presenters/checkout_presenter.rb
@@ -223,6 +223,8 @@ class CheckoutPresenter
         is_overdue_for_charge: subscription.overdue_for_charge?,
         is_gift: subscription.gift?,
         is_installment_plan: subscription.is_installment_plan,
+        paused_until: subscription.paused_until&.iso8601,
+        can_be_paused: subscription.can_be_paused_by_buyer?,
       }
     }
   end

--- a/app/sidekiq/recurring_charge_worker.rb
+++ b/app/sidekiq/recurring_charge_worker.rb
@@ -11,6 +11,7 @@ class RecurringChargeWorker
       subscription = Subscription.find(subscription_id)
       return if subscription.link.user.suspended?
       return unless subscription.alive?(include_pending_cancellation: false)
+      return if subscription.paused?
       return if subscription.is_test_subscription || subscription.current_subscription_price_cents == 0
       return if subscription.charges_completed?
       return if subscription.in_free_trial?

--- a/app/views/customer_low_priority_mailer/subscription_paused.html.erb
+++ b/app/views/customer_low_priority_mailer/subscription_paused.html.erb
@@ -1,0 +1,4 @@
+<%= header_section("Your membership is paused.") %>
+<div>
+  <p>Your membership to <%= @subscription.link.name %> is paused until <%= @subscription.paused_until.to_date.to_fs(:long) %>. You will not be charged during this time, and your access will resume automatically when the next charge succeeds.</p>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -848,6 +848,7 @@ Rails.application.routes.draw do
         get :manage
         post :unsubscribe_by_user
         post :unsubscribe_by_seller
+        post :pause_by_user
         put :update, to: "purchases#update_subscription"
       end
       scope module: "subscriptions" do

--- a/db/migrate/20261124000000_add_paused_until_to_subscriptions.rb
+++ b/db/migrate/20261124000000_add_paused_until_to_subscriptions.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddPausedUntilToSubscriptions < ActiveRecord::Migration[7.1]
+  def change
+    change_table :subscriptions, bulk: true do |t|
+      t.datetime :paused_until
+      t.index :paused_until
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_11_23_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_11_24_000000) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -2213,12 +2213,14 @@ ActiveRecord::Schema[7.1].define(version: 2026_11_23_000000) do
     t.string "token"
     t.datetime "token_expires_at"
     t.string "business_vat_id", limit: 191
+    t.datetime "paused_until"
     t.index ["cancelled_at"], name: "index_subscriptions_on_cancelled_at"
     t.index ["deactivated_at"], name: "index_subscriptions_on_deactivated_at"
     t.index ["ended_at"], name: "index_subscriptions_on_ended_at"
     t.index ["failed_at"], name: "index_subscriptions_on_failed_at"
     t.index ["link_id", "flags"], name: "index_subscriptions_on_link_id_and_flags"
     t.index ["link_id"], name: "index_subscriptions_on_link_id"
+    t.index ["paused_until"], name: "index_subscriptions_on_paused_until"
     t.index ["seller_id", "created_at"], name: "index_subscriptions_on_seller_id_and_created_at"
     t.index ["user_id"], name: "index_subscriptions_on_user_id"
   end

--- a/spec/controllers/subscriptions_controller_spec.rb
+++ b/spec/controllers/subscriptions_controller_spec.rb
@@ -99,6 +99,60 @@ describe SubscriptionsController do
       end
     end
 
+    describe "POST pause_by_user" do
+      before do
+        cookies.encrypted[@subscription.cookie_key] = @subscription.external_id
+      end
+
+      it "pauses the subscription for 1 cycle" do
+        post :pause_by_user, params: { id: @subscription.external_id, cycles: 1 }
+
+        expect(@subscription.reload.paused_until).to be_present
+        expect(response).to redirect_to(manage_subscription_path(@subscription.external_id))
+        expect(flash[:notice]).to include("paused until")
+      end
+
+      it "pauses the subscription for 3 cycles" do
+        post :pause_by_user, params: { id: @subscription.external_id, cycles: 3 }
+
+        expect(@subscription.reload.paused_until).to be_present
+      end
+
+      it "rejects an unsupported cycle count" do
+        post :pause_by_user, params: { id: @subscription.external_id, cycles: 2 }
+
+        expect(@subscription.reload.paused_until).to be_nil
+        expect(response).to redirect_to(manage_subscription_path(@subscription.external_id))
+        expect(flash[:alert]).to be_present
+      end
+
+      it "rejects pausing an installment plan" do
+        product = create(:product, :with_installment_plan, user: seller, price_cents: 30_00)
+        purchase_with_installment_plan = create(:installment_plan_purchase, link: product, purchaser: subscriber)
+        subscription = purchase_with_installment_plan.subscription
+        cookies.encrypted[subscription.cookie_key] = subscription.external_id
+
+        post :pause_by_user, params: { id: subscription.external_id, cycles: 1 }
+
+        expect(subscription.reload.paused_until).to be_nil
+        expect(flash[:alert]).to eq("This membership cannot be paused.")
+      end
+
+      context "when the encrypted cookie is not present" do
+        before do
+          cookies.encrypted[@subscription.cookie_key] = nil
+        end
+
+        it "redirects to magic link page" do
+          expect do
+            post :pause_by_user, params: { id: @subscription.external_id, cycles: 1 }
+          end.not_to change { @subscription.reload.paused_until }
+
+          expect(response).to redirect_to(new_subscription_magic_link_path(@subscription.external_id))
+        end
+      end
+    end
+
     describe "GET manage" do
       context "when subscription has ended" do
         it "returns 404" do

--- a/spec/mailers/customer_low_priority_mailer_spec.rb
+++ b/spec/mailers/customer_low_priority_mailer_spec.rb
@@ -67,6 +67,22 @@ describe CustomerLowPriorityMailer do
     end
   end
 
+  describe "subscription_paused" do
+    let(:product) { create(:membership_product, name: "fan club", subscription_duration: "monthly") }
+    let(:subscription) { create(:subscription, link: product, paused_until: Date.parse("2027-01-15")) }
+
+    before do
+      create(:purchase, is_original_subscription_purchase: true, link: product, subscription:)
+    end
+
+    it "tells the buyer when the membership resumes" do
+      mail = CustomerLowPriorityMailer.subscription_paused(subscription.id)
+      expect(mail.subject).to eq("Your membership is paused.")
+      expect(mail.body.encoded).to include("fan club")
+      expect(mail.body.encoded).to include("January 15, 2027")
+    end
+  end
+
   describe "subscription_cancelled_by_seller" do
     context "memberships" do
       before do

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -2432,6 +2432,103 @@ describe Subscription, :vcr do
     end
   end
 
+  describe "#paused?" do
+    it "returns false when paused_until is nil" do
+      expect(@subscription.paused?).to be(false)
+    end
+
+    it "returns true when paused_until is in the future" do
+      @subscription.update!(paused_until: 1.day.from_now)
+      expect(@subscription.paused?).to be(true)
+    end
+
+    it "returns false when paused_until is in the past" do
+      @subscription.update_columns(paused_until: 1.day.ago)
+      expect(@subscription.paused?).to be(false)
+    end
+  end
+
+  describe "#can_be_paused_by_buyer?" do
+    it "returns true for an alive monthly subscription" do
+      expect(@subscription.can_be_paused_by_buyer?).to be(true)
+    end
+
+    it "returns false when the subscription is an installment plan" do
+      @subscription.update!(is_installment_plan: true)
+      expect(@subscription.can_be_paused_by_buyer?).to be(false)
+    end
+
+    it "returns false when the subscription is a test subscription" do
+      @subscription.update!(is_test_subscription: true)
+      expect(@subscription.can_be_paused_by_buyer?).to be(false)
+    end
+
+    it "returns false when the subscription is in a free trial" do
+      allow(@subscription).to receive(:in_free_trial?).and_return(true)
+      expect(@subscription.can_be_paused_by_buyer?).to be(false)
+    end
+
+    it "returns false when the subscription is pending cancellation" do
+      @subscription.cancel!(by_seller: false)
+      expect(@subscription.can_be_paused_by_buyer?).to be(false)
+    end
+
+    it "returns false when the subscription is already paused" do
+      @subscription.update!(paused_until: 1.month.from_now)
+      expect(@subscription.can_be_paused_by_buyer?).to be(false)
+    end
+
+    it "returns false when the subscription has failed" do
+      @subscription.update!(failed_at: Time.current)
+      expect(@subscription.can_be_paused_by_buyer?).to be(false)
+    end
+
+    it "returns false when the fixed-length subscription is on its final cycle" do
+      allow(@subscription).to receive(:has_fixed_length?).and_return(true)
+      allow(@subscription).to receive(:remaining_charges_count).and_return(1)
+      expect(@subscription.can_be_paused_by_buyer?).to be(false)
+    end
+  end
+
+  describe "#pause!" do
+    it "sets paused_until to last_paid_period_end + cycles * period for 1 cycle" do
+      @subscription.pause!(cycles: 1)
+      expected = @subscription.end_time_of_last_paid_period + @subscription.period
+      expect(@subscription.reload.paused_until.to_i).to eq(expected.to_i)
+    end
+
+    it "sets paused_until to last_paid_period_end + 3 * period for 3 cycles" do
+      @subscription.pause!(cycles: 3)
+      expected = @subscription.end_time_of_last_paid_period + 3 * @subscription.period
+      expect(@subscription.reload.paused_until.to_i).to eq(expected.to_i)
+    end
+
+    it "raises ArgumentError when cycles is not in PAUSE_CYCLES_ALLOWED" do
+      expect { @subscription.pause!(cycles: 2) }.to raise_error(ArgumentError)
+      expect { @subscription.pause!(cycles: 0) }.to raise_error(ArgumentError)
+    end
+
+    it "raises CannotBePaused when ineligible" do
+      @subscription.update!(is_test_subscription: true)
+      expect { @subscription.pause!(cycles: 1) }.to raise_error(Subscription::CannotBePaused)
+    end
+
+    it "raises CannotBePaused for installment plans" do
+      @subscription.update!(is_installment_plan: true)
+      expect { @subscription.pause!(cycles: 1) }.to raise_error(Subscription::CannotBePaused)
+    end
+
+    it "raises CannotBePaused when already paused" do
+      @subscription.update!(paused_until: 2.months.from_now)
+      expect { @subscription.pause!(cycles: 1) }.to raise_error(Subscription::CannotBePaused)
+    end
+
+    it "raises CannotBePaused when pending cancellation" do
+      @subscription.cancel!(by_seller: false)
+      expect { @subscription.pause!(cycles: 1) }.to raise_error(Subscription::CannotBePaused)
+    end
+  end
+
   describe "#for_tier?" do
     let(:product) { create(:membership_product_with_preset_tiered_pricing) }
     let(:tier_1) { product.tiers.first }

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -2344,6 +2344,16 @@ describe Subscription, :vcr do
         end.to raise_error(Subscription::UpdateFailed).with_message("Installment plans cannot be updated.")
       end
     end
+
+    context "when paused" do
+      it "raises an error" do
+        @subscription.update!(paused_until: 1.month.from_now)
+
+        expect do
+          @subscription.update_current_plan!(new_variants: [@original_tier], new_price: @yearly_product_price)
+        end.to raise_error(Subscription::UpdateFailed).with_message("Resume your membership to change tier or plan.")
+      end
+    end
   end
 
   describe "last purchase state" do

--- a/spec/presenters/checkout_presenter_spec.rb
+++ b/spec/presenters/checkout_presenter_spec.rb
@@ -691,6 +691,8 @@ describe CheckoutPresenter do
                                  is_overdue_for_charge: false,
                                  is_gift: false,
                                  is_installment_plan: false,
+                                 paused_until: nil,
+                                 can_be_paused: false,
                                },
                                contact_info: { city: "San Francisco", country: "US", email: @subscription.email, full_name: "Jane Gumroad", state: "CA", street: "100 Main St", zip: "00000" },
                                discover_url: discover_url(protocol: PROTOCOL, host: DISCOVER_DOMAIN),

--- a/spec/sidekiq/recurring_charge_worker_spec.rb
+++ b/spec/sidekiq/recurring_charge_worker_spec.rb
@@ -30,6 +30,26 @@ describe RecurringChargeWorker, :vcr do
     described_class.new.perform(subscription.id)
   end
 
+  it "doesn't call charge while the subscription is paused" do
+    link = create(:product, user: create(:user), subscription_duration: "monthly")
+    subscription = create(:subscription, user: create(:user), link:)
+    create(:purchase, link:, price_cents: link.price_cents, is_original_subscription_purchase: true,
+                      subscription:, created_at: 2.months.ago)
+    subscription.update!(paused_until: 1.month.from_now)
+    expect_any_instance_of(Subscription).not_to receive(:charge!)
+    described_class.new.perform(subscription.id)
+  end
+
+  it "calls charge after the pause window has elapsed" do
+    link = create(:product, user: create(:user), subscription_duration: "monthly")
+    subscription = create(:subscription, user: create(:user, credit_card: create(:credit_card)), link:)
+    create(:purchase, link:, price_cents: link.price_cents, is_original_subscription_purchase: true,
+                      subscription:, created_at: 2.months.ago)
+    subscription.update_columns(paused_until: 1.day.ago)
+    expect_any_instance_of(Subscription).to receive(:charge!)
+    described_class.new.perform(subscription.id)
+  end
+
   it "doesn't call charge if there was a purchase made the period for a monthly subscription" do
     link = create(:product, user: create(:user), subscription_duration: "monthly")
     subscription = create(:subscription, user: create(:user), link:)

--- a/spec/support/fixtures/vcr_cassettes/RecurringChargeWorker/calls_charge_after_the_pause_window_has_elapsed.yml
+++ b/spec/support/fixtures/vcr_cassettes/RecurringChargeWorker/calls_charge_after_the_pause_window_has_elapsed.yml
@@ -1,0 +1,787 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_2UCtbOR8uYxrAd","request_duration_ms":780}}'
+      Idempotency-Key:
+      - 9d88aaeb-5a86-4767-b10e-003644843d95
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
+        version 6.6.87.2-microsoft-standard-WSL2 (root@439a258ad544) (gcc (GCC) 11.2.0,
+        GNU ld (GNU Binutils) 2.37) #1 SMP PREEMPT_DYNAMIC Thu Jun  5 18:30:46 UTC
+        2025","hostname":"hyper"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 29 Apr 2026 16:35:25 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=kuh9kvc7FhdUMCX6qd0aerGtCFcZXacGWdDvbXO_F6NatK-6Q78nspH4Pn8P_oPGFQYnVCwJzZhDrUYJ
+      Idempotency-Key:
+      - 9d88aaeb-5a86-4767-b10e-003644843d95
+      Original-Request:
+      - req_7W4wVg0zLrt2ai
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=kuh9kvc7FhdUMCX6qd0aerGtCFcZXacGWdDvbXO_F6NatK-6Q78nspH4Pn8P_oPGFQYnVCwJzZhDrUYJ&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=kuh9kvc7FhdUMCX6qd0aerGtCFcZXacGWdDvbXO_F6NatK-6Q78nspH4Pn8P_oPGFQYnVCwJzZhDrUYJ&t=1"
+      Request-Id:
+      - req_7W4wVg0zLrt2ai
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TRb57IBOqvOFDrfRoCub7Ce",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 4,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1777480525,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 29 Apr 2026 16:35:27 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1TRb57IBOqvOFDrfRoCub7Ce
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_7W4wVg0zLrt2ai","request_duration_ms":201}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
+        version 6.6.87.2-microsoft-standard-WSL2 (root@439a258ad544) (gcc (GCC) 11.2.0,
+        GNU ld (GNU Binutils) 2.37) #1 SMP PREEMPT_DYNAMIC Thu Jun  5 18:30:46 UTC
+        2025","hostname":"hyper"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 29 Apr 2026 16:35:25 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=kuh9kvc7FhdUMCX6qd0aerGtCFcZXacGWdDvbXO_F6NatK-6Q78nspH4Pn8P_oPGFQYnVCwJzZhDrUYJ
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=kuh9kvc7FhdUMCX6qd0aerGtCFcZXacGWdDvbXO_F6NatK-6Q78nspH4Pn8P_oPGFQYnVCwJzZhDrUYJ&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=kuh9kvc7FhdUMCX6qd0aerGtCFcZXacGWdDvbXO_F6NatK-6Q78nspH4Pn8P_oPGFQYnVCwJzZhDrUYJ&t=1"
+      Request-Id:
+      - req_PyMoY2CrYGAXN9
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TRb57IBOqvOFDrfRoCub7Ce",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 4,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1777480525,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 29 Apr 2026 16:35:27 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers
+    body:
+      encoding: UTF-8
+      string: description=&payment_method=pm_1TRb57IBOqvOFDrfRoCub7Ce
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_PyMoY2CrYGAXN9","request_duration_ms":188}}'
+      Idempotency-Key:
+      - 5e751683-c9c3-4d4b-af59-5d8bfcd2f372
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
+        version 6.6.87.2-microsoft-standard-WSL2 (root@439a258ad544) (gcc (GCC) 11.2.0,
+        GNU ld (GNU Binutils) 2.37) #1 SMP PREEMPT_DYNAMIC Thu Jun  5 18:30:46 UTC
+        2025","hostname":"hyper"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 29 Apr 2026 16:35:26 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '642'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=kuh9kvc7FhdUMCX6qd0aerGtCFcZXacGWdDvbXO_F6NatK-6Q78nspH4Pn8P_oPGFQYnVCwJzZhDrUYJ
+      Idempotency-Key:
+      - 5e751683-c9c3-4d4b-af59-5d8bfcd2f372
+      Original-Request:
+      - req_Y7d9Q5vs9GA8OK
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=kuh9kvc7FhdUMCX6qd0aerGtCFcZXacGWdDvbXO_F6NatK-6Q78nspH4Pn8P_oPGFQYnVCwJzZhDrUYJ&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=kuh9kvc7FhdUMCX6qd0aerGtCFcZXacGWdDvbXO_F6NatK-6Q78nspH4Pn8P_oPGFQYnVCwJzZhDrUYJ&t=1"
+      Request-Id:
+      - req_Y7d9Q5vs9GA8OK
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "cus_UQRzZ7TH37tNHr",
+          "object": "customer",
+          "address": null,
+          "balance": 0,
+          "created": 1777480525,
+          "currency": null,
+          "customer_account": null,
+          "default_source": null,
+          "delinquent": false,
+          "description": null,
+          "discount": null,
+          "email": null,
+          "invoice_prefix": "QRRYLXL2",
+          "invoice_settings": {
+            "custom_fields": null,
+            "default_payment_method": null,
+            "footer": null,
+            "rendering_options": null
+          },
+          "livemode": false,
+          "metadata": {},
+          "name": null,
+          "next_invoice_sequence": 1,
+          "phone": null,
+          "preferred_locales": [],
+          "shipping": null,
+          "tax_exempt": "none",
+          "test_clock": null
+        }
+  recorded_at: Wed, 29 Apr 2026 16:35:28 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_Y7d9Q5vs9GA8OK","request_duration_ms":724}}'
+      Idempotency-Key:
+      - eed45ec9-09bd-4160-87bc-87364fd1d75d
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
+        version 6.6.87.2-microsoft-standard-WSL2 (root@439a258ad544) (gcc (GCC) 11.2.0,
+        GNU ld (GNU Binutils) 2.37) #1 SMP PREEMPT_DYNAMIC Thu Jun  5 18:30:46 UTC
+        2025","hostname":"hyper"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 29 Apr 2026 16:35:26 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=kuh9kvc7FhdUMCX6qd0aerGtCFcZXacGWdDvbXO_F6NatK-6Q78nspH4Pn8P_oPGFQYnVCwJzZhDrUYJ
+      Idempotency-Key:
+      - eed45ec9-09bd-4160-87bc-87364fd1d75d
+      Original-Request:
+      - req_cXm5j7f0GFL43r
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=kuh9kvc7FhdUMCX6qd0aerGtCFcZXacGWdDvbXO_F6NatK-6Q78nspH4Pn8P_oPGFQYnVCwJzZhDrUYJ&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=kuh9kvc7FhdUMCX6qd0aerGtCFcZXacGWdDvbXO_F6NatK-6Q78nspH4Pn8P_oPGFQYnVCwJzZhDrUYJ&t=1"
+      Request-Id:
+      - req_cXm5j7f0GFL43r
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TRb58IBOqvOFDrfJmANdLco",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 4,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1777480526,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 29 Apr 2026 16:35:28 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1TRb58IBOqvOFDrfJmANdLco
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_cXm5j7f0GFL43r","request_duration_ms":234}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
+        version 6.6.87.2-microsoft-standard-WSL2 (root@439a258ad544) (gcc (GCC) 11.2.0,
+        GNU ld (GNU Binutils) 2.37) #1 SMP PREEMPT_DYNAMIC Thu Jun  5 18:30:46 UTC
+        2025","hostname":"hyper"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 29 Apr 2026 16:35:26 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=kuh9kvc7FhdUMCX6qd0aerGtCFcZXacGWdDvbXO_F6NatK-6Q78nspH4Pn8P_oPGFQYnVCwJzZhDrUYJ
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=kuh9kvc7FhdUMCX6qd0aerGtCFcZXacGWdDvbXO_F6NatK-6Q78nspH4Pn8P_oPGFQYnVCwJzZhDrUYJ&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=kuh9kvc7FhdUMCX6qd0aerGtCFcZXacGWdDvbXO_F6NatK-6Q78nspH4Pn8P_oPGFQYnVCwJzZhDrUYJ&t=1"
+      Request-Id:
+      - req_O2MfElNaYgKOkx
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TRb58IBOqvOFDrfJmANdLco",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 4,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1777480526,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 29 Apr 2026 16:35:28 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers
+    body:
+      encoding: UTF-8
+      string: description=&payment_method=pm_1TRb58IBOqvOFDrfJmANdLco
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_O2MfElNaYgKOkx","request_duration_ms":209}}'
+      Idempotency-Key:
+      - f3e60cff-caf4-4035-8996-44587a84e8a3
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
+        version 6.6.87.2-microsoft-standard-WSL2 (root@439a258ad544) (gcc (GCC) 11.2.0,
+        GNU ld (GNU Binutils) 2.37) #1 SMP PREEMPT_DYNAMIC Thu Jun  5 18:30:46 UTC
+        2025","hostname":"hyper"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 29 Apr 2026 16:35:27 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '642'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=kuh9kvc7FhdUMCX6qd0aerGtCFcZXacGWdDvbXO_F6NatK-6Q78nspH4Pn8P_oPGFQYnVCwJzZhDrUYJ
+      Idempotency-Key:
+      - f3e60cff-caf4-4035-8996-44587a84e8a3
+      Original-Request:
+      - req_9xhiQgzj7aElSz
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=kuh9kvc7FhdUMCX6qd0aerGtCFcZXacGWdDvbXO_F6NatK-6Q78nspH4Pn8P_oPGFQYnVCwJzZhDrUYJ&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=kuh9kvc7FhdUMCX6qd0aerGtCFcZXacGWdDvbXO_F6NatK-6Q78nspH4Pn8P_oPGFQYnVCwJzZhDrUYJ&t=1"
+      Request-Id:
+      - req_9xhiQgzj7aElSz
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "cus_UQRzsMCr9J8wIG",
+          "object": "customer",
+          "address": null,
+          "balance": 0,
+          "created": 1777480527,
+          "currency": null,
+          "customer_account": null,
+          "default_source": null,
+          "delinquent": false,
+          "description": null,
+          "discount": null,
+          "email": null,
+          "invoice_prefix": "CCTYXYPV",
+          "invoice_settings": {
+            "custom_fields": null,
+            "default_payment_method": null,
+            "footer": null,
+            "rendering_options": null
+          },
+          "livemode": false,
+          "metadata": {},
+          "name": null,
+          "next_invoice_sequence": 1,
+          "phone": null,
+          "preferred_locales": [],
+          "shipping": null,
+          "tax_exempt": "none",
+          "test_clock": null
+        }
+  recorded_at: Wed, 29 Apr 2026 16:35:29 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/RecurringChargeWorker/doesn_t_call_charge_while_the_subscription_is_paused.yml
+++ b/spec/support/fixtures/vcr_cassettes/RecurringChargeWorker/doesn_t_call_charge_while_the_subscription_is_paused.yml
@@ -1,0 +1,393 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Idempotency-Key:
+      - aaa9b800-a787-411b-b38e-d8756e2c18cc
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
+        version 6.6.87.2-microsoft-standard-WSL2 (root@439a258ad544) (gcc (GCC) 11.2.0,
+        GNU ld (GNU Binutils) 2.37) #1 SMP PREEMPT_DYNAMIC Thu Jun  5 18:30:46 UTC
+        2025","hostname":"hyper"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 29 Apr 2026 16:35:22 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=GqF_VPPdKULg_NwLqbwVw1PyQrSUHcVJHJ5S1F4VObeH7rgIVojynTKBo2OsWsOrg4Ppe81eNlmVdwez
+      Idempotency-Key:
+      - aaa9b800-a787-411b-b38e-d8756e2c18cc
+      Original-Request:
+      - req_jVOzPGzmyHl68e
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=GqF_VPPdKULg_NwLqbwVw1PyQrSUHcVJHJ5S1F4VObeH7rgIVojynTKBo2OsWsOrg4Ppe81eNlmVdwez&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=GqF_VPPdKULg_NwLqbwVw1PyQrSUHcVJHJ5S1F4VObeH7rgIVojynTKBo2OsWsOrg4Ppe81eNlmVdwez&t=1"
+      Request-Id:
+      - req_jVOzPGzmyHl68e
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TRb54IBOqvOFDrfJgqQBxEa",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 4,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1777480522,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 29 Apr 2026 16:35:24 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1TRb54IBOqvOFDrfJgqQBxEa
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_jVOzPGzmyHl68e","request_duration_ms":280}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
+        version 6.6.87.2-microsoft-standard-WSL2 (root@439a258ad544) (gcc (GCC) 11.2.0,
+        GNU ld (GNU Binutils) 2.37) #1 SMP PREEMPT_DYNAMIC Thu Jun  5 18:30:46 UTC
+        2025","hostname":"hyper"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 29 Apr 2026 16:35:23 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=kuh9kvc7FhdUMCX6qd0aerGtCFcZXacGWdDvbXO_F6NatK-6Q78nspH4Pn8P_oPGFQYnVCwJzZhDrUYJ
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=kuh9kvc7FhdUMCX6qd0aerGtCFcZXacGWdDvbXO_F6NatK-6Q78nspH4Pn8P_oPGFQYnVCwJzZhDrUYJ&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=kuh9kvc7FhdUMCX6qd0aerGtCFcZXacGWdDvbXO_F6NatK-6Q78nspH4Pn8P_oPGFQYnVCwJzZhDrUYJ&t=1"
+      Request-Id:
+      - req_MkCh1e4Yw9rwoR
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TRb54IBOqvOFDrfJgqQBxEa",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 4,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1777480522,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 29 Apr 2026 16:35:25 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers
+    body:
+      encoding: UTF-8
+      string: description=&payment_method=pm_1TRb54IBOqvOFDrfJgqQBxEa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_MkCh1e4Yw9rwoR","request_duration_ms":213}}'
+      Idempotency-Key:
+      - 49c3ee47-b4df-42cd-bf5e-a89231a34658
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"x86_64-linux","engine":"ruby","publisher":"stripe","uname":"Linux
+        version 6.6.87.2-microsoft-standard-WSL2 (root@439a258ad544) (gcc (GCC) 11.2.0,
+        GNU ld (GNU Binutils) 2.37) #1 SMP PREEMPT_DYNAMIC Thu Jun  5 18:30:46 UTC
+        2025","hostname":"hyper"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 29 Apr 2026 16:35:23 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '642'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=kuh9kvc7FhdUMCX6qd0aerGtCFcZXacGWdDvbXO_F6NatK-6Q78nspH4Pn8P_oPGFQYnVCwJzZhDrUYJ
+      Idempotency-Key:
+      - 49c3ee47-b4df-42cd-bf5e-a89231a34658
+      Original-Request:
+      - req_2UCtbOR8uYxrAd
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=kuh9kvc7FhdUMCX6qd0aerGtCFcZXacGWdDvbXO_F6NatK-6Q78nspH4Pn8P_oPGFQYnVCwJzZhDrUYJ&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=kuh9kvc7FhdUMCX6qd0aerGtCFcZXacGWdDvbXO_F6NatK-6Q78nspH4Pn8P_oPGFQYnVCwJzZhDrUYJ&t=1"
+      Request-Id:
+      - req_2UCtbOR8uYxrAd
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "cus_UQRzlFTUXJxQ5Z",
+          "object": "customer",
+          "address": null,
+          "balance": 0,
+          "created": 1777480523,
+          "currency": null,
+          "customer_account": null,
+          "default_source": null,
+          "delinquent": false,
+          "description": null,
+          "discount": null,
+          "email": null,
+          "invoice_prefix": "J3Y9F6KR",
+          "invoice_settings": {
+            "custom_fields": null,
+            "default_payment_method": null,
+            "footer": null,
+            "rendering_options": null
+          },
+          "livemode": false,
+          "metadata": {},
+          "name": null,
+          "next_invoice_sequence": 1,
+          "phone": null,
+          "preferred_locales": [],
+          "shipping": null,
+          "tax_exempt": "none",
+          "test_clock": null
+        }
+  recorded_at: Wed, 29 Apr 2026 16:35:25 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
## What

Buyers clicking "Cancel" on their Manage membership page now see a modal first: pause for 1 month, pause for 3 months, or cancel anyway.

Pausing defers the next charge by N billing cycles. The buyer's last paid period resolves as usual, access lapses at its end (same as cancelling), and `RecurringChargeWorker` picks back up on its next tick after the pause expires.

Few cases are blocked from pausing: installment plans, free trials, test subs, anything already pending cancellation, and fixed-length memberships on final cycle. Tier upgrades and downgrades are also blocked while paused, since they'd otherwise fire an immediate prorated charge mid-pause (which is kinda rude). Plan changes already queued before the pause apply on the resume charge automatically, since `RecurringChargeWorker` already handles that path.

## Why
[Recharge](https://getrecharge.com/blog/reduce-your-cancellations-by-10-with-pause-subscriptions/), a subscriptions SaaS for Shopify, shared findings showing merchants who added a pause-as-deflection saw an average 9.6% save rate on attempted cancellations. Netflix also does this. Gumroad offers cancel and restart with no middle ground for a buyer just wanting to pause for a month so they can make better use of the sub.

Rather than creating a new pause state, we're reframing it as a deferred charge date.

### Notes on scope

- Buyer surface is cancel-flow modal only. Proactive pause from management page can come later if the save-rate metric pays off.
- No seller-facing config. We just make it storewide to keep it simple. Per-product opt-out is easy to add if creators on Gumroad ask for it.
- Durations are 1 and 3 cycles. This also avoids the "pause forever as a free cancel" loophole without having to worry about defending against abuse.
- Anchor date drift: pausing shifts the day-of-month anchor by the pause length permanently. This same drift already happens after card-decline retries so the documented "we charge on the original day" is best-effort. Worth hardening later.

## Out of Scope

- Manual resume endpoint (auto-resume fine for now)
- Per-product seller opt-out
- Pause analytics dashboard
- Multiple consecutive pauses
- Cancel-during-pause path
- Pausing gifted memberships

## Before / After

### Pause 1 Month
https://github.com/user-attachments/assets/8b7d73ba-6905-4499-abd8-99093e3f9519

### Pause 3 Months
https://github.com/user-attachments/assets/74dc24c5-2a54-42a5-a0c2-d6a101667eb2

### Cancel Anyway
https://github.com/user-attachments/assets/c2759caa-e21c-4e89-9e0d-a92765351b57

### Light Mode + mobile
https://github.com/user-attachments/assets/3a492005-3ceb-4853-b10a-619b9e911a42

## QA Steps

1. Sign in as a buyer who owns an active monthly membership
2. Open `/subscriptions/<external_id>/manage`. Confirm page renders with "Cancel membership" button at the bottom and no paused banner.
3. Click `Cancel membership`. The "Need a break?" modal should open with two primary CTAs ("Pause for 1 month", "Pause for 3 months") and a danger "Cancel anyway" in the footer.
4. Click `Pause for 1 month`. Modal closes, page refreshes props and shows an info banner: "Your membership is paused until <date>. It will resume automatically on the next charge." The `Cancel membership` button is hidden.
5. In Rails console, verify backend state:
```ruby
sub = Subscription.find_by_external_id("<external_id>")
sub.paused?    # => true
sub.can_be_paused_by_buyer?   # => false (already paused)
```
6. Run `RecurringChargeWorker.new.perform(sub.id)` while paused. There will be no charge so worker returns early.
7. Set `sub.update_column(:paused_until, 1.day.ago)` and re-run the worker. It should proceed with normal charge attempt.
8. Re-pause, then attempt tier change: `sub.update_current_plan!(new_variants: [], new_price: nil)`. This raises `Subscription::UpdateFailed: "Resume your membership to change tier or plan."`
9. Try paths the modal should not open on (installment plans, free trials, test subs). Click Cancel; it should bypass the modal and properly cancel directly.

## Test Results

-  spec/models/subscription_spec.rb: 18 new
-  spec/sidekiq/recurring_charge_worker_spec.rb: 2 new
-  spec/controllers/subscriptions_controller_spec.rb: 5 new
-  spec/mailers/customer_low_priority_mailer_spec.rb: 1 new
-  spec/presenters/checkout_presenter_spec.rb: 10 examples (existing + new props)

<img width="1572" height="1152" alt="test screenshot" src="https://github.com/user-attachments/assets/38cc904a-ca03-4824-8ad9-b6256432cd2a" />

---

AI Disclosure: Used Claude Opus 4.7 for planning research (reading Recharge's blog post, merchant docs, auditing codebase to understand existing features (`Gift` model, `BlockedCustomerObject`, abandoned-cart job)), and for per-commit code and spec review.