### PR TITLE
Integrate Stripe Radar signals into admin UI + value list sync

### DIFF
--- a/.hermes/plans/2026-05-07-stripe-radar-integration.md
+++ b/.hermes/plans/2026-05-07-stripe-radar-integration.md
@@ -1,0 +1,313 @@
+# Stripe Radar Integration — Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Surface Stripe Radar signals (risk scores, early fraud warnings, dispute predictions) in Gumroad's admin/risk UI and use them to auto-flag or auto-suspend sellers.
+
+**Architecture:** Persist `outcome.risk_level` on every charge (standard Radar — no Fraud Teams). Aggregate per-seller Radar signals into a risk profile shown in admin. Auto-flag sellers who cross configurable thresholds. Feed Gumroad's blocked buyers/sellers back to Stripe via Radar value lists.
+
+**Note:** We use standard Radar (free), not Radar for Fraud Teams ($0.07/txn). This means: no numeric `risk_score` (0-99), no `review.opened/closed` events, no custom rule predicates. We work with `risk_level` (normal/elevated/highest) only.
+
+**Tech Stack:** Rails 8, Stripe API (v2025+), Inertia/React admin UI, Sidekiq jobs
+
+---
+
+## Audit Summary — What Exists Today
+
+### Already working
+- `radar.early_fraud_warning.created/updated` → `StripeChargeRadarProcessor` → `EarlyFraudWarning` model → `ProcessEarlyFraudWarningJob` (auto-refunds actionable fraud)
+- `charge.dispute.*` → full dispute lifecycle (formalize → fight → win/lost)
+- `charge.outcome.risk_level` extracted in `StripeCharge` but **not persisted** on Purchase/Charge
+- Buyer-side auto-blocking: card testing detection, fraudulent decline auto-suspend, chargeback count blocking
+- Seller-side auto-probation: balance < -$100
+- Seller risk state machine: `not_reviewed → compliant/on_probation/flagged/suspended`
+- WatchedUser model for manual watchlist
+- Internal admin API with full user/purchase/payout management
+- Admin UI: risk state, suspend for fraud, watchlist, unreviewed queue
+
+### Gaps (what this plan builds)
+1. **`outcome.risk_level` not persisted** — we capture it in `StripeCharge` but discard it, never stored on Charge records
+2. **No per-seller risk aggregation** — no way to see "this seller's buyers have 40% elevated+ charges"
+3. **No auto-flag from Radar signals** — sellers accumulating high-risk charges don't get flagged automatically
+4. **No Radar signals in admin UI** — reviewers don't see risk levels, EFW history, or charge outcomes
+5. **No Stripe value list sync** — Gumroad's blocked buyers aren't pushed to Stripe Radar
+6. **No data to evaluate "maximize protection"** — can't project false positive impact without persisted risk levels
+
+---
+
+## Phase 1: Persist Radar Data on Charges
+
+### Task 1: Add risk columns to charges table
+
+**Objective:** Store `outcome.risk_level` and `outcome.risk_score` on every charge
+
+**Files:**
+- Create: `db/migrate/XXXX_add_radar_fields_to_charges.rb`
+- Modify: `app/models/charge.rb`
+
+```ruby
+# Migration
+class AddRadarFieldsToCharges < ActiveRecord::Migration[8.0]
+  def change
+    add_column :charges, :stripe_risk_level, :string
+    add_column :charges, :stripe_outcome_type, :string
+    add_column :charges, :stripe_outcome_reason, :string
+    add_index :charges, :stripe_risk_level
+  end
+end
+```
+
+**Verification:** `rails db:migrate` succeeds, `Charge.column_names` includes new fields
+
+### Task 2: Populate risk fields when charges are created
+
+**Objective:** Extract Radar outcome data from Stripe charge objects and persist it
+
+**Files:**
+- Modify: `app/business/payments/charging/implementations/stripe/stripe_charge.rb`
+- Modify: wherever `Charge` records are created from Stripe responses
+
+Find where `StripeCharge` maps Stripe data → Gumroad fields. Add:
+```ruby
+charge.stripe_risk_level = stripe_charge.outcome&.risk_level
+charge.stripe_outcome_type = stripe_charge.outcome&.type
+charge.stripe_outcome_reason = stripe_charge.outcome&.reason
+```
+
+**Verification:** Create a test charge in Stripe test mode, confirm `Charge.last.stripe_risk_level` is populated
+
+### Task 3: Backfill risk data for recent charges
+
+**Objective:** Populate risk fields for last 90 days of charges from Stripe API
+
+**Files:**
+- Create: `app/sidekiq/backfill_charge_radar_data_job.rb`
+
+```ruby
+class BackfillChargeRadarDataJob
+  include Sidekiq::Job
+  sidekiq_options queue: :low_priority
+
+  def perform(charge_id)
+    charge = Charge.find(charge_id)
+    return if charge.stripe_risk_level.present?
+    return unless charge.stripe_transaction_id.present?
+
+    stripe_charge = Stripe::Charge.retrieve(charge.stripe_transaction_id)
+    charge.update!(
+      stripe_risk_level: stripe_charge.outcome&.risk_level,
+      stripe_outcome_type: stripe_charge.outcome&.type,
+      stripe_outcome_reason: stripe_charge.outcome&.reason
+    )
+  end
+end
+```
+
+Run via: `Charge.where(stripe_risk_level: nil).where("created_at > ?", 90.days.ago).find_each { |c| BackfillChargeRadarDataJob.perform_async(c.id) }`
+
+---
+
+## Phase 2: Per-Seller Risk Aggregation
+
+### Task 4: Add seller risk stats service
+
+**Objective:** Compute per-seller Radar risk stats: % elevated charges, % highest charges, EFW count, dispute rate
+
+**Files:**
+- Create: `app/services/radar/seller_risk_stats_service.rb`
+
+```ruby
+module Radar
+  class SellerRiskStatsService
+    def initialize(user)
+      @user = user
+    end
+
+    def stats(period: 90.days)
+      charges = @user.charges.where("created_at > ?", period.ago)
+      total = charges.count
+      return {} if total.zero?
+
+      {
+        total_charges: total,
+        elevated_count: charges.where(stripe_risk_level: "elevated").count,
+        highest_count: charges.where(stripe_risk_level: "highest").count,
+        elevated_pct: (charges.where(stripe_risk_level: "elevated").count * 100.0 / total).round(1),
+        highest_pct: (charges.where(stripe_risk_level: "highest").count * 100.0 / total).round(1),
+        efw_count: @user.purchases.joins(:early_fraud_warning).where("purchases.created_at > ?", period.ago).count,
+        dispute_count: @user.disputes.where("created_at > ?", period.ago).count,
+        dispute_rate: (@user.disputes.where("created_at > ?", period.ago).count * 100.0 / total).round(2)
+      }
+    end
+  end
+end
+```
+
+**Verification:** `Radar::SellerRiskStatsService.new(User.find(X)).stats` returns populated hash
+
+### Task 5: Auto-flag sellers based on Radar thresholds
+
+**Objective:** Automatically flag sellers when their Radar stats exceed thresholds
+
+**Files:**
+- Create: `app/sidekiq/radar/check_seller_risk_job.rb`
+
+```ruby
+module Radar
+  class CheckSellerRiskJob
+    include Sidekiq::Job
+    sidekiq_options queue: :default
+
+    # Configurable thresholds
+    ELEVATED_PCT_THRESHOLD = 20  # >20% elevated charges → flag
+    HIGHEST_PCT_THRESHOLD = 5   # >5% highest charges → flag
+    EFW_COUNT_THRESHOLD = 3     # 3+ EFWs in 90 days → flag
+    DISPUTE_RATE_THRESHOLD = 1  # >1% dispute rate → flag
+
+    def perform(user_id)
+      user = User.find(user_id)
+      return unless user.user_risk_state.in?(%w[not_reviewed compliant])
+
+      stats = SellerRiskStatsService.new(user).stats
+      return if stats[:total_charges].to_i < 10  # skip low-volume
+
+      reasons = []
+      reasons << "#{stats[:elevated_pct]}% elevated-risk charges" if stats[:elevated_pct] > ELEVATED_PCT_THRESHOLD
+      reasons << "#{stats[:highest_pct]}% highest-risk charges" if stats[:highest_pct] > HIGHEST_PCT_THRESHOLD
+      reasons << "#{stats[:efw_count]} early fraud warnings" if stats[:efw_count] >= EFW_COUNT_THRESHOLD
+      reasons << "#{stats[:dispute_rate]}% dispute rate" if stats[:dispute_rate] > DISPUTE_RATE_THRESHOLD
+
+      return if reasons.empty?
+
+      user.flag_for_fraud!
+      user.add_comment(
+        author_name: "radar_auto_flag",
+        content: "Auto-flagged by Radar signals (90d): #{reasons.join(', ')}. Stats: #{stats.inspect}"
+      )
+    end
+  end
+end
+```
+
+Trigger: run after each charge via `charge.succeeded` event, or on a daily cron for all sellers with recent charges.
+
+**Verification:** Create seller with test charges above threshold, run job, confirm state changes to `flagged_for_fraud`
+
+---
+
+## Phase 3: Surface Radar Signals in Admin UI
+
+### Task 6: Add Radar stats to admin user presenter
+
+**Objective:** Include Radar risk stats in the admin user card
+
+**Files:**
+- Modify: `app/presenters/admin/user_presenter/card.rb`
+
+Add to the presenter hash:
+```ruby
+radar_stats: Radar::SellerRiskStatsService.new(user).stats,
+recent_efws: user.purchases.joins(:early_fraud_warning)
+  .order(created_at: :desc).limit(5)
+  .map { |p| { purchase_id: p.external_id, fraud_type: p.early_fraud_warning.fraud_type, risk_level: p.early_fraud_warning.charge_risk_level, created_at: p.early_fraud_warning.created_at } },
+```
+
+### Task 7: Build Radar signals panel in admin UI
+
+**Objective:** Show Radar stats, EFW history, and risk score distribution in the admin user page
+
+**Files:**
+- Create: `app/javascript/components/Admin/Users/PermissionRisk/RadarSignals.tsx`
+- Modify: `app/javascript/components/Admin/Users/PermissionRisk/index.tsx`
+
+Component shows:
+- Risk level distribution bar (normal/elevated/highest)
+- EFW count with fraud types
+- Dispute rate
+- Color-coded thresholds (green/yellow/red)
+
+### Task 8: Add risk level to admin purchase search results
+
+**Objective:** Show Stripe risk level in purchase search results in admin
+
+**Files:**
+- Modify: `app/controllers/admin/search/purchases_controller.rb` or relevant presenter
+- Modify: admin purchases search UI component
+
+Add `stripe_risk_level` to purchase search result cards.
+
+---
+
+## Phase 4: Sync Gumroad Blocks → Stripe Radar Value Lists
+
+### Task 9: Create Stripe Radar value list sync service
+
+**Objective:** Push Gumroad's blocked buyers (emails, card fingerprints) to Stripe Radar block lists so Radar rules can reference them
+
+**Files:**
+- Create: `app/services/radar/value_list_sync_service.rb`
+- Create: `app/sidekiq/radar/sync_value_lists_job.rb`
+
+```ruby
+module Radar
+  class ValueListSyncService
+    BLOCKED_EMAILS_LIST = "gumroad_blocked_emails"
+    BLOCKED_CARDS_LIST = "gumroad_blocked_cards"
+
+    def sync_blocked_emails
+      list = find_or_create_list(BLOCKED_EMAILS_LIST, "email")
+      BlockedObject.where(object_type: "email").where("created_at > ?", 1.day.ago).find_each do |bo|
+        Stripe::Radar::ValueListItem.create(value_list: list.id, value: bo.object_value)
+      rescue Stripe::InvalidRequestError => e
+        # Already exists, skip
+        raise unless e.message.include?("already exists")
+      end
+    end
+
+    def sync_blocked_cards
+      list = find_or_create_list(BLOCKED_CARDS_LIST, "card_fingerprint")
+      BlockedObject.where(object_type: "stripe_fingerprint").where("created_at > ?", 1.day.ago).find_each do |bo|
+        Stripe::Radar::ValueListItem.create(value_list: list.id, value: bo.object_value)
+      rescue Stripe::InvalidRequestError => e
+        raise unless e.message.include?("already exists")
+      end
+    end
+
+    private
+
+    def find_or_create_list(alias_name, item_type)
+      Stripe::Radar::ValueList.retrieve(alias_name)
+    rescue Stripe::InvalidRequestError
+      Stripe::Radar::ValueList.create(alias: alias_name, name: alias_name.titleize, item_type: item_type)
+    end
+  end
+end
+```
+
+Then create Radar rules in Stripe Dashboard:
+- `Block if ::is_blocked::` (using `gumroad_blocked_emails` list)
+- `Block if :card_fingerprint: in ::gumroad_blocked_cards::`
+
+**Verification:** Block a test email in Gumroad, run sync, confirm it appears in Stripe Radar value list via Dashboard
+
+---
+
+## Execution Order
+
+| Phase | Tasks | Deps | Est. |
+|-------|-------|------|------|
+| 1. Persist Radar data | 1-3 | None | 1 day |
+| 2. Risk aggregation | 4-5 | Phase 1 | 0.5 day |
+| 3. Admin UI | 6-8 | Phases 1-2 | 1 day |
+| 4. Value list sync | 9 | None (independent) | 0.5 day |
+
+**Total: ~3 days of focused work**
+
+Phases 1+4 can run in parallel.
+
+---
+
+## Open Questions
+
+1. **Auto-flag vs auto-suspend?** Plan uses auto-flag (human reviews before suspension). Could auto-suspend for extreme thresholds (e.g., >10% highest-risk charges).
+2. **Threshold tuning** — The constants in Task 5 are starting points. Adjust based on actual data after backfill.

--- a/app/controllers/admin/search/purchases_controller.rb
+++ b/app/controllers/admin/search/purchases_controller.rb
@@ -22,7 +22,7 @@ class Admin::Search::PurchasesController < Admin::BaseController
       query: params[:query]&.strip,
       product_title_query: params[:product_title_query]&.strip,
       **search_params,
-    )
+    ).includes(:early_fraud_warning, :disputes)
 
     pagination, purchases = pagy_countless(
       @purchases,

--- a/app/javascript/components/Admin/Users/PermissionRisk/RadarSignals.tsx
+++ b/app/javascript/components/Admin/Users/PermissionRisk/RadarSignals.tsx
@@ -1,0 +1,152 @@
+import React from "react";
+
+import type { User } from "$app/components/Admin/Users/User";
+import { Details, DetailsToggle } from "$app/components/ui/Details";
+
+type RadarSignalsProps = {
+  user: User;
+};
+
+const disputeRateColor = (rate: number): string => {
+  if (rate > 1) return "text-red-600";
+  if (rate >= 0.5) return "text-yellow-600";
+  return "text-green-600";
+};
+
+const efwCountColor = (count: number): string => {
+  if (count >= 3) return "text-red-600";
+  if (count >= 1) return "text-yellow-600";
+  return "text-green-600";
+};
+
+const riskLevelBadge = (level: string): string => {
+  switch (level) {
+    case "highest":
+      return "bg-red-100 text-red-800";
+    case "elevated":
+      return "bg-yellow-100 text-yellow-800";
+    default:
+      return "bg-gray-100 text-gray-800";
+  }
+};
+
+const formatDate = (iso: string) => {
+  const d = new Date(iso);
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+};
+
+const RadarSignals = ({ user }: RadarSignalsProps) => {
+  const stats = user.radar_stats;
+  const recentEfws = user.recent_efws ?? [];
+
+  if (!stats) return null;
+
+  const fraudTypeEntries = Object.entries(stats.efw_by_fraud_type);
+
+  return (
+    <>
+      <hr />
+      <Details>
+        <DetailsToggle>
+          <h3>Radar Signals (90 days)</h3>
+        </DetailsToggle>
+        <div className="grid gap-4">
+          {/* Summary stats */}
+          <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+            <div className="rounded border border-border p-3">
+              <span className="text-xs tracking-wide text-muted uppercase">Total Purchases</span>
+              <p className="text-lg font-medium">{stats.total_purchases}</p>
+            </div>
+            <div className="rounded border border-border p-3">
+              <span className="text-xs tracking-wide text-muted uppercase">EFW Count</span>
+              <p className={`text-lg font-medium ${efwCountColor(stats.efw_count)}`}>{stats.efw_count}</p>
+            </div>
+            <div className="rounded border border-border p-3">
+              <span className="text-xs tracking-wide text-muted uppercase">Dispute Count</span>
+              <p className="text-lg font-medium">{stats.dispute_count}</p>
+            </div>
+            <div className="rounded border border-border p-3">
+              <span className="text-xs tracking-wide text-muted uppercase">Dispute Rate</span>
+              <p className={`text-lg font-medium ${disputeRateColor(stats.dispute_rate)}`}>{stats.dispute_rate}%</p>
+            </div>
+          </div>
+
+          {/* Risk level breakdown */}
+          {(stats.efw_with_elevated_risk > 0 || stats.efw_with_highest_risk > 0) && (
+            <div className="grid gap-1">
+              <span className="text-xs font-medium tracking-wide text-muted uppercase">EFW Risk Levels</span>
+              <div className="flex gap-3">
+                {stats.efw_with_elevated_risk > 0 && (
+                  <span className="inline-flex items-center rounded-full bg-yellow-100 px-2.5 py-0.5 text-xs font-medium text-yellow-800">
+                    Elevated: {stats.efw_with_elevated_risk}
+                  </span>
+                )}
+                {stats.efw_with_highest_risk > 0 && (
+                  <span className="inline-flex items-center rounded-full bg-red-100 px-2.5 py-0.5 text-xs font-medium text-red-800">
+                    Highest: {stats.efw_with_highest_risk}
+                  </span>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Fraud type breakdown */}
+          {fraudTypeEntries.length > 0 && (
+            <div className="grid gap-1">
+              <span className="text-xs font-medium tracking-wide text-muted uppercase">EFW by Fraud Type</span>
+              <div className="flex flex-wrap gap-2">
+                {fraudTypeEntries.map(([type, count]) => (
+                  <span
+                    key={type}
+                    className="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-800"
+                  >
+                    {type.replace(/_/gu, " ")}: {count}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Recent EFWs table */}
+          {recentEfws.length > 0 && (
+            <div className="grid gap-1">
+              <span className="text-xs font-medium tracking-wide text-muted uppercase">Recent EFWs</span>
+              <div className="overflow-x-auto">
+                <table className="w-full text-left text-sm">
+                  <thead>
+                    <tr className="border-b border-border text-xs text-muted uppercase">
+                      <th className="px-2 py-1">Purchase ID</th>
+                      <th className="px-2 py-1">Fraud Type</th>
+                      <th className="px-2 py-1">Risk Level</th>
+                      <th className="px-2 py-1">Resolution</th>
+                      <th className="px-2 py-1">Date</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {recentEfws.map((efw, idx) => (
+                      <tr key={idx} className="border-b border-border last:border-0">
+                        <td className="px-2 py-1 font-mono text-xs">{efw.purchase_id ?? "—"}</td>
+                        <td className="px-2 py-1">{efw.fraud_type.replace(/_/gu, " ")}</td>
+                        <td className="px-2 py-1">
+                          <span
+                            className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${riskLevelBadge(efw.charge_risk_level)}`}
+                          >
+                            {efw.charge_risk_level}
+                          </span>
+                        </td>
+                        <td className="px-2 py-1">{efw.resolution.replace(/_/gu, " ")}</td>
+                        <td className="px-2 py-1 text-muted">{formatDate(efw.created_at)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+        </div>
+      </Details>
+    </>
+  );
+};
+
+export default RadarSignals;

--- a/app/javascript/components/Admin/Users/PermissionRisk/index.tsx
+++ b/app/javascript/components/Admin/Users/PermissionRisk/index.tsx
@@ -5,6 +5,7 @@ import Bio from "$app/components/Admin/Users/PermissionRisk/Bio";
 import CompliantStatus from "$app/components/Admin/Users/PermissionRisk/CompliantStatus";
 import UserGuids from "$app/components/Admin/Users/PermissionRisk/Guids";
 import LatestPosts from "$app/components/Admin/Users/PermissionRisk/LatestPosts";
+import RadarSignals from "$app/components/Admin/Users/PermissionRisk/RadarSignals";
 import SchedulePayout from "$app/components/Admin/Users/PermissionRisk/SchedulePayout";
 import SuspendForFraud from "$app/components/Admin/Users/PermissionRisk/SuspendForFraud";
 import WatchedUser from "$app/components/Admin/Users/PermissionRisk/WatchedUser";
@@ -24,6 +25,7 @@ const AdminUserPermissionRisk = ({ user }: AdminUserPermissionRiskProps) => (
     </div>
 
     <SuspendForFraud user={user} />
+    <RadarSignals user={user} />
     <SchedulePayout user={user} />
     <WatchedUser user={user} />
     <UserGuids user_external_id={user.external_id} />

--- a/app/javascript/components/Admin/Users/User.tsx
+++ b/app/javascript/components/Admin/Users/User.tsx
@@ -45,6 +45,24 @@ export type ActiveWatchedUser = {
   created_at: string;
 };
 
+export type RadarStats = {
+  total_purchases: number;
+  efw_count: number;
+  efw_by_fraud_type: Record<string, number>;
+  efw_with_elevated_risk: number;
+  efw_with_highest_risk: number;
+  dispute_count: number;
+  dispute_rate: number;
+};
+
+export type RecentEfw = {
+  purchase_id: number | null;
+  fraud_type: string;
+  charge_risk_level: string;
+  resolution: string;
+  created_at: string;
+};
+
 export type User = {
   external_id: string;
   email: string;
@@ -79,6 +97,8 @@ export type User = {
   created_at: string;
   updated_at: string;
   deleted_at: string | null;
+  radar_stats?: RadarStats | null;
+  recent_efws?: RecentEfw[];
 };
 
 export type Props = {

--- a/app/javascript/pages/Admin/Search/Purchases/Index.tsx
+++ b/app/javascript/pages/Admin/Search/Purchases/Index.tsx
@@ -11,6 +11,7 @@ import { Button } from "$app/components/Button";
 import { CopyToClipboard } from "$app/components/CopyToClipboard";
 import { InlineList } from "$app/components/ui/InlineList";
 import { Input } from "$app/components/ui/Input";
+import { Pill } from "$app/components/ui/Pill";
 import { Select } from "$app/components/ui/Select";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "$app/components/ui/Table";
 import { useOriginalLocation } from "$app/components/useOriginalLocation";
@@ -34,6 +35,8 @@ type Purchase = {
   chargeback_reversed: boolean;
   error_code: string | null;
   last_chargebacked_purchase: string | null;
+  early_fraud_warning: { fraud_type: string; charge_risk_level: string } | null;
+  disputes: { state: string }[];
 };
 
 export default function Purchases() {
@@ -105,6 +108,21 @@ export default function Purchases() {
                       <ArrowUpRightSquare className="size-5" />
                     </a>{" "}
                     <PurchaseStates purchase={purchase} />
+                    {purchase.early_fraud_warning ? (
+                      <Pill size="small" color="warning">
+                        EFW: {purchase.early_fraud_warning.fraud_type.replaceAll("_", " ")} (risk:{" "}
+                        {purchase.early_fraud_warning.charge_risk_level})
+                      </Pill>
+                    ) : null}
+                    {purchase.disputes.map((dispute, i) => (
+                      <Pill
+                        key={i}
+                        size="small"
+                        color={dispute.state === "won" ? "success" : dispute.state === "lost" ? "danger" : "warning"}
+                      >
+                        Dispute: {dispute.state}
+                      </Pill>
+                    ))}
                     <div className="text-sm">
                       <InlineList>
                         {purchase.refund_policy ? (

--- a/app/presenters/admin/purchase_presenter.rb
+++ b/app/presenters/admin/purchase_presenter.rb
@@ -30,6 +30,11 @@ class Admin::PurchasePresenter
       chargeback_reversed: purchase.chargeback_reversed?,
       error_code: purchase.failed? ? purchase.formatted_error_code : nil,
       last_chargebacked_purchase: purchase.find_past_chargebacked_purchases.first&.external_id,
+      early_fraud_warning: purchase.early_fraud_warning ? {
+        fraud_type: purchase.early_fraud_warning.fraud_type,
+        charge_risk_level: purchase.early_fraud_warning.charge_risk_level,
+      } : nil,
+      disputes: purchase.disputes.map { |d| { state: d.state } },
     }
   end
 

--- a/app/presenters/admin/user_presenter/card.rb
+++ b/app/presenters/admin/user_presenter/card.rb
@@ -64,7 +64,11 @@ class Admin::UserPresenter::Card
 
       # Associations
       admin_manageable_user_memberships: user_memberships,
-      alive_user_compliance_info: compliance_info
+      alive_user_compliance_info: compliance_info,
+
+      # Radar risk signals
+      radar_stats: radar_stats,
+      recent_efws: recent_efws
     }
   end
 
@@ -136,5 +140,17 @@ class Admin::UserPresenter::Card
         has_individual_tax_id: info.has_individual_tax_id,
         has_business_tax_id: info.has_business_tax_id
       }
+    end
+
+    def radar_stats
+      radar_service.stats
+    end
+
+    def recent_efws
+      radar_service.recent_efws
+    end
+
+    def radar_service
+      @radar_service ||= Radar::SellerRiskStatsService.new(user)
     end
 end

--- a/app/services/radar/seller_risk_stats_service.rb
+++ b/app/services/radar/seller_risk_stats_service.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module Radar
+  class SellerRiskStatsService
+    LOOKBACK_PERIOD = 90.days
+
+    attr_reader :user
+
+    def initialize(user)
+      @user = user
+    end
+
+    def stats
+      {
+        total_purchases: total_purchases_count,
+        efw_count: efws.count,
+        efw_by_fraud_type: efw_by_fraud_type,
+        efw_with_elevated_risk: efws.where(charge_risk_level: EarlyFraudWarning::CHARGE_RISK_LEVEL_ELEVATED).count,
+        efw_with_highest_risk: efws.where(charge_risk_level: EarlyFraudWarning::CHARGE_RISK_LEVEL_HIGHEST).count,
+        dispute_count: dispute_count,
+        dispute_rate: dispute_rate
+      }
+    end
+
+    def recent_efws(limit = 5)
+      efws.includes(:purchase).order(created_at: :desc).limit(limit).map do |efw|
+        {
+          purchase_id: efw.purchase&.external_id,
+          fraud_type: efw.fraud_type,
+          charge_risk_level: efw.charge_risk_level,
+          resolution: efw.resolution,
+          created_at: efw.created_at
+        }
+      end
+    end
+
+    private
+      def cutoff_date
+        @cutoff_date ||= LOOKBACK_PERIOD.ago
+      end
+
+      def total_purchases_count
+        @total_purchases_count ||= user.sales.where("purchases.created_at >= ?", cutoff_date).count
+      end
+
+      def efws
+        @efws ||= EarlyFraudWarning
+          .joins(:purchase)
+          .where(purchases: { seller_id: user.id })
+          .where("purchase_early_fraud_warnings.created_at >= ?", cutoff_date)
+      end
+
+      def dispute_count
+        @dispute_count ||= Dispute
+          .where(seller_id: user.id)
+          .where("disputes.created_at >= ?", cutoff_date)
+          .count
+      end
+
+      def dispute_rate
+        return 0.0 if total_purchases_count.zero?
+
+        (dispute_count.to_f / total_purchases_count * 100).round(2)
+      end
+
+      def efw_by_fraud_type
+        efws.group(:fraud_type).count
+      end
+  end
+end

--- a/app/services/radar/value_list_sync_service.rb
+++ b/app/services/radar/value_list_sync_service.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class Radar::ValueListSyncService
+  BLOCKED_EMAILS_LIST = "gumroad_blocked_emails"
+  BLOCKED_CARDS_LIST = "gumroad_blocked_cards"
+
+  def sync_blocked_emails
+    value_list = find_or_create_list(
+      list_alias: BLOCKED_EMAILS_LIST,
+      name: "Gumroad Blocked Emails",
+      item_type: "email"
+    )
+
+    blocked_emails = BlockedObject.email.active.where(:created_at.gte => 1.day.ago)
+    blocked_emails.each do |blocked_object|
+      add_item_to_list(value_list.id, blocked_object.object_value)
+    end
+  end
+
+  def sync_blocked_cards
+    value_list = find_or_create_list(
+      list_alias: BLOCKED_CARDS_LIST,
+      name: "Gumroad Blocked Cards",
+      item_type: "card_fingerprint"
+    )
+
+    blocked_cards = BlockedObject.charge_processor_fingerprint.active.where(:created_at.gte => 1.day.ago)
+    blocked_cards.each do |blocked_object|
+      add_item_to_list(value_list.id, blocked_object.object_value)
+    end
+  end
+
+  private
+
+  def find_or_create_list(list_alias:, name:, item_type:)
+    Stripe::Radar::ValueList.retrieve(list_alias)
+  rescue Stripe::InvalidRequestError
+    Stripe::Radar::ValueList.create(
+      alias: list_alias,
+      name: name,
+      item_type: item_type
+    )
+  end
+
+  def add_item_to_list(value_list_id, value)
+    Stripe::Radar::ValueListItem.create(
+      value_list: value_list_id,
+      value: value
+    )
+  rescue Stripe::InvalidRequestError => e
+    raise unless e.message.include?("already exists")
+  end
+end

--- a/app/sidekiq/radar/sync_value_lists_job.rb
+++ b/app/sidekiq/radar/sync_value_lists_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class Radar::SyncValueListsJob
+  include Sidekiq::Job
+
+  sidekiq_options queue: :low, retry: 3
+
+  def perform
+    service = Radar::ValueListSyncService.new
+    service.sync_blocked_emails
+    service.sync_blocked_cards
+  end
+end

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -36,6 +36,10 @@ forcefully_finish_long_running_community_chat_recap_runs:
   description: Forcefully finishes long running community chat recap runs
 
 # Daily in format: [minute] [hour] * * *
+sync_radar_value_lists:
+  cron: "0 3 * * *" # UTC 03:00
+  class: Radar::SyncValueListsJob
+  description: Syncs blocked emails and card fingerprints to Stripe Radar value lists
 perform_daily_instant_payouts_worker:
   cron: "0 8 * * *" # UTC 08:00, should be run before the weekly payouts job at 10:00
   class: PerformDailyInstantPayoutsWorker

--- a/spec/services/radar/value_list_sync_service_spec.rb
+++ b/spec/services/radar/value_list_sync_service_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Radar::ValueListSyncService do
+  let(:service) { described_class.new }
+
+  let(:value_list) { double("ValueList", id: "rsl_123") }
+
+  describe "#sync_blocked_emails" do
+    before do
+      allow(Stripe::Radar::ValueList).to receive(:retrieve)
+        .with("gumroad_blocked_emails")
+        .and_return(value_list)
+    end
+
+    it "pushes recently blocked emails to Stripe Radar" do
+      blocked_email = BlockedObject.block!(BLOCKED_OBJECT_TYPES[:email], "bad@example.com", nil)
+
+      expect(Stripe::Radar::ValueListItem).to receive(:create).with(
+        value_list: "rsl_123",
+        value: "bad@example.com"
+      )
+
+      service.sync_blocked_emails
+    end
+
+    it "skips emails blocked more than a day ago" do
+      travel_to 2.days.ago do
+        BlockedObject.block!(BLOCKED_OBJECT_TYPES[:email], "old@example.com", nil)
+      end
+
+      expect(Stripe::Radar::ValueListItem).not_to receive(:create)
+
+      service.sync_blocked_emails
+    end
+
+    it "creates the value list if it does not exist" do
+      allow(Stripe::Radar::ValueList).to receive(:retrieve)
+        .with("gumroad_blocked_emails")
+        .and_raise(Stripe::InvalidRequestError.new("No such value list", "alias"))
+
+      expect(Stripe::Radar::ValueList).to receive(:create).with(
+        alias: "gumroad_blocked_emails",
+        name: "Gumroad Blocked Emails",
+        item_type: "email"
+      ).and_return(value_list)
+
+      service.sync_blocked_emails
+    end
+
+    it "ignores duplicate item errors" do
+      BlockedObject.block!(BLOCKED_OBJECT_TYPES[:email], "dup@example.com", nil)
+
+      allow(Stripe::Radar::ValueListItem).to receive(:create)
+        .and_raise(Stripe::InvalidRequestError.new("This value already exists", "value"))
+
+      expect { service.sync_blocked_emails }.not_to raise_error
+    end
+  end
+
+  describe "#sync_blocked_cards" do
+    before do
+      allow(Stripe::Radar::ValueList).to receive(:retrieve)
+        .with("gumroad_blocked_cards")
+        .and_return(value_list)
+    end
+
+    it "pushes recently blocked card fingerprints to Stripe Radar" do
+      BlockedObject.block!(BLOCKED_OBJECT_TYPES[:charge_processor_fingerprint], "fp_abc123", nil)
+
+      expect(Stripe::Radar::ValueListItem).to receive(:create).with(
+        value_list: "rsl_123",
+        value: "fp_abc123"
+      )
+
+      service.sync_blocked_cards
+    end
+
+    it "skips fingerprints blocked more than a day ago" do
+      travel_to 2.days.ago do
+        BlockedObject.block!(BLOCKED_OBJECT_TYPES[:charge_processor_fingerprint], "fp_old", nil)
+      end
+
+      expect(Stripe::Radar::ValueListItem).not_to receive(:create)
+
+      service.sync_blocked_cards
+    end
+
+    it "ignores duplicate item errors" do
+      BlockedObject.block!(BLOCKED_OBJECT_TYPES[:charge_processor_fingerprint], "fp_dup", nil)
+
+      allow(Stripe::Radar::ValueListItem).to receive(:create)
+        .and_raise(Stripe::InvalidRequestError.new("This value already exists", "value"))
+
+      expect { service.sync_blocked_cards }.not_to raise_error
+    end
+  end
+end

--- a/spec/sidekiq/radar/sync_value_lists_job_spec.rb
+++ b/spec/sidekiq/radar/sync_value_lists_job_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Radar::SyncValueListsJob do
+  it "is enqueued in the low queue" do
+    expect(described_class.sidekiq_options["queue"]).to eq("low")
+  end
+
+  describe "#perform" do
+    it "calls sync_blocked_emails and sync_blocked_cards on the service" do
+      service = instance_double(Radar::ValueListSyncService)
+      allow(Radar::ValueListSyncService).to receive(:new).and_return(service)
+
+      expect(service).to receive(:sync_blocked_emails)
+      expect(service).to receive(:sync_blocked_cards)
+
+      described_class.new.perform
+    end
+  end
+end


### PR DESCRIPTION
## What

Surface Stripe Radar signals in admin for fraud reviewers and sync Gumroad's blocked buyers to Stripe Radar value lists.

Closes antiwork/gumroad-private#348

## Changes

### Admin UI — Radar Signals Panel
- **`Radar::SellerRiskStatsService`** — computes per-seller risk stats over 90 days:
  - Total purchases, EFW count, dispute count/rate
  - EFW breakdown by fraud type and risk level (elevated/highest)
  - Recent EFWs with purchase ID, fraud type, risk level, resolution
- **`RadarSignals.tsx`** — new panel on admin user page:
  - 4-column stat cards with color-coded thresholds (green/yellow/red)
  - EFW risk level badges and fraud type breakdown
  - Recent EFWs table
- **Purchase search** — EFW and dispute indicators (pills) on admin purchase search results

### Value List Sync
- **`Radar::ValueListSyncService`** — pushes recently blocked emails and card fingerprints to Stripe Radar value lists (`gumroad_blocked_emails`, `gumroad_blocked_cards`)
- **`Radar::SyncValueListsJob`** — daily cron at 3 AM UTC
- Once synced, create Radar rules in Stripe Dashboard to block known bad actors at checkout

## Files (14 changed, +788 −2)

**New:**
- `app/services/radar/seller_risk_stats_service.rb`
- `app/services/radar/value_list_sync_service.rb`
- `app/sidekiq/radar/sync_value_lists_job.rb`
- `app/javascript/components/Admin/Users/PermissionRisk/RadarSignals.tsx`
- `spec/services/radar/value_list_sync_service_spec.rb`
- `spec/sidekiq/radar/sync_value_lists_job_spec.rb`

**Modified:**
- `app/presenters/admin/user_presenter/card.rb` — added radar_stats + recent_efws
- `app/presenters/admin/purchase_presenter.rb` — added EFW/dispute to list_props
- `app/controllers/admin/search/purchases_controller.rb` — eager load EFW/disputes
- `app/javascript/components/Admin/Users/User.tsx` — added types
- `app/javascript/components/Admin/Users/PermissionRisk/index.tsx` — render RadarSignals
- `app/javascript/pages/Admin/Search/Purchases/Index.tsx` — EFW/dispute pills
- `config/sidekiq_schedule.yml` — daily sync job

## Notes
- Uses standard Radar (free), not Radar for Fraud Teams — works with `risk_level` (normal/elevated/highest) only, no numeric scores
- No migrations needed — all data comes from existing EFW and dispute tables
- Value list sync is additive (silently skips duplicates)

> This PR was authored by Gumclaw (AI agent). All code was written by AI.