### PR TITLE
Add /internal/admin Phase 2 write endpoints

### DIFF
--- a/app/controllers/api/internal/admin/payouts_controller.rb
+++ b/app/controllers/api/internal/admin/payouts_controller.rb
@@ -16,6 +16,62 @@ class Api::Internal::Admin::PayoutsController < Api::Internal::Admin::BaseContro
     }
   end
 
+  def pause
+    if @user.payouts_paused_internally?
+      return render json: {
+        success: true,
+        status: "already_paused",
+        message: "Payouts are already paused",
+        payouts_paused: true
+      }
+    end
+
+    reason = params[:reason].to_s.strip.presence
+
+    User.transaction do
+      @user.update!(payouts_paused_internally: true, payouts_paused_by: GUMROAD_ADMIN_ID)
+      if reason.present?
+        @user.comments.create!(
+          author_id: GUMROAD_ADMIN_ID,
+          comment_type: Comment::COMMENT_TYPE_PAYOUTS_PAUSED,
+          content: reason
+        )
+      end
+    end
+
+    render json: {
+      success: true,
+      message: "Payouts paused for #{@user.email}",
+      payouts_paused: true
+    }
+  end
+
+  def resume
+    unless @user.payouts_paused_internally?
+      return render json: {
+        success: true,
+        status: "not_paused",
+        message: "Payouts are not paused",
+        payouts_paused: false
+      }
+    end
+
+    User.transaction do
+      @user.update!(payouts_paused_internally: false, payouts_paused_by: nil)
+      @user.comments.create!(
+        author_id: GUMROAD_ADMIN_ID,
+        comment_type: Comment::COMMENT_TYPE_PAYOUTS_RESUMED,
+        content: "Payouts resumed."
+      )
+    end
+
+    render json: {
+      success: true,
+      message: "Payouts resumed for #{@user.email}",
+      payouts_paused: false
+    }
+  end
+
   private
     def fetch_user
       return render json: { success: false, message: "email is required" }, status: :bad_request if params[:email].blank?

--- a/app/controllers/api/internal/admin/payouts_controller.rb
+++ b/app/controllers/api/internal/admin/payouts_controller.rb
@@ -17,11 +17,11 @@ class Api::Internal::Admin::PayoutsController < Api::Internal::Admin::BaseContro
   end
 
   def pause
-    if @user.payouts_paused_internally?
+    if @user.payouts_paused_by_source == User::PAYOUT_PAUSE_SOURCE_ADMIN
       return render json: {
         success: true,
         status: "already_paused",
-        message: "Payouts are already paused",
+        message: "Payouts are already paused by admin",
         payouts_paused: true
       }
     end

--- a/app/controllers/api/internal/admin/payouts_controller.rb
+++ b/app/controllers/api/internal/admin/payouts_controller.rb
@@ -51,8 +51,8 @@ class Api::Internal::Admin::PayoutsController < Api::Internal::Admin::BaseContro
       return render json: {
         success: true,
         status: "not_paused",
-        message: "Payouts are not paused",
-        payouts_paused: false
+        message: "Payouts are not paused by admin",
+        payouts_paused: @user.payouts_paused?
       }
     end
 
@@ -68,7 +68,7 @@ class Api::Internal::Admin::PayoutsController < Api::Internal::Admin::BaseContro
     render json: {
       success: true,
       message: "Payouts resumed for #{@user.email}",
-      payouts_paused: false
+      payouts_paused: @user.reload.payouts_paused?
     }
   end
 

--- a/app/controllers/api/internal/admin/purchases_controller.rb
+++ b/app/controllers/api/internal/admin/purchases_controller.rb
@@ -187,13 +187,23 @@ class Api::Internal::Admin::PurchasesController < Api::Internal::Admin::BaseCont
       return render json: { success: false, message: "Purchase has no subscription" }, status: :unprocessable_entity
     end
 
-    if subscription.cancelled_at.present? || subscription.deactivated?
+    if subscription.cancelled_at.present?
       return render json: {
         success: true,
         status: "already_cancelled",
         message: "Subscription is already cancelled",
-        cancelled_at: subscription.cancelled_at&.as_json,
+        cancelled_at: subscription.cancelled_at.as_json,
         cancelled_by_admin: subscription.cancelled_by_admin?
+      }
+    end
+
+    if subscription.deactivated?
+      return render json: {
+        success: true,
+        status: "already_inactive",
+        message: "Subscription is no longer active",
+        termination_reason: subscription.termination_reason,
+        deactivated_at: subscription.deactivated_at&.as_json
       }
     end
 
@@ -213,11 +223,11 @@ class Api::Internal::Admin::PurchasesController < Api::Internal::Admin::BaseCont
     purchase = fetch_purchase_with_email_match
     return unless purchase
 
-    if purchase.buyer_blocked?
+    if purchase.is_buyer_blocked_by_admin?
       return render json: {
         success: true,
         status: "already_blocked",
-        message: "Buyer is already blocked"
+        message: "Buyer is already blocked by admin"
       }
     end
 
@@ -242,6 +252,7 @@ class Api::Internal::Admin::PurchasesController < Api::Internal::Admin::BaseCont
     end
 
     purchase.unblock_buyer!
+    create_unblock_buyer_comments!(purchase)
 
     render json: {
       success: true,
@@ -275,6 +286,14 @@ class Api::Internal::Admin::PurchasesController < Api::Internal::Admin::BaseCont
   end
 
   private
+    def create_unblock_buyer_comments!(purchase)
+      content = "Buyer unblocked by Admin"
+      purchase.comments.create!(content:, comment_type: Comment::COMMENT_TYPE_NOTE, author_id: GUMROAD_ADMIN_ID)
+      if purchase.purchaser.present?
+        purchase.purchaser.comments.create!(content:, comment_type: Comment::COMMENT_TYPE_NOTE, author_id: GUMROAD_ADMIN_ID, purchase:)
+      end
+    end
+
     def fetch_purchase_with_email_match
       buyer_email = params[:email].to_s.strip.downcase
       if buyer_email.blank?

--- a/app/controllers/api/internal/admin/purchases_controller.rb
+++ b/app/controllers/api/internal/admin/purchases_controller.rb
@@ -178,7 +178,119 @@ class Api::Internal::Admin::PurchasesController < Api::Internal::Admin::BaseCont
     }.compact
   end
 
+  def cancel_subscription
+    purchase = fetch_purchase_with_email_match
+    return unless purchase
+
+    subscription = purchase.subscription
+    if subscription.blank?
+      return render json: { success: false, message: "Purchase has no subscription" }, status: :unprocessable_entity
+    end
+
+    if subscription.cancelled_at.present? || subscription.deactivated?
+      return render json: {
+        success: true,
+        status: "already_cancelled",
+        message: "Subscription is already cancelled",
+        cancelled_at: subscription.cancelled_at&.as_json,
+        cancelled_by_admin: subscription.cancelled_by_admin?
+      }
+    end
+
+    by_seller = ActiveModel::Type::Boolean.new.cast(params[:by_seller]) == true
+    subscription.cancel!(by_seller: by_seller, by_admin: true)
+
+    render json: {
+      success: true,
+      message: "Successfully cancelled subscription for purchase number #{purchase.external_id_numeric}",
+      cancelled_at: subscription.cancelled_at&.as_json,
+      cancelled_by_admin: subscription.cancelled_by_admin?,
+      cancelled_by_seller: !subscription.cancelled_by_buyer?
+    }
+  end
+
+  def block_buyer
+    purchase = fetch_purchase_with_email_match
+    return unless purchase
+
+    if purchase.buyer_blocked?
+      return render json: {
+        success: true,
+        status: "already_blocked",
+        message: "Buyer is already blocked"
+      }
+    end
+
+    purchase.block_buyer!(blocking_user_id: GUMROAD_ADMIN_ID, comment_content: params[:comment_content].presence)
+
+    render json: {
+      success: true,
+      message: "Successfully blocked buyer for purchase number #{purchase.external_id_numeric}"
+    }
+  end
+
+  def unblock_buyer
+    purchase = fetch_purchase_with_email_match
+    return unless purchase
+
+    unless purchase.buyer_blocked?
+      return render json: {
+        success: true,
+        status: "not_blocked",
+        message: "Buyer is not blocked"
+      }
+    end
+
+    purchase.unblock_buyer!
+
+    render json: {
+      success: true,
+      message: "Successfully unblocked buyer for purchase number #{purchase.external_id_numeric}"
+    }
+  end
+
+  def refund_for_fraud
+    purchase = fetch_purchase_with_email_match
+    return unless purchase
+
+    if purchase.stripe_refunded
+      return render json: { success: false, message: "Purchase has already been fully refunded" }, status: :unprocessable_entity
+    end
+
+    if purchase.stripe_transaction_id.blank? || purchase.amount_refundable_cents <= 0
+      return render json: { success: false, message: "Purchase has no charge to refund" }, status: :unprocessable_entity
+    end
+
+    unless purchase.refund_for_fraud_and_block_buyer!(GUMROAD_ADMIN_ID)
+      message = purchase.errors.full_messages.presence&.to_sentence || "Refund-for-fraud failed for purchase number #{purchase.external_id_numeric}"
+      return render json: { success: false, message: }, status: :unprocessable_entity
+    end
+
+    render json: {
+      success: true,
+      message: "Successfully refunded purchase number #{purchase.external_id_numeric} for fraud and blocked the buyer",
+      purchase: serialize_purchase(purchase),
+      subscription_cancelled: purchase.subscription&.cancelled_at.present?
+    }
+  end
+
   private
+    def fetch_purchase_with_email_match
+      buyer_email = params[:email].to_s.strip.downcase
+      if buyer_email.blank?
+        render json: { success: false, message: "email is required" }, status: :bad_request
+        return nil
+      end
+
+      purchase = fetch_purchase
+      if purchase.blank? || purchase.email.to_s.downcase != buyer_email
+        render json: { success: false, message: "Purchase not found or email doesn't match" }, status: :not_found
+        return nil
+      end
+
+      purchase
+    end
+
     def fetch_purchase
       return nil unless params[:id].to_s.match?(/\A\d+\z/)
       Purchase.find_by_external_id_numeric(params[:id].to_i)

--- a/app/controllers/api/internal/admin/purchases_controller.rb
+++ b/app/controllers/api/internal/admin/purchases_controller.rb
@@ -223,7 +223,7 @@ class Api::Internal::Admin::PurchasesController < Api::Internal::Admin::BaseCont
     purchase = fetch_purchase_with_email_match
     return unless purchase
 
-    if purchase.is_buyer_blocked_by_admin?
+    if purchase.is_buyer_blocked_by_admin? && purchase.buyer_blocked?
       return render json: {
         success: true,
         status: "already_blocked",

--- a/app/controllers/api/internal/admin/purchases_controller.rb
+++ b/app/controllers/api/internal/admin/purchases_controller.rb
@@ -243,7 +243,7 @@ class Api::Internal::Admin::PurchasesController < Api::Internal::Admin::BaseCont
     purchase = fetch_purchase_with_email_match
     return unless purchase
 
-    unless purchase.buyer_blocked?
+    unless purchase.buyer_blocked? || purchase.is_buyer_blocked_by_admin?
       return render json: {
         success: true,
         status: "not_blocked",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -305,6 +305,10 @@ Rails.application.routes.draw do
               post :refund
               post :resend_receipt
               post :refund_taxes
+              post :cancel_subscription
+              post :block_buyer
+              post :unblock_buyer
+              post :refund_for_fraud
             end
           end
 
@@ -329,6 +333,8 @@ Rails.application.routes.draw do
           resources :payouts, only: [] do
             collection do
               post :list
+              post :pause
+              post :resume
             end
           end
         end

--- a/spec/controllers/api/internal/admin/payouts_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/payouts_controller_spec.rb
@@ -192,7 +192,19 @@ describe Api::Internal::Admin::PayoutsController do
       expect(comment.content).to eq("Payouts resumed.")
     end
 
-    it "short-circuits when payouts are not paused" do
+    it "reports payouts_paused: true after admin resume when the seller is still self-paused" do
+      user.update!(payouts_paused_internally: true, payouts_paused_by: GUMROAD_ADMIN_ID, payouts_paused_by_user: true)
+
+      post :resume, params: { email: user.email }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["success"]).to be(true)
+      expect(response.parsed_body["payouts_paused"]).to be(true)
+      expect(user.reload.payouts_paused_internally?).to be(false)
+      expect(user.payouts_paused_by_user?).to be(true)
+    end
+
+    it "short-circuits when payouts are not paused by admin" do
       expect { post :resume, params: { email: user.email } }
         .not_to change { user.comments.count }
 
@@ -200,8 +212,21 @@ describe Api::Internal::Admin::PayoutsController do
       expect(response.parsed_body).to include(
         "success" => true,
         "status" => "not_paused",
-        "message" => "Payouts are not paused",
+        "message" => "Payouts are not paused by admin",
         "payouts_paused" => false
+      )
+    end
+
+    it "reports payouts_paused: true on short-circuit when the seller has self-paused" do
+      user.update!(payouts_paused_by_user: true)
+
+      post :resume, params: { email: user.email }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(
+        "success" => true,
+        "status" => "not_paused",
+        "payouts_paused" => true
       )
     end
   end

--- a/spec/controllers/api/internal/admin/payouts_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/payouts_controller_spec.rb
@@ -117,7 +117,7 @@ describe Api::Internal::Admin::PayoutsController do
       expect(user.reload.payouts_paused_internally?).to be(true)
     end
 
-    it "short-circuits when payouts are already paused" do
+    it "short-circuits when payouts are already paused by admin" do
       user.update!(payouts_paused_internally: true, payouts_paused_by: GUMROAD_ADMIN_ID)
 
       expect { post :pause, params: { email: user.email, reason: "again" } }
@@ -127,9 +127,32 @@ describe Api::Internal::Admin::PayoutsController do
       expect(response.parsed_body).to include(
         "success" => true,
         "status" => "already_paused",
-        "message" => "Payouts are already paused",
+        "message" => "Payouts are already paused by admin",
         "payouts_paused" => true
       )
+    end
+
+    it "asserts admin attribution when payouts were previously paused by the system" do
+      user.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_SYSTEM)
+      reason = "Manual review pending"
+
+      expect { post :pause, params: { email: user.email, reason: reason } }
+        .to change { user.comments.with_type_payouts_paused.count }.by(1)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["success"]).to be(true)
+      expect(response.parsed_body).not_to have_key("status")
+      expect(user.reload.payouts_paused_by.to_s).to eq(GUMROAD_ADMIN_ID.to_s)
+      expect(user.payouts_paused_for_reason).to eq(reason)
+    end
+
+    it "asserts admin attribution when payouts were previously paused by Stripe" do
+      user.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_STRIPE)
+
+      post :pause, params: { email: user.email, reason: "Stripe escalation" }
+
+      expect(response).to have_http_status(:ok)
+      expect(user.reload.payouts_paused_by_source).to eq(User::PAYOUT_PAUSE_SOURCE_ADMIN)
     end
   end
 

--- a/spec/controllers/api/internal/admin/payouts_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/payouts_controller_spec.rb
@@ -68,4 +68,118 @@ describe Api::Internal::Admin::PayoutsController do
       expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
     end
   end
+
+  describe "POST pause" do
+    include_examples "admin api authorization required", :post, :pause
+
+    it "returns 400 when email is missing" do
+      post :pause
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "email is required" }.as_json)
+    end
+
+    it "returns 404 when the user does not exist" do
+      post :pause, params: { email: "missing@example.com" }
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
+    end
+
+    it "pauses payouts and records the admin as the pause source" do
+      expect { post :pause, params: { email: user.email } }.to change { user.reload.payouts_paused_internally? }.from(false).to(true)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(
+        "success" => true,
+        "message" => "Payouts paused for #{user.email}",
+        "payouts_paused" => true
+      )
+      expect(user.reload.payouts_paused_by.to_s).to eq(GUMROAD_ADMIN_ID.to_s)
+    end
+
+    it "creates a COMMENT_TYPE_PAYOUTS_PAUSED comment when reason is provided" do
+      reason = "Payouts paused due to verification"
+
+      expect { post :pause, params: { email: user.email, reason: reason } }
+        .to change { user.comments.with_type_payouts_paused.count }.by(1)
+
+      comment = user.comments.with_type_payouts_paused.last
+      expect(comment.author_id).to eq(GUMROAD_ADMIN_ID)
+      expect(comment.content).to eq(reason)
+    end
+
+    it "does not create a comment when reason is blank" do
+      expect { post :pause, params: { email: user.email, reason: "   " } }
+        .not_to change { user.comments.count }
+
+      expect(response).to have_http_status(:ok)
+      expect(user.reload.payouts_paused_internally?).to be(true)
+    end
+
+    it "short-circuits when payouts are already paused" do
+      user.update!(payouts_paused_internally: true, payouts_paused_by: GUMROAD_ADMIN_ID)
+
+      expect { post :pause, params: { email: user.email, reason: "again" } }
+        .not_to change { user.comments.count }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(
+        "success" => true,
+        "status" => "already_paused",
+        "message" => "Payouts are already paused",
+        "payouts_paused" => true
+      )
+    end
+  end
+
+  describe "POST resume" do
+    include_examples "admin api authorization required", :post, :resume
+
+    it "returns 400 when email is missing" do
+      post :resume
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "email is required" }.as_json)
+    end
+
+    it "returns 404 when the user does not exist" do
+      post :resume, params: { email: "missing@example.com" }
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "resumes payouts, clears payouts_paused_by, and records a resume comment" do
+      user.update!(payouts_paused_internally: true, payouts_paused_by: GUMROAD_ADMIN_ID)
+
+      expect { post :resume, params: { email: user.email } }
+        .to change { user.reload.payouts_paused_internally? }.from(true).to(false)
+        .and change { user.comments.with_type_payouts_resumed.count }.by(1)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(
+        "success" => true,
+        "message" => "Payouts resumed for #{user.email}",
+        "payouts_paused" => false
+      )
+      expect(user.reload.payouts_paused_by).to be_nil
+
+      comment = user.comments.with_type_payouts_resumed.last
+      expect(comment.author_id).to eq(GUMROAD_ADMIN_ID)
+      expect(comment.content).to eq("Payouts resumed.")
+    end
+
+    it "short-circuits when payouts are not paused" do
+      expect { post :resume, params: { email: user.email } }
+        .not_to change { user.comments.count }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(
+        "success" => true,
+        "status" => "not_paused",
+        "message" => "Payouts are not paused",
+        "payouts_paused" => false
+      )
+    end
+  end
 end

--- a/spec/controllers/api/internal/admin/purchases_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/purchases_controller_spec.rb
@@ -751,4 +751,340 @@ describe Api::Internal::Admin::PurchasesController do
       expect(response.parsed_body).to eq({ success: false, message: "from and to emails are the same" }.as_json)
     end
   end
+
+  describe "POST cancel_subscription" do
+    let(:admin_user) { create(:admin_user) }
+    let(:purchase) { create(:free_purchase, email: "buyer@example.com") }
+    let(:params) { { id: purchase.external_id_numeric.to_s, email: purchase.email } }
+
+    include_examples "admin api authorization required", :post, :cancel_subscription, { id: "123", email: "buyer@example.com" }
+
+    before { stub_const("GUMROAD_ADMIN_ID", admin_user.id) }
+
+    it "returns 400 when email is missing" do
+      post :cancel_subscription, params: { id: purchase.external_id_numeric.to_s }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "email is required" }.as_json)
+    end
+
+    it "returns 404 when the purchase is missing" do
+      post :cancel_subscription, params: { id: "999999999", email: "buyer@example.com" }
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body).to eq({ success: false, message: "Purchase not found or email doesn't match" }.as_json)
+    end
+
+    it "returns 404 when the email does not match the purchase email" do
+      post :cancel_subscription, params: params.merge(email: "wrong@example.com")
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body).to eq({ success: false, message: "Purchase not found or email doesn't match" }.as_json)
+    end
+
+    it "returns 422 when the purchase has no subscription" do
+      post :cancel_subscription, params: params
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body).to eq({ success: false, message: "Purchase has no subscription" }.as_json)
+    end
+
+    context "when the purchase has a subscription" do
+      let(:subscription) { instance_double(Subscription, deactivated?: false, cancelled_at: nil) }
+
+      before do
+        allow(Purchase).to receive(:find_by_external_id_numeric).with(purchase.external_id_numeric).and_return(purchase)
+        allow(purchase).to receive(:subscription).and_return(subscription)
+      end
+
+      it "cancels the subscription as buyer-initiated by default" do
+        cancelled_at = Time.current
+        expect(subscription).to receive(:cancel!).with(by_seller: false, by_admin: true) do
+          allow(subscription).to receive(:cancelled_at).and_return(cancelled_at)
+          allow(subscription).to receive(:cancelled_by_buyer?).and_return(true)
+          allow(subscription).to receive(:cancelled_by_admin?).and_return(true)
+        end
+
+        post :cancel_subscription, params: params
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["success"]).to be(true)
+        expect(response.parsed_body["message"]).to eq("Successfully cancelled subscription for purchase number #{purchase.external_id_numeric}")
+        expect(response.parsed_body["cancelled_at"]).to eq(cancelled_at.as_json)
+        expect(response.parsed_body["cancelled_by_admin"]).to be(true)
+        expect(response.parsed_body["cancelled_by_seller"]).to be(false)
+      end
+
+      it "cancels with seller-initiated semantics when by_seller is true" do
+        expect(subscription).to receive(:cancel!).with(by_seller: true, by_admin: true) do
+          allow(subscription).to receive(:cancelled_at).and_return(Time.current)
+          allow(subscription).to receive(:cancelled_by_buyer?).and_return(false)
+          allow(subscription).to receive(:cancelled_by_admin?).and_return(true)
+        end
+
+        post :cancel_subscription, params: params.merge(by_seller: "true")
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["cancelled_by_seller"]).to be(true)
+      end
+
+      it "short-circuits when the subscription is already pending cancellation" do
+        cancelled_at = 1.day.from_now
+        allow(subscription).to receive(:cancelled_at).and_return(cancelled_at)
+        allow(subscription).to receive(:cancelled_by_admin?).and_return(false)
+        expect(subscription).not_to receive(:cancel!)
+
+        post :cancel_subscription, params: params
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to include(
+          "success" => true,
+          "status" => "already_cancelled",
+          "message" => "Subscription is already cancelled",
+          "cancelled_at" => cancelled_at.as_json,
+          "cancelled_by_admin" => false
+        )
+      end
+
+      it "short-circuits when the subscription is already deactivated" do
+        allow(subscription).to receive(:deactivated?).and_return(true)
+        allow(subscription).to receive(:cancelled_by_admin?).and_return(true)
+        expect(subscription).not_to receive(:cancel!)
+
+        post :cancel_subscription, params: params
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["status"]).to eq("already_cancelled")
+      end
+    end
+  end
+
+  describe "POST block_buyer" do
+    let(:admin_user) { create(:admin_user) }
+    let(:purchase) { create(:free_purchase, email: "buyer@example.com") }
+    let(:params) { { id: purchase.external_id_numeric.to_s, email: purchase.email } }
+
+    include_examples "admin api authorization required", :post, :block_buyer, { id: "123", email: "buyer@example.com" }
+
+    before { stub_const("GUMROAD_ADMIN_ID", admin_user.id) }
+
+    it "returns 400 when email is missing" do
+      post :block_buyer, params: { id: purchase.external_id_numeric.to_s }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "email is required" }.as_json)
+    end
+
+    it "returns 404 when the purchase is missing" do
+      post :block_buyer, params: { id: "999999999", email: "buyer@example.com" }
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "returns 404 when the email does not match" do
+      post :block_buyer, params: params.merge(email: "wrong@example.com")
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "blocks the buyer and flips buyer_blocked? to true" do
+      expect { post :block_buyer, params: params }.to change { purchase.reload.buyer_blocked? }.from(false).to(true)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["success"]).to be(true)
+      expect(response.parsed_body["message"]).to eq("Successfully blocked buyer for purchase number #{purchase.external_id_numeric}")
+      expect(purchase.reload.is_buyer_blocked_by_admin?).to be(true)
+    end
+
+    it "creates an audit comment with the provided comment_content" do
+      post :block_buyer, params: params.merge(comment_content: "Refund abuse")
+
+      expect(response).to have_http_status(:ok)
+      expect(purchase.comments.where(author_id: admin_user.id, content: "Refund abuse").count).to eq(1)
+    end
+
+    it "creates a default audit comment when comment_content is omitted" do
+      post :block_buyer, params: params
+
+      expect(response).to have_http_status(:ok)
+      expect(purchase.comments.where(author_id: admin_user.id).where("content LIKE ?", "Buyer blocked%").count).to eq(1)
+    end
+
+    it "short-circuits when the buyer is already blocked" do
+      purchase.block_buyer!(blocking_user_id: admin_user.id)
+      expect_any_instance_of(Purchase).not_to receive(:block_buyer!)
+
+      post :block_buyer, params: params
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(
+        "success" => true,
+        "status" => "already_blocked",
+        "message" => "Buyer is already blocked"
+      )
+    end
+  end
+
+  describe "POST unblock_buyer" do
+    let(:admin_user) { create(:admin_user) }
+    let(:purchase) { create(:free_purchase, email: "buyer@example.com") }
+    let(:params) { { id: purchase.external_id_numeric.to_s, email: purchase.email } }
+
+    include_examples "admin api authorization required", :post, :unblock_buyer, { id: "123", email: "buyer@example.com" }
+
+    before { stub_const("GUMROAD_ADMIN_ID", admin_user.id) }
+
+    it "returns 400 when email is missing" do
+      post :unblock_buyer, params: { id: purchase.external_id_numeric.to_s }
+
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it "returns 404 when the purchase is missing" do
+      post :unblock_buyer, params: { id: "999999999", email: "buyer@example.com" }
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "unblocks the buyer and flips buyer_blocked? to false" do
+      purchase.block_buyer!(blocking_user_id: admin_user.id)
+      expect(purchase.reload.buyer_blocked?).to be(true)
+
+      post :unblock_buyer, params: params
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["success"]).to be(true)
+      expect(response.parsed_body["message"]).to eq("Successfully unblocked buyer for purchase number #{purchase.external_id_numeric}")
+      expect(purchase.reload.buyer_blocked?).to be(false)
+      expect(purchase.reload.is_buyer_blocked_by_admin?).to be(false)
+    end
+
+    it "short-circuits when the buyer is not blocked" do
+      expect_any_instance_of(Purchase).not_to receive(:unblock_buyer!)
+
+      post :unblock_buyer, params: params
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(
+        "success" => true,
+        "status" => "not_blocked",
+        "message" => "Buyer is not blocked"
+      )
+    end
+  end
+
+  describe "POST refund_for_fraud" do
+    let(:admin_user) { create(:admin_user) }
+    let(:purchase) { create(:free_purchase, email: "buyer@example.com") }
+    let(:params) { { id: purchase.external_id_numeric.to_s, email: purchase.email } }
+
+    include_examples "admin api authorization required", :post, :refund_for_fraud, { id: "123", email: "buyer@example.com" }
+
+    before { stub_const("GUMROAD_ADMIN_ID", admin_user.id) }
+
+    it "returns 400 when email is missing" do
+      post :refund_for_fraud, params: { id: purchase.external_id_numeric.to_s }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "email is required" }.as_json)
+    end
+
+    it "returns 404 when the purchase is missing" do
+      post :refund_for_fraud, params: { id: "999999999", email: "buyer@example.com" }
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body).to eq({ success: false, message: "Purchase not found or email doesn't match" }.as_json)
+    end
+
+    it "returns 404 when the email does not match" do
+      post :refund_for_fraud, params: params.merge(email: "wrong@example.com")
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    context "when the purchase exists" do
+      before do
+        allow(Purchase).to receive(:find_by_external_id_numeric).with(purchase.external_id_numeric).and_return(purchase)
+        allow(purchase).to receive(:stripe_transaction_id).and_return("ch_test")
+        allow(purchase).to receive(:amount_refundable_cents).and_return(1000)
+        purchase.errors.clear
+      end
+
+      it "returns 422 when the purchase is already fully refunded" do
+        allow(purchase).to receive(:stripe_refunded).and_return(true)
+        expect(purchase).not_to receive(:refund_for_fraud_and_block_buyer!)
+
+        post :refund_for_fraud, params: params
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body).to eq({ success: false, message: "Purchase has already been fully refunded" }.as_json)
+      end
+
+      it "returns 422 when the purchase has no charge to refund" do
+        allow(purchase).to receive(:stripe_transaction_id).and_return(nil)
+        expect(purchase).not_to receive(:refund_for_fraud_and_block_buyer!)
+
+        post :refund_for_fraud, params: params
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body).to eq({ success: false, message: "Purchase has no charge to refund" }.as_json)
+      end
+
+      it "returns 422 when the purchase has no remaining refundable amount" do
+        allow(purchase).to receive(:amount_refundable_cents).and_return(0)
+        expect(purchase).not_to receive(:refund_for_fraud_and_block_buyer!)
+
+        post :refund_for_fraud, params: params
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body).to eq({ success: false, message: "Purchase has no charge to refund" }.as_json)
+      end
+
+      it "delegates to refund_for_fraud_and_block_buyer! and returns the serialized purchase" do
+        expect(purchase).to receive(:refund_for_fraud_and_block_buyer!).with(admin_user.id).and_return(true)
+        cancelled_at = Time.current
+        subscription = instance_double(Subscription, cancelled_at: cancelled_at, price: nil)
+        allow(purchase).to receive(:subscription).and_return(subscription)
+
+        post :refund_for_fraud, params: params
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["success"]).to be(true)
+        expect(response.parsed_body["message"]).to eq("Successfully refunded purchase number #{purchase.external_id_numeric} for fraud and blocked the buyer")
+        expect(response.parsed_body["purchase"]).to include("id" => purchase.external_id_numeric.to_s)
+        expect(response.parsed_body["subscription_cancelled"]).to be(true)
+      end
+
+      it "returns subscription_cancelled: false when there is no subscription" do
+        expect(purchase).to receive(:refund_for_fraud_and_block_buyer!).with(admin_user.id).and_return(true)
+        allow(purchase).to receive(:subscription).and_return(nil)
+
+        post :refund_for_fraud, params: params
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["subscription_cancelled"]).to be(false)
+      end
+
+      it "returns 422 with the model error when refund_for_fraud_and_block_buyer! fails" do
+        allow(purchase).to receive(:refund_for_fraud_and_block_buyer!).with(admin_user.id) do
+          purchase.errors.add :base, "Refund amount cannot be greater than the purchase price."
+          false
+        end
+
+        post :refund_for_fraud, params: params
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body).to eq({ success: false, message: "Refund amount cannot be greater than the purchase price." }.as_json)
+      end
+
+      it "returns 422 with a generic message when refund_for_fraud_and_block_buyer! fails without errors" do
+        allow(purchase).to receive(:refund_for_fraud_and_block_buyer!).with(admin_user.id).and_return(false)
+
+        post :refund_for_fraud, params: params
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body).to eq({ success: false, message: "Refund-for-fraud failed for purchase number #{purchase.external_id_numeric}" }.as_json)
+      end
+    end
+  end
 end

--- a/spec/controllers/api/internal/admin/purchases_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/purchases_controller_spec.rb
@@ -960,6 +960,22 @@ describe Api::Internal::Admin::PurchasesController do
       expect(response.parsed_body["success"]).to be(true)
       expect(response.parsed_body).not_to have_key("status")
     end
+
+    it "re-establishes the block when the admin flag is stale and BlockedObject was cleared elsewhere" do
+      purchase.block_buyer!(blocking_user_id: admin_user.id)
+      purchase.unblock_buyer!
+      purchase.update!(is_buyer_blocked_by_admin: true)
+      expect(purchase.reload.is_buyer_blocked_by_admin?).to be(true)
+      expect(purchase.buyer_blocked?).to be(false)
+
+      expect { post :block_buyer, params: params }
+        .to change { purchase.reload.buyer_blocked? }.from(false).to(true)
+        .and change { purchase.comments.where(author_id: admin_user.id).count }.by(1)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["success"]).to be(true)
+      expect(response.parsed_body).not_to have_key("status")
+    end
   end
 
   describe "POST unblock_buyer" do

--- a/spec/controllers/api/internal/admin/purchases_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/purchases_controller_spec.rb
@@ -1034,6 +1034,22 @@ describe Api::Internal::Admin::PurchasesController do
         "message" => "Buyer is not blocked"
       )
     end
+
+    it "clears the stale admin flag when BlockedObject was cleared elsewhere" do
+      purchase.block_buyer!(blocking_user_id: admin_user.id)
+      purchase.unblock_buyer!
+      purchase.update!(is_buyer_blocked_by_admin: true)
+      expect(purchase.reload.is_buyer_blocked_by_admin?).to be(true)
+      expect(purchase.buyer_blocked?).to be(false)
+
+      expect { post :unblock_buyer, params: params }
+        .to change { purchase.reload.is_buyer_blocked_by_admin? }.from(true).to(false)
+        .and change { purchase.comments.where(author_id: admin_user.id, content: "Buyer unblocked by Admin").count }.by(1)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["success"]).to be(true)
+      expect(response.parsed_body).not_to have_key("status")
+    end
   end
 
   describe "POST refund_for_fraud" do

--- a/spec/controllers/api/internal/admin/purchases_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/purchases_controller_spec.rb
@@ -846,15 +846,36 @@ describe Api::Internal::Admin::PurchasesController do
         )
       end
 
-      it "short-circuits when the subscription is already deactivated" do
+      it "returns already_inactive with the termination reason when the subscription is deactivated via failed payment" do
+        deactivated_at = 1.day.ago
         allow(subscription).to receive(:deactivated?).and_return(true)
-        allow(subscription).to receive(:cancelled_by_admin?).and_return(true)
+        allow(subscription).to receive(:deactivated_at).and_return(deactivated_at)
+        allow(subscription).to receive(:termination_reason).and_return("failed_payment")
         expect(subscription).not_to receive(:cancel!)
 
         post :cancel_subscription, params: params
 
         expect(response).to have_http_status(:ok)
-        expect(response.parsed_body["status"]).to eq("already_cancelled")
+        expect(response.parsed_body).to include(
+          "success" => true,
+          "status" => "already_inactive",
+          "message" => "Subscription is no longer active",
+          "termination_reason" => "failed_payment",
+          "deactivated_at" => deactivated_at.as_json
+        )
+      end
+
+      it "returns already_inactive when the subscription ended naturally" do
+        allow(subscription).to receive(:deactivated?).and_return(true)
+        allow(subscription).to receive(:deactivated_at).and_return(2.days.ago)
+        allow(subscription).to receive(:termination_reason).and_return("fixed_subscription_period_ended")
+        expect(subscription).not_to receive(:cancel!)
+
+        post :cancel_subscription, params: params
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["status"]).to eq("already_inactive")
+        expect(response.parsed_body["termination_reason"]).to eq("fixed_subscription_period_ended")
       end
     end
   end
@@ -910,8 +931,9 @@ describe Api::Internal::Admin::PurchasesController do
       expect(purchase.comments.where(author_id: admin_user.id).where("content LIKE ?", "Buyer blocked%").count).to eq(1)
     end
 
-    it "short-circuits when the buyer is already blocked" do
+    it "short-circuits when the buyer is already blocked by admin on this purchase" do
       purchase.block_buyer!(blocking_user_id: admin_user.id)
+      expect(purchase.reload.is_buyer_blocked_by_admin?).to be(true)
       expect_any_instance_of(Purchase).not_to receive(:block_buyer!)
 
       post :block_buyer, params: params
@@ -920,8 +942,23 @@ describe Api::Internal::Admin::PurchasesController do
       expect(response.parsed_body).to include(
         "success" => true,
         "status" => "already_blocked",
-        "message" => "Buyer is already blocked"
+        "message" => "Buyer is already blocked by admin"
       )
+    end
+
+    it "does not short-circuit when the buyer was auto-blocked without admin attribution" do
+      previous_purchase = create(:free_purchase, email: purchase.email)
+      previous_purchase.block_buyer!(blocking_user_id: nil, comment_content: "Auto-blocked: chargeback rate")
+      expect(purchase.reload.buyer_blocked?).to be(true)
+      expect(purchase.is_buyer_blocked_by_admin?).to be(false)
+
+      expect { post :block_buyer, params: params }
+        .to change { purchase.reload.is_buyer_blocked_by_admin? }.from(false).to(true)
+        .and change { purchase.comments.where(author_id: admin_user.id).count }.by(1)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["success"]).to be(true)
+      expect(response.parsed_body).not_to have_key("status")
     end
   end
 
@@ -946,17 +983,27 @@ describe Api::Internal::Admin::PurchasesController do
       expect(response).to have_http_status(:not_found)
     end
 
-    it "unblocks the buyer and flips buyer_blocked? to false" do
+    it "unblocks the buyer, flips buyer_blocked? to false, and creates an audit comment" do
       purchase.block_buyer!(blocking_user_id: admin_user.id)
       expect(purchase.reload.buyer_blocked?).to be(true)
 
-      post :unblock_buyer, params: params
+      expect { post :unblock_buyer, params: params }
+        .to change { purchase.comments.where(author_id: admin_user.id, content: "Buyer unblocked by Admin").count }.by(1)
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["success"]).to be(true)
       expect(response.parsed_body["message"]).to eq("Successfully unblocked buyer for purchase number #{purchase.external_id_numeric}")
       expect(purchase.reload.buyer_blocked?).to be(false)
       expect(purchase.reload.is_buyer_blocked_by_admin?).to be(false)
+    end
+
+    it "creates an unblock comment on the purchaser when present" do
+      buyer = create(:user, email: "buyer@example.com")
+      purchase.update!(purchaser: buyer)
+      purchase.block_buyer!(blocking_user_id: admin_user.id)
+
+      expect { post :unblock_buyer, params: params }
+        .to change { buyer.reload.comments.where(author_id: admin_user.id, content: "Buyer unblocked by Admin").count }.by(1)
     end
 
     it "short-circuits when the buyer is not blocked" do


### PR DESCRIPTION
Part of #4677

## What

Adds the six `/internal/admin` write endpoints the upcoming `gumroad-cli` Phase 2 support commands need:

- `POST /api/internal/admin/purchases/:id/cancel_subscription`
- `POST /api/internal/admin/purchases/:id/block_buyer`
- `POST /api/internal/admin/purchases/:id/unblock_buyer`
- `POST /api/internal/admin/purchases/:id/refund_for_fraud`
- `POST /api/internal/admin/payouts/pause`
- `POST /api/internal/admin/payouts/resume`

Each controller action stays thin and delegates to existing model logic — `Subscription#cancel!`, `Purchase#block_buyer!` / `#unblock_buyer!`, `Purchase#refund_for_fraud_and_block_buyer!`, and `User#update!` plus the matching `Comment::COMMENT_TYPE_PAYOUTS_PAUSED` / `COMMENT_TYPE_PAYOUTS_RESUMED` audit comments. No duplicated business logic; all side effects (subscription cancellation emails, buyer-block audit comments, fraud-refund email, payout-pause comments) flow through the model paths the admin web UI already uses.

Together with #4861 (Phase 1 writes) and #4825 (precise refund), this completes the server-side surface for the Phase 2 CLI commands (`gumroad admin users info`, `manual refund`, `subscription cancel`, `buyer block/unblock`, `payouts pause/resume`).

## Why

This is the server-side prerequisite for PR 8 in the rollout plan on #4677. The plan rule still applies: commands should call `/internal/admin`; if a write endpoint only exists under `/internal/helper`, add the matching `/internal/admin` endpoint first. All six endpoints either had no API surface at all (admin-web-only actions) or only existed under the legacy `/internal/helper` namespace.

A few design choices worth calling out:

1. **Separate one-way endpoints for toggle pairs**, not unified `state: true|false` endpoints. Matches the existing `mark_compliant` / `suspend_for_fraud` precedent rather than the `two_factor_authentication` toggle. Keeps each endpoint's params and audit-comment type distinct (pause carries a `reason`, resume doesn't; block carries `comment_content`, unblock doesn't), and maps 1:1 to PR 8 CLI subcommands.

2. **`cancel_subscription` defaults to buyer-initiated.** `params[:by_seller]` is coerced via `ActiveModel::Type::Boolean.new.cast(...) == true`, so omitting it gives `by_seller: false` (matching admin web behavior at `admin/purchases#cancel_subscription`). This is the opposite of `Subscription#cancel!`'s default — passing the parameter explicitly is intentional so the controller's behavior doesn't depend on the model's default.

3. **Idempotent short-circuits return 200 with a `status:` discriminator** instead of 422 when the target state already holds (`already_cancelled`, `already_blocked`, `not_blocked`, `already_paused`, `not_paused`). PR 8's CLI commands can treat this as success, so retrying a CLI invocation against a buyer who's already blocked doesn't error.

4. **`refund_for_fraud` reuses the same precondition guards as the existing `refund` endpoint** (`!stripe_refunded`, `stripe_transaction_id.present?`, `amount_refundable_cents > 0`) so behavior is consistent. The composite effect (refund + buyer-block + immediate subscription cancel + fraud-specific seller email) lives entirely inside `Purchase#refund_for_fraud_and_block_buyer!` — the controller just validates input and serializes the response.

This PR was implemented with AI assistance using Claude Opus 4.7.
