### PR TITLE
Add admin API endpoint for user compliance info

### DIFF
--- a/app/controllers/api/internal/admin/users_controller.rb
+++ b/app/controllers/api/internal/admin/users_controller.rb
@@ -32,6 +32,16 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
                                                      })
   end
 
+  def compliance_info
+    user = find_internal_admin_user_for_read_or_render(include_deleted: true)
+    return unless user
+
+    render json: internal_admin_user_success_payload(user, {
+                                                       compliance_info: serialize_compliance_info(user.alive_user_compliance_info),
+                                                       info_requests: open_compliance_info_requests(user).map { serialize_compliance_info_request(_1) },
+                                                     })
+  end
+
   def suspension
     user = find_internal_admin_user_for_read_or_render
     return unless user
@@ -292,6 +302,95 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
         name: product&.name,
         basis_points: product_affiliate.affiliate_basis_points || parent_basis_points,
         destination_url: product_affiliate.destination_url,
+      }
+    end
+
+    def serialize_compliance_info(info)
+      return nil if info.nil?
+
+      {
+        id: info.external_id,
+        is_business: info.is_business?,
+        legal_name: info.legal_entity_name.presence,
+        first_name: info.first_name,
+        last_name: info.last_name,
+        dba: info.dba,
+        birthday: info.birthday&.iso8601,
+        nationality: info.nationality,
+        phone: info.phone,
+        job_title: info.job_title,
+        address: serialize_compliance_address(
+          street_address: info.street_address,
+          city: info.city,
+          state: info.state,
+          state_code: info.state_code,
+          zip_code: info.zip_code,
+          country: info.country,
+          country_code: info.country_code
+        ),
+        business_name: info.business_name,
+        business_type: info.business_type,
+        business_phone: info.business_phone,
+        business_vat_id_number: info.business_vat_id_number,
+        business_address: info.is_business? ? serialize_compliance_address(
+          street_address: info.business_street_address,
+          city: info.business_city,
+          state: info.business_state,
+          state_code: info.business_state_code,
+          zip_code: info.business_zip_code,
+          country: info.business_country,
+          country_code: info.business_country_code
+        ) : nil,
+        tax_ids: {
+          individual_last_four: tax_id_last_four(info.individual_tax_id),
+          business_last_four: tax_id_last_four(info.business_tax_id, digits_only: true),
+        },
+        identity_documents: {
+          stripe_identity_document_id: info.stripe_identity_document_id,
+          stripe_company_document_id: info.stripe_company_document_id,
+          stripe_additional_document_id: info.stripe_additional_document_id,
+        },
+        created_at: info.created_at.as_json,
+        updated_at: info.updated_at.as_json,
+      }
+    end
+
+    def serialize_compliance_address(street_address:, city:, state:, state_code:, zip_code:, country:, country_code:)
+      {
+        street_address:,
+        city:,
+        state:,
+        state_code:,
+        zip_code:,
+        country:,
+        country_code:,
+      }
+    end
+
+    def tax_id_last_four(encrypted_tax_id, digits_only: false)
+      return nil if encrypted_tax_id.blank?
+
+      decrypted = encrypted_tax_id.decrypt(GlobalConfig.get("STRONGBOX_GENERAL_PASSWORD")).to_s
+      decrypted = decrypted.gsub(/\D/, "") if digits_only
+      decrypted[-4..]
+    end
+
+    def open_compliance_info_requests(user)
+      user.user_compliance_info_requests
+          .requested
+          .order(Arel.sql("ISNULL(due_at), due_at ASC, created_at ASC"))
+    end
+
+    def serialize_compliance_info_request(request)
+      due_at = request.due_at
+      {
+        id: request.external_id,
+        field_needed: request.field_needed,
+        state: request.state,
+        due_at: due_at&.as_json,
+        overdue: due_at.present? && due_at < Time.current,
+        created_at: request.created_at.as_json,
+        last_email_sent_at: request.last_email_sent_at&.as_json,
       }
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -328,6 +328,7 @@ Rails.application.routes.draw do
             collection do
               get :info
               get :affiliates
+              get :compliance_info
               get :suspension
               post :reset_password
               post :update_email

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -743,6 +743,235 @@ describe Api::Internal::Admin::UsersController do
     include_examples "supports user lookup by user_id", :affiliates, method: :get, extra_params: { direction: "granted" }
   end
 
+  describe "GET compliance_info" do
+    include_examples "admin api authorization required", :get, :compliance_info
+
+    before { stub_const("GUMROAD_ADMIN_ID", admin_user.id) }
+
+    it "returns bad request when neither user_id nor email is provided" do
+      get :compliance_info
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "email or user_id is required" }.as_json)
+    end
+
+    it "returns not found when the user does not exist" do
+      get :compliance_info, params: { user_id: "missing" }
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
+    end
+
+    it "returns null compliance_info and an empty info_requests list when the user has never submitted KYC" do
+      user = create(:user)
+
+      get :compliance_info, params: { user_id: user.external_id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq(
+        "success" => true,
+        "user_id" => user.external_id,
+        "compliance_info" => nil,
+        "info_requests" => []
+      )
+    end
+
+    it "looks up soft-deleted users" do
+      user = create(:user, :deleted)
+
+      get :compliance_info, params: { user_id: user.external_id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["user_id"]).to eq(user.external_id)
+    end
+
+    it "does not write an admin audit log" do
+      user = create(:user)
+
+      expect do
+        get :compliance_info, params: { user_id: user.external_id }
+      end.not_to change { AdminApiAuditLog.count }
+    end
+
+    it "returns submitted KYC fields for an individual seller with the tax ID masked to last four" do
+      user = create(:user)
+      info = create(:user_compliance_info,
+                    user:,
+                    first_name: "Alice",
+                    last_name: "Investigator",
+                    dba: "Alice & Co",
+                    birthday: Date.new(1985, 6, 7),
+                    individual_tax_id: "123456789",
+                    nationality: "US",
+                    phone: "5551234567",
+                    job_title: "Owner",
+                    stripe_identity_document_id: "idoc_individual")
+
+      get :compliance_info, params: { user_id: user.external_id }
+
+      payload = response.parsed_body["compliance_info"]
+      expect(payload).to include(
+        "id" => info.external_id,
+        "is_business" => false,
+        "first_name" => "Alice",
+        "last_name" => "Investigator",
+        "legal_name" => "Alice Investigator",
+        "dba" => "Alice & Co",
+        "birthday" => "1985-06-07",
+        "nationality" => "US",
+        "phone" => "5551234567",
+        "job_title" => "Owner",
+        "business_name" => nil,
+        "business_type" => nil,
+        "business_phone" => nil,
+        "business_vat_id_number" => nil,
+        "business_address" => nil
+      )
+      expect(payload["address"]).to eq(
+        "street_address" => "address_full_match",
+        "city" => "San Francisco",
+        "state" => "California",
+        "state_code" => "CA",
+        "zip_code" => "94107",
+        "country" => "United States",
+        "country_code" => "US"
+      )
+      expect(payload["tax_ids"]).to eq(
+        "individual_last_four" => "6789",
+        "business_last_four" => nil
+      )
+      expect(payload["identity_documents"]).to eq(
+        "stripe_identity_document_id" => "idoc_individual",
+        "stripe_company_document_id" => nil,
+        "stripe_additional_document_id" => nil
+      )
+      expect(payload["created_at"]).to eq(info.created_at.as_json)
+      expect(payload["updated_at"]).to eq(info.updated_at.as_json)
+    end
+
+    it "returns business KYC fields with the business address and business tax ID last four (digits only)" do
+      user = create(:user)
+      info = create(:user_compliance_info_business,
+                    user:,
+                    business_name: "Acme LLC",
+                    business_type: UserComplianceInfo::BusinessTypes::LLC,
+                    business_tax_id: "12-3456789",
+                    business_phone: "5550009999",
+                    business_vat_id_number: "GB123456789",
+                    stripe_company_document_id: "idoc_company",
+                    stripe_additional_document_id: "idoc_additional")
+
+      get :compliance_info, params: { user_id: user.external_id }
+
+      payload = response.parsed_body["compliance_info"]
+      expect(payload).to include(
+        "id" => info.external_id,
+        "is_business" => true,
+        "legal_name" => "Acme LLC",
+        "business_name" => "Acme LLC",
+        "business_type" => UserComplianceInfo::BusinessTypes::LLC,
+        "business_phone" => "5550009999",
+        "business_vat_id_number" => "GB123456789"
+      )
+      expect(payload["business_address"]).to eq(
+        "street_address" => "address_full_match",
+        "city" => "Burbank",
+        "state" => "California",
+        "state_code" => "CA",
+        "zip_code" => "91506",
+        "country" => "United States",
+        "country_code" => "US"
+      )
+      expect(payload["tax_ids"]).to eq(
+        "individual_last_four" => "0000",
+        "business_last_four" => "6789"
+      )
+      expect(payload["identity_documents"]).to include(
+        "stripe_company_document_id" => "idoc_company",
+        "stripe_additional_document_id" => "idoc_additional"
+      )
+    end
+
+    it "returns the latest alive compliance info when older records are soft-deleted" do
+      user = create(:user)
+      old_info = create(:user_compliance_info, user:, first_name: "Old")
+      old_info.mark_deleted!
+      newest = create(:user_compliance_info, user:, first_name: "Newest")
+
+      get :compliance_info, params: { user_id: user.external_id }
+
+      expect(response.parsed_body["compliance_info"]["id"]).to eq(newest.external_id)
+      expect(response.parsed_body["compliance_info"]["first_name"]).to eq("Newest")
+    end
+
+    it "omits last_four for tax IDs that were never set" do
+      user = create(:user)
+      create(:user_compliance_info_empty, user:)
+
+      get :compliance_info, params: { user_id: user.external_id }
+
+      expect(response.parsed_body["compliance_info"]["tax_ids"]).to eq(
+        "individual_last_four" => nil,
+        "business_last_four" => nil
+      )
+    end
+
+    it "lists only requested info_requests and excludes provided ones, marking overdue rows" do
+      user = create(:user)
+      overdue = create(:user_compliance_info_request, user:, field_needed: UserComplianceInfoFields::Individual::TAX_ID, state: "requested", due_at: 3.days.ago, created_at: 5.days.ago)
+      upcoming = create(:user_compliance_info_request, user:, field_needed: UserComplianceInfoFields::Individual::DATE_OF_BIRTH, state: "requested", due_at: 5.days.from_now, created_at: 2.days.ago)
+      undated = create(:user_compliance_info_request, user:, field_needed: UserComplianceInfoFields::Business::TAX_ID, state: "requested", due_at: nil, created_at: 1.day.ago)
+      create(:user_compliance_info_request, user:, field_needed: UserComplianceInfoFields::Individual::FIRST_NAME, state: "provided", provided_at: 1.day.ago)
+
+      get :compliance_info, params: { user_id: user.external_id }
+
+      rows = response.parsed_body["info_requests"]
+      expect(rows.map { _1["id"] }).to eq([overdue, upcoming, undated].map(&:external_id))
+      expect(rows.first).to include(
+        "field_needed" => UserComplianceInfoFields::Individual::TAX_ID,
+        "state" => "requested",
+        "due_at" => overdue.due_at.as_json,
+        "overdue" => true,
+        "created_at" => overdue.created_at.as_json,
+        "last_email_sent_at" => nil
+      )
+      expect(rows[1]).to include(
+        "field_needed" => UserComplianceInfoFields::Individual::DATE_OF_BIRTH,
+        "overdue" => false
+      )
+      expect(rows[2]).to include(
+        "field_needed" => UserComplianceInfoFields::Business::TAX_ID,
+        "due_at" => nil,
+        "overdue" => false
+      )
+    end
+
+    it "exposes the most recent email reminder timestamp when present" do
+      user = create(:user)
+      request_record = create(:user_compliance_info_request, user:, field_needed: UserComplianceInfoFields::Individual::TAX_ID, state: "requested", due_at: 1.day.from_now)
+      reminder_time = 2.hours.ago.change(usec: 0)
+      request_record.record_email_sent!(reminder_time)
+
+      get :compliance_info, params: { user_id: user.external_id }
+
+      row = response.parsed_body["info_requests"].first
+      expect(row["last_email_sent_at"]).to eq(reminder_time.as_json)
+    end
+
+    it "scopes info_requests to the requested user" do
+      user = create(:user)
+      other_user = create(:user)
+      mine = create(:user_compliance_info_request, user:, field_needed: UserComplianceInfoFields::Individual::TAX_ID, state: "requested")
+      create(:user_compliance_info_request, user: other_user, field_needed: UserComplianceInfoFields::Individual::TAX_ID, state: "requested")
+
+      get :compliance_info, params: { user_id: user.external_id }
+
+      expect(response.parsed_body["info_requests"].map { _1["id"] }).to eq([mine.external_id])
+    end
+
+    include_examples "supports user lookup by user_id", :compliance_info, method: :get
+  end
+
   describe "GET suspension" do
     include_examples "admin api authorization required", :get, :suspension
 

--- a/spec/routing/api_internal_admin_contract_spec.rb
+++ b/spec/routing/api_internal_admin_contract_spec.rb
@@ -13,6 +13,7 @@ describe "internal admin API routing" do
     expect(route_for("/internal/admin/licenses/lookup", :get)).to include(controller: "api/internal/admin/licenses", action: "lookup")
     expect(route_for("/internal/admin/users/info", :get)).to include(controller: "api/internal/admin/users", action: "info")
     expect(route_for("/internal/admin/users/affiliates", :get)).to include(controller: "api/internal/admin/users", action: "affiliates")
+    expect(route_for("/internal/admin/users/compliance_info", :get)).to include(controller: "api/internal/admin/users", action: "compliance_info")
     expect(route_for("/internal/admin/users/suspension", :get)).to include(controller: "api/internal/admin/users", action: "suspension")
     expect(route_for("/internal/admin/payouts", :get)).to include(controller: "api/internal/admin/payouts", action: "index")
   end


### PR DESCRIPTION
Ref #4989

## What

- Adds `GET /api/internal/admin/users/compliance_info`, a read over the user's submitted KYC data and any open requests for additional info.
- `compliance_info` is built from `user.alive_user_compliance_info` and returns `null` when no record exists.
- Tax IDs are decrypted server-side and exposed only as `tax_ids.individual_last_four` (raw last 4) and `tax_ids.business_last_four` (digits-only last 4) - the rest of the encrypted value never leaves the server.
- Covers individual vs business cleanly: legal name, DBA, birthday, nationality, phone, job title, individual address with state/country codes, business address (only when `is_business`), business type / phone / VAT ID number, and the three Stripe identity-document references (individual, company, additional).
- `info_requests` lists every `requested`-state `UserComplianceInfoRequest` for the user (provided rows filtered out), ordered most-overdue first (`due_at ASC NULLS LAST, created_at ASC`). Each row carries an `overdue` boolean (`due_at < now`) and `last_email_sent_at` when reminders have gone out.
- Read-only; no `record_admin_write`.

## Why

- This is the primitive the `Compliance info` checkbox on #4989 calls for: a single read that lets investigators see exactly what KYC the seller has submitted, what's still outstanding, and how stale the outstanding asks are - without having to compose several admin endpoints together.
- Decrypting tax IDs server-side and emitting only the last four keeps the sensitive ciphertext where it belongs. The masking convention matches what `SettingsPresenter` already does for the seller-facing settings page, so callers see consistent values across surfaces.
- Sorting info requests by `due_at` puts the most-actionable rows at the top of the response, which is the natural order for a triage UI.
- Filtering to `requested` state matches the issue text (\"open or overdue requests for additional info\"); already-provided requests aren't useful for fraud triage and would just inflate the response.



---
This PR was implemented with AI assistance using Claude Opus 4.7 (1M context).