### PR TITLE
Add product readiness states and first-product workspace

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -32,7 +32,7 @@ class LinksController < ApplicationController
   before_action :fetch_product_and_enforce_ownership, only: %i[destroy]
   before_action :fetch_product_and_enforce_access, only: %i[update publish unpublish release_preorder update_sections]
 
-  layout "inertia", only: %i[index new show cart_items_count edit]
+  layout "inertia", only: %i[index new show cart_items_count edit workspace]
 
   def index
     authorize Link
@@ -86,11 +86,23 @@ class LinksController < ApplicationController
     end
 
     create_user_event("add_product")
-    if ai_generated
+    if first_time_seller_for?(@product)
+      redirect_to workspace_link_path(@product), status: :see_other
+    elsif ai_generated
       redirect_to edit_link_path(@product, ai_generated: true), status: :see_other
     else
       redirect_to edit_link_path(@product), status: :see_other
     end
+  end
+
+  def workspace
+    fetch_product_by_unique_permalink
+    authorize @product
+
+    set_meta_tag(title: @product.name)
+
+    presenter = ProductWorkspacePresenter.new(product: @product, pundit_user:)
+    render inertia: "Products/Workspace", props: presenter.props
   end
 
   def show
@@ -509,6 +521,10 @@ class LinksController < ApplicationController
   end
 
   private
+    def first_time_seller_for?(product)
+      !current_seller.products.where.not(id: product.id).exists?
+    end
+
     def fetch_product_for_show
       fetch_product_by_custom_domain || fetch_product_by_general_permalink
     end

--- a/app/javascript/components/ProductsPage/ProductsTable.tsx
+++ b/app/javascript/components/ProductsPage/ProductsTable.tsx
@@ -1,7 +1,7 @@
 import { Link, router } from "@inertiajs/react";
 import * as React from "react";
 
-import { Product, SortKey } from "$app/data/products";
+import { Product, ProductReadiness, ProductReadinessMissingItem, SortKey } from "$app/data/products";
 import { classNames } from "$app/utils/classNames";
 import { formatPriceCentsWithCurrencySymbol } from "$app/utils/currency";
 
@@ -9,6 +9,7 @@ import { Pagination, PaginationProps } from "$app/components/Pagination";
 import { Tab } from "$app/components/ProductsLayout";
 import ActionsPopover from "$app/components/ProductsPage/ActionsPopover";
 import { ProductIconCell } from "$app/components/ProductsPage/ProductIconCell";
+import { Pill } from "$app/components/ui/Pill";
 import {
   Table,
   TableBody,
@@ -143,16 +144,20 @@ export const ProductsPageProductsTable = (props: {
               <TableCell className="whitespace-nowrap">{product.price_formatted}</TableCell>
 
               <TableCell className="whitespace-nowrap">
-                {(() => {
-                  switch (product.status) {
-                    case "unpublished":
-                      return <>Unpublished</>;
-                    case "preorder":
-                      return <>Pre-order</>;
-                    case "published":
-                      return <>Published</>;
-                  }
-                })()}
+                {product.readiness ? (
+                  <ReadinessCell readiness={product.readiness} />
+                ) : (
+                  (() => {
+                    switch (product.status) {
+                      case "unpublished":
+                        return <>Unpublished</>;
+                      case "preorder":
+                        return <>Pre-order</>;
+                      case "published":
+                        return <>Published</>;
+                    }
+                  })()
+                )}
               </TableCell>
               {product.can_duplicate || product.can_destroy ? (
                 <TableCell>
@@ -200,3 +205,36 @@ export const ProductsPageProductsTable = (props: {
     </div>
   );
 };
+
+const READINESS_LABELS: Record<ProductReadiness["state"], string> = {
+  draft: "Drafted",
+  ready: "Ready to sell",
+  live: "On the road",
+};
+
+const READINESS_COLORS: Record<ProductReadiness["state"], "warning" | "primary" | "success"> = {
+  draft: "warning",
+  ready: "primary",
+  live: "success",
+};
+
+const MISSING_ITEM_LABELS: Record<ProductReadinessMissingItem, string> = {
+  name: "name",
+  price: "price",
+  content: "content",
+  cover: "cover",
+  payment: "payments",
+};
+
+const ReadinessCell = ({ readiness }: { readiness: ProductReadiness }) => (
+  <div className="flex flex-col gap-1">
+    <Pill size="small" color={READINESS_COLORS[readiness.state]}>
+      {READINESS_LABELS[readiness.state]}
+    </Pill>
+    {readiness.state === "draft" && readiness.missing.length > 0 ? (
+      <small className="text-muted">
+        Missing: {readiness.missing.map((item) => MISSING_ITEM_LABELS[item]).join(", ")}
+      </small>
+    ) : null}
+  </div>
+);

--- a/app/javascript/data/products.ts
+++ b/app/javascript/data/products.ts
@@ -61,6 +61,31 @@ export type Product = {
 
 export type RecurringProductType = "membership" | "newsletter" | "podcast";
 
+export type ProductWorkspaceSections = {
+  basics: boolean;
+  offer: boolean;
+  payments: boolean;
+};
+
+export type ProductWorkspaceProduct = {
+  id: number;
+  name: string;
+  native_type: string;
+  custom_summary: string | null;
+  permalink: string;
+  edit_url: string;
+  url: string;
+  thumbnail_url: string | null;
+  price_formatted: string;
+};
+
+export type ProductWorkspaceProps = {
+  product: ProductWorkspaceProduct;
+  readiness: ProductReadiness | null;
+  sections: ProductWorkspaceSections;
+  settings_payments_url: string;
+};
+
 export async function getFolderArchiveDownloadUrl(request_url: string) {
   const res = await request({
     method: "GET",

--- a/app/javascript/data/products.ts
+++ b/app/javascript/data/products.ts
@@ -4,6 +4,13 @@ import { request } from "$app/utils/request";
 
 export type SortKey = "name" | "successful_sales_count" | "revenue" | "display_price_cents" | "status" | "cut";
 
+export type ProductReadinessMissingItem = "name" | "price" | "content" | "cover" | "payment";
+
+export type ProductReadiness = {
+  state: "draft" | "ready" | "live";
+  missing: ProductReadinessMissingItem[];
+};
+
 export type Membership = {
   id: number;
   edit_url: string;
@@ -41,6 +48,7 @@ export type Product = {
   successful_sales_count: number;
   remaining_for_sale_count: number | null;
   status: "preorder" | "published" | "unpublished";
+  readiness: ProductReadiness | null;
   thumbnail: { url: string } | null;
   url: string;
   url_without_protocol: string;

--- a/app/javascript/pages/Products/Workspace.tsx
+++ b/app/javascript/pages/Products/Workspace.tsx
@@ -23,10 +23,12 @@ const READINESS_COLORS: Record<ProductReadiness["state"], "warning" | "primary" 
 };
 
 const READINESS_HELPER: Record<ProductReadiness["state"], string> = {
-  draft: "Your product is drafted. Finish setup before it can sell.",
+  draft: "Your product has been drafted. Finish the offer and payments before it can go on the road.",
   ready: "Your setup is complete. This can now go on the road.",
   live: "Your product is live. Share it with the people most likely to care.",
 };
+
+const SECTIONS_HELPER = "Basics creates the product. Offer makes it sellable. Payments lets Gumroad process the sale.";
 
 const SECTION_LABELS: Record<keyof ProductWorkspaceSections, string> = {
   basics: "Basics",
@@ -35,8 +37,8 @@ const SECTION_LABELS: Record<keyof ProductWorkspaceSections, string> = {
 };
 
 const TEMPLATE_CARDS: { name: string; price_label: string }[] = [
-  { name: "Example layout", price_label: "$9" },
-  { name: "Example layout", price_label: "Free" },
+  { name: "Example slot", price_label: "$9" },
+  { name: "Example slot", price_label: "Free" },
 ];
 
 const SectionChip = ({ complete, label, href }: { complete: boolean; label: string; href: string }) => (
@@ -90,6 +92,7 @@ const ProductWorkspacePage = () => {
                   />
                 ))}
               </div>
+              <small className="text-muted">{SECTIONS_HELPER}</small>
             </div>
           ) : (
             <p className="text-muted">Manage this product from the editor.</p>

--- a/app/javascript/pages/Products/Workspace.tsx
+++ b/app/javascript/pages/Products/Workspace.tsx
@@ -1,0 +1,134 @@
+import { Link, usePage } from "@inertiajs/react";
+import * as React from "react";
+import { cast } from "ts-safe-cast";
+
+import { ProductReadiness, ProductWorkspaceProps, ProductWorkspaceSections } from "$app/data/products";
+
+import { Button } from "$app/components/Button";
+import { PageHeader } from "$app/components/ui/PageHeader";
+import { Pill } from "$app/components/ui/Pill";
+import { ProductCard, ProductCardFigure, ProductCardFooter, ProductCardHeader } from "$app/components/ui/ProductCard";
+import { ProductCardGrid } from "$app/components/ui/ProductCardGrid";
+
+const READINESS_LABELS: Record<ProductReadiness["state"], string> = {
+  draft: "Drafted",
+  ready: "Ready to sell",
+  live: "On the road",
+};
+
+const READINESS_COLORS: Record<ProductReadiness["state"], "warning" | "primary" | "success"> = {
+  draft: "warning",
+  ready: "primary",
+  live: "success",
+};
+
+const READINESS_HELPER: Record<ProductReadiness["state"], string> = {
+  draft: "Your product is drafted. Finish setup before it can sell.",
+  ready: "Your setup is complete. This can now go on the road.",
+  live: "Your product is live. Share it with the people most likely to care.",
+};
+
+const SECTION_LABELS: Record<keyof ProductWorkspaceSections, string> = {
+  basics: "Basics",
+  offer: "Offer",
+  payments: "Payments",
+};
+
+const TEMPLATE_CARDS: { name: string; price_label: string }[] = [
+  { name: "Example layout", price_label: "$9" },
+  { name: "Example layout", price_label: "Free" },
+];
+
+const SectionChip = ({ complete, label, href }: { complete: boolean; label: string; href: string }) => (
+  <Pill asChild size="small" color={complete ? "success" : undefined}>
+    <Link href={href}>
+      <span aria-hidden className="mr-1">
+        {complete ? "✓" : "○"}
+      </span>
+      <span>{label}</span>
+    </Link>
+  </Pill>
+);
+
+const ProductWorkspacePage = () => {
+  const { product, readiness, sections, settings_payments_url } = cast<ProductWorkspaceProps>(usePage().props);
+
+  const sectionLinks: Record<keyof ProductWorkspaceSections, string> = {
+    basics: product.edit_url,
+    offer: product.edit_url,
+    payments: settings_payments_url,
+  };
+
+  return (
+    <>
+      <PageHeader
+        className="sticky-top"
+        title={product.name || "Workspace"}
+        actions={
+          <Button asChild>
+            <Link href={product.edit_url}>
+              <span>Open editor</span>
+            </Link>
+          </Button>
+        }
+      />
+      <div className="flex flex-col gap-6 p-6">
+        <section aria-label="Readiness">
+          {readiness ? (
+            <div className="flex flex-col gap-3">
+              <div className="flex flex-wrap items-center gap-3">
+                <Pill color={READINESS_COLORS[readiness.state]}>{READINESS_LABELS[readiness.state]}</Pill>
+                <p className="text-muted">{READINESS_HELPER[readiness.state]}</p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {(["basics", "offer", "payments"] as const).map((key) => (
+                  <SectionChip
+                    key={key}
+                    complete={sections[key]}
+                    label={SECTION_LABELS[key]}
+                    href={sectionLinks[key]}
+                  />
+                ))}
+              </div>
+            </div>
+          ) : (
+            <p className="text-muted">Manage this product from the editor.</p>
+          )}
+        </section>
+
+        <section aria-label="Preview">
+          <h3 className="mb-3 font-bold">How your product looks on a shelf</h3>
+          <ProductCardGrid>
+            <ProductCard>
+              <ProductCardFigure>
+                {product.thumbnail_url ? <img src={product.thumbnail_url} alt="" /> : null}
+              </ProductCardFigure>
+              <ProductCardHeader>
+                <h4 className="font-bold">{product.name || "Untitled"}</h4>
+                {product.custom_summary ? <p>{product.custom_summary}</p> : null}
+              </ProductCardHeader>
+              <ProductCardFooter>
+                <span className="p-3">{product.price_formatted}</span>
+              </ProductCardFooter>
+            </ProductCard>
+
+            {TEMPLATE_CARDS.map((card, idx) => (
+              <ProductCard key={`example-${idx}`} aria-hidden="true" className="opacity-60">
+                <ProductCardFigure>{null}</ProductCardFigure>
+                <ProductCardHeader>
+                  <h4 className="font-bold">{card.name}</h4>
+                  <small className="text-muted">Layout placeholder</small>
+                </ProductCardHeader>
+                <ProductCardFooter>
+                  <span className="p-3">{card.price_label}</span>
+                </ProductCardFooter>
+              </ProductCard>
+            ))}
+          </ProductCardGrid>
+        </section>
+      </div>
+    </>
+  );
+};
+
+export default ProductWorkspacePage;

--- a/app/policies/link_policy.rb
+++ b/app/policies/link_policy.rb
@@ -24,6 +24,10 @@ class LinkPolicy < ApplicationPolicy
     update?
   end
 
+  def workspace?
+    edit?
+  end
+
   def show?
     new?
   end

--- a/app/presenters/dashboard_products_page_presenter.rb
+++ b/app/presenters/dashboard_products_page_presenter.rb
@@ -124,6 +124,9 @@ class DashboardProductsPagePresenter
       products = seller
         .products
         .includes([
+                    :alive_rich_contents,
+                    :display_asset_previews,
+                    { variant_categories_alive: { alive_variants: :alive_rich_contents } },
                     thumbnail: { file_attachment: { blob: { variant_records: { image_attachment: :blob } } } },
                     thumbnail_alive: { file_attachment: { blob: { variant_records: { image_attachment: :blob } } } },
                   ])
@@ -165,6 +168,7 @@ class DashboardProductsPagePresenter
         "price_formatted" => product.price_formatted_including_rental_verbose,
         "revenue" => product.total_usd_cents,
         "status" => product_status(product),
+        "readiness" => product_readiness(product),
         "thumbnail" => product.thumbnail&.alive&.as_json,
         "display_price_cents" => product.display_price_cents,
         "url" => product.long_url,
@@ -186,5 +190,25 @@ class DashboardProductsPagePresenter
       else
         "published"
       end
+    end
+
+    def product_readiness(product)
+      return nil if product.is_recurring_billing?
+      return nil if product.is_in_preorder_state?
+      return nil if product.archived?
+      return nil if product.banned_at.present?
+      return nil if product.purchase_disabled_at.present?
+
+      if product.published? && product.alive?
+        return { "state" => "live", "missing" => [] }
+      end
+
+      missing = []
+      missing << "name" if product.name.blank?
+      missing << "price" if product.price_cents.nil?
+      missing << "content" unless product.has_content?
+      missing << "cover" if product.thumbnail_or_cover_url.blank?
+
+      { "state" => missing.empty? ? "ready" : "building", "missing" => missing }
     end
 end

--- a/app/presenters/dashboard_products_page_presenter.rb
+++ b/app/presenters/dashboard_products_page_presenter.rb
@@ -208,7 +208,13 @@ class DashboardProductsPagePresenter
       missing << "price" if product.price_cents.nil?
       missing << "content" unless product.has_content?
       missing << "cover" if product.thumbnail_or_cover_url.blank?
+      missing << "payment" unless seller_can_publish_products?
 
-      { "state" => missing.empty? ? "ready" : "building", "missing" => missing }
+      { "state" => missing.empty? ? "ready" : "draft", "missing" => missing }
+    end
+
+    def seller_can_publish_products?
+      return @seller_can_publish_products if defined?(@seller_can_publish_products)
+      @seller_can_publish_products = seller.can_publish_products?
     end
 end

--- a/app/presenters/dashboard_products_page_presenter.rb
+++ b/app/presenters/dashboard_products_page_presenter.rb
@@ -193,24 +193,7 @@ class DashboardProductsPagePresenter
     end
 
     def product_readiness(product)
-      return nil if product.is_recurring_billing?
-      return nil if product.is_in_preorder_state?
-      return nil if product.archived?
-      return nil if product.banned_at.present?
-      return nil if product.purchase_disabled_at.present?
-
-      if product.published? && product.alive?
-        return { "state" => "live", "missing" => [] }
-      end
-
-      missing = []
-      missing << "name" if product.name.blank?
-      missing << "price" if product.price_cents.nil?
-      missing << "content" unless product.has_content?
-      missing << "cover" if product.thumbnail_or_cover_url.blank?
-      missing << "payment" unless seller_can_publish_products?
-
-      { "state" => missing.empty? ? "ready" : "draft", "missing" => missing }
+      Product::Readiness.for(product:, seller_can_publish_products: seller_can_publish_products?)
     end
 
     def seller_can_publish_products?

--- a/app/presenters/product_workspace_presenter.rb
+++ b/app/presenters/product_workspace_presenter.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+class ProductWorkspacePresenter
+  include Rails.application.routes.url_helpers
+
+  def initialize(product:, pundit_user:)
+    @product = product
+    @pundit_user = pundit_user
+  end
+
+  def props
+    {
+      product: product_props,
+      readiness: readiness,
+      sections: sections,
+      settings_payments_url: settings_payments_path,
+    }
+  end
+
+  private
+    attr_reader :product, :pundit_user
+
+    def seller
+      pundit_user.seller
+    end
+
+    def seller_can_publish_products?
+      return @seller_can_publish_products if defined?(@seller_can_publish_products)
+      @seller_can_publish_products = seller.can_publish_products?
+    end
+
+    def readiness
+      Product::Readiness.for(product:, seller_can_publish_products: seller_can_publish_products?)
+    end
+
+    def sections
+      {
+        "basics" => basics_complete?,
+        "offer" => offer_complete?,
+        "payments" => payments_complete?,
+      }
+    end
+
+    def basics_complete?
+      product.persisted? && product.name.present?
+    end
+
+    def offer_complete?
+      product.price_cents.present? && product.has_content? && product.thumbnail_or_cover_url.present?
+    end
+
+    def payments_complete?
+      seller_can_publish_products?
+    end
+
+    def product_props
+      {
+        "id" => product.id,
+        "name" => product.name,
+        "native_type" => product.native_type,
+        "custom_summary" => product.custom_summary,
+        "permalink" => product.unique_permalink,
+        "edit_url" => edit_link_path(product),
+        "url" => product.long_url,
+        "thumbnail_url" => product.thumbnail_or_cover_url,
+        "price_formatted" => product.price_formatted_including_rental_verbose,
+      }
+    end
+end

--- a/app/services/product/readiness.rb
+++ b/app/services/product/readiness.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Product
+  module Readiness
+    NORMAL_LIFECYCLE_STATES = %w[draft ready live].freeze
+
+    def self.for(product:, seller_can_publish_products:)
+      return nil if product.is_recurring_billing?
+      return nil if product.is_in_preorder_state?
+      return nil if product.archived?
+      return nil if product.banned_at.present?
+      return nil if product.purchase_disabled_at.present?
+
+      if product.published? && product.alive?
+        return { "state" => "live", "missing" => [] }
+      end
+
+      missing = []
+      missing << "name" if product.name.blank?
+      missing << "price" if product.price_cents.nil?
+      missing << "content" unless product.has_content?
+      missing << "cover" if product.thumbnail_or_cover_url.blank?
+      missing << "payment" unless seller_can_publish_products
+
+      { "state" => missing.empty? ? "ready" : "draft", "missing" => missing }
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -768,6 +768,7 @@ Rails.application.routes.draw do
 
     get "/products/:id/edit", to: "links#edit", as: :edit_link
     get "/products/:id/edit/*other", to: "links#edit"
+    get "/products/:id/workspace", to: "links#workspace", as: :workspace_link
     get "/products/:id/card", to: "links#card", as: :product_card
     get "/products/search", to: "links#search"
 

--- a/spec/presenters/dashboard_products_page_presenter_spec.rb
+++ b/spec/presenters/dashboard_products_page_presenter_spec.rb
@@ -841,12 +841,24 @@ describe DashboardProductsPagePresenter do
       expect(readiness["missing"]).not_to include("price")
     end
 
-    it "returns building with the missing items for a draft product without content or cover" do
-      product = create(:product, user: seller, name: "building one", price_cents: 1000, draft: true)
+    it "returns draft with the missing basics for a draft product without content or cover" do
+      product = create(:product, user: seller, name: "draft one", price_cents: 1000, draft: true)
 
       readiness = readiness_for(product)
-      expect(readiness["state"]).to eq("building")
+      expect(readiness["state"]).to eq("draft")
       expect(readiness["missing"]).to match_array(["content", "cover"])
+    end
+
+    it "returns draft with payment missing when basics are complete but the seller has no payment setup" do
+      seller.update!(payment_address: nil)
+
+      product = create(:product, user: seller, name: "needs payment", price_cents: 1000, draft: true)
+      create(:rich_content, entity: product, description: rich_content_description)
+      create(:thumbnail, product:)
+
+      readiness = readiness_for(product.reload)
+      expect(readiness["state"]).to eq("draft")
+      expect(readiness["missing"]).to eq(["payment"])
     end
 
     it "returns nil for preorder products to leave existing status untouched" do

--- a/spec/presenters/dashboard_products_page_presenter_spec.rb
+++ b/spec/presenters/dashboard_products_page_presenter_spec.rb
@@ -811,6 +811,71 @@ describe DashboardProductsPagePresenter do
     end
   end
 
+  describe "product readiness" do
+    let(:rich_content_description) { [{ "type" => "paragraph", "content" => [{ "type" => "text", "text" => "hello" }] }] }
+
+    def readiness_for(product)
+      described_class.new(pundit_user:).product_props(product)["readiness"]
+    end
+
+    it "returns live for a published, alive product" do
+      product = create(:product, user: seller, name: "live one", price_cents: 1000)
+      expect(readiness_for(product)).to eq("state" => "live", "missing" => [])
+    end
+
+    it "returns ready for a draft product with name, price, content, and cover" do
+      product = create(:product, user: seller, name: "ready one", price_cents: 1000, draft: true)
+      create(:rich_content, entity: product, description: rich_content_description)
+      create(:thumbnail, product:)
+
+      expect(readiness_for(product.reload)).to eq("state" => "ready", "missing" => [])
+    end
+
+    it "treats free products with price_cents 0 as having valid price intent" do
+      product = create(:product, user: seller, name: "free one", price_cents: 0, draft: true)
+      create(:rich_content, entity: product, description: rich_content_description)
+      create(:thumbnail, product:)
+
+      readiness = readiness_for(product.reload)
+      expect(readiness["state"]).to eq("ready")
+      expect(readiness["missing"]).not_to include("price")
+    end
+
+    it "returns building with the missing items for a draft product without content or cover" do
+      product = create(:product, user: seller, name: "building one", price_cents: 1000, draft: true)
+
+      readiness = readiness_for(product)
+      expect(readiness["state"]).to eq("building")
+      expect(readiness["missing"]).to match_array(["content", "cover"])
+    end
+
+    it "returns nil for preorder products to leave existing status untouched" do
+      product = create(:product, user: seller, name: "preorder one", price_cents: 1000, is_in_preorder_state: true)
+      expect(readiness_for(product)).to be_nil
+    end
+
+    it "returns nil for archived products" do
+      product = create(:product, user: seller, name: "archived one", price_cents: 1000, archived: true)
+      expect(readiness_for(product)).to be_nil
+    end
+
+    it "returns nil for purchase-disabled products" do
+      product = create(:product, user: seller, name: "paused one", price_cents: 1000,
+                                 purchase_disabled_at: Time.current)
+      expect(readiness_for(product)).to be_nil
+    end
+
+    it "returns nil for banned products" do
+      product = create(:product, user: seller, name: "banned one", price_cents: 1000, banned_at: Time.current)
+      expect(readiness_for(product)).to be_nil
+    end
+
+    it "returns nil for membership / recurring billing products" do
+      product = create(:membership_product, user: seller, name: "membership one")
+      expect(readiness_for(product)).to be_nil
+    end
+  end
+
   describe "#empty?" do
     context "when archived: false (default)" do
       it "returns nil" do

--- a/spec/presenters/product_workspace_presenter_spec.rb
+++ b/spec/presenters/product_workspace_presenter_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe ProductWorkspacePresenter do
+  let(:seller) { create(:named_seller) }
+  let(:pundit_user) { SellerContext.new(user: seller, seller:) }
+  let(:rich_content_description) { [{ "type" => "paragraph", "content" => [{ "type" => "text", "text" => "hello" }] }] }
+
+  def props_for(product)
+    described_class.new(product:, pundit_user:).props
+  end
+
+  describe "#props" do
+    it "returns product subset, readiness, sections, and settings_payments_url" do
+      product = create(:product, user: seller, name: "live one", price_cents: 1000)
+      props = props_for(product)
+
+      expect(props[:product]).to include(
+        "id" => product.id,
+        "name" => "live one",
+        "native_type" => product.native_type,
+        "permalink" => product.unique_permalink,
+        "edit_url" => Rails.application.routes.url_helpers.edit_link_path(product),
+      )
+      expect(props[:readiness]).to eq("state" => "live", "missing" => [])
+      expect(props[:sections]).to include("basics" => true)
+      expect(props[:settings_payments_url]).to eq(Rails.application.routes.url_helpers.settings_payments_path)
+    end
+  end
+
+  describe "section completion" do
+    it "marks basics complete when the product is saved with a name" do
+      product = create(:product, user: seller, name: "draft one", draft: true)
+      expect(props_for(product)[:sections]["basics"]).to be(true)
+    end
+
+    it "marks offer incomplete when content or cover are missing" do
+      product = create(:product, user: seller, name: "no content", price_cents: 1000, draft: true)
+      expect(props_for(product)[:sections]["offer"]).to be(false)
+    end
+
+    it "marks offer complete when price, content, and cover are all present" do
+      product = create(:product, user: seller, name: "ready", price_cents: 1000, draft: true)
+      create(:rich_content, entity: product, description: rich_content_description)
+      create(:thumbnail, product:)
+
+      expect(props_for(product.reload)[:sections]["offer"]).to be(true)
+    end
+
+    it "treats free products with price_cents 0 as having a complete offer" do
+      product = create(:product, user: seller, name: "free", price_cents: 0, draft: true)
+      create(:rich_content, entity: product, description: rich_content_description)
+      create(:thumbnail, product:)
+
+      expect(props_for(product.reload)[:sections]["offer"]).to be(true)
+    end
+
+    it "marks payments complete when the seller can publish products" do
+      product = create(:product, user: seller, name: "ok", price_cents: 1000)
+      expect(props_for(product)[:sections]["payments"]).to be(true)
+    end
+
+    it "marks payments incomplete when the seller has no payment setup" do
+      seller.update!(payment_address: nil)
+      product = create(:product, user: seller, name: "needs payment", price_cents: 1000, draft: true)
+
+      expect(props_for(product)[:sections]["payments"]).to be(false)
+    end
+  end
+
+  describe "readiness" do
+    it "returns nil for membership / recurring billing products while still deriving sections" do
+      product = create(:membership_product, user: seller, name: "membership")
+      props = props_for(product)
+
+      expect(props[:readiness]).to be_nil
+      expect(props[:sections]).to include("basics", "offer", "payments")
+    end
+  end
+end

--- a/spec/requests/products/creation_spec.rb
+++ b/spec/requests/products/creation_spec.rb
@@ -11,6 +11,11 @@ describe "Product creation", type: :system, js: true do
   include_context "with switching account to user as admin for seller"
 
   describe "native types" do
+    # Examples in this block exercise the returning-seller create flow
+    # that lands on the legacy editor. The first-time-seller redirect
+    # is covered separately in spec/requests/products/workspace_spec.rb.
+    let!(:_prior_product) { create(:product, user: seller, name: "Existing product") }
+
     it "selects 'digital' by default" do
       visit new_product_path
       fill_in("Name", with: "Default digital native type")
@@ -175,6 +180,8 @@ describe "Product creation", type: :system, js: true do
   end
 
   context "user can create multiple products in one session" do
+    let!(:_prior_product) { create(:product, user: seller, name: "Existing product") }
+
     it "creates multiple products" do
       visit new_product_path
       fill_in("Name", with: "My First product")
@@ -224,6 +231,7 @@ describe "Product creation", type: :system, js: true do
 
   context "seller is eligible for service products" do
     let(:seller) { create(:user, :eligible_for_service_products) }
+    let!(:_prior_product) { create(:product, user: seller, name: "Existing product") }
     before do
       Feature.activate(:product_edit_react)
     end
@@ -266,6 +274,8 @@ describe "Product creation", type: :system, js: true do
   end
 
   describe "currencies" do
+    let!(:_prior_product) { create(:product, user: seller, name: "Existing product") }
+
     it "creates a membership priced in a single-unit currency" do
       visit new_product_path
       fill_in("Name", with: "membership in yen")
@@ -359,6 +369,8 @@ describe "Product creation", type: :system, js: true do
   end
 
   describe "bundles" do
+    let!(:_prior_product) { create(:product, user: seller, name: "Existing product") }
+
     it "allows the creation of a bundle" do
       visit new_product_path
       choose "Bundle"
@@ -374,6 +386,7 @@ describe "Product creation", type: :system, js: true do
   end
 
   it "does not automatically enable the community chat on creating a product" do
+    create(:product, user: seller, name: "Existing product")
     Feature.activate_user(:communities, seller)
     visit new_product_path
     choose "Digital product"
@@ -388,6 +401,8 @@ describe "Product creation", type: :system, js: true do
   end
 
   describe "AI Product Generation" do
+    let!(:_prior_product) { create(:product, user: seller, name: "Existing product") }
+
     before do
       Feature.activate_user(:ai_product_generation, seller)
       allow_any_instance_of(User).to receive(:eligible_for_ai_product_generation?).and_return(true)

--- a/spec/requests/products/workspace_spec.rb
+++ b/spec/requests/products/workspace_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Products workspace", type: :request do
+  let(:seller) { create(:named_seller) }
+
+  describe "GET /products/:id/workspace" do
+    let(:product) { create(:product, user: seller, name: "test product") }
+
+    it "renders the workspace Inertia page for the owning seller" do
+      sign_in seller
+
+      get workspace_link_path(product), headers: { "X-Inertia" => "true" }
+
+      expect(response).to be_successful
+    end
+
+    it "denies access to a different seller" do
+      other_seller = create(:user)
+      sign_in other_seller
+
+      get workspace_link_path(product)
+
+      expect(response).not_to be_successful
+    end
+  end
+
+  describe "POST /products" do
+    let(:link_params) do
+      {
+        link: {
+          name: "Brand new product",
+          price_range: "5",
+          price_currency_type: "usd",
+          native_type: "digital",
+          is_physical: false,
+          is_recurring_billing: false,
+          subscription_duration: nil,
+          description: nil,
+          custom_summary: nil,
+          ai_prompt: "",
+          number_of_content_pages: nil,
+          release_at_date: 1.day.from_now.to_date.to_s,
+        },
+      }
+    end
+
+    before { sign_in seller }
+
+    it "redirects first-time sellers to the product workspace" do
+      expect(seller.products.count).to eq(0)
+
+      post links_path, params: link_params
+
+      created = seller.products.last
+      expect(response).to redirect_to(workspace_link_path(created))
+    end
+
+    it "redirects returning sellers to the legacy editor" do
+      create(:product, user: seller, name: "Existing product")
+
+      post links_path, params: link_params
+
+      created = seller.products.where.not(name: "Existing product").last
+      expect(response).to redirect_to(edit_link_path(created))
+    end
+  end
+end


### PR DESCRIPTION
## What

Inspired by discussion in #4892 around improving the first-time seller experience.
This PR introduces a creator-facing product readiness model:

**Drafted → Ready to sell → On the road**

It adds two changes:

1. **Readiness states in the product dashboard**
   - Products now show whether they are Drafted, Ready to sell, or On the road.
   - Drafted products show missing setup items like `content`, `cover`, or `payments`.

2. **First-product workspace**
   - First-time sellers are redirected to a workspace after creating their first product.
   - The workspace shows:
     - the product’s current state
     - Basics / Offer / Payments progress
     - a mini preview of the product
     - links to continue setup

---

## Why

After creating a product, a first-time seller lands directly in the editor.

The product exists, but its state is unclear.

They have to infer:
- what is missing
- whether the product is ready to sell
- what to do next

This creates friction at the most important moment: turning a product into something real and sellable.

This PR treats onboarding as a **time-to-value problem**.

The goal is to make the path to selling visible:

**Drafted → Ready to sell → On the road**

And structure setup around:

**Basics → Offer → Payments**

---

## Before

- Product creation leads directly to the editor  
- No clear indication of product readiness  
- Setup feels like a collection of fields  

---

## After

- Dashboard shows product readiness states  
- First-time sellers land in a workspace instead of the editor  
- Sellers can see:
  - what exists
  - what is missing
  - what to do next  
- The product is visible as an artifact, not just a form  

---

## Scope

This PR is intentionally creator-facing and additive.

It does not change:
- checkout
- payouts
- buyer-facing product pages
- publishing behavior
- Discover or marketplace visibility
- existing editor structure
- database schema

---

## Implementation notes

- Adds a reusable `Product::Readiness` service
- Adds a `readiness` field to the dashboard payload
- Adds readiness UI to the product dashboard
- Adds `/products/:id/workspace`
- Redirects first-time sellers to the workspace
- Returning sellers continue to use the existing editor flow
- Uses existing signals (e.g. `seller.can_publish_products?`) for payment readiness

---

## Video

[Loom response to #4892 ](https://www.loom.com/share/dc6c8ffc16f44bf98d365786135a03dd)

---

## Concept (direction)

<img width="1044" height="139" alt="image" src="https://github.com/user-attachments/assets/dfeb0a3e-a2ae-4ec3-b1bb-b2346129691b" />

---

<img width="1046" height="856" alt="image" src="https://github.com/user-attachments/assets/94670aaf-252b-4f4f-9c5c-7d52fc11a3c1" />

---

<img width="1036" height="911" alt="image" src="https://github.com/user-attachments/assets/c7cef5dc-208f-475d-aa08-f5a00be72dc3" />

---

**Interactive wireframe:**
[Vision artifact](https://htmlpreview.github.io/?https://github.com/niharya/gumroad/blob/design/product-readiness-concept/design/product_readiness_concept_wireframe.html)

---

## Test results

- ESLint: passed  
- TypeScript: passed  
- RuboCop: passed  
- Ruby syntax: passed  
- RSpec: deferred to CI (local setup requires Sidekiq Pro credentials)

---

## Future direction

This PR implements the first safe slice.

Possible extensions:

- simplify first-time product creation into a true Basics flow  
- add fuller product detail preview  
- deep-link Basics / Offer to editor sections  
- support product-type-specific readiness  
- optional interest capture / notify flows  