### PR TITLE
Add admin user risk actions

### DIFF
--- a/app/controllers/api/internal/admin/users_controller.rb
+++ b/app/controllers/api/internal/admin/users_controller.rb
@@ -110,6 +110,39 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
     render json: { success: false, message: "Idempotency key already used with different content" }, status: :conflict
   end
 
+  def mark_compliant
+    return render json: { success: false, message: "email is required" }, status: :bad_request if params[:email].blank?
+
+    user = find_user_or_render(params[:email])
+    return unless user
+
+    if user.compliant?
+      return render json: { success: true, status: "already_compliant", message: "User is already compliant" }
+    end
+
+    user.mark_compliant!(author_id: GUMROAD_ADMIN_ID, content: params[:note].presence)
+    render json: { success: true, status: "marked_compliant", message: "User marked compliant" }
+  rescue StateMachines::InvalidTransition => e
+    render json: { success: false, message: e.message }, status: :unprocessable_entity
+  end
+
+  def suspend_for_fraud
+    return render json: { success: false, message: "email is required" }, status: :bad_request if params[:email].blank?
+
+    user = find_user_or_render(params[:email])
+    return unless user
+
+    if user.suspended?
+      return render json: { success: true, status: "already_suspended", message: "User is already suspended" }
+    end
+
+    user.suspend_for_fraud!(author_id: GUMROAD_ADMIN_ID)
+    create_suspension_note(user) if params[:suspension_note].present?
+    render json: { success: true, status: "suspended_for_fraud", message: "User suspended for fraud" }
+  rescue StateMachines::InvalidTransition => e
+    render json: { success: false, message: e.message }, status: :unprocessable_entity
+  end
+
   private
     def find_user_or_render(email)
       user = User.alive.by_email(email).first
@@ -137,5 +170,13 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
         comment_type: comment.comment_type,
         created_at: comment.created_at.iso8601
       }
+    end
+
+    def create_suspension_note(user)
+      user.comments.create!(
+        author_id: GUMROAD_ADMIN_ID,
+        comment_type: Comment::COMMENT_TYPE_SUSPENSION_NOTE,
+        content: params[:suspension_note]
+      )
     end
 end

--- a/app/controllers/api/internal/admin/users_controller.rb
+++ b/app/controllers/api/internal/admin/users_controller.rb
@@ -120,7 +120,11 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
       return render json: { success: true, status: "already_compliant", message: "User is already compliant" }
     end
 
-    user.mark_compliant!(author_id: GUMROAD_ADMIN_ID, content: params[:note].presence)
+    note = build_admin_note(user, params[:note]) if params[:note].present?
+    return render_invalid_comment(note) if note&.invalid?
+
+    user.mark_compliant!(author_id: GUMROAD_ADMIN_ID)
+    note&.save!
     render json: { success: true, status: "marked_compliant", message: "User marked compliant" }
   rescue StateMachines::InvalidTransition => e
     render json: { success: false, message: e.message }, status: :unprocessable_entity
@@ -136,8 +140,11 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
       return render json: { success: true, status: "already_suspended", message: "User is already suspended" }
     end
 
+    suspension_note = build_suspension_note(user) if params[:suspension_note].present?
+    return render_invalid_comment(suspension_note) if suspension_note&.invalid?
+
     user.suspend_for_fraud!(author_id: GUMROAD_ADMIN_ID)
-    create_suspension_note(user) if params[:suspension_note].present?
+    suspension_note&.save!
     render json: { success: true, status: "suspended_for_fraud", message: "User suspended for fraud" }
   rescue StateMachines::InvalidTransition => e
     render json: { success: false, message: e.message }, status: :unprocessable_entity
@@ -172,11 +179,23 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
       }
     end
 
-    def create_suspension_note(user)
-      user.comments.create!(
+    def build_admin_note(user, content)
+      user.comments.new(
+        author_id: GUMROAD_ADMIN_ID,
+        comment_type: Comment::COMMENT_TYPE_NOTE,
+        content:
+      )
+    end
+
+    def build_suspension_note(user)
+      user.comments.new(
         author_id: GUMROAD_ADMIN_ID,
         comment_type: Comment::COMMENT_TYPE_SUSPENSION_NOTE,
         content: params[:suspension_note]
       )
+    end
+
+    def render_invalid_comment(comment)
+      render json: { success: false, message: comment.errors.full_messages.to_sentence }, status: :unprocessable_entity
     end
 end

--- a/app/controllers/api/internal/admin/users_controller.rb
+++ b/app/controllers/api/internal/admin/users_controller.rb
@@ -136,8 +136,8 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
     user = find_user_or_render(params[:email])
     return unless user
 
-    if user.suspended?
-      return render json: { success: true, status: "already_suspended", message: "User is already suspended" }
+    if user.suspended_for_fraud?
+      return render json: { success: true, status: "already_suspended", message: "User is already suspended for fraud" }
     end
 
     suspension_note = build_suspension_note(user) if params[:suspension_note].present?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -321,6 +321,8 @@ Rails.application.routes.draw do
               post :update_email
               post :two_factor_authentication
               post :create_comment
+              post :mark_compliant
+              post :suspend_for_fraud
             end
           end
 

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -315,4 +315,161 @@ describe Api::Internal::Admin::UsersController do
       expect(response.parsed_body["success"]).to be(false)
     end
   end
+
+  describe "POST mark_compliant" do
+    let(:user) { create(:user, user_risk_state: "suspended_for_fraud", email: "seller@example.com") }
+
+    include_examples "admin api authorization required", :post, :mark_compliant
+
+    before { stub_const("GUMROAD_ADMIN_ID", admin_user.id) }
+
+    it "returns 400 when email is missing" do
+      post :mark_compliant
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "email is required" }.as_json)
+    end
+
+    it "returns 404 when the user does not exist" do
+      post :mark_compliant, params: { email: "missing@example.com" }
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
+    end
+
+    it "marks the user compliant and creates an audit comment attributed to GUMROAD_ADMIN_ID" do
+      expect do
+        post :mark_compliant, params: { email: user.email, note: "Cleared after review" }
+      end.to change { user.comments.reload.count }.by(1)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq({
+        success: true,
+        status: "marked_compliant",
+        message: "User marked compliant"
+      }.as_json)
+      expect(user.reload).to be_compliant
+
+      comment = user.comments.last
+      expect(comment).to have_attributes(
+        author_id: admin_user.id,
+        comment_type: Comment::COMMENT_TYPE_COMPLIANT,
+        content: "Cleared after review"
+      )
+    end
+
+    it "keeps the existing sibling-account compliant side effect" do
+      payment_address = "shared@example.com"
+      user.update!(payment_address:)
+      sibling = create(:user, user_risk_state: "suspended_for_fraud", payment_address:)
+
+      post :mark_compliant, params: { email: user.email }
+
+      expect(response).to have_http_status(:ok)
+      expect(user.reload).to be_compliant
+      expect(sibling.reload).to be_compliant
+      expect(sibling.comments.last).to have_attributes(
+        author_name: "enable_sellers_other_accounts",
+        comment_type: Comment::COMMENT_TYPE_COMPLIANT
+      )
+      expect(sibling.comments.last.content).to include("payment address #{payment_address} is now unblocked")
+    end
+
+    it "returns success without creating another comment when the user is already compliant" do
+      user.update!(user_risk_state: "compliant")
+
+      expect do
+        post :mark_compliant, params: { email: user.email, note: "Retry" }
+      end.not_to change { user.comments.reload.count }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq({
+        success: true,
+        status: "already_compliant",
+        message: "User is already compliant"
+      }.as_json)
+    end
+  end
+
+  describe "POST suspend_for_fraud" do
+    let(:user) { create(:compliant_user, email: "seller@example.com") }
+
+    include_examples "admin api authorization required", :post, :suspend_for_fraud
+
+    before { stub_const("GUMROAD_ADMIN_ID", admin_user.id) }
+
+    it "returns 400 when email is missing" do
+      post :suspend_for_fraud
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "email is required" }.as_json)
+    end
+
+    it "returns 404 when the user does not exist" do
+      post :suspend_for_fraud, params: { email: "missing@example.com" }
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
+    end
+
+    it "suspends the user for fraud and creates an audit comment attributed to GUMROAD_ADMIN_ID" do
+      expect do
+        post :suspend_for_fraud, params: { email: user.email }
+      end.to change { user.comments.reload.count }.by(1)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq({
+        success: true,
+        status: "suspended_for_fraud",
+        message: "User suspended for fraud"
+      }.as_json)
+      expect(user.reload).to be_suspended_for_fraud
+
+      comment = user.comments.last
+      expect(comment).to have_attributes(
+        author_id: admin_user.id,
+        comment_type: Comment::COMMENT_TYPE_SUSPENDED
+      )
+      expect(comment.content).to include("Suspended for fraud")
+    end
+
+    it "creates an extra suspension note when one is provided" do
+      expect do
+        post :suspend_for_fraud, params: { email: user.email, suspension_note: "Chargeback risk confirmed" }
+      end.to change { user.comments.reload.count }.by(2)
+
+      expect(response).to have_http_status(:ok)
+      note = user.comments.find_by!(comment_type: Comment::COMMENT_TYPE_SUSPENSION_NOTE)
+      expect(note).to have_attributes(
+        author_id: admin_user.id,
+        comment_type: Comment::COMMENT_TYPE_SUSPENSION_NOTE,
+        content: "Chargeback risk confirmed"
+      )
+    end
+
+    it "returns success without creating another comment when the user is already suspended" do
+      user.update!(user_risk_state: "suspended_for_fraud")
+
+      expect do
+        post :suspend_for_fraud, params: { email: user.email, suspension_note: "Retry" }
+      end.not_to change { user.comments.reload.count }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq({
+        success: true,
+        status: "already_suspended",
+        message: "User is already suspended"
+      }.as_json)
+    end
+
+    it "returns 422 when the state machine rejects the suspension" do
+      user.update!(verified: true)
+
+      post :suspend_for_fraud, params: { email: user.email }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["success"]).to be(false)
+      expect(user.reload).to be_compliant
+    end
+  end
 end

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -487,8 +487,20 @@ describe Api::Internal::Admin::UsersController do
       expect(response.parsed_body).to eq({
         success: true,
         status: "already_suspended",
-        message: "User is already suspended"
+        message: "User is already suspended for fraud"
       }.as_json)
+    end
+
+    it "returns 422 when the user is suspended for a different reason" do
+      user.update!(user_risk_state: "suspended_for_tos_violation")
+
+      expect do
+        post :suspend_for_fraud, params: { email: user.email }
+      end.not_to change { user.comments.reload.count }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["success"]).to be(false)
+      expect(user.reload).to be_suspended_for_tos_violation
     end
 
     it "returns 422 when the state machine rejects the suspension" do

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -337,10 +337,10 @@ describe Api::Internal::Admin::UsersController do
       expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
     end
 
-    it "marks the user compliant and creates an audit comment attributed to GUMROAD_ADMIN_ID" do
+    it "marks the user compliant and creates separate audit and note comments attributed to GUMROAD_ADMIN_ID" do
       expect do
         post :mark_compliant, params: { email: user.email, note: "Cleared after review" }
-      end.to change { user.comments.reload.count }.by(1)
+      end.to change { user.comments.reload.count }.by(2)
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to eq({
@@ -350,12 +350,30 @@ describe Api::Internal::Admin::UsersController do
       }.as_json)
       expect(user.reload).to be_compliant
 
-      comment = user.comments.last
-      expect(comment).to have_attributes(
+      audit_comment = user.comments.find_by!(comment_type: Comment::COMMENT_TYPE_COMPLIANT)
+      expect(audit_comment).to have_attributes(
         author_id: admin_user.id,
-        comment_type: Comment::COMMENT_TYPE_COMPLIANT,
+        comment_type: Comment::COMMENT_TYPE_COMPLIANT
+      )
+      expect(audit_comment.content).to include("Marked compliant by")
+
+      note = user.comments.find_by!(comment_type: Comment::COMMENT_TYPE_NOTE)
+      expect(note).to have_attributes(
+        author_id: admin_user.id,
+        comment_type: Comment::COMMENT_TYPE_NOTE,
         content: "Cleared after review"
       )
+    end
+
+    it "returns 422 without marking the user compliant when the note is invalid" do
+      expect do
+        post :mark_compliant, params: { email: user.email, note: "x" * 10_001 }
+      end.not_to change { user.comments.reload.count }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["success"]).to be(false)
+      expect(response.parsed_body["message"]).to include("Content is too long")
+      expect(user.reload).to be_suspended_for_fraud
     end
 
     it "keeps the existing sibling-account compliant side effect" do
@@ -445,6 +463,17 @@ describe Api::Internal::Admin::UsersController do
         comment_type: Comment::COMMENT_TYPE_SUSPENSION_NOTE,
         content: "Chargeback risk confirmed"
       )
+    end
+
+    it "returns 422 without suspending the user when the suspension note is invalid" do
+      expect do
+        post :suspend_for_fraud, params: { email: user.email, suspension_note: "x" * 10_001 }
+      end.not_to change { user.comments.reload.count }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["success"]).to be(false)
+      expect(response.parsed_body["message"]).to include("Content is too long")
+      expect(user.reload).to be_compliant
     end
 
     it "returns success without creating another comment when the user is already suspended" do


### PR DESCRIPTION
Ref #4677

## What

Adds internal admin endpoints to mark a user as compliant or suspend them for fraud by email.

Both actions use the same behavior as the existing admin web buttons. Repeat calls return success without adding duplicate comments, and fraud suspension can also save an optional suspension note.

## Why

We want to prioritize these two admin actions for the CLI. This keeps the server change narrow: it exposes only the requested actions and does not add payout scheduling or other risk actions.

---

This PR was implemented with AI assistance using gpt‑5.5 xhigh.
