### PR TITLE
Add the internal admin cursor pagination helper

### DIFF
--- a/app/controllers/concerns/api/internal/admin/cursor_paginated.rb
+++ b/app/controllers/concerns/api/internal/admin/cursor_paginated.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Api::Internal::Admin::CursorPaginated
+  extend ActiveSupport::Concern
+
+  DEFAULT_LIMIT = 20
+  MAX_LIMIT = 100
+
+  included do
+    rescue_from Api::Internal::Admin::CursorPagination::InvalidCursor do |_|
+      render json: { success: false, message: "invalid cursor" }, status: :bad_request
+    end
+  end
+
+  private
+    def cursor_limit
+      requested_limit = Integer(params[:limit], exception: false)
+      return DEFAULT_LIMIT if requested_limit.blank? || requested_limit <= 0
+
+      [requested_limit, MAX_LIMIT].min
+    end
+
+    def paginate_with_cursor(scope, order:)
+      limit = cursor_limit
+      records, next_cursor = Api::Internal::Admin::CursorPagination.paginate(
+        scope,
+        cursor: params[:cursor].presence,
+        limit:,
+        order:
+      )
+
+      [records, { next: next_cursor, limit: }]
+    end
+end

--- a/app/services/api/internal/admin/cursor_pagination.rb
+++ b/app/services/api/internal/admin/cursor_pagination.rb
@@ -62,7 +62,7 @@ class Api::Internal::Admin::CursorPagination
         expected_keys = normalized_order.map(&:first)
         return if payload.keys.sort == expected_keys.sort
 
-        raise ArgumentError, "cursor keys must match order columns"
+        raise InvalidCursor
       end
 
       def cast_cursor_values(model, payload, normalized_order)

--- a/app/services/api/internal/admin/cursor_pagination.rb
+++ b/app/services/api/internal/admin/cursor_pagination.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+# Keyset pagination helper for NOT NULL sort columns.
+class Api::Internal::Admin::CursorPagination
+  class InvalidCursor < StandardError; end
+
+  class << self
+    def encode(payload)
+      Base64.urlsafe_encode64(verifier.generate(JSON.dump(payload)))
+    end
+
+    def decode(token)
+      raise InvalidCursor unless token.is_a?(String) && token.present?
+
+      payload = JSON.parse(verifier.verify(Base64.urlsafe_decode64(token)))
+      raise InvalidCursor unless payload.is_a?(Hash)
+
+      payload
+    rescue ActiveSupport::MessageVerifier::InvalidSignature, ArgumentError, JSON::ParserError, EncodingError
+      raise InvalidCursor
+    end
+
+    def paginate(scope, cursor: nil, limit: 20, order: [[:created_at, :desc], [:id, :desc]])
+      limit = Integer(limit)
+      raise ArgumentError, "limit must be positive" if limit <= 0
+
+      normalized_order = normalize_order(order)
+      relation = scope.reorder(nil)
+      relation = apply_cursor(relation, cursor, normalized_order) if cursor.present?
+      relation = relation.order(Arel.sql(order_sql(scope.klass, normalized_order)))
+      records = relation.limit(limit + 1).to_a
+      page_records = records.first(limit)
+      next_cursor = records.length > limit ? encode(cursor_payload(page_records.last, normalized_order)) : nil
+
+      [page_records, next_cursor]
+    end
+
+    private
+      def verifier
+        Rails.application.message_verifier(:admin_api_cursor)
+      end
+
+      def normalize_order(order)
+        raise ArgumentError, "order must be present" if order.blank?
+
+        order.map do |column, direction|
+          direction = direction.to_s.to_sym
+          raise ArgumentError, "invalid order direction" unless %i[asc desc].include?(direction)
+
+          [column.to_s, direction]
+        end
+      end
+
+      def apply_cursor(relation, cursor, normalized_order)
+        payload = decode(cursor)
+        validate_cursor_keys!(payload, normalized_order)
+        values = cast_cursor_values(relation.klass, payload, normalized_order)
+        relation.where(*cursor_condition(relation.klass, normalized_order, values))
+      end
+
+      def validate_cursor_keys!(payload, normalized_order)
+        expected_keys = normalized_order.map(&:first)
+        return if payload.keys.sort == expected_keys.sort
+
+        raise ArgumentError, "cursor keys must match order columns"
+      end
+
+      def cast_cursor_values(model, payload, normalized_order)
+        normalized_order.map do |column, _direction|
+          model.type_for_attribute(column).cast(payload.fetch(column))
+        end
+      end
+
+      def cursor_condition(model, normalized_order, values)
+        if normalized_order.map(&:second).uniq.one?
+          direction = normalized_order.first.second
+          comparator = direction == :desc ? "<" : ">"
+          placeholders = (["?"] * normalized_order.length).join(", ")
+
+          ["(#{column_list_sql(model, normalized_order)}) #{comparator} (#{placeholders})", *values]
+        else
+          mixed_direction_cursor_condition(model, normalized_order, values)
+        end
+      end
+
+      def mixed_direction_cursor_condition(model, normalized_order, values)
+        sql_fragments = []
+        bind_values = []
+
+        normalized_order.each_with_index do |(column, direction), index|
+          prefix_fragments = normalized_order.first(index).map { |prefix_column, _| "#{column_sql(model, prefix_column)} = ?" }
+          comparator = direction == :desc ? "<" : ">"
+          sql_fragments << "(#{(prefix_fragments + ["#{column_sql(model, column)} #{comparator} ?"]).join(" AND ")})"
+          bind_values.concat(values.first(index))
+          bind_values << values[index]
+        end
+
+        [sql_fragments.join(" OR "), *bind_values]
+      end
+
+      def order_sql(model, normalized_order)
+        normalized_order.map do |column, direction|
+          "#{column_sql(model, column)} #{direction.to_s.upcase}"
+        end.join(", ")
+      end
+
+      def column_list_sql(model, normalized_order)
+        normalized_order.map { |column, _direction| column_sql(model, column) }.join(", ")
+      end
+
+      def column_sql(model, column)
+        "#{model.quoted_table_name}.#{model.connection.quote_column_name(column)}"
+      end
+
+      def cursor_payload(record, normalized_order)
+        normalized_order.to_h do |column, _direction|
+          [column, serialize_value(record.public_send(column))]
+        end
+      end
+
+      def serialize_value(value)
+        case value
+        when Time, ActiveSupport::TimeWithZone
+          value.iso8601(6)
+        when Date, DateTime
+          value.iso8601
+        else
+          value
+        end
+      end
+  end
+end

--- a/spec/controllers/concerns/api/internal/admin/cursor_paginated_spec.rb
+++ b/spec/controllers/concerns/api/internal/admin/cursor_paginated_spec.rb
@@ -13,17 +13,32 @@ describe Api::Internal::Admin::CursorPaginated do
     def invalid
       raise Api::Internal::Admin::CursorPagination::InvalidCursor
     end
+
+    def mismatched
+      paginate_with_cursor(Payment.all, order: [[:created_at, :desc], [:id, :desc]])
+      render json: { success: true }
+    end
   end
 
   before do
     routes.draw do
       get :index, to: "anonymous#index"
       get :invalid, to: "anonymous#invalid"
+      get :mismatched, to: "anonymous#mismatched"
     end
   end
 
   it "returns a bad request response for invalid cursors" do
     get :invalid
+
+    expect(response).to have_http_status(:bad_request)
+    expect(response.parsed_body).to eq({ success: false, message: "invalid cursor" }.as_json)
+  end
+
+  it "returns a bad request response when a signed cursor has the wrong sort keys" do
+    cursor = Api::Internal::Admin::CursorPagination.encode("id" => 1)
+
+    get :mismatched, params: { cursor: }
 
     expect(response).to have_http_status(:bad_request)
     expect(response.parsed_body).to eq({ success: false, message: "invalid cursor" }.as_json)

--- a/spec/controllers/concerns/api/internal/admin/cursor_paginated_spec.rb
+++ b/spec/controllers/concerns/api/internal/admin/cursor_paginated_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Api::Internal::Admin::CursorPaginated do
+  controller(ActionController::Base) do
+    include Api::Internal::Admin::CursorPaginated
+
+    def index
+      render json: { limit: cursor_limit }
+    end
+
+    def invalid
+      raise Api::Internal::Admin::CursorPagination::InvalidCursor
+    end
+  end
+
+  before do
+    routes.draw do
+      get :index, to: "anonymous#index"
+      get :invalid, to: "anonymous#invalid"
+    end
+  end
+
+  it "returns a bad request response for invalid cursors" do
+    get :invalid
+
+    expect(response).to have_http_status(:bad_request)
+    expect(response.parsed_body).to eq({ success: false, message: "invalid cursor" }.as_json)
+  end
+
+  it "uses the default limit when the limit parameter is missing" do
+    get :index
+
+    expect(response.parsed_body["limit"]).to eq(described_class::DEFAULT_LIMIT)
+  end
+
+  it "uses the requested limit when it is in range" do
+    get :index, params: { limit: 37 }
+
+    expect(response.parsed_body["limit"]).to eq(37)
+  end
+
+  it "caps the requested limit at the maximum" do
+    get :index, params: { limit: 10_000 }
+
+    expect(response.parsed_body["limit"]).to eq(described_class::MAX_LIMIT)
+  end
+
+  it "uses the default limit when the requested limit is non-positive or non-numeric" do
+    ["0", "-5", "abc", "2abc", ""].each do |limit|
+      get :index, params: { limit: }
+
+      expect(response.parsed_body["limit"]).to eq(described_class::DEFAULT_LIMIT), "limit=#{limit.inspect}"
+    end
+  end
+end

--- a/spec/services/api/internal/admin/cursor_pagination_spec.rb
+++ b/spec/services/api/internal/admin/cursor_pagination_spec.rb
@@ -122,14 +122,17 @@ describe Api::Internal::Admin::CursorPagination do
     end
 
     it "raises ArgumentError for invalid pagination configuration" do
-      mismatched_cursor = described_class.encode("id" => 1)
-
       expect { described_class.paginate(payment_scope, order: []) }.to raise_error(ArgumentError, /order/)
       expect { described_class.paginate(payment_scope, order: [[:id, :sideways]]) }.to raise_error(ArgumentError, /direction/)
       expect { described_class.paginate(payment_scope, order: [[:id, nil]]) }.to raise_error(ArgumentError, /direction/)
+    end
+
+    it "raises InvalidCursor when the cursor keys do not match the order columns" do
+      mismatched_cursor = described_class.encode("id" => 1)
+
       expect do
         described_class.paginate(payment_scope, cursor: mismatched_cursor, order: default_order)
-      end.to raise_error(ArgumentError, /cursor keys/)
+      end.to raise_error(described_class::InvalidCursor)
     end
   end
 

--- a/spec/services/api/internal/admin/cursor_pagination_spec.rb
+++ b/spec/services/api/internal/admin/cursor_pagination_spec.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Api::Internal::Admin::CursorPagination do
+  let(:base_time) { Time.zone.local(2026, 1, 15, 12, 0, 0) }
+  let(:default_order) { [[:created_at, :desc], [:id, :desc]] }
+
+  describe ".encode and .decode" do
+    it "round trips a cursor payload" do
+      payload = { "created_at" => base_time.iso8601, "id" => 123 }
+
+      token = described_class.encode(payload)
+
+      expect(described_class.decode(token)).to eq(payload)
+    end
+
+    it "raises InvalidCursor for bad cursor tokens" do
+      bad_tokens = [
+        "",
+        "garbage",
+        Base64.urlsafe_encode64("not-json"),
+        Base64.urlsafe_encode64(JSON.dump({ "id" => 1 })),
+        signed_token("not-json"),
+        signed_token(JSON.dump(["id", 1]))
+      ]
+
+      bad_tokens.each do |token|
+        expect { described_class.decode(token) }.to raise_error(described_class::InvalidCursor), "token=#{token.inspect}"
+      end
+    end
+  end
+
+  describe ".paginate" do
+    it "returns up to the limit and emits a next cursor when another page exists" do
+      newest = create_payment(created_at: base_time)
+      middle = create_payment(created_at: base_time - 1.minute)
+      create_payment(created_at: base_time - 2.minutes)
+
+      records, next_cursor = described_class.paginate(payment_scope, limit: 2, order: default_order)
+
+      expect(records).to eq([newest, middle])
+      expect(next_cursor).to be_present
+    end
+
+    it "returns a nil next cursor on the last page" do
+      first = create_payment(created_at: base_time)
+      second = create_payment(created_at: base_time - 1.minute)
+
+      records, next_cursor = described_class.paginate(payment_scope, limit: 3, order: default_order)
+
+      expect(records).to eq([first, second])
+      expect(next_cursor).to be_nil
+    end
+
+    it "walks the full result set in pages without duplicates or gaps" do
+      create_payment(created_at: base_time)
+      create_payment(created_at: base_time - 1.minute)
+      create_payment(created_at: base_time - 2.minutes)
+      create_payment(created_at: base_time - 3.minutes)
+      create_payment(created_at: base_time - 4.minutes)
+      seen_ids = []
+      cursor = nil
+
+      loop do
+        records, cursor = described_class.paginate(payment_scope, cursor:, limit: 2, order: default_order)
+        seen_ids.concat(records.map(&:id))
+        break if cursor.nil?
+      end
+
+      expect(seen_ids).to eq(payment_scope.order(created_at: :desc, id: :desc).pluck(:id))
+      expect(seen_ids.uniq).to eq(seen_ids)
+    end
+
+    it "does not include a row inserted before the cursor during a paginated walk" do
+      newest = create_payment(created_at: base_time)
+      middle = create_payment(created_at: base_time - 1.minute)
+      oldest = create_payment(created_at: base_time - 2.minutes)
+
+      first_page, cursor = described_class.paginate(payment_scope, limit: 2, order: default_order)
+      inserted = create_payment(created_at: base_time + 1.minute)
+      second_page, next_cursor = described_class.paginate(payment_scope, cursor:, limit: 2, order: default_order)
+
+      expect(first_page).to eq([newest, middle])
+      expect(second_page).to eq([oldest])
+      expect(second_page).not_to include(inserted)
+      expect(next_cursor).to be_nil
+    end
+
+    it "uses later order columns when records share the leading sort key" do
+      older = create_payment(created_at: base_time - 1.minute)
+      first = create_payment(created_at: base_time)
+      second = create_payment(created_at: base_time)
+
+      first_page, cursor = described_class.paginate(payment_scope, limit: 1, order: default_order)
+      second_page, next_cursor = described_class.paginate(payment_scope, cursor:, limit: 2, order: default_order)
+
+      expect(first_page).to eq([second])
+      expect(second_page).to eq([first, older])
+      expect(next_cursor).to be_nil
+    end
+
+    it "honors ascending order" do
+      oldest = create_payment(created_at: base_time - 2.minutes)
+      middle = create_payment(created_at: base_time - 1.minute)
+      newest = create_payment(created_at: base_time)
+      order = [[:created_at, :asc], [:id, :asc]]
+
+      first_page, cursor = described_class.paginate(payment_scope, limit: 2, order:)
+      second_page, next_cursor = described_class.paginate(payment_scope, cursor:, limit: 2, order:)
+
+      expect(first_page).to eq([oldest, middle])
+      expect(second_page).to eq([newest])
+      expect(next_cursor).to be_nil
+    end
+
+    it "returns an empty page for an empty scope" do
+      records, next_cursor = described_class.paginate(Payment.none, limit: 2, order: default_order)
+
+      expect(records).to eq([])
+      expect(next_cursor).to be_nil
+    end
+
+    it "raises ArgumentError for invalid pagination configuration" do
+      mismatched_cursor = described_class.encode("id" => 1)
+
+      expect { described_class.paginate(payment_scope, order: []) }.to raise_error(ArgumentError, /order/)
+      expect { described_class.paginate(payment_scope, order: [[:id, :sideways]]) }.to raise_error(ArgumentError, /direction/)
+      expect { described_class.paginate(payment_scope, order: [[:id, nil]]) }.to raise_error(ArgumentError, /direction/)
+      expect do
+        described_class.paginate(payment_scope, cursor: mismatched_cursor, order: default_order)
+      end.to raise_error(ArgumentError, /cursor keys/)
+    end
+  end
+
+  def create_payment(created_at:)
+    create(:payment, created_at:, updated_at: created_at)
+  end
+
+  def payment_scope
+    Payment.all
+  end
+
+  def signed_token(payload_json)
+    Base64.urlsafe_encode64(Rails.application.message_verifier(:admin_api_cursor).generate(payload_json))
+  end
+end


### PR DESCRIPTION
Ref #4989

## What
- Add a reusable, signed cursor helper for internal admin list endpoints.
- Support keyset pagination with opaque cursors, limit caps, and invalid-cursor handling.
- Add focused tests for cursor encoding, bad input, pagination behavior, and controller error handling.

## Why
- This gives the later admin list endpoints a single pagination primitive instead of each one inventing its own cursor logic.
- Signed cursors keep clients from guessing or editing pagination state, while keyset pagination stays stable on growing datasets.

---
This PR was implemented with AI assistance using gpt-5.5 xhigh.