### PR TITLE
Add /api/v2/meta endpoint for token introspection

### DIFF
--- a/app/controllers/api/v2/meta_controller.rb
+++ b/app/controllers/api/v2/meta_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class Api::V2::MetaController < Api::V2::BaseController
+  before_action -> { doorkeeper_authorize!(*Doorkeeper.configuration.public_scopes.concat([:view_public])) }
+
+  API_DOCUMENTATION_URL = "https://app.gumroad.com/api"
+
+  def show
+    render_response(
+      true,
+      user: { id: current_resource_owner.external_id },
+      token: {
+        scopes: doorkeeper_token.scopes.to_a,
+        application_name: doorkeeper_token.application&.name,
+      },
+      api: {
+        version: "v2",
+        documentation_url: API_DOCUMENTATION_URL,
+      }
+    )
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,7 @@ Rails.application.routes.draw do
       end
 
       get "/user", to: "users#show"
+      get "/meta", to: "meta#show"
       resources :links, path: "products", only: [:index, :show, :update, :create, :destroy] do
         resources :custom_fields, only: [:index, :create, :update, :destroy]
         resources :offer_codes, only: [:index, :create, :show, :update, :destroy]

--- a/spec/controllers/api/v2/meta_controller_spec.rb
+++ b/spec/controllers/api/v2/meta_controller_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "shared_examples/authorized_oauth_v1_api_method"
+
+describe Api::V2::MetaController do
+  before do
+    @user = create(:user, email: "creator@example.com")
+    @app = create(:oauth_application, name: "Acme Agent", owner: create(:user))
+  end
+
+  describe "GET 'show'" do
+    before do
+      @action = :show
+      @params = {}
+    end
+
+    it_behaves_like "authorized oauth v1 api method"
+
+    it "returns the token scopes, application name, user external_id, and api metadata" do
+      token = create("doorkeeper/access_token", application: @app, resource_owner_id: @user.id, scopes: "view_sales edit_products")
+
+      get @action, params: { access_token: token.token }
+
+      expect(response).to be_successful
+      body = response.parsed_body
+      expect(body["success"]).to eq(true)
+      expect(body["user"]).to eq("id" => @user.external_id)
+      expect(body["token"]["scopes"]).to match_array(%w[view_sales edit_products])
+      expect(body["token"]["application_name"]).to eq("Acme Agent")
+      expect(body["api"]).to eq("version" => "v2", "documentation_url" => "https://app.gumroad.com/api")
+    end
+
+    it "accepts the default view_public scope" do
+      token = create("doorkeeper/access_token", application: @app, resource_owner_id: @user.id, scopes: "view_public")
+
+      get @action, params: { access_token: token.token }
+
+      expect(response).to be_successful
+      expect(response.parsed_body["token"]["scopes"]).to eq(["view_public"])
+    end
+
+    it "accepts the account scope" do
+      token = create("doorkeeper/access_token", application: @app, resource_owner_id: @user.id, scopes: "account")
+
+      get @action, params: { access_token: token.token }
+
+      expect(response).to be_successful
+      expect(response.parsed_body["token"]["scopes"]).to eq(["account"])
+    end
+
+    it "rejects a token whose scope is not recognized" do
+      token = create("doorkeeper/access_token", application: @app, resource_owner_id: @user.id, scopes: "mobile_api")
+
+      get @action, params: { access_token: token.token }
+
+      expect(response.status).to eq(403)
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds `GET /api/v2/meta`, a new authenticated endpoint that returns:

- the OAuth token's **scopes**
- the OAuth **application_name**
- the resource owner's **external_id**
- the **api version** and a static **documentation_url**

```
$ curl -H "Authorization: Bearer $TOKEN" https://api.gumroad.com/v2/meta
{
  "success": true,
  "user": { "id": "abc123" },
  "token": { "scopes": ["view_sales", "edit_products"], "application_name": "Acme Agent" },
  "api": { "version": "v2", "documentation_url": "https://app.gumroad.com/api" }
}
```

3 files changed, 83 insertions(+).

## Why

Today an API consumer holding an opaque OAuth token has no way to ask the API "what can this token do?" The only way to learn the scope set is to try a privileged endpoint and see if it 403s. For human integrations that's annoying; for AI agents (Claude Code, the gumroad-cli, third-party automations) it's a real blocker — they have to either guess capabilities or bake assumptions into client code.

This is the smallest possible step toward a discoverable API: one round trip, no migration, no new model, no PII beyond what the token holder already has access to.

This is a proof-of-concept for a broader API-discoverability effort (rate-limit headers, machine-readable error codes, a published OpenAPI spec). Each of those is independent and can land separately. This PR ships the smallest piece.

### Why this auth pattern

`before_action -> { doorkeeper_authorize!(*Doorkeeper.configuration.public_scopes.concat([:view_public])) }` matches `Api::V2::UsersController#show` — any token with a public scope (or the default `view_public`) is accepted. The endpoint only exposes metadata the token holder already knows about itself, so a tighter scope check would just be friction.

### Why no user email / name

Those are scope-gated on `/v2/user`. The meta endpoint is meant to be safe to call before knowing your scope set, so it returns only `external_id`. An agent that needs richer user info can call `/v2/user` once it knows it has `view_profile` or `account` scope — which it learns from `/v2/meta`.

## Before / After


https://github.com/user-attachments/assets/b4e3ed32-f57d-49a3-b58b-51c42262a594


### Showing the changes + skill using Claude Code:

https://github.com/user-attachments/assets/4004d087-3b12-449f-b333-99b283230340


## Test Results

<img width="3000" height="1312" alt="CleanShot 2026-05-01 at 13 40 47@2x" src="https://github.com/user-attachments/assets/e62f32dc-628f-4a68-9998-c643d85f509b" />

---

**AI disclosure:** Drafted with Claude Opus 4.7 (1M context) 

Conversation History: https://isolated.tech/share/gswll9Ld

