### PR TITLE
Fix self-affiliate registration bypass via email casing

### DIFF
--- a/app/models/affiliate_request.rb
+++ b/app/models/affiliate_request.rb
@@ -68,6 +68,7 @@ class AffiliateRequest < ApplicationRecord
                             .deliver_later(queue: "default", wait: 3.seconds)
       return
     end
+    return if requester == seller
 
     affiliate = seller.direct_affiliates.alive.find_by(affiliate_user_id: requester.id)
     affiliate ||= seller.direct_affiliates.new
@@ -115,7 +116,7 @@ class AffiliateRequest < ApplicationRecord
 
     def requester_is_not_seller
       return unless seller_id
-      return if email != seller.email
+      return if email&.downcase != seller.email&.downcase
 
       errors.add(:base, "You cannot request to become an affiliate of yourself.")
     end

--- a/spec/models/affiliate_request_spec.rb
+++ b/spec/models/affiliate_request_spec.rb
@@ -81,6 +81,12 @@ describe AffiliateRequest do
         expect(affiliate_request).to be_invalid
         expect(affiliate_request.errors.full_messages.first).to eq("You cannot request to become an affiliate of yourself.")
       end
+
+      it "doesn't allow the creator to become an affiliate of oneself when email casing differs" do
+        affiliate_request = build(:affiliate_request, seller: creator, email: creator.email.upcase)
+        expect(affiliate_request).to be_invalid
+        expect(affiliate_request.errors.full_messages.first).to eq("You cannot request to become an affiliate of yourself.")
+      end
     end
   end
 
@@ -301,6 +307,17 @@ describe AffiliateRequest do
             end.to_not change { creator.direct_affiliates.count }
           end.to_not have_enqueued_mail(AffiliateRequestMailer, :notify_requester_of_request_approval)
         end.to have_enqueued_mail(AffiliateRequestMailer, :notify_unregistered_requester_of_request_approval)
+      end
+    end
+
+    context "when the requester user is the seller" do
+      it "does not make the seller an affiliate of themselves" do
+        affiliate_request = build(:affiliate_request, email: creator.email.upcase, seller: creator, state: :approved)
+        affiliate_request.save!(validate: false)
+
+        expect do
+          affiliate_request.make_requester_an_affiliate!
+        end.to_not change { creator.direct_affiliates.count }
       end
     end
 


### PR DESCRIPTION
## Problem

Sellers could register as affiliates on their own products by using different email casing (e.g. `User@example.com` vs `user@example.com`). When a sale came through a self-referral affiliate link, only the affiliate commission was credited to the seller's balance, and the main sale earnings were lost.

The existing `requester_is_not_seller` validation used a case-sensitive string comparison, so differently-cased emails bypassed the check.

## Fix

1. **Case-insensitive email comparison** in the `requester_is_not_seller` validation — uses `downcase` on both sides
2. **Defense-in-depth guard** in `make_requester_an_affiliate!` — if the resolved requester user is the seller, skip affiliate creation entirely (catches edge cases where the seller changes their email between request creation and approval)

## Tests

- Validates that differently-cased seller email is correctly blocked
- Validates that `make_requester_an_affiliate!` does not create an affiliate when requester == seller

Issue antiwork/gumroad-private#337