### PR TITLE
Handle MerchantRegistrationUserAlreadyHasAccountError race condition in PaymentsController

### DIFF
--- a/app/controllers/settings/payments_controller.rb
+++ b/app/controllers/settings/payments_controller.rb
@@ -81,6 +81,8 @@ class Settings::PaymentsController < Settings::BaseController
     if current_seller.active_bank_account && current_seller.merchant_accounts.stripe.alive.empty? && current_seller.native_payouts_supported?
       begin
         StripeMerchantAccountManager.create_account(current_seller, passphrase: GlobalConfig.get("STRONGBOX_GENERAL_PASSWORD"))
+      rescue MerchantRegistrationUserAlreadyHasAccountError
+        # A concurrent request already created the merchant account; treat as success.
       rescue Stripe::StripeError, MerchantRegistrationUserNotReadyError => e
         if e.is_a?(Stripe::InvalidRequestError) && e.code == "postal_code_invalid"
           country = current_seller.fetch_or_build_user_compliance_info.legal_entity_country

--- a/spec/controllers/settings/payments_controller_spec.rb
+++ b/spec/controllers/settings/payments_controller_spec.rb
@@ -439,6 +439,26 @@ describe Settings::PaymentsController, :vcr, type: :controller, inertia: true do
             expect(response).to have_http_status :found
             expect(session[:inertia_errors][:base]).to eq(["Bank payouts are not supported in your country yet. Please use PayPal instead."])
           end
+
+          it "treats MerchantRegistrationUserAlreadyHasAccountError as success when a concurrent request created the account" do
+            all_params.merge!(
+              bank_account: {
+                type: AchAccount.name,
+                account_number: "000123456789",
+                account_number_confirmation: "000123456789",
+                routing_number: "110000000",
+                account_holder_full_name: "gumbot"
+              }
+            )
+
+            expect(StripeMerchantAccountManager).to receive(:create_account).and_raise(MerchantRegistrationUserAlreadyHasAccountError.new(user.id, StripeChargeProcessor.charge_processor_id))
+
+            put :update, params: all_params
+
+            expect(response).to redirect_to(settings_payments_path)
+            expect(response).to have_http_status :see_other
+            expect(flash[:notice]).to eq("Thanks! You're all set.")
+          end
         end
       end
 


### PR DESCRIPTION
## Problem

`Settings::PaymentsController#update` raises an unhandled `MerchantRegistrationUserAlreadyHasAccountError` due to a race condition.

**Sentry issue:** https://gumroad-to.sentry.io/issues/7465850997/

The controller checks `merchant_accounts.stripe.alive.empty?` outside a database lock, then calls `StripeMerchantAccountManager.create_account` which re-checks inside `with_lock`. When two concurrent requests hit this endpoint, both pass the controller guard, but the second fails inside `create_account` with `MerchantRegistrationUserAlreadyHasAccountError`.

The rescue clause only catches `Stripe::StripeError` and `MerchantRegistrationUserNotReadyError`, so this error bubbles up unhandled.

## Fix

Add a rescue for `MerchantRegistrationUserAlreadyHasAccountError` that treats it as a success (the merchant account exists, which is the desired end state). This matches how the admin controller already handles this error.

## Impact

- **Sentry events:** 1 (first occurrence)
- **Estimated affected users:** Low, requires exact concurrent request timing
- **Support tickets:** Likely minimal, but users see a 500 error when it occurs

## Video

Non-user-facing backend error handling change. The test demonstrates the fix: when `create_account` raises `MerchantRegistrationUserAlreadyHasAccountError`, the controller now redirects with a success notice instead of raising.