### PR TITLE
Fix unhandled Link::LinkInvalid when price exceeds maximum on product create

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -81,8 +81,10 @@ class LinksController < ApplicationController
       if ai_generated
         generate_product_details_using_ai
       end
-    rescue ActiveRecord::RecordNotSaved, ActiveRecord::RecordInvalid, Link::LinkInvalid
-      return redirect_to new_product_path, alert: @product.errors.to_hash.transform_values(&:to_sentence).first, inertia: inertia_errors(@product)
+    rescue ActiveRecord::RecordNotSaved, ActiveRecord::RecordInvalid, Link::LinkInvalid => e
+      alert = @product&.errors&.to_hash&.transform_values(&:to_sentence)&.first || e.message
+      inertia = @product ? inertia_errors(@product) : { errors: {} }
+      return redirect_to new_product_path, alert:, inertia:
     end
 
     create_user_event("add_product")

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -57,25 +57,25 @@ class LinksController < ApplicationController
       params[:link][:quantity_enabled] = true
     end
 
-    @product = current_seller.links.build(link_params)
-
-    @product.price_range = params[:link][:price_range]
-
-    @product.save_custom_summary(params[:link][:custom_summary]) if params[:link][:custom_summary].present?
-    @product.draft = true
-    @product.purchase_disabled_at = Time.current
-    @product.require_shipping = true if @product.is_physical
-    @product.display_product_reviews = true
-    @product.is_tiered_membership = @product.is_recurring_billing
-    @product.should_show_all_posts = @product.is_tiered_membership
-    @product.set_template_properties_if_needed
-    @product.taxonomy = Taxonomy.find_by(slug: "other")
-    @product.is_bundle = @product.native_type == Link::NATIVE_TYPE_BUNDLE
-    @product.json_data[:custom_button_text_option] = "donate_prompt" if @product.native_type == Link::NATIVE_TYPE_COFFEE
-
-    ai_generated = params[:link][:ai_prompt].present? && Feature.active?(:ai_product_generation, current_seller)
-
     begin
+      @product = current_seller.links.build(link_params)
+
+      @product.price_range = params[:link][:price_range]
+
+      @product.save_custom_summary(params[:link][:custom_summary]) if params[:link][:custom_summary].present?
+      @product.draft = true
+      @product.purchase_disabled_at = Time.current
+      @product.require_shipping = true if @product.is_physical
+      @product.display_product_reviews = true
+      @product.is_tiered_membership = @product.is_recurring_billing
+      @product.should_show_all_posts = @product.is_tiered_membership
+      @product.set_template_properties_if_needed
+      @product.taxonomy = Taxonomy.find_by(slug: "other")
+      @product.is_bundle = @product.native_type == Link::NATIVE_TYPE_BUNDLE
+      @product.json_data[:custom_button_text_option] = "donate_prompt" if @product.native_type == Link::NATIVE_TYPE_COFFEE
+
+      ai_generated = params[:link][:ai_prompt].present? && Feature.active?(:ai_product_generation, current_seller)
+
       @product.save!
 
       if ai_generated

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -2922,7 +2922,7 @@ describe LinksController, :vcr, inertia: true do
         params = { price_cents: 0, name: "test link", price_range: "99999999999+" }
         post :create, params: { link: params }
         expect(response).to redirect_to(new_product_path)
-        expect(flash[:alert]).to include("price")
+        expect(flash[:alert]).to include("price entered is too large")
       end
 
       it "ignores is_in_preorder_state param" do

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -2918,6 +2918,13 @@ describe LinksController, :vcr, inertia: true do
         expect(link.display_product_reviews).to be(true)
       end
 
+      it "redirects with an error when price_range exceeds MAX_PRICE_CENTS" do
+        params = { price_cents: 0, name: "test link", price_range: "99999999999+" }
+        post :create, params: { link: params }
+        expect(response).to redirect_to(new_product_path)
+        expect(flash[:alert]).to include("price")
+      end
+
       it "ignores is_in_preorder_state param" do
         params = { price_cents: 100, name: "preorder", is_in_preorder_state: true, release_at: 1.year.from_now.iso8601 }
         post :create, params: { link: params }


### PR DESCRIPTION
## Problem

`Link::LinkInvalid: Sorry, the price entered is too large.` was hitting Sentry as an unhandled exception in `LinksController#create`.

**Sentry:** https://gumroad-to.sentry.io/issues/7452782475/
**Occurrences:** 1 (first seen 2026-04-30)
**Estimated users affected:** Low volume, but causes a 500 error instead of a user-friendly message.

## Root Cause

In `LinksController#create`, the `begin/rescue` block only wrapped `@product.save!`, but `Link::LinkInvalid` can also be raised earlier during:
- `current_seller.links.build(link_params)` — mass assignment calls `price_cents=`
- `@product.price_range = params[:link][:price_range]` — also calls `price_cents=`

Both of these happen before the `begin`, so the exception bubbled up uncaught.

## Fix

Moved the `begin` to wrap all attribute assignments that can raise `Link::LinkInvalid`, so the user sees a flash error and redirect instead of a 500.

## Test

Added a test confirming that creating a product with a price exceeding `MAX_PRICE_CENTS` redirects with an error flash instead of raising.