### PR TITLE
Fix Rack::Timeout in AnalyticsController#data_by_referral by clamping date range

### DIFF
--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -2,9 +2,11 @@
 
 class AnalyticsController < Sellers::BaseController
   MAX_BY_STATE_DATE_RANGE_DAYS = 365
+  MAX_BY_REFERRAL_DATE_RANGE_DAYS = 365
 
   before_action :set_time_range, only: %i[data_by_date data_by_state data_by_referral]
   before_action :clamp_date_range_for_by_state, only: :data_by_state
+  before_action :clamp_date_range_for_by_referral, only: :data_by_referral
 
   after_action :set_dashboard_preference_to_sales, only: :index
   before_action :check_payment_details, only: :index
@@ -70,6 +72,12 @@ class AnalyticsController < Sellers::BaseController
     def clamp_date_range_for_by_state
       if (@end_date - @start_date).to_i > MAX_BY_STATE_DATE_RANGE_DAYS
         @start_date = @end_date - MAX_BY_STATE_DATE_RANGE_DAYS.days
+      end
+    end
+
+    def clamp_date_range_for_by_referral
+      if (@end_date - @start_date).to_i > MAX_BY_REFERRAL_DATE_RANGE_DAYS
+        @start_date = @end_date - MAX_BY_REFERRAL_DATE_RANGE_DAYS.days
       end
     end
 

--- a/spec/controllers/analytics_controller_spec.rb
+++ b/spec/controllers/analytics_controller_spec.rb
@@ -145,6 +145,37 @@ describe AnalyticsController do
     end
   end
 
+  describe "GET data_by_referral" do
+    it_behaves_like "supports start and end times", :data_by_referral
+
+    it_behaves_like "authorize called for action", :get, :data_by_referral do
+      let(:record) { :analytics }
+      let(:policy_method) { :index? }
+    end
+
+    it "clamps the date range to #{AnalyticsController::MAX_BY_REFERRAL_DATE_RANGE_DAYS} days" do
+      start_time = "Mon Jan 01 2024 00:00:00 GMT-0000"
+      end_time = "Tue Dec 31 2025 00:00:00 GMT-0000"
+      expect_any_instance_of(CreatorAnalytics::CachingProxy).to receive(:data_for_dates).with(
+        Date.new(2025, 12, 31) - AnalyticsController::MAX_BY_REFERRAL_DATE_RANGE_DAYS.days,
+        Date.new(2025, 12, 31),
+        by: :referral
+      ).and_return({})
+      get :data_by_referral, params: { start_time:, end_time: }
+    end
+
+    it "does not clamp the date range when within the limit" do
+      start_time = "Mon Jun 01 2025 00:00:00 GMT-0000"
+      end_time = "Wed Jul 30 2025 00:00:00 GMT-0000"
+      expect_any_instance_of(CreatorAnalytics::CachingProxy).to receive(:data_for_dates).with(
+        Date.new(2025, 6, 1),
+        Date.new(2025, 7, 30),
+        by: :referral
+      ).and_return({})
+      get :data_by_referral, params: { start_time:, end_time: }
+    end
+  end
+
   describe "GET data_by_date" do
     before do
       @stats = { data: "data" }


### PR DESCRIPTION
## Problem

`AnalyticsController#data_by_referral` was hitting Rack::Timeout (120s) for large sellers. Unlike `data_by_state` which clamps the date range to 365 days, `data_by_referral` had no limit.

The referral endpoint runs composite aggregations on Elasticsearch with 3 dimensions (product × referrer × date). For sellers with many products and referrers, an unbounded date range creates an enormous bucket space that requires extensive pagination, easily exceeding the 120s timeout.

[Sentry issue](https://gumroad-to.sentry.io/issues/7453080631/)

## Fix

Add `MAX_BY_REFERRAL_DATE_RANGE_DAYS = 365` and a `before_action :clamp_date_range_for_by_referral` that mirrors the existing `data_by_state` pattern. When the requested date range exceeds 365 days, the start date is moved forward to keep the range within bounds.

## Tests

Added tests verifying:
- Date range is clamped when it exceeds the limit
- Date range is left alone when within the limit
- Authorization and time parsing shared examples