### PR TITLE
Add payout queue enrichment for seller context

### DIFF
--- a/app/controllers/api/internal/admin/payouts_controller.rb
+++ b/app/controllers/api/internal/admin/payouts_controller.rb
@@ -139,7 +139,9 @@ class Api::Internal::Admin::PayoutsController < Api::Internal::Admin::BaseContro
     limit = SCHEDULED_PAYOUTS_DEFAULT_LIMIT if limit <= 0
     limit = [limit, SCHEDULED_PAYOUTS_MAX_LIMIT].min
 
-    scheduled_payouts = scope.limit(limit).map { serialize_scheduled_payout(_1) }
+    records = scope.limit(limit).to_a
+    enrichment_by_user_id = Admin::ScheduledPayoutEnrichmentService.new(records).call
+    scheduled_payouts = records.map { serialize_scheduled_payout(_1, enrichment: enrichment_by_user_id[_1.user_id] || {}) }
 
     render json: { success: true, scheduled_payouts:, limit: }
   end
@@ -195,8 +197,9 @@ class Api::Internal::Admin::PayoutsController < Api::Internal::Admin::BaseContro
       render json: { success: false, message: "Scheduled payout not found" }, status: :not_found if @scheduled_payout.blank?
     end
 
-    def serialize_scheduled_payout(scheduled_payout)
-      Admin::ScheduledPayoutPresenter.new(scheduled_payout:).props
+    def serialize_scheduled_payout(scheduled_payout, enrichment: nil)
+      enrichment ||= Admin::ScheduledPayoutEnrichmentService.new([scheduled_payout]).call[scheduled_payout.user_id] || {}
+      Admin::ScheduledPayoutPresenter.new(scheduled_payout:, enrichment:).props
     end
 
     def render_scheduled_payout_error(error)

--- a/app/controllers/api/internal/admin/users_controller.rb
+++ b/app/controllers/api/internal/admin/users_controller.rb
@@ -296,21 +296,11 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
     end
 
     def suspension_status(user)
-      if user.suspended?
-        "Suspended"
-      elsif user.flagged?
-        "Flagged"
-      else
-        "Compliant"
-      end
+      Admin::UserRiskStatePresenter.new(user).props[:status]
     end
 
     def last_status_changed_at(user)
-      user.comments
-        .where(comment_type: Comment::RISK_STATE_COMMENT_TYPES)
-        .order(created_at: :desc)
-        .first
-        &.created_at
+      Admin::UserRiskStatePresenter.new(user).props[:last_status_changed_at]
     end
 
     def serialize_user_info(user)
@@ -325,16 +315,7 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
         country: compliance_info&.country,
         created_at: user.created_at.as_json,
         deleted_at: user.deleted_at&.as_json,
-        risk_state: {
-          status: suspension_status(user),
-          user_risk_state: user.user_risk_state,
-          suspended: user.suspended?,
-          flagged_for_fraud: user.flagged_for_fraud?,
-          flagged_for_tos_violation: user.flagged_for_tos_violation?,
-          on_probation: user.on_probation?,
-          compliant: user.compliant?,
-          last_status_changed_at: last_status_changed_at(user)&.as_json
-        },
+        risk_state: Admin::UserRiskStatePresenter.new(user).props,
         active_watched_user: serialize_watched_user(user.active_watched_user),
         two_factor_authentication_enabled: user.two_factor_authentication_enabled?,
         payouts: {

--- a/app/presenters/admin/scheduled_payout_presenter.rb
+++ b/app/presenters/admin/scheduled_payout_presenter.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 class Admin::ScheduledPayoutPresenter
-  attr_reader :scheduled_payout
+  attr_reader :scheduled_payout, :enrichment
 
-  def initialize(scheduled_payout:)
+  def initialize(scheduled_payout:, enrichment: {})
     @scheduled_payout = scheduled_payout
+    @enrichment = enrichment
   end
 
   def props
@@ -24,7 +25,8 @@ class Admin::ScheduledPayoutPresenter
       },
       created_by: scheduled_payout.created_by ? {
         name: scheduled_payout.created_by.name
-      } : nil
+      } : nil,
+      **enrichment
     }
   end
 end

--- a/app/presenters/admin/user_risk_state_presenter.rb
+++ b/app/presenters/admin/user_risk_state_presenter.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class Admin::UserRiskStatePresenter
+  RISK_STATE_COMMENT_TYPES = Comment::RISK_STATE_COMMENT_TYPES
+  LAST_STATUS_CHANGED_AT_NOT_PROVIDED = Object.new
+  private_constant :LAST_STATUS_CHANGED_AT_NOT_PROVIDED
+
+  attr_reader :user, :last_status_changed_at_override
+
+  def initialize(user, last_status_changed_at: LAST_STATUS_CHANGED_AT_NOT_PROVIDED)
+    @user = user
+    @last_status_changed_at_override = last_status_changed_at
+  end
+
+  def props
+    {
+      status:,
+      user_risk_state: user.user_risk_state,
+      suspended: user.suspended?,
+      flagged_for_fraud: user.flagged_for_fraud?,
+      flagged_for_tos_violation: user.flagged_for_tos_violation?,
+      on_probation: user.on_probation?,
+      compliant: user.compliant?,
+      last_status_changed_at: last_status_changed_at&.as_json,
+    }
+  end
+
+  private
+    def status
+      return "Suspended" if user.suspended?
+      return "Flagged" if user.flagged?
+
+      "Compliant"
+    end
+
+    def last_status_changed_at
+      return last_status_changed_at_override unless last_status_changed_at_override.equal?(LAST_STATUS_CHANGED_AT_NOT_PROVIDED)
+
+      if user.association(:comments).loaded?
+        return user.comments.select { _1.comment_type.in?(RISK_STATE_COMMENT_TYPES) }.max_by(&:created_at)&.created_at
+      end
+
+      user.comments.where(comment_type: RISK_STATE_COMMENT_TYPES).order(created_at: :desc).first&.created_at
+    end
+end

--- a/app/services/admin/scheduled_payout_enrichment_service.rb
+++ b/app/services/admin/scheduled_payout_enrichment_service.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+class Admin::ScheduledPayoutEnrichmentService
+  TOP_CATEGORIES_LIMIT = 3
+  ENRICHED_AFFILIATE_TYPES = [DirectAffiliate.name, Collaborator.name].freeze
+  private_constant :TOP_CATEGORIES_LIMIT, :ENRICHED_AFFILIATE_TYPES
+
+  def initialize(scheduled_payouts)
+    @users = scheduled_payouts.map(&:user).compact.uniq(&:id)
+    @user_ids = @users.map(&:id)
+  end
+
+  def call
+    return {} if @user_ids.empty?
+
+    last_status_changed_at_by_user = build_last_status_changed_at_by_user
+    product_counts = Link.alive.where(user_id: @user_ids).group(:user_id).count
+    affiliate_counts = Affiliate.alive
+      .where(seller_id: @user_ids, type: ENRICHED_AFFILIATE_TYPES)
+      .group(:seller_id)
+      .count
+    unpaid_by_user = Balance.unpaid.where(user_id: @user_ids).group(:user_id).sum(:amount_cents)
+    top_categories_by_user = build_top_categories
+
+    @users.index_with do |user|
+      unpaid_cents = unpaid_by_user.fetch(user.id, 0)
+      {
+        product_count: product_counts.fetch(user.id, 0),
+        incoming_affiliate_count: affiliate_counts.fetch(user.id, 0),
+        risk_state: Admin::UserRiskStatePresenter.new(user, last_status_changed_at: last_status_changed_at_by_user[user.id]).props,
+        top_categories: top_categories_by_user.fetch(user.id, []),
+        unpaid_balance_cents: unpaid_cents,
+        unpaid_balance_formatted: Money.from_cents(unpaid_cents).format,
+      }
+    end.transform_keys(&:id)
+  end
+
+  private
+    def build_last_status_changed_at_by_user
+      Comment
+        .where(
+          commentable_type: User.name,
+          commentable_id: @user_ids,
+          comment_type: Admin::UserRiskStatePresenter::RISK_STATE_COMMENT_TYPES
+        )
+        .group(:commentable_id)
+        .maximum(:created_at)
+    end
+
+    def build_top_categories
+      counts_by_user_taxonomy = Link.alive
+        .where(user_id: @user_ids)
+        .where.not(taxonomy_id: nil)
+        .group(:user_id, :taxonomy_id)
+        .count
+
+      taxonomy_ids = counts_by_user_taxonomy.keys.map(&:last).uniq
+      taxonomies_by_id = Taxonomy.where(id: taxonomy_ids).index_by(&:id)
+
+      counts_by_user_taxonomy.each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |((user_id, taxonomy_id), count), result|
+        taxonomy = taxonomies_by_id[taxonomy_id]
+        next unless taxonomy
+
+        result[user_id] << { taxonomy:, count: }
+      end.transform_values do |rows|
+        rows
+          .sort_by { [_1[:count] * -1, _1[:taxonomy].id] }
+          .first(TOP_CATEGORIES_LIMIT)
+          .map { { slug: _1[:taxonomy].slug, product_count: _1[:count] } }
+      end
+    end
+end

--- a/spec/controllers/api/internal/admin/payouts_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/payouts_controller_spec.rb
@@ -439,6 +439,19 @@ describe Api::Internal::Admin::PayoutsController do
   describe "POST scheduled_list" do
     include_examples "admin api authorization required", :post, :scheduled_list
 
+    let(:merchant_account) { create(:merchant_account, user: nil) }
+
+    let(:enrichment_keys) do
+      %w[
+        product_count
+        incoming_affiliate_count
+        risk_state
+        top_categories
+        unpaid_balance_cents
+        unpaid_balance_formatted
+      ]
+    end
+
     it "returns scheduled payouts ordered by id desc" do
       first = create(:scheduled_payout, user:)
       second = create(:scheduled_payout, user: create(:user))
@@ -484,6 +497,90 @@ describe Api::Internal::Admin::PayoutsController do
 
       expect(response.parsed_body["limit"]).to eq(20)
     end
+
+    it "includes enrichment keys for each scheduled payout" do
+      scheduled_payout = create(:scheduled_payout, user:)
+
+      post :scheduled_list
+
+      row = response.parsed_body["scheduled_payouts"].find { _1["external_id"] == scheduled_payout.external_id }
+      expect(row.keys).to include(*enrichment_keys)
+      expect(row["risk_state"]).to eq(Admin::UserRiskStatePresenter.new(user).props.as_json)
+    end
+
+    it "reports alive product count" do
+      seller = create(:compliant_user)
+      create_list(:product, 2, user: seller)
+      create(:product, user: seller, deleted_at: Time.current)
+      scheduled_payout = create(:scheduled_payout, user: seller)
+
+      post :scheduled_list
+
+      row = response.parsed_body["scheduled_payouts"].find { _1["external_id"] == scheduled_payout.external_id }
+      expect(row["product_count"]).to eq(2)
+    end
+
+    it "reports incoming affiliate count without global or deleted affiliates" do
+      seller = create(:compliant_user)
+      create_list(:direct_affiliate, 2, seller:)
+      create(:collaborator, seller:)
+      create(:direct_affiliate, seller:, deleted_at: Time.current)
+      seller.global_affiliate.update_column(:seller_id, seller.id)
+      scheduled_payout = create(:scheduled_payout, user: seller)
+
+      post :scheduled_list
+
+      row = response.parsed_body["scheduled_payouts"].find { _1["external_id"] == scheduled_payout.external_id }
+      expect(row["incoming_affiliate_count"]).to eq(3)
+    end
+
+    it "reports top categories by alive product count" do
+      seller = create(:compliant_user)
+      taxonomy_a = create(:taxonomy, slug: "taxonomy-a")
+      taxonomy_b = create(:taxonomy, slug: "taxonomy-b")
+      create_list(:product, 2, user: seller, taxonomy: taxonomy_a)
+      create(:product, user: seller, taxonomy: taxonomy_b)
+      scheduled_payout = create(:scheduled_payout, user: seller)
+
+      post :scheduled_list
+
+      row = response.parsed_body["scheduled_payouts"].find { _1["external_id"] == scheduled_payout.external_id }
+      expected_categories = [
+        { "slug" => "taxonomy-a", "product_count" => 2 },
+        { "slug" => "taxonomy-b", "product_count" => 1 }
+      ]
+      expect(row["top_categories"]).to eq(expected_categories)
+    end
+
+    it "reports unpaid balance" do
+      seller = create(:compliant_user)
+      create(:balance, user: seller, merchant_account:, amount_cents: 12_345, state: "unpaid")
+      create(:balance, user: seller, merchant_account:, amount_cents: 9_999, state: "paid")
+      scheduled_payout = create(:scheduled_payout, user: seller)
+
+      post :scheduled_list
+
+      row = response.parsed_body["scheduled_payouts"].find { _1["external_id"] == scheduled_payout.external_id }
+      expect(row["unpaid_balance_cents"]).to eq(12_345)
+      expect(row["unpaid_balance_formatted"]).to eq("$123.45")
+    end
+
+    it "keeps scheduled payout list enrichment queries bounded" do
+      taxonomy = create(:taxonomy)
+      5.times do
+        seller = create(:compliant_user)
+        create(:product, user: seller, taxonomy:)
+        create(:direct_affiliate, seller:)
+        create(:balance, user: seller, merchant_account:, amount_cents: 1_00)
+        create(:comment, commentable: seller, comment_type: Comment::COMMENT_TYPE_COMPLIANT)
+        create(:scheduled_payout, user: seller)
+      end
+
+      queries = sql_queries_for { post :scheduled_list, params: { limit: 5 } }
+
+      expect(response).to have_http_status(:ok)
+      expect(queries.count).to be <= 14
+    end
   end
 
   describe "POST scheduled_execute" do
@@ -503,6 +600,14 @@ describe Api::Internal::Admin::PayoutsController do
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include("success" => true, "result" => "executed")
+      expect(response.parsed_body["scheduled_payout"].keys).to include(
+        "product_count",
+        "incoming_affiliate_count",
+        "risk_state",
+        "top_categories",
+        "unpaid_balance_cents",
+        "unpaid_balance_formatted"
+      )
     end
 
     it "promotes a flagged scheduled payout to pending before executing" do
@@ -572,6 +677,14 @@ describe Api::Internal::Admin::PayoutsController do
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["success"]).to be(true)
+      expect(response.parsed_body["scheduled_payout"].keys).to include(
+        "product_count",
+        "incoming_affiliate_count",
+        "risk_state",
+        "top_categories",
+        "unpaid_balance_cents",
+        "unpaid_balance_formatted"
+      )
     end
 
     it "returns 422 and the error message when cancel! raises" do
@@ -598,5 +711,17 @@ describe Api::Internal::Admin::PayoutsController do
         response_status: 200
       )
     end
+  end
+
+  def sql_queries_for(&block)
+    queries = []
+    counter = lambda do |*, payload|
+      next if payload[:cached] || payload[:name].in?(["SCHEMA", "TRANSACTION"])
+
+      queries << payload[:sql]
+    end
+
+    ActiveSupport::Notifications.subscribed(counter, "sql.active_record", &block)
+    queries
   end
 end

--- a/spec/presenters/admin/scheduled_payout_presenter_spec.rb
+++ b/spec/presenters/admin/scheduled_payout_presenter_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Admin::ScheduledPayoutPresenter do
+  describe "#props" do
+    it "returns the existing scheduled payout shape without enrichment" do
+      seller = create(:compliant_user, email: "seller@example.com", name: "Seller One")
+      created_by = create(:admin_user, name: "Admin One")
+      scheduled_payout = create(:scheduled_payout, user: seller, created_by:)
+
+      expect(described_class.new(scheduled_payout:).props).to eq(
+        external_id: scheduled_payout.external_id,
+        action: scheduled_payout.action,
+        status: scheduled_payout.status,
+        delay_days: scheduled_payout.delay_days,
+        scheduled_at: scheduled_payout.scheduled_at,
+        executed_at: scheduled_payout.executed_at,
+        payout_amount_cents: scheduled_payout.payout_amount_cents,
+        created_at: scheduled_payout.created_at,
+        user: {
+          external_id: seller.external_id,
+          email: seller.form_email,
+          name: "Seller One"
+        },
+        created_by: { name: "Admin One" }
+      )
+    end
+
+    it "adds enrichment without changing existing keys" do
+      scheduled_payout = create(:scheduled_payout)
+      enrichment = {
+        product_count: 2,
+        incoming_affiliate_count: 3,
+        risk_state: { status: "Compliant" },
+        top_categories: [{ slug: "design", product_count: 2 }],
+        unpaid_balance_cents: 12_345,
+        unpaid_balance_formatted: "$123.45",
+      }
+      original_props = described_class.new(scheduled_payout:).props
+
+      enriched_props = described_class.new(scheduled_payout:, enrichment:).props
+
+      expect(enriched_props.except(*enrichment.keys)).to eq(original_props)
+      expect(enriched_props).to include(enrichment)
+    end
+  end
+end

--- a/spec/presenters/admin/user_risk_state_presenter_spec.rb
+++ b/spec/presenters/admin/user_risk_state_presenter_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Admin::UserRiskStatePresenter do
+  describe "#props" do
+    it "returns compliant state for a compliant user" do
+      user = create(:compliant_user)
+
+      expect(described_class.new(user).props).to include(
+        status: "Compliant",
+        user_risk_state: "compliant",
+        suspended: false,
+        flagged_for_fraud: false,
+        flagged_for_tos_violation: false,
+        on_probation: false,
+        compliant: true,
+        last_status_changed_at: nil
+      )
+    end
+
+    it "returns suspended state for a suspended fraud user" do
+      user = create(:user, user_risk_state: "suspended_for_fraud")
+
+      expect(described_class.new(user).props).to include(
+        status: "Suspended",
+        user_risk_state: "suspended_for_fraud",
+        suspended: true,
+        flagged_for_fraud: false,
+        compliant: false
+      )
+    end
+
+    it "returns flagged state for a flagged fraud user" do
+      user = create(:user, user_risk_state: "flagged_for_fraud")
+
+      expect(described_class.new(user).props).to include(
+        status: "Flagged",
+        user_risk_state: "flagged_for_fraud",
+        suspended: false,
+        flagged_for_fraud: true,
+        compliant: false
+      )
+    end
+
+    it "returns the most recent risk-state comment timestamp" do
+      user = create(:compliant_user)
+      older_comment = create(:comment, commentable: user, comment_type: Comment::COMMENT_TYPE_FLAGGED, created_at: 2.days.ago)
+      newer_comment = create(:comment, commentable: user, comment_type: Comment::COMMENT_TYPE_COMPLIANT, created_at: 1.day.ago)
+      create(:comment, commentable: user, comment_type: Comment::COMMENT_TYPE_NOTE, created_at: Time.current)
+
+      expect(described_class.new(user).props[:last_status_changed_at]).to eq(newer_comment.created_at.as_json)
+      expect(described_class.new(user).props[:last_status_changed_at]).not_to eq(older_comment.created_at.as_json)
+    end
+  end
+end

--- a/spec/services/admin/scheduled_payout_enrichment_service_spec.rb
+++ b/spec/services/admin/scheduled_payout_enrichment_service_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Admin::ScheduledPayoutEnrichmentService do
+  describe "#call" do
+    let(:merchant_account) { create(:merchant_account, user: nil) }
+
+    it "returns an empty hash for an empty input" do
+      expect(described_class.new([]).call).to eq({})
+    end
+
+    it "counts alive products only" do
+      seller = create(:compliant_user)
+      create_list(:product, 2, user: seller)
+      create(:product, user: seller, deleted_at: Time.current)
+      scheduled_payout = create(:scheduled_payout, user: seller)
+
+      enrichment = described_class.new([scheduled_payout]).call.fetch(seller.id)
+
+      expect(enrichment[:product_count]).to eq(2)
+    end
+
+    it "counts alive direct affiliates and collaborators granted by the seller" do
+      seller = create(:compliant_user)
+      create_list(:direct_affiliate, 2, seller:)
+      create(:collaborator, seller:)
+      create(:direct_affiliate, seller:, deleted_at: Time.current)
+      create(:collaborator, seller:, deleted_at: Time.current)
+      seller.global_affiliate.update_column(:seller_id, seller.id)
+      scheduled_payout = create(:scheduled_payout, user: seller)
+
+      enrichment = described_class.new([scheduled_payout]).call.fetch(seller.id)
+
+      expect(enrichment[:incoming_affiliate_count]).to eq(3)
+    end
+
+    it "sums unpaid balances only and formats the total" do
+      seller = create(:compliant_user)
+      create(:balance, user: seller, merchant_account:, amount_cents: 1_234, state: "unpaid")
+      create(:balance, user: seller, merchant_account:, amount_cents: 11_111, state: "unpaid")
+      create(:balance, user: seller, merchant_account:, amount_cents: 99_999, state: "processing")
+      create(:balance, user: seller, merchant_account:, amount_cents: 99_999, state: "paid")
+      create(:balance, user: seller, merchant_account:, amount_cents: 99_999, state: "forfeited")
+      scheduled_payout = create(:scheduled_payout, user: seller)
+
+      enrichment = described_class.new([scheduled_payout]).call.fetch(seller.id)
+
+      expect(enrichment[:unpaid_balance_cents]).to eq(12_345)
+      expect(enrichment[:unpaid_balance_formatted]).to eq("$123.45")
+    end
+
+    it "formats zero unpaid balance" do
+      seller = create(:compliant_user)
+      scheduled_payout = create(:scheduled_payout, user: seller)
+
+      enrichment = described_class.new([scheduled_payout]).call.fetch(seller.id)
+
+      expect(enrichment[:unpaid_balance_cents]).to eq(0)
+      expect(enrichment[:unpaid_balance_formatted]).to eq("$0.00")
+    end
+
+    it "returns the top three categories by product count with a stable tie-breaker" do
+      seller = create(:compliant_user)
+      top_taxonomy = create(:taxonomy, slug: "top")
+      second_taxonomy = create(:taxonomy, slug: "second")
+      tied_first_taxonomy = create(:taxonomy, slug: "tied-first")
+      tied_second_taxonomy = create(:taxonomy, slug: "tied-second")
+      create_list(:product, 3, user: seller, taxonomy: top_taxonomy)
+      create_list(:product, 2, user: seller, taxonomy: second_taxonomy)
+      create(:product, user: seller, taxonomy: tied_first_taxonomy)
+      create(:product, user: seller, taxonomy: tied_second_taxonomy)
+      scheduled_payout = create(:scheduled_payout, user: seller)
+
+      enrichment = described_class.new([scheduled_payout]).call.fetch(seller.id)
+
+      expected_categories = [
+        { slug: "top", product_count: 3 },
+        { slug: "second", product_count: 2 },
+        { slug: "tied-first", product_count: 1 }
+      ]
+      expect(enrichment[:top_categories]).to eq(expected_categories)
+    end
+
+    it "excludes products without taxonomies from top categories" do
+      seller = create(:compliant_user)
+      create(:product, user: seller, taxonomy: nil)
+      scheduled_payout = create(:scheduled_payout, user: seller)
+
+      enrichment = described_class.new([scheduled_payout]).call.fetch(seller.id)
+
+      expect(enrichment[:top_categories]).to eq([])
+    end
+
+    it "returns risk state from the shared presenter" do
+      users = [
+        create(:compliant_user),
+        create(:user, user_risk_state: "suspended_for_fraud"),
+        create(:user, user_risk_state: "flagged_for_fraud")
+      ]
+      scheduled_payouts = users.map { create(:scheduled_payout, user: _1) }
+
+      enrichment_by_user_id = described_class.new(scheduled_payouts).call
+
+      users.each do |user|
+        expect(enrichment_by_user_id[user.id][:risk_state]).to eq(Admin::UserRiskStatePresenter.new(user).props)
+      end
+    end
+
+    it "uses a bounded number of queries for distinct users" do
+      taxonomy = create(:taxonomy)
+      users = 3.times.map do
+        create(:compliant_user).tap do |seller|
+          create(:product, user: seller, taxonomy:)
+          create(:direct_affiliate, seller:)
+          create(:balance, user: seller, merchant_account:, amount_cents: 1_00)
+          create(:comment, commentable: seller, comment_type: Comment::COMMENT_TYPE_COMPLIANT)
+        end
+      end
+      scheduled_payouts = users.map { create(:scheduled_payout, user: _1) }
+
+      queries = sql_queries_for { described_class.new(scheduled_payouts).call }
+
+      expect(queries.count).to be <= 6
+    end
+  end
+
+  def sql_queries_for(&block)
+    queries = []
+    counter = lambda do |*, payload|
+      next if payload[:cached] || payload[:name].in?(["SCHEMA", "TRANSACTION"])
+
+      queries << payload[:sql]
+    end
+
+    ActiveSupport::Notifications.subscribed(counter, "sql.active_record", &block)
+    queries
+  end
+end


### PR DESCRIPTION
Ref #4989

## What

Added seller context to scheduled payout responses so reviewers can see product count, incoming affiliate count, risk state, top categories, and unpaid balance inline.

Also extracted the shared risk-state shape into a presenter so the same data is reused across internal admin user info and payout responses without duplicating logic.

## Why

This makes the payout review queue more useful without adding extra clicks or per-row queries. The enrichment is batched so the response stays efficient as the queue grows, and the risk-state payload now has a single source of truth.

---
This PR was implemented with AI assistance using gpt-5.5 xhigh.