### PR TITLE
Add whitespace-nowrap to navbar buttons to prevent text wrapping

### DIFF
--- a/app/javascript/components/Home/Shared/Nav.tsx
+++ b/app/javascript/components/Home/Shared/Nav.tsx
@@ -84,7 +84,7 @@ const NavButton = ({
   }
 
   const className = classNames(
-    "flex w-full items-center justify-center h-full border-black bg-black p-4 text-lg text-white no-underline transition-colors duration-200 hover:bg-pink hover:text-black lg:w-auto lg:border-l lg:py-2 lg:px-6",
+    "flex w-full items-center justify-center h-full border-black bg-black p-4 text-lg text-white no-underline transition-colors duration-200 hover:bg-pink hover:text-black lg:w-auto lg:border-l lg:py-2 lg:px-6 whitespace-nowrap",
     modifier1,
     modifier2,
   );


### PR DESCRIPTION
## What

Add `whitespace-nowrap` to the `NavButton` component in the marketing page navbar (`Home/Shared/Nav.tsx`). The `NavLink` component already had this class, but `NavButton` (used for "Dashboard", "Log in", "Start selling") was missing it, causing button text to wrap at intermediate viewport widths (~1009-1090px) before the hamburger menu kicks in.

## Why

At viewport widths between roughly 1009px and 1090px, button text breaks onto two lines because there's a gap between where the text starts overflowing and where the navbar collapses to the mobile hamburger menu. The `NavLink` component already prevents this with `whitespace-nowrap`, but the `NavButton` component was missing it. This is the simplest fix since it matches the existing pattern and prevents wrapping without changing breakpoints.

Affected pages: /pricing, /features, /about, /careers
Not affected: /blog (uses a different navbar)

Fixes #4985

## Before (logged in, no fix)

**Normal width (1200px) — Dashboard button renders fine:**
![before-normal](https://i.imgur.com/r8e5BOT.png)

**1090px — "Dashboard" text wraps onto two lines:**
![before-1090px](https://i.imgur.com/u49S0zY.png)

**1009px — collapses to hamburger menu:**
![before-1009px](https://i.imgur.com/rNKOJVI.png)

## After

The fix adds `whitespace-nowrap` to `NavButton`, matching the existing behavior of `NavLink`. At 1090px the "Dashboard" button text stays on one line instead of wrapping. The hamburger menu still kicks in at the same 1009px breakpoint.

## Test results

This is a single Tailwind class addition to a presentational component with no logic change. No existing tests cover navbar button text wrapping at specific viewport widths.

---

**AI disclosure:** This fix was written by Gumclaw (Claude Opus 4.6). Prompt: Mac McClellan reported the bug with screenshots showing Dashboard button text wrapping at intermediate viewport widths and asked for a PR to fix it.