### PR TITLE
Fix flaky refund policy screenshot race that silently breaks dispute evidence

### DIFF
--- a/app/services/dispute_evidence/create_from_dispute_service.rb
+++ b/app/services/dispute_evidence/create_from_dispute_service.rb
@@ -117,6 +117,8 @@ class DisputeEvidence::CreateFromDisputeService
       )
     rescue DisputeEvidence::GenerateRefundPolicyImageService::ImageTooLargeError
       ErrorNotifier.notify("DisputeEvidence::CreateFromDisputeService (purchase #{purchase.id}): Refund policy image not attached because was too large")
+    rescue => e
+      ErrorNotifier.notify(e, context: { service: "DisputeEvidence::CreateFromDisputeService#attach_refund_policy_image", purchase_id: purchase.id })
     end
 
     def mobile_purchase?

--- a/app/services/dispute_evidence/generate_refund_policy_image_service.rb
+++ b/app/services/dispute_evidence/generate_refund_policy_image_service.rb
@@ -44,6 +44,7 @@ class DisputeEvidence::GenerateRefundPolicyImageService
 
     IMAGE_RESIZE_FACTOR = 2
     IMAGE_QUALITY = 80
+    ARTICLE_WAIT_TIMEOUT_SECONDS = 5
 
     attr_reader :url, :width, :open_fine_print_modal, :max_size_allowed
 
@@ -73,8 +74,14 @@ class DisputeEvidence::GenerateRefundPolicyImageService
         modal_height = driver.execute_script(%{ return document.querySelector("dialog").scrollHeight; })
         [modal_height, document_height].max
       else
-        # We need to calculate the height of the content, plus the padding added by the parent element
-        content_height = driver.execute_script(%{ return document.querySelector("article").parentElement.scrollHeight; })
+        begin
+          Selenium::WebDriver::Wait.new(timeout: ARTICLE_WAIT_TIMEOUT_SECONDS).until do
+            driver.execute_script(%{ return document.querySelector("article") !== null; })
+          end
+        rescue Selenium::WebDriver::Error::TimeoutError
+          return document_height
+        end
+        content_height = driver.execute_script(%{ return document.querySelector("article")?.parentElement?.scrollHeight ?? 0; })
         [content_height, document_height].max
       end
     end

--- a/spec/services/dispute_evidence/create_from_dispute_service_spec.rb
+++ b/spec/services/dispute_evidence/create_from_dispute_service_spec.rb
@@ -233,6 +233,26 @@ describe DisputeEvidence::CreateFromDisputeService, :vcr, :versioning do
       end
     end
 
+    context "when the refund policy image generation raises an unexpected error" do
+      let(:js_error) do
+        Selenium::WebDriver::Error::JavascriptError.new("javascript error: Cannot read properties of null (reading 'parentElement')")
+      end
+
+      before do
+        allow(DisputeEvidence::GenerateRefundPolicyImageService).to receive(:perform).and_raise(js_error)
+      end
+
+      it "still creates the dispute evidence without the refund policy image" do
+        expect(ErrorNotifier).to receive(:notify).with(js_error, context: hash_including(purchase_id: disputed_purchase.id))
+
+        dispute_evidence = DisputeEvidence.create_from_dispute!(disputed_purchase.dispute)
+
+        expect(dispute_evidence).to be_persisted
+        expect(dispute_evidence.refund_policy_image).not_to be_attached
+        expect(dispute_evidence.receipt_image).to be_attached
+      end
+    end
+
     context "when there is a view event before the purchase" do
       let!(:event) do
         disputed_purchase.events.create!(

--- a/spec/services/dispute_evidence/generate_refund_policy_image_service_spec.rb
+++ b/spec/services/dispute_evidence/generate_refund_policy_image_service_spec.rb
@@ -2,6 +2,45 @@
 
 require "spec_helper"
 
+describe DisputeEvidence::GenerateRefundPolicyImageService do
+  describe "#calculate_height" do
+    let(:service) { described_class.new("https://example.com", mobile_purchase: false, open_fine_print_modal: false, max_size_allowed: 5_000_000) }
+    let(:driver) { instance_double(Selenium::WebDriver::Driver) }
+    let(:document_height) { 1_000 }
+    let(:article_height) { 1_500 }
+
+    before do
+      allow(driver).to receive(:execute_script).with(/Math\.max/).and_return(document_height)
+    end
+
+    context "when the <article> element is mounted before the timeout" do
+      before do
+        fake_wait = instance_double(Selenium::WebDriver::Wait)
+        allow(Selenium::WebDriver::Wait).to receive(:new).and_return(fake_wait)
+        allow(fake_wait).to receive(:until).and_return(true)
+        allow(driver).to receive(:execute_script).with(/parentElement\?\.scrollHeight/).and_return(article_height)
+      end
+
+      it "returns the larger of the article and document heights" do
+        expect(service.send(:calculate_height, driver, open_fine_print_modal: false)).to eq(article_height)
+      end
+    end
+
+    context "when the <article> element never mounts" do
+      before do
+        fake_wait = instance_double(Selenium::WebDriver::Wait)
+        allow(Selenium::WebDriver::Wait).to receive(:new).and_return(fake_wait)
+        allow(fake_wait).to receive(:until).and_raise(Selenium::WebDriver::Error::TimeoutError)
+      end
+
+      it "falls back to the document height without raising" do
+        expect(service.send(:calculate_height, driver, open_fine_print_modal: false)).to eq(document_height)
+        expect(driver).not_to have_received(:execute_script).with(/parentElement/)
+      end
+    end
+  end
+end
+
 describe DisputeEvidence::GenerateRefundPolicyImageService, type: :system, js: true do
   let(:purchase) { create(:purchase) }
   let(:url) do

--- a/spec/support/fixtures/vcr_cassettes/DisputeEvidence_CreateFromDisputeService/when_the_purchase_has_a_refund_policy/when_the_refund_policy_image_generation_raises_an_unexpected_error/still_creates_the_dispute_evidence_without_the_refund_policy_image.yml
+++ b/spec/support/fixtures/vcr_cassettes/DisputeEvidence_CreateFromDisputeService/when_the_purchase_has_a_refund_policy/when_the_refund_policy_image_generation_raises_an_unexpected_error/still_creates_the_dispute_evidence_without_the_refund_policy_image.yml
@@ -1,0 +1,129 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[number]=4000+0000+0000+0259&card[exp_month]=12&card[exp_year]=2023&card[cvc]=123
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/10.0.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_MEfi5fDjwnc0zg","request_duration_ms":725}}'
+      Idempotency-Key:
+      - 58f7aab7-4d74-4b0a-aa35-6ee947886dc7
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"10.0.0","lang":"ruby","lang_version":"3.2.2 p53 (2023-03-30)","platform":"arm64-darwin20","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Harbakshs-MacBook-Air.local 20.5.0 Darwin Kernel Version 20.5.0: Sat May  8
+        05:10:31 PDT 2021; root:xnu-7195.121.3~9/RELEASE_ARM64_T8101 arm64","hostname":"Harbakshs-MacBook-Air.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 31 Oct 2023 19:17:50 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '931'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET,HEAD,PUT,PATCH,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy-Report-Only:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Fpayment_methods; block-all-mixed-content;
+        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+      Idempotency-Key:
+      - 58f7aab7-4d74-4b0a-aa35-6ee947886dc7
+      Original-Request:
+      - req_se96JOopQy3c4F
+      Request-Id:
+      - req_se96JOopQy3c4F
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_0O7NRi9e1RjUNIyYJBTuOxoo",
+          "object": "payment_method",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "exp_month": 12,
+            "exp_year": 2023,
+            "fingerprint": "VxUGbAs1AGxaj8mD",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "0259",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1698779870,
+          "customer": null,
+          "livemode": false,
+          "metadata": {},
+          "type": "card"
+        }
+  recorded_at: Tue, 31 Oct 2023 19:17:50 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
Closes https://github.com/antiwork/gumroad-private/issues/347

## What

Two changes to stop disputes from silently auto-losing when the refund policy screenshot fails:

1. **Root cause fix** — In [`GenerateRefundPolicyImageService#calculate_height`](app/services/dispute_evidence/generate_refund_policy_image_service.rb), wait for the React/Inertia-rendered `<article>` element to mount before measuring its height, and short-circuit defensively on null. Falls back to document height on timeout.
2. **Defense in depth** — In [`CreateFromDisputeService#attach_refund_policy_image`](app/services/dispute_evidence/create_from_dispute_service.rb), broaden the rescue clause to catch any error from the screenshot path, not just `ImageTooLargeError`. Logs to `ErrorNotifier` with the purchase ID and lets the rest of evidence creation continue.

## Why

In production, `GenerateRefundPolicyImageService` intermittently raises:

```
Selenium::WebDriver::Error::JavascriptError:
  javascript error: Cannot read properties of null (reading 'parentElement')
  (Session info: chrome-headless-shell=125.0.6422.76)
```

Reproduced against dispute 125734 (created 2026-05-11 03:10 UTC, still in `formalized` state with no evidence at the time of this PR).

### Where it comes from

[generate_refund_policy_image_service.rb:77](app/services/dispute_evidence/generate_refund_policy_image_service.rb#L77) (on `main`):

```ruby
content_height = driver.execute_script(%{ return document.querySelector("article").parentElement.scrollHeight; })
```

The wait on line 59-60 only waits for `document.readyState === "complete"`, which fires when the initial HTML is parsed, not after React/Inertia has hydrated. So we have a race: sometimes the article is mounted by the time we measure it (succeeds), sometimes it isn't (`null.parentElement` throws).

### Why it kills disputes

When `attach_refund_policy_image` raises anything other than `ImageTooLargeError`, the exception propagates past `dispute_evidence.save!` and out of `handle_event_dispute_formalized!`. By then `mark_formalized!` has already committed. The Sidekiq retry hits the state gate at [`Charge::Disputable:99`](app/models/concerns/charge/disputable.rb#L99) and returns early because the dispute is no longer in `initiated` or `created` state. The retry "succeeds" with no evidence created, no `FightDisputeJob` enqueued, and the dispute auto-loses. The exception only surfaces once per failure, which is why it has been leaking quietly.

The two fixes together: (1) eliminates the race so the screenshot succeeds in the first place, and (2) ensures even if it does fail, evidence is still saved without the optional policy image — Stripe accepts the package without it; the receipt image, access activity log, and uncategorized text carry the dispute.

---

## AI Disclosure

Drafted with Claude Opus 4.7 (1M context).
