### PR TITLE
Allow serialized creative posts in content moderation spam check

### DIFF
--- a/app/services/content_moderation/strategies/prompt_strategy.rb
+++ b/app/services/content_moderation/strategies/prompt_strategy.rb
@@ -18,13 +18,22 @@ class ContentModeration::Strategies::PromptStrategy
 
   SPAM_RULES = <<~RULES
     You are a content moderator for Gumroad, a marketplace where creators sell digital
-    products, courses, bundles, and licenses. Evaluate the following content for spam
-    policy violations.
+    products, courses, bundles, licenses, AND ongoing email subscriptions, newsletters,
+    serialized fiction, comics, podcasts, and other recurring content. Evaluate the
+    following content for spam policy violations.
 
     Default: do not flag. Only flag content that is unmistakably spam. When in doubt,
     treat the content as compliant.
 
-    ALLOW (these are normal Gumroad listings, never flag them):
+    The content you receive comes from one of two surfaces:
+    1. A product listing — description, marketing copy, feature lists, license terms.
+    2. A post or email sent to existing subscribers — newsletters, serial fiction,
+       daily comics, dialogue-driven storylines, journal entries, or any installment
+       of an ongoing subscription where the post itself IS the product the
+       subscriber paid for. These posts often contain no marketing copy and no
+       reference to a product, because they ARE the product.
+
+    ALLOW (these are normal Gumroad content, never flag them):
     - Product descriptions, marketing copy, and promotional language
     - Bundles that repeat the base product name across items
     - Multi-tier products that reuse feature descriptions across tiers
@@ -37,25 +46,40 @@ class ContentModeration::Strategies::PromptStrategy
       always image alt-text or captions extracted from a product image gallery
       where each image carries the same caption, and they describe the product
       itself. Treat as compliant even when the image context isn't visible.
+    - Serialized creative content: comic-strip dialogue, fiction installments,
+      poetry, song lyrics, character interactions, scene narration, recurring
+      story beats. A single installment from a long-running series will often
+      look out-of-context, surreal, or "nonsensical" on its own — that is
+      normal for serial fiction and comics, not spam.
+    - Conversational dialogue between named or fictional characters, even when
+      short, absurd, humorous, or non-sequitur. If a human could plausibly have
+      written it as part of a story, comic, or newsletter, treat as compliant.
+    - Newsletter, journal, or daily-update content with no product description
+      and no marketing copy.
 
-    Important: this content is extracted from a product page's HTML and stripped
-    of structure. You will not see images, headings, or layout. Repetition that
-    looks suspicious in plain text is often legitimate in the rendered page (alt
-    text on a gallery, table cells, list items). Do not flag based on plain-text
-    repetition alone — ask whether the repeated text describes the product. If it
-    does, it is not spam.
+    Important: this content is extracted from HTML and stripped of structure. You
+    will not see images, headings, or layout. For posts/emails the visual content
+    (cartoon panels, screenshots, illustrations) is often the primary payload and
+    the text alone is dialogue or captions. Repetition that looks suspicious in
+    plain text is often legitimate in the rendered page (alt text on a gallery,
+    table cells, list items). Do not flag based on plain-text repetition alone.
 
-    Repetition alone is NOT spam. Flag only when:
-    - Content is clearly machine-generated nonsense or word salad
-    - Repeated phrases are unrelated to the product being sold (e.g., promotional
-      slogans for a different brand, off-topic keywords, link farms)
+    Repetition alone is NOT spam. Lack of a product description is NOT spam.
+    Coherent prose that doesn't mention a product is NOT spam.
+
+    Flag only when:
+    - Content is clearly machine-generated nonsense or word salad — random tokens,
+      gibberish character sequences, not coherent prose or dialogue
+    - Repeated phrases are unrelated to a product AND are obviously promotional
+      (slogans for unrelated brands, off-topic SEO keywords, link farms)
     - Obvious keyword stuffing of unrelated terms
     - Fake reviews, artificial engagement, or bot-generated text
     - Aggressive call-to-action spam ("BUY NOW BUY NOW BUY NOW", "click here click
-      here click here") with no product information
+      here click here") with no other information
 
-    If the content describes a real product — even one with a repetitive structure
-    or duplicated captions — it is not spam.
+    If the content describes a real product, OR reads as a coherent installment of
+    creative or editorial work — even one that is repetitive, surreal, or makes no
+    reference to a product — it is not spam.
   RULES
 
   MODEL = "gpt-4o-mini"


### PR DESCRIPTION
Fixes antiwork/gumroad-private#349

## What

Update `SPAM_RULES` in `ContentModeration::Strategies::PromptStrategy` so the spam preset stops flagging legitimate post/email content where the post itself is the product (newsletters, serial fiction, daily comics, podcasts, journal entries).

No control flow changes — only the prompt text the LLM sees.

## Why

The spam preset runs text-only (`skip_images: true`, `prompt_strategy.rb:82`). The same `PromptStrategy` is invoked for both products and posts (`installment.rb:954`, plus the product validation), but the rules were written exclusively for product listings — they instructed the model to flag anything that "lacks coherence and relevance to a digital product being sold."

For a serialized post (a comic strip, a fiction installment, a daily-update newsletter) the visual content carries the meaning and the text is just dialogue or a caption. The model behaved correctly given the prompt: short out-of-context dialogue with no product mention reads as spam. The fix is to teach the prompt that posts can be the product.

### Repro vs. fix

A short paragraph of fictional character dialogue — coherent, written by a human, no product mention, the kind of content that appears in a serialized comic — was run against the deployed prompt and the updated prompt:

| Prompt | Result |
| --- | --- |
| Current (`main`) | **5/5 flagged** as "nonsensical conversation that does not describe a product" |
| This PR | **0/5 flagged** |

Adversarial check on the updated prompt — every standard spam pattern still flags consistently:

| Input | Flagged |
| --- | --- |
| Aggressive CTA spam (`BUY NOW BUY NOW…`) | 3/3 |
| Keyword stuffing (`cheap viagra cialis loans payday casino…`) | 3/3 |
| Gibberish word salad (`asdf qwerty xkcd zzzz…`) | 3/3 |
| Link-farm spam | 3/3 |

So this isn't a blanket loosening — it's specifically opening up coherent narrative/dialogue content for posts.

### Why a prompt edit, not a code change

Two alternatives considered and rejected:

1. **Pass `entity_type` into the strategy and use different rules per entity.** Cleaner long-term, but the strategy is already invoked from two call sites and the prompt was the only thing wrong — the extraction and orchestration code is fine.
2. **Bypass moderation for creators with N successful publishes.** Useful as a defense in depth (the existing `vip_creator?` check at `installment.rb:952` already does this for $5K+ payouts), but doesn't fix the underlying false-positive — newer creators in the same category would still be blocked.

## Before / After

> ⚠️ Reviewer: please add a screenshot from a preview app deployed off this branch — publish a post whose body is a few lines of fictional character dialogue with no product description and confirm it succeeds. I cannot deploy a preview app from here.

## Test results

- `bundle exec rspec spec/services/content_moderation/strategies/prompt_strategy_spec.rb` — 16 examples, 0 failures.
- `bundle exec rubocop app/services/content_moderation/strategies/prompt_strategy.rb` — no offenses.
- Existing specs are mock-based and don't assert on prompt text, so they're unaffected.
- Live behavioral verification was performed against the production OpenAI client by overriding `SPAM_RULES` in a `rails runner` session (read-only DB) — see numbers above.

## Test plan

- [ ] Deploy to a branch app.
- [ ] Have an internal account create an installment whose body is a few lines of character dialogue with no product description, attempt to publish, confirm it succeeds.
- [ ] Re-test a known spam fixture (e.g. an installment whose body is just `BUY NOW BUY NOW BUY NOW click here click here`); confirm it is still blocked with `Content moderation failed: spam: …`.

---

This PR was implemented with AI assistance using Claude Opus 4.7. Prompts given to the agent: investigate the linked issue via the production console without writing to the DB; run a representative content snippet against the current production moderation prompt; update `SPAM_RULES` so the same content passes; verify against real spam fixtures; open a PR.