### PR TITLE
Fix Guyana payouts by collecting branch code

### DIFF
--- a/app/javascript/components/Settings/PaymentsPage/BankAccountSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/BankAccountSection.tsx
@@ -226,6 +226,7 @@ export type BankAccount =
       type: "GuyanaBankAccount";
       account_holder_full_name: string;
       bank_code: string;
+      branch_code: string;
       account_number: string;
       account_number_confirmation: string;
     }
@@ -810,6 +811,8 @@ const BankAccountSection = ({
         return "Clearing and branch code";
       case countryCode === "PH":
         return "Bank Identifier Code (BIC)";
+      case countryCode === "GY":
+        return "SWIFT/BIC and branch code";
       case BANK_AND_BRANCH_CODE_COUNTRIES.includes(countryCode):
         return "Bank and branch code";
       case BANK_CODE_COUNTRIES.includes(countryCode):
@@ -1908,21 +1911,39 @@ const BankAccountSection = ({
                   />
                 </Fieldset>
               ) : user.country_code === "GY" ? (
-                <Fieldset state={errorFieldNames.has("bank_code") ? "danger" : undefined}>
-                  <FieldsetTitle>
-                    <Label htmlFor={`${uid}-bank-code`}>SWIFT / BIC Code</Label>
-                  </FieldsetTitle>
-                  <Input
-                    type="text"
-                    id={`${uid}-bank-code`}
-                    placeholder="AAAAGYGGXYZ"
-                    maxLength={11}
-                    required
-                    disabled={isFormDisabled}
-                    aria-invalid={errorFieldNames.has("bank_code")}
-                    onChange={(evt) => updateBankAccount({ bank_code: evt.target.value })}
-                  />
-                </Fieldset>
+                <>
+                  <Fieldset state={errorFieldNames.has("bank_code") ? "danger" : undefined}>
+                    <FieldsetTitle>
+                      <Label htmlFor={`${uid}-bank-code`}>SWIFT / BIC Code</Label>
+                    </FieldsetTitle>
+                    <Input
+                      type="text"
+                      id={`${uid}-bank-code`}
+                      placeholder="AAAAGYGGXYZ"
+                      maxLength={11}
+                      required
+                      disabled={isFormDisabled}
+                      aria-invalid={errorFieldNames.has("bank_code")}
+                      onChange={(evt) => updateBankAccount({ bank_code: evt.target.value })}
+                    />
+                  </Fieldset>
+                  <Fieldset state={errorFieldNames.has("branch_code") ? "danger" : undefined}>
+                    <FieldsetTitle>
+                      <Label htmlFor={`${uid}-branch-code`}>Branch code</Label>
+                    </FieldsetTitle>
+                    <Input
+                      type="text"
+                      id={`${uid}-branch-code`}
+                      placeholder="12345678"
+                      maxLength={8}
+                      inputMode="numeric"
+                      required
+                      disabled={isFormDisabled}
+                      aria-invalid={errorFieldNames.has("branch_code")}
+                      onChange={(evt) => updateBankAccount({ branch_code: evt.target.value })}
+                    />
+                  </Fieldset>
+                </>
               ) : user.country_code === "MK" ? (
                 <Fieldset state={errorFieldNames.has("bank_code") ? "danger" : undefined}>
                   <FieldsetTitle>

--- a/app/javascript/pages/Settings/Payments/Show.tsx
+++ b/app/javascript/pages/Settings/Payments/Show.tsx
@@ -387,6 +387,9 @@ export default function PaymentsPage() {
     if (form.data.bank_account.type === "GuyanaBankAccount" && !form.data.bank_account.bank_code) {
       markFieldInvalid("bank_code");
     }
+    if (form.data.bank_account.type === "GuyanaBankAccount" && !form.data.bank_account.branch_code) {
+      markFieldInvalid("branch_code");
+    }
     if (form.data.bank_account.type === "GuatemalaBankAccount" && !form.data.bank_account.bank_code) {
       markFieldInvalid("bank_code");
     }

--- a/app/models/guyana_bank_account.rb
+++ b/app/models/guyana_bank_account.rb
@@ -46,11 +46,13 @@ class GuyanaBankAccount < BankAccount
 
   private
     def validate_bank_code
+      return unless new_record? || bank_number_changed?
       return if BANK_CODE_FORMAT_REGEX.match?(bank_code)
       errors.add :base, "The bank code is invalid."
     end
 
     def validate_branch_code
+      return unless new_record? || branch_code_changed?
       return if BRANCH_CODE_FORMAT_REGEX.match?(branch_code)
       errors.add :base, "The branch code is invalid."
     end

--- a/app/models/guyana_bank_account.rb
+++ b/app/models/guyana_bank_account.rb
@@ -3,8 +3,9 @@
 class GuyanaBankAccount < BankAccount
   BANK_ACCOUNT_TYPE = "GY"
 
-  BANK_CODE_FORMAT_REGEX = /^[0-9a-zA-Z]{8,11}$/
-  private_constant :BANK_CODE_FORMAT_REGEX
+  BANK_CODE_FORMAT_REGEX = /^[0-9a-zA-Z]{11}$/
+  BRANCH_CODE_FORMAT_REGEX = /^\d{8}$/
+  private_constant :BANK_CODE_FORMAT_REGEX, :BRANCH_CODE_FORMAT_REGEX
 
   ACCOUNT_NUMBER_FORMAT_REGEX = /^[0-9a-zA-Z]{1,32}$/
   private_constant :ACCOUNT_NUMBER_FORMAT_REGEX
@@ -12,10 +13,11 @@ class GuyanaBankAccount < BankAccount
   alias_attribute :bank_code, :bank_number
 
   validate :validate_bank_code
+  validate :validate_branch_code
   validate :validate_account_number
 
   def routing_number
-    "#{bank_code}"
+    "#{bank_code}-#{branch_code}"
   end
 
   def bank_account_type
@@ -46,6 +48,11 @@ class GuyanaBankAccount < BankAccount
     def validate_bank_code
       return if BANK_CODE_FORMAT_REGEX.match?(bank_code)
       errors.add :base, "The bank code is invalid."
+    end
+
+    def validate_branch_code
+      return if BRANCH_CODE_FORMAT_REGEX.match?(branch_code)
+      errors.add :base, "The branch code is invalid."
     end
 
     def validate_account_number

--- a/app/services/update_payout_method.rb
+++ b/app/services/update_payout_method.rb
@@ -53,7 +53,7 @@ class UpdatePayoutMethod
     JordanBankAccount.name => { class: JordanBankAccount, permitted_params: [:bank_code] },
     EthiopiaBankAccount.name => { class: EthiopiaBankAccount, permitted_params: [:bank_code] },
     BruneiBankAccount.name => { class: BruneiBankAccount, permitted_params: [:bank_code] },
-    GuyanaBankAccount.name => { class: GuyanaBankAccount, permitted_params: [:bank_code] },
+    GuyanaBankAccount.name => { class: GuyanaBankAccount, permitted_params: [:bank_code, :branch_code] },
     GuatemalaBankAccount.name => { class: GuatemalaBankAccount, permitted_params: [:bank_code] },
     NigeriaBankAccount.name => { class: NigeriaBankAccount, permitted_params: [:bank_code] },
     SerbiaBankAccount.name => { class: SerbiaBankAccount, permitted_params: [:bank_code] },

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -4399,7 +4399,7 @@ describe StripeMerchantAccountManager, :vcr do
             country: "GY",
             currency: "gyd",
             account_number: "000123456789",
-            routing_number: "AAAAGYGGXYZ"
+            routing_number: "AAAAGYGGXYZ-12345678"
           },
           settings: {
             payouts: {

--- a/spec/models/guyana_bank_account_spec.rb
+++ b/spec/models/guyana_bank_account_spec.rb
@@ -20,16 +20,62 @@ describe GuyanaBankAccount do
   end
 
   describe "#routing_number" do
-    it "returns valid for 11 characters" do
+    it "joins the bank code and branch code with a dash" do
       ba = create(:guyana_bank_account)
       expect(ba).to be_valid
-      expect(ba.routing_number).to eq("AAAAGYGGXYZ")
+      expect(ba.routing_number).to eq("AAAAGYGGXYZ-12345678")
     end
   end
 
   describe "#account_number_visual" do
     it "returns the visual account number" do
       expect(create(:guyana_bank_account, account_number_last_four: "6789").account_number_visual).to eq("******6789")
+    end
+  end
+
+  describe "#validate_bank_code" do
+    it "requires exactly 11 alphanumeric characters" do
+      expect(build(:guyana_bank_account)).to be_valid
+      expect(build(:guyana_bank_account, bank_code: "AAAAGYGGXXX")).to be_valid
+
+      ba = build(:guyana_bank_account, bank_code: "AAAAGYGG")
+      expect(ba).to_not be_valid
+      expect(ba.errors.full_messages.to_sentence).to eq("The bank code is invalid.")
+
+      ba = build(:guyana_bank_account, bank_code: "AAAAGYGGXX")
+      expect(ba).to_not be_valid
+      expect(ba.errors.full_messages.to_sentence).to eq("The bank code is invalid.")
+
+      ba = build(:guyana_bank_account, bank_code: "AAAAGYGGXXXX")
+      expect(ba).to_not be_valid
+      expect(ba.errors.full_messages.to_sentence).to eq("The bank code is invalid.")
+
+      ba = build(:guyana_bank_account, bank_code: "AAAAGYGG-XX")
+      expect(ba).to_not be_valid
+      expect(ba.errors.full_messages.to_sentence).to eq("The bank code is invalid.")
+    end
+  end
+
+  describe "#validate_branch_code" do
+    it "requires exactly 8 digits" do
+      expect(build(:guyana_bank_account, branch_code: "12345678")).to be_valid
+      expect(build(:guyana_bank_account, branch_code: "00000000")).to be_valid
+
+      ba = build(:guyana_bank_account, branch_code: "1234567")
+      expect(ba).to_not be_valid
+      expect(ba.errors.full_messages.to_sentence).to eq("The branch code is invalid.")
+
+      ba = build(:guyana_bank_account, branch_code: "123456789")
+      expect(ba).to_not be_valid
+      expect(ba.errors.full_messages.to_sentence).to eq("The branch code is invalid.")
+
+      ba = build(:guyana_bank_account, branch_code: "abcdefgh")
+      expect(ba).to_not be_valid
+      expect(ba.errors.full_messages.to_sentence).to eq("The branch code is invalid.")
+
+      ba = build(:guyana_bank_account, branch_code: "")
+      expect(ba).to_not be_valid
+      expect(ba.errors.full_messages.to_sentence).to eq("The branch code is invalid.")
     end
   end
 

--- a/spec/models/guyana_bank_account_spec.rb
+++ b/spec/models/guyana_bank_account_spec.rb
@@ -79,6 +79,37 @@ describe GuyanaBankAccount do
     end
   end
 
+  describe "validations on legacy records" do
+    it "skips bank_code and branch_code checks when neither has changed" do
+      ba = create(:guyana_bank_account)
+      ba.update_columns(bank_number: "AAAAGYGG", branch_code: nil)
+      ba.reload
+
+      ba.account_holder_full_name = "Renamed Creator"
+      expect(ba.save).to eq(true)
+    end
+
+    it "validates branch_code when it changes on a legacy record" do
+      ba = create(:guyana_bank_account)
+      ba.update_columns(branch_code: nil)
+      ba.reload
+
+      ba.branch_code = "123"
+      expect(ba).to_not be_valid
+      expect(ba.errors.full_messages.to_sentence).to eq("The branch code is invalid.")
+    end
+
+    it "validates bank_code when it changes on a legacy record" do
+      ba = create(:guyana_bank_account)
+      ba.update_columns(bank_number: "AAAAGYGG")
+      ba.reload
+
+      ba.bank_code = "TOOSHORT"
+      expect(ba).to_not be_valid
+      expect(ba.errors.full_messages.to_sentence).to eq("The bank code is invalid.")
+    end
+  end
+
   describe "#validate_account_number" do
     it "allows records that match the required account number regex" do
       expect(build(:guyana_bank_account)).to be_valid

--- a/spec/requests/settings/payments_spec.rb
+++ b/spec/requests/settings/payments_spec.rb
@@ -4947,6 +4947,7 @@ describe("Payments Settings Scenario", type: :system, js: true) do
 
         fill_in("Pay to the order of", with: "Guyana Creator")
         fill_in("SWIFT / BIC Code", with: "AAAAGYGGXYZ")
+        fill_in("Branch code", with: "12345678")
         fill_in("Account #", with: "000123456789")
         fill_in("Confirm account #", with: "000123456789")
 
@@ -4956,7 +4957,7 @@ describe("Payments Settings Scenario", type: :system, js: true) do
         click_on("Update settings")
 
         expect(page).to have_alert(text: "Thanks! You're all set.")
-        expect(page).to have_content("SWIFT / BIC code")
+        expect(page).to have_content("SWIFT/BIC and branch code")
         compliance_info = @user.alive_user_compliance_info
         expect(compliance_info.first_name).to eq("Guyana")
         expect(compliance_info.last_name).to eq("Creator")
@@ -4966,7 +4967,7 @@ describe("Payments Settings Scenario", type: :system, js: true) do
         expect(compliance_info.phone).to eq("+5926291234")
         expect(compliance_info.birthday).to eq(Date.new(1901, 1, 1))
         expect(@user.reload.active_bank_account.send(:account_number_decrypted)).to eq("000123456789")
-        expect(@user.reload.active_bank_account.routing_number).to eq("AAAAGYGGXYZ")
+        expect(@user.reload.active_bank_account.routing_number).to eq("AAAAGYGGXYZ-12345678")
       end
     end
 

--- a/spec/support/factories/guyana_bank_accounts.rb
+++ b/spec/support/factories/guyana_bank_accounts.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     account_number { "000123456789" }
     account_number_last_four { "6789" }
     bank_code { "AAAAGYGGXYZ" }
+    branch_code { "12345678" }
     account_holder_full_name { "Guyana Creator" }
   end
 end


### PR DESCRIPTION
Fixes antiwork/gumroad-private#308

## What

Adds a Branch code field to the Guyana bank account form. Stripe requires `BIC11-branchcode8` for GY. We'd been sending only the BIC, and every Guyana payout was rejected as `routing_number_invalid`.

## Why

After exchanging request IDs with Stripe support, they confirmed the real blocker is the missing 8-digit branch code. Once both fields are sent, all five major Guyana banks (Republic, Demerara, GBTI, Citizens, Scotiabank) accept the routing.

Mirrored the existing `SriLankaBankAccount` (SWIFT BIC + numeric branch code, dash-joined) rather than adding a PayPal fallback. The fallback would have unblocked creators but bypassed the fix; this is the root-cause change.

Existing Guyana accounts will need creators to refile with their branch code before payouts resume. 

## Before/After

|         | Before                                  | After                                  |
| ------- | --------------------------------------- | -------------------------------------- |
| Desktop |  <img width="2880" height="1800" alt="before-desktop" src="https://github.com/user-attachments/assets/26f9bcb3-a72e-4b93-b91c-0a6f2d5be2dc" /> |  <img width="2880" height="1800" alt="after-desktop" src="https://github.com/user-attachments/assets/fdd9f855-2b82-4684-9cde-bfa922683f28" /> |
| Mobile  |  <img width="1000" height="1688" alt="before-mobile" src="https://github.com/user-attachments/assets/6b3fd3f1-8ae0-4700-b697-e66234e88829" /> | <img width="1000" height="1688" alt="after-mobile" src="https://github.com/user-attachments/assets/9e11c431-369d-4acf-bac0-2efd0c457753" /> |


---

This PR was implemented with AI assistance using Claude Opus 4.7.