### PR TITLE
Support cross-country IBAN payouts in SEPA zone

### DIFF
--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -445,8 +445,8 @@ module StripeMerchantAccountManager
             bank_account.account_number.decrypt(passphrase).gsub(/[ -]/, "")
           end
         bank_account_hash = {
-          country: bank_account.country,
-          currency: bank_account.currency,
+          country: bank_account.stripe_external_account_country,
+          currency: bank_account.stripe_external_account_currency,
           account_number: account_number_for_stripe
         }
         if bank_account.routing_number.present?

--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -449,8 +449,8 @@ module StripeMerchantAccountManager
           currency: bank_account.stripe_external_account_currency,
           account_number: account_number_for_stripe
         }
-        if bank_account.routing_number.present?
-          routing_number = bank_account.routing_number
+        routing_number = bank_account.stripe_external_account_routing_number
+        if routing_number.present?
           routing_number = routing_number.gsub(/[ -]/, "") if country_code == Compliance::Countries::GIB.alpha2
           bank_account_hash[:routing_number] = routing_number
         end

--- a/app/models/bank_account.rb
+++ b/app/models/bank_account.rb
@@ -58,6 +58,14 @@ class BankAccount < ApplicationRecord
     Currency::USD
   end
 
+  def stripe_external_account_country
+    country
+  end
+
+  def stripe_external_account_currency
+    currency
+  end
+
   def to_hash
     hash = {
       bank_number:,

--- a/app/models/bank_account.rb
+++ b/app/models/bank_account.rb
@@ -66,6 +66,10 @@ class BankAccount < ApplicationRecord
     currency
   end
 
+  def stripe_external_account_routing_number
+    routing_number
+  end
+
   def to_hash
     hash = {
       bank_number:,

--- a/app/models/bulgaria_bank_account.rb
+++ b/app/models/bulgaria_bank_account.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class BulgariaBankAccount < BankAccount
+  include IbanBankAccount
+
   BANK_ACCOUNT_TYPE = "BG"
 
   validate :validate_account_number, if: -> { Rails.env.production? }
@@ -27,11 +29,4 @@ class BulgariaBankAccount < BankAccount
       bank_account_type:
     }
   end
-
-  private
-    def validate_account_number
-      return if Ibandit::IBAN.new(account_number_decrypted).valid?
-
-      errors.add :base, "The account number is invalid."
-    end
 end

--- a/app/models/concerns/iban_bank_account.rb
+++ b/app/models/concerns/iban_bank_account.rb
@@ -35,7 +35,6 @@ module IbanBankAccount
         errors.add(:base, "The account number is invalid.")
         return
       end
-      return if iban.country_code == country
       return if SEPA_COUNTRY_CODES.include?(iban.country_code)
       errors.add(:base, "The account number is invalid.")
     end

--- a/app/models/concerns/iban_bank_account.rb
+++ b/app/models/concerns/iban_bank_account.rb
@@ -4,9 +4,9 @@ module IbanBankAccount
   extend ActiveSupport::Concern
 
   SEPA_COUNTRY_CODES = %w[
-    AD AL AT BE BG CH CY CZ DE DK EE ES FI FR GB GI
-    GR HR HU IE IS IT LI LT LU LV MC MD ME MK MT NL
-    NO PL PT RO RS SE SI SK SM VA
+    AD AT BE BG CH CY CZ DE DK EE ES FI FR GB GI GR
+    HR HU IE IS IT LI LT LU LV MC MT NL NO PL PT RO
+    SE SI SK SM VA
   ].freeze
 
   def stripe_external_account_country

--- a/app/models/concerns/iban_bank_account.rb
+++ b/app/models/concerns/iban_bank_account.rb
@@ -17,6 +17,10 @@ module IbanBankAccount
     cross_border_sepa_payout? ? Currency::EUR : currency
   end
 
+  def stripe_external_account_routing_number
+    cross_border_sepa_payout? ? nil : routing_number
+  end
+
   private
     def iban_country_code
       return if account_number_decrypted.blank?

--- a/app/models/concerns/iban_bank_account.rb
+++ b/app/models/concerns/iban_bank_account.rb
@@ -4,9 +4,9 @@ module IbanBankAccount
   extend ActiveSupport::Concern
 
   SEPA_COUNTRY_CODES = %w[
-    AD AT BE BG CH CY CZ DE DK EE ES FI FR GB GI GR
-    HR HU IE IS IT LI LT LU LV MC MT NL NO PL PT RO
-    SE SI SK SM VA
+    AT BE BG CH CY CZ DE DK EE ES FI FR GB GI GR HR
+    HU IE IS IT LI LT LU LV MC MT NL NO PL PT RO SE
+    SI SK SM
   ].freeze
 
   def stripe_external_account_country

--- a/app/models/concerns/iban_bank_account.rb
+++ b/app/models/concerns/iban_bank_account.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module IbanBankAccount
+  extend ActiveSupport::Concern
+
+  SEPA_COUNTRY_CODES = %w[
+    AD AT BE BG CH CY CZ DE DK EE ES FI FR GB GI GR
+    HR HU IE IS IT LI LT LU LV MC MT NL NO PL PT RO
+    SE SI SK SM VA
+  ].freeze
+
+  def stripe_external_account_country
+    cross_border_sepa_payout? ? iban_country_code : country
+  end
+
+  def stripe_external_account_currency
+    cross_border_sepa_payout? ? Currency::EUR : currency
+  end
+
+  private
+    def iban_country_code
+      return if account_number_decrypted.blank?
+      Ibandit::IBAN.new(account_number_decrypted).country_code
+    end
+
+    def cross_border_sepa_payout?
+      iban = iban_country_code
+      return false if iban.blank? || iban == country
+      SEPA_COUNTRY_CODES.include?(iban)
+    end
+
+    def validate_account_number
+      iban = Ibandit::IBAN.new(account_number_decrypted)
+      unless iban.valid?
+        errors.add(:base, "The account number is invalid.")
+        return
+      end
+      return if iban.country_code == country
+      return if SEPA_COUNTRY_CODES.include?(iban.country_code)
+      errors.add(:base, "The account number is invalid.")
+    end
+end

--- a/app/models/concerns/iban_bank_account.rb
+++ b/app/models/concerns/iban_bank_account.rb
@@ -4,9 +4,9 @@ module IbanBankAccount
   extend ActiveSupport::Concern
 
   SEPA_COUNTRY_CODES = %w[
-    AD AT BE BG CH CY CZ DE DK EE ES FI FR GB GI GR
-    HR HU IE IS IT LI LT LU LV MC MT NL NO PL PT RO
-    SE SI SK SM VA
+    AD AL AT BE BG CH CY CZ DE DK EE ES FI FR GB GI
+    GR HR HU IE IS IT LI LT LU LV MC MD ME MK MT NL
+    NO PL PT RO RS SE SI SK SM VA
   ].freeze
 
   def stripe_external_account_country

--- a/app/models/czech_republic_bank_account.rb
+++ b/app/models/czech_republic_bank_account.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CzechRepublicBankAccount < BankAccount
+  include IbanBankAccount
+
   BANK_ACCOUNT_TYPE = "CZ"
 
   validate :validate_account_number, if: -> { Rails.env.production? }
@@ -27,11 +29,4 @@ class CzechRepublicBankAccount < BankAccount
       bank_account_type:
     }
   end
-
-  private
-    def validate_account_number
-      return if Ibandit::IBAN.new(account_number_decrypted).valid?
-
-      errors.add :base, "The account number is invalid."
-    end
 end

--- a/app/models/denmark_bank_account.rb
+++ b/app/models/denmark_bank_account.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class DenmarkBankAccount < BankAccount
+  include IbanBankAccount
+
   BANK_ACCOUNT_TYPE = "DK"
 
   validate :validate_account_number, if: -> { Rails.env.production? }
@@ -27,11 +29,4 @@ class DenmarkBankAccount < BankAccount
       bank_account_type:
     }
   end
-
-  private
-    def validate_account_number
-      return if Ibandit::IBAN.new(account_number_decrypted).valid?
-
-      errors.add :base, "The account number is invalid."
-    end
 end

--- a/app/models/european_bank_account.rb
+++ b/app/models/european_bank_account.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class EuropeanBankAccount < BankAccount
+  include IbanBankAccount
+
   BANK_ACCOUNT_TYPE = "EU"
 
   # On sandbox, the test IBAN numbers are of same length for all countries
@@ -30,11 +32,4 @@ class EuropeanBankAccount < BankAccount
       bank_account_type:
     }
   end
-
-  private
-    def validate_account_number
-      return if Ibandit::IBAN.new(account_number_decrypted).valid?
-
-      errors.add :base, "The account number is invalid."
-    end
 end

--- a/app/models/hungary_bank_account.rb
+++ b/app/models/hungary_bank_account.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class HungaryBankAccount < BankAccount
+  include IbanBankAccount
+
   BANK_ACCOUNT_TYPE = "HU"
 
   validate :validate_account_number, if: -> { Rails.env.production? }
@@ -27,11 +29,4 @@ class HungaryBankAccount < BankAccount
       bank_account_type:
     }
   end
-
-  private
-    def validate_account_number
-      return if Ibandit::IBAN.new(account_number_decrypted).valid?
-
-      errors.add :base, "The account number is invalid."
-    end
 end

--- a/app/models/iceland_bank_account.rb
+++ b/app/models/iceland_bank_account.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class IcelandBankAccount < BankAccount
+  include IbanBankAccount
+
   BANK_ACCOUNT_TYPE = "IS"
 
   validate :validate_account_number
@@ -27,11 +29,4 @@ class IcelandBankAccount < BankAccount
       bank_account_type:
     }
   end
-
-  private
-    def validate_account_number
-      return if Ibandit::IBAN.new(account_number_decrypted).valid?
-
-      errors.add :base, "The account number is invalid."
-    end
 end

--- a/app/models/liechtenstein_bank_account.rb
+++ b/app/models/liechtenstein_bank_account.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class LiechtensteinBankAccount < BankAccount
+  include IbanBankAccount
+
   BANK_ACCOUNT_TYPE = "LI"
 
   validate :validate_account_number, if: -> { Rails.env.production? }
@@ -27,11 +29,4 @@ class LiechtensteinBankAccount < BankAccount
       bank_account_type:
     }
   end
-
-  private
-    def validate_account_number
-      return if Ibandit::IBAN.new(account_number_decrypted).valid?
-
-      errors.add :base, "The account number is invalid."
-    end
 end

--- a/app/models/monaco_bank_account.rb
+++ b/app/models/monaco_bank_account.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class MonacoBankAccount < BankAccount
+  include IbanBankAccount
+
   BANK_ACCOUNT_TYPE = "MC"
 
   validate :validate_account_number, if: -> { Rails.env.production? }
@@ -27,10 +29,4 @@ class MonacoBankAccount < BankAccount
       bank_account_type:
     }
   end
-
-  private
-    def validate_account_number
-      return if Ibandit::IBAN.new(account_number_decrypted).valid?
-      errors.add :base, "The account number is invalid."
-    end
 end

--- a/app/models/norway_bank_account.rb
+++ b/app/models/norway_bank_account.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class NorwayBankAccount < BankAccount
+  include IbanBankAccount
+
   BANK_ACCOUNT_TYPE = "NO"
 
   validate :validate_account_number, if: -> { Rails.env.production? }
@@ -27,11 +29,4 @@ class NorwayBankAccount < BankAccount
       bank_account_type:
     }
   end
-
-  private
-    def validate_account_number
-      return if Ibandit::IBAN.new(account_number_decrypted).valid?
-
-      errors.add :base, "The account number is invalid."
-    end
 end

--- a/app/models/poland_bank_account.rb
+++ b/app/models/poland_bank_account.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class PolandBankAccount < BankAccount
+  include IbanBankAccount
+
   BANK_ACCOUNT_TYPE = "PL"
 
   validate :validate_account_number, if: -> { Rails.env.production? }
@@ -27,11 +29,4 @@ class PolandBankAccount < BankAccount
       bank_account_type:
     }
   end
-
-  private
-    def validate_account_number
-      return if Ibandit::IBAN.new(account_number_decrypted).valid?
-
-      errors.add :base, "The account number is invalid."
-    end
 end

--- a/app/models/romania_bank_account.rb
+++ b/app/models/romania_bank_account.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class RomaniaBankAccount < BankAccount
+  include IbanBankAccount
+
   BANK_ACCOUNT_TYPE = "RO"
 
   validate :validate_account_number, if: -> { Rails.env.production? }
@@ -27,11 +29,4 @@ class RomaniaBankAccount < BankAccount
       bank_account_type:
     }
   end
-
-  private
-    def validate_account_number
-      return if Ibandit::IBAN.new(account_number_decrypted).valid?
-
-      errors.add :base, "The account number is invalid."
-    end
 end

--- a/app/models/san_marino_bank_account.rb
+++ b/app/models/san_marino_bank_account.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class SanMarinoBankAccount < BankAccount
+  include IbanBankAccount
+
   BANK_ACCOUNT_TYPE = "SM"
 
   BANK_CODE_FORMAT_REGEX = /^[0-9a-zA-Z]{8,11}$/
@@ -43,10 +45,5 @@ class SanMarinoBankAccount < BankAccount
     def validate_bank_code
       return if BANK_CODE_FORMAT_REGEX.match?(bank_code)
       errors.add :base, "The bank code is invalid."
-    end
-
-    def validate_account_number
-      return if Ibandit::IBAN.new(account_number_decrypted).valid?
-      errors.add :base, "The account number is invalid."
     end
 end

--- a/app/models/sweden_bank_account.rb
+++ b/app/models/sweden_bank_account.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class SwedenBankAccount < BankAccount
+  include IbanBankAccount
+
   BANK_ACCOUNT_TYPE = "SE"
 
   validate :validate_account_number, if: -> { Rails.env.production? }
@@ -27,11 +29,4 @@ class SwedenBankAccount < BankAccount
       bank_account_type:
     }
   end
-
-  private
-    def validate_account_number
-      return if Ibandit::IBAN.new(account_number_decrypted).valid?
-
-      errors.add :base, "The account number is invalid."
-    end
 end

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -9252,6 +9252,176 @@ describe StripeMerchantAccountManager, :vcr do
     end
   end
 
+  describe "cross-border SEPA IBAN payouts" do
+    let(:user) { create(:named_user) }
+    let(:tos_agreement) { travel_to(Time.find_zone("UTC").local(2015, 4, 1)) { create(:tos_agreement, user:) } }
+
+    before { tos_agreement }
+
+    context "when a Bulgaria-based creator submits a Lithuanian IBAN (the issue case)" do
+      let(:user_compliance_info) do
+        create(:user_compliance_info, user:, city: "Sofia", street_address: "address_full_match",
+                                      state: nil, zip_code: "1000", country: "Bulgaria")
+      end
+      let(:bank_account) { create(:bulgaria_bank_account, user:, account_number: "LT121000011101001000") }
+
+      before do
+        user_compliance_info
+        bank_account
+      end
+
+      it "creates a Stripe account in BG and registers the LT IBAN as an EUR external account" do
+        expect(Stripe::Account).to receive(:create).with(
+          hash_including(
+            country: "BG",
+            default_currency: "eur",
+            bank_account: hash_including(country: "LT", currency: "eur", account_number: "LT121000011101001000")
+          )
+        ).and_call_original
+
+        merchant_account = subject.create_account(user, passphrase: "1234")
+
+        expect(merchant_account.country).to eq("BG")
+        expect(merchant_account.currency).to eq("eur")
+        expect(merchant_account.charge_processor_merchant_id).to match(/acct_[a-zA-Z0-9]+/)
+        expect(bank_account.reload.stripe_connect_account_id).to eq(merchant_account.charge_processor_merchant_id)
+        expect(bank_account.reload.stripe_external_account_id).to match(/ba_[a-zA-Z0-9]+/)
+        expect(bank_account.reload.stripe_fingerprint).to be_present
+      end
+    end
+
+    context "when a Bulgaria-based creator with an existing BG IBAN switches to a Lithuanian IBAN" do
+      let(:user_compliance_info) do
+        create(:user_compliance_info, user:, city: "Sofia", street_address: "address_full_match",
+                                      state: nil, zip_code: "1000", country: "Bulgaria")
+      end
+      let(:original_bank_account) { create(:bulgaria_bank_account, user:, account_number: "BG80BNBG96611020345678") }
+      let(:cross_border_bank_account) { create(:bulgaria_bank_account, user:, account_number: "LT121000011101001000") }
+      let(:merchant_account) { subject.create_account(user, passphrase: "1234") }
+
+      before do
+        user_compliance_info
+        original_bank_account
+        merchant_account
+        original_bank_account.update!(deleted_at: Time.current)
+        cross_border_bank_account
+      end
+
+      it "syncs the LT IBAN with EUR currency to the existing BG Stripe account" do
+        expect(Stripe::Account).to receive(:update).with(
+          merchant_account.charge_processor_merchant_id,
+          hash_including(bank_account: hash_including(country: "LT", currency: "eur", account_number: "LT121000011101001000"))
+        ).and_call_original
+
+        result = subject.update_bank_account(user, passphrase: "1234")
+
+        expect(result).to eq(:synced)
+        expect(cross_border_bank_account.reload.stripe_connect_account_id).to eq(merchant_account.charge_processor_merchant_id)
+        expect(cross_border_bank_account.reload.stripe_external_account_id).to match(/ba_[a-zA-Z0-9]+/)
+        expect(cross_border_bank_account.reload.stripe_fingerprint).to be_present
+      end
+    end
+
+    context "when a Denmark-based creator submits a Lithuanian IBAN (Stripe's stated cross-border SEPA example)" do
+      let(:user_compliance_info) do
+        create(:user_compliance_info, user:, city: "Copenhagen", street_address: "address_full_match",
+                                      state: nil, zip_code: "1050", country: "Denmark")
+      end
+      let(:bank_account) { create(:denmark_bank_account, user:, account_number: "LT121000011101001000") }
+
+      before do
+        user_compliance_info
+        bank_account
+      end
+
+      it "creates a Stripe account in DK with DKK default currency but registers the LT IBAN as an EUR external account" do
+        expect(Stripe::Account).to receive(:create).with(
+          hash_including(
+            country: "DK",
+            default_currency: "dkk",
+            bank_account: hash_including(country: "LT", currency: "eur", account_number: "LT121000011101001000")
+          )
+        ).and_call_original
+
+        merchant_account = subject.create_account(user, passphrase: "1234")
+
+        expect(merchant_account.country).to eq("DK")
+        expect(merchant_account.currency).to eq("dkk")
+        expect(merchant_account.charge_processor_merchant_id).to match(/acct_[a-zA-Z0-9]+/)
+        expect(bank_account.reload.stripe_external_account_id).to match(/ba_[a-zA-Z0-9]+/)
+      end
+    end
+
+    context "when a Bulgaria-based creator submits a Bulgarian IBAN (regression: same-country still works)" do
+      let(:user_compliance_info) do
+        create(:user_compliance_info, user:, city: "Sofia", street_address: "address_full_match",
+                                      state: nil, zip_code: "1000", country: "Bulgaria")
+      end
+      let(:bank_account) { create(:bulgaria_bank_account, user:, account_number: "BG80BNBG96611020345678") }
+
+      before do
+        user_compliance_info
+        bank_account
+      end
+
+      it "creates a Stripe account in BG and registers the BG IBAN as an EUR external account" do
+        expect(Stripe::Account).to receive(:create).with(
+          hash_including(
+            country: "BG",
+            default_currency: "eur",
+            bank_account: hash_including(country: "BG", currency: "eur", account_number: "BG80BNBG96611020345678")
+          )
+        ).and_call_original
+
+        merchant_account = subject.create_account(user, passphrase: "1234")
+
+        expect(merchant_account.country).to eq("BG")
+        expect(merchant_account.currency).to eq("eur")
+        expect(bank_account.reload.stripe_external_account_id).to match(/ba_[a-zA-Z0-9]+/)
+      end
+    end
+
+    context "when a Denmark-based creator submits a Danish IBAN (regression: same-country still works)" do
+      let(:user_compliance_info) do
+        create(:user_compliance_info, user:, city: "Copenhagen", street_address: "address_full_match",
+                                      state: nil, zip_code: "1050", country: "Denmark")
+      end
+      let(:bank_account) { create(:denmark_bank_account, user:, account_number: "DK5000400440116243") }
+
+      before do
+        user_compliance_info
+        bank_account
+      end
+
+      it "creates a Stripe account in DK and registers the DK IBAN as a DKK external account" do
+        expect(Stripe::Account).to receive(:create).with(
+          hash_including(
+            country: "DK",
+            default_currency: "dkk",
+            bank_account: hash_including(country: "DK", currency: "dkk", account_number: "DK5000400440116243")
+          )
+        ).and_call_original
+
+        merchant_account = subject.create_account(user, passphrase: "1234")
+
+        expect(merchant_account.country).to eq("DK")
+        expect(merchant_account.currency).to eq("dkk")
+        expect(bank_account.reload.stripe_external_account_id).to match(/ba_[a-zA-Z0-9]+/)
+      end
+    end
+
+    context "when a Bulgaria-based creator submits a Saudi IBAN (non-SEPA)" do
+      it "is rejected at the model layer before any Stripe call" do
+        allow(Rails.env).to receive(:production?).and_return(true)
+        bank_account = build(:bulgaria_bank_account, user:, account_number: "SA0380000000608010167519")
+
+        expect(Stripe::Account).not_to receive(:create)
+        expect(bank_account).not_to be_valid
+        expect(bank_account.errors.full_messages.to_sentence).to eq("The account number is invalid.")
+      end
+    end
+  end
+
   describe ".save_stripe_bank_account_info" do
     let(:user) { create(:named_user) }
     let(:bank_account) { create(:japan_bank_account, user:) }

--- a/spec/models/concerns/iban_bank_account_spec.rb
+++ b/spec/models/concerns/iban_bank_account_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe IbanBankAccount do
+  describe "#stripe_external_account_country" do
+    it "returns the IBAN's country prefix when it differs from the account country and is in SEPA" do
+      bank_account = build(:bulgaria_bank_account, account_number: "LT121000011101001000")
+      expect(bank_account.stripe_external_account_country).to eq("LT")
+    end
+
+    it "returns the account's home country when the IBAN matches it" do
+      bank_account = build(:bulgaria_bank_account, account_number: "BG80BNBG96611020345678")
+      expect(bank_account.stripe_external_account_country).to eq("BG")
+    end
+
+    it "returns the account's home country when the IBAN prefix is non-SEPA" do
+      bank_account = build(:bulgaria_bank_account, account_number: "SA0380000000608010167519")
+      expect(bank_account.stripe_external_account_country).to eq("BG")
+    end
+
+    it "handles non-EUR home currency accounts (Denmark with Lithuanian IBAN)" do
+      bank_account = build(:denmark_bank_account, account_number: "LT121000011101001000")
+      expect(bank_account.stripe_external_account_country).to eq("LT")
+    end
+  end
+
+  describe "#stripe_external_account_currency" do
+    it "returns 'eur' when the IBAN is cross-border within SEPA" do
+      bank_account = build(:denmark_bank_account, account_number: "LT121000011101001000")
+      expect(bank_account.stripe_external_account_currency).to eq("eur")
+    end
+
+    it "returns the account's home currency when the IBAN matches the home country" do
+      bank_account = build(:denmark_bank_account, account_number: "DK5000400440116243")
+      expect(bank_account.stripe_external_account_currency).to eq("dkk")
+    end
+
+    it "returns the account's home currency when the IBAN prefix is non-SEPA" do
+      bank_account = build(:denmark_bank_account, account_number: "SA0380000000608010167519")
+      expect(bank_account.stripe_external_account_currency).to eq("dkk")
+    end
+  end
+
+  describe "#validate_account_number" do
+    before { allow(Rails.env).to receive(:production?).and_return(true) }
+
+    it "accepts an IBAN whose country matches the account's home country" do
+      expect(build(:bulgaria_bank_account, account_number: "BG80BNBG96611020345678")).to be_valid
+    end
+
+    it "accepts a cross-border IBAN within the SEPA zone" do
+      expect(build(:bulgaria_bank_account, account_number: "LT121000011101001000")).to be_valid
+      expect(build(:denmark_bank_account, account_number: "LT121000011101001000")).to be_valid
+    end
+
+    it "rejects an IBAN from a country outside the SEPA zone" do
+      bank_account = build(:bulgaria_bank_account, account_number: "SA0380000000608010167519")
+      expect(bank_account).not_to be_valid
+      expect(bank_account.errors.full_messages.to_sentence).to eq("The account number is invalid.")
+    end
+
+    it "rejects an IBAN with an invalid format" do
+      bank_account = build(:bulgaria_bank_account, account_number: "BG12345")
+      expect(bank_account).not_to be_valid
+      expect(bank_account.errors.full_messages.to_sentence).to eq("The account number is invalid.")
+    end
+  end
+end

--- a/spec/models/concerns/iban_bank_account_spec.rb
+++ b/spec/models/concerns/iban_bank_account_spec.rb
@@ -54,6 +54,14 @@ describe IbanBankAccount do
       expect(build(:denmark_bank_account, account_number: "LT121000011101001000")).to be_valid
     end
 
+    it "accepts IBANs from SEPA countries that joined recently (AL, MD, ME, MK, RS)" do
+      expect(build(:bulgaria_bank_account, account_number: "AL35202111090000000001234567")).to be_valid
+      expect(build(:bulgaria_bank_account, account_number: "MD24AG000225100013104168")).to be_valid
+      expect(build(:bulgaria_bank_account, account_number: "ME25505000012345678951")).to be_valid
+      expect(build(:bulgaria_bank_account, account_number: "MK07250120000058984")).to be_valid
+      expect(build(:bulgaria_bank_account, account_number: "RS35260005601001611379")).to be_valid
+    end
+
     it "rejects an IBAN from a country outside the SEPA zone" do
       bank_account = build(:bulgaria_bank_account, account_number: "SA0380000000608010167519")
       expect(bank_account).not_to be_valid

--- a/spec/models/concerns/iban_bank_account_spec.rb
+++ b/spec/models/concerns/iban_bank_account_spec.rb
@@ -75,5 +75,11 @@ describe IbanBankAccount do
       expect(bank_account).not_to be_valid
       expect(bank_account.errors.full_messages.to_sentence).to eq("The account number is invalid.")
     end
+
+    it "rejects a non-SEPA IBAN on EuropeanBankAccount, whose country derives from the IBAN prefix" do
+      bank_account = build(:european_bank_account, account_number: "SA0380000000608010167519")
+      expect(bank_account).not_to be_valid
+      expect(bank_account.errors.full_messages.to_sentence).to eq("The account number is invalid.")
+    end
   end
 end

--- a/spec/models/concerns/iban_bank_account_spec.rb
+++ b/spec/models/concerns/iban_bank_account_spec.rb
@@ -60,6 +60,16 @@ describe IbanBankAccount do
       expect(bank_account.errors.full_messages.to_sentence).to eq("The account number is invalid.")
     end
 
+    it "rejects IBANs from countries Stripe does not support (AD, VA)" do
+      ad_account = build(:bulgaria_bank_account, account_number: "AD1400080001001234567890")
+      expect(ad_account).not_to be_valid
+      expect(ad_account.errors.full_messages.to_sentence).to eq("The account number is invalid.")
+
+      va_account = build(:bulgaria_bank_account, account_number: "VA59001123000012345678")
+      expect(va_account).not_to be_valid
+      expect(va_account.errors.full_messages.to_sentence).to eq("The account number is invalid.")
+    end
+
     it "rejects an IBAN with an invalid format" do
       bank_account = build(:bulgaria_bank_account, account_number: "BG12345")
       expect(bank_account).not_to be_valid

--- a/spec/models/concerns/iban_bank_account_spec.rb
+++ b/spec/models/concerns/iban_bank_account_spec.rb
@@ -42,6 +42,23 @@ describe IbanBankAccount do
     end
   end
 
+  describe "#stripe_external_account_routing_number" do
+    it "returns nil when the IBAN is cross-border within SEPA, so a home-country BIC is not paired with a foreign IBAN" do
+      bank_account = build(:san_marino_bank_account, account_number: "IT60X0542811101000000123456")
+      expect(bank_account.stripe_external_account_routing_number).to be_nil
+    end
+
+    it "returns the account's routing_number when the IBAN matches the home country" do
+      bank_account = build(:san_marino_bank_account, account_number: "SM86U0322509800000000270100")
+      expect(bank_account.stripe_external_account_routing_number).to eq("AAAASMSMXXX")
+    end
+
+    it "returns nil for SEPA models that have no routing_number, regardless of cross-border status" do
+      expect(build(:bulgaria_bank_account, account_number: "LT121000011101001000").stripe_external_account_routing_number).to be_nil
+      expect(build(:bulgaria_bank_account, account_number: "BG80BNBG96611020345678").stripe_external_account_routing_number).to be_nil
+    end
+  end
+
   describe "#validate_account_number" do
     before { allow(Rails.env).to receive(:production?).and_return(true) }
 

--- a/spec/models/concerns/iban_bank_account_spec.rb
+++ b/spec/models/concerns/iban_bank_account_spec.rb
@@ -54,14 +54,6 @@ describe IbanBankAccount do
       expect(build(:denmark_bank_account, account_number: "LT121000011101001000")).to be_valid
     end
 
-    it "accepts IBANs from SEPA countries that joined recently (AL, MD, ME, MK, RS)" do
-      expect(build(:bulgaria_bank_account, account_number: "AL35202111090000000001234567")).to be_valid
-      expect(build(:bulgaria_bank_account, account_number: "MD24AG000225100013104168")).to be_valid
-      expect(build(:bulgaria_bank_account, account_number: "ME25505000012345678951")).to be_valid
-      expect(build(:bulgaria_bank_account, account_number: "MK07250120000058984")).to be_valid
-      expect(build(:bulgaria_bank_account, account_number: "RS35260005601001611379")).to be_valid
-    end
-
     it "rejects an IBAN from a country outside the SEPA zone" do
       bank_account = build(:bulgaria_bank_account, account_number: "SA0380000000608010167519")
       expect(bank_account).not_to be_valid

--- a/spec/support/fixtures/vcr_cassettes/StripeMerchantAccountManager/cross-border_SEPA_IBAN_payouts/when_a_Bulgaria-based_creator_submits_a_Bulgarian_IBAN_regression_same-country_still_works_/creates_a_Stripe_account_in_BG_and_registers_the_BG_IBAN_as_an_EUR_external_account.yml
+++ b/spec/support/fixtures/vcr_cassettes/StripeMerchantAccountManager/cross-border_SEPA_IBAN_payouts/when_a_Bulgaria-based_creator_submits_a_Bulgarian_IBAN_regression_same-country_still_works_/creates_a_Stripe_account_in_BG_and_registers_the_BG_IBAN_as_an_EUR_external_account.yml
@@ -1,0 +1,355 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/accounts
+    body:
+      encoding: UTF-8
+      string: type=custom&requested_capabilities[0]=card_payments&requested_capabilities[1]=transfers&country=BG&default_currency=eur&metadata[user_id]=1678873363666&metadata[tos_agreement_id]=Ndi2r61ahsr4VqEFanuDyw%3D%3D&metadata[user_compliance_info_id]=Pr75-BkaxgYLVaYaKmODsg%3D%3D&metadata[bank_account_id]=ARLpakZof0Q5C7RCUmcQ7w%3D%3D&tos_acceptance[date]=1427846400&tos_acceptance[ip]=54.234.242.13&business_type=individual&business_profile[name]=Chuck+Bartowski&business_profile[url]=https%3A%2F%2Fvipul.gumroad.com%2F&business_profile[product_description]=Chuck+Bartowski&individual[first_name]=Chuck&individual[last_name]=Bartowski&individual[email]=edgar_7%40gumroad.com&individual[phone]=0000000000&individual[dob][day]=1&individual[dob][month]=1&individual[dob][year]=1901&individual[address][line1]=address_full_match&individual[address][city]=Sofia&individual[address][postal_code]=1000&individual[address][country]=BG&individual[id_number]=000000000&bank_account[country]=BG&bank_account[currency]=eur&bank_account[account_number]=BG80BNBG96611020345678&settings[payouts][schedule][interval]=manual&settings[payouts][debit_negative_balances]=true
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_QskH8uWv5ZMo5B","request_duration_ms":4659}}'
+      Idempotency-Key:
+      - 1efae8a4-0ab3-4802-b294-209c9006c558
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Is-MacBook-Air.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56
+        PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132 arm64","hostname":"Is-MacBook-Air.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 04 May 2026 09:05:58 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '6411'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=XjacyA1lBPBfyXMbNXZuTW5hInUjdinmlKw8BLHGkFuaushe22IVRVpSmvCjyh_fRZGKtVhg4gdp9BoM
+      Idempotency-Key:
+      - 1efae8a4-0ab3-4802-b294-209c9006c558
+      Original-Request:
+      - req_kDLjsNXtRltAum
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=XjacyA1lBPBfyXMbNXZuTW5hInUjdinmlKw8BLHGkFuaushe22IVRVpSmvCjyh_fRZGKtVhg4gdp9BoM&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=XjacyA1lBPBfyXMbNXZuTW5hInUjdinmlKw8BLHGkFuaushe22IVRVpSmvCjyh_fRZGKtVhg4gdp9BoM&t=1"
+      Request-Id:
+      - req_kDLjsNXtRltAum
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1TTIRrEsT3ZIXwRz",
+          "object": "account",
+          "business_profile": {
+            "annual_revenue": null,
+            "estimated_worker_count": null,
+            "mcc": null,
+            "minority_owned_business_designation": null,
+            "name": "Chuck Bartowski",
+            "product_description": "Chuck Bartowski",
+            "specified_commercial_transactions_act_url": null,
+            "support_address": null,
+            "support_email": null,
+            "support_phone": null,
+            "support_url": null,
+            "url": "https://vipul.gumroad.com/"
+          },
+          "business_type": "individual",
+          "capabilities": {
+            "card_payments": "inactive",
+            "transfers": "active"
+          },
+          "charges_enabled": false,
+          "company": {
+            "address": {
+              "city": "Sofia",
+              "country": "BG",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "1000",
+              "state": null
+            },
+            "directors_provided": true,
+            "executives_provided": true,
+            "name": null,
+            "owners_provided": true,
+            "phone": "+10000000000",
+            "tax_id_provided": false,
+            "verification": {
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              }
+            }
+          },
+          "controller": {
+            "fees": {
+              "payer": "application_custom"
+            },
+            "is_controller": true,
+            "losses": {
+              "payments": "application"
+            },
+            "requirement_collection": "application",
+            "stripe_dashboard": {
+              "type": "none"
+            },
+            "type": "application"
+          },
+          "country": "BG",
+          "created": 1777885557,
+          "default_currency": "eur",
+          "details_submitted": false,
+          "email": null,
+          "external_accounts": {
+            "object": "list",
+            "data": [
+              {
+                "id": "ba_1TTIRrEsT3ZIXwRzCD1aNyhY",
+                "object": "bank_account",
+                "account": "acct_1TTIRrEsT3ZIXwRz",
+                "account_holder_name": null,
+                "account_holder_type": null,
+                "account_type": null,
+                "available_payout_methods": [
+                  "standard"
+                ],
+                "bank_name": "STRIPE TEST BANK",
+                "country": "BG",
+                "currency": "eur",
+                "default_for_currency": true,
+                "fingerprint": "V6BdEFgeYsbSjzV7",
+                "future_requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "last4": "5678",
+                "metadata": {},
+                "requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "routing_number": "110000000",
+                "status": "new"
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/accounts/acct_1TTIRrEsT3ZIXwRz/external_accounts"
+          },
+          "future_requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [],
+            "disabled_reason": null,
+            "errors": [],
+            "eventually_due": [],
+            "past_due": [],
+            "pending_verification": []
+          },
+          "individual": {
+            "id": "person_1TTIRrEsT3ZIXwRz4uSaj3et",
+            "object": "person",
+            "account": "acct_1TTIRrEsT3ZIXwRz",
+            "address": {
+              "city": "Sofia",
+              "country": "BG",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "1000",
+              "state": null
+            },
+            "created": 1777885556,
+            "dob": {
+              "day": 1,
+              "month": 1,
+              "year": 1901
+            },
+            "email": "edgar_7@gumroad.com",
+            "first_name": "Chuck",
+            "future_requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "id_number_provided": true,
+            "last_name": "Bartowski",
+            "metadata": {},
+            "phone": "+10000000000",
+            "relationship": {
+              "authorizer": false,
+              "director": false,
+              "executive": false,
+              "legal_guardian": false,
+              "owner": false,
+              "percent_ownership": null,
+              "representative": true,
+              "title": null
+            },
+            "requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "ssn_last_4_provided": true,
+            "verification": {
+              "additional_document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "details": null,
+              "details_code": null,
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "status": "pending"
+            }
+          },
+          "metadata": {
+            "bank_account_id": "ARLpakZof0Q5C7RCUmcQ7w==",
+            "tos_agreement_id": "Ndi2r61ahsr4VqEFanuDyw==",
+            "user_compliance_info_id": "Pr75-BkaxgYLVaYaKmODsg==",
+            "user_id": "1678873363666"
+          },
+          "payouts_enabled": false,
+          "requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [
+              "business_profile.mcc"
+            ],
+            "disabled_reason": "requirements.past_due",
+            "errors": [],
+            "eventually_due": [
+              "business_profile.mcc"
+            ],
+            "past_due": [
+              "business_profile.mcc"
+            ],
+            "pending_verification": []
+          },
+          "settings": {
+            "bacs_debit_payments": {
+              "display_name": null,
+              "service_user_number": null
+            },
+            "branding": {
+              "icon": null,
+              "logo": null,
+              "primary_color": null,
+              "secondary_color": null
+            },
+            "card_issuing": {
+              "tos_acceptance": {
+                "date": null,
+                "ip": null
+              }
+            },
+            "card_payments": {
+              "decline_on": {
+                "avs_failure": false,
+                "cvc_failure": false
+              },
+              "statement_descriptor_prefix": "CHUCK BART",
+              "statement_descriptor_prefix_kana": null,
+              "statement_descriptor_prefix_kanji": null
+            },
+            "dashboard": {
+              "display_name": "Chuck Bartowski",
+              "timezone": "Etc/UTC"
+            },
+            "invoices": {
+              "default_account_tax_ids": null,
+              "hosted_payment_method_save": "offer"
+            },
+            "payments": {
+              "statement_descriptor": "CHUCK BARTOWSKI",
+              "statement_descriptor_kana": null,
+              "statement_descriptor_kanji": null
+            },
+            "payouts": {
+              "debit_negative_balances": true,
+              "schedule": {
+                "delay_days": 7,
+                "interval": "manual"
+              },
+              "statement_descriptor": null
+            },
+            "sepa_debit_payments": {}
+          },
+          "tos_acceptance": {
+            "date": 1427846400,
+            "ip": "54.234.242.13",
+            "user_agent": null
+          },
+          "type": "custom"
+        }
+  recorded_at: Mon, 04 May 2026 09:05:58 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/StripeMerchantAccountManager/cross-border_SEPA_IBAN_payouts/when_a_Bulgaria-based_creator_submits_a_Lithuanian_IBAN_the_issue_case_/creates_a_Stripe_account_in_BG_and_registers_the_LT_IBAN_as_an_EUR_external_account.yml
+++ b/spec/support/fixtures/vcr_cassettes/StripeMerchantAccountManager/cross-border_SEPA_IBAN_payouts/when_a_Bulgaria-based_creator_submits_a_Lithuanian_IBAN_the_issue_case_/creates_a_Stripe_account_in_BG_and_registers_the_LT_IBAN_as_an_EUR_external_account.yml
@@ -1,0 +1,353 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/accounts
+    body:
+      encoding: UTF-8
+      string: type=custom&requested_capabilities[0]=card_payments&requested_capabilities[1]=transfers&country=BG&default_currency=eur&metadata[user_id]=1740949222714&metadata[tos_agreement_id]=rUFoI3aoSiVffxRgqZLJBA%3D%3D&metadata[user_compliance_info_id]=r02pUDVp2RFCHDtR_6mcDw%3D%3D&metadata[bank_account_id]=H1VnEuKtEUcex5IQ2u6fiQ%3D%3D&tos_acceptance[date]=1427846400&tos_acceptance[ip]=54.234.242.13&business_type=individual&business_profile[name]=Chuck+Bartowski&business_profile[url]=https%3A%2F%2Fvipul.gumroad.com%2F&business_profile[product_description]=Chuck+Bartowski&individual[first_name]=Chuck&individual[last_name]=Bartowski&individual[email]=edgar_1%40gumroad.com&individual[phone]=0000000000&individual[dob][day]=1&individual[dob][month]=1&individual[dob][year]=1901&individual[address][line1]=address_full_match&individual[address][city]=Sofia&individual[address][postal_code]=1000&individual[address][country]=BG&individual[id_number]=000000000&bank_account[country]=LT&bank_account[currency]=eur&bank_account[account_number]=LT121000011101001000&settings[payouts][schedule][interval]=manual&settings[payouts][debit_negative_balances]=true
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Idempotency-Key:
+      - a9e83940-6116-4a41-9cb1-67c6f41eae61
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Is-MacBook-Air.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56
+        PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132 arm64","hostname":"Is-MacBook-Air.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 04 May 2026 09:05:39 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '6411'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=tNFADfbQDZtXE8dX-RxepMR0xhl0Y6uHBZZ0PApHu0p8WnhfFY61cX6dfv2juxZMVfFkvXZ7MXffdmKl
+      Idempotency-Key:
+      - a9e83940-6116-4a41-9cb1-67c6f41eae61
+      Original-Request:
+      - req_6D8ctPQHowxQ0V
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=tNFADfbQDZtXE8dX-RxepMR0xhl0Y6uHBZZ0PApHu0p8WnhfFY61cX6dfv2juxZMVfFkvXZ7MXffdmKl&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=tNFADfbQDZtXE8dX-RxepMR0xhl0Y6uHBZZ0PApHu0p8WnhfFY61cX6dfv2juxZMVfFkvXZ7MXffdmKl&t=1"
+      Request-Id:
+      - req_6D8ctPQHowxQ0V
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1TTIRWEYL0tJjGDa",
+          "object": "account",
+          "business_profile": {
+            "annual_revenue": null,
+            "estimated_worker_count": null,
+            "mcc": null,
+            "minority_owned_business_designation": null,
+            "name": "Chuck Bartowski",
+            "product_description": "Chuck Bartowski",
+            "specified_commercial_transactions_act_url": null,
+            "support_address": null,
+            "support_email": null,
+            "support_phone": null,
+            "support_url": null,
+            "url": "https://vipul.gumroad.com/"
+          },
+          "business_type": "individual",
+          "capabilities": {
+            "card_payments": "inactive",
+            "transfers": "active"
+          },
+          "charges_enabled": false,
+          "company": {
+            "address": {
+              "city": "Sofia",
+              "country": "BG",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "1000",
+              "state": null
+            },
+            "directors_provided": true,
+            "executives_provided": true,
+            "name": null,
+            "owners_provided": true,
+            "phone": "+10000000000",
+            "tax_id_provided": false,
+            "verification": {
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              }
+            }
+          },
+          "controller": {
+            "fees": {
+              "payer": "application_custom"
+            },
+            "is_controller": true,
+            "losses": {
+              "payments": "application"
+            },
+            "requirement_collection": "application",
+            "stripe_dashboard": {
+              "type": "none"
+            },
+            "type": "application"
+          },
+          "country": "BG",
+          "created": 1777885536,
+          "default_currency": "eur",
+          "details_submitted": false,
+          "email": null,
+          "external_accounts": {
+            "object": "list",
+            "data": [
+              {
+                "id": "ba_1TTIRWEYL0tJjGDaUPcW5nmY",
+                "object": "bank_account",
+                "account": "acct_1TTIRWEYL0tJjGDa",
+                "account_holder_name": null,
+                "account_holder_type": null,
+                "account_type": null,
+                "available_payout_methods": [
+                  "standard"
+                ],
+                "bank_name": "STRIPE TEST BANK",
+                "country": "LT",
+                "currency": "eur",
+                "default_for_currency": true,
+                "fingerprint": "IFXjz7SwQO4Jz8mz",
+                "future_requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "last4": "1000",
+                "metadata": {},
+                "requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "routing_number": "110000000",
+                "status": "new"
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/accounts/acct_1TTIRWEYL0tJjGDa/external_accounts"
+          },
+          "future_requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [],
+            "disabled_reason": null,
+            "errors": [],
+            "eventually_due": [],
+            "past_due": [],
+            "pending_verification": []
+          },
+          "individual": {
+            "id": "person_1TTIRWEYL0tJjGDaiH3KgfdS",
+            "object": "person",
+            "account": "acct_1TTIRWEYL0tJjGDa",
+            "address": {
+              "city": "Sofia",
+              "country": "BG",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "1000",
+              "state": null
+            },
+            "created": 1777885535,
+            "dob": {
+              "day": 1,
+              "month": 1,
+              "year": 1901
+            },
+            "email": "edgar_1@gumroad.com",
+            "first_name": "Chuck",
+            "future_requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "id_number_provided": true,
+            "last_name": "Bartowski",
+            "metadata": {},
+            "phone": "+10000000000",
+            "relationship": {
+              "authorizer": false,
+              "director": false,
+              "executive": false,
+              "legal_guardian": false,
+              "owner": false,
+              "percent_ownership": null,
+              "representative": true,
+              "title": null
+            },
+            "requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "ssn_last_4_provided": true,
+            "verification": {
+              "additional_document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "details": null,
+              "details_code": null,
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "status": "pending"
+            }
+          },
+          "metadata": {
+            "bank_account_id": "H1VnEuKtEUcex5IQ2u6fiQ==",
+            "tos_agreement_id": "rUFoI3aoSiVffxRgqZLJBA==",
+            "user_compliance_info_id": "r02pUDVp2RFCHDtR_6mcDw==",
+            "user_id": "1740949222714"
+          },
+          "payouts_enabled": false,
+          "requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [
+              "business_profile.mcc"
+            ],
+            "disabled_reason": "requirements.past_due",
+            "errors": [],
+            "eventually_due": [
+              "business_profile.mcc"
+            ],
+            "past_due": [
+              "business_profile.mcc"
+            ],
+            "pending_verification": []
+          },
+          "settings": {
+            "bacs_debit_payments": {
+              "display_name": null,
+              "service_user_number": null
+            },
+            "branding": {
+              "icon": null,
+              "logo": null,
+              "primary_color": null,
+              "secondary_color": null
+            },
+            "card_issuing": {
+              "tos_acceptance": {
+                "date": null,
+                "ip": null
+              }
+            },
+            "card_payments": {
+              "decline_on": {
+                "avs_failure": false,
+                "cvc_failure": false
+              },
+              "statement_descriptor_prefix": "CHUCK BART",
+              "statement_descriptor_prefix_kana": null,
+              "statement_descriptor_prefix_kanji": null
+            },
+            "dashboard": {
+              "display_name": "Chuck Bartowski",
+              "timezone": "Etc/UTC"
+            },
+            "invoices": {
+              "default_account_tax_ids": null,
+              "hosted_payment_method_save": "offer"
+            },
+            "payments": {
+              "statement_descriptor": "CHUCK BARTOWSKI",
+              "statement_descriptor_kana": null,
+              "statement_descriptor_kanji": null
+            },
+            "payouts": {
+              "debit_negative_balances": true,
+              "schedule": {
+                "delay_days": 7,
+                "interval": "manual"
+              },
+              "statement_descriptor": null
+            },
+            "sepa_debit_payments": {}
+          },
+          "tos_acceptance": {
+            "date": 1427846400,
+            "ip": "54.234.242.13",
+            "user_agent": null
+          },
+          "type": "custom"
+        }
+  recorded_at: Mon, 04 May 2026 09:05:39 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/StripeMerchantAccountManager/cross-border_SEPA_IBAN_payouts/when_a_Bulgaria-based_creator_with_an_existing_BG_IBAN_switches_to_a_Lithuanian_IBAN/syncs_the_LT_IBAN_with_EUR_currency_to_the_existing_BG_Stripe_account.yml
+++ b/spec/support/fixtures/vcr_cassettes/StripeMerchantAccountManager/cross-border_SEPA_IBAN_payouts/when_a_Bulgaria-based_creator_with_an_existing_BG_IBAN_switches_to_a_Lithuanian_IBAN/syncs_the_LT_IBAN_with_EUR_currency_to_the_existing_BG_Stripe_account.yml
@@ -1,0 +1,1401 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/accounts
+    body:
+      encoding: UTF-8
+      string: type=custom&requested_capabilities[0]=card_payments&requested_capabilities[1]=transfers&country=BG&default_currency=eur&metadata[user_id]=3202313146383&metadata[tos_agreement_id]=z-k7JlXJ1MqGvSWSEYzgVQ%3D%3D&metadata[user_compliance_info_id]=qNDOQZuxI0P3WTbxbAl6DA%3D%3D&metadata[bank_account_id]=cL9eWoQzVs2QT63DNYkZZg%3D%3D&tos_acceptance[date]=1427846400&tos_acceptance[ip]=54.234.242.13&business_type=individual&business_profile[name]=Chuck+Bartowski&business_profile[url]=https%3A%2F%2Fvipul.gumroad.com%2F&business_profile[product_description]=Chuck+Bartowski&individual[first_name]=Chuck&individual[last_name]=Bartowski&individual[email]=edgar_3%40gumroad.com&individual[phone]=0000000000&individual[dob][day]=1&individual[dob][month]=1&individual[dob][year]=1901&individual[address][line1]=address_full_match&individual[address][city]=Sofia&individual[address][postal_code]=1000&individual[address][country]=BG&individual[id_number]=000000000&bank_account[country]=BG&bank_account[currency]=eur&bank_account[account_number]=BG80BNBG96611020345678&settings[payouts][schedule][interval]=manual&settings[payouts][debit_negative_balances]=true
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_6D8ctPQHowxQ0V","request_duration_ms":5602}}'
+      Idempotency-Key:
+      - 6aaef539-76ed-4f63-9f00-733c56d7df6b
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Is-MacBook-Air.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56
+        PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132 arm64","hostname":"Is-MacBook-Air.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 04 May 2026 09:05:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '6411'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=XjacyA1lBPBfyXMbNXZuTW5hInUjdinmlKw8BLHGkFuaushe22IVRVpSmvCjyh_fRZGKtVhg4gdp9BoM
+      Idempotency-Key:
+      - 6aaef539-76ed-4f63-9f00-733c56d7df6b
+      Original-Request:
+      - req_8E6hl1N3EqXAd2
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=XjacyA1lBPBfyXMbNXZuTW5hInUjdinmlKw8BLHGkFuaushe22IVRVpSmvCjyh_fRZGKtVhg4gdp9BoM&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=XjacyA1lBPBfyXMbNXZuTW5hInUjdinmlKw8BLHGkFuaushe22IVRVpSmvCjyh_fRZGKtVhg4gdp9BoM&t=1"
+      Request-Id:
+      - req_8E6hl1N3EqXAd2
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1TTIRcRJ54bAZgCS",
+          "object": "account",
+          "business_profile": {
+            "annual_revenue": null,
+            "estimated_worker_count": null,
+            "mcc": null,
+            "minority_owned_business_designation": null,
+            "name": "Chuck Bartowski",
+            "product_description": "Chuck Bartowski",
+            "specified_commercial_transactions_act_url": null,
+            "support_address": null,
+            "support_email": null,
+            "support_phone": null,
+            "support_url": null,
+            "url": "https://vipul.gumroad.com/"
+          },
+          "business_type": "individual",
+          "capabilities": {
+            "card_payments": "inactive",
+            "transfers": "active"
+          },
+          "charges_enabled": false,
+          "company": {
+            "address": {
+              "city": "Sofia",
+              "country": "BG",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "1000",
+              "state": null
+            },
+            "directors_provided": true,
+            "executives_provided": true,
+            "name": null,
+            "owners_provided": true,
+            "phone": "+10000000000",
+            "tax_id_provided": false,
+            "verification": {
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              }
+            }
+          },
+          "controller": {
+            "fees": {
+              "payer": "application_custom"
+            },
+            "is_controller": true,
+            "losses": {
+              "payments": "application"
+            },
+            "requirement_collection": "application",
+            "stripe_dashboard": {
+              "type": "none"
+            },
+            "type": "application"
+          },
+          "country": "BG",
+          "created": 1777885542,
+          "default_currency": "eur",
+          "details_submitted": false,
+          "email": null,
+          "external_accounts": {
+            "object": "list",
+            "data": [
+              {
+                "id": "ba_1TTIRcRJ54bAZgCSJ5vwgVci",
+                "object": "bank_account",
+                "account": "acct_1TTIRcRJ54bAZgCS",
+                "account_holder_name": null,
+                "account_holder_type": null,
+                "account_type": null,
+                "available_payout_methods": [
+                  "standard"
+                ],
+                "bank_name": "STRIPE TEST BANK",
+                "country": "BG",
+                "currency": "eur",
+                "default_for_currency": true,
+                "fingerprint": "V6BdEFgeYsbSjzV7",
+                "future_requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "last4": "5678",
+                "metadata": {},
+                "requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "routing_number": "110000000",
+                "status": "new"
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/accounts/acct_1TTIRcRJ54bAZgCS/external_accounts"
+          },
+          "future_requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [],
+            "disabled_reason": null,
+            "errors": [],
+            "eventually_due": [],
+            "past_due": [],
+            "pending_verification": []
+          },
+          "individual": {
+            "id": "person_1TTIRdRJ54bAZgCSdlS59hBB",
+            "object": "person",
+            "account": "acct_1TTIRcRJ54bAZgCS",
+            "address": {
+              "city": "Sofia",
+              "country": "BG",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "1000",
+              "state": null
+            },
+            "created": 1777885541,
+            "dob": {
+              "day": 1,
+              "month": 1,
+              "year": 1901
+            },
+            "email": "edgar_3@gumroad.com",
+            "first_name": "Chuck",
+            "future_requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "id_number_provided": true,
+            "last_name": "Bartowski",
+            "metadata": {},
+            "phone": "+10000000000",
+            "relationship": {
+              "authorizer": false,
+              "director": false,
+              "executive": false,
+              "legal_guardian": false,
+              "owner": false,
+              "percent_ownership": null,
+              "representative": true,
+              "title": null
+            },
+            "requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "ssn_last_4_provided": true,
+            "verification": {
+              "additional_document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "details": null,
+              "details_code": null,
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "status": "pending"
+            }
+          },
+          "metadata": {
+            "bank_account_id": "cL9eWoQzVs2QT63DNYkZZg==",
+            "tos_agreement_id": "z-k7JlXJ1MqGvSWSEYzgVQ==",
+            "user_compliance_info_id": "qNDOQZuxI0P3WTbxbAl6DA==",
+            "user_id": "3202313146383"
+          },
+          "payouts_enabled": false,
+          "requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [
+              "business_profile.mcc"
+            ],
+            "disabled_reason": "requirements.past_due",
+            "errors": [],
+            "eventually_due": [
+              "business_profile.mcc"
+            ],
+            "past_due": [
+              "business_profile.mcc"
+            ],
+            "pending_verification": []
+          },
+          "settings": {
+            "bacs_debit_payments": {
+              "display_name": null,
+              "service_user_number": null
+            },
+            "branding": {
+              "icon": null,
+              "logo": null,
+              "primary_color": null,
+              "secondary_color": null
+            },
+            "card_issuing": {
+              "tos_acceptance": {
+                "date": null,
+                "ip": null
+              }
+            },
+            "card_payments": {
+              "decline_on": {
+                "avs_failure": false,
+                "cvc_failure": false
+              },
+              "statement_descriptor_prefix": "CHUCK BART",
+              "statement_descriptor_prefix_kana": null,
+              "statement_descriptor_prefix_kanji": null
+            },
+            "dashboard": {
+              "display_name": "Chuck Bartowski",
+              "timezone": "Etc/UTC"
+            },
+            "invoices": {
+              "default_account_tax_ids": null,
+              "hosted_payment_method_save": "offer"
+            },
+            "payments": {
+              "statement_descriptor": "CHUCK BARTOWSKI",
+              "statement_descriptor_kana": null,
+              "statement_descriptor_kanji": null
+            },
+            "payouts": {
+              "debit_negative_balances": true,
+              "schedule": {
+                "delay_days": 7,
+                "interval": "manual"
+              },
+              "statement_descriptor": null
+            },
+            "sepa_debit_payments": {}
+          },
+          "tos_acceptance": {
+            "date": 1427846400,
+            "ip": "54.234.242.13",
+            "user_agent": null
+          },
+          "type": "custom"
+        }
+  recorded_at: Mon, 04 May 2026 09:05:45 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/accounts/acct_1TTIRcRJ54bAZgCS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_8E6hl1N3EqXAd2","request_duration_ms":5253}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Is-MacBook-Air.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56
+        PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132 arm64","hostname":"Is-MacBook-Air.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 04 May 2026 09:05:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '6411'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=XjacyA1lBPBfyXMbNXZuTW5hInUjdinmlKw8BLHGkFuaushe22IVRVpSmvCjyh_fRZGKtVhg4gdp9BoM
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=XjacyA1lBPBfyXMbNXZuTW5hInUjdinmlKw8BLHGkFuaushe22IVRVpSmvCjyh_fRZGKtVhg4gdp9BoM&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=XjacyA1lBPBfyXMbNXZuTW5hInUjdinmlKw8BLHGkFuaushe22IVRVpSmvCjyh_fRZGKtVhg4gdp9BoM&t=1"
+      Request-Id:
+      - req_M7HVuD8tb4deTw
+      Stripe-Account:
+      - acct_1TTIRcRJ54bAZgCS
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1TTIRcRJ54bAZgCS",
+          "object": "account",
+          "business_profile": {
+            "annual_revenue": null,
+            "estimated_worker_count": null,
+            "mcc": null,
+            "minority_owned_business_designation": null,
+            "name": "Chuck Bartowski",
+            "product_description": "Chuck Bartowski",
+            "specified_commercial_transactions_act_url": null,
+            "support_address": null,
+            "support_email": null,
+            "support_phone": null,
+            "support_url": null,
+            "url": "https://vipul.gumroad.com/"
+          },
+          "business_type": "individual",
+          "capabilities": {
+            "card_payments": "inactive",
+            "transfers": "active"
+          },
+          "charges_enabled": false,
+          "company": {
+            "address": {
+              "city": "Sofia",
+              "country": "BG",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "1000",
+              "state": null
+            },
+            "directors_provided": true,
+            "executives_provided": true,
+            "name": null,
+            "owners_provided": true,
+            "phone": "+10000000000",
+            "tax_id_provided": false,
+            "verification": {
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              }
+            }
+          },
+          "controller": {
+            "fees": {
+              "payer": "application_custom"
+            },
+            "is_controller": true,
+            "losses": {
+              "payments": "application"
+            },
+            "requirement_collection": "application",
+            "stripe_dashboard": {
+              "type": "none"
+            },
+            "type": "application"
+          },
+          "country": "BG",
+          "created": 1777885542,
+          "default_currency": "eur",
+          "details_submitted": false,
+          "email": null,
+          "external_accounts": {
+            "object": "list",
+            "data": [
+              {
+                "id": "ba_1TTIRcRJ54bAZgCSJ5vwgVci",
+                "object": "bank_account",
+                "account": "acct_1TTIRcRJ54bAZgCS",
+                "account_holder_name": null,
+                "account_holder_type": null,
+                "account_type": null,
+                "available_payout_methods": [
+                  "standard"
+                ],
+                "bank_name": "STRIPE TEST BANK",
+                "country": "BG",
+                "currency": "eur",
+                "default_for_currency": true,
+                "fingerprint": "V6BdEFgeYsbSjzV7",
+                "future_requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "last4": "5678",
+                "metadata": {},
+                "requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "routing_number": "110000000",
+                "status": "new"
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/accounts/acct_1TTIRcRJ54bAZgCS/external_accounts"
+          },
+          "future_requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [],
+            "disabled_reason": null,
+            "errors": [],
+            "eventually_due": [],
+            "past_due": [],
+            "pending_verification": []
+          },
+          "individual": {
+            "id": "person_1TTIRdRJ54bAZgCSdlS59hBB",
+            "object": "person",
+            "account": "acct_1TTIRcRJ54bAZgCS",
+            "address": {
+              "city": "Sofia",
+              "country": "BG",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "1000",
+              "state": null
+            },
+            "created": 1777885541,
+            "dob": {
+              "day": 1,
+              "month": 1,
+              "year": 1901
+            },
+            "email": "edgar_3@gumroad.com",
+            "first_name": "Chuck",
+            "future_requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "id_number_provided": true,
+            "last_name": "Bartowski",
+            "metadata": {},
+            "phone": "+10000000000",
+            "relationship": {
+              "authorizer": false,
+              "director": false,
+              "executive": false,
+              "legal_guardian": false,
+              "owner": false,
+              "percent_ownership": null,
+              "representative": true,
+              "title": null
+            },
+            "requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "ssn_last_4_provided": true,
+            "verification": {
+              "additional_document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "details": null,
+              "details_code": null,
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "status": "pending"
+            }
+          },
+          "metadata": {
+            "bank_account_id": "cL9eWoQzVs2QT63DNYkZZg==",
+            "tos_agreement_id": "z-k7JlXJ1MqGvSWSEYzgVQ==",
+            "user_compliance_info_id": "qNDOQZuxI0P3WTbxbAl6DA==",
+            "user_id": "3202313146383"
+          },
+          "payouts_enabled": false,
+          "requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [
+              "business_profile.mcc"
+            ],
+            "disabled_reason": "requirements.past_due",
+            "errors": [],
+            "eventually_due": [
+              "business_profile.mcc"
+            ],
+            "past_due": [
+              "business_profile.mcc"
+            ],
+            "pending_verification": []
+          },
+          "settings": {
+            "bacs_debit_payments": {
+              "display_name": null,
+              "service_user_number": null
+            },
+            "branding": {
+              "icon": null,
+              "logo": null,
+              "primary_color": null,
+              "secondary_color": null
+            },
+            "card_issuing": {
+              "tos_acceptance": {
+                "date": null,
+                "ip": null
+              }
+            },
+            "card_payments": {
+              "decline_on": {
+                "avs_failure": false,
+                "cvc_failure": false
+              },
+              "statement_descriptor_prefix": "CHUCK BART",
+              "statement_descriptor_prefix_kana": null,
+              "statement_descriptor_prefix_kanji": null
+            },
+            "dashboard": {
+              "display_name": "Chuck Bartowski",
+              "timezone": "Etc/UTC"
+            },
+            "invoices": {
+              "default_account_tax_ids": null,
+              "hosted_payment_method_save": "offer"
+            },
+            "payments": {
+              "statement_descriptor": "CHUCK BARTOWSKI",
+              "statement_descriptor_kana": null,
+              "statement_descriptor_kanji": null
+            },
+            "payouts": {
+              "debit_negative_balances": true,
+              "schedule": {
+                "delay_days": 7,
+                "interval": "manual"
+              },
+              "statement_descriptor": null
+            },
+            "sepa_debit_payments": {}
+          },
+          "tos_acceptance": {
+            "date": 1427846400,
+            "ip": "54.234.242.13",
+            "user_agent": null
+          },
+          "type": "custom"
+        }
+  recorded_at: Mon, 04 May 2026 09:05:45 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/accounts/acct_1TTIRcRJ54bAZgCS
+    body:
+      encoding: UTF-8
+      string: metadata[bank_account_id]=a__qznzY0iDNXCcjYG3LLg%3D%3D&metadata[tos_agreement_id]=z-k7JlXJ1MqGvSWSEYzgVQ%3D%3D&metadata[user_compliance_info_id]=qNDOQZuxI0P3WTbxbAl6DA%3D%3D&metadata[user_id]=3202313146383&bank_account[country]=LT&bank_account[currency]=eur&bank_account[account_number]=LT121000011101001000&settings[payouts][schedule][interval]=manual&settings[payouts][debit_negative_balances]=true
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_M7HVuD8tb4deTw","request_duration_ms":809}}'
+      Idempotency-Key:
+      - 335838a0-abcf-44b4-8693-ffd7f212af84
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Is-MacBook-Air.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56
+        PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132 arm64","hostname":"Is-MacBook-Air.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 04 May 2026 09:05:48 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '6411'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=XjacyA1lBPBfyXMbNXZuTW5hInUjdinmlKw8BLHGkFuaushe22IVRVpSmvCjyh_fRZGKtVhg4gdp9BoM
+      Idempotency-Key:
+      - 335838a0-abcf-44b4-8693-ffd7f212af84
+      Original-Request:
+      - req_1VJLcx2uyclY6K
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=XjacyA1lBPBfyXMbNXZuTW5hInUjdinmlKw8BLHGkFuaushe22IVRVpSmvCjyh_fRZGKtVhg4gdp9BoM&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=XjacyA1lBPBfyXMbNXZuTW5hInUjdinmlKw8BLHGkFuaushe22IVRVpSmvCjyh_fRZGKtVhg4gdp9BoM&t=1"
+      Request-Id:
+      - req_1VJLcx2uyclY6K
+      Stripe-Account:
+      - acct_1TTIRcRJ54bAZgCS
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1TTIRcRJ54bAZgCS",
+          "object": "account",
+          "business_profile": {
+            "annual_revenue": null,
+            "estimated_worker_count": null,
+            "mcc": null,
+            "minority_owned_business_designation": null,
+            "name": "Chuck Bartowski",
+            "product_description": "Chuck Bartowski",
+            "specified_commercial_transactions_act_url": null,
+            "support_address": null,
+            "support_email": null,
+            "support_phone": null,
+            "support_url": null,
+            "url": "https://vipul.gumroad.com/"
+          },
+          "business_type": "individual",
+          "capabilities": {
+            "card_payments": "inactive",
+            "transfers": "active"
+          },
+          "charges_enabled": false,
+          "company": {
+            "address": {
+              "city": "Sofia",
+              "country": "BG",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "1000",
+              "state": null
+            },
+            "directors_provided": true,
+            "executives_provided": true,
+            "name": null,
+            "owners_provided": true,
+            "phone": "+10000000000",
+            "tax_id_provided": false,
+            "verification": {
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              }
+            }
+          },
+          "controller": {
+            "fees": {
+              "payer": "application_custom"
+            },
+            "is_controller": true,
+            "losses": {
+              "payments": "application"
+            },
+            "requirement_collection": "application",
+            "stripe_dashboard": {
+              "type": "none"
+            },
+            "type": "application"
+          },
+          "country": "BG",
+          "created": 1777885542,
+          "default_currency": "eur",
+          "details_submitted": false,
+          "email": null,
+          "external_accounts": {
+            "object": "list",
+            "data": [
+              {
+                "id": "ba_1TTIRiRJ54bAZgCSuAAtpxnQ",
+                "object": "bank_account",
+                "account": "acct_1TTIRcRJ54bAZgCS",
+                "account_holder_name": null,
+                "account_holder_type": null,
+                "account_type": null,
+                "available_payout_methods": [
+                  "standard"
+                ],
+                "bank_name": "STRIPE TEST BANK",
+                "country": "LT",
+                "currency": "eur",
+                "default_for_currency": true,
+                "fingerprint": "IFXjz7SwQO4Jz8mz",
+                "future_requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "last4": "1000",
+                "metadata": {},
+                "requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "routing_number": "110000000",
+                "status": "new"
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/accounts/acct_1TTIRcRJ54bAZgCS/external_accounts"
+          },
+          "future_requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [],
+            "disabled_reason": null,
+            "errors": [],
+            "eventually_due": [],
+            "past_due": [],
+            "pending_verification": []
+          },
+          "individual": {
+            "id": "person_1TTIRdRJ54bAZgCSdlS59hBB",
+            "object": "person",
+            "account": "acct_1TTIRcRJ54bAZgCS",
+            "address": {
+              "city": "Sofia",
+              "country": "BG",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "1000",
+              "state": null
+            },
+            "created": 1777885541,
+            "dob": {
+              "day": 1,
+              "month": 1,
+              "year": 1901
+            },
+            "email": "edgar_3@gumroad.com",
+            "first_name": "Chuck",
+            "future_requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "id_number_provided": true,
+            "last_name": "Bartowski",
+            "metadata": {},
+            "phone": "+10000000000",
+            "relationship": {
+              "authorizer": false,
+              "director": false,
+              "executive": false,
+              "legal_guardian": false,
+              "owner": false,
+              "percent_ownership": null,
+              "representative": true,
+              "title": null
+            },
+            "requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "ssn_last_4_provided": true,
+            "verification": {
+              "additional_document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "details": null,
+              "details_code": null,
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "status": "pending"
+            }
+          },
+          "metadata": {
+            "bank_account_id": "a__qznzY0iDNXCcjYG3LLg==",
+            "tos_agreement_id": "z-k7JlXJ1MqGvSWSEYzgVQ==",
+            "user_compliance_info_id": "qNDOQZuxI0P3WTbxbAl6DA==",
+            "user_id": "3202313146383"
+          },
+          "payouts_enabled": false,
+          "requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [
+              "business_profile.mcc"
+            ],
+            "disabled_reason": "requirements.past_due",
+            "errors": [],
+            "eventually_due": [
+              "business_profile.mcc"
+            ],
+            "past_due": [
+              "business_profile.mcc"
+            ],
+            "pending_verification": []
+          },
+          "settings": {
+            "bacs_debit_payments": {
+              "display_name": null,
+              "service_user_number": null
+            },
+            "branding": {
+              "icon": null,
+              "logo": null,
+              "primary_color": null,
+              "secondary_color": null
+            },
+            "card_issuing": {
+              "tos_acceptance": {
+                "date": null,
+                "ip": null
+              }
+            },
+            "card_payments": {
+              "decline_on": {
+                "avs_failure": false,
+                "cvc_failure": false
+              },
+              "statement_descriptor_prefix": "CHUCK BART",
+              "statement_descriptor_prefix_kana": null,
+              "statement_descriptor_prefix_kanji": null
+            },
+            "dashboard": {
+              "display_name": "Chuck Bartowski",
+              "timezone": "Etc/UTC"
+            },
+            "invoices": {
+              "default_account_tax_ids": null,
+              "hosted_payment_method_save": "offer"
+            },
+            "payments": {
+              "statement_descriptor": "CHUCK BARTOWSKI",
+              "statement_descriptor_kana": null,
+              "statement_descriptor_kanji": null
+            },
+            "payouts": {
+              "debit_negative_balances": true,
+              "schedule": {
+                "delay_days": 7,
+                "interval": "manual"
+              },
+              "statement_descriptor": null
+            },
+            "sepa_debit_payments": {}
+          },
+          "tos_acceptance": {
+            "date": 1427846400,
+            "ip": "54.234.242.13",
+            "user_agent": null
+          },
+          "type": "custom"
+        }
+  recorded_at: Mon, 04 May 2026 09:05:48 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/accounts/acct_1TTIRcRJ54bAZgCS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_1VJLcx2uyclY6K","request_duration_ms":2453}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Is-MacBook-Air.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56
+        PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132 arm64","hostname":"Is-MacBook-Air.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 04 May 2026 09:05:49 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '6411'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=XjacyA1lBPBfyXMbNXZuTW5hInUjdinmlKw8BLHGkFuaushe22IVRVpSmvCjyh_fRZGKtVhg4gdp9BoM
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=XjacyA1lBPBfyXMbNXZuTW5hInUjdinmlKw8BLHGkFuaushe22IVRVpSmvCjyh_fRZGKtVhg4gdp9BoM&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=XjacyA1lBPBfyXMbNXZuTW5hInUjdinmlKw8BLHGkFuaushe22IVRVpSmvCjyh_fRZGKtVhg4gdp9BoM&t=1"
+      Request-Id:
+      - req_OyMJCSBY1kRX1U
+      Stripe-Account:
+      - acct_1TTIRcRJ54bAZgCS
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1TTIRcRJ54bAZgCS",
+          "object": "account",
+          "business_profile": {
+            "annual_revenue": null,
+            "estimated_worker_count": null,
+            "mcc": null,
+            "minority_owned_business_designation": null,
+            "name": "Chuck Bartowski",
+            "product_description": "Chuck Bartowski",
+            "specified_commercial_transactions_act_url": null,
+            "support_address": null,
+            "support_email": null,
+            "support_phone": null,
+            "support_url": null,
+            "url": "https://vipul.gumroad.com/"
+          },
+          "business_type": "individual",
+          "capabilities": {
+            "card_payments": "inactive",
+            "transfers": "active"
+          },
+          "charges_enabled": false,
+          "company": {
+            "address": {
+              "city": "Sofia",
+              "country": "BG",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "1000",
+              "state": null
+            },
+            "directors_provided": true,
+            "executives_provided": true,
+            "name": null,
+            "owners_provided": true,
+            "phone": "+10000000000",
+            "tax_id_provided": false,
+            "verification": {
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              }
+            }
+          },
+          "controller": {
+            "fees": {
+              "payer": "application_custom"
+            },
+            "is_controller": true,
+            "losses": {
+              "payments": "application"
+            },
+            "requirement_collection": "application",
+            "stripe_dashboard": {
+              "type": "none"
+            },
+            "type": "application"
+          },
+          "country": "BG",
+          "created": 1777885542,
+          "default_currency": "eur",
+          "details_submitted": false,
+          "email": null,
+          "external_accounts": {
+            "object": "list",
+            "data": [
+              {
+                "id": "ba_1TTIRiRJ54bAZgCSuAAtpxnQ",
+                "object": "bank_account",
+                "account": "acct_1TTIRcRJ54bAZgCS",
+                "account_holder_name": null,
+                "account_holder_type": null,
+                "account_type": null,
+                "available_payout_methods": [
+                  "standard"
+                ],
+                "bank_name": "STRIPE TEST BANK",
+                "country": "LT",
+                "currency": "eur",
+                "default_for_currency": true,
+                "fingerprint": "IFXjz7SwQO4Jz8mz",
+                "future_requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "last4": "1000",
+                "metadata": {},
+                "requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "routing_number": "110000000",
+                "status": "new"
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/accounts/acct_1TTIRcRJ54bAZgCS/external_accounts"
+          },
+          "future_requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [],
+            "disabled_reason": null,
+            "errors": [],
+            "eventually_due": [],
+            "past_due": [],
+            "pending_verification": []
+          },
+          "individual": {
+            "id": "person_1TTIRdRJ54bAZgCSdlS59hBB",
+            "object": "person",
+            "account": "acct_1TTIRcRJ54bAZgCS",
+            "address": {
+              "city": "Sofia",
+              "country": "BG",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "1000",
+              "state": null
+            },
+            "created": 1777885541,
+            "dob": {
+              "day": 1,
+              "month": 1,
+              "year": 1901
+            },
+            "email": "edgar_3@gumroad.com",
+            "first_name": "Chuck",
+            "future_requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "id_number_provided": true,
+            "last_name": "Bartowski",
+            "metadata": {},
+            "phone": "+10000000000",
+            "relationship": {
+              "authorizer": false,
+              "director": false,
+              "executive": false,
+              "legal_guardian": false,
+              "owner": false,
+              "percent_ownership": null,
+              "representative": true,
+              "title": null
+            },
+            "requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "ssn_last_4_provided": true,
+            "verification": {
+              "additional_document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "details": null,
+              "details_code": null,
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "status": "pending"
+            }
+          },
+          "metadata": {
+            "bank_account_id": "a__qznzY0iDNXCcjYG3LLg==",
+            "tos_agreement_id": "z-k7JlXJ1MqGvSWSEYzgVQ==",
+            "user_compliance_info_id": "qNDOQZuxI0P3WTbxbAl6DA==",
+            "user_id": "3202313146383"
+          },
+          "payouts_enabled": false,
+          "requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [
+              "business_profile.mcc"
+            ],
+            "disabled_reason": "requirements.past_due",
+            "errors": [],
+            "eventually_due": [
+              "business_profile.mcc"
+            ],
+            "past_due": [
+              "business_profile.mcc"
+            ],
+            "pending_verification": []
+          },
+          "settings": {
+            "bacs_debit_payments": {
+              "display_name": null,
+              "service_user_number": null
+            },
+            "branding": {
+              "icon": null,
+              "logo": null,
+              "primary_color": null,
+              "secondary_color": null
+            },
+            "card_issuing": {
+              "tos_acceptance": {
+                "date": null,
+                "ip": null
+              }
+            },
+            "card_payments": {
+              "decline_on": {
+                "avs_failure": false,
+                "cvc_failure": false
+              },
+              "statement_descriptor_prefix": "CHUCK BART",
+              "statement_descriptor_prefix_kana": null,
+              "statement_descriptor_prefix_kanji": null
+            },
+            "dashboard": {
+              "display_name": "Chuck Bartowski",
+              "timezone": "Etc/UTC"
+            },
+            "invoices": {
+              "default_account_tax_ids": null,
+              "hosted_payment_method_save": "offer"
+            },
+            "payments": {
+              "statement_descriptor": "CHUCK BARTOWSKI",
+              "statement_descriptor_kana": null,
+              "statement_descriptor_kanji": null
+            },
+            "payouts": {
+              "debit_negative_balances": true,
+              "schedule": {
+                "delay_days": 7,
+                "interval": "manual"
+              },
+              "statement_descriptor": null
+            },
+            "sepa_debit_payments": {}
+          },
+          "tos_acceptance": {
+            "date": 1427846400,
+            "ip": "54.234.242.13",
+            "user_agent": null
+          },
+          "type": "custom"
+        }
+  recorded_at: Mon, 04 May 2026 09:05:49 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/StripeMerchantAccountManager/cross-border_SEPA_IBAN_payouts/when_a_Denmark-based_creator_submits_a_Danish_IBAN_regression_same-country_still_works_/creates_a_Stripe_account_in_DK_and_registers_the_DK_IBAN_as_a_DKK_external_account.yml
+++ b/spec/support/fixtures/vcr_cassettes/StripeMerchantAccountManager/cross-border_SEPA_IBAN_payouts/when_a_Denmark-based_creator_submits_a_Danish_IBAN_regression_same-country_still_works_/creates_a_Stripe_account_in_DK_and_registers_the_DK_IBAN_as_a_DKK_external_account.yml
@@ -1,0 +1,355 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/accounts
+    body:
+      encoding: UTF-8
+      string: type=custom&requested_capabilities[0]=card_payments&requested_capabilities[1]=transfers&country=DK&default_currency=dkk&metadata[user_id]=8977351636247&metadata[tos_agreement_id]=oK5A3mGI_glPbCQPFQhP4Q%3D%3D&metadata[user_compliance_info_id]=S-PuSL3fquHFtHLH6qxCtQ%3D%3D&metadata[bank_account_id]=gjsblPy20dz76SlBEvGJjA%3D%3D&tos_acceptance[date]=1427846400&tos_acceptance[ip]=54.234.242.13&business_type=individual&business_profile[name]=Chuck+Bartowski&business_profile[url]=https%3A%2F%2Fvipul.gumroad.com%2F&business_profile[product_description]=Chuck+Bartowski&individual[first_name]=Chuck&individual[last_name]=Bartowski&individual[email]=edgar_9%40gumroad.com&individual[phone]=0000000000&individual[dob][day]=1&individual[dob][month]=1&individual[dob][year]=1901&individual[address][line1]=address_full_match&individual[address][city]=Copenhagen&individual[address][postal_code]=1050&individual[address][country]=DK&individual[id_number]=000000000&bank_account[country]=DK&bank_account[currency]=dkk&bank_account[account_number]=DK5000400440116243&settings[payouts][schedule][interval]=manual&settings[payouts][debit_negative_balances]=true
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_kDLjsNXtRltAum","request_duration_ms":4120}}'
+      Idempotency-Key:
+      - 6afa81b6-2214-4598-967b-9819f73c095b
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Is-MacBook-Air.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56
+        PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132 arm64","hostname":"Is-MacBook-Air.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 04 May 2026 09:06:03 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '6421'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=XjacyA1lBPBfyXMbNXZuTW5hInUjdinmlKw8BLHGkFuaushe22IVRVpSmvCjyh_fRZGKtVhg4gdp9BoM
+      Idempotency-Key:
+      - 6afa81b6-2214-4598-967b-9819f73c095b
+      Original-Request:
+      - req_WZFtzeoepuEt3q
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=XjacyA1lBPBfyXMbNXZuTW5hInUjdinmlKw8BLHGkFuaushe22IVRVpSmvCjyh_fRZGKtVhg4gdp9BoM&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=XjacyA1lBPBfyXMbNXZuTW5hInUjdinmlKw8BLHGkFuaushe22IVRVpSmvCjyh_fRZGKtVhg4gdp9BoM&t=1"
+      Request-Id:
+      - req_WZFtzeoepuEt3q
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1TTIRvIdGeWpzhoy",
+          "object": "account",
+          "business_profile": {
+            "annual_revenue": null,
+            "estimated_worker_count": null,
+            "mcc": null,
+            "minority_owned_business_designation": null,
+            "name": "Chuck Bartowski",
+            "product_description": "Chuck Bartowski",
+            "specified_commercial_transactions_act_url": null,
+            "support_address": null,
+            "support_email": null,
+            "support_phone": null,
+            "support_url": null,
+            "url": "https://vipul.gumroad.com/"
+          },
+          "business_type": "individual",
+          "capabilities": {
+            "card_payments": "inactive",
+            "transfers": "active"
+          },
+          "charges_enabled": false,
+          "company": {
+            "address": {
+              "city": "Copenhagen",
+              "country": "DK",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "1050",
+              "state": null
+            },
+            "directors_provided": true,
+            "executives_provided": true,
+            "name": null,
+            "owners_provided": true,
+            "phone": "+10000000000",
+            "tax_id_provided": false,
+            "verification": {
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              }
+            }
+          },
+          "controller": {
+            "fees": {
+              "payer": "application_custom"
+            },
+            "is_controller": true,
+            "losses": {
+              "payments": "application"
+            },
+            "requirement_collection": "application",
+            "stripe_dashboard": {
+              "type": "none"
+            },
+            "type": "application"
+          },
+          "country": "DK",
+          "created": 1777885561,
+          "default_currency": "dkk",
+          "details_submitted": false,
+          "email": null,
+          "external_accounts": {
+            "object": "list",
+            "data": [
+              {
+                "id": "ba_1TTIRvIdGeWpzhoyAflcdqZ6",
+                "object": "bank_account",
+                "account": "acct_1TTIRvIdGeWpzhoy",
+                "account_holder_name": null,
+                "account_holder_type": null,
+                "account_type": null,
+                "available_payout_methods": [
+                  "standard"
+                ],
+                "bank_name": "STRIPE TEST BANK",
+                "country": "DK",
+                "currency": "dkk",
+                "default_for_currency": true,
+                "fingerprint": "zzh6MvJPK4ti6O28",
+                "future_requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "last4": "6243",
+                "metadata": {},
+                "requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "routing_number": "110000000",
+                "status": "new"
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/accounts/acct_1TTIRvIdGeWpzhoy/external_accounts"
+          },
+          "future_requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [],
+            "disabled_reason": null,
+            "errors": [],
+            "eventually_due": [],
+            "past_due": [],
+            "pending_verification": []
+          },
+          "individual": {
+            "id": "person_1TTIRwIdGeWpzhoyIrfZBYI9",
+            "object": "person",
+            "account": "acct_1TTIRvIdGeWpzhoy",
+            "address": {
+              "city": "Copenhagen",
+              "country": "DK",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "1050",
+              "state": null
+            },
+            "created": 1777885560,
+            "dob": {
+              "day": 1,
+              "month": 1,
+              "year": 1901
+            },
+            "email": "edgar_9@gumroad.com",
+            "first_name": "Chuck",
+            "future_requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "id_number_provided": true,
+            "last_name": "Bartowski",
+            "metadata": {},
+            "phone": "+10000000000",
+            "relationship": {
+              "authorizer": false,
+              "director": false,
+              "executive": false,
+              "legal_guardian": false,
+              "owner": false,
+              "percent_ownership": null,
+              "representative": true,
+              "title": null
+            },
+            "requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "ssn_last_4_provided": true,
+            "verification": {
+              "additional_document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "details": null,
+              "details_code": null,
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "status": "pending"
+            }
+          },
+          "metadata": {
+            "bank_account_id": "gjsblPy20dz76SlBEvGJjA==",
+            "tos_agreement_id": "oK5A3mGI_glPbCQPFQhP4Q==",
+            "user_compliance_info_id": "S-PuSL3fquHFtHLH6qxCtQ==",
+            "user_id": "8977351636247"
+          },
+          "payouts_enabled": false,
+          "requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [
+              "business_profile.mcc"
+            ],
+            "disabled_reason": "requirements.past_due",
+            "errors": [],
+            "eventually_due": [
+              "business_profile.mcc"
+            ],
+            "past_due": [
+              "business_profile.mcc"
+            ],
+            "pending_verification": []
+          },
+          "settings": {
+            "bacs_debit_payments": {
+              "display_name": null,
+              "service_user_number": null
+            },
+            "branding": {
+              "icon": null,
+              "logo": null,
+              "primary_color": null,
+              "secondary_color": null
+            },
+            "card_issuing": {
+              "tos_acceptance": {
+                "date": null,
+                "ip": null
+              }
+            },
+            "card_payments": {
+              "decline_on": {
+                "avs_failure": false,
+                "cvc_failure": false
+              },
+              "statement_descriptor_prefix": "CHUCK BART",
+              "statement_descriptor_prefix_kana": null,
+              "statement_descriptor_prefix_kanji": null
+            },
+            "dashboard": {
+              "display_name": "Chuck Bartowski",
+              "timezone": "Etc/UTC"
+            },
+            "invoices": {
+              "default_account_tax_ids": null,
+              "hosted_payment_method_save": "offer"
+            },
+            "payments": {
+              "statement_descriptor": "CHUCK BARTOWSKI",
+              "statement_descriptor_kana": null,
+              "statement_descriptor_kanji": null
+            },
+            "payouts": {
+              "debit_negative_balances": true,
+              "schedule": {
+                "delay_days": 7,
+                "interval": "manual"
+              },
+              "statement_descriptor": null
+            },
+            "sepa_debit_payments": {}
+          },
+          "tos_acceptance": {
+            "date": 1427846400,
+            "ip": "54.234.242.13",
+            "user_agent": null
+          },
+          "type": "custom"
+        }
+  recorded_at: Mon, 04 May 2026 09:06:03 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/StripeMerchantAccountManager/cross-border_SEPA_IBAN_payouts/when_a_Denmark-based_creator_submits_a_Lithuanian_IBAN_Stripe_s_stated_cross-border_SEPA_example_/creates_a_Stripe_account_in_DK_with_DKK_default_currency_but_registers_the_LT_IBAN_as_an_EUR_external_account.yml
+++ b/spec/support/fixtures/vcr_cassettes/StripeMerchantAccountManager/cross-border_SEPA_IBAN_payouts/when_a_Denmark-based_creator_submits_a_Lithuanian_IBAN_Stripe_s_stated_cross-border_SEPA_example_/creates_a_Stripe_account_in_DK_with_DKK_default_currency_but_registers_the_LT_IBAN_as_an_EUR_external_account.yml
@@ -1,0 +1,355 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/accounts
+    body:
+      encoding: UTF-8
+      string: type=custom&requested_capabilities[0]=card_payments&requested_capabilities[1]=transfers&country=DK&default_currency=dkk&metadata[user_id]=8533046874042&metadata[tos_agreement_id]=gjzTBqVIK695GBnnuo4oyg%3D%3D&metadata[user_compliance_info_id]=Xq94nnshcFR2F5FCI9ETbw%3D%3D&metadata[bank_account_id]=GZZbI6AQ2JD9VxH31BVnvA%3D%3D&tos_acceptance[date]=1427846400&tos_acceptance[ip]=54.234.242.13&business_type=individual&business_profile[name]=Chuck+Bartowski&business_profile[url]=https%3A%2F%2Fvipul.gumroad.com%2F&business_profile[product_description]=Chuck+Bartowski&individual[first_name]=Chuck&individual[last_name]=Bartowski&individual[email]=edgar_5%40gumroad.com&individual[phone]=0000000000&individual[dob][day]=1&individual[dob][month]=1&individual[dob][year]=1901&individual[address][line1]=address_full_match&individual[address][city]=Copenhagen&individual[address][postal_code]=1050&individual[address][country]=DK&individual[id_number]=000000000&bank_account[country]=LT&bank_account[currency]=eur&bank_account[account_number]=LT121000011101001000&settings[payouts][schedule][interval]=manual&settings[payouts][debit_negative_balances]=true
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_OyMJCSBY1kRX1U","request_duration_ms":765}}'
+      Idempotency-Key:
+      - 3deeb085-b5ff-4ae7-b373-748e17e3cfcc
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Is-MacBook-Air.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56
+        PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132 arm64","hostname":"Is-MacBook-Air.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 04 May 2026 09:05:54 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '6421'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=XjacyA1lBPBfyXMbNXZuTW5hInUjdinmlKw8BLHGkFuaushe22IVRVpSmvCjyh_fRZGKtVhg4gdp9BoM
+      Idempotency-Key:
+      - 3deeb085-b5ff-4ae7-b373-748e17e3cfcc
+      Original-Request:
+      - req_QskH8uWv5ZMo5B
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=XjacyA1lBPBfyXMbNXZuTW5hInUjdinmlKw8BLHGkFuaushe22IVRVpSmvCjyh_fRZGKtVhg4gdp9BoM&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=XjacyA1lBPBfyXMbNXZuTW5hInUjdinmlKw8BLHGkFuaushe22IVRVpSmvCjyh_fRZGKtVhg4gdp9BoM&t=1"
+      Request-Id:
+      - req_QskH8uWv5ZMo5B
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1TTIRmEZRA2nLuzM",
+          "object": "account",
+          "business_profile": {
+            "annual_revenue": null,
+            "estimated_worker_count": null,
+            "mcc": null,
+            "minority_owned_business_designation": null,
+            "name": "Chuck Bartowski",
+            "product_description": "Chuck Bartowski",
+            "specified_commercial_transactions_act_url": null,
+            "support_address": null,
+            "support_email": null,
+            "support_phone": null,
+            "support_url": null,
+            "url": "https://vipul.gumroad.com/"
+          },
+          "business_type": "individual",
+          "capabilities": {
+            "card_payments": "inactive",
+            "transfers": "active"
+          },
+          "charges_enabled": false,
+          "company": {
+            "address": {
+              "city": "Copenhagen",
+              "country": "DK",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "1050",
+              "state": null
+            },
+            "directors_provided": true,
+            "executives_provided": true,
+            "name": null,
+            "owners_provided": true,
+            "phone": "+10000000000",
+            "tax_id_provided": false,
+            "verification": {
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              }
+            }
+          },
+          "controller": {
+            "fees": {
+              "payer": "application_custom"
+            },
+            "is_controller": true,
+            "losses": {
+              "payments": "application"
+            },
+            "requirement_collection": "application",
+            "stripe_dashboard": {
+              "type": "none"
+            },
+            "type": "application"
+          },
+          "country": "DK",
+          "created": 1777885551,
+          "default_currency": "dkk",
+          "details_submitted": false,
+          "email": null,
+          "external_accounts": {
+            "object": "list",
+            "data": [
+              {
+                "id": "ba_1TTIRmEZRA2nLuzMVThjD8ya",
+                "object": "bank_account",
+                "account": "acct_1TTIRmEZRA2nLuzM",
+                "account_holder_name": null,
+                "account_holder_type": null,
+                "account_type": null,
+                "available_payout_methods": [
+                  "standard"
+                ],
+                "bank_name": "STRIPE TEST BANK",
+                "country": "LT",
+                "currency": "eur",
+                "default_for_currency": true,
+                "fingerprint": "IFXjz7SwQO4Jz8mz",
+                "future_requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "last4": "1000",
+                "metadata": {},
+                "requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "routing_number": "110000000",
+                "status": "new"
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/accounts/acct_1TTIRmEZRA2nLuzM/external_accounts"
+          },
+          "future_requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [],
+            "disabled_reason": null,
+            "errors": [],
+            "eventually_due": [],
+            "past_due": [],
+            "pending_verification": []
+          },
+          "individual": {
+            "id": "person_1TTIRmEZRA2nLuzMgnBhPaO8",
+            "object": "person",
+            "account": "acct_1TTIRmEZRA2nLuzM",
+            "address": {
+              "city": "Copenhagen",
+              "country": "DK",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "1050",
+              "state": null
+            },
+            "created": 1777885551,
+            "dob": {
+              "day": 1,
+              "month": 1,
+              "year": 1901
+            },
+            "email": "edgar_5@gumroad.com",
+            "first_name": "Chuck",
+            "future_requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "id_number_provided": true,
+            "last_name": "Bartowski",
+            "metadata": {},
+            "phone": "+10000000000",
+            "relationship": {
+              "authorizer": false,
+              "director": false,
+              "executive": false,
+              "legal_guardian": false,
+              "owner": false,
+              "percent_ownership": null,
+              "representative": true,
+              "title": null
+            },
+            "requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "ssn_last_4_provided": true,
+            "verification": {
+              "additional_document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "details": null,
+              "details_code": null,
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "status": "pending"
+            }
+          },
+          "metadata": {
+            "bank_account_id": "GZZbI6AQ2JD9VxH31BVnvA==",
+            "tos_agreement_id": "gjzTBqVIK695GBnnuo4oyg==",
+            "user_compliance_info_id": "Xq94nnshcFR2F5FCI9ETbw==",
+            "user_id": "8533046874042"
+          },
+          "payouts_enabled": false,
+          "requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [
+              "business_profile.mcc"
+            ],
+            "disabled_reason": "requirements.past_due",
+            "errors": [],
+            "eventually_due": [
+              "business_profile.mcc"
+            ],
+            "past_due": [
+              "business_profile.mcc"
+            ],
+            "pending_verification": []
+          },
+          "settings": {
+            "bacs_debit_payments": {
+              "display_name": null,
+              "service_user_number": null
+            },
+            "branding": {
+              "icon": null,
+              "logo": null,
+              "primary_color": null,
+              "secondary_color": null
+            },
+            "card_issuing": {
+              "tos_acceptance": {
+                "date": null,
+                "ip": null
+              }
+            },
+            "card_payments": {
+              "decline_on": {
+                "avs_failure": false,
+                "cvc_failure": false
+              },
+              "statement_descriptor_prefix": "CHUCK BART",
+              "statement_descriptor_prefix_kana": null,
+              "statement_descriptor_prefix_kanji": null
+            },
+            "dashboard": {
+              "display_name": "Chuck Bartowski",
+              "timezone": "Etc/UTC"
+            },
+            "invoices": {
+              "default_account_tax_ids": null,
+              "hosted_payment_method_save": "offer"
+            },
+            "payments": {
+              "statement_descriptor": "CHUCK BARTOWSKI",
+              "statement_descriptor_kana": null,
+              "statement_descriptor_kanji": null
+            },
+            "payouts": {
+              "debit_negative_balances": true,
+              "schedule": {
+                "delay_days": 7,
+                "interval": "manual"
+              },
+              "statement_descriptor": null
+            },
+            "sepa_debit_payments": {}
+          },
+          "tos_acceptance": {
+            "date": 1427846400,
+            "ip": "54.234.242.13",
+            "user_agent": null
+          },
+          "type": "custom"
+        }
+  recorded_at: Mon, 04 May 2026 09:05:54 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
Closes https://github.com/antiwork/gumroad-private/issues/328

## What

Adds support for cross-country IBAN payouts within the SEPA zone, fixing cases where a creator's IBAN country prefix doesn't match their account country (e.g., IBAN starting with a different SEPA country code). Stripe rejects these as `bank_account_unusable` when the account country is sent instead of the IBAN country.

Concrete changes:

- New `IbanBankAccount` concern (`app/models/concerns/iban_bank_account.rb`) with:
  - SEPA country list  
  - Shared IBAN validation  
  - Two new methods:  
    - `stripe_external_account_country`  
    - `stripe_external_account_currency`  

- When the IBAN is cross-border within SEPA:
  - Use IBAN country (first two chars)
  - Use `"eur"` as currency  

- Otherwise:
  - Fall back to model’s existing `country` / `currency`

- 12 SEPA IBAN bank account models include the concern and remove duplicated `validate_account_number`:
  - `EuropeanBankAccount`
  - `BulgariaBankAccount`
  - `DenmarkBankAccount`
  - `CzechRepublicBankAccount`
  - `HungaryBankAccount`
  - `PolandBankAccount`
  - `RomaniaBankAccount`
  - `SwedenBankAccount`
  - `NorwayBankAccount`
  - `IcelandBankAccount`
  - `LiechtensteinBankAccount`
  - `MonacoBankAccount`

- `StripeMerchantAccountManager.bank_account_hash` now uses the new methods (one-line change)

- `BankAccount` base class adds default:
  - `stripe_external_account_country`
  - `stripe_external_account_currency`  
  (mirrors existing `country` / `currency`, so non-IBAN accounts remain unchanged)

- `validate_account_number` now rejects IBANs from outside SEPA with a clear model-level error

## Why

`country` and `currency` currently serve two different responsibilities:

1. **Account identity**
   - Used for display (`account_number_visual`)
   - Used for payout validation (`bank_account.currency != country.payout_currency`)
   - Should reflect the creator’s actual account country

2. **Stripe external account parameters**
   - Must match IBAN prefix per Stripe requirements
   - For cross-border SEPA IBANs:
     - `country` = IBAN prefix
     - `currency` = `"eur"`

Separating these concerns ensures:
- No changes to existing account semantics
- Stripe receives the correct values for cross-border SEPA payouts
- Eliminates `bank_account_unusable` errors for valid IBANs

---

AI disclosure: implementation assisted by Claude Opus 4.7