### PR TITLE
Fix ActiveRecord::StatementInvalid for out-of-range DATETIME in recipient count

### DIFF
--- a/app/models/concerns/with_filtering.rb
+++ b/app/models/concerns/with_filtering.rb
@@ -73,9 +73,11 @@ module WithFiltering
     self.bought_products = (!audience_type? && params[:bought_products].present?) ? Array.wrap(params[:bought_products]) : []
     self.not_bought_products = params[:not_bought_products].present? ? Array.wrap(params[:not_bought_products]) : []
     # created "on and after" this timestamp:
-    self.created_after = params[:created_after].present? ? Date.parse(params[:created_after]).in_time_zone(user.timezone) : nil
+    created_after_date = safe_parse_filter_date(params[:created_after])
+    self.created_after = created_after_date ? created_after_date.in_time_zone(user.timezone) : nil
     # created "on and before" this timestamp:
-    self.created_before = params[:created_before].present? ? Date.parse(params[:created_before]).in_time_zone(user.timezone).end_of_day : nil
+    created_before_date = safe_parse_filter_date(params[:created_before])
+    self.created_before = created_before_date ? created_before_date.in_time_zone(user.timezone).end_of_day : nil
     self.bought_from = seller_or_product_or_variant_type? ? params[:bought_from].presence : nil
     self.bought_variants = (!audience_type? && params[:bought_variants].present?) ? Array.wrap(params[:bought_variants]) : []
     self.not_bought_variants = params[:not_bought_variants].present? ? Array.wrap(params[:not_bought_variants]) : []
@@ -172,5 +174,17 @@ module WithFiltering
 
   def convert_to_date(date)
     date.is_a?(String) ? Date.parse(date) : date
+  end
+
+  # Parses a user-supplied date filter and rejects values outside MySQL's
+  # DATETIME range (years 1000-9999). Browser <input type="date"> fields can
+  # submit 6-digit years that Date.parse accepts but MySQL refuses.
+  def safe_parse_filter_date(value)
+    return nil if value.blank?
+    date = Date.parse(value.to_s)
+    return nil if date.year < 1000 || date.year > 9999
+    date
+  rescue Date::Error, TypeError
+    nil
   end
 end

--- a/app/models/installment.rb
+++ b/app/models/installment.rb
@@ -768,8 +768,12 @@ class Installment < ApplicationRecord
     params[:not_bought_variant_ids] = not_bought_variants&.map { ObfuscateIds.decrypt(_1) }
     params[:paid_more_than_cents] = paid_more_than_cents.presence
     params[:paid_less_than_cents] = paid_less_than_cents.presence
-    params[:created_after] = Date.parse(created_after.to_s).in_time_zone(seller.timezone).iso8601 if created_after.present?
-    params[:created_before] = Date.parse(created_before.to_s).in_time_zone(seller.timezone).end_of_day.iso8601 if created_before.present?
+    if (date = safe_parse_filter_date(created_after))
+      params[:created_after] = date.in_time_zone(seller.timezone).iso8601
+    end
+    if (date = safe_parse_filter_date(created_before))
+      params[:created_before] = date.in_time_zone(seller.timezone).end_of_day.iso8601
+    end
     params[:bought_from] = bought_from if bought_from.present?
     params[:affiliate_product_ids] = seller.products.where(unique_permalink: affiliate_products).ids if affiliate_products.present?
 

--- a/spec/controllers/api/internal/installments/recipient_counts_controller_spec.rb
+++ b/spec/controllers/api/internal/installments/recipient_counts_controller_spec.rb
@@ -67,6 +67,24 @@ describe Api::Internal::Installments::RecipientCountsController do
       expect(response.parsed_body).to eq("recipient_count" => 3, "audience_count" => 5)
     end
 
+    it "ignores out-of-range year in created_before filter without raising a database error" do
+      get :show, params: { installment_type: "audience", created_before: "252026-05-06" }
+      expect(response).to be_successful
+      expect(response.parsed_body).to eq("recipient_count" => 5, "audience_count" => 5)
+    end
+
+    it "ignores out-of-range year in created_after filter without raising a database error" do
+      get :show, params: { installment_type: "audience", created_after: "252026-05-06" }
+      expect(response).to be_successful
+      expect(response.parsed_body).to eq("recipient_count" => 5, "audience_count" => 5)
+    end
+
+    it "ignores unparseable created_before filter without raising" do
+      get :show, params: { installment_type: "audience", created_before: "not-a-date" }
+      expect(response).to be_successful
+      expect(response.parsed_body).to eq("recipient_count" => 5, "audience_count" => 5)
+    end
+
     it "returns counts for seller installment type with paid_more_than_cents filter" do
       product1_purchase2.update!(price_cents: 99)
       product1_purchase3.update!(price_cents: 500)


### PR DESCRIPTION
## Problem

`Api::Internal::Installments::RecipientCountsController#show` crashes with:

```
ActiveRecord::StatementInvalid: Mysql2::Error: Incorrect DATETIME value: '252026-05-06T23:59:59-08:00'
```

**Sentry:** https://gumroad-to.sentry.io/issues/7464234017/
**Occurrences:** 4 (first seen 2026-05-06)

## Root Cause

Browser `<input type="date">` fields allow users to type 6-digit years (e.g. `252026`). Ruby's `Date.parse` happily accepts these, but MySQL's DATETIME range only supports years 1000-9999, causing the query to crash.

The same unvalidated `Date.parse` pattern existed in two places:
- `Installment#audience_members_filter_params` 
- `WithFiltering#add_and_validate_filters`

## Fix

Added a shared `safe_parse_filter_date` helper to `WithFiltering` that:
1. Parses the date string
2. Validates the year is within MySQL's DATETIME range (1000-9999)
3. Returns `nil` for out-of-range or unparseable dates
4. Rescues `Date::Error` and `TypeError` gracefully

Both call sites now use this helper. Invalid dates are silently ignored (the filter is skipped), matching the behavior of omitting the filter entirely.

## Test Plan

Added 3 controller specs:
- Out-of-range year in `created_before` (the exact Sentry scenario)
- Out-of-range year in `created_after`  
- Unparseable date string