### PR TITLE
Construct IBAN from SWIFT and account number for El Salvador payouts

### DIFF
--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -438,10 +438,16 @@ module StripeMerchantAccountManager
       if bank_account.is_a?(CardBankAccount)
         Stripe::Token.create({ customer: bank_account.credit_card.stripe_customer_id }, { stripe_account: stripe_account["id"] }).id
       else
+        account_number_for_stripe =
+          if bank_account.respond_to?(:stripe_account_number)
+            bank_account.stripe_account_number(passphrase)
+          else
+            bank_account.account_number.decrypt(passphrase).gsub(/[ -]/, "")
+          end
         bank_account_hash = {
           country: bank_account.country,
           currency: bank_account.currency,
-          account_number: bank_account.account_number.decrypt(passphrase).gsub(/[ -]/, "")
+          account_number: account_number_for_stripe
         }
         if bank_account.routing_number.present?
           routing_number = bank_account.routing_number

--- a/app/models/el_salvador_bank_account.rb
+++ b/app/models/el_salvador_bank_account.rb
@@ -4,8 +4,9 @@ class ElSalvadorBankAccount < BankAccount
   BANK_ACCOUNT_TYPE = "SV"
 
   BANK_CODE_FORMAT_REGEX = /^[a-zA-Z0-9]{8,11}$/
-  ACCOUNT_NUMBER_FORMAT_REGEX = /\A[0-9]{10,20}\z/
-  private_constant :BANK_CODE_FORMAT_REGEX, :ACCOUNT_NUMBER_FORMAT_REGEX
+  PLAIN_ACCOUNT_NUMBER_REGEX = /\A[0-9]{10,20}\z/
+  IBAN_FORMAT_REGEX = /\ASV[0-9]{2}[A-Z]{4}[0-9]{20}\z/
+  private_constant :BANK_CODE_FORMAT_REGEX, :PLAIN_ACCOUNT_NUMBER_REGEX, :IBAN_FORMAT_REGEX
 
   alias_attribute :bank_code, :bank_number
 
@@ -40,6 +41,21 @@ class ElSalvadorBankAccount < BankAccount
     }
   end
 
+  def stripe_account_number(passphrase)
+    raw = account_number.decrypt(passphrase).gsub(/[ -]/, "")
+    return raw if IBAN_FORMAT_REGEX.match?(raw)
+    self.class.build_iban(bank_code, raw)
+  end
+
+  def self.build_iban(swift, account)
+    bank_code = swift[0, 4].upcase
+    bban = "#{bank_code}#{account.rjust(20, "0")}"
+    rearranged = "#{bban}SV00"
+    numeric = rearranged.upcase.chars.map { |c| c.match?(/[A-Z]/) ? (c.ord - 55).to_s : c }.join
+    check_digits = (98 - (numeric.to_i % 97)).to_s.rjust(2, "0")
+    "SV#{check_digits}#{bban}"
+  end
+
   private
     def validate_bank_code
       return if BANK_CODE_FORMAT_REGEX.match?(bank_code)
@@ -47,7 +63,9 @@ class ElSalvadorBankAccount < BankAccount
     end
 
     def validate_account_number
-      return if ACCOUNT_NUMBER_FORMAT_REGEX.match?(account_number_decrypted)
+      decrypted = account_number_decrypted
+      return if PLAIN_ACCOUNT_NUMBER_REGEX.match?(decrypted)
+      return if IBAN_FORMAT_REGEX.match?(decrypted) && Ibandit::IBAN.new(decrypted).valid?
       errors.add :base, "The account number is invalid."
     end
 end

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -3067,7 +3067,7 @@ describe StripeMerchantAccountManager, :vcr do
           bank_account: {
             country: "SV",
             currency: "usd",
-            account_number: "12345678901234",
+            account_number: "SV44BCIE12345678901234567890",
             routing_number: "AAAASVS1XXX"
           },
           settings: {
@@ -3094,6 +3094,22 @@ describe StripeMerchantAccountManager, :vcr do
         expect(bank_account.reload.stripe_connect_account_id).to eq(merchant_account.charge_processor_merchant_id)
         expect(bank_account.reload.stripe_bank_account_id).to match(/ba_[a-zA-Z0-9]+/)
         expect(bank_account.reload.stripe_fingerprint).to match(/[a-zA-Z0-9]+/)
+      end
+
+      context "when the seller stored a plain account number instead of an IBAN" do
+        let(:bank_account) { create(:el_salvador_bank_account, user:, bank_number: "CAGRSVSS", account_number: "3280602160", account_number_last_four: "2160") }
+
+        it "constructs an IBAN from the SWIFT/BIC and account number before sending to Stripe" do
+          captured_params = nil
+          allow(Stripe::Account).to receive(:create) do |params|
+            captured_params = params
+            raise Stripe::APIError, "stop_here"
+          end
+
+          expect { subject.create_account(user, passphrase: "1234") }.to raise_error(Stripe::APIError, "stop_here")
+          expect(captured_params[:bank_account][:account_number]).to eq("SV88CAGR00000000003280602160")
+          expect(captured_params[:bank_account][:routing_number]).to eq("CAGRSVSS")
+        end
       end
     end
     describe "all info provided of a Chile individual" do

--- a/spec/factories/el_salvador_bank_accounts.rb
+++ b/spec/factories/el_salvador_bank_accounts.rb
@@ -4,8 +4,8 @@ FactoryBot.define do
   factory :el_salvador_bank_account do
     association :user
     bank_number { "AAAASVS1XXX" }
-    account_number { "12345678901234" }
-    account_number_last_four { "1234" }
+    account_number { "SV44BCIE12345678901234567890" }
+    account_number_last_four { "7890" }
     account_holder_full_name { "Chuck Bartowski" }
   end
 end

--- a/spec/models/el_salvador_bank_account_spec.rb
+++ b/spec/models/el_salvador_bank_account_spec.rb
@@ -31,7 +31,7 @@ describe ElSalvadorBankAccount do
 
   describe "#account_number_visual" do
     it "returns the visual account number" do
-      expect(create(:el_salvador_bank_account, account_number_last_four: "1234").account_number_visual).to eq("******1234")
+      expect(create(:el_salvador_bank_account, account_number_last_four: "7890").account_number_visual).to eq("******7890")
     end
   end
 
@@ -45,13 +45,52 @@ describe ElSalvadorBankAccount do
   end
 
   describe "#validate_account_number" do
-    it "allows only valid format" do
+    it "accepts plain account numbers (10-20 digits)" do
       expect(build(:el_salvador_bank_account, account_number: "1234567890")).to be_valid
       expect(build(:el_salvador_bank_account, account_number: "12345678901234567890")).to be_valid
+    end
+
+    it "accepts valid SV IBAN format (28 chars)" do
+      expect(build(:el_salvador_bank_account, account_number: "SV44BCIE12345678901234567890")).to be_valid
+      expect(build(:el_salvador_bank_account, account_number: "SV88CAGR00000000003280602160")).to be_valid
+    end
+
+    it "rejects invalid formats" do
       expect(build(:el_salvador_bank_account, account_number: "123456789")).not_to be_valid
       expect(build(:el_salvador_bank_account, account_number: "123456789012345678901")).not_to be_valid
       expect(build(:el_salvador_bank_account, account_number: "12345ABC90")).not_to be_valid
-      expect(build(:el_salvador_bank_account, account_number: "SV44BCIE12345678901234567890")).not_to be_valid
+      expect(build(:el_salvador_bank_account, account_number: "SV99BCIE12345678901234567890")).not_to be_valid
+    end
+  end
+
+  describe ".build_iban" do
+    it "constructs the IBAN from a SWIFT/BIC and a plain account number" do
+      expect(described_class.build_iban("CAGRSVSS", "3280602160")).to eq("SV88CAGR00000000003280602160")
+      expect(described_class.build_iban("BCIESVS1", "12345678901234567890")).to eq("SV44BCIE12345678901234567890")
+      expect(described_class.build_iban("AAAASVS1XXX", "12345678901234")).to eq("SV12AAAA00000012345678901234")
+    end
+
+    it "uppercases the bank code" do
+      expect(described_class.build_iban("cagrsvss", "3280602160")).to eq("SV88CAGR00000000003280602160")
+    end
+
+    it "produces an IBAN that passes Ibandit structural validation" do
+      iban = described_class.build_iban("CAGRSVSS", "3280602160")
+      expect(Ibandit::IBAN.new(iban).valid?).to be(true)
+    end
+  end
+
+  describe "#stripe_account_number" do
+    let(:passphrase) { GlobalConfig.get("STRONGBOX_GENERAL_PASSWORD") }
+
+    it "constructs an IBAN when a plain account number is stored" do
+      ba = create(:el_salvador_bank_account, account_number: "3280602160", bank_number: "CAGRSVSS", account_number_last_four: "2160")
+      expect(ba.stripe_account_number(passphrase)).to eq("SV88CAGR00000000003280602160")
+    end
+
+    it "passes through a stored IBAN unchanged" do
+      ba = create(:el_salvador_bank_account, account_number: "SV88CAGR00000000003280602160", bank_number: "CAGRSVSS", account_number_last_four: "2160")
+      expect(ba.stripe_account_number(passphrase)).to eq("SV88CAGR00000000003280602160")
     end
   end
 end

--- a/spec/support/fixtures/vcr_cassettes/StripeMerchantAccountManager/_create_account/all_info_provided_of_an_El_Salvador_individual/creates_an_account_at_stripe_with_all_the_params_and_returns_the_corresponding_merchant_account.yml
+++ b/spec/support/fixtures/vcr_cassettes/StripeMerchantAccountManager/_create_account/all_info_provided_of_an_El_Salvador_individual/creates_an_account_at_stripe_with_all_the_params_and_returns_the_corresponding_merchant_account.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.stripe.com/v1/accounts
     body:
       encoding: UTF-8
-      string: type=custom&requested_capabilities[0]=transfers&country=SV&default_currency=usd&metadata[user_id]=9423701199386&metadata[tos_agreement_id]=G_-mnBf9b1j9A7a4ub4nFQ%3D%3D&metadata[user_compliance_info_id]=G_-mnBf9b1j9A7a4ub4nFQ%3D%3D&metadata[bank_account_id]=G_-mnBf9b1j9A7a4ub4nFQ%3D%3D&tos_acceptance[date]=1427846400&tos_acceptance[ip]=54.234.242.13&tos_acceptance[service_agreement]=recipient&business_type=individual&business_profile[name]=Chuck+Bartowski&business_profile[url]=https%3A%2F%2Fvipul.gumroad.com%2F&business_profile[product_description]=Chuck+Bartowski&individual[first_name]=Chuck&individual[last_name]=Bartowski&individual[email]=chuck%40gum.com&individual[phone]=0000000000&individual[dob][day]=1&individual[dob][month]=1&individual[dob][year]=1901&individual[address][line1]=address_full_match&individual[address][city]=San+Salvador&individual[address][postal_code]=1101&individual[address][country]=SV&individual[id_number]=000000000&bank_account[country]=SV&bank_account[currency]=usd&bank_account[account_number]=12345678901234&bank_account[routing_number]=AAAASVS1XXX&settings[payouts][schedule][interval]=manual&settings[payouts][debit_negative_balances]=false
+      string: type=custom&requested_capabilities[0]=transfers&country=SV&default_currency=usd&metadata[user_id]=4879875581670&metadata[tos_agreement_id]=syHodx2a-2zKPbStWz-nfQ%3D%3D&metadata[user_compliance_info_id]=QCRTDCCsSE30wUXCUDHekw%3D%3D&metadata[bank_account_id]=cqeYfxgtTtDoPeb5y8MTpg%3D%3D&tos_acceptance[date]=1427846400&tos_acceptance[ip]=54.234.242.13&tos_acceptance[service_agreement]=recipient&business_type=individual&business_profile[name]=Chuck+Bartowski&business_profile[url]=https%3A%2F%2Fvipul.gumroad.com%2F&business_profile[product_description]=Chuck+Bartowski&individual[first_name]=Chuck&individual[last_name]=Bartowski&individual[email]=chuck%40gum.com&individual[phone]=0000000000&individual[dob][day]=1&individual[dob][month]=1&individual[dob][year]=1901&individual[address][line1]=address_full_match&individual[address][city]=San+Salvador&individual[address][postal_code]=1101&individual[address][country]=SV&individual[id_number]=000000000&bank_account[country]=SV&bank_account[currency]=usd&bank_account[account_number]=SV44BCIE<AWS_ACCOUNT_ID>34567890&bank_account[routing_number]=AAAASVS1XXX&settings[payouts][schedule][interval]=manual&settings[payouts][debit_negative_balances]=false
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/12.5.0
@@ -14,13 +14,13 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Idempotency-Key:
-      - c33d9b35-eec5-4949-9b7e-d5416ae216e3
+      - c41be5f3-3f06-4001-b153-4ddb09f3dcbb
       Stripe-Version:
-      - 2023-10-16; risk_in_requirements_beta=v1
+      - '2023-10-16'
       X-Stripe-Client-User-Agent:
-      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.3.4 p94 (2024-07-09)","platform":"arm64-darwin20","engine":"ruby","publisher":"stripe","uname":"Darwin
-        Harbakshs-MacBook-Air.local 20.5.0 Darwin Kernel Version 20.5.0: Sat May  8
-        05:10:31 PDT 2021; root:xnu-7195.121.3~9/RELEASE_ARM64_T8101 arm64","hostname":"Harbakshs-MacBook-Air.local"}'
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Is-MacBook-Air.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56
+        PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132 arm64","hostname":"Is-MacBook-Air.local"}'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -33,11 +33,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 28 Oct 2024 13:28:59 GMT
+      - Fri, 01 May 2026 05:22:20 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '6534'
+      - '6767'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -54,49 +54,48 @@ http_interactions:
       Cache-Control:
       - no-cache, no-store
       Content-Security-Policy:
-      - report-uri https://q.stripe.com/csp-report?p=v1%2Faccounts; block-all-mixed-content;
-        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
-        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
-      Cross-Origin-Opener-Policy-Report-Only:
-      - same-origin; report-to="coop"
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=htmBdZYIq_ruOfydWpGJy690oMEuLdpWTp7_IBAuexNKnyhQpdbakrbOr-c1oPQXQteyYcx6PJ7ZHBXu
       Idempotency-Key:
-      - c33d9b35-eec5-4949-9b7e-d5416ae216e3
+      - c41be5f3-3f06-4001-b153-4ddb09f3dcbb
       Original-Request:
-      - req_vWoD05F42LRfdj
+      - req_ne6ab9sLu5k32O
       Report-To:
-      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=accounts-bapi-srv"}],"include_subdomains":true}'
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=htmBdZYIq_ruOfydWpGJy690oMEuLdpWTp7_IBAuexNKnyhQpdbakrbOr-c1oPQXQteyYcx6PJ7ZHBXu&t=1"}],"include_subdomains":true}'
       Reporting-Endpoints:
-      - coop="https://q.stripe.com/coop-report?s=accounts-bapi-srv"
+      - csp="https://q.stripe.com/csp-report-v2?q=htmBdZYIq_ruOfydWpGJy690oMEuLdpWTp7_IBAuexNKnyhQpdbakrbOr-c1oPQXQteyYcx6PJ7ZHBXu&t=1"
       Request-Id:
-      - req_vWoD05F42LRfdj
+      - req_ne6ab9sLu5k32O
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
-      - 2023-10-16; risk_in_requirements_beta=v1
+      - '2023-10-16'
       Vary:
       - Origin
-      X-Content-Type-Options:
-      - nosniff
       X-Stripe-Priority-Routing-Enabled:
       - 'true'
       X-Stripe-Routing-Context-Priority-Tier:
       - api-testmode
       X-Wc:
-      - A
+      - 3c3
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
     body:
       encoding: UTF-8
       string: |-
         {
-          "id": "acct_1QEt08S7Bs8oBAul",
+          "id": "acct_1TS9WmEx1Cqwfsab",
           "object": "account",
           "business_profile": {
             "annual_revenue": null,
             "estimated_worker_count": null,
-            "mcc": "5192",
+            "mcc": null,
+            "minority_owned_business_designation": null,
             "name": "Chuck Bartowski",
             "product_description": "Chuck Bartowski",
+            "specified_commercial_transactions_act_url": null,
             "support_address": null,
             "support_email": null,
             "support_phone": null,
@@ -118,6 +117,7 @@ http_interactions:
               "state": null
             },
             "directors_provided": true,
+            "directorship_declaration": null,
             "executives_provided": true,
             "name": null,
             "name_kana": null,
@@ -125,6 +125,7 @@ http_interactions:
             "owners_provided": true,
             "ownership_declaration": null,
             "phone": "+10000000000",
+            "representative_declaration": null,
             "tax_id_provided": false,
             "vat_id_provided": false,
             "verification": {
@@ -151,7 +152,7 @@ http_interactions:
             "type": "application"
           },
           "country": "SV",
-          "created": 1730122137,
+          "created": 1777612938,
           "default_currency": "usd",
           "details_submitted": true,
           "email": null,
@@ -159,9 +160,9 @@ http_interactions:
             "object": "list",
             "data": [
               {
-                "id": "ba_1QEt08S7Bs8oBAulpidrdCpQ",
+                "id": "ba_1TS9WnEx1CqwfsabsdQoRjdq",
                 "object": "bank_account",
-                "account": "acct_1QEt08S7Bs8oBAul",
+                "account": "acct_1TS9WmEx1Cqwfsab",
                 "account_holder_name": null,
                 "account_holder_type": null,
                 "account_type": null,
@@ -172,7 +173,7 @@ http_interactions:
                 "country": "SV",
                 "currency": "usd",
                 "default_for_currency": true,
-                "fingerprint": "7RxMKatOt1dZGSvf",
+                "fingerprint": "CFAkGinNkVjFb75j",
                 "future_requirements": {
                   "currently_due": [],
                   "errors": [],
@@ -193,7 +194,7 @@ http_interactions:
             ],
             "has_more": false,
             "total_count": 1,
-            "url": "/v1/accounts/acct_1QEt08S7Bs8oBAul/external_accounts"
+            "url": "/v1/accounts/acct_1TS9WmEx1Cqwfsab/external_accounts"
           },
           "future_requirements": {
             "alternatives": [],
@@ -206,9 +207,9 @@ http_interactions:
             "pending_verification": []
           },
           "individual": {
-            "id": "person_1QEt09S7Bs8oBAulgEF2BHCm",
+            "id": "person_1TS9WnEx1CqwfsabmVOvtjbW",
             "object": "person",
-            "account": "acct_1QEt08S7Bs8oBAul",
+            "account": "acct_1TS9WmEx1Cqwfsab",
             "address": {
               "city": "San Salvador",
               "country": "SV",
@@ -217,7 +218,7 @@ http_interactions:
               "postal_code": "1101",
               "state": null
             },
-            "created": 1730122137,
+            "created": 1777612937,
             "dob": {
               "day": 1,
               "month": 1,
@@ -245,6 +246,7 @@ http_interactions:
             "nationality": null,
             "phone": "+10000000000",
             "relationship": {
+              "authorizer": false,
               "director": false,
               "executive": false,
               "legal_guardian": false,
@@ -283,10 +285,10 @@ http_interactions:
             }
           },
           "metadata": {
-            "bank_account_id": "G_-mnBf9b1j9A7a4ub4nFQ==",
-            "tos_agreement_id": "G_-mnBf9b1j9A7a4ub4nFQ==",
-            "user_compliance_info_id": "G_-mnBf9b1j9A7a4ub4nFQ==",
-            "user_id": "9423701199386"
+            "bank_account_id": "cqeYfxgtTtDoPeb5y8MTpg==",
+            "tos_agreement_id": "syHodx2a-2zKPbStWz-nfQ==",
+            "user_compliance_info_id": "QCRTDCCsSE30wUXCUDHekw==",
+            "user_id": "4879875581670"
           },
           "payouts_enabled": true,
           "requirements": {
@@ -312,7 +314,6 @@ http_interactions:
               "primary_color": null,
               "secondary_color": null
             },
-            "capital": {},
             "card_issuing": {
               "tos_acceptance": {
                 "date": null,
@@ -333,7 +334,8 @@ http_interactions:
               "timezone": "Etc/UTC"
             },
             "invoices": {
-              "default_account_tax_ids": null
+              "default_account_tax_ids": null,
+              "hosted_payment_method_save": "offer"
             },
             "payments": {
               "statement_descriptor": "CHUCK BARTOWSKI",
@@ -358,5 +360,5 @@ http_interactions:
           },
           "type": "custom"
         }
-  recorded_at: Mon, 28 Oct 2024 13:28:59 GMT
+  recorded_at: Fri, 01 May 2026 05:22:19 GMT
 recorded_with: VCR 6.2.0


### PR DESCRIPTION
Closes https://github.com/antiwork/gumroad-private/issues/320. Supersedes #4640.

## What

El Salvador sellers can complete payout setup again. Form keeps PR #4640's UX (Account Number + SWIFT/BIC), but the backend now constructs an IBAN from those inputs before submitting to Stripe — because Stripe's API requires IBAN format for `country=SV`.

- Validation: accept either a 10-20 digit plain account number OR a structurally valid SV IBAN.
- Submission: `stripe_account_number(passphrase)` returns the IBAN form. Plain inputs get converted via ISO 13616 (mod-97 check digits, 4-letter bank code from SWIFT, zero-padded 20-digit account). IBAN inputs pass through.
- `StripeMerchantAccountManager#bank_account_hash` calls `stripe_account_number` when defined, otherwise falls back to raw decryption. Other countries unaffected.

## Why

PR #4640's frontend was correct per the issue's UX spec, but it sent plain account numbers to Stripe — which Stripe rejects for SV. Verified against live Stripe test mode:

| Submitted | Result |
|---|---|
| plain account + bank SWIFT (post-#4640) | ❌ *"You must use a test bank account number. Try `SV44BCIE12345678901234567890` …"* |
| `SV44BCIE…` + `AAAASVS1XXX` | ✅ |
| plain account + 9-digit routing (Schema 1 per [docs.stripe.com/payouts](https://docs.stripe.com/payouts)) | ❌ *"Invalid routing number for SV … must be in the format `AAAASVBB` or `AAAASVBBXYZ`"* |

The third row rules out the docs' "Routing Number" alternative. Only SWIFT/BIC + IBAN works.

Construction matches Wise's output bit-for-bit and Stripe's test fixture (`BCIESVS1 + 12345678901234567890 → SV44BCIE12345678901234567890`).

---

Generated with Claude Code Opus 4.7