### PR TITLE
Fix empty placeholder flashing when switching content pages

### DIFF
--- a/app/javascript/components/ProductEdit/ContentTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/index.tsx
@@ -973,7 +973,7 @@ const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: string | 
         >
           <NodeVisibilityProvider scrollRef={scrollContainerRef}>
             <div className="relative h-full flex-1">
-              {editor?.isEmpty && isSelectedPageEmpty ? (
+              {isSelectedPageEmpty ? (
                 <div className="pointer-events-none absolute inset-0 flex items-start">
                   <p className="flex flex-wrap items-center gap-1 text-muted">
                     <span>Enter the content you want to sell.</span>

--- a/app/javascript/components/ProductEdit/ContentTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/index.tsx
@@ -207,6 +207,15 @@ const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: string | 
     pages.length > 1 || selectedPage?.title || renamingPageId != null || product.native_type === "commission";
   const [insertMenuState, setInsertMenuState] = React.useState<"open" | "inputs" | null>(null);
   const initialValue = React.useMemo(() => selectedPage?.description ?? "", [selectedPageId]);
+  const isSelectedPageEmpty =
+    !selectedPage?.description ||
+    (typeof selectedPage.description === "object" &&
+      "content" in selectedPage.description &&
+      Array.isArray(selectedPage.description.content) &&
+      selectedPage.description.content.every(
+        (node: { type?: string; content?: unknown[] }) =>
+          node.type === "paragraph" && (!node.content || node.content.length === 0),
+      ));
 
   const onSelectFiles = (ids: string[]) => {
     if (!editor) return;
@@ -964,7 +973,7 @@ const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: string | 
         >
           <NodeVisibilityProvider scrollRef={scrollContainerRef}>
             <div className="relative h-full flex-1">
-              {editor?.isEmpty ? (
+              {editor?.isEmpty && isSelectedPageEmpty ? (
                 <div className="pointer-events-none absolute inset-0 flex items-start">
                   <p className="flex flex-wrap items-center gap-1 text-muted">
                     <span>Enter the content you want to sell.</span>

--- a/app/javascript/components/RichTextEditor.tsx
+++ b/app/javascript/components/RichTextEditor.tsx
@@ -322,20 +322,16 @@ export const useRichTextEditor = ({
 
   React.useEffect(() => editor?.setOptions({ editable }), [editable]);
 
-  React.useEffect(
-    () =>
-      queueMicrotask(() => {
-        // discard any history from before content was reset
-        editor?.view.updateState(
-          EditorState.create({
-            doc: createDocument(content, editor.state.schema),
-            schema: editor.schema,
-            plugins: editor.state.plugins,
-          }),
-        );
+  React.useLayoutEffect(() => {
+    // discard any history from before content was reset
+    editor?.view.updateState(
+      EditorState.create({
+        doc: createDocument(content, editor.state.schema),
+        schema: editor.schema,
+        plugins: editor.state.plugins,
       }),
-    [content],
-  );
+    );
+  }, [content]);
 
   return editor ?? null;
 };


### PR DESCRIPTION
## What

When switching between pages on the content editor, the empty state placeholder ("Enter the content you want to sell.") briefly flashes even when navigating to a page that already has content.

## Why

The editor content was updated via `useEffect` + `queueMicrotask`, which defers the update to after the browser paint. During that gap, the editor still holds the previous page's state, and if that page was empty, the `isEmpty` check shows the placeholder before the new content loads.

## Fix

Two changes, belt-and-suspenders:

1. **`RichTextEditor.tsx`**: Replace `useEffect` + `queueMicrotask` with `useLayoutEffect` so the editor state updates synchronously before the browser paints. This eliminates the frame where stale content is visible.

2. **`ContentTab/index.tsx`**: Add an `isSelectedPageEmpty` guard alongside `editor?.isEmpty` so the placeholder also checks the selected page's actual description data, not just the editor's potentially-stale state.