### PR TITLE
Replace support ticket UI with mailto: flow

### DIFF
--- a/app/javascript/components/server-components/support/Header.tsx
+++ b/app/javascript/components/server-components/support/Header.tsx
@@ -12,11 +12,9 @@ import { useOriginalLocation } from "$app/components/useOriginalLocation";
 export function SupportHeader({
   onOpenNewTicket,
   hasHelperSession = true,
-  recaptchaSiteKey,
 }: {
   onOpenNewTicket: () => void;
   hasHelperSession?: boolean;
-  recaptchaSiteKey?: string | null;
 }) {
   const { pathname, searchParams } = new URL(useOriginalLocation());
   const isHelpCenterHome = pathname === Routes.help_center_root_path();
@@ -52,11 +50,11 @@ export function SupportHeader({
             </Button>
           ) : isAnonymousUserOnHelpCenter ? (
               <Button color="accent" onClick={() => setIsUnauthenticatedNewTicketOpen(true)}>
-                Contact support
+                Email support
               </Button>
           ) : hasHelperSession ? (
               <Button color="accent" onClick={onOpenNewTicket}>
-                New ticket
+                Email support
               </Button>
           ) : null
         }
@@ -82,7 +80,6 @@ export function SupportHeader({
           open={isUnauthenticatedNewTicketOpen}
           onClose={() => setIsUnauthenticatedNewTicketOpen(false)}
           onCreated={() => setIsUnauthenticatedNewTicketOpen(false)}
-          recaptchaSiteKey={recaptchaSiteKey ?? null}
         />
       ) : null}
     </>
@@ -103,20 +100,15 @@ type WrapperProps = {
     currentToken?: string | null;
   } | null;
   new_ticket_url: string;
-  recaptcha_site_key?: string | null;
 };
 
-const Wrapper = ({ host, session, new_ticket_url, recaptcha_site_key }: WrapperProps) =>
+const Wrapper = ({ host, session, new_ticket_url }: WrapperProps) =>
   host && session ? (
     <HelperClientProvider host={host} session={session}>
       <SupportHeader onOpenNewTicket={() => (window.location.href = new_ticket_url)} />
     </HelperClientProvider>
   ) : (
-    <SupportHeader
-      onOpenNewTicket={() => (window.location.href = new_ticket_url)}
-      hasHelperSession={false}
-      recaptchaSiteKey={recaptcha_site_key ?? null}
-    />
+    <SupportHeader onOpenNewTicket={() => (window.location.href = new_ticket_url)} hasHelperSession={false} />
   );
 
 export default Wrapper;

--- a/app/javascript/components/support/NewTicketModal.tsx
+++ b/app/javascript/components/support/NewTicketModal.tsx
@@ -1,61 +1,27 @@
-import { Paperclip, Trash } from "@boxicons/react";
-import { useCreateConversation, useCreateMessage } from "@helperai/react";
 import React from "react";
 
-import FileUtils from "$app/utils/file";
-
 import { Button } from "$app/components/Button";
-import { useDomains } from "$app/components/DomainSettings";
-import { FileRowContent } from "$app/components/FileRowContent";
 import { Modal } from "$app/components/Modal";
 import { showAlert } from "$app/components/server-components/Alert";
-import { ALLOWED_ATTACHMENT_MIMETYPES } from "$app/components/support/ConversationDetail";
 import { SupportSlaMessage } from "$app/components/support/SupportSlaMessage";
 import { Input } from "$app/components/ui/Input";
-import { Row, RowActions, RowContent, Rows } from "$app/components/ui/Rows";
 import { Textarea } from "$app/components/ui/Textarea";
 
-export function NewTicketModal({
-  open,
-  onClose,
-  onCreated,
-}: {
-  open: boolean;
-  onClose: () => void;
-  onCreated: (slug: string) => void;
-}) {
-  const { apiDomain } = useDomains();
-  const { mutateAsync: createConversation } = useCreateConversation();
-  const { mutateAsync: createMessage } = useCreateMessage();
-
+export function NewTicketModal({ open, onClose }: { open: boolean; onClose: () => void }) {
   const [subject, setSubject] = React.useState("");
   const [message, setMessage] = React.useState("");
-  const [attachments, setAttachments] = React.useState<File[]>([]);
-  const [isSubmitting, setIsSubmitting] = React.useState(false);
   const formRef = React.useRef<HTMLFormElement | null>(null);
-  const fileInputRef = React.useRef<HTMLInputElement | null>(null);
 
   const isFormValid = subject.trim() && message.trim();
 
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!isFormValid) return;
 
-    setIsSubmitting(true);
-    try {
-      const { conversationSlug } = await createConversation({ subject: subject.trim() });
-      await createMessage({
-        conversationSlug,
-        content: message.trim(),
-        attachments,
-        customerInfoUrl: Routes.user_info_api_internal_helper_users_url({ host: apiDomain }),
-      });
-      onCreated(conversationSlug);
-    } catch (error) {
-      showAlert(error instanceof Error ? error.message : "Something went wrong.", "error");
-    } finally {
-      setIsSubmitting(false);
-    }
+    const url = `mailto:support@gumroad.com?subject=${encodeURIComponent(subject.trim())}&body=${encodeURIComponent(message.trim())}`;
+    window.location.href = url;
+    showAlert("Your email client should open shortly. Send the email to complete your support request.", "success");
+    onClose();
   };
 
   return (
@@ -64,30 +30,15 @@ export function NewTicketModal({
       onClose={onClose}
       title="How can we help you today?"
       footer={
-        <>
-          <Button onClick={() => fileInputRef.current?.click()} disabled={isSubmitting}>
-            <Paperclip className="size-5" /> Attach files
-          </Button>
-          <Button
-            color="accent"
-            onClick={() => formRef.current?.requestSubmit()}
-            disabled={isSubmitting || !isFormValid}
-          >
-            {isSubmitting ? "Sending..." : "Send message"}
-          </Button>
-        </>
+        <Button color="accent" onClick={() => formRef.current?.requestSubmit()} disabled={!isFormValid}>
+          Open email
+        </Button>
       }
     >
       <p>
         <SupportSlaMessage />
       </p>
-      <form
-        ref={formRef}
-        className="space-y-4 md:w-[700px]"
-        onSubmit={(e) => {
-          void handleSubmit(e);
-        }}
-      >
+      <form ref={formRef} className="space-y-4 md:w-[700px]" onSubmit={handleSubmit}>
         <label className="sr-only">Subject</label>
         <Input value={subject} placeholder="Subject" onChange={(e) => setSubject(e.target.value)} />
         <label className="sr-only">Message</label>
@@ -97,46 +48,6 @@ export function NewTicketModal({
           onChange={(e) => setMessage(e.target.value)}
           placeholder="Tell us about your issue or question..."
         />
-        <input
-          ref={fileInputRef}
-          type="file"
-          multiple
-          accept={ALLOWED_ATTACHMENT_MIMETYPES}
-          className="sr-only"
-          onChange={(e) => {
-            const files = Array.from(e.target.files ?? []);
-            if (files.length === 0) return;
-            setAttachments((prev) => [...prev, ...files]);
-            e.currentTarget.value = "";
-          }}
-        />
-        {attachments.length > 0 ? (
-          <Rows role="list" aria-label="Files">
-            {attachments.map((file, index) => (
-              <Row role="listitem" key={`${file.name}-${index}`}>
-                <RowContent>
-                  <FileRowContent
-                    name={FileUtils.getFileNameWithoutExtension(file.name)}
-                    extension={FileUtils.getFileExtension(file.name).toUpperCase()}
-                    externalLinkUrl={null}
-                    isUploading={false}
-                    details={<li>{FileUtils.getReadableFileSize(file.size)}</li>}
-                  />
-                </RowContent>
-                <RowActions>
-                  <Button
-                    outline
-                    color="danger"
-                    aria-label="Remove"
-                    onClick={() => setAttachments((prev) => prev.filter((_, i) => i !== index))}
-                  >
-                    <Trash className="size-5" />
-                  </Button>
-                </RowActions>
-              </Row>
-            ))}
-          </Rows>
-        ) : null}
       </form>
     </Modal>
   );

--- a/app/javascript/components/support/SupportPortal.tsx
+++ b/app/javascript/components/support/SupportPortal.tsx
@@ -56,14 +56,7 @@ export default function SupportPortal() {
         <SupportHeader onOpenNewTicket={() => setIsNewTicketOpen(true)} />
         <ConversationList onSelect={setSelectedConversationSlug} onOpenNewTicket={() => setIsNewTicketOpen(true)} />
       </div>
-      <NewTicketModal
-        open={isNewTicketOpen}
-        onClose={() => setIsNewTicketOpen(false)}
-        onCreated={(slug) => {
-          setIsNewTicketOpen(false);
-          setSelectedConversationSlug(slug);
-        }}
-      />
+      <NewTicketModal open={isNewTicketOpen} onClose={() => setIsNewTicketOpen(false)} />
     </>
   );
 }

--- a/app/javascript/components/support/UnauthenticatedNewTicketModal.tsx
+++ b/app/javascript/components/support/UnauthenticatedNewTicketModal.tsx
@@ -1,72 +1,39 @@
 import React from "react";
 
-import { assertResponseError, request, ResponseError } from "$app/utils/request";
-
 import { Button } from "$app/components/Button";
 import { Modal } from "$app/components/Modal";
 import { showAlert } from "$app/components/server-components/Alert";
 import { SupportSlaMessage } from "$app/components/support/SupportSlaMessage";
 import { Input } from "$app/components/ui/Input";
 import { Textarea } from "$app/components/ui/Textarea";
-import { useRecaptcha, RecaptchaCancelledError } from "$app/components/useRecaptcha";
 
 export function UnauthenticatedNewTicketModal({
   open,
   onClose,
   onCreated,
-  recaptchaSiteKey,
 }: {
   open: boolean;
   onClose: () => void;
   onCreated: () => void;
-  recaptchaSiteKey: string | null;
 }) {
-  const { container: recaptchaContainer, execute: executeRecaptcha } = useRecaptcha({
-    siteKey: recaptchaSiteKey,
-  });
-
   const [email, setEmail] = React.useState("");
   const [subject, setSubject] = React.useState("");
   const [message, setMessage] = React.useState("");
-  const [isSubmitting, setIsSubmitting] = React.useState(false);
   const formRef = React.useRef<HTMLFormElement | null>(null);
 
   const isFormValid = email.trim() && subject.trim() && message.trim();
 
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!isFormValid) return;
 
-    setIsSubmitting(true);
-    try {
-      const recaptchaResponse = recaptchaSiteKey ? await executeRecaptcha() : null;
-
-      const response = await request({
-        method: "POST",
-        url: "/support/create_unauthenticated_ticket",
-        accept: "json",
-        data: {
-          email: email.trim(),
-          subject: subject.trim(),
-          message: message.trim(),
-          "g-recaptcha-response": recaptchaResponse,
-        },
-      });
-
-      if (!response.ok) throw new ResponseError("Failed to create support ticket");
-
-      showAlert("Your support ticket has been created successfully! We'll get back to you via email.", "success");
-      onCreated();
-      setEmail("");
-      setSubject("");
-      setMessage("");
-    } catch (error) {
-      if (error instanceof RecaptchaCancelledError) return;
-      assertResponseError(error);
-      showAlert(error.message, "error");
-    } finally {
-      setIsSubmitting(false);
-    }
+    const url = `mailto:support@gumroad.com?subject=${encodeURIComponent(subject.trim())}&body=${encodeURIComponent(`From: ${email.trim()}\n\n${message.trim()}`)}`;
+    window.location.href = url;
+    showAlert("Your email client should open shortly. Send the email to complete your support request.", "success");
+    onCreated();
+    setEmail("");
+    setSubject("");
+    setMessage("");
   };
 
   return (
@@ -80,22 +47,16 @@ export function UnauthenticatedNewTicketModal({
           onClick={() => {
             formRef.current?.requestSubmit();
           }}
-          disabled={isSubmitting || !isFormValid}
+          disabled={!isFormValid}
         >
-          {isSubmitting ? "Sending..." : "Send message"}
+          Open email
         </Button>
       }
     >
       <p>
         <SupportSlaMessage />
       </p>
-      <form
-        ref={formRef}
-        className="space-y-4 md:w-[700px] [&_.grecaptcha-badge]:invisible"
-        onSubmit={(e) => {
-          void handleSubmit(e);
-        }}
-      >
+      <form ref={formRef} className="space-y-4 md:w-[700px]" onSubmit={handleSubmit}>
         <div>
           <label className="sr-only">Email address</label>
           <Input
@@ -120,19 +81,6 @@ export function UnauthenticatedNewTicketModal({
             required
           />
         </div>
-        {recaptchaContainer}
-        {/* We hide the reCAPTCHA badge to avoid it overlapping the modal content and show this standard disclaimer instead (see https://developers.google.com/recaptcha/docs/faq#id-like-to-hide-the-recaptcha-badge.-what-is-allowed) */}
-        <p className="text-sm text-muted">
-          This site is protected by reCAPTCHA and the Google{" "}
-          <a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer">
-            Privacy Policy
-          </a>{" "}
-          and{" "}
-          <a href="https://policies.google.com/terms" target="_blank" rel="noopener noreferrer">
-            Terms of Service
-          </a>{" "}
-          apply.
-        </p>
       </form>
     </Modal>
   );

--- a/app/javascript/pages/HelpCenter/Layout.tsx
+++ b/app/javascript/pages/HelpCenter/Layout.tsx
@@ -1,6 +1,6 @@
 import { Search } from "@boxicons/react";
 import { HelperClientProvider } from "@helperai/react";
-import { Link, router, usePage } from "@inertiajs/react";
+import { Link, usePage } from "@inertiajs/react";
 import * as React from "react";
 
 import { Button } from "$app/components/Button";
@@ -20,7 +20,6 @@ type HelperSession = {
 type HelpCenterSharedProps = {
   helper_widget_host?: string | null;
   helper_session?: HelperSession | null;
-  recaptcha_site_key?: string | null;
 };
 
 type HelpCenterLayoutProps = {
@@ -30,12 +29,10 @@ type HelpCenterLayoutProps = {
 
 function HelpCenterHeader({
   hasHelperSession,
-  recaptchaSiteKey,
   showSearchButton = false,
   onOpenNewTicket,
 }: {
   hasHelperSession: boolean;
-  recaptchaSiteKey: string | null;
   showSearchButton?: boolean | undefined;
   onOpenNewTicket?: () => void;
 }) {
@@ -87,7 +84,7 @@ function HelpCenterHeader({
     if (isAnonymousUserOnHelpCenter) {
       return (
         <Button color="accent" onClick={() => setIsUnauthenticatedNewTicketOpen(true)}>
-          Contact support
+          Email support
         </Button>
       );
     }
@@ -95,7 +92,7 @@ function HelpCenterHeader({
     if (hasHelperSession) {
       return (
         <Button color="accent" onClick={() => onOpenNewTicket?.()}>
-          New ticket
+          Email support
         </Button>
       );
     }
@@ -123,7 +120,6 @@ function HelpCenterHeader({
           open={isUnauthenticatedNewTicketOpen}
           onClose={() => setIsUnauthenticatedNewTicketOpen(false)}
           onCreated={() => setIsUnauthenticatedNewTicketOpen(false)}
-          recaptchaSiteKey={recaptchaSiteKey}
         />
       ) : null}
     </>
@@ -141,11 +137,6 @@ function AuthenticatedHelpCenterContent({
 }) {
   const [isNewTicketOpen, setIsNewTicketOpen] = React.useState(false);
 
-  const onTicketCreated = (_slug: string) => {
-    setIsNewTicketOpen(false);
-    router.visit(Routes.support_index_path());
-  };
-
   return (
     <>
       <HelpCenterHeader
@@ -155,7 +146,7 @@ function AuthenticatedHelpCenterContent({
         onOpenNewTicket={() => setIsNewTicketOpen(true)}
       />
       <section className="p-4 md:p-8">{children}</section>
-      <NewTicketModal open={isNewTicketOpen} onClose={() => setIsNewTicketOpen(false)} onCreated={onTicketCreated} />
+      <NewTicketModal open={isNewTicketOpen} onClose={() => setIsNewTicketOpen(false)} />
     </>
   );
 }


### PR DESCRIPTION
## What

Replaces the Helper API ticket creation flow with a simple `mailto:` link. The modal UI is preserved (subject, message fields, inline validation) but instead of creating tickets via the Helper API, clicking submit opens the user's email client with a pre-filled email to support@gumroad.com.

## Why

Simplifies the support flow. Both sides (user and support) get email as the tracker. We can still do inline validation/checking in the modal before the mailto opens.

## Changes

- **NewTicketModal** (authenticated users): Removed `@helperai/react` SDK calls, attachment UI. Now builds a `mailto:` URL and opens it.
- **UnauthenticatedNewTicketModal** (anonymous users): Removed reCAPTCHA, removed POST to `/support/create_unauthenticated_ticket`. Prepends "From: {email}" to the body.
- **SupportPortal**: Updated callback (no conversation slug).
- **HelpCenter Layout**: Updated callback, removed recaptchaSiteKey prop.
- **Header**: Button text → "Email support"

## What's NOT changed

- ConversationList, ConversationDetail, SupportPortal pages still work for viewing existing Helper tickets
- Helper provider/session still loads for existing conversations
- SLA message component preserved

## Testing

- [x] Modals open/close properly
- [ ] mailto links properly encoded (subject + body)
- [ ] "Support tickets" tab still works for existing conversations
- [ ] Anonymous flow includes email in body