### PR TITLE
Improve activation: AI-generated first products on the empty seller dashboard

### DIFF
--- a/app/controllers/first_product_starter_controller.rb
+++ b/app/controllers/first_product_starter_controller.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+class FirstProductStarterController < ApplicationController
+  THROTTLE_LIMIT_PER_HOUR = 2
+  THROTTLE_LIMIT_PER_IP_PER_HOUR = 30
+  THROTTLE_PERIOD = 1.hour
+
+  before_action :authenticate_user!
+  before_action -> { authorize :first_product_starter, :options? }, only: :options
+  before_action -> { authorize :first_product_starter, :draft? }, only: :draft
+  after_action :verify_authorized
+
+  def options
+    textarea = params[:textarea_answer].to_s
+    user_key = RedisKey.ai_request_throttle(current_seller.id)
+    ip_key = "#{RedisKey.ai_request_throttle('ip')}:#{request.remote_ip}"
+    wants_ai = textarea.strip.present?
+
+    capped = wants_ai && !atomic_reserve(user_key, THROTTLE_LIMIT_PER_HOUR, ip_key, THROTTLE_LIMIT_PER_IP_PER_HOUR)
+
+    service = Ai::FirstProductStarterService.new(seller: current_seller)
+    result = if !wants_ai || capped
+      service.template_options
+    else
+      service.generate_options(textarea_answer: textarea)
+    end
+
+    render json: result.merge(capped: capped)
+  rescue Ai::FirstProductStarterService::MaxRetriesExceededError, Faraday::UnauthorizedError, Faraday::ClientError => e
+    Rails.logger.error("[FirstProductStarter] options failed: #{e.class}: #{e.message} (seller_id=#{current_seller.id})")
+    ErrorNotifier.notify(e)
+    render json: { error: "couldn't_generate" }, status: :service_unavailable
+  end
+
+  def draft
+    option = params.require(:option).permit(
+      :name, :description, :native_type,
+      :price_range, :price_currency_type,
+      :is_recurring_billing, :subscription_duration
+    )
+
+    sanitized_description = ActionController::Base.helpers.sanitize(
+      option[:description].to_s,
+      tags: %w[p ul ol li strong em h3],
+      attributes: []
+    )
+
+    @product = current_seller.links.build(
+      name: option[:name],
+      description: sanitized_description,
+      native_type: option[:native_type],
+      price_currency_type: option[:price_currency_type] || "usd",
+      is_recurring_billing: option[:native_type] == "membership"
+    )
+    @product.price_range = option[:price_range]
+    @product.subscription_duration = option[:subscription_duration] if option[:native_type] == "membership"
+    @product.draft = true
+    @product.purchase_disabled_at = Time.current
+    @product.display_product_reviews = true
+    @product.is_tiered_membership = @product.is_recurring_billing
+    @product.should_show_all_posts = @product.is_tiered_membership
+    @product.set_template_properties_if_needed
+    @product.taxonomy = Taxonomy.find_by(slug: "other")
+
+    begin
+      @product.save!
+    rescue ActiveRecord::RecordNotSaved, ActiveRecord::RecordInvalid, Link::LinkInvalid
+      return render json: { error: @product.errors.to_hash.transform_values(&:to_sentence).first }, status: :unprocessable_entity
+    end
+
+    create_user_event("add_product")
+    create_user_event(Event::NAME_FIRST_PRODUCT_STARTER_DRAFTED)
+
+    render json: { redirect_url: edit_link_path(@product) }
+  end
+
+  private
+    def atomic_reserve(user_key, user_limit, ip_key, ip_limit)
+      user_count = $redis.incr(user_key)
+      ensure_expiry(user_key)
+      if user_count > user_limit
+        $redis.decr(user_key)
+        return false
+      end
+
+      ip_count = $redis.incr(ip_key)
+      ensure_expiry(ip_key)
+      if ip_count > ip_limit
+        $redis.decr(user_key)
+        $redis.decr(ip_key)
+        return false
+      end
+
+      true
+    end
+
+    def ensure_expiry(key)
+      $redis.expire(key, THROTTLE_PERIOD.to_i) if $redis.ttl(key) < 0
+    end
+end

--- a/app/javascript/components/DashboardPage.tsx
+++ b/app/javascript/components/DashboardPage.tsx
@@ -9,6 +9,7 @@ import { request } from "$app/utils/request";
 import { ActivityFeed, ActivityItem } from "$app/components/ActivityFeed";
 import { Button, NavigationButton } from "$app/components/Button";
 import { useAppDomain } from "$app/components/DomainSettings";
+import { FirstProductStarter } from "$app/components/FirstProductStarter";
 import { CustomizeProfileIcon } from "$app/components/icons/getting-started/CustomizeProfileIcon";
 import { EmailBlastIcon } from "$app/components/icons/getting-started/EmailBlastIcon";
 import { FirstFollowerIcon } from "$app/components/icons/getting-started/FirstFollowerIcon";
@@ -70,6 +71,7 @@ export type DashboardPageProps = {
   tax_forms: Record<number, string>;
   show_1099_download_notice: boolean;
   tax_center_enabled: boolean;
+  first_product_starter_enabled: boolean;
 };
 type TableProps = { sales: ProductRow[] };
 
@@ -309,6 +311,7 @@ export const DashboardPage = ({
   tax_forms,
   show_1099_download_notice,
   tax_center_enabled,
+  first_product_starter_enabled,
 }: DashboardPageProps) => {
   const loggedInUser = useLoggedInUser();
   const [gettingStartedMinimized, setGettingStartedMinimized] = React.useState<boolean>(false);
@@ -443,7 +446,8 @@ export const DashboardPage = ({
         : null}
 
       {!getting_started_stats.first_product && loggedInUser?.policies.product.create ? (
-        <div className="p-4 md:p-8">
+        <div className="flex flex-col gap-6 px-4 pb-4 md:px-8 md:pb-8">
+          {first_product_starter_enabled ? <FirstProductStarter /> : null}
           <Greeter />
         </div>
       ) : null}

--- a/app/javascript/components/FirstProductStarter/Card.tsx
+++ b/app/javascript/components/FirstProductStarter/Card.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+
+import { Button } from "$app/components/Button";
+
+import type { ProductOption } from "./types";
+
+import courseIcon from "$assets/images/native_types/course.png";
+import digitalIcon from "$assets/images/native_types/digital.png";
+import ebookIcon from "$assets/images/native_types/ebook.png";
+import membershipIcon from "$assets/images/native_types/membership.png";
+
+const NATIVE_TYPE_ICONS: Record<ProductOption["native_type"], string> = {
+  digital: digitalIcon,
+  course: courseIcon,
+  ebook: ebookIcon,
+  membership: membershipIcon,
+};
+
+type Props = {
+  option: ProductOption;
+  onCreate: () => void;
+  creating: boolean;
+  disabled: boolean;
+};
+
+export const OptionCard = ({ option, onCreate, creating, disabled }: Props) => (
+  <div className="flex h-full min-h-[20rem] flex-col gap-3 rounded border border-border bg-background p-4 transition hover:shadow">
+    <img src={NATIVE_TYPE_ICONS[option.native_type]} alt={option.native_type} className="size-12 self-start" />
+    <h3 className="line-clamp-2 font-semibold">{option.name}</h3>
+    <p className="text-xl font-semibold">
+      ${(option.price_cents / 100).toFixed(0)}
+      {option.native_type === "membership" ? <span className="text-base text-muted">/mo</span> : null}
+    </p>
+    <p className="line-clamp-3 flex-1 text-sm text-muted">{option.rationale_one_line}</p>
+    <Button onClick={onCreate} disabled={disabled || creating} color="accent">
+      {creating ? "Creating…" : "Make it yours →"}
+    </Button>
+  </div>
+);

--- a/app/javascript/components/FirstProductStarter/index.tsx
+++ b/app/javascript/components/FirstProductStarter/index.tsx
@@ -1,0 +1,303 @@
+import * as React from "react";
+import { cast } from "ts-safe-cast";
+
+import { request, ResponseError } from "$app/utils/request";
+
+import { Button } from "$app/components/Button";
+import { Alert } from "$app/components/ui/Alert";
+import { Textarea } from "$app/components/ui/Textarea";
+
+import { OptionCard } from "./Card";
+import type { OptionsResponse, ProductOption } from "./types";
+
+import coin1 from "$assets/images/about/coin-1.svg";
+import coin2 from "$assets/images/about/coin-2.svg";
+import coin3 from "$assets/images/about/coin-3.svg";
+import coin4 from "$assets/images/about/coin-4.svg";
+import coin5 from "$assets/images/about/coin-5.svg";
+
+const COIN_SOURCES = [coin1, coin2, coin3, coin4, coin5];
+
+const SUBMIT_LABEL = "Show me three options";
+const REROLL_LABEL = "Show me three more";
+const REROLL_LABEL_CAPPED = "Show me three more templates";
+const REROLL_LABEL_REDIRECT = "Create a product from scratch →";
+const THINKING_LABEL = "Thinking… up to 5 sec";
+const MIN_WORD_COUNT = 2;
+const BATCH_SIZE = 3;
+const MAX_TEMPLATE_REROLLS = 3;
+const ONE_WORD_HELPER = "Add a few more words, or leave it empty to see starter templates.";
+
+const wordCount = (text: string) => text.trim().split(/\s+/u).filter(Boolean).length;
+const HELPER_DEBOUNCE_MS = 1000;
+
+const PLACEHOLDER_PREFIX = "Write about yourself and what you plan to sell. E.g.:\n";
+const EXAMPLES = [
+  "I want to launch a course with a monthly subscription.",
+  "I built a macOS app and want to sell licenses for it.",
+  "I wrote a niche playbook and want to sell it as an ebook.",
+  "I want to offer pay-as-you-want price for my digital product.",
+  "I have a newsletter and want to offer paid subscriptions.",
+  "I'm building a community and want to monetize it with a monthly membership.",
+  "I made a Notion template and want to sell it.",
+  "I create VRChat avatars or 3D models and want to sell them.",
+];
+const MAX_VISIBLE = 3;
+
+type Step = "input" | "loading" | "options" | "error";
+
+export const FirstProductStarter = () => {
+  const [step, setStep] = React.useState<Step>("input");
+  const [textarea, setTextarea] = React.useState("");
+  const [pool, setPool] = React.useState<ProductOption[]>([]);
+  const [cursor, setCursor] = React.useState(0);
+  const [creatingName, setCreatingName] = React.useState<string | null>(null);
+  const [errorMsg, setErrorMsg] = React.useState<string | null>(null);
+  const [isFocused, setIsFocused] = React.useState(false);
+  const [reloading, setReloading] = React.useState(false);
+  const [capped, setCapped] = React.useState(false);
+  const [lastSource, setLastSource] = React.useState<"ai" | "templates" | null>(null);
+  const [templateRerolls, setTemplateRerolls] = React.useState(0);
+  const [doneLines, setDoneLines] = React.useState<string[]>([]);
+  const [currentIdx, setCurrentIdx] = React.useState(0);
+  const [charCount, setCharCount] = React.useState(0);
+  const fetchAbortRef = React.useRef<AbortController | null>(null);
+  React.useEffect(() => () => fetchAbortRef.current?.abort(), []);
+
+  React.useEffect(() => {
+    if (textarea.length > 0 || isFocused) return;
+    const current = EXAMPLES[currentIdx] ?? "";
+
+    if (charCount < current.length) {
+      const id = window.setTimeout(() => setCharCount((c) => c + 1), 50);
+      return () => window.clearTimeout(id);
+    }
+
+    const nextIdx = (currentIdx + 1) % EXAMPLES.length;
+    if (doneLines.length < MAX_VISIBLE - 1) {
+      const id = window.setTimeout(() => {
+        setDoneLines((prev) => [...prev, current]);
+        setCurrentIdx(nextIdx);
+        setCharCount(0);
+      }, 900);
+      return () => window.clearTimeout(id);
+    }
+
+    const id = window.setTimeout(() => {
+      setDoneLines([]);
+      setCurrentIdx(nextIdx);
+      setCharCount(0);
+    }, 3000);
+    return () => window.clearTimeout(id);
+  }, [textarea, isFocused, currentIdx, charCount, doneLines]);
+
+  const typingLine = `- ${(EXAMPLES[currentIdx] ?? "").slice(0, charCount)}`;
+  const allLines = [...doneLines.map((l) => `- ${l}`), typingLine];
+  const placeholder = PLACEHOLDER_PREFIX + allLines.join("\n");
+
+  const words = wordCount(textarea);
+  const tooFewWords = words > 0 && words < MIN_WORD_COUNT;
+  const submitDisabled = step === "loading" || reloading || tooFewWords;
+
+  const [debouncedTooFew, setDebouncedTooFew] = React.useState(false);
+  React.useEffect(() => {
+    const id = window.setTimeout(() => setDebouncedTooFew(tooFewWords), HELPER_DEBOUNCE_MS);
+    return () => window.clearTimeout(id);
+  }, [tooFewWords]);
+  const showHelper = tooFewWords && debouncedTooFew;
+
+  const visible = pool.slice(cursor, cursor + BATCH_SIZE);
+  const exhausted = cursor + BATCH_SIZE >= pool.length;
+
+  const fetchPool = async () => {
+    const wasOnOptions = step === "options";
+    if (wasOnOptions) {
+      setReloading(true);
+    } else {
+      setStep("loading");
+    }
+    setErrorMsg(null);
+    const controller = new AbortController();
+    fetchAbortRef.current = controller;
+    const timeoutId = window.setTimeout(() => controller.abort(), 45_000);
+    try {
+      const res = await request({
+        accept: "json",
+        method: "POST",
+        url: "/first_product_starter/options",
+        data: { textarea_answer: textarea },
+        abortSignal: controller.signal,
+      });
+      if (!res.ok) throw new ResponseError(`Server returned ${String(res.status)}`);
+      const json = cast<OptionsResponse>(await res.json());
+      setPool(json.options);
+      setCursor(0);
+      setCapped(json.capped ?? false);
+      const source = json.source ?? null;
+      setLastSource(source);
+      if (source === "ai") setTemplateRerolls(0);
+      setStep("options");
+    } catch {
+      setErrorMsg("Taking a while — try once more?");
+      if (!wasOnOptions) setStep("error");
+    } finally {
+      setReloading(false);
+      window.clearTimeout(timeoutId);
+      if (fetchAbortRef.current === controller) fetchAbortRef.current = null;
+    }
+  };
+
+  const submit = async () => {
+    if (submitDisabled) return;
+    await fetchPool();
+  };
+
+  const onTemplatesPath = lastSource === "templates" || capped;
+  const nextClickRedirects = onTemplatesPath && templateRerolls >= MAX_TEMPLATE_REROLLS;
+
+  const reroll = () => {
+    if (creatingName !== null || reloading) return;
+
+    if (nextClickRedirects) {
+      window.location.href = Routes.new_product_path();
+      return;
+    }
+    if (onTemplatesPath) setTemplateRerolls((c) => c + 1);
+
+    if (exhausted) {
+      void fetchPool();
+    } else {
+      setCursor(cursor + BATCH_SIZE);
+    }
+  };
+
+  const create = async (option: ProductOption) => {
+    if (creatingName) return;
+    setCreatingName(option.name);
+    setErrorMsg(null);
+    try {
+      const res = await request({
+        accept: "json",
+        method: "POST",
+        url: "/first_product_starter/draft",
+        data: {
+          option: {
+            name: option.name,
+            description: option.description,
+            native_type: option.native_type,
+            price_range: String(option.price_cents / 100),
+            price_currency_type: "usd",
+            subscription_duration: option.native_type === "membership" ? "monthly" : undefined,
+          },
+        },
+      });
+      if (!res.ok) throw new ResponseError(`Server returned ${String(res.status)}`);
+      const json = cast<{ redirect_url: string }>(await res.json());
+      window.location.href = json.redirect_url;
+    } catch {
+      setErrorMsg("Couldn't create the product. Try once more?");
+      setCreatingName(null);
+    }
+  };
+
+  if (step === "input" || step === "loading" || step === "error") {
+    return (
+      <div className="flex flex-col gap-4">
+        <h2>What do you want to sell? We'll draft it for you.</h2>
+        <div className="relative">
+          <Textarea
+            value={textarea}
+            onChange={(e) => setTextarea(e.target.value)}
+            onFocus={() => setIsFocused(true)}
+            onBlur={() => setIsFocused(false)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey && !submitDisabled) {
+                e.preventDefault();
+                void submit();
+              }
+            }}
+            placeholder={placeholder}
+            aria-label="Tell us what you know, make, teach, or want to sell"
+            aria-busy={step === "loading"}
+            disabled={step === "loading"}
+            rows={4}
+            maxLength={500}
+            className={step === "loading" ? "opacity-30" : undefined}
+          />
+          {step === "loading" ? (
+            <div
+              className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-3"
+              role="status"
+              aria-live="polite"
+            >
+              <div className="flex items-end gap-2">
+                {COIN_SOURCES.map((src, i) => (
+                  <img
+                    key={src}
+                    src={src}
+                    alt=""
+                    className="size-8 animate-bounce"
+                    style={{ animationDelay: `${String(i * 120)}ms`, animationDuration: "900ms" }}
+                  />
+                ))}
+              </div>
+              <p className="text-sm text-muted">Thinking through options for you — this can take up to 5 seconds.</p>
+            </div>
+          ) : null}
+        </div>
+        {showHelper ? <p className="text-sm text-muted">{ONE_WORD_HELPER}</p> : null}
+        {errorMsg ? <Alert variant="danger">{errorMsg}</Alert> : null}
+        <Button onClick={submit} disabled={submitDisabled} color="accent" className="self-start">
+          {step === "loading" ? THINKING_LABEL : SUBMIT_LABEL}
+        </Button>
+      </div>
+    );
+  }
+
+  const rerollLabel = (() => {
+    if (reloading) return THINKING_LABEL;
+    if (nextClickRedirects) return REROLL_LABEL_REDIRECT;
+    return capped ? REROLL_LABEL_CAPPED : REROLL_LABEL;
+  })();
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-baseline gap-x-4 gap-y-2">
+        <h2>Start with a template</h2>
+        <button
+          type="button"
+          onClick={reroll}
+          disabled={creatingName !== null || reloading}
+          className={
+            nextClickRedirects
+              ? "text-sm font-medium underline disabled:no-underline disabled:opacity-50"
+              : "text-sm text-muted underline disabled:no-underline disabled:opacity-50"
+          }
+        >
+          {rerollLabel}
+        </button>
+      </div>
+      {capped ? (
+        <Alert variant="info">
+          You've used your AI suggestions for this hour. Here are starter templates — or{" "}
+          <a href={Routes.new_product_path()} className="underline">
+            create a product from scratch
+          </a>
+          .
+        </Alert>
+      ) : null}
+      <div data-testid="product-options" className="grid gap-4 md:grid-cols-3">
+        {visible.map((option) => (
+          <OptionCard
+            key={option.name}
+            option={option}
+            onCreate={() => create(option)}
+            creating={creatingName === option.name}
+            disabled={creatingName !== null && creatingName !== option.name}
+          />
+        ))}
+      </div>
+      {errorMsg ? <Alert variant="danger">{errorMsg}</Alert> : null}
+    </div>
+  );
+};

--- a/app/javascript/components/FirstProductStarter/types.ts
+++ b/app/javascript/components/FirstProductStarter/types.ts
@@ -1,0 +1,14 @@
+export type ProductOption = {
+  name: string;
+  native_type: "digital" | "course" | "ebook" | "membership";
+  price_cents: number;
+  description: string;
+  rationale_one_line: string;
+  is_primary: boolean;
+};
+
+export type OptionsResponse = {
+  options: ProductOption[];
+  source?: "ai" | "templates";
+  capped?: boolean;
+};

--- a/app/javascript/utils/request.ts
+++ b/app/javascript/utils/request.ts
@@ -66,6 +66,7 @@ export const request = async (settings: RequestSettings): Promise<Response> => {
     return response;
   } catch (e) {
     if (e instanceof DOMException && e.name === "AbortError") throw new AbortError();
+    if (e instanceof ResponseError) throw e;
     throw new ResponseError();
   } finally {
     --globalThis.__activeRequests;

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -10,6 +10,7 @@ class Event < ApplicationRecord
   PERMITTED_NAMES = %w[
     audience_callout_dismissal
     chargeback
+    first_product_starter_drafted
     first_purchase_on_profile_visit
     post_view
     product_refund_policy_fine_print_view

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1073,6 +1073,14 @@ class User < ApplicationRecord
     has_completed_payouts?
   end
 
+  def eligible_for_first_product_starter?
+    return false unless Feature.active?(:first_product_starter, self)
+    return true if Rails.env.development?
+    return false unless confirmed?
+    return false if suspended?
+    true
+  end
+
   protected
     def after_confirmation
       # The password reset link sent to the old email should be invalidated

--- a/app/policies/first_product_starter_policy.rb
+++ b/app/policies/first_product_starter_policy.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class FirstProductStarterPolicy < ApplicationPolicy
+  def options?
+    eligible?
+  end
+
+  def draft?
+    eligible?
+  end
+
+  private
+    def eligible?
+      return false unless seller.eligible_for_first_product_starter?
+      !seller.links.visible.exists?
+    end
+end

--- a/app/presenters/creator_home_presenter.rb
+++ b/app/presenters/creator_home_presenter.rb
@@ -33,6 +33,8 @@ class CreatorHomePresenter
       }
     end
 
+    first_product_starter_enabled = seller.eligible_for_first_product_starter?
+
     today = Time.now.in_time_zone(seller.timezone).to_date
     analytics = CreatorAnalytics::CachingProxy.new(seller).data_for_dates(today - 30, today)
     top_sales_data = analytics[:by_date][:sales]
@@ -106,7 +108,8 @@ class CreatorHomePresenter
       stripe_verification_message:,
       tax_forms:,
       show_1099_download_notice:,
-      tax_center_enabled:
+      tax_center_enabled:,
+      first_product_starter_enabled:,
     }
   end
 

--- a/app/services/ai/first_product_starter_service.rb
+++ b/app/services/ai/first_product_starter_service.rb
@@ -1,0 +1,201 @@
+# frozen_string_literal: true
+
+class Ai::FirstProductStarterService
+  class MaxRetriesExceededError < StandardError; end
+
+  TIMEOUT_SECONDS = 30
+  MODEL = "gpt-5.4-nano"
+  PROMPT_PATH = Rails.root.join("lib/prompts/first_product_starter/options.md")
+  TEMPLATES_PATH = Rails.root.join("lib/first_product_starter/templates.yml")
+  MAX_RETRIES = 2
+  REASONING_EFFORT = "none"
+  PROMPT_CACHE_KEY = "first_product_starter:v7_pool3"
+  TEMPLATE_FIELDS = %i[name native_type price_cents description rationale_one_line].freeze
+  SHARED_BRAND_TOKENS = %w[notion figma blender lightroom vrchat premiere photoshop canva obsidian unity unreal].freeze
+  POOL_SIZE = 3
+  PER_GROUP_TARGET = 1
+  INSTRUCTIONAL_TYPES = %w[course ebook].freeze
+  MEMBERSHIP_PRICE_HIGH_THRESHOLD_CENTS = 2900
+  MEMBERSHIP_PRICE_LOW_THRESHOLD_CENTS = 500
+  MEMBERSHIP_PRICE_HIGH_FALLBACK_CENTS = 1500
+  MEMBERSHIP_PRICE_LOW_FALLBACK_CENTS = 999
+
+  TEMPLATES = YAML.load_file(TEMPLATES_PATH, symbolize_names: true)[:templates].each { |t| t.freeze }.freeze
+  SYSTEM_PROMPT = File.read(PROMPT_PATH).freeze
+  BRAND_TOKEN_PATTERNS = SHARED_BRAND_TOKENS.each_with_object({}) do |token, h|
+    h[token] = /(?<![a-z0-9])#{Regexp.escape(token)}(?![a-z0-9])/i
+  end.freeze
+
+  OPTIONS_SCHEMA = {
+    type: "object",
+    additionalProperties: false,
+    required: ["options"],
+    properties: {
+      options: {
+        type: "array",
+        minItems: POOL_SIZE,
+        maxItems: POOL_SIZE,
+        items: {
+          type: "object",
+          additionalProperties: false,
+          required: ["name", "native_type", "price_cents", "description", "rationale_one_line", "is_primary"],
+          properties: {
+            name: { type: "string", minLength: 1, maxLength: 80 },
+            native_type: { type: "string", enum: ["digital", "course", "ebook", "membership"] },
+            price_cents: { type: "integer", minimum: 0 },
+            description: { type: "string", minLength: 250, maxLength: 1000 },
+            rationale_one_line: { type: "string", maxLength: 140 },
+            is_primary: { type: "boolean" }
+          }
+        }
+      }
+    }
+  }.freeze
+
+  def initialize(seller:)
+    @seller = seller
+  end
+
+  def generate_options(textarea_answer:)
+    return template_options if textarea_answer.to_s.strip.blank?
+
+    parsed = with_retries do
+      response = openai_client.chat(parameters: build_params(textarea_answer: textarea_answer))
+      JSON.parse(response.dig("choices", 0, "message", "content"), symbolize_names: true)
+    end
+    enforce_one_primary!(parsed[:options])
+    ensure_membership_present!(parsed[:options])
+    enforce_unique_domains!(parsed[:options])
+    interleave_pool_by_type!(parsed[:options])
+    parsed.merge(source: "ai")
+  end
+
+  def template_options
+    random_template_set.merge(source: "templates")
+  end
+
+  private
+    attr_reader :seller
+
+    def build_params(textarea_answer:)
+      params = {
+        model: MODEL,
+        messages: [
+          { role: "system", content: SYSTEM_PROMPT },
+          { role: "user", content: textarea_answer.to_s.strip }
+        ],
+        response_format: {
+          type: "json_schema",
+          json_schema: { name: "first_product_starter_options", strict: true, schema: OPTIONS_SCHEMA }
+        },
+        max_completion_tokens: 3000,
+        prompt_cache_key: PROMPT_CACHE_KEY,
+        user: seller.external_id.to_s
+      }
+      params[:reasoning_effort] = REASONING_EFFORT unless REASONING_EFFORT == "none"
+      params
+    end
+
+    def openai_client
+      OpenAI::Client.new(request_timeout: TIMEOUT_SECONDS)
+    end
+
+    def with_retries
+      attempts = 0
+      begin
+        attempts += 1
+        yield
+      rescue Faraday::TimeoutError, Faraday::ServerError, JSON::ParserError => e
+        raise MaxRetriesExceededError, "OpenAI failed after #{MAX_RETRIES} attempts: #{e.class}" if attempts >= MAX_RETRIES
+        retry
+      end
+    end
+
+    def enforce_one_primary!(options)
+      return if options.count { |o| o[:is_primary] } == 1
+      options.each_with_index { |o, i| o[:is_primary] = (i == 0) }
+    end
+
+    def group_for(option)
+      return :membership if option[:native_type] == "membership"
+      return :instructional if INSTRUCTIONAL_TYPES.include?(option[:native_type])
+      :digital
+    end
+
+    def interleave_pool_by_type!(options)
+      groups = options.group_by { |o| group_for(o) }
+
+      primary = options.find { |o| o[:is_primary] }
+      primary_group = primary ? group_for(primary) : :membership
+
+      base_order = case primary_group
+                   when :membership then %i[membership digital instructional]
+                   when :digital then %i[digital membership instructional]
+                   else %i[instructional membership digital]
+      end
+
+      if primary && groups[primary_group]
+        groups[primary_group].delete(primary)
+        groups[primary_group].unshift(primary)
+      end
+
+      arranged = []
+      PER_GROUP_TARGET.times do |batch|
+        order = base_order.rotate(batch)
+        order.each do |g|
+          item = groups[g]&.shift
+          arranged << item if item
+        end
+      end
+
+      arranged += (options - arranged)
+      options.replace(arranged.first(POOL_SIZE))
+    end
+
+    def ensure_membership_present!(options)
+      return if options.any? { |o| o[:native_type] == "membership" }
+      target = options.find { |o| !o[:is_primary] } || options.last
+      target[:native_type] = "membership"
+      target[:price_cents] = membership_fallback_price_cents(target[:price_cents].to_i)
+    end
+
+    def membership_fallback_price_cents(price_cents)
+      return MEMBERSHIP_PRICE_HIGH_FALLBACK_CENTS if price_cents > MEMBERSHIP_PRICE_HIGH_THRESHOLD_CENTS
+      return MEMBERSHIP_PRICE_LOW_FALLBACK_CENTS if price_cents < MEMBERSHIP_PRICE_LOW_THRESHOLD_CENTS
+      price_cents
+    end
+
+    def enforce_unique_domains!(options)
+      seen = {}
+      options.each do |option|
+        name_lower = option[:name].to_s.downcase
+        BRAND_TOKEN_PATTERNS.each do |token, pattern|
+          next unless name_lower.match?(pattern)
+          if seen[token]
+            stripped_name = option[:name].gsub(pattern, "").squeeze(" ").strip
+            next if stripped_name.empty?
+            option[:name] = stripped_name
+            option[:rationale_one_line] = option[:rationale_one_line].to_s.gsub(pattern, "").squeeze(" ").strip
+          else
+            seen[token] = true
+          end
+        end
+      end
+    end
+
+    def random_template_set
+      memberships = TEMPLATES.select { |t| t[:native_type] == "membership" }
+      digitals = TEMPLATES.select { |t| t[:native_type] == "digital" }
+      instructional = TEMPLATES.select { |t| INSTRUCTIONAL_TYPES.include?(t[:native_type]) }
+
+      picks = memberships.sample([memberships.length, PER_GROUP_TARGET].min) +
+              digitals.sample([digitals.length, PER_GROUP_TARGET].min) +
+              instructional.sample([instructional.length, PER_GROUP_TARGET].min)
+
+      picks = picks.first(POOL_SIZE).map { |t| t.slice(*TEMPLATE_FIELDS) }
+      picks.first[:is_primary] = true
+      picks.drop(1).each { |t| t[:is_primary] = false }
+      interleave_pool_by_type!(picks)
+      { options: picks }
+    end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -569,6 +569,11 @@ Rails.application.routes.draw do
       resource :dismiss_ai_product_generation_promo, only: [:create]
     end
 
+    resource :first_product_starter, only: [], controller: "first_product_starter" do
+      post :options
+      post :draft
+    end
+
     namespace :checkout do
       resources :discounts, only: %i[index create update destroy] do
         get :paged, on: :collection

--- a/db/seeds/020_development_staging/01_users.rb
+++ b/db/seeds/020_development_staging/01_users.rb
@@ -28,6 +28,8 @@ if seller.blank?
   seller.save!(validate: false)
 end
 
+Feature.activate_user(:first_product_starter, seller)
+
 TeamMembership::ROLES.excluding(TeamMembership::ROLE_OWNER).each do |role|
   email = "seller+#{role}@gumroad.com"
   user = User.find_by(email:)

--- a/lib/first_product_starter/templates.yml
+++ b/lib/first_product_starter/templates.yml
@@ -1,0 +1,388 @@
+# Universal product templates for the empty-input path of FirstProductStarter.
+# Bracketed [tokens] are the seller's edit surface — the placeholder shows
+# them what to fill in. No real brand or author names are used here.
+#
+# Shape for each entry:
+#   id, native_type, price_cents, name, rationale_one_line, description
+# `is_primary` is assigned at runtime by the service.
+
+templates:
+  - id: app_license
+    native_type: digital
+    price_cents: 1900
+    name: "[Your app name] — lifetime license"
+    rationale_one_line: "Native utilities are a top-selling category — small, focused, no subscription."
+    description: |
+      <p>You want a small, native app that does one thing and gets out of your way.</p>
+      <h3>What's included</h3>
+      <ul>
+        <li>The full [Your app name], signed and notarized for [your platform]</li>
+        <li>License valid for life on up to [3] devices</li>
+        <li>Free updates for [12] months after purchase</li>
+        <li>Quick-start guide and a cheatsheet of every keyboard shortcut</li>
+        <li>[Optional power-user mode] — turn it on or off anytime</li>
+      </ul>
+      <h3>Who this is for</h3>
+      <p>People who want [the one job your app does] without a monthly fee, login screen, or telemetry.</p>
+      <p>Buy once, install in a minute, use it the same day. 30-day money-back guarantee.</p>
+
+  - id: productivity_template
+    native_type: digital
+    price_cents: 4900
+    name: "The [Your system] productivity template"
+    rationale_one_line: "Productivity templates are one of the highest-volume tags on Gumroad."
+    description: |
+      <p>You want to stop juggling tabs, sticky notes, and half-finished docs. One template, one place, all of it.</p>
+      <h3>What's included</h3>
+      <ul>
+        <li>The full [Your system] template, ready to drop into [your knowledge tool]</li>
+        <li>[Tasks, projects, notes, and a journal] linked to one dashboard</li>
+        <li>A walkthrough video showing how to use it day to day</li>
+        <li>[50] starter [journal prompts / weekly reviews / dashboard views]</li>
+        <li>Free updates whenever the template improves</li>
+      </ul>
+      <h3>Who this is for</h3>
+      <p>People who tried five productivity systems and want one that finally sticks.</p>
+      <p>Duplicate it once, drop in [your projects], start the same hour. 30-day money-back guarantee.</p>
+
+  - id: typeface
+    native_type: digital
+    price_cents: 1900
+    name: "[Your font name] — variable typeface, [number] styles"
+    rationale_one_line: "Independent type designers consistently sell fonts as one-off licenses."
+    description: |
+      <p>You want a typeface that earns its place in the work — bold, distinctive, not another safe sans-serif.</p>
+      <h3>What's included</h3>
+      <ul>
+        <li>[Your font name] in [number] styles, including a variable typeface</li>
+        <li>OTF, TTF, and WOFF2 files for every weight</li>
+        <li>Web-font license for use on [up to 3] domains</li>
+        <li>Style specimen PDF and a printable poster</li>
+        <li>Personal and commercial license — no attribution required</li>
+      </ul>
+      <h3>Who this is for</h3>
+      <p>Designers and brand teams who pick fonts on character, not safety.</p>
+      <p>Drop it into [your design tool] and ship the same week.</p>
+
+  - id: ai_prompt_pack
+    native_type: digital
+    price_cents: 1900
+    name: "[Number]+ [your domain] prompts for AI chatbots"
+    rationale_one_line: "Curated prompt packs sell well even at pay-what-you-want."
+    description: |
+      <p>You want prompts that already work. Not "tips," not "tricks" — a library you can paste and ship.</p>
+      <h3>What's included</h3>
+      <ul>
+        <li>[Number]+ tested prompts across [your domain]</li>
+        <li>Categorized by use case: [marketing, support, research, writing]</li>
+        <li>Notes on which model each prompt works best with</li>
+        <li>Quarterly updates whenever new techniques emerge</li>
+        <li>Lifetime updates — no recurring fee</li>
+      </ul>
+      <h3>Who this is for</h3>
+      <p>People who use AI chatbots every day and are tired of starting from scratch.</p>
+      <p>Bookmark it, copy a prompt, paste, ship. Refund within 30 days, no questions asked.</p>
+
+  - id: brand_kit
+    native_type: digital
+    price_cents: 3900
+    name: "[Your brand] identity package — logo files, mockups, and guidelines"
+    rationale_one_line: "Brand designers package handoff outputs into a single buyable kit."
+    description: |
+      <p>You want a logo package that feels finished — every variation, every size, every file your client will ever ask for.</p>
+      <h3>What's included</h3>
+      <ul>
+        <li>[Your brand] full logo, mark, and wordmark — [number] lockups in total</li>
+        <li>Color, black, white, inverted, and grayscale versions of each</li>
+        <li>Vector files: AI, EPS, PDF, SVG. Raster: PNG, JPG.</li>
+        <li>Brand guidelines PDF — color, type, spacing, do's and don'ts</li>
+        <li>Mockup gallery: business cards, signage, social posts, web</li>
+      </ul>
+      <h3>Who this is for</h3>
+      <p>Designers handing off a brand and clients who want one zip with everything inside.</p>
+      <p>Hand it over, get paid, move to the next project.</p>
+
+  - id: color_preset_pack
+    native_type: digital
+    price_cents: 1900
+    name: "[Your style] color preset pack for [your video editor]"
+    rationale_one_line: "LUT and preset packs are a steady seller for video creators."
+    description: |
+      <p>You shoot good footage. Color is what makes it look like something. This pack saves the hour of grading every clip from scratch.</p>
+      <h3>What's included</h3>
+      <ul>
+        <li>[Number] presets in the [Your style] family — cinematic, warm, neutral, contrast-heavy</li>
+        <li>.cube files compatible with [your video editor]</li>
+        <li>Before-and-after clips so you can see what each preset does</li>
+        <li>Short PDF on layering presets without crushing the highlights</li>
+        <li>Lifetime updates as new looks get added</li>
+      </ul>
+      <h3>Who this is for</h3>
+      <p>Editors and creators who want a consistent look across [your channel].</p>
+      <p>Drop a preset on the timeline, finish the cut, post the same day.</p>
+
+  - id: motion_preset_pack
+    native_type: digital
+    price_cents: 3900
+    name: "[Number]+ motion presets for [your motion graphics editor]"
+    rationale_one_line: "Preset packs scale with quantity hooks — '1,400 presets' beats 'lots of presets'."
+    description: |
+      <p>You want clean transitions and motion that doesn't look like every YouTube tutorial. This pack gets you there in one drag.</p>
+      <h3>What's included</h3>
+      <ul>
+        <li>[Number]+ presets: cuts, overlays, transitions, glitch, light leaks</li>
+        <li>Drop-in compatibility with [your motion graphics editor] [version and newer]</li>
+        <li>Each preset is fully editable — duration, color, motion blur</li>
+        <li>Project files for the most-used effects so you can study the rigging</li>
+        <li>Sound design pack as a free bonus</li>
+      </ul>
+      <h3>Who this is for</h3>
+      <p>Editors who'd rather assemble than build from scratch.</p>
+      <p>Install once, use forever. 14-day money-back guarantee.</p>
+
+  - id: software_addon
+    native_type: digital
+    price_cents: 2900
+    name: "[Your add-on name] for [your 3D tool] — [what it does]"
+    rationale_one_line: "Power-tool add-ons sell at higher price points than other one-off digital products."
+    description: |
+      <p>You spend more time fighting your software than using it. [Your add-on name] does the [tedious part] in one click.</p>
+      <h3>What's included</h3>
+      <ul>
+        <li>[Your add-on name] — installable .zip for [your 3D tool] [version and newer]</li>
+        <li>[Constraint sketching / retopo / UV unwrap / rigging] tools that work non-destructively</li>
+        <li>Sample files showing the workflow start to finish</li>
+        <li>Documentation and a 5-minute getting-started video</li>
+        <li>Lifetime updates and access to a beta channel</li>
+      </ul>
+      <h3>Who this is for</h3>
+      <p>Modelers who hit the same wall every project and want a tool, not a workaround.</p>
+      <p>Install in under a minute, run the demo file, see if it earns its place.</p>
+
+  - id: illustration_kit
+    native_type: digital
+    price_cents: 3900
+    name: "[Your kit name] — hand-drawn illustration library"
+    rationale_one_line: "Illustration kits convert when source files cover every common design tool."
+    description: |
+      <p>You want characters in your designs, not stock photos. Hand-drawn, mixable, on-brand.</p>
+      <h3>What's included</h3>
+      <ul>
+        <li>[Number] illustrated characters with mix-and-match parts</li>
+        <li>Source files for [your design tool] — components, color tokens, variants</li>
+        <li>Flat SVG and PNG exports for the web</li>
+        <li>[Expressions, poses, accessories, hair] you can swap freely</li>
+        <li>Personal and commercial license, no attribution required</li>
+      </ul>
+      <h3>Who this is for</h3>
+      <p>Product designers, marketers, and indie founders who want their landing pages to feel human.</p>
+      <p>Drop a character into [your hero section] and ship.</p>
+
+  - id: niche_playbook
+    native_type: ebook
+    price_cents: 2900
+    name: "How to start and grow a [your niche] business"
+    rationale_one_line: "Numbers-first niche playbooks consistently outperform abstract advice."
+    description: |
+      <p>You're tired of generic "start a business" guides. You want the specific [your niche] thing — what to charge, who to call, where the first dollar comes from.</p>
+      <h3>What's included</h3>
+      <ul>
+        <li>[Number]-page playbook covering setup, first customer, and scaling to [your goal]</li>
+        <li>The exact pricing I used and what I'd charge today</li>
+        <li>The customer-acquisition method that landed [number] of my first clients</li>
+        <li>Equipment, tools, and software list with current costs</li>
+        <li>Real numbers: revenue, expenses, margins from my first [time period]</li>
+      </ul>
+      <h3>Who this is for</h3>
+      <p>People stuck on the first step of a [your niche] business and tired of theory.</p>
+      <p>Read it in an evening, take action by the end of the week.</p>
+
+  - id: walkthrough_course
+    native_type: course
+    price_cents: 5900
+    name: "Make a [your project] in [your tool] — even if you've never opened it"
+    rationale_one_line: "'Make-this-thing' walkthroughs outperform abstract instruction for first-time creators."
+    description: |
+      <p>You want to make [your project] but every tutorial stops at the boring part. This course goes all the way through, and assumes nothing.</p>
+      <h3>What's included</h3>
+      <ul>
+        <li>[Number] short videos — under [10] minutes each, downloadable forever</li>
+        <li>Project files for every lesson, including the final result</li>
+        <li>Access to a community channel where I answer questions weekly</li>
+        <li>A starter kit so you can skip past setup and get to the work</li>
+        <li>Lifetime updates as [your tool] evolves</li>
+      </ul>
+      <h3>Who this is for</h3>
+      <p>People who've never opened [your tool] and want to ship something real, not a "hello world."</p>
+      <p>Spend an hour a day for a week and walk away with [your project] you can show.</p>
+
+  - id: practice_bundle
+    native_type: digital
+    price_cents: 1900
+    name: "[Your skill] practice bundle — [number] cards and a tracker"
+    rationale_one_line: "Practice bundles convert when paired with a habit tracker."
+    description: |
+      <p>You want to practice [your skill] consistently, not in unfocused 10-minute bursts.</p>
+      <h3>What's included</h3>
+      <ul>
+        <li>[Number]+ practice cards in PDF and PNG, sorted by difficulty</li>
+        <li>A 30-day habit tracker so you can see the streak build</li>
+        <li>[Number]-page guide on the principles behind every prompt</li>
+        <li>Warm-up exercises for short days and deep sessions for long ones</li>
+        <li>Lifetime access and free updates whenever new cards drop</li>
+      </ul>
+      <h3>Who this is for</h3>
+      <p>Beginner and intermediate [your discipline] practitioners who care about reps over perfection.</p>
+      <p>Print it, tape it to your wall, do one a day.</p>
+
+  - id: homeschool_curriculum
+    native_type: digital
+    price_cents: 9900
+    name: "[Grade level] [subject] curriculum — full bundle"
+    rationale_one_line: "Curriculum bundles sustain $50-200 price points on the discover page."
+    description: |
+      <p>You want a curriculum your kid asks to come back to. Wonder, discovery, and just enough structure to keep the year moving.</p>
+      <h3>What's included</h3>
+      <ul>
+        <li>Complete parent guide for [grade level] [subject] — [number] weeks of lessons</li>
+        <li>Student notebooks for [language arts, science, art, nature]</li>
+        <li>Book lists, copywork, and project ideas with materials lists</li>
+        <li>Printables, weekly planners, and progress trackers</li>
+        <li>[Bonus] seasonal units you can drop in throughout the year</li>
+      </ul>
+      <h3>Who this is for</h3>
+      <p>Homeschool parents who want a secular, hands-on curriculum without burning evenings on prep.</p>
+      <p>PDF download — print, bind, start Monday.</p>
+
+  - id: avatar_pack
+    native_type: digital
+    price_cents: 1900
+    name: "[Your avatar name] — [style] avatar for [your virtual world platform]"
+    rationale_one_line: "Avatar and 3D-asset packs are the largest category by tag volume."
+    description: |
+      <p>You want an avatar that stands out in worlds full of defaults. [Style] vibe, ready to rig, ready to wear.</p>
+      <h3>What's included</h3>
+      <ul>
+        <li>[Your avatar name] base mesh, fully rigged for [your virtual world platform]</li>
+        <li>[Number] outfit variants and accessories included</li>
+        <li>Texture files in PSD so you can recolor anything</li>
+        <li>Setup video showing upload and visemes step by step</li>
+        <li>Personal-use license — wear it on any account you own</li>
+      </ul>
+      <h3>Who this is for</h3>
+      <p>People in [your virtual world platform] who care how they show up.</p>
+      <p>Download, upload, log in. The lobby will notice.</p>
+
+  - id: trading_course
+    native_type: course
+    price_cents: 9900
+    name: "[Your strategy] trading — full walkthrough"
+    rationale_one_line: "Trading and finance courses anchor at $99-149."
+    description: |
+      <p>You want a clear method, not another influencer feed. Real setups, real risk management, real screen time.</p>
+      <h3>What's included</h3>
+      <ul>
+        <li>[Number] hours of recorded lessons, sectioned by topic</li>
+        <li>Live walk-throughs of the [Your strategy] setup on real charts</li>
+        <li>A risk-management framework with a position-size calculator</li>
+        <li>The [number] indicators I actually use and the rest you can ignore</li>
+        <li>Access to a private channel where I post setups during market hours</li>
+      </ul>
+      <h3>Who this is for</h3>
+      <p>Traders who want process, not promises. Educational only — no signals, no guarantees.</p>
+      <p>Watch a module, paper-trade the setup for a week, decide if it fits your style.</p>
+
+  - id: community_monthly
+    native_type: membership
+    price_cents: 1900
+    name: "[Your community name] — monthly membership"
+    rationale_one_line: "A small, active room beats a big audience for ongoing revenue."
+    description: |
+      <p>You want a room of people doing the same thing as you, who pick up the phone when you ask.</p>
+      <h3>What's included</h3>
+      <ul>
+        <li>Active membership in [Your community name] — pay monthly, cancel anytime</li>
+        <li>[Weekly] live calls with guest speakers from [your field]</li>
+        <li>A members-only channel that's actually active, not a graveyard</li>
+        <li>Members-only archive of every past session</li>
+        <li>Brainstorming threads where members share work for feedback</li>
+      </ul>
+      <h3>Who this is for</h3>
+      <p>Operators in [your space] who'd rather invest in one room than chase ten newsletters.</p>
+      <p>Cancel anytime, no contract, no upsells.</p>
+
+  - id: monthly_drops
+    native_type: membership
+    price_cents: 900
+    name: "[Your audience] — monthly [drops/templates/assets]"
+    rationale_one_line: "Low-friction monthly drops scale with backlog — every past month adds value."
+    description: |
+      <p>You want fresh material every month without thinking about it. Show up, find something new, get to work.</p>
+      <h3>What's included</h3>
+      <ul>
+        <li>[Number] new [templates / assets / drops] every month</li>
+        <li>Members-only archive of every past drop, downloadable forever</li>
+        <li>A short note from me on how each one was made and why</li>
+        <li>Members vote on next month's theme — I build what wins</li>
+        <li>Cancel anytime, keep what you've already downloaded</li>
+      </ul>
+      <h3>Who this is for</h3>
+      <p>People in [your audience] who'd rather pay a few dollars a month than scroll for inspiration.</p>
+      <p>Subscribe, log in once a month, leave with [your next thing] ready to use.</p>
+
+  - id: research_subscription
+    native_type: membership
+    price_cents: 7900
+    name: "[Your market] research and signals — monthly"
+    rationale_one_line: "Research subscriptions sit in the $29-99/month band on the discover page."
+    description: |
+      <p>You want one clear voice on [your market] every day, not a feed of thirty.</p>
+      <h3>What's included</h3>
+      <ul>
+        <li>Daily research note delivered before [your market] opens</li>
+        <li>Weekly long-form deep dive on a single setup or theme</li>
+        <li>Live Q&amp;A every [Friday] — I answer whatever's on your screen</li>
+        <li>Members-only archive of every note, searchable and tagged</li>
+        <li>Educational only — no recommendations, no signals service</li>
+      </ul>
+      <h3>Who this is for</h3>
+      <p>Independent investors and traders who care about process and want one source they can trust.</p>
+      <p>Try the first month, cancel anytime. You keep everything you've already read.</p>
+
+  - id: office_hours
+    native_type: membership
+    price_cents: 2900
+    name: "[Your topic] office hours — monthly Q&A"
+    rationale_one_line: "Q&A formats monetize expertise without a course backlog."
+    description: |
+      <p>You want one hour a month with someone who's been there. No course, no ebook — just answers to your specific questions.</p>
+      <h3>What's included</h3>
+      <ul>
+        <li>Monthly group office hours — bring your problem, get a real answer</li>
+        <li>A private channel where I answer asynchronously between sessions</li>
+        <li>Recorded sessions of every past Q&amp;A, searchable by topic</li>
+        <li>A monthly write-up of the most useful threads</li>
+        <li>Cancel anytime, keep what you've downloaded</li>
+      </ul>
+      <h3>Who this is for</h3>
+      <p>Independent operators in [your topic] who want feedback from someone who's shipped what they're building.</p>
+      <p>Subscribe, send the question you've been sitting on, hear back the same week.</p>
+
+  - id: power_user_paywall
+    native_type: membership
+    price_cents: 1500
+    name: "Power users of [your main product] — direct line and early access"
+    rationale_one_line: "Tool-makers monetize their power users via Q&A and early-access tiers."
+    description: |
+      <p>You bought [my main product] and want to get more out of it — directly from the person who made it.</p>
+      <h3>What's included</h3>
+      <ul>
+        <li>A private channel where I answer questions, usually within a day</li>
+        <li>Early access to new versions and features before public release</li>
+        <li>Short walk-throughs of advanced and lesser-known features</li>
+        <li>A vote on what gets built next — your wishlist matters here</li>
+        <li>Cancel anytime, no contract, no minimum</li>
+      </ul>
+      <h3>Who this is for</h3>
+      <p>Power users of [my main product] who want a direct line to the person building it.</p>
+      <p>Subscribe, ask the question you've been sitting on, get an answer.</p>

--- a/lib/prompts/first_product_starter/options.md
+++ b/lib/prompts/first_product_starter/options.md
@@ -1,0 +1,138 @@
+# Task
+
+You are a sales coach for new sellers on **gumroad.com** — the marketplace where independent creators sell digital downloads, courses, ebooks, and memberships. Turn the seller's two-or-more-word input into 3 publishable first-product drafts that fit what actually sells on gumroad.com (browse the discover page in your training data: macOS utilities, Notion templates, fonts, AI prompt packs, Lightroom presets, AE/Premiere preset packs, VRChat avatars, Blender add-ons, illustration kits, niche playbook ebooks, "make this thing" courses, lifetime communities, monthly drops, signal subscriptions). Return strict JSON. Do not ask follow-up questions, do not narrate your reasoning, and do not output anything outside the JSON schema.
+
+# Output contract — apply before reasoning about content
+
+1. Return EXACTLY 3 options.
+2. EXACTLY 1 has `is_primary: true`. The frontend shows it first — make it the strongest fit.
+3. AT LEAST 1 is `native_type: "membership"` (the subscription twin at position 2).
+4. Mix the types — 3 distinct shapes if possible. Never all 3 the same shape.
+5. Order the array as: [primary, subscription twin (membership), adjacent course/ebook]. Position 1 is the strongest fit; positions 2 and 3 expand the angle.
+6. No two names share a primary brand or topic word (e.g., if one says "Notion", no other can). Same for: Figma, Blender, Lightroom, VRChat, Premiere, Photoshop, Canva, Obsidian, Unity, Unreal, and any platform/tool name.
+7. Each option:
+   - `name`: 1-80 chars, sentence case, concrete. No emojis.
+   - `native_type`: `digital` | `course` | `ebook` | `membership`.
+   - `price_cents`: integer ≥ 0, anchored to the reference ranges below. `0` (PWW) only for explicit lead-magnet intent.
+   - `description`: 80-130 words of structured HTML using only `<p>`, `<h3>`, `<ul>`, `<li>`, `<strong>`, `<em>`, in this order:
+     - Opening `<p>` (1 sentence): the buyer's outcome. Use "you", never "I".
+     - `<h3>What's included</h3>` + `<ul>` of 3-4 concrete deliverables (5-12 words each).
+     - `<h3>Who this is for</h3>` + 1 sentence in `<p>`.
+     - Closing `<p>` (1 sentence): what the buyer does with it.
+   - `rationale_one_line`: ≤ 120 chars. Plain text.
+
+# Picking native_type
+
+Ask: "what does the buyer get next month after their first purchase?"
+
+- **digital** — one-time downloads: app licenses, fonts, presets, plugins, templates, swipe files, asset packs.
+- **course** — video walkthroughs with multiple modules.
+- **ebook** — written guides under ~100 pages.
+- **membership** — ongoing access: newsletters, communities, monthly drops, recurring Q&A, signal/research subs, premium support tiers, early-access tiers.
+
+If the buyer keeps receiving things on a schedule → membership. If they get one file and that's it → digital/course/ebook.
+
+# Subscription twin (position 2 of the pool)
+
+Whatever the seller sells, design ONE membership as the recurring shape of the same domain. Examples:
+
+- App license → power-user community for that app
+- Notion template → monthly template drops
+- Newsletter → premium tier with deeper analysis
+- Course → student community / office hours
+- Music album → monthly stems/sample drops
+- Plugin → early-access tier
+- Preset pack → monthly preset drops
+- Niche playbook → mastermind community
+- Trading walkthrough → daily research subscription
+- 3D model pack → monthly model drops
+
+The subscription twin must appear at position 2 of the returned array.
+
+# Picking the primary (position 1)
+
+If the seller named a concrete artifact (app, book, template, music, add-on, font, course, avatar, preset pack, podcast, newsletter), the primary IS that artifact, packaged for direct sale. Don't substitute content *about* the artifact.
+
+| Seller input | ✅ Primary | ❌ Wrong primary |
+|---|---|---|
+| "sell the app" | App license ($19-49 digital) | "App launch toolkit" course |
+| "I wrote a book" | Book as ebook ($9-29) | "Course on writing books" |
+| "I made a Notion template" | The template ($10-49) | "Notion productivity course" |
+| "I make ambient music" | Album / track pack | "Music production course" |
+| "I built a Figma plugin" | Plugin license ($15-49) | "Plugin development course" |
+
+If they described themselves but named no artifact, build the primary around their craft, domain, or audience.
+
+# Step order — design the pool in this sequence
+
+1. Read the seller's input. Identify the concrete artifact (app, book, template, music, plugin, course recording, avatar pack, podcast, newsletter, etc.). If there's no artifact, identify the seller's craft, audience, or domain.
+2. Design **position 1 (primary)**: that artifact packaged for direct sale. If the artifact is itself recurring (newsletter, community), the primary is `native_type: membership`. Otherwise use the matching one-time type.
+3. Design **position 2 (subscription twin)**: a `native_type: membership` that is the recurring shape of the same domain — see "Subscription twin" section.
+4. Design **position 3**: an adjacent `course` or `ebook` that teaches how the primary works, or a behind-the-scenes companion.
+5. Apply the brand-uniqueness rule: no two names share a primary brand or topic word.
+6. Verify the contract before returning: count is 3, exactly 1 has `is_primary: true`, at least 1 has `native_type: "membership"`, types are mixed.
+
+# Edge case behavior
+
+- **Off-topic input** (food complaint, weather, gibberish that hints at no product): build the pool around the closest sellable interpretation a Gumroad seller could reasonably ship — generic productivity, creative templates, or a niche playbook.
+- **Harmful, illegal, or regulated request** (weapons, drugs, financial advice promising returns): pivot to a legitimate adjacent niche and ignore the harmful intent. Do not refuse outright — the seller still gets 3 publishable drafts.
+- **Very vague input** ("help me sell something"): pick three loosely connected domains the seller could plausibly own and design the 3 options across them, with the strongest fit as primary.
+- **Ambiguity about native_type**: apply the "what does the buyer get next month" test (see "Picking native_type"). Do not ask the seller to clarify.
+
+# One correct example
+
+User input: `sell the app`
+
+Returned in this order. Your real output must contain 3 with all fields present.
+
+```json
+{
+  "options": [
+    {
+      "name": "App license — lifetime download",
+      "native_type": "digital",
+      "price_cents": 2900,
+      "description": "<p>You found a focused app that does one thing without subscriptions or bloat.</p><h3>What's included</h3><ul><li>The full app, signed and notarized for macOS</li><li>License valid for life on up to 3 devices</li><li>Free minor-version updates for 12 months</li><li>Quick-start guide and changelog</li></ul><h3>Who this is for</h3><p>People who want a focused tool with no login, telemetry, or upsell.</p><p>Buy once and start using it the same day.</p>",
+      "rationale_one_line": "The seller already has the app — sell the app, not content about it.",
+      "is_primary": true
+    },
+    {
+      "name": "Power users — monthly updates and Q&A",
+      "native_type": "membership",
+      "price_cents": 900,
+      "description": "<p>You bought the app and want to get more out of it directly from the developer.</p><h3>What's included</h3><ul><li>Early access to new versions before public release</li><li>Private channel where the developer answers questions</li><li>Short walkthroughs of advanced and lesser-known features</li><li>Cancel anytime, no contract</li></ul><h3>Who this is for</h3><p>Power users who want a direct line to the maker.</p><p>Subscribe and check the channel whenever you hit a wall — answers come within a day.</p>",
+      "rationale_one_line": "Subscription twin: recurring revenue from existing buyers without a new artifact.",
+      "is_primary": false
+    }
+  ]
+}
+```
+
+# Anti-patterns
+
+- Substituting content *about* the artifact for the artifact itself.
+- Treating the seller as a beginner when they've named what they have.
+- Slop openers: "Unlock the power of…", "Are you tired of…", "In today's fast-paced world…".
+- Restating the seller's input verbatim.
+- Service types (1:1 coaching, calls, commissions, Calendly bookings).
+- Physical products (hardware, print, merch, coins).
+- Crypto presales, ICOs, regulated investments.
+- All 3 options the same `native_type`.
+- Pricing 2x+ outside the reference ranges.
+- Marking a recurring product as `digital` instead of `membership`.
+- Padding the pool with near-duplicates of the primary.
+
+# Style
+
+Plain language. Active voice. Short sentences. Cut every word that doesn't earn its place.
+
+# Price anchors — calibrated to gumroad.com discover-page top sellers (USD, 2026)
+
+- **Digital one-time**: Mac apps $5-30, Notion templates $10-49, Blender/CAD add-ons $15-70, fonts $10-40, AE/Premiere presets $20-80, VRChat avatars / 3D models $10-30, AI prompt packs $9-49, logo/mockup packs $20-80, LUT presets $10-30, stock illustration $19-49 (or PWW for lead-gen).
+- **Practice/study bundles**: $19-49 (sketching/prompt decks), $50-200 (homeschool grades), $39-99 (exam toolkits).
+- **Courses**: coding/design/fitness/finance $29-149, "make this thing" walkthroughs $29-89.
+- **Niche-knowledge ebooks**: industry playbooks $9-29, health/cycle/fitness $9-29.
+- **Memberships**: monthly $5-29, annual $79-299, lifetime $150-500.
+- **Signal/research subs**: $29-99/month.
+- **Bundles**: 2-5 related items at $19-99.
+- **PWW** (`price_cents = 0`): deliberate lead-gen only.

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3795,6 +3795,39 @@ describe User, :vcr do
     end
   end
 
+  describe "#eligible_for_first_product_starter?" do
+    let(:user) { create(:user) }
+
+    context "when the feature flag is off" do
+      it "returns false" do
+        expect(user.eligible_for_first_product_starter?).to be(false)
+      end
+    end
+
+    context "when the feature flag is on" do
+      before { Feature.activate_user(:first_product_starter, user) }
+
+      it "returns true for a confirmed, non-suspended user with zero sales" do
+        expect(user.eligible_for_first_product_starter?).to be(true)
+      end
+
+      it "returns false when the user is unconfirmed" do
+        user.update!(confirmed_at: nil)
+        expect(user.eligible_for_first_product_starter?).to be(false)
+      end
+
+      it "returns false when the user is suspended" do
+        user.update!(user_risk_state: "suspended_for_fraud")
+        expect(user.eligible_for_first_product_starter?).to be(false)
+      end
+
+      it "does NOT require past sales (independent of eligible_for_ai_product_generation?)" do
+        expect(user.sales_cents_total).to eq(0)
+        expect(user.eligible_for_first_product_starter?).to be(true)
+      end
+    end
+  end
+
   describe ".id?" do
     context "with valid numeric values" do
       it "returns true for integer 1" do

--- a/spec/policies/first_product_starter_policy_spec.rb
+++ b/spec/policies/first_product_starter_policy_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe FirstProductStarterPolicy do
+  subject { described_class }
+
+  let(:seller) { create(:user) }
+  let(:context) { SellerContext.new(user: seller, seller: seller) }
+
+  permissions :options?, :draft? do
+    it "denies when the flag is off" do
+      expect(subject).not_to permit(context, :first_product_starter)
+    end
+
+    it "permits when the flag is on and the seller is eligible" do
+      Feature.activate_user(:first_product_starter, seller)
+      seller.confirm
+      expect(subject).to permit(context, :first_product_starter)
+    end
+
+    it "denies when the seller already has a visible product" do
+      Feature.activate_user(:first_product_starter, seller)
+      seller.confirm
+      create(:product, user: seller, draft: false)
+      expect(subject).not_to permit(context, :first_product_starter)
+    end
+  end
+end

--- a/spec/presenters/creator_home_presenter_spec.rb
+++ b/spec/presenters/creator_home_presenter_spec.rb
@@ -387,5 +387,22 @@ describe CreatorHomePresenter do
         expect(props[:tax_center_enabled]).to be(false)
       end
     end
+
+    describe "first_product_starter_enabled" do
+      it "returns false when the flag is off" do
+        expect(presenter.creator_home_props[:first_product_starter_enabled]).to be(false)
+      end
+
+      it "returns true when the flag is on and the seller is eligible" do
+        Feature.activate_user(:first_product_starter, seller)
+        expect(presenter.creator_home_props[:first_product_starter_enabled]).to be(true)
+      end
+
+      it "returns false when the flag is on but the seller is suspended" do
+        Feature.activate_user(:first_product_starter, seller)
+        seller.update!(user_risk_state: "suspended_for_fraud")
+        expect(presenter.creator_home_props[:first_product_starter_enabled]).to be(false)
+      end
+    end
   end
 end

--- a/spec/requests/first_product_starter_controller_spec.rb
+++ b/spec/requests/first_product_starter_controller_spec.rb
@@ -1,0 +1,208 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe FirstProductStarterController, type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:seller) { create(:user) }
+
+  before do
+    host! UrlService.domain_with_protocol.gsub(%r{^https?://}, "")
+    allow_any_instance_of(ActionController::Base).to receive(:protect_against_forgery?).and_return(false)
+    Feature.activate_user(:first_product_starter, seller)
+    sign_in(seller)
+  end
+
+  describe "POST /first_product_starter/options" do
+    def make_options(source: "ai")
+      {
+        source: source,
+        options: 3.times.map do |i|
+          {
+            name: "Option #{i + 1}",
+            native_type: "digital",
+            price_cents: 999,
+            description: "<p>" + ("Lorem ipsum sample copy. " * 20) + "</p>",
+            rationale_one_line: "Plausible default.",
+            is_primary: i.zero?
+          }
+        end
+      }
+    end
+
+    let(:fake_ai_options) { make_options(source: "ai") }
+    let(:fake_template_options) { make_options(source: "templates") }
+
+    before do
+      $redis.del(RedisKey.ai_request_throttle(seller.id))
+      $redis.del("#{RedisKey.ai_request_throttle('ip')}:127.0.0.1")
+    end
+
+    it "returns three product options with capped: false under the cap" do
+      allow_any_instance_of(Ai::FirstProductStarterService)
+        .to receive(:generate_options).and_return(fake_ai_options)
+
+      post "/first_product_starter/options", as: :json, params: { textarea_answer: "I'm a Figma designer." }
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body, symbolize_names: true)
+      expect(body[:options].length).to eq(3)
+      expect(body[:capped]).to be(false)
+    end
+
+    it "returns 401 when the flag is off" do
+      Feature.deactivate_user(:first_product_starter, seller)
+      post "/first_product_starter/options", as: :json, params: { textarea_answer: "anything" }
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "falls through to template_options with capped: true once the per-user cap is hit" do
+      stub_const("FirstProductStarterController::THROTTLE_LIMIT_PER_HOUR", 0)
+      allow_any_instance_of(Ai::FirstProductStarterService)
+        .to receive(:template_options).and_return(fake_template_options)
+      expect_any_instance_of(Ai::FirstProductStarterService).not_to receive(:generate_options)
+
+      post "/first_product_starter/options", as: :json, params: { textarea_answer: "anything" }
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body, symbolize_names: true)
+      expect(body[:options].length).to eq(3)
+      expect(body[:capped]).to be(true)
+    end
+
+    it "does not increment the throttle bucket when the service serves templates (empty input)" do
+      allow_any_instance_of(Ai::FirstProductStarterService)
+        .to receive(:generate_options).and_return(fake_template_options)
+
+      post "/first_product_starter/options", as: :json, params: { textarea_answer: "" }
+
+      expect($redis.get(RedisKey.ai_request_throttle(seller.id)).to_i).to eq(0)
+    end
+
+    it "increments the throttle bucket only when the service ran the AI path" do
+      allow_any_instance_of(Ai::FirstProductStarterService)
+        .to receive(:generate_options).and_return(fake_ai_options)
+
+      post "/first_product_starter/options", as: :json, params: { textarea_answer: "I want to sell my book" }
+      expect($redis.get(RedisKey.ai_request_throttle(seller.id)).to_i).to eq(1)
+
+      post "/first_product_starter/options", as: :json, params: { textarea_answer: "I want to sell my book" }
+      expect($redis.get(RedisKey.ai_request_throttle(seller.id)).to_i).to eq(2)
+    end
+
+    it "caps the AI path at 2 per user per hour and falls through to templates without ticking the bucket further" do
+      allow_any_instance_of(Ai::FirstProductStarterService)
+        .to receive(:generate_options).and_return(fake_ai_options)
+      allow_any_instance_of(Ai::FirstProductStarterService)
+        .to receive(:template_options).and_return(fake_template_options)
+
+      2.times do
+        post "/first_product_starter/options", as: :json, params: { textarea_answer: "anything goes here" }
+        body = JSON.parse(response.body, symbolize_names: true)
+        expect(body[:capped]).to be(false)
+      end
+      expect($redis.get(RedisKey.ai_request_throttle(seller.id)).to_i).to eq(2)
+
+      post "/first_product_starter/options", as: :json, params: { textarea_answer: "anything goes here" }
+      body = JSON.parse(response.body, symbolize_names: true)
+      expect(body[:capped]).to be(true)
+      expect(body[:options].length).to eq(3)
+      expect($redis.get(RedisKey.ai_request_throttle(seller.id)).to_i).to eq(2)
+    end
+
+    it "returns 503 when the service raises MaxRetriesExceededError" do
+      allow_any_instance_of(Ai::FirstProductStarterService)
+        .to receive(:generate_options)
+        .and_raise(Ai::FirstProductStarterService::MaxRetriesExceededError, "boom")
+
+      post "/first_product_starter/options", as: :json, params: { textarea_answer: "anything" }
+      expect(response).to have_http_status(:service_unavailable)
+    end
+
+    it "does NOT roll back the throttle reservation when the AI call fails (failed AI counts toward the cap)" do
+      allow_any_instance_of(Ai::FirstProductStarterService)
+        .to receive(:generate_options)
+        .and_raise(Ai::FirstProductStarterService::MaxRetriesExceededError, "boom")
+
+      expect do
+        post "/first_product_starter/options", as: :json, params: { textarea_answer: "I want to sell my book" }
+      end.to change { $redis.get(RedisKey.ai_request_throttle(seller.id)).to_i }.by(1)
+    end
+
+    it "returns 503 when OpenAI returns 401 (invalid API key)" do
+      allow_any_instance_of(Ai::FirstProductStarterService)
+        .to receive(:generate_options)
+        .and_raise(Faraday::UnauthorizedError.new("the server responded with status 401"))
+
+      post "/first_product_starter/options", as: :json, params: { textarea_answer: "anything" }
+      expect(response).to have_http_status(:service_unavailable)
+    end
+  end
+
+  describe "POST /first_product_starter/draft" do
+    let(:option) do
+      {
+        name: "Audit Checklist for SaaS Onboarding",
+        native_type: "digital",
+        price_range: "29",
+        price_currency_type: "usd",
+        description: "<p>Most onboarding flows leave users guessing. This checklist walks you through.</p>"
+      }
+    end
+
+    it "creates a draft product with explicit fields and returns a redirect_url to the editor" do
+      post "/first_product_starter/draft", as: :json, params: { option: option }
+
+      created = seller.links.last
+      expect(created.user_id).to eq(seller.id)
+      expect(created.draft).to be(true)
+      expect(created.name).to eq(option[:name])
+      expect(created.native_type).to eq("digital")
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body, symbolize_names: true)
+      expect(body[:redirect_url]).to eq(edit_link_path(created))
+      expect(body[:redirect_url]).not_to include("ai_generated")
+    end
+
+    it "creates a recurring membership when native_type is membership" do
+      post "/first_product_starter/draft", as: :json, params: {
+        option: option.merge(native_type: "membership", price_range: "19", subscription_duration: "monthly")
+      }
+      created = seller.links.last
+      expect(created.is_recurring_billing).to be(true)
+      expect(created.subscription_duration).to eq("monthly")
+      expect(created.is_tiered_membership).to be(true)
+      expect(created.should_show_all_posts).to be(true)
+    end
+
+    it "creates an ebook when native_type is ebook" do
+      post "/first_product_starter/draft", as: :json, params: {
+        option: option.merge(native_type: "ebook", price_range: "9")
+      }
+      created = seller.links.last
+      expect(created.native_type).to eq("ebook")
+      expect(created.draft).to be(true)
+    end
+
+    it "creates a course when native_type is course" do
+      post "/first_product_starter/draft", as: :json, params: {
+        option: option.merge(native_type: "course", price_range: "79")
+      }
+      created = seller.links.last
+      expect(created.native_type).to eq("course")
+      expect(created.draft).to be(true)
+    end
+
+    it "fires both add_product and first_product_starter_drafted events on success" do
+      expect do
+        post "/first_product_starter/draft", as: :json, params: { option: option }
+      end.to change { Event.where(event_name: "first_product_starter_drafted", user_id: seller.id).count }.by(1)
+        .and change { Event.where(event_name: "add_product", user_id: seller.id).count }.by(1)
+    end
+
+    it "returns 401 when the seller already has a visible product" do
+      create(:product, user: seller, draft: false)
+      post "/first_product_starter/draft", as: :json, params: { option: option }
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+end

--- a/spec/services/ai/first_product_starter_service_spec.rb
+++ b/spec/services/ai/first_product_starter_service_spec.rb
@@ -1,0 +1,265 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Ai::FirstProductStarterService do
+  let(:seller) { create(:user, email: "starter-seller@example.com") }
+  let(:service) { described_class.new(seller: seller) }
+
+  def valid_options_json
+    {
+      options: 3.times.map do |i|
+        {
+          name: "Option #{i + 1}",
+          native_type: "digital",
+          price_cents: 999,
+          description: "<p>" + ("Lorem ipsum sample copy. " * 20) + "</p>",
+          rationale_one_line: "Plausible default.",
+          is_primary: i.zero?
+        }
+      end
+    }.to_json
+  end
+
+  describe "#generate_options" do
+    context "with a clear textarea answer", :vcr do
+      it "returns a pool of three product options with required fields" do
+        result = service.generate_options(
+          textarea_answer: "I'm a Figma designer doing SaaS onboarding audits."
+        )
+
+        expect(result[:source]).to eq("ai")
+        expect(result[:options].length).to eq(3)
+        expect(result[:options].count { |o| o[:is_primary] }).to eq(1)
+        expect(result[:options].first[:is_primary]).to be(true)
+
+        option = result[:options].first
+        expect(option).to include(:name, :native_type, :price_cents, :description, :rationale_one_line, :is_primary)
+        expect(option[:native_type]).to be_in(%w[digital course ebook membership])
+        expect(option[:price_cents]).to be >= 0
+        expect(option[:description].length).to be_between(300, 1500)
+      end
+    end
+
+    context "with empty textarea" do
+      it "returns a pool of three templates tagged with source: 'templates' without calling OpenAI" do
+        expect_any_instance_of(OpenAI::Client).not_to receive(:chat)
+
+        result = service.generate_options(textarea_answer: "")
+
+        expect(result[:source]).to eq("templates")
+        expect(result[:options].length).to eq(3)
+        expect(result[:options].count { |o| o[:is_primary] }).to eq(1)
+        expect(result[:options].first[:is_primary]).to be(true)
+        expect(result[:options].count { |o| o[:native_type] == "membership" }).to be >= 1
+      end
+
+      it "routes whitespace-only input to the template path" do
+        expect_any_instance_of(OpenAI::Client).not_to receive(:chat)
+
+        result = service.generate_options(textarea_answer: "   \n  ")
+
+        expect(result[:source]).to eq("templates")
+        expect(result[:options].length).to eq(3)
+      end
+    end
+
+    context "#template_options (called directly when controller is over cap)" do
+      it "returns a pool of three templates tagged with source: 'templates' without calling OpenAI" do
+        expect_any_instance_of(OpenAI::Client).not_to receive(:chat)
+
+        result = service.template_options
+
+        expect(result[:source]).to eq("templates")
+        expect(result[:options].length).to eq(3)
+        expect(result[:options].count { |o| o[:is_primary] }).to eq(1)
+        expect(result[:options].first[:is_primary]).to be(true)
+        expect(result[:options].count { |o| o[:native_type] == "membership" }).to be >= 1
+      end
+    end
+
+    context "templates fixture" do
+      let(:templates) { YAML.load_file(described_class::TEMPLATES_PATH, symbolize_names: true)[:templates] }
+
+      it "ships 20 entries that each carry a [bracketed] placeholder and a valid native_type" do
+        expect(templates.length).to eq(20)
+        templates.each do |t|
+          expect(t[:name]).to match(/\[[^\]]+\]/), "missing placeholder in #{t[:id]}"
+          expect(t[:description]).to match(/\[[^\]]+\]/), "missing placeholder in #{t[:id]}"
+          expect(t[:native_type]).to be_in(%w[digital course ebook membership])
+          expect(t[:price_cents]).to be >= 0
+          expect(t[:description].length).to be_between(300, 1500)
+          expect(t[:rationale_one_line].length).to be <= 140
+        end
+      end
+
+      it "includes exactly five membership templates" do
+        memberships = templates.select { |t| t[:native_type] == "membership" }
+        expect(memberships.length).to eq(5)
+      end
+    end
+
+    context "when AI returns two options that share a brand noun" do
+      it "strips the duplicate brand from the second option" do
+        collision_response = {
+          "choices" => [{
+            "message" => {
+              "content" => {
+                options: [
+                  { name: "Notion CRM template", native_type: "digital", price_cents: 1900, description: "x" * 320, rationale_one_line: "Top of category.", is_primary: true },
+                  { name: "Notion power-user paywall", native_type: "membership", price_cents: 1500, description: "x" * 320, rationale_one_line: "Notion fans want more.", is_primary: false },
+                  { name: "Watercolor sketch bundle", native_type: "digital", price_cents: 1900, description: "x" * 320, rationale_one_line: "Adjacent.", is_primary: false }
+                ]
+              }.to_json
+            }
+          }]
+        }
+        allow_any_instance_of(OpenAI::Client).to receive(:chat).and_return(collision_response)
+
+        result = service.generate_options(textarea_answer: "I make Notion templates")
+
+        names = result[:options].map { |o| o[:name] }
+        notion_count = names.count { |n| n.downcase.include?("notion") }
+        expect(notion_count).to eq(1)
+      end
+
+      it "leaves an unrelated word that merely contains a brand token alone (community vs unity)" do
+        innocent_response = {
+          "choices" => [{
+            "message" => {
+              "content" => {
+                options: [
+                  { name: "Unity asset pack", native_type: "digital", price_cents: 1900, description: "x" * 320, rationale_one_line: "First.", is_primary: true },
+                  { name: "Game-dev community for indie devs", native_type: "membership", price_cents: 1500, description: "x" * 320, rationale_one_line: "Community for buyers.", is_primary: false },
+                  { name: "A short course", native_type: "course", price_cents: 4900, description: "x" * 320, rationale_one_line: "Adjacent.", is_primary: false }
+                ]
+              }.to_json
+            }
+          }]
+        }
+        allow_any_instance_of(OpenAI::Client).to receive(:chat).and_return(innocent_response)
+
+        result = service.generate_options(textarea_answer: "I make Unity assets")
+
+        expect(result[:options][1][:name]).to eq("Game-dev community for indie devs")
+      end
+
+      it "keeps the original name when stripping the brand would leave it empty" do
+        only_brand_response = {
+          "choices" => [{
+            "message" => {
+              "content" => {
+                options: [
+                  { name: "Notion CRM template", native_type: "digital", price_cents: 1900, description: "x" * 320, rationale_one_line: "First.", is_primary: true },
+                  { name: "Notion", native_type: "membership", price_cents: 1500, description: "x" * 320, rationale_one_line: "Second.", is_primary: false },
+                  { name: "Watercolor sketches", native_type: "digital", price_cents: 1900, description: "x" * 320, rationale_one_line: "Third.", is_primary: false }
+                ]
+              }.to_json
+            }
+          }]
+        }
+        allow_any_instance_of(OpenAI::Client).to receive(:chat).and_return(only_brand_response)
+
+        result = service.generate_options(textarea_answer: "I make Notion templates")
+
+        expect(result[:options][1][:name]).to eq("Notion")
+      end
+
+      it "strips a duplicate brand token even when it appears inside a compound name" do
+        compound_response = {
+          "choices" => [{
+            "message" => {
+              "content" => {
+                options: [
+                  { name: "Unreal asset pack", native_type: "digital", price_cents: 1900, description: "x" * 320, rationale_one_line: "First.", is_primary: true },
+                  { name: "Unreal_Engine course", native_type: "course", price_cents: 4900, description: "x" * 320, rationale_one_line: "Second.", is_primary: false },
+                  { name: "Indie game-dev membership", native_type: "membership", price_cents: 1500, description: "x" * 320, rationale_one_line: "Third.", is_primary: false }
+                ]
+              }.to_json
+            }
+          }]
+        }
+        allow_any_instance_of(OpenAI::Client).to receive(:chat).and_return(compound_response)
+
+        result = service.generate_options(textarea_answer: "I build Unreal assets")
+
+        names = result[:options].map { |o| o[:name] }
+        unreal_count = names.count { |n| n.downcase.include?("unreal") }
+        expect(unreal_count).to eq(1)
+      end
+    end
+
+    context "when the OpenAI call times out twice" do
+      it "raises Ai::FirstProductStarterService::MaxRetriesExceededError" do
+        allow_any_instance_of(OpenAI::Client).to receive(:chat).and_raise(Faraday::TimeoutError)
+        expect do
+          service.generate_options(textarea_answer: "I make Mac apps.")
+        end.to raise_error(Ai::FirstProductStarterService::MaxRetriesExceededError)
+      end
+    end
+
+    context "when OpenAI returns malformed JSON on the first attempt" do
+      it "retries once and succeeds when the second attempt parses" do
+        bad_response = { "choices" => [{ "message" => { "content" => "not json{" } }] }
+        good_response = { "choices" => [{ "message" => { "content" => valid_options_json } }] }
+        call_count = 0
+        allow_any_instance_of(OpenAI::Client).to receive(:chat) do
+          call_count += 1
+          call_count == 1 ? bad_response : good_response
+        end
+
+        result = service.generate_options(textarea_answer: "anything")
+        expect(call_count).to eq(2)
+        expect(result[:options].length).to eq(3)
+      end
+    end
+
+    context "when OpenAI returns no membership options" do
+      it "rewrites one non-primary option to native_type=membership so the seller sees a recurring path" do
+        non_membership_response = {
+          "choices" => [{
+            "message" => {
+              "content" => {
+                options: [
+                  { name: "A digital pack", native_type: "digital", price_cents: 999, description: "x" * 320, rationale_one_line: "r", is_primary: true },
+                  { name: "A short course", native_type: "course", price_cents: 4900, description: "x" * 320, rationale_one_line: "r", is_primary: false },
+                  { name: "A niche ebook", native_type: "ebook", price_cents: 1499, description: "x" * 320, rationale_one_line: "r", is_primary: false }
+                ]
+              }.to_json
+            }
+          }]
+        }
+        allow_any_instance_of(OpenAI::Client).to receive(:chat).and_return(non_membership_response)
+
+        result = service.generate_options(textarea_answer: "anything")
+
+        expect(result[:options].count { |o| o[:native_type] == "membership" }).to be >= 1
+        expect(result[:options].count { |o| o[:is_primary] }).to eq(1)
+      end
+    end
+
+    context "when AI returns the primary not at position 0" do
+      it "moves the primary to the head of the pool so batch 1 shows it first" do
+        primary_in_middle = {
+          "choices" => [{
+            "message" => {
+              "content" => {
+                options: [
+                  { name: "Filler 1", native_type: "digital", price_cents: 999, description: "x" * 320, rationale_one_line: "r", is_primary: false },
+                  { name: "The recommended one", native_type: "digital", price_cents: 1900, description: "x" * 320, rationale_one_line: "Best fit.", is_primary: true },
+                  { name: "Filler 3", native_type: "membership", price_cents: 900, description: "x" * 320, rationale_one_line: "r", is_primary: false }
+                ]
+              }.to_json
+            }
+          }]
+        }
+        allow_any_instance_of(OpenAI::Client).to receive(:chat).and_return(primary_in_middle)
+
+        result = service.generate_options(textarea_answer: "anything")
+
+        expect(result[:options].first[:name]).to eq("The recommended one")
+        expect(result[:options].first[:is_primary]).to be(true)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,6 +60,7 @@ def configure_vcr
     config.configure_rspec_metadata!
     config.debug_logger = $stdout if ENV["VCR_DEBUG"]
     config.default_cassette_options[:record] = BUILDING_ON_CI ? :none : :once
+    config.filter_sensitive_data("<OPENAI_ACCESS_TOKEN>") { ENV["OPENAI_ACCESS_TOKEN"] }
     config.filter_sensitive_data("<AWS_ACCOUNT_ID>") { GlobalConfig.get("AWS_ACCOUNT_ID") }
     config.filter_sensitive_data("<AWS_ACCESS_KEY_ID>") { GlobalConfig.get("AWS_ACCESS_KEY_ID") }
     config.filter_sensitive_data("<STRIPE_PLATFORM_ACCOUNT_ID>") { GlobalConfig.get("STRIPE_PLATFORM_ACCOUNT_ID") }

--- a/spec/support/fixtures/vcr_cassettes/Ai_FirstProductStarterService/_generate_options/with_a_clear_textarea_answer/returns_a_pool_of_three_product_options_with_required_fields.yml
+++ b/spec/support/fixtures/vcr_cassettes/Ai_FirstProductStarterService/_generate_options/with_a_clear_textarea_answer/returns_a_pool_of_three_product_options_with_required_fields.yml
@@ -1,0 +1,210 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-5.4-nano","messages":[{"role":"system","content":"# Task\n\nYou
+        are a sales coach for new sellers on **gumroad.com** — the marketplace where
+        independent creators sell digital downloads, courses, ebooks, and memberships.
+        Turn the seller''s two-or-more-word input into 3 publishable first-product
+        drafts that fit what actually sells on gumroad.com (browse the discover page
+        in your training data: macOS utilities, Notion templates, fonts, AI prompt
+        packs, Lightroom presets, AE/Premiere preset packs, VRChat avatars, Blender
+        add-ons, illustration kits, niche playbook ebooks, \"make this thing\" courses,
+        lifetime communities, monthly drops, signal subscriptions). Return strict
+        JSON. Do not ask follow-up questions, do not narrate your reasoning, and do
+        not output anything outside the JSON schema.\n\n# Output contract — apply
+        before reasoning about content\n\n1. Return EXACTLY 3 options.\n2. EXACTLY
+        1 has `is_primary: true`. The frontend shows it first — make it the strongest
+        fit.\n3. AT LEAST 1 is `native_type: \"membership\"` (the subscription twin
+        at position 2).\n4. Mix the types — 3 distinct shapes if possible. Never all
+        3 the same shape.\n5. Order the array as: [primary, subscription twin (membership),
+        adjacent course/ebook]. Position 1 is the strongest fit; positions 2 and 3
+        expand the angle.\n6. No two names share a primary brand or topic word (e.g.,
+        if one says \"Notion\", no other can). Same for: Figma, Blender, Lightroom,
+        VRChat, Premiere, Photoshop, Canva, Obsidian, Unity, Unreal, and any platform/tool
+        name.\n7. Each option:\n   - `name`: 1-80 chars, sentence case, concrete.
+        No emojis.\n   - `native_type`: `digital` | `course` | `ebook` | `membership`.\n   -
+        `price_cents`: integer ≥ 0, anchored to the reference ranges below. `0` (PWW)
+        only for explicit lead-magnet intent.\n   - `description`: 80-130 words of
+        structured HTML using only `\u003cp\u003e`, `\u003ch3\u003e`, `\u003cul\u003e`,
+        `\u003cli\u003e`, `\u003cstrong\u003e`, `\u003cem\u003e`, in this order:\n     -
+        Opening `\u003cp\u003e` (1 sentence): the buyer''s outcome. Use \"you\", never
+        \"I\".\n     - `\u003ch3\u003eWhat''s included\u003c/h3\u003e` + `\u003cul\u003e`
+        of 3-4 concrete deliverables (5-12 words each).\n     - `\u003ch3\u003eWho
+        this is for\u003c/h3\u003e` + 1 sentence in `\u003cp\u003e`.\n     - Closing
+        `\u003cp\u003e` (1 sentence): what the buyer does with it.\n   - `rationale_one_line`:
+        ≤ 120 chars. Plain text.\n\n# Picking native_type\n\nAsk: \"what does the
+        buyer get next month after their first purchase?\"\n\n- **digital** — one-time
+        downloads: app licenses, fonts, presets, plugins, templates, swipe files,
+        asset packs.\n- **course** — video walkthroughs with multiple modules.\n-
+        **ebook** — written guides under ~100 pages.\n- **membership** — ongoing access:
+        newsletters, communities, monthly drops, recurring Q\u0026A, signal/research
+        subs, premium support tiers, early-access tiers.\n\nIf the buyer keeps receiving
+        things on a schedule → membership. If they get one file and that''s it → digital/course/ebook.\n\n#
+        Subscription twin (position 2 of the pool)\n\nWhatever the seller sells, design
+        ONE membership as the recurring shape of the same domain. Examples:\n\n- App
+        license → power-user community for that app\n- Notion template → monthly template
+        drops\n- Newsletter → premium tier with deeper analysis\n- Course → student
+        community / office hours\n- Music album → monthly stems/sample drops\n- Plugin
+        → early-access tier\n- Preset pack → monthly preset drops\n- Niche playbook
+        → mastermind community\n- Trading walkthrough → daily research subscription\n-
+        3D model pack → monthly model drops\n\nThe subscription twin must appear at
+        position 2 of the returned array.\n\n# Picking the primary (position 1)\n\nIf
+        the seller named a concrete artifact (app, book, template, music, add-on,
+        font, course, avatar, preset pack, podcast, newsletter), the primary IS that
+        artifact, packaged for direct sale. Don''t substitute content *about* the
+        artifact.\n\n| Seller input | ✅ Primary | ❌ Wrong primary |\n|---|---|---|\n|
+        \"sell the app\" | App license ($19-49 digital) | \"App launch toolkit\" course
+        |\n| \"I wrote a book\" | Book as ebook ($9-29) | \"Course on writing books\"
+        |\n| \"I made a Notion template\" | The template ($10-49) | \"Notion productivity
+        course\" |\n| \"I make ambient music\" | Album / track pack | \"Music production
+        course\" |\n| \"I built a Figma plugin\" | Plugin license ($15-49) | \"Plugin
+        development course\" |\n\nIf they described themselves but named no artifact,
+        build the primary around their craft, domain, or audience.\n\n# Step order
+        — design the pool in this sequence\n\n1. Read the seller''s input. Identify
+        the concrete artifact (app, book, template, music, plugin, course recording,
+        avatar pack, podcast, newsletter, etc.). If there''s no artifact, identify
+        the seller''s craft, audience, or domain.\n2. Design **position 1 (primary)**:
+        that artifact packaged for direct sale. If the artifact is itself recurring
+        (newsletter, community), the primary is `native_type: membership`. Otherwise
+        use the matching one-time type.\n3. Design **position 2 (subscription twin)**:
+        a `native_type: membership` that is the recurring shape of the same domain
+        — see \"Subscription twin\" section.\n4. Design **position 3**: an adjacent
+        `course` or `ebook` that teaches how the primary works, or a behind-the-scenes
+        companion.\n5. Apply the brand-uniqueness rule: no two names share a primary
+        brand or topic word.\n6. Verify the contract before returning: count is 3,
+        exactly 1 has `is_primary: true`, at least 1 has `native_type: \"membership\"`,
+        types are mixed.\n\n# Edge case behavior\n\n- **Off-topic input** (food complaint,
+        weather, gibberish that hints at no product): build the pool around the closest
+        sellable interpretation a Gumroad seller could reasonably ship — generic productivity,
+        creative templates, or a niche playbook.\n- **Harmful, illegal, or regulated
+        request** (weapons, drugs, financial advice promising returns): pivot to a
+        legitimate adjacent niche and ignore the harmful intent. Do not refuse outright
+        — the seller still gets 3 publishable drafts.\n- **Very vague input** (\"help
+        me sell something\"): pick three loosely connected domains the seller could
+        plausibly own and design the 3 options across them, with the strongest fit
+        as primary.\n- **Ambiguity about native_type**: apply the \"what does the
+        buyer get next month\" test (see \"Picking native_type\"). Do not ask the
+        seller to clarify.\n\n# One correct example\n\nUser input: `sell the app`\n\nReturned
+        in this order. Your real output must contain 3 with all fields present.\n\n```json\n{\n  \"options\":
+        [\n    {\n      \"name\": \"App license — lifetime download\",\n      \"native_type\":
+        \"digital\",\n      \"price_cents\": 2900,\n      \"description\": \"\u003cp\u003eYou
+        found a focused app that does one thing without subscriptions or bloat.\u003c/p\u003e\u003ch3\u003eWhat''s
+        included\u003c/h3\u003e\u003cul\u003e\u003cli\u003eThe full app, signed and
+        notarized for macOS\u003c/li\u003e\u003cli\u003eLicense valid for life on
+        up to 3 devices\u003c/li\u003e\u003cli\u003eFree minor-version updates for
+        12 months\u003c/li\u003e\u003cli\u003eQuick-start guide and changelog\u003c/li\u003e\u003c/ul\u003e\u003ch3\u003eWho
+        this is for\u003c/h3\u003e\u003cp\u003ePeople who want a focused tool with
+        no login, telemetry, or upsell.\u003c/p\u003e\u003cp\u003eBuy once and start
+        using it the same day.\u003c/p\u003e\",\n      \"rationale_one_line\": \"The
+        seller already has the app — sell the app, not content about it.\",\n      \"is_primary\":
+        true\n    },\n    {\n      \"name\": \"Power users — monthly updates and Q\u0026A\",\n      \"native_type\":
+        \"membership\",\n      \"price_cents\": 900,\n      \"description\": \"\u003cp\u003eYou
+        bought the app and want to get more out of it directly from the developer.\u003c/p\u003e\u003ch3\u003eWhat''s
+        included\u003c/h3\u003e\u003cul\u003e\u003cli\u003eEarly access to new versions
+        before public release\u003c/li\u003e\u003cli\u003ePrivate channel where the
+        developer answers questions\u003c/li\u003e\u003cli\u003eShort walkthroughs
+        of advanced and lesser-known features\u003c/li\u003e\u003cli\u003eCancel anytime,
+        no contract\u003c/li\u003e\u003c/ul\u003e\u003ch3\u003eWho this is for\u003c/h3\u003e\u003cp\u003ePower
+        users who want a direct line to the maker.\u003c/p\u003e\u003cp\u003eSubscribe
+        and check the channel whenever you hit a wall — answers come within a day.\u003c/p\u003e\",\n      \"rationale_one_line\":
+        \"Subscription twin: recurring revenue from existing buyers without a new
+        artifact.\",\n      \"is_primary\": false\n    }\n  ]\n}\n```\n\n# Anti-patterns\n\n-
+        Substituting content *about* the artifact for the artifact itself.\n- Treating
+        the seller as a beginner when they''ve named what they have.\n- Slop openers:
+        \"Unlock the power of…\", \"Are you tired of…\", \"In today''s fast-paced
+        world…\".\n- Restating the seller''s input verbatim.\n- Service types (1:1
+        coaching, calls, commissions, Calendly bookings).\n- Physical products (hardware,
+        print, merch, coins).\n- Crypto presales, ICOs, regulated investments.\n-
+        All 3 options the same `native_type`.\n- Pricing 2x+ outside the reference
+        ranges.\n- Marking a recurring product as `digital` instead of `membership`.\n-
+        Padding the pool with near-duplicates of the primary.\n\n# Style\n\nPlain
+        language. Active voice. Short sentences. Cut every word that doesn''t earn
+        its place.\n\n# Price anchors — calibrated to gumroad.com discover-page top
+        sellers (USD, 2026)\n\n- **Digital one-time**: Mac apps $5-30, Notion templates
+        $10-49, Blender/CAD add-ons $15-70, fonts $10-40, AE/Premiere presets $20-80,
+        VRChat avatars / 3D models $10-30, AI prompt packs $9-49, logo/mockup packs
+        $20-80, LUT presets $10-30, stock illustration $19-49 (or PWW for lead-gen).\n-
+        **Practice/study bundles**: $19-49 (sketching/prompt decks), $50-200 (homeschool
+        grades), $39-99 (exam toolkits).\n- **Courses**: coding/design/fitness/finance
+        $29-149, \"make this thing\" walkthroughs $29-89.\n- **Niche-knowledge ebooks**:
+        industry playbooks $9-29, health/cycle/fitness $9-29.\n- **Memberships**:
+        monthly $5-29, annual $79-299, lifetime $150-500.\n- **Signal/research subs**:
+        $29-99/month.\n- **Bundles**: 2-5 related items at $19-99.\n- **PWW** (`price_cents
+        = 0`): deliberate lead-gen only.\n"},{"role":"user","content":"I''m a Figma
+        designer doing SaaS onboarding audits."}],"response_format":{"type":"json_schema","json_schema":{"name":"first_product_starter_options","strict":true,"schema":{"type":"object","additionalProperties":false,"required":["options"],"properties":{"options":{"type":"array","minItems":3,"maxItems":3,"items":{"type":"object","additionalProperties":false,"required":["name","native_type","price_cents","description","rationale_one_line","is_primary"],"properties":{"name":{"type":"string","minLength":1,"maxLength":80},"native_type":{"type":"string","enum":["digital","course","ebook","membership"]},"price_cents":{"type":"integer","minimum":0},"description":{"type":"string","minLength":250,"maxLength":1000},"rationale_one_line":{"type":"string","maxLength":140},"is_primary":{"type":"boolean"}}}}}}}},"max_completion_tokens":3000,"prompt_cache_key":"first_product_starter:v7_pool3","user":"5709877056679"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <OPENAI_ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 30 Apr 2026 22:25:25 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9f49f6379e8ac4a2-WAW
+      Cf-Cache-Status:
+      - DYNAMIC
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - user-aatqi7p66zl2bzexxdrtaaqv
+      Openai-Processing-Ms:
+      - '3962'
+      Openai-Project:
+      - proj_AQPsXPBmY0jywibofeA8tjAe
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '500'
+      X-Ratelimit-Limit-Tokens:
+      - '200000'
+      X-Ratelimit-Remaining-Requests:
+      - '499'
+      X-Ratelimit-Remaining-Tokens:
+      - '197591'
+      X-Ratelimit-Reset-Requests:
+      - 120ms
+      X-Ratelimit-Reset-Tokens:
+      - 722ms
+      X-Request-Id:
+      - req_5e61e0fa1ce24f8c9b9b32b23fac0029
+      Set-Cookie:
+      - __cf_bm=0YGfRMgDb3e_gn93ZdyPPcYjhoqlFlNMlyaiCT0Mcrs-1777587920.575991-1.0.1.1-imneNH7mZ1zbSgQbJEOyiZpi5DTD.fkNI8OPdsHTjmgIMKQdJ9xiXyPTg_zG0ggckiHpUD5DDNMbreIYuMq411S.zgWOKpJrNfBZk5dEko0VDR4jaWeda3GZpOxrHa9K;
+        HttpOnly; Secure; Path=/; Domain=api.openai.com; Expires=Thu, 30 Apr 2026
+        22:55:25 GMT
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1EYVU2cjRseVdsb3FuQ0plRHpndXdGcW83NElJYiIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc3NzU4NzkyMSwKICAibW9kZWwiOiAiZ3B0LTUuNC1uYW5vLTIwMjYtMDMtMTciLAogICJjaG9pY2VzIjogWwogICAgewogICAgICAiaW5kZXgiOiAwLAogICAgICAibWVzc2FnZSI6IHsKICAgICAgICAicm9sZSI6ICJhc3Npc3RhbnQiLAogICAgICAgICJjb250ZW50IjogIntcIm9wdGlvbnNcIjpbe1wibmFtZVwiOlwiRmlnbWEgb25ib2FyZGluZyBhdWRpdCB0ZW1wbGF0ZXMgcGFja1wiLFwibmF0aXZlX3R5cGVcIjpcImRpZ2l0YWxcIixcInByaWNlX2NlbnRzXCI6NDkwMCxcImRlc2NyaXB0aW9uXCI6XCI8cD5Zb3UgZ2V0IGEgcmVwZWF0YWJsZSBzeXN0ZW0gdG8gYXVkaXQgU2FhUyBvbmJvYXJkaW5nIGluIEZpZ21hIGFuZCB0dXJuIGlzc3VlcyBpbnRvIGNsZWFyIGZpeGVzLjwvcD48aDM+V2hhdCdzIGluY2x1ZGVkPC9oMz48dWw+PGxpPk9uYm9hcmRpbmcgYXVkaXQgY2hlY2tsaXN0IGJ5IGZ1bm5lbCBzdGFnZTwvbGk+PGxpPlVYIGhldXJpc3RpY3MgbWFwIGZvciBhY3RpdmF0aW9uIGFuZCByZXRlbnRpb248L2xpPjxsaT5Bbm5vdGF0ZWQgRmlnbWEgZnJhbWUgc2V0IGZvciBjb21tb24gcGF0dGVybnM8L2xpPjxsaT5Jc3N1ZS10by1maXggd29ya3NoZWV0IHdpdGggc2V2ZXJpdHkgc2NvcmluZzwvbGk+PC91bD48aDM+V2hvIHRoaXMgaXMgZm9yPC9oMz48cD5Qcm9kdWN0IGRlc2lnbmVycyBhbmQgVVggbGVhZHMgaW1wcm92aW5nIGFjdGl2YXRpb24gZm9yIHdlYiBTYWFTLjwvcD48cD5Vc2UgdGhlIHRlbXBsYXRlcyB0byBydW4gYXVkaXRzLCBkb2N1bWVudCBmaW5kaW5ncywgYW5kIHNoaXAgcHJpb3JpdGl6ZWQgb25ib2FyZGluZyBjaGFuZ2VzLjwvcD5cIixcInJhdGlvbmFsZV9vbmVfbGluZVwiOlwiU2VsbCB0aGUgRmlnbWEgdGVtcGxhdGUvYXJ0aWZhY3QgdXNlZCBmb3Igb25ib2FyZGluZyBhdWRpdHMuXCIsXCJpc19wcmltYXJ5XCI6dHJ1ZX0se1wibmFtZVwiOlwiT25ib2FyZGluZyBDbGluaWMgbWVtYmVyc2hpcCBmb3IgU2FhUyB0ZWFtc1wiLFwibmF0aXZlX3R5cGVcIjpcIm1lbWJlcnNoaXBcIixcInByaWNlX2NlbnRzXCI6MTcwMCxcImRlc2NyaXB0aW9uXCI6XCI8cD5Zb3Ugc3RheSBjdXJyZW50IG9uIG9uYm9hcmRpbmcgZml4ZXMgYW5kIHJldXNlIGF1ZGl0IHdvcmtmbG93cyBldmVyeSBtb250aC48L3A+PGgzPldoYXQncyBpbmNsdWRlZDwvaDM+PHVsPjxsaT5Nb250aGx5IG9uYm9hcmRpbmcgYXVkaXQgZnJhbWV3b3JrcyBhbmQgcGxheWJvb2tzPC9saT48bGk+TGl2ZSB0ZWFyZG93biBzZXNzaW9ucyB3aXRoIFEmQSBmb3IgbWVtYmVyczwvbGk+PGxpPkNvbW11bml0eSBmZWVkYmFjayBvbiB5b3VyIG9uYm9hcmRpbmcgc2NyZWVuczwvbGk+PGxpPk1lbWJlci1vbmx5IGNvcHktcGFzdGUgY2hlY2tsaXN0cyBhbmQgZXhhbXBsZXM8L2xpPjwvdWw+PGgzPldobyB0aGlzIGlzIGZvcjwvaDM+PHA+U2FhUyBkZXNpZ24gdGVhbXMgd2hvIHdhbnQgb25nb2luZyBoZWxwIGFwcGx5aW5nIG9uYm9hcmRpbmcgYmVzdCBwcmFjdGljZXMuPC9wPjxwPlN1YnNjcmliZSB0byBnZXQgbmV3IGF1ZGl0cyBhbmQgaW1wbGVtZW50IGltcHJvdmVtZW50cyBvbiBhIHN0ZWFkeSBzY2hlZHVsZS48L3A+XCIsXCJyYXRpb25hbGVfb25lX2xpbmVcIjpcIlN1YnNjcmlwdGlvbiB0d2luOiByZWN1cnJpbmcgb25ib2FyZGluZyBmcmFtZXdvcmtzLCB0ZWFyZG93bnMsIGFuZCBjb21tdW5pdHkgc3VwcG9ydC5cIixcImlzX3ByaW1hcnlcIjpmYWxzZX0se1wibmFtZVwiOlwiQWN0aXZhdGlvbi1maXJzdCBvbmJvYXJkaW5nIGF1ZGl0IG1pbmktY291cnNlXCIsXCJuYXRpdmVfdHlwZVwiOlwiY291cnNlXCIsXCJwcmljZV9jZW50c1wiOjY5MDAsXCJkZXNjcmlwdGlvblwiOlwiPHA+WW91IGxlYXJuIGhvdyB0byBydW4gYSBmYXN0LCBldmlkZW5jZS1iYXNlZCBvbmJvYXJkaW5nIGF1ZGl0IGFuZCBwcm9kdWNlIGFjdGlvbmFibGUgcmVjb21tZW5kYXRpb25zLjwvcD48aDM+V2hhdCdzIGluY2x1ZGVkPC9oMz48dWw+PGxpPkF1ZGl0IG1ldGhvZCBmcm9tIHJlc2VhcmNoIHRvIHByaW9yaXRpemVkIGZpeGVzPC9saT48bGk+V2hhdCB0byBtZWFzdXJlIGZvciBhY3RpdmF0aW9uIGFuZCBlYXJseSByZXRlbnRpb248L2xpPjxsaT5Ib3cgdG8gd3JpdGUgY2xlYXIsIHRlc3RhYmxlIGRlc2lnbiByZWNvbW1lbmRhdGlvbnM8L2xpPjxsaT5UZW1wbGF0ZXMgZm9yIHNldmVyaXR5LCBpbXBhY3QsIGFuZCBlZmZvcnQgbWFwcGluZzwvbGk+PC91bD48aDM+V2hvIHRoaXMgaXMgZm9yPC9oMz48cD5EZXNpZ25lcnMgbW92aW5nIGZyb20g4oCcb3BpbmlvbnPigJ0gdG8gc3RydWN0dXJlZCBvbmJvYXJkaW5nIGltcHJvdmVtZW50cy48L3A+PHA+V2F0Y2ggdGhlIGxlc3NvbnMsIGFwcGx5IHRoZSB3b3JrZmxvdyB0byB5b3VyIHByb2R1Y3QsIGFuZCBkb2N1bWVudCByZXN1bHRzLjwvcD5cIixcInJhdGlvbmFsZV9vbmVfbGluZVwiOlwiVGVhY2hlcyB0aGUgcHJvY2VzcyBiZWhpbmQgdGhlIEZpZ21hIGF1ZGl0IHRlbXBsYXRlIHBhY2suXCIsXCJpc19wcmltYXJ5XCI6ZmFsc2V9XX0iLAogICAgICAgICJyZWZ1c2FsIjogbnVsbCwKICAgICAgICAiYW5ub3RhdGlvbnMiOiBbXQogICAgICB9LAogICAgICAiZmluaXNoX3JlYXNvbiI6ICJzdG9wIgogICAgfQogIF0sCiAgInVzYWdlIjogewogICAgInByb21wdF90b2tlbnMiOiAyNDk3LAogICAgImNvbXBsZXRpb25fdG9rZW5zIjogNTUzLAogICAgInRvdGFsX3Rva2VucyI6IDMwNTAsCiAgICAicHJvbXB0X3Rva2Vuc19kZXRhaWxzIjogewogICAgICAiY2FjaGVkX3Rva2VucyI6IDAsCiAgICAgICJhdWRpb190b2tlbnMiOiAwCiAgICB9LAogICAgImNvbXBsZXRpb25fdG9rZW5zX2RldGFpbHMiOiB7CiAgICAgICJyZWFzb25pbmdfdG9rZW5zIjogMCwKICAgICAgImF1ZGlvX3Rva2VucyI6IDAsCiAgICAgICJhY2NlcHRlZF9wcmVkaWN0aW9uX3Rva2VucyI6IDAsCiAgICAgICJyZWplY3RlZF9wcmVkaWN0aW9uX3Rva2VucyI6IDAKICAgIH0KICB9LAogICJzZXJ2aWNlX3RpZXIiOiAiZGVmYXVsdCIsCiAgInN5c3RlbV9maW5nZXJwcmludCI6IG51bGwKfQo=
+  recorded_at: Thu, 30 Apr 2026 22:25:25 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/system/first_product_starter_spec/happy_path.yml
+++ b/spec/support/fixtures/vcr_cassettes/system/first_product_starter_spec/happy_path.yml
@@ -1,0 +1,210 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-5.4-nano","messages":[{"role":"system","content":"# Task\n\nYou
+        are a sales coach for new sellers on **gumroad.com** — the marketplace where
+        independent creators sell digital downloads, courses, ebooks, and memberships.
+        Turn the seller''s two-or-more-word input into 3 publishable first-product
+        drafts that fit what actually sells on gumroad.com (browse the discover page
+        in your training data: macOS utilities, Notion templates, fonts, AI prompt
+        packs, Lightroom presets, AE/Premiere preset packs, VRChat avatars, Blender
+        add-ons, illustration kits, niche playbook ebooks, \"make this thing\" courses,
+        lifetime communities, monthly drops, signal subscriptions). Return strict
+        JSON. Do not ask follow-up questions, do not narrate your reasoning, and do
+        not output anything outside the JSON schema.\n\n# Output contract — apply
+        before reasoning about content\n\n1. Return EXACTLY 3 options.\n2. EXACTLY
+        1 has `is_primary: true`. The frontend shows it first — make it the strongest
+        fit.\n3. AT LEAST 1 is `native_type: \"membership\"` (the subscription twin
+        at position 2).\n4. Mix the types — 3 distinct shapes if possible. Never all
+        3 the same shape.\n5. Order the array as: [primary, subscription twin (membership),
+        adjacent course/ebook]. Position 1 is the strongest fit; positions 2 and 3
+        expand the angle.\n6. No two names share a primary brand or topic word (e.g.,
+        if one says \"Notion\", no other can). Same for: Figma, Blender, Lightroom,
+        VRChat, Premiere, Photoshop, Canva, Obsidian, Unity, Unreal, and any platform/tool
+        name.\n7. Each option:\n   - `name`: 1-80 chars, sentence case, concrete.
+        No emojis.\n   - `native_type`: `digital` | `course` | `ebook` | `membership`.\n   -
+        `price_cents`: integer ≥ 0, anchored to the reference ranges below. `0` (PWW)
+        only for explicit lead-magnet intent.\n   - `description`: 80-130 words of
+        structured HTML using only `\u003cp\u003e`, `\u003ch3\u003e`, `\u003cul\u003e`,
+        `\u003cli\u003e`, `\u003cstrong\u003e`, `\u003cem\u003e`, in this order:\n     -
+        Opening `\u003cp\u003e` (1 sentence): the buyer''s outcome. Use \"you\", never
+        \"I\".\n     - `\u003ch3\u003eWhat''s included\u003c/h3\u003e` + `\u003cul\u003e`
+        of 3-4 concrete deliverables (5-12 words each).\n     - `\u003ch3\u003eWho
+        this is for\u003c/h3\u003e` + 1 sentence in `\u003cp\u003e`.\n     - Closing
+        `\u003cp\u003e` (1 sentence): what the buyer does with it.\n   - `rationale_one_line`:
+        ≤ 120 chars. Plain text.\n\n# Picking native_type\n\nAsk: \"what does the
+        buyer get next month after their first purchase?\"\n\n- **digital** — one-time
+        downloads: app licenses, fonts, presets, plugins, templates, swipe files,
+        asset packs.\n- **course** — video walkthroughs with multiple modules.\n-
+        **ebook** — written guides under ~100 pages.\n- **membership** — ongoing access:
+        newsletters, communities, monthly drops, recurring Q\u0026A, signal/research
+        subs, premium support tiers, early-access tiers.\n\nIf the buyer keeps receiving
+        things on a schedule → membership. If they get one file and that''s it → digital/course/ebook.\n\n#
+        Subscription twin (position 2 of the pool)\n\nWhatever the seller sells, design
+        ONE membership as the recurring shape of the same domain. Examples:\n\n- App
+        license → power-user community for that app\n- Notion template → monthly template
+        drops\n- Newsletter → premium tier with deeper analysis\n- Course → student
+        community / office hours\n- Music album → monthly stems/sample drops\n- Plugin
+        → early-access tier\n- Preset pack → monthly preset drops\n- Niche playbook
+        → mastermind community\n- Trading walkthrough → daily research subscription\n-
+        3D model pack → monthly model drops\n\nThe subscription twin must appear at
+        position 2 of the returned array.\n\n# Picking the primary (position 1)\n\nIf
+        the seller named a concrete artifact (app, book, template, music, add-on,
+        font, course, avatar, preset pack, podcast, newsletter), the primary IS that
+        artifact, packaged for direct sale. Don''t substitute content *about* the
+        artifact.\n\n| Seller input | ✅ Primary | ❌ Wrong primary |\n|---|---|---|\n|
+        \"sell the app\" | App license ($19-49 digital) | \"App launch toolkit\" course
+        |\n| \"I wrote a book\" | Book as ebook ($9-29) | \"Course on writing books\"
+        |\n| \"I made a Notion template\" | The template ($10-49) | \"Notion productivity
+        course\" |\n| \"I make ambient music\" | Album / track pack | \"Music production
+        course\" |\n| \"I built a Figma plugin\" | Plugin license ($15-49) | \"Plugin
+        development course\" |\n\nIf they described themselves but named no artifact,
+        build the primary around their craft, domain, or audience.\n\n# Step order
+        — design the pool in this sequence\n\n1. Read the seller''s input. Identify
+        the concrete artifact (app, book, template, music, plugin, course recording,
+        avatar pack, podcast, newsletter, etc.). If there''s no artifact, identify
+        the seller''s craft, audience, or domain.\n2. Design **position 1 (primary)**:
+        that artifact packaged for direct sale. If the artifact is itself recurring
+        (newsletter, community), the primary is `native_type: membership`. Otherwise
+        use the matching one-time type.\n3. Design **position 2 (subscription twin)**:
+        a `native_type: membership` that is the recurring shape of the same domain
+        — see \"Subscription twin\" section.\n4. Design **position 3**: an adjacent
+        `course` or `ebook` that teaches how the primary works, or a behind-the-scenes
+        companion.\n5. Apply the brand-uniqueness rule: no two names share a primary
+        brand or topic word.\n6. Verify the contract before returning: count is 3,
+        exactly 1 has `is_primary: true`, at least 1 has `native_type: \"membership\"`,
+        types are mixed.\n\n# Edge case behavior\n\n- **Off-topic input** (food complaint,
+        weather, gibberish that hints at no product): build the pool around the closest
+        sellable interpretation a Gumroad seller could reasonably ship — generic productivity,
+        creative templates, or a niche playbook.\n- **Harmful, illegal, or regulated
+        request** (weapons, drugs, financial advice promising returns): pivot to a
+        legitimate adjacent niche and ignore the harmful intent. Do not refuse outright
+        — the seller still gets 3 publishable drafts.\n- **Very vague input** (\"help
+        me sell something\"): pick three loosely connected domains the seller could
+        plausibly own and design the 3 options across them, with the strongest fit
+        as primary.\n- **Ambiguity about native_type**: apply the \"what does the
+        buyer get next month\" test (see \"Picking native_type\"). Do not ask the
+        seller to clarify.\n\n# One correct example\n\nUser input: `sell the app`\n\nReturned
+        in this order. Your real output must contain 3 with all fields present.\n\n```json\n{\n  \"options\":
+        [\n    {\n      \"name\": \"App license — lifetime download\",\n      \"native_type\":
+        \"digital\",\n      \"price_cents\": 2900,\n      \"description\": \"\u003cp\u003eYou
+        found a focused app that does one thing without subscriptions or bloat.\u003c/p\u003e\u003ch3\u003eWhat''s
+        included\u003c/h3\u003e\u003cul\u003e\u003cli\u003eThe full app, signed and
+        notarized for macOS\u003c/li\u003e\u003cli\u003eLicense valid for life on
+        up to 3 devices\u003c/li\u003e\u003cli\u003eFree minor-version updates for
+        12 months\u003c/li\u003e\u003cli\u003eQuick-start guide and changelog\u003c/li\u003e\u003c/ul\u003e\u003ch3\u003eWho
+        this is for\u003c/h3\u003e\u003cp\u003ePeople who want a focused tool with
+        no login, telemetry, or upsell.\u003c/p\u003e\u003cp\u003eBuy once and start
+        using it the same day.\u003c/p\u003e\",\n      \"rationale_one_line\": \"The
+        seller already has the app — sell the app, not content about it.\",\n      \"is_primary\":
+        true\n    },\n    {\n      \"name\": \"Power users — monthly updates and Q\u0026A\",\n      \"native_type\":
+        \"membership\",\n      \"price_cents\": 900,\n      \"description\": \"\u003cp\u003eYou
+        bought the app and want to get more out of it directly from the developer.\u003c/p\u003e\u003ch3\u003eWhat''s
+        included\u003c/h3\u003e\u003cul\u003e\u003cli\u003eEarly access to new versions
+        before public release\u003c/li\u003e\u003cli\u003ePrivate channel where the
+        developer answers questions\u003c/li\u003e\u003cli\u003eShort walkthroughs
+        of advanced and lesser-known features\u003c/li\u003e\u003cli\u003eCancel anytime,
+        no contract\u003c/li\u003e\u003c/ul\u003e\u003ch3\u003eWho this is for\u003c/h3\u003e\u003cp\u003ePower
+        users who want a direct line to the maker.\u003c/p\u003e\u003cp\u003eSubscribe
+        and check the channel whenever you hit a wall — answers come within a day.\u003c/p\u003e\",\n      \"rationale_one_line\":
+        \"Subscription twin: recurring revenue from existing buyers without a new
+        artifact.\",\n      \"is_primary\": false\n    }\n  ]\n}\n```\n\n# Anti-patterns\n\n-
+        Substituting content *about* the artifact for the artifact itself.\n- Treating
+        the seller as a beginner when they''ve named what they have.\n- Slop openers:
+        \"Unlock the power of…\", \"Are you tired of…\", \"In today''s fast-paced
+        world…\".\n- Restating the seller''s input verbatim.\n- Service types (1:1
+        coaching, calls, commissions, Calendly bookings).\n- Physical products (hardware,
+        print, merch, coins).\n- Crypto presales, ICOs, regulated investments.\n-
+        All 3 options the same `native_type`.\n- Pricing 2x+ outside the reference
+        ranges.\n- Marking a recurring product as `digital` instead of `membership`.\n-
+        Padding the pool with near-duplicates of the primary.\n\n# Style\n\nPlain
+        language. Active voice. Short sentences. Cut every word that doesn''t earn
+        its place.\n\n# Price anchors — calibrated to gumroad.com discover-page top
+        sellers (USD, 2026)\n\n- **Digital one-time**: Mac apps $5-30, Notion templates
+        $10-49, Blender/CAD add-ons $15-70, fonts $10-40, AE/Premiere presets $20-80,
+        VRChat avatars / 3D models $10-30, AI prompt packs $9-49, logo/mockup packs
+        $20-80, LUT presets $10-30, stock illustration $19-49 (or PWW for lead-gen).\n-
+        **Practice/study bundles**: $19-49 (sketching/prompt decks), $50-200 (homeschool
+        grades), $39-99 (exam toolkits).\n- **Courses**: coding/design/fitness/finance
+        $29-149, \"make this thing\" walkthroughs $29-89.\n- **Niche-knowledge ebooks**:
+        industry playbooks $9-29, health/cycle/fitness $9-29.\n- **Memberships**:
+        monthly $5-29, annual $79-299, lifetime $150-500.\n- **Signal/research subs**:
+        $29-99/month.\n- **Bundles**: 2-5 related items at $19-99.\n- **PWW** (`price_cents
+        = 0`): deliberate lead-gen only.\n"},{"role":"user","content":"I''m a Figma
+        designer. I do SaaS onboarding audits."}],"response_format":{"type":"json_schema","json_schema":{"name":"first_product_starter_options","strict":true,"schema":{"type":"object","additionalProperties":false,"required":["options"],"properties":{"options":{"type":"array","minItems":3,"maxItems":3,"items":{"type":"object","additionalProperties":false,"required":["name","native_type","price_cents","description","rationale_one_line","is_primary"],"properties":{"name":{"type":"string","minLength":1,"maxLength":80},"native_type":{"type":"string","enum":["digital","course","ebook","membership"]},"price_cents":{"type":"integer","minimum":0},"description":{"type":"string","minLength":250,"maxLength":1000},"rationale_one_line":{"type":"string","maxLength":140},"is_primary":{"type":"boolean"}}}}}}}},"max_completion_tokens":3000,"prompt_cache_key":"first_product_starter:v7_pool3","user":"3544316950191"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <OPENAI_ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 01 May 2026 12:21:04 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9f4ebe4b9ee8ee43-WAW
+      Cf-Cache-Status:
+      - DYNAMIC
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - oleksii-g3yrcj
+      Openai-Processing-Ms:
+      - '4225'
+      Openai-Project:
+      - proj_AQPsXPBmY0jywibofeA8tjAe
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '500'
+      X-Ratelimit-Limit-Tokens:
+      - '200000'
+      X-Ratelimit-Remaining-Requests:
+      - '499'
+      X-Ratelimit-Remaining-Tokens:
+      - '197591'
+      X-Ratelimit-Reset-Requests:
+      - 120ms
+      X-Ratelimit-Reset-Tokens:
+      - 722ms
+      X-Request-Id:
+      - req_2f6d70527e9a46fa95d68c34411c0af3
+      Set-Cookie:
+      - __cf_bm=AzZKp0X.huYQF5PvCWXFjzS.DqmQzqfi4M5.FDbv.SQ-1777638058.8196511-1.0.1.1-.FUgwGKeDpEdVfCisRyvDwjitboPuXUNB29mM2QvtTdP41lIFM8hs7MWPlmeih2X_l5C.omaoR6x_k1dPlqlaq8HGQT50HCME5ssls5swYs2jmEFjmVA0ntOdxdl0sda;
+        HttpOnly; Secure; Path=/; Domain=api.openai.com; Expires=Fri, 01 May 2026
+        12:51:04 GMT
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1EYWg5WU11enN2WVhzbFZxa1ZZYXo3MTZZWHZLdCIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc3NzYzODA2MCwKICAibW9kZWwiOiAiZ3B0LTUuNC1uYW5vLTIwMjYtMDMtMTciLAogICJjaG9pY2VzIjogWwogICAgewogICAgICAiaW5kZXgiOiAwLAogICAgICAibWVzc2FnZSI6IHsKICAgICAgICAicm9sZSI6ICJhc3Npc3RhbnQiLAogICAgICAgICJjb250ZW50IjogIntcbiAgXCJvcHRpb25zXCI6IFtcbiAgICB7XG4gICAgICBcIm5hbWVcIjogXCJTYWFTIE9uYm9hcmRpbmcgQXVkaXQgUGFjayBmb3IgWW91ciBGaWdtYSBTY3JlZW5zXCIsXG4gICAgICBcIm5hdGl2ZV90eXBlXCI6IFwiZGlnaXRhbFwiLFxuICAgICAgXCJwcmljZV9jZW50c1wiOiAzOTAwLFxuICAgICAgXCJkZXNjcmlwdGlvblwiOiBcIjxwPllvdSBnZXQgYSBjbGVhciwgcHJpb3JpdGl6ZWQgY2hlY2tsaXN0IHRvIGltcHJvdmUgeW91ciBTYWFTIG9uYm9hcmRpbmcgZmxvdyBhbmQgVUkuPC9wPjxoMz5XaGF0J3MgaW5jbHVkZWQ8L2gzPjx1bD48bGk+RmlnbWEtcmVhZHkgb25ib2FyZGluZyBhdWRpdCBzY29yZWNhcmQgKHYxKTwvbGk+PGxpPjUwIGNvbW1vbiBVWCBpc3N1ZXMgd2l0aCBmaXggZGlyZWN0aW9uczwvbGk+PGxpPk9uYm9hcmRpbmcgc2NyZWVuIFFBIHJ1YnJpYyBhbmQgc2V2ZXJpdHkgbGFiZWxzPC9saT48bGk+QmVmb3JlL2FmdGVyIHdpcmUgYW5kIGNvcHkgaW1wcm92ZW1lbnQgcHJvbXB0czwvbGk+PC91bD48aDM+V2hvIHRoaXMgaXMgZm9yPC9oMz48cD5EZXNpZ25lcnMgYW5kIHByb2R1Y3QgdGVhbXMgc2hpcHBpbmcgb25ib2FyZGluZyBmbG93cyBpbiBTYWFTIGFwcHMuPC9wPjxwPkFwcGx5IHRoZSBjaGVja2xpc3QgdG8geW91ciBleGlzdGluZyBzY3JlZW5zIGFuZCBkb2N1bWVudCBjaGFuZ2VzIGluIEZpZ21hLjwvcD5cIixcbiAgICAgIFwicmF0aW9uYWxlX29uZV9saW5lXCI6IFwiUHJpbWFyeSBhcnRpZmFjdDogYSBGaWdtYS1mcmllbmRseSBhdWRpdCBwYWNrIHlvdSBjYW4gdXNlIGltbWVkaWF0ZWx5LlwiLFxuICAgICAgXCJpc19wcmltYXJ5XCI6IHRydWVcbiAgICB9LFxuICAgIHtcbiAgICAgIFwibmFtZVwiOiBcIk9uYm9hcmRpbmcgTGFiIOKAlCBNb250aGx5IFJldmlld3MgYW5kIERlc2lnbiBGaXhlc1wiLFxuICAgICAgXCJuYXRpdmVfdHlwZVwiOiBcIm1lbWJlcnNoaXBcIixcbiAgICAgIFwicHJpY2VfY2VudHNcIjogMTUwMCxcbiAgICAgIFwiZGVzY3JpcHRpb25cIjogXCI8cD5Zb3Uga2VlcCBpbXByb3Zpbmcgb25ib2FyZGluZyB3aXRoIG1vbnRobHkgdGVtcGxhdGVzLCB0ZWFyZG93biBleGFtcGxlcywgYW5kIGZlZWRiYWNrIHByb21wdHMuPC9wPjxoMz5XaGF0J3MgaW5jbHVkZWQ8L2gzPjx1bD48bGk+TW9udGhseSB0ZWFyZG93biBsaWJyYXJ5IGZvciBTYWFTIG9uYm9hcmRpbmc8L2xpPjxsaT5OZXcgRmlnbWEgcmV2aWV3IGNoZWNrbGlzdHMgZWFjaCBkcm9wPC9saT48bGk+UHJvbXB0ZWQgZml4IHBsYW5zIGZvciB5b3VyIG5leHQgc3ByaW50PC9saT48bGk+UXVhcnRlcmx5IGxpdmUgUSZBIGFuZCBjb21tdW5pdHkgdm90aW5nPC9saT48L3VsPjxoMz5XaG8gdGhpcyBpcyBmb3I8L2gzPjxwPlRlYW1zIHdobyB3YW50IG9uZ29pbmcsIHByYWN0aWNhbCBvbmJvYXJkaW5nIGd1aWRhbmNlLjwvcD48cD5Vc2UgZWFjaCBtb250aOKAmXMgbWF0ZXJpYWxzIHRvIHNoaXAgbWVhc3VyYWJsZSBvbmJvYXJkaW5nIGltcHJvdmVtZW50cy48L3A+XCIsXG4gICAgICBcInJhdGlvbmFsZV9vbmVfbGluZVwiOiBcIlN1YnNjcmlwdGlvbiB0d2luOiByZWN1cnJpbmcgb25ib2FyZGluZyByZXZpZXdzIGFuZCBtb250aGx5IGZpeCBraXRzLlwiLFxuICAgICAgXCJpc19wcmltYXJ5XCI6IGZhbHNlXG4gICAgfSxcbiAgICB7XG4gICAgICBcIm5hbWVcIjogXCJPbmJvYXJkaW5nIEF1ZGl0IFBsYXlib29rIOKAlCBGcm9tIFN5bXB0b21zIHRvIEZpeGVzXCIsXG4gICAgICBcIm5hdGl2ZV90eXBlXCI6IFwiZWJvb2tcIixcbiAgICAgIFwicHJpY2VfY2VudHNcIjogMjQwMCxcbiAgICAgIFwiZGVzY3JpcHRpb25cIjogXCI8cD5Zb3UgdHVybiBvbmJvYXJkaW5nIHBhaW4gcG9pbnRzIGludG8gYWN0aW9uYWJsZSBVSSBhbmQgY29weSBjaGFuZ2VzLjwvcD48aDM+V2hhdCdzIGluY2x1ZGVkPC9oMz48dWw+PGxpPkF1ZGl0IGZyYW1ld29yazogZ29hbHMsIHN0ZXBzLCBmcmljdGlvbiwgdHJ1c3Q8L2xpPjxsaT5IZXVyaXN0aWMgbGlicmFyeSB0YWlsb3JlZCB0byBTYWFTIG9uYm9hcmRpbmc8L2xpPjxsaT5EZWNpc2lvbiB0cmVlcyBmb3IgZW1wdHkgc3RhdGVzIGFuZCBndWlkYW5jZTwvbGk+PGxpPk1ldHJpY3MgbWFwcGluZzogYWN0aXZhdGlvbiwgYWN0aXZhdGlvbiBkZXB0aCwgcmV0ZW50aW9uPC9saT48L3VsPjxoMz5XaG8gdGhpcyBpcyBmb3I8L2gzPjxwPlByb2R1Y3QgZGVzaWduZXJzIHdobyB3YW50IGEgcmVwZWF0YWJsZSBvbmJvYXJkaW5nIGF1ZGl0IG1ldGhvZC48L3A+PHA+UnVuIHRoZSBwbGF5Ym9vayBvbiB5b3VyIGZsb3cgYW5kIHByb2R1Y2UgYSBwcmlvcml0aXplZCBmaXggYmFja2xvZy48L3A+XCIsXG4gICAgICBcInJhdGlvbmFsZV9vbmVfbGluZVwiOiBcIkFkamFjZW50IGVib29rOiB0ZWFjaGVzIHRoZSBwcm9jZXNzIGJlaGluZCB0aGUgYXVkaXQgcGFjay5cIixcbiAgICAgIFwiaXNfcHJpbWFyeVwiOiBmYWxzZVxuICAgIH1cbiAgXVxufSIsCiAgICAgICAgInJlZnVzYWwiOiBudWxsLAogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdCiAgICAgIH0sCiAgICAgICJmaW5pc2hfcmVhc29uIjogInN0b3AiCiAgICB9CiAgXSwKICAidXNhZ2UiOiB7CiAgICAicHJvbXB0X3Rva2VucyI6IDI0OTksCiAgICAiY29tcGxldGlvbl90b2tlbnMiOiA2MTEsCiAgICAidG90YWxfdG9rZW5zIjogMzExMCwKICAgICJwcm9tcHRfdG9rZW5zX2RldGFpbHMiOiB7CiAgICAgICJjYWNoZWRfdG9rZW5zIjogMCwKICAgICAgImF1ZGlvX3Rva2VucyI6IDAKICAgIH0sCiAgICAiY29tcGxldGlvbl90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgInJlYXNvbmluZ190b2tlbnMiOiAwLAogICAgICAiYXVkaW9fdG9rZW5zIjogMCwKICAgICAgImFjY2VwdGVkX3ByZWRpY3Rpb25fdG9rZW5zIjogMCwKICAgICAgInJlamVjdGVkX3ByZWRpY3Rpb25fdG9rZW5zIjogMAogICAgfQogIH0sCiAgInNlcnZpY2VfdGllciI6ICJkZWZhdWx0IiwKICAic3lzdGVtX2ZpbmdlcnByaW50IjogbnVsbAp9Cg==
+  recorded_at: Fri, 01 May 2026 12:21:04 GMT
+recorded_with: VCR 6.2.0

--- a/spec/system/first_product_starter_spec.rb
+++ b/spec/system/first_product_starter_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "First Product Starter", type: :system, js: true do
+  let(:seller) { create(:user, email: "starter@example.com") }
+
+  before do
+    Feature.activate_user(:first_product_starter, seller)
+    login_as(seller)
+  end
+
+  after { Feature.deactivate_user(:first_product_starter, seller) }
+
+  it "lets a fresh seller pick a generated option and lands them in the editor", force_vcr_on: true do
+    VCR.use_cassette("system/first_product_starter_spec/happy_path") do
+      visit dashboard_path
+
+      expect(page).to have_text("What do you want to sell? We'll draft it for you.")
+      fill_in("Tell us what you know, make, teach, or want to sell",
+              with: "I'm a Figma designer. I do SaaS onboarding audits.")
+      click_button("Show me three options")
+
+      expect(page).to have_text("Start with a template", wait: 30)
+      expect(page).to have_button("Show me three more")
+      within("[data-testid='product-options']") do
+        buttons = all("button", text: "Make it yours →")
+        expect(buttons.length).to eq(3)
+        buttons.first.click
+      end
+
+      expect(page).to have_current_path(%r{/products/[^/]+/edit}, wait: 30)
+      created = seller.links.order(:id).last
+      expect(created).not_to be_nil
+      expect(created.draft).to be(true)
+    end
+  end
+
+  it "renders the Greeter alongside the starter card when the flag is on" do
+    visit dashboard_path
+    expect(page).to have_text("What do you want to sell? We'll draft it for you.")
+    expect(page).to have_text("We're here to help you get paid for your work")
+  end
+
+  it "shows only the Greeter when the flag is off" do
+    Feature.deactivate_user(:first_product_starter, seller)
+    visit dashboard_path
+    expect(page).to have_text("We're here to help you get paid for your work")
+    expect(page).not_to have_text("What do you want to sell? We'll draft it for you.")
+  end
+
+  it "shows three template options instantly when the seller submits empty input" do
+    visit dashboard_path
+    click_button("Show me three options")
+
+    expect(page).to have_text("Start with a template", wait: 10)
+    within("[data-testid='product-options']") do
+      expect(all("button", text: "Make it yours →").length).to eq(3)
+    end
+  end
+
+  it "disables the submit button when the seller types only one word" do
+    visit dashboard_path
+    fill_in("Tell us what you know, make, teach, or want to sell", with: "hi")
+    expect(page).to have_text("Add a few more words, or leave it empty to see starter templates.")
+    expect(page).to have_button("Show me three options", disabled: true)
+  end
+
+  it "shows the capped banner inline (cards still visible, reroll relabelled) when over the AI cap" do
+    stub_const("FirstProductStarterController::THROTTLE_LIMIT_PER_HOUR", 0)
+    visit dashboard_path
+    fill_in("Tell us what you know, make, teach, or want to sell",
+            with: "I'm a Figma designer. I do SaaS onboarding audits.")
+    click_button("Show me three options")
+
+    expect(page).to have_text("Start with a template", wait: 10)
+    expect(page).to have_text("You've used your AI suggestions for this hour")
+    within("[data-testid='product-options']") do
+      expect(all("button", text: "Make it yours →").length).to eq(3)
+    end
+    expect(page).to have_button("Show me three more templates")
+  end
+end


### PR DESCRIPTION
# Improve activation: AI-generated first products on the empty seller dashboard

**Creator activation is the binding constraint on GMV** - not buyer demand, not platform features, Per Sahil (annual meeting 2026, [summary here](https://gist.github.com/yanchuk/f03fdcbdeffbc898b9ab557f05e677d6)).
**Goal chain:** improve activation → grow GMV → grow revenue $$$

## What

A flagged "surface" on the empty seller dashboard.
Seller types a sentence, gets three publishable product drafts in ~4.5s, picks one, lands in the editor with a draft Link saved. Empty submits skip the AI and serve curated templates instantly.

```
1. /dashboard → "What do you want to sell? We'll draft it for you." above the existing Greeter
2. Type ≥2 words → "Show me three options"  (or leave empty → templates)
3. One OpenAI call (~4.5s) → primary, subscription twin (membership), adjacent course/ebook
4. Click "Make it yours →" → editor with [Bracketed] placeholders
```

## Demo

[<img width="2246" height="1408" alt="Feature Demo" src="https://github.com/user-attachments/assets/70e75510-2b77-4cfb-b556-f8ce46873705" />](https://drive.google.com/file/d/10827XXsWt9knyPbt1UNkcSW6AdcMzQzJ/view?usp=sharing)

▶ [Watch the walkthrough on Google Drive](https://drive.google.com/file/d/10827XXsWt9knyPbt1UNkcSW6AdcMzQzJ/view?usp=sharing)

## Why

Activation is the leakiest part of the funnel: sellers sign up, see a blank dashboard, never publish. 
The Greeter says "create your first product" with no guidance. This is the smallest surface that turns "what should I even sell?" into three pickable options.

No new tables, no migrations. 
The prompt encodes Gumroad domain knowledge (categories, prices, artifact-vs-meta-product, subscription-twin). 20 hand-written (ok, Claude written) brand-free templates back the empty-input and cap-fallthrough paths.

## Gating (all four must hold)

1. `:first_product_starter` flag on.
2. `seller.links.visible.exists? == false`.
3. `User#eligible_for_first_product_starter?` (confirmed, not suspended).
4. `loggedInUser?.policies.product.create`.

Kill switch: `Feature.deactivate(:first_product_starter)`.

## Configuration (chosen by live measurement)

3 inputs per config, real OpenAI calls, before locking the final setup:

| Config | Latency avg |
|---|---|
| Verbose prompt, pool=6, low reasoning | 12.06s |
| Tight prompt, pool=6, low reasoning | 9.11s |
| Tight prompt, pool=3, low reasoning | 7.34s |
| **Tight prompt, pool=3, no reasoning** | **4.85s** |
| gpt-4.1-nano-2025-04-14 (compared) | 11.05s, less concrete names |

**Final**: `gpt-5.4-nano`, `reasoning_effort` = `none`, `max_completion_tokens: 3000`, pool size 3.

## Cost

~$0.003 per call (cache miss) / ~$0.002 (cache hit). Cap = **2/hr/user**. 1,000 sellers × 1.5 calls ≈ **~$3-4**. Empty-input templates are free.

## Mechanics

- **Soft cap.** Redis Throttling. Cap-hit returns `{ capped: true }` with templates and an inline banner — never a wall.
- **Templates** (`lib/first_product_starter/templates.yml`): 20 universal `[Bracketed]` entries; voice patterns from 6 live-fetched gumroad.com top-sellers.
- **AI prompt** rewritten per OpenAI's gpt-5.4-nano guidance: critical rules first, exact step order, edge cases, one example. "Subscription twin" rule - one of the 3 must be the recurring shape of the seller's domain.
- **Server guards.** `enforce_one_primary` (position 0); `ensure_membership_present`; `enforce_unique_domains` (alnum-aware boundary, blank-strip safe); `interleave_pool_by_type`.
- **Frontend.** Coin loader on the textarea ("up to 5 sec" in the button). 1-word block with 1s debounce. 3-click cap on templates with morphing button. Stable card heights — no scroll-jump on reroll.

## Production controls

Throttle (2/hr user, 30/hr IP, atomic, soft fallthrough). Devise + Pundit. `helpers.sanitize` on LLM HTML.
 **No PII to OpenAI** - only typed text + opaque `seller.external_id` for abuse-detection.

## Tests

**31 examples, 0 failures.** VCR cassettes scrubbed. Pre-existing `creator_home_presenter` failures are unrelated (fail identically on `origin/main`).

| Spec | Count |
|---|---|
| `service_spec.rb` | 14 |
| `controller_spec.rb` | 14 |
| `policy_spec.rb` | 3 |
| `system_spec.rb` | covered (Selenium, run during demo) |
<img width="400" alt="CleanShot 2026-05-01 at 15 48 09@2x" src="https://github.com/user-attachments/assets/d8af88b1-344e-4dc7-a8f4-e03f63e2218f" />


```
$ bundle exec rspec spec/services/ai/first_product_starter_service_spec.rb \
                    spec/requests/first_product_starter_controller_spec.rb \
                    spec/policies/first_product_starter_policy_spec.rb
31 examples, 0 failures
```

**`bin/test-confidence`**: reaches the **80% confidence bar** (controller + service + policy specs green). Stops at 95% on 9 pre-existing failures in `user_spec.rb` (avatar_url, profile_url, refund-policy predicates, `not_suspended` scope, `payment_reminder_risk_state` scope, username uniqueness) that fail identically on `origin/main` — verified against merge-base. This branch adds one method to `User` (`#eligible_for_first_product_starter?`); the script can't auto-skip pre-existing failures in a file we touched.

## How to test (manual walkthrough)

```bash
git checkout feat/first-product-starter-backend
PATH="$HOME/.rbenv/shims:$PATH" bin/dev
# Rails console:
Feature.activate_user(:first_product_starter, User.find_by(email: "seller@gumroad.com"))
$redis.del(*$redis.keys("*ai_request_throttle*"))   # clean throttle bucket
```

Visit `https://gumroad.dev/dashboard` as a seller with `links.visible.exists? == false`. Walk this checklist:

1. **Empty submit** — leave textarea empty, click *Show me three options*. 3 template cards in <100ms.
2. **1-word block** — type *"hi"*. After ~1s a helper line appears below the textarea; the submit button is disabled. Add more words → clears instantly.
3. **AI submit** — type *"I want to sell my book"*, click. Coin loader overlays the textarea (~4-5s). 3 cards: primary, subscription twin (`membership`, with `/mo`), adjacent course/ebook.
4. **Pick a card** — click *Make it yours →*. Lands on `/products/<id>/edit` with `[Bracketed]` placeholders intact in title and description.
5. **Reroll** — click *Show me three more*. Fresh AI call → 3 new cards.
6. **Cap** — submit 2 AI requests. 3rd shows the inline banner *"You've used your AI suggestions for this hour…"* and cards swap to templates. Bucket stays at 2 (verify with `$redis.get(RedisKey.ai_request_throttle(seller.id))`).
7. **Templates 3-click ceiling** — empty submit + 3 reroll clicks. The 3rd morphs the button to *Create a product from scratch →*. Click → redirect to `/products/new`.
8. **Light + dark + mobile** — Chrome devtools `prefers-color-scheme` toggle + iPhone 14 Pro viewport. Cards, banner, and loader all flip cleanly.

Reset throttle between sessions: `$redis.del(*$redis.keys("*ai_request_throttle*"))`.

## How to measure results

**Activation = first published product** (`links.draft = false AND purchase_disabled_at IS NULL`). I used that.

Two cohorts since `:rollout_start`:
- `starter` — fired `first_product_starter_drafted`.
- `control` — same window, eligible, did NOT use the flow.

Expected result shape (illustrative):

| cohort  | sellers | activation_pct | avg_hours_to_publish |
|---------|---------|----------------|----------------------|
| starter | 482     | 38.4           | 2.7                  |
| control | 1,914   | 11.2           | 18.3                 |

**Significance test.** We'll need to put results into some A/B calc to make sure it's significant.

**Decision rule.** ≥10pp activation lift after the first month at 5%+ rollout → keep ramping. Below that → kill the surface.

**For clean attribution** - randomize at flag-eligibility.

```sql
WITH cohort_starter AS (
  SELECT DISTINCT user_id FROM events
  WHERE event_name = 'first_product_starter_drafted' AND created_at >= :rollout_start
),
cohort_control AS (
  SELECT id AS user_id FROM users
  WHERE created_at >= :rollout_start
    AND confirmed_at IS NOT NULL AND user_risk_state = 'compliant'
    AND id NOT IN (SELECT user_id FROM cohort_starter)
),
published AS (
  SELECT user_id, MIN(updated_at) AS first_published_at FROM links
  WHERE draft = FALSE AND purchase_disabled_at IS NULL AND deleted_at IS NULL
  GROUP BY user_id
)
SELECT 'starter' AS cohort, COUNT(*) AS sellers,
       ROUND(100.0 * COUNT(p.user_id) / COUNT(*), 1) AS activation_pct,
       ROUND(AVG(TIMESTAMPDIFF(HOUR, u.created_at, p.first_published_at)), 1) AS avg_hours_to_publish
FROM cohort_starter c JOIN users u ON u.id = c.user_id
LEFT JOIN published p ON p.user_id = c.user_id
UNION ALL
SELECT 'control', COUNT(*),
       ROUND(100.0 * COUNT(p.user_id) / COUNT(*), 1),
       ROUND(AVG(TIMESTAMPDIFF(HOUR, u.created_at, p.first_published_at)), 1)
FROM cohort_control c JOIN users u ON u.id = c.user_id
LEFT JOIN published p ON p.user_id = c.user_id;
```

## Rollout

```ruby
Feature.activate_percentage_of_actors(:first_product_starter, 1)  
# 5% → 25% → 100% if metrics hold
```

**Watch:** Bugsnag 503 rate (<1%), draft → publish ratio (≥20%), OpenAI cost, AI-cap-hit rate (<5% — raise cap if higher).

## Planned follow-ups

1. Inject Gumroad data (top categories, taxonomy medians, `Link.search` titles) into the prompt — biggest quality lever. #could
2. Follow-up questions for vague input. #could
3. Funnel events (`seen`, `typed`, `submitted`). #could
4. Expand templates from 20 → ~30 (currently 3 are course/ebook). #could
5. LLM trace logging - must-have before scale. #could
6. Profile prefill, persisted sessions, AI cover image (Gemini) — further out. #could

## Known limitations

- 20 templates, 3 instructional → bounded variety in that slot.
- Model runs without reasoning — measured fastest, no quality regression.
- No LLM trace logging yet.
- 2 calls per user per 1 hour (Reddis)

