### PR TITLE
Add physical product listing restriction notice to help articles

### DIFF
--- a/app/views/help_center/articles/contents/_10-dealing-with-vat.html.erb
+++ b/app/views/help_center/articles/contents/_10-dealing-with-vat.html.erb
@@ -5,7 +5,6 @@
   <p>Gumroad handles VAT on behalf of creators for all digital product sales in the EU and the UK. We collect, remit, and even allow buyers to refund VAT without sellers having to lift a finger.</p>
   <p>No forms to fill out, no submissions required – Gumroad does it all for you.</p>
   <p>For all sales to EU and UK buyers, Gumroad acts as the 'merchant of record' for the sale, making Gumroad responsible for collecting and remitting VAT. </p>
-  <p><b>Note: </b>We do not collect VAT on physical products. VAT due on physical products is paid by the buyer on the inbound shipment receipt.</p>
   <h3>Reduced VAT for e-publications</h3>
   <p>Since 2015, many EU countries have <a href="https://www.consilium.europa.eu/en/policies/reduced-vat-epublications/">reduced their local VAT rates</a> for e-publications.</p>
   <p>The EU defines E-publications as:</p>

--- a/app/views/help_center/articles/contents/_155-things-you-cant-sell-on-gumroad.html.erb
+++ b/app/views/help_center/articles/contents/_155-things-you-cant-sell-on-gumroad.html.erb
@@ -19,10 +19,9 @@
     <li>Reselling software that you've purchased in the past, like Windows 10 license keys, etc. </li>
     <li>Web hosting or servers</li>
     <li>Tickets to events or using Gumroad to process money for events you are hosting</li>
-    <li>Selling physical goods (new or old) that you didn't create or own the rights to such as toys, electronics, or mass-produced goods like sneakers</li>
+    <li>Physical products</li>
     <li>Selling jewelry</li>
     <li>Selling Steam keys or hacks to other websites</li>
-    <li>Selling physical products that violate our terms of service or federal laws of the US, like CBD-related businesses. </li>
     <li>Any NSFW or sexually explicit content—<a href="156-gumroad-and-adult-content">See why here</a></li>
     <li>Services that are fulfilled outside Gumroad's purview. More on that <a href="70-can-i-sell-services">here</a>.</li>
     <li>Food products, medical products, skincare or beauty supplies</li>

--- a/app/views/help_center/articles/contents/_268-customer-dashboard.html.erb
+++ b/app/views/help_center/articles/contents/_268-customer-dashboard.html.erb
@@ -8,7 +8,6 @@
         <li><a href="#Edit-a-customers-email-address-fJhCO" target="_self">Edit a customer's email address</a></li>
         <li><a href="#Tiers-versions-and-variants-5tqxu" target="_self">Tiers, versions, and variants</a></li>
         <li><a href="#Manage-license-keys-5AuIs" target="_self">Manage license keys</a></li>
-        <li><a href="#Shipping-information-l476B" target="_self">Shipping information</a></li>
         <li><a href="#Ratings-HLwRM" target="_self">Ratings</a></li>
         <li><a href="#Cancel-a-membership-M5JjP" target="_self">Cancel a membership</a></li>
         <li><a href="#Refund-a-customer-tQVdX" target="_self">Refund a customer</a></li>
@@ -51,9 +50,6 @@
   <p>You can disable a <a href="76-license-keys">license key</a> or change the number of seats for a multi-seat license key.</p>
   <p>Customers will immediately be charged a prorated amount if the number of seats is increased. However, for a decrease in the number of seats, their membership will get updated at the end of the current billing cycle, and they will be charged the reduced amount for subsequent renewals.</p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/639b0a1c2e586565571c20eb/file-4oW74KD2yB.gif" %></figure>
-  <h3 id="Shipping-information-l476B">Shipping information</h3>
-  <p>You can mark a physical product as being shipped and enter tracking information in the dashboard. You need to enter the full URL of the tracking order, not just the tracking ID. </p>
-  <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/621753c21173d072c69fb5c1/file-yPe5TFUA88.png" %></figure>
   <h3 id="Ratings-HLwRM">Ratings</h3>
   <p>You can see how a customer has rated your product. If you're unhappy with your ratings, you can hide all of <a href="222-product-ratings-on-gumroad">them</a> from being visible or refund the customer to automatically delete their rating.  You cannot hide a single rating only.</p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/6216fcb4528a5515a2fcbffd/file-pN4ODMgP44.png" %></figure>


### PR DESCRIPTION
Addresses problem 2 from https://github.com/antiwork/gumroad/issues/4962

New physical product listings are no longer accepted on Gumroad (existing creators with prior listings can keep selling). Three help center articles still described physical product flows without noting this restriction.

**Changes:**

- **_155-things-you-cant-sell-on-gumroad**: Added a yellow callout note before the High-risk products section stating new physical product listings are no longer accepted
- **_268-customer-dashboard**: Added a note in the Shipping information section clarifying it applies to existing physical product listings only
- **_10-dealing-with-vat**: Appended a note to the existing physical product VAT disclaimer about the listing restriction