### PR TITLE
Allow content publish when image moderation API fails but text is clean

### DIFF
--- a/app/services/content_moderation/strategies/classifier_strategy.rb
+++ b/app/services/content_moderation/strategies/classifier_strategy.rb
@@ -38,12 +38,14 @@ class ContentModeration::Strategies::ClassifierStrategy
     thresholds = load_thresholds
 
     flagged_categories = []
+    text_moderated = false
 
     if @text.present?
       scores = moderate([{ type: "text", text: @text }])
       if scores.nil?
         return Result.new(status: "flagged", reasoning: [UNAVAILABLE_REASON])
       end
+      text_moderated = true
       flagged_categories.concat(collect_flagged(scores, thresholds))
     end
 
@@ -68,7 +70,7 @@ class ContentModeration::Strategies::ClassifierStrategy
         image_url_count: @image_urls.size,
         skipped_urls: skipped_urls,
       )
-      return Result.new(status: "flagged", reasoning: [UNAVAILABLE_REASON])
+      return Result.new(status: "flagged", reasoning: [UNAVAILABLE_REASON]) unless text_moderated
     end
 
     if flagged_categories.any?

--- a/spec/services/content_moderation/strategies/classifier_strategy_spec.rb
+++ b/spec/services/content_moderation/strategies/classifier_strategy_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe ContentModeration::Strategies::ClassifierStrategy, :vcr do
     expect(result.reasoning).to eq(["OpenAI moderation flagged: violence (score: 0.95, threshold: 0.8)"])
   end
 
-  it "returns flagged with a retry reason and notifies Sentry when every image URL fails" do
+  it "returns flagged with a retry reason and notifies Sentry when every image URL fails and there is no text" do
     image_urls = [
       "blob:https://gumroad.com/bad-1",
       "https://cdn.example.com/bad-2.png",
@@ -159,13 +159,9 @@ RSpec.describe ContentModeration::Strategies::ClassifierStrategy, :vcr do
       { status: 400, body: { "error" => { "code" => "image_url_unavailable" } } },
       bad_response
     )
-    allow(client).to receive(:moderations) do |parameters:|
-      part = parameters[:input].first
-      raise bad_error if part[:type] == "image_url"
-      { "results" => [{ "category_scores" => {} }] }
-    end
+    allow(client).to receive(:moderations).and_raise(bad_error)
 
-    result = described_class.new(text: "some text", image_urls:).perform
+    result = described_class.new(text: "", image_urls:).perform
 
     expect(result.status).to eq("flagged")
     expect(result.reasoning).to eq([described_class::UNAVAILABLE_REASON])
@@ -174,6 +170,42 @@ RSpec.describe ContentModeration::Strategies::ClassifierStrategy, :vcr do
       image_url_count: 3,
       skipped_urls: match_array(image_urls),
     )
+  end
+
+  it "returns compliant and notifies Sentry when every image fails but text was moderated successfully" do
+    image_urls = [
+      "https://cdn.example.com/bad-1.png",
+      "https://cdn.example.com/bad-2.png",
+    ]
+    allow(client).to receive(:moderations) do |parameters:|
+      part = parameters[:input].first
+      raise Faraday::ServerError, "500 Internal Server Error" if part[:type] == "image_url"
+      { "results" => [{ "category_scores" => {} }] }
+    end
+
+    result = described_class.new(text: "some clean text", image_urls:).perform
+
+    expect(result.status).to eq("compliant")
+    expect(result.reasoning).to eq([])
+    expect(ErrorNotifier).to have_received(:notify).with(
+      "ContentModeration::ClassifierStrategy could not moderate any image",
+      image_url_count: 2,
+      skipped_urls: match_array(image_urls),
+    )
+  end
+
+  it "still flags text-flagged categories when image moderation fails alongside successful text moderation" do
+    image_urls = ["https://cdn.example.com/bad.png"]
+    allow(client).to receive(:moderations) do |parameters:|
+      part = parameters[:input].first
+      raise Faraday::ServerError, "500 Internal Server Error" if part[:type] == "image_url"
+      { "results" => [{ "category_scores" => { "violence" => 0.95 } }] }
+    end
+
+    result = described_class.new(text: "violent text", image_urls:).perform
+
+    expect(result.status).to eq("flagged")
+    expect(result.reasoning).to eq(["OpenAI moderation flagged: violence (score: 0.95, threshold: 0.8)"])
   end
 
   it "does not flag unavailability when text exists and image_urls is empty" do


### PR DESCRIPTION
## What

`ContentModeration::Strategies::ClassifierStrategy` no longer blocks a publish when OpenAI's image moderation endpoint fails on every image URL, **as long as text moderation succeeded**. The all-images-fail path now returns `flagged` only when there is no text signal either. Sentry notification is preserved so we still track upstream image-moderation failures.

Closes antiwork/gumroad-private#351.

## Why

A new seller hit `"Content moderation failed: We cannot moderate the content at this time."` on every publish attempt — rename, rewrite, re-upload, different times of day, all failed.

Root cause: OpenAI's `omni-moderation-latest` endpoint returns **HTTP 500 ("Unexpected error")** deterministically on the seller's PNGs. The images are valid (`HEAD` returns `200`, `content-type: image/png`) — they're 600×600 **8-bit grayscale+alpha** PNGs (PNG color type 4). Other sellers' images at the same URL pattern moderate fine, so it isn't the URL format. Confirmed by calling OpenAI directly with each of the affected image URLs — all 500.

Failure flow before this PR (`classifier_strategy.rb`):
1. Text moderation → compliant
2. Each image → 3 retries on `Faraday::ServerError` → all fail → `moderated_count == 0`
3. `@image_urls.any? && moderated_count == 0` → return `flagged` with `UNAVAILABLE_REASON`

The retry doesn't help because the failure is deterministic per-image, not transient. The "try again later" message is a lie, and the seller has no way to fix it from the UI.

Why fail-open is safe here:
- Text content is already moderated by both `ClassifierStrategy` and `PromptStrategy`.
- `PromptStrategy` separately checks images for adult content (skips the same URLs based on its own extension filter and was already failing open).
- `BlocklistStrategy` runs unaffected.
- Downstream guardrails (admin review, customer reports) remain.

Net result: when we have *any* successfully moderated text, an image-moderation outage no longer flips the verdict to flagged.

## Before / after — verification against real content

Ran the new `ClassifierStrategy` through the full `ModerateRecordService` against the affected products via the read-only prod console, using the live OpenAI API. `leave_admin_comment` stubbed to avoid writes.

```
 * 6 products with text + 1 affected image each:  before=FAIL  after=PASS
   1 product with text + no images:               before=PASS  after=PASS
```

All previously blocked products move from `FAIL` → `PASS` with the new code. The image-less product stays `PASS` (no regression).

OpenAI still returns 500 on the affected PNGs during the after-run — the fix doesn't paper over that, it just stops treating image-API outages as content violations when text was successfully checked.

## Test Results

```
$ bundle exec rspec spec/services/content_moderation/strategies/classifier_strategy_spec.rb spec/services/content_moderation/moderate_record_service_spec.rb
21 examples, 0 failures  (classifier_strategy_spec)
12 examples, 0 failures  (moderate_record_service_spec)
```

Added two new specs and reframed one existing spec:
- `returns flagged ... when every image URL fails and there is no text` — keeps the fail-closed assertion for the no-signal case (existing test, reframed to use blank text).
- `returns compliant ... when every image fails but text was moderated successfully` — regression test for this issue. Fails on `main`, passes on this branch.
- `still flags text-flagged categories when image moderation fails alongside successful text moderation` — confirms text-side flags (e.g. `violence`) aren't accidentally swallowed by the new fail-open path.

## Out of scope

- **Underlying OpenAI quirk** on grayscale+alpha PNGs. Possible follow-ups: re-encode images to RGBA before sending, or pre-validate via ImageMagick. Heavier, separate PR.
- **`PromptStrategy`'s URL-extension filter** is overly strict (it also skipped these valid PNGs) but it fails open today, so it didn't cause user-visible harm. Could be revisited.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) using Claude Opus 4.7 (1M context).