### PR TITLE
Add internal admin products API for risk reviews

### DIFF
--- a/app/controllers/api/internal/admin/products_controller.rb
+++ b/app/controllers/api/internal/admin/products_controller.rb
@@ -74,7 +74,7 @@ class Api::Internal::Admin::ProductsController < Api::Internal::Admin::BaseContr
           id: product.user&.external_id,
           email: product.user&.email
         },
-        files: product.product_files.in_order.map { serialize_file(_1) }
+        files: product.product_files.sort_by { |f| [f.position || Float::INFINITY, f.id] }.map { serialize_file(_1) }
       }
     end
 
@@ -82,8 +82,8 @@ class Api::Internal::Admin::ProductsController < Api::Internal::Admin::BaseContr
       {
         id: file.external_id,
         display_name: file.name_displayable,
-        file_name: file.s3_filename,
-        extension: file.s3_display_extension,
+        file_name: file.external_link? ? file.url : file.s3_filename,
+        extension: file.display_extension,
         filegroup: file.filegroup,
         file_size: file.size,
         created_at: file.created_at.iso8601,

--- a/app/controllers/api/internal/admin/products_controller.rb
+++ b/app/controllers/api/internal/admin/products_controller.rb
@@ -17,7 +17,7 @@ class Api::Internal::Admin::ProductsController < Api::Internal::Admin::BaseContr
     return unless user
 
     products = user.products
-      .includes(:product_files, :display_asset_previews, :thumbnail_alive)
+      .includes(:product_files, :display_asset_previews)
       .order(Admin::Users::ListPaginatedProducts::PRODUCTS_ORDER)
 
     pagination, paginated = pagy(products, page: requested_page, limit: per_page, overflow: :empty_page)

--- a/app/controllers/api/internal/admin/products_controller.rb
+++ b/app/controllers/api/internal/admin/products_controller.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+class Api::Internal::Admin::ProductsController < Api::Internal::Admin::BaseController
+  include Pagy::Backend
+
+  DEFAULT_PER_PAGE = Admin::Users::ListPaginatedProducts::PRODUCTS_PER_PAGE
+  MAX_PER_PAGE = 100
+  private_constant :DEFAULT_PER_PAGE, :MAX_PER_PAGE
+
+  def list
+    return render json: { success: false, message: "email is required" }, status: :bad_request if params[:email].blank?
+
+    user = User.by_email(params[:email]).first
+    return render json: { success: false, message: "User not found" }, status: :not_found if user.blank?
+
+    products = user.products
+      .includes(:product_files, :display_asset_previews, :thumbnail_alive)
+      .order(Admin::Users::ListPaginatedProducts::PRODUCTS_ORDER)
+
+    pagination, paginated = pagy(products, page: params[:page], limit: per_page)
+
+    render json: {
+      success: true,
+      products: paginated.map { serialize_product(_1) },
+      pagination: PagyPresenter.new(pagination).metadata
+    }
+  end
+
+  def show
+    product = Link.find_by_external_id(params[:id])
+    return render json: { success: false, message: "Product not found" }, status: :not_found if product.blank?
+
+    render json: { success: true, product: serialize_product(product) }
+  end
+
+  private
+    def per_page
+      requested = params[:per_page].to_i
+      return DEFAULT_PER_PAGE unless requested.positive?
+
+      [requested, MAX_PER_PAGE].min
+    end
+
+    def serialize_product(product)
+      {
+        id: product.external_id,
+        name: product.name,
+        description: product.description,
+        price_cents: product.price_cents,
+        currency_code: product.price_currency_type,
+        permalink: product.unique_permalink,
+        long_url: product.long_url,
+        preview_url: product.preview_url,
+        created_at: product.created_at.iso8601,
+        deleted_at: product.deleted_at&.iso8601,
+        alive: product.alive?,
+        is_adult: product.is_adult?,
+        seller: {
+          id: product.user&.external_id,
+          email: product.user&.email
+        },
+        files: product.product_files.in_order.map { serialize_file(_1) }
+      }
+    end
+
+    def serialize_file(file)
+      {
+        id: file.external_id,
+        display_name: file.name_displayable,
+        file_name: file.s3_filename,
+        extension: file.s3_display_extension,
+        filegroup: file.filegroup,
+        file_size: file.size,
+        created_at: file.created_at.iso8601,
+        deleted_at: file.deleted_at&.iso8601
+      }
+    end
+end

--- a/app/controllers/api/internal/admin/products_controller.rb
+++ b/app/controllers/api/internal/admin/products_controller.rb
@@ -5,13 +5,16 @@ class Api::Internal::Admin::ProductsController < Api::Internal::Admin::BaseContr
 
   DEFAULT_PER_PAGE = Admin::Users::ListPaginatedProducts::PRODUCTS_PER_PAGE
   MAX_PER_PAGE = 100
-  private_constant :DEFAULT_PER_PAGE, :MAX_PER_PAGE
+  SELLER_LOOKUP_BAD_REQUEST_MESSAGE = "email or external_id is required"
+  private_constant :DEFAULT_PER_PAGE, :MAX_PER_PAGE, :SELLER_LOOKUP_BAD_REQUEST_MESSAGE
 
   def list
-    return render json: { success: false, message: "email is required" }, status: :bad_request if params[:email].blank?
+    if params[:email].blank? && params[:external_id].blank?
+      return render json: { success: false, message: SELLER_LOOKUP_BAD_REQUEST_MESSAGE }, status: :bad_request
+    end
 
-    user = User.by_email(params[:email]).first
-    return render json: { success: false, message: "User not found" }, status: :not_found if user.blank?
+    user = find_seller_or_render
+    return unless user
 
     products = user.products
       .includes(:product_files, :display_asset_previews, :thumbnail_alive)
@@ -34,6 +37,18 @@ class Api::Internal::Admin::ProductsController < Api::Internal::Admin::BaseContr
   end
 
   private
+    def find_seller_or_render
+      user = if params[:external_id].present?
+        User.find_by(external_id: params[:external_id])
+      else
+        User.by_email(params[:email]).first
+      end
+      return user if user.present?
+
+      render json: { success: false, message: "User not found" }, status: :not_found
+      nil
+    end
+
     def per_page
       requested = params[:per_page].to_i
       return DEFAULT_PER_PAGE unless requested.positive?

--- a/app/controllers/api/internal/admin/products_controller.rb
+++ b/app/controllers/api/internal/admin/products_controller.rb
@@ -20,7 +20,7 @@ class Api::Internal::Admin::ProductsController < Api::Internal::Admin::BaseContr
       .includes(:product_files, :display_asset_previews, :thumbnail_alive)
       .order(Admin::Users::ListPaginatedProducts::PRODUCTS_ORDER)
 
-    pagination, paginated = pagy(products, page: params[:page], limit: per_page, overflow: :empty_page)
+    pagination, paginated = pagy(products, page: requested_page, limit: per_page, overflow: :empty_page)
 
     render json: {
       success: true,
@@ -54,6 +54,10 @@ class Api::Internal::Admin::ProductsController < Api::Internal::Admin::BaseContr
       return DEFAULT_PER_PAGE unless requested.positive?
 
       [requested, MAX_PER_PAGE].min
+    end
+
+    def requested_page
+      [params[:page].to_i, 1].max
     end
 
     def serialize_product(product)

--- a/app/controllers/api/internal/admin/products_controller.rb
+++ b/app/controllers/api/internal/admin/products_controller.rb
@@ -20,7 +20,7 @@ class Api::Internal::Admin::ProductsController < Api::Internal::Admin::BaseContr
       .includes(:product_files, :display_asset_previews, :thumbnail_alive)
       .order(Admin::Users::ListPaginatedProducts::PRODUCTS_ORDER)
 
-    pagination, paginated = pagy(products, page: params[:page], limit: per_page)
+    pagination, paginated = pagy(products, page: params[:page], limit: per_page, overflow: :empty_page)
 
     render json: {
       success: true,
@@ -74,7 +74,7 @@ class Api::Internal::Admin::ProductsController < Api::Internal::Admin::BaseContr
           id: product.user&.external_id,
           email: product.user&.email
         },
-        files: product.product_files.sort_by { |f| [f.position || Float::INFINITY, f.id] }.map { serialize_file(_1) }
+        files: product.product_files.sort_by { |f| [f.position.nil? ? 0 : 1, f.position.to_i, f.id] }.map { serialize_file(_1) }
       }
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -353,6 +353,12 @@ Rails.application.routes.draw do
               post :scheduled_cancel
             end
           end
+
+          resources :products, only: [:show] do
+            collection do
+              post :list
+            end
+          end
         end
 
         namespace :grmc do

--- a/spec/controllers/api/internal/admin/products_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/products_controller_spec.rb
@@ -12,11 +12,11 @@ describe Api::Internal::Admin::ProductsController do
   describe "POST list" do
     include_examples "admin api authorization required", :post, :list
 
-    it "returns a bad request when email is missing" do
+    it "returns a bad request when neither email nor external_id is provided" do
       post :list
 
       expect(response).to have_http_status(:bad_request)
-      expect(response.parsed_body).to eq({ success: false, message: "email is required" }.as_json)
+      expect(response.parsed_body).to eq({ success: false, message: "email or external_id is required" }.as_json)
     end
 
     it "returns not found when the user does not exist" do
@@ -24,6 +24,42 @@ describe Api::Internal::Admin::ProductsController do
 
       expect(response).to have_http_status(:not_found)
       expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
+    end
+
+    it "looks up the seller by external_id when provided" do
+      product = create(:product, user: seller)
+
+      post :list, params: { external_id: seller.external_id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["products"].map { _1["id"] }).to eq([product.external_id])
+    end
+
+    it "returns not found when the external_id does not match any user" do
+      post :list, params: { external_id: "nonexistent" }
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
+    end
+
+    it "prefers external_id over email when both are provided" do
+      other_seller = create(:user, email: "other@example.com")
+      external_match = create(:product, user: seller, name: "via external_id")
+      create(:product, user: other_seller, name: "via email")
+
+      post :list, params: { email: other_seller.email, external_id: seller.external_id }
+
+      expect(response.parsed_body["products"].map { _1["name"] }).to eq([external_match.name])
+    end
+
+    it "returns products for a soft-deleted seller looked up by external_id" do
+      product = create(:product, user: seller)
+      seller.mark_deleted!
+
+      post :list, params: { external_id: seller.external_id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["products"].map { _1["id"] }).to eq([product.external_id])
     end
 
     it "returns an empty list with pagination metadata when the seller has no products" do

--- a/spec/controllers/api/internal/admin/products_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/products_controller_spec.rb
@@ -194,6 +194,30 @@ describe Api::Internal::Admin::ProductsController do
       expect(response.parsed_body["pagination"]).to include("page" => 2, "next" => nil)
     end
 
+    it "returns an empty page in the JSON envelope when page is past the end (rather than raising 500)" do
+      create(:product, user: seller)
+
+      post :list, params: { email: seller.email, page: 99 }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["success"]).to be(true)
+      expect(response.parsed_body["products"]).to eq([])
+      expect(response.parsed_body["pagination"]["next"]).to be_nil
+    end
+
+    it "orders product files with NULL position first to match MySQL ORDER BY ASC" do
+      product = create(:product, user: seller)
+      first = create(:readable_document, link: product, display_name: "First (null pos)")
+      second = create(:readable_document, link: product, display_name: "Second", position: 0)
+      third = create(:readable_document, link: product, display_name: "Third", position: 1)
+      first.update_column(:position, nil)
+
+      post :list, params: { email: seller.email }
+
+      ids = response.parsed_body["products"].first["files"].map { _1["id"] }
+      expect(ids).to eq([first.external_id, second.external_id, third.external_id])
+    end
+
     it "honors per_page and caps it at the maximum" do
       create_list(:product, 5, user: seller)
 

--- a/spec/controllers/api/internal/admin/products_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/products_controller_spec.rb
@@ -105,6 +105,46 @@ describe Api::Internal::Admin::ProductsController do
       expect(names).to eq(["New alive", "Old alive", "Deleted"])
     end
 
+    it "surfaces external-link files with their URL and a URL extension" do
+      product = create(:product, user: seller)
+      external = create(:external_link, link: product, display_name: "Telegram channel", url: "https://t.me/secret-channel")
+
+      post :list, params: { email: seller.email }
+
+      files = response.parsed_body["products"].first["files"]
+      payload = files.find { _1["id"] == external.external_id }
+      expect(payload).to include(
+        "display_name" => "Telegram channel",
+        "file_name" => "https://t.me/secret-channel",
+        "extension" => "URL",
+        "filegroup" => external.filegroup
+      )
+    end
+
+    it "preloads product files instead of issuing one query per product" do
+      3.times do
+        product = create(:product, user: seller)
+        create(:readable_document, link: product)
+        create(:readable_document, link: product)
+      end
+
+      product_files_queries = []
+      counter = lambda do |*, payload|
+        sql = payload[:sql]
+        next if sql.blank? || sql.start_with?("INSERT", "UPDATE", "DELETE", "BEGIN", "COMMIT", "SAVEPOINT", "RELEASE")
+        product_files_queries << sql if sql.include?("`product_files`") && sql.include?("SELECT")
+      end
+
+      ActiveSupport::Notifications.subscribed(counter, "sql.active_record") do
+        post :list, params: { email: seller.email }
+      end
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["products"].length).to eq(3)
+      expect(product_files_queries.length).to eq(1), "expected one product_files SELECT but got #{product_files_queries.length}:\n#{product_files_queries.join("\n")}"
+      expect(product_files_queries.first).to include("IN (")
+    end
+
     it "exposes file metadata including soft-deleted files" do
       product = create(:product, user: seller)
       alive_file = create(:readable_document, link: product, display_name: "Big guide", size: 1_048_576)

--- a/spec/controllers/api/internal/admin/products_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/products_controller_spec.rb
@@ -1,0 +1,203 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "shared_examples/authorized_admin_api_method"
+
+describe Api::Internal::Admin::ProductsController do
+  let(:admin_user) { create(:admin_user) }
+  let(:seller) { create(:user, email: "seller@example.com") }
+
+  before { stub_const("GUMROAD_ADMIN_ID", admin_user.id) }
+
+  describe "POST list" do
+    include_examples "admin api authorization required", :post, :list
+
+    it "returns a bad request when email is missing" do
+      post :list
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "email is required" }.as_json)
+    end
+
+    it "returns not found when the user does not exist" do
+      post :list, params: { email: "missing@example.com" }
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
+    end
+
+    it "returns an empty list with pagination metadata when the seller has no products" do
+      post :list, params: { email: seller.email }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["success"]).to be(true)
+      expect(response.parsed_body["products"]).to eq([])
+      expect(response.parsed_body["pagination"]).to include("count" => 0, "page" => 1)
+    end
+
+    it "returns alive and soft-deleted products with their deletion state exposed" do
+      alive_product = create(:product, user: seller, name: "Alive guide")
+      deleted_product = create(:product, user: seller, name: "Old draft")
+      deleted_product.mark_deleted!
+
+      post :list, params: { email: seller.email }
+
+      expect(response).to have_http_status(:ok)
+      products = response.parsed_body["products"]
+      expect(products.length).to eq(2)
+      ids = products.map { _1["id"] }
+      expect(ids).to contain_exactly(alive_product.external_id, deleted_product.external_id)
+
+      alive_payload = products.find { _1["id"] == alive_product.external_id }
+      expect(alive_payload["deleted_at"]).to be_nil
+      expect(alive_payload["alive"]).to be(true)
+
+      deleted_payload = products.find { _1["id"] == deleted_product.external_id }
+      expect(deleted_payload["deleted_at"]).to be_present
+      expect(deleted_payload["alive"]).to be(false)
+    end
+
+    it "orders alive products before deleted ones, then by created_at desc" do
+      create(:product, user: seller, name: "Old alive", created_at: 3.days.ago)
+      create(:product, user: seller, name: "New alive", created_at: 1.day.ago)
+      deleted = create(:product, user: seller, name: "Deleted")
+      deleted.mark_deleted!
+
+      post :list, params: { email: seller.email }
+
+      names = response.parsed_body["products"].map { _1["name"] }
+      expect(names).to eq(["New alive", "Old alive", "Deleted"])
+    end
+
+    it "exposes file metadata including soft-deleted files" do
+      product = create(:product, user: seller)
+      alive_file = create(:readable_document, link: product, display_name: "Big guide", size: 1_048_576)
+      deleted_file = create(:readable_document, link: product, display_name: "Removed extra", size: 256)
+      deleted_file.mark_deleted!
+
+      post :list, params: { email: seller.email }
+
+      files = response.parsed_body["products"].first["files"]
+      expect(files.length).to eq(2)
+
+      alive_payload = files.find { _1["id"] == alive_file.external_id }
+      expect(alive_payload).to include(
+        "display_name" => "Big guide",
+        "extension" => "PDF",
+        "filegroup" => "document",
+        "file_size" => 1_048_576,
+        "deleted_at" => nil
+      )
+      expect(alive_payload["file_name"]).to end_with(".pdf")
+
+      deleted_payload = files.find { _1["id"] == deleted_file.external_id }
+      expect(deleted_payload["file_size"]).to eq(256)
+      expect(deleted_payload["deleted_at"]).to be_present
+    end
+
+    it "returns the cover image url when one is present" do
+      product = create(:product, :with_youtube_preview, user: seller)
+
+      post :list, params: { email: seller.email }
+
+      payload = response.parsed_body["products"].first
+      expect(payload["preview_url"]).to eq(product.preview_url)
+      expect(payload["preview_url"]).to be_present
+    end
+
+    it "paginates with the default per_page" do
+      stub_const("Api::Internal::Admin::ProductsController::DEFAULT_PER_PAGE", 2)
+      create_list(:product, 3, user: seller)
+
+      post :list, params: { email: seller.email }
+      expect(response.parsed_body["products"].length).to eq(2)
+      expect(response.parsed_body["pagination"]).to include("count" => 3, "page" => 1, "next" => 2)
+
+      post :list, params: { email: seller.email, page: 2 }
+      expect(response.parsed_body["products"].length).to eq(1)
+      expect(response.parsed_body["pagination"]).to include("page" => 2, "next" => nil)
+    end
+
+    it "honors per_page and caps it at the maximum" do
+      create_list(:product, 5, user: seller)
+
+      post :list, params: { email: seller.email, per_page: 2 }
+      expect(response.parsed_body["products"].length).to eq(2)
+
+      post :list, params: { email: seller.email, per_page: 10_000 }
+      expect(response.parsed_body["products"].length).to eq(5)
+    end
+
+    it "scopes results to the requested seller and excludes other sellers' products" do
+      other_seller = create(:user, email: "other@example.com")
+      mine = create(:product, user: seller)
+      create(:product, user: other_seller)
+
+      post :list, params: { email: seller.email }
+
+      ids = response.parsed_body["products"].map { _1["id"] }
+      expect(ids).to eq([mine.external_id])
+    end
+  end
+
+  describe "GET show" do
+    include_examples "admin api authorization required", :get, :show, { id: "fake" }
+
+    it "returns not found when no product matches" do
+      get :show, params: { id: "fake" }
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body).to eq({ success: false, message: "Product not found" }.as_json)
+    end
+
+    it "returns the full product payload with file metadata" do
+      product = create(:product, user: seller, name: "Edgar Gumstein anthology", description: "The full collection.", price_cents: 20_000)
+      file = create(:readable_document, link: product, display_name: "Anthology", size: 5_242_880)
+
+      get :show, params: { id: product.external_id }
+
+      expect(response).to have_http_status(:ok)
+      payload = response.parsed_body["product"]
+      expect(payload).to include(
+        "id" => product.external_id,
+        "name" => "Edgar Gumstein anthology",
+        "description" => "The full collection.",
+        "price_cents" => 20_000,
+        "permalink" => product.unique_permalink,
+        "alive" => true,
+        "deleted_at" => nil
+      )
+      expect(payload["files"].length).to eq(1)
+      expect(payload["files"].first).to include(
+        "id" => file.external_id,
+        "file_size" => 5_242_880,
+        "extension" => "PDF",
+        "filegroup" => "document",
+        "display_name" => "Anthology"
+      )
+    end
+
+    it "returns a soft-deleted product so admins can inspect tombstones" do
+      product = create(:product, user: seller)
+      product.mark_deleted!
+
+      get :show, params: { id: product.external_id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["product"]["deleted_at"]).to be_present
+      expect(response.parsed_body["product"]["alive"]).to be(false)
+    end
+
+    it "includes soft-deleted files with deleted_at populated" do
+      product = create(:product, user: seller)
+      file = create(:readable_document, link: product, display_name: "Removed", size: 100)
+      file.mark_deleted!
+
+      get :show, params: { id: product.external_id }
+
+      payload = response.parsed_body["product"]["files"].first
+      expect(payload["id"]).to eq(file.external_id)
+      expect(payload["deleted_at"]).to be_present
+    end
+  end
+end

--- a/spec/controllers/api/internal/admin/products_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/products_controller_spec.rb
@@ -194,6 +194,19 @@ describe Api::Internal::Admin::ProductsController do
       expect(response.parsed_body["pagination"]).to include("page" => 2, "next" => nil)
     end
 
+    it "treats non-positive or non-numeric page as page 1 (rather than raising 500)" do
+      product = create(:product, user: seller)
+
+      ["0", "-5", "abc", ""].each do |bad_page|
+        post :list, params: { email: seller.email, page: bad_page }
+
+        expect(response).to have_http_status(:ok), "page=#{bad_page.inspect} returned #{response.status}"
+        expect(response.parsed_body["success"]).to be(true)
+        expect(response.parsed_body["pagination"]["page"]).to eq(1)
+        expect(response.parsed_body["products"].map { _1["id"] }).to eq([product.external_id])
+      end
+    end
+
     it "returns an empty page in the JSON envelope when page is past the end (rather than raising 500)" do
       create(:product, user: seller)
 

--- a/spec/routing/api_internal_admin_contract_spec.rb
+++ b/spec/routing/api_internal_admin_contract_spec.rb
@@ -24,4 +24,9 @@ describe "internal admin API routing" do
     expect(route_for("/internal/admin/users/update_watch", :post)).to include(controller: "api/internal/admin/users", action: "update_watch")
     expect(route_for("/internal/admin/users/unwatch", :post)).to include(controller: "api/internal/admin/users", action: "unwatch")
   end
+
+  it "routes the products endpoints" do
+    expect(route_for("/internal/admin/products/list", :post)).to include(controller: "api/internal/admin/products", action: "list")
+    expect(route_for("/internal/admin/products/abc123", :get)).to include(controller: "api/internal/admin/products", action: "show", id: "abc123")
+  end
 end


### PR DESCRIPTION
Closes #4973.

## What

Adds two read-only endpoints to the existing internal admin API so the risk-review CLI can inspect a seller's products without falling back to Metabase:

- `POST /api/internal/admin/products/list` — paginated list of a seller's products (alive + deleted). Accepts `email` **or** `external_id` to identify the seller (mirrors #4977).
- `GET /api/internal/admin/products/:id` — single product by external id.

Both return product metadata plus a `files` array with display name, S3 filename, extension, filegroup, byte size, and per-file `deleted_at`.

When both `email` and `external_id` are supplied to `list`, `external_id` wins. When neither is supplied, returns `400` with `"email or external_id is required"` — same shape as #4977.

## Why

Risk reviewers currently have to switch to Metabase SQL to look at a seller's products mid-investigation, and **file metadata isn't reachable from any current tool** — neither admin web UI nor Metabase exposes file size or extension. Whether a $200 "ebook" is a 2-page PDF or a 68-page guide is the signal that decides whether to flag or clear; without it the review is guesswork.

This stays inside the established `Api::Internal::Admin::*` controller pattern (bearer-token auth via [base_controller.rb](app/controllers/api/internal/admin/base_controller.rb)) so the existing CLI just gets two new commands rather than a new auth path.

The `external_id` lookup option exists for the same reason it does in #4977: risk reviewers most need this endpoint when a seller is suspended-for-fraud, soft-deleted, or has had their email rotated — exactly the cases where the email path can't resolve them. `User.find_by(external_id: ...)` is used without the `.alive` scope, matching the existing email path's permissive behavior so a deleted seller's products are still inspectable.

---

### AI disclosure

Implemented with **Claude Opus 4.7** in Claude Code