### PR TITLE
Fix payout method update to clean all alive bank accounts

### DIFF
--- a/app/services/update_payout_method.rb
+++ b/app/services/update_payout_method.rb
@@ -254,13 +254,16 @@ class UpdatePayoutMethod
     end
 
     def replace_active_bank_account_with_validated_delete!(new_bank_account)
-      user.active_bank_account&.mark_deleted!
+      user.bank_accounts.alive.each(&:mark_deleted!)
       new_bank_account.save!
       notify_if_unexpected_alive_bank_accounts(new_bank_account)
     end
 
     def replace_active_bank_account_with_unvalidated_delete!(new_bank_account)
-      user.active_bank_account&.mark_deleted(validate: false)
+      user.bank_accounts.alive.find_each do |bank_account|
+        bank_account.deleted_at = Time.current
+        bank_account.save!(validate: false)
+      end
       new_bank_account.save!
       notify_if_unexpected_alive_bank_accounts(new_bank_account)
     end

--- a/spec/services/update_payout_method_spec.rb
+++ b/spec/services/update_payout_method_spec.rb
@@ -109,7 +109,7 @@ describe UpdatePayoutMethod do
       context "when the user already has multiple alive bank accounts" do
         let!(:orphaned_bank_account) { create(:ach_account, user:) }
 
-        it "does not block the replacement and reports the inconsistency" do
+        it "deletes all existing alive bank accounts and does not report an inconsistency" do
           params = ActionController::Parameters.new(
             bank_account: {
               type: AchAccount.name,
@@ -121,21 +121,17 @@ describe UpdatePayoutMethod do
           )
 
           allow(ErrorNotifier).to receive(:notify)
-          allow(Rails.logger).to receive(:error)
 
           result = described_class.new(user_params: params, seller: user).process
 
           expect(result).to eq(success: true)
-          expect(user.bank_accounts.alive.count).to eq(2)
-          expect(ErrorNotifier).to have_received(:notify).with(
-            "Unexpected alive bank account count after payout method update",
-            user_id: user.id,
-            alive_count: 2,
-            alive_bank_account_ids: match_array(user.bank_accounts.alive.pluck(:id)),
-            new_bank_account_id: user.bank_accounts.order(:id).last.id
-          )
+          expect(user.bank_accounts.alive.count).to eq(1)
+          expect(existing_bank_account.reload.deleted_at).to be_present
+          expect(orphaned_bank_account.reload.deleted_at).to be_present
+          expect(ErrorNotifier).not_to have_received(:notify)
         end
       end
+
     end
 
     describe "when account number exceeds maximum length" do


### PR DESCRIPTION
## What

When a seller updates their payout method, both `replace_active_bank_account_with_validated_delete!` and `replace_active_bank_account_with_unvalidated_delete!` now delete **all** alive bank accounts—not just the single active one—before saving the new bank account.

## Why

Previously, only `user.active_bank_account` (the most recently created alive bank account) was deleted. If a user had orphaned alive bank accounts from prior bugs or race conditions, those were left behind. This caused `notify_if_unexpected_alive_bank_accounts` to fire on every subsequent payout method update, creating noise in error tracking without ever resolving the underlying inconsistency.

By iterating over `user.bank_accounts.alive`, we clean up all stale records in one pass, so the alert only fires if something genuinely unexpected happens after the replacement.

## Test results

```
10 examples, 0 failures
```

---

AI disclosure: Claude Opus 4.6 was used to implement and test this fix.