### PR TITLE
Fix NoMethodError on discover page with empty tags

### DIFF
--- a/app/presenters/discover/tag_page_meta_presenter.rb
+++ b/app/presenters/discover/tag_page_meta_presenter.rb
@@ -37,7 +37,7 @@ class Discover::TagPageMetaPresenter
       default = opts.delete(:default) || ""
       str = DISCOVER_META_TAGS.dig(*(path.split(".")))
 
-      return default if str.blank?
+      return default if !str.is_a?(String) || str.blank?
 
       str % opts
     end

--- a/spec/presenters/discover/tag_page_meta_presenter_spec.rb
+++ b/spec/presenters/discover/tag_page_meta_presenter_spec.rb
@@ -21,6 +21,20 @@ describe Discover::TagPageMetaPresenter do
         expect(described_class.new(["tag 1", "tag 2"], 1000).title).to eq("tag 1, tag 2")
       end
     end
+
+    context "when a single empty tag is provided" do
+      it "does not raise and returns the default title" do
+        expect { described_class.new([""], 1000).title }.not_to raise_error
+        expect(described_class.new([""], 1000).title).to eq("")
+      end
+    end
+
+    context "when a single whitespace-only tag is provided" do
+      it "does not raise and returns the default title" do
+        expect { described_class.new([" "], 1000).title }.not_to raise_error
+        expect(described_class.new([" "], 1000).title).to eq(" ")
+      end
+    end
   end
 
   describe "#meta_description" do
@@ -43,6 +57,18 @@ describe Discover::TagPageMetaPresenter do
         expect(described_class.new(["tag 1", "tag 2"], 1000).meta_description).to eq("Browse over 1,000 unique tag 1" \
           " and tag 2 products published by independent creators on Gumroad. Discover the best things to read, watch," \
           " create & more!")
+      end
+    end
+
+    context "when a single empty tag is provided" do
+      it "does not raise and returns the default meta description" do
+        expect { described_class.new([""], 1000).meta_description }.not_to raise_error
+      end
+    end
+
+    context "when a single whitespace-only tag is provided" do
+      it "does not raise and returns the default meta description" do
+        expect { described_class.new([" "], 1000).meta_description }.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
## Problem

When a user visits `/discover` with empty or whitespace-only tags (e.g. `/discover?tags=`), `DiscoverController#index` raises:

```
NoMethodError: undefined method '%' for an instance of Hash
```

**Sentry:** https://gumroad-to.sentry.io/issues/7464023376/
- 7-day events: 1
- 14-day events: 1
- Users affected: ~1/month (just appeared)
- Estimated support tickets: 0

## Root Cause

In `Discover::TagPageMetaPresenter#fetch_discover_meta`, the path is built as `"titles.#{first_tag_key}"`. When the tag is empty, `first_tag_key` is `""`, making the path `"titles."`. Ruby's `String#split(".")` drops the trailing dot, producing `["titles"]`. Then `DISCOVER_META_TAGS.dig("titles")` returns the entire titles Hash instead of a String, and `Hash#%` doesn't exist.

## Fix

Add a type check in `fetch_discover_meta` so non-String results from `dig` fall back to the default value. One-line change.

## Tests

Added 4 test cases covering empty and whitespace-only tags for both `#title` and `#meta_description`.