### PR TITLE
Fix Addressable::URI::InvalidURIError for malformed URL schemes in SafeRedirectPathService

### DIFF
--- a/app/services/safe_redirect_path_service.rb
+++ b/app/services/safe_redirect_path_service.rb
@@ -33,6 +33,8 @@ class SafeRedirectPathService
 
     def url
       @_url ||= URI.parse(Addressable::URI.escape(CGI.unescape(path).split("#").first))
+    rescue Addressable::URI::InvalidURIError, URI::InvalidURIError
+      @_url = URI.parse("/")
     end
 
     def domain

--- a/spec/services/safe_redirect_path_service_spec.rb
+++ b/spec/services/safe_redirect_path_service_spec.rb
@@ -91,6 +91,13 @@ describe "SafeRedirectPathService" do
       end
     end
 
+    context "when path has an invalid URI scheme" do
+      it "falls back to root path" do
+        @path = "https ://example.com/test"
+        expect(service.process).to eq "/"
+      end
+    end
+
     context "when path is nil" do
       it "raises TypeError" do
         @path = nil


### PR DESCRIPTION
## Problem

`SafeRedirectPathService#url` raises `Addressable::URI::InvalidURIError: Invalid scheme format: 'https '` when a malformed URL with a trailing space in the scheme (e.g. `https ://...`) is passed via the `next` parameter during login.

**Sentry:** https://gumroad-to.sentry.io/issues/7453262303/
**Events (7d):** 1
**Users affected:** 1

### Stacktrace
```
app/services/safe_redirect_path_service.rb:35 in url
app/services/safe_redirect_path_service.rb:31 in same_host?
app/services/safe_redirect_path_service.rb:11 in process
app/controllers/application_controller.rb:55 in safe_redirect_path
app/controllers/application_controller.rb:171 in after_sign_in_path_for
```

## Root Cause

`Addressable::URI.escape` internally parses the URI to identify components for encoding. When the scheme contains a trailing space (`'https '`), parsing fails with `InvalidURIError`.

## Fix

Rescue `Addressable::URI::InvalidURIError` and `URI::InvalidURIError` in `SafeRedirectPathService#url` and fall back to `URI.parse("/")`. This causes `process` to return `"/"` (root path), which is a safe default for malformed input.