### PR TITLE
Allow CORS requests from CUSTOM_DOMAIN

### DIFF
--- a/config/domain.rb
+++ b/config/domain.rb
@@ -94,6 +94,7 @@ if custom_domain
   VALID_REQUEST_HOSTS << custom_domain
   VALID_API_REQUEST_HOSTS << "api.#{custom_domain}"
   VALID_API_REQUEST_HOSTS << custom_domain if ENV["BRANCH_DEPLOYMENT"].present? # Allow CORS to branch-apps's root domain
+  VALID_CORS_ORIGINS << custom_domain
   DISCOVER_DOMAIN = custom_domain
   VALID_DISCOVER_REQUEST_HOST = custom_domain
 else

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -23,4 +23,14 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
       resource "/assets/ABCFavorit-Regular*"
     end
   end
+
+  if ENV["CUSTOM_DOMAIN"].present?
+    allow do
+      origins ENV["CUSTOM_DOMAIN"]
+      resource "*",
+               headers: :any,
+               methods: [:get, :post, :put, :patch, :delete, :options],
+               credentials: true
+    end
+  end
 end


### PR DESCRIPTION
## What

When `CUSTOM_DOMAIN` is set (e.g. for Cloudflare tunnel dev access like `gumroad.antiwork.dev`), CORS preflight requests to app routes like `/checkout/discounts` fail because the custom domain isn't in the allowed origins.

## Changes

- **`config/domain.rb`**: Add `custom_domain` to `VALID_CORS_ORIGINS` in the `if custom_domain` block
- **`config/initializers/cors.rb`**: Add a CORS allow block when `CUSTOM_DOMAIN` env var is present, allowing all resources with credentials from that origin

## Why

When accessing the local dev app through a Cloudflare tunnel (`gumroad.antiwork.dev`), the browser blocks AJAX requests because no `Access-Control-Allow-Origin` header is returned for the custom domain. This only activates when `CUSTOM_DOMAIN` is explicitly set, so it has no effect on production or standard local dev.