### PR TITLE
Pages Milestone 1 — Rendering spine + per-route CSP

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class PagesController < ApplicationController
+  before_action :apply_pages_csp
+
+  layout "page"
+
+  def show
+    page = Page.find_by(unique_permalink: params[:unique_permalink])
+    return redirect_to(UrlService.domain_with_protocol, status: :found) if page.nil?
+    return head :gone unless page.published?
+
+    @page = page
+  end
+
+  private
+    def apply_pages_csp
+      use_secure_headers_override(:pages_csp)
+    end
+end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class Page < ApplicationRecord
+  include Deletable
+
+  TITLE_MAX_LENGTH = 255
+  CONTENT_MAX_BYTES = 1.megabyte
+  PERMALINK_LENGTH = 8
+  PERMALINK_FORMAT = /\A[a-z0-9]{#{PERMALINK_LENGTH}}\z/
+
+  belongs_to :seller, class_name: "User"
+
+  validates :unique_permalink, presence: true, uniqueness: true, format: { with: PERMALINK_FORMAT }
+  validates :title, presence: true, length: { maximum: TITLE_MAX_LENGTH }
+  validates :raw_html, presence: true
+  validate :raw_html_within_size_limit
+
+  before_validation :set_unique_permalink
+  before_validation :resanitize
+
+  def published?
+    alive? && unpublished_at.nil?
+  end
+
+  def self.generate_unique_permalink(max_retries: 10)
+    retries = 0
+    candidate = SecureRandom.alphanumeric(PERMALINK_LENGTH).downcase
+
+    while exists?(unique_permalink: candidate)
+      retries += 1
+      raise "Failed to generate unique permalink after #{max_retries} attempts" if retries >= max_retries
+
+      candidate = SecureRandom.alphanumeric(PERMALINK_LENGTH).downcase
+    end
+
+    candidate
+  end
+
+  private
+    def set_unique_permalink
+      self.unique_permalink ||= self.class.generate_unique_permalink
+    end
+
+    def resanitize
+      result = Pages::SanitizeHtmlService.new(raw_html.to_s).perform
+      self.sanitized_html = result[:html]
+    end
+
+    def raw_html_within_size_limit
+      return if raw_html.to_s.bytesize <= CONTENT_MAX_BYTES
+      errors.add(:raw_html, "exceeds #{CONTENT_MAX_BYTES} bytes")
+    end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -128,6 +128,7 @@ class User < ApplicationRecord
   has_one :refund_policy, -> { where(product_id: nil) }, foreign_key: "seller_id", class_name: "SellerRefundPolicy", dependent: :destroy
   has_one :totp_credential, dependent: :destroy
   has_many :utm_links, dependent: :destroy, foreign_key: :seller_id
+  has_many :pages, dependent: :destroy, foreign_key: :seller_id
   has_many :seller_communities, class_name: "Community", foreign_key: :seller_id, dependent: :destroy
   has_many :community_chat_messages, dependent: :destroy
   has_many :last_read_community_chat_messages, dependent: :destroy

--- a/app/services/pages/sanitize_html_service.rb
+++ b/app/services/pages/sanitize_html_service.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+
+module Pages
+  class SanitizeHtmlService
+    ALLOWED_TAGS = %w[
+      div section article header footer main aside nav
+      h1 h2 h3 h4 h5 h6 p span strong em b i u s small br hr
+      ul ol li dl dt dd
+      img figure figcaption picture source video audio
+      table thead tbody tr th td caption
+      pre code blockquote cite kbd
+      svg path circle ellipse rect line polyline polygon g defs text tspan use
+      a link
+    ].freeze
+
+    GLOBAL_ATTRS = %w[class id title lang dir role].freeze
+
+    PER_TAG_ATTRS = {
+      "a" => %w[href target rel],
+      "img" => %w[src alt width height loading decoding srcset sizes],
+      "video" => %w[src controls poster width height autoplay loop muted playsinline preload],
+      "audio" => %w[src controls autoplay loop muted preload],
+      "source" => %w[src srcset type media sizes],
+      "picture" => %w[],
+      "th" => %w[scope colspan rowspan abbr],
+      "td" => %w[colspan rowspan headers],
+      "table" => %w[summary],
+      "ol" => %w[start type reversed],
+      "li" => %w[value],
+      "link" => %w[rel href type as crossorigin],
+      "blockquote" => %w[cite],
+      "q" => %w[cite],
+      "svg" => %w[viewbox xmlns width height fill stroke preserveaspectratio aria-hidden focusable],
+      "path" => %w[d fill stroke stroke-width stroke-linecap stroke-linejoin stroke-miterlimit fill-rule clip-rule transform],
+      "circle" => %w[cx cy r fill stroke stroke-width transform],
+      "ellipse" => %w[cx cy rx ry fill stroke stroke-width transform],
+      "rect" => %w[x y width height rx ry fill stroke stroke-width transform],
+      "line" => %w[x1 y1 x2 y2 stroke stroke-width transform],
+      "polyline" => %w[points fill stroke stroke-width transform],
+      "polygon" => %w[points fill stroke stroke-width transform],
+      "g" => %w[fill stroke transform],
+      "defs" => %w[],
+      "text" => %w[x y dx dy text-anchor font-family font-size font-weight fill stroke transform],
+      "tspan" => %w[x y dx dy text-anchor font-family font-size font-weight fill],
+      "use" => %w[href x y width height transform],
+    }.freeze
+
+    DATA_ATTR_ALLOWLIST = [].freeze
+
+    HTTP_SCHEMES = %w[http https].freeze
+    IMG_DATA_URL = %r{\Adata:image/(png|jpe?g|gif|webp|svg\+xml|avif|x-icon|bmp);base64,}i
+
+    FONT_HOST_ALLOWLIST = %w[fonts.googleapis.com fonts.gstatic.com].freeze
+
+    def initialize(html)
+      @html = html.to_s
+      @errors = []
+    end
+
+    def perform
+      fragment = Loofah.fragment(@html)
+      fragment.scrub!(scrubber)
+      sanitized = fragment.to_html
+      { html: sanitized, errors: @errors }
+    end
+
+    private
+      def scrubber
+        Loofah::Scrubber.new do |node|
+          process(node)
+        end
+      end
+
+      def process(node)
+        return Loofah::Scrubber::CONTINUE if node.text? || node.cdata? || node.document? || node.fragment?
+
+        if node.comment?
+          record_error(tag: "comment", line: node.line, reason: "disallowed comment")
+          node.remove
+          return Loofah::Scrubber::STOP
+        end
+
+        unless ALLOWED_TAGS.include?(node.name)
+          record_error(tag: node.name, line: node.line, reason: "disallowed tag")
+          node.remove
+          return Loofah::Scrubber::STOP
+        end
+
+        case node.name
+        when "a"      then sanitize_anchor(node)
+        when "img"    then sanitize_img(node)
+        when "video", "audio", "source" then sanitize_media(node)
+        when "link"   then sanitize_link_tag(node)
+        when "use"    then sanitize_use(node)
+        end
+
+        scrub_attributes!(node)
+        Loofah::Scrubber::CONTINUE
+      end
+
+      def scrub_attributes!(node)
+        allowed = (GLOBAL_ATTRS + (PER_TAG_ATTRS[node.name] || [])).map(&:downcase)
+        node.attribute_nodes.to_a.each do |attr|
+          name = attr.name.downcase
+          next if allowed.include?(name)
+          next if data_attr_allowed?(name)
+          record_error(tag: node.name, attr: name, line: node.line, reason: "disallowed attribute")
+          node.remove_attribute(name)
+        end
+      end
+
+      def data_attr_allowed?(name)
+        return false unless name.start_with?("data-")
+        DATA_ATTR_ALLOWLIST.include?(name)
+      end
+
+      def sanitize_anchor(node)
+        href = node["href"]
+        if href.present? && !http_scheme?(href)
+          record_error(tag: "a", attr: "href", line: node.line, reason: "disallowed href scheme")
+          node.remove_attribute("href")
+        end
+        if node["target"].to_s.downcase == "_blank"
+          existing = node["rel"].to_s.split
+          forced = (existing | %w[noopener noreferrer]).join(" ")
+          node["rel"] = forced
+        end
+      end
+
+      def sanitize_img(node)
+        src = node["src"]
+        return if src.blank?
+        return if http_scheme?(src) || src =~ IMG_DATA_URL
+        record_error(tag: "img", attr: "src", line: node.line, reason: "disallowed src scheme")
+        node.remove_attribute("src")
+      end
+
+      def sanitize_media(node)
+        src = node["src"]
+        return if src.blank?
+        unless http_scheme?(src)
+          record_error(tag: node.name, attr: "src", line: node.line, reason: "disallowed src scheme")
+          node.remove_attribute("src")
+        end
+      end
+
+      def sanitize_link_tag(node)
+        rel = node["rel"].to_s.downcase
+        href = node["href"].to_s
+        unless rel == "stylesheet" && font_link_allowed?(href)
+          record_error(tag: "link", line: node.line, reason: "link rel=stylesheet only allowed for trusted font hosts")
+          node.remove
+        end
+      end
+
+      def sanitize_use(node)
+        href = node["href"]
+        if href.blank? || !href.start_with?("#")
+          record_error(tag: "use", attr: "href", line: node.line, reason: "use must reference a fragment id")
+          node.remove
+        end
+      end
+
+      def http_scheme?(url)
+        uri = parse_uri(url)
+        return false if uri.nil?
+        scheme = uri.scheme.to_s.downcase
+        HTTP_SCHEMES.include?(scheme)
+      end
+
+      def font_link_allowed?(url)
+        uri = parse_uri(url)
+        return false if uri.nil?
+        return false unless HTTP_SCHEMES.include?(uri.scheme.to_s.downcase)
+        host = uri.host.to_s.downcase
+        FONT_HOST_ALLOWLIST.include?(host)
+      end
+
+      def parse_uri(url)
+        Addressable::URI.parse(url)
+      rescue Addressable::URI::InvalidURIError, ArgumentError
+        nil
+      end
+
+      def record_error(tag:, line:, reason:, attr: nil)
+        @errors << { tag:, attr:, line:, reason: }
+      end
+  end
+end

--- a/app/views/layouts/page.html.erb
+++ b/app/views/layouts/page.html.erb
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="robots" content="noindex">
+  <title><%= @page.title %></title>
+  <link rel="canonical" href="<%= UrlService.domain_with_protocol %>/pg/<%= @page.unique_permalink %>">
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body>
+  <%= yield %>
+</body>
+</html>

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -1,0 +1,1 @@
+<%== @page.sanitized_html %>

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -214,3 +214,18 @@ SecureHeaders::Configuration.default do |config|
     config.csp[:script_src] << "helperai.dev" # Required by Helper widget
   end
 end
+
+SecureHeaders::Configuration.override(:pages_csp) do |config|
+  config.csp = {
+    default_src: %w('self'),
+    script_src: %w('self' 'unsafe-eval' cdn.tailwindcss.com),
+    style_src: %w('self' 'unsafe-inline' fonts.googleapis.com),
+    img_src: %w('self' https: data:),
+    font_src: %w('self' https: data: fonts.gstatic.com),
+    frame_src: %w('self'),
+    form_action: %w('none'),
+    base_uri: %w('none'),
+    object_src: %w('none'),
+    frame_ancestors: %w('self'),
+  }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -827,6 +827,7 @@ Rails.application.routes.draw do
     get "/products", to: "links#index", as: :products
     get "/l/:id", to: "links#show", defaults: { format: "html" }, as: :short_link
     get "/l/:id/:code", to: "links#show", defaults: { format: "html" }, as: :short_link_offer_code
+    get "/pg/:unique_permalink", to: "pages#show", as: :view_page
     get "/cart_items_count", to: "links#cart_items_count"
 
     get "/products/:id" => redirect("/l/%{id}")

--- a/db/migrate/20261125000000_create_pages.rb
+++ b/db/migrate/20261125000000_create_pages.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreatePages < ActiveRecord::Migration[7.1]
+  def change
+    create_table :pages do |t|
+      t.bigint :seller_id, null: false
+      t.string :unique_permalink, null: false
+      t.string :title, null: false
+      t.text :raw_html, size: :long
+      t.text :sanitized_html, size: :long
+      t.datetime :unpublished_at
+      t.datetime :deleted_at
+      t.timestamps
+
+      t.index [:seller_id, :deleted_at]
+      t.index :unique_permalink, unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_11_24_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_11_25_000000) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -1344,6 +1344,20 @@ ActiveRecord::Schema[7.1].define(version: 2026_11_24_000000) do
     t.bigint "flags", default: 0, null: false
     t.datetime "review_reminder_scheduled_at"
     t.index ["purchaser_id"], name: "index_orders_on_purchaser_id"
+  end
+
+  create_table "pages", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "seller_id", null: false
+    t.string "unique_permalink", null: false
+    t.string "title", null: false
+    t.text "raw_html", size: :long
+    t.text "sanitized_html", size: :long
+    t.datetime "unpublished_at"
+    t.datetime "deleted_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["seller_id", "deleted_at"], name: "index_pages_on_seller_id_and_deleted_at"
+    t.index ["unique_permalink"], name: "index_pages_on_unique_permalink", unique: true
   end
 
   create_table "payment_options", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|

--- a/db/seeds/030_development/pages.rb
+++ b/db/seeds/030_development/pages.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+PAGES_DEMO_PERMALINK = "demopage"
+
+def load_pages
+  if Rails.env.production?
+    puts "Shouldn't run pages seed on production"
+    raise
+  end
+
+  seller = User.find_by(email: "seller@gumroad.com")
+  return unless seller
+
+  product = seller.links.alive.first
+  unless product
+    product = Link.new(user_id: seller.id, name: "Beautiful widget for Pages demo", filetype: "link", price_cents: 0)
+    product.display_product_reviews = true
+    product.prices.build(price_cents: 0, recurrence: 0)
+    product.save!
+  end
+
+  return if Page.find_by(unique_permalink: PAGES_DEMO_PERMALINK)
+
+  checkout_url = "#{UrlService.domain_with_protocol}/checkout?product=#{product.unique_permalink}"
+  raw = <<~HTML
+    <div class="max-w-2xl mx-auto p-12 font-sans">
+      <h1 class="text-4xl font-bold mb-4">Pages demo</h1>
+      <p class="text-lg text-gray-700 mb-8">Rendered from a creator-supplied <code>Page</code> record. Any HTML, any Tailwind, one buy button.</p>
+      <a href="#{checkout_url}" class="inline-block bg-black text-white px-6 py-3 rounded-md font-semibold">Buy now</a>
+    </div>
+  HTML
+  raise "Pages demo HTML failed sanitize" if Pages::SanitizeHtmlService.new(raw).perform[:errors].any?
+  Page.create!(seller_id: seller.id, unique_permalink: PAGES_DEMO_PERMALINK, title: "Pages demo", raw_html: raw)
+end
+
+load_pages

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Page do
+  describe "associations" do
+    it { is_expected.to belong_to(:seller).class_name("User").optional(false) }
+  end
+
+  describe "validations" do
+    subject { build(:page) }
+
+    it { is_expected.to validate_presence_of(:title) }
+    it { is_expected.to validate_length_of(:title).is_at_most(Page::TITLE_MAX_LENGTH) }
+    it { is_expected.to validate_presence_of(:raw_html) }
+    it { is_expected.to allow_value("abcd1234").for(:unique_permalink) }
+    it { is_expected.not_to allow_value("abc-123").for(:unique_permalink) }
+    it { is_expected.not_to allow_value("ABCD1234").for(:unique_permalink) }
+
+    it "rejects a duplicate unique_permalink" do
+      create(:page, unique_permalink: "abcd1234")
+      duplicate = build(:page, unique_permalink: "abcd1234")
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:unique_permalink]).to be_present
+    end
+
+    it "rejects raw_html exceeding CONTENT_MAX_BYTES" do
+      page = build(:page, raw_html: "a" * (Page::CONTENT_MAX_BYTES + 1))
+      expect(page).not_to be_valid
+      expect(page.errors[:raw_html]).to be_present
+    end
+
+    it "auto-fills unique_permalink when blank" do
+      page = build(:page, unique_permalink: nil)
+      page.valid?
+      expect(page.unique_permalink).to match(/\A[a-z0-9]{8}\z/)
+    end
+  end
+
+  describe "permalink generation" do
+    it "retries when the first candidate collides with an existing record" do
+      create(:page, unique_permalink: "aaaaaaaa")
+      allow(SecureRandom).to receive(:alphanumeric).with(Page::PERMALINK_LENGTH).and_return("AAAAAAAA", "BBBBBBBB")
+      page = build(:page, unique_permalink: nil)
+      page.valid?
+      expect(page.unique_permalink).to eq("bbbbbbbb")
+    end
+
+    it "raises when no unique candidate is found within max_retries" do
+      create(:page, unique_permalink: "aaaaaaaa")
+      allow(SecureRandom).to receive(:alphanumeric).with(Page::PERMALINK_LENGTH).and_return("AAAAAAAA")
+      expect { Page.generate_unique_permalink(max_retries: 2) }.to raise_error(/Failed to generate unique permalink/)
+    end
+
+    it "preserves an explicitly assigned unique_permalink" do
+      page = build(:page, unique_permalink: "explicit")
+      page.valid?
+      expect(page.unique_permalink).to eq("explicit")
+    end
+  end
+
+  describe "before_validation :resanitize" do
+    it "fills sanitized_html by stripping disallowed tags from raw_html" do
+      page = build(:page, raw_html: "<p>kept</p><script>alert(1)</script>", sanitized_html: nil)
+      page.valid?
+      expect(page.sanitized_html).to include("kept")
+      expect(page.sanitized_html).not_to include("<script>")
+      expect(page.sanitized_html).not_to include("alert(1)")
+    end
+
+    it "overwrites direct writes to sanitized_html on subsequent saves" do
+      page = create(:page, raw_html: "<p>safe</p>")
+      page.sanitized_html = "<script>alert(1)</script>"
+      page.save!
+      expect(page.sanitized_html).to include("safe")
+      expect(page.sanitized_html).not_to include("<script>")
+    end
+  end
+
+  describe "#published?" do
+    it "is true when both deleted_at and unpublished_at are nil" do
+      expect(build(:page, deleted_at: nil, unpublished_at: nil)).to be_published
+    end
+
+    it "is false when deleted_at is set" do
+      expect(build(:page, deleted_at: Time.current, unpublished_at: nil)).not_to be_published
+    end
+
+    it "is false when unpublished_at is set" do
+      expect(build(:page, deleted_at: nil, unpublished_at: Time.current)).not_to be_published
+    end
+  end
+end

--- a/spec/requests/pages_demo_spec.rb
+++ b/spec/requests/pages_demo_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Pages demo flow", :js, type: :system do
+  let(:seller) { create(:user) }
+  let(:product) { create(:product, user: seller, name: "Beautiful widget", price_cents: 1000) }
+  let(:checkout_url) { "#{PROTOCOL}://#{DOMAIN}/checkout?product=#{product.unique_permalink}" }
+  let(:page_html) do
+    <<~HTML
+      <section class="bg-black text-white px-6 py-32 text-center">
+        <h1 class="text-7xl font-bold mb-10">Pages demo render</h1>
+        <a href="#{checkout_url}" id="page-buy-link" class="inline-block bg-white text-black px-8 py-4 rounded-full">Buy</a>
+      </section>
+    HTML
+  end
+  let(:page_record) { create(:page, seller:, raw_html: page_html) }
+
+  it "renders the page chromeless and preserves the buy link href through sanitization" do
+    visit "/pg/#{page_record.unique_permalink}"
+    expect(page).to have_text("Pages demo render")
+    expect(find("#page-buy-link")[:href]).to eq(checkout_url)
+  end
+
+  it "navigates from the page to checkout with the product hydrated" do
+    visit "/pg/#{page_record.unique_permalink}"
+    find("#page-buy-link").click
+
+    expect(page).to have_current_path(/\/checkout/)
+    expect(page).to have_text(product.name)
+  end
+end

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Pages public render", type: :request do
+  before { host! DOMAIN }
+
+  let(:seller) { create(:user) }
+  let(:safe_html) do
+    <<~HTML
+      <section class="bg-yellow-300 border-b-[8px] border-black py-32">
+        <h1 class="font-mono text-[160px]">Buy this</h1>
+        <a href="https://example.com/checkout?product=abc" class="bg-black text-white px-8 py-4">Buy</a>
+      </section>
+    HTML
+  end
+
+  let(:page_record) { create(:page, seller:, raw_html: safe_html) }
+
+  it "returns 200 with the chromeless layout for a published page" do
+    get "/pg/#{page_record.unique_permalink}"
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("<title>#{page_record.title}</title>")
+    expect(response.body).to include("cdn.tailwindcss.com")
+    expect(response.body).to include('name="robots" content="noindex"')
+    expect(response.body).to include("rel=\"canonical\"")
+    expect(response.body).to include("bg-yellow-300")
+  end
+
+  it "does not include the legacy widget JS in the layout" do
+    get "/pg/#{page_record.unique_permalink}"
+    expect(response.body).not_to include("/js/gumroad.js")
+    expect(response.body).not_to include("/js/gumroad-embed.js")
+  end
+
+  it "returns 410 for a soft-deleted page" do
+    page_record.mark_deleted!
+    get "/pg/#{page_record.unique_permalink}"
+    expect(response).to have_http_status(:gone)
+  end
+
+  it "returns 410 for a page with unpublished_at set" do
+    page_record.update!(unpublished_at: Time.current)
+    get "/pg/#{page_record.unique_permalink}"
+    expect(response).to have_http_status(:gone)
+  end
+
+  it "returns 302 to the gumroad.com home for an unknown permalink" do
+    get "/pg/zzz"
+    expect(response).to have_http_status(:found)
+    expect(response.headers["Location"]).to eq(UrlService.domain_with_protocol)
+  end
+
+  it "sets the per-route enforced CSP header" do
+    get "/pg/#{page_record.unique_permalink}"
+    csp = response.headers["Content-Security-Policy"]
+    expect(csp).to include("object-src 'none'")
+    expect(csp).to include("base-uri 'none'")
+    expect(csp).to include("form-action 'none'")
+    expect(csp).to include("cdn.tailwindcss.com")
+    expect(response.headers["Content-Security-Policy-Report-Only"]).to be_blank
+  end
+
+  it "never renders sanitizer-stripped content" do
+    create(:page, seller:, unique_permalink: "xsstest1",
+                  raw_html: "<script>alert(1)</script><p>kept</p>")
+    get "/pg/xsstest1"
+    expect(response).to have_http_status(:ok)
+    expect(response.body).not_to include("alert(1)")
+    expect(response.body).not_to include("<script>")
+  end
+end

--- a/spec/services/pages/sanitize_html_service_spec.rb
+++ b/spec/services/pages/sanitize_html_service_spec.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Pages::SanitizeHtmlService do
+  def scrub(html)
+    described_class.new(html).perform
+  end
+
+  describe "negative XSS corpus" do
+    {
+      "script tag" => "<script>alert(1)</script>",
+      "img onerror" => "<img src=x onerror=alert(1)>",
+      "javascript: href" => "<a href=\"javascript:alert(1)\">x</a>",
+      "iframe" => "<iframe src=\"https://example.org\"></iframe>",
+      "style tag" => "<style>body{background:red}</style>",
+      "form input" => "<form action=\"/x\"><input name=\"x\"></form>",
+      "inline style attribute" => "<div style=\"background:url(javascript:alert(1))\">x</div>",
+      "svg onload" => "<svg onload=\"alert(1)\"></svg>",
+      "svg containing script" => "<svg><script>alert(1)</script></svg>",
+      "svg foreignObject" => "<svg><foreignObject><body><script>alert(1)</script></body></foreignObject></svg>",
+      "math element" => "<math><mi>x</mi></math>",
+      "details element" => "<details><summary>x</summary></details>",
+      "template element" => "<template><script>alert(1)</script></template>",
+      "embed" => "<embed src=\"https://example.org\">",
+      "object" => "<object data=\"https://example.org\"></object>",
+      "meta refresh" => "<meta http-equiv=\"refresh\" content=\"0; url=https://example.org\">",
+      "base tag" => "<base href=\"https://example.org\">",
+      "noscript element" => "<noscript><script>alert(1)</script></noscript>",
+      "untrusted stylesheet link" => "<link rel=\"stylesheet\" href=\"https://example.org/x.css\">",
+      "data text/html href" => "<a href=\"data:text/html,<script>alert(1)</script>\">x</a>",
+      "vbscript href" => "<a href=\"vbscript:msgbox(1)\">x</a>",
+      "use external href" => "<svg><use href=\"https://example.org/x.svg#a\"/></svg>",
+      "srcdoc on iframe" => "<iframe srcdoc=\"<script>alert(1)</script>\"></iframe>",
+      "formaction smuggle" => "<button formaction=\"javascript:alert(1)\">x</button>",
+      "html comment with script" => "<!--<script>alert(1)</script>--><p>x</p>",
+      "conditional comment" => "<!--[if IE]><script>alert(1)</script><![endif]--><p>x</p>",
+    }.each do |name, html|
+      it "strips #{name}" do
+        result = scrub(html)
+        sanitized = result[:html]
+        expect(sanitized).not_to include("alert(1)")
+        expect(sanitized).not_to include("<script")
+        expect(sanitized).not_to include("onerror")
+        expect(sanitized).not_to include("onload")
+        expect(sanitized).not_to include("javascript:")
+        expect(sanitized).not_to include("vbscript:")
+        expect(sanitized).not_to include("<form")
+        expect(sanitized).not_to include("<iframe")
+        expect(sanitized).not_to include("<style")
+        expect(sanitized).not_to include("<embed")
+        expect(sanitized).not_to include("<object")
+        expect(sanitized).not_to include("<meta")
+        expect(sanitized).not_to include("<base")
+        expect(sanitized).not_to include("<noscript")
+        expect(sanitized).not_to include("foreignObject")
+        expect(result[:errors]).not_to be_empty
+      end
+    end
+
+    it "strips mutation-XSS (noscript title smuggle)" do
+      payload = '<noscript><p title="</noscript><img src=x onerror=alert(1)>"></noscript>'
+      result = scrub(payload)
+      expect(result[:html]).not_to include("onerror")
+      expect(result[:html]).not_to include("alert(1)")
+    end
+
+    it "strips bg-[url(javascript:...)] inline-style smuggles" do
+      payload = '<div class="bg-[url(javascript:alert(1))]" style="background:url(javascript:alert(1))">x</div>'
+      result = scrub(payload)
+      expect(result[:html]).not_to include("style=")
+      expect(result[:html]).to include("class=")
+    end
+
+    it "strips all data-* attributes" do
+      payload = '<a class="btn" href="https://example.com" data-gumroad-overlay-checkout="true" data-gumroad-product-id="abc" data-anything="x">Buy</a>'
+      result = scrub(payload)
+      expect(result[:html]).not_to include("data-gumroad-overlay-checkout")
+      expect(result[:html]).not_to include("data-gumroad-product-id")
+      expect(result[:html]).not_to include("data-anything")
+      expect(result[:html]).to include("class=\"btn\"")
+      expect(result[:html]).to include("href=\"https://example.com\"")
+      expect(result[:errors].map { |e| e[:attr] }).to include("data-gumroad-overlay-checkout", "data-gumroad-product-id", "data-anything")
+    end
+  end
+
+  describe "positive corpus" do
+    [
+      "<section><h1>Hello</h1><p>world</p></section>",
+      "<article><header><h2>Title</h2></header><p>Body</p><footer>End</footer></article>",
+      "<ul><li>one</li><li>two</li></ul>",
+      "<table><thead><tr><th>name</th></tr></thead><tbody><tr><td>x</td></tr></tbody></table>",
+      "<pre><code>print(1)</code></pre>",
+      "<blockquote cite=\"https://example.com\">quoted</blockquote>",
+      "<svg viewBox=\"0 0 24 24\"><path d=\"M0 0H24V24H0Z\" fill=\"red\"/></svg>",
+      "<svg><use href=\"#icon-buy\"/></svg>",
+      "<img src=\"https://example.com/x.png\" alt=\"x\" loading=\"lazy\"/>",
+      "<picture><source srcset=\"https://example.com/x.webp\" type=\"image/webp\"/><img src=\"https://example.com/x.png\" alt=\"x\"/></picture>",
+      '<a class="btn bg-black text-white px-8 py-4" href="https://example.com/checkout?product=abc">Buy</a>',
+      '<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter">',
+      '<div class="bg-[#ff0000] rotate-[3deg] text-[180px]">brutalist</div>',
+    ].each do |html|
+      it "preserves #{html.first(80).tr("\n", " ")}" do
+        result = scrub(html)
+        expect(result[:errors]).to be_empty, "unexpected errors: #{result[:errors].inspect}"
+      end
+    end
+
+    it "preserves Tailwind class names verbatim including arbitrary values" do
+      result = scrub('<div class="border-[8px] border-black font-mono bg-yellow-300">x</div>')
+      expect(result[:html]).to include("border-[8px]")
+      expect(result[:html]).to include("bg-yellow-300")
+    end
+
+    it "forces rel=noopener noreferrer on target=_blank anchors" do
+      result = scrub('<a href="https://example.com" target="_blank">x</a>')
+      expect(result[:html]).to include('rel="noopener noreferrer"')
+    end
+  end
+
+  describe "error reporting" do
+    it "returns one error per stripped tag with line numbers" do
+      payload = "<p>ok</p>\n<script>bad()</script>"
+      result = scrub(payload)
+      expect(result[:errors]).to include(
+        a_hash_including(tag: "script", reason: "disallowed tag", line: 2)
+      )
+    end
+
+    it "surfaces stripped attributes" do
+      payload = '<div onclick="alert(1)">x</div>'
+      result = scrub(payload)
+      expect(result[:errors]).to include(
+        a_hash_including(tag: "div", attr: "onclick", reason: "disallowed attribute")
+      )
+    end
+
+    it "still returns sanitized output when content is fully stripped" do
+      payload = "<script>alert(1)</script><p>kept</p>"
+      result = scrub(payload)
+      expect(result[:html]).to include("kept")
+      expect(result[:html]).not_to include("alert")
+    end
+  end
+
+  describe "data:image/* URLs" do
+    it "permits inline image data URLs" do
+      payload = '<img src="data:image/png;base64,iVBORw0KGgo=" alt="x"/>'
+      result = scrub(payload)
+      expect(result[:html]).to include("data:image/png;base64")
+      expect(result[:errors]).to be_empty
+    end
+
+    it "rejects non-image data URLs on img" do
+      payload = '<img src="data:text/html,<script>alert(1)</script>"/>'
+      result = scrub(payload)
+      expect(result[:html]).not_to include("data:text/html")
+    end
+  end
+end

--- a/spec/support/factories/pages.rb
+++ b/spec/support/factories/pages.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :page do
+    association :seller, factory: :user
+    sequence(:title) { |n| "Page #{n}" }
+    raw_html { "<section><h1>Hello</h1></section>" }
+
+    trait :unpublished do
+      unpublished_at { Time.current }
+    end
+  end
+end


### PR DESCRIPTION
Part of #4933.

## What

Adds a public route `/pg/:permalink` that renders a `Page` record's sanitized HTML on gumroad.com. The render path is the only thing this PR adds — `Page` model, Loofah-based sanitizer, chromeless layout, per-route enforced CSP override, and the route. Buy buttons inside creator HTML are plain `<a href>` to `/checkout?product=...`, so checkout works without the widget JS.

**Creation is Rails-console-only in this PR.** No API, no CLI, no creator UI — those land in [Milestone 4](https://github.com/antiwork/gumroad/issues/4933) (API behind a default-off Flipper flag) and [Milestone 5](https://github.com/antiwork/gumroad/issues/4933) (CLI). At merge, the prod `pages` table is empty; the dev seed file early-returns on `Rails.env.production?` so no Page is created automatically. Every `/pg/<anything>` 302s to gumroad.com home until an operator explicitly creates a row from the console — the route is functionally invisible in production until then.

## Why

Creators today fill in a fixed product page template — they can't redesign it. Pages widens "the page" into a separate primitive that can back a custom product page, profile, bundle, or microsite. AI codegen makes this practical: a creator prompts an LLM, generates Tailwind HTML, and pipes it through `gumroad-cli`.

[Milestone 1](https://github.com/antiwork/gumroad/issues/4933) ships first because the render path is the security boundary the rest of the roadmap stacks on. CSP enforced from day 1. Shipping render-only (no creation surface) gives the security spine runway to harden in [Milestone 1.5](https://github.com/antiwork/gumroad/issues/4933) (server-side Tailwind compile, drops `'unsafe-eval'`). This allow PR to be easily reviewed and be as atomic as possible.

## Before/After

Inserted a html via rails console and it's rendered inside gumroad.dev

https://github.com/user-attachments/assets/6755cb51-78f6-400a-a92b-b9c8d23c3c1b






## Test Results

Confidence test is failing on user spec on non related changes. Any guidance on this is appreciated.
<img width="577" height="946" alt="Screenshot 2026-05-04 at 12 24 33 AM" src="https://github.com/user-attachments/assets/ae28f6ca-3829-4ebd-a928-69d3570f6044" />


---

🤖 Generated with [Claude Code](https://claude.com/claude-code) using Claude Opus 4.7.

Prompts used:

- "please sync the plan on pages-prod, make it implementation-ready, ultrathink. when in doubt check codebase, when finished check codebase." (planning sync)
- "yep let's go implement M1 in a new branch, ok ultrathink" (start implementation)
- "go for full implementation for m1 / pr1 ultrathink" (autonomous through migration, specs, validation, PR-body draft)
- "ultrathink fix everything. look at the other part of codebase, how did they do it" (codebase-conventions audit — `size: :long` LONGTEXT syntax, composite `[seller_id, deleted_at]` index, restored `CONTENT_MAX_BYTES`, dropped MacWhisper-themed seed in favor of "Beautiful widget" matching codebase fixture aesthetic)
- "i think we can make this ready for push branch. maybe regenerate PR description and PR review. fix any stuff that comes up. do test-confidence, lint, rubocop, and all that." (regeneration pass — re-aligned PR body to current diff, ran rubocop / eslint / `bin/test-confidence`)
- "fix everything ultrathink" (24-item pre-push polish pass + post-/review-pr fix-up — comment-stripping in scrubber, dropped dead `mode:`/`xlink:href`/`DEFAULT_ROOT_TAG`, snapshotted `attribute_nodes`, `published?` composes via `alive?`, controller delegates to `published?`, `dependent: :destroy` on `User has_many :pages`, `validates :raw_html, presence: true`, dropped `raw_html_changed?` guard with a fails-on-revert spec, renamed service to `Pages::SanitizeHtmlService` with instance `#perform`, shoulda-matchers in model spec, seed `at_exit` → inline `puts`, `UrlService.domain_with_protocol` for the checkout URL)
- "the seed shouldn't have any special printing, it should be like any other seed" + "or can it create a hardcoded slug?" (seed quietness sweep — dropped 8 `puts` + bar banner, hardcoded slug `demopage` for stable demo URL, idempotent via `Page.find_by(unique_permalink: ...)`)
- "the system spec shouldn't have a misaligned button" (spec fixture polish — `inline-block` + `mb-10` + `rounded-full` on the buy button so failure screenshots don't show H1 descenders kissing the button top)
- "rename M1 to Milestone 1 whenever you mention milestone, link to the URL block in GitHub" (verbatim mentions in body became `[Milestone N](https://github.com/antiwork/gumroad/issues/4933)`; verbatim quoted prompts in this AI-disclosure list left as-is per voice-preservation rule)
- "use whatever the skill has, update the sections, for sections not relevant it'll be a comment that I write" (collapsed dense Threat-model / Design-decisions / Files / What-this-PR-is-NOT sections per /pr-description skill template; left HTML-comment placeholders in Before/After + Test Results for Denis to fill)
- "make it clearer that creation is Rails-console-only right now, and frame this as a safe-to-deploy change" (sharpened `## What` to call out console-only scope explicitly + the prod-empty-table + 302-to-home fallback story; sharpened `## Why` to tie M1's render-first sequencing to the security-spine-has-runway-to-harden rationale)