### PR TITLE
Add /internal/admin users info endpoint

### DIFF
--- a/app/controllers/api/internal/admin/users_controller.rb
+++ b/app/controllers/api/internal/admin/users_controller.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
 class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseController
-  STATUS_COMMENT_TYPES = [Comment::COMMENT_TYPE_SUSPENSION_NOTE, Comment::COMMENT_TYPE_SUSPENDED, Comment::COMMENT_TYPE_FLAGGED, Comment::COMMENT_TYPE_COMPLIANT].freeze
-
   def info
     return render json: { success: false, message: "email is required" }, status: :bad_request if params[:email].blank?
 
-    user = find_user_or_render(params[:email])
-    return unless user
+    user = User.by_email(params[:email]).first
+    return render json: { success: false, message: "User not found" }, status: :not_found if user.blank?
 
     render json: { success: true, user: serialize_user_info(user) }
   end
@@ -177,7 +175,7 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
 
     def last_status_changed_at(user)
       user.comments
-        .where(comment_type: STATUS_COMMENT_TYPES)
+        .where(comment_type: Comment::RISK_STATE_COMMENT_TYPES)
         .order(created_at: :desc)
         .first
         &.created_at

--- a/app/controllers/api/internal/admin/users_controller.rb
+++ b/app/controllers/api/internal/admin/users_controller.rb
@@ -1,21 +1,27 @@
 # frozen_string_literal: true
 
 class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseController
+  STATUS_COMMENT_TYPES = [Comment::COMMENT_TYPE_SUSPENSION_NOTE, Comment::COMMENT_TYPE_SUSPENDED, Comment::COMMENT_TYPE_FLAGGED, Comment::COMMENT_TYPE_COMPLIANT].freeze
+
+  def info
+    return render json: { success: false, message: "email is required" }, status: :bad_request if params[:email].blank?
+
+    user = find_user_or_render(params[:email])
+    return unless user
+
+    render json: { success: true, user: serialize_user_info(user) }
+  end
+
   def suspension
     return render json: { success: false, message: "email is required" }, status: :bad_request if params[:email].blank?
 
     user = find_user_or_render(params[:email])
     return unless user
 
-    last_status_comment = user.comments
-      .where(comment_type: [Comment::COMMENT_TYPE_SUSPENSION_NOTE, Comment::COMMENT_TYPE_SUSPENDED, Comment::COMMENT_TYPE_FLAGGED, Comment::COMMENT_TYPE_COMPLIANT])
-      .order(created_at: :desc)
-      .first
-
     render json: {
       success: true,
       status: suspension_status(user),
-      updated_at: last_status_comment&.created_at&.as_json,
+      updated_at: last_status_changed_at(user)&.as_json,
       appeal_url: nil
     }
   end
@@ -167,6 +173,54 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
       else
         "Compliant"
       end
+    end
+
+    def last_status_changed_at(user)
+      user.comments
+        .where(comment_type: STATUS_COMMENT_TYPES)
+        .order(created_at: :desc)
+        .first
+        &.created_at
+    end
+
+    def serialize_user_info(user)
+      compliance_info = user.alive_user_compliance_info
+
+      {
+        id: user.external_id,
+        email: user.form_email,
+        name: user.name,
+        username: user.username,
+        profile_url: user.subdomain_with_protocol,
+        country: compliance_info&.country,
+        created_at: user.created_at.as_json,
+        deleted_at: user.deleted_at&.as_json,
+        risk_state: {
+          status: suspension_status(user),
+          user_risk_state: user.user_risk_state,
+          suspended: user.suspended?,
+          flagged_for_fraud: user.flagged_for_fraud?,
+          flagged_for_tos_violation: user.flagged_for_tos_violation?,
+          on_probation: user.on_probation?,
+          compliant: user.compliant?,
+          last_status_changed_at: last_status_changed_at(user)&.as_json
+        },
+        two_factor_authentication_enabled: user.two_factor_authentication_enabled?,
+        payouts: {
+          paused_internally: user.payouts_paused_internally?,
+          paused_by_user: user.payouts_paused_by_user?,
+          paused_by_source: user.payouts_paused_by_source,
+          paused_for_reason: user.payouts_paused_for_reason,
+          next_payout_date: user.next_payout_date&.to_s,
+          balance_for_next_payout: user.formatted_balance_for_next_payout_date
+        },
+        stats: {
+          sales_count: user.sales.successful.count,
+          total_earnings_formatted: Money.from_cents(user.sales_cents_total).format,
+          unpaid_balance_formatted: Money.from_cents(user.unpaid_balance_cents).format,
+          comments_count: user.comments.size
+        }
+      }
     end
 
     def serialize_comment(comment)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -316,6 +316,7 @@ Rails.application.routes.draw do
 
           resources :users, only: [] do
             collection do
+              post :info
               post :suspension
               post :reset_password
               post :update_email

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -6,6 +6,159 @@ require "shared_examples/authorized_admin_api_method"
 describe Api::Internal::Admin::UsersController do
   let(:admin_user) { create(:admin_user) }
 
+  describe "POST info" do
+    include_examples "admin api authorization required", :post, :info
+
+    before { stub_const("GUMROAD_ADMIN_ID", admin_user.id) }
+
+    it "returns a bad request when email is missing" do
+      post :info
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "email is required" }.as_json)
+    end
+
+    it "returns not found when the user does not exist" do
+      post :info, params: { email: "missing@example.com" }
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
+    end
+
+    it "returns a comprehensive info payload for a compliant seller" do
+      user = create(:compliant_user, email: "seller@example.com", name: "Seller One", username: "sellerone")
+
+      post :info, params: { email: user.email }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["success"]).to be(true)
+
+      info = response.parsed_body["user"]
+      expect(info).to include(
+        "id" => user.external_id,
+        "email" => user.form_email,
+        "name" => "Seller One",
+        "username" => "sellerone",
+        "deleted_at" => nil,
+        "two_factor_authentication_enabled" => false
+      )
+      expect(info["created_at"]).to eq(user.created_at.as_json)
+
+      expect(info["risk_state"]).to include(
+        "status" => "Compliant",
+        "user_risk_state" => "compliant",
+        "suspended" => false,
+        "flagged_for_fraud" => false,
+        "flagged_for_tos_violation" => false,
+        "on_probation" => false,
+        "compliant" => true,
+        "last_status_changed_at" => nil
+      )
+
+      expect(info["payouts"]).to include(
+        "paused_internally" => false,
+        "paused_by_user" => false,
+        "paused_by_source" => nil,
+        "paused_for_reason" => nil
+      )
+
+      expect(info["stats"]).to include(
+        "sales_count" => 0,
+        "total_earnings_formatted" => "$0.00",
+        "unpaid_balance_formatted" => "$0.00",
+        "comments_count" => 0
+      )
+    end
+
+    it "reports the suspension status and latest status timestamp for a suspended user" do
+      user = create(:tos_user, email: "suspended@example.com")
+      comment = create(:comment, commentable: user, comment_type: Comment::COMMENT_TYPE_SUSPENDED, created_at: 2.days.ago)
+
+      post :info, params: { email: user.email }
+
+      info = response.parsed_body["user"]
+      expect(info["risk_state"]).to include(
+        "status" => "Suspended",
+        "suspended" => true,
+        "compliant" => false,
+        "last_status_changed_at" => comment.created_at.as_json
+      )
+    end
+
+    it "reflects two-factor authentication when enabled" do
+      user = create(:compliant_user, email: "tfa@example.com")
+      user.update!(two_factor_authentication_enabled: true)
+
+      post :info, params: { email: user.email }
+
+      expect(response.parsed_body["user"]["two_factor_authentication_enabled"]).to be(true)
+    end
+
+    it "surfaces the country from the alive user compliance info" do
+      user = create(:compliant_user, email: "geo@example.com")
+      create(:user_compliance_info, user:, country: "Germany")
+
+      post :info, params: { email: user.email }
+
+      expect(response.parsed_body["user"]["country"]).to eq("Germany")
+    end
+
+    it "reports admin-paused payouts with the latest pause comment as the reason" do
+      user = create(:compliant_user, email: "paused@example.com")
+      user.update!(payouts_paused_internally: true, payouts_paused_by: GUMROAD_ADMIN_ID)
+      user.comments.create!(author_id: GUMROAD_ADMIN_ID, comment_type: Comment::COMMENT_TYPE_PAYOUTS_PAUSED, content: "Manual review pending")
+
+      post :info, params: { email: user.email }
+
+      expect(response.parsed_body["user"]["payouts"]).to include(
+        "paused_internally" => true,
+        "paused_by_source" => User::PAYOUT_PAUSE_SOURCE_ADMIN,
+        "paused_for_reason" => "Manual review pending"
+      )
+    end
+
+    it "reports system-paused payouts without exposing a paused_for_reason" do
+      user = create(:compliant_user, email: "syspaused@example.com")
+      user.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_SYSTEM)
+
+      post :info, params: { email: user.email }
+
+      expect(response.parsed_body["user"]["payouts"]).to include(
+        "paused_internally" => true,
+        "paused_by_source" => User::PAYOUT_PAUSE_SOURCE_SYSTEM,
+        "paused_for_reason" => nil
+      )
+    end
+
+    it "reports paused_by_user when the seller has self-paused via Settings" do
+      user = create(:compliant_user, email: "selfpaused@example.com")
+      user.update!(payouts_paused_by_user: true)
+
+      post :info, params: { email: user.email }
+
+      expect(response.parsed_body["user"]["payouts"]).to include(
+        "paused_internally" => false,
+        "paused_by_user" => true,
+        "paused_by_source" => User::PAYOUT_PAUSE_SOURCE_USER
+      )
+    end
+
+    it "computes sales_count and total_earnings_formatted from the seller's successful sales" do
+      seller = create(:compliant_user, email: "earner@example.com")
+      product = create(:product, user: seller)
+      create(:free_purchase, link: product, seller:)
+      create(:free_purchase, link: product, seller:)
+      create(:failed_purchase, link: product, seller:)
+      allow_any_instance_of(User).to receive(:sales_cents_total).and_return(1500)
+
+      post :info, params: { email: seller.email }
+
+      stats = response.parsed_body["user"]["stats"]
+      expect(stats["sales_count"]).to eq(2)
+      expect(stats["total_earnings_formatted"]).to eq("$15.00")
+    end
+  end
+
   describe "POST suspension" do
     include_examples "admin api authorization required", :post, :suspension
 

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -143,6 +143,33 @@ describe Api::Internal::Admin::UsersController do
       )
     end
 
+    it "surfaces a deactivated user with a populated deleted_at" do
+      user = create(:compliant_user, email: "deactivated@example.com")
+      user.deactivate!
+
+      post :info, params: { email: user.email }
+
+      expect(response).to have_http_status(:ok)
+      info = response.parsed_body["user"]
+      expect(info["id"]).to eq(user.external_id)
+      expect(info["deleted_at"]).to eq(user.reload.deleted_at.as_json)
+    end
+
+    it "uses the latest risk-state comment for last_status_changed_at, including on_probation transitions" do
+      user = create(:compliant_user, email: "probation@example.com")
+      create(:comment, commentable: user, comment_type: Comment::COMMENT_TYPE_COMPLIANT, created_at: 1.month.ago)
+      probation_comment = create(:comment, commentable: user, comment_type: Comment::COMMENT_TYPE_ON_PROBATION, created_at: 1.day.ago)
+      user.update_column(:user_risk_state, "on_probation")
+
+      post :info, params: { email: user.email }
+
+      expect(response.parsed_body["user"]["risk_state"]).to include(
+        "user_risk_state" => "on_probation",
+        "on_probation" => true,
+        "last_status_changed_at" => probation_comment.created_at.as_json
+      )
+    end
+
     it "computes sales_count and total_earnings_formatted from the seller's successful sales" do
       seller = create(:compliant_user, email: "earner@example.com")
       product = create(:product, user: seller)


### PR DESCRIPTION
Part of #4677

## What

Adds `POST /api/internal/admin/users/info` — the missing server-side endpoint for the upcoming `gumroad-cli` Phase 2 `gumroad admin users info <email>` command.

The CLI command was listed in PR 8 of the rollout plan, but PR 7 ([#4900](https://github.com/antiwork/gumroad/pull/4900)) — which shipped the rest of the Phase 2 server-side endpoints — didn't include it. This is the gap fix.

Body: `{ \"email\": \"seller@example.com\" }`. Auth via the existing `Api::Internal::Admin::BaseController#authorize_admin_token!`.

Response payload (nested by section so it has room to grow without flattening):

- **Identity**: `id`, `email`, `name`, `username`, `profile_url`, `country`, `created_at`, `deleted_at`.
- **Risk state**: `status` (Compliant / Flagged / Suspended), `user_risk_state`, suspended/flagged/on_probation/compliant flags, `last_status_changed_at`.
- **2FA**: `two_factor_authentication_enabled`.
- **Payouts**: `paused_internally`, `paused_by_user`, `paused_by_source` (admin / stripe / system / user / null), `paused_for_reason`, `next_payout_date`, `balance_for_next_payout`.
- **Stats**: `sales_count`, `total_earnings_formatted`, `unpaid_balance_formatted`, `comments_count`.

Extracted the suspension-status + last-status-comment lookup that was inlined in the existing `suspension` action into a private `last_status_changed_at(user)` helper so `info` and `suspension` share it.

## Why

A support agent triaging a user via the CLI today has to call `users/suspension`, `payouts/list`, and read admin web for stats — three round-trips. PR 8's `users info` command needs a single endpoint that mirrors the admin web user-detail page so the CLI can be self-contained.

The endpoint follows the same thin-controller / reuse-existing-logic pattern as the rest of `/internal/admin`:

- No new presenter or serializer class — a private `serialize_user_info(user)` helper, consistent with `serialize_purchase` / `serialize_payout` in `base_controller.rb`.
- All field sources reuse existing accessors: `User#payouts_paused_by_source`, `User#payouts_paused_for_reason`, `alive_user_compliance_info`, `sales_cents_total`.
- POST with email in JSON body, never in URL — matches the security rule from PR 5/7.
- Read-only endpoint — no side effects, no audit comment.

This PR was implemented with AI assistance using Claude Opus 4.7.