### PR TITLE
Add admin API endpoint for user purchases

### DIFF
--- a/app/controllers/api/internal/admin/users_controller.rb
+++ b/app/controllers/api/internal/admin/users_controller.rb
@@ -4,7 +4,18 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
   include Api::Internal::Admin::CursorPaginated
 
   VALID_AFFILIATE_DIRECTIONS = %w[granted received].freeze
-  private_constant :VALID_AFFILIATE_DIRECTIONS
+  VALID_PURCHASE_STATES = %w[
+    in_progress
+    successful
+    failed
+    preorder_authorization_successful
+    preorder_authorization_failed
+    preorder_concluded_successfully
+    not_charged
+    gift_receiver_purchase_successful
+    test_successful
+  ].freeze
+  private_constant :VALID_AFFILIATE_DIRECTIONS, :VALID_PURCHASE_STATES
 
   def info
     user = find_internal_admin_user_for_read_or_render(include_deleted: true)
@@ -28,6 +39,24 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
     render json: internal_admin_user_success_payload(user, {
                                                        direction:,
                                                        affiliates: records.map { serialize_affiliate(_1, direction:, sellers_by_id:) },
+                                                       pagination:,
+                                                     })
+  end
+
+  def purchases
+    user = find_internal_admin_user_for_read_or_render(include_deleted: true)
+    return unless user
+
+    filters = parse_purchases_filters
+    return if filters.nil?
+
+    records, pagination = paginate_with_cursor(
+      purchases_scope(user, filters),
+      order: [[:created_at, :desc], [:id, :desc]]
+    )
+
+    render json: internal_admin_user_success_payload(user, {
+                                                       purchases: records.map { serialize_purchase(_1) },
                                                        pagination:,
                                                      })
   end
@@ -293,6 +322,85 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
         basis_points: product_affiliate.affiliate_basis_points || parent_basis_points,
         destination_url: product_affiliate.destination_url,
       }
+    end
+
+    def parse_purchases_filters
+      filters = {}
+
+      if params[:status].present?
+        states = Array(params[:status]).flat_map { _1.to_s.split(",") }.map(&:strip).reject(&:blank?)
+        invalid = states - VALID_PURCHASE_STATES
+        if invalid.any?
+          render json: { success: false, message: "status must be one of: #{VALID_PURCHASE_STATES.join(", ")}" }, status: :bad_request
+          return nil
+        end
+        filters[:states] = states
+      end
+
+      if params[:start_at].present?
+        filters[:start_at] = parse_iso8601_param(params[:start_at])
+        return render_invalid_purchases_filter("start_at") if filters[:start_at].nil?
+      end
+
+      if params[:end_at].present?
+        filters[:end_at] = parse_iso8601_param(params[:end_at])
+        return render_invalid_purchases_filter("end_at") if filters[:end_at].nil?
+      end
+
+      filters[:chargedback] = boolean_param(params[:chargedback]) if params.key?(:chargedback)
+      filters[:has_early_fraud_warning] = boolean_param(params[:has_early_fraud_warning]) if params.key?(:has_early_fraud_warning)
+      filters[:has_affiliate] = boolean_param(params[:has_affiliate]) if params.key?(:has_affiliate)
+      filters[:stripe_fingerprint] = params[:stripe_fingerprint].to_s if params[:stripe_fingerprint].present?
+      filters[:ip_address] = params[:ip_address].to_s if params[:ip_address].present?
+
+      filters
+    end
+
+    def parse_iso8601_param(value)
+      Time.iso8601(value.to_s)
+    rescue ArgumentError, TypeError
+      nil
+    end
+
+    def boolean_param(value)
+      ActiveModel::Type::Boolean.new.cast(value)
+    end
+
+    def render_invalid_purchases_filter(name)
+      render json: { success: false, message: "#{name} must be a valid ISO 8601 timestamp" }, status: :bad_request
+      nil
+    end
+
+    def purchases_scope(user, filters)
+      scope = Purchase
+        .where(purchaser_id: user.id)
+        .or(Purchase.where(email: user.email))
+        .includes(:link, :seller, :refunds)
+
+      scope = scope.where(purchase_state: filters[:states]) if filters[:states]
+      scope = scope.where("purchases.created_at >= ?", filters[:start_at]) if filters[:start_at]
+      scope = scope.where("purchases.created_at <= ?", filters[:end_at]) if filters[:end_at]
+
+      if filters.key?(:chargedback)
+        scope = filters[:chargedback] ? scope.where.not(chargeback_date: nil) : scope.where(chargeback_date: nil)
+      end
+
+      if filters.key?(:has_early_fraud_warning)
+        scope = if filters[:has_early_fraud_warning]
+          scope.joins(:early_fraud_warning)
+        else
+          scope.left_outer_joins(:early_fraud_warning).where(purchase_early_fraud_warnings: { id: nil })
+        end
+      end
+
+      if filters.key?(:has_affiliate)
+        scope = filters[:has_affiliate] ? scope.where.not(affiliate_id: nil) : scope.where(affiliate_id: nil)
+      end
+
+      scope = scope.where(stripe_fingerprint: filters[:stripe_fingerprint]) if filters[:stripe_fingerprint]
+      scope = scope.where(ip_address: filters[:ip_address]) if filters[:ip_address]
+
+      scope
     end
 
     def suspension_status(user)

--- a/app/controllers/api/internal/admin/users_controller.rb
+++ b/app/controllers/api/internal/admin/users_controller.rb
@@ -4,18 +4,11 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
   include Api::Internal::Admin::CursorPaginated
 
   VALID_AFFILIATE_DIRECTIONS = %w[granted received].freeze
-  VALID_PURCHASE_STATES = %w[
-    in_progress
-    successful
-    failed
-    preorder_authorization_successful
-    preorder_authorization_failed
-    preorder_concluded_successfully
-    not_charged
-    gift_receiver_purchase_successful
-    test_successful
-  ].freeze
-  private_constant :VALID_AFFILIATE_DIRECTIONS, :VALID_PURCHASE_STATES
+  private_constant :VALID_AFFILIATE_DIRECTIONS
+
+  def self.valid_purchase_states
+    @valid_purchase_states ||= Purchase.state_machines[:purchase_state].states.map { _1.name.to_s }.freeze
+  end
 
   def info
     user = find_internal_admin_user_for_read_or_render(include_deleted: true)
@@ -326,12 +319,13 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
 
     def parse_purchases_filters
       filters = {}
+      valid_states = self.class.valid_purchase_states
 
       if params[:status].present?
         states = Array(params[:status]).flat_map { _1.to_s.split(",") }.map(&:strip).reject(&:blank?)
-        invalid = states - VALID_PURCHASE_STATES
+        invalid = states - valid_states
         if invalid.any?
-          render json: { success: false, message: "status must be one of: #{VALID_PURCHASE_STATES.join(", ")}" }, status: :bad_request
+          render json: { success: false, message: "status must be one of: #{valid_states.join(", ")}" }, status: :bad_request
           return nil
         end
         filters[:states] = states
@@ -339,17 +333,23 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
 
       if params[:start_at].present?
         filters[:start_at] = parse_iso8601_param(params[:start_at])
-        return render_invalid_purchases_filter("start_at") if filters[:start_at].nil?
+        return render_invalid_purchases_filter_timestamp("start_at") if filters[:start_at].nil?
       end
 
       if params[:end_at].present?
         filters[:end_at] = parse_iso8601_param(params[:end_at])
-        return render_invalid_purchases_filter("end_at") if filters[:end_at].nil?
+        return render_invalid_purchases_filter_timestamp("end_at") if filters[:end_at].nil?
       end
 
-      filters[:chargedback] = boolean_param(params[:chargedback]) if params.key?(:chargedback)
-      filters[:has_early_fraud_warning] = boolean_param(params[:has_early_fraud_warning]) if params.key?(:has_early_fraud_warning)
-      filters[:has_affiliate] = boolean_param(params[:has_affiliate]) if params.key?(:has_affiliate)
+      %i[chargedback has_early_fraud_warning has_affiliate].each do |key|
+        next unless params.key?(key)
+
+        casted = boolean_param(params[key])
+        return render_invalid_purchases_filter_boolean(key) if casted.nil?
+
+        filters[key] = casted
+      end
+
       filters[:stripe_fingerprint] = params[:stripe_fingerprint].to_s if params[:stripe_fingerprint].present?
       filters[:ip_address] = params[:ip_address].to_s if params[:ip_address].present?
 
@@ -366,16 +366,20 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
       ActiveModel::Type::Boolean.new.cast(value)
     end
 
-    def render_invalid_purchases_filter(name)
+    def render_invalid_purchases_filter_timestamp(name)
       render json: { success: false, message: "#{name} must be a valid ISO 8601 timestamp" }, status: :bad_request
       nil
     end
 
+    def render_invalid_purchases_filter_boolean(name)
+      render json: { success: false, message: "#{name} must be true or false" }, status: :bad_request
+      nil
+    end
+
     def purchases_scope(user, filters)
-      scope = Purchase
-        .where(purchaser_id: user.id)
-        .or(Purchase.where(email: user.email))
-        .includes(:link, :seller, :refunds)
+      scope = Purchase.where(purchaser_id: user.id)
+      scope = scope.or(Purchase.where(email: user.email)) if user.email.present?
+      scope = scope.includes(:link, :seller, :refunds)
 
       scope = scope.where(purchase_state: filters[:states]) if filters[:states]
       scope = scope.where("purchases.created_at >= ?", filters[:start_at]) if filters[:start_at]

--- a/app/controllers/api/internal/admin/users_controller.rb
+++ b/app/controllers/api/internal/admin/users_controller.rb
@@ -423,7 +423,7 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
       if params[:status].present?
         states = Array(params[:status]).flat_map { _1.to_s.split(",") }.map(&:strip).reject(&:blank?)
         invalid = states - valid_states
-        if invalid.any?
+        if states.empty? || invalid.any?
           render json: { success: false, message: "status must be one of: #{valid_states.join(", ")}" }, status: :bad_request
           return nil
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -328,6 +328,7 @@ Rails.application.routes.draw do
             collection do
               get :info
               get :affiliates
+              get :purchases
               get :suspension
               post :reset_password
               post :update_email

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -1090,6 +1090,16 @@ describe Api::Internal::Admin::UsersController do
       expect(response.parsed_body["message"]).to start_with("status must be one of")
     end
 
+    it "rejects a comma-only status value instead of silently returning an empty list" do
+      buyer = create(:user)
+      create(:purchase, purchaser: buyer)
+
+      get :purchases, params: { user_id: buyer.external_id, status: "," }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body["message"]).to start_with("status must be one of")
+    end
+
     it "accepts every state defined on the Purchase state machine, including preorder_concluded_unsuccessfully" do
       buyer = create(:user)
       purchase = create(:purchase, purchaser: buyer)

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -743,6 +743,278 @@ describe Api::Internal::Admin::UsersController do
     include_examples "supports user lookup by user_id", :affiliates, method: :get, extra_params: { direction: "granted" }
   end
 
+  describe "GET purchases" do
+    include_examples "admin api authorization required", :get, :purchases
+
+    before { stub_const("GUMROAD_ADMIN_ID", admin_user.id) }
+
+    let!(:gumroad_merchant_account) { create(:merchant_account, user: nil) }
+
+    def purchase_ids
+      response.parsed_body["purchases"].map { _1["id"] }
+    end
+
+    it "returns bad request when neither user_id nor email is provided" do
+      get :purchases
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "email or user_id is required" }.as_json)
+    end
+
+    it "returns not found when the user does not exist" do
+      get :purchases, params: { user_id: "missing" }
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
+    end
+
+    it "returns an empty list with cursor pagination metadata" do
+      user = create(:user)
+
+      get :purchases, params: { user_id: user.external_id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(
+        "success" => true,
+        "user_id" => user.external_id,
+        "purchases" => [],
+        "pagination" => { "next" => nil, "limit" => 20 }
+      )
+    end
+
+    it "looks up soft-deleted users" do
+      user = create(:user, :deleted)
+
+      get :purchases, params: { user_id: user.external_id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["user_id"]).to eq(user.external_id)
+    end
+
+    it "does not write an admin audit log" do
+      user = create(:user)
+
+      expect do
+        get :purchases, params: { user_id: user.external_id }
+      end.not_to change { AdminApiAuditLog.count }
+    end
+
+    it "returns purchases matched by purchaser_id and by email, newest first" do
+      buyer = create(:user, email: "buyer@example.com")
+      anonymous_match = create(:purchase, email: buyer.email, created_at: 3.hours.ago)
+      logged_in = create(:purchase, purchaser: buyer, email: "other@example.com", created_at: 2.hours.ago)
+      newest = create(:purchase, purchaser: buyer, email: buyer.email, created_at: 1.hour.ago)
+      create(:purchase, email: "someone-else@example.com", created_at: 30.minutes.ago)
+
+      get :purchases, params: { user_id: buyer.external_id }
+
+      expect(response).to have_http_status(:ok)
+      expect(purchase_ids).to eq([newest, logged_in, anonymous_match].map { _1.external_id_numeric.to_s })
+    end
+
+    it "serializes each row with the shared purchase payload" do
+      buyer = create(:user, email: "buyer@example.com")
+      seller = create(:user, email: "seller@example.com")
+      product = create(:product, user: seller, name: "Investigation guide")
+      purchase = create(:purchase, purchaser: buyer, seller:, link: product, email: buyer.email, price_cents: 12_34)
+
+      get :purchases, params: { user_id: buyer.external_id }
+
+      payload = response.parsed_body["purchases"].first
+      expect(payload).to include(
+        "id" => purchase.external_id_numeric.to_s,
+        "email" => buyer.email,
+        "seller_email" => "seller@example.com",
+        "product_name" => "Investigation guide",
+        "price_cents" => 12_34,
+        "purchase_state" => "successful"
+      )
+    end
+
+    it "filters by a single purchase_state" do
+      buyer = create(:user)
+      successful = create(:purchase, purchaser: buyer)
+      create(:failed_purchase, purchaser: buyer)
+
+      get :purchases, params: { user_id: buyer.external_id, status: "successful" }
+
+      expect(purchase_ids).to eq([successful.external_id_numeric.to_s])
+    end
+
+    it "filters by multiple purchase states from a comma-separated list" do
+      buyer = create(:user)
+      successful = create(:purchase, purchaser: buyer, created_at: 2.hours.ago)
+      failed = create(:failed_purchase, purchaser: buyer, created_at: 1.hour.ago)
+      create(:purchase, purchaser: buyer, purchase_state: "not_charged", created_at: 30.minutes.ago)
+
+      get :purchases, params: { user_id: buyer.external_id, status: "successful,failed" }
+
+      expect(purchase_ids).to eq([failed, successful].map { _1.external_id_numeric.to_s })
+    end
+
+    it "rejects an unknown status value" do
+      user = create(:user)
+
+      get :purchases, params: { user_id: user.external_id, status: "not_a_state" }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body["message"]).to start_with("status must be one of")
+    end
+
+    it "filters by a created_at window using ISO 8601 timestamps" do
+      buyer = create(:user)
+      too_old = create(:purchase, purchaser: buyer, created_at: 3.days.ago)
+      in_window = create(:purchase, purchaser: buyer, created_at: 1.day.ago)
+      too_new = create(:purchase, purchaser: buyer, created_at: 1.hour.ago)
+
+      get :purchases, params: {
+        user_id: buyer.external_id,
+        start_at: 2.days.ago.iso8601,
+        end_at: 6.hours.ago.iso8601
+      }
+
+      expect(purchase_ids).to eq([in_window.external_id_numeric.to_s])
+      expect(purchase_ids).not_to include(too_old.external_id_numeric.to_s, too_new.external_id_numeric.to_s)
+    end
+
+    it "rejects an unparseable start_at" do
+      user = create(:user)
+
+      get :purchases, params: { user_id: user.external_id, start_at: "yesterday" }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "start_at must be a valid ISO 8601 timestamp" }.as_json)
+    end
+
+    it "rejects an unparseable end_at" do
+      user = create(:user)
+
+      get :purchases, params: { user_id: user.external_id, end_at: "soon" }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "end_at must be a valid ISO 8601 timestamp" }.as_json)
+    end
+
+    it "filters by chargedback=true" do
+      buyer = create(:user)
+      clean = create(:purchase, purchaser: buyer)
+      chargedback = create(:purchase, purchaser: buyer, chargeback_date: 1.day.ago)
+
+      get :purchases, params: { user_id: buyer.external_id, chargedback: true }
+
+      expect(purchase_ids).to eq([chargedback.external_id_numeric.to_s])
+      expect(purchase_ids).not_to include(clean.external_id_numeric.to_s)
+    end
+
+    it "filters by chargedback=false" do
+      buyer = create(:user)
+      clean = create(:purchase, purchaser: buyer)
+      create(:purchase, purchaser: buyer, chargeback_date: 1.day.ago)
+
+      get :purchases, params: { user_id: buyer.external_id, chargedback: false }
+
+      expect(purchase_ids).to eq([clean.external_id_numeric.to_s])
+    end
+
+    it "filters by has_early_fraud_warning=true" do
+      buyer = create(:user)
+      flagged = create(:purchase, purchaser: buyer)
+      create(:early_fraud_warning, purchase: flagged)
+      create(:purchase, purchaser: buyer)
+
+      get :purchases, params: { user_id: buyer.external_id, has_early_fraud_warning: true }
+
+      expect(purchase_ids).to eq([flagged.external_id_numeric.to_s])
+    end
+
+    it "filters by has_early_fraud_warning=false" do
+      buyer = create(:user)
+      flagged = create(:purchase, purchaser: buyer)
+      create(:early_fraud_warning, purchase: flagged)
+      clean = create(:purchase, purchaser: buyer)
+
+      get :purchases, params: { user_id: buyer.external_id, has_early_fraud_warning: false }
+
+      expect(purchase_ids).to eq([clean.external_id_numeric.to_s])
+    end
+
+    it "filters by has_affiliate=true" do
+      buyer = create(:user)
+      seller = create(:user)
+      product = create(:product, user: seller)
+      affiliate = create(:direct_affiliate, seller:, affiliate_user: create(:user))
+      with_affiliate = create(:purchase, purchaser: buyer, seller:, link: product, affiliate:)
+      create(:purchase, purchaser: buyer)
+
+      get :purchases, params: { user_id: buyer.external_id, has_affiliate: true }
+
+      expect(purchase_ids).to eq([with_affiliate.external_id_numeric.to_s])
+    end
+
+    it "filters by stripe_fingerprint" do
+      buyer = create(:user)
+      matching = create(:purchase, purchaser: buyer, stripe_fingerprint: "fp_shared")
+      create(:purchase, purchaser: buyer, stripe_fingerprint: "fp_other")
+
+      get :purchases, params: { user_id: buyer.external_id, stripe_fingerprint: "fp_shared" }
+
+      expect(purchase_ids).to eq([matching.external_id_numeric.to_s])
+    end
+
+    it "filters by ip_address" do
+      buyer = create(:user)
+      matching = create(:purchase, purchaser: buyer, ip_address: "203.0.113.7")
+      create(:purchase, purchaser: buyer, ip_address: "198.51.100.4")
+
+      get :purchases, params: { user_id: buyer.external_id, ip_address: "203.0.113.7" }
+
+      expect(purchase_ids).to eq([matching.external_id_numeric.to_s])
+    end
+
+    it "scopes results to the requested user" do
+      buyer = create(:user)
+      other_buyer = create(:user)
+      mine = create(:purchase, purchaser: buyer)
+      create(:purchase, purchaser: other_buyer)
+
+      get :purchases, params: { user_id: buyer.external_id }
+
+      expect(purchase_ids).to eq([mine.external_id_numeric.to_s])
+    end
+
+    it "paginates purchases with a cursor" do
+      buyer = create(:user)
+      newest = create(:purchase, purchaser: buyer, created_at: 1.hour.ago)
+      middle = create(:purchase, purchaser: buyer, created_at: 2.hours.ago)
+      oldest = create(:purchase, purchaser: buyer, created_at: 3.hours.ago)
+
+      get :purchases, params: { user_id: buyer.external_id, limit: 2 }
+
+      expect(response).to have_http_status(:ok)
+      expect(purchase_ids).to eq([newest, middle].map { _1.external_id_numeric.to_s })
+      cursor = response.parsed_body["pagination"]["next"]
+      expect(cursor).to be_present
+      expect(response.parsed_body["pagination"]["limit"]).to eq(2)
+
+      get :purchases, params: { user_id: buyer.external_id, limit: 2, cursor: }
+
+      expect(response).to have_http_status(:ok)
+      expect(purchase_ids).to eq([oldest.external_id_numeric.to_s])
+      expect(response.parsed_body["pagination"]).to eq({ "next" => nil, "limit" => 2 })
+    end
+
+    it "returns bad request when the cursor is invalid" do
+      user = create(:user)
+
+      get :purchases, params: { user_id: user.external_id, cursor: "invalid" }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "invalid cursor" }.as_json)
+    end
+
+    include_examples "supports user lookup by user_id", :purchases, method: :get
+  end
+
   describe "GET suspension" do
     include_examples "admin api authorization required", :get, :suspension
 

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -861,6 +861,17 @@ describe Api::Internal::Admin::UsersController do
       expect(response.parsed_body["message"]).to start_with("status must be one of")
     end
 
+    it "accepts every state defined on the Purchase state machine, including preorder_concluded_unsuccessfully" do
+      buyer = create(:user)
+      purchase = create(:purchase, purchaser: buyer)
+      purchase.update_column(:purchase_state, "preorder_concluded_unsuccessfully")
+
+      get :purchases, params: { user_id: buyer.external_id, status: "preorder_concluded_unsuccessfully" }
+
+      expect(response).to have_http_status(:ok)
+      expect(purchase_ids).to eq([purchase.external_id_numeric.to_s])
+    end
+
     it "filters by a created_at window using ISO 8601 timestamps" do
       buyer = create(:user)
       too_old = create(:purchase, purchaser: buyer, created_at: 3.days.ago)
@@ -914,6 +925,33 @@ describe Api::Internal::Admin::UsersController do
       get :purchases, params: { user_id: buyer.external_id, chargedback: false }
 
       expect(purchase_ids).to eq([clean.external_id_numeric.to_s])
+    end
+
+    it "rejects an empty chargedback value instead of silently filtering to chargedback=false" do
+      user = create(:user)
+
+      get :purchases, params: { user_id: user.external_id, chargedback: "" }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "chargedback must be true or false" }.as_json)
+    end
+
+    it "rejects an empty has_early_fraud_warning value" do
+      user = create(:user)
+
+      get :purchases, params: { user_id: user.external_id, has_early_fraud_warning: "" }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "has_early_fraud_warning must be true or false" }.as_json)
+    end
+
+    it "rejects an unparseable has_affiliate value" do
+      user = create(:user)
+
+      get :purchases, params: { user_id: user.external_id, has_affiliate: "" }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "has_affiliate must be true or false" }.as_json)
     end
 
     it "filters by has_early_fraud_warning=true" do
@@ -980,6 +1018,20 @@ describe Api::Internal::Admin::UsersController do
       get :purchases, params: { user_id: buyer.external_id }
 
       expect(purchase_ids).to eq([mine.external_id_numeric.to_s])
+    end
+
+    it "skips the email branch when the user has no email so NULL-email purchases are not leaked" do
+      oauth_buyer = create(:user, provider: "google_oauth2", google_uid: "g-uid")
+      oauth_buyer.update_columns(email: nil)
+      own_purchase = create(:purchase, purchaser: oauth_buyer)
+      unrelated = create(:purchase)
+      unrelated.update_columns(email: nil)
+
+      get :purchases, params: { user_id: oauth_buyer.external_id }
+
+      expect(response).to have_http_status(:ok)
+      expect(purchase_ids).to eq([own_purchase.external_id_numeric.to_s])
+      expect(purchase_ids).not_to include(unrelated.external_id_numeric.to_s)
     end
 
     it "paginates purchases with a cursor" do

--- a/spec/routing/api_internal_admin_contract_spec.rb
+++ b/spec/routing/api_internal_admin_contract_spec.rb
@@ -13,6 +13,7 @@ describe "internal admin API routing" do
     expect(route_for("/internal/admin/licenses/lookup", :get)).to include(controller: "api/internal/admin/licenses", action: "lookup")
     expect(route_for("/internal/admin/users/info", :get)).to include(controller: "api/internal/admin/users", action: "info")
     expect(route_for("/internal/admin/users/affiliates", :get)).to include(controller: "api/internal/admin/users", action: "affiliates")
+    expect(route_for("/internal/admin/users/purchases", :get)).to include(controller: "api/internal/admin/users", action: "purchases")
     expect(route_for("/internal/admin/users/suspension", :get)).to include(controller: "api/internal/admin/users", action: "suspension")
     expect(route_for("/internal/admin/payouts", :get)).to include(controller: "api/internal/admin/payouts", action: "index")
   end


### PR DESCRIPTION
Ref #4989

## What

- Adds `GET /api/internal/admin/users/purchases`, a paginated read of purchases for a given user.
- Matches buyer-side records two ways: by `purchaser_id` **and** by `email`, so anonymous email-only purchases are not missed.
- Filters: `status` (single value or comma-separated list, validated against the purchase state set), `start_at` / `end_at` (ISO 8601), `chargedback`, `has_early_fraud_warning`, `has_affiliate`, `stripe_fingerprint`, `ip_address`.
- Pagination via the existing `Api::Internal::Admin::CursorPaginated` concern, ordered `created_at DESC, id DESC` to match `affiliates`.
- Lookup supports `email` or `user_id` and includes soft-deleted accounts, mirroring `info` and `affiliates`.
- No `record_admin_write`; this is a read.

## Why

- This is the primitive the `Purchases` checkbox on #4989 calls for: walk a buyer's history (across sellers) and compute velocity over a window.
- Buyer-side via `purchaser_id` alone misses anonymous Gumroad purchases that only carry an `email`. The OR with `email` catches both shapes without needing a new column or index.
- Rows serialize through the existing `serialize_purchase` helper on `Api::Internal::Admin::BaseController`. Keeping the row shape stable means the richer fields (card BIN, IP country, EFW details) land in PR #9 (purchase response extension) for free, without churn here.
- `status` validates against a fixed allowlist so callers can't smuggle arbitrary state values, and `start_at` / `end_at` reject anything `Time.iso8601` can't parse.

---
This PR was implemented with AI assistance using Claude Opus 4.7 (1M context)