### PR TITLE
Rescue Errno::ENOENT in LinksController#publish with retry-friendly message

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -447,6 +447,9 @@ class LinksController < ApplicationController
       @product.publish!
     rescue Link::LinkInvalid, ActiveRecord::RecordInvalid
       return render json: { success: false, error_message: @product.errors.full_messages[0] }
+    rescue Errno::ENOENT => e
+      ErrorNotifier.notify(e)
+      return render json: { success: false, error_message: "There was a temporary issue processing your product images. Please try again." }
     rescue => e
       ErrorNotifier.notify(e)
       return render json: { success: false, error_message: "Something broke. We're looking into what happened. Sorry about this!" }

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -115,6 +115,32 @@ describe LinksController, :vcr, inertia: true do
         end
       end
 
+      context "when a temp file is missing during publish" do
+        before do
+          allow_any_instance_of(Link).to receive(:publish!).and_raise(Errno::ENOENT, "No such file or directory @ rb_file_s_size - /tmp/image_processing_test.png")
+        end
+
+        it "notifies error tracker" do
+          expect(ErrorNotifier).to receive(:notify).once
+
+          post :publish, params: { id: @disabled_link.unique_permalink }
+        end
+
+        it "returns a retry-friendly error message" do
+          post :publish, params: { id: @disabled_link.unique_permalink }
+
+          expect(response.parsed_body["success"]).to eq(false)
+          expect(response.parsed_body["error_message"]).to eq("There was a temporary issue processing your product images. Please try again.")
+        end
+
+        it "does not publish the link" do
+          post :publish, params: { id: @disabled_link.unique_permalink }
+
+          expect(response.parsed_body["success"]).to eq(false)
+          expect(@disabled_link.reload.purchase_disabled_at).to be_present
+        end
+      end
+
       context "when an unknown exception is raised" do
         before do
           allow_any_instance_of(Link).to receive(:publish!).and_raise("error")


### PR DESCRIPTION
## What

Add a specific `rescue Errno::ENOENT` clause in `LinksController#publish` that returns a retry-friendly error message instead of the generic "Something broke" response.

## Why

[Sentry issue](https://gumroad-to.sentry.io/issues/7449949225/) (1 event, 1 user affected): During `publish!`, ActiveStorage's `after_commit` callback can fail with `Errno::ENOENT` when a temp file from the `image_processing` gem is cleaned up before S3 upload completes. This is a transient race condition where the temp file at `/tmp/image_processing*.png` no longer exists when `File.size` is called during the S3 upload.

The previous fix ([PR #4764](https://github.com/antiwork/gumroad/pull/4764)) addressed `Errno::ENOENT` in variant URL generation (`Thumbnail#url` and `User#resized_avatar_url`). This new error is in a different code path: the S3 upload during the `after_commit` callback triggered by `save!` inside `publish!`.

The underlying product data is saved successfully (the transaction commits before `after_commit` fires), so a retry typically succeeds.

**Impact estimate:** ~1 event/month, ~0 support tickets. Low priority but improves UX for affected users who currently see a confusing "Something broke" message.

### Changes
- `LinksController#publish`: rescue `Errno::ENOENT` with actionable error message asking the user to retry
- Controller specs: 3 tests verifying error notification, retry-friendly message, and non-publication

---

AI disclosure: This PR was authored with Claude Opus 4.6. Prompted by Sentry alert to add specific error handling for transient temp file race conditions during publish.

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>