### PR TITLE
Add internal admin watchlist API

### DIFF
--- a/app/controllers/api/internal/admin/users_controller.rb
+++ b/app/controllers/api/internal/admin/users_controller.rb
@@ -311,7 +311,10 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
     end
 
     def parse_threshold_cents(raw)
-      cents = (BigDecimal(raw.to_s) * 100).round
+      threshold = BigDecimal(raw.to_s)
+      return nil unless threshold.finite?
+
+      cents = (threshold * 100).round
       cents.positive? ? cents : nil
     rescue ArgumentError
       nil

--- a/app/controllers/api/internal/admin/users_controller.rb
+++ b/app/controllers/api/internal/admin/users_controller.rb
@@ -198,6 +198,35 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
     end
   end
 
+  def update_watch
+    return render json: { success: false, message: "email is required" }, status: :bad_request if params[:email].blank?
+    return render json: { success: false, message: "revenue_threshold is required" }, status: :bad_request if params[:revenue_threshold].blank?
+
+    user = find_user_or_render(params[:email])
+    return unless user
+
+    record_admin_write(action: "users.update_watch", target: user) do
+      threshold_cents = parse_threshold_cents(params[:revenue_threshold])
+      return render json: { success: false, message: "revenue_threshold must be a positive number" }, status: :bad_request if threshold_cents.nil?
+
+      watched_user = user.active_watched_user
+      return render json: { success: false, message: "User is not currently being watched" }, status: :unprocessable_entity if watched_user.nil?
+
+      watched_user.update!(
+        revenue_threshold_cents: threshold_cents,
+        notes: params.key?(:notes) ? params[:notes].presence : watched_user.notes
+      )
+
+      render json: {
+        success: true,
+        message: "Watchlist updated",
+        watched_user: serialize_watched_user(watched_user)
+      }
+    rescue ActiveRecord::RecordInvalid => e
+      render json: { success: false, message: e.record.errors.full_messages.first }, status: :unprocessable_entity
+    end
+  end
+
   def unwatch
     return render json: { success: false, message: "email is required" }, status: :bad_request if params[:email].blank?
 

--- a/app/controllers/api/internal/admin/users_controller.rb
+++ b/app/controllers/api/internal/admin/users_controller.rb
@@ -166,6 +166,53 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
     end
   end
 
+  def watch
+    return render json: { success: false, message: "email is required" }, status: :bad_request if params[:email].blank?
+    return render json: { success: false, message: "revenue_threshold is required" }, status: :bad_request if params[:revenue_threshold].blank?
+
+    user = find_user_or_render(params[:email])
+    return unless user
+
+    record_admin_write(action: "users.watch", target: user) do
+      threshold_cents = parse_threshold_cents(params[:revenue_threshold])
+      return render json: { success: false, message: "revenue_threshold must be a positive number" }, status: :bad_request if threshold_cents.nil?
+
+      if user.active_watched_user.present?
+        return render json: { success: false, message: "User is already being watched" }, status: :unprocessable_entity
+      end
+
+      watched_user = user.watched_users.create!(
+        revenue_threshold_cents: threshold_cents,
+        notes: params[:notes].presence,
+        created_by_id: current_admin_actor_id
+      )
+      watched_user.sync!
+
+      render json: {
+        success: true,
+        message: "User added to watchlist",
+        watched_user: serialize_watched_user(watched_user)
+      }
+    rescue ActiveRecord::RecordInvalid => e
+      render json: { success: false, message: e.record.errors.full_messages.first }, status: :unprocessable_entity
+    end
+  end
+
+  def unwatch
+    return render json: { success: false, message: "email is required" }, status: :bad_request if params[:email].blank?
+
+    user = find_user_or_render(params[:email])
+    return unless user
+
+    record_admin_write(action: "users.unwatch", target: user) do
+      watched_user = user.active_watched_user
+      return render json: { success: false, message: "User is not currently being watched" }, status: :unprocessable_entity if watched_user.nil?
+
+      watched_user.mark_deleted!
+      render json: { success: true, message: "User removed from watchlist" }
+    end
+  end
+
   private
     def find_user_or_render(email)
       user = User.alive.by_email(email).first
@@ -261,5 +308,24 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
 
     def render_invalid_comment(comment)
       render json: { success: false, message: comment.errors.full_messages.to_sentence }, status: :unprocessable_entity
+    end
+
+    def parse_threshold_cents(raw)
+      cents = (BigDecimal(raw.to_s) * 100).round
+      cents.positive? ? cents : nil
+    rescue ArgumentError
+      nil
+    end
+
+    def serialize_watched_user(watched_user)
+      {
+        id: watched_user.external_id,
+        revenue_threshold_cents: watched_user.revenue_threshold_cents,
+        revenue_cents: watched_user.revenue_cents,
+        unpaid_balance_cents: watched_user.unpaid_balance_cents,
+        notes: watched_user.notes,
+        created_at: watched_user.created_at.iso8601,
+        last_synced_at: watched_user.last_synced_at&.iso8601
+      }
     end
 end

--- a/app/controllers/api/internal/admin/users_controller.rb
+++ b/app/controllers/api/internal/admin/users_controller.rb
@@ -262,6 +262,7 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
           compliant: user.compliant?,
           last_status_changed_at: last_status_changed_at(user)&.as_json
         },
+        active_watched_user: serialize_watched_user(user.active_watched_user),
         two_factor_authentication_enabled: user.two_factor_authentication_enabled?,
         payouts: {
           paused_internally: user.payouts_paused_internally?,
@@ -321,6 +322,8 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
     end
 
     def serialize_watched_user(watched_user)
+      return nil unless watched_user
+
       {
         id: watched_user.external_id,
         revenue_threshold_cents: watched_user.revenue_threshold_cents,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -334,6 +334,8 @@ Rails.application.routes.draw do
               post :create_comment
               post :mark_compliant
               post :suspend_for_fraud
+              post :watch
+              post :unwatch
             end
           end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -335,6 +335,7 @@ Rails.application.routes.draw do
               post :mark_compliant
               post :suspend_for_fraud
               post :watch
+              post :update_watch
               post :unwatch
             end
           end

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -836,4 +836,79 @@ describe Api::Internal::Admin::UsersController do
       expect(response.parsed_body["message"]).to eq("User is not currently being watched")
     end
   end
+
+  describe "POST update_watch" do
+    let(:user) { create(:user) }
+
+    include_examples "admin api authorization required", :post, :update_watch
+
+    it "returns bad request when email is missing" do
+      post :update_watch, params: { revenue_threshold: "200" }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body["message"]).to eq("email is required")
+    end
+
+    it "returns bad request when revenue_threshold is missing" do
+      post :update_watch, params: { email: user.email }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body["message"]).to eq("revenue_threshold is required")
+    end
+
+    it "returns bad request when revenue_threshold is not positive" do
+      create(:watched_user, user:)
+
+      post :update_watch, params: { email: user.email, revenue_threshold: "0" }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body["message"]).to eq("revenue_threshold must be a positive number")
+    end
+
+    it "returns not found when user does not exist" do
+      post :update_watch, params: { email: "missing@example.com", revenue_threshold: "200" }
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "returns 422 when user is not being watched" do
+      post :update_watch, params: { email: user.email, revenue_threshold: "200" }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["message"]).to eq("User is not currently being watched")
+    end
+
+    it "updates the active watched user" do
+      watched_user = create(:watched_user, user:, revenue_threshold_cents: 20_000, notes: "Old notes")
+
+      expect do
+        post :update_watch, params: { email: user.email, revenue_threshold: "500", notes: "New notes" }
+      end.not_to change { WatchedUser.count }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["success"]).to be(true)
+      expect(response.parsed_body["message"]).to eq("Watchlist updated")
+      expect(response.parsed_body["watched_user"]["revenue_threshold_cents"]).to eq(50_000)
+      expect(response.parsed_body["watched_user"]["notes"]).to eq("New notes")
+      expect(watched_user.reload).to have_attributes(revenue_threshold_cents: 50_000, notes: "New notes")
+    end
+
+    it "preserves notes when notes is omitted" do
+      watched_user = create(:watched_user, user:, notes: "Keep this")
+
+      post :update_watch, params: { email: user.email, revenue_threshold: "300" }
+
+      expect(response).to have_http_status(:ok)
+      expect(watched_user.reload.notes).to eq("Keep this")
+    end
+
+    it "clears notes when notes is blank" do
+      watched_user = create(:watched_user, user:, notes: "Clear this")
+
+      post :update_watch, params: { email: user.email, revenue_threshold: "300", notes: "" }
+
+      expect(response).to have_http_status(:ok)
+      expect(watched_user.reload.notes).to be_nil
+    end
+  end
 end

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -739,6 +739,15 @@ describe Api::Internal::Admin::UsersController do
       expect(response.parsed_body["message"]).to eq("revenue_threshold must be a positive number")
     end
 
+    it "returns bad request when revenue_threshold is non-finite" do
+      ["Infinity", "-Infinity", "NaN"].each do |revenue_threshold|
+        post :watch, params: { email: user.email, revenue_threshold: }
+
+        expect(response).to have_http_status(:bad_request)
+        expect(response.parsed_body["message"]).to eq("revenue_threshold must be a positive number")
+      end
+    end
+
     it "returns not found when user does not exist" do
       post :watch, params: { email: "missing@example.com", revenue_threshold: "200" }
 

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -40,6 +40,7 @@ describe Api::Internal::Admin::UsersController do
         "name" => "Seller One",
         "username" => "sellerone",
         "deleted_at" => nil,
+        "active_watched_user" => nil,
         "two_factor_authentication_enabled" => false
       )
       expect(info["created_at"]).to eq(user.created_at.as_json)
@@ -183,6 +184,29 @@ describe Api::Internal::Admin::UsersController do
       stats = response.parsed_body["user"]["stats"]
       expect(stats["sales_count"]).to eq(2)
       expect(stats["total_earnings_formatted"]).to eq("$15.00")
+    end
+
+    it "includes the active watched user" do
+      user = create(:compliant_user, email: "watched@example.com")
+      watched_user = create(:watched_user,
+                            user:,
+                            revenue_threshold_cents: 20_000,
+                            revenue_cents: 12_500,
+                            unpaid_balance_cents: 2_500,
+                            notes: "Review again")
+      watched_user.update!(last_synced_at: 1.hour.ago)
+
+      post :info, params: { email: user.email }
+
+      expect(response.parsed_body["user"]["active_watched_user"]).to eq(
+        "id" => watched_user.external_id,
+        "revenue_threshold_cents" => 20_000,
+        "revenue_cents" => 12_500,
+        "unpaid_balance_cents" => 2_500,
+        "notes" => "Review again",
+        "created_at" => watched_user.created_at.iso8601,
+        "last_synced_at" => watched_user.last_synced_at.iso8601
+      )
     end
   end
 

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -712,4 +712,95 @@ describe Api::Internal::Admin::UsersController do
       expect(user.reload).to be_compliant
     end
   end
+
+  describe "POST watch" do
+    let(:user) { create(:user) }
+
+    include_examples "admin api authorization required", :post, :watch
+
+    it "returns bad request when email is missing" do
+      post :watch, params: { revenue_threshold: "200" }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body["message"]).to eq("email is required")
+    end
+
+    it "returns bad request when revenue_threshold is missing" do
+      post :watch, params: { email: user.email }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body["message"]).to eq("revenue_threshold is required")
+    end
+
+    it "returns bad request when revenue_threshold is not positive" do
+      post :watch, params: { email: user.email, revenue_threshold: "0" }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body["message"]).to eq("revenue_threshold must be a positive number")
+    end
+
+    it "returns not found when user does not exist" do
+      post :watch, params: { email: "missing@example.com", revenue_threshold: "200" }
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "creates a watched user record" do
+      expect do
+        post :watch, params: { email: user.email, revenue_threshold: "200", notes: "Risk review: monitoring" }
+      end.to change { WatchedUser.count }.by(1)
+
+      expect(response).to have_http_status(:ok)
+      body = response.parsed_body
+      expect(body["success"]).to be(true)
+      expect(body["message"]).to eq("User added to watchlist")
+      expect(body["watched_user"]["revenue_threshold_cents"]).to eq(20_000)
+      expect(body["watched_user"]["notes"]).to eq("Risk review: monitoring")
+    end
+
+    it "returns 422 when user is already being watched" do
+      create(:watched_user, user: user)
+
+      post :watch, params: { email: user.email, revenue_threshold: "500" }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["message"]).to eq("User is already being watched")
+    end
+  end
+
+  describe "POST unwatch" do
+    let(:user) { create(:user) }
+
+    include_examples "admin api authorization required", :post, :unwatch
+
+    it "returns bad request when email is missing" do
+      post :unwatch
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body["message"]).to eq("email is required")
+    end
+
+    it "returns not found when user does not exist" do
+      post :unwatch, params: { email: "missing@example.com" }
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "removes the user from the watchlist" do
+      watched_user = create(:watched_user, user: user)
+
+      post :unwatch, params: { email: user.email }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["success"]).to be(true)
+      expect(watched_user.reload.deleted_at).not_to be_nil
+    end
+
+    it "returns 422 when user is not being watched" do
+      post :unwatch, params: { email: user.email }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["message"]).to eq("User is not currently being watched")
+    end
+  end
 end

--- a/spec/routing/api_internal_admin_contract_spec.rb
+++ b/spec/routing/api_internal_admin_contract_spec.rb
@@ -18,4 +18,10 @@ describe "internal admin API routing" do
   it "routes the precise refund endpoint" do
     expect(route_for("/internal/admin/purchases/123/refund", :post)).to include(controller: "api/internal/admin/purchases", action: "refund", id: "123")
   end
+
+  it "routes the user watchlist write endpoints" do
+    expect(route_for("/internal/admin/users/watch", :post)).to include(controller: "api/internal/admin/users", action: "watch")
+    expect(route_for("/internal/admin/users/update_watch", :post)).to include(controller: "api/internal/admin/users", action: "update_watch")
+    expect(route_for("/internal/admin/users/unwatch", :post)).to include(controller: "api/internal/admin/users", action: "unwatch")
+  end
 end


### PR DESCRIPTION
Ref antiwork/dashboards#34

## What

Adds internal admin API support for the full watchlist workflow that already exists in the admin UI.

The API can now return the current watch status from `users/info`, add a user to the watchlist, update the active watch threshold or notes, and remove the active watch. Threshold parsing also rejects non-finite values like `Infinity` and `NaN` instead of returning a server error.

## Why

Risk reviews need a watched state for accounts that should be monitored without blocking payouts. The admin UI already supports adding, updating, and removing watchlist entries, and Gumclaw/the Gumroad CLI need the same capabilities through the internal admin API.

Keeping read, create, update, and remove as separate operations makes the CLI behavior explicit instead of relying on a write endpoint to infer status.

## Before/After

API-only change; no user-facing UI changed. The internal API now mirrors the existing admin watchlist flow.

## Test Results

- `bundle exec rubocop --force-exclusion -a app/controllers/api/internal/admin/users_controller.rb spec/controllers/api/internal/admin/users_controller_spec.rb spec/routing/api_internal_admin_contract_spec.rb`
- `bundle exec rspec spec/controllers/api/internal/admin/users_controller_spec.rb spec/routing/api_internal_admin_contract_spec.rb spec/models/watched_user_spec.rb` - 112 examples, 0 failures
- `bin/test-confidence` - 99% confidence, 5 tests passed

---

This PR was implemented with AI assistance using gpt-5.5 xhigh and Opus 4.7
