### PR TITLE
Fix: Retry on ActiveRecord::Deadlocked in LinksController#update

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -300,6 +300,7 @@ class LinksController < ApplicationController
 
   def update
     authorize @product
+    deadlock_retries = 0
     begin
       ActiveRecord::Base.transaction do
         @product.assign_attributes(product_permitted_params.except(
@@ -393,6 +394,13 @@ class LinksController < ApplicationController
         toggle_community_chat!(product_permitted_params[:community_chat_enabled])
         @product.generate_product_files_archives!
       end
+    rescue ActiveRecord::Deadlocked
+      deadlock_retries += 1
+      if deadlock_retries <= 2
+        @product.reload
+        retry
+      end
+      raise
     rescue ActiveRecord::RecordNotSaved, ActiveRecord::RecordInvalid, Link::LinkInvalid => e
       if @product.errors.details[:custom_fields].present?
         error_message = "You must add titles to all of your inputs"

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -2842,6 +2842,40 @@ describe LinksController, :vcr, inertia: true do
           end
         end
       end
+
+      context "when a deadlock occurs" do
+        it "retries and succeeds on the second attempt" do
+          deadlock_raised = false
+          allow(ActiveRecord::Base).to receive(:transaction).and_wrap_original do |original, *args, **kwargs, &block|
+            if !deadlock_raised && block && caller.any? { |frame| frame.include?("links_controller") }
+              deadlock_raised = true
+              raise ActiveRecord::Deadlocked
+            end
+            original.call(*args, **kwargs, &block)
+          end
+
+          put :update, params: @params, as: :json
+
+          expect(response).to have_http_status(:no_content)
+          expect(deadlock_raised).to be(true)
+        end
+
+        it "re-raises after exhausting retries" do
+          deadlock_count = 0
+          allow(ActiveRecord::Base).to receive(:transaction).and_wrap_original do |original, *args, **kwargs, &block|
+            if block && caller.any? { |frame| frame.include?("links_controller") }
+              deadlock_count += 1
+              raise ActiveRecord::Deadlocked
+            end
+            original.call(*args, **kwargs, &block)
+          end
+
+          expect {
+            put :update, params: @params, as: :json
+          }.to raise_error(ActiveRecord::Deadlocked)
+          expect(deadlock_count).to eq(3)
+        end
+      end
     end
 
     describe "GET new" do


### PR DESCRIPTION
## Problem

`LinksController#update` wraps a large transaction touching multiple tables (product attributes, variants, tags, sections, rich content, integrations, files, etc.). Under concurrent updates to the same or related products, MySQL can deadlock, raising `ActiveRecord::Deadlocked` which was not caught — resulting in an unhandled 500 error.

**Sentry:** https://gumroad-to.sentry.io/issues/7453788565/
**7-day events:** 1 (just surfaced)
**Estimated affected users/month:** Low (sporadic, triggered by concurrent product saves)
**Estimated support tickets/month:** ~0 (transient error, user can retry)

## Fix

Add deadlock retry logic around the transaction, following the existing pattern in `Link#publish!`:
- Up to 2 retries on `ActiveRecord::Deadlocked`
- `@product.reload` before each retry to clear dirty in-memory state from the rolled-back transaction
- Re-raises after exhausting retries

## Tests

Added two specs:
1. Verifies deadlock is retried and the request succeeds on the second attempt
2. Verifies the error re-raises after 3 consecutive deadlocks (initial + 2 retries)