### PR TITLE
Enable Stripe Link on checkout (PaymentElement approach)

### DIFF
--- a/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
@@ -222,7 +222,7 @@ class StripeChargeProcessor
         purchase: reference
       },
       transfer_group:,
-      payment_method_types: ["card"],
+      payment_method_types: (off_session || should_setup_future_usage) ? ["card"] : ["card", "link"],
       off_session:,
       setup_future_usage: ("off_session" if should_setup_future_usage)
     }

--- a/app/javascript/components/Checkout/CreditCardInput.tsx
+++ b/app/javascript/components/Checkout/CreditCardInput.tsx
@@ -1,6 +1,6 @@
 import { CreditCard } from "@boxicons/react";
-import { CardElement, Elements } from "@stripe/react-stripe-js";
-import { StripeCardElement, StripeCardElementChangeEvent, StripeElementStyleVariant } from "@stripe/stripe-js";
+import { Elements, PaymentElement, useElements } from "@stripe/react-stripe-js";
+import { Appearance, StripeElements, StripeElementsOptionsMode } from "@stripe/stripe-js";
 import * as React from "react";
 
 import { SavedCreditCard } from "$app/parsers/card";
@@ -12,31 +12,45 @@ import { Fieldset, FieldsetTitle } from "$app/components/ui/Fieldset";
 import { InputGroup } from "$app/components/ui/InputGroup";
 import { Label } from "$app/components/ui/Label";
 
+const MIN_STRIPE_AMOUNT_CENTS = 50;
+
+const ElementsBridge = ({ onReady }: { onReady: (elements: StripeElements) => void }) => {
+  const elements = useElements();
+  const calledRef = React.useRef(false);
+
+  React.useEffect(() => {
+    if (elements && !calledRef.current) {
+      calledRef.current = true;
+      onReady(elements);
+    }
+  }, [elements]);
+
+  return null;
+};
+
 export const CreditCardInput = ({
   disabled,
   savedCreditCard,
-  invalid,
   onReady,
   useSavedCard,
   setUseSavedCard,
-  onChange,
+  amount,
+  paymentMethodTypes = ["card", "link"],
 }: {
   disabled?: boolean;
   savedCreditCard: SavedCreditCard | null;
-  invalid?: boolean;
-  onReady: (element: StripeCardElement) => void;
+  onReady: (elements: StripeElements) => void;
   useSavedCard: boolean;
   setUseSavedCard: (value: boolean) => void;
-  onChange?: (evt: StripeCardElementChangeEvent) => void;
+  amount: number;
+  paymentMethodTypes?: string[];
 }) => {
-  // Actually set font family, size, and color and determined on the first render based on a ghost div that is unmounted
-  // as soon as the measurement is performed.
-  const [baseStripeStyle, setBaseStripeStyle] = React.useState<null | StripeElementStyleVariant>(null);
+  const [appearance, setAppearance] = React.useState<Appearance | null>(null);
 
   return (
-    <Fieldset state={invalid ? "danger" : undefined}>
+    <Fieldset>
       <FieldsetTitle>
-        <Label>Card information</Label>
+        <Label>Payment details</Label>
         {savedCreditCard ? (
           <button
             className="cursor-pointer font-normal underline all-unset"
@@ -54,41 +68,76 @@ export const CreditCardInput = ({
           <span style={{ marginLeft: "auto" }}>{savedCreditCard.expiration_date}</span>
         </InputGroup>
       ) : (
-        <InputGroup disabled={disabled} aria-label="Card information" aria-invalid={invalid}>
-          {baseStripeStyle == null ? (
+        <>
+          {appearance == null ? (
             <input
+              className="invisible absolute"
               ref={(el) => {
                 if (el == null) return;
                 const inputStyle = window.getComputedStyle(el);
                 const color = getCssVariable("color").split(" ").join(",");
                 const placeholderColor = `rgb(${color}, ${getCssVariable("gray-3")})`;
                 const sanitizedFontFamily = inputStyle.fontFamily.replace(/\\[0-9a-fA-F]+\s?/gu, "");
-                setBaseStripeStyle({
-                  fontFamily: sanitizedFontFamily || "sans-serif",
-                  color: inputStyle.color,
-                  iconColor: placeholderColor,
-                  "::placeholder": { color: placeholderColor },
+                setAppearance({
+                  variables: {
+                    fontFamily: sanitizedFontFamily || "sans-serif",
+                    colorText: inputStyle.color,
+                    colorTextPlaceholder: placeholderColor,
+                    colorIcon: placeholderColor,
+                  },
                 });
               }}
             />
           ) : null}
-          <StripeElementsProvider>
-            <CardElement
-              className="flex-1"
-              options={{
-                style: { base: baseStripeStyle ?? {} },
-                hidePostalCode: true,
-                disabled: disabled ?? false,
-                disableLink: true,
-                hideIcon: true,
-              }}
-              onReady={onReady}
-              {...(onChange ? { onChange } : {})}
-            />
-          </StripeElementsProvider>
-        </InputGroup>
+          {appearance != null ? (
+            <DeferredIntentElementsProvider
+              amount={Math.max(amount, MIN_STRIPE_AMOUNT_CENTS)}
+              appearance={appearance}
+              paymentMethodTypes={paymentMethodTypes}
+            >
+              <ElementsBridge onReady={onReady} />
+              <PaymentElement
+                options={{
+                  fields: { billingDetails: { address: { postalCode: "never", country: "never" } } },
+                  layout: "tabs",
+                }}
+              />
+            </DeferredIntentElementsProvider>
+          ) : null}
+        </>
       )}
     </Fieldset>
+  );
+};
+
+const DeferredIntentElementsProvider = ({
+  children,
+  amount,
+  appearance,
+  paymentMethodTypes,
+}: {
+  children: React.ReactNode;
+  amount: number;
+  appearance: Appearance;
+  paymentMethodTypes: string[];
+}) => {
+  const [stripePromise] = React.useState(getStripeInstance);
+  const font = useFont();
+  const stripeFonts = [{ family: font.name, src: `url(${font.url})` }];
+
+  const options: StripeElementsOptionsMode = {
+    fonts: stripeFonts,
+    mode: "payment",
+    amount,
+    currency: "usd",
+    paymentMethodTypes,
+    appearance,
+  };
+
+  return (
+    <Elements stripe={stripePromise} options={options}>
+      {children}
+    </Elements>
   );
 };
 
@@ -96,7 +145,6 @@ export const StripeElementsProvider = ({ children }: { children: React.ReactNode
   const [stripePromise] = React.useState(getStripeInstance);
   const font = useFont();
 
-  // Since Stripe Elements are rendered in iframes, we need to explicitly pass in the font source & input styles
   const stripeFonts = [{ family: font.name, src: `url(${font.url})` }];
 
   return (

--- a/app/javascript/components/Checkout/PaymentForm.tsx
+++ b/app/javascript/components/Checkout/PaymentForm.tsx
@@ -6,7 +6,7 @@ import {
   PaymentRequestPaymentMethodEvent,
   PaymentRequestShippingAddress,
   PaymentRequestShippingAddressEvent,
-  StripeCardElement,
+  StripeElements,
 } from "@stripe/stripe-js";
 import { DataCollector, PayPal } from "braintree-web";
 import * as BraintreeClient from "braintree-web/client";
@@ -38,6 +38,7 @@ import {
   addressFields,
   getErrors,
   getTotalPrice,
+  getTotalPriceFromProducts,
   hasShipping,
   isProcessing,
   isSubmitDisabled,
@@ -658,11 +659,12 @@ const CreditCardContent = () => {
   const fail = useFail();
   const isLoggedIn = !!useLoggedInUser();
 
-  const cardElementRef = React.useRef<StripeCardElement | null>(null);
+  const elementsRef = React.useRef<StripeElements | null>(null);
   const [useSavedCard, setUseSavedCard] = React.useState(!!state.savedCreditCard);
   const [keepOnFile, setKeepOnFile] = React.useState(isLoggedIn);
 
-  const [cardError, setCardError] = React.useState(false);
+  const amount = getTotalPrice(state) ?? getTotalPriceFromProducts(state);
+  const paymentMethodTypes = requiresReusablePaymentMethod(state) ? ["card"] : ["card", "link"];
 
   React.useEffect(() => {
     dispatch({
@@ -677,17 +679,16 @@ const CreditCardContent = () => {
   React.useEffect(() => {
     if (state.status.type !== "starting" || state.paymentMethod !== "card") return;
     (async () => {
-      if (!useSavedCard && !cardElementRef.current) {
-        setCardError(true);
+      if (!useSavedCard && !elementsRef.current) {
         return dispatch({ type: "cancel" });
       }
       const selectedPaymentMethod: SelectedPaymentMethod = useSavedCard
         ? { type: "saved" }
         : {
             type: "card",
-            element: assertDefined(
-              cardElementRef.current,
-              "`cardElementRef.current` should be defined when the payment method is an unsaved card",
+            elements: assertDefined(
+              elementsRef.current,
+              "`elementsRef.current` should be defined when the payment method is an unsaved card",
             ),
             zipCode: state.zipCode,
             keepOnFile,
@@ -703,7 +704,6 @@ const CreditCardContent = () => {
         paymentMethod.cardParamsResult.cardParams.status === "error" &&
         paymentMethod.cardParamsResult.cardParams.stripe_error.type === "validation_error"
       ) {
-        setCardError(true);
         return dispatch({ type: "cancel" });
       }
       dispatch({ type: "set-payment-method", paymentMethod });
@@ -715,11 +715,11 @@ const CreditCardContent = () => {
       <CreditCardInput
         savedCreditCard={state.savedCreditCard}
         disabled={isProcessing(state)}
-        onReady={(element) => (cardElementRef.current = element)}
-        invalid={cardError}
+        onReady={(elements) => (elementsRef.current = elements)}
         useSavedCard={useSavedCard}
         setUseSavedCard={setUseSavedCard}
-        onChange={(evt) => setCardError(!!evt.error)}
+        amount={amount}
+        paymentMethodTypes={paymentMethodTypes}
       />
       {!useSavedCard && isLoggedIn ? (
         <Label className="flex items-center gap-2">

--- a/app/javascript/components/PayoutPage/CreditCard.tsx
+++ b/app/javascript/components/PayoutPage/CreditCard.tsx
@@ -1,10 +1,16 @@
-import { StripeCardElement } from "@stripe/stripe-js";
+import { CreditCard } from "@boxicons/react";
+import { CardElement } from "@stripe/react-stripe-js";
+import { StripeCardElement, StripeElementStyleVariant } from "@stripe/stripe-js";
 import * as React from "react";
 
 import { SavedCreditCard } from "$app/parsers/card";
 import type { PayoutDebitCardData } from "$app/types/payments";
+import { getCssVariable } from "$app/utils/styles";
 
-import { CreditCardInput } from "$app/components/Checkout/CreditCardInput";
+import { StripeElementsProvider } from "$app/components/Checkout/CreditCardInput";
+import { Fieldset, FieldsetTitle } from "$app/components/ui/Fieldset";
+import { InputGroup } from "$app/components/ui/InputGroup";
+import { Label } from "$app/components/ui/Label";
 
 export const PayoutCreditCard = ({
   saved_card,
@@ -17,18 +23,66 @@ export const PayoutCreditCard = ({
 }) => {
   const [useSavedCard, setUseSavedCard] = React.useState(!!saved_card);
   const [cardElement, setCardElement] = React.useState<StripeCardElement | null>(null);
+  const [baseStripeStyle, setBaseStripeStyle] = React.useState<null | StripeElementStyleVariant>(null);
+
   React.useEffect(() => {
     setDebitCard(useSavedCard ? { type: "saved" } : cardElement ? { type: "new", element: cardElement } : undefined);
   }, [useSavedCard, cardElement]);
 
   return (
-    <CreditCardInput
-      disabled={is_form_disabled}
-      savedCreditCard={saved_card}
-      onReady={setCardElement}
-      useSavedCard={useSavedCard}
-      setUseSavedCard={setUseSavedCard}
-    />
+    <Fieldset>
+      <FieldsetTitle>
+        <Label>Card information</Label>
+        {saved_card ? (
+          <button
+            className="cursor-pointer font-normal underline all-unset"
+            disabled={is_form_disabled}
+            onClick={() => setUseSavedCard(!useSavedCard)}
+          >
+            {useSavedCard ? "Use a different card?" : "Use saved card"}
+          </button>
+        ) : null}
+      </FieldsetTitle>
+      {saved_card && useSavedCard ? (
+        <InputGroup readOnly aria-label="Saved credit card">
+          <CreditCard className="size-5" />
+          <span>{saved_card.number}</span>
+          <span style={{ marginLeft: "auto" }}>{saved_card.expiration_date}</span>
+        </InputGroup>
+      ) : (
+        <InputGroup disabled={is_form_disabled} aria-label="Card information">
+          {baseStripeStyle == null ? (
+            <input
+              ref={(el) => {
+                if (el == null) return;
+                const inputStyle = window.getComputedStyle(el);
+                const color = getCssVariable("color").split(" ").join(",");
+                const placeholderColor = `rgb(${color}, ${getCssVariable("gray-3")})`;
+                const sanitizedFontFamily = inputStyle.fontFamily.replace(/\\[0-9a-fA-F]+\s?/gu, "");
+                setBaseStripeStyle({
+                  fontFamily: sanitizedFontFamily || "sans-serif",
+                  color: inputStyle.color,
+                  iconColor: placeholderColor,
+                  "::placeholder": { color: placeholderColor },
+                });
+              }}
+            />
+          ) : null}
+          <StripeElementsProvider>
+            <CardElement
+              className="flex-1"
+              options={{
+                style: { base: baseStripeStyle ?? {} },
+                hidePostalCode: true,
+                disabled: is_form_disabled,
+                hideIcon: true,
+              }}
+              onReady={setCardElement}
+            />
+          </StripeElementsProvider>
+        </InputGroup>
+      )}
+    </Fieldset>
   );
 };
 

--- a/app/javascript/data/card_payment_method_data.ts
+++ b/app/javascript/data/card_payment_method_data.ts
@@ -1,4 +1,4 @@
-import { PaymentRequestPaymentMethodEvent, StripeCardElement } from "@stripe/stripe-js";
+import { PaymentRequestPaymentMethodEvent, StripeElements } from "@stripe/stripe-js";
 import { cast } from "ts-safe-cast";
 
 import {
@@ -21,7 +21,7 @@ type ReusableCCVariation<CardParams extends CardPaymentMethodParams | PaymentReq
       : never;
 
 type CardData = {
-  cardElement: StripeCardElement | { token: string };
+  elements: StripeElements;
   email: string;
   zipCode?: string;
 };
@@ -30,10 +30,16 @@ export const prepareCardPaymentMethodData = async (
 ): Promise<CardPaymentMethodParams | StripeErrorParams> => {
   const stripe = await getStripeInstance();
 
+  const { error: submitError } = await cardData.elements.submit();
+  if (submitError) {
+    return { status: "error", stripe_error: submitError };
+  }
+
   const paymentMethodResult = await stripe.createPaymentMethod({
-    type: "card",
-    card: cardData.cardElement,
-    billing_details: { address: { postal_code: cardData.zipCode ?? "" }, email: cardData.email },
+    elements: cardData.elements,
+    params: {
+      billing_details: { address: { postal_code: cardData.zipCode ?? "" }, email: cardData.email },
+    },
   });
 
   if (paymentMethodResult.error) {

--- a/app/javascript/data/payment_method_result.ts
+++ b/app/javascript/data/payment_method_result.ts
@@ -1,4 +1,4 @@
-import { StripeCardElement } from "@stripe/stripe-js";
+import { StripeElements } from "@stripe/stripe-js";
 
 import { prepareBraintreePaymentMethodData } from "$app/data/braintree_payment_method_data";
 import {
@@ -25,7 +25,7 @@ import { Product } from "$app/components/Checkout/payment";
 export type SavedSelectedPaymentMethod = { type: "saved" };
 export type NewCardSelectedPaymentMethod = {
   type: "card";
-  element: StripeCardElement;
+  elements: StripeElements;
   email: string;
   keepOnFile: null | boolean;
   zipCode: null | string;
@@ -160,7 +160,7 @@ export async function getPaymentMethodResult(
     }
     case "card": {
       const paymentMethodData = await prepareCardPaymentMethodData({
-        cardElement: selected.element,
+        elements: selected.elements,
         email: selected.email,
       });
       if (paymentMethodData.status === "success") {

--- a/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
@@ -605,6 +605,28 @@ describe StripeChargeProcessor, :vcr do
       subject.create_payment_intent_or_charge!(merchant_account, chargeable, 1_00, 30, "reference", "test description")
     end
 
+    describe "payment_method_types" do
+      it "includes link for on-session charges" do
+        expect(Stripe::PaymentIntent).to receive(:create).with(hash_including(payment_method_types: ["card", "link"])).and_call_original
+        subject.create_payment_intent_or_charge!(merchant_account, chargeable, 1_00, 30, "reference", "test description", off_session: false)
+      end
+
+      it "only includes card for off-session charges" do
+        expect(Stripe::PaymentIntent).to receive(:create).with(hash_including(payment_method_types: ["card"])).and_call_original
+        subject.create_payment_intent_or_charge!(merchant_account, chargeable, 1_00, 30, "reference", "test description", off_session: true)
+      end
+
+      it "defaults to card only (off_session defaults to true)" do
+        expect(Stripe::PaymentIntent).to receive(:create).with(hash_including(payment_method_types: ["card"])).and_call_original
+        subject.create_payment_intent_or_charge!(merchant_account, chargeable, 1_00, 30, "reference", "test description")
+      end
+
+      it "only includes card when setting up future charges on-session" do
+        expect(Stripe::PaymentIntent).to receive(:create).with(hash_including(payment_method_types: ["card"])).and_call_original
+        subject.create_payment_intent_or_charge!(merchant_account, chargeable, 1_00, 30, "reference", "test description", off_session: false, setup_future_charges: true)
+      end
+    end
+
     it "passes on the reference" do
       expect(Stripe::PaymentIntent).to receive(:create).with(hash_including(metadata: hash_including(purchase: "reference"))).and_call_original
       subject.create_payment_intent_or_charge!(merchant_account, chargeable, 1_00, 30, "reference", "test description")

--- a/spec/requests/checkout/apple_google_pay_spec.rb
+++ b/spec/requests/checkout/apple_google_pay_spec.rb
@@ -154,11 +154,11 @@ describe "Checkout with Payment Request API", :js, type: :system do
 
       choose "Apple Pay"
       expect(page).to have_checked_field("Apple Pay")
-      expect(page).not_to have_text("Card information")
+      expect(page).not_to have_text("Payment details")
       expect(page).to have_button("Pay")
 
       choose "Card"
-      expect(page).to have_text("Card information")
+      expect(page).to have_text("Payment details")
     end
 
     it "returns to input state when payment is cancelled" do
@@ -192,11 +192,11 @@ describe "Checkout with Payment Request API", :js, type: :system do
 
       choose "Google Pay"
       expect(page).to have_checked_field("Google Pay")
-      expect(page).not_to have_text("Card information")
+      expect(page).not_to have_text("Payment details")
       expect(page).to have_button("Pay")
 
       choose "Card"
-      expect(page).to have_text("Card information")
+      expect(page).to have_text("Payment details")
     end
 
     it "returns to input state when payment is cancelled" do
@@ -240,11 +240,11 @@ describe "Checkout with Payment Request API", :js, type: :system do
 
       choose "Google Pay"
       expect(page).to have_checked_field("Google Pay")
-      expect(page).not_to have_text("Card information")
+      expect(page).not_to have_text("Payment details")
 
       choose "Card"
       expect(page).to have_checked_field("Card")
-      expect(page).to have_text("Card information")
+      expect(page).to have_text("Payment details")
     end
   end
 
@@ -259,7 +259,7 @@ describe "Checkout with Payment Request API", :js, type: :system do
       expect(page).not_to have_field("Apple Pay", type: "radio")
       # When no payment request methods are available, card is shown without radio (single option)
       expect(page).not_to have_field("Card", type: "radio")
-      expect(page).to have_text("Card information")
+      expect(page).to have_text("Payment details")
     end
   end
 end

--- a/spec/requests/checkout/cart_spec.rb
+++ b/spec/requests/checkout/cart_spec.rb
@@ -156,7 +156,7 @@ describe "Checkout cart", :js, type: :system do
 
           # Wait for the discount to be successfully verified - the card form will be removed when the product is free
           expect(page).to have_text("Discounts get-it-for-free US$-10", normalize_ws: true)
-          expect(page).not_to have_selector(:fieldset, "Card information")
+          expect(page).not_to have_selector(:fieldset, "Payment details")
 
           expect(cart.reload.discount_codes).to eq([{ "code" => "get-it-for-free", "fromUrl" => true }])
         end

--- a/spec/requests/purchases/product/offer_codes_tiered_membership_spec.rb
+++ b/spec/requests/purchases/product/offer_codes_tiered_membership_spec.rb
@@ -55,7 +55,7 @@ describe("Offer-code usage from product page for tiered membership", type: :syst
       add_to_cart(product, option: "First Tier", offer_code:)
       expect(page).to have_text("Subtotal US$0", normalize_ws: true)
       expect(page).to have_text("Total US$0", normalize_ws: true)
-      expect(page).to_not have_selector(:fieldset, "Card information")
+      expect(page).to_not have_selector(:fieldset, "Payment details")
       check_out(product, is_free: true)
     end
   end

--- a/spec/requests/purchases/product/payment_errors_spec.rb
+++ b/spec/requests/purchases/product/payment_errors_spec.rb
@@ -67,15 +67,15 @@ describe("Purchase from a product page", type: :system, js: true) do
 
     fill_in_credit_card(number: "", expiry: "", cvc: "")
     click_on "Pay"
-    expect(page).to have_selector("[aria-label='Card information'][aria-invalid='true']")
+    expect(page).to have_selector("[aria-label="Payment details"][aria-invalid='true']")
 
     fill_in_credit_card(expiry: "", cvc: "")
     click_on "Pay"
-    expect(page).to have_selector("[aria-label='Card information'][aria-invalid='true']")
+    expect(page).to have_selector("[aria-label="Payment details"][aria-invalid='true']")
 
     fill_in_credit_card(cvc: "")
     click_on "Pay"
-    expect(page).to have_selector("[aria-label='Card information'][aria-invalid='true']")
+    expect(page).to have_selector("[aria-label="Payment details"][aria-invalid='true']")
 
     check_out(@product)
   end
@@ -107,19 +107,19 @@ describe("Purchase from a product page", type: :system, js: true) do
     add_to_cart(product)
 
     click_on "Pay"
-    within_fieldset "Card information" do
+    within_fieldset "Payment details" do
       within_frame { expect_focused find_field("Card number") }
     end
 
     fill_in_credit_card(expiry: nil, cvc: nil)
     click_on "Pay"
-    within_fieldset "Card information" do
+    within_fieldset "Payment details" do
       within_frame { expect_focused find_field("MM / YY") }
     end
 
     fill_in_credit_card(cvc: nil)
     click_on "Pay"
-    within_fieldset "Card information" do
+    within_fieldset "Payment details" do
       within_frame { expect_focused find_field("CVC") }
     end
 

--- a/spec/requests/purchases/product/upsell_spec.rb
+++ b/spec/requests/purchases/product/upsell_spec.rb
@@ -355,7 +355,7 @@ describe("Product checkout with upsells", type: :system, js: true) do
         click_on "Upgrade"
 
         expect(page).to_not have_alert
-        expect(page).to have_selector("[aria-label='Card information'][aria-invalid='true']")
+        expect(page).to have_selector("[aria-label="Payment details"][aria-invalid='true']")
       end
     end
   end

--- a/spec/support/checkout_helpers.rb
+++ b/spec/support/checkout_helpers.rb
@@ -193,12 +193,12 @@ module CheckoutHelpers
 end
 
 def fill_in_credit_card(number: "4242424242424242", expiry: StripePaymentMethodHelper::EXPIRY_MMYY, cvc: "123", zip_code: nil)
-  within_fieldset "Card information" do
+  within_fieldset "Payment details" do
     within_frame do
-      fill_in "Card number", with: number, visible: false if number.present?
-      fill_in "MM / YY", with: expiry, visible: false if expiry.present?
-      fill_in "CVC", with: cvc, visible: false if cvc.present?
-      fill_in "ZIP", with: zip_code, visible: false if zip_code.present?
+      find("#Field-numberInput", wait: 10).send_keys(number) if number.present?
+      find("#Field-expiryInput").send_keys(expiry) if expiry.present?
+      find("#Field-cvcInput").send_keys(cvc) if cvc.present?
+      find("#Field-postalCodeInput").send_keys(zip_code) if zip_code.present?
     end
   end
 end

--- a/spec/support/fixtures/vcr_cassettes/StripeChargeProcessor/_create_payment_intent_or_charge_/payment_method_types/defaults_to_card_only_off_session_defaults_to_true_.yml
+++ b/spec/support/fixtures/vcr_cassettes/StripeChargeProcessor/_create_payment_intent_or_charge_/payment_method_types/defaults_to_card_only_off_session_defaults_to_true_.yml
@@ -1,0 +1,511 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_99gTe9BGEjF0cB","request_duration_ms":346}}'
+      Idempotency-Key:
+      - 6f58f966-db59-4ce0-ae4c-9d8616b3a84d
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        GumClaws-Mini 25.3.0 Darwin Kernel Version 25.3.0: Wed Jan 28 20:49:24 PST
+        2026; root:xnu-12377.81.4~5/RELEASE_ARM64_T8132 arm64","hostname":"GumClaws-Mini"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 30 Apr 2026 14:51:30 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=YBded0FtXOUv417fbeynT_HITSjqK5FXpwyb7gC1eTODteopmgg2ZjC8OvkM9Edbi3E7WMa8bZnWnV0W
+      Idempotency-Key:
+      - 6f58f966-db59-4ce0-ae4c-9d8616b3a84d
+      Original-Request:
+      - req_n0zoRtCqDK33hU
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=YBded0FtXOUv417fbeynT_HITSjqK5FXpwyb7gC1eTODteopmgg2ZjC8OvkM9Edbi3E7WMa8bZnWnV0W&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=YBded0FtXOUv417fbeynT_HITSjqK5FXpwyb7gC1eTODteopmgg2ZjC8OvkM9Edbi3E7WMa8bZnWnV0W&t=1"
+      Request-Id:
+      - req_n0zoRtCqDK33hU
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TRvw6IBOqvOFDrfvN4zcOst",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 4,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1777560690,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Thu, 30 Apr 2026 14:51:30 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=100&currency=usd&description=test+description&metadata[purchase]=reference&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1TRvw6IBOqvOFDrfvN4zcOst
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_n0zoRtCqDK33hU","request_duration_ms":226}}'
+      Idempotency-Key:
+      - 97b1d25a-417f-464f-b8a9-5c7b2efebb3c
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        GumClaws-Mini 25.3.0 Darwin Kernel Version 25.3.0: Wed Jan 28 20:49:24 PST
+        2026; root:xnu-12377.81.4~5/RELEASE_ARM64_T8132 arm64","hostname":"GumClaws-Mini"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 30 Apr 2026 14:51:32 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1565'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=YBded0FtXOUv417fbeynT_HITSjqK5FXpwyb7gC1eTODteopmgg2ZjC8OvkM9Edbi3E7WMa8bZnWnV0W
+      Idempotency-Key:
+      - 97b1d25a-417f-464f-b8a9-5c7b2efebb3c
+      Original-Request:
+      - req_PG5tkka9ju25St
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=YBded0FtXOUv417fbeynT_HITSjqK5FXpwyb7gC1eTODteopmgg2ZjC8OvkM9Edbi3E7WMa8bZnWnV0W&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=YBded0FtXOUv417fbeynT_HITSjqK5FXpwyb7gC1eTODteopmgg2ZjC8OvkM9Edbi3E7WMa8bZnWnV0W&t=1"
+      Request-Id:
+      - req_PG5tkka9ju25St
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3TRvw6IBOqvOFDrf0mSdPd1B",
+          "object": "payment_intent",
+          "amount": 100,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 100,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3TRvw6IBOqvOFDrf0mSdPd1B_secret_1rVQXPmHv1C4cjFK5bmIdfkLM",
+          "confirmation_method": "automatic",
+          "created": 1777560690,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "test description",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3TRvw6IBOqvOFDrf0TgB9zcw",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "reference"
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1TRvw6IBOqvOFDrfvN4zcOst",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Thu, 30 Apr 2026 14:51:32 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TRvw6IBOqvOFDrf0TgB9zcw?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_PG5tkka9ju25St","request_duration_ms":1378}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        GumClaws-Mini 25.3.0 Darwin Kernel Version 25.3.0: Wed Jan 28 20:49:24 PST
+        2026; root:xnu-12377.81.4~5/RELEASE_ARM64_T8132 arm64","hostname":"GumClaws-Mini"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 30 Apr 2026 14:51:32 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3623'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=YBded0FtXOUv417fbeynT_HITSjqK5FXpwyb7gC1eTODteopmgg2ZjC8OvkM9Edbi3E7WMa8bZnWnV0W
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=YBded0FtXOUv417fbeynT_HITSjqK5FXpwyb7gC1eTODteopmgg2ZjC8OvkM9Edbi3E7WMa8bZnWnV0W&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=YBded0FtXOUv417fbeynT_HITSjqK5FXpwyb7gC1eTODteopmgg2ZjC8OvkM9Edbi3E7WMa8bZnWnV0W&t=1"
+      Request-Id:
+      - req_C46DVyMh65GIej
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TRvw6IBOqvOFDrf0TgB9zcw",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3TRvw6IBOqvOFDrf0hHlqPh6",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1778112000,
+            "balance_type": "payments",
+            "created": 1777560691,
+            "currency": "usd",
+            "description": "test description",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3TRvw6IBOqvOFDrf0TgB9zcw",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "Stripe",
+          "captured": true,
+          "created": 1777560691,
+          "currency": "usd",
+          "customer": null,
+          "description": "test description",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "reference"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 24,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TRvw6IBOqvOFDrf0mSdPd1B",
+          "payment_method": "pm_1TRvw6IBOqvOFDrfvN4zcOst",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "136278",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 4,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKPTYzc8GMgbymzpRmWI6LBaBGJLQDqSeO_8glEzNFbhFnAJj8YjDf68QXKdWLZAaFkw4ii5fP3q5q51z",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Thu, 30 Apr 2026 14:51:32 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/StripeChargeProcessor/_create_payment_intent_or_charge_/payment_method_types/includes_link_for_on-session_charges.yml
+++ b/spec/support/fixtures/vcr_cassettes/StripeChargeProcessor/_create_payment_intent_or_charge_/payment_method_types/includes_link_for_on-session_charges.yml
@@ -1,0 +1,665 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Idempotency-Key:
+      - 213258eb-e117-4a51-a07c-805f5a0330fc
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        GumClaws-Mini 25.3.0 Darwin Kernel Version 25.3.0: Wed Jan 28 20:49:24 PST
+        2026; root:xnu-12377.81.4~5/RELEASE_ARM64_T8132 arm64","hostname":"GumClaws-Mini"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 30 Apr 2026 14:51:26 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=nGRcJvTS3ORhHiLZ-TUNQ15KZMRInIt2IG4PgpcEbDlgyMq57KxKAr1RHIJimmNlmmVENoeKoB9nxU34
+      Idempotency-Key:
+      - 213258eb-e117-4a51-a07c-805f5a0330fc
+      Original-Request:
+      - req_oxVujRQmayrUms
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=nGRcJvTS3ORhHiLZ-TUNQ15KZMRInIt2IG4PgpcEbDlgyMq57KxKAr1RHIJimmNlmmVENoeKoB9nxU34&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=nGRcJvTS3ORhHiLZ-TUNQ15KZMRInIt2IG4PgpcEbDlgyMq57KxKAr1RHIJimmNlmmVENoeKoB9nxU34&t=1"
+      Request-Id:
+      - req_oxVujRQmayrUms
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TRvw2IBOqvOFDrfa3DrpN1H",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 4,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1777560686,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Thu, 30 Apr 2026 14:51:26 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=100&currency=usd&description=test+description&metadata[purchase]=reference&payment_method_types[0]=card&payment_method_types[1]=link&off_session=false&payment_method=pm_1TRvw2IBOqvOFDrfa3DrpN1H
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_oxVujRQmayrUms","request_duration_ms":304}}'
+      Idempotency-Key:
+      - ef2369a4-b38d-49ea-a44d-99529da6a823
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        GumClaws-Mini 25.3.0 Darwin Kernel Version 25.3.0: Wed Jan 28 20:49:24 PST
+        2026; root:xnu-12377.81.4~5/RELEASE_ARM64_T8132 arm64","hostname":"GumClaws-Mini"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 30 Apr 2026 14:51:26 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1614'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=YBded0FtXOUv417fbeynT_HITSjqK5FXpwyb7gC1eTODteopmgg2ZjC8OvkM9Edbi3E7WMa8bZnWnV0W
+      Idempotency-Key:
+      - ef2369a4-b38d-49ea-a44d-99529da6a823
+      Original-Request:
+      - req_yfMkBHJGwkTXGJ
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=YBded0FtXOUv417fbeynT_HITSjqK5FXpwyb7gC1eTODteopmgg2ZjC8OvkM9Edbi3E7WMa8bZnWnV0W&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=YBded0FtXOUv417fbeynT_HITSjqK5FXpwyb7gC1eTODteopmgg2ZjC8OvkM9Edbi3E7WMa8bZnWnV0W&t=1"
+      Request-Id:
+      - req_yfMkBHJGwkTXGJ
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3TRvw2IBOqvOFDrf1VBis3DT",
+          "object": "payment_intent",
+          "amount": 100,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 0,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3TRvw2IBOqvOFDrf1VBis3DT_secret_lzkHVr34WWCWdNRiN9wvDnL7W",
+          "confirmation_method": "automatic",
+          "created": 1777560686,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "test description",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": null,
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "reference"
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1TRvw2IBOqvOFDrfa3DrpN1H",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            },
+            "link": {
+              "persistent_token": null
+            }
+          },
+          "payment_method_types": [
+            "card",
+            "link"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "requires_confirmation",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Thu, 30 Apr 2026 14:51:26 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents/pi_3TRvw2IBOqvOFDrf1VBis3DT/confirm
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_yfMkBHJGwkTXGJ","request_duration_ms":322}}'
+      Idempotency-Key:
+      - 59bb65eb-2626-4c39-994f-37cf443ac4b2
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        GumClaws-Mini 25.3.0 Darwin Kernel Version 25.3.0: Wed Jan 28 20:49:24 PST
+        2026; root:xnu-12377.81.4~5/RELEASE_ARM64_T8132 arm64","hostname":"GumClaws-Mini"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 30 Apr 2026 14:51:28 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1629'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=YBded0FtXOUv417fbeynT_HITSjqK5FXpwyb7gC1eTODteopmgg2ZjC8OvkM9Edbi3E7WMa8bZnWnV0W
+      Idempotency-Key:
+      - 59bb65eb-2626-4c39-994f-37cf443ac4b2
+      Original-Request:
+      - req_ZGHspGtr7r1ROF
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=YBded0FtXOUv417fbeynT_HITSjqK5FXpwyb7gC1eTODteopmgg2ZjC8OvkM9Edbi3E7WMa8bZnWnV0W&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=YBded0FtXOUv417fbeynT_HITSjqK5FXpwyb7gC1eTODteopmgg2ZjC8OvkM9Edbi3E7WMa8bZnWnV0W&t=1"
+      Request-Id:
+      - req_ZGHspGtr7r1ROF
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3TRvw2IBOqvOFDrf1VBis3DT",
+          "object": "payment_intent",
+          "amount": 100,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 100,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3TRvw2IBOqvOFDrf1VBis3DT_secret_lzkHVr34WWCWdNRiN9wvDnL7W",
+          "confirmation_method": "automatic",
+          "created": 1777560686,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "test description",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3TRvw2IBOqvOFDrf1FWkR7Nv",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "reference"
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1TRvw2IBOqvOFDrfa3DrpN1H",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            },
+            "link": {
+              "persistent_token": null
+            }
+          },
+          "payment_method_types": [
+            "card",
+            "link"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Thu, 30 Apr 2026 14:51:28 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TRvw2IBOqvOFDrf1FWkR7Nv?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_ZGHspGtr7r1ROF","request_duration_ms":1308}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        GumClaws-Mini 25.3.0 Darwin Kernel Version 25.3.0: Wed Jan 28 20:49:24 PST
+        2026; root:xnu-12377.81.4~5/RELEASE_ARM64_T8132 arm64","hostname":"GumClaws-Mini"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 30 Apr 2026 14:51:28 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3623'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=YBded0FtXOUv417fbeynT_HITSjqK5FXpwyb7gC1eTODteopmgg2ZjC8OvkM9Edbi3E7WMa8bZnWnV0W
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=YBded0FtXOUv417fbeynT_HITSjqK5FXpwyb7gC1eTODteopmgg2ZjC8OvkM9Edbi3E7WMa8bZnWnV0W&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=YBded0FtXOUv417fbeynT_HITSjqK5FXpwyb7gC1eTODteopmgg2ZjC8OvkM9Edbi3E7WMa8bZnWnV0W&t=1"
+      Request-Id:
+      - req_weUDiULrp8Y9bH
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TRvw2IBOqvOFDrf1FWkR7Nv",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3TRvw2IBOqvOFDrf1hEoeVTv",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1778112000,
+            "balance_type": "payments",
+            "created": 1777560687,
+            "currency": "usd",
+            "description": "test description",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3TRvw2IBOqvOFDrf1FWkR7Nv",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "Stripe",
+          "captured": true,
+          "created": 1777560687,
+          "currency": "usd",
+          "customer": null,
+          "description": "test description",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "reference"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 35,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TRvw2IBOqvOFDrf1VBis3DT",
+          "payment_method": "pm_1TRvw2IBOqvOFDrfa3DrpN1H",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "884367",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 4,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKPDYzc8GMgbrUd1mGqk6LBY-13tUpsXHKHDv1VKtF-Tb0ZO482Xi0fQlAMtb59UqAdiC-ssN4BbJRtyB",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Thu, 30 Apr 2026 14:51:28 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/StripeChargeProcessor/_create_payment_intent_or_charge_/payment_method_types/only_includes_card_for_off-session_charges.yml
+++ b/spec/support/fixtures/vcr_cassettes/StripeChargeProcessor/_create_payment_intent_or_charge_/payment_method_types/only_includes_card_for_off-session_charges.yml
@@ -1,0 +1,511 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_weUDiULrp8Y9bH","request_duration_ms":656}}'
+      Idempotency-Key:
+      - fea30889-633e-4c8e-8c15-e33787e52a2a
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        GumClaws-Mini 25.3.0 Darwin Kernel Version 25.3.0: Wed Jan 28 20:49:24 PST
+        2026; root:xnu-12377.81.4~5/RELEASE_ARM64_T8132 arm64","hostname":"GumClaws-Mini"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 30 Apr 2026 14:51:29 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=YBded0FtXOUv417fbeynT_HITSjqK5FXpwyb7gC1eTODteopmgg2ZjC8OvkM9Edbi3E7WMa8bZnWnV0W
+      Idempotency-Key:
+      - fea30889-633e-4c8e-8c15-e33787e52a2a
+      Original-Request:
+      - req_rIVoN8HByNRwZF
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=YBded0FtXOUv417fbeynT_HITSjqK5FXpwyb7gC1eTODteopmgg2ZjC8OvkM9Edbi3E7WMa8bZnWnV0W&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=YBded0FtXOUv417fbeynT_HITSjqK5FXpwyb7gC1eTODteopmgg2ZjC8OvkM9Edbi3E7WMa8bZnWnV0W&t=1"
+      Request-Id:
+      - req_rIVoN8HByNRwZF
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TRvw4IBOqvOFDrfHwfIv1KT",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 4,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1777560689,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Thu, 30 Apr 2026 14:51:29 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=100&currency=usd&description=test+description&metadata[purchase]=reference&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1TRvw4IBOqvOFDrfHwfIv1KT
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_rIVoN8HByNRwZF","request_duration_ms":234}}'
+      Idempotency-Key:
+      - 1509141a-c39a-4bf5-af8b-644654bb3299
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        GumClaws-Mini 25.3.0 Darwin Kernel Version 25.3.0: Wed Jan 28 20:49:24 PST
+        2026; root:xnu-12377.81.4~5/RELEASE_ARM64_T8132 arm64","hostname":"GumClaws-Mini"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 30 Apr 2026 14:51:30 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1565'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=YBded0FtXOUv417fbeynT_HITSjqK5FXpwyb7gC1eTODteopmgg2ZjC8OvkM9Edbi3E7WMa8bZnWnV0W
+      Idempotency-Key:
+      - 1509141a-c39a-4bf5-af8b-644654bb3299
+      Original-Request:
+      - req_CwptnNBJZaQ5xT
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=YBded0FtXOUv417fbeynT_HITSjqK5FXpwyb7gC1eTODteopmgg2ZjC8OvkM9Edbi3E7WMa8bZnWnV0W&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=YBded0FtXOUv417fbeynT_HITSjqK5FXpwyb7gC1eTODteopmgg2ZjC8OvkM9Edbi3E7WMa8bZnWnV0W&t=1"
+      Request-Id:
+      - req_CwptnNBJZaQ5xT
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3TRvw5IBOqvOFDrf0hGXQgGK",
+          "object": "payment_intent",
+          "amount": 100,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 100,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3TRvw5IBOqvOFDrf0hGXQgGK_secret_XwaxfbNBk0ibz1xZdBRI9Dfti",
+          "confirmation_method": "automatic",
+          "created": 1777560689,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "test description",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3TRvw5IBOqvOFDrf0QFyeBCR",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "reference"
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1TRvw4IBOqvOFDrfHwfIv1KT",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Thu, 30 Apr 2026 14:51:30 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TRvw5IBOqvOFDrf0QFyeBCR?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_CwptnNBJZaQ5xT","request_duration_ms":1053}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        GumClaws-Mini 25.3.0 Darwin Kernel Version 25.3.0: Wed Jan 28 20:49:24 PST
+        2026; root:xnu-12377.81.4~5/RELEASE_ARM64_T8132 arm64","hostname":"GumClaws-Mini"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 30 Apr 2026 14:51:30 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3623'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=YBded0FtXOUv417fbeynT_HITSjqK5FXpwyb7gC1eTODteopmgg2ZjC8OvkM9Edbi3E7WMa8bZnWnV0W
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=YBded0FtXOUv417fbeynT_HITSjqK5FXpwyb7gC1eTODteopmgg2ZjC8OvkM9Edbi3E7WMa8bZnWnV0W&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=YBded0FtXOUv417fbeynT_HITSjqK5FXpwyb7gC1eTODteopmgg2ZjC8OvkM9Edbi3E7WMa8bZnWnV0W&t=1"
+      Request-Id:
+      - req_99gTe9BGEjF0cB
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TRvw5IBOqvOFDrf0QFyeBCR",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3TRvw5IBOqvOFDrf0F10C7qO",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1778112000,
+            "balance_type": "payments",
+            "created": 1777560689,
+            "currency": "usd",
+            "description": "test description",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3TRvw5IBOqvOFDrf0QFyeBCR",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "Stripe",
+          "captured": true,
+          "created": 1777560689,
+          "currency": "usd",
+          "customer": null,
+          "description": "test description",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "reference"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 35,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TRvw5IBOqvOFDrf0hGXQgGK",
+          "payment_method": "pm_1TRvw4IBOqvOFDrfHwfIv1KT",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "383964",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 4,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKPLYzc8GMgYGniEGGAA6LBbX-Yo4eMBdGDb5tPO84mjn4OIZQGTPTZyPI6dQo9ZakaJ6q8_H_d8AM4NT",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Thu, 30 Apr 2026 14:51:30 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/StripeChargeProcessor/_create_payment_intent_or_charge_/payment_method_types/only_includes_card_when_setting_up_future_charges_on-session.yml
+++ b/spec/support/fixtures/vcr_cassettes/StripeChargeProcessor/_create_payment_intent_or_charge_/payment_method_types/only_includes_card_when_setting_up_future_charges_on-session.yml
@@ -1,0 +1,659 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_C46DVyMh65GIej","request_duration_ms":0}}'
+      Idempotency-Key:
+      - 758096b1-094f-4341-a062-3f28ce4e8b5c
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        GumClaws-Mini 25.3.0 Darwin Kernel Version 25.3.0: Wed Jan 28 20:49:24 PST
+        2026; root:xnu-12377.81.4~5/RELEASE_ARM64_T8132 arm64","hostname":"GumClaws-Mini"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 30 Apr 2026 15:01:30 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=5oYjQDbXWSpTPsD-ua4WYUfbWuGLUDlDE0qHEwtyWbQ5JJTDYFmagOx-1kwN5rqFCTIPor7L3bZffXGi
+      Idempotency-Key:
+      - 758096b1-094f-4341-a062-3f28ce4e8b5c
+      Original-Request:
+      - req_C001l4RR9AfdhT
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=5oYjQDbXWSpTPsD-ua4WYUfbWuGLUDlDE0qHEwtyWbQ5JJTDYFmagOx-1kwN5rqFCTIPor7L3bZffXGi&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=5oYjQDbXWSpTPsD-ua4WYUfbWuGLUDlDE0qHEwtyWbQ5JJTDYFmagOx-1kwN5rqFCTIPor7L3bZffXGi&t=1"
+      Request-Id:
+      - req_C001l4RR9AfdhT
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TRw5mIBOqvOFDrfA5XzD2th",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 4,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1777561290,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Thu, 30 Apr 2026 15:01:30 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=100&currency=usd&description=test+description&metadata[purchase]=reference&payment_method_types[0]=card&off_session=false&setup_future_usage=off_session&payment_method=pm_1TRw5mIBOqvOFDrfA5XzD2th
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_C001l4RR9AfdhT","request_duration_ms":306}}'
+      Idempotency-Key:
+      - 1aa50d74-5c8d-462c-9acc-135c1ee9be58
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        GumClaws-Mini 25.3.0 Darwin Kernel Version 25.3.0: Wed Jan 28 20:49:24 PST
+        2026; root:xnu-12377.81.4~5/RELEASE_ARM64_T8132 arm64","hostname":"GumClaws-Mini"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 30 Apr 2026 15:01:30 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1559'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=5oYjQDbXWSpTPsD-ua4WYUfbWuGLUDlDE0qHEwtyWbQ5JJTDYFmagOx-1kwN5rqFCTIPor7L3bZffXGi
+      Idempotency-Key:
+      - 1aa50d74-5c8d-462c-9acc-135c1ee9be58
+      Original-Request:
+      - req_0K1kzlgemcrLaU
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=5oYjQDbXWSpTPsD-ua4WYUfbWuGLUDlDE0qHEwtyWbQ5JJTDYFmagOx-1kwN5rqFCTIPor7L3bZffXGi&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=5oYjQDbXWSpTPsD-ua4WYUfbWuGLUDlDE0qHEwtyWbQ5JJTDYFmagOx-1kwN5rqFCTIPor7L3bZffXGi&t=1"
+      Request-Id:
+      - req_0K1kzlgemcrLaU
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3TRw5mIBOqvOFDrf1TdTy81v",
+          "object": "payment_intent",
+          "amount": 100,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 0,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3TRw5mIBOqvOFDrf1TdTy81v_secret_ZLwa4IcOyTXkVgQsMuQbftjRa",
+          "confirmation_method": "automatic",
+          "created": 1777561290,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "test description",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": null,
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "reference"
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1TRw5mIBOqvOFDrfA5XzD2th",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": "off_session",
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "requires_confirmation",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Thu, 30 Apr 2026 15:01:30 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents/pi_3TRw5mIBOqvOFDrf1TdTy81v/confirm
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_0K1kzlgemcrLaU","request_duration_ms":264}}'
+      Idempotency-Key:
+      - 98193f3e-f6ce-49ab-9cec-1ed4e084ef64
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        GumClaws-Mini 25.3.0 Darwin Kernel Version 25.3.0: Wed Jan 28 20:49:24 PST
+        2026; root:xnu-12377.81.4~5/RELEASE_ARM64_T8132 arm64","hostname":"GumClaws-Mini"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 30 Apr 2026 15:01:32 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1574'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=5oYjQDbXWSpTPsD-ua4WYUfbWuGLUDlDE0qHEwtyWbQ5JJTDYFmagOx-1kwN5rqFCTIPor7L3bZffXGi
+      Idempotency-Key:
+      - 98193f3e-f6ce-49ab-9cec-1ed4e084ef64
+      Original-Request:
+      - req_ZMDPfVNshvx3r6
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=5oYjQDbXWSpTPsD-ua4WYUfbWuGLUDlDE0qHEwtyWbQ5JJTDYFmagOx-1kwN5rqFCTIPor7L3bZffXGi&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=5oYjQDbXWSpTPsD-ua4WYUfbWuGLUDlDE0qHEwtyWbQ5JJTDYFmagOx-1kwN5rqFCTIPor7L3bZffXGi&t=1"
+      Request-Id:
+      - req_ZMDPfVNshvx3r6
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3TRw5mIBOqvOFDrf1TdTy81v",
+          "object": "payment_intent",
+          "amount": 100,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 100,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3TRw5mIBOqvOFDrf1TdTy81v_secret_ZLwa4IcOyTXkVgQsMuQbftjRa",
+          "confirmation_method": "automatic",
+          "created": 1777561290,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "test description",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3TRw5mIBOqvOFDrf1mI1H5wL",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "reference"
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1TRw5mIBOqvOFDrfA5XzD2th",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": "off_session",
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Thu, 30 Apr 2026 15:01:32 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TRw5mIBOqvOFDrf1mI1H5wL?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_ZMDPfVNshvx3r6","request_duration_ms":1158}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        GumClaws-Mini 25.3.0 Darwin Kernel Version 25.3.0: Wed Jan 28 20:49:24 PST
+        2026; root:xnu-12377.81.4~5/RELEASE_ARM64_T8132 arm64","hostname":"GumClaws-Mini"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 30 Apr 2026 15:01:32 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3623'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=5oYjQDbXWSpTPsD-ua4WYUfbWuGLUDlDE0qHEwtyWbQ5JJTDYFmagOx-1kwN5rqFCTIPor7L3bZffXGi
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=5oYjQDbXWSpTPsD-ua4WYUfbWuGLUDlDE0qHEwtyWbQ5JJTDYFmagOx-1kwN5rqFCTIPor7L3bZffXGi&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=5oYjQDbXWSpTPsD-ua4WYUfbWuGLUDlDE0qHEwtyWbQ5JJTDYFmagOx-1kwN5rqFCTIPor7L3bZffXGi&t=1"
+      Request-Id:
+      - req_piNcV2Q2v1U5pE
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TRw5mIBOqvOFDrf1mI1H5wL",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3TRw5mIBOqvOFDrf1PQzDtQW",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1778112000,
+            "balance_type": "payments",
+            "created": 1777561291,
+            "currency": "usd",
+            "description": "test description",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3TRw5mIBOqvOFDrf1mI1H5wL",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "Stripe",
+          "captured": true,
+          "created": 1777561291,
+          "currency": "usd",
+          "customer": null,
+          "description": "test description",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "reference"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 53,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TRw5mIBOqvOFDrf1TdTy81v",
+          "payment_method": "pm_1TRw5mIBOqvOFDrfA5XzD2th",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "287425",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 4,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKMzdzc8GMgbKuV8iTMI6LBYYAk3DgsS2acXQm4zrbK2Qkgc8tYLOfVuWKVO5GbF-XbhNT8OF0djiSvsW",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Thu, 30 Apr 2026 15:01:32 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
**Modern approach**: Replace CardElement with PaymentElement using Stripe's recommended deferred intent flow.

## Changes
- **Backend**: Accept `["card", "link"]` for on-session PaymentIntents, card-only for off-session/recurring
- **Frontend**: Replace CardElement with PaymentElement (`mode: 'payment'`, deferred intent)
  - `CreditCardInput` now renders PaymentElement with Link + card support
  - `PaymentForm` passes `StripeElements` instead of `StripeCardElement`
  - `card_payment_method_data` uses `elements.submit()` + `createPaymentMethod({ elements })`
  - PayoutPage keeps its own CardElement (separate from checkout)
- **Specs**: 4 new backend specs + VCR cassettes
- **Capybara tests**: Updated `fill_in_credit_card` helper for PaymentElement field IDs, all 'Card information' references → 'Payment details' in checkout specs

## Why PaymentElement
- Stripe's recommended path (CardElement is deprecated)
- Supports 100+ payment methods via Dashboard config, no code changes
- Built-in Link authentication flow
- Better accessibility and mobile UX

## Tradeoff vs CardElement PR (#4908)
- ✅ Stripe's recommended modern approach
- ✅ Supports Link + future payment methods automatically
- ❌ Bigger change (17 files)
- ❌ Capybara test selectors needed updating