### PR TITLE
Fix popover glitch on offer code page in Safari

### DIFF
--- a/app/javascript/components/CheckoutDashboard/DiscountsPage.tsx
+++ b/app/javascript/components/CheckoutDashboard/DiscountsPage.tsx
@@ -445,7 +445,7 @@ const DiscountsPage = ({
                                 <DotsHorizontalRounded className="size-5" />
                               </Button>
                             </PopoverTrigger>
-                            <PopoverContent sideOffset={4} className="border-0 p-0 shadow-none">
+                            <PopoverContent sideOffset={4} className="border-0 p-0 shadow-none" usePortal>
                               <Menu>
                                 <MenuItem
                                   inert={!offerCode.can_update || isLoading}

--- a/app/javascript/pages/Reviews/Index.tsx
+++ b/app/javascript/pages/Reviews/Index.tsx
@@ -93,7 +93,7 @@ const Row = ({ review, onChange }: { review: Review; onChange: (review: Review) 
                 </Button>
               </PopoverTrigger>
             </PopoverAnchor>
-            <PopoverContent sideOffset={4} className="border-0 p-0 shadow-none">
+            <PopoverContent sideOffset={4} className="border-0 p-0 shadow-none" usePortal>
               <Card>
                 <ReviewForm
                   permalink={review.product.permalink}

--- a/app/javascript/pages/UtmLinks/Index.tsx
+++ b/app/javascript/pages/UtmLinks/Index.tsx
@@ -335,7 +335,7 @@ const UtmLinkActions = ({ link, onDelete }: { link: SavedUtmLink; onDelete: () =
             </Button>
           </PopoverTrigger>
         </PopoverAnchor>
-        <PopoverContent className="w-48 border-none p-0 shadow-none">
+        <PopoverContent className="w-48 border-none p-0 shadow-none" usePortal>
           <Menu>
             <MenuItem asChild>
               <Link href={Routes.edit_dashboard_utm_link_path(link.id)} className="no-underline">


### PR DESCRIPTION
Fixes the popover overlay jumping around when hovering over edit/delete buttons on the offer codes page in Safari.

The `PopoverContent` was rendering inline inside the table cell DOM, causing Safari positioning glitches. Added `usePortal` so the popover renders outside the table hierarchy.

Closes #4886