### PR TITLE
Capture failure_reason and error_message for Stripe payout failures

### DIFF
--- a/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
+++ b/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
@@ -133,6 +133,7 @@ class StripePayoutProcessor
   #   * Setting the amount_cents.
   # Returns an array of errors.
   def self.prepare_payment_and_set_amount(payment, balances)
+    failed = false
     merchant_account, balances_held_by_gumroad, balances_held_by_stripe = get_payout_details(payment.user, balances)
 
     if merchant_account.nil?
@@ -229,6 +230,8 @@ class StripePayoutProcessor
   # Public: Actually sends the money.
   # Returns an array of errors.
   def self.perform_payment(payment)
+    failed = false
+    failure_reason = nil
     # We have transferred the balance held by gumroad to the connected Stripe standard account.
     # No payout needs to be issued in this case.
     merchant_account = payment.user.merchant_accounts.find_by(charge_processor_merchant_id: payment.stripe_connect_account_id)
@@ -291,8 +294,10 @@ class StripePayoutProcessor
     Rails.logger.info("Payouts: Payout of #{payment.amount_cents} attempted for user with id: #{payment.user_id}")
     if failed
       payment.mark_failed!(failure_reason)
-      reverse_internal_transfer!(payment)
+      # Mark the bank account deleted before the reversal so a transient Stripe error
+      # in `reverse_internal_transfer!` cannot leave a dead bank reference alive for the next nightly run.
       payment.bank_account&.mark_deleted! if failure_reason == Payment::FailureReason::BANK_ACCOUNT_NOT_FOUND_AT_STRIPE
+      reverse_internal_transfer!(payment)
     end
   end
 

--- a/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
+++ b/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
@@ -194,17 +194,21 @@ class StripePayoutProcessor
     []
   rescue Stripe::InvalidRequestError => e
     failed = true
+    payment.error_message = e.message.to_s.truncate(1000)
     ErrorNotifier.notify(e)
     [e.message]
-  rescue Stripe::AuthenticationError, Stripe::APIConnectionError
+  rescue Stripe::AuthenticationError, Stripe::APIConnectionError => e
     failed = true
+    payment.error_message = "#{e.class.name}: #{e.message}".truncate(1000)
     raise
   rescue Stripe::StripeError => e
     failed = true
+    payment.error_message = e.message.to_s.truncate(1000)
     ErrorNotifier.notify(e)
     [e.message]
-  rescue RuntimeError
+  rescue RuntimeError => e
     failed = true
+    payment.error_message = "#{e.class.name}: #{e.message}".truncate(1000)
     raise
   ensure
     payment.mark_failed! if failed
@@ -268,22 +272,18 @@ class StripePayoutProcessor
     []
   rescue Stripe::InvalidRequestError => e
     failed = true
-    if e.message["Cannot create live transfers"] || e.message["Cannot create payouts"]
-      failure_reason = Payment::FailureReason::CANNOT_PAY
-    elsif e.message["Debit card transfers are only supported for amounts less"]
-      failure_reason = Payment::FailureReason::DEBIT_CARD_LIMIT
-    elsif e.message["Insufficient funds in Stripe account"]
-      failure_reason = Payment::FailureReason::INSUFFICIENT_FUNDS
-    else
-      ErrorNotifier.notify(e)
-    end
+    failure_reason = stripe_invalid_request_error_failure_reason(e)
+    ErrorNotifier.notify(e) if failure_reason.nil?
+    payment.error_message = e.message.to_s.truncate(1000)
     Rails.logger.info("Payouts: Payout errors for user with id: #{payment.user_id} #{e.message}")
     [e.message]
-  rescue Stripe::AuthenticationError, Stripe::APIConnectionError
+  rescue Stripe::AuthenticationError, Stripe::APIConnectionError => e
     failed = true
+    payment.error_message = "#{e.class.name}: #{e.message}".truncate(1000)
     raise
   rescue Stripe::StripeError => e
     failed = true
+    payment.error_message = e.message.to_s.truncate(1000)
     ErrorNotifier.notify(e)
     Rails.logger.info("Payouts: Payout errors for user with id: #{payment.user_id} #{e.message}")
     [e.message]
@@ -292,8 +292,23 @@ class StripePayoutProcessor
     if failed
       payment.mark_failed!(failure_reason)
       reverse_internal_transfer!(payment)
+      payment.bank_account&.mark_deleted! if failure_reason == Payment::FailureReason::BANK_ACCOUNT_NOT_FOUND_AT_STRIPE
     end
   end
+
+  def self.stripe_invalid_request_error_failure_reason(error)
+    case error.message.to_s
+    when /Cannot create live transfers/, /Cannot create payouts/
+      Payment::FailureReason::CANNOT_PAY
+    when /Debit card transfers are only supported for amounts less/
+      Payment::FailureReason::DEBIT_CARD_LIMIT
+    when /Insufficient funds in Stripe account/
+      Payment::FailureReason::INSUFFICIENT_FUNDS
+    when /has been deleted and can no longer be used/
+      Payment::FailureReason::BANK_ACCOUNT_NOT_FOUND_AT_STRIPE
+    end
+  end
+  private_class_method :stripe_invalid_request_error_failure_reason
 
   def self.handle_stripe_event(stripe_event, stripe_connect_account_id:)
     stripe_event_id = stripe_event["id"]

--- a/app/models/bank_account.rb
+++ b/app/models/bank_account.rb
@@ -97,7 +97,7 @@ class BankAccount < ApplicationRecord
 
       external_account.available_payout_methods.include?("instant")
     rescue Stripe::StripeError => e
-      ErrorNotifier.notify(e)
+      ErrorNotifier.notify(e) unless e.message.to_s.include?("has been deleted and can no longer be used")
       false
     end
   end

--- a/app/models/concerns/payment/failure_reason.rb
+++ b/app/models/concerns/payment/failure_reason.rb
@@ -6,6 +6,7 @@ module Payment::FailureReason
   CANNOT_PAY = "cannot_pay"
   DEBIT_CARD_LIMIT = "debit_card_limit"
   INSUFFICIENT_FUNDS = "insufficient_funds"
+  BANK_ACCOUNT_NOT_FOUND_AT_STRIPE = "bank_account_not_found_at_stripe"
 
   PAYPAL_MASS_PAY = {
     "PAYPAL 1000" => "Unknown error",
@@ -81,6 +82,10 @@ module Payment::FailureReason
     "account_frozen" => {
       reason: "the bank account has been frozen",
       solution: "Use another bank account",
+    },
+    "bank_account_not_found_at_stripe" => {
+      reason: "the bank account on file at Stripe was replaced, so payouts can no longer be sent to the saved reference",
+      solution: "Re-add the bank account in payout settings to refresh the saved reference",
     },
     "bank_account_restricted" => {
       reason: "the bank account has restrictions on either the type, or the number, of payouts allowed. This normally indicates that the bank account is a savings or other non-checking account",

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -28,6 +28,7 @@ class Payment < ApplicationRecord
   attr_json_data_accessor :arrival_date
   attr_json_data_accessor :payout_type
   attr_json_data_accessor :gumroad_fee_cents
+  attr_json_data_accessor :error_message
 
   # Payment state transitions:
   #

--- a/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
+++ b/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
@@ -840,7 +840,6 @@ describe StripePayoutProcessor, :vcr do
         expect(errors.first).to match(/You have insufficient funds in your Stripe account for this transfer/)
       end
     end
-
   end
 
   describe "perform_payment for a US account with instant payout method type" do
@@ -3665,6 +3664,18 @@ describe StripePayoutProcessor, :vcr do
         expect { described_class.perform_payment(payment) }
           .to change { user.comments.with_type_payout_note.count }.by(1)
         expect(user.comments.with_type_payout_note.last.content).to include("Re-add the bank account in payout settings")
+      end
+
+      context "and the internal transfer reversal raises a transient Stripe error afterwards" do
+        before do
+          payment.update!(stripe_internal_transfer_id: "tr_test_xxx")
+          allow(Stripe::Transfer).to receive(:retrieve).and_raise(Stripe::APIConnectionError.new("connection refused"))
+        end
+
+        it "still marks the bank account deleted before the reversal runs" do
+          expect { described_class.perform_payment(payment) }.to raise_error(Stripe::APIConnectionError)
+          expect(bank_account.reload.deleted_at).to be_present
+        end
       end
     end
 

--- a/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
+++ b/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
@@ -840,6 +840,7 @@ describe StripePayoutProcessor, :vcr do
         expect(errors.first).to match(/You have insufficient funds in your Stripe account for this transfer/)
       end
     end
+
   end
 
   describe "perform_payment for a US account with instant payout method type" do
@@ -3610,6 +3611,103 @@ describe StripePayoutProcessor, :vcr do
 
       it "returns 0" do
         expect(described_class.instantly_payable_amount_cents_on_stripe(user)).to eq(0)
+      end
+    end
+  end
+
+  describe ".perform_payment Stripe error handling" do
+    let(:user) { create(:user) }
+    let(:bank_account) { create(:ach_account, user:, stripe_connect_account_id: "acct_test_xxx", stripe_bank_account_id: "ba_test_xxx") }
+    let!(:merchant_account) do
+      create(:merchant_account, user:, charge_processor_merchant_id: "acct_test_xxx", currency: "usd")
+    end
+    let(:payment) do
+      create(:payment,
+             user:, bank_account:, processor: PayoutProcessorType::STRIPE,
+             state: "processing", amount_cents: 1_000,
+             stripe_connect_account_id: merchant_account.charge_processor_merchant_id,
+             currency: "usd",
+             payout_period_end_date: Date.current - 1,
+             correlation_id: nil,
+             payout_type: Payouts::PAYOUT_TYPE_STANDARD)
+    end
+
+    context "when Stripe rejects the payout because the destination bank account has been deleted" do
+      let(:stripe_error_message) do
+        "The bank account ba_test_xxx has been deleted and can no longer be used."
+      end
+
+      before do
+        allow(Stripe::Payout).to receive(:create).and_raise(Stripe::InvalidRequestError.new(stripe_error_message, "destination"))
+      end
+
+      it "marks the payment with failure_reason BANK_ACCOUNT_NOT_FOUND_AT_STRIPE" do
+        described_class.perform_payment(payment)
+        expect(payment.reload.failure_reason).to eq(Payment::FailureReason::BANK_ACCOUNT_NOT_FOUND_AT_STRIPE)
+      end
+
+      it "marks the bank account deleted so subsequent runs skip until the seller re-adds it" do
+        expect { described_class.perform_payment(payment) }
+          .to change { bank_account.reload.deleted_at }.from(nil)
+      end
+
+      it "stores the Stripe error message on the payment" do
+        described_class.perform_payment(payment)
+        expect(payment.reload.error_message).to eq(stripe_error_message)
+      end
+
+      it "does not notify the error tracker" do
+        expect(ErrorNotifier).not_to receive(:notify)
+        described_class.perform_payment(payment)
+      end
+
+      it "adds a payout note directing the seller to re-add their bank account" do
+        expect { described_class.perform_payment(payment) }
+          .to change { user.comments.with_type_payout_note.count }.by(1)
+        expect(user.comments.with_type_payout_note.last.content).to include("Re-add the bank account in payout settings")
+      end
+    end
+
+    context "when Stripe raises an unmatched Stripe::InvalidRequestError" do
+      before do
+        allow(Stripe::Payout).to receive(:create).and_raise(Stripe::InvalidRequestError.new("Something unexpected.", "param"))
+      end
+
+      it "captures the error message on the payment" do
+        described_class.perform_payment(payment)
+        expect(payment.reload.error_message).to eq("Something unexpected.")
+      end
+
+      it "leaves failure_reason nil so the existing flow is unchanged" do
+        described_class.perform_payment(payment)
+        expect(payment.reload.failure_reason).to be_nil
+      end
+
+      it "still notifies the error tracker for unmatched errors" do
+        expect(ErrorNotifier).to receive(:notify)
+        described_class.perform_payment(payment)
+      end
+    end
+
+    context "when Stripe raises a generic Stripe::StripeError" do
+      before do
+        allow(Stripe::Payout).to receive(:create).and_raise(Stripe::StripeError.new("Generic Stripe error."))
+      end
+
+      it "captures the error message on the payment" do
+        described_class.perform_payment(payment)
+        expect(payment.reload.error_message).to eq("Generic Stripe error.")
+      end
+    end
+
+    context "when Stripe raises Stripe::APIConnectionError" do
+      before do
+        allow(Stripe::Payout).to receive(:create).and_raise(Stripe::APIConnectionError.new("connection refused"))
+      end
+
+      it "re-raises the error and stores the class and message on the payment" do
+        expect { described_class.perform_payment(payment) }.to raise_error(Stripe::APIConnectionError)
+        expect(payment.reload.error_message).to eq("Stripe::APIConnectionError: connection refused")
       end
     end
   end

--- a/spec/models/bank_account_spec.rb
+++ b/spec/models/bank_account_spec.rb
@@ -63,6 +63,27 @@ describe BankAccount do
         it "returns false" do
           expect(bank_account.supports_instant_payouts?).to be false
         end
+
+        it "notifies the error tracker" do
+          expect(ErrorNotifier).to receive(:notify)
+          bank_account.supports_instant_payouts?
+        end
+      end
+
+      context "when stripe says the bank account has been deleted" do
+        before do
+          allow(Stripe::Account).to receive(:retrieve_external_account)
+            .and_raise(Stripe::InvalidRequestError.new("The bank account ba_xxx has been deleted and can no longer be used.", "external_account"))
+        end
+
+        it "returns false" do
+          expect(bank_account.supports_instant_payouts?).to be false
+        end
+
+        it "does not notify the error tracker" do
+          expect(ErrorNotifier).not_to receive(:notify)
+          bank_account.supports_instant_payouts?
+        end
       end
     end
   end

--- a/spec/models/concerns/payment/failure_reason_spec.rb
+++ b/spec/models/concerns/payment/failure_reason_spec.rb
@@ -55,6 +55,18 @@ describe Payment::FailureReason do
           end
         end
 
+        context "when failure reason is bank_account_not_found_at_stripe" do
+          it "adds a payout note explaining the bank account needs to be re-added" do
+            expect do
+              payment.mark_failed!(Payment::FailureReason::BANK_ACCOUNT_NOT_FOUND_AT_STRIPE)
+            end.to change { payment.user.comments.count }.by(1)
+
+            payout_note = "Payout via Stripe on #{payment.created_at} failed because the bank account on file at Stripe was replaced, so payouts can no longer be sent to the saved reference. "
+            payout_note += "Solution: Re-add the bank account in payout settings to refresh the saved reference."
+            expect(payment.user.comments.last.content).to eq payout_note
+          end
+        end
+
         context "when solution is not present" do
           it "doesn't add payout note to the user" do
             expect do


### PR DESCRIPTION
Closes https://github.com/antiwork/gumroad-private/issues/334

## What

When a Stripe payout fails, the rescue branches in `StripePayoutProcessor.perform_payment` only set `failure_reason` for three hardcoded message substrings (`Cannot create live transfers`, `Debit card transfers are only supported`, `Insufficient funds in Stripe account`). Every other Stripe error - any unmatched `Stripe::InvalidRequestError`, any `Stripe::StripeError` subclass, and auth/connection errors - falls through to `mark_failed!(nil)` and the `failure_reason` column ends up null in the DB. The error goes to Sentry, but with no Gumroad-side tag tying it to a user, triage requires correlating by external IDs (e.g. `ba_…`).

This PR:

- Adds `Payment::FailureReason::BANK_ACCOUNT_NOT_FOUND_AT_STRIPE` plus a `STRIPE_FAILURE_SOLUTIONS` entry directing the seller to re-add their bank account. Maps the Stripe error string `has been deleted and can no longer be used` (the canonical signal Stripe sends when an external account ID has been replaced - usually after a Financial Connections session, e.g. Stripe Capital onboarding).
- Refactors the substring matching in `perform_payment` into a private `stripe_invalid_request_error_failure_reason` helper.
- When that specific reason fires, also calls `payment.bank_account.mark_deleted!`. Without this, the nightly run will keep producing failed `Payment` rows against the same dead reference until the seller manually re-adds the account.
- Adds an `attr_json_data_accessor :error_message` on `Payment` and stores `e.message` (truncated to 1000 chars) in `payment.json_data["error_message"]` in every Stripe rescue branch (both `perform_payment` and `prepare_payment_and_set_amount`). So next time an unmatched Stripe error fires, the message is in the DB without needing Sentry.
- Updates `BankAccount#supports_instant_payouts?` to skip `ErrorNotifier.notify` for the same `has been deleted and can no longer be used` message - that method runs on every balance/settings page render, so a stale `ba_…` was generating tens of Sentry events per day per affected seller.

## Why

A real seller had four consecutive payout failures over 9 days (Apr 26 - May 5) with `failure_reason: nil`. Their Stripe Connect account was healthy, the bank account on Stripe was healthy, but Stripe had rotated the external account ID via Financial Connections during Stripe Capital onboarding. Our DB still pointed at the old ID, every payout attempt got rejected as deleted-bank-account, and the rescue path silently dropped both the reason and the message. The seller's settings page also generated 31+ Sentry events from the same root cause via `supports_instant_payouts?`.

---

AI disclosure: drafted with Claude Opus 4.7 (1M context)