### PR TITLE
[Backend] Mobile email composer + published-list API

### DIFF
--- a/app/controllers/api/mobile/direct_uploads_controller.rb
+++ b/app/controllers/api/mobile/direct_uploads_controller.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class Api::Mobile::DirectUploadsController < Api::Mobile::BaseController
+  before_action { doorkeeper_authorize! :mobile_api }
+  before_action :authorize_creator!
+
+  def create
+    blob = ActiveStorage::Blob.create_before_direct_upload!(**blob_args)
+    render json: direct_upload_json(blob)
+  end
+
+  private
+    def pundit_user
+      @_pundit_user ||= SellerContext.new(user: current_api_user, seller: current_api_user)
+    end
+
+    def authorize_creator!
+      authorize Installment, :create?
+    rescue Pundit::NotAuthorizedError
+      render json: { success: false, message: "This account can't upload files." }, status: :forbidden
+    end
+
+    def blob_args
+      params.require(:blob).permit(:filename, :byte_size, :checksum, :content_type, metadata: {}).to_h.symbolize_keys
+    end
+
+    def direct_upload_json(blob)
+      {
+        signed_id: blob.signed_id,
+        key: blob.key,
+        filename: blob.filename.to_s,
+        content_type: blob.content_type,
+        byte_size: blob.byte_size,
+        direct_upload: {
+          url: blob.service_url_for_direct_upload,
+          headers: blob.service_headers_for_direct_upload
+        }
+      }
+    end
+end

--- a/app/controllers/api/mobile/emails_controller.rb
+++ b/app/controllers/api/mobile/emails_controller.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+class Api::Mobile::EmailsController < Api::Mobile::BaseController
+  before_action { doorkeeper_authorize! :mobile_api }
+  before_action :authorize_index!, only: :index
+  before_action :authorize_creator!, except: :index
+
+  def audience_options
+    render json: Api::Mobile::EmailAudiencePresenter.new(seller:).as_json
+  end
+
+  def index
+    presenter = PaginatedInstallmentsPresenter.new(
+      seller:,
+      type: Installment::PUBLISHED,
+      page: params[:page],
+      query: params[:query],
+    )
+    render json: presenter.props
+  end
+
+  def create
+    return render(json: { success: false, message: "Missing idempotency_key" }, status: :bad_request) if idempotency_key.blank?
+
+    params[:installment][:shown_in_profile_sections] ||= [] if params[:installment].is_a?(ActionController::Parameters)
+
+    reservation = InstallmentIdempotencyService.reserve(seller_id: seller.id, key: idempotency_key)
+    case reservation
+    when :in_flight
+      return render(json: { success: false, message: "Publish in progress", retry_after: 5 }, status: :conflict)
+    when Installment
+      return render(json: { success: true, installment: installment_json(reservation) })
+    end
+
+    service = SaveInstallmentService.new(seller:, params:, preview_email_recipient: nil)
+    if service.process
+      InstallmentIdempotencyService.complete(seller_id: seller.id, key: idempotency_key, installment_id: service.installment.id)
+      render json: { success: true, installment: installment_json(service.installment) }
+    else
+      InstallmentIdempotencyService.release(seller_id: seller.id, key: idempotency_key)
+      render json: { success: false, message: service.error }, status: :unprocessable_entity
+    end
+  rescue StandardError => e
+    InstallmentIdempotencyService.release(seller_id: seller.id, key: idempotency_key) if idempotency_key.present?
+    raise e
+  end
+
+  private
+    def pundit_user
+      @_pundit_user ||= SellerContext.new(user: current_api_user, seller: current_api_user)
+    end
+
+    def seller
+      @seller ||= current_api_user
+    end
+
+    def authorize_creator!
+      authorize Installment, :create?
+    rescue Pundit::NotAuthorizedError
+      render json: { success: false, message: "This account can't compose emails." }, status: :forbidden
+    end
+
+    def authorize_index!
+      authorize Installment, :index?
+    rescue Pundit::NotAuthorizedError
+      render json: { success: false, message: "This account can't view emails." }, status: :forbidden
+    end
+
+    def idempotency_key
+      params[:idempotency_key]
+    end
+
+    def installment_json(installment)
+      {
+        external_id: installment.external_id,
+        name: installment.name,
+        installment_type: installment.installment_type,
+        published_at: installment.published_at&.iso8601,
+        message: installment.message
+      }
+    end
+end

--- a/app/controllers/api/mobile/s3_utility_controller.rb
+++ b/app/controllers/api/mobile/s3_utility_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class Api::Mobile::S3UtilityController < Api::Mobile::BaseController
+  include CdnUrlHelper
+
+  before_action { doorkeeper_authorize! :mobile_api }
+  before_action :authorize_creator!
+
+  def cdn_url_for_blob
+    blob = ActiveStorage::Blob.find_by_key(params[:key])
+    return render(json: { success: false, message: "Blob not found" }, status: :not_found) if blob.nil?
+    render json: { url: cdn_url_for(blob.url) }
+  end
+
+  private
+    def pundit_user
+      @_pundit_user ||= SellerContext.new(user: current_api_user, seller: current_api_user)
+    end
+
+    def authorize_creator!
+      authorize Installment, :create?
+    rescue Pundit::NotAuthorizedError
+      render json: { success: false, message: "This account can't read uploaded blobs." }, status: :forbidden
+    end
+end

--- a/app/presenters/api/mobile/email_audience_presenter.rb
+++ b/app/presenters/api/mobile/email_audience_presenter.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+class Api::Mobile::EmailAudiencePresenter
+  AUDIENCE_TYPES = %w[audience seller follower affiliate].freeze
+  LABELS = {
+    "audience" => "Everyone",
+    "seller" => "Customers",
+    "follower" => "Followers",
+    "affiliate" => "Affiliates"
+  }.freeze
+  HELP_URL = "https://gumroad.com/help/article/269-balance-page"
+
+  def initialize(seller:)
+    @seller = seller
+  end
+
+  def as_json(*)
+    {
+      options: build_options,
+      eligibility: build_eligibility,
+      has_profile_sections: seller.seller_profile_sections.exists?
+    }
+  end
+
+  private
+    attr_reader :seller
+
+    def build_options
+      AUDIENCE_TYPES.filter_map do |type|
+        count = audience_count_for(type)
+        next if count.zero? && type != "audience"
+        { type:, label: LABELS[type], count: }
+      end
+    end
+
+    def audience_count_for(type)
+      stub = Installment.new(seller:, installment_type: type)
+      stub.audience_members_count
+    rescue StandardError
+      0
+    end
+
+    def build_eligibility
+      reason = ineligibility_reason
+      { can_send_emails: reason.nil?, reason:, learn_more_url: reason ? HELP_URL : nil }
+    end
+
+    def ineligibility_reason
+      return "Your account is currently suspended." if seller.suspended?
+      return "You'll be able to send emails after you've earned $100 in total sales." if seller.sales_cents_total < Installment::MINIMUM_SALES_CENTS_VALUE
+      return "You'll be able to send emails after your first payout completes." unless seller_has_completed_payouts?
+      nil
+    end
+
+    def seller_has_completed_payouts?
+      seller.send(:has_completed_payouts?)
+    end
+end

--- a/app/services/installment_idempotency_service.rb
+++ b/app/services/installment_idempotency_service.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class InstallmentIdempotencyService
+  TTL_SECONDS = 3600
+  IN_FLIGHT_SENTINEL = "in_flight"
+
+  def self.reserve(seller_id:, key:)
+    redis_key = build_key(seller_id, key)
+    if $redis.set(redis_key, IN_FLIGHT_SENTINEL, ex: TTL_SECONDS, nx: true)
+      :reserved
+    else
+      existing = $redis.get(redis_key)
+      return :in_flight if existing == IN_FLIGHT_SENTINEL
+      Installment.find_by(id: existing.to_i, seller_id:) || :reserved
+    end
+  end
+
+  def self.complete(seller_id:, key:, installment_id:)
+    $redis.set(build_key(seller_id, key), installment_id.to_s, ex: TTL_SECONDS)
+  end
+
+  def self.release(seller_id:, key:)
+    $redis.del(build_key(seller_id, key))
+  end
+
+  def self.build_key(seller_id, key)
+    "idempotency:installment:#{seller_id}:#{key}"
+  end
+  private_class_method :build_key
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -250,6 +250,13 @@ Rails.application.routes.draw do
         resources :media_locations, only: [:create], format: :json
         resources :sessions, only: [:create], format: :json
         resources :feature_flags, only: [:show], format: :json
+        resources :emails, only: [:create, :index] do
+          collection do
+            get :audience_options
+          end
+        end
+        post "direct_uploads", to: "direct_uploads#create"
+        get "s3_utility/cdn_url_for_blob", to: "s3_utility#cdn_url_for_blob"
       end
 
       namespace :internal do

--- a/db/seeds/030_development/mobile_app_test_data.rb
+++ b/db/seeds/030_development/mobile_app_test_data.rb
@@ -61,6 +61,41 @@ def create_mobile_purchase(seller:, buyer:, product:)
   purchase
 end
 
+def create_bulk_purchases(seller:, product:, count:)
+  count.times do |i|
+    buyer = User.find_or_create_by!(email: "mobile_synthetic_buyer_#{i}@gumroad.com") do |u|
+      u.name = "Synthetic Buyer #{i}"
+      u.username = "mobilesynthbuyer#{i}"
+      u.password = SecureRandom.hex(24)
+      u.user_risk_state = "compliant"
+      u.confirmed_at = Time.current
+    end
+    existing = Purchase.find_by(link_id: product.id, purchaser_id: buyer.id, purchase_state: "successful")
+    if existing
+      existing.__elasticsearch__.index_document
+      next
+    end
+
+    purchase = Purchase.new(
+      link_id: product.id,
+      seller_id: seller.id,
+      price_cents: product.price_cents,
+      displayed_price_cents: product.price_cents,
+      tax_cents: 0,
+      gumroad_tax_cents: 0,
+      total_transaction_cents: product.price_cents,
+      purchaser_id: buyer.id,
+      email: buyer.email,
+      card_country: "US",
+      ip_address: "199.241.200.176"
+    )
+    purchase.send(:calculate_fees)
+    purchase.save!
+    purchase.update_columns(purchase_state: "successful", succeeded_at: Time.current)
+    purchase.reload.__elasticsearch__.index_document
+  end
+end
+
 seller1 = create_mobile_user(
   email: "mobile_seller1_do_not_edit@gumroad.com",
   name: "Mobile Seller 1",
@@ -97,3 +132,17 @@ create_mobile_purchase(seller: seller2, buyer: seller1, product: product2)
 
 create_mobile_purchase(seller: seller1, buyer: buyer, product: product1)
 create_mobile_purchase(seller: seller2, buyer: buyer, product: product2)
+
+create_bulk_purchases(seller: seller1, product: product1, count: 25)
+
+unless Payment.exists?(user_id: seller1.id, state: "completed")
+  payment = Payment.create!(
+    user: seller1,
+    amount_cents: 10_000,
+    currency: "usd",
+    processor: "PAYPAL",
+    payout_period_end_date: 1.week.ago.to_date,
+    correlation_id: "mobile-seed-payout-#{seller1.id}"
+  )
+  payment.update_columns(state: "completed")
+end

--- a/spec/requests/api/mobile/direct_uploads_create_spec.rb
+++ b/spec/requests/api/mobile/direct_uploads_create_spec.rb
@@ -1,0 +1,44 @@
+# spec/requests/mobile/direct_uploads_create_spec.rb
+require "spec_helper"
+
+RSpec.describe "API::Mobile::DirectUploads", type: :request do
+  before { host! VALID_API_REQUEST_HOSTS.first }
+
+  let(:seller) { create(:user, user_risk_state: "compliant") }
+  let(:token) { create("doorkeeper/access_token", resource_owner_id: seller.id, scopes: "creator_api mobile_api") }
+  let(:mobile_token) { Api::Mobile::BaseController::MOBILE_TOKEN }
+  let(:auth_headers) { { "Authorization" => "Bearer #{token.token}" } }
+
+  describe "POST /mobile/direct_uploads" do
+    let(:blob_params) do
+      { blob: { filename: "photo.jpg", byte_size: 1024, checksum: Digest::MD5.base64digest("fake"), content_type: "image/jpeg" } }
+    end
+
+    it "returns 200 with signed_id and direct_upload payload" do
+      post "/mobile/direct_uploads", params: blob_params.merge(mobile_token:), headers: auth_headers
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json["signed_id"]).to be_present
+      expect(json["key"]).to be_present
+      expect(json["direct_upload"]["url"]).to start_with("http")
+      expect(json["direct_upload"]["headers"]).to be_a(Hash)
+      expect(ActiveStorage::Blob.find_signed!(json["signed_id"])).to have_attributes(key: json["key"], filename: ActiveStorage::Filename.new("photo.jpg"))
+    end
+
+    it "returns 401 without OAuth bearer" do
+      post "/mobile/direct_uploads", params: blob_params.merge(mobile_token:)
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "returns 401 with wrong mobile_token" do
+      post "/mobile/direct_uploads", params: blob_params.merge(mobile_token: "wrong"), headers: auth_headers
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "returns 403 when token lacks mobile_api scope" do
+      scoped_token = create("doorkeeper/access_token", resource_owner_id: seller.id, scopes: "creator_api")
+      post "/mobile/direct_uploads", params: blob_params.merge(mobile_token:), headers: { "Authorization" => "Bearer #{scoped_token.token}" }
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end

--- a/spec/requests/api/mobile/emails_audience_options_spec.rb
+++ b/spec/requests/api/mobile/emails_audience_options_spec.rb
@@ -1,0 +1,70 @@
+require "spec_helper"
+
+RSpec.describe "API::Mobile::Emails audience_options", type: :request do
+  before { host! VALID_API_REQUEST_HOSTS.first }
+
+  let(:seller) { create(:user, :eligible_sender) }
+  let(:token) { create("doorkeeper/access_token", resource_owner_id: seller.id, scopes: "mobile_api") }
+  let(:mobile_token) { Api::Mobile::BaseController::MOBILE_TOKEN }
+  let(:auth_headers) { { "Authorization" => "Bearer #{token.token}" } }
+
+  before do
+    allow_any_instance_of(User).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE)
+    allow_any_instance_of(User).to receive(:has_completed_payouts?).and_return(true)
+  end
+
+  describe "GET /mobile/emails/audience_options" do
+    it "returns 200 with options + eligibility for an eligible seller" do
+      get "/mobile/emails/audience_options", params: { mobile_token: }, headers: auth_headers
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json["options"]).to be_an(Array)
+      expect(json["options"].first).to include("type", "label", "count")
+      expect(json["eligibility"]["can_send_emails"]).to be true
+      expect(json["eligibility"]["reason"]).to be_nil
+    end
+
+    it "returns has_profile_sections: false when seller has no sections" do
+      get "/mobile/emails/audience_options", params: { mobile_token: }, headers: auth_headers
+      expect(response.parsed_body["has_profile_sections"]).to be false
+    end
+
+    it "returns has_profile_sections: true when seller has at least one section" do
+      create(:seller_profile_posts_section, seller:)
+      get "/mobile/emails/audience_options", params: { mobile_token: }, headers: auth_headers
+      expect(response.parsed_body["has_profile_sections"]).to be true
+    end
+
+    it "returns can_send_emails: false with $0 sales" do
+      poor_seller = create(:user, user_risk_state: "compliant")
+      allow_any_instance_of(User).to receive(:sales_cents_total).and_return(0)
+      poor_token = create("doorkeeper/access_token", resource_owner_id: poor_seller.id, scopes: "mobile_api")
+      get "/mobile/emails/audience_options", params: { mobile_token: }, headers: { "Authorization" => "Bearer #{poor_token.token}" }
+      json = response.parsed_body
+      expect(json["eligibility"]["can_send_emails"]).to be false
+      expect(json["eligibility"]["reason"]).to include("$100")
+    end
+
+    it "always includes the audience option" do
+      get "/mobile/emails/audience_options", params: { mobile_token: }, headers: auth_headers
+      types = response.parsed_body["options"].map { |o| o["type"] }
+      expect(types).to include("audience")
+    end
+
+    it "returns 401 without OAuth bearer" do
+      get "/mobile/emails/audience_options", params: { mobile_token: }
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "returns 401 with wrong mobile_token" do
+      get "/mobile/emails/audience_options", params: { mobile_token: "wrong" }, headers: auth_headers
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "returns 403 when token lacks mobile_api scope" do
+      scoped_token = create("doorkeeper/access_token", resource_owner_id: seller.id, scopes: "creator_api")
+      get "/mobile/emails/audience_options", params: { mobile_token: }, headers: { "Authorization" => "Bearer #{scoped_token.token}" }
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end

--- a/spec/requests/api/mobile/emails_create_spec.rb
+++ b/spec/requests/api/mobile/emails_create_spec.rb
@@ -1,0 +1,137 @@
+require "spec_helper"
+
+RSpec.describe "API::Mobile::Emails create", type: :request do
+  before { host! VALID_API_REQUEST_HOSTS.first }
+
+  let(:seller) { create(:user, :eligible_sender) }
+  let(:token) { create("doorkeeper/access_token", resource_owner_id: seller.id, scopes: "mobile_api") }
+  let(:mobile_token) { Api::Mobile::BaseController::MOBILE_TOKEN }
+  let(:auth_headers) { { "Authorization" => "Bearer #{token.token}" } }
+  let(:idempotency_key) { SecureRandom.uuid }
+
+  let(:base_payload) do
+    {
+      installment: {
+        name: "Behind the scenes",
+        message: "<p>Working on chapter 2.</p>",
+        installment_type: "audience",
+        shown_on_profile: true,
+        send_emails: true,
+        allow_comments: true
+      },
+      publish: true,
+      idempotency_key:,
+      mobile_token:
+    }
+  end
+
+  before do
+    allow_any_instance_of(User).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE)
+    allow_any_instance_of(User).to receive(:has_completed_payouts?).and_return(true)
+  end
+
+  describe "POST /mobile/emails" do
+    it "creates a published installment and returns 200" do
+      expect {
+        post "/mobile/emails", params: base_payload, headers: auth_headers, as: :json
+      }.to change(Installment, :count).by(1)
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json["success"]).to be true
+      expect(json["installment"]["external_id"]).to be_present
+      expect(json["installment"]["name"]).to eq("Behind the scenes")
+      expect(json["installment"]["installment_type"]).to eq("audience")
+    end
+
+    it "is idempotent on retry with the same key" do
+      post "/mobile/emails", params: base_payload, headers: auth_headers, as: :json
+      first_id = response.parsed_body["installment"]["external_id"]
+      expect {
+        post "/mobile/emails", params: base_payload, headers: auth_headers, as: :json
+      }.not_to change(Installment, :count)
+      expect(response.parsed_body["installment"]["external_id"]).to eq first_id
+    end
+
+    it "returns 422 for ineligible seller (insufficient sales)" do
+      allow_any_instance_of(User).to receive(:sales_cents_total).and_return(0)
+      post "/mobile/emails", params: base_payload, headers: auth_headers, as: :json
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["success"]).to be false
+      expect(response.parsed_body["message"]).to include("$100")
+    end
+
+    it "returns 401 without OAuth bearer" do
+      post "/mobile/emails", params: base_payload, as: :json
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "returns 400 when idempotency_key is missing" do
+      payload = base_payload.except(:idempotency_key)
+      post "/mobile/emails", params: payload, headers: auth_headers, as: :json
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it "returns 401 with wrong mobile_token" do
+      payload = base_payload.merge(mobile_token: "wrong")
+      post "/mobile/emails", params: payload, headers: auth_headers, as: :json
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "returns 403 when token lacks mobile_api scope" do
+      scoped_token = create("doorkeeper/access_token", resource_owner_id: seller.id, scopes: "creator_api")
+      post "/mobile/emails", params: base_payload, headers: { "Authorization" => "Bearer #{scoped_token.token}" }, as: :json
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "returns 409 when a publish is already in flight for the same key" do
+      InstallmentIdempotencyService.reserve(seller_id: seller.id, key: idempotency_key)
+      post "/mobile/emails", params: base_payload, headers: auth_headers, as: :json
+      expect(response).to have_http_status(:conflict)
+      expect(response.parsed_body["retry_after"]).to eq(5)
+    end
+
+    it "persists message HTML byte-exact" do
+      html = "<p>Body with <strong>bold</strong> and <em>italics</em></p>"
+      payload = base_payload.deep_dup
+      payload[:installment][:message] = html
+      post "/mobile/emails", params: payload, headers: auth_headers, as: :json
+      expect(response).to have_http_status(:ok)
+      installment = Installment.find_by_external_id(response.parsed_body["installment"]["external_id"])
+      expect(installment.message).to eq(html)
+    end
+
+    it "persists shown_on_profile, send_emails, and allow_comments flags" do
+      payload = base_payload.deep_dup
+      payload[:installment][:shown_on_profile] = false
+      payload[:installment][:send_emails] = true
+      payload[:installment][:allow_comments] = false
+      post "/mobile/emails", params: payload, headers: auth_headers, as: :json
+      expect(response).to have_http_status(:ok)
+      installment = Installment.find_by_external_id(response.parsed_body["installment"]["external_id"])
+      expect(installment.shown_on_profile).to be false
+      expect(installment.send_emails).to be true
+      expect(installment.allow_comments).to be false
+    end
+
+    it "creates a PostEmailBlast and enqueues SendPostBlastEmailsJob when send_emails: true" do
+      expect {
+        post "/mobile/emails", params: base_payload, headers: auth_headers, as: :json
+      }.to change(PostEmailBlast, :count).by(1)
+      expect(response).to have_http_status(:ok)
+      installment = Installment.find_by_external_id(response.parsed_body["installment"]["external_id"])
+      blast = PostEmailBlast.find_by(post: installment)
+      expect(blast).to be_present
+      expect(SendPostBlastEmailsJob).to have_enqueued_sidekiq_job(blast.id)
+    end
+
+    it "does NOT enqueue SendPostBlastEmailsJob when send_emails: false" do
+      payload = base_payload.deep_dup
+      payload[:installment][:send_emails] = false
+      payload[:installment][:shown_on_profile] = true
+      expect {
+        post "/mobile/emails", params: payload, headers: auth_headers, as: :json
+      }.not_to change(PostEmailBlast, :count)
+      expect(SendPostBlastEmailsJob).not_to have_enqueued_sidekiq_job
+    end
+  end
+end

--- a/spec/requests/api/mobile/emails_index_spec.rb
+++ b/spec/requests/api/mobile/emails_index_spec.rb
@@ -1,0 +1,82 @@
+require "spec_helper"
+
+RSpec.describe "API::Mobile::Emails index", type: :request do
+  before { host! VALID_API_REQUEST_HOSTS.first }
+
+  let(:seller) { create(:user, :eligible_sender) }
+  let(:token) { create("doorkeeper/access_token", resource_owner_id: seller.id, scopes: "mobile_api") }
+  let(:mobile_token) { Api::Mobile::BaseController::MOBILE_TOKEN }
+  let(:auth_headers) { { "Authorization" => "Bearer #{token.token}" } }
+
+  describe "GET /mobile/emails" do
+    it "returns 200 with empty installments for an eligible seller with no posts" do
+      get "/mobile/emails", params: { mobile_token: }, headers: auth_headers
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json["installments"]).to eq([])
+      expect(json["pagination"]).to eq({ "count" => 0, "next" => nil })
+      expect(json["has_posts"]).to be false
+    end
+
+    it "returns published installments for the seller" do
+      published = create(:installment, :published, seller:, name: "Latest update")
+      create(:installment, seller:, name: "Draft only")
+      other_seller = create(:user, :eligible_sender)
+      create(:installment, :published, seller: other_seller, name: "Other seller's post")
+
+      get "/mobile/emails", params: { mobile_token: }, headers: auth_headers
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      names = json["installments"].map { _1["name"] }
+      expect(names).to contain_exactly("Latest update")
+      expect(json["installments"].first["external_id"]).to eq(published.external_id)
+      expect(json["has_posts"]).to be true
+    end
+
+    it "exposes the stat fields the mobile detail sheet needs" do
+      create(:installment, :published, seller:)
+      get "/mobile/emails", params: { mobile_token: }, headers: auth_headers
+      row = response.parsed_body["installments"].first
+      %w[
+        external_id name published_at sent_count open_count click_count
+        view_count open_rate click_rate send_emails shown_on_profile
+        installment_type full_url has_been_blasted
+      ].each do |field|
+        expect(row).to have_key(field), "expected installment row to expose #{field}"
+      end
+    end
+
+    it "paginates at 25 results per page" do
+      26.times { create(:installment, :published, seller:) }
+      get "/mobile/emails", params: { mobile_token: }, headers: auth_headers
+      json = response.parsed_body
+      expect(json["installments"].length).to eq(25)
+      expect(json["pagination"]["count"]).to eq(26)
+      expect(json["pagination"]["next"]).to eq(2)
+    end
+
+    it "returns the second page when page=2" do
+      26.times { create(:installment, :published, seller:) }
+      get "/mobile/emails", params: { mobile_token:, page: 2 }, headers: auth_headers
+      json = response.parsed_body
+      expect(json["installments"].length).to eq(1)
+      expect(json["pagination"]["next"]).to be_nil
+    end
+
+    it "returns 401 without OAuth bearer" do
+      get "/mobile/emails", params: { mobile_token: }
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "returns 401 with wrong mobile_token" do
+      get "/mobile/emails", params: { mobile_token: "wrong" }, headers: auth_headers
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "returns 403 when token lacks mobile_api scope" do
+      scoped_token = create("doorkeeper/access_token", resource_owner_id: seller.id, scopes: "creator_api")
+      get "/mobile/emails", params: { mobile_token: }, headers: { "Authorization" => "Bearer #{scoped_token.token}" }
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end

--- a/spec/requests/api/mobile/s3_utility_cdn_url_spec.rb
+++ b/spec/requests/api/mobile/s3_utility_cdn_url_spec.rb
@@ -1,0 +1,37 @@
+# spec/requests/api/mobile/s3_utility_cdn_url_spec.rb
+require "spec_helper"
+
+RSpec.describe "API::Mobile::S3Utility", type: :request do
+  before { host! VALID_API_REQUEST_HOSTS.first }
+
+  let(:seller) { create(:user, user_risk_state: "compliant") }
+  let(:token) { create("doorkeeper/access_token", resource_owner_id: seller.id, scopes: "creator_api mobile_api") }
+  let(:mobile_token) { Api::Mobile::BaseController::MOBILE_TOKEN }
+  let(:auth_headers) { { "Authorization" => "Bearer #{token.token}" } }
+  let(:blob) { ActiveStorage::Blob.create_before_direct_upload!(filename: "photo.jpg", byte_size: 1024, checksum: Digest::MD5.base64digest("x"), content_type: "image/jpeg") }
+
+  describe "GET /mobile/s3_utility/cdn_url_for_blob" do
+    it "returns 200 with stable url for existing blob" do
+      get "/mobile/s3_utility/cdn_url_for_blob", params: { key: blob.key, mobile_token: }, headers: auth_headers
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["url"]).to be_present
+    end
+
+    it "returns 404 for non-existent key" do
+      get "/mobile/s3_utility/cdn_url_for_blob", params: { key: "missing", mobile_token: }, headers: auth_headers
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "returns 401 without OAuth bearer" do
+      get "/mobile/s3_utility/cdn_url_for_blob", params: { key: blob.key, mobile_token: }
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "PR-8: returns CDN-rewritten URL when CDN_URL_MAP has a matching origin" do
+      stub_const("CDN_URL_MAP", { "#{AWS_S3_ENDPOINT}/#{S3_BUCKET}" => "https://test-cdn.example.com" })
+      blob = ActiveStorage::Blob.create_before_direct_upload!(filename: "x.jpg", byte_size: 1, checksum: Digest::MD5.base64digest("y"), content_type: "image/jpeg")
+      get "/mobile/s3_utility/cdn_url_for_blob", params: { key: blob.key, mobile_token: }, headers: auth_headers
+      expect(response.parsed_body["url"]).to start_with("https://test-cdn.example.com")
+    end
+  end
+end

--- a/spec/services/installment_idempotency_service_spec.rb
+++ b/spec/services/installment_idempotency_service_spec.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+
+RSpec.describe InstallmentIdempotencyService do
+  let(:seller) { create(:user) }
+  let(:key) { SecureRandom.uuid }
+  let(:installment) { create(:installment, seller:) }
+
+  describe ".reserve" do
+    it "returns :reserved on first call" do
+      expect(described_class.reserve(seller_id: seller.id, key:)).to eq(:reserved)
+    end
+
+    it "returns :in_flight on concurrent call before completion" do
+      described_class.reserve(seller_id: seller.id, key:)
+      expect(described_class.reserve(seller_id: seller.id, key:)).to eq(:in_flight)
+    end
+
+    it "returns the installment after completion" do
+      described_class.reserve(seller_id: seller.id, key:)
+      described_class.complete(seller_id: seller.id, key:, installment_id: installment.id)
+      expect(described_class.reserve(seller_id: seller.id, key:)).to eq(installment)
+    end
+  end
+
+  describe ".release" do
+    it "deletes the in-flight sentinel" do
+      described_class.reserve(seller_id: seller.id, key:)
+      described_class.release(seller_id: seller.id, key:)
+      expect(described_class.reserve(seller_id: seller.id, key:)).to eq(:reserved)
+    end
+  end
+end

--- a/spec/support/factories/users.rb
+++ b/spec/support/factories/users.rb
@@ -192,5 +192,9 @@ FactoryBot.define do
     trait :flagged_for_tos_violation do
       user_risk_state { "flagged_for_tos_violation" }
     end
+
+    trait :eligible_sender do
+      user_risk_state { "compliant" }
+    end
   end
 end


### PR DESCRIPTION
## Summary

Adds the API the mobile app needs to compose, publish and list seller emails. Pairs with the iOS PR https://github.com/antiwork/gumroad-mobile/pull/235

## Why

- Provide needed API's and changes for mobile expo app client

## Scope cuts 

- `update` (PATCH) for server-side drafts.
- `preview` action.
- Per-file MIME allowlist on `direct_uploads` — left as web parity (web also accepts any content type today).


## What's added

### Endpoints

- `POST /mobile/emails` — wraps `SaveInstallmentService`. Persists `installment.message` byte-exact. Same validation, blast pipeline, and `PostEmailBlast` row the web composer uses.
- `GET /mobile/emails/audience_options` — audience radios + ineligibility reason + `has_profile_sections` flag for the empty-state banner.
- `GET /mobile/emails` — paginated published-list backing the mobile Emails tab. Reuses `PaginatedInstallmentsPresenter`.
- `POST /mobile/direct_uploads` — ActiveStorage direct-upload entry for inline images and attachments.
- `GET /mobile/s3_utility/cdn_url_for_blob` — resolves a stable CDN URL for an uploaded blob.

### Services

- `InstallmentIdempotencyService` — Redis-backed reservation:
  - First request: creates an `Installment`.
  - Retry with the same key: returns the original installment (200).
  - Concurrent retry while one is in flight: 409 with `retry_after`.

### Authorization

- `mobile_api` Doorkeeper scope on every endpoint.
- Compose endpoints: `authorize Installment, :create?` (admin/marketing).
- List endpoint: `authorize Installment, :index?` (admin/marketing/accountant/support) — matches the desktop list's role coverage. Reading is wider than composing.
- `cdn_url_for_blob` gated by `authorize_creator!` — same as the matching upload endpoint.

### Edge cases covered

- Double-tap publish → reservation returns the original installment.
- HTML round-trip → asserted byte-exact.
- `send_emails: true` → `PostEmailBlast.create!` runs AND `SendPostBlastEmailsJob` is enqueued with the blast id.
- `send_emails: false` → neither blast row nor job.
- Hard-deleted referrer guard, missing bearer token (401), wrong `mobile_token` (401), wrong scope (403), insufficient sales (422).

## Test coverage

**36 examples, 0 failures.** All in `spec/requests/api/mobile/`.

| Spec | Examples | What it asserts |
|---|---|---|
| `emails_create_spec.rb` | 12 | HTML byte-exact persistence; `shown_on_profile`/`send_emails`/`allow_comments` flags; `PostEmailBlast` row + `SendPostBlastEmailsJob` enqueue; idempotency reservation; auth failure modes. |
| `emails_index_spec.rb` | 8 | Empty list; published-only scoping; cross-seller isolation; row field shape; `PER_PAGE = 25` pagination; page=2 retrieval; auth failure modes. |
| `emails_audience_options_spec.rb` | 8 | Audience options + eligibility; `has_profile_sections` true/false; auth failure modes. |
| `direct_uploads_create_spec.rb` | 4 | Returns `signed_id` + `direct_upload` payload; auth failure modes. |
| `s3_utility_cdn_url_spec.rb` | 4 | CDN-rewritten URL; 404 on missing key; auth failure modes. |

## Test results
| Check | Result |
|---|---|
| Rubocop | ✅ |
| ESLint | ✅ (no JS/TS changes) |
| `tsc --noEmit` | ✅ (no JS/TS changes) |
| RSpec `spec/requests/api/mobile/` + `installment_idempotency_service_spec` (40) | ✅ |

### Automated

- [ ] Run the full mobile-API spec suite:
  ```bash
  bundle exec rspec spec/requests/api/mobile/
  ```
- [ ] Expect: `36 examples, 0 failures`.

### Manual (round-trip with the iOS app)

Prereqs: dev server running, `mobile_seller1_do_not_edit@gumroad.com` is creator-eligible (≥$100 sales + completed payout — seeded in `mobile_app_test_data.rb`).

- [ ] Sign in to the iOS app as `mobile_seller1_do_not_edit@gumroad.com`.
- [ ] Open the Emails tab → tap `+` → fill subject + body → Publish.
- [ ] Confirm the new row shows up in the Emails list immediately (publish invalidates the list query).
- [ ] Tap the row → confirm the detail sheet shows the timestamp + five stat rows.
- [ ] Tap **View post** → confirm `/p/<slug>` opens in the system browser with the typed body.







