### PR TITLE
Switch admin read endpoints to GET

### DIFF
--- a/app/controllers/api/internal/admin/products_controller.rb
+++ b/app/controllers/api/internal/admin/products_controller.rb
@@ -8,7 +8,7 @@ class Api::Internal::Admin::ProductsController < Api::Internal::Admin::BaseContr
   SELLER_LOOKUP_BAD_REQUEST_MESSAGE = "email or external_id is required"
   private_constant :DEFAULT_PER_PAGE, :MAX_PER_PAGE, :SELLER_LOOKUP_BAD_REQUEST_MESSAGE
 
-  def list
+  def index
     if params[:email].blank? && params[:external_id].blank?
       return render json: { success: false, message: SELLER_LOOKUP_BAD_REQUEST_MESSAGE }, status: :bad_request
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -303,7 +303,7 @@ Rails.application.routes.draw do
 
           resources :purchases, only: [:show] do
             collection do
-              post :search
+              get :search
               post :resend_all_receipts
               post :reassign
             end
@@ -320,15 +320,15 @@ Rails.application.routes.draw do
 
           resources :licenses, only: [] do
             collection do
-              post :lookup
+              get :lookup
             end
           end
 
           resources :users, only: [] do
             collection do
-              post :info
-              post :affiliates
-              post :suspension
+              get :info
+              get :affiliates
+              get :suspension
               post :reset_password
               post :update_email
               post :two_factor_authentication
@@ -356,11 +356,7 @@ Rails.application.routes.draw do
             end
           end
 
-          resources :products, only: [:show] do
-            collection do
-              post :list
-            end
-          end
+          resources :products, only: [:index, :show]
         end
 
         namespace :grmc do

--- a/spec/controllers/api/internal/admin/licenses_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/licenses_controller_spec.rb
@@ -4,15 +4,15 @@ require "spec_helper"
 require "shared_examples/authorized_admin_api_method"
 
 describe Api::Internal::Admin::LicensesController do
-  describe "POST lookup" do
-    include_examples "admin api authorization required", :post, :lookup
+  describe "GET lookup" do
+    include_examples "admin api authorization required", :get, :lookup
 
     let(:product) { create(:product, name: "Licensed product") }
     let(:purchase) { create(:free_purchase, link: product, email: "buyer@example.com") }
     let(:license) { create(:license, link: product, purchase:, uses: 3) }
 
     it "returns license and purchase details for a license key" do
-      post :lookup, params: { license_key: license.serial }
+      get :lookup, params: { license_key: license.serial }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["success"]).to be(true)
@@ -34,14 +34,14 @@ describe Api::Internal::Admin::LicensesController do
     end
 
     it "returns a bad request when the license key is missing" do
-      post :lookup
+      get :lookup
 
       expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body).to eq({ success: false, message: "license_key is required" }.as_json)
     end
 
     it "returns not found when the license key does not exist" do
-      post :lookup, params: { license_key: "missing-key" }
+      get :lookup, params: { license_key: "missing-key" }
 
       expect(response).to have_http_status(:not_found)
       expect(response.parsed_body).to eq({ success: false, message: "License not found" }.as_json)

--- a/spec/controllers/api/internal/admin/products_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/products_controller_spec.rb
@@ -9,18 +9,18 @@ describe Api::Internal::Admin::ProductsController do
 
   before { stub_const("GUMROAD_ADMIN_ID", admin_user.id) }
 
-  describe "POST list" do
-    include_examples "admin api authorization required", :post, :list
+  describe "GET index" do
+    include_examples "admin api authorization required", :get, :index
 
     it "returns a bad request when neither email nor external_id is provided" do
-      post :list
+      get :index
 
       expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body).to eq({ success: false, message: "email or external_id is required" }.as_json)
     end
 
     it "returns not found when the user does not exist" do
-      post :list, params: { email: "missing@example.com" }
+      get :index, params: { email: "missing@example.com" }
 
       expect(response).to have_http_status(:not_found)
       expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
@@ -29,14 +29,14 @@ describe Api::Internal::Admin::ProductsController do
     it "looks up the seller by external_id when provided" do
       product = create(:product, user: seller)
 
-      post :list, params: { external_id: seller.external_id }
+      get :index, params: { external_id: seller.external_id }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["products"].map { _1["id"] }).to eq([product.external_id])
     end
 
     it "returns not found when the external_id does not match any user" do
-      post :list, params: { external_id: "nonexistent" }
+      get :index, params: { external_id: "nonexistent" }
 
       expect(response).to have_http_status(:not_found)
       expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
@@ -47,7 +47,7 @@ describe Api::Internal::Admin::ProductsController do
       external_match = create(:product, user: seller, name: "via external_id")
       create(:product, user: other_seller, name: "via email")
 
-      post :list, params: { email: other_seller.email, external_id: seller.external_id }
+      get :index, params: { email: other_seller.email, external_id: seller.external_id }
 
       expect(response.parsed_body["products"].map { _1["name"] }).to eq([external_match.name])
     end
@@ -56,14 +56,14 @@ describe Api::Internal::Admin::ProductsController do
       product = create(:product, user: seller)
       seller.mark_deleted!
 
-      post :list, params: { external_id: seller.external_id }
+      get :index, params: { external_id: seller.external_id }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["products"].map { _1["id"] }).to eq([product.external_id])
     end
 
     it "returns an empty list with pagination metadata when the seller has no products" do
-      post :list, params: { email: seller.email }
+      get :index, params: { email: seller.email }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["success"]).to be(true)
@@ -76,7 +76,7 @@ describe Api::Internal::Admin::ProductsController do
       deleted_product = create(:product, user: seller, name: "Old draft")
       deleted_product.mark_deleted!
 
-      post :list, params: { email: seller.email }
+      get :index, params: { email: seller.email }
 
       expect(response).to have_http_status(:ok)
       products = response.parsed_body["products"]
@@ -99,7 +99,7 @@ describe Api::Internal::Admin::ProductsController do
       deleted = create(:product, user: seller, name: "Deleted")
       deleted.mark_deleted!
 
-      post :list, params: { email: seller.email }
+      get :index, params: { email: seller.email }
 
       names = response.parsed_body["products"].map { _1["name"] }
       expect(names).to eq(["New alive", "Old alive", "Deleted"])
@@ -109,7 +109,7 @@ describe Api::Internal::Admin::ProductsController do
       product = create(:product, user: seller)
       external = create(:external_link, link: product, display_name: "Telegram channel", url: "https://t.me/secret-channel")
 
-      post :list, params: { email: seller.email }
+      get :index, params: { email: seller.email }
 
       files = response.parsed_body["products"].first["files"]
       payload = files.find { _1["id"] == external.external_id }
@@ -136,7 +136,7 @@ describe Api::Internal::Admin::ProductsController do
       end
 
       ActiveSupport::Notifications.subscribed(counter, "sql.active_record") do
-        post :list, params: { email: seller.email }
+        get :index, params: { email: seller.email }
       end
 
       expect(response).to have_http_status(:ok)
@@ -151,7 +151,7 @@ describe Api::Internal::Admin::ProductsController do
       deleted_file = create(:readable_document, link: product, display_name: "Removed extra", size: 256)
       deleted_file.mark_deleted!
 
-      post :list, params: { email: seller.email }
+      get :index, params: { email: seller.email }
 
       files = response.parsed_body["products"].first["files"]
       expect(files.length).to eq(2)
@@ -174,7 +174,7 @@ describe Api::Internal::Admin::ProductsController do
     it "returns the cover image url when one is present" do
       product = create(:product, :with_youtube_preview, user: seller)
 
-      post :list, params: { email: seller.email }
+      get :index, params: { email: seller.email }
 
       payload = response.parsed_body["products"].first
       expect(payload["preview_url"]).to eq(product.preview_url)
@@ -185,11 +185,11 @@ describe Api::Internal::Admin::ProductsController do
       stub_const("Api::Internal::Admin::ProductsController::DEFAULT_PER_PAGE", 2)
       create_list(:product, 3, user: seller)
 
-      post :list, params: { email: seller.email }
+      get :index, params: { email: seller.email }
       expect(response.parsed_body["products"].length).to eq(2)
       expect(response.parsed_body["pagination"]).to include("count" => 3, "page" => 1, "next" => 2)
 
-      post :list, params: { email: seller.email, page: 2 }
+      get :index, params: { email: seller.email, page: 2 }
       expect(response.parsed_body["products"].length).to eq(1)
       expect(response.parsed_body["pagination"]).to include("page" => 2, "next" => nil)
     end
@@ -198,7 +198,7 @@ describe Api::Internal::Admin::ProductsController do
       product = create(:product, user: seller)
 
       ["0", "-5", "abc", ""].each do |bad_page|
-        post :list, params: { email: seller.email, page: bad_page }
+        get :index, params: { email: seller.email, page: bad_page }
 
         expect(response).to have_http_status(:ok), "page=#{bad_page.inspect} returned #{response.status}"
         expect(response.parsed_body["success"]).to be(true)
@@ -210,7 +210,7 @@ describe Api::Internal::Admin::ProductsController do
     it "returns an empty page in the JSON envelope when page is past the end (rather than raising 500)" do
       create(:product, user: seller)
 
-      post :list, params: { email: seller.email, page: 99 }
+      get :index, params: { email: seller.email, page: 99 }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["success"]).to be(true)
@@ -225,7 +225,7 @@ describe Api::Internal::Admin::ProductsController do
       third = create(:readable_document, link: product, display_name: "Third", position: 1)
       first.update_column(:position, nil)
 
-      post :list, params: { email: seller.email }
+      get :index, params: { email: seller.email }
 
       ids = response.parsed_body["products"].first["files"].map { _1["id"] }
       expect(ids).to eq([first.external_id, second.external_id, third.external_id])
@@ -234,10 +234,10 @@ describe Api::Internal::Admin::ProductsController do
     it "honors per_page and caps it at the maximum" do
       create_list(:product, 5, user: seller)
 
-      post :list, params: { email: seller.email, per_page: 2 }
+      get :index, params: { email: seller.email, per_page: 2 }
       expect(response.parsed_body["products"].length).to eq(2)
 
-      post :list, params: { email: seller.email, per_page: 10_000 }
+      get :index, params: { email: seller.email, per_page: 10_000 }
       expect(response.parsed_body["products"].length).to eq(5)
     end
 
@@ -246,7 +246,7 @@ describe Api::Internal::Admin::ProductsController do
       mine = create(:product, user: seller)
       create(:product, user: other_seller)
 
-      post :list, params: { email: seller.email }
+      get :index, params: { email: seller.email }
 
       ids = response.parsed_body["products"].map { _1["id"] }
       expect(ids).to eq([mine.external_id])

--- a/spec/controllers/api/internal/admin/purchases_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/purchases_controller_spec.rb
@@ -4,25 +4,25 @@ require "spec_helper"
 require "shared_examples/authorized_admin_api_method"
 
 describe Api::Internal::Admin::PurchasesController do
-  describe "POST search" do
-    include_examples "admin api authorization required", :post, :search
+  describe "GET search" do
+    include_examples "admin api authorization required", :get, :search
 
     it "returns a bad request when no search parameters are provided" do
-      post :search
+      get :search
 
       expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body).to eq({ success: false, message: "At least one search parameter is required." }.as_json)
     end
 
     it "requires query when query-only modifiers are provided" do
-      post :search, params: { purchase_status: "successful" }
+      get :search, params: { purchase_status: "successful" }
 
       expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body).to eq({ success: false, message: "query is required when product_title_query or purchase_status is provided." }.as_json)
     end
 
     it "returns a bad request when purchase_status is invalid" do
-      post :search, params: { query: "buyer@example.com", purchase_status: "succesful" }
+      get :search, params: { query: "buyer@example.com", purchase_status: "succesful" }
 
       expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body).to eq({ success: false, message: "purchase_status must be one of: #{described_class::VALID_PURCHASE_STATUSES.to_sentence(last_word_connector: ', or ')}." }.as_json)
@@ -34,7 +34,7 @@ describe Api::Internal::Admin::PurchasesController do
       newer_purchase = create(:free_purchase, email: buyer_email, created_at: 1.day.ago)
       create(:free_purchase, email: "other@example.com")
 
-      post :search, params: { query: buyer_email }
+      get :search, params: { query: buyer_email }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["success"]).to be(true)
@@ -66,7 +66,7 @@ describe Api::Internal::Admin::PurchasesController do
       other_product = create(:product, name: "Writing course")
       create(:free_purchase, link: other_product, email: buyer_email)
 
-      post :search, params: { query: " #{buyer_email} ", product_title_query: " Design " }
+      get :search, params: { query: " #{buyer_email} ", product_title_query: " Design " }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["purchases"].map { _1["id"] }).to eq([matching_purchase.external_id_numeric.to_s])
@@ -87,7 +87,7 @@ describe Api::Internal::Admin::PurchasesController do
         { card_last4: " 4242 " },
         { card_type: " visa " },
       ].each do |search_params|
-        post :search, params: search_params
+        get :search, params: search_params
 
         aggregate_failures(search_params.inspect) do
           expect(response).to have_http_status(:ok)
@@ -105,7 +105,7 @@ describe Api::Internal::Admin::PurchasesController do
       allow(search_service).to receive(:search_purchases).and_return(search_relation)
       expect(search_relation).to receive(:includes).with(:link, :seller, :refunds).and_call_original
 
-      post :search, params: { query: purchase.email }
+      get :search, params: { query: purchase.email }
 
       expect(response).to have_http_status(:ok)
     end
@@ -116,7 +116,7 @@ describe Api::Internal::Admin::PurchasesController do
 
       expect_any_instance_of(Purchase).not_to receive(:amount_refunded_cents)
 
-      post :search, params: { query: purchase.email }
+      get :search, params: { query: purchase.email }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["purchases"].first).to include(
@@ -133,7 +133,7 @@ describe Api::Internal::Admin::PurchasesController do
 
       expect_any_instance_of(Purchase).not_to receive(:amount_refunded_cents)
 
-      post :search, params: { query: purchase.email }
+      get :search, params: { query: purchase.email }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["purchases"].first).to include(
@@ -149,7 +149,7 @@ describe Api::Internal::Admin::PurchasesController do
       second_purchase = create(:free_purchase, email: buyer_email, created_at: 2.days.ago)
       first_purchase = create(:free_purchase, email: buyer_email, created_at: 1.day.ago)
 
-      post :search, params: { query: buyer_email }
+      get :search, params: { query: buyer_email }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["count"]).to eq(2)
@@ -164,7 +164,7 @@ describe Api::Internal::Admin::PurchasesController do
       create(:free_purchase, email: buyer_email, created_at: 2.days.ago)
       returned_purchase = create(:free_purchase, email: buyer_email, created_at: 1.day.ago)
 
-      post :search, params: { query: buyer_email, limit: 1 }
+      get :search, params: { query: buyer_email, limit: 1 }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["count"]).to eq(1)
@@ -174,7 +174,7 @@ describe Api::Internal::Admin::PurchasesController do
     end
 
     it "returns an empty list when no purchases match" do
-      post :search, params: { query: "missing@example.com" }
+      get :search, params: { query: "missing@example.com" }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(
@@ -187,7 +187,7 @@ describe Api::Internal::Admin::PurchasesController do
     end
 
     it "returns a bad request when purchase_date is invalid" do
-      post :search, params: { purchase_date: "2021-01", card_type: "visa" }
+      get :search, params: { purchase_date: "2021-01", card_type: "visa" }
 
       expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body).to eq({ success: false, message: "purchase_date must use YYYY-MM-DD format." }.as_json)

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -7,16 +7,16 @@ describe Api::Internal::Admin::UsersController do
   let(:admin_user) { create(:admin_user) }
   let(:user_id_required_message) { "user_id is required for mutating admin actions. Use /internal/admin/users/info to look up the user_id by email." }
 
-  shared_examples "supports user lookup by user_id" do |action, build_user: -> { create(:user) }, extra_params: {}, success_status: :ok|
+  shared_examples "supports user lookup by user_id" do |action, method: :post, build_user: -> { create(:user) }, extra_params: {}, success_status: :ok|
     describe "user_id lookup" do
       it "looks up the user by user_id" do
         user = instance_exec(&build_user)
-        post action, params: extra_params.merge(user_id: user.external_id)
+        public_send(method, action, params: extra_params.merge(user_id: user.external_id))
         expect(response).to have_http_status(success_status)
       end
 
       it "returns 404 when user_id does not match any user" do
-        post action, params: extra_params.merge(user_id: "999999999999")
+        public_send(method, action, params: extra_params.merge(user_id: "999999999999"))
         expect(response).to have_http_status(:not_found)
         expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
       end
@@ -24,7 +24,7 @@ describe Api::Internal::Admin::UsersController do
       it "prefers user_id over email when both are provided" do
         target = instance_exec(&build_user)
         other = instance_exec(&build_user)
-        post action, params: extra_params.merge(user_id: target.external_id, email: other.email)
+        public_send(method, action, params: extra_params.merge(user_id: target.external_id, email: other.email))
         expect(response).to have_http_status(success_status)
       end
     end
@@ -52,20 +52,20 @@ describe Api::Internal::Admin::UsersController do
     end
   end
 
-  describe "POST info" do
-    include_examples "admin api authorization required", :post, :info
+  describe "GET info" do
+    include_examples "admin api authorization required", :get, :info
 
     before { stub_const("GUMROAD_ADMIN_ID", admin_user.id) }
 
     it "returns a bad request when email is missing" do
-      post :info
+      get :info
 
       expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body).to eq({ success: false, message: "email or user_id is required" }.as_json)
     end
 
     it "returns not found when the user does not exist" do
-      post :info, params: { email: "missing@example.com" }
+      get :info, params: { email: "missing@example.com" }
 
       expect(response).to have_http_status(:not_found)
       expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
@@ -74,7 +74,7 @@ describe Api::Internal::Admin::UsersController do
     it "returns a comprehensive info payload for a compliant seller" do
       user = create(:compliant_user, email: "seller@example.com", name: "Seller One", username: "sellerone")
 
-      post :info, params: { email: user.email }
+      get :info, params: { email: user.email }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["success"]).to be(true)
@@ -122,7 +122,7 @@ describe Api::Internal::Admin::UsersController do
       user = create(:tos_user, email: "suspended@example.com")
       comment = create(:comment, commentable: user, comment_type: Comment::COMMENT_TYPE_SUSPENDED, created_at: 2.days.ago)
 
-      post :info, params: { email: user.email }
+      get :info, params: { email: user.email }
 
       info = response.parsed_body["user"]
       expect(info["risk_state"]).to include(
@@ -137,7 +137,7 @@ describe Api::Internal::Admin::UsersController do
       user = create(:compliant_user, email: "tfa@example.com")
       user.update!(two_factor_authentication_enabled: true)
 
-      post :info, params: { email: user.email }
+      get :info, params: { email: user.email }
 
       expect(response.parsed_body["user"]["two_factor_authentication_enabled"]).to be(true)
     end
@@ -146,7 +146,7 @@ describe Api::Internal::Admin::UsersController do
       user = create(:compliant_user, email: "geo@example.com")
       create(:user_compliance_info, user:, country: "Germany")
 
-      post :info, params: { email: user.email }
+      get :info, params: { email: user.email }
 
       expect(response.parsed_body["user"]["country"]).to eq("Germany")
     end
@@ -156,7 +156,7 @@ describe Api::Internal::Admin::UsersController do
       user.update!(payouts_paused_internally: true, payouts_paused_by: GUMROAD_ADMIN_ID)
       user.comments.create!(author_id: GUMROAD_ADMIN_ID, comment_type: Comment::COMMENT_TYPE_PAYOUTS_PAUSED, content: "Manual review pending")
 
-      post :info, params: { email: user.email }
+      get :info, params: { email: user.email }
 
       expect(response.parsed_body["user"]["payouts"]).to include(
         "paused_internally" => true,
@@ -169,7 +169,7 @@ describe Api::Internal::Admin::UsersController do
       user = create(:compliant_user, email: "syspaused@example.com")
       user.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_SYSTEM)
 
-      post :info, params: { email: user.email }
+      get :info, params: { email: user.email }
 
       expect(response.parsed_body["user"]["payouts"]).to include(
         "paused_internally" => true,
@@ -182,7 +182,7 @@ describe Api::Internal::Admin::UsersController do
       user = create(:compliant_user, email: "selfpaused@example.com")
       user.update!(payouts_paused_by_user: true)
 
-      post :info, params: { email: user.email }
+      get :info, params: { email: user.email }
 
       expect(response.parsed_body["user"]["payouts"]).to include(
         "paused_internally" => false,
@@ -195,7 +195,7 @@ describe Api::Internal::Admin::UsersController do
       user = create(:compliant_user, email: "deactivated@example.com")
       user.deactivate!
 
-      post :info, params: { email: user.email }
+      get :info, params: { email: user.email }
 
       expect(response).to have_http_status(:ok)
       info = response.parsed_body["user"]
@@ -207,7 +207,7 @@ describe Api::Internal::Admin::UsersController do
       user = create(:compliant_user, email: "deleted-by-id@example.com")
       user.mark_deleted!
 
-      post :info, params: { user_id: user.external_id }
+      get :info, params: { user_id: user.external_id }
 
       expect(response).to have_http_status(:ok)
       info = response.parsed_body["user"]
@@ -215,7 +215,7 @@ describe Api::Internal::Admin::UsersController do
       expect(info["deleted_at"]).to eq(user.reload.deleted_at.as_json)
     end
 
-    include_examples "supports user lookup by user_id", :info, build_user: -> { create(:compliant_user) }
+    include_examples "supports user lookup by user_id", :info, method: :get, build_user: -> { create(:compliant_user) }
 
     it "uses the latest risk-state comment for last_status_changed_at, including on_probation transitions" do
       user = create(:compliant_user, email: "probation@example.com")
@@ -223,7 +223,7 @@ describe Api::Internal::Admin::UsersController do
       probation_comment = create(:comment, commentable: user, comment_type: Comment::COMMENT_TYPE_ON_PROBATION, created_at: 1.day.ago)
       user.update_column(:user_risk_state, "on_probation")
 
-      post :info, params: { email: user.email }
+      get :info, params: { email: user.email }
 
       expect(response.parsed_body["user"]["risk_state"]).to include(
         "user_risk_state" => "on_probation",
@@ -240,7 +240,7 @@ describe Api::Internal::Admin::UsersController do
       create(:failed_purchase, link: product, seller:)
       allow_any_instance_of(User).to receive(:sales_cents_total).and_return(1500)
 
-      post :info, params: { email: seller.email }
+      get :info, params: { email: seller.email }
 
       stats = response.parsed_body["user"]["stats"]
       expect(stats["sales_count"]).to eq(2)
@@ -257,7 +257,7 @@ describe Api::Internal::Admin::UsersController do
                             notes: "Review again")
       watched_user.update!(last_synced_at: 1.hour.ago)
 
-      post :info, params: { email: user.email }
+      get :info, params: { email: user.email }
 
       expect(response.parsed_body["user"]["active_watched_user"]).to eq(
         "id" => watched_user.external_id,
@@ -271,8 +271,8 @@ describe Api::Internal::Admin::UsersController do
     end
   end
 
-  describe "POST affiliates" do
-    include_examples "admin api authorization required", :post, :affiliates
+  describe "GET affiliates" do
+    include_examples "admin api authorization required", :get, :affiliates
 
     before { stub_const("GUMROAD_ADMIN_ID", admin_user.id) }
 
@@ -283,7 +283,7 @@ describe Api::Internal::Admin::UsersController do
     it "returns bad request when direction is missing" do
       user = create(:user)
 
-      post :affiliates, params: { user_id: user.external_id }
+      get :affiliates, params: { user_id: user.external_id }
 
       expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body).to eq({ success: false, message: "direction must be 'granted' or 'received'" }.as_json)
@@ -292,21 +292,21 @@ describe Api::Internal::Admin::UsersController do
     it "returns bad request when direction is invalid" do
       user = create(:user)
 
-      post :affiliates, params: { user_id: user.external_id, direction: "both" }
+      get :affiliates, params: { user_id: user.external_id, direction: "both" }
 
       expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body).to eq({ success: false, message: "direction must be 'granted' or 'received'" }.as_json)
     end
 
     it "returns bad request when neither user_id nor email is provided" do
-      post :affiliates, params: { direction: "granted" }
+      get :affiliates, params: { direction: "granted" }
 
       expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body).to eq({ success: false, message: "email or user_id is required" }.as_json)
     end
 
     it "returns not found when the user does not exist" do
-      post :affiliates, params: { user_id: "missing", direction: "granted" }
+      get :affiliates, params: { user_id: "missing", direction: "granted" }
 
       expect(response).to have_http_status(:not_found)
       expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
@@ -315,7 +315,7 @@ describe Api::Internal::Admin::UsersController do
     it "returns an empty list with cursor pagination metadata" do
       user = create(:user)
 
-      post :affiliates, params: { email: user.email, direction: "received" }
+      get :affiliates, params: { email: user.email, direction: "received" }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(
@@ -330,7 +330,7 @@ describe Api::Internal::Admin::UsersController do
     it "looks up soft-deleted users" do
       user = create(:user, :deleted)
 
-      post :affiliates, params: { user_id: user.external_id, direction: "granted" }
+      get :affiliates, params: { user_id: user.external_id, direction: "granted" }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["user_id"]).to eq(user.external_id)
@@ -340,7 +340,7 @@ describe Api::Internal::Admin::UsersController do
       user = create(:user)
 
       expect do
-        post :affiliates, params: { user_id: user.external_id, direction: "granted" }
+        get :affiliates, params: { user_id: user.external_id, direction: "granted" }
       end.not_to change { AdminApiAuditLog.count }
     end
 
@@ -355,7 +355,7 @@ describe Api::Internal::Admin::UsersController do
       collaborator = create(:collaborator, seller:, affiliate_user: collaborator_user, apply_to_all_products: false, affiliate_basis_points: 2000, created_at: 1.hour.ago)
       create(:product_affiliate, affiliate: collaborator, product: collaborator_product, affiliate_basis_points: 1500)
 
-      post :affiliates, params: { user_id: seller.external_id, direction: "granted" }
+      get :affiliates, params: { user_id: seller.external_id, direction: "granted" }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["affiliates"].map { _1["id"] }).to eq([collaborator.external_id, direct_affiliate.external_id])
@@ -410,7 +410,7 @@ describe Api::Internal::Admin::UsersController do
       product = create(:product, user: seller, name: "Seller guide")
       direct_affiliate = create(:direct_affiliate, seller:, affiliate_user:, affiliate_basis_points: 1200, products: [product])
 
-      post :affiliates, params: { email: affiliate_user.email, direction: "received" }
+      get :affiliates, params: { email: affiliate_user.email, direction: "received" }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["affiliates"].map { _1["id"] }).to eq([direct_affiliate.external_id])
@@ -432,7 +432,7 @@ describe Api::Internal::Admin::UsersController do
       product = create(:product)
       create(:product_affiliate, affiliate: user.global_affiliate, product:)
 
-      post :affiliates, params: { user_id: user.external_id, direction: "received" }
+      get :affiliates, params: { user_id: user.external_id, direction: "received" }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["affiliates"]).to eq([])
@@ -444,7 +444,7 @@ describe Api::Internal::Admin::UsersController do
       deleted_at = 1.day.ago
       direct_affiliate = create(:direct_affiliate, seller:, affiliate_user:, deleted_at:)
 
-      post :affiliates, params: { user_id: seller.external_id, direction: "granted" }
+      get :affiliates, params: { user_id: seller.external_id, direction: "granted" }
 
       expect(response).to have_http_status(:ok)
       payload = response.parsed_body["affiliates"].first
@@ -462,7 +462,7 @@ describe Api::Internal::Admin::UsersController do
       direct_affiliate = create(:direct_affiliate, seller:, affiliate_user:, affiliate_basis_points: 1800, products: [product])
       ProductAffiliate.find_by!(affiliate: direct_affiliate, product:).update!(affiliate_basis_points: nil)
 
-      post :affiliates, params: { user_id: seller.external_id, direction: "granted" }
+      get :affiliates, params: { user_id: seller.external_id, direction: "granted" }
 
       expect(response.parsed_body["affiliates"].first["products"].first["basis_points"]).to eq(1800)
     end
@@ -474,7 +474,7 @@ describe Api::Internal::Admin::UsersController do
       collaborator = create(:collaborator, seller:, affiliate_user:, apply_to_all_products: false, affiliate_basis_points: 2000)
       create(:product_affiliate, affiliate: collaborator, product:, affiliate_basis_points: 2500, destination_url: "https://example.com/collab")
 
-      post :affiliates, params: { user_id: seller.external_id, direction: "granted" }
+      get :affiliates, params: { user_id: seller.external_id, direction: "granted" }
 
       expect(response.parsed_body["affiliates"].first["products"]).to contain_exactly(
         {
@@ -491,7 +491,7 @@ describe Api::Internal::Admin::UsersController do
       affiliate_user = create(:user)
       direct_affiliate = create(:direct_affiliate, seller:, affiliate_user:, apply_to_all_products: true)
 
-      post :affiliates, params: { user_id: seller.external_id, direction: "granted" }
+      get :affiliates, params: { user_id: seller.external_id, direction: "granted" }
 
       payload = response.parsed_body["affiliates"].first
       expect(payload).to include(
@@ -507,7 +507,7 @@ describe Api::Internal::Admin::UsersController do
       middle = create(:direct_affiliate, seller:, affiliate_user: create(:user), created_at: 2.hours.ago)
       oldest = create(:direct_affiliate, seller:, affiliate_user: create(:user), created_at: 3.hours.ago)
 
-      post :affiliates, params: { user_id: seller.external_id, direction: "granted", limit: 2 }
+      get :affiliates, params: { user_id: seller.external_id, direction: "granted", limit: 2 }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["affiliates"].map { _1["id"] }).to eq([newest.external_id, middle.external_id])
@@ -515,7 +515,7 @@ describe Api::Internal::Admin::UsersController do
       expect(cursor).to be_present
       expect(response.parsed_body["pagination"]["limit"]).to eq(2)
 
-      post :affiliates, params: { user_id: seller.external_id, direction: "granted", limit: 2, cursor: }
+      get :affiliates, params: { user_id: seller.external_id, direction: "granted", limit: 2, cursor: }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["affiliates"].map { _1["id"] }).to eq([oldest.external_id])
@@ -525,7 +525,7 @@ describe Api::Internal::Admin::UsersController do
     it "returns bad request when the cursor is invalid" do
       user = create(:user)
 
-      post :affiliates, params: { user_id: user.external_id, direction: "granted", cursor: "invalid" }
+      get :affiliates, params: { user_id: user.external_id, direction: "granted", cursor: "invalid" }
 
       expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body).to eq({ success: false, message: "invalid cursor" }.as_json)
@@ -538,12 +538,12 @@ describe Api::Internal::Admin::UsersController do
       newer_received = create(:direct_affiliate, seller: create(:user), affiliate_user: user, created_at: 2.days.ago)
       older_received = create(:direct_affiliate, seller: create(:user), affiliate_user: user, created_at: 4.days.ago)
 
-      post :affiliates, params: { user_id: user.external_id, direction: "granted", limit: 1 }
+      get :affiliates, params: { user_id: user.external_id, direction: "granted", limit: 1 }
 
       expect(response.parsed_body["affiliates"].map { _1["id"] }).to eq([granted_anchor.external_id])
       cursor = response.parsed_body["pagination"]["next"]
 
-      post :affiliates, params: { user_id: user.external_id, direction: "received", limit: 2, cursor: }
+      get :affiliates, params: { user_id: user.external_id, direction: "received", limit: 2, cursor: }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["affiliates"].map { _1["id"] }).to eq([older_received.external_id])
@@ -556,7 +556,7 @@ describe Api::Internal::Admin::UsersController do
       matching_affiliate = create(:direct_affiliate, seller:, affiliate_user: create(:user))
       create(:direct_affiliate, seller: other_seller, affiliate_user: create(:user))
 
-      post :affiliates, params: { user_id: seller.external_id, direction: "granted" }
+      get :affiliates, params: { user_id: seller.external_id, direction: "granted" }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["affiliates"].map { _1["id"] }).to eq([matching_affiliate.external_id])
@@ -581,7 +581,7 @@ describe Api::Internal::Admin::UsersController do
       end
 
       ActiveSupport::Notifications.subscribed(counter, "sql.active_record") do
-        post :affiliates, params: { user_id: affiliate_user.external_id, direction: "received" }
+        get :affiliates, params: { user_id: affiliate_user.external_id, direction: "received" }
       end
 
       expect(response).to have_http_status(:ok)
@@ -589,16 +589,16 @@ describe Api::Internal::Admin::UsersController do
       expect(select_queries.length).to be <= 6, "expected at most 6 SELECTs but got #{select_queries.length}:\n#{select_queries.join("\n")}"
     end
 
-    include_examples "supports user lookup by user_id", :affiliates, extra_params: { direction: "granted" }
+    include_examples "supports user lookup by user_id", :affiliates, method: :get, extra_params: { direction: "granted" }
   end
 
-  describe "POST suspension" do
-    include_examples "admin api authorization required", :post, :suspension
+  describe "GET suspension" do
+    include_examples "admin api authorization required", :get, :suspension
 
     it "returns compliant status for an unsuspended user" do
       user = create(:compliant_user, email: "seller@example.com")
 
-      post :suspension, params: { email: user.email }
+      get :suspension, params: { email: user.email }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to eq({
@@ -614,7 +614,7 @@ describe Api::Internal::Admin::UsersController do
       user = create(:tos_user, email: "suspended@example.com")
       comment = create(:comment, commentable: user, comment_type: Comment::COMMENT_TYPE_SUSPENDED, created_at: 2.days.ago)
 
-      post :suspension, params: { email: user.email }
+      get :suspension, params: { email: user.email }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to eq({
@@ -627,14 +627,14 @@ describe Api::Internal::Admin::UsersController do
     end
 
     it "returns a bad request when email is missing" do
-      post :suspension
+      get :suspension
 
       expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body).to eq({ success: false, message: "email or user_id is required" }.as_json)
     end
 
     it "returns not found when the user does not exist" do
-      post :suspension, params: { email: "missing@example.com" }
+      get :suspension, params: { email: "missing@example.com" }
 
       expect(response).to have_http_status(:not_found)
       expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
@@ -644,13 +644,13 @@ describe Api::Internal::Admin::UsersController do
       user = create(:compliant_user)
       user.mark_deleted!
 
-      post :suspension, params: { user_id: user.external_id }
+      get :suspension, params: { user_id: user.external_id }
 
       expect(response).to have_http_status(:not_found)
       expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
     end
 
-    include_examples "supports user lookup by user_id", :suspension, build_user: -> { create(:compliant_user) }
+    include_examples "supports user lookup by user_id", :suspension, method: :get, build_user: -> { create(:compliant_user) }
   end
 
   describe "POST reset_password" do

--- a/spec/routing/api_internal_admin_contract_spec.rb
+++ b/spec/routing/api_internal_admin_contract_spec.rb
@@ -9,9 +9,11 @@ describe "internal admin API routing" do
 
   it "routes the safe read endpoints that gumroad-cli consumes" do
     expect(route_for("/internal/admin/purchases/123", :get)).to include(controller: "api/internal/admin/purchases", action: "show", id: "123")
-    expect(route_for("/internal/admin/purchases/search", :post)).to include(controller: "api/internal/admin/purchases", action: "search")
-    expect(route_for("/internal/admin/licenses/lookup", :post)).to include(controller: "api/internal/admin/licenses", action: "lookup")
-    expect(route_for("/internal/admin/users/suspension", :post)).to include(controller: "api/internal/admin/users", action: "suspension")
+    expect(route_for("/internal/admin/purchases/search", :get)).to include(controller: "api/internal/admin/purchases", action: "search")
+    expect(route_for("/internal/admin/licenses/lookup", :get)).to include(controller: "api/internal/admin/licenses", action: "lookup")
+    expect(route_for("/internal/admin/users/info", :get)).to include(controller: "api/internal/admin/users", action: "info")
+    expect(route_for("/internal/admin/users/affiliates", :get)).to include(controller: "api/internal/admin/users", action: "affiliates")
+    expect(route_for("/internal/admin/users/suspension", :get)).to include(controller: "api/internal/admin/users", action: "suspension")
     expect(route_for("/internal/admin/payouts", :get)).to include(controller: "api/internal/admin/payouts", action: "index")
   end
 
@@ -26,7 +28,7 @@ describe "internal admin API routing" do
   end
 
   it "routes the products endpoints" do
-    expect(route_for("/internal/admin/products/list", :post)).to include(controller: "api/internal/admin/products", action: "list")
+    expect(route_for("/internal/admin/products", :get)).to include(controller: "api/internal/admin/products", action: "index")
     expect(route_for("/internal/admin/products/abc123", :get)).to include(controller: "api/internal/admin/products", action: "show", id: "abc123")
   end
 end


### PR DESCRIPTION
Ref #4989

## What

- Moved the remaining admin read endpoints from `POST` to `GET` so reads and writes follow the same contract.
- Renamed the admin products list action to the standard REST `index` route while keeping the response shape unchanged.
- Updated the affected controller and routing specs to match the new request methods and paths.

## Why

- These endpoints only read data, so `GET` is the correct public contract.
- Using the standard verb and REST index path makes the admin API easier to understand and align with the CLI migration plan.

---

This PR was implemented with AI assistance using gpt‑5.5 xhigh.