### PR TITLE
Add /api/v2/meta endpoint for token introspection

### DIFF
--- a/.agents/skills/gumroad-api-meta/SKILL.md
+++ b/.agents/skills/gumroad-api-meta/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: gumroad-api-meta
+description: >
+  Discover what an OAuth token can do against Gumroad's API by calling GET /v2/meta. Use
+  when planning or debugging any Gumroad API integration: deciding which endpoint to call,
+  why a /v2/* request returned 401 or 403, what scopes a token has, who the token belongs
+  to, or what OAuth application minted it. Triggers on: "what scopes does this token have",
+  "why am I getting 403 from gumroad", "what can this gumroad token do", "introspect this
+  token", "what user owns this token", before calling any /v2/* endpoint for the first
+  time, or when designing a multi-step workflow against Gumroad's public API.
+---
+
+# Gumroad API meta
+
+`GET /v2/meta` is the token-introspection endpoint for Gumroad's v2 API. One round trip tells you everything you need to plan a workflow.
+
+## When to call it
+
+- **Before any other v2 call.** Cheaper to discover scopes once than to branch on 403s after the fact.
+- **On 403 from a known endpoint.** Confirm the token actually has the required scope. If it doesn't, surface a precise "this token lacks the `X` scope" message instead of a generic auth error.
+- **When stitching multi-step flows.** If a flow needs `view_sales` for step 1 and `edit_products` for step 2, check both up front — fail fast.
+
+## Finding a token
+
+Never ask the user to paste a token if one is already discoverable. Check these sources in order:
+
+1. **`$GUMROAD_ACCESS_TOKEN` environment variable** (explicit override, same convention the gumroad-cli uses).
+
+2. **gumroad-cli stored credentials.** If the CLI has been used to authenticate, the token is saved at:
+   - `$XDG_CONFIG_HOME/gumroad/config.json` (if `XDG_CONFIG_HOME` is set), otherwise
+   - `~/.config/gumroad/config.json` on macOS/Linux
+   - `%APPDATA%\gumroad\config.json` on Windows
+
+   The file is JSON-shaped `{"access_token": "..."}` with `0600` permissions. Read it with:
+   ```bash
+   jq -r .access_token "${XDG_CONFIG_HOME:-$HOME/.config}/gumroad/config.json"
+   ```
+   The CLI refuses to load it if permissions are wider than `0600`; agents should not loosen them.
+
+3. **Bootstrap auth via the CLI** if neither source has a token. Tell the user:
+   > "Run `gumroad auth login` — it'll open your browser. Reply when you've approved access."
+
+   This starts the gumroad-cli's OAuth PKCE flow, which writes the token to the path in step 2. If the CLI isn't installed, suggest `brew install antiwork/cli/gumroad` (macOS) or the install script at `https://gumroad.com/install-cli.sh`. Then return to step 2.
+
+4. **Last resort:** ask the user to paste a token in the chat. Only if nothing above works.
+
+For non-production hosts, also check `$GUMROAD_API_URL` (defaults to `https://api.gumroad.com`). Use it as the base URL for `/v2/meta` and any other API calls.
+
+## Request
+
+```bash
+curl -sS -H "Authorization: Bearer $TOKEN" https://api.gumroad.com/v2/meta
+```
+
+The endpoint is also reachable at `https://gumroad.com/api/v2/meta`. In local dev, the API mounts at root and the path is `http://127.0.0.1:3000/v2/meta`.
+
+## Response
+
+```json
+{
+  "success": true,
+  "user": { "id": "<external_id>" },
+  "token": {
+    "scopes": ["view_sales", "edit_products"],
+    "application_name": "<oauth_app_name_or_null>"
+  },
+  "api": {
+    "version": "v2",
+    "documentation_url": "https://app.gumroad.com/api"
+  }
+}
+```
+
+- `user.id` is the external ID (obfuscated). Never a database ID.
+- `token.scopes` lists every scope the token holds. Match against the scope listed in the docs for whichever endpoint you intend to call.
+- `token.application_name` is `null` for tokens not associated with an OAuth application.
+
+## Status codes
+
+| Status | Meaning |
+|---|---|
+| 200 | Token is valid and has at least one public scope. |
+| 401 | No `Authorization` header, or the token is unknown / revoked. |
+| 403 | Token has only private scopes (e.g. `mobile_api`). Treat as "wrong tool for this surface". |
+
+## Public scopes you may see
+
+`account`, `edit_products`, `view_sales`, `mark_sales_as_shipped`, `edit_sales`, `revenue_share`, `ifttt`, `view_profile`, `view_payouts`, `view_tax_data`, `view_public`.
+
+The `account` scope is a superset — every other public-scope endpoint accepts it. If you see only `account`, you can call any v2 public endpoint.
+
+## What this endpoint deliberately does NOT return
+
+- The user's email, name, or profile details. Those are scope-gated on `/v2/user`.
+- A list of available endpoints. Use the OpenAPI spec (when published) for that.
+- The token's expiration. Gumroad access tokens do not expire (`access_token_expires_in nil` in the Doorkeeper config).
+
+If you need email or profile data, call `/v2/user` after `/v2/meta` confirms you have `view_profile` (or any higher scope).
+
+## Source
+
+- Controller: `app/controllers/api/v2/meta_controller.rb`
+- Route: `config/routes.rb` (inside `api_routes` → `scope "v2"`)
+- Spec: `spec/controllers/api/v2/meta_controller_spec.rb`

--- a/.claude/skills/gumroad-api-meta
+++ b/.claude/skills/gumroad-api-meta
@@ -1,0 +1,1 @@
+../../.agents/skills/gumroad-api-meta

--- a/app/controllers/api/v2/meta_controller.rb
+++ b/app/controllers/api/v2/meta_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class Api::V2::MetaController < Api::V2::BaseController
+  before_action -> { doorkeeper_authorize!(*Doorkeeper.configuration.public_scopes.concat([:view_public])) }
+
+  API_DOCUMENTATION_URL = "https://app.gumroad.com/api"
+
+  def show
+    render_response(
+      true,
+      user: { id: current_resource_owner.external_id },
+      token: {
+        scopes: doorkeeper_token.scopes.to_a,
+        application_name: doorkeeper_token.application&.name,
+      },
+      api: {
+        version: "v2",
+        documentation_url: API_DOCUMENTATION_URL,
+      }
+    )
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,7 @@ Rails.application.routes.draw do
       end
 
       get "/user", to: "users#show"
+      get "/meta", to: "meta#show"
       resources :links, path: "products", only: [:index, :show, :update, :create, :destroy] do
         resources :custom_fields, only: [:index, :create, :update, :destroy]
         resources :offer_codes, only: [:index, :create, :show, :update, :destroy]

--- a/spec/controllers/api/v2/meta_controller_spec.rb
+++ b/spec/controllers/api/v2/meta_controller_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "shared_examples/authorized_oauth_v1_api_method"
+
+describe Api::V2::MetaController do
+  before do
+    @user = create(:user, email: "creator@example.com")
+    @app = create(:oauth_application, name: "Acme Agent", owner: create(:user))
+  end
+
+  describe "GET 'show'" do
+    before do
+      @action = :show
+      @params = {}
+    end
+
+    it_behaves_like "authorized oauth v1 api method"
+
+    it "returns the token scopes, application name, user external_id, and api metadata" do
+      token = create("doorkeeper/access_token", application: @app, resource_owner_id: @user.id, scopes: "view_sales edit_products")
+
+      get @action, params: { access_token: token.token }
+
+      expect(response).to be_successful
+      body = response.parsed_body
+      expect(body["success"]).to eq(true)
+      expect(body["user"]).to eq("id" => @user.external_id)
+      expect(body["token"]["scopes"]).to match_array(%w[view_sales edit_products])
+      expect(body["token"]["application_name"]).to eq("Acme Agent")
+      expect(body["api"]).to eq("version" => "v2", "documentation_url" => "https://app.gumroad.com/api")
+    end
+
+    it "accepts the default view_public scope" do
+      token = create("doorkeeper/access_token", application: @app, resource_owner_id: @user.id, scopes: "view_public")
+
+      get @action, params: { access_token: token.token }
+
+      expect(response).to be_successful
+      expect(response.parsed_body["token"]["scopes"]).to eq(["view_public"])
+    end
+
+    it "accepts the account scope" do
+      token = create("doorkeeper/access_token", application: @app, resource_owner_id: @user.id, scopes: "account")
+
+      get @action, params: { access_token: token.token }
+
+      expect(response).to be_successful
+      expect(response.parsed_body["token"]["scopes"]).to eq(["account"])
+    end
+
+    it "rejects a token whose scope is not recognized" do
+      token = create("doorkeeper/access_token", application: @app, resource_owner_id: @user.id, scopes: "mobile_api")
+
+      get @action, params: { access_token: token.token }
+
+      expect(response.status).to eq(403)
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds `GET /api/v2/meta`, a new authenticated endpoint that returns:

- the OAuth token's **scopes**
- the OAuth **application_name**
- the resource owner's **external_id**
- the **api version** and a static **documentation_url**

```json
$ curl -H "Authorization: Bearer $TOKEN" https://api.gumroad.com/v2/meta
{
  "success": true,
  "user": {
    "id": "2687846168522"
  },
  "token": {
    "scopes": [
      "view_sales",
      "edit_products",
      "view_profile"
    ],
    "application_name": "Local Test"
  },
  "api": {
    "version": "v2",
    "documentation_url": "https://app.gumroad.com/api"
  }
}
```

## Why

Today an API consumer holding an opaque OAuth token has no way to ask the API "what can this token do?" The only way to learn the scope set is to try a privileged endpoint and see if it 403s. For human integrations that's annoying; for AI agents (Claude Code, the gumroad-cli, third-party automations) it's a real blocker — they have to either guess capabilities or bake assumptions into client code.

This is the smallest possible step toward a discoverable API: one round trip, no migration, no new model, no PII beyond what the token holder already has access to.

This is a proof-of-concept for a broader API-discoverability effort (rate-limit headers, machine-readable error codes, a published OpenAPI spec). Each of those is independent and can land separately. This PR ships the smallest piece.

### Why this auth pattern

`before_action -> { doorkeeper_authorize!(*Doorkeeper.configuration.public_scopes.concat([:view_public])) }` matches `Api::V2::UsersController#show` — any token with a public scope (or the default `view_public`) is accepted. The endpoint only exposes metadata the token holder already knows about itself, so a tighter scope check would just be friction.

### Why no user email / name

Those are scope-gated on `/v2/user`. The meta endpoint is meant to be safe to call before knowing your scope set, so it returns only `external_id`. An agent that needs richer user info can call `/v2/user` once it knows it has `view_profile` or `account` scope — which it learns from `/v2/meta`.

## Before / After


https://github.com/user-attachments/assets/b4e3ed32-f57d-49a3-b58b-51c42262a594


### Showing the changes + skill using Claude Code:

https://github.com/user-attachments/assets/4004d087-3b12-449f-b333-99b283230340


## Test Results

<img width="3000" height="1312" alt="CleanShot 2026-05-01 at 13 40 47@2x" src="https://github.com/user-attachments/assets/e62f32dc-628f-4a68-9998-c643d85f509b" />

---

**AI disclosure:** Drafted with Claude Opus 4.7 (1M context) 

Conversation History: https://isolated.tech/share/gswll9Ld

