### PR TITLE
Remove India from supported payout countries in help article

### DIFF
--- a/app/views/help_center/articles/contents/_13-getting-paid.html.erb
+++ b/app/views/help_center/articles/contents/_13-getting-paid.html.erb
@@ -180,212 +180,210 @@
           <td>EUR</td>
         </tr>
         <tr>
-          <td>India</td>
-          <td>INR</td>
           <td>Indonesia</td>
           <td>IDR</td>
-        </tr>
-        <tr>
           <td>Ireland</td>
           <td>EUR</td>
+        </tr>
+        <tr>
           <td>Israel</td>
           <td>ILS</td>
-        </tr>
-        <tr>
           <td>Italy</td>
           <td>EUR</td>
+        </tr>
+        <tr>
           <td>Jamaica</td>
           <td>JMD</td>
-        </tr>
-        <tr>
           <td>Japan</td>
           <td>JPY</td>
+        </tr>
+        <tr>
           <td>Jordan</td>
           <td>JOD</td>
-        </tr>
-        <tr>
           <td>Kazakhstan</td>
           <td>KZT</td>
+        </tr>
+        <tr>
           <td>Kenya</td>
           <td>KES</td>
-        </tr>
-        <tr>
           <td>Korea</td>
           <td>KRW (min 40,000)</td>
+        </tr>
+        <tr>
           <td>Kuwait</td>
           <td>KWD</td>
-        </tr>
-        <tr>
           <td>Laos</td>
           <td>LAK (min 516,000)</td>
+        </tr>
+        <tr>
           <td>Latvia</td>
           <td>EUR</td>
-        </tr>
-        <tr>
           <td>Liechtenstein</td>
           <td>CHF</td>
+        </tr>
+        <tr>
           <td>Lithuania</td>
           <td>EUR</td>
-        </tr>
-        <tr>
           <td>Luxembourg</td>
           <td>EUR</td>
+        </tr>
+        <tr>
           <td>Macao</td>
           <td>MOP</td>
-        </tr>
-        <tr>
           <td>Madagascar</td>
           <td>MGA (min 132,300)</td>
+        </tr>
+        <tr>
           <td>Malaysia</td>
           <td>MYR (min 133)</td>
-        </tr>
-        <tr>
           <td>Malta</td>
           <td>EUR</td>
+        </tr>
+        <tr>
           <td>Mauritius</td>
           <td>MUR</td>
-        </tr>
-        <tr>
           <td>Mexico</td>
           <td>MXN</td>
+        </tr>
+        <tr>
           <td>Moldova</td>
           <td>MDL (min 500)</td>
-        </tr>
-        <tr>
           <td>Monaco</td>
           <td>EUR</td>
+        </tr>
+        <tr>
           <td>Mongolia</td>
           <td>MNT (min 105,000)</td>
-        </tr>
-        <tr>
           <td>Morocco</td>
           <td>MAD</td>
+        </tr>
+        <tr>
           <td>Mozambique</td>
           <td>MZN (min 1,700)</td>
-        </tr>
-        <tr>
           <td>Namibia</td>
           <td>NAD (min 550)</td>
+        </tr>
+        <tr>
           <td>Netherlands</td>
           <td>EUR</td>
-        </tr>
-        <tr>
           <td>New Zealand</td>
           <td>NZD</td>
+        </tr>
+        <tr>
           <td>Niger</td>
           <td>XOF</td>
-        </tr>
-        <tr>
           <td>Nigeria</td>
           <td>NGN</td>
+        </tr>
+        <tr>
           <td>North Macedonia</td>
           <td>MKD (min 1,500)</td>
-        </tr>
-        <tr>
           <td>Norway</td>
           <td>NOK</td>
+        </tr>
+        <tr>
           <td>Oman</td>
           <td>OMR</td>
-        </tr>
-        <tr>
           <td>Pakistan</td>
           <td>PKR</td>
+        </tr>
+        <tr>
           <td>Panama</td>
           <td>USD (min 50)</td>
-        </tr>
-        <tr>
           <td>Paraguay</td>
           <td>PYG (min 210,000)</td>
+        </tr>
+        <tr>
           <td>Peru</td>
           <td>PEN</td>
-        </tr>
-        <tr>
           <td>Philippines</td>
           <td>PHP</td>
+        </tr>
+        <tr>
           <td>Poland</td>
           <td>PLN</td>
-        </tr>
-        <tr>
           <td>Portugal</td>
           <td>EUR</td>
+        </tr>
+        <tr>
           <td>Qatar</td>
           <td>QAR</td>
-        </tr>
-        <tr>
           <td>Romania</td>
           <td>RON</td>
+        </tr>
+        <tr>
           <td>Rwanda</td>
           <td>RWF</td>
-        </tr>
-        <tr>
           <td>Saint Lucia</td>
           <td>XCD</td>
+        </tr>
+        <tr>
           <td>San Marino</td>
           <td>EUR</td>
-        </tr>
-        <tr>
           <td>Saudi Arabia</td>
           <td>SAR</td>
+        </tr>
+        <tr>
           <td>Senegal</td>
           <td>XOF</td>
-        </tr>
-        <tr>
           <td>Serbia</td>
           <td>RSD (min 3,000)</td>
+        </tr>
+        <tr>
           <td>Singapore</td>
           <td>SGD</td>
-        </tr>
-        <tr>
           <td>Slovakia</td>
           <td>EUR</td>
+        </tr>
+        <tr>
           <td>Slovenia</td>
           <td>EUR</td>
-        </tr>
-        <tr>
           <td>South Africa</td>
           <td>ZAR</td>
+        </tr>
+        <tr>
           <td>Spain</td>
           <td>EUR</td>
-        </tr>
-        <tr>
           <td>Sri Lanka</td>
           <td>LKR</td>
+        </tr>
+        <tr>
           <td>Sweden</td>
           <td>SEK</td>
-        </tr>
-        <tr>
           <td>Switzerland</td>
           <td>CHF</td>
+        </tr>
+        <tr>
           <td>Taiwan</td>
           <td>TWD (min 800)</td>
-        </tr>
-        <tr>
           <td>Tanzania</td>
           <td>TZS</td>
+        </tr>
+        <tr>
           <td>Thailand</td>
           <td>THB (min 600)</td>
-        </tr>
-        <tr>
           <td>Trinidad and Tobago</td>
           <td>TTD</td>
+        </tr>
+        <tr>
           <td>Tunisia</td>
           <td>TND</td>
-        </tr>
-        <tr>
           <td>Turkey</td>
           <td>TRY</td>
+        </tr>
+        <tr>
           <td>UAE (Business accounts)</td>
           <td>AED</td>
-        </tr>
-        <tr>
           <td>UK</td>
           <td>GBP</td>
-          <td>Uruguay</td>
-          <td>UYU</td>
         </tr>
         <tr>
+          <td>Uruguay</td>
+          <td>UYU</td>
           <td>Uzbekistan</td>
           <td>UZS (min 343,000)</td>
+        </tr>
+        <tr>
           <td>Vietnam</td>
           <td>VND</td>
         </tr>


### PR DESCRIPTION
## What

Removes India (INR) from the supported payout countries table in the "Getting paid" help article.

## Why

India was blocked for new Stripe Connect account creation in #4803 (merged 2026-04-27), but the help article was never updated. This causes confusion for Indian sellers who see India listed as supported but then get a "Bank payouts are not supported in your country" error when trying to set up bank payouts.

## Changes

- Removed India/INR row from the countries table
- Re-paired subsequent rows to maintain the 2-countries-per-row layout
- Last two entries (Uzbekistan, Vietnam) are now single-country rows since the total count is odd