### PR TITLE
Introduce seeded admin API tokens for internal admin auth

### DIFF
--- a/app/controllers/api/internal/admin/base_controller.rb
+++ b/app/controllers/api/internal/admin/base_controller.rb
@@ -1,22 +1,39 @@
 # frozen_string_literal: true
 
 class Api::Internal::Admin::BaseController < Api::Internal::BaseController
+  include AdminActor
+
   skip_before_action :verify_authenticity_token
   before_action :verify_authorization_header!
   before_action :authorize_admin_token!
 
   private
     def authorize_admin_token!
-      token = request.authorization.split(" ").last
-      expected_token = GlobalConfig.get("INTERNAL_ADMIN_API_TOKEN").to_s
+      token = bearer_token
+      admin_api_token = AdminApiToken.authenticate(token)
+      return render_invalid_authorization unless admin_api_token
 
-      unless expected_token.present? && token.present? && ActiveSupport::SecurityUtils.secure_compare(token, expected_token)
-        render json: { success: false, message: "authorization is invalid" }, status: :unauthorized
-      end
+      set_current_admin_actor!(admin_api_token.actor_user, admin_token: admin_api_token)
+      admin_api_token.record_used!
+    end
+
+    def require_per_actor_token!
+      return if Current.admin_token.present? && !Current.admin_token.legacy_admin_token?
+
+      render json: { success: false, message: "per-actor admin token is required" }, status: :unauthorized
     end
 
     def verify_authorization_header!
       render json: { success: false, message: "unauthenticated" }, status: :unauthorized if request.authorization.nil?
+    end
+
+    def bearer_token
+      authorization_header = request.authorization.to_s
+      authorization_header.match(/\ABearer (.+)\z/)&.[](1)
+    end
+
+    def render_invalid_authorization
+      render json: { success: false, message: "authorization is invalid" }, status: :unauthorized
     end
 
     def serialize_purchase(purchase)

--- a/app/controllers/concerns/admin_actor.rb
+++ b/app/controllers/concerns/admin_actor.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module AdminActor
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :clear_current_admin_actor!
+    after_action :clear_current_admin_actor!
+  end
+
+  private
+    def set_current_admin_actor!(actor, admin_token: nil)
+      Current.admin_actor = actor
+      Current.admin_token = admin_token
+    end
+
+    def clear_current_admin_actor!
+      Current.admin_actor = nil
+      Current.admin_token = nil
+    end
+end

--- a/app/models/admin_api_token.rb
+++ b/app/models/admin_api_token.rb
@@ -22,6 +22,15 @@ class AdminApiToken < ApplicationRecord
     plaintext_token
   end
 
+  def self.seed_legacy_admin_token!
+    legacy_token = GlobalConfig.get("INTERNAL_ADMIN_API_TOKEN").to_s
+    return nil if legacy_token.blank?
+
+    find_or_create_by!(token_hash: hash_token(legacy_token)) do |admin_api_token|
+      admin_api_token.actor_user_id = GUMROAD_ADMIN_ID
+    end
+  end
+
   def self.authenticate(plaintext_token)
     return nil if plaintext_token.blank?
 

--- a/app/models/admin_api_token.rb
+++ b/app/models/admin_api_token.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+class AdminApiToken < ApplicationRecord
+  EXTERNAL_ID_LENGTH = 21
+  PLAINTEXT_TOKEN_LENGTH = 43
+  TOKEN_ALPHABET = "_-0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+  belongs_to :actor_user, class_name: "User"
+
+  validates :external_id, presence: true, uniqueness: true
+  validates :token_hash, presence: true, uniqueness: true
+  validates :actor_user, presence: true
+
+  before_validation :generate_external_id, on: :create
+
+  scope :active, -> { where(revoked_at: nil).where("expires_at IS NULL OR expires_at > ?", Time.current) }
+
+  def self.mint!(actor_user_id:, expires_at: nil)
+    plaintext_token = generate_plaintext_token
+    create!(actor_user_id:, expires_at:, token_hash: hash_token(plaintext_token))
+
+    plaintext_token
+  end
+
+  def self.authenticate(plaintext_token)
+    return nil if plaintext_token.blank?
+
+    token_hash = hash_token(plaintext_token)
+    admin_api_token = find_by(token_hash:)
+    return nil if admin_api_token.blank?
+    return nil unless ActiveSupport::SecurityUtils.secure_compare(admin_api_token.token_hash, token_hash)
+    return nil unless admin_api_token.active?
+
+    admin_api_token
+  end
+
+  def self.hash_token(plaintext_token)
+    Digest::SHA256.hexdigest(plaintext_token.to_s)
+  end
+
+  def self.generate_plaintext_token
+    generate_token(PLAINTEXT_TOKEN_LENGTH)
+  end
+
+  def self.generate_token(length)
+    Array.new(length) { TOKEN_ALPHABET[SecureRandom.random_number(TOKEN_ALPHABET.length)] }.join
+  end
+
+  def self.legacy_admin_token
+    where(actor_user_id: GUMROAD_ADMIN_ID).order(:id).first
+  end
+
+  def active?
+    revoked_at.blank? && !expired?
+  end
+
+  def legacy_admin_token?
+    legacy_admin_token = self.class.legacy_admin_token
+    legacy_admin_token.present? && id == legacy_admin_token.id
+  end
+
+  def expired?
+    expires_at.present? && expires_at <= Time.current
+  end
+
+  def record_used!
+    update_column(:last_used_at, Time.current)
+  end
+
+  private
+    def generate_external_id
+      return if external_id.present?
+
+      loop do
+        self.external_id = self.class.generate_token(EXTERNAL_ID_LENGTH)
+        break unless self.class.exists?(external_id:)
+      end
+    end
+end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Current < ActiveSupport::CurrentAttributes
+  attribute :admin_actor, :admin_token
+end

--- a/db/migrate/20260430200000_create_admin_api_tokens.rb
+++ b/db/migrate/20260430200000_create_admin_api_tokens.rb
@@ -32,7 +32,11 @@ class CreateAdminApiTokens < ActiveRecord::Migration[7.1]
   private
     def seed_legacy_admin_token!
       legacy_token = GlobalConfig.get("INTERNAL_ADMIN_API_TOKEN").to_s
-      return if legacy_token.blank?
+      if legacy_token.blank?
+        say "INTERNAL_ADMIN_API_TOKEN is blank; skipping legacy admin token seed. " \
+            "Set it and run AdminApiToken.seed_legacy_admin_token! before using the shared token."
+        return
+      end
 
       now = Time.current
       execute <<~SQL.squish

--- a/db/migrate/20260430200000_create_admin_api_tokens.rb
+++ b/db/migrate/20260430200000_create_admin_api_tokens.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "digest"
+
+class CreateAdminApiTokens < ActiveRecord::Migration[7.1]
+  TOKEN_ALPHABET = "_-0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+  def up
+    create_table :admin_api_tokens do |t|
+      t.string :external_id, null: false, limit: 21
+      t.bigint :actor_user_id, null: false
+      t.string :token_hash, null: false, limit: 64
+      t.datetime :last_used_at
+      t.datetime :revoked_at
+      t.datetime :expires_at
+      t.timestamps
+
+      t.index :external_id, unique: true
+      t.index :token_hash, unique: true
+      t.index :actor_user_id
+      t.index :revoked_at
+      t.index :expires_at
+    end
+
+    seed_legacy_admin_token!
+  end
+
+  def down
+    drop_table :admin_api_tokens
+  end
+
+  private
+    def seed_legacy_admin_token!
+      legacy_token = GlobalConfig.get("INTERNAL_ADMIN_API_TOKEN").to_s
+      return if legacy_token.blank?
+
+      now = Time.current
+      execute <<~SQL.squish
+        INSERT INTO admin_api_tokens (external_id, actor_user_id, token_hash, created_at, updated_at)
+        VALUES (
+          #{quote(generate_token(21))},
+          #{GUMROAD_ADMIN_ID},
+          #{quote(Digest::SHA256.hexdigest(legacy_token))},
+          #{quote(now)},
+          #{quote(now)}
+        )
+      SQL
+    end
+
+    def generate_token(length)
+      Array.new(length) { TOKEN_ALPHABET[SecureRandom.random_number(TOKEN_ALPHABET.length)] }.join
+    end
+
+    def quote(value)
+      connection.quote(value)
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -39,6 +39,22 @@ ActiveRecord::Schema[7.1].define(version: 2026_11_24_000000) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "admin_api_tokens", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "external_id", limit: 21, null: false
+    t.bigint "actor_user_id", null: false
+    t.string "token_hash", limit: 64, null: false
+    t.datetime "last_used_at"
+    t.datetime "revoked_at"
+    t.datetime "expires_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["actor_user_id"], name: "index_admin_api_tokens_on_actor_user_id"
+    t.index ["expires_at"], name: "index_admin_api_tokens_on_expires_at"
+    t.index ["external_id"], name: "index_admin_api_tokens_on_external_id", unique: true
+    t.index ["revoked_at"], name: "index_admin_api_tokens_on_revoked_at"
+    t.index ["token_hash"], name: "index_admin_api_tokens_on_token_hash", unique: true
+  end
+
   create_table "admin_action_call_infos", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "controller_name", null: false
     t.string "action_name", null: false

--- a/spec/controllers/api/internal/admin/base_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/base_controller_spec.rb
@@ -4,24 +4,60 @@ require "spec_helper"
 
 describe Api::Internal::Admin::BaseController do
   controller(described_class) do
+    before_action :require_per_actor_token!, only: :create
+
     def index
+      render json: {
+        success: true,
+        admin_actor_id: Current.admin_actor&.id,
+        admin_token_id: Current.admin_token&.id
+      }
+    end
+
+    def create
       render json: { success: true }
     end
   end
 
+  let(:legacy_admin_actor) { create(:admin_user) }
+
   before do
-    allow(GlobalConfig).to receive(:get).and_call_original
-    allow(GlobalConfig).to receive(:get).with("INTERNAL_ADMIN_API_TOKEN").and_return("test-admin-token")
+    stub_const("GUMROAD_ADMIN_ID", legacy_admin_actor.id)
   end
 
   describe "admin token authorization" do
+    let!(:legacy_admin_token) do
+      create(:admin_api_token, actor_user: legacy_admin_actor, token_hash: AdminApiToken.hash_token("test-admin-token"))
+    end
+
     it "allows requests with the configured bearer token" do
       request.headers["Authorization"] = "Bearer test-admin-token"
 
       get :index
 
       expect(response).to have_http_status(:ok)
-      expect(response.body).to eq({ success: true }.to_json)
+      expect(response.parsed_body).to eq({
+        success: true,
+        admin_actor_id: legacy_admin_actor.id,
+        admin_token_id: legacy_admin_token.id
+      }.as_json)
+    end
+
+    it "allows requests with a per-actor admin token" do
+      actor = create(:admin_user)
+      plaintext_token = AdminApiToken.mint!(actor_user_id: actor.id)
+      admin_api_token = AdminApiToken.find_by!(actor_user: actor, token_hash: AdminApiToken.hash_token(plaintext_token))
+      request.headers["Authorization"] = "Bearer #{plaintext_token}"
+
+      get :index
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq({
+        success: true,
+        admin_actor_id: actor.id,
+        admin_token_id: admin_api_token.id
+      }.as_json)
+      expect(admin_api_token.reload.last_used_at).to be_present
     end
 
     it "rejects requests with an invalid token" do
@@ -33,11 +69,91 @@ describe Api::Internal::Admin::BaseController do
       expect(response.body).to eq({ success: false, message: "authorization is invalid" }.to_json)
     end
 
+    it "rejects requests with a revoked per-actor admin token" do
+      actor = create(:admin_user)
+      plaintext_token = AdminApiToken.mint!(actor_user_id: actor.id)
+      admin_api_token = AdminApiToken.find_by!(actor_user: actor, token_hash: AdminApiToken.hash_token(plaintext_token))
+      admin_api_token.update!(revoked_at: Time.current)
+      request.headers["Authorization"] = "Bearer #{plaintext_token}"
+
+      get :index
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.body).to eq({ success: false, message: "authorization is invalid" }.to_json)
+    end
+
+    it "rejects requests with an expired per-actor admin token" do
+      actor = create(:admin_user)
+      plaintext_token = AdminApiToken.mint!(actor_user_id: actor.id, expires_at: 1.minute.ago)
+      request.headers["Authorization"] = "Bearer #{plaintext_token}"
+
+      get :index
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.body).to eq({ success: false, message: "authorization is invalid" }.to_json)
+    end
+
+    it "rejects malformed authorization headers" do
+      request.headers["Authorization"] = "Basic test-admin-token"
+
+      get :index
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.body).to eq({ success: false, message: "authorization is invalid" }.to_json)
+    end
+
+    it "uses the admin token row as the rotation point" do
+      request.headers["Authorization"] = "Bearer test-admin-token"
+
+      get :index
+
+      expect(response).to have_http_status(:ok)
+
+      legacy_admin_token.update!(token_hash: AdminApiToken.hash_token("rotated-admin-token"))
+
+      get :index
+
+      expect(response).to have_http_status(:unauthorized)
+
+      request.headers["Authorization"] = "Bearer rotated-admin-token"
+
+      get :index
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["admin_token_id"]).to eq(legacy_admin_token.id)
+    end
+
     it "rejects requests without an authorization header" do
       get :index
 
       expect(response).to have_http_status(:unauthorized)
       expect(response.body).to eq({ success: false, message: "unauthenticated" }.to_json)
+    end
+  end
+
+  describe "per-actor admin token requirement" do
+    let!(:legacy_admin_token) do
+      create(:admin_api_token, actor_user: legacy_admin_actor, token_hash: AdminApiToken.hash_token("test-admin-token"))
+    end
+
+    it "allows per-actor admin tokens" do
+      actor = create(:admin_user)
+      plaintext_token = AdminApiToken.mint!(actor_user_id: actor.id)
+      request.headers["Authorization"] = "Bearer #{plaintext_token}"
+
+      post :create
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq({ success: true }.as_json)
+    end
+
+    it "rejects the legacy admin token" do
+      request.headers["Authorization"] = "Bearer test-admin-token"
+
+      post :create
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.body).to eq({ success: false, message: "per-actor admin token is required" }.to_json)
     end
   end
 end

--- a/spec/controllers/api/internal/admin/purchases_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/purchases_controller_spec.rb
@@ -1059,8 +1059,6 @@ describe Api::Internal::Admin::PurchasesController do
 
     include_examples "admin api authorization required", :post, :refund_for_fraud, { id: "123", email: "buyer@example.com" }
 
-    before { stub_const("GUMROAD_ADMIN_ID", admin_user.id) }
-
     it "returns 400 when email is missing" do
       post :refund_for_fraud, params: { id: purchase.external_id_numeric.to_s }
 

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -501,8 +501,6 @@ describe Api::Internal::Admin::UsersController do
 
     include_examples "admin api authorization required", :post, :mark_compliant
 
-    before { stub_const("GUMROAD_ADMIN_ID", admin_user.id) }
-
     it "returns 400 when email is missing" do
       post :mark_compliant
 
@@ -593,8 +591,6 @@ describe Api::Internal::Admin::UsersController do
     let(:user) { create(:compliant_user, email: "seller@example.com") }
 
     include_examples "admin api authorization required", :post, :suspend_for_fraud
-
-    before { stub_const("GUMROAD_ADMIN_ID", admin_user.id) }
 
     it "returns 400 when email is missing" do
       post :suspend_for_fraud

--- a/spec/models/admin_api_token_spec.rb
+++ b/spec/models/admin_api_token_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe AdminApiToken do
+  describe ".mint!" do
+    it "stores the token hash and returns the plaintext token once" do
+      actor = create(:admin_user)
+
+      plaintext_token = described_class.mint!(actor_user_id: actor.id)
+      admin_api_token = described_class.find_by!(actor_user: actor, token_hash: described_class.hash_token(plaintext_token))
+
+      expect(plaintext_token).to be_present
+      expect(admin_api_token.token_hash).to eq(described_class.hash_token(plaintext_token))
+      expect(admin_api_token.token_hash).not_to eq(plaintext_token)
+      expect(admin_api_token).to have_attributes(
+        actor_user: actor,
+        external_id: a_string_matching(/\A[-_0-9a-zA-Z]{21}\z/)
+      )
+    end
+  end
+
+  describe ".authenticate" do
+    it "returns an active token for the matching plaintext token" do
+      actor = create(:admin_user)
+      plaintext_token = described_class.mint!(actor_user_id: actor.id)
+      admin_api_token = described_class.find_by!(actor_user: actor, token_hash: described_class.hash_token(plaintext_token))
+
+      expect(described_class.authenticate(plaintext_token)).to eq(admin_api_token)
+    end
+
+    it "does not authenticate revoked or expired tokens" do
+      actor = create(:admin_user)
+      revoked_plaintext_token = described_class.mint!(actor_user_id: actor.id)
+      revoked_token = described_class.find_by!(actor_user: actor, token_hash: described_class.hash_token(revoked_plaintext_token))
+      expired_plaintext_token = described_class.mint!(actor_user_id: actor.id, expires_at: 1.minute.ago)
+      revoked_token.update!(revoked_at: Time.current)
+
+      expect(described_class.authenticate(revoked_plaintext_token)).to be_nil
+      expect(described_class.authenticate(expired_plaintext_token)).to be_nil
+      expect(described_class.authenticate("missing")).to be_nil
+    end
+  end
+
+  describe "#legacy_admin_token?" do
+    it "only treats the seeded legacy row as the legacy admin token" do
+      legacy_actor = create(:admin_user)
+      service_actor = create(:admin_user)
+      stub_const("GUMROAD_ADMIN_ID", legacy_actor.id)
+      legacy_admin_token = create(:admin_api_token, actor_user: legacy_actor)
+      later_admin_actor_token = create(:admin_api_token, actor_user: legacy_actor)
+      service_token = create(:admin_api_token, actor_user: service_actor)
+
+      expect(legacy_admin_token).to be_legacy_admin_token
+      expect(later_admin_actor_token).not_to be_legacy_admin_token
+      expect(service_token).not_to be_legacy_admin_token
+    end
+  end
+end

--- a/spec/models/admin_api_token_spec.rb
+++ b/spec/models/admin_api_token_spec.rb
@@ -20,6 +20,29 @@ describe AdminApiToken do
     end
   end
 
+  describe ".seed_legacy_admin_token!" do
+    it "creates the legacy admin token from the configured shared token" do
+      actor = create(:admin_user)
+      stub_const("GUMROAD_ADMIN_ID", actor.id)
+      allow(GlobalConfig).to receive(:get).with("INTERNAL_ADMIN_API_TOKEN").and_return("legacy-token")
+
+      admin_api_token = described_class.seed_legacy_admin_token!
+
+      expect(admin_api_token).to have_attributes(
+        actor_user: actor,
+        token_hash: described_class.hash_token("legacy-token")
+      )
+      expect { described_class.seed_legacy_admin_token! }.not_to change(described_class, :count)
+    end
+
+    it "does not create a token when the configured shared token is blank" do
+      allow(GlobalConfig).to receive(:get).with("INTERNAL_ADMIN_API_TOKEN").and_return("")
+
+      expect(described_class.seed_legacy_admin_token!).to be_nil
+      expect(described_class.count).to eq(0)
+    end
+  end
+
   describe ".authenticate" do
     it "returns an active token for the matching plaintext token" do
       actor = create(:admin_user)

--- a/spec/shared_examples/authorized_admin_api_method.rb
+++ b/spec/shared_examples/authorized_admin_api_method.rb
@@ -3,9 +3,11 @@
 require "spec_helper"
 
 RSpec.shared_examples_for "admin api authorization required" do |verb, action, params = {}|
+  let(:legacy_admin_actor) { respond_to?(:admin_user) ? admin_user : create(:admin_user) }
+
   before do
-    allow(GlobalConfig).to receive(:get).and_call_original
-    allow(GlobalConfig).to receive(:get).with("INTERNAL_ADMIN_API_TOKEN").and_return("test-admin-token")
+    stub_const("GUMROAD_ADMIN_ID", legacy_admin_actor.id)
+    create(:admin_api_token, actor_user: legacy_admin_actor, token_hash: AdminApiToken.hash_token("test-admin-token"))
     request.headers["Authorization"] = "Bearer test-admin-token"
   end
 

--- a/spec/support/factories/admin_api_tokens.rb
+++ b/spec/support/factories/admin_api_tokens.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :admin_api_token do
+    association :actor_user, factory: :admin_user
+    token_hash { AdminApiToken.hash_token(SecureRandom.uuid) }
+  end
+end


### PR DESCRIPTION
Ref #4677

## What

This PR adds database-backed admin API tokens for `/internal/admin` and binds each token to a Gumroad user through `actor_user_id`.

The existing `INTERNAL_ADMIN_API_TOKEN` is seeded as an `admin_api_tokens` row tied to `GUMROAD_ADMIN_ID`, so current callers keep using the same bearer token while the server resolves it through the same path as per-actor tokens.

Authenticated requests now set the current admin actor and token for the request. Existing admin API calls continue to work with the seeded shared token, including fraud/compliance endpoints that Gumclaw or other callers may already use. The per-actor guard is introduced for a later audited rollout, but this PR does not wire it onto existing endpoints.

## Why

The shared admin bearer token proves that a request is allowed, but it does not say who or what made the request. This adds that identity boundary before the audit and actor-attribution work in the next PR.

Keeping the legacy token as data avoids a second auth path and lets existing callers keep working during the migration. The per-actor guard is intentionally left as a building block for the next phase, so we do not break current shared-token workflows before the write audit layer and caller migration are ready.

---

This PR was implemented with AI assistance using gpt‑5.5 xhigh.