### PR TITLE
Allow admin endpoints to target users by user ID

### DIFF
--- a/app/controllers/api/internal/admin/base_controller.rb
+++ b/app/controllers/api/internal/admin/base_controller.rb
@@ -12,6 +12,10 @@ class Api::Internal::Admin::BaseController < Api::Internal::BaseController
     purchases.reassign
     purchases.resend_all_receipts
   ].freeze
+  USER_LOOKUP_BAD_REQUEST_MESSAGE = "email or user_id is required"
+  USER_ID_REQUIRED_MESSAGE = "user_id is required for mutating admin actions. " \
+    "Use /internal/admin/users/info to look up the user_id by email."
+  private_constant :USER_LOOKUP_BAD_REQUEST_MESSAGE, :USER_ID_REQUIRED_MESSAGE
 
   skip_before_action :verify_authenticity_token
   before_action :verify_authorization_header!
@@ -63,6 +67,45 @@ class Api::Internal::Admin::BaseController < Api::Internal::BaseController
 
     def current_admin_actor_id
       Current.admin_actor.id
+    end
+
+    def find_internal_admin_user_for_read_or_render(include_deleted: false)
+      unless params[:email].present? || internal_admin_user_id_param.present?
+        render json: { success: false, message: USER_LOOKUP_BAD_REQUEST_MESSAGE }, status: :bad_request
+        return
+      end
+
+      user = internal_admin_user_for(include_deleted:)
+      return user if user.present?
+
+      render json: { success: false, message: "User not found" }, status: :not_found
+      nil
+    end
+
+    def find_internal_admin_user_for_write_or_render
+      if params[:user_id].blank?
+        render_internal_admin_user_id_required
+        return
+      end
+
+      user = User.alive.find_by(external_id: params[:user_id])
+      if user.blank?
+        render json: { success: false, message: "User not found" }, status: :not_found
+        return
+      end
+
+      return user if params[:expected_email].blank? || user.email.to_s.casecmp(params[:expected_email].to_s).zero?
+
+      render json: { success: false, message: "expected_email does not match the user's current email" }, status: :conflict
+      nil
+    end
+
+    def internal_admin_user_success_payload(user, payload = {})
+      { success: true, user_id: user.external_id }.merge(payload)
+    end
+
+    def render_internal_admin_user_id_required
+      render json: { success: false, message: USER_ID_REQUIRED_MESSAGE }, status: :bad_request
     end
 
     def record_admin_write(action:, target: nil)
@@ -153,6 +196,19 @@ class Api::Internal::Admin::BaseController < Api::Internal::BaseController
     def admin_audit_redacted_param_key?(key, action:)
       key.to_s.match?(ADMIN_AUDIT_REDACTED_PARAM_PATTERN) ||
         ADMIN_AUDIT_ACTION_REDACTED_PARAM_KEYS.fetch(action, []).include?(key.to_s)
+    end
+
+    def internal_admin_user_id_param
+      params[:user_id].presence || params[:external_id].presence
+    end
+
+    def internal_admin_user_for(include_deleted:)
+      scope = include_deleted ? User : User.alive
+      if internal_admin_user_id_param.present?
+        scope.find_by(external_id: internal_admin_user_id_param)
+      else
+        scope.by_email(params[:email]).first
+      end
     end
 
     def serialize_purchase(purchase)

--- a/app/controllers/api/internal/admin/payouts_controller.rb
+++ b/app/controllers/api/internal/admin/payouts_controller.rb
@@ -5,7 +5,8 @@ class Api::Internal::Admin::PayoutsController < Api::Internal::Admin::BaseContro
   SCHEDULED_PAYOUTS_MAX_LIMIT = 50
   private_constant :SCHEDULED_PAYOUTS_DEFAULT_LIMIT, :SCHEDULED_PAYOUTS_MAX_LIMIT
 
-  before_action :fetch_user, only: [:list, :pause, :resume, :issue]
+  before_action :fetch_user_for_read, only: [:list]
+  before_action :fetch_user_for_write, only: [:pause, :resume, :issue]
   before_action :fetch_scheduled_payout, only: [:scheduled_execute, :scheduled_cancel]
 
   def list
@@ -14,6 +15,7 @@ class Api::Internal::Admin::PayoutsController < Api::Internal::Admin::BaseContro
 
     render json: {
       success: true,
+      user_id: @user.external_id,
       last_payouts: payouts,
       next_payout_date: @user.next_payout_date,
       balance_for_next_payout: @user.formatted_balance_for_next_payout_date,
@@ -26,6 +28,7 @@ class Api::Internal::Admin::PayoutsController < Api::Internal::Admin::BaseContro
       if @user.payouts_paused_by_source == User::PAYOUT_PAUSE_SOURCE_ADMIN
         return render json: {
           success: true,
+          user_id: @user.external_id,
           status: "already_paused",
           message: "Payouts are already paused by admin",
           payouts_paused: true
@@ -47,7 +50,8 @@ class Api::Internal::Admin::PayoutsController < Api::Internal::Admin::BaseContro
 
       render json: {
         success: true,
-        message: "Payouts paused for #{@user.email}",
+        user_id: @user.external_id,
+        message: "Payouts paused for #{@user.external_id}",
         payouts_paused: true
       }
     end
@@ -58,6 +62,7 @@ class Api::Internal::Admin::PayoutsController < Api::Internal::Admin::BaseContro
       unless @user.payouts_paused_internally?
         return render json: {
           success: true,
+          user_id: @user.external_id,
           status: "not_paused",
           message: "Payouts are not paused by admin",
           payouts_paused: @user.payouts_paused?
@@ -75,7 +80,8 @@ class Api::Internal::Admin::PayoutsController < Api::Internal::Admin::BaseContro
 
       render json: {
         success: true,
-        message: "Payouts resumed for #{@user.email}",
+        user_id: @user.external_id,
+        message: "Payouts resumed for #{@user.external_id}",
         payouts_paused: @user.reload.payouts_paused?
       }
     end
@@ -115,7 +121,7 @@ class Api::Internal::Admin::PayoutsController < Api::Internal::Admin::BaseContro
           message: payment&.errors&.full_messages&.first || "Payment was not sent."
         }, status: :unprocessable_entity
       else
-        render json: { success: true, payout: serialize_payout(payment) }
+        render json: { success: true, user_id: @user.external_id, payout: serialize_payout(payment) }
       end
     end
   end
@@ -176,11 +182,12 @@ class Api::Internal::Admin::PayoutsController < Api::Internal::Admin::BaseContro
   end
 
   private
-    def fetch_user
-      return render json: { success: false, message: "email is required" }, status: :bad_request if params[:email].blank?
+    def fetch_user_for_read
+      @user = find_internal_admin_user_for_read_or_render
+    end
 
-      @user = User.alive.by_email(params[:email]).first
-      render json: { success: false, message: "User not found" }, status: :not_found if @user.blank?
+    def fetch_user_for_write
+      @user = find_internal_admin_user_for_write_or_render
     end
 
     def fetch_scheduled_payout

--- a/app/controllers/api/internal/admin/users_controller.rb
+++ b/app/controllers/api/internal/admin/users_controller.rb
@@ -1,61 +1,44 @@
 # frozen_string_literal: true
 
 class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseController
-  USER_LOOKUP_BAD_REQUEST_MESSAGE = "email or external_id is required"
-
   def info
-    return unless require_user_lookup_params!
-
-    user = find_user_or_render(include_deleted: true)
+    user = find_internal_admin_user_for_read_or_render(include_deleted: true)
     return unless user
 
-    render json: { success: true, user: serialize_user_info(user) }
+    render json: internal_admin_user_success_payload(user, user: serialize_user_info(user))
   end
 
   def suspension
-    return unless require_user_lookup_params!
-
-    user = find_user_or_render
+    user = find_internal_admin_user_for_read_or_render
     return unless user
 
-    render json: {
-      success: true,
-      status: suspension_status(user),
-      updated_at: last_status_changed_at(user)&.as_json,
-      appeal_url: nil
-    }
+    render json: internal_admin_user_success_payload(user, {
+                                                       status: suspension_status(user),
+                                                       updated_at: last_status_changed_at(user)&.as_json,
+                                                       appeal_url: nil
+                                                     })
   end
 
   def reset_password
-    return unless require_user_lookup_params!
-    if params[:external_id].blank? && params[:email].present? && !EmailFormatValidator.valid?(params[:email])
-      return render json: { success: false, message: "Invalid email format" }, status: :bad_request
-    end
-
-    user = find_user_or_render
+    user = find_internal_admin_user_for_write_or_render
     return unless user
 
     record_admin_write(action: "users.reset_password", target: user) do
       user.send_reset_password_instructions
-      render json: { success: true, message: "Reset password instructions sent" }
+      render json: internal_admin_user_success_payload(user, message: "Reset password instructions sent")
     end
   end
 
   def update_email
-    if (params[:current_email].blank? && params[:external_id].blank?) || params[:new_email].blank?
-      return render json: { success: false, message: "current_email (or external_id) and new_email are required" }, status: :bad_request
-    end
+    return render_internal_admin_user_id_required if params[:user_id].blank?
+    return render json: { success: false, message: "new_email is required" }, status: :bad_request if params[:new_email].blank?
 
     unless EmailFormatValidator.valid?(params[:new_email])
       return render json: { success: false, message: "Invalid new email format" }, status: :bad_request
     end
 
-    user = if params[:external_id].present?
-      User.alive.find_by(external_id: params[:external_id])
-    else
-      User.alive.by_email(params[:current_email]).first
-    end
-    return render json: { success: false, message: "User not found" }, status: :not_found if user.blank?
+    user = find_internal_admin_user_for_write_or_render
+    return unless user
 
     record_admin_write(action: "users.update_email", target: user) do
       if user.email.to_s.casecmp(params[:new_email].to_s).zero?
@@ -68,28 +51,25 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
       end
 
       if user.unconfirmed_email.present?
-        render json: {
-          success: true,
-          message: "Email change pending confirmation. Confirmation email sent to #{user.unconfirmed_email}.",
-          unconfirmed_email: user.unconfirmed_email,
-          pending_confirmation: true
-        }
+        render json: internal_admin_user_success_payload(user, {
+                                                           message: "Email change pending confirmation. Confirmation email sent to #{user.unconfirmed_email}.",
+                                                           unconfirmed_email: user.unconfirmed_email,
+                                                           pending_confirmation: true
+                                                         })
       else
-        render json: {
-          success: true,
-          message: "Email updated.",
-          email: user.email,
-          pending_confirmation: false
-        }
+        render json: internal_admin_user_success_payload(user, {
+                                                           message: "Email updated.",
+                                                           email: user.email,
+                                                           pending_confirmation: false
+                                                         })
       end
     end
   end
 
   def two_factor_authentication
-    return unless require_user_lookup_params!
     return render json: { success: false, message: "enabled is required" }, status: :bad_request if params[:enabled].to_s.blank?
 
-    user = find_user_or_render
+    user = find_internal_admin_user_for_write_or_render
     return unless user
 
     record_admin_write(action: "users.two_factor_authentication", target: user) do
@@ -98,11 +78,10 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
 
       if user.save
         user.totp_credential&.destroy unless user.two_factor_authentication_enabled?
-        render json: {
-          success: true,
-          message: "Two-factor authentication #{enabled ? "enabled" : "disabled"}",
-          two_factor_authentication_enabled: user.two_factor_authentication_enabled?
-        }
+        render json: internal_admin_user_success_payload(user, {
+                                                           message: "Two-factor authentication #{enabled ? "enabled" : "disabled"}",
+                                                           two_factor_authentication_enabled: user.two_factor_authentication_enabled?
+                                                         })
       else
         render json: { success: false, message: user.errors.full_messages.to_sentence }, status: :unprocessable_entity
       end
@@ -110,18 +89,17 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
   end
 
   def create_comment
-    return unless require_user_lookup_params!
     return render json: { success: false, message: "content is required" }, status: :bad_request if params[:content].blank?
     return render json: { success: false, message: "idempotency_key is required" }, status: :bad_request if params[:idempotency_key].blank?
 
-    user = find_user_or_render
+    user = find_internal_admin_user_for_write_or_render
     return unless user
 
     record_admin_write(action: "users.create_comment", target: user) do
       comment = User::CreateAdminCommentService.new(user:, content: params[:content], idempotency_key: params[:idempotency_key], author_id: current_admin_actor_id).perform
 
       if comment.persisted?
-        render json: { success: true, comment: serialize_comment(comment) }
+        render json: internal_admin_user_success_payload(user, comment: serialize_comment(comment))
       else
         render json: { success: false, message: comment.errors.full_messages.to_sentence }, status: :unprocessable_entity
       end
@@ -131,14 +109,12 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
   end
 
   def mark_compliant
-    return unless require_user_lookup_params!
-
-    user = find_user_or_render
+    user = find_internal_admin_user_for_write_or_render
     return unless user
 
     record_admin_write(action: "users.mark_compliant", target: user) do
       if user.compliant?
-        return render json: { success: true, status: "already_compliant", message: "User is already compliant" }
+        return render json: internal_admin_user_success_payload(user, status: "already_compliant", message: "User is already compliant")
       end
 
       note = build_admin_note(user, params[:note]) if params[:note].present?
@@ -146,21 +122,19 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
 
       user.mark_compliant!(author_id: current_admin_actor_id)
       note&.save!
-      render json: { success: true, status: "marked_compliant", message: "User marked compliant" }
+      render json: internal_admin_user_success_payload(user, status: "marked_compliant", message: "User marked compliant")
     rescue StateMachines::InvalidTransition => e
       render json: { success: false, message: e.message }, status: :unprocessable_entity
     end
   end
 
   def suspend_for_fraud
-    return unless require_user_lookup_params!
-
-    user = find_user_or_render
+    user = find_internal_admin_user_for_write_or_render
     return unless user
 
     record_admin_write(action: "users.suspend_for_fraud", target: user) do
       if user.suspended_for_fraud?
-        return render json: { success: true, status: "already_suspended", message: "User is already suspended for fraud" }
+        return render json: internal_admin_user_success_payload(user, status: "already_suspended", message: "User is already suspended for fraud")
       end
 
       suspension_note = build_suspension_note(user) if params[:suspension_note].present?
@@ -168,17 +142,16 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
 
       user.suspend_for_fraud!(author_id: current_admin_actor_id)
       suspension_note&.save!
-      render json: { success: true, status: "suspended_for_fraud", message: "User suspended for fraud" }
+      render json: internal_admin_user_success_payload(user, status: "suspended_for_fraud", message: "User suspended for fraud")
     rescue StateMachines::InvalidTransition => e
       render json: { success: false, message: e.message }, status: :unprocessable_entity
     end
   end
 
   def watch
-    return unless require_user_lookup_params!
     return render json: { success: false, message: "revenue_threshold is required" }, status: :bad_request if params[:revenue_threshold].blank?
 
-    user = find_user_or_render
+    user = find_internal_admin_user_for_write_or_render
     return unless user
 
     record_admin_write(action: "users.watch", target: user) do
@@ -196,21 +169,19 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
       )
       watched_user.sync!
 
-      render json: {
-        success: true,
-        message: "User added to watchlist",
-        watched_user: serialize_watched_user(watched_user)
-      }
+      render json: internal_admin_user_success_payload(user, {
+                                                         message: "User added to watchlist",
+                                                         watched_user: serialize_watched_user(watched_user)
+                                                       })
     rescue ActiveRecord::RecordInvalid => e
       render json: { success: false, message: e.record.errors.full_messages.first }, status: :unprocessable_entity
     end
   end
 
   def update_watch
-    return unless require_user_lookup_params!
     return render json: { success: false, message: "revenue_threshold is required" }, status: :bad_request if params[:revenue_threshold].blank?
 
-    user = find_user_or_render
+    user = find_internal_admin_user_for_write_or_render
     return unless user
 
     record_admin_write(action: "users.update_watch", target: user) do
@@ -225,20 +196,17 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
         notes: params.key?(:notes) ? params[:notes].presence : watched_user.notes
       )
 
-      render json: {
-        success: true,
-        message: "Watchlist updated",
-        watched_user: serialize_watched_user(watched_user)
-      }
+      render json: internal_admin_user_success_payload(user, {
+                                                         message: "Watchlist updated",
+                                                         watched_user: serialize_watched_user(watched_user)
+                                                       })
     rescue ActiveRecord::RecordInvalid => e
       render json: { success: false, message: e.record.errors.full_messages.first }, status: :unprocessable_entity
     end
   end
 
   def unwatch
-    return unless require_user_lookup_params!
-
-    user = find_user_or_render
+    user = find_internal_admin_user_for_write_or_render
     return unless user
 
     record_admin_write(action: "users.unwatch", target: user) do
@@ -246,31 +214,11 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
       return render json: { success: false, message: "User is not currently being watched" }, status: :unprocessable_entity if watched_user.nil?
 
       watched_user.mark_deleted!
-      render json: { success: true, message: "User removed from watchlist" }
+      render json: internal_admin_user_success_payload(user, message: "User removed from watchlist")
     end
   end
 
   private
-    def require_user_lookup_params!
-      return true if params[:email].present? || params[:external_id].present?
-
-      render json: { success: false, message: USER_LOOKUP_BAD_REQUEST_MESSAGE }, status: :bad_request
-      false
-    end
-
-    def find_user_or_render(include_deleted: false)
-      scope = include_deleted ? User : User.alive
-      user = if params[:external_id].present?
-        scope.find_by(external_id: params[:external_id])
-      else
-        scope.by_email(params[:email]).first
-      end
-      return user if user.present?
-
-      render json: { success: false, message: "User not found" }, status: :not_found
-      nil
-    end
-
     def suspension_status(user)
       if user.suspended?
         "Suspended"

--- a/spec/controllers/api/internal/admin/payouts_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/payouts_controller_spec.rb
@@ -5,6 +5,25 @@ require "shared_examples/authorized_admin_api_method"
 
 describe Api::Internal::Admin::PayoutsController do
   let(:user) { create(:compliant_user) }
+  let(:user_id_required_message) { "user_id is required for mutating admin actions. Use /internal/admin/users/info to look up the user_id by email." }
+
+  shared_examples "requires user_id for payout mutation" do |action, extra_params: {}|
+    it "returns 400 when only email is provided" do
+      post action, params: extra_params.merge(email: user.email)
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: user_id_required_message }.as_json)
+    end
+  end
+
+  shared_examples "checks expected_email for payout mutation" do |action, extra_params: {}|
+    it "rejects mismatched expected_email without mutating payouts" do
+      post action, params: extra_params.merge(user_id: user.external_id, expected_email: "other@example.com")
+
+      expect(response).to have_http_status(:conflict)
+      expect(response.parsed_body).to eq({ success: false, message: "expected_email does not match the user's current email" }.as_json)
+    end
+  end
 
   before do
     stub_const("GUMROAD_ADMIN_ID", create(:admin_user).id)
@@ -30,6 +49,7 @@ describe Api::Internal::Admin::PayoutsController do
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["success"]).to be(true)
+      expect(response.parsed_body["user_id"]).to eq(user.external_id)
       expect(response.parsed_body["next_payout_date"]).to eq(Date.tomorrow.to_s)
       expect(response.parsed_body["balance_for_next_payout"]).to eq("$100.00")
       expect(response.parsed_body["payout_note"]).to eq(payout_note)
@@ -54,11 +74,11 @@ describe Api::Internal::Admin::PayoutsController do
       expect(payouts.map { _1["external_id"] }).not_to include(payment6.external_id)
     end
 
-    it "returns a bad request when email is missing" do
+    it "returns a bad request when email and user_id are missing" do
       post :list
 
       expect(response).to have_http_status(:bad_request)
-      expect(response.parsed_body).to eq({ success: false, message: "email is required" }.as_json)
+      expect(response.parsed_body).to eq({ success: false, message: "email or user_id is required" }.as_json)
     end
 
     it "returns not found when the user does not exist" do
@@ -67,32 +87,40 @@ describe Api::Internal::Admin::PayoutsController do
       expect(response).to have_http_status(:not_found)
       expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
     end
+
+    it "lists payouts by user_id" do
+      post :list, params: { user_id: user.external_id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["user_id"]).to eq(user.external_id)
+    end
   end
 
   describe "POST pause" do
     include_examples "admin api authorization required", :post, :pause
 
-    it "returns 400 when email is missing" do
+    it "returns 400 when user_id is missing" do
       post :pause
 
       expect(response).to have_http_status(:bad_request)
-      expect(response.parsed_body).to eq({ success: false, message: "email is required" }.as_json)
+      expect(response.parsed_body).to eq({ success: false, message: user_id_required_message }.as_json)
     end
 
     it "returns 404 when the user does not exist" do
-      post :pause, params: { email: "missing@example.com" }
+      post :pause, params: { user_id: "missing" }
 
       expect(response).to have_http_status(:not_found)
       expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
     end
 
     it "pauses payouts and records the admin as the pause source" do
-      expect { post :pause, params: { email: user.email } }.to change { user.reload.payouts_paused_internally? }.from(false).to(true)
+      expect { post :pause, params: { user_id: user.external_id } }.to change { user.reload.payouts_paused_internally? }.from(false).to(true)
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(
         "success" => true,
-        "message" => "Payouts paused for #{user.email}",
+        "user_id" => user.external_id,
+        "message" => "Payouts paused for #{user.external_id}",
         "payouts_paused" => true
       )
       expect(user.reload.payouts_paused_by.to_s).to eq(GUMROAD_ADMIN_ID.to_s)
@@ -101,7 +129,7 @@ describe Api::Internal::Admin::PayoutsController do
     it "creates a COMMENT_TYPE_PAYOUTS_PAUSED comment when reason is provided" do
       reason = "Payouts paused due to verification"
 
-      expect { post :pause, params: { email: user.email, reason: reason } }
+      expect { post :pause, params: { user_id: user.external_id, reason: reason } }
         .to change { user.comments.with_type_payouts_paused.count }.by(1)
 
       comment = user.comments.with_type_payouts_paused.last
@@ -113,7 +141,7 @@ describe Api::Internal::Admin::PayoutsController do
       legacy_admin_token = AdminApiToken.find_by!(token_hash: AdminApiToken.hash_token("test-admin-token"))
 
       expect do
-        post :pause, params: { email: user.email, reason: "Manual review" }
+        post :pause, params: { user_id: user.external_id, expected_email: user.email, reason: "Manual review" }
       end.to change { AdminApiAuditLog.count }.by(1)
 
       audit_log = AdminApiAuditLog.last
@@ -127,7 +155,8 @@ describe Api::Internal::Admin::PayoutsController do
         response_status: 200
       )
       expect(audit_log.params_snapshot).to include(
-        "email" => "[REDACTED]",
+        "user_id" => user.external_id,
+        "expected_email" => "[REDACTED]",
         "reason" => "Manual review"
       )
     end
@@ -138,7 +167,7 @@ describe Api::Internal::Admin::PayoutsController do
       admin_api_token = AdminApiToken.find_by!(actor_user: actor, token_hash: AdminApiToken.hash_token(plaintext_token))
       request.headers["Authorization"] = "Bearer #{plaintext_token}"
 
-      post :pause, params: { email: user.email, reason: "Actor review" }
+      post :pause, params: { user_id: user.external_id, reason: "Actor review" }
 
       expect(response).to have_http_status(:ok)
       expect(user.comments.with_type_payouts_paused.last).to have_attributes(
@@ -154,7 +183,7 @@ describe Api::Internal::Admin::PayoutsController do
     end
 
     it "does not create a comment when reason is blank" do
-      expect { post :pause, params: { email: user.email, reason: "   " } }
+      expect { post :pause, params: { user_id: user.external_id, reason: "   " } }
         .not_to change { user.comments.count }
 
       expect(response).to have_http_status(:ok)
@@ -164,12 +193,13 @@ describe Api::Internal::Admin::PayoutsController do
     it "short-circuits when payouts are already paused by admin" do
       user.update!(payouts_paused_internally: true, payouts_paused_by: GUMROAD_ADMIN_ID)
 
-      expect { post :pause, params: { email: user.email, reason: "again" } }
+      expect { post :pause, params: { user_id: user.external_id, reason: "again" } }
         .not_to change { user.comments.count }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(
         "success" => true,
+        "user_id" => user.external_id,
         "status" => "already_paused",
         "message" => "Payouts are already paused by admin",
         "payouts_paused" => true
@@ -180,7 +210,7 @@ describe Api::Internal::Admin::PayoutsController do
       user.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_SYSTEM)
       reason = "Manual review pending"
 
-      expect { post :pause, params: { email: user.email, reason: reason } }
+      expect { post :pause, params: { user_id: user.external_id, reason: reason } }
         .to change { user.comments.with_type_payouts_paused.count }.by(1)
 
       expect(response).to have_http_status(:ok)
@@ -193,25 +223,28 @@ describe Api::Internal::Admin::PayoutsController do
     it "asserts admin attribution when payouts were previously paused by Stripe" do
       user.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_STRIPE)
 
-      post :pause, params: { email: user.email, reason: "Stripe escalation" }
+      post :pause, params: { user_id: user.external_id, reason: "Stripe escalation" }
 
       expect(response).to have_http_status(:ok)
       expect(user.reload.payouts_paused_by_source).to eq(User::PAYOUT_PAUSE_SOURCE_ADMIN)
     end
+
+    include_examples "requires user_id for payout mutation", :pause
+    include_examples "checks expected_email for payout mutation", :pause
   end
 
   describe "POST resume" do
     include_examples "admin api authorization required", :post, :resume
 
-    it "returns 400 when email is missing" do
+    it "returns 400 when user_id is missing" do
       post :resume
 
       expect(response).to have_http_status(:bad_request)
-      expect(response.parsed_body).to eq({ success: false, message: "email is required" }.as_json)
+      expect(response.parsed_body).to eq({ success: false, message: user_id_required_message }.as_json)
     end
 
     it "returns 404 when the user does not exist" do
-      post :resume, params: { email: "missing@example.com" }
+      post :resume, params: { user_id: "missing" }
 
       expect(response).to have_http_status(:not_found)
     end
@@ -219,14 +252,15 @@ describe Api::Internal::Admin::PayoutsController do
     it "resumes payouts, clears payouts_paused_by, and records a resume comment" do
       user.update!(payouts_paused_internally: true, payouts_paused_by: GUMROAD_ADMIN_ID)
 
-      expect { post :resume, params: { email: user.email } }
+      expect { post :resume, params: { user_id: user.external_id } }
         .to change { user.reload.payouts_paused_internally? }.from(true).to(false)
         .and change { user.comments.with_type_payouts_resumed.count }.by(1)
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(
         "success" => true,
-        "message" => "Payouts resumed for #{user.email}",
+        "user_id" => user.external_id,
+        "message" => "Payouts resumed for #{user.external_id}",
         "payouts_paused" => false
       )
       expect(user.reload.payouts_paused_by).to be_nil
@@ -239,7 +273,7 @@ describe Api::Internal::Admin::PayoutsController do
     it "reports payouts_paused: true after admin resume when the seller is still self-paused" do
       user.update!(payouts_paused_internally: true, payouts_paused_by: GUMROAD_ADMIN_ID, payouts_paused_by_user: true)
 
-      post :resume, params: { email: user.email }
+      post :resume, params: { user_id: user.external_id }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["success"]).to be(true)
@@ -249,12 +283,13 @@ describe Api::Internal::Admin::PayoutsController do
     end
 
     it "short-circuits when payouts are not paused by admin" do
-      expect { post :resume, params: { email: user.email } }
+      expect { post :resume, params: { user_id: user.external_id } }
         .not_to change { user.comments.count }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(
         "success" => true,
+        "user_id" => user.external_id,
         "status" => "not_paused",
         "message" => "Payouts are not paused by admin",
         "payouts_paused" => false
@@ -264,48 +299,53 @@ describe Api::Internal::Admin::PayoutsController do
     it "reports payouts_paused: true on short-circuit when the seller has self-paused" do
       user.update!(payouts_paused_by_user: true)
 
-      post :resume, params: { email: user.email }
+      post :resume, params: { user_id: user.external_id }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(
         "success" => true,
+        "user_id" => user.external_id,
         "status" => "not_paused",
         "payouts_paused" => true
       )
     end
+
+    include_examples "requires user_id for payout mutation", :resume
+    include_examples "checks expected_email for payout mutation", :resume
   end
 
   describe "POST issue" do
     include_examples "admin api authorization required", :post, :issue
 
-    it "returns 400 when email is missing" do
+    it "returns 400 when user_id is missing" do
       post :issue, params: { payout_processor: "stripe", payout_period_end_date: 1.day.ago.to_date.to_s }
 
       expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: user_id_required_message }.as_json)
     end
 
     it "returns 404 when the user does not exist" do
-      post :issue, params: { email: "missing@example.com", payout_processor: "stripe", payout_period_end_date: 1.day.ago.to_date.to_s }
+      post :issue, params: { user_id: "missing", payout_processor: "stripe", payout_period_end_date: 1.day.ago.to_date.to_s }
 
       expect(response).to have_http_status(:not_found)
     end
 
     it "returns 400 when payout_processor is invalid" do
-      post :issue, params: { email: user.email, payout_processor: "ach", payout_period_end_date: 1.day.ago.to_date.to_s }
+      post :issue, params: { user_id: user.external_id, payout_processor: "ach", payout_period_end_date: 1.day.ago.to_date.to_s }
 
       expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body["message"]).to eq("payout_processor must be stripe or paypal")
     end
 
     it "returns 400 when payout_period_end_date is missing" do
-      post :issue, params: { email: user.email, payout_processor: "stripe" }
+      post :issue, params: { user_id: user.external_id, payout_processor: "stripe" }
 
       expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body["message"]).to eq("payout_period_end_date is required")
     end
 
     it "returns 400 when payout_period_end_date is invalid" do
-      post :issue, params: { email: user.email, payout_processor: "stripe", payout_period_end_date: "not-a-date" }
+      post :issue, params: { user_id: user.external_id, payout_processor: "stripe", payout_period_end_date: "not-a-date" }
 
       expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body["message"]).to eq("payout_period_end_date is invalid")
@@ -314,7 +354,7 @@ describe Api::Internal::Admin::PayoutsController do
     it "returns 400 without writing an audit row when payout_period_end_date is today or in the future" do
       [Date.current, Date.current + 1].each do |date|
         expect do
-          post :issue, params: { email: user.email, payout_processor: "stripe", payout_period_end_date: date.to_s }
+          post :issue, params: { user_id: user.external_id, payout_processor: "stripe", payout_period_end_date: date.to_s }
         end.not_to change { AdminApiAuditLog.count }
 
         expect(response).to have_http_status(:bad_request)
@@ -330,11 +370,12 @@ describe Api::Internal::Admin::PayoutsController do
         date, PayoutProcessorType::STRIPE, [user], from_admin: true
       ).and_return([[payment]])
 
-      post :issue, params: { email: user.email, payout_processor: "stripe", payout_period_end_date: date.to_s }
+      post :issue, params: { user_id: user.external_id, payout_processor: "stripe", payout_period_end_date: date.to_s }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(
         "success" => true,
+        "user_id" => user.external_id,
         "payout" => hash_including("external_id" => payment.external_id, "state" => "completed")
       )
     end
@@ -346,7 +387,7 @@ describe Api::Internal::Admin::PayoutsController do
       allow(Payouts).to receive(:create_payments_for_balances_up_to_date_for_users).and_return([[payment]])
 
       expect do
-        post :issue, params: { email: user.email, payout_processor: "paypal", payout_period_end_date: date.to_s, should_split_the_amount: "true" }
+        post :issue, params: { user_id: user.external_id, payout_processor: "paypal", payout_period_end_date: date.to_s, should_split_the_amount: "true" }
       end.to change { user.reload.should_paypal_payout_be_split? }.from(false).to(true)
 
       expect(response).to have_http_status(:ok)
@@ -356,7 +397,7 @@ describe Api::Internal::Admin::PayoutsController do
       date = 1.day.ago.to_date
       allow(Payouts).to receive(:create_payments_for_balances_up_to_date_for_users).and_return([])
 
-      post :issue, params: { email: user.email, payout_processor: "stripe", payout_period_end_date: date.to_s }
+      post :issue, params: { user_id: user.external_id, payout_processor: "stripe", payout_period_end_date: date.to_s }
 
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response.parsed_body).to include("success" => false, "message" => "Payment was not sent.")
@@ -368,7 +409,7 @@ describe Api::Internal::Admin::PayoutsController do
       date = 1.day.ago.to_date
       allow(Payouts).to receive(:create_payments_for_balances_up_to_date_for_users).and_return([[failed_payment]])
 
-      post :issue, params: { email: user.email, payout_processor: "stripe", payout_period_end_date: date.to_s }
+      post :issue, params: { user_id: user.external_id, payout_processor: "stripe", payout_period_end_date: date.to_s }
 
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response.parsed_body["message"]).to eq("Insufficient funds")
@@ -380,7 +421,7 @@ describe Api::Internal::Admin::PayoutsController do
       allow(Payouts).to receive(:create_payments_for_balances_up_to_date_for_users).and_return([[payment]])
 
       expect do
-        post :issue, params: { email: user.email, payout_processor: "stripe", payout_period_end_date: date.to_s }
+        post :issue, params: { user_id: user.external_id, payout_processor: "stripe", payout_period_end_date: date.to_s }
       end.to change { AdminApiAuditLog.count }.by(1)
 
       expect(AdminApiAuditLog.last).to have_attributes(
@@ -390,6 +431,9 @@ describe Api::Internal::Admin::PayoutsController do
         response_status: 200
       )
     end
+
+    include_examples "requires user_id for payout mutation", :issue, extra_params: { payout_processor: "stripe", payout_period_end_date: 1.day.ago.to_date.to_s }
+    include_examples "checks expected_email for payout mutation", :issue, extra_params: { payout_processor: "stripe", payout_period_end_date: 1.day.ago.to_date.to_s }
   end
 
   describe "POST scheduled_list" do

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -5,27 +5,50 @@ require "shared_examples/authorized_admin_api_method"
 
 describe Api::Internal::Admin::UsersController do
   let(:admin_user) { create(:admin_user) }
+  let(:user_id_required_message) { "user_id is required for mutating admin actions. Use /internal/admin/users/info to look up the user_id by email." }
 
-  shared_examples "supports user lookup by external_id" do |action, build_user: -> { create(:user) }, extra_params: {}, success_status: :ok|
-    describe "external_id lookup" do
-      it "looks up the user by external_id" do
+  shared_examples "supports user lookup by user_id" do |action, build_user: -> { create(:user) }, extra_params: {}, success_status: :ok|
+    describe "user_id lookup" do
+      it "looks up the user by user_id" do
         user = instance_exec(&build_user)
-        post action, params: extra_params.merge(external_id: user.external_id)
+        post action, params: extra_params.merge(user_id: user.external_id)
         expect(response).to have_http_status(success_status)
       end
 
-      it "returns 404 when external_id does not match any user" do
-        post action, params: extra_params.merge(external_id: "999999999999")
+      it "returns 404 when user_id does not match any user" do
+        post action, params: extra_params.merge(user_id: "999999999999")
         expect(response).to have_http_status(:not_found)
         expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
       end
 
-      it "prefers external_id over email when both are provided" do
+      it "prefers user_id over email when both are provided" do
         target = instance_exec(&build_user)
         other = instance_exec(&build_user)
-        post action, params: extra_params.merge(external_id: target.external_id, email: other.email)
+        post action, params: extra_params.merge(user_id: target.external_id, email: other.email)
         expect(response).to have_http_status(success_status)
       end
+    end
+  end
+
+  shared_examples "requires user_id for user mutation" do |action, extra_params: {}|
+    it "returns 400 when only email is provided" do
+      user = create(:user)
+
+      post action, params: extra_params.merge(email: user.email)
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: user_id_required_message }.as_json)
+    end
+  end
+
+  shared_examples "checks expected_email for user mutation" do |action, build_user: -> { create(:user) }, extra_params: {}|
+    it "rejects mismatched expected_email without mutating the user" do
+      user = instance_exec(&build_user)
+
+      post action, params: extra_params.merge(user_id: user.external_id, expected_email: "other@example.com")
+
+      expect(response).to have_http_status(:conflict)
+      expect(response.parsed_body).to eq({ success: false, message: "expected_email does not match the user's current email" }.as_json)
     end
   end
 
@@ -38,7 +61,7 @@ describe Api::Internal::Admin::UsersController do
       post :info
 
       expect(response).to have_http_status(:bad_request)
-      expect(response.parsed_body).to eq({ success: false, message: "email or external_id is required" }.as_json)
+      expect(response.parsed_body).to eq({ success: false, message: "email or user_id is required" }.as_json)
     end
 
     it "returns not found when the user does not exist" do
@@ -55,6 +78,7 @@ describe Api::Internal::Admin::UsersController do
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["success"]).to be(true)
+      expect(response.parsed_body["user_id"]).to eq(user.external_id)
 
       info = response.parsed_body["user"]
       expect(info).to include(
@@ -179,11 +203,11 @@ describe Api::Internal::Admin::UsersController do
       expect(info["deleted_at"]).to eq(user.reload.deleted_at.as_json)
     end
 
-    it "looks up a soft-deleted user by external_id" do
+    it "looks up a soft-deleted user by user_id" do
       user = create(:compliant_user, email: "deleted-by-id@example.com")
       user.mark_deleted!
 
-      post :info, params: { external_id: user.external_id }
+      post :info, params: { user_id: user.external_id }
 
       expect(response).to have_http_status(:ok)
       info = response.parsed_body["user"]
@@ -191,7 +215,7 @@ describe Api::Internal::Admin::UsersController do
       expect(info["deleted_at"]).to eq(user.reload.deleted_at.as_json)
     end
 
-    include_examples "supports user lookup by external_id", :info, build_user: -> { create(:compliant_user) }
+    include_examples "supports user lookup by user_id", :info, build_user: -> { create(:compliant_user) }
 
     it "uses the latest risk-state comment for last_status_changed_at, including on_probation transitions" do
       user = create(:compliant_user, email: "probation@example.com")
@@ -258,6 +282,7 @@ describe Api::Internal::Admin::UsersController do
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to eq({
         success: true,
+        user_id: user.external_id,
         status: "Compliant",
         updated_at: nil,
         appeal_url: nil
@@ -273,6 +298,7 @@ describe Api::Internal::Admin::UsersController do
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to eq({
         success: true,
+        user_id: user.external_id,
         status: "Suspended",
         updated_at: comment.created_at.as_json,
         appeal_url: nil
@@ -283,7 +309,7 @@ describe Api::Internal::Admin::UsersController do
       post :suspension
 
       expect(response).to have_http_status(:bad_request)
-      expect(response.parsed_body).to eq({ success: false, message: "email or external_id is required" }.as_json)
+      expect(response.parsed_body).to eq({ success: false, message: "email or user_id is required" }.as_json)
     end
 
     it "returns not found when the user does not exist" do
@@ -293,17 +319,17 @@ describe Api::Internal::Admin::UsersController do
       expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
     end
 
-    it "returns not found when external_id matches a soft-deleted user" do
+    it "returns not found when user_id matches a soft-deleted user" do
       user = create(:compliant_user)
       user.mark_deleted!
 
-      post :suspension, params: { external_id: user.external_id }
+      post :suspension, params: { user_id: user.external_id }
 
       expect(response).to have_http_status(:not_found)
       expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
     end
 
-    include_examples "supports user lookup by external_id", :suspension, build_user: -> { create(:compliant_user) }
+    include_examples "supports user lookup by user_id", :suspension, build_user: -> { create(:compliant_user) }
   end
 
   describe "POST reset_password" do
@@ -311,22 +337,17 @@ describe Api::Internal::Admin::UsersController do
 
     include_examples "admin api authorization required", :post, :reset_password
 
-    it "returns 400 when email is missing" do
+    it "returns 400 when user_id is missing" do
       post :reset_password
 
       expect(response).to have_http_status(:bad_request)
-      expect(response.parsed_body).to eq({ success: false, message: "email or external_id is required" }.as_json)
+      expect(response.parsed_body).to eq({ success: false, message: user_id_required_message }.as_json)
     end
 
-    it "returns 400 when email is malformed" do
-      post :reset_password, params: { email: "not-an-email" }
-
-      expect(response).to have_http_status(:bad_request)
-      expect(response.parsed_body).to eq({ success: false, message: "Invalid email format" }.as_json)
-    end
+    include_examples "requires user_id for user mutation", :reset_password
 
     it "returns 404 when the user does not exist" do
-      post :reset_password, params: { email: "nobody@example.com" }
+      post :reset_password, params: { user_id: "missing" }
 
       expect(response).to have_http_status(:not_found)
       expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
@@ -335,34 +356,17 @@ describe Api::Internal::Admin::UsersController do
     it "sends reset password instructions and returns success" do
       expect_any_instance_of(User).to receive(:send_reset_password_instructions)
 
-      post :reset_password, params: { email: user.email }
+      post :reset_password, params: { user_id: user.external_id }
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to eq({ success: true, message: "Reset password instructions sent" }.as_json)
-    end
-
-    it "skips the email-format check when only external_id is provided" do
-      expect_any_instance_of(User).to receive(:send_reset_password_instructions)
-
-      post :reset_password, params: { external_id: user.external_id }
-
-      expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to eq({ success: true, message: "Reset password instructions sent" }.as_json)
-    end
-
-    it "skips the email-format check when external_id is provided alongside a malformed email" do
-      expect_any_instance_of(User).to receive(:send_reset_password_instructions)
-
-      post :reset_password, params: { external_id: user.external_id, email: "garbage" }
-
-      expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to eq({ success: true, message: "Reset password instructions sent" }.as_json)
+      expect(response.parsed_body).to eq({ success: true, user_id: user.external_id, message: "Reset password instructions sent" }.as_json)
     end
 
     context "with a user lookup helper stubbed" do
       before { allow_any_instance_of(User).to receive(:send_reset_password_instructions) }
 
-      include_examples "supports user lookup by external_id", :reset_password
+      include_examples "supports user lookup by user_id", :reset_password
+      include_examples "checks expected_email for user mutation", :reset_password
     end
   end
 
@@ -372,39 +376,40 @@ describe Api::Internal::Admin::UsersController do
 
     include_examples "admin api authorization required", :post, :update_email
 
-    it "returns 400 when current_email is missing" do
+    it "returns 400 when user_id is missing" do
       post :update_email, params: { new_email: new_email }
 
       expect(response).to have_http_status(:bad_request)
-      expect(response.parsed_body).to eq({ success: false, message: "current_email (or external_id) and new_email are required" }.as_json)
+      expect(response.parsed_body).to eq({ success: false, message: user_id_required_message }.as_json)
     end
 
     it "returns 400 when new_email is missing" do
-      post :update_email, params: { current_email: user.email }
+      post :update_email, params: { user_id: user.external_id }
 
       expect(response).to have_http_status(:bad_request)
-      expect(response.parsed_body).to eq({ success: false, message: "current_email (or external_id) and new_email are required" }.as_json)
+      expect(response.parsed_body).to eq({ success: false, message: "new_email is required" }.as_json)
     end
 
     it "returns 400 when new_email is malformed" do
-      post :update_email, params: { current_email: user.email, new_email: "not-an-email" }
+      post :update_email, params: { user_id: user.external_id, new_email: "not-an-email" }
 
       expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body).to eq({ success: false, message: "Invalid new email format" }.as_json)
     end
 
-    it "returns 404 when the current_email does not match a user" do
-      post :update_email, params: { current_email: "missing@example.com", new_email: new_email }
+    it "returns 404 when user_id does not match a user" do
+      post :update_email, params: { user_id: "missing", new_email: new_email }
 
       expect(response).to have_http_status(:not_found)
       expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
     end
 
     it "updates the email and returns the pending confirmation state" do
-      post :update_email, params: { current_email: user.email, new_email: new_email }
+      post :update_email, params: { user_id: user.external_id, new_email: new_email }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["success"]).to be(true)
+      expect(response.parsed_body["user_id"]).to eq(user.external_id)
       expect(response.parsed_body["message"]).to include("Email change pending confirmation")
       expect(response.parsed_body["unconfirmed_email"]).to eq(new_email)
       expect(response.parsed_body["pending_confirmation"]).to be(true)
@@ -414,14 +419,14 @@ describe Api::Internal::Admin::UsersController do
     it "returns 422 when the new email collides with an existing user" do
       other_user = create(:user)
 
-      post :update_email, params: { current_email: user.email, new_email: other_user.email }
+      post :update_email, params: { user_id: user.external_id, new_email: other_user.email }
 
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response.parsed_body["success"]).to be(false)
     end
 
     it "returns 422 when the new email matches the current email" do
-      post :update_email, params: { current_email: user.email, new_email: user.email }
+      post :update_email, params: { user_id: user.external_id, new_email: user.email }
 
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response.parsed_body).to eq({ success: false, message: "New email is the same as the current email" }.as_json)
@@ -429,45 +434,48 @@ describe Api::Internal::Admin::UsersController do
     end
 
     it "rejects same-email submissions case-insensitively" do
-      post :update_email, params: { current_email: user.email, new_email: user.email.upcase }
+      post :update_email, params: { user_id: user.external_id, new_email: user.email.upcase }
 
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response.parsed_body["message"]).to eq("New email is the same as the current email")
     end
 
-    it "looks up the user by external_id and updates the email" do
-      post :update_email, params: { external_id: user.external_id, new_email: new_email }
+    it "accepts expected_email when it matches the target user" do
+      post :update_email, params: { user_id: user.external_id, expected_email: user.email.upcase, new_email: new_email }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["success"]).to be(true)
       expect(user.reload.unconfirmed_email).to eq(new_email)
     end
 
-    it "returns 400 when neither current_email nor external_id is provided" do
-      post :update_email, params: { new_email: new_email }
+    it "returns 400 when only current_email is provided" do
+      post :update_email, params: { current_email: user.email, new_email: new_email }
 
       expect(response).to have_http_status(:bad_request)
-      expect(response.parsed_body).to eq({ success: false, message: "current_email (or external_id) and new_email are required" }.as_json)
+      expect(response.parsed_body).to eq({ success: false, message: user_id_required_message }.as_json)
     end
 
-    it "returns 404 when external_id matches a soft-deleted user" do
+    it "returns 404 when user_id matches a soft-deleted user" do
       user.mark_deleted!
 
-      post :update_email, params: { external_id: user.external_id, new_email: new_email }
+      post :update_email, params: { user_id: user.external_id, new_email: new_email }
 
       expect(response).to have_http_status(:not_found)
       expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
     end
 
-    it "prefers external_id over current_email when both are provided" do
+    it "uses user_id as the lookup key when current_email is also provided" do
       other_user = create(:user)
 
-      post :update_email, params: { external_id: user.external_id, current_email: other_user.email, new_email: new_email }
+      post :update_email, params: { user_id: user.external_id, current_email: other_user.email, new_email: new_email }
 
       expect(response).to have_http_status(:ok)
       expect(user.reload.unconfirmed_email).to eq(new_email)
       expect(other_user.reload.unconfirmed_email).to be_nil
     end
+
+    include_examples "requires user_id for user mutation", :update_email, extra_params: { new_email: "fresh@example.com" }
+    include_examples "checks expected_email for user mutation", :update_email, extra_params: { new_email: "fresh@example.com" }
   end
 
   describe "POST two_factor_authentication" do
@@ -475,15 +483,15 @@ describe Api::Internal::Admin::UsersController do
 
     include_examples "admin api authorization required", :post, :two_factor_authentication
 
-    it "returns 400 when email is missing" do
+    it "returns 400 when user_id is missing" do
       post :two_factor_authentication, params: { enabled: true }
 
       expect(response).to have_http_status(:bad_request)
-      expect(response.parsed_body).to eq({ success: false, message: "email or external_id is required" }.as_json)
+      expect(response.parsed_body).to eq({ success: false, message: user_id_required_message }.as_json)
     end
 
     it "returns 400 when enabled is missing" do
-      post :two_factor_authentication, params: { email: user.email }
+      post :two_factor_authentication, params: { user_id: user.external_id }
 
       expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body).to eq({ success: false, message: "enabled is required" }.as_json)
@@ -493,7 +501,7 @@ describe Api::Internal::Admin::UsersController do
       user.update!(two_factor_authentication_enabled: true)
       totp_credential = TotpCredential.create!(user: user)
 
-      post :two_factor_authentication, params: { email: user.email, enabled: "" }
+      post :two_factor_authentication, params: { user_id: user.external_id, enabled: "" }
 
       expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body).to eq({ success: false, message: "enabled is required" }.as_json)
@@ -504,14 +512,14 @@ describe Api::Internal::Admin::UsersController do
     it "treats Ruby false as a valid disable request" do
       user.update!(two_factor_authentication_enabled: true)
 
-      post :two_factor_authentication, params: { email: user.email, enabled: false }
+      post :two_factor_authentication, params: { user_id: user.external_id, enabled: false }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["two_factor_authentication_enabled"]).to be(false)
     end
 
     it "returns 404 when the user does not exist" do
-      post :two_factor_authentication, params: { email: "missing@example.com", enabled: true }
+      post :two_factor_authentication, params: { user_id: "missing", enabled: true }
 
       expect(response).to have_http_status(:not_found)
       expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
@@ -520,11 +528,12 @@ describe Api::Internal::Admin::UsersController do
     it "enables two-factor authentication" do
       user.update!(two_factor_authentication_enabled: false)
 
-      post :two_factor_authentication, params: { email: user.email, enabled: true }
+      post :two_factor_authentication, params: { user_id: user.external_id, enabled: true }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(
         "success" => true,
+        "user_id" => user.external_id,
         "message" => "Two-factor authentication enabled",
         "two_factor_authentication_enabled" => true
       )
@@ -535,11 +544,12 @@ describe Api::Internal::Admin::UsersController do
       user.update!(two_factor_authentication_enabled: true)
       totp_credential = TotpCredential.create!(user: user)
 
-      post :two_factor_authentication, params: { email: user.email, enabled: false }
+      post :two_factor_authentication, params: { user_id: user.external_id, enabled: false }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(
         "success" => true,
+        "user_id" => user.external_id,
         "message" => "Two-factor authentication disabled",
         "two_factor_authentication_enabled" => false
       )
@@ -547,7 +557,9 @@ describe Api::Internal::Admin::UsersController do
       expect(TotpCredential.where(id: totp_credential.id)).to be_empty
     end
 
-    include_examples "supports user lookup by external_id", :two_factor_authentication, extra_params: { enabled: true }
+    include_examples "requires user_id for user mutation", :two_factor_authentication, extra_params: { enabled: true }
+    include_examples "supports user lookup by user_id", :two_factor_authentication, extra_params: { enabled: true }
+    include_examples "checks expected_email for user mutation", :two_factor_authentication, extra_params: { enabled: true }
   end
 
   describe "POST create_comment" do
@@ -562,25 +574,25 @@ describe Api::Internal::Admin::UsersController do
       post :create_comment, params: { content: "hi", idempotency_key: idempotency_key }
 
       expect(response).to have_http_status(:bad_request)
-      expect(response.parsed_body).to eq({ success: false, message: "email or external_id is required" }.as_json)
+      expect(response.parsed_body).to eq({ success: false, message: user_id_required_message }.as_json)
     end
 
     it "returns 400 when content is missing" do
-      post :create_comment, params: { email: user.email, idempotency_key: idempotency_key }
+      post :create_comment, params: { user_id: user.external_id, idempotency_key: idempotency_key }
 
       expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body).to eq({ success: false, message: "content is required" }.as_json)
     end
 
     it "returns 400 when idempotency_key is missing" do
-      post :create_comment, params: { email: user.email, content: "hi" }
+      post :create_comment, params: { user_id: user.external_id, content: "hi" }
 
       expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body).to eq({ success: false, message: "idempotency_key is required" }.as_json)
     end
 
     it "returns 404 when the user does not exist" do
-      post :create_comment, params: { email: "missing@example.com", content: "hi", idempotency_key: idempotency_key }
+      post :create_comment, params: { user_id: "missing", content: "hi", idempotency_key: idempotency_key }
 
       expect(response).to have_http_status(:not_found)
       expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
@@ -588,11 +600,12 @@ describe Api::Internal::Admin::UsersController do
 
     it "creates a comment attributed to GUMROAD_ADMIN_ID" do
       expect do
-        post :create_comment, params: { email: user.email, content: "An admin note", idempotency_key: idempotency_key }
+        post :create_comment, params: { user_id: user.external_id, content: "An admin note", idempotency_key: idempotency_key }
       end.to change { user.comments.count }.by(1)
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["success"]).to be(true)
+      expect(response.parsed_body["user_id"]).to eq(user.external_id)
       comment_data = response.parsed_body["comment"]
       expect(comment_data).to include("content" => "An admin note", "comment_type" => Comment::COMMENT_TYPE_NOTE)
       expect(comment_data["id"]).to be_present
@@ -605,7 +618,7 @@ describe Api::Internal::Admin::UsersController do
       admin_api_token = AdminApiToken.find_by!(actor_user: actor, token_hash: AdminApiToken.hash_token(plaintext_token))
       request.headers["Authorization"] = "Bearer #{plaintext_token}"
 
-      post :create_comment, params: { email: user.email, content: "Actor note", idempotency_key: idempotency_key }
+      post :create_comment, params: { user_id: user.external_id, content: "Actor note", idempotency_key: idempotency_key }
 
       expect(response).to have_http_status(:ok)
       expect(user.comments.last).to have_attributes(
@@ -623,11 +636,11 @@ describe Api::Internal::Admin::UsersController do
     end
 
     it "returns the existing comment when called twice with the same key and matching content" do
-      post :create_comment, params: { email: user.email, content: "Note", idempotency_key: idempotency_key }
+      post :create_comment, params: { user_id: user.external_id, content: "Note", idempotency_key: idempotency_key }
       first_id = response.parsed_body["comment"]["id"]
 
       expect do
-        post :create_comment, params: { email: user.email, content: "Note", idempotency_key: idempotency_key }
+        post :create_comment, params: { user_id: user.external_id, content: "Note", idempotency_key: idempotency_key }
       end.not_to change { user.comments.count }
 
       expect(response).to have_http_status(:ok)
@@ -635,23 +648,25 @@ describe Api::Internal::Admin::UsersController do
     end
 
     it "returns 409 conflict when the same key is reused with different content" do
-      post :create_comment, params: { email: user.email, content: "First", idempotency_key: idempotency_key }
+      post :create_comment, params: { user_id: user.external_id, content: "First", idempotency_key: idempotency_key }
       expect(response).to have_http_status(:ok)
 
-      post :create_comment, params: { email: user.email, content: "Different", idempotency_key: idempotency_key }
+      post :create_comment, params: { user_id: user.external_id, content: "Different", idempotency_key: idempotency_key }
 
       expect(response).to have_http_status(:conflict)
       expect(response.parsed_body).to eq({ success: false, message: "Idempotency key already used with different content" }.as_json)
     end
 
     it "returns 422 when the content fails validation" do
-      post :create_comment, params: { email: user.email, content: "x" * 10_001, idempotency_key: idempotency_key }
+      post :create_comment, params: { user_id: user.external_id, content: "x" * 10_001, idempotency_key: idempotency_key }
 
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response.parsed_body["success"]).to be(false)
     end
 
-    include_examples "supports user lookup by external_id", :create_comment, extra_params: { content: "via external_id", idempotency_key: SecureRandom.uuid }
+    include_examples "requires user_id for user mutation", :create_comment, extra_params: { content: "via user_id", idempotency_key: SecureRandom.uuid }
+    include_examples "supports user lookup by user_id", :create_comment, extra_params: { content: "via user_id", idempotency_key: SecureRandom.uuid }
+    include_examples "checks expected_email for user mutation", :create_comment, extra_params: { content: "via user_id", idempotency_key: SecureRandom.uuid }
   end
 
   describe "POST mark_compliant" do
@@ -663,11 +678,11 @@ describe Api::Internal::Admin::UsersController do
       post :mark_compliant
 
       expect(response).to have_http_status(:bad_request)
-      expect(response.parsed_body).to eq({ success: false, message: "email or external_id is required" }.as_json)
+      expect(response.parsed_body).to eq({ success: false, message: user_id_required_message }.as_json)
     end
 
     it "returns 404 when the user does not exist" do
-      post :mark_compliant, params: { email: "missing@example.com" }
+      post :mark_compliant, params: { user_id: "missing" }
 
       expect(response).to have_http_status(:not_found)
       expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
@@ -675,12 +690,13 @@ describe Api::Internal::Admin::UsersController do
 
     it "marks the user compliant and creates separate audit and note comments attributed to GUMROAD_ADMIN_ID" do
       expect do
-        post :mark_compliant, params: { email: user.email, note: "Cleared after review" }
+        post :mark_compliant, params: { user_id: user.external_id, note: "Cleared after review" }
       end.to change { user.comments.reload.count }.by(2)
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to eq({
         success: true,
+        user_id: user.external_id,
         status: "marked_compliant",
         message: "User marked compliant"
       }.as_json)
@@ -703,7 +719,7 @@ describe Api::Internal::Admin::UsersController do
 
     it "returns 422 without marking the user compliant when the note is invalid" do
       expect do
-        post :mark_compliant, params: { email: user.email, note: "x" * 10_001 }
+        post :mark_compliant, params: { user_id: user.external_id, note: "x" * 10_001 }
       end.not_to change { user.comments.reload.count }
 
       expect(response).to have_http_status(:unprocessable_entity)
@@ -717,7 +733,7 @@ describe Api::Internal::Admin::UsersController do
       user.update!(payment_address:)
       sibling = create(:user, user_risk_state: "suspended_for_fraud", payment_address:)
 
-      post :mark_compliant, params: { email: user.email }
+      post :mark_compliant, params: { user_id: user.external_id }
 
       expect(response).to have_http_status(:ok)
       expect(user.reload).to be_compliant
@@ -733,18 +749,21 @@ describe Api::Internal::Admin::UsersController do
       user.update!(user_risk_state: "compliant")
 
       expect do
-        post :mark_compliant, params: { email: user.email, note: "Retry" }
+        post :mark_compliant, params: { user_id: user.external_id, note: "Retry" }
       end.not_to change { user.comments.reload.count }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to eq({
         success: true,
+        user_id: user.external_id,
         status: "already_compliant",
         message: "User is already compliant"
       }.as_json)
     end
 
-    include_examples "supports user lookup by external_id", :mark_compliant, build_user: -> { create(:user, user_risk_state: "suspended_for_fraud") }
+    include_examples "requires user_id for user mutation", :mark_compliant
+    include_examples "supports user lookup by user_id", :mark_compliant, build_user: -> { create(:user, user_risk_state: "suspended_for_fraud") }
+    include_examples "checks expected_email for user mutation", :mark_compliant, build_user: -> { create(:user, user_risk_state: "suspended_for_fraud") }
   end
 
   describe "POST suspend_for_fraud" do
@@ -756,11 +775,11 @@ describe Api::Internal::Admin::UsersController do
       post :suspend_for_fraud
 
       expect(response).to have_http_status(:bad_request)
-      expect(response.parsed_body).to eq({ success: false, message: "email or external_id is required" }.as_json)
+      expect(response.parsed_body).to eq({ success: false, message: user_id_required_message }.as_json)
     end
 
     it "returns 404 when the user does not exist" do
-      post :suspend_for_fraud, params: { email: "missing@example.com" }
+      post :suspend_for_fraud, params: { user_id: "missing" }
 
       expect(response).to have_http_status(:not_found)
       expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
@@ -768,12 +787,13 @@ describe Api::Internal::Admin::UsersController do
 
     it "suspends the user for fraud and creates an audit comment attributed to GUMROAD_ADMIN_ID" do
       expect do
-        post :suspend_for_fraud, params: { email: user.email }
+        post :suspend_for_fraud, params: { user_id: user.external_id }
       end.to change { user.comments.reload.count }.by(1)
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to eq({
         success: true,
+        user_id: user.external_id,
         status: "suspended_for_fraud",
         message: "User suspended for fraud"
       }.as_json)
@@ -789,7 +809,7 @@ describe Api::Internal::Admin::UsersController do
 
     it "creates an extra suspension note when one is provided" do
       expect do
-        post :suspend_for_fraud, params: { email: user.email, suspension_note: "Chargeback risk confirmed" }
+        post :suspend_for_fraud, params: { user_id: user.external_id, suspension_note: "Chargeback risk confirmed" }
       end.to change { user.comments.reload.count }.by(2)
 
       expect(response).to have_http_status(:ok)
@@ -803,7 +823,7 @@ describe Api::Internal::Admin::UsersController do
 
     it "returns 422 without suspending the user when the suspension note is invalid" do
       expect do
-        post :suspend_for_fraud, params: { email: user.email, suspension_note: "x" * 10_001 }
+        post :suspend_for_fraud, params: { user_id: user.external_id, suspension_note: "x" * 10_001 }
       end.not_to change { user.comments.reload.count }
 
       expect(response).to have_http_status(:unprocessable_entity)
@@ -816,12 +836,13 @@ describe Api::Internal::Admin::UsersController do
       user.update!(user_risk_state: "suspended_for_fraud")
 
       expect do
-        post :suspend_for_fraud, params: { email: user.email, suspension_note: "Retry" }
+        post :suspend_for_fraud, params: { user_id: user.external_id, suspension_note: "Retry" }
       end.not_to change { user.comments.reload.count }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to eq({
         success: true,
+        user_id: user.external_id,
         status: "already_suspended",
         message: "User is already suspended for fraud"
       }.as_json)
@@ -831,7 +852,7 @@ describe Api::Internal::Admin::UsersController do
       user.update!(user_risk_state: "suspended_for_tos_violation")
 
       expect do
-        post :suspend_for_fraud, params: { email: user.email }
+        post :suspend_for_fraud, params: { user_id: user.external_id }
       end.not_to change { user.comments.reload.count }
 
       expect(response).to have_http_status(:unprocessable_entity)
@@ -842,14 +863,16 @@ describe Api::Internal::Admin::UsersController do
     it "returns 422 when the state machine rejects the suspension" do
       user.update!(verified: true)
 
-      post :suspend_for_fraud, params: { email: user.email }
+      post :suspend_for_fraud, params: { user_id: user.external_id }
 
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response.parsed_body["success"]).to be(false)
       expect(user.reload).to be_compliant
     end
 
-    include_examples "supports user lookup by external_id", :suspend_for_fraud, build_user: -> { create(:compliant_user) }
+    include_examples "requires user_id for user mutation", :suspend_for_fraud
+    include_examples "supports user lookup by user_id", :suspend_for_fraud, build_user: -> { create(:compliant_user) }
+    include_examples "checks expected_email for user mutation", :suspend_for_fraud, build_user: -> { create(:compliant_user) }
   end
 
   describe "POST watch" do
@@ -857,22 +880,22 @@ describe Api::Internal::Admin::UsersController do
 
     include_examples "admin api authorization required", :post, :watch
 
-    it "returns bad request when email is missing" do
+    it "returns bad request when user_id is missing" do
       post :watch, params: { revenue_threshold: "200" }
 
       expect(response).to have_http_status(:bad_request)
-      expect(response.parsed_body["message"]).to eq("email or external_id is required")
+      expect(response.parsed_body["message"]).to eq(user_id_required_message)
     end
 
     it "returns bad request when revenue_threshold is missing" do
-      post :watch, params: { email: user.email }
+      post :watch, params: { user_id: user.external_id }
 
       expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body["message"]).to eq("revenue_threshold is required")
     end
 
     it "returns bad request when revenue_threshold is not positive" do
-      post :watch, params: { email: user.email, revenue_threshold: "0" }
+      post :watch, params: { user_id: user.external_id, revenue_threshold: "0" }
 
       expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body["message"]).to eq("revenue_threshold must be a positive number")
@@ -880,7 +903,7 @@ describe Api::Internal::Admin::UsersController do
 
     it "returns bad request when revenue_threshold is non-finite" do
       ["Infinity", "-Infinity", "NaN"].each do |revenue_threshold|
-        post :watch, params: { email: user.email, revenue_threshold: }
+        post :watch, params: { user_id: user.external_id, revenue_threshold: }
 
         expect(response).to have_http_status(:bad_request)
         expect(response.parsed_body["message"]).to eq("revenue_threshold must be a positive number")
@@ -888,19 +911,20 @@ describe Api::Internal::Admin::UsersController do
     end
 
     it "returns not found when user does not exist" do
-      post :watch, params: { email: "missing@example.com", revenue_threshold: "200" }
+      post :watch, params: { user_id: "missing", revenue_threshold: "200" }
 
       expect(response).to have_http_status(:not_found)
     end
 
     it "creates a watched user record" do
       expect do
-        post :watch, params: { email: user.email, revenue_threshold: "200", notes: "Risk review: monitoring" }
+        post :watch, params: { user_id: user.external_id, revenue_threshold: "200", notes: "Risk review: monitoring" }
       end.to change { WatchedUser.count }.by(1)
 
       expect(response).to have_http_status(:ok)
       body = response.parsed_body
       expect(body["success"]).to be(true)
+      expect(body["user_id"]).to eq(user.external_id)
       expect(body["message"]).to eq("User added to watchlist")
       expect(body["watched_user"]["revenue_threshold_cents"]).to eq(20_000)
       expect(body["watched_user"]["notes"]).to eq("Risk review: monitoring")
@@ -909,13 +933,15 @@ describe Api::Internal::Admin::UsersController do
     it "returns 422 when user is already being watched" do
       create(:watched_user, user: user)
 
-      post :watch, params: { email: user.email, revenue_threshold: "500" }
+      post :watch, params: { user_id: user.external_id, revenue_threshold: "500" }
 
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response.parsed_body["message"]).to eq("User is already being watched")
     end
 
-    include_examples "supports user lookup by external_id", :watch, extra_params: { revenue_threshold: "200" }
+    include_examples "requires user_id for user mutation", :watch, extra_params: { revenue_threshold: "200" }
+    include_examples "supports user lookup by user_id", :watch, extra_params: { revenue_threshold: "200" }
+    include_examples "checks expected_email for user mutation", :watch, extra_params: { revenue_threshold: "200" }
   end
 
   describe "POST unwatch" do
@@ -923,15 +949,15 @@ describe Api::Internal::Admin::UsersController do
 
     include_examples "admin api authorization required", :post, :unwatch
 
-    it "returns bad request when email is missing" do
+    it "returns bad request when user_id is missing" do
       post :unwatch
 
       expect(response).to have_http_status(:bad_request)
-      expect(response.parsed_body["message"]).to eq("email or external_id is required")
+      expect(response.parsed_body["message"]).to eq(user_id_required_message)
     end
 
     it "returns not found when user does not exist" do
-      post :unwatch, params: { email: "missing@example.com" }
+      post :unwatch, params: { user_id: "missing" }
 
       expect(response).to have_http_status(:not_found)
     end
@@ -939,21 +965,24 @@ describe Api::Internal::Admin::UsersController do
     it "removes the user from the watchlist" do
       watched_user = create(:watched_user, user: user)
 
-      post :unwatch, params: { email: user.email }
+      post :unwatch, params: { user_id: user.external_id }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["success"]).to be(true)
+      expect(response.parsed_body["user_id"]).to eq(user.external_id)
       expect(watched_user.reload.deleted_at).not_to be_nil
     end
 
     it "returns 422 when user is not being watched" do
-      post :unwatch, params: { email: user.email }
+      post :unwatch, params: { user_id: user.external_id }
 
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response.parsed_body["message"]).to eq("User is not currently being watched")
     end
 
-    include_examples "supports user lookup by external_id", :unwatch, build_user: -> { user = create(:user); create(:watched_user, user:); user }
+    include_examples "requires user_id for user mutation", :unwatch
+    include_examples "supports user lookup by user_id", :unwatch, build_user: -> { user = create(:user); create(:watched_user, user:); user }
+    include_examples "checks expected_email for user mutation", :unwatch, build_user: -> { user = create(:user); create(:watched_user, user:); user }
   end
 
   describe "POST update_watch" do
@@ -961,15 +990,15 @@ describe Api::Internal::Admin::UsersController do
 
     include_examples "admin api authorization required", :post, :update_watch
 
-    it "returns bad request when email is missing" do
+    it "returns bad request when user_id is missing" do
       post :update_watch, params: { revenue_threshold: "200" }
 
       expect(response).to have_http_status(:bad_request)
-      expect(response.parsed_body["message"]).to eq("email or external_id is required")
+      expect(response.parsed_body["message"]).to eq(user_id_required_message)
     end
 
     it "returns bad request when revenue_threshold is missing" do
-      post :update_watch, params: { email: user.email }
+      post :update_watch, params: { user_id: user.external_id }
 
       expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body["message"]).to eq("revenue_threshold is required")
@@ -978,20 +1007,20 @@ describe Api::Internal::Admin::UsersController do
     it "returns bad request when revenue_threshold is not positive" do
       create(:watched_user, user:)
 
-      post :update_watch, params: { email: user.email, revenue_threshold: "0" }
+      post :update_watch, params: { user_id: user.external_id, revenue_threshold: "0" }
 
       expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body["message"]).to eq("revenue_threshold must be a positive number")
     end
 
     it "returns not found when user does not exist" do
-      post :update_watch, params: { email: "missing@example.com", revenue_threshold: "200" }
+      post :update_watch, params: { user_id: "missing", revenue_threshold: "200" }
 
       expect(response).to have_http_status(:not_found)
     end
 
     it "returns 422 when user is not being watched" do
-      post :update_watch, params: { email: user.email, revenue_threshold: "200" }
+      post :update_watch, params: { user_id: user.external_id, revenue_threshold: "200" }
 
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response.parsed_body["message"]).to eq("User is not currently being watched")
@@ -1001,11 +1030,12 @@ describe Api::Internal::Admin::UsersController do
       watched_user = create(:watched_user, user:, revenue_threshold_cents: 20_000, notes: "Old notes")
 
       expect do
-        post :update_watch, params: { email: user.email, revenue_threshold: "500", notes: "New notes" }
+        post :update_watch, params: { user_id: user.external_id, revenue_threshold: "500", notes: "New notes" }
       end.not_to change { WatchedUser.count }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["success"]).to be(true)
+      expect(response.parsed_body["user_id"]).to eq(user.external_id)
       expect(response.parsed_body["message"]).to eq("Watchlist updated")
       expect(response.parsed_body["watched_user"]["revenue_threshold_cents"]).to eq(50_000)
       expect(response.parsed_body["watched_user"]["notes"]).to eq("New notes")
@@ -1015,7 +1045,7 @@ describe Api::Internal::Admin::UsersController do
     it "preserves notes when notes is omitted" do
       watched_user = create(:watched_user, user:, notes: "Keep this")
 
-      post :update_watch, params: { email: user.email, revenue_threshold: "300" }
+      post :update_watch, params: { user_id: user.external_id, revenue_threshold: "300" }
 
       expect(response).to have_http_status(:ok)
       expect(watched_user.reload.notes).to eq("Keep this")
@@ -1024,13 +1054,17 @@ describe Api::Internal::Admin::UsersController do
     it "clears notes when notes is blank" do
       watched_user = create(:watched_user, user:, notes: "Clear this")
 
-      post :update_watch, params: { email: user.email, revenue_threshold: "300", notes: "" }
+      post :update_watch, params: { user_id: user.external_id, revenue_threshold: "300", notes: "" }
 
       expect(response).to have_http_status(:ok)
       expect(watched_user.reload.notes).to be_nil
     end
 
-    include_examples "supports user lookup by external_id", :update_watch,
+    include_examples "requires user_id for user mutation", :update_watch, extra_params: { revenue_threshold: "200" }
+    include_examples "supports user lookup by user_id", :update_watch,
+                     build_user: -> { user = create(:user); create(:watched_user, user:); user },
+                     extra_params: { revenue_threshold: "200" }
+    include_examples "checks expected_email for user mutation", :update_watch,
                      build_user: -> { user = create(:user); create(:watched_user, user:); user },
                      extra_params: { revenue_threshold: "200" }
   end


### PR DESCRIPTION
Ref #4980

## What

This PR lets internal admin endpoints resolve the intended user more directly by user ID instead of relying on looser targeting. That makes admin actions more predictable and reduces the chance of acting on the wrong account.

## Why

Admins need a clear, reliable way to point actions at the exact user they mean. Using user ID as the target removes ambiguity and makes these internal flows safer and easier to reason about.

---

This PR was implemented with AI assistance using gpt‑5.5 xhigh.