### PR TITLE
Fix false EIN length error on compliance resubmits

### DIFF
--- a/app/services/update_user_compliance_info.rb
+++ b/app/services/update_user_compliance_info.rb
@@ -86,7 +86,7 @@ class UpdateUserComplianceInfo
       return { success: false, error_message: new_compliance_info.errors.full_messages.to_sentence } unless saved
 
       if new_compliance_info.is_business && new_compliance_info.legal_entity_country_code == "US" &&
-          new_compliance_info.business_tax_id.present? && new_compliance_info.business_tax_id.length != 9
+          compliance_params[:business_tax_id].present? && new_compliance_info.business_tax_id.length != 9
         return { success: false, error_message: "US business tax IDs (EIN) must have 9 digits." }
       end
 

--- a/spec/requests/settings/payments_spec.rb
+++ b/spec/requests/settings/payments_spec.rb
@@ -777,6 +777,37 @@ describe("Payments Settings Scenario", type: :system, js: true) do
       end
     end
 
+    describe "US business with EIN already saved, editing non-EIN fields" do
+      before do
+        create(:ach_account_stripe_succeed, user: @user)
+        ActiveRecord::Base.transaction do
+          @user.alive_user_compliance_info.mark_deleted!
+          create(
+            :user_compliance_info_business,
+            user: @user,
+            business_phone: "+15052426789",
+            phone: "+15022541982",
+            birthday: Date.new(1980, 1, 1),
+          )
+        end
+      end
+
+      it "saves changes without rejecting the saved EIN" do
+        visit settings_payments_path
+
+        find_field("Address", match: :first).set("456 Updated Business Lane")
+
+        click_on("Update settings")
+
+        expect(page).to have_alert(text: "Thanks! You're all set.")
+        expect(page).not_to have_status(text: "US business tax IDs (EIN) must have 9 digits.")
+
+        compliance_info = @user.reload.alive_user_compliance_info
+        expect(compliance_info.business_street_address).to eq("456 Updated Business Lane")
+        expect(compliance_info.business_tax_id.decrypt(GlobalConfig.get("STRONGBOX_GENERAL_PASSWORD"))).to eq("000000000")
+      end
+    end
+
     describe "CA corporation requiring company registration verification document" do
       before do
         old_user_compliance_info = @user.alive_user_compliance_info

--- a/spec/requests/settings/payments_spec.rb
+++ b/spec/requests/settings/payments_spec.rb
@@ -795,16 +795,15 @@ describe("Payments Settings Scenario", type: :system, js: true) do
       it "saves changes without rejecting the saved EIN" do
         visit settings_payments_path
 
-        find_field("Address", match: :first).set("456 Updated Business Lane")
+        fill_in "Address", match: :first, with: "456 Updated Business Lane", fill_options: { clear: :backspace }
 
         click_on("Update settings")
 
         expect(page).to have_alert(text: "Thanks! You're all set.")
-        expect(page).not_to have_status(text: "US business tax IDs (EIN) must have 9 digits.")
 
         compliance_info = @user.reload.alive_user_compliance_info
         expect(compliance_info.business_street_address).to eq("456 Updated Business Lane")
-        expect(compliance_info.business_tax_id.decrypt(GlobalConfig.get("STRONGBOX_GENERAL_PASSWORD"))).to eq("000000000")
+        expect(compliance_info.business_tax_id.decrypt("1234")).to eq("000000000")
       end
     end
 

--- a/spec/services/update_user_compliance_info_spec.rb
+++ b/spec/services/update_user_compliance_info_spec.rb
@@ -52,5 +52,46 @@ describe UpdateUserComplianceInfo do
         expect(result[:error_message]).to eq("Individual tax id is too long")
       end
     end
+
+    context "with a US business that already has a 9-digit business_tax_id saved" do
+      let(:us_business_user) do
+        create(:user).tap { |u| create(:user_compliance_info_business, user: u) }
+      end
+
+      it "accepts a non-tax-id field update without re-submitting business_tax_id" do
+        params = ActionController::Parameters.new(
+          is_business: true,
+          business_street_address: "456 Updated Street",
+        )
+
+        result = described_class.new(compliance_params: params, user: us_business_user).process
+
+        expect(result[:success]).to be true
+        expect(us_business_user.alive_user_compliance_info.business_street_address).to eq("456 Updated Street")
+      end
+
+      it "rejects a too-short business_tax_id submitted in the same request" do
+        params = ActionController::Parameters.new(
+          is_business: true,
+          business_tax_id: "12345",
+        )
+
+        result = described_class.new(compliance_params: params, user: us_business_user).process
+
+        expect(result[:success]).to be false
+        expect(result[:error_message]).to eq("US business tax IDs (EIN) must have 9 digits.")
+      end
+
+      it "accepts a 9-digit business_tax_id submitted with formatting" do
+        params = ActionController::Parameters.new(
+          is_business: true,
+          business_tax_id: "12-3456789",
+        )
+
+        result = described_class.new(compliance_params: params, user: us_business_user).process
+
+        expect(result[:success]).to be true
+      end
+    end
   end
 end


### PR DESCRIPTION
Ref antiwork/gumroad-private/issues/329  

## What

US business creators with a saved EIN were getting falsely rejected with "US business tax IDs (EIN) must have 9 digits." every time they updated any compliance field. Even unrelated ones like a business address.

The EIN length check in `UpdateUserComplianceInfo` was reading the Strongbox-encrypted `business_tax_id.length` after `dup_and_save`. Strongbox tracks plaintext size only for values assigned in the current request. A duped record carries over the encrypted blob but reports `length = 0`. The validation gated on `business_tax_id.present?`, which was true (encrypted blob present), so it tripped on every resubmit that didn't re-type the EIN.

The frontend's EIN `<Input>` is uncontrolled and shows a "Hidden for security" placeholder when one is already saved, so users don't re-type it on routine updates. Every such submit failed.

Fix: gate the length check on `compliance_params[:business_tax_id].present?` so the validation only runs when the user actually submitted a tax ID this request.

## Why

This is a regression I introduced in [#3525](https://github.com/antiwork/gumroad/pull/3525). The length check is correct but the gate was wrong.

A creator with a US LLC and saved EIN hit this error 10+ times across 4 days, with a new compliance record created each time (each retaining the saved EIN), unable to complete any update through the payments settings UI.

---

This PR was implemented with AI assistance using Claude Opus 4.7.