### PR TITLE
fix: add analytics.tiktok.com to CSP script-src and connect-src

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -73,6 +73,9 @@ SecureHeaders::Configuration.default do |config|
       "analytics.google.com",
       "*.analytics.google.com",
 
+      # tiktok pixel
+      "analytics.tiktok.com",
+
       # cloudfront
       FILE_DOWNLOAD_DISTRIBUTION_URL,
       HLS_DISTRIBUTION_URL,
@@ -153,6 +156,9 @@ SecureHeaders::Configuration.default do |config|
 
       # twitter
       "analytics.twitter.com",
+
+      # tiktok pixel
+      "analytics.tiktok.com",
 
       # helper widget
       "help.gumroad.com",


### PR DESCRIPTION
## What

Add `analytics.tiktok.com` to the Content Security Policy `script-src` and `connect-src` directives in `config/initializers/secure_headers.rb`.

## Why

The TikTok Pixel field (added in #4037) dynamically loads a script from `https://analytics.tiktok.com/i18n/pixel/events.js`. However, that domain was never added to the CSP allowlist. The browser blocks the script entirely:

> Loading the script `https://analytics.tiktok.com/i18n/pixel/events.js?sdkid=...` violates the following Content Security Policy directive: "script-src 'self' 'unsafe-eval' ..."

Facebook (`*.facebook.net`, `*.facebook.com`) and Google (`*.google-analytics.com`, `*.googletagmanager.com`) are already in the CSP — TikTok was simply missed when the integration was added.

This is a config-only change. The pixel integration code in `vendor/assets/javascripts/tiktok_pixel.js` is already correct; only the CSP was blocking it.

## Changes

- **`script-src`**: Added `analytics.tiktok.com` (allows the pixel script to load)
- **`connect-src`**: Added `analytics.tiktok.com` (allows the pixel to send event data back to TikTok)

## Before / After

**Before:** TikTok Pixel field exists in settings but the script is blocked by CSP. Sellers see no events in TikTok Events Manager.

**After:** The script loads successfully, and ViewContent / AddToCart / CompletePayment events fire as designed.

## Test Results

Config-only change — no application logic changed. Existing TikTok pixel specs (product rendering, settings) remain unaffected.

## Support Tickets

- [c3ac254638b920b2fa40068f3a394b3b](https://help.gumroad.com/conversations?id=c3ac254638b920b2fa40068f3a394b3b)

Closes #5001

---

AI disclosure: Claude Opus 4.6 via Hermes Agent. Prompt: "work on https://github.com/antiwork/gumroad/issues/5001 create a PR"