### PR TITLE
Add audit logging for internal admin writes

### DIFF
--- a/app/controllers/api/internal/admin/base_controller.rb
+++ b/app/controllers/api/internal/admin/base_controller.rb
@@ -2,6 +2,13 @@
 
 class Api::Internal::Admin::BaseController < Api::Internal::BaseController
   include AdminActor
+  include AfterCommitEverywhere
+
+  ADMIN_AUDIT_REDACTED_PARAM_PATTERN = /password|secret|token|two_factor|otp|webhook_url|license_key|email/i
+  ADMIN_AUDIT_ACTIONS_ALLOWING_NULL_TARGET = %w[
+    purchases.reassign
+    purchases.resend_all_receipts
+  ].freeze
 
   skip_before_action :verify_authenticity_token
   before_action :verify_authorization_header!
@@ -34,6 +41,84 @@ class Api::Internal::Admin::BaseController < Api::Internal::BaseController
 
     def render_invalid_authorization
       render json: { success: false, message: "authorization is invalid" }, status: :unauthorized
+    end
+
+    def current_admin_actor_id
+      Current.admin_actor.id
+    end
+
+    def record_admin_write(action:, target: nil)
+      validate_admin_audit_target!(action:, target:)
+
+      error = nil
+      begin
+        yield
+      rescue => e
+        error = e
+        raise
+      ensure
+        write_admin_audit_log(action:, target:, error:)
+      end
+    end
+
+    def validate_admin_audit_target!(action:, target:)
+      return if action.present? && (target.present? || ADMIN_AUDIT_ACTIONS_ALLOWING_NULL_TARGET.include?(action))
+
+      raise ArgumentError, "admin write audit target is required for #{action.presence || "unknown action"}"
+    end
+
+    def write_admin_audit_log(action:, target:, error:)
+      return if Current.admin_actor.blank? || Current.admin_token.blank?
+
+      attributes = {
+        actor_user_id: Current.admin_actor.id,
+        admin_api_token_id: Current.admin_token.id,
+        action:,
+        target_type: admin_audit_target_type(target),
+        target_id: target&.id,
+        target_external_id: admin_audit_target_external_id(target),
+        route: request.path,
+        http_method: request.request_method,
+        params_snapshot: admin_audit_params_snapshot,
+        request_id: request.request_id,
+        response_status: error.present? ? Rack::Utils.status_code(:internal_server_error) : response.status,
+        error_class: error&.class&.name,
+        created_at: Time.current
+      }
+
+      after_commit { AdminApiAuditLog.create!(attributes) }
+    end
+
+    def admin_audit_target_type(target)
+      target&.class&.base_class&.name
+    end
+
+    def admin_audit_target_external_id(target)
+      return if target.blank?
+      return target.external_id.to_s if target.respond_to?(:external_id) && target.external_id.present?
+
+      target.external_id_numeric.to_s if target.respond_to?(:external_id_numeric) && target.external_id_numeric.present?
+    end
+
+    def admin_audit_params_snapshot
+      redacted_admin_audit_value(params.to_unsafe_h.except("controller", "action", "format"))
+    end
+
+    def redacted_admin_audit_value(value, key: nil)
+      return "[REDACTED]" if key.to_s.match?(ADMIN_AUDIT_REDACTED_PARAM_PATTERN)
+
+      case value
+      when ActionController::Parameters
+        redacted_admin_audit_value(value.to_unsafe_h, key:)
+      when Hash
+        value.to_h.each_with_object({}) do |(nested_key, nested_value), redacted|
+          redacted[nested_key] = redacted_admin_audit_value(nested_value, key: nested_key)
+        end
+      when Array
+        value.map { redacted_admin_audit_value(_1, key:) }
+      else
+        value
+      end
     end
 
     def serialize_purchase(purchase)

--- a/app/controllers/api/internal/admin/base_controller.rb
+++ b/app/controllers/api/internal/admin/base_controller.rb
@@ -5,6 +5,9 @@ class Api::Internal::Admin::BaseController < Api::Internal::BaseController
   include AfterCommitEverywhere
 
   ADMIN_AUDIT_REDACTED_PARAM_PATTERN = /password|secret|token|two_factor|otp|webhook_url|license_key|email/i
+  ADMIN_AUDIT_ACTION_REDACTED_PARAM_KEYS = {
+    "purchases.reassign" => %w[from to]
+  }.freeze
   ADMIN_AUDIT_ACTIONS_ALLOWING_NULL_TARGET = %w[
     purchases.reassign
     purchases.resend_all_receipts
@@ -79,14 +82,18 @@ class Api::Internal::Admin::BaseController < Api::Internal::BaseController
         target_external_id: admin_audit_target_external_id(target),
         route: request.path,
         http_method: request.request_method,
-        params_snapshot: admin_audit_params_snapshot,
+        params_snapshot: admin_audit_params_snapshot(action),
         request_id: request.request_id,
         response_status: error.present? ? Rack::Utils.status_code(:internal_server_error) : response.status,
         error_class: error&.class&.name,
         created_at: Time.current
       }
 
-      after_commit { AdminApiAuditLog.create!(attributes) }
+      after_commit do
+        AdminApiAuditLog.create!(attributes)
+      rescue => e
+        handle_admin_audit_log_failure(e, attributes)
+      end
     end
 
     def admin_audit_target_type(target)
@@ -100,25 +107,37 @@ class Api::Internal::Admin::BaseController < Api::Internal::BaseController
       target.external_id_numeric.to_s if target.respond_to?(:external_id_numeric) && target.external_id_numeric.present?
     end
 
-    def admin_audit_params_snapshot
-      redacted_admin_audit_value(params.to_unsafe_h.except("controller", "action", "format"))
+    def handle_admin_audit_log_failure(error, attributes)
+      Rails.logger.error("Failed to record admin audit log for #{attributes[:action]}: #{error.class.name}: #{error.message}")
+      ErrorNotifier.notify(error) do |report|
+        report.add_metadata(:admin_audit_log, attributes.except(:params_snapshot))
+      end
     end
 
-    def redacted_admin_audit_value(value, key: nil)
-      return "[REDACTED]" if key.to_s.match?(ADMIN_AUDIT_REDACTED_PARAM_PATTERN)
+    def admin_audit_params_snapshot(action)
+      redacted_admin_audit_value(params.to_unsafe_h.except("controller", "action", "format"), action:)
+    end
+
+    def redacted_admin_audit_value(value, key: nil, action:)
+      return "[REDACTED]" if admin_audit_redacted_param_key?(key, action:)
 
       case value
       when ActionController::Parameters
-        redacted_admin_audit_value(value.to_unsafe_h, key:)
+        redacted_admin_audit_value(value.to_unsafe_h, key:, action:)
       when Hash
         value.to_h.each_with_object({}) do |(nested_key, nested_value), redacted|
-          redacted[nested_key] = redacted_admin_audit_value(nested_value, key: nested_key)
+          redacted[nested_key] = redacted_admin_audit_value(nested_value, key: nested_key, action:)
         end
       when Array
-        value.map { redacted_admin_audit_value(_1, key:) }
+        value.map { redacted_admin_audit_value(_1, key:, action:) }
       else
         value
       end
+    end
+
+    def admin_audit_redacted_param_key?(key, action:)
+      key.to_s.match?(ADMIN_AUDIT_REDACTED_PARAM_PATTERN) ||
+        ADMIN_AUDIT_ACTION_REDACTED_PARAM_KEYS.fetch(action, []).include?(key.to_s)
     end
 
     def serialize_purchase(purchase)

--- a/app/controllers/api/internal/admin/payouts_controller.rb
+++ b/app/controllers/api/internal/admin/payouts_controller.rb
@@ -17,59 +17,63 @@ class Api::Internal::Admin::PayoutsController < Api::Internal::Admin::BaseContro
   end
 
   def pause
-    if @user.payouts_paused_by_source == User::PAYOUT_PAUSE_SOURCE_ADMIN
-      return render json: {
+    record_admin_write(action: "payouts.pause", target: @user) do
+      if @user.payouts_paused_by_source == User::PAYOUT_PAUSE_SOURCE_ADMIN
+        return render json: {
+          success: true,
+          status: "already_paused",
+          message: "Payouts are already paused by admin",
+          payouts_paused: true
+        }
+      end
+
+      reason = params[:reason].to_s.strip.presence
+
+      User.transaction do
+        @user.update!(payouts_paused_internally: true, payouts_paused_by: current_admin_actor_id)
+        if reason.present?
+          @user.comments.create!(
+            author_id: current_admin_actor_id,
+            comment_type: Comment::COMMENT_TYPE_PAYOUTS_PAUSED,
+            content: reason
+          )
+        end
+      end
+
+      render json: {
         success: true,
-        status: "already_paused",
-        message: "Payouts are already paused by admin",
+        message: "Payouts paused for #{@user.email}",
         payouts_paused: true
       }
     end
-
-    reason = params[:reason].to_s.strip.presence
-
-    User.transaction do
-      @user.update!(payouts_paused_internally: true, payouts_paused_by: GUMROAD_ADMIN_ID)
-      if reason.present?
-        @user.comments.create!(
-          author_id: GUMROAD_ADMIN_ID,
-          comment_type: Comment::COMMENT_TYPE_PAYOUTS_PAUSED,
-          content: reason
-        )
-      end
-    end
-
-    render json: {
-      success: true,
-      message: "Payouts paused for #{@user.email}",
-      payouts_paused: true
-    }
   end
 
   def resume
-    unless @user.payouts_paused_internally?
-      return render json: {
+    record_admin_write(action: "payouts.resume", target: @user) do
+      unless @user.payouts_paused_internally?
+        return render json: {
+          success: true,
+          status: "not_paused",
+          message: "Payouts are not paused by admin",
+          payouts_paused: @user.payouts_paused?
+        }
+      end
+
+      User.transaction do
+        @user.update!(payouts_paused_internally: false, payouts_paused_by: nil)
+        @user.comments.create!(
+          author_id: current_admin_actor_id,
+          comment_type: Comment::COMMENT_TYPE_PAYOUTS_RESUMED,
+          content: "Payouts resumed."
+        )
+      end
+
+      render json: {
         success: true,
-        status: "not_paused",
-        message: "Payouts are not paused by admin",
-        payouts_paused: @user.payouts_paused?
+        message: "Payouts resumed for #{@user.email}",
+        payouts_paused: @user.reload.payouts_paused?
       }
     end
-
-    User.transaction do
-      @user.update!(payouts_paused_internally: false, payouts_paused_by: nil)
-      @user.comments.create!(
-        author_id: GUMROAD_ADMIN_ID,
-        comment_type: Comment::COMMENT_TYPE_PAYOUTS_RESUMED,
-        content: "Payouts resumed."
-      )
-    end
-
-    render json: {
-      success: true,
-      message: "Payouts resumed for #{@user.email}",
-      payouts_paused: @user.reload.payouts_paused?
-    }
   end
 
   private

--- a/app/controllers/api/internal/admin/purchases_controller.rb
+++ b/app/controllers/api/internal/admin/purchases_controller.rb
@@ -45,11 +45,13 @@ class Api::Internal::Admin::PurchasesController < Api::Internal::Admin::BaseCont
     purchase = fetch_purchase
     return render json: { success: false, message: "Purchase not found" }, status: :not_found if purchase.blank?
 
-    purchase.resend_receipt
-    render json: {
-      success: true,
-      message: "Successfully resent receipt for purchase number #{purchase.external_id_numeric} to #{purchase.email}"
-    }
+    record_admin_write(action: "purchases.resend_receipt", target: purchase) do
+      purchase.resend_receipt
+      render json: {
+        success: true,
+        message: "Successfully resent receipt for purchase number #{purchase.external_id_numeric} to #{purchase.email}"
+      }
+    end
   end
 
   def resend_all_receipts
@@ -59,12 +61,14 @@ class Api::Internal::Admin::PurchasesController < Api::Internal::Admin::BaseCont
     purchases = Purchase.where(email: email).successful
     return render json: { success: false, message: "No purchases found for email: #{email}" }, status: :not_found if purchases.empty?
 
-    CustomerMailer.grouped_receipt(purchases.ids).deliver_later(queue: "critical")
-    render json: {
-      success: true,
-      message: "Successfully resent all receipts to #{email}",
-      count: purchases.count
-    }
+    record_admin_write(action: "purchases.resend_all_receipts") do
+      CustomerMailer.grouped_receipt(purchases.ids).deliver_later(queue: "critical")
+      render json: {
+        success: true,
+        message: "Successfully resent all receipts to #{email}",
+        count: purchases.count
+      }
+    end
   end
 
   def refund_taxes
@@ -76,15 +80,17 @@ class Api::Internal::Admin::PurchasesController < Api::Internal::Admin::BaseCont
       return render json: { success: false, message: "Purchase not found or email doesn't match" }, status: :not_found
     end
 
-    if purchase.refund_gumroad_taxes!(refunding_user_id: GUMROAD_ADMIN_ID, note: params[:note], business_vat_id: params[:business_vat_id])
-      render json: {
-        success: true,
-        message: "Successfully refunded taxes for purchase number #{purchase.external_id_numeric}",
-        purchase: serialize_purchase(purchase)
-      }
-    else
-      message = purchase.errors.full_messages.presence&.to_sentence || "No refundable taxes available"
-      render json: { success: false, message: message }, status: :unprocessable_entity
+    record_admin_write(action: "purchases.refund_taxes", target: purchase) do
+      if purchase.refund_gumroad_taxes!(refunding_user_id: current_admin_actor_id, note: params[:note], business_vat_id: params[:business_vat_id])
+        render json: {
+          success: true,
+          message: "Successfully refunded taxes for purchase number #{purchase.external_id_numeric}",
+          purchase: serialize_purchase(purchase)
+        }
+      else
+        message = purchase.errors.full_messages.presence&.to_sentence || "No refundable taxes available"
+        render json: { success: false, message: message }, status: :unprocessable_entity
+      end
     end
   end
 
@@ -92,18 +98,20 @@ class Api::Internal::Admin::PurchasesController < Api::Internal::Admin::BaseCont
     from_email = params[:from].to_s.strip.presence
     to_email = params[:to].to_s.strip.presence
 
-    result = Purchase::ReassignByEmailService.new(from_email:, to_email:).perform
+    record_admin_write(action: "purchases.reassign") do
+      result = Purchase::ReassignByEmailService.new(from_email:, to_email:).perform
 
-    unless result.success?
-      return render json: { success: false, message: result.error_message }, status: status_for_reason(result.reason)
+      unless result.success?
+        return render json: { success: false, message: result.error_message }, status: status_for_reason(result.reason)
+      end
+
+      render json: {
+        success: true,
+        message: "Successfully reassigned #{result.count} purchases from #{from_email} to #{to_email}. Receipt sent to #{to_email}.",
+        count: result.count,
+        reassigned_purchase_ids: result.reassigned_purchase_ids
+      }
     end
-
-    render json: {
-      success: true,
-      message: "Successfully reassigned #{result.count} purchases from #{from_email} to #{to_email}. Receipt sent to #{to_email}.",
-      count: result.count,
-      reassigned_purchase_ids: result.reassigned_purchase_ids
-    }
   end
 
   def refund
@@ -115,182 +123,192 @@ class Api::Internal::Admin::PurchasesController < Api::Internal::Admin::BaseCont
       return render json: { success: false, message: "Purchase not found or email doesn't match" }, status: :not_found
     end
 
-    if purchase.stripe_refunded
-      return render json: { success: false, message: "Purchase has already been fully refunded" }, status: :unprocessable_entity
-    end
-
-    if purchase.stripe_transaction_id.blank? || purchase.amount_refundable_cents <= 0
-      return render json: { success: false, message: "Purchase has no charge to refund" }, status: :unprocessable_entity
-    end
-
-    force = ActiveModel::Type::Boolean.new.cast(params[:force])
-
-    unless force
-      unless purchase.within_refund_policy_timeframe?
-        return render json: { success: false, message: "Purchase is outside of the refund policy timeframe" }, status: :unprocessable_entity
+    record_admin_write(action: "purchases.refund", target: purchase) do
+      if purchase.stripe_refunded
+        return render json: { success: false, message: "Purchase has already been fully refunded" }, status: :unprocessable_entity
       end
 
-      if purchase.purchase_refund_policy&.fine_print.present?
-        return render json: { success: false, message: "This product has specific refund conditions that require seller review" }, status: :unprocessable_entity
+      if purchase.stripe_transaction_id.blank? || purchase.amount_refundable_cents <= 0
+        return render json: { success: false, message: "Purchase has no charge to refund" }, status: :unprocessable_entity
       end
-    end
 
-    amount = nil
-    if params[:amount_cents].present?
-      raw_amount_cents = params[:amount_cents]
-      unless raw_amount_cents.is_a?(Integer) || raw_amount_cents.to_s.match?(/\A\d+\z/)
-        return render json: { success: false, message: "amount_cents must be a positive integer" }, status: :unprocessable_entity
+      force = ActiveModel::Type::Boolean.new.cast(params[:force])
+
+      unless force
+        unless purchase.within_refund_policy_timeframe?
+          return render json: { success: false, message: "Purchase is outside of the refund policy timeframe" }, status: :unprocessable_entity
+        end
+
+        if purchase.purchase_refund_policy&.fine_print.present?
+          return render json: { success: false, message: "This product has specific refund conditions that require seller review" }, status: :unprocessable_entity
+        end
       end
-      amount_cents = raw_amount_cents.to_i
-      if amount_cents <= 0
-        return render json: { success: false, message: "amount_cents must be a positive integer" }, status: :unprocessable_entity
+
+      amount = nil
+      if params[:amount_cents].present?
+        raw_amount_cents = params[:amount_cents]
+        unless raw_amount_cents.is_a?(Integer) || raw_amount_cents.to_s.match?(/\A\d+\z/)
+          return render json: { success: false, message: "amount_cents must be a positive integer" }, status: :unprocessable_entity
+        end
+        amount_cents = raw_amount_cents.to_i
+        if amount_cents <= 0
+          return render json: { success: false, message: "amount_cents must be a positive integer" }, status: :unprocessable_entity
+        end
+        amount = amount_cents / unit_scaling_factor(purchase.displayed_price_currency_type).to_f
       end
-      amount = amount_cents / unit_scaling_factor(purchase.displayed_price_currency_type).to_f
-    end
 
-    unless purchase.refund!(refunding_user_id: GUMROAD_ADMIN_ID, amount:)
-      message = purchase.errors.full_messages.presence&.to_sentence || "Refund failed for purchase number #{purchase.external_id_numeric}"
-      return render json: { success: false, message: }, status: :unprocessable_entity
-    end
-
-    subscription_cancelled = false
-    subscription_cancel_error = nil
-    subscription = purchase.subscription
-    if ActiveModel::Type::Boolean.new.cast(params[:cancel_subscription]) &&
-        subscription.present? &&
-        subscription.cancelled_at.blank? &&
-        !subscription.deactivated?
-      begin
-        subscription.cancel!(by_seller: true, by_admin: true)
-        subscription_cancelled = subscription.cancelled_at.present?
-      rescue => e
-        subscription_cancel_error = e.message
-        Rails.logger.error("[admin/refund] subscription cancel failed for purchase #{purchase.external_id_numeric}: #{e.class}: #{e.message}")
+      unless purchase.refund!(refunding_user_id: current_admin_actor_id, amount:)
+        message = purchase.errors.full_messages.presence&.to_sentence || "Refund failed for purchase number #{purchase.external_id_numeric}"
+        return render json: { success: false, message: }, status: :unprocessable_entity
       end
-    end
 
-    render json: {
-      success: true,
-      message: "Successfully refunded purchase number #{purchase.external_id_numeric}",
-      purchase: serialize_purchase(purchase),
-      subscription_cancelled:,
-      subscription_cancel_error:
-    }.compact
+      subscription_cancelled = false
+      subscription_cancel_error = nil
+      subscription = purchase.subscription
+      if ActiveModel::Type::Boolean.new.cast(params[:cancel_subscription]) &&
+          subscription.present? &&
+          subscription.cancelled_at.blank? &&
+          !subscription.deactivated?
+        begin
+          subscription.cancel!(by_seller: true, by_admin: true)
+          subscription_cancelled = subscription.cancelled_at.present?
+        rescue => e
+          subscription_cancel_error = e.message
+          Rails.logger.error("[admin/refund] subscription cancel failed for purchase #{purchase.external_id_numeric}: #{e.class}: #{e.message}")
+        end
+      end
+
+      render json: {
+        success: true,
+        message: "Successfully refunded purchase number #{purchase.external_id_numeric}",
+        purchase: serialize_purchase(purchase),
+        subscription_cancelled:,
+        subscription_cancel_error:
+      }.compact
+    end
   end
 
   def cancel_subscription
     purchase = fetch_purchase_with_email_match
     return unless purchase
 
-    subscription = purchase.subscription
-    if subscription.blank?
-      return render json: { success: false, message: "Purchase has no subscription" }, status: :unprocessable_entity
-    end
+    record_admin_write(action: "purchases.cancel_subscription", target: purchase) do
+      subscription = purchase.subscription
+      if subscription.blank?
+        return render json: { success: false, message: "Purchase has no subscription" }, status: :unprocessable_entity
+      end
 
-    if subscription.cancelled_at.present?
-      return render json: {
+      if subscription.cancelled_at.present?
+        return render json: {
+          success: true,
+          status: "already_cancelled",
+          message: "Subscription is already cancelled",
+          cancelled_at: subscription.cancelled_at.as_json,
+          cancelled_by_admin: subscription.cancelled_by_admin?
+        }
+      end
+
+      if subscription.deactivated?
+        return render json: {
+          success: true,
+          status: "already_inactive",
+          message: "Subscription is no longer active",
+          termination_reason: subscription.termination_reason,
+          deactivated_at: subscription.deactivated_at&.as_json
+        }
+      end
+
+      by_seller = ActiveModel::Type::Boolean.new.cast(params[:by_seller]) == true
+      subscription.cancel!(by_seller: by_seller, by_admin: true)
+
+      render json: {
         success: true,
-        status: "already_cancelled",
-        message: "Subscription is already cancelled",
-        cancelled_at: subscription.cancelled_at.as_json,
-        cancelled_by_admin: subscription.cancelled_by_admin?
+        message: "Successfully cancelled subscription for purchase number #{purchase.external_id_numeric}",
+        cancelled_at: subscription.cancelled_at&.as_json,
+        cancelled_by_admin: subscription.cancelled_by_admin?,
+        cancelled_by_seller: !subscription.cancelled_by_buyer?
       }
     end
-
-    if subscription.deactivated?
-      return render json: {
-        success: true,
-        status: "already_inactive",
-        message: "Subscription is no longer active",
-        termination_reason: subscription.termination_reason,
-        deactivated_at: subscription.deactivated_at&.as_json
-      }
-    end
-
-    by_seller = ActiveModel::Type::Boolean.new.cast(params[:by_seller]) == true
-    subscription.cancel!(by_seller: by_seller, by_admin: true)
-
-    render json: {
-      success: true,
-      message: "Successfully cancelled subscription for purchase number #{purchase.external_id_numeric}",
-      cancelled_at: subscription.cancelled_at&.as_json,
-      cancelled_by_admin: subscription.cancelled_by_admin?,
-      cancelled_by_seller: !subscription.cancelled_by_buyer?
-    }
   end
 
   def block_buyer
     purchase = fetch_purchase_with_email_match
     return unless purchase
 
-    if purchase.is_buyer_blocked_by_admin? && purchase.buyer_blocked?
-      return render json: {
+    record_admin_write(action: "purchases.block_buyer", target: purchase) do
+      if purchase.is_buyer_blocked_by_admin? && purchase.buyer_blocked?
+        return render json: {
+          success: true,
+          status: "already_blocked",
+          message: "Buyer is already blocked by admin"
+        }
+      end
+
+      purchase.block_buyer!(blocking_user_id: current_admin_actor_id, comment_content: params[:comment_content].presence)
+
+      render json: {
         success: true,
-        status: "already_blocked",
-        message: "Buyer is already blocked by admin"
+        message: "Successfully blocked buyer for purchase number #{purchase.external_id_numeric}"
       }
     end
-
-    purchase.block_buyer!(blocking_user_id: GUMROAD_ADMIN_ID, comment_content: params[:comment_content].presence)
-
-    render json: {
-      success: true,
-      message: "Successfully blocked buyer for purchase number #{purchase.external_id_numeric}"
-    }
   end
 
   def unblock_buyer
     purchase = fetch_purchase_with_email_match
     return unless purchase
 
-    unless purchase.buyer_blocked? || purchase.is_buyer_blocked_by_admin?
-      return render json: {
+    record_admin_write(action: "purchases.unblock_buyer", target: purchase) do
+      unless purchase.buyer_blocked? || purchase.is_buyer_blocked_by_admin?
+        return render json: {
+          success: true,
+          status: "not_blocked",
+          message: "Buyer is not blocked"
+        }
+      end
+
+      purchase.unblock_buyer!
+      create_unblock_buyer_comments!(purchase)
+
+      render json: {
         success: true,
-        status: "not_blocked",
-        message: "Buyer is not blocked"
+        message: "Successfully unblocked buyer for purchase number #{purchase.external_id_numeric}"
       }
     end
-
-    purchase.unblock_buyer!
-    create_unblock_buyer_comments!(purchase)
-
-    render json: {
-      success: true,
-      message: "Successfully unblocked buyer for purchase number #{purchase.external_id_numeric}"
-    }
   end
 
   def refund_for_fraud
     purchase = fetch_purchase_with_email_match
     return unless purchase
 
-    if purchase.stripe_refunded
-      return render json: { success: false, message: "Purchase has already been fully refunded" }, status: :unprocessable_entity
-    end
+    record_admin_write(action: "purchases.refund_for_fraud", target: purchase) do
+      if purchase.stripe_refunded
+        return render json: { success: false, message: "Purchase has already been fully refunded" }, status: :unprocessable_entity
+      end
 
-    if purchase.stripe_transaction_id.blank? || purchase.amount_refundable_cents <= 0
-      return render json: { success: false, message: "Purchase has no charge to refund" }, status: :unprocessable_entity
-    end
+      if purchase.stripe_transaction_id.blank? || purchase.amount_refundable_cents <= 0
+        return render json: { success: false, message: "Purchase has no charge to refund" }, status: :unprocessable_entity
+      end
 
-    unless purchase.refund_for_fraud_and_block_buyer!(GUMROAD_ADMIN_ID)
-      message = purchase.errors.full_messages.presence&.to_sentence || "Refund-for-fraud failed for purchase number #{purchase.external_id_numeric}"
-      return render json: { success: false, message: }, status: :unprocessable_entity
-    end
+      unless purchase.refund_for_fraud_and_block_buyer!(current_admin_actor_id)
+        message = purchase.errors.full_messages.presence&.to_sentence || "Refund-for-fraud failed for purchase number #{purchase.external_id_numeric}"
+        return render json: { success: false, message: }, status: :unprocessable_entity
+      end
 
-    render json: {
-      success: true,
-      message: "Successfully refunded purchase number #{purchase.external_id_numeric} for fraud and blocked the buyer",
-      purchase: serialize_purchase(purchase),
-      subscription_cancelled: purchase.subscription&.cancelled_at.present?
-    }
+      render json: {
+        success: true,
+        message: "Successfully refunded purchase number #{purchase.external_id_numeric} for fraud and blocked the buyer",
+        purchase: serialize_purchase(purchase),
+        subscription_cancelled: purchase.subscription&.cancelled_at.present?
+      }
+    end
   end
 
   private
     def create_unblock_buyer_comments!(purchase)
       content = "Buyer unblocked by Admin"
-      purchase.comments.create!(content:, comment_type: Comment::COMMENT_TYPE_NOTE, author_id: GUMROAD_ADMIN_ID)
+      purchase.comments.create!(content:, comment_type: Comment::COMMENT_TYPE_NOTE, author_id: current_admin_actor_id)
       if purchase.purchaser.present?
-        purchase.purchaser.comments.create!(content:, comment_type: Comment::COMMENT_TYPE_NOTE, author_id: GUMROAD_ADMIN_ID, purchase:)
+        purchase.purchaser.comments.create!(content:, comment_type: Comment::COMMENT_TYPE_NOTE, author_id: current_admin_actor_id, purchase:)
       end
     end
 

--- a/app/controllers/api/internal/admin/users_controller.rb
+++ b/app/controllers/api/internal/admin/users_controller.rb
@@ -31,8 +31,10 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
     user = find_user_or_render(params[:email])
     return unless user
 
-    user.send_reset_password_instructions
-    render json: { success: true, message: "Reset password instructions sent" }
+    record_admin_write(action: "users.reset_password", target: user) do
+      user.send_reset_password_instructions
+      render json: { success: true, message: "Reset password instructions sent" }
+    end
   end
 
   def update_email
@@ -47,29 +49,31 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
     user = find_user_or_render(params[:current_email])
     return unless user
 
-    if user.email.to_s.casecmp(params[:new_email].to_s).zero?
-      return render json: { success: false, message: "New email is the same as the current email" }, status: :unprocessable_entity
-    end
+    record_admin_write(action: "users.update_email", target: user) do
+      if user.email.to_s.casecmp(params[:new_email].to_s).zero?
+        return render json: { success: false, message: "New email is the same as the current email" }, status: :unprocessable_entity
+      end
 
-    user.email = params[:new_email]
-    unless user.save
-      return render json: { success: false, message: user.errors.full_messages.to_sentence }, status: :unprocessable_entity
-    end
+      user.email = params[:new_email]
+      unless user.save
+        return render json: { success: false, message: user.errors.full_messages.to_sentence }, status: :unprocessable_entity
+      end
 
-    if user.unconfirmed_email.present?
-      render json: {
-        success: true,
-        message: "Email change pending confirmation. Confirmation email sent to #{user.unconfirmed_email}.",
-        unconfirmed_email: user.unconfirmed_email,
-        pending_confirmation: true
-      }
-    else
-      render json: {
-        success: true,
-        message: "Email updated.",
-        email: user.email,
-        pending_confirmation: false
-      }
+      if user.unconfirmed_email.present?
+        render json: {
+          success: true,
+          message: "Email change pending confirmation. Confirmation email sent to #{user.unconfirmed_email}.",
+          unconfirmed_email: user.unconfirmed_email,
+          pending_confirmation: true
+        }
+      else
+        render json: {
+          success: true,
+          message: "Email updated.",
+          email: user.email,
+          pending_confirmation: false
+        }
+      end
     end
   end
 
@@ -80,18 +84,20 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
     user = find_user_or_render(params[:email])
     return unless user
 
-    enabled = ActiveModel::Type::Boolean.new.cast(params[:enabled])
-    user.two_factor_authentication_enabled = enabled
+    record_admin_write(action: "users.two_factor_authentication", target: user) do
+      enabled = ActiveModel::Type::Boolean.new.cast(params[:enabled])
+      user.two_factor_authentication_enabled = enabled
 
-    if user.save
-      user.totp_credential&.destroy unless user.two_factor_authentication_enabled?
-      render json: {
-        success: true,
-        message: "Two-factor authentication #{enabled ? "enabled" : "disabled"}",
-        two_factor_authentication_enabled: user.two_factor_authentication_enabled?
-      }
-    else
-      render json: { success: false, message: user.errors.full_messages.to_sentence }, status: :unprocessable_entity
+      if user.save
+        user.totp_credential&.destroy unless user.two_factor_authentication_enabled?
+        render json: {
+          success: true,
+          message: "Two-factor authentication #{enabled ? "enabled" : "disabled"}",
+          two_factor_authentication_enabled: user.two_factor_authentication_enabled?
+        }
+      else
+        render json: { success: false, message: user.errors.full_messages.to_sentence }, status: :unprocessable_entity
+      end
     end
   end
 
@@ -103,15 +109,17 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
     user = find_user_or_render(params[:email])
     return unless user
 
-    comment = User::CreateAdminCommentService.new(user:, content: params[:content], idempotency_key: params[:idempotency_key]).perform
+    record_admin_write(action: "users.create_comment", target: user) do
+      comment = User::CreateAdminCommentService.new(user:, content: params[:content], idempotency_key: params[:idempotency_key], author_id: current_admin_actor_id).perform
 
-    if comment.persisted?
-      render json: { success: true, comment: serialize_comment(comment) }
-    else
-      render json: { success: false, message: comment.errors.full_messages.to_sentence }, status: :unprocessable_entity
+      if comment.persisted?
+        render json: { success: true, comment: serialize_comment(comment) }
+      else
+        render json: { success: false, message: comment.errors.full_messages.to_sentence }, status: :unprocessable_entity
+      end
+    rescue User::CreateAdminCommentService::IdempotencyConflictError
+      render json: { success: false, message: "Idempotency key already used with different content" }, status: :conflict
     end
-  rescue User::CreateAdminCommentService::IdempotencyConflictError
-    render json: { success: false, message: "Idempotency key already used with different content" }, status: :conflict
   end
 
   def mark_compliant
@@ -120,18 +128,20 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
     user = find_user_or_render(params[:email])
     return unless user
 
-    if user.compliant?
-      return render json: { success: true, status: "already_compliant", message: "User is already compliant" }
+    record_admin_write(action: "users.mark_compliant", target: user) do
+      if user.compliant?
+        return render json: { success: true, status: "already_compliant", message: "User is already compliant" }
+      end
+
+      note = build_admin_note(user, params[:note]) if params[:note].present?
+      return render_invalid_comment(note) if note&.invalid?
+
+      user.mark_compliant!(author_id: current_admin_actor_id)
+      note&.save!
+      render json: { success: true, status: "marked_compliant", message: "User marked compliant" }
+    rescue StateMachines::InvalidTransition => e
+      render json: { success: false, message: e.message }, status: :unprocessable_entity
     end
-
-    note = build_admin_note(user, params[:note]) if params[:note].present?
-    return render_invalid_comment(note) if note&.invalid?
-
-    user.mark_compliant!(author_id: GUMROAD_ADMIN_ID)
-    note&.save!
-    render json: { success: true, status: "marked_compliant", message: "User marked compliant" }
-  rescue StateMachines::InvalidTransition => e
-    render json: { success: false, message: e.message }, status: :unprocessable_entity
   end
 
   def suspend_for_fraud
@@ -140,18 +150,20 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
     user = find_user_or_render(params[:email])
     return unless user
 
-    if user.suspended_for_fraud?
-      return render json: { success: true, status: "already_suspended", message: "User is already suspended for fraud" }
+    record_admin_write(action: "users.suspend_for_fraud", target: user) do
+      if user.suspended_for_fraud?
+        return render json: { success: true, status: "already_suspended", message: "User is already suspended for fraud" }
+      end
+
+      suspension_note = build_suspension_note(user) if params[:suspension_note].present?
+      return render_invalid_comment(suspension_note) if suspension_note&.invalid?
+
+      user.suspend_for_fraud!(author_id: current_admin_actor_id)
+      suspension_note&.save!
+      render json: { success: true, status: "suspended_for_fraud", message: "User suspended for fraud" }
+    rescue StateMachines::InvalidTransition => e
+      render json: { success: false, message: e.message }, status: :unprocessable_entity
     end
-
-    suspension_note = build_suspension_note(user) if params[:suspension_note].present?
-    return render_invalid_comment(suspension_note) if suspension_note&.invalid?
-
-    user.suspend_for_fraud!(author_id: GUMROAD_ADMIN_ID)
-    suspension_note&.save!
-    render json: { success: true, status: "suspended_for_fraud", message: "User suspended for fraud" }
-  rescue StateMachines::InvalidTransition => e
-    render json: { success: false, message: e.message }, status: :unprocessable_entity
   end
 
   private
@@ -233,7 +245,7 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
 
     def build_admin_note(user, content)
       user.comments.new(
-        author_id: GUMROAD_ADMIN_ID,
+        author_id: current_admin_actor_id,
         comment_type: Comment::COMMENT_TYPE_NOTE,
         content:
       )
@@ -241,7 +253,7 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
 
     def build_suspension_note(user)
       user.comments.new(
-        author_id: GUMROAD_ADMIN_ID,
+        author_id: current_admin_actor_id,
         comment_type: Comment::COMMENT_TYPE_SUSPENSION_NOTE,
         content: params[:suspension_note]
       )

--- a/app/models/admin_api_audit_log.rb
+++ b/app/models/admin_api_audit_log.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AdminApiAuditLog < ApplicationRecord
+  belongs_to :actor_user, class_name: "User"
+  belongs_to :admin_api_token
+
+  validates :actor_user, :admin_api_token, :action, :route, :http_method, presence: true
+end

--- a/app/models/admin_api_token.rb
+++ b/app/models/admin_api_token.rb
@@ -6,6 +6,7 @@ class AdminApiToken < ApplicationRecord
   TOKEN_ALPHABET = "_-0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
   belongs_to :actor_user, class_name: "User"
+  has_many :admin_api_audit_logs
 
   validates :external_id, presence: true, uniqueness: true
   validates :token_hash, presence: true, uniqueness: true

--- a/app/services/user/create_admin_comment_service.rb
+++ b/app/services/user/create_admin_comment_service.rb
@@ -3,10 +3,11 @@
 class User::CreateAdminCommentService
   class IdempotencyConflictError < StandardError; end
 
-  def initialize(user:, content:, idempotency_key:)
+  def initialize(user:, content:, idempotency_key:, author_id: GUMROAD_ADMIN_ID)
     @user = user
     @content = content
     @idempotency_key = idempotency_key
+    @author_id = author_id
   end
 
   def perform
@@ -21,7 +22,7 @@ class User::CreateAdminCommentService
     comment = @user.comments.new(
       content: @content,
       comment_type: Comment::COMMENT_TYPE_NOTE,
-      author_id: GUMROAD_ADMIN_ID,
+      author_id: @author_id,
       idempotency_key: @idempotency_key
     )
     comment.save

--- a/db/migrate/20260501160000_create_admin_api_audit_logs.rb
+++ b/db/migrate/20260501160000_create_admin_api_audit_logs.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class CreateAdminApiAuditLogs < ActiveRecord::Migration[7.1]
+  def change
+    create_table :admin_api_audit_logs do |t|
+      t.bigint :actor_user_id, null: false
+      t.bigint :admin_api_token_id, null: false
+      t.string :action, null: false
+      t.string :target_type
+      t.bigint :target_id
+      t.string :target_external_id
+      t.string :route, null: false
+      t.string :http_method, null: false
+      t.json :params_snapshot
+      t.string :request_id
+      t.integer :response_status
+      t.string :error_class
+      t.datetime :created_at, null: false
+
+      t.index [:actor_user_id, :created_at]
+      t.index [:admin_api_token_id, :created_at]
+      t.index [:target_type, :target_id, :created_at]
+      t.index :created_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -55,6 +55,26 @@ ActiveRecord::Schema[7.1].define(version: 2026_11_24_000000) do
     t.index ["token_hash"], name: "index_admin_api_tokens_on_token_hash", unique: true
   end
 
+  create_table "admin_api_audit_logs", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "actor_user_id", null: false
+    t.bigint "admin_api_token_id", null: false
+    t.string "action", null: false
+    t.string "target_type"
+    t.bigint "target_id"
+    t.string "target_external_id"
+    t.string "route", null: false
+    t.string "http_method", null: false
+    t.json "params_snapshot"
+    t.string "request_id"
+    t.integer "response_status"
+    t.string "error_class"
+    t.datetime "created_at", null: false
+    t.index ["actor_user_id", "created_at"], name: "index_admin_api_audit_logs_on_actor_user_id_and_created_at"
+    t.index ["admin_api_token_id", "created_at"], name: "idx_on_admin_api_token_id_created_at_95eabf5e0d"
+    t.index ["created_at"], name: "index_admin_api_audit_logs_on_created_at"
+    t.index ["target_type", "target_id", "created_at"], name: "idx_on_target_type_target_id_created_at_bc67bbc74b"
+  end
+
   create_table "admin_action_call_infos", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "controller_name", null: false
     t.string "action_name", null: false

--- a/spec/controllers/api/internal/admin/base_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/base_controller_spec.rb
@@ -261,5 +261,17 @@ describe Api::Internal::Admin::BaseController do
       expect(response).to have_http_status(:unprocessable_entity)
       expect(legacy_admin_actor.reload.name).not_to eq("Rolled Back")
     end
+
+    it "does not fail the write request when audit logging fails" do
+      error = ActiveRecord::StatementInvalid.new("boom")
+      allow(AdminApiAuditLog).to receive(:create!).and_raise(error)
+      allow(ErrorNotifier).to receive(:notify)
+      expect(Rails.logger).to receive(:error).with(include("Failed to record admin audit log for users.update_email"))
+
+      patch :update, params: { id: legacy_admin_actor.id }
+
+      expect(response).to have_http_status(:ok)
+      expect(ErrorNotifier).to have_received(:notify).with(error)
+    end
   end
 end

--- a/spec/controllers/api/internal/admin/base_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/base_controller_spec.rb
@@ -17,6 +17,34 @@ describe Api::Internal::Admin::BaseController do
     def create
       render json: { success: true }
     end
+
+    def update
+      record_admin_write(action: "users.update_email", target: Current.admin_actor) do
+        render json: { success: true }
+      end
+    end
+
+    def destroy
+      record_admin_write(action: "users.update_email", target: Current.admin_actor) do
+        render json: { success: false }, status: :unprocessable_entity
+      end
+    end
+
+    def edit
+      record_admin_write(action: "users.update_email", target: Current.admin_actor) do
+        raise RuntimeError, "boom"
+      end
+    end
+
+    def new
+      User.transaction do
+        record_admin_write(action: "users.update_email", target: Current.admin_actor) do
+          Current.admin_actor.update!(name: "Rolled Back")
+          raise ActiveRecord::Rollback
+        end
+      end
+      render json: { success: false }, status: :unprocessable_entity
+    end
   end
 
   let(:legacy_admin_actor) { create(:admin_user) }
@@ -154,6 +182,84 @@ describe Api::Internal::Admin::BaseController do
 
       expect(response).to have_http_status(:unauthorized)
       expect(response.body).to eq({ success: false, message: "per-actor admin token is required" }.to_json)
+    end
+  end
+
+  describe "admin write auditing" do
+    let!(:legacy_admin_token) do
+      create(:admin_api_token, actor_user: legacy_admin_actor, token_hash: AdminApiToken.hash_token("test-admin-token"))
+    end
+
+    before do
+      request.headers["Authorization"] = "Bearer test-admin-token"
+    end
+
+    it "records the actor, token, target, route, request id, and redacted params for write requests" do
+      patch :update, params: {
+        id: legacy_admin_actor.id,
+        email: "seller@example.com",
+        note: "safe note",
+        nested: {
+          api_token: "secret",
+          kept: "visible"
+        }
+      }
+
+      expect(response).to have_http_status(:ok)
+      audit_log = AdminApiAuditLog.last
+      expect(audit_log).to have_attributes(
+        actor_user_id: legacy_admin_actor.id,
+        admin_api_token_id: legacy_admin_token.id,
+        action: "users.update_email",
+        target_type: "User",
+        target_id: legacy_admin_actor.id,
+        target_external_id: legacy_admin_actor.external_id,
+        route: request.path,
+        http_method: "PATCH",
+        request_id: request.request_id,
+        response_status: 200,
+        error_class: nil
+      )
+      expect(audit_log.params_snapshot).to include(
+        "email" => "[REDACTED]",
+        "note" => "safe note",
+        "nested" => {
+          "api_token" => "[REDACTED]",
+          "kept" => "visible"
+        }
+      )
+    end
+
+    it "records handled client errors with their response status" do
+      delete :destroy, params: { id: legacy_admin_actor.id }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(AdminApiAuditLog.last).to have_attributes(
+        action: "users.update_email",
+        response_status: 422,
+        error_class: nil
+      )
+    end
+
+    it "records unhandled server errors with the exception class" do
+      expect do
+        get :edit, params: { id: legacy_admin_actor.id }
+      end.to raise_error(RuntimeError, "boom")
+
+      expect(AdminApiAuditLog.last).to have_attributes(
+        action: "users.update_email",
+        response_status: 500,
+        error_class: "RuntimeError"
+      )
+    end
+
+    it "does not leave an audit row when the wrapped transaction rolls back" do
+      expect do
+        get :new
+      end.not_to change { AdminApiAuditLog.count }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(legacy_admin_actor.reload.name).not_to eq("Rolled Back")
     end
   end
 end

--- a/spec/controllers/api/internal/admin/payouts_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/payouts_controller_spec.rb
@@ -109,6 +109,50 @@ describe Api::Internal::Admin::PayoutsController do
       expect(comment.content).to eq(reason)
     end
 
+    it "records the legacy token in the audit log" do
+      legacy_admin_token = AdminApiToken.find_by!(token_hash: AdminApiToken.hash_token("test-admin-token"))
+
+      expect do
+        post :pause, params: { email: user.email, reason: "Manual review" }
+      end.to change { AdminApiAuditLog.count }.by(1)
+
+      audit_log = AdminApiAuditLog.last
+      expect(audit_log).to have_attributes(
+        action: "payouts.pause",
+        target_type: "User",
+        target_id: user.id,
+        target_external_id: user.external_id,
+        actor_user_id: GUMROAD_ADMIN_ID,
+        admin_api_token_id: legacy_admin_token.id,
+        response_status: 200
+      )
+      expect(audit_log.params_snapshot).to include(
+        "email" => "[REDACTED]",
+        "reason" => "Manual review"
+      )
+    end
+
+    it "attributes payout comments and audit rows to a per-actor token" do
+      actor = create(:admin_user)
+      plaintext_token = AdminApiToken.mint!(actor_user_id: actor.id)
+      admin_api_token = AdminApiToken.find_by!(actor_user: actor, token_hash: AdminApiToken.hash_token(plaintext_token))
+      request.headers["Authorization"] = "Bearer #{plaintext_token}"
+
+      post :pause, params: { email: user.email, reason: "Actor review" }
+
+      expect(response).to have_http_status(:ok)
+      expect(user.comments.with_type_payouts_paused.last).to have_attributes(
+        author_id: actor.id,
+        content: "Actor review"
+      )
+      expect(AdminApiAuditLog.last).to have_attributes(
+        action: "payouts.pause",
+        actor_user_id: actor.id,
+        admin_api_token_id: admin_api_token.id,
+        target_id: user.id
+      )
+    end
+
     it "does not create a comment when reason is blank" do
       expect { post :pause, params: { email: user.email, reason: "   " } }
         .not_to change { user.comments.count }

--- a/spec/controllers/api/internal/admin/purchases_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/purchases_controller_spec.rb
@@ -565,6 +565,23 @@ describe Api::Internal::Admin::PurchasesController do
       expect(SendPurchaseReceiptJob).to have_enqueued_sidekiq_job(purchase.id).on("critical")
     end
 
+    it "records an audit log with the purchase target" do
+      legacy_admin_token = AdminApiToken.find_by!(token_hash: AdminApiToken.hash_token("test-admin-token"))
+
+      expect do
+        post :resend_receipt, params: { id: purchase.external_id_numeric.to_s }
+      end.to change { AdminApiAuditLog.count }.by(1)
+
+      expect(AdminApiAuditLog.last).to have_attributes(
+        action: "purchases.resend_receipt",
+        target_type: "Purchase",
+        target_id: purchase.id,
+        target_external_id: purchase.external_id,
+        admin_api_token_id: legacy_admin_token.id,
+        response_status: 200
+      )
+    end
+
     it "returns 404 when the purchase does not exist" do
       post :resend_receipt, params: { id: "999999999" }
 

--- a/spec/controllers/api/internal/admin/purchases_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/purchases_controller_spec.rb
@@ -752,6 +752,16 @@ describe Api::Internal::Admin::PurchasesController do
       expect(purchase2.reload.email).to eq(to_email)
     end
 
+    it "redacts the reassignment email addresses from the audit snapshot" do
+      post :reassign, params: { from: from_email, to: to_email }
+
+      expect(response).to have_http_status(:ok)
+      expect(AdminApiAuditLog.last.params_snapshot).to include(
+        "from" => "[REDACTED]",
+        "to" => "[REDACTED]"
+      )
+    end
+
     it "returns 422 when every purchase save fails" do
       allow_any_instance_of(Purchase).to receive(:save).and_return(false)
 

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -466,6 +466,29 @@ describe Api::Internal::Admin::UsersController do
       expect(user.comments.last.author_id).to eq(admin_user.id)
     end
 
+    it "creates comments and audit rows attributed to a per-actor token" do
+      actor = create(:admin_user)
+      plaintext_token = AdminApiToken.mint!(actor_user_id: actor.id)
+      admin_api_token = AdminApiToken.find_by!(actor_user: actor, token_hash: AdminApiToken.hash_token(plaintext_token))
+      request.headers["Authorization"] = "Bearer #{plaintext_token}"
+
+      post :create_comment, params: { email: user.email, content: "Actor note", idempotency_key: idempotency_key }
+
+      expect(response).to have_http_status(:ok)
+      expect(user.comments.last).to have_attributes(
+        author_id: actor.id,
+        content: "Actor note"
+      )
+      expect(AdminApiAuditLog.last).to have_attributes(
+        action: "users.create_comment",
+        actor_user_id: actor.id,
+        admin_api_token_id: admin_api_token.id,
+        target_type: "User",
+        target_id: user.id,
+        response_status: 200
+      )
+    end
+
     it "returns the existing comment when called twice with the same key and matching content" do
       post :create_comment, params: { email: user.email, content: "Note", idempotency_key: idempotency_key }
       first_id = response.parsed_body["comment"]["id"]

--- a/spec/services/user/create_admin_comment_service_spec.rb
+++ b/spec/services/user/create_admin_comment_service_spec.rb
@@ -20,6 +20,15 @@ describe User::CreateAdminCommentService do
       expect(comment.commentable).to eq(user)
     end
 
+    it "creates a comment attributed to the supplied author" do
+      actor = create(:admin_user)
+
+      comment = described_class.new(user:, content: "Note from support", idempotency_key: "key-1", author_id: actor.id).perform
+
+      expect(comment).to be_persisted
+      expect(comment.author_id).to eq(actor.id)
+    end
+
     it "returns the existing comment when called twice with the same idempotency key and matching content" do
       first = described_class.new(user:, content: "Same content", idempotency_key: "dup").perform
       second = described_class.new(user:, content: "Same content", idempotency_key: "dup").perform

--- a/spec/support/factories/admin_api_audit_logs.rb
+++ b/spec/support/factories/admin_api_audit_logs.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :admin_api_audit_log do
+    association :actor_user, factory: :admin_user
+    admin_api_token { association :admin_api_token, actor_user: }
+    action { "purchases.refund" }
+    route { "/api/internal/admin/purchases/123/refund" }
+    http_method { "POST" }
+    response_status { 200 }
+    created_at { Time.current }
+  end
+end


### PR DESCRIPTION
Ref #4677

## What

Adds write audit logging for `/internal/admin` actions and uses the authenticated admin actor for write attribution.

Every wrapped admin write now records the actor, token, action, target, route, request id, redacted params, response status, and server error class when applicable. Existing shared-token traffic still resolves to the seeded legacy admin token and keeps the same `GUMROAD_ADMIN_ID` attribution, while per-actor tokens now leave their own actor id on comments and audit rows.

## Why

The admin CLI can perform support actions, but the server previously only knew that the shared bearer token was used. That made it hard to tell whether a write came from Gumclaw, a human, or another script.

This keeps existing callers working while making new per-actor tokens useful for attribution. The audit log is writes-only because these are the actions where forensic history matters most, and it stores a redacted params snapshot instead of a digest so bad writes can actually be investigated.

---

This PR was implemented with AI assistance using gpt-5.5 xhigh.