### PR TITLE
Bulk-aggregate inventory counter cache backfill

### DIFF
--- a/app/services/onetime/backfill_inventory_counter_cache.rb
+++ b/app/services/onetime/backfill_inventory_counter_cache.rb
@@ -2,15 +2,33 @@
 
 module Onetime
   class BackfillInventoryCounterCache
-    BATCH_SIZE = 500
+    BATCH_SIZE = 1_000
 
-    def self.process(start_base_variant_id: 0, start_link_id: 0)
-      new.process(start_base_variant_id:, start_link_id:)
+    def self.process(
+      start_base_variant_id: 0,
+      end_base_variant_id: nil,
+      start_link_id: 0,
+      end_link_id: nil,
+      batch_size: BATCH_SIZE
+    )
+      new.process(
+        start_base_variant_id:,
+        end_base_variant_id:,
+        start_link_id:,
+        end_link_id:,
+        batch_size:,
+      )
     end
 
-    def process(start_base_variant_id: 0, start_link_id: 0)
-      backfill_base_variants(start_base_variant_id)
-      backfill_links(start_link_id)
+    def process(
+      start_base_variant_id: 0,
+      end_base_variant_id: nil,
+      start_link_id: 0,
+      end_link_id: nil,
+      batch_size: BATCH_SIZE
+    )
+      backfill_base_variants(start_base_variant_id, end_base_variant_id, batch_size)
+      backfill_links(start_link_id, end_link_id, batch_size)
     end
 
     private
@@ -30,39 +48,49 @@ module Onetime
         SQL
       end
 
-      def backfill_base_variants(start_id)
-        BaseVariant.where("id >= ?", start_id).in_batches(of: BATCH_SIZE) do |batch|
+      def bounded_scope(model, start_id, end_id)
+        scope = model.where("id >= ?", start_id)
+        scope = scope.where("id <= ?", end_id) if end_id
+        scope
+      end
+
+      def backfill_base_variants(start_id, end_id, batch_size)
+        bounded_scope(BaseVariant, start_id, end_id).in_batches(of: batch_size) do |batch|
           ReplicaLagWatcher.watch
           min_id, max_id = batch.minimum(:id), batch.maximum(:id)
           ActiveRecord::Base.connection.execute(<<~SQL.squish)
             UPDATE base_variants bv
-            SET bv.sales_count_for_inventory_cache = COALESCE((
-              SELECT SUM(p.quantity)
+            LEFT JOIN (
+              SELECT bvp.base_variant_id AS bv_id, SUM(p.quantity) AS total
               FROM base_variants_purchases bvp
               INNER JOIN purchases p ON p.id = bvp.purchase_id
               LEFT JOIN subscriptions s ON s.id = p.subscription_id
-              WHERE bvp.base_variant_id = bv.id
+              WHERE bvp.base_variant_id BETWEEN #{min_id.to_i} AND #{max_id.to_i}
                 AND #{qualifying_purchase_conditions}
-            ), 0)
+              GROUP BY bvp.base_variant_id
+            ) agg ON agg.bv_id = bv.id
+            SET bv.sales_count_for_inventory_cache = COALESCE(agg.total, 0)
             WHERE bv.id BETWEEN #{min_id.to_i} AND #{max_id.to_i}
           SQL
           puts "BaseVariant backfill: reached id=#{max_id}"
         end
       end
 
-      def backfill_links(start_id)
-        Link.where("id >= ?", start_id).in_batches(of: BATCH_SIZE) do |batch|
+      def backfill_links(start_id, end_id, batch_size)
+        bounded_scope(Link, start_id, end_id).in_batches(of: batch_size) do |batch|
           ReplicaLagWatcher.watch
           min_id, max_id = batch.minimum(:id), batch.maximum(:id)
           ActiveRecord::Base.connection.execute(<<~SQL.squish)
             UPDATE links l
-            SET l.sales_count_for_inventory_cache = COALESCE((
-              SELECT SUM(p.quantity)
+            LEFT JOIN (
+              SELECT p.link_id AS l_id, SUM(p.quantity) AS total
               FROM purchases p
               LEFT JOIN subscriptions s ON s.id = p.subscription_id
-              WHERE p.link_id = l.id
+              WHERE p.link_id BETWEEN #{min_id.to_i} AND #{max_id.to_i}
                 AND #{qualifying_purchase_conditions}
-            ), 0)
+              GROUP BY p.link_id
+            ) agg ON agg.l_id = l.id
+            SET l.sales_count_for_inventory_cache = COALESCE(agg.total, 0)
             WHERE l.id BETWEEN #{min_id.to_i} AND #{max_id.to_i}
           SQL
           puts "Link backfill: reached id=#{max_id}"

--- a/spec/services/onetime/backfill_inventory_counter_cache_spec.rb
+++ b/spec/services/onetime/backfill_inventory_counter_cache_spec.rb
@@ -1,0 +1,296 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Onetime::BackfillInventoryCounterCache do
+  describe ".process" do
+    let(:product) { create(:product) }
+    let(:variant_category) { create(:variant_category, link: product) }
+    let(:variant) { create(:variant, variant_category:) }
+
+    def create_historical_purchase(**attrs)
+      Purchase.skip_inventory_counter_callbacks do
+        create(:purchase, link: product, purchase_state: "successful", quantity: 1, **attrs)
+      end
+    end
+
+    def set_caches(link_value:, variant_value: nil)
+      Link.where(id: product.id).update_all(sales_count_for_inventory_cache: link_value)
+      BaseVariant.where(id: variant.id).update_all(sales_count_for_inventory_cache: variant_value) unless variant_value.nil?
+    end
+
+    it "sums quantities of qualifying purchases into both link and variant caches" do
+      create_historical_purchase(variant_attributes: [variant], quantity: 3)
+      create_historical_purchase(variant_attributes: [variant], quantity: 2)
+
+      described_class.process
+
+      expect(variant.reload.sales_count_for_inventory_cache).to eq(5)
+      expect(product.reload.sales_count_for_inventory_cache).to eq(5)
+    end
+
+    it "writes 0 when there are no qualifying purchases, overwriting any stale value" do
+      variant
+      set_caches(link_value: 999, variant_value: 999)
+
+      described_class.process
+
+      expect(variant.reload.sales_count_for_inventory_cache).to eq(0)
+      expect(product.reload.sales_count_for_inventory_cache).to eq(0)
+    end
+
+    it "overwrites stale cache values with the correct sum" do
+      create_historical_purchase(variant_attributes: [variant], quantity: 4)
+      set_caches(link_value: 999, variant_value: 999)
+
+      described_class.process
+
+      expect(variant.reload.sales_count_for_inventory_cache).to eq(4)
+      expect(product.reload.sales_count_for_inventory_cache).to eq(4)
+    end
+
+    it "is idempotent across repeated runs" do
+      create_historical_purchase(variant_attributes: [variant], quantity: 7)
+
+      described_class.process
+      first = variant.reload.sales_count_for_inventory_cache
+
+      described_class.process
+
+      expect(variant.reload.sales_count_for_inventory_cache).to eq(first)
+      expect(first).to eq(7)
+    end
+
+    describe "purchase state filtering" do
+      it "excludes purchases not in COUNTS_TOWARDS_INVENTORY_STATES" do
+        create_historical_purchase(variant_attributes: [variant], purchase_state: "successful", quantity: 1)
+        create_historical_purchase(variant_attributes: [variant], purchase_state: "failed", quantity: 99)
+
+        described_class.process
+
+        expect(variant.reload.sales_count_for_inventory_cache).to eq(1)
+        expect(product.reload.sales_count_for_inventory_cache).to eq(1)
+      end
+
+      it "includes preorder_authorization_successful, in_progress, and not_charged states" do
+        create_historical_purchase(variant_attributes: [variant], purchase_state: "preorder_authorization_successful", quantity: 1)
+        create_historical_purchase(variant_attributes: [variant], purchase_state: "in_progress", quantity: 1)
+        create_historical_purchase(variant_attributes: [variant], purchase_state: "not_charged", quantity: 1)
+
+        described_class.process
+
+        expect(variant.reload.sales_count_for_inventory_cache).to eq(3)
+        expect(product.reload.sales_count_for_inventory_cache).to eq(3)
+      end
+    end
+
+    describe "flag-based filtering" do
+      it "excludes additional contributions" do
+        create_historical_purchase(variant_attributes: [variant], quantity: 1)
+        create_historical_purchase(variant_attributes: [variant], is_additional_contribution: true, quantity: 99)
+
+        described_class.process
+
+        expect(variant.reload.sales_count_for_inventory_cache).to eq(1)
+        expect(product.reload.sales_count_for_inventory_cache).to eq(1)
+      end
+
+      it "excludes archived original subscription purchases" do
+        create_historical_purchase(variant_attributes: [variant], quantity: 1)
+        create_historical_purchase(variant_attributes: [variant], is_archived_original_subscription_purchase: true, quantity: 99)
+
+        described_class.process
+
+        expect(variant.reload.sales_count_for_inventory_cache).to eq(1)
+        expect(product.reload.sales_count_for_inventory_cache).to eq(1)
+      end
+    end
+
+    describe "subscription handling" do
+      let(:membership) { create(:membership_product) }
+      let(:membership_variant) { membership.variant_categories_alive.first.variants.first }
+
+      def reset_membership_caches
+        Link.where(id: membership.id).update_all(sales_count_for_inventory_cache: 0)
+        BaseVariant.where(id: membership_variant.id).update_all(sales_count_for_inventory_cache: 0)
+      end
+
+      def create_membership_purchase(subscription:, **attrs)
+        Purchase.skip_inventory_counter_callbacks do
+          create(:purchase,
+                 link: membership,
+                 subscription: subscription,
+                 variant_attributes: [membership_variant],
+                 purchase_state: "successful",
+                 quantity: 1, **attrs)
+        end
+      end
+
+      it "counts the original subscription purchase" do
+        sub = create(:subscription, link: membership)
+        create_membership_purchase(subscription: sub, is_original_subscription_purchase: true)
+        reset_membership_caches
+
+        described_class.process
+
+        expect(membership_variant.reload.sales_count_for_inventory_cache).to eq(1)
+        expect(membership.reload.sales_count_for_inventory_cache).to eq(1)
+      end
+
+      it "counts a gift receiver purchase on a subscription" do
+        sub = create(:subscription, link: membership)
+        create_membership_purchase(subscription: sub, is_gift_receiver_purchase: true)
+        reset_membership_caches
+
+        described_class.process
+
+        expect(membership_variant.reload.sales_count_for_inventory_cache).to eq(1)
+        expect(membership.reload.sales_count_for_inventory_cache).to eq(1)
+      end
+
+      it "does not count recurring (non-original, non-gift) subscription charges" do
+        sub = create(:subscription, link: membership)
+        create_membership_purchase(subscription: sub, is_original_subscription_purchase: true, quantity: 1)
+        create_membership_purchase(subscription: sub, quantity: 99)
+        reset_membership_caches
+
+        described_class.process
+
+        expect(membership_variant.reload.sales_count_for_inventory_cache).to eq(1)
+        expect(membership.reload.sales_count_for_inventory_cache).to eq(1)
+      end
+
+      it "does not count subscription purchases when the subscription is deactivated" do
+        sub = create(:subscription, link: membership, deactivated_at: 1.day.ago)
+        create_membership_purchase(subscription: sub, is_original_subscription_purchase: true, quantity: 1)
+        Link.where(id: membership.id).update_all(sales_count_for_inventory_cache: 5)
+        BaseVariant.where(id: membership_variant.id).update_all(sales_count_for_inventory_cache: 5)
+
+        described_class.process
+
+        expect(membership_variant.reload.sales_count_for_inventory_cache).to eq(0)
+        expect(membership.reload.sales_count_for_inventory_cache).to eq(0)
+      end
+    end
+
+    describe "range scoping" do
+      let!(:product_a) { create(:product) }
+      let!(:product_b) { create(:product) }
+      let!(:product_c) { create(:product) }
+
+      def create_purchase_for(target_product)
+        Purchase.skip_inventory_counter_callbacks do
+          create(:purchase, link: target_product, purchase_state: "successful", quantity: 1)
+        end
+      end
+
+      def reset_link_caches
+        Link.where(id: [product_a.id, product_b.id, product_c.id]).update_all(sales_count_for_inventory_cache: 0)
+      end
+
+      it "respects start_link_id, leaving earlier links untouched" do
+        create_purchase_for(product_a)
+        create_purchase_for(product_b)
+        create_purchase_for(product_c)
+        Link.where(id: product_a.id).update_all(sales_count_for_inventory_cache: 999)
+        Link.where(id: [product_b.id, product_c.id]).update_all(sales_count_for_inventory_cache: 0)
+
+        described_class.process(start_link_id: product_b.id)
+
+        expect(product_a.reload.sales_count_for_inventory_cache).to eq(999)
+        expect(product_b.reload.sales_count_for_inventory_cache).to eq(1)
+        expect(product_c.reload.sales_count_for_inventory_cache).to eq(1)
+      end
+
+      it "respects end_link_id, leaving later links untouched" do
+        create_purchase_for(product_a)
+        create_purchase_for(product_b)
+        create_purchase_for(product_c)
+        Link.where(id: product_c.id).update_all(sales_count_for_inventory_cache: 999)
+        Link.where(id: [product_a.id, product_b.id]).update_all(sales_count_for_inventory_cache: 0)
+
+        described_class.process(end_link_id: product_b.id)
+
+        expect(product_a.reload.sales_count_for_inventory_cache).to eq(1)
+        expect(product_b.reload.sales_count_for_inventory_cache).to eq(1)
+        expect(product_c.reload.sales_count_for_inventory_cache).to eq(999)
+      end
+
+      it "respects start_base_variant_id and end_base_variant_id" do
+        cat_a = create(:variant_category, link: product_a)
+        cat_b = create(:variant_category, link: product_b)
+        cat_c = create(:variant_category, link: product_c)
+        var_a = create(:variant, variant_category: cat_a)
+        var_b = create(:variant, variant_category: cat_b)
+        var_c = create(:variant, variant_category: cat_c)
+
+        Purchase.skip_inventory_counter_callbacks do
+          create(:purchase, link: product_a, variant_attributes: [var_a], purchase_state: "successful", quantity: 1)
+          create(:purchase, link: product_b, variant_attributes: [var_b], purchase_state: "successful", quantity: 1)
+          create(:purchase, link: product_c, variant_attributes: [var_c], purchase_state: "successful", quantity: 1)
+        end
+        BaseVariant.where(id: var_a.id).update_all(sales_count_for_inventory_cache: 999)
+        BaseVariant.where(id: var_c.id).update_all(sales_count_for_inventory_cache: 999)
+
+        described_class.process(
+          start_base_variant_id: var_b.id,
+          end_base_variant_id: var_b.id,
+          start_link_id: 2_000_000_000,
+        )
+
+        expect(var_a.reload.sales_count_for_inventory_cache).to eq(999)
+        expect(var_b.reload.sales_count_for_inventory_cache).to eq(1)
+        expect(var_c.reload.sales_count_for_inventory_cache).to eq(999)
+      end
+
+      it "supports running disjoint ranges in parallel without overlap" do
+        create_purchase_for(product_a)
+        create_purchase_for(product_b)
+        create_purchase_for(product_c)
+        reset_link_caches
+
+        described_class.process(start_link_id: product_a.id, end_link_id: product_a.id)
+        described_class.process(start_link_id: product_b.id, end_link_id: product_b.id)
+        described_class.process(start_link_id: product_c.id, end_link_id: product_c.id)
+
+        expect(product_a.reload.sales_count_for_inventory_cache).to eq(1)
+        expect(product_b.reload.sales_count_for_inventory_cache).to eq(1)
+        expect(product_c.reload.sales_count_for_inventory_cache).to eq(1)
+      end
+    end
+
+    describe "aggregation across multiple purchases" do
+      it "groups by base_variant_id correctly when multiple variants share an id range" do
+        other_variant = create(:variant, variant_category:)
+        Purchase.skip_inventory_counter_callbacks do
+          create(:purchase, link: product, variant_attributes: [variant], purchase_state: "successful", quantity: 2)
+          create(:purchase, link: product, variant_attributes: [variant], purchase_state: "successful", quantity: 3)
+          create(:purchase, link: product, variant_attributes: [other_variant], purchase_state: "successful", quantity: 7)
+        end
+
+        described_class.process
+
+        expect(variant.reload.sales_count_for_inventory_cache).to eq(5)
+        expect(other_variant.reload.sales_count_for_inventory_cache).to eq(7)
+        expect(product.reload.sales_count_for_inventory_cache).to eq(12)
+      end
+    end
+
+    describe "batch_size parameter" do
+      it "produces the same result with a small batch size as a large one" do
+        create_historical_purchase(variant_attributes: [variant], quantity: 4)
+
+        described_class.process(batch_size: 1)
+        small_batch_value = variant.reload.sales_count_for_inventory_cache
+
+        BaseVariant.where(id: variant.id).update_all(sales_count_for_inventory_cache: 0)
+        Link.where(id: product.id).update_all(sales_count_for_inventory_cache: 0)
+        described_class.process(batch_size: 10_000)
+
+        expect(small_batch_value).to eq(4)
+        expect(variant.reload.sales_count_for_inventory_cache).to eq(4)
+        expect(product.reload.sales_count_for_inventory_cache).to eq(4)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

Rewrites `Onetime::BackfillInventoryCounterCache` to make the backfill from PR #4665 tractable at production scale.

- Replaces the per-row correlated SUM subquery with a single `GROUP BY` + `LEFT JOIN ... UPDATE` per batch.
- Adds `end_base_variant_id`, `end_link_id`, and `batch_size` keyword arguments so multiple prod consoles can backfill disjoint id ranges in parallel without overlap.
- Bumps default `BATCH_SIZE` from 500 to 1000 (bulk aggregation amortizes plan overhead, so larger batches are net-positive).
- Adds `spec/services/onetime/backfill_inventory_counter_cache_spec.rb` (18 examples) covering aggregation correctness, all `purchase_state`/flag filters, subscription cases, range scoping, idempotency, and batch-size invariance.

## Why

The original backfill from #4665 ran one correlated SUM subquery per row in each batch of 500. At production scale this turned out to be far slower than the PR description estimated:

- `BaseVariant`: 5.4M rows. Observed rate during the prod backfill in the heavy id range: **~14 ids/sec** (~3.5 days remaining).
- `Link`: ~17M rows. Projected at the same per-row cost: **~10+ days more** in series.

That's because each batch executed 500 separate planned SUM subqueries, each doing its own random PK lookups into `purchases` — exactly the bottleneck #4665 was meant to eliminate at *runtime*. The backfill itself paid that cost once per row.

The bulk rewrite collapses each batch into:

```sql
UPDATE base_variants bv
LEFT JOIN (
  SELECT bvp.base_variant_id AS bv_id, SUM(p.quantity) AS total
  FROM base_variants_purchases bvp
  INNER JOIN purchases p ON p.id = bvp.purchase_id
  LEFT JOIN subscriptions s ON s.id = p.subscription_id
  WHERE bvp.base_variant_id BETWEEN <min> AND <max>
    AND <qualifying_conditions>
  GROUP BY bvp.base_variant_id
) agg ON agg.bv_id = bv.id
SET bv.sales_count_for_inventory_cache = COALESCE(agg.total, 0)
WHERE bv.id BETWEEN <min> AND <max>
```

One range scan over `bvp.base_variant_id`, one GROUP BY pass, MySQL is free to apply Multi-Range Read on `purchases` PK lookups (sequential pages instead of N random reads). The `LEFT JOIN ... COALESCE(agg.total, 0)` preserves the original behavior for rows without qualifying purchases (writes 0, overwriting any stale value from live `after_commit` deltas).

The new `end_*_id` parameters let us run 4 prod consoles concurrently on disjoint id ranges — disjoint rows mean no lock contention, and each session's `ReplicaLagWatcher` self-throttles independently.

Combined: ~13 days projected → expected to complete overnight.

---

Generated with assistance from Claude Opus 4.7