### PR TITLE
Fix NoMethodError: make charge_discover_fee? public on Purchase

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -3333,6 +3333,7 @@ class Purchase < ApplicationRecord
       return false unless link.recommendable? || (not_is_original_subscription_purchase? && original_purchase&.was_discover_fee_charged?)
       was_product_recommended? && !RecommendationType.is_free_recommendation_type?(recommended_by)
     end
+    public :charge_discover_fee?
 
     # Calculates the fees we charge based on price_cents
     #

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -3982,28 +3982,28 @@ describe Purchase, :vcr do
     end
 
     it "is false if the purchase is not recommended" do
-      expect(@purchase.send(:charge_discover_fee?)).to eq(false)
+      expect(@purchase.charge_discover_fee?).to eq(false)
     end
 
     it "returns true if the purchase is recommended" do
       @purchase.was_product_recommended = true
       @purchase.save
-      expect(@purchase.send(:charge_discover_fee?)).to eq(true)
+      expect(@purchase.charge_discover_fee?).to eq(true)
       @purchase.seller.recommendation_type = User::RecommendationType::NO_RECOMMENDATIONS
       @purchase.seller.save
-      expect(@purchase.send(:charge_discover_fee?)).to eq(true)
+      expect(@purchase.charge_discover_fee?).to eq(true)
     end
 
     it "returns false if the purchase is recommended by library or more like this" do
-      expect(@purchase.send(:charge_discover_fee?)).to eq(false)
+      expect(@purchase.charge_discover_fee?).to eq(false)
 
       @purchase.update!(was_product_recommended: true)
-      expect(@purchase.send(:charge_discover_fee?)).to eq(true)
+      expect(@purchase.charge_discover_fee?).to eq(true)
 
       RecommendationType.all.each do |recommendation_type|
         @purchase.update!(recommended_by: recommendation_type)
         expect(@purchase.was_product_recommended?).to eq(true)
-        expect(@purchase.send(:charge_discover_fee?)).to eq(!RecommendationType.is_free_recommendation_type?(recommendation_type))
+        expect(@purchase.charge_discover_fee?).to eq(!RecommendationType.is_free_recommendation_type?(recommendation_type))
       end
     end
   end


### PR DESCRIPTION
## What

`Purchase#charge_discover_fee?` is defined inside the `private` block (below line 2865) but is called by external code (rails runner scripts that recalculate fees). Ruby raises `NoMethodError: private method 'charge_discover_fee?' called for an instance of Purchase` when a private method is called with an explicit receiver from outside the class.

## Fix

Add `public :charge_discover_fee?` immediately after the method definition. This re-exports the single method while keeping surrounding calculation methods private. Updated specs to call the method directly instead of via `send`.

## Sentry

- **Issue:** https://gumroad-to.sentry.io/issues/7450334564/
- **Occurrences (7-day):** 1
- **Occurrences (14-day):** 1
- **Estimated affected users/month:** ~0 (single occurrence from a one-off rails runner script)
- **Estimated support tickets/month:** 0

## Test results

```
bundle exec rspec spec/models/purchase_spec.rb -e "charge_discover_fee"
3 examples, 0 failures
```

(Local environment has a pre-existing Stripe test-mode issue unrelated to this change; CI should pass clean.)