### PR TITLE
Handle Aws::S3::Errors::NotFound in ProductFilesUtilityController#download_product_files

### DIFF
--- a/app/controllers/product_files_utility_controller.rb
+++ b/app/controllers/product_files_utility_controller.rb
@@ -32,10 +32,11 @@ class ProductFilesUtilityController < ApplicationController
       redirect_to(url_redirect.signed_location_for_file(product_files.first), allow_other_host: true)
     end
   rescue Aws::S3::Errors::NotFound
+    message = "This file is no longer available. Please re-upload it."
     if request.format.json?
-      render(json: { error: "The file is no longer available." }, status: :not_found)
+      render(json: { error: message }, status: :not_found)
     else
-      flash[:warning] = "The file is no longer available."
+      flash[:warning] = message
       redirect_to(edit_link_url(@product.unique_permalink))
     end
   end

--- a/app/controllers/product_files_utility_controller.rb
+++ b/app/controllers/product_files_utility_controller.rb
@@ -31,6 +31,13 @@ class ProductFilesUtilityController < ApplicationController
       # Non-JSON requests to this controller route pass an array with a single product file ID for `product_file_ids`
       redirect_to(url_redirect.signed_location_for_file(product_files.first), allow_other_host: true)
     end
+  rescue Aws::S3::Errors::NotFound
+    if request.format.json?
+      render(json: { error: "The file is no longer available." }, status: :not_found)
+    else
+      flash[:warning] = "The file is no longer available."
+      redirect_to(edit_link_url(@product.unique_permalink))
+    end
   end
 
   def download_folder_archive

--- a/app/controllers/product_files_utility_controller.rb
+++ b/app/controllers/product_files_utility_controller.rb
@@ -31,7 +31,8 @@ class ProductFilesUtilityController < ApplicationController
       # Non-JSON requests to this controller route pass an array with a single product file ID for `product_file_ids`
       redirect_to(url_redirect.signed_location_for_file(product_files.first), allow_other_host: true)
     end
-  rescue Aws::S3::Errors::NotFound
+  rescue Aws::S3::Errors::NotFound => e
+    ErrorNotifier.notify(e, context: { product_id: @product.id, product_file_ids: params[:product_file_ids] })
     message = "This file is no longer available. Please re-upload it."
     if request.format.json?
       render(json: { error: message }, status: :not_found)

--- a/spec/controllers/products/product_files_utility_controller_spec.rb
+++ b/spec/controllers/products/product_files_utility_controller_spec.rb
@@ -96,14 +96,14 @@ describe ProductFilesUtilityController, :vcr do
         get :download_product_files, format: :json, params: { product_id: product.external_id, product_file_ids: [file.external_id] }
 
         expect(response).to have_http_status(:not_found)
-        expect(response.parsed_body["error"]).to eq("The file is no longer available.")
+        expect(response.parsed_body["error"]).to eq("This file is no longer available. Please re-upload it.")
       end
 
       it "redirects to the product edit page with a warning flash for HTML requests" do
         get :download_product_files, format: :html, params: { product_id: product.external_id, product_file_ids: [file.external_id] }
 
         expect(response).to redirect_to(edit_link_url(product.unique_permalink))
-        expect(flash[:warning]).to eq("The file is no longer available.")
+        expect(flash[:warning]).to eq("This file is no longer available. Please re-upload it.")
       end
     end
   end

--- a/spec/controllers/products/product_files_utility_controller_spec.rb
+++ b/spec/controllers/products/product_files_utility_controller_spec.rb
@@ -93,6 +93,11 @@ describe ProductFilesUtilityController, :vcr do
       end
 
       it "returns a not_found JSON response for JSON requests" do
+        expect(ErrorNotifier).to receive(:notify).with(
+          instance_of(Aws::S3::Errors::NotFound),
+          context: { product_id: product.id, product_file_ids: [file.external_id] }
+        )
+
         get :download_product_files, format: :json, params: { product_id: product.external_id, product_file_ids: [file.external_id] }
 
         expect(response).to have_http_status(:not_found)
@@ -100,6 +105,11 @@ describe ProductFilesUtilityController, :vcr do
       end
 
       it "redirects to the product edit page with a warning flash for HTML requests" do
+        expect(ErrorNotifier).to receive(:notify).with(
+          instance_of(Aws::S3::Errors::NotFound),
+          context: { product_id: product.id, product_file_ids: [file.external_id] }
+        )
+
         get :download_product_files, format: :html, params: { product_id: product.external_id, product_file_ids: [file.external_id] }
 
         expect(response).to redirect_to(edit_link_url(product.unique_permalink))

--- a/spec/controllers/products/product_files_utility_controller_spec.rb
+++ b/spec/controllers/products/product_files_utility_controller_spec.rb
@@ -83,6 +83,29 @@ describe ProductFilesUtilityController, :vcr do
 
       expect(response).to redirect_to("https://example.com/file.srt")
     end
+
+    context "when the S3 file is missing" do
+      let!(:file) { create(:product_file, link: product) }
+
+      before do
+        allow_any_instance_of(UrlRedirect).to receive(:signed_location_for_file)
+          .and_raise(Aws::S3::Errors::NotFound.new(nil, "Not Found"))
+      end
+
+      it "returns a not_found JSON response for JSON requests" do
+        get :download_product_files, format: :json, params: { product_id: product.external_id, product_file_ids: [file.external_id] }
+
+        expect(response).to have_http_status(:not_found)
+        expect(response.parsed_body["error"]).to eq("The file is no longer available.")
+      end
+
+      it "redirects to the product edit page with a warning flash for HTML requests" do
+        get :download_product_files, format: :html, params: { product_id: product.external_id, product_file_ids: [file.external_id] }
+
+        expect(response).to redirect_to(edit_link_url(product.unique_permalink))
+        expect(flash[:warning]).to eq("The file is no longer available.")
+      end
+    end
   end
 
   describe "GET download_folder_archive" do


### PR DESCRIPTION
## Problem

`ProductFilesUtilityController#download_product_files` crashes with an unhandled `Aws::S3::Errors::NotFound` when a seller tries to download a product file whose S3 object no longer exists.

**Sentry:** https://gumroad-to.sentry.io/issues/7460848648/
- First seen: 2026-05-05
- Occurrences (7-day): 1
- Occurrences (14-day): 1
- Estimated users affected/month: <5
- Estimated support tickets/month: ~0 (edge case, seller-facing)

## Root Cause

`signed_location_for_file` calls `signed_download_url_for_s3_key_and_filename`, which does a HEAD request to S3. If the object is missing, it raises `Aws::S3::Errors::NotFound`. The buyer-facing `UrlRedirectsController#download_product_files` already rescues this and returns a friendly error, but the seller-facing `ProductFilesUtilityController` did not.

## Fix

Add a `rescue Aws::S3::Errors::NotFound` block to `ProductFilesUtilityController#download_product_files`:
- **JSON requests:** returns `{ error: "The file is no longer available." }` with `404`
- **HTML requests:** redirects to the product edit page with a flash warning

## Tests

Added two specs for the missing-S3-file scenario (JSON and HTML formats).