### PR TITLE
Harden CreateUsStatesSalesSummaryReportJob with retries and failure alerts

### DIFF
--- a/app/mailers/accounting_mailer.rb
+++ b/app/mailers/accounting_mailer.rb
@@ -106,7 +106,8 @@ class AccountingMailer < ApplicationMailer
     @error_class = error_class
     @error_message = error_message
 
-    mail subject: "#{SUBJECT_PREFIX}US States Sales Summary Report failed - #{month}/#{year}",
+    error_tag = error_class.to_s.start_with?("Taxjar::") ? "[TaxJar] " : ""
+    mail subject: "#{SUBJECT_PREFIX}#{error_tag}US States Sales Summary Report failed - #{month}/#{year}",
          to: PAYMENTS_NOTIFICATION_EMAIL
   end
 

--- a/app/mailers/accounting_mailer.rb
+++ b/app/mailers/accounting_mailer.rb
@@ -99,6 +99,17 @@ class AccountingMailer < ApplicationMailer
          subject: "Outstanding balances"
   end
 
+  def us_states_sales_summary_report_failed(subdivision_codes, month, year, error_class, error_message)
+    @subdivision_codes = subdivision_codes
+    @month = month
+    @year = year
+    @error_class = error_class
+    @error_message = error_message
+
+    mail subject: "#{SUBJECT_PREFIX}US States Sales Summary Report failed - #{month}/#{year}",
+         to: PAYMENTS_NOTIFICATION_EMAIL
+  end
+
   def global_sales_tax_summary_report(month, year, s3_read_url)
     @subject_and_title = "Global Sales Tax Summary Report for #{month}/#{year}"
     @s3_url = s3_read_url

--- a/app/sidekiq/create_us_states_sales_summary_report_job.rb
+++ b/app/sidekiq/create_us_states_sales_summary_report_job.rb
@@ -4,6 +4,13 @@ class CreateUsStatesSalesSummaryReportJob
   include Sidekiq::Job
   sidekiq_options retry: 3, queue: :default, lock: :until_executed
 
+  sidekiq_retries_exhausted do |msg, exception|
+    subdivision_codes, month, year = msg["args"]
+    AccountingMailer.us_states_sales_summary_report_failed(
+      subdivision_codes, month, year, exception.class.name, exception.message
+    ).deliver_later
+  end
+
   attr_reader :taxjar_api
 
   def perform(subdivision_codes, month, year, push_to_taxjar: true)

--- a/app/sidekiq/create_us_states_sales_summary_report_job.rb
+++ b/app/sidekiq/create_us_states_sales_summary_report_job.rb
@@ -4,8 +4,8 @@ class CreateUsStatesSalesSummaryReportJob
   include Sidekiq::Job
   sidekiq_options retry: 3, queue: :default, lock: :until_executed
 
-  sidekiq_retries_exhausted do |msg, exception|
-    subdivision_codes, month, year = msg["args"]
+  sidekiq_retries_exhausted do |job, exception|
+    subdivision_codes, month, year = job["args"]
     AccountingMailer.us_states_sales_summary_report_failed(
       subdivision_codes, month, year, exception.class.name, exception.message
     ).deliver_later

--- a/app/sidekiq/create_us_states_sales_summary_report_job.rb
+++ b/app/sidekiq/create_us_states_sales_summary_report_job.rb
@@ -2,7 +2,7 @@
 
 class CreateUsStatesSalesSummaryReportJob
   include Sidekiq::Job
-  sidekiq_options retry: 1, queue: :default, lock: :until_executed
+  sidekiq_options retry: 3, queue: :default, lock: :until_executed
 
   attr_reader :taxjar_api
 

--- a/app/views/accounting_mailer/us_states_sales_summary_report_failed.html.erb
+++ b/app/views/accounting_mailer/us_states_sales_summary_report_failed.html.erb
@@ -1,0 +1,10 @@
+<%= header_section("US States Sales Summary Report failed - #{@month}/#{@year}") %>
+<div>
+  <p><code>CreateUsStatesSalesSummaryReportJob</code> exhausted Sidekiq retries and did not produce the report.</p>
+  <ul>
+    <li>Period: <%= @month %>/<%= @year %></li>
+    <li>Subdivision codes: <%= Array(@subdivision_codes).join(", ") %></li>
+    <li>Error: <%= @error_class %>: <%= @error_message %></li>
+  </ul>
+  <p>See Sentry and Sidekiq dead set for more details.</p>
+</div>

--- a/spec/mailers/accounting_mailer_spec.rb
+++ b/spec/mailers/accounting_mailer_spec.rb
@@ -114,6 +114,30 @@ describe AccountingMailer, :vcr do
     end
   end
 
+  describe "#us_states_sales_summary_report_failed" do
+    let(:mail) do
+      AccountingMailer.us_states_sales_summary_report_failed(
+        ["WA", "WI"], 4, 2026, "ActiveRecord::StatementTimeout", "maximum statement execution time exceeded"
+      )
+    end
+
+    it "sends to the payments notification email" do
+      expect(mail.to).to eq([PAYMENTS_NOTIFICATION_EMAIL])
+    end
+
+    it "includes the period in the subject" do
+      expect(mail.subject).to eq("US States Sales Summary Report failed - 4/2026")
+    end
+
+    it "includes the failure context in the body" do
+      body = mail.body.encoded
+      expect(body).to include("4/2026")
+      expect(body).to include("WA, WI")
+      expect(body).to include("ActiveRecord::StatementTimeout")
+      expect(body).to include("maximum statement execution time exceeded")
+    end
+  end
+
   describe "ytd_sales_report" do
     let(:csv_data) { "country,state,sales\\nUSA,CA,100\\nUSA,NY,200" }
     let(:recipient_email) { "test@example.com" }

--- a/spec/mailers/accounting_mailer_spec.rb
+++ b/spec/mailers/accounting_mailer_spec.rb
@@ -129,6 +129,17 @@ describe AccountingMailer, :vcr do
       expect(mail.subject).to include("US States Sales Summary Report failed - 4/2026")
     end
 
+    it "does not tag non-TaxJar errors in the subject" do
+      expect(mail.subject).not_to include("[TaxJar]")
+    end
+
+    it "tags TaxJar errors in the subject" do
+      taxjar_mail = AccountingMailer.us_states_sales_summary_report_failed(
+        ["WA", "WI"], 4, 2026, "Taxjar::Error::ServerError", "Couldn't parse response as JSON."
+      )
+      expect(taxjar_mail.subject).to include("[TaxJar] US States Sales Summary Report failed - 4/2026")
+    end
+
     it "includes the failure context in the body" do
       body = mail.body.encoded
       expect(body).to include("4/2026")

--- a/spec/mailers/accounting_mailer_spec.rb
+++ b/spec/mailers/accounting_mailer_spec.rb
@@ -126,7 +126,7 @@ describe AccountingMailer, :vcr do
     end
 
     it "includes the period in the subject" do
-      expect(mail.subject).to eq("US States Sales Summary Report failed - 4/2026")
+      expect(mail.subject).to include("US States Sales Summary Report failed - 4/2026")
     end
 
     it "includes the failure context in the body" do

--- a/spec/sidekiq/create_us_states_sales_summary_report_job_spec.rb
+++ b/spec/sidekiq/create_us_states_sales_summary_report_job_spec.rb
@@ -7,6 +7,25 @@ describe CreateUsStatesSalesSummaryReportJob do
   let(:month) { 8 }
   let(:year) { 2022 }
 
+  it "is configured with retry: 3" do
+    expect(described_class.sidekiq_options["retry"]).to eq(3)
+  end
+
+  describe "sidekiq_retries_exhausted" do
+    it "emails payments notification with the failure context" do
+      msg = { "args" => [["WA", "WI"], 4, 2026] }
+      exception = ActiveRecord::StatementTimeout.new("maximum statement execution time exceeded")
+      mailer = double("mailer")
+
+      expect(AccountingMailer).to receive(:us_states_sales_summary_report_failed)
+        .with(["WA", "WI"], 4, 2026, "ActiveRecord::StatementTimeout", "maximum statement execution time exceeded")
+        .and_return(mailer)
+      expect(mailer).to receive(:deliver_later)
+
+      described_class.sidekiq_retries_exhausted_block.call(msg, exception)
+    end
+  end
+
   it "raises an argument error if the year is out of bounds" do
     expect { described_class.new.perform(subdivision_codes, month, 2013) }.to raise_error(ArgumentError)
   end

--- a/spec/sidekiq/create_us_states_sales_summary_report_job_spec.rb
+++ b/spec/sidekiq/create_us_states_sales_summary_report_job_spec.rb
@@ -13,7 +13,7 @@ describe CreateUsStatesSalesSummaryReportJob do
 
   describe "sidekiq_retries_exhausted" do
     it "emails payments notification with the failure context" do
-      msg = { "args" => [["WA", "WI"], 4, 2026] }
+      job = { "args" => [["WA", "WI"], 4, 2026] }
       exception = ActiveRecord::StatementTimeout.new("maximum statement execution time exceeded")
       mailer = double("mailer")
 
@@ -22,7 +22,7 @@ describe CreateUsStatesSalesSummaryReportJob do
         .and_return(mailer)
       expect(mailer).to receive(:deliver_later)
 
-      described_class.sidekiq_retries_exhausted_block.call(msg, exception)
+      described_class.sidekiq_retries_exhausted_block.call(job, exception)
     end
   end
 


### PR DESCRIPTION
## What
- Bumps `sidekiq_options retry` on `CreateUsStatesSalesSummaryReportJob` from 1 to 3.
- Adds a `sidekiq_retries_exhausted` handler that emails the payments notification address with the failure context (period, subdivision codes, error class, error message) when the job exhausts its retries.
- Tags the email subject with `[TaxJar]` when the exhausted error is a `Taxjar::*` error, so a failed TaxJar upload is visible in the inbox without opening the email.

## Why
The April 2026 run of `CreateUsStatesSalesSummaryReportJob` succeeded. To reduce the chance of silent or noticed-late failures going forward:

1. Increasing the retry count from 1 to 3.
2. Configuring an email alert if that job fails for any reason (as suggested by Steven).

The alert only fires for errors that halt the job (e.g. `ActiveRecord::StatementTimeout`, `Taxjar::Error::ServerError`, generic `Taxjar::Error` connection failures — all observed in the dead set). Errors already swallowed inside `perform` (`Taxjar::Error::UnprocessableEntity`, `Taxjar::Error::BadRequest`) never reach the handler, so they continue to be ignored as today.

## Test plan
- [ ] `spec/mailers/accounting_mailer_spec.rb` — recipient, subject (with and without `[TaxJar]` tag), and body assertions pass.
- [ ] `spec/sidekiq/create_us_states_sales_summary_report_job_spec.rb` — `retry: 3` config and exhaustion handler tests pass.
- [ ] Confirm the job still enqueues and runs as expected.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) using Claude Opus 4.7