### PR TITLE
Remove retries from Test Fast CI step

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -240,31 +240,27 @@ jobs:
           WEB_REPO: gumroadteam/web
 
       - name: Run tests
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 15
-          max_attempts: 2
-          retry_wait_seconds: 10
-          command: |
-            docker run --rm --entrypoint="" --network ${{ env.COMPOSE_PROJECT_NAME }}_default \
-              -e RUBY_YJIT_ENABLE \
-              -e KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC \
-              -e KNAPSACK_PRO_CI_NODE_TOTAL \
-              -e KNAPSACK_PRO_CI_NODE_INDEX \
-              -e KNAPSACK_PRO_LOG_LEVEL \
-              -e KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES \
-              -e KNAPSACK_PRO_TEST_FILE_PATTERN \
-              -e KNAPSACK_PRO_TEST_FILE_EXCLUDE_PATTERN \
-              -e KNAPSACK_PRO_COMMIT_HASH \
-              -e KNAPSACK_PRO_BRANCH \
-              -e KNAPSACK_PRO_CI_NODE_BUILD_ID \
-              -e KNAPSACK_PRO_CI_NODE_RETRY_COUNT \
-              -e KNAPSACK_PRO_PROJECT_DIR \
-              -e KNAPSACK_PRO_FIXED_QUEUE_SPLIT \
-              -e CI \
-              -e IN_DOCKER \
-              $WEB_REPO:${{ needs.build.outputs.test_image_tag }} \
-              /usr/local/bin/gosu app bundle exec rake "knapsack_pro:queue:rspec[--format RSpec::Github::Formatter --tag ~skip --format progress]"
+        timeout-minutes: 15
+        run: |
+          docker run --rm --entrypoint="" --network ${{ env.COMPOSE_PROJECT_NAME }}_default \
+            -e RUBY_YJIT_ENABLE \
+            -e KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC \
+            -e KNAPSACK_PRO_CI_NODE_TOTAL \
+            -e KNAPSACK_PRO_CI_NODE_INDEX \
+            -e KNAPSACK_PRO_LOG_LEVEL \
+            -e KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES \
+            -e KNAPSACK_PRO_TEST_FILE_PATTERN \
+            -e KNAPSACK_PRO_TEST_FILE_EXCLUDE_PATTERN \
+            -e KNAPSACK_PRO_COMMIT_HASH \
+            -e KNAPSACK_PRO_BRANCH \
+            -e KNAPSACK_PRO_CI_NODE_BUILD_ID \
+            -e KNAPSACK_PRO_CI_NODE_RETRY_COUNT \
+            -e KNAPSACK_PRO_PROJECT_DIR \
+            -e KNAPSACK_PRO_FIXED_QUEUE_SPLIT \
+            -e CI \
+            -e IN_DOCKER \
+            $WEB_REPO:${{ needs.build.outputs.test_image_tag }} \
+            /usr/local/bin/gosu app bundle exec rake "knapsack_pro:queue:rspec[--format RSpec::Github::Formatter --tag ~skip --format progress]"
         env:
           RUBY_YJIT_ENABLE: 1
           KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC_FAST }}


### PR DESCRIPTION
Removes the `nick-fields/retry` wrapper (max_attempts: 2) from the Test Fast run step. Flaky tests should be fixed, not retried.

Infra steps (Docker login, service startup, DB prep) keep their retries since those are legitimate transient failures.