### PR TITLE
Align payouts help with non-resident owner support

### DIFF
--- a/app/views/help_center/articles/contents/_13-getting-paid.html.erb
+++ b/app/views/help_center/articles/contents/_13-getting-paid.html.erb
@@ -399,7 +399,7 @@
     <li>A valid, government-issued photo ID</li>
     <li>Proof of residence within the country</li>
   </ul>
-  <p>If you are selling as a business, the business must be registered in the same country. You cannot get paid to another country's bank account by just having a business registered in that country. You must physically live (and can prove residence) in that country.</p>
+  <p>If you sell as a business, your bank account must be in the country where your business is registered. For example, a US LLC needs a US bank account. You can live in another country and use your real home address.</p>
   <p>Depending on your country, bank payouts can take 2-7 business days to process, and can be delayed around bank holidays.</p>
   <h3 id="paypal">Get paid to PayPal</h3>
   <p>If bank payouts aren't supported in your country, we will pay you via PayPal. You just need an individual or business PayPal account without any restrictions.</p>


### PR DESCRIPTION
Ref antiwork/gumroad-private/issues/329

## What

Rewrites one paragraph in the "Getting paid" help article to allow non-resident business owners.

## Why

The old wording said the owner must physically live in the same country as the business. But Stripe Connect doesn't require that, and we shipped explicit support for it in [gumroad-old#29326](https://github.com/antiwork/gumroad-old/pull/29326) (Dec 2024). We have active creators today with US business + non-US residence, and a system spec covers the flow. The article has been out of sync for ~16 months, surfacing now via a support ticket misdiagnosed as a policy block (the underlying bug was fixed in [#4924](https://github.com/antiwork/gumroad/pull/4924)).

---

This PR was implemented with AI assistance using Claude Opus 4.7.