### PR TITLE
Normalize ASCII spaces to full-width in JP katakana bank names

### DIFF
--- a/app/javascript/components/Settings/PaymentsPage/BankAccountSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/BankAccountSection.tsx
@@ -938,10 +938,10 @@ const BankAccountSection = ({
     if (!holderNameTouched) return null;
     const name = bankAccount?.account_holder_full_name?.trim() ?? "";
     if (name === "") return null;
-    const isKatakanaOnly = /^[\p{Script=Katakana}ー・\uFF65-\uFF9F\u3000]+$/u.test(name);
+    const isKatakanaOnly = /^[\p{Script=Katakana}ー・\uFF65-\uFF9F\u3000 ]+$/u.test(name);
     const isLatinOnly = /^[A-Za-z ]+$/u.test(name);
     if (isKatakanaOnly || isLatinOnly) return null;
-    return "Use either katakana or Latin letters — not both. If using katakana, separate names with a full-width space.";
+    return "Use either katakana or Latin letters — not both.";
   })();
 
   return (

--- a/app/models/indonesia_bank_account.rb
+++ b/app/models/indonesia_bank_account.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class IndonesiaBankAccount < BankAccount
+  include StrippedFields
+
   BANK_ACCOUNT_TYPE = "ID"
 
   BANK_CODE_FORMAT_REGEX = /\A[0-9a-zA-Z]{3,4}\z/
@@ -10,6 +12,8 @@ class IndonesiaBankAccount < BankAccount
   private_constant :ACCOUNT_NUMBER_FORMAT_REGEX
 
   alias_attribute :bank_code, :bank_number
+
+  stripped_fields :account_holder_full_name, remove_duplicate_spaces: false, nilify_blanks: false
 
   validate :validate_bank_code
   validate :validate_account_number

--- a/app/models/japan_bank_account.rb
+++ b/app/models/japan_bank_account.rb
@@ -22,7 +22,13 @@ class JapanBankAccount < BankAccount
 
   alias_attribute :bank_code, :bank_number
 
-  stripped_fields :account_holder_full_name, remove_duplicate_spaces: false, nilify_blanks: false
+  stripped_fields :account_holder_full_name,
+                  remove_duplicate_spaces: false,
+                  nilify_blanks: false,
+                  transform: ->(value) {
+                    full_width = value.tr(" ", "　")
+                    KATAKANA_NAME_FORMAT_REGEX.match?(full_width) ? full_width : value
+                  }
 
   validate :validate_bank_code
   validate :validate_branch_code
@@ -77,6 +83,6 @@ class JapanBankAccount < BankAccount
 
     def validate_account_holder_full_name
       return if KATAKANA_NAME_FORMAT_REGEX.match?(account_holder_full_name) || LATIN_NAME_FORMAT_REGEX.match?(account_holder_full_name)
-      errors.add :account_holder_full_name, "must be written in either katakana or Latin letters — not both. If using katakana, separate names with a full-width space."
+      errors.add :account_holder_full_name, "must be written in either katakana or Latin letters — not both."
     end
 end

--- a/app/models/vietnam_bank_account.rb
+++ b/app/models/vietnam_bank_account.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class VietnamBankAccount < BankAccount
+  include StrippedFields
+
   BANK_ACCOUNT_TYPE = "VN"
 
   BANK_CODE_FORMAT_REGEX = /\A[0-9]{8}\z/
@@ -10,6 +12,8 @@ class VietnamBankAccount < BankAccount
   private_constant :ACCOUNT_NUMBER_FORMAT_REGEX
 
   alias_attribute :bank_code, :bank_number
+
+  stripped_fields :account_holder_full_name, remove_duplicate_spaces: false, nilify_blanks: false
 
   validate :validate_bank_code
   validate :validate_account_number

--- a/app/services/update_payout_method.rb
+++ b/app/services/update_payout_method.rb
@@ -216,16 +216,9 @@ class UpdatePayoutMethod
       current_active = user.active_bank_account
       return { success: true } if current_active.blank? || current_active.is_a?(CardBankAccount)
 
-      submitted_holder_name = params[:bank_account][:account_holder_full_name].to_s.strip
-      if current_active.account_holder_full_name == submitted_holder_name
-        current_active.valid?
-        return bank_account_error_for_attribute(current_active, :account_holder_full_name) if current_active.errors[:account_holder_full_name].any?
-        return { success: true }
-      end
-
       current_active.account_holder_full_name = params[:bank_account][:account_holder_full_name]
-      return bank_account_error_for(current_active) unless current_active.valid?
-      current_active.save!
+      return bank_account_error_for(current_active) unless current_active.save
+      return { success: true } if current_active.previous_changes["account_holder_full_name"].nil?
 
       if StripeMerchantAccountManager.account_holder_name_synced_to_stripe?(user)
         after_commit { HandleNewBankAccountWorker.perform_in(5.seconds, current_active.id) }
@@ -283,10 +276,6 @@ class UpdatePayoutMethod
 
     def bank_account_error_for(record)
       { error: :bank_account_error, data: record.errors.full_messages.to_sentence }
-    end
-
-    def bank_account_error_for_attribute(record, attribute)
-      { error: :bank_account_error, data: record.errors.full_messages_for(attribute).to_sentence }
     end
 
     def bank_account_params_for_bank_account_type

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -9429,7 +9429,7 @@ describe StripeMerchantAccountManager, :vcr do
     let(:stripe_account) { double(id: "acct_123", external_accounts: [stripe_external_account]) }
 
     before do
-      bank_account.update_columns(account_holder_full_name: "ハルナ マサシ")
+      bank_account.update_columns(account_holder_full_name: "Haruna マサシ")
     end
 
     it "persists Stripe metadata without revalidating a legacy invalid holder name" do

--- a/spec/models/japan_bank_account_spec.rb
+++ b/spec/models/japan_bank_account_spec.rb
@@ -98,10 +98,16 @@ describe JapanBankAccount do
       expect(build(:japan_bank_account, account_holder_full_name: "ﾋﾟｰﾀｰ")).to be_valid
     end
 
-    it "rejects katakana mixed with ASCII space (the incident case)" do
+    it "normalizes ASCII spaces to full-width when the rest is katakana (the incident case)" do
       account = build(:japan_bank_account, account_holder_full_name: "ハルナ マサシ")
-      expect(account).to_not be_valid
-      expect(account.errors[:account_holder_full_name]).to be_present
+      expect(account).to be_valid
+      expect(account.account_holder_full_name).to eq("ハルナ　マサシ")
+    end
+
+    it "leaves ASCII spaces alone when the name is Latin-only" do
+      account = build(:japan_bank_account, account_holder_full_name: "Masashi Haruna")
+      expect(account).to be_valid
+      expect(account.account_holder_full_name).to eq("Masashi Haruna")
     end
 
     it "rejects scripts outside the two allowed variants" do
@@ -119,7 +125,7 @@ describe JapanBankAccount do
 
     it "does not run on soft-delete so pre-validator invalid names can still be marked deleted" do
       account = create(:japan_bank_account)
-      account.update_columns(account_holder_full_name: "ハルナ マサシ")
+      account.update_columns(account_holder_full_name: "Haruna マサシ")
 
       expect { account.mark_deleted! }.not_to raise_error
       expect(account.reload.deleted_at).to be_present

--- a/spec/services/update_payout_method_spec.rb
+++ b/spec/services/update_payout_method_spec.rb
@@ -77,6 +77,28 @@ describe UpdatePayoutMethod do
 
           expect(bank_account.reload.account_holder_full_name).to eq("Japanese Creator")
         end
+
+        {
+          VietnamBankAccount => :vietnam_bank_account,
+          IndonesiaBankAccount => :indonesia_bank_account,
+        }.each do |klass, factory|
+          it "does not enqueue HandleNewBankAccountWorker for #{klass.name.gsub('BankAccount', '')} when the submitted name differs only by surrounding whitespace" do
+            user = create(:named_user)
+            bank_account = create(factory, user:, account_holder_full_name: "Pham Minh")
+            create(:user_compliance_info, user:, country: klass == VietnamBankAccount ? "Vietnam" : "Indonesia")
+
+            params = ActionController::Parameters.new(
+              bank_account: { type: klass.name, account_holder_full_name: "Pham Minh " }
+            )
+
+            expect do
+              result = described_class.new(user_params: params, seller: user).process
+              expect(result).to eq(success: true)
+            end.not_to change { HandleNewBankAccountWorker.jobs.size }
+
+            expect(bank_account.reload.account_holder_full_name).to eq("Pham Minh")
+          end
+        end
       end
 
       context "when the seller is in a country that does NOT sync holder name to Stripe" do

--- a/spec/services/update_payout_method_spec.rb
+++ b/spec/services/update_payout_method_spec.rb
@@ -24,20 +24,20 @@ describe UpdatePayoutMethod do
           expect(bank_account.reload.account_holder_full_name).to eq("ヤマダ\u3000タロウ")
         end
 
-        it "returns a validation error and does not enqueue HandleNewBankAccountWorker when the new name mixes scripts" do
+        it "normalizes ASCII spaces to full-width and enqueues HandleNewBankAccountWorker" do
           params = ActionController::Parameters.new(
             bank_account: { type: JapanBankAccount.name, account_holder_full_name: "ハルナ マサシ" }
           )
 
           expect do
             result = described_class.new(user_params: params, seller: user).process
-            expect(result[:error]).to eq(:bank_account_error)
-          end.not_to change { HandleNewBankAccountWorker.jobs.size }
+            expect(result).to eq(success: true)
+          end.to change { HandleNewBankAccountWorker.jobs.size }.by(1)
 
-          expect(bank_account.reload.account_holder_full_name).to eq("Japanese Creator")
+          expect(bank_account.reload.account_holder_full_name).to eq("ハルナ　マサシ")
         end
 
-        it "surfaces a validation error when the submitted name equals a pre-validator invalid stored name" do
+        it "syncs a pre-validator invalid stored ASCII-space name when the seller re-saves it" do
           bank_account.update_columns(account_holder_full_name: "ハルナ マサシ")
 
           params = ActionController::Parameters.new(
@@ -46,8 +46,23 @@ describe UpdatePayoutMethod do
 
           expect do
             result = described_class.new(user_params: params, seller: user).process
+            expect(result).to eq(success: true)
+          end.to change { HandleNewBankAccountWorker.jobs.size }.by(1)
+
+          expect(bank_account.reload.account_holder_full_name).to eq("ハルナ　マサシ")
+        end
+
+        it "returns a validation error and does not enqueue HandleNewBankAccountWorker when the name mixes scripts" do
+          params = ActionController::Parameters.new(
+            bank_account: { type: JapanBankAccount.name, account_holder_full_name: "Haruna マサシ" }
+          )
+
+          expect do
+            result = described_class.new(user_params: params, seller: user).process
             expect(result[:error]).to eq(:bank_account_error)
           end.not_to change { HandleNewBankAccountWorker.jobs.size }
+
+          expect(bank_account.reload.account_holder_full_name).to eq("Japanese Creator")
         end
 
         it "does not enqueue HandleNewBankAccountWorker when the submitted name differs only by surrounding whitespace" do
@@ -131,7 +146,6 @@ describe UpdatePayoutMethod do
           expect(ErrorNotifier).not_to have_received(:notify)
         end
       end
-
     end
 
     describe "when account number exceeds maximum length" do


### PR DESCRIPTION
Ref antiwork/gumroad-private/issues/338

## What

When a Japanese seller types their bank-account holder name in katakana with regular spaces, the spaces are now silently converted to the full-width space (U+3000) Stripe Japan requires. Previously the same name with regular spaces failed validation. The form rejected the save, and (before that validation existed) the sync to Stripe failed with `incorrect_account_holder_name`, blocking payouts.

## Why

This is the second incident of the same kind: a JP seller's payout settings look correct in Gumroad, but Stripe Japan rejects the bank-account holder name because the space character is U+0020, not U+3000. Visually they're almost identical, so the issue is impossible to spot from the form. The most recent occurrence kept a seller waiting six weeks for a held payout.

The JS hint and validator message were updated to match: the inline error now only fires for actually-mixed scripts (e.g. Latin + katakana), not for ASCII spaces in pure katakana.

---

This PR was implemented with AI assistance using Claude Opus 4.7.