### PR TITLE
Fix RequestTimeoutException in Admin::Search::PurchasesController#index

### DIFF
--- a/app/services/admin_search_service.rb
+++ b/app/services/admin_search_service.rb
@@ -3,7 +3,12 @@
 class AdminSearchService
   class InvalidDateError < StandardError; end
 
+  MAX_RESULTS = 500
+
   def search_purchases(query: nil, email: nil, product_title_query: nil, purchase_status: nil, creator_email: nil, license_key: nil, transaction_date: nil, last_4: nil, card_type: nil, price: nil, expiry_date: nil, limit: nil)
+    has_search_criteria = [query, email, creator_email, license_key, transaction_date, last_4, card_type, price, expiry_date].any?(&:present?)
+    return Purchase.none unless has_search_criteria
+
     purchases = Purchase.order(created_at: :desc)
 
     if email.present?
@@ -89,7 +94,7 @@ class AdminSearchService
       end
     end
 
-    purchases.limit(limit)
+    purchases.limit(limit || MAX_RESULTS)
   end
 
   private

--- a/spec/controllers/admin/search/purchases_controller_spec.rb
+++ b/spec/controllers/admin/search/purchases_controller_spec.rb
@@ -96,13 +96,13 @@ describe Admin::Search::PurchasesController, type: :controller, inertia: true do
       end
 
       context "when query is not set" do
-        it "ignores product_title_query" do
+        it "returns no results without search criteria" do
           expect_any_instance_of(AdminSearchService).to receive(:search_purchases).with(query: "", product_title_query:).and_call_original
 
           get :index, params: { query: "", product_title_query: product_title_query }
 
           assert_response :success
-          expect(assigns(:purchases)).to include(purchase)
+          expect(assigns(:purchases)).to be_empty
         end
       end
     end
@@ -130,13 +130,13 @@ describe Admin::Search::PurchasesController, type: :controller, inertia: true do
       end
 
       context "when query is not set" do
-        it "ignores purchase_status" do
+        it "returns no results without search criteria" do
           expect_any_instance_of(AdminSearchService).to receive(:search_purchases).with(query: "", product_title_query: nil, purchase_status:).and_call_original
 
           get :index, params: { query: "", purchase_status: purchase_status }
 
           assert_response :success
-          expect(assigns(:purchases)).to include(successful_purchase)
+          expect(assigns(:purchases)).to be_empty
         end
       end
     end

--- a/spec/services/admin_search_service_spec.rb
+++ b/spec/services/admin_search_service_spec.rb
@@ -4,6 +4,18 @@ require "spec_helper"
 
 describe AdminSearchService do
   describe "#search_purchases" do
+    it "returns no results when no search criteria are provided" do
+      create(:purchase)
+      purchases = AdminSearchService.new.search_purchases
+      expect(purchases).to be_empty
+    end
+
+    it "applies a default limit of MAX_RESULTS" do
+      email = "limit-test@example.com"
+      purchases = AdminSearchService.new.search_purchases(query: email)
+      expect(purchases.to_sql).to include("LIMIT #{AdminSearchService::MAX_RESULTS}")
+    end
+
     it "returns no Purchases if query is invalid" do
       purchases = AdminSearchService.new.search_purchases(query: "invalidquery")
 
@@ -211,9 +223,9 @@ describe AdminSearchService do
       context "when query is not set" do
         let(:query) { nil }
 
-        it "ignores product_title_query" do
+        it "returns no results without search criteria" do
           purchases = AdminSearchService.new.search_purchases(query:, product_title_query:)
-          expect(purchases).to include(purchase)
+          expect(purchases).to be_empty
         end
       end
     end
@@ -272,9 +284,9 @@ describe AdminSearchService do
       context "when query is not set" do
         let(:query) { nil }
 
-        it "ignores purchase_status" do
+        it "returns no results without search criteria" do
           purchases = AdminSearchService.new.search_purchases(query:, purchase_status: "successful")
-          expect(purchases).to include(successful_purchase, failed_purchase, not_charged_purchase, chargebacked_purchase, chargebacked_reversed_purchase, refunded_purchase)
+          expect(purchases).to be_empty
         end
       end
     end


### PR DESCRIPTION
## What

Fixes `Rack::Timeout::RequestTimeoutException` in `Admin::Search::PurchasesController#index` by:

- Returning `Purchase.none` immediately when no search criteria are provided (query, email, creator_email, license_key, transaction_date, last_4, card_type, price, expiry_date)
- Adding a default result limit of 500 (`MAX_RESULTS`) when no explicit limit is passed

## Why

The admin purchase search endpoint could scan the entire `purchases` table when no meaningful search criteria were provided, causing queries that exceeded the 120s Rack::Timeout threshold. This was triggered when parameters like `product_title_query` or `purchase_status` were passed without a primary search criterion — these filters only narrow results but don't prevent a full table scan.

Sentry issue: https://gumroad-to.sentry.io/issues/7451021240/

## Test results

All test failures in the affected spec files are pre-existing environment issues (purchase factory validation failures unrelated to this change), confirmed by verifying the same failures occur on `main`.

---

AI disclosure: Built with Claude Opus 4.6. Prompted to fix the Rack::Timeout in admin purchase search by requiring search criteria and adding a default limit.