### PR TITLE
AI Product Page Assistant

### DIFF
--- a/app/controllers/api/internal/ai_product_page_drafts_controller.rb
+++ b/app/controllers/api/internal/ai_product_page_drafts_controller.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+class Api::Internal::AiProductPageDraftsController < Api::Internal::BaseController
+  include Throttling
+
+  before_action :authenticate_user!
+  before_action :throttle_ai_requests
+  after_action :verify_authorized
+
+  AI_REQUESTS_PER_PERIOD = 10
+  AI_REQUESTS_PERIOD_WINDOW = 1.hour
+  private_constant :AI_REQUESTS_PER_PERIOD, :AI_REQUESTS_PERIOD_WINDOW
+
+  def create
+    authorize current_seller, :generate_product_details_with_ai?
+
+    payload = draft_params
+    product = payload.fetch(:product, {})
+    quiz = payload.fetch(:quiz, {})
+
+    begin
+      service = ::Ai::ProductDetailsGeneratorService.new(current_seller:)
+      result = service.generate_product_page_draft(product:, quiz:)
+
+      render json: {
+        success: true,
+        data: result
+      }
+    rescue => e
+      Rails.logger.error "Product page draft generation using AI failed: #{e.full_message}"
+      ErrorNotifier.notify(e)
+      render json: {
+        success: false,
+        error: "Failed to generate product page draft. Please try again."
+      }, status: :internal_server_error
+    end
+  end
+
+  private
+    def throttle_ai_requests
+      return unless current_user
+
+      key = RedisKey.ai_request_throttle(current_seller.id)
+      throttle!(key:, limit: AI_REQUESTS_PER_PERIOD, period: AI_REQUESTS_PERIOD_WINDOW)
+    end
+
+    def draft_params
+      params
+        .permit(
+          product: [:name, :description, :receipt_button_text, :receipt_custom_message, { rich_content_section_titles: [] }],
+          quiz: [:business_summary, :audience, :pricing_shape, :tone, :delivery_notes, :generation_tick, { value_drivers: [] }]
+        )
+        .to_h
+        .deep_symbolize_keys
+    end
+end

--- a/app/javascript/components/Modal.tsx
+++ b/app/javascript/components/Modal.tsx
@@ -6,6 +6,7 @@ import { classNames } from "$app/utils/classNames";
 
 export const Modal = ({
   className,
+  width,
   title,
   children,
   footer,
@@ -16,6 +17,7 @@ export const Modal = ({
   ...props
 }: {
   className?: string;
+  width?: string;
   title?: string;
   children: React.ReactNode;
   footer?: React.ReactNode;
@@ -27,6 +29,7 @@ export const Modal = ({
     <>
       <Dialog.Content
         aria-modal={modal}
+        style={width ? { width, maxWidth: "none" } : undefined}
         className={classNames(
           "fixed top-[50%] left-[50%] z-51 flex max-h-[90vh] max-w-175 min-w-80 translate-[-50%] flex-col gap-4 overflow-y-auto rounded border border-border bg-background p-8 shadow-lg dark:shadow-none",
           className,

--- a/app/javascript/components/ProductEdit/Layout.tsx
+++ b/app/javascript/components/ProductEdit/Layout.tsx
@@ -126,6 +126,7 @@ export const Layout = ({
   preview,
   isLoading = false,
   headerActions,
+  topActions,
   previewScaleFactor = 0.4,
   showBorder = true,
   showNavigationButton = true,
@@ -134,6 +135,7 @@ export const Layout = ({
   preview?: React.ReactNode;
   isLoading?: boolean;
   headerActions?: React.ReactNode;
+  topActions?: React.ReactNode;
   previewScaleFactor?: number;
   showBorder?: boolean;
   showNavigationButton?: boolean;
@@ -252,6 +254,7 @@ export const Layout = ({
               <Button disabled={isBusy} onClick={() => void setPublished(false)}>
                 {isPublishing ? "Unpublishing..." : "Unpublish"}
               </Button>
+              {topActions}
               {saveButton}
               <CopyToClipboard text={url} copyTooltip="Copy product URL">
                 <Button size="icon">
@@ -265,15 +268,19 @@ export const Layout = ({
               </CopyToClipboard>
             </>
           ) : tab === "product" && !isCoffee ? (
-            <Button
-              color="primary"
-              disabled={isBusy}
-              onClick={() => void save().then(() => navigate.current(`${rootPath}/content`))}
-            >
-              {saving ? "Saving changes..." : "Save and continue"}
-            </Button>
+            <>
+              <Button
+                color="primary"
+                disabled={isBusy}
+                onClick={() => void save().then(() => navigate.current(`${rootPath}/content`))}
+              >
+                {saving ? "Saving changes..." : "Save and continue"}
+              </Button>
+              {topActions}
+            </>
           ) : (
             <>
+              {topActions}
               {saveButton}
               <WithTooltip tip={saveButtonTooltip}>
                 <Button color="accent" disabled={isBusy} onClick={() => void setPublished(true)}>

--- a/app/javascript/components/ProductEdit/Layout.tsx
+++ b/app/javascript/components/ProductEdit/Layout.tsx
@@ -24,6 +24,7 @@ import { Tab, Tabs } from "$app/components/ui/Tabs";
 import { useRefToLatest } from "$app/components/useRefToLatest";
 import { WithTooltip } from "$app/components/WithTooltip";
 
+import { AIProductPageAssistant } from "./ProductTab/AIProductPageAssistant";
 import { FileEntry, useProductEditContext } from "./state";
 
 export const useProductUrl = (params = {}) => {
@@ -239,6 +240,7 @@ export const Layout = ({
   };
 
   const isCoffee = product.native_type === "coffee";
+  const aiAssistant = <AIProductPageAssistant />;
 
   return (
     <>
@@ -254,6 +256,7 @@ export const Layout = ({
               <Button disabled={isBusy} onClick={() => void setPublished(false)}>
                 {isPublishing ? "Unpublishing..." : "Unpublish"}
               </Button>
+              {aiAssistant}
               {topActions}
               {saveButton}
               <CopyToClipboard text={url} copyTooltip="Copy product URL">
@@ -269,6 +272,7 @@ export const Layout = ({
             </>
           ) : tab === "product" && !isCoffee ? (
             <>
+              {aiAssistant}
               <Button
                 color="primary"
                 disabled={isBusy}
@@ -280,6 +284,7 @@ export const Layout = ({
             </>
           ) : (
             <>
+              {aiAssistant}
               {topActions}
               {saveButton}
               <WithTooltip tip={saveButtonTooltip}>

--- a/app/javascript/components/ProductEdit/ProductTab/AIProductPageAssistant.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/AIProductPageAssistant.tsx
@@ -7,6 +7,7 @@ import { request } from "$app/utils/request";
 import { Button } from "$app/components/Button";
 import { Modal } from "$app/components/Modal";
 import { useProductEditContext } from "$app/components/ProductEdit/state";
+import { showAlert } from "$app/components/server-components/Alert";
 import { Alert } from "$app/components/ui/Alert";
 import { Card, CardContent } from "$app/components/ui/Card";
 import { Fieldset, FieldsetDescription, FieldsetTitle } from "$app/components/ui/Fieldset";
@@ -269,7 +270,7 @@ const SectionCard = ({ title, eyebrow, children }: { title: string; eyebrow: str
   </Card>
 );
 
-export const AIProductPageAssistant = ({ onApply }: { onApply: (draft: BuildWithAIDraft) => void }) => {
+export const AIProductPageAssistant = () => {
   const uid = React.useId();
   const [open, setOpen] = React.useState(false);
   const [hasGenerated, setHasGenerated] = React.useState(false);
@@ -286,7 +287,7 @@ export const AIProductPageAssistant = ({ onApply }: { onApply: (draft: BuildWith
   const [deliveryNotes, setDeliveryNotes] = React.useState("");
   const [previewTab, setPreviewTab] = React.useState<"product" | "content" | "receipt">("product");
 
-  const { product } = useProductEditContext();
+  const { product, updateProduct, setDescriptionResetKey, save } = useProductEditContext();
   const isCoffee = product.native_type === "coffee";
   const currentContentSections = React.useMemo(
     () =>
@@ -331,6 +332,38 @@ export const AIProductPageAssistant = ({ onApply }: { onApply: (draft: BuildWith
   );
   const fallbackDraft = React.useMemo(() => buildDraftFromState(generationTick), [buildDraftFromState, generationTick]);
   const draft = generatedDraft ?? fallbackDraft;
+
+  const applyDraft = async () => {
+    const contentPages = draft.content.pages.map((page) => ({
+      ...page,
+      description: JSON.parse(JSON.stringify(page.description)),
+    }));
+    const nextProduct: typeof product = {
+      ...product,
+      name: draft.product.title,
+      description: draft.product.description,
+      custom_summary: draft.content.outline,
+      has_same_rich_content_for_all_variants: true,
+      rich_content: contentPages,
+      custom_view_content_button_text: draft.receipt.buttonText,
+      custom_receipt_text: draft.receipt.customMessage,
+    };
+
+    updateProduct(nextProduct);
+    setDescriptionResetKey((value) => value + 1);
+
+    save(nextProduct)
+      .then(() => {
+        setOpen(false);
+        setHasGenerated(false);
+        setGeneratedDraft(null);
+        setPreviewSource(null);
+        setQuizStep(0);
+      })
+      .catch((e) => {
+        showAlert(e instanceof Error ? e.message : "Something went wrong.", "error");
+      });
+  };
 
   const intakeSteps = [
     {
@@ -719,9 +752,7 @@ export const AIProductPageAssistant = ({ onApply }: { onApply: (draft: BuildWith
                 <Button
                   className="border-black bg-pink text-black hover:bg-pink/90 hover:text-black"
                   onClick={() => {
-                    onApply(draft);
-                    setOpen(false);
-                    setHasGenerated(false);
+                    void applyDraft();
                   }}
                 >
                   Apply to product

--- a/app/javascript/components/ProductEdit/ProductTab/AIProductPageAssistant.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/AIProductPageAssistant.tsx
@@ -1,0 +1,736 @@
+import { Sparkle } from "@boxicons/react";
+import * as React from "react";
+
+import GuidGenerator from "$app/utils/guid_generator";
+import { request } from "$app/utils/request";
+
+import { Button } from "$app/components/Button";
+import { Modal } from "$app/components/Modal";
+import { useProductEditContext } from "$app/components/ProductEdit/state";
+import { Alert } from "$app/components/ui/Alert";
+import { Card, CardContent } from "$app/components/ui/Card";
+import { Fieldset, FieldsetDescription, FieldsetTitle } from "$app/components/ui/Fieldset";
+import { Input } from "$app/components/ui/Input";
+import { Label } from "$app/components/ui/Label";
+import { Tab, Tabs } from "$app/components/ui/Tabs";
+import { Textarea } from "$app/components/ui/Textarea";
+
+const stripHtml = (value: string) =>
+  value
+    .replace(/<[^>]*>/gu, " ")
+    .replace(/&nbsp;/gu, " ")
+    .replace(/\s+/gu, " ")
+    .trim();
+
+const escapeHtml = (value: string) =>
+  value
+    .replace(/&/gu, "&amp;")
+    .replace(/</gu, "&lt;")
+    .replace(/>/gu, "&gt;")
+    .replace(/"/gu, "&quot;")
+    .replace(/'/gu, "&#39;");
+
+const truncate = (value: string, maxLength: number) =>
+  value.length > maxLength ? `${value.slice(0, maxLength).trimEnd()}…` : value;
+
+const extractAudience = (value: string) => {
+  const pattern = /\b(?:for|to)\s+([^.,;:!?]+)(?:[.,;:!?]|$)/iu;
+  const match = pattern.exec(value);
+  return match?.[1]?.trim();
+};
+
+const joinWithCommas = (values: string[]) =>
+  values.length <= 1 ? (values[0] ?? "") : `${values.slice(0, -1).join(", ")} and ${values[values.length - 1]}`;
+
+const valueDriverOptions = ["Speed", "Trust", "Transformation", "Quality", "Convenience", "Price", "Exclusivity"];
+
+const pricingOptions = ["One price", "Multiple tiers", "Quote/custom", "Not sure yet"];
+
+const inferPriceSuggestion = (title: string, description: string, note: string, isCoffee: boolean) => {
+  const haystack = `${title} ${description} ${note}`.toLowerCase();
+  if (isCoffee) return "Consider $12-$39";
+  if (/\b(service|consulting|audit|done-for-you|strategy)\b/u.test(haystack)) return "Consider $149-$499";
+  if (/\b(course|masterclass|bootcamp|workshop|lesson)\b/u.test(haystack)) return "Consider $49-$149";
+  if (/\b(template|notion|checklist|prompt|swipe|guide|ebook)\b/u.test(haystack)) return "Consider $19-$79";
+  if (/\b(software|app|tool|widget|plugin)\b/u.test(haystack)) return "Consider $29-$99";
+  return "Consider $29-$79";
+};
+
+export type BuildWithAIDraft = {
+  product: {
+    title: string;
+    description: string;
+    bullets: string[];
+    priceSuggestion: string;
+  };
+  content: {
+    outline: string;
+    sectionIdeas: string[];
+    existingSections: string[];
+    pages: {
+      id: string;
+      title: string;
+      description: object;
+      updated_at: string;
+    }[];
+  };
+  receipt: {
+    buttonText: string;
+    customMessage: string;
+  };
+  rationale: string;
+  missingInfo: string[];
+};
+
+type BuildWithAIApiResponse =
+  | {
+      success: true;
+      data: BuildWithAIDraft;
+    }
+  | {
+      success: false;
+      error: string;
+    };
+
+const isBuildWithAIApiResponse = (value: unknown): value is BuildWithAIApiResponse => {
+  if (!value || typeof value !== "object") return false;
+  return "success" in value;
+};
+
+const buildDraft = ({
+  title,
+  description,
+  businessSummary,
+  audience,
+  valueDrivers,
+  pricingShape,
+  tone,
+  deliveryNotes,
+  generationTick,
+  currentContentSections,
+  currentReceiptButton,
+  currentReceiptMessage,
+  isCoffee,
+}: {
+  title: string;
+  description: string;
+  businessSummary: string;
+  audience: string;
+  valueDrivers: string[];
+  pricingShape: string;
+  tone: string;
+  deliveryNotes: string;
+  generationTick: number;
+  currentContentSections: string[];
+  currentReceiptButton: string;
+  currentReceiptMessage: string;
+  isCoffee: boolean;
+}): BuildWithAIDraft => {
+  const cleanTitle = title.trim() || "Your product";
+  const cleanDescription = stripHtml(description);
+  const summary = businessSummary.trim() || cleanDescription || cleanTitle;
+  const audienceText = audience.trim() || extractAudience(summary) || "your ideal buyers";
+  const valueDriverText = valueDrivers.length ? joinWithCommas(valueDrivers.map((value) => value.toLowerCase())) : "";
+  const pricingText = pricingShape.trim();
+  const toneText = tone.trim() || "clear, credible, and easy to act on";
+  const deliveryText = deliveryNotes.trim();
+  const productFocus = truncate(summary, 120);
+  const toneVariant = generationTick % 2 === 0 ? toneText : `${toneText}, but simpler`;
+  const proofLine = deliveryText
+    ? `It frames the offer around ${truncate(deliveryText, 90)} so buyers understand the outcome faster.`
+    : "It makes the offer easier to scan and gives buyers a sharper reason to buy.";
+
+  const productTitle =
+    cleanTitle.toLowerCase().includes(audienceText.toLowerCase()) || !audienceText
+      ? cleanTitle
+      : truncate(`${cleanTitle} for ${audienceText}`, 64);
+
+  const productDescription = isCoffee
+    ? [`Built for ${audienceText}.`, `Tone: ${toneText}.`, productFocus, proofLine].filter(Boolean).join("\n\n")
+    : [
+        `<p><strong>Built for ${escapeHtml(audienceText)}.</strong> This version keeps the promise direct, benefits visible, and the tone ${escapeHtml(toneVariant)}.</p>`,
+        `<p>${escapeHtml(proofLine)} It keeps the core idea of ${escapeHtml(truncate(cleanDescription || cleanTitle, 90))} while making the page easier to skim.</p>`,
+      ].join("");
+
+  const productBullets = [
+    `Clearer promise for ${audienceText}`,
+    valueDriverText ? `Messaging leans into ${valueDriverText}` : null,
+    pricingText ? `Structured for ${pricingText.toLowerCase()}` : null,
+    `Tighter framing around ${truncate(productFocus, 42)}`,
+    `Skimmable benefits that make the value obvious`,
+    deliveryText
+      ? `Aligned to the buyer outcome: ${truncate(deliveryText, 40)}`
+      : "Stronger support for the page's preview and checkout scan",
+  ].filter((value): value is string => Boolean(value));
+
+  const contentSectionIdeas = [
+    `Start here: what ${truncate(cleanTitle, 40)} helps buyers do`,
+    `What's included: the core files, lessons, or pages`,
+    `Quick start: the fastest path to first value`,
+    `FAQ: common objections and what happens after purchase`,
+  ];
+  const updatedAt = new Date().toISOString();
+  const contentPages = [
+    {
+      id: GuidGenerator.generate(),
+      title: "Start here",
+      description: {
+        type: "doc",
+        content: [{ type: "paragraph", content: [{ type: "text", text: `This is for ${audienceText}.` }] }],
+      },
+      updated_at: updatedAt,
+    },
+    {
+      id: GuidGenerator.generate(),
+      title: "What’s included",
+      description: {
+        type: "doc",
+        content: [
+          { type: "paragraph", content: [{ type: "text", text: contentSectionIdeas.slice(0, 3).join(" • ") }] },
+        ],
+      },
+      updated_at: updatedAt,
+    },
+    {
+      id: GuidGenerator.generate(),
+      title: "FAQ",
+      description: {
+        type: "doc",
+        content: [
+          { type: "paragraph", content: [{ type: "text", text: "What happens after purchase?" }] },
+          {
+            type: "paragraph",
+            content: [
+              {
+                type: "text",
+                text:
+                  currentReceiptMessage.trim() ||
+                  "Buyers get immediate access and can start with the quick-start guidance inside.",
+              },
+            ],
+          },
+        ],
+      },
+      updated_at: updatedAt,
+    },
+  ];
+
+  const receiptButtonText =
+    currentReceiptButton.trim() ||
+    truncate(`View your ${summary.toLowerCase().includes("content") ? "content" : "purchase"}`, 26);
+  const receiptCustomMessage =
+    currentReceiptMessage.trim() ||
+    `Thanks for buying ${cleanTitle}. Start with the first step, then follow the quick-start guidance inside.`;
+
+  return {
+    product: {
+      title: productTitle,
+      description: productDescription,
+      bullets: productBullets,
+      priceSuggestion: inferPriceSuggestion(
+        cleanTitle,
+        cleanDescription,
+        `${businessSummary} ${audience} ${valueDrivers.join(" ")} ${pricingShape} ${tone} ${deliveryNotes}`,
+        isCoffee,
+      ),
+    },
+    content: {
+      outline: `A lightweight structure that keeps the buying journey simple for ${audienceText}`,
+      sectionIdeas: contentSectionIdeas,
+      existingSections: currentContentSections.length
+        ? currentContentSections
+        : ["No existing content yet, so the agent would start a first draft outline"],
+      pages: contentPages,
+    },
+    receipt: {
+      buttonText: truncate(receiptButtonText, 26),
+      customMessage: receiptCustomMessage,
+    },
+    rationale: `It aligns the product page, content delivery, and receipt flow around ${audienceText}, which makes the whole experience feel more deliberate and easier to buy from`,
+    missingInfo: [
+      businessSummary.trim() ? null : "Add a short business summary to make the draft sharper",
+      audience.trim() ? null : "Call out the exact audience for a stronger messaging",
+      valueDrivers.length ? null : "Choose what buyers should care about most",
+      pricingShape.trim() ? null : "Choose a rough pricing shape",
+      deliveryNotes.trim() ? null : "Add delivery notes so the content and receipt can match the promise",
+    ].filter((value): value is string => Boolean(value)),
+  };
+};
+
+const SectionCard = ({ title, eyebrow, children }: { title: string; eyebrow: string; children: React.ReactNode }) => (
+  <Card className="border-border/80 shadow-none">
+    <CardContent details className="grid justify-normal gap-3 p-4">
+      <div className="grid gap-1">
+        <div className="text-xs font-medium tracking-wide text-muted uppercase">{eyebrow}</div>
+        <div className="text-sm font-bold">{title}</div>
+      </div>
+      {children}
+    </CardContent>
+  </Card>
+);
+
+export const AIProductPageAssistant = ({ onApply }: { onApply: (draft: BuildWithAIDraft) => void }) => {
+  const uid = React.useId();
+  const [open, setOpen] = React.useState(false);
+  const [hasGenerated, setHasGenerated] = React.useState(false);
+  const [generatedDraft, setGeneratedDraft] = React.useState<BuildWithAIDraft | null>(null);
+  const [isGenerating, setIsGenerating] = React.useState(false);
+  const [previewSource, setPreviewSource] = React.useState<"local" | "api" | null>(null);
+  const [generationTick, setGenerationTick] = React.useState(0);
+  const [quizStep, setQuizStep] = React.useState(0);
+  const [businessSummary, setBusinessSummary] = React.useState("");
+  const [audience, setAudience] = React.useState("");
+  const [valueDrivers, setValueDrivers] = React.useState<string[]>([]);
+  const [pricingShape, setPricingShape] = React.useState("");
+  const [tone, setTone] = React.useState("");
+  const [deliveryNotes, setDeliveryNotes] = React.useState("");
+  const [previewTab, setPreviewTab] = React.useState<"product" | "content" | "receipt">("product");
+
+  const { product } = useProductEditContext();
+  const isCoffee = product.native_type === "coffee";
+  const currentContentSections = React.useMemo(
+    () =>
+      product.rich_content
+        .map((page) => stripHtml(page.title ?? ""))
+        .filter(Boolean)
+        .slice(0, 5),
+    [product.rich_content],
+  );
+
+  const buildDraftFromState = React.useCallback(
+    (tick: number) =>
+      buildDraft({
+        title: product.name,
+        description: product.description,
+        businessSummary,
+        audience,
+        valueDrivers,
+        pricingShape,
+        tone,
+        deliveryNotes,
+        generationTick: tick,
+        currentContentSections,
+        currentReceiptButton: product.custom_view_content_button_text ?? "",
+        currentReceiptMessage: product.custom_receipt_text ?? "",
+        isCoffee,
+      }),
+    [
+      product.name,
+      product.description,
+      businessSummary,
+      audience,
+      valueDrivers,
+      pricingShape,
+      tone,
+      deliveryNotes,
+      currentContentSections,
+      product.custom_view_content_button_text,
+      product.custom_receipt_text,
+      isCoffee,
+    ],
+  );
+  const fallbackDraft = React.useMemo(() => buildDraftFromState(generationTick), [buildDraftFromState, generationTick]);
+  const draft = generatedDraft ?? fallbackDraft;
+
+  const intakeSteps = [
+    {
+      eyebrow: "Step 1 of 4",
+      title: "Start with the product or service",
+      description: "One clear sentence is fine",
+    },
+    {
+      eyebrow: "Step 2 of 4",
+      title: "Choose the audience",
+      description: "Target demographic for your product or service",
+    },
+    {
+      eyebrow: "Step 3 of 4",
+      title: "Pick what they should care about",
+      description: "Choose the main reason to buy",
+    },
+    {
+      eyebrow: "Step 4 of 4",
+      title: "Add optional details",
+      description: "A few light constraints before preview",
+    },
+  ];
+  const currentStep = intakeSteps[quizStep] ?? {
+    eyebrow: "Step 1 of 4",
+    title: "Start with the product or service",
+    description: "One clear sentence is fine",
+  };
+  const canContinue =
+    quizStep === 0
+      ? businessSummary.trim().length > 0
+      : quizStep === 1
+        ? audience.trim().length > 0
+        : quizStep === 2
+          ? valueDrivers.length > 0
+          : true;
+
+  const toggleValueDriver = (value: string) =>
+    setValueDrivers((current) =>
+      current.includes(value) ? current.filter((item) => item !== value) : [...current, value].slice(0, 2),
+    );
+
+  const generateDraft = async () => {
+    const nextGenerationTick = generationTick + 1;
+    setGenerationTick(nextGenerationTick);
+
+    const localDraft = buildDraftFromState(nextGenerationTick);
+    setGeneratedDraft(localDraft);
+    setHasGenerated(true);
+    setPreviewTab("product");
+    setPreviewSource("local");
+    setIsGenerating(true);
+
+    try {
+      const response = await request({
+        method: "POST",
+        url: "/internal/ai_product_page_drafts",
+        accept: "json",
+        data: {
+          product: {
+            name: product.name,
+            description: stripHtml(product.description),
+            rich_content_section_titles: currentContentSections,
+            receipt_button_text: product.custom_view_content_button_text ?? "",
+            receipt_custom_message: product.custom_receipt_text ?? "",
+          },
+          quiz: {
+            business_summary: businessSummary,
+            audience,
+            value_drivers: valueDrivers,
+            pricing_shape: pricingShape,
+            tone,
+            delivery_notes: deliveryNotes,
+            generation_tick: generationTick,
+          },
+        },
+      });
+
+      const result = await response.json();
+      if (isBuildWithAIApiResponse(result) && result.success) {
+        setGeneratedDraft(result.data);
+        setPreviewSource("api");
+      }
+    } catch {
+      // Keep the local fallback preview when the API is unavailable.
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
+  return (
+    <>
+      <Button
+        className="border-black bg-pink text-black hover:bg-pink/90 hover:text-black"
+        onClick={() => {
+          setHasGenerated(false);
+          setGeneratedDraft(null);
+          setPreviewSource(null);
+          setOpen(true);
+        }}
+      >
+        <Sparkle className="size-4" />
+        Build with AI
+      </Button>
+
+      <Modal
+        open={open}
+        onClose={() => {
+          setOpen(false);
+          setHasGenerated(false);
+          setGeneratedDraft(null);
+          setPreviewSource(null);
+          setIsGenerating(false);
+          setQuizStep(0);
+        }}
+        width="min(800px, 96vw)"
+        title="Build with AI"
+        footer={
+          <Button outline onClick={() => setOpen(false)}>
+            Cancel
+          </Button>
+        }
+      >
+        <div className="grid gap-6">
+          <div className="grid min-w-0 gap-4">
+            {quizStep === 0 ? (
+              <Alert role="status" variant="info">
+                Answer a few prompts, and we'll generate a polished output
+              </Alert>
+            ) : null}
+
+            <SectionCard title={currentStep.title} eyebrow={currentStep.eyebrow}>
+              <div className="grid w-full min-w-0 gap-4">
+                <div className="text-sm text-muted">{currentStep.description}</div>
+
+                {quizStep === 0 ? (
+                  <Fieldset className="w-full min-w-0">
+                    <FieldsetTitle>
+                      <Label htmlFor={`${uid}-business`}>What are you selling?</Label>
+                    </FieldsetTitle>
+                    <Textarea
+                      id={`${uid}-business`}
+                      value={businessSummary}
+                      placeholder="A coaching package for first-time founders"
+                      onChange={(evt) => setBusinessSummary(evt.target.value)}
+                      className="min-h-32 w-full max-w-full min-w-0 self-stretch"
+                    />
+                    <FieldsetDescription>Required</FieldsetDescription>
+                  </Fieldset>
+                ) : null}
+
+                {quizStep === 1 ? (
+                  <Fieldset>
+                    <FieldsetTitle>
+                      <Label htmlFor={`${uid}-audience`}>Who is it for?</Label>
+                    </FieldsetTitle>
+                    <Input
+                      id={`${uid}-audience`}
+                      value={audience}
+                      placeholder="Busy creators, designers, educators"
+                      onChange={(evt) => setAudience(evt.target.value)}
+                      className="w-full"
+                    />
+                    <FieldsetDescription>Required</FieldsetDescription>
+                  </Fieldset>
+                ) : null}
+
+                {quizStep === 2 ? (
+                  <Fieldset>
+                    <FieldsetTitle>What should buyers care about most?</FieldsetTitle>
+                    <div className="grid gap-2 sm:grid-cols-2">
+                      {valueDriverOptions.map((option) => (
+                        <Button
+                          key={option}
+                          type="button"
+                          outline={!valueDrivers.includes(option)}
+                          color={valueDrivers.includes(option) ? "primary" : undefined}
+                          className="w-full"
+                          onClick={() => toggleValueDriver(option)}
+                        >
+                          {option}
+                        </Button>
+                      ))}
+                    </div>
+                    <FieldsetDescription>Pick up to two</FieldsetDescription>
+                  </Fieldset>
+                ) : null}
+
+                {quizStep === 3 ? (
+                  <>
+                    <Fieldset>
+                      <FieldsetTitle>Pricing shape</FieldsetTitle>
+                      <div className="grid gap-2 sm:grid-cols-2">
+                        {pricingOptions.map((option) => (
+                          <Button
+                            key={option}
+                            type="button"
+                            outline={pricingShape !== option}
+                            color={pricingShape === option ? "primary" : undefined}
+                            onClick={() => setPricingShape(option)}
+                          >
+                            {option}
+                          </Button>
+                        ))}
+                      </div>
+                      <FieldsetDescription>Optional</FieldsetDescription>
+                    </Fieldset>
+                    <Fieldset>
+                      <FieldsetTitle>
+                        <Label htmlFor={`${uid}-tone`}>Tone</Label>
+                      </FieldsetTitle>
+                      <Input
+                        id={`${uid}-tone`}
+                        value={tone}
+                        placeholder="Premium, direct, calm, playful"
+                        onChange={(evt) => setTone(evt.target.value)}
+                        className="w-full"
+                      />
+                    </Fieldset>
+                    <Fieldset>
+                      <FieldsetTitle>
+                        <Label htmlFor={`${uid}-delivery`}>Anything else buyers should know?</Label>
+                      </FieldsetTitle>
+                      <Textarea
+                        id={`${uid}-delivery`}
+                        value={deliveryNotes}
+                        placeholder="What they get, how delivery works, or what outcome to emphasize"
+                        onChange={(evt) => setDeliveryNotes(evt.target.value)}
+                        className="min-h-24 w-full"
+                      />
+                    </Fieldset>
+                  </>
+                ) : null}
+
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <Button
+                    outline
+                    disabled={quizStep === 0}
+                    onClick={() => setQuizStep((step) => Math.max(step - 1, 0))}
+                  >
+                    Back
+                  </Button>
+                  {quizStep < intakeSteps.length - 1 ? (
+                    <Button
+                      className="border-black bg-pink text-black hover:bg-pink/90 hover:text-black"
+                      disabled={!canContinue}
+                      onClick={() => setQuizStep((step) => Math.min(step + 1, intakeSteps.length - 1))}
+                    >
+                      Continue
+                    </Button>
+                  ) : (
+                    <Button
+                      className="border-black bg-pink text-black hover:bg-pink/90 hover:text-black"
+                      disabled={isGenerating}
+                      onClick={() => {
+                        void generateDraft();
+                      }}
+                    >
+                      {isGenerating ? "Generating..." : "Generate draft"}
+                    </Button>
+                  )}
+                </div>
+              </div>
+            </SectionCard>
+          </div>
+
+          {hasGenerated ? (
+            <div className="grid min-w-0 gap-3 rounded border border-border bg-muted/20 p-3">
+              <div className="flex items-center justify-between gap-3">
+                <div className="text-sm font-bold">Draft preview</div>
+                {previewSource === "local" ? (
+                  <div className="text-xs tracking-wide text-muted uppercase">local preview</div>
+                ) : null}
+              </div>
+              <Tabs variant="buttons" className="grid min-w-0 grid-cols-3 gap-2">
+                <Tab asChild isSelected={previewTab === "product"}>
+                  <button type="button" onClick={() => setPreviewTab("product")}>
+                    Product
+                  </button>
+                </Tab>
+                <Tab asChild isSelected={previewTab === "content"}>
+                  <button type="button" onClick={() => setPreviewTab("content")}>
+                    Content
+                  </button>
+                </Tab>
+                <Tab asChild isSelected={previewTab === "receipt"}>
+                  <button type="button" onClick={() => setPreviewTab("receipt")}>
+                    Receipt
+                  </button>
+                </Tab>
+              </Tabs>
+              <div className="text-xs text-muted">These tabs are just for review</div>
+
+              {previewTab === "product" ? (
+                <SectionCard title="Product page" eyebrow="Generated">
+                  <div className="grid min-w-0 gap-3">
+                    <div className="grid gap-1">
+                      <div className="text-xs font-medium tracking-wide text-muted uppercase">Title</div>
+                      <div className="text-2xl leading-tight font-semibold">{draft.product.title}</div>
+                    </div>
+                    <div className="grid gap-1">
+                      <div className="text-xs font-medium tracking-wide text-muted uppercase">Description</div>
+                      {isCoffee ? (
+                        <pre className="text-base leading-relaxed whitespace-pre-wrap">{draft.product.description}</pre>
+                      ) : (
+                        <div
+                          className="rich-text text-base leading-relaxed"
+                          dangerouslySetInnerHTML={{ __html: draft.product.description }}
+                        />
+                      )}
+                    </div>
+                    <div className="grid gap-1">
+                      <div className="text-xs font-medium tracking-wide text-muted uppercase">Key benefits</div>
+                      <ul className="list-disc space-y-1 pl-5 text-sm">
+                        {draft.product.bullets.map((bullet) => (
+                          <li key={bullet}>{bullet}</li>
+                        ))}
+                      </ul>
+                    </div>
+                    <div className="grid gap-1">
+                      <div className="text-xs font-medium tracking-wide text-muted uppercase">Price suggestion</div>
+                      <div className="text-sm">{draft.product.priceSuggestion}</div>
+                    </div>
+                  </div>
+                </SectionCard>
+              ) : null}
+
+              {previewTab === "content" ? (
+                <SectionCard title="Content page" eyebrow="Generated">
+                  <div className="grid min-w-0 gap-3">
+                    <div className="text-sm leading-snug">{draft.content.outline}</div>
+                    <div className="grid gap-1">
+                      <div className="text-xs font-medium tracking-wide text-muted uppercase">Suggested sections</div>
+                      <ul className="list-disc space-y-1 pl-5 text-sm">
+                        {draft.content.sectionIdeas.map((section) => (
+                          <li key={section}>{section}</li>
+                        ))}
+                      </ul>
+                    </div>
+                    <div className="grid gap-1">
+                      <div className="text-xs font-medium tracking-wide text-muted uppercase">
+                        What is already there
+                      </div>
+                      <div className="text-sm text-muted">{joinWithCommas(draft.content.existingSections)}</div>
+                    </div>
+                    <div className="grid gap-1">
+                      <div className="text-xs font-medium tracking-wide text-muted uppercase">Pages to add</div>
+                      <ul className="list-disc space-y-1 pl-5 text-sm">
+                        {draft.content.pages.map((page) => (
+                          <li key={page.id}>{page.title}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  </div>
+                </SectionCard>
+              ) : null}
+
+              {previewTab === "receipt" ? (
+                <SectionCard title="Receipt page" eyebrow="Generated">
+                  <div className="grid min-w-0 gap-3">
+                    <div className="grid gap-1">
+                      <div className="text-xs font-medium tracking-wide text-muted uppercase">Button text</div>
+                      <div className="text-sm">{draft.receipt.buttonText}</div>
+                    </div>
+                    <div className="grid gap-1">
+                      <div className="text-xs font-medium tracking-wide text-muted uppercase">Custom message</div>
+                      <div className="text-sm leading-snug">{draft.receipt.customMessage}</div>
+                    </div>
+                  </div>
+                </SectionCard>
+              ) : null}
+
+              <details className="rounded border border-border bg-background">
+                <summary className="cursor-pointer list-none px-4 py-3 text-sm font-semibold">
+                  Why this works <span className="text-muted">▾</span>
+                </summary>
+                <div className="border-t border-border p-4">
+                  <div className="text-sm leading-snug">{draft.rationale}</div>
+                </div>
+              </details>
+
+              <div className="flex flex-wrap items-center gap-2">
+                <Button outline disabled={isGenerating} onClick={() => void generateDraft()}>
+                  {isGenerating ? "Generating..." : "Regenerate"}
+                </Button>
+                <Button
+                  className="border-black bg-pink text-black hover:bg-pink/90 hover:text-black"
+                  onClick={() => {
+                    onApply(draft);
+                    setOpen(false);
+                    setHasGenerated(false);
+                  }}
+                >
+                  Apply to product
+                </Button>
+              </div>
+            </div>
+          ) : null}
+        </div>
+      </Modal>
+    </>
+  );
+};

--- a/app/javascript/components/ProductEdit/ProductTab/DescriptionEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/DescriptionEditor.tsx
@@ -130,6 +130,8 @@ class Uploader implements DirectUploadDelegate {
 export const DescriptionEditor = ({
   id,
   initialDescription,
+  resetContent,
+  resetContentKey,
   onChange,
   publicFiles,
   updatePublicFiles,
@@ -138,6 +140,8 @@ export const DescriptionEditor = ({
 }: {
   id: string;
   initialDescription: string;
+  resetContent?: string | null;
+  resetContentKey?: number;
   onChange: (description: string) => void;
   publicFiles: PublicFileWithStatus[];
   updatePublicFiles: (updater: (prev: PublicFileWithStatus[]) => void) => void;
@@ -162,6 +166,11 @@ export const DescriptionEditor = ({
     },
     extensions: [PublicFileEmbed, MoveNode],
   });
+  React.useEffect(() => {
+    if (!editor || resetContent == null || resetContentKey == null || resetContentKey === 0) return;
+
+    editor.commands.setContent(resetContent, true);
+  }, [editor, resetContent, resetContentKey]);
   const [activeUploaders, setActiveUploaders] = React.useState<Map<string, Uploader>>(new Map());
   const deleteActiveUploader = (id: string) =>
     setActiveUploaders((prev) => {

--- a/app/javascript/components/ProductEdit/ProductTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/index.tsx
@@ -1,7 +1,6 @@
 import { Sparkle } from "@boxicons/react";
 import * as React from "react";
 
-import { saveProduct } from "$app/data/product_edit";
 import { COFFEE_CUSTOM_BUTTON_TEXT_OPTIONS, CUSTOM_BUTTON_TEXT_OPTIONS } from "$app/parsers/product";
 import { currencyCodeList } from "$app/utils/currency";
 import { recurrenceIds, recurrenceLabels } from "$app/utils/recurringPricing";
@@ -36,7 +35,6 @@ import { TiersEditor } from "$app/components/ProductEdit/ProductTab/TiersEditor"
 import { VersionsEditor } from "$app/components/ProductEdit/ProductTab/VersionsEditor";
 import { RefundPolicySelector } from "$app/components/ProductEdit/RefundPolicy";
 import { useProductEditContext } from "$app/components/ProductEdit/state";
-import { showAlert } from "$app/components/server-components/Alert";
 import { ToggleSettingRow } from "$app/components/SettingRow";
 import { TypeSafeOptionSelect } from "$app/components/TypeSafeOptionSelect";
 import { Alert } from "$app/components/ui/Alert";
@@ -45,8 +43,6 @@ import { Input } from "$app/components/ui/Input";
 import { Label } from "$app/components/ui/Label";
 import { Switch } from "$app/components/ui/Switch";
 import { Textarea } from "$app/components/ui/Textarea";
-
-import { AIProductPageAssistant, type BuildWithAIDraft } from "./AIProductPageAssistant";
 
 export const ProductTab = () => {
   const uid = React.useId();
@@ -67,12 +63,12 @@ export const ProductTab = () => {
     seller_refund_policy_enabled,
     cancellationDiscountsEnabled,
     aiGenerated,
+    descriptionResetKey,
   } = useProductEditContext();
   const [initialProduct] = React.useState(product);
 
   const [thumbnail, setThumbnail] = React.useState(initialThumbnail);
   const [showAiNotification, setShowAiNotification] = React.useState(aiGenerated);
-  const [descriptionResetKey, setDescriptionResetKey] = React.useState(0);
 
   const { isUploading, setImagesUploading } = useImageUpload();
 
@@ -81,38 +77,11 @@ export const ProductTab = () => {
   const isCoffee = product.native_type === "coffee";
 
   const url = useProductUrl();
-  const applyAiSuggestion = (draft: BuildWithAIDraft) => {
-    const contentPages = draft.content.pages.map((page) => ({
-      ...page,
-      description: JSON.parse(JSON.stringify(page.description)),
-    }));
-    const nextProduct: typeof product = {
-      ...product,
-      name: draft.product.title,
-      description: draft.product.description,
-      custom_summary: draft.content.outline,
-      has_same_rich_content_for_all_variants: true,
-      rich_content: contentPages,
-      custom_view_content_button_text: draft.receipt.buttonText,
-      custom_receipt_text: draft.receipt.customMessage,
-    };
-
-    updateProduct(nextProduct);
-    setDescriptionResetKey((value) => value + 1);
-
-    void saveProduct(uniquePermalink, id, nextProduct, currencyType).catch((e) => {
-      showAlert(e instanceof Error ? e.message : "Something went wrong.", "error");
-    });
-  };
 
   if (!currentSeller) return null;
 
   return (
-    <Layout
-      preview={<ProductPreview showRefundPolicyModal={showRefundPolicyPreview} />}
-      isLoading={isUploading}
-      topActions={<AIProductPageAssistant onApply={applyAiSuggestion} />}
-    >
+    <Layout preview={<ProductPreview showRefundPolicyModal={showRefundPolicyPreview} />} isLoading={isUploading}>
       <div className="squished">
         <form>
           <section className="grid gap-8 p-4! md:p-8!">

--- a/app/javascript/components/ProductEdit/ProductTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/index.tsx
@@ -1,6 +1,7 @@
 import { Sparkle } from "@boxicons/react";
 import * as React from "react";
 
+import { saveProduct } from "$app/data/product_edit";
 import { COFFEE_CUSTOM_BUTTON_TEXT_OPTIONS, CUSTOM_BUTTON_TEXT_OPTIONS } from "$app/parsers/product";
 import { currencyCodeList } from "$app/utils/currency";
 import { recurrenceIds, recurrenceLabels } from "$app/utils/recurringPricing";
@@ -35,6 +36,7 @@ import { TiersEditor } from "$app/components/ProductEdit/ProductTab/TiersEditor"
 import { VersionsEditor } from "$app/components/ProductEdit/ProductTab/VersionsEditor";
 import { RefundPolicySelector } from "$app/components/ProductEdit/RefundPolicy";
 import { useProductEditContext } from "$app/components/ProductEdit/state";
+import { showAlert } from "$app/components/server-components/Alert";
 import { ToggleSettingRow } from "$app/components/SettingRow";
 import { TypeSafeOptionSelect } from "$app/components/TypeSafeOptionSelect";
 import { Alert } from "$app/components/ui/Alert";
@@ -43,6 +45,8 @@ import { Input } from "$app/components/ui/Input";
 import { Label } from "$app/components/ui/Label";
 import { Switch } from "$app/components/ui/Switch";
 import { Textarea } from "$app/components/ui/Textarea";
+
+import { AIProductPageAssistant, type BuildWithAIDraft } from "./AIProductPageAssistant";
 
 export const ProductTab = () => {
   const uid = React.useId();
@@ -68,6 +72,7 @@ export const ProductTab = () => {
 
   const [thumbnail, setThumbnail] = React.useState(initialThumbnail);
   const [showAiNotification, setShowAiNotification] = React.useState(aiGenerated);
+  const [descriptionResetKey, setDescriptionResetKey] = React.useState(0);
 
   const { isUploading, setImagesUploading } = useImageUpload();
 
@@ -76,11 +81,38 @@ export const ProductTab = () => {
   const isCoffee = product.native_type === "coffee";
 
   const url = useProductUrl();
+  const applyAiSuggestion = (draft: BuildWithAIDraft) => {
+    const contentPages = draft.content.pages.map((page) => ({
+      ...page,
+      description: JSON.parse(JSON.stringify(page.description)),
+    }));
+    const nextProduct: typeof product = {
+      ...product,
+      name: draft.product.title,
+      description: draft.product.description,
+      custom_summary: draft.content.outline,
+      has_same_rich_content_for_all_variants: true,
+      rich_content: contentPages,
+      custom_view_content_button_text: draft.receipt.buttonText,
+      custom_receipt_text: draft.receipt.customMessage,
+    };
+
+    updateProduct(nextProduct);
+    setDescriptionResetKey((value) => value + 1);
+
+    void saveProduct(uniquePermalink, id, nextProduct, currencyType).catch((e) => {
+      showAlert(e instanceof Error ? e.message : "Something went wrong.", "error");
+    });
+  };
 
   if (!currentSeller) return null;
 
   return (
-    <Layout preview={<ProductPreview showRefundPolicyModal={showRefundPolicyPreview} />} isLoading={isUploading}>
+    <Layout
+      preview={<ProductPreview showRefundPolicyModal={showRefundPolicyPreview} />}
+      isLoading={isUploading}
+      topActions={<AIProductPageAssistant onApply={applyAiSuggestion} />}
+    >
       <div className="squished">
         <form>
           <section className="grid gap-8 p-4! md:p-8!">
@@ -139,6 +171,8 @@ export const ProductTab = () => {
                 <DescriptionEditor
                   id={id}
                   initialDescription={initialProduct.description}
+                  resetContent={product.description}
+                  resetContentKey={descriptionResetKey}
                   onChange={(description) => updateProduct({ description })}
                   setImagesUploading={setImagesUploading}
                   publicFiles={product.public_files}

--- a/app/javascript/components/ProductEdit/state.ts
+++ b/app/javascript/components/ProductEdit/state.ts
@@ -195,7 +195,9 @@ export const ProductEditContext = React.createContext<{
   s3Url: string;
   availableCountries: ShippingCountry[];
   saving: boolean;
-  save: () => Promise<void>;
+  save: (productOverride?: Product) => Promise<void>;
+  descriptionResetKey: number;
+  setDescriptionResetKey: React.Dispatch<React.SetStateAction<number>>;
   googleClientId: string;
   googleCalendarEnabled: boolean;
   seller_refund_policy_enabled: boolean;

--- a/app/javascript/components/server-components/ProductEditPage.tsx
+++ b/app/javascript/components/server-components/ProductEditPage.tsx
@@ -146,6 +146,7 @@ const ProductEditPage = (props: Props) => {
   const [product, setProduct] = React.useState(props.product);
   const [contentUpdates, setContentUpdates] = React.useState<ContentUpdates>(null);
   const [currencyType, setCurrencyType] = React.useState<CurrencyCode>(props.currency_type);
+  const [descriptionResetKey, setDescriptionResetKey] = React.useState(0);
   const lastSavedProductRef = React.useRef<Product>(structuredClone(props.product));
 
   const updateProduct = (update: Partial<Product> | ((product: Product) => void)) =>
@@ -160,20 +161,20 @@ const ProductEditPage = (props: Props) => {
 
   const [saving, setSaving] = React.useState(false);
   const [imagesUploading, setImagesUploading] = React.useState<Set<File>>(new Set());
-  const save = async () => {
+  const save = async (productToSave = product) => {
     try {
       setSaving(true);
-      const response = await saveProduct(props.unique_permalink, props.id, product, currencyType);
+      const response = await saveProduct(props.unique_permalink, props.id, productToSave, currencyType);
       if (response.warning_message) showAlert(response.warning_message, "warning");
       else {
         const { contentUpdatedVariantIds, sharedContentUpdated } = findUpdatedContent(
-          product,
+          productToSave,
           lastSavedProductRef.current,
         );
         const contentUpdated = sharedContentUpdated || contentUpdatedVariantIds.length > 0;
 
         if (props.successful_sales_count > 0 && contentUpdated) {
-          const uniquePermalinkOrVariantIds = product.has_same_rich_content_for_all_variants
+          const uniquePermalinkOrVariantIds = productToSave.has_same_rich_content_for_all_variants
             ? [props.unique_permalink]
             : contentUpdatedVariantIds;
 
@@ -183,7 +184,7 @@ const ProductEditPage = (props: Props) => {
         } else {
           showAlert("Changes saved!", "success");
         }
-        lastSavedProductRef.current = structuredClone(product);
+        lastSavedProductRef.current = structuredClone(productToSave);
       }
     } catch (e) {
       assertResponseError(e);
@@ -206,9 +207,11 @@ const ProductEditPage = (props: Props) => {
       saving,
       contentUpdates,
       setContentUpdates,
+      descriptionResetKey,
+      setDescriptionResetKey,
       filesById,
     }),
-    [product, updateProduct, existingFiles, setExistingFiles, filesById],
+    [product, updateProduct, existingFiles, setExistingFiles, filesById, descriptionResetKey],
   );
 
   const imageSettings = React.useMemo(

--- a/app/services/ai/product_details_generator_service.rb
+++ b/app/services/ai/product_details_generator_service.rb
@@ -5,6 +5,7 @@ class Ai::ProductDetailsGeneratorService
   class InvalidPromptError < StandardError; end
 
   PRODUCT_DETAILS_GENERATION_TIMEOUT_IN_SECONDS = 30
+  PRODUCT_PAGE_DRAFT_GENERATION_TIMEOUT_IN_SECONDS = 45
   RICH_CONTENT_PAGES_GENERATION_TIMEOUT_IN_SECONDS = 90
   COVER_IMAGE_GENERATION_TIMEOUT_IN_SECONDS = 90
 
@@ -86,6 +87,81 @@ class Ai::ProductDetailsGeneratorService
     end
 
     result.merge(duration_in_seconds: duration)
+  end
+
+  def generate_product_page_draft(product:, quiz:)
+    product = product.to_h.symbolize_keys
+    quiz = quiz.to_h.symbolize_keys
+
+    result, duration = with_retries(operation: "Generate product page draft", context: product[:name] || quiz[:business_summary]) do
+      response = openai_client(PRODUCT_PAGE_DRAFT_GENERATION_TIMEOUT_IN_SECONDS).chat(
+        parameters: {
+          model: "gpt-4o-mini",
+          messages: [
+            {
+              role: "system",
+              content: %Q{
+                You help Gumroad creators build a complete product page experience.
+                Use the supplied JSON context to write a concise, practical draft that feels useful to a creator.
+
+                Return JSON only in this format:
+                {
+                  "product": {
+                    "title": "Short, natural title",
+                    "description": "Safe HTML using only <p>, <ul>, <ol>, <li>, <h2>, <h3>, <h4>, <strong>, and <em>",
+                    "bullets": ["Short benefit", "Short benefit"],
+                    "priceSuggestion": "Consider $29-$99"
+                  },
+                  "content": {
+                    "outline": "One-sentence outline for the content page",
+                    "sectionIdeas": ["Section 1", "Section 2", "Section 3"],
+                    "pages": [
+                      {
+                        "id": "page-id",
+                        "title": "Start here",
+                        "description": {
+                          "type": "doc",
+                          "content": [
+                            { "type": "paragraph", "content": [ { "type": "text", "text": "Short page copy" } ] }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  "receipt": {
+                    "buttonText": "View content",
+                    "customMessage": "Short buyer-friendly receipt copy"
+                  },
+                  "rationale": "One or two plain-language sentences explaining why this draft works",
+                  "missingInfo": ["Optional follow-up prompt"]
+                }
+
+                Keep the response short, specific, and aligned to the seller's audience and offer. The content pages should be simple and ready to preview. The receipt copy should feel helpful, not technical.
+              }.split("\n").map(&:strip).join("\n")
+            },
+            {
+              role: "user",
+              content: {
+                product:,
+                quiz:,
+                current_content_section_titles: Array(product[:rich_content_section_titles]),
+                current_receipt_button_text: product[:receipt_button_text].to_s,
+                current_receipt_custom_message: product[:receipt_custom_message].to_s
+              }.to_json
+            }
+          ],
+          response_format: { type: "json_object" },
+          temperature: 0.5
+        }
+      )
+
+      content = response.dig("choices", 0, "message", "content")
+      raise "Failed to generate product page draft - no content returned" if content.blank?
+
+      JSON.parse(content, symbolize_names: true)
+    end
+
+    normalize_product_page_draft(result, product:, quiz:).merge(duration_in_seconds: duration)
   end
 
   # @param product_name [String] The product name
@@ -214,5 +290,78 @@ class Ai::ProductDetailsGeneratorService
           raise MaxRetriesExceededError, "Failed to perform '#{operation}' after #{max_tries} attempts: #{e.message}"
         end
       end
+    end
+
+    def normalize_product_page_draft(result, product:, quiz:)
+      current_content_sections = Array(product[:rich_content_section_titles]).map { |value| value.to_s.strip }.reject(&:blank?)
+      current_content_sections = ["No existing content yet, so the agent would start a first draft outline"] if current_content_sections.empty?
+
+      content = value_for(result, :content) || {}
+      product_result = value_for(result, :product) || {}
+      receipt = value_for(result, :receipt) || {}
+
+      pages = Array(value_for(content, :pages)).first(3).map.with_index do |page, index|
+        normalize_draft_page(page, index)
+      end
+
+      {
+        product: {
+          title: value_for(product_result, :title).presence || product[:name].to_s.presence || "Your product",
+          description: value_for(product_result, :description).presence || "<p>Built for your buyers.</p>",
+          bullets: Array(value_for(product_result, :bullets)).map(&:to_s).map(&:strip).reject(&:blank?),
+          priceSuggestion: value_for(product_result, :priceSuggestion).presence || "Consider $29-$79"
+        },
+        content: {
+          outline: value_for(content, :outline).presence || "A lightweight structure that keeps the buying journey simple",
+          sectionIdeas: Array(value_for(content, :sectionIdeas)).map(&:to_s).map(&:strip).reject(&:blank?),
+          existingSections: current_content_sections,
+          pages: pages
+        },
+        receipt: {
+          buttonText: truncate_string(value_for(receipt, :buttonText).presence || "View content", 26),
+          customMessage: value_for(receipt, :customMessage).presence || "Thanks for buying. Start with the first step inside."
+        },
+        rationale: value_for(result, :rationale).presence || "This draft makes the offer easier to scan and connects the product, content, and receipt flow for the buyer.",
+        missingInfo: Array(value_for(result, :missingInfo)).map(&:to_s).map(&:strip).reject(&:blank?)
+      }
+    end
+
+    def normalize_draft_page(page, index)
+      page = page.to_h.symbolize_keys
+      description = value_for(page, :description)
+
+      {
+        id: value_for(page, :id).presence || SecureRandom.uuid,
+        title: value_for(page, :title).presence || "Page #{index + 1}",
+        description: normalize_draft_page_description(description, value_for(page, :title).presence || "Page #{index + 1}"),
+        updated_at: value_for(page, :updated_at).presence || Time.current.iso8601
+      }
+    end
+
+    def normalize_draft_page_description(description, fallback_title)
+      return description if description.is_a?(Hash)
+
+      text = description.to_s.strip
+      text = "#{fallback_title} content" if text.blank?
+
+      {
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              { type: "text", text: text }
+            ]
+          }
+        ]
+      }
+    end
+
+    def value_for(hash, key)
+      hash[key] || hash[key.to_s]
+    end
+
+    def truncate_string(value, max_length)
+      value.length > max_length ? "#{value.slice(0, max_length).rstrip}…" : value
     end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1003,6 +1003,7 @@ Rails.application.routes.draw do
         end
 
         resources :ai_product_details_generations, only: [:create]
+        resources :ai_product_page_drafts, only: [:create]
       end
     end
 


### PR DESCRIPTION
**WHAT** -- Added an AI Product Page Assistant inside the Product page editor

- New **"Build with AI"** button guides creators through a short prompt flow
- Generates drafts for product title, description, benefit bullets, pricing guidance, content outline, and receipt copy
- Lets creators preview the draft before applying it to the Product/Content/Receipt tabs
- Includes a local fallback preview if the API endpoint isn’t available

**WHY** -- Creators often know _what_ they want to sell, but not _how_ to present it clearly. This feature helps turn rough inputs into a more polished, sales-ready product page

**HOW IT WORKS**

- Collects a few lightweight prompts about the offer, audience, and priorities
- Sends one structured payload to a Rails-backed AI endpoint (currently defaults to a local fallback)
- Returns one draft covering product, content, and receipt copy
- Applies the draft back into the editor after review

**TESTING**

- Verified in the browser
- Ran lint on the edited frontend files
- Ran Ruby syntax checks on the new controller and service
____________________________________________________________

**SCREENSHOTS**

- **Image 1:** "Build with AI" button added to the editor
<img width="1676" height="1120" alt="1" src="https://github.com/user-attachments/assets/70804d3e-90fb-44c0-baf2-03dcf592ec70" />

- **Image 2:** Guided modal flow with a few quick prompts
<img width="1676" height="1120" alt="2" src="https://github.com/user-attachments/assets/53983fdf-7e9c-4cc3-899a-85c5498d5ac2" />

- **Image 3:** Generated draft preview across Product, Content, and Receipt
<img width="1676" height="1120" alt="5" src="https://github.com/user-attachments/assets/8953e1a5-a076-41b4-a11c-5858d8febafc" />

- **Image 4:** Draft applied back into the editor
<img width="1676" height="1120" alt="6" src="https://github.com/user-attachments/assets/562c28c7-fb2c-4731-b3f3-c9bced907b91" />