### PR TITLE
Discard ActiveStorage::AnalyzeJob on S3 NoSuchKey

### DIFF
--- a/config/initializers/active_storage_jobs.rb
+++ b/config/initializers/active_storage_jobs.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# ActiveStorage::AnalyzeJob runs asynchronously after a blob is attached.
+# If the blob is purged from S3 before the job executes (e.g., the parent
+# record is deleted), S3 returns NoSuchKey. Retrying is pointless because the
+# object will never reappear, so we discard the job silently.
+Rails.application.config.after_initialize do
+  ActiveStorage::AnalyzeJob.discard_on(Aws::S3::Errors::NoSuchKey)
+end

--- a/spec/config/initializers/active_storage_jobs_spec.rb
+++ b/spec/config/initializers/active_storage_jobs_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "ActiveStorage::AnalyzeJob error handling" do
+  it "discards the job when S3 returns NoSuchKey" do
+    expect(ActiveStorage::AnalyzeJob.rescue_handlers).to include(
+      satisfy { |handler| handler[0] == "Aws::S3::Errors::NoSuchKey" }
+    )
+  end
+end


### PR DESCRIPTION
## Problem

`ActiveStorage::AnalyzeJob` fails with `Aws::S3::Errors::NoSuchKey` when a blob is purged from S3 before the background job runs. This is a race condition: the parent record (and its attachment) gets deleted, but the enqueued AnalyzeJob still tries to download the blob for analysis.

**Sentry:** https://gumroad-to.sentry.io/issues/7450213337/
**Events (7d):** 1
**Events (14d):** 1
**Estimated affected users/month:** <5 (low frequency, race condition)
**Estimated support tickets/month:** 0 (no user-facing impact, background job failure)

## Fix

Add an initializer that configures `ActiveStorage::AnalyzeJob` to `discard_on Aws::S3::Errors::NoSuchKey`. Retrying is pointless since the S3 object will never reappear after deletion. This pattern is consistent with how the codebase already handles `NoSuchKey` in other places (e.g., `Streamable`, `User`, `UpdateProductFilesArchiveWorker`).

## Changes

- `config/initializers/active_storage_jobs.rb` — patches `ActiveStorage::AnalyzeJob` to discard on `NoSuchKey`
- `spec/config/initializers/active_storage_jobs_spec.rb` — verifies the discard handler is registered