### PR TITLE
Cap analytics date picker and add full-history export

### DIFF
--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
 class AnalyticsController < Sellers::BaseController
-  MAX_BY_STATE_DATE_RANGE_DAYS = 365
-  MAX_BY_REFERRAL_DATE_RANGE_DAYS = 365
+  MAX_DATE_RANGE_DAYS = 366
 
   before_action :set_time_range, only: %i[data_by_date data_by_state data_by_referral]
-  before_action :clamp_date_range_for_by_state, only: :data_by_state
-  before_action :clamp_date_range_for_by_referral, only: :data_by_referral
+  before_action :clamp_date_range, only: %i[data_by_state data_by_referral]
 
   after_action :set_dashboard_preference_to_sales, only: :index
   before_action :check_payment_details, only: :index
@@ -69,15 +67,9 @@ class AnalyticsController < Sellers::BaseController
       @end_date = end_time.to_date
     end
 
-    def clamp_date_range_for_by_state
-      if (@end_date - @start_date).to_i > MAX_BY_STATE_DATE_RANGE_DAYS
-        @start_date = @end_date - MAX_BY_STATE_DATE_RANGE_DAYS.days
-      end
-    end
-
-    def clamp_date_range_for_by_referral
-      if (@end_date - @start_date).to_i > MAX_BY_REFERRAL_DATE_RANGE_DAYS
-        @start_date = @end_date - MAX_BY_REFERRAL_DATE_RANGE_DAYS.days
+    def clamp_date_range
+      if (@end_date - @start_date).to_i > MAX_DATE_RANGE_DAYS
+        @start_date = @end_date - MAX_DATE_RANGE_DAYS.days
       end
     end
 

--- a/app/javascript/components/Analytics/ExportSalesPopover.tsx
+++ b/app/javascript/components/Analytics/ExportSalesPopover.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+
+import { Button } from "$app/components/Button";
+import { NavigationButtonInertia } from "$app/components/NavigationButton";
+import { Popover, PopoverAnchor, PopoverContent, PopoverTrigger } from "$app/components/Popover";
+
+export const ExportSalesPopover = () => {
+  const [open, setOpen] = React.useState(false);
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverAnchor>
+        <PopoverTrigger asChild>
+          <Button>Export all sales</Button>
+        </PopoverTrigger>
+      </PopoverAnchor>
+      <PopoverContent>
+        <div className="flex flex-col gap-4">
+          <h3>Export all sales</h3>
+          <div>You'll get a CSV of every sale you've made. Large exports arrive by email.</div>
+          <NavigationButtonInertia
+            color="primary"
+            href={Routes.export_purchases_path()}
+            onSuccess={() => setOpen(false)}
+          >
+            Export
+          </NavigationButtonInertia>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/app/javascript/components/Analytics/index.tsx
+++ b/app/javascript/components/Analytics/index.tsx
@@ -12,6 +12,7 @@ import { assertDefined } from "$app/utils/assert";
 import { AbortError } from "$app/utils/request";
 
 import { AnalyticsLayout } from "$app/components/Analytics/AnalyticsLayout";
+import { ExportSalesPopover } from "$app/components/Analytics/ExportSalesPopover";
 import { LocationsTable } from "$app/components/Analytics/LocationsTable";
 import { ProductsPopover } from "$app/components/Analytics/ProductsPopover";
 import { ReferrersTable } from "$app/components/Analytics/ReferrersTable";
@@ -26,6 +27,8 @@ import { Placeholder, PlaceholderImage } from "$app/components/ui/Placeholder";
 import { Select } from "$app/components/ui/Select";
 
 import placeholder from "$assets/images/placeholders/sales.png";
+
+const MAX_DATE_RANGE_DAYS = 366;
 
 export type Product = {
   name: string;
@@ -107,7 +110,7 @@ const Analytics = ({ products: initialProducts, country_codes, state_names }: An
     initialProducts.map((product) => ({ ...product, selected: product.alive })),
   );
   const [aggregateBy, setAggregateBy] = React.useState<"daily" | "monthly">("daily");
-  const dateRange = useAnalyticsDateRange();
+  const dateRange = useAnalyticsDateRange({ maxRangeDays: MAX_DATE_RANGE_DAYS });
   const [data, setData] = React.useState<{
     byReferral: AnalyticsDataByReferral;
     byState: AnalyticsDataByState;
@@ -162,8 +165,9 @@ const Analytics = ({ products: initialProducts, country_codes, state_names }: An
             </Select>
             <ProductsPopover products={products} setProducts={setProducts} />
             <div className="col-span-2">
-              <DateRangePicker {...dateRange} />
+              <DateRangePicker {...dateRange} maxRangeDays={MAX_DATE_RANGE_DAYS} />
             </div>
+            <ExportSalesPopover />
           </>
         ) : null
       }

--- a/app/javascript/components/Analytics/useAnalyticsDateRange.tsx
+++ b/app/javascript/components/Analytics/useAnalyticsDateRange.tsx
@@ -1,10 +1,10 @@
 import { router } from "@inertiajs/react";
-import { lightFormat, parseISO, subMonths } from "date-fns";
+import { differenceInDays, lightFormat, parseISO, subDays, subMonths } from "date-fns";
 import * as React from "react";
 
 import { useOriginalLocation } from "$app/components/useOriginalLocation";
 
-export const useAnalyticsDateRange = () => {
+export const useAnalyticsDateRange = ({ maxRangeDays }: { maxRangeDays?: number } = {}) => {
   const location = useOriginalLocation();
   const url = new URL(location);
 
@@ -15,7 +15,14 @@ export const useAnalyticsDateRange = () => {
     return isNaN(parsed.getTime()) ? null : parsed;
   };
 
-  const [from, setFrom] = React.useState(() => tryParseDateParam("from") ?? subMonths(new Date(), 1));
+  const [from, setFrom] = React.useState(() => {
+    const fromParsed = tryParseDateParam("from") ?? subMonths(new Date(), 1);
+    const toParsed = tryParseDateParam("to") ?? new Date();
+    const correctedTo = toParsed < fromParsed ? fromParsed : toParsed;
+    return maxRangeDays != null && differenceInDays(correctedTo, fromParsed) > maxRangeDays
+      ? subDays(correctedTo, maxRangeDays)
+      : fromParsed;
+  });
   const [to, setTo] = React.useState(() => {
     const value = tryParseDateParam("to") ?? new Date();
     return value < from ? from : value;

--- a/app/javascript/components/DateRangePicker.tsx
+++ b/app/javascript/components/DateRangePicker.tsx
@@ -1,5 +1,6 @@
 import { ChevronDown } from "@boxicons/react";
 import {
+  differenceInDays,
   endOfMonth,
   endOfQuarter,
   endOfYear,
@@ -26,11 +27,13 @@ export const DateRangePicker = ({
   to,
   setFrom,
   setTo,
+  maxRangeDays,
 }: {
   from: Date;
   to: Date;
   setFrom: (from: Date) => void;
   setTo: (to: Date) => void;
+  maxRangeDays?: number;
 }) => {
   const today = new Date();
   const uid = React.useId();
@@ -42,6 +45,36 @@ export const DateRangePicker = ({
     setTo(to);
     setOpen(false);
   };
+  const presets = [
+    { label: "Last 30 days", from: subDays(today, 30), to: today },
+    { label: "This month", from: startOfMonth(today), to: today },
+    {
+      label: "Last month",
+      from: startOfMonth(subMonths(today, 1)),
+      to: endOfMonth(subMonths(today, 1)),
+    },
+    {
+      label: "Last 3 months",
+      from: startOfMonth(subMonths(today, 3)),
+      to: endOfMonth(subMonths(today, 1)),
+    },
+    { label: "This quarter", from: startOfQuarter(today), to: today },
+    {
+      label: "Last quarter",
+      from: startOfQuarter(subQuarters(today, 1)),
+      to: endOfQuarter(subQuarters(today, 1)),
+    },
+    { label: "This year", from: startOfYear(today), to: today },
+    {
+      label: "Last year",
+      from: startOfYear(subYears(today, 1)),
+      to: endOfYear(subYears(today, 1)),
+    },
+    { label: "All time", from: new Date("2012-10-13"), to: today },
+  ];
+  const visiblePresets =
+    maxRangeDays != null ? presets.filter((p) => differenceInDays(p.to, p.from) <= maxRangeDays) : presets;
+  const customRangeExceedsMax = maxRangeDays != null && differenceInDays(to, from) > maxRangeDays;
   return (
     <Popover
       open={open}
@@ -76,7 +109,7 @@ export const DateRangePicker = ({
                 }}
               />
             </Fieldset>
-            <Fieldset state={to < from ? "danger" : undefined}>
+            <Fieldset state={to < from || customRangeExceedsMax ? "danger" : undefined}>
               <FieldsetTitle>
                 <Label htmlFor={`${uid}-to`}>To (including)</Label>
               </FieldsetTitle>
@@ -86,45 +119,22 @@ export const DateRangePicker = ({
                 onChange={(date) => {
                   if (date) setTo(date);
                 }}
-                aria-invalid={to < from}
+                aria-invalid={to < from || customRangeExceedsMax}
               />
-              {to < from ? <FieldsetDescription>Must be after from date</FieldsetDescription> : null}
+              {to < from ? (
+                <FieldsetDescription>Must be after from date</FieldsetDescription>
+              ) : customRangeExceedsMax ? (
+                <FieldsetDescription>Range can be at most {maxRangeDays} days</FieldsetDescription>
+              ) : null}
             </Fieldset>
           </div>
         ) : (
           <Menu>
-            <MenuItem onClick={() => quickSet(subDays(today, 30), today)}>Last 30 days</MenuItem>
-            <MenuItem onClick={() => quickSet(startOfMonth(today), today)}>This month</MenuItem>
-            <MenuItem
-              onClick={() => {
-                const lastMonth = subMonths(today, 1);
-                quickSet(startOfMonth(lastMonth), endOfMonth(lastMonth));
-              }}
-            >
-              Last month
-            </MenuItem>
-            <MenuItem onClick={() => quickSet(startOfMonth(subMonths(today, 3)), endOfMonth(subMonths(today, 1)))}>
-              Last 3 months
-            </MenuItem>
-            <MenuItem onClick={() => quickSet(startOfQuarter(today), today)}>This quarter</MenuItem>
-            <MenuItem
-              onClick={() => {
-                const lastQuarter = subQuarters(today, 1);
-                quickSet(startOfQuarter(lastQuarter), endOfQuarter(lastQuarter));
-              }}
-            >
-              Last quarter
-            </MenuItem>
-            <MenuItem onClick={() => quickSet(startOfYear(today), today)}>This year</MenuItem>
-            <MenuItem
-              onClick={() => {
-                const lastYear = subYears(today, 1);
-                quickSet(startOfYear(lastYear), endOfYear(lastYear));
-              }}
-            >
-              Last year
-            </MenuItem>
-            <MenuItem onClick={() => quickSet(new Date("2012-10-13"), today)}>All time</MenuItem>
+            {visiblePresets.map((preset) => (
+              <MenuItem key={preset.label} onClick={() => quickSet(preset.from, preset.to)}>
+                {preset.label}
+              </MenuItem>
+            ))}
             <MenuItem onClick={() => setIsCustom(true)}>Custom range...</MenuItem>
           </Menu>
         )}

--- a/spec/controllers/analytics_controller_spec.rb
+++ b/spec/controllers/analytics_controller_spec.rb
@@ -122,11 +122,11 @@ describe AnalyticsController do
       let(:policy_method) { :index? }
     end
 
-    it "clamps the date range to #{AnalyticsController::MAX_BY_STATE_DATE_RANGE_DAYS} days" do
+    it "clamps the date range to #{AnalyticsController::MAX_DATE_RANGE_DAYS} days" do
       start_time = "Mon Jan 01 2024 00:00:00 GMT-0000"
       end_time = "Tue Dec 31 2025 00:00:00 GMT-0000"
       expect_any_instance_of(CreatorAnalytics::CachingProxy).to receive(:data_for_dates).with(
-        Date.new(2025, 12, 31) - AnalyticsController::MAX_BY_STATE_DATE_RANGE_DAYS.days,
+        Date.new(2025, 12, 31) - AnalyticsController::MAX_DATE_RANGE_DAYS.days,
         Date.new(2025, 12, 31),
         by: :state
       ).and_return({})
@@ -153,11 +153,11 @@ describe AnalyticsController do
       let(:policy_method) { :index? }
     end
 
-    it "clamps the date range to #{AnalyticsController::MAX_BY_REFERRAL_DATE_RANGE_DAYS} days" do
+    it "clamps the date range to #{AnalyticsController::MAX_DATE_RANGE_DAYS} days" do
       start_time = "Mon Jan 01 2024 00:00:00 GMT-0000"
       end_time = "Tue Dec 31 2025 00:00:00 GMT-0000"
       expect_any_instance_of(CreatorAnalytics::CachingProxy).to receive(:data_for_dates).with(
-        Date.new(2025, 12, 31) - AnalyticsController::MAX_BY_REFERRAL_DATE_RANGE_DAYS.days,
+        Date.new(2025, 12, 31) - AnalyticsController::MAX_DATE_RANGE_DAYS.days,
         Date.new(2025, 12, 31),
         by: :referral
       ).and_return({})

--- a/spec/requests/analytics/sales_spec.rb
+++ b/spec/requests/analytics/sales_spec.rb
@@ -18,6 +18,44 @@ describe "Sales analytics", :js, :sidekiq_inline, :elasticsearch_wait_for_refres
     expect(page).to have_text("You don't have any sales yet.")
   end
 
+  context "with the 366-day date range cap" do
+    let!(:product) { create(:product, user: seller) }
+
+    it "clamps the URL when the requested range exceeds 366 days" do
+      visit sales_dashboard_path(from: "2020-01-01", to: "2024-06-01")
+      expect(page).to have_current_path(sales_dashboard_path(from: "2023-05-31", to: "2024-06-01"))
+    end
+
+    it "hides All time and any preset wider than 366 days" do
+      visit sales_dashboard_path
+      initial = find('[aria-label="Date range selector"]').text
+      select_disclosure initial do
+        expect(page).not_to have_content("All time")
+        expect(page).to have_content("Last 30 days")
+        expect(page).to have_content("Last year")
+      end
+    end
+
+    it "rejects a custom range wider than 366 days" do
+      visit sales_dashboard_path
+      initial = find('[aria-label="Date range selector"]').text
+      select_disclosure initial do
+        click_on "Custom range..."
+        fill_in "From (including)", with: "01/01/2020"
+        fill_in "To (including)", with: "01/01/2024"
+      end
+      expect(page).to have_text("Range can be at most 366 days")
+    end
+
+    it "shows the export confirmation popover linking to the unfiltered export" do
+      visit sales_dashboard_path
+      select_disclosure "Export all sales" do
+        expect(page).to have_text("You'll get a CSV of every sale you've made. Large exports arrive by email.")
+        expect(page).to have_link("Export", href: export_purchases_path)
+      end
+    end
+  end
+
   context "with views and sales" do
     let(:product1) { create(:product, user: seller, name: "Product 1") }
     let(:product2) { create(:product, user: seller, name: "Product 2") }

--- a/spec/requests/analytics/sales_spec.rb
+++ b/spec/requests/analytics/sales_spec.rb
@@ -23,7 +23,7 @@ describe "Sales analytics", :js, :sidekiq_inline, :elasticsearch_wait_for_refres
 
     it "clamps the URL when the requested range exceeds 366 days" do
       visit sales_dashboard_path(from: "2020-01-01", to: "2024-06-01")
-      expect(page).to have_current_path(sales_dashboard_path(from: "2023-05-31", to: "2024-06-01"))
+      expect(page).to have_current_path(sales_dashboard_path(from: "2023-06-01", to: "2024-06-01"))
     end
 
     it "hides All time and any preset wider than 366 days" do


### PR DESCRIPTION
Fixes #4960

## What

The Analytics → Sales date picker now caps at 366 days. The "All time" preset is hidden and any preset that would exceed the cap is filtered out. A custom range exceeding 366 days fails validation in place. URL-typed ranges that exceed the cap are clamped to the most recent 366 days on first render. A new "Export all sales" button next to the picker opens a confirmation that exports the unfiltered, all-time CSV.

The two backend constants (`MAX_BY_STATE_DATE_RANGE_DAYS`, `MAX_BY_REFERRAL_DATE_RANGE_DAYS`) are collapsed into a single `MAX_DATE_RANGE_DAYS = 366` since they were already identical.

## Why

[#4960](https://github.com/antiwork/gumroad/issues/4960) reports that selecting "All time" silently truncates to the last 12 months. The chart and stats reflect the truncation but nothing tells the user. Now the user can't get into the bad state in the first place, and the misleading "All time" label is gone. Long-time creators who want their full sales history have a first-class action for it ("Export all sales") that doesn't pretend to fit on a one-year chart.

The cap moves from 365 to 366 so the calendar-year "Last year" preset stays selectable in leap years (366 days). The cap stays a server-enforced limit too, so third-party API consumers and direct URL hits remain protected.

## Before/After

The picker on the left shows the bug surface area (selecting "All time" leads to silent truncation). The picker on the right has "All time" filtered out by the cap.

|         | Before                                                                         | After                                                                       |
| ------- | ------------------------------------------------------------------------------ | --------------------------------------------------------------------------- |
| Desktop | <img width="2880" height="1800" alt="pickercap-before-desktop-light" src="https://github.com/user-attachments/assets/32bcca5d-f27b-42f7-b236-4a4399c46883" /> | <img width="2880" height="1800" alt="pickercap-after-desktop-light" src="https://github.com/user-attachments/assets/011bd6f2-cc28-48ac-a7aa-8200aa2e3544" /> 
| Mobile  | <img width="1000" height="1688" alt="pickercap-before-mobile-light" src="https://github.com/user-attachments/assets/48720092-cf67-41c1-addb-dc70c4187f33" /> | <img width="1000" height="1688" alt="pickercap-after-mobile-light" src="https://github.com/user-attachments/assets/6aff6917-c5a2-49d8-b401-bf5beb581203" /> |

The new "Export all sales" button sits in the actions row alongside the picker (mobile shown below; on desktop it's the rightmost item):
<img width="280" src="https://github.com/user-attachments/assets/5ee88405-edab-4286-8b0e-e419206c0eb4" />

Tapping it opens a confirmation popover:
<img width="480" src="https://github.com/user-attachments/assets/75bfce04-9f0a-4b9c-b96c-daddbdc0a1a2" />

The Export action goes to `GET /purchases/export` with no date filters, so a CSV of every sale is generated. ≤2,000 rows downloads immediately; >2,000 rows is queued and emailed. Same behavior as before.

---

This PR was implemented with AI assistance using Claude Opus 4.7.