### PR TITLE
Handle LockWaitTimeout in Google OAuth2 sign-in flow

### DIFF
--- a/app/models/concerns/user/social_google.rb
+++ b/app/models/concerns/user/social_google.rb
@@ -74,11 +74,11 @@ module User::SocialGoogle
         end
 
         user
-      rescue ActiveRecord::Deadlocked => e
+      rescue ActiveRecord::Deadlocked, ActiveRecord::LockWaitTimeout => e
         retries += 1
         retry if retries <= 2
 
-        logger.error("Deadlock finding or creating user via Google OAuth2 after #{retries} retries: #{e.message}")
+        logger.error("Lock error finding or creating user via Google OAuth2 after #{retries} retries: #{e.class} - #{e.message}")
         ErrorNotifier.notify(e)
         nil
       end

--- a/spec/modules/user/social_google_spec.rb
+++ b/spec/modules/user/social_google_spec.rb
@@ -95,6 +95,45 @@ describe User::SocialGoogle do
 
       expect(result).to be_nil
     end
+
+    it "retries after a lock wait timeout and returns the created user" do
+      lock_timeout_data = @data.deep_dup
+      lock_timeout_data["uid"] = "google-lock-timeout-retry-uid"
+      lock_timeout_data["info"]["email"] = "google-lock-timeout-retry@example.com"
+      lock_timeout_data["extra"]["raw_info"]["email"] = "google-lock-timeout-retry@example.com"
+
+      allow_any_instance_of(User).to receive(:google_picture_url).and_return(nil)
+
+      save_attempts = 0
+      allow_any_instance_of(User).to receive(:save!).and_wrap_original do |original, *args|
+        save_attempts += 1
+        raise ActiveRecord::LockWaitTimeout, "Lock wait timeout exceeded" if save_attempts == 1
+
+        original.call(*args)
+      end
+
+      result = User.find_or_create_for_google_oauth2(lock_timeout_data)
+
+      expect(result).to be_persisted
+      expect(result).to be_valid
+      expect(result.google_uid).to eq(lock_timeout_data["uid"])
+      expect(save_attempts).to be >= 2
+    end
+
+    it "returns nil and notifies after exhausting lock wait timeout retries" do
+      lock_timeout_data = @data.deep_dup
+      lock_timeout_data["uid"] = "google-lock-timeout-failure-uid"
+      lock_timeout_data["info"]["email"] = "google-lock-timeout-failure@example.com"
+      lock_timeout_data["extra"]["raw_info"]["email"] = "google-lock-timeout-failure@example.com"
+
+      allow_any_instance_of(User).to receive(:google_picture_url).and_return(nil)
+      allow_any_instance_of(User).to receive(:save!).and_raise(ActiveRecord::LockWaitTimeout, "Lock wait timeout exceeded")
+      expect(ErrorNotifier).to receive(:notify).with(instance_of(ActiveRecord::LockWaitTimeout))
+
+      result = User.find_or_create_for_google_oauth2(lock_timeout_data)
+
+      expect(result).to be_nil
+    end
   end
 
   describe ".google_picture_url", :vcr do


### PR DESCRIPTION
## Problem

`User::OmniauthCallbacksController#google_oauth2` calls `User.find_or_create_for_google_oauth2`, which performs a `save!` inside `query_google`. When another transaction holds a row lock on the same user record for too long, MySQL raises `ActiveRecord::LockWaitTimeout` instead of a deadlock.

The existing retry logic only rescues `ActiveRecord::Deadlocked`, so `LockWaitTimeout` errors bubble up unhandled and crash the OAuth flow.

**Sentry:** https://gumroad-to.sentry.io/issues/7451458485/

## Fix

Add `ActiveRecord::LockWaitTimeout` to the existing `rescue` clause alongside `ActiveRecord::Deadlocked`. The same retry-up-to-2-times logic now applies to both lock-related errors.

## Changes

- `app/models/concerns/user/social_google.rb`: Rescue `LockWaitTimeout` alongside `Deadlocked`
- `spec/modules/user/social_google_spec.rb`: Two new tests mirroring the existing deadlock specs