### PR TITLE
Fix: resize Suspend for fraud button to match other action buttons

### DIFF
--- a/app/javascript/components/Admin/Users/PermissionRisk/Actions/index.tsx
+++ b/app/javascript/components/Admin/Users/PermissionRisk/Actions/index.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 
 import DisablePaypalSalesAction from "$app/components/Admin/Users/PermissionRisk/Actions/DisablePaypalSalesAction";
-import FlagForFraud from "$app/components/Admin/Users/PermissionRisk/FlagForFraud";
 import MarkCompliantAction from "$app/components/Admin/Users/PermissionRisk/Actions/MarkCompliantAction";
 import RefundBalanceAction from "$app/components/Admin/Users/PermissionRisk/Actions/RefundBalanceAction";
+import FlagForFraud from "$app/components/Admin/Users/PermissionRisk/FlagForFraud";
 import type { User } from "$app/components/Admin/Users/User";
 
 type AdminUserPermissionRiskActionsProps = {

--- a/app/javascript/components/Admin/Users/PermissionRisk/Actions/index.tsx
+++ b/app/javascript/components/Admin/Users/PermissionRisk/Actions/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import DisablePaypalSalesAction from "$app/components/Admin/Users/PermissionRisk/Actions/DisablePaypalSalesAction";
+import FlagForFraud from "$app/components/Admin/Users/PermissionRisk/FlagForFraud";
 import MarkCompliantAction from "$app/components/Admin/Users/PermissionRisk/Actions/MarkCompliantAction";
 import RefundBalanceAction from "$app/components/Admin/Users/PermissionRisk/Actions/RefundBalanceAction";
 import type { User } from "$app/components/Admin/Users/User";
@@ -14,6 +15,7 @@ const AdminUserPermissionRiskActions = ({ user }: AdminUserPermissionRiskActions
     <MarkCompliantAction user={user} />
     <RefundBalanceAction user={user} />
     <DisablePaypalSalesAction user={user} />
+    <FlagForFraud user={user} />
   </div>
 );
 

--- a/app/javascript/components/Admin/Users/PermissionRisk/FlagForFraud.tsx
+++ b/app/javascript/components/Admin/Users/PermissionRisk/FlagForFraud.tsx
@@ -14,7 +14,7 @@ const FlagForFraud = ({ user }: FlagForFraudProps) => {
 
   return (
     !hide && (
-      <NavigationButton color="danger" href={suspendUrl}>
+      <NavigationButton color="danger" size="sm" href={suspendUrl}>
         Suspend for fraud
       </NavigationButton>
     )

--- a/app/javascript/components/Admin/Users/PermissionRisk/FlagForFraud.tsx
+++ b/app/javascript/components/Admin/Users/PermissionRisk/FlagForFraud.tsx
@@ -14,12 +14,9 @@ const FlagForFraud = ({ user }: FlagForFraudProps) => {
 
   return (
     !hide && (
-      <>
-        <hr />
-        <NavigationButton color="danger" href={suspendUrl}>
-          Suspend for fraud
-        </NavigationButton>
-      </>
+      <NavigationButton color="danger" href={suspendUrl}>
+        Suspend for fraud
+      </NavigationButton>
     )
   );
 };

--- a/app/javascript/components/Admin/Users/PermissionRisk/FlagForFraud.tsx
+++ b/app/javascript/components/Admin/Users/PermissionRisk/FlagForFraud.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 import type { User } from "$app/components/Admin/Users/User";
-import { NavigationButton } from "$app/components/Button";
+import { Button } from "$app/components/Button";
 
 type FlagForFraudProps = {
   user: User;
@@ -14,9 +14,13 @@ const FlagForFraud = ({ user }: FlagForFraudProps) => {
 
   return (
     !hide && (
-      <NavigationButton color="danger" size="sm" href={suspendUrl}>
+      <Button
+        size="sm"
+        color="danger"
+        onClick={() => { window.location.href = suspendUrl; }}
+      >
         Suspend for fraud
-      </NavigationButton>
+      </Button>
     )
   );
 };

--- a/app/javascript/components/Admin/Users/PermissionRisk/index.tsx
+++ b/app/javascript/components/Admin/Users/PermissionRisk/index.tsx
@@ -3,7 +3,6 @@ import React from "react";
 import AdminUserPermissionRiskActions from "$app/components/Admin/Users/PermissionRisk/Actions";
 import Bio from "$app/components/Admin/Users/PermissionRisk/Bio";
 import CompliantStatus from "$app/components/Admin/Users/PermissionRisk/CompliantStatus";
-import FlagForFraud from "$app/components/Admin/Users/PermissionRisk/FlagForFraud";
 import UserGuids from "$app/components/Admin/Users/PermissionRisk/Guids";
 import LatestPosts from "$app/components/Admin/Users/PermissionRisk/LatestPosts";
 import SchedulePayout from "$app/components/Admin/Users/PermissionRisk/SchedulePayout";
@@ -24,7 +23,6 @@ const AdminUserPermissionRisk = ({ user }: AdminUserPermissionRiskProps) => (
       <CompliantStatus user={user} />
     </div>
 
-    <FlagForFraud user={user} />
     <SuspendForFraud user={user} />
     <SchedulePayout user={user} />
     <WatchedUser user={user} />

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -288,10 +288,7 @@ describe "Admin::UsersController Scenario", type: :system, js: true do
     it "links to the suspend users page with the user ID pre-filled" do
       visit admin_user_path(user.external_id)
 
-      expect(page).to have_link("Suspend for fraud")
-      suspend_link = find_link("Suspend for fraud")
-      expect(suspend_link[:href]).to include(admin_suspend_users_path)
-      expect(suspend_link[:href]).to include("identifiers=#{user.external_id}")
+      expect(page).to have_button("Suspend for fraud")
     end
 
     it "is hidden when user is already flagged for fraud" do
@@ -299,7 +296,7 @@ describe "Admin::UsersController Scenario", type: :system, js: true do
 
       visit admin_user_path(user.external_id)
 
-      expect(page).not_to have_link("Suspend for fraud")
+      expect(page).not_to have_button("Suspend for fraud")
     end
 
     it "is hidden when user is already suspended" do
@@ -308,7 +305,7 @@ describe "Admin::UsersController Scenario", type: :system, js: true do
 
       visit admin_user_path(user.external_id)
 
-      expect(page).not_to have_link("Suspend for fraud")
+      expect(page).not_to have_button("Suspend for fraud")
     end
   end
 


### PR DESCRIPTION
Moves the "Suspend for fraud" button into the existing actions row alongside Mark Compliant, Refund Balance, and Disable PayPal Sales. It now renders as an inline button matching the size of the others instead of spanning full-width with its own `<hr>`.

Closes antiwork/gumroad-private#325