### PR TITLE
Send member-cancels workflow to past canceled members

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -91,8 +91,16 @@ class Workflow < ApplicationRecord
   def schedule_installment(installment, old_delayed_delivery_time: nil)
     return if installment.abandoned_cart_type?
     return unless alive?
-    return unless new_customer_trigger?
     return unless installment.published?
+
+    if member_cancellation_trigger?
+      if send_to_past_customers? && old_delayed_delivery_time.nil?
+        SendWorkflowEmailsToPastCanceledMembersJob.perform_async(installment.id)
+      end
+      return
+    end
+
+    return unless new_customer_trigger?
     # don't schedule the installment if it is only for new customers/followers and it hasn't been scheduled before (old_delayed_delivery_time is nil)
     return if old_delayed_delivery_time.nil? && installment.is_for_new_customers_of_workflow
 

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -94,9 +94,7 @@ class Workflow < ApplicationRecord
     return unless installment.published?
 
     if member_cancellation_trigger?
-      if send_to_past_customers? && old_delayed_delivery_time.nil?
-        SendWorkflowEmailsToPastCanceledMembersJob.perform_async(installment.id)
-      end
+      SendWorkflowEmailsToPastCanceledMembersJob.perform_async(installment.id) if send_to_past_customers?
       return
     end
 

--- a/app/sidekiq/send_workflow_emails_to_past_canceled_members_job.rb
+++ b/app/sidekiq/send_workflow_emails_to_past_canceled_members_job.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class SendWorkflowEmailsToPastCanceledMembersJob
+  include Sidekiq::Job
+  sidekiq_options retry: 5, queue: :low
+
+  def perform(installment_id)
+    installment = Installment.find(installment_id)
+    workflow = installment.workflow
+    return unless workflow&.alive? && installment.alive? && installment.published?
+    return unless workflow.member_cancellation_trigger?
+    return unless workflow.send_to_past_customers?
+    return unless workflow.seller_or_product_or_variant_type?
+
+    rule = installment.installment_rule
+    return if rule.nil?
+
+    delay = rule.delayed_delivery_time
+    rule_version = rule.version
+
+    candidate_subscriptions(workflow).includes(:original_purchase).find_each do |subscription|
+      next unless subscription.cancelled?
+      original_purchase = subscription.original_purchase
+      next if original_purchase.nil?
+      next unless workflow.applies_to_purchase?(original_purchase)
+
+      SendWorkflowInstallmentWorker.perform_at(
+        subscription.deactivated_at + delay,
+        installment.id, rule_version, nil, nil, nil, subscription.id
+      )
+    end
+  end
+
+  private
+    def candidate_subscriptions(workflow)
+      scope = Subscription.where.not(deactivated_at: nil).where.not(cancelled_at: nil)
+      if workflow.product_or_variant_type?
+        scope.where(link_id: workflow.link_id)
+      else
+        scope.where(seller_id: workflow.seller_id)
+      end
+    end
+end

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -168,9 +168,9 @@ describe Workflow do
         expect(SendWorkflowPostEmailsJob.jobs).to be_empty
       end
 
-      it "does nothing when called from an installment rule edit (old_delayed_delivery_time is set)" do
+      it "re-enqueues SendWorkflowEmailsToPastCanceledMembersJob when called from an installment rule edit so version-stale workers are replaced" do
         @workflow.schedule_installment(@post, old_delayed_delivery_time: 1.day.to_i)
-        expect(SendWorkflowEmailsToPastCanceledMembersJob.jobs).to be_empty
+        expect(SendWorkflowEmailsToPastCanceledMembersJob).to have_enqueued_sidekiq_job(@post.id)
         expect(SendWorkflowPostEmailsJob.jobs).to be_empty
       end
     end

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -150,10 +150,29 @@ describe Workflow do
       expect(SendWorkflowPostEmailsJob.jobs).to be_empty
     end
 
-    it "does nothing when workflow has a trigger" do
-      @workflow.update!(workflow_trigger: Workflow::MEMBER_CANCELLATION_WORKFLOW_TRIGGER)
+    it "does nothing when workflow has a member_cancellation trigger and send_to_past_customers is false" do
+      @workflow.update!(workflow_trigger: Workflow::MEMBER_CANCELLATION_WORKFLOW_TRIGGER, send_to_past_customers: false)
       @workflow.schedule_installment(@post)
       expect(SendWorkflowPostEmailsJob.jobs).to be_empty
+      expect(SendWorkflowEmailsToPastCanceledMembersJob.jobs).to be_empty
+    end
+
+    context "when workflow has a member_cancellation trigger and send_to_past_customers is true" do
+      before do
+        @workflow.update!(workflow_trigger: Workflow::MEMBER_CANCELLATION_WORKFLOW_TRIGGER, send_to_past_customers: true)
+      end
+
+      it "enqueues SendWorkflowEmailsToPastCanceledMembersJob on first publish" do
+        @workflow.schedule_installment(@post)
+        expect(SendWorkflowEmailsToPastCanceledMembersJob).to have_enqueued_sidekiq_job(@post.id)
+        expect(SendWorkflowPostEmailsJob.jobs).to be_empty
+      end
+
+      it "does nothing when called from an installment rule edit (old_delayed_delivery_time is set)" do
+        @workflow.schedule_installment(@post, old_delayed_delivery_time: 1.day.to_i)
+        expect(SendWorkflowEmailsToPastCanceledMembersJob.jobs).to be_empty
+        expect(SendWorkflowPostEmailsJob.jobs).to be_empty
+      end
     end
 
     it "does nothing if the post is only for new recipients and it hasn't been scheduled before" do

--- a/spec/sidekiq/send_workflow_emails_to_past_canceled_members_job_spec.rb
+++ b/spec/sidekiq/send_workflow_emails_to_past_canceled_members_job_spec.rb
@@ -14,11 +14,20 @@ describe SendWorkflowEmailsToPastCanceledMembersJob, :freeze_time do
     create(:purchase, is_original_subscription_purchase: true, link: @product, subscription: @canceled_subscription, created_at: 60.days.ago)
   end
 
-  it "schedules a worker for each canceled subscription at deactivated_at + delay" do
+  it "schedules a worker immediately for past cancellations whose deactivated_at + delay is in the past" do
     described_class.new.perform(@installment.id)
 
     expect(SendWorkflowInstallmentWorker.jobs.size).to eq(1)
-    expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(@installment.id, @rule.version, nil, nil, nil, @canceled_subscription.id).at(@canceled_subscription.deactivated_at + @rule.delayed_delivery_time)
+    expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(@installment.id, @rule.version, nil, nil, nil, @canceled_subscription.id).immediately
+  end
+
+  it "schedules a worker at deactivated_at + delay when that time is in the future" do
+    recent = create(:subscription, link: @product, cancelled_at: 1.hour.ago, deactivated_at: 1.hour.ago)
+    create(:purchase, is_original_subscription_purchase: true, link: @product, subscription: recent, created_at: 2.hours.ago)
+
+    described_class.new.perform(@installment.id)
+
+    expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(@installment.id, @rule.version, nil, nil, nil, recent.id).at(recent.deactivated_at + @rule.delayed_delivery_time)
   end
 
   it "does nothing when the workflow has been deleted" do

--- a/spec/sidekiq/send_workflow_emails_to_past_canceled_members_job_spec.rb
+++ b/spec/sidekiq/send_workflow_emails_to_past_canceled_members_job_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe SendWorkflowEmailsToPastCanceledMembersJob, :freeze_time do
+  before do
+    @seller = create(:user)
+    @product = create(:subscription_product, user: @seller)
+    @workflow = create(:workflow, seller: @seller, link: @product, workflow_trigger: Workflow::MEMBER_CANCELLATION_WORKFLOW_TRIGGER, send_to_past_customers: true)
+    @installment = create(:published_installment, link: @product, workflow: @workflow, workflow_trigger: Workflow::MEMBER_CANCELLATION_WORKFLOW_TRIGGER)
+    @rule = create(:installment_rule, installment: @installment, delayed_delivery_time: 14.days)
+
+    @canceled_subscription = create(:subscription, link: @product, cancelled_at: 30.days.ago, deactivated_at: 30.days.ago)
+    create(:purchase, is_original_subscription_purchase: true, link: @product, subscription: @canceled_subscription, created_at: 60.days.ago)
+  end
+
+  it "schedules a worker for each canceled subscription at deactivated_at + delay" do
+    described_class.new.perform(@installment.id)
+
+    expect(SendWorkflowInstallmentWorker.jobs.size).to eq(1)
+    expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(@installment.id, @rule.version, nil, nil, nil, @canceled_subscription.id).at(@canceled_subscription.deactivated_at + @rule.delayed_delivery_time)
+  end
+
+  it "does nothing when the workflow has been deleted" do
+    @workflow.mark_deleted!
+    described_class.new.perform(@installment.id)
+    expect(SendWorkflowInstallmentWorker.jobs).to be_empty
+  end
+
+  it "does nothing when the installment has been deleted" do
+    @installment.mark_deleted!
+    described_class.new.perform(@installment.id)
+    expect(SendWorkflowInstallmentWorker.jobs).to be_empty
+  end
+
+  it "does nothing when the installment is unpublished" do
+    @installment.update!(published_at: nil)
+    described_class.new.perform(@installment.id)
+    expect(SendWorkflowInstallmentWorker.jobs).to be_empty
+  end
+
+  it "does nothing when send_to_past_customers is false" do
+    @workflow.update!(send_to_past_customers: false)
+    described_class.new.perform(@installment.id)
+    expect(SendWorkflowInstallmentWorker.jobs).to be_empty
+  end
+
+  it "does nothing when workflow trigger is not member_cancellation" do
+    @workflow.update!(workflow_trigger: nil)
+    described_class.new.perform(@installment.id)
+    expect(SendWorkflowInstallmentWorker.jobs).to be_empty
+  end
+
+  it "does nothing when workflow type is not seller, product, or variant" do
+    audience_workflow = create(:audience_workflow, seller: @seller, workflow_trigger: Workflow::MEMBER_CANCELLATION_WORKFLOW_TRIGGER, send_to_past_customers: true)
+    audience_installment = create(:published_installment, workflow: audience_workflow, workflow_trigger: Workflow::MEMBER_CANCELLATION_WORKFLOW_TRIGGER)
+    create(:installment_rule, installment: audience_installment, delayed_delivery_time: 14.days)
+
+    described_class.new.perform(audience_installment.id)
+    expect(SendWorkflowInstallmentWorker.jobs).to be_empty
+  end
+
+  it "does nothing when the installment has no rule" do
+    @rule.destroy!
+    described_class.new.perform(@installment.id)
+    expect(SendWorkflowInstallmentWorker.jobs).to be_empty
+  end
+
+  it "skips alive subscriptions" do
+    create(:subscription, link: @product)
+    described_class.new.perform(@installment.id)
+    expect(SendWorkflowInstallmentWorker.jobs.size).to eq(1)
+    expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(@installment.id, @rule.version, nil, nil, nil, @canceled_subscription.id)
+  end
+
+  it "skips pending-cancellation subscriptions (not yet deactivated)" do
+    pending = create(:subscription, link: @product, cancelled_at: 1.hour.from_now)
+    create(:purchase, is_original_subscription_purchase: true, link: @product, subscription: pending)
+    described_class.new.perform(@installment.id)
+    expect(SendWorkflowInstallmentWorker.jobs.size).to eq(1)
+    expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(@installment.id, @rule.version, nil, nil, nil, @canceled_subscription.id)
+  end
+
+  context "for a seller-type workflow" do
+    before do
+      @other_seller_product = create(:subscription_product)
+      create(:subscription, link: @other_seller_product, cancelled_at: 30.days.ago, deactivated_at: 30.days.ago)
+
+      @other_product = create(:subscription_product, user: @seller)
+      @other_product_canceled_subscription = create(:subscription, link: @other_product, cancelled_at: 30.days.ago, deactivated_at: 30.days.ago)
+      create(:purchase, is_original_subscription_purchase: true, link: @other_product, subscription: @other_product_canceled_subscription, created_at: 60.days.ago)
+
+      @seller_workflow = create(:seller_workflow, seller: @seller, workflow_trigger: Workflow::MEMBER_CANCELLATION_WORKFLOW_TRIGGER, send_to_past_customers: true)
+      @seller_installment = create(:published_installment, workflow: @seller_workflow, workflow_trigger: Workflow::MEMBER_CANCELLATION_WORKFLOW_TRIGGER)
+      @seller_rule = create(:installment_rule, installment: @seller_installment, delayed_delivery_time: 14.days)
+    end
+
+    it "schedules workers for canceled subscriptions across all seller's products" do
+      described_class.new.perform(@seller_installment.id)
+
+      expect(SendWorkflowInstallmentWorker.jobs.size).to eq(2)
+      expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(@seller_installment.id, @seller_rule.version, nil, nil, nil, @canceled_subscription.id)
+      expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(@seller_installment.id, @seller_rule.version, nil, nil, nil, @other_product_canceled_subscription.id)
+    end
+  end
+end


### PR DESCRIPTION
Fixes antiwork/gumroad-private#339

## What

For workflows triggered by "Member cancels", publishing with "Also send to past members who canceled" enabled did not actually send to past canceled members. The toggle persisted on the workflow record, but `Workflow#schedule_installment` bailed out for any non-new-customer trigger, so no retroactive backfill was ever enqueued.

A new `SendWorkflowEmailsToPastCanceledMembersJob` runs on publish for member-cancels workflows. It iterates the seller's (or product's) canceled subscriptions, applies the workflow filters, and schedules the existing `SendWorkflowInstallmentWorker` per subscription at `deactivated_at + delay`. Past-dated schedules fire immediately; the worker's existing `SentPostEmail.ensure_uniqueness` dedup prevents double-sends if the workflow is later unpublished and re-published.

## Why

`SendWorkflowPostEmailsJob` is purchase/follower/affiliate-centric and has no subscription path. The only existing scheduler for member-cancels sends ran reactively on `Subscription#deactivate!`, which only fires for new cancellations. A separate, subscription-centric job keeps the two paths cleanly separated and reuses the per-subscription delivery logic already in `Installment#send_installment_from_workflow_for_member_cancellation`.

Verified in prod against the reporting seller's "Vault Cancelled" workflow: 61 eligible past-canceled members existed; zero `SentPostEmail` rows had been created for the published installment.

---

This PR was implemented with AI assistance using Claude Opus 4.7.