### PR TITLE
Add /internal/admin payout edge case endpoints

### DIFF
--- a/app/controllers/api/internal/admin/payouts_controller.rb
+++ b/app/controllers/api/internal/admin/payouts_controller.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 class Api::Internal::Admin::PayoutsController < Api::Internal::Admin::BaseController
-  before_action :fetch_user
+  SCHEDULED_PAYOUTS_DEFAULT_LIMIT = 20
+  SCHEDULED_PAYOUTS_MAX_LIMIT = 50
+  private_constant :SCHEDULED_PAYOUTS_DEFAULT_LIMIT, :SCHEDULED_PAYOUTS_MAX_LIMIT
+
+  before_action :fetch_user, only: [:list, :pause, :resume, :issue]
+  before_action :fetch_scheduled_payout, only: [:scheduled_execute, :scheduled_cancel]
 
   def list
     payouts = @user.payments.order(created_at: :desc).limit(5).map { serialize_payout(_1) }
@@ -76,11 +81,114 @@ class Api::Internal::Admin::PayoutsController < Api::Internal::Admin::BaseContro
     end
   end
 
+  def issue
+    processor_param = params[:payout_processor].to_s.upcase
+    unless PayoutProcessorType.all.include?(processor_param)
+      return render json: { success: false, message: "payout_processor must be stripe or paypal" }, status: :bad_request
+    end
+
+    if params[:payout_period_end_date].blank?
+      return render json: { success: false, message: "payout_period_end_date is required" }, status: :bad_request
+    end
+
+    begin
+      date = Date.parse(params[:payout_period_end_date].to_s)
+    rescue ArgumentError
+      return render json: { success: false, message: "payout_period_end_date is invalid" }, status: :bad_request
+    end
+
+    record_admin_write(action: "payouts.issue", target: @user) do
+      if processor_param == PayoutProcessorType::PAYPAL && ActiveModel::Type::Boolean.new.cast(params[:should_split_the_amount])
+        @user.update!(should_paypal_payout_be_split: true)
+      end
+
+      payments = Payouts.create_payments_for_balances_up_to_date_for_users(date, processor_param, [@user], from_admin: true)
+      payment = payments.first&.first
+
+      if payment.blank? || payment.failed?
+        render json: {
+          success: false,
+          message: payment&.errors&.full_messages&.first || "Payment was not sent."
+        }, status: :unprocessable_entity
+      else
+        render json: { success: true, payout: serialize_payout(payment) }
+      end
+    end
+  end
+
+  def scheduled_list
+    scope = ScheduledPayout.includes(:user, :created_by).order(id: :desc)
+    if params[:status].present?
+      unless ScheduledPayout::STATUSES.include?(params[:status])
+        return render json: { success: false, message: "status is invalid" }, status: :bad_request
+      end
+      scope = scope.where(status: params[:status])
+    end
+
+    limit = params[:limit].to_i
+    limit = SCHEDULED_PAYOUTS_DEFAULT_LIMIT if limit <= 0
+    limit = [limit, SCHEDULED_PAYOUTS_MAX_LIMIT].min
+
+    scheduled_payouts = scope.limit(limit).map { serialize_scheduled_payout(_1) }
+
+    render json: { success: true, scheduled_payouts:, limit: }
+  end
+
+  def scheduled_execute
+    record_admin_write(action: "payouts.scheduled_execute", target: @scheduled_payout) do
+      unless @scheduled_payout.pending? || @scheduled_payout.flagged?
+        next render json: {
+          success: false,
+          message: "Cannot execute a #{@scheduled_payout.status} scheduled payout."
+        }, status: :unprocessable_entity
+      end
+
+      @scheduled_payout.update!(status: "pending") if @scheduled_payout.flagged?
+
+      result = @scheduled_payout.execute!
+      message = case result
+                when :held then "Payout is now on hold for manual release."
+                when :flagged then "Payout was flagged for review instead of executing."
+      end
+
+      render json: {
+        success: true,
+        result: result.to_s,
+        message:,
+        scheduled_payout: serialize_scheduled_payout(@scheduled_payout)
+      }
+    rescue => e
+      render_scheduled_payout_error(e)
+    end
+  end
+
+  def scheduled_cancel
+    record_admin_write(action: "payouts.scheduled_cancel", target: @scheduled_payout) do
+      @scheduled_payout.cancel!
+      render json: { success: true, scheduled_payout: serialize_scheduled_payout(@scheduled_payout) }
+    rescue => e
+      render_scheduled_payout_error(e)
+    end
+  end
+
   private
     def fetch_user
       return render json: { success: false, message: "email is required" }, status: :bad_request if params[:email].blank?
 
       @user = User.alive.by_email(params[:email]).first
       render json: { success: false, message: "User not found" }, status: :not_found if @user.blank?
+    end
+
+    def fetch_scheduled_payout
+      @scheduled_payout = ScheduledPayout.includes(:user, :created_by).find_by_external_id(params[:id])
+      render json: { success: false, message: "Scheduled payout not found" }, status: :not_found if @scheduled_payout.blank?
+    end
+
+    def serialize_scheduled_payout(scheduled_payout)
+      Admin::ScheduledPayoutPresenter.new(scheduled_payout:).props
+    end
+
+    def render_scheduled_payout_error(error)
+      render json: { success: false, message: error.message }, status: :unprocessable_entity
     end
 end

--- a/app/controllers/api/internal/admin/payouts_controller.rb
+++ b/app/controllers/api/internal/admin/payouts_controller.rb
@@ -97,6 +97,10 @@ class Api::Internal::Admin::PayoutsController < Api::Internal::Admin::BaseContro
       return render json: { success: false, message: "payout_period_end_date is invalid" }, status: :bad_request
     end
 
+    if date >= Date.current
+      return render json: { success: false, message: "payout_period_end_date must be in the past" }, status: :bad_request
+    end
+
     record_admin_write(action: "payouts.issue", target: @user) do
       if processor_param == PayoutProcessorType::PAYPAL && ActiveModel::Type::Boolean.new.cast(params[:should_split_the_amount])
         @user.update!(should_paypal_payout_be_split: true)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -342,6 +342,12 @@ Rails.application.routes.draw do
               post :list
               post :pause
               post :resume
+              post :issue
+              post :scheduled_list
+            end
+            member do
+              post :scheduled_execute
+              post :scheduled_cancel
             end
           end
         end

--- a/spec/controllers/api/internal/admin/payouts_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/payouts_controller_spec.rb
@@ -311,6 +311,17 @@ describe Api::Internal::Admin::PayoutsController do
       expect(response.parsed_body["message"]).to eq("payout_period_end_date is invalid")
     end
 
+    it "returns 400 without writing an audit row when payout_period_end_date is today or in the future" do
+      [Date.current, Date.current + 1].each do |date|
+        expect do
+          post :issue, params: { email: user.email, payout_processor: "stripe", payout_period_end_date: date.to_s }
+        end.not_to change { AdminApiAuditLog.count }
+
+        expect(response).to have_http_status(:bad_request)
+        expect(response.parsed_body["message"]).to eq("payout_period_end_date must be in the past")
+      end
+    end
+
     it "issues a stripe payout via Payouts.create_payments_for_balances_up_to_date_for_users" do
       payment = create(:payment_completed, user:)
       date = 1.day.ago.to_date

--- a/spec/controllers/api/internal/admin/payouts_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/payouts_controller_spec.rb
@@ -274,4 +274,274 @@ describe Api::Internal::Admin::PayoutsController do
       )
     end
   end
+
+  describe "POST issue" do
+    include_examples "admin api authorization required", :post, :issue
+
+    it "returns 400 when email is missing" do
+      post :issue, params: { payout_processor: "stripe", payout_period_end_date: 1.day.ago.to_date.to_s }
+
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it "returns 404 when the user does not exist" do
+      post :issue, params: { email: "missing@example.com", payout_processor: "stripe", payout_period_end_date: 1.day.ago.to_date.to_s }
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "returns 400 when payout_processor is invalid" do
+      post :issue, params: { email: user.email, payout_processor: "ach", payout_period_end_date: 1.day.ago.to_date.to_s }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body["message"]).to eq("payout_processor must be stripe or paypal")
+    end
+
+    it "returns 400 when payout_period_end_date is missing" do
+      post :issue, params: { email: user.email, payout_processor: "stripe" }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body["message"]).to eq("payout_period_end_date is required")
+    end
+
+    it "returns 400 when payout_period_end_date is invalid" do
+      post :issue, params: { email: user.email, payout_processor: "stripe", payout_period_end_date: "not-a-date" }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body["message"]).to eq("payout_period_end_date is invalid")
+    end
+
+    it "issues a stripe payout via Payouts.create_payments_for_balances_up_to_date_for_users" do
+      payment = create(:payment_completed, user:)
+      date = 1.day.ago.to_date
+
+      expect(Payouts).to receive(:create_payments_for_balances_up_to_date_for_users).with(
+        date, PayoutProcessorType::STRIPE, [user], from_admin: true
+      ).and_return([[payment]])
+
+      post :issue, params: { email: user.email, payout_processor: "stripe", payout_period_end_date: date.to_s }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(
+        "success" => true,
+        "payout" => hash_including("external_id" => payment.external_id, "state" => "completed")
+      )
+    end
+
+    it "sets should_paypal_payout_be_split when paypal split is requested" do
+      payment = create(:payment_completed, user:, processor: PayoutProcessorType::PAYPAL)
+      date = 1.day.ago.to_date
+
+      allow(Payouts).to receive(:create_payments_for_balances_up_to_date_for_users).and_return([[payment]])
+
+      expect do
+        post :issue, params: { email: user.email, payout_processor: "paypal", payout_period_end_date: date.to_s, should_split_the_amount: "true" }
+      end.to change { user.reload.should_paypal_payout_be_split? }.from(false).to(true)
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "returns 422 when no payment is created" do
+      date = 1.day.ago.to_date
+      allow(Payouts).to receive(:create_payments_for_balances_up_to_date_for_users).and_return([])
+
+      post :issue, params: { email: user.email, payout_processor: "stripe", payout_period_end_date: date.to_s }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body).to include("success" => false, "message" => "Payment was not sent.")
+    end
+
+    it "returns 422 when the payment failed" do
+      failed_payment = create(:payment_failed, user:)
+      failed_payment.errors.add(:base, "Insufficient funds")
+      date = 1.day.ago.to_date
+      allow(Payouts).to receive(:create_payments_for_balances_up_to_date_for_users).and_return([[failed_payment]])
+
+      post :issue, params: { email: user.email, payout_processor: "stripe", payout_period_end_date: date.to_s }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["message"]).to eq("Insufficient funds")
+    end
+
+    it "writes an admin audit log" do
+      payment = create(:payment_completed, user:)
+      date = 1.day.ago.to_date
+      allow(Payouts).to receive(:create_payments_for_balances_up_to_date_for_users).and_return([[payment]])
+
+      expect do
+        post :issue, params: { email: user.email, payout_processor: "stripe", payout_period_end_date: date.to_s }
+      end.to change { AdminApiAuditLog.count }.by(1)
+
+      expect(AdminApiAuditLog.last).to have_attributes(
+        action: "payouts.issue",
+        target_type: "User",
+        target_id: user.id,
+        response_status: 200
+      )
+    end
+  end
+
+  describe "POST scheduled_list" do
+    include_examples "admin api authorization required", :post, :scheduled_list
+
+    it "returns scheduled payouts ordered by id desc" do
+      first = create(:scheduled_payout, user:)
+      second = create(:scheduled_payout, user: create(:user))
+
+      post :scheduled_list
+
+      expect(response).to have_http_status(:ok)
+      payload = response.parsed_body
+      expect(payload["success"]).to be(true)
+      expect(payload["scheduled_payouts"].map { _1["external_id"] }).to eq([second.external_id, first.external_id])
+    end
+
+    it "filters by status when provided" do
+      flagged = create(:scheduled_payout, user:, status: "flagged")
+      create(:scheduled_payout, user: create(:user), status: "pending")
+
+      post :scheduled_list, params: { status: "flagged" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["scheduled_payouts"].map { _1["external_id"] }).to eq([flagged.external_id])
+    end
+
+    it "returns 400 when status is invalid" do
+      post :scheduled_list, params: { status: "bogus" }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "status is invalid" }.as_json)
+    end
+
+    it "caps the limit at SCHEDULED_PAYOUTS_MAX_LIMIT" do
+      post :scheduled_list, params: { limit: 9999 }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["limit"]).to eq(50)
+    end
+
+    it "uses the default limit when limit is missing or non-positive" do
+      post :scheduled_list
+
+      expect(response.parsed_body["limit"]).to eq(20)
+
+      post :scheduled_list, params: { limit: 0 }
+
+      expect(response.parsed_body["limit"]).to eq(20)
+    end
+  end
+
+  describe "POST scheduled_execute" do
+    include_examples "admin api authorization required", :post, :scheduled_execute, { id: "abc" }
+
+    it "returns 404 when the scheduled payout is not found" do
+      post :scheduled_execute, params: { id: "missing" }
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "executes a pending scheduled payout" do
+      scheduled_payout = create(:scheduled_payout, user:)
+      allow_any_instance_of(ScheduledPayout).to receive(:execute!).and_return(:executed)
+
+      post :scheduled_execute, params: { id: scheduled_payout.external_id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include("success" => true, "result" => "executed")
+    end
+
+    it "promotes a flagged scheduled payout to pending before executing" do
+      scheduled_payout = create(:scheduled_payout, user:, status: "flagged")
+      allow_any_instance_of(ScheduledPayout).to receive(:execute!).and_return(:executed)
+
+      expect do
+        post :scheduled_execute, params: { id: scheduled_payout.external_id }
+      end.to change { scheduled_payout.reload.status }.from("flagged").to("pending")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["result"]).to eq("executed")
+    end
+
+    it "returns 422 when the scheduled payout is already executed" do
+      scheduled_payout = create(:scheduled_payout, user:, status: "executed")
+
+      post :scheduled_execute, params: { id: scheduled_payout.external_id }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["message"]).to eq("Cannot execute a executed scheduled payout.")
+    end
+
+    it "returns 422 and the error message when execute! raises" do
+      scheduled_payout = create(:scheduled_payout, user:)
+      allow_any_instance_of(ScheduledPayout).to receive(:execute!).and_raise("nope")
+
+      post :scheduled_execute, params: { id: scheduled_payout.external_id }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body).to include("success" => false, "message" => "nope")
+    end
+
+    it "writes an admin audit log targeting the scheduled payout" do
+      scheduled_payout = create(:scheduled_payout, user:)
+      allow_any_instance_of(ScheduledPayout).to receive(:execute!).and_return(:executed)
+
+      expect do
+        post :scheduled_execute, params: { id: scheduled_payout.external_id }
+      end.to change { AdminApiAuditLog.count }.by(1)
+
+      expect(AdminApiAuditLog.last).to have_attributes(
+        action: "payouts.scheduled_execute",
+        target_type: "ScheduledPayout",
+        target_id: scheduled_payout.id,
+        target_external_id: scheduled_payout.external_id,
+        response_status: 200
+      )
+    end
+  end
+
+  describe "POST scheduled_cancel" do
+    include_examples "admin api authorization required", :post, :scheduled_cancel, { id: "abc" }
+
+    it "returns 404 when the scheduled payout is not found" do
+      post :scheduled_cancel, params: { id: "missing" }
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "cancels a pending scheduled payout" do
+      scheduled_payout = create(:scheduled_payout, user:)
+
+      expect do
+        post :scheduled_cancel, params: { id: scheduled_payout.external_id }
+      end.to change { scheduled_payout.reload.status }.from("pending").to("cancelled")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["success"]).to be(true)
+    end
+
+    it "returns 422 and the error message when cancel! raises" do
+      scheduled_payout = create(:scheduled_payout, user:)
+      allow_any_instance_of(ScheduledPayout).to receive(:cancel!).and_raise("already executed")
+
+      post :scheduled_cancel, params: { id: scheduled_payout.external_id }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body).to include("success" => false, "message" => "already executed")
+    end
+
+    it "writes an admin audit log targeting the scheduled payout" do
+      scheduled_payout = create(:scheduled_payout, user:)
+
+      expect do
+        post :scheduled_cancel, params: { id: scheduled_payout.external_id }
+      end.to change { AdminApiAuditLog.count }.by(1)
+
+      expect(AdminApiAuditLog.last).to have_attributes(
+        action: "payouts.scheduled_cancel",
+        target_type: "ScheduledPayout",
+        target_id: scheduled_payout.id,
+        response_status: 200
+      )
+    end
+  end
 end


### PR DESCRIPTION
## What

Closes the last server-side gap in the admin CLI rollout (#4677, PR 12 in the rollout plan). Adds four endpoints to `/internal/admin/payouts`:

- `POST /internal/admin/payouts/issue` — manual payout for a seller, Stripe or PayPal, with optional PayPal split.
- `POST /internal/admin/payouts/scheduled_list` — list `ScheduledPayout` rows (optional status filter, capped at 50).
- `POST /internal/admin/payouts/:id/scheduled_execute` — execute a pending or flagged scheduled payout.
- `POST /internal/admin/payouts/:id/scheduled_cancel` — cancel a scheduled payout.

## Why

These two flows (manual issue-payout and the scheduled-payout review queue) are still admin-web-only. The rollout plan in #4677 intentionally split them out from the Phase 2 batch because they involve money movement and warrant explicit human confirmation on the CLI side. With this PR merged, the CLI side (`gumroad admin payouts issue` / `payouts scheduled …`) is unblocked.

No new business logic — every endpoint reuses what the admin web controllers already use:

- `Payouts.create_payments_for_balances_up_to_date_for_users(..., from_admin: true)` (same call `Admin::PaydaysController#pay_user` makes)
- `ScheduledPayout#execute!` / `#cancel!` and the same `pending? || flagged?` guard from `Admin::ScheduledPayoutsController`
- `Admin::ScheduledPayoutPresenter` for serialization
- `record_admin_write` so writes land in `admin_api_audit_logs` (PR 10B)

## Notes

- Inputs go in POST JSON bodies — no email or external_id in query strings.
- `fetch_scheduled_payout` eager-loads `:user, :created_by` so the presenter doesn't N+1.
- `payouts.issue` validates processor and date before entering `record_admin_write` so input errors don't write audit rows.

---

AI disclosure: drafted with Claude Opus 4.7.
