### PR TITLE
fix: prevent duplicate mass fraud refunds

### DIFF
--- a/app/sidekiq/mass_refund_for_fraud_job.rb
+++ b/app/sidekiq/mass_refund_for_fraud_job.rb
@@ -15,8 +15,10 @@ class MassRefundForFraudJob
         next
       end
 
+      next if purchase.refunded_at.present?
+
       begin
-        purchase.refund_for_fraud_and_block_buyer!(admin_user_id)
+        purchase.refund_for_fraud_and_block_buyer!(admin_user_id, idempotency_key: "mass-fraud-#{purchase.id}-#{jid}")
         results[:success] += 1
       rescue StandardError => e
         results[:failed] += 1


### PR DESCRIPTION
Closes #4941

- Skip purchases where refunded_at is already set
- Add Stripe idempotency key to refund_for_fraud_and_block_buyer!