### PR TITLE
Fix Stripe Connect help article: add missing $0.50 flat fee

### DIFF
--- a/app/views/help_center/articles/contents/_330-stripe-connect.html.erb
+++ b/app/views/help_center/articles/contents/_330-stripe-connect.html.erb
@@ -9,7 +9,7 @@
     <li><a href="#disconnect">Disconnect your Stripe account</a></li>
   </ul>
   <p>Connecting your Stripe account allows you to receive payments directly to your Stripe account at the time of sale.</p>
-  <p>This is valid for all purchases made via a credit card or Apple/Google Pay. Gumroad will still retain its 10% <a href="66-gumroads-fees" target="_blank">fee</a>, any VAT/GST charged, and any affiliate commission.</p>
+  <p>This is valid for all purchases made via a credit card or Apple/Google Pay. Gumroad will still retain its 10% + $0.50 <a href="66-gumroads-fees" target="_blank">fee</a>, any VAT/GST charged, and any affiliate commission.</p>
   <p>When you connect your own Stripe account, you pay Stripe directly for the card processing fees. You can learn about Stripe's <a href="https://stripe.com/pricing">card processing fees here</a>. </p>
   <h3 id="connect">Connect with Stripe</h3>
   <p>Go to your <a href="https://gumroad.com/settings/payments">payment settings</a> and select “Stripe”.</p>
@@ -17,7 +17,7 @@
   <p>Clicking the “Connect with Stripe” button will open a Stripe window, giving you the option to connect an existing Stripe account or create a new one.</p>
   <p>Alternatively, you can also login/signup to Gumroad with your Stripe account!</p>
   <h3 id="get-paid">Get paid to Stripe</h3>
-  <p>Once connected, all sales via a credit card or Apple/Google pay will be credited to your Stripe account at the time of sale. Gumroad will only retain its 10% fee, any VAT/GST charged, and any affiliate commission.</p>
+  <p>Once connected, all sales via a credit card or Apple/Google pay will be credited to your Stripe account at the time of sale. Gumroad will only retain its 10% + $0.50 fee, any VAT/GST charged, and any affiliate commission.</p>
   <p>As always, <a href="46-what-currency-does-gumroad-use">we will charge the customer in USD</a>, but if you do not have a USD bank account connected to your Stripe account, Stripe will convert the payments to your default currency based on <a href="https://dashboard.stripe.com/currency_conversion">their exchange rates</a>. If you have multiple currency support in your Stripe account and a USD bank account, then the amount will remain in USD.</p>
   <p>You will also find the Stripe transaction ID, fee amount, and fee currency for these sales in the <a href="74-the-analytics-dashboard#sales-csv">sales CSV export</a>. </p>
   <p>These payouts will be listed on your <a href="https://gumroad.com/payouts">payouts page</a> under “Stripe Connect Payouts”. This is not a debit, but the amount that has already been paid to your Stripe at the time of sale. Any unpaid balance collected before you connect your Stripe account will still get paid out via the previous payment method.</p>


### PR DESCRIPTION
## What

Updated the Stripe Connect help article (`_330-stripe-connect.html.erb`) to include the $0.50 flat fee that was missing from two fee descriptions.

## Why

Lines 12 and 20 both said "10% fee" but should say "10% + $0.50 fee" to match:
- The canonical fees article (`_66-gumroads-fees.html.erb:4`)
- The codebase (`purchase.rb:26-28`: `GUMROAD_FLAT_FEE_PER_THOUSAND = 100 + GUMROAD_FIXED_FEE_CENTS = 50`)

## Changes

- Line 12: "10% fee" → "10% + $0.50 fee"
- Line 20: "10% fee" → "10% + $0.50 fee"

Ref #4962 (item 1). Items 2 and 3 from that issue (physical product articles and stale reference doc) need team discussion.