### PR TITLE
Admin API: support user lookup by external_id

### DIFF
--- a/app/controllers/api/internal/admin/users_controller.rb
+++ b/app/controllers/api/internal/admin/users_controller.rb
@@ -28,7 +28,7 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
 
   def reset_password
     return unless require_user_lookup_params!
-    if params[:email].present? && !EmailFormatValidator.valid?(params[:email])
+    if params[:external_id].blank? && params[:email].present? && !EmailFormatValidator.valid?(params[:email])
       return render json: { success: false, message: "Invalid email format" }, status: :bad_request
     end
 

--- a/app/controllers/api/internal/admin/users_controller.rb
+++ b/app/controllers/api/internal/admin/users_controller.rb
@@ -1,19 +1,21 @@
 # frozen_string_literal: true
 
 class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseController
-  def info
-    return render json: { success: false, message: "email is required" }, status: :bad_request if params[:email].blank?
+  USER_LOOKUP_BAD_REQUEST_MESSAGE = "email or external_id is required"
 
-    user = User.by_email(params[:email]).first
-    return render json: { success: false, message: "User not found" }, status: :not_found if user.blank?
+  def info
+    return unless require_user_lookup_params!
+
+    user = find_user_or_render(include_deleted: true)
+    return unless user
 
     render json: { success: true, user: serialize_user_info(user) }
   end
 
   def suspension
-    return render json: { success: false, message: "email is required" }, status: :bad_request if params[:email].blank?
+    return unless require_user_lookup_params!
 
-    user = find_user_or_render(params[:email])
+    user = find_user_or_render
     return unless user
 
     render json: {
@@ -25,10 +27,12 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
   end
 
   def reset_password
-    return render json: { success: false, message: "email is required" }, status: :bad_request if params[:email].blank?
-    return render json: { success: false, message: "Invalid email format" }, status: :bad_request unless EmailFormatValidator.valid?(params[:email])
+    return unless require_user_lookup_params!
+    if params[:email].present? && !EmailFormatValidator.valid?(params[:email])
+      return render json: { success: false, message: "Invalid email format" }, status: :bad_request
+    end
 
-    user = find_user_or_render(params[:email])
+    user = find_user_or_render
     return unless user
 
     record_admin_write(action: "users.reset_password", target: user) do
@@ -38,16 +42,20 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
   end
 
   def update_email
-    if params[:current_email].blank? || params[:new_email].blank?
-      return render json: { success: false, message: "Both current_email and new_email are required" }, status: :bad_request
+    if (params[:current_email].blank? && params[:external_id].blank?) || params[:new_email].blank?
+      return render json: { success: false, message: "current_email (or external_id) and new_email are required" }, status: :bad_request
     end
 
     unless EmailFormatValidator.valid?(params[:new_email])
       return render json: { success: false, message: "Invalid new email format" }, status: :bad_request
     end
 
-    user = find_user_or_render(params[:current_email])
-    return unless user
+    user = if params[:external_id].present?
+      User.alive.find_by(external_id: params[:external_id])
+    else
+      User.alive.by_email(params[:current_email]).first
+    end
+    return render json: { success: false, message: "User not found" }, status: :not_found if user.blank?
 
     record_admin_write(action: "users.update_email", target: user) do
       if user.email.to_s.casecmp(params[:new_email].to_s).zero?
@@ -78,10 +86,10 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
   end
 
   def two_factor_authentication
-    return render json: { success: false, message: "email is required" }, status: :bad_request if params[:email].blank?
+    return unless require_user_lookup_params!
     return render json: { success: false, message: "enabled is required" }, status: :bad_request if params[:enabled].to_s.blank?
 
-    user = find_user_or_render(params[:email])
+    user = find_user_or_render
     return unless user
 
     record_admin_write(action: "users.two_factor_authentication", target: user) do
@@ -102,11 +110,11 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
   end
 
   def create_comment
-    return render json: { success: false, message: "email is required" }, status: :bad_request if params[:email].blank?
+    return unless require_user_lookup_params!
     return render json: { success: false, message: "content is required" }, status: :bad_request if params[:content].blank?
     return render json: { success: false, message: "idempotency_key is required" }, status: :bad_request if params[:idempotency_key].blank?
 
-    user = find_user_or_render(params[:email])
+    user = find_user_or_render
     return unless user
 
     record_admin_write(action: "users.create_comment", target: user) do
@@ -123,9 +131,9 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
   end
 
   def mark_compliant
-    return render json: { success: false, message: "email is required" }, status: :bad_request if params[:email].blank?
+    return unless require_user_lookup_params!
 
-    user = find_user_or_render(params[:email])
+    user = find_user_or_render
     return unless user
 
     record_admin_write(action: "users.mark_compliant", target: user) do
@@ -145,9 +153,9 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
   end
 
   def suspend_for_fraud
-    return render json: { success: false, message: "email is required" }, status: :bad_request if params[:email].blank?
+    return unless require_user_lookup_params!
 
-    user = find_user_or_render(params[:email])
+    user = find_user_or_render
     return unless user
 
     record_admin_write(action: "users.suspend_for_fraud", target: user) do
@@ -167,10 +175,10 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
   end
 
   def watch
-    return render json: { success: false, message: "email is required" }, status: :bad_request if params[:email].blank?
+    return unless require_user_lookup_params!
     return render json: { success: false, message: "revenue_threshold is required" }, status: :bad_request if params[:revenue_threshold].blank?
 
-    user = find_user_or_render(params[:email])
+    user = find_user_or_render
     return unless user
 
     record_admin_write(action: "users.watch", target: user) do
@@ -199,10 +207,10 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
   end
 
   def update_watch
-    return render json: { success: false, message: "email is required" }, status: :bad_request if params[:email].blank?
+    return unless require_user_lookup_params!
     return render json: { success: false, message: "revenue_threshold is required" }, status: :bad_request if params[:revenue_threshold].blank?
 
-    user = find_user_or_render(params[:email])
+    user = find_user_or_render
     return unless user
 
     record_admin_write(action: "users.update_watch", target: user) do
@@ -228,9 +236,9 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
   end
 
   def unwatch
-    return render json: { success: false, message: "email is required" }, status: :bad_request if params[:email].blank?
+    return unless require_user_lookup_params!
 
-    user = find_user_or_render(params[:email])
+    user = find_user_or_render
     return unless user
 
     record_admin_write(action: "users.unwatch", target: user) do
@@ -243,8 +251,20 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
   end
 
   private
-    def find_user_or_render(email)
-      user = User.alive.by_email(email).first
+    def require_user_lookup_params!
+      return true if params[:email].present? || params[:external_id].present?
+
+      render json: { success: false, message: USER_LOOKUP_BAD_REQUEST_MESSAGE }, status: :bad_request
+      false
+    end
+
+    def find_user_or_render(include_deleted: false)
+      scope = include_deleted ? User : User.alive
+      user = if params[:external_id].present?
+        scope.find_by(external_id: params[:external_id])
+      else
+        scope.by_email(params[:email]).first
+      end
       return user if user.present?
 
       render json: { success: false, message: "User not found" }, status: :not_found

--- a/app/controllers/api/internal/helper/users_controller.rb
+++ b/app/controllers/api/internal/helper/users_controller.rb
@@ -108,8 +108,8 @@ class Api::Internal::Helper::UsersController < Api::Internal::Helper::BaseContro
   end
 
   def create_comment
-    if params[:email].blank?
-      return render json: { success: false, error_message: "'email' parameter is required" }, status: :bad_request
+    if params[:email].blank? && params[:external_id].blank?
+      return render json: { success: false, error_message: "'email' or 'external_id' parameter is required" }, status: :bad_request
     end
     if params[:content].blank?
       return render json: { success: false, error_message: "'content' parameter is required" }, status: :bad_request
@@ -118,9 +118,13 @@ class Api::Internal::Helper::UsersController < Api::Internal::Helper::BaseContro
       return render json: { success: false, error_message: "'idempotency_key' parameter is required" }, status: :bad_request
     end
 
-    user = User.alive.by_email(params[:email]).first
+    user = if params[:external_id].present?
+      User.alive.find_by(external_id: params[:external_id])
+    else
+      User.alive.by_email(params[:email]).first
+    end
     if user.blank?
-      return render json: { success: false, error_message: "An account does not exist with that email." }, status: :unprocessable_entity
+      return render json: { success: false, error_message: "An account does not exist with that email or external_id." }, status: :unprocessable_entity
     end
 
     comment = User::CreateAdminCommentService.new(user:, content: params[:content], idempotency_key: params[:idempotency_key]).perform

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -6,6 +6,29 @@ require "shared_examples/authorized_admin_api_method"
 describe Api::Internal::Admin::UsersController do
   let(:admin_user) { create(:admin_user) }
 
+  shared_examples "supports user lookup by external_id" do |action, build_user: -> { create(:user) }, extra_params: {}, success_status: :ok|
+    describe "external_id lookup" do
+      it "looks up the user by external_id" do
+        user = instance_exec(&build_user)
+        post action, params: extra_params.merge(external_id: user.external_id)
+        expect(response).to have_http_status(success_status)
+      end
+
+      it "returns 404 when external_id does not match any user" do
+        post action, params: extra_params.merge(external_id: "999999999999")
+        expect(response).to have_http_status(:not_found)
+        expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
+      end
+
+      it "prefers external_id over email when both are provided" do
+        target = instance_exec(&build_user)
+        other = instance_exec(&build_user)
+        post action, params: extra_params.merge(external_id: target.external_id, email: other.email)
+        expect(response).to have_http_status(success_status)
+      end
+    end
+  end
+
   describe "POST info" do
     include_examples "admin api authorization required", :post, :info
 
@@ -15,7 +38,7 @@ describe Api::Internal::Admin::UsersController do
       post :info
 
       expect(response).to have_http_status(:bad_request)
-      expect(response.parsed_body).to eq({ success: false, message: "email is required" }.as_json)
+      expect(response.parsed_body).to eq({ success: false, message: "email or external_id is required" }.as_json)
     end
 
     it "returns not found when the user does not exist" do
@@ -156,6 +179,20 @@ describe Api::Internal::Admin::UsersController do
       expect(info["deleted_at"]).to eq(user.reload.deleted_at.as_json)
     end
 
+    it "looks up a soft-deleted user by external_id" do
+      user = create(:compliant_user, email: "deleted-by-id@example.com")
+      user.mark_deleted!
+
+      post :info, params: { external_id: user.external_id }
+
+      expect(response).to have_http_status(:ok)
+      info = response.parsed_body["user"]
+      expect(info["id"]).to eq(user.external_id)
+      expect(info["deleted_at"]).to eq(user.reload.deleted_at.as_json)
+    end
+
+    include_examples "supports user lookup by external_id", :info, build_user: -> { create(:compliant_user) }
+
     it "uses the latest risk-state comment for last_status_changed_at, including on_probation transitions" do
       user = create(:compliant_user, email: "probation@example.com")
       create(:comment, commentable: user, comment_type: Comment::COMMENT_TYPE_COMPLIANT, created_at: 1.month.ago)
@@ -246,7 +283,7 @@ describe Api::Internal::Admin::UsersController do
       post :suspension
 
       expect(response).to have_http_status(:bad_request)
-      expect(response.parsed_body).to eq({ success: false, message: "email is required" }.as_json)
+      expect(response.parsed_body).to eq({ success: false, message: "email or external_id is required" }.as_json)
     end
 
     it "returns not found when the user does not exist" do
@@ -255,6 +292,18 @@ describe Api::Internal::Admin::UsersController do
       expect(response).to have_http_status(:not_found)
       expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
     end
+
+    it "returns not found when external_id matches a soft-deleted user" do
+      user = create(:compliant_user)
+      user.mark_deleted!
+
+      post :suspension, params: { external_id: user.external_id }
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
+    end
+
+    include_examples "supports user lookup by external_id", :suspension, build_user: -> { create(:compliant_user) }
   end
 
   describe "POST reset_password" do
@@ -266,7 +315,7 @@ describe Api::Internal::Admin::UsersController do
       post :reset_password
 
       expect(response).to have_http_status(:bad_request)
-      expect(response.parsed_body).to eq({ success: false, message: "email is required" }.as_json)
+      expect(response.parsed_body).to eq({ success: false, message: "email or external_id is required" }.as_json)
     end
 
     it "returns 400 when email is malformed" do
@@ -291,6 +340,21 @@ describe Api::Internal::Admin::UsersController do
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to eq({ success: true, message: "Reset password instructions sent" }.as_json)
     end
+
+    it "skips the email-format check when only external_id is provided" do
+      expect_any_instance_of(User).to receive(:send_reset_password_instructions)
+
+      post :reset_password, params: { external_id: user.external_id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq({ success: true, message: "Reset password instructions sent" }.as_json)
+    end
+
+    context "with a user lookup helper stubbed" do
+      before { allow_any_instance_of(User).to receive(:send_reset_password_instructions) }
+
+      include_examples "supports user lookup by external_id", :reset_password
+    end
   end
 
   describe "POST update_email" do
@@ -303,14 +367,14 @@ describe Api::Internal::Admin::UsersController do
       post :update_email, params: { new_email: new_email }
 
       expect(response).to have_http_status(:bad_request)
-      expect(response.parsed_body).to eq({ success: false, message: "Both current_email and new_email are required" }.as_json)
+      expect(response.parsed_body).to eq({ success: false, message: "current_email (or external_id) and new_email are required" }.as_json)
     end
 
     it "returns 400 when new_email is missing" do
       post :update_email, params: { current_email: user.email }
 
       expect(response).to have_http_status(:bad_request)
-      expect(response.parsed_body).to eq({ success: false, message: "Both current_email and new_email are required" }.as_json)
+      expect(response.parsed_body).to eq({ success: false, message: "current_email (or external_id) and new_email are required" }.as_json)
     end
 
     it "returns 400 when new_email is malformed" do
@@ -361,6 +425,40 @@ describe Api::Internal::Admin::UsersController do
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response.parsed_body["message"]).to eq("New email is the same as the current email")
     end
+
+    it "looks up the user by external_id and updates the email" do
+      post :update_email, params: { external_id: user.external_id, new_email: new_email }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["success"]).to be(true)
+      expect(user.reload.unconfirmed_email).to eq(new_email)
+    end
+
+    it "returns 400 when neither current_email nor external_id is provided" do
+      post :update_email, params: { new_email: new_email }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "current_email (or external_id) and new_email are required" }.as_json)
+    end
+
+    it "returns 404 when external_id matches a soft-deleted user" do
+      user.mark_deleted!
+
+      post :update_email, params: { external_id: user.external_id, new_email: new_email }
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
+    end
+
+    it "prefers external_id over current_email when both are provided" do
+      other_user = create(:user)
+
+      post :update_email, params: { external_id: user.external_id, current_email: other_user.email, new_email: new_email }
+
+      expect(response).to have_http_status(:ok)
+      expect(user.reload.unconfirmed_email).to eq(new_email)
+      expect(other_user.reload.unconfirmed_email).to be_nil
+    end
   end
 
   describe "POST two_factor_authentication" do
@@ -372,7 +470,7 @@ describe Api::Internal::Admin::UsersController do
       post :two_factor_authentication, params: { enabled: true }
 
       expect(response).to have_http_status(:bad_request)
-      expect(response.parsed_body).to eq({ success: false, message: "email is required" }.as_json)
+      expect(response.parsed_body).to eq({ success: false, message: "email or external_id is required" }.as_json)
     end
 
     it "returns 400 when enabled is missing" do
@@ -439,6 +537,8 @@ describe Api::Internal::Admin::UsersController do
       expect(user.reload.two_factor_authentication_enabled?).to be(false)
       expect(TotpCredential.where(id: totp_credential.id)).to be_empty
     end
+
+    include_examples "supports user lookup by external_id", :two_factor_authentication, extra_params: { enabled: true }
   end
 
   describe "POST create_comment" do
@@ -453,7 +553,7 @@ describe Api::Internal::Admin::UsersController do
       post :create_comment, params: { content: "hi", idempotency_key: idempotency_key }
 
       expect(response).to have_http_status(:bad_request)
-      expect(response.parsed_body).to eq({ success: false, message: "email is required" }.as_json)
+      expect(response.parsed_body).to eq({ success: false, message: "email or external_id is required" }.as_json)
     end
 
     it "returns 400 when content is missing" do
@@ -541,6 +641,8 @@ describe Api::Internal::Admin::UsersController do
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response.parsed_body["success"]).to be(false)
     end
+
+    include_examples "supports user lookup by external_id", :create_comment, extra_params: { content: "via external_id", idempotency_key: SecureRandom.uuid }
   end
 
   describe "POST mark_compliant" do
@@ -552,7 +654,7 @@ describe Api::Internal::Admin::UsersController do
       post :mark_compliant
 
       expect(response).to have_http_status(:bad_request)
-      expect(response.parsed_body).to eq({ success: false, message: "email is required" }.as_json)
+      expect(response.parsed_body).to eq({ success: false, message: "email or external_id is required" }.as_json)
     end
 
     it "returns 404 when the user does not exist" do
@@ -632,6 +734,8 @@ describe Api::Internal::Admin::UsersController do
         message: "User is already compliant"
       }.as_json)
     end
+
+    include_examples "supports user lookup by external_id", :mark_compliant, build_user: -> { create(:user, user_risk_state: "suspended_for_fraud") }
   end
 
   describe "POST suspend_for_fraud" do
@@ -643,7 +747,7 @@ describe Api::Internal::Admin::UsersController do
       post :suspend_for_fraud
 
       expect(response).to have_http_status(:bad_request)
-      expect(response.parsed_body).to eq({ success: false, message: "email is required" }.as_json)
+      expect(response.parsed_body).to eq({ success: false, message: "email or external_id is required" }.as_json)
     end
 
     it "returns 404 when the user does not exist" do
@@ -735,6 +839,8 @@ describe Api::Internal::Admin::UsersController do
       expect(response.parsed_body["success"]).to be(false)
       expect(user.reload).to be_compliant
     end
+
+    include_examples "supports user lookup by external_id", :suspend_for_fraud, build_user: -> { create(:compliant_user) }
   end
 
   describe "POST watch" do
@@ -746,7 +852,7 @@ describe Api::Internal::Admin::UsersController do
       post :watch, params: { revenue_threshold: "200" }
 
       expect(response).to have_http_status(:bad_request)
-      expect(response.parsed_body["message"]).to eq("email is required")
+      expect(response.parsed_body["message"]).to eq("email or external_id is required")
     end
 
     it "returns bad request when revenue_threshold is missing" do
@@ -799,6 +905,8 @@ describe Api::Internal::Admin::UsersController do
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response.parsed_body["message"]).to eq("User is already being watched")
     end
+
+    include_examples "supports user lookup by external_id", :watch, extra_params: { revenue_threshold: "200" }
   end
 
   describe "POST unwatch" do
@@ -810,7 +918,7 @@ describe Api::Internal::Admin::UsersController do
       post :unwatch
 
       expect(response).to have_http_status(:bad_request)
-      expect(response.parsed_body["message"]).to eq("email is required")
+      expect(response.parsed_body["message"]).to eq("email or external_id is required")
     end
 
     it "returns not found when user does not exist" do
@@ -835,6 +943,8 @@ describe Api::Internal::Admin::UsersController do
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response.parsed_body["message"]).to eq("User is not currently being watched")
     end
+
+    include_examples "supports user lookup by external_id", :unwatch, build_user: -> { user = create(:user); create(:watched_user, user:); user }
   end
 
   describe "POST update_watch" do
@@ -846,7 +956,7 @@ describe Api::Internal::Admin::UsersController do
       post :update_watch, params: { revenue_threshold: "200" }
 
       expect(response).to have_http_status(:bad_request)
-      expect(response.parsed_body["message"]).to eq("email is required")
+      expect(response.parsed_body["message"]).to eq("email or external_id is required")
     end
 
     it "returns bad request when revenue_threshold is missing" do
@@ -910,5 +1020,9 @@ describe Api::Internal::Admin::UsersController do
       expect(response).to have_http_status(:ok)
       expect(watched_user.reload.notes).to be_nil
     end
+
+    include_examples "supports user lookup by external_id", :update_watch,
+                     build_user: -> { user = create(:user); create(:watched_user, user:); user },
+                     extra_params: { revenue_threshold: "200" }
   end
 end

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -350,6 +350,15 @@ describe Api::Internal::Admin::UsersController do
       expect(response.parsed_body).to eq({ success: true, message: "Reset password instructions sent" }.as_json)
     end
 
+    it "skips the email-format check when external_id is provided alongside a malformed email" do
+      expect_any_instance_of(User).to receive(:send_reset_password_instructions)
+
+      post :reset_password, params: { external_id: user.external_id, email: "garbage" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq({ success: true, message: "Reset password instructions sent" }.as_json)
+    end
+
     context "with a user lookup helper stubbed" do
       before { allow_any_instance_of(User).to receive(:send_reset_password_instructions) }
 

--- a/spec/controllers/api/internal/helper/users_controller_spec.rb
+++ b/spec/controllers/api/internal/helper/users_controller_spec.rb
@@ -212,13 +212,13 @@ describe Api::Internal::Helper::UsersController do
   describe "POST create_comment" do
     include_examples "helper api authorization required", :post, :create_comment
 
-    context "when email parameter is missing" do
+    context "when neither email nor external_id is provided" do
       it "returns a bad request error" do
         post :create_comment, params: { content: "Test", idempotency_key: SecureRandom.uuid }
 
         expect(response).to have_http_status(:bad_request)
         expect(response.parsed_body["success"]).to be false
-        expect(response.parsed_body["error_message"]).to eq("'email' parameter is required")
+        expect(response.parsed_body["error_message"]).to eq("'email' or 'external_id' parameter is required")
       end
     end
 
@@ -248,7 +248,43 @@ describe Api::Internal::Helper::UsersController do
 
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.parsed_body["success"]).to be false
-        expect(response.parsed_body["error_message"]).to eq("An account does not exist with that email.")
+        expect(response.parsed_body["error_message"]).to eq("An account does not exist with that email or external_id.")
+      end
+    end
+
+    context "when external_id parameter is used" do
+      it "creates a comment when external_id matches an alive user" do
+        post :create_comment, params: { external_id: user.external_id, content: "via external_id", idempotency_key: SecureRandom.uuid }
+
+        expect(response).to have_http_status(:success)
+        expect(response.parsed_body["success"]).to be true
+        expect(user.comments.last.content).to eq("via external_id")
+      end
+
+      it "returns 422 when external_id does not match any user" do
+        post :create_comment, params: { external_id: "999999999999", content: "Test", idempotency_key: SecureRandom.uuid }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body["error_message"]).to eq("An account does not exist with that email or external_id.")
+      end
+
+      it "returns 422 when external_id matches a soft-deleted user" do
+        user.mark_deleted!
+
+        post :create_comment, params: { external_id: user.external_id, content: "Test", idempotency_key: SecureRandom.uuid }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body["error_message"]).to eq("An account does not exist with that email or external_id.")
+      end
+
+      it "prefers external_id over email when both are provided" do
+        other_user = create(:user)
+
+        post :create_comment, params: { external_id: user.external_id, email: other_user.email, content: "via external_id", idempotency_key: SecureRandom.uuid }
+
+        expect(response).to have_http_status(:success)
+        expect(user.comments.last.content).to eq("via external_id")
+        expect(other_user.comments.count).to eq(0)
       end
     end
 


### PR DESCRIPTION
Closes antiwork/gumroad-private#343

## What

Adds an optional `external_id` parameter as an alternative to `email` for identifying the target user on every internal admin and helper user endpoint that currently only accepts `email`:

- `POST /api/internal/admin/users/info`
- `POST /api/internal/admin/users/suspension`
- `POST /api/internal/admin/users/reset_password`
- `POST /api/internal/admin/users/update_email` (alongside `current_email`)
- `POST /api/internal/admin/users/two_factor_authentication`
- `POST /api/internal/admin/users/create_comment`
- `POST /api/internal/admin/users/mark_compliant`
- `POST /api/internal/admin/users/suspend_for_fraud`
- `POST /api/internal/admin/users/watch`
- `POST /api/internal/admin/users/update_watch`
- `POST /api/internal/admin/users/unwatch`
- `POST /api/internal/helper/users/create_comment`

Lookup behavior matches the admin UI at `/admin/users/:external_id` — `User.find_by(external_id: …)`. When both `email` and `external_id` are supplied, `external_id` wins. When neither is supplied, the endpoints return `400` (`"email or external_id is required"` for admin; `"'email' or 'external_id' parameter is required"` for the helper, matching its existing message style). Existing email-only callers keep working unchanged.

`info` continues to allow lookup of soft-deleted users (it never used `User.alive`); all mutations keep the `User.alive` scope, so an `external_id` resolving to a soft-deleted user returns `404` consistently with the email path.

The other 6 helper actions (`user_info`, `user_suspension_info`, `send_reset_password_instructions`, `update_email`, `update_two_factor_authentication_enabled`, `create_appeal`) are out of scope per the issue and remain email-only.

## Why

The admin UI loads suspended/soft-deleted/hard-to-find accounts fine at `/admin/users/2245593582708`, but the API returned `404` because the only handle into the lookup was `email`, which:

- Doesn't resolve via the API for accounts the email path can't find (suspended-for-fraud accounts, accounts not yet replicated to Metabase, accounts whose email has changed).
- Forces support to skip recording fraud-review notes on suspended accounts — exactly when an audit trail matters most.

The motivation applies more strongly to mutations (`create_comment`, `mark_compliant`, `suspend_for_fraud`, `update_email`) than to read-only `info`, so I extended `external_id` support to all 11 admin actions rather than just the 3 listed in the issue. Marginal cost was near zero (the lookup is centralized in `find_user_or_render`) and a split contract (3 endpoints support it, 8 don't) would be confusing. Confirmed in planning before writing code.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) Model: Claude Opus 4.7 (
