### PR TITLE
Fix unhandled ActiveRecord::RecordInvalid in ProfileSectionsController#update

### DIFF
--- a/app/controllers/profile_sections_controller.rb
+++ b/app/controllers/profile_sections_controller.rb
@@ -15,6 +15,8 @@ class ProfileSectionsController < ApplicationController
     render json: { id: section.external_id }
   rescue ActiveRecord::SubclassNotFound
     render json: { error: "Invalid section type" }, status: :unprocessable_entity
+  rescue ActiveRecord::RecordInvalid => e
+    render json: { error: e.record.errors.full_messages.to_sentence }, status: :unprocessable_entity
   end
 
   def update
@@ -29,6 +31,8 @@ class ProfileSectionsController < ApplicationController
     unless section.update(attributes)
       render json: { error: section.errors.full_messages.to_sentence }, status: :unprocessable_entity
     end
+  rescue ActiveRecord::RecordInvalid => e
+    render json: { error: e.record.errors.full_messages.to_sentence }, status: :unprocessable_entity
   end
 
   def destroy

--- a/spec/controllers/profile_sections_controller_spec.rb
+++ b/spec/controllers/profile_sections_controller_spec.rb
@@ -271,6 +271,22 @@ describe ProfileSectionsController do
         expect(new_upsell).to be_alive
         expect(new_upsell.product_id).to eq(product.id)
       end
+
+      it "returns a validation error when an upsell discount results in an invalid price" do
+        product.update!(price_cents: 150)
+        invalid_discount_text = {
+          "type" => "doc",
+          "content" => [
+            { "type" => "paragraph", "content" => [{ "text" => "hi", "type" => "text" }] },
+            { "type" => "upsellCard", "attrs" => { "discount" => { "type" => "fixed", "cents" => 100 }, "productId" => product.external_id } }
+          ]
+        }
+
+        patch :update, params: { id: section.external_id, text: invalid_discount_text }, as: :json
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.parsed_body["error"]).to include("price after discount")
+      end
     end
   end
 


### PR DESCRIPTION
## Problem

When a seller updates a profile section with rich text containing an upsell card whose discount results in an invalid price (e.g., a price after discount between $0.01 and $0.98), `SaveContentUpsellsService` raises `ActiveRecord::RecordInvalid` from the `OfferCode` validation. This exception was not handled, resulting in a 500 error.

Sentry: https://gumroad-to.sentry.io/issues/7452810179/

## Root Cause

`ProfileSectionsController#update` calls `SaveContentUpsellsService#from_rich_content`, which calls `Upsell.create!`. The `Upsell` model has `belongs_to :offer_code, autosave: true`, so the `OfferCode` validation runs during save. When the discount leaves the price in the invalid range (not $0 and not >= $0.99), the validation fails and `RecordInvalid` is raised unhandled.

## Fix

Rescue `ActiveRecord::RecordInvalid` in both the `create` and `update` actions and return the validation error message as a 422 response, consistent with how other validation errors are already handled in the controller.

## Test

Added a test that creates a product at $1.50 with a $1.00 fixed discount (leaving $0.50, which is invalid), confirming the controller returns a 422 with an appropriate error message instead of raising.