### PR TITLE
Fix Addressable::URI::InvalidURIError in AffiliateRedirectController

### DIFF
--- a/app/controllers/affiliate_redirect_controller.rb
+++ b/app/controllers/affiliate_redirect_controller.rb
@@ -19,7 +19,7 @@ class AffiliateRedirectController < ApplicationController
     def redirect_url(affiliate)
       product = Link.find_by(unique_permalink: params[:unique_permalink]) if params[:unique_permalink].present?
       final_destination_url = affiliate.final_destination_url(product:)
-      uri = Addressable::URI.parse(final_destination_url)
+      uri = Addressable::URI.parse(final_destination_url.strip)
 
       request_uri = Addressable::URI.parse(request.url)
 

--- a/spec/controllers/affiliate_redirect_controller_spec.rb
+++ b/spec/controllers/affiliate_redirect_controller_spec.rb
@@ -75,6 +75,19 @@ describe AffiliateRedirectController do
       end
     end
 
+    context "when destination URL has leading/trailing whitespace" do
+      it "strips whitespace and redirects successfully" do
+        direct_affiliate.update_column(:destination_url, " https://example.gumroad.com/l/abc ")
+        direct_affiliate.apply_to_all_products = true
+        direct_affiliate.save!(validate: false)
+
+        get :set_cookie_and_redirect, params: { affiliate_id: direct_affiliate.external_id_numeric }
+
+        expect(response).to be_redirect
+        expect(response.location).to include("example.gumroad.com")
+      end
+    end
+
     it_behaves_like "AffiliateCookie concern" do
       subject(:make_request) { get :set_cookie_and_redirect, params: { affiliate_id: direct_affiliate.external_id_numeric } }
     end


### PR DESCRIPTION
## What
Strip whitespace from affiliate destination URLs before parsing with `Addressable::URI` in `AffiliateRedirectController#redirect_url`.

## Why
Affiliate destination URLs stored with leading/trailing whitespace (e.g. ` tippica.gumroad.com`) cause `Addressable::URI::InvalidURIError` when the affiliate redirect endpoint tries to parse them.

Adding `.strip` before parsing handles any existing malformed data gracefully.

## Sentry
- Issue: https://gumroad-to.sentry.io/issues/7465359008/
- Occurrences: 2
- Users affected: ~2/month (low volume)
- Estimated support tickets: 0 (redirect fails silently for the user)

## Changes
- `app/controllers/affiliate_redirect_controller.rb`: Added `.strip` to `final_destination_url` before `Addressable::URI.parse`
- `spec/controllers/affiliate_redirect_controller_spec.rb`: Added test for whitespace in destination URL