### PR TITLE
Extend admin purchase response with fraud-investigation fields

### DIFF
--- a/app/controllers/api/internal/admin/base_controller.rb
+++ b/app/controllers/api/internal/admin/base_controller.rb
@@ -12,7 +12,7 @@ class Api::Internal::Admin::BaseController < Api::Internal::BaseController
     purchases.reassign
     purchases.resend_all_receipts
   ].freeze
-  ADMIN_PURCHASE_INCLUDES = [:link, :seller, :refunds, :affiliate_credit, :early_fraud_warning, :disputes].freeze
+  ADMIN_PURCHASE_INCLUDES = [:link, :seller, :refunds, { affiliate_credit: :affiliate_user }, :early_fraud_warning, :disputes].freeze
   USER_LOOKUP_BAD_REQUEST_MESSAGE = "email or user_id is required"
   USER_ID_REQUIRED_MESSAGE = "user_id is required for mutating admin actions. " \
     "Use /internal/admin/users/info to look up the user_id by email."
@@ -259,9 +259,9 @@ class Api::Internal::Admin::BaseController < Api::Internal::BaseController
     end
 
     def serialize_purchase_country_mismatches(purchase)
-      billing = purchase.country
-      ip = purchase.ip_country
-      card = purchase.card_country
+      billing = normalize_country_to_alpha2(purchase.country)
+      ip = normalize_country_to_alpha2(purchase.ip_country)
+      card = normalize_country_to_alpha2(purchase.card_country)
       {
         billing_vs_ip: countries_differ?(billing, ip),
         billing_vs_card: countries_differ?(billing, card),
@@ -272,7 +272,16 @@ class Api::Internal::Admin::BaseController < Api::Internal::BaseController
     def countries_differ?(a, b)
       return false if a.blank? || b.blank?
 
-      a.to_s.upcase != b.to_s.upcase
+      a != b
+    end
+
+    def normalize_country_to_alpha2(value)
+      return nil if value.blank?
+
+      string = value.to_s
+      return string.upcase if string.length == 2
+
+      Compliance::Countries.find_by_name(string)&.alpha2 || string.upcase
     end
 
     def serialize_purchase_latest_dispute(purchase)

--- a/app/controllers/api/internal/admin/base_controller.rb
+++ b/app/controllers/api/internal/admin/base_controller.rb
@@ -12,6 +12,7 @@ class Api::Internal::Admin::BaseController < Api::Internal::BaseController
     purchases.reassign
     purchases.resend_all_receipts
   ].freeze
+  ADMIN_PURCHASE_INCLUDES = [:link, :seller, :refunds, :affiliate_credit, :early_fraud_warning, :disputes].freeze
   USER_LOOKUP_BAD_REQUEST_MESSAGE = "email or user_id is required"
   USER_ID_REQUIRED_MESSAGE = "user_id is required for mutating admin actions. " \
     "Use /internal/admin/users/info to look up the user_id by email."
@@ -211,7 +212,7 @@ class Api::Internal::Admin::BaseController < Api::Internal::BaseController
       end
     end
 
-    def serialize_purchase(purchase)
+    def serialize_purchase(purchase, with_clusters: false)
       {
         id: purchase.external_id_numeric.to_s,
         email: purchase.email,
@@ -225,13 +226,117 @@ class Api::Internal::Admin::BaseController < Api::Internal::BaseController
         amount_refundable_cents_in_currency: amount_refundable_cents_in_currency(purchase),
         purchase_state: purchase.purchase_state,
         refund_status: refund_status(purchase),
+        chargeback_date: purchase.chargeback_date&.as_json,
         created_at: purchase.created_at.as_json,
-        receipt_url: receipt_purchase_url(purchase.external_id, host: UrlService.domain_with_protocol, email: purchase.email)
+        receipt_url: receipt_purchase_url(purchase.external_id, host: UrlService.domain_with_protocol, email: purchase.email),
+        charge_processor: purchase.charge_processor_id,
+        paypal_order_id: purchase.paypal_order_id,
+        ip_address: purchase.ip_address,
+        ip_country: purchase.ip_country,
+        billing_country: purchase.country,
+        card_country: purchase.card_country,
+        country_mismatches: serialize_purchase_country_mismatches(purchase),
+        card: serialize_purchase_card(purchase),
+        dispute: serialize_purchase_latest_dispute(purchase),
+        early_fraud_warning: serialize_purchase_early_fraud_warning(purchase),
+        affiliate_credit: serialize_purchase_affiliate_credit(purchase),
       }.tap do |payload|
         refund_amount = refund_amount_cents(purchase)
         payload[:refund_amount] = refund_amount if refund_amount.positive?
         payload[:refund_date] = latest_refund(purchase)&.created_at&.as_json if payload[:refund_status].present?
+        payload[:clusters] = serialize_purchase_clusters(purchase) if with_clusters
       end
+    end
+
+    def serialize_purchase_card(purchase)
+      {
+        bin: purchase.card_bin,
+        type: purchase.card_type,
+        visual: purchase.card_visual,
+        expiry_month: purchase.card_expiry_month,
+        expiry_year: purchase.card_expiry_year,
+      }
+    end
+
+    def serialize_purchase_country_mismatches(purchase)
+      billing = purchase.country
+      ip = purchase.ip_country
+      card = purchase.card_country
+      {
+        billing_vs_ip: countries_differ?(billing, ip),
+        billing_vs_card: countries_differ?(billing, card),
+        ip_vs_card: countries_differ?(ip, card),
+      }
+    end
+
+    def countries_differ?(a, b)
+      return false if a.blank? || b.blank?
+
+      a.to_s.upcase != b.to_s.upcase
+    end
+
+    def serialize_purchase_latest_dispute(purchase)
+      dispute = if purchase.association(:disputes).loaded?
+        purchase.disputes.max_by(&:created_at)
+      else
+        purchase.disputes.order(:created_at).last
+      end
+      return nil if dispute.nil?
+
+      {
+        id: dispute.external_id,
+        state: dispute.state,
+        reason: dispute.reason,
+        charge_processor_dispute_id: dispute.charge_processor_dispute_id,
+        created_at: dispute.created_at.as_json,
+        initiated_at: dispute.initiated_at&.as_json,
+        formalized_at: dispute.formalized_at&.as_json,
+        won_at: dispute.won_at&.as_json,
+        lost_at: dispute.lost_at&.as_json,
+      }
+    end
+
+    def serialize_purchase_early_fraud_warning(purchase)
+      efw = purchase.early_fraud_warning
+      return nil if efw.nil?
+
+      {
+        id: efw.id.to_s,
+        processor_id: efw.processor_id,
+        fraud_type: efw.fraud_type,
+        charge_risk_level: efw.charge_risk_level,
+        actionable: efw.actionable,
+        resolution: efw.resolution,
+        resolution_message: efw.resolution_message,
+        resolved_at: efw.resolved_at&.as_json,
+        processor_created_at: efw.processor_created_at.as_json,
+      }
+    end
+
+    def serialize_purchase_affiliate_credit(purchase)
+      credit = purchase.affiliate_credit
+      return nil if credit.nil?
+
+      {
+        amount_cents: credit.amount_cents,
+        fee_cents: credit.fee_cents,
+        basis_points: credit.basis_points,
+        affiliate_user_id: credit.affiliate_user&.external_id,
+      }
+    end
+
+    def serialize_purchase_clusters(purchase)
+      {
+        fingerprint_count: purchase_cluster_count(:stripe_fingerprint, purchase.stripe_fingerprint, purchase.id),
+        browser_count: purchase_cluster_count(:browser_guid, purchase.browser_guid, purchase.id),
+        ip_count: purchase_cluster_count(:ip_address, purchase.ip_address, purchase.id),
+      }
+    end
+
+    def purchase_cluster_count(column, value, exclude_id)
+      return nil if value.blank?
+
+      Purchase.where(column => value).where.not(id: exclude_id).count
     end
 
     def serialize_payout(payment)

--- a/app/controllers/api/internal/admin/purchases_controller.rb
+++ b/app/controllers/api/internal/admin/purchases_controller.rb
@@ -10,7 +10,8 @@ class Api::Internal::Admin::PurchasesController < Api::Internal::Admin::BaseCont
     purchase = fetch_purchase
     return render json: { success: false, message: "Purchase not found" }, status: :not_found if purchase.blank?
 
-    render json: { success: true, purchase: serialize_purchase(purchase) }
+    ActiveRecord::Associations::Preloader.new(records: [purchase], associations: ADMIN_PURCHASE_INCLUDES).call
+    render json: { success: true, purchase: serialize_purchase(purchase, with_clusters: true) }
   end
 
   def search
@@ -27,7 +28,7 @@ class Api::Internal::Admin::PurchasesController < Api::Internal::Admin::BaseCont
     end
 
     limit = purchase_search_limit
-    purchases = AdminSearchService.new.search_purchases(**search_params, limit: limit.next).includes(:link, :seller, :refunds).to_a
+    purchases = AdminSearchService.new.search_purchases(**search_params, limit: limit.next).includes(*ADMIN_PURCHASE_INCLUDES).to_a
     has_more = purchases.length > limit
 
     render json: {

--- a/spec/controllers/api/internal/admin/purchases_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/purchases_controller_spec.rb
@@ -110,6 +110,43 @@ describe Api::Internal::Admin::PurchasesController do
       expect(response).to have_http_status(:ok)
     end
 
+    it "preloads the affiliate_credit's affiliate_user so serialization does not fire one users SELECT per row" do
+      buyer_email = "affiliate-cluster@example.com"
+      affiliate_user_ids = 3.times.map do
+        affiliate_user = create(:user)
+        affiliate = create(:direct_affiliate, affiliate_user:)
+        purchase = create(:free_purchase, email: buyer_email, affiliate:)
+        create(:affiliate_credit, purchase:, affiliate:, affiliate_user:, amount_cents: 100, fee_cents: 10, basis_points: 500)
+        affiliate_user.id
+      end
+
+      single_row_user_lookups = []
+      counter = lambda do |*, payload|
+        sql = payload[:sql].to_s
+        next if sql.start_with?("INSERT", "UPDATE", "DELETE", "BEGIN", "COMMIT", "SAVEPOINT", "RELEASE")
+        next unless sql.start_with?("SELECT") && sql.include?("`users`")
+        next unless sql.match?(/`users`\.`id` = \d+ LIMIT 1\z/)
+
+        single_row_user_lookups << sql
+      end
+
+      ActiveSupport::Notifications.subscribed(counter, "sql.active_record") do
+        get :search, params: { query: buyer_email }
+      end
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["purchases"].length).to eq(3)
+      response.parsed_body["purchases"].each do |row|
+        expect(row["affiliate_credit"]["affiliate_user_id"]).to be_present
+      end
+
+      lookups_for_affiliate_users = single_row_user_lookups.select do |sql|
+        affiliate_user_ids.any? { |id| sql.include?("`id` = #{id} ") }
+      end
+      expect(lookups_for_affiliate_users).to be_empty,
+                                             "expected zero per-row SELECTs for affiliate_user (preload should batch via IN), but got:\n#{lookups_for_affiliate_users.join("\n")}"
+    end
+
     it "uses preloaded refunds when serializing refund details" do
       purchase = create(:free_purchase, stripe_refunded: true, stripe_partially_refunded: false, email: "refunded@example.com")
       refund = create(:refund, purchase:, amount_cents: 0)
@@ -266,22 +303,22 @@ describe Api::Internal::Admin::PurchasesController do
       )
     end
 
-    it "computes country mismatch booleans across billing, IP, and card" do
+    it "computes country mismatch booleans across the production storage schemes (names for billing/ip, alpha-2 for card)" do
       purchase = create(:free_purchase)
-      purchase.update_columns(country: "US", ip_country: "US", card_country: "GB")
+      purchase.update_columns(country: "Germany", ip_country: "United States", card_country: "GB")
 
       get :show, params: { id: purchase.external_id_numeric }
 
       expect(response.parsed_body["purchase"]["country_mismatches"]).to eq(
-        "billing_vs_ip" => false,
+        "billing_vs_ip" => true,
         "billing_vs_card" => true,
         "ip_vs_card" => true
       )
     end
 
-    it "treats blank country values as non-mismatches" do
+    it "treats a billing/IP country name and a matching card alpha-2 as equal" do
       purchase = create(:free_purchase)
-      purchase.update_columns(country: nil, ip_country: "US", card_country: nil)
+      purchase.update_columns(country: "United States", ip_country: "United States", card_country: "US")
 
       get :show, params: { id: purchase.external_id_numeric }
 
@@ -292,9 +329,22 @@ describe Api::Internal::Admin::PurchasesController do
       )
     end
 
-    it "ignores case when comparing country codes" do
+    it "treats blank country values as non-mismatches" do
       purchase = create(:free_purchase)
-      purchase.update_columns(country: "us", ip_country: "US", card_country: "Us")
+      purchase.update_columns(country: nil, ip_country: "United States", card_country: nil)
+
+      get :show, params: { id: purchase.external_id_numeric }
+
+      expect(response.parsed_body["purchase"]["country_mismatches"]).to eq(
+        "billing_vs_ip" => false,
+        "billing_vs_card" => false,
+        "ip_vs_card" => false
+      )
+    end
+
+    it "ignores case when comparing alpha-2 codes" do
+      purchase = create(:free_purchase)
+      purchase.update_columns(country: "United States", ip_country: "United States", card_country: "us")
 
       get :show, params: { id: purchase.external_id_numeric }
 

--- a/spec/controllers/api/internal/admin/purchases_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/purchases_controller_spec.rb
@@ -103,7 +103,7 @@ describe Api::Internal::Admin::PurchasesController do
 
       allow(AdminSearchService).to receive(:new).and_return(search_service)
       allow(search_service).to receive(:search_purchases).and_return(search_relation)
-      expect(search_relation).to receive(:includes).with(:link, :seller, :refunds).and_call_original
+      expect(search_relation).to receive(:includes).with(*Api::Internal::Admin::BaseController::ADMIN_PURCHASE_INCLUDES).and_call_original
 
       get :search, params: { query: purchase.email }
 
@@ -236,6 +236,220 @@ describe Api::Internal::Admin::PurchasesController do
 
       expect(response).to have_http_status(:not_found)
       expect(response.parsed_body).to eq({ success: false, message: "Purchase not found" }.as_json)
+    end
+
+    it "exposes the chargeback date when the purchase has been charged back" do
+      purchase = create(:free_purchase, chargeback_date: 2.days.ago)
+
+      get :show, params: { id: purchase.external_id_numeric }
+
+      expect(response.parsed_body["purchase"]["chargeback_date"]).to eq(purchase.chargeback_date.as_json)
+    end
+
+    it "returns the raw IP, IP country, billing country, and card country" do
+      purchase = create(:free_purchase)
+      purchase.update_columns(
+        ip_address: "203.0.113.42",
+        ip_country: "United States",
+        country: "Germany",
+        card_country: "FR"
+      )
+
+      get :show, params: { id: purchase.external_id_numeric }
+
+      payload = response.parsed_body["purchase"]
+      expect(payload).to include(
+        "ip_address" => "203.0.113.42",
+        "ip_country" => "United States",
+        "billing_country" => "Germany",
+        "card_country" => "FR"
+      )
+    end
+
+    it "computes country mismatch booleans across billing, IP, and card" do
+      purchase = create(:free_purchase)
+      purchase.update_columns(country: "US", ip_country: "US", card_country: "GB")
+
+      get :show, params: { id: purchase.external_id_numeric }
+
+      expect(response.parsed_body["purchase"]["country_mismatches"]).to eq(
+        "billing_vs_ip" => false,
+        "billing_vs_card" => true,
+        "ip_vs_card" => true
+      )
+    end
+
+    it "treats blank country values as non-mismatches" do
+      purchase = create(:free_purchase)
+      purchase.update_columns(country: nil, ip_country: "US", card_country: nil)
+
+      get :show, params: { id: purchase.external_id_numeric }
+
+      expect(response.parsed_body["purchase"]["country_mismatches"]).to eq(
+        "billing_vs_ip" => false,
+        "billing_vs_card" => false,
+        "ip_vs_card" => false
+      )
+    end
+
+    it "ignores case when comparing country codes" do
+      purchase = create(:free_purchase)
+      purchase.update_columns(country: "us", ip_country: "US", card_country: "Us")
+
+      get :show, params: { id: purchase.external_id_numeric }
+
+      expect(response.parsed_body["purchase"]["country_mismatches"].values).to all(eq(false))
+    end
+
+    it "returns card BIN, type, visual, and expiry" do
+      purchase = create(:free_purchase)
+      purchase.update_columns(
+        card_bin: "424242",
+        card_type: "visa",
+        card_visual: "**** **** **** 4242",
+        card_expiry_month: 11,
+        card_expiry_year: 2030
+      )
+
+      get :show, params: { id: purchase.external_id_numeric }
+
+      expect(response.parsed_body["purchase"]["card"]).to eq(
+        "bin" => "424242",
+        "type" => "visa",
+        "visual" => "**** **** **** 4242",
+        "expiry_month" => 11,
+        "expiry_year" => 2030
+      )
+    end
+
+    it "returns the charge processor and PayPal order ID" do
+      purchase = create(:free_purchase)
+      purchase.update_columns(charge_processor_id: "paypal", paypal_order_id: "PAY-TEST-123")
+
+      get :show, params: { id: purchase.external_id_numeric }
+
+      payload = response.parsed_body["purchase"]
+      expect(payload["charge_processor"]).to eq("paypal")
+      expect(payload["paypal_order_id"]).to eq("PAY-TEST-123")
+    end
+
+    it "serializes the latest dispute when one exists" do
+      purchase = create(:free_purchase)
+      create(:dispute, purchase:, state: "lost", reason: Dispute::REASON_FRAUDULENT, charge_processor_dispute_id: "dp_old", created_at: 5.days.ago, lost_at: 1.day.ago)
+      newest = create(:dispute, purchase:, state: "formalized", reason: Dispute::REASON_FRAUDULENT, charge_processor_dispute_id: "dp_new", created_at: 1.hour.ago, formalized_at: 30.minutes.ago)
+
+      get :show, params: { id: purchase.external_id_numeric }
+
+      dispute_payload = response.parsed_body["purchase"]["dispute"]
+      expect(dispute_payload).to include(
+        "id" => newest.external_id,
+        "state" => "formalized",
+        "reason" => Dispute::REASON_FRAUDULENT,
+        "charge_processor_dispute_id" => "dp_new",
+        "formalized_at" => newest.formalized_at.as_json,
+        "won_at" => nil,
+        "lost_at" => nil
+      )
+    end
+
+    it "returns null dispute when the purchase has none" do
+      purchase = create(:free_purchase)
+
+      get :show, params: { id: purchase.external_id_numeric }
+
+      expect(response.parsed_body["purchase"]["dispute"]).to be_nil
+    end
+
+    it "serializes the early fraud warning when present" do
+      purchase = create(:free_purchase)
+      efw = create(:early_fraud_warning, purchase:, processor_id: "issfr_test_42", fraud_type: "made_with_stolen_card", charge_risk_level: "highest", actionable: true)
+
+      get :show, params: { id: purchase.external_id_numeric }
+
+      expect(response.parsed_body["purchase"]["early_fraud_warning"]).to include(
+        "id" => efw.id.to_s,
+        "processor_id" => "issfr_test_42",
+        "fraud_type" => "made_with_stolen_card",
+        "charge_risk_level" => "highest",
+        "actionable" => true,
+        "resolution" => "unknown",
+        "processor_created_at" => efw.processor_created_at.as_json
+      )
+    end
+
+    it "returns null early fraud warning when the purchase has none" do
+      purchase = create(:free_purchase)
+
+      get :show, params: { id: purchase.external_id_numeric }
+
+      expect(response.parsed_body["purchase"]["early_fraud_warning"]).to be_nil
+    end
+
+    it "serializes the affiliate credit when the purchase used an affiliate" do
+      affiliate_user = create(:user)
+      affiliate = create(:direct_affiliate, affiliate_user:)
+      purchase = create(:free_purchase, affiliate:)
+      create(:affiliate_credit, purchase:, affiliate:, affiliate_user:, amount_cents: 750, fee_cents: 50, basis_points: 1000)
+
+      get :show, params: { id: purchase.external_id_numeric }
+
+      expect(response.parsed_body["purchase"]["affiliate_credit"]).to eq(
+        "amount_cents" => 750,
+        "fee_cents" => 50,
+        "basis_points" => 1000,
+        "affiliate_user_id" => affiliate_user.external_id
+      )
+    end
+
+    it "returns null affiliate credit when none is attached" do
+      purchase = create(:free_purchase)
+
+      get :show, params: { id: purchase.external_id_numeric }
+
+      expect(response.parsed_body["purchase"]["affiliate_credit"]).to be_nil
+    end
+
+    it "counts purchases sharing the same fingerprint, browser, and IP excluding the current one" do
+      shared_fingerprint = "fp_shared"
+      shared_browser = "bg_shared"
+      shared_ip = "203.0.113.7"
+      purchase = create(:free_purchase)
+      purchase.update_columns(stripe_fingerprint: shared_fingerprint, browser_guid: shared_browser, ip_address: shared_ip)
+      2.times { create(:free_purchase).update_columns(stripe_fingerprint: shared_fingerprint) }
+      create(:free_purchase).update_columns(browser_guid: shared_browser)
+      3.times { create(:free_purchase).update_columns(ip_address: shared_ip) }
+      create(:free_purchase)
+
+      get :show, params: { id: purchase.external_id_numeric }
+
+      expect(response.parsed_body["purchase"]["clusters"]).to eq(
+        "fingerprint_count" => 2,
+        "browser_count" => 1,
+        "ip_count" => 3
+      )
+    end
+
+    it "returns nil cluster counts when the source column is blank" do
+      purchase = create(:free_purchase)
+      purchase.update_columns(stripe_fingerprint: nil, browser_guid: nil, ip_address: nil)
+
+      get :show, params: { id: purchase.external_id_numeric }
+
+      expect(response.parsed_body["purchase"]["clusters"]).to eq(
+        "fingerprint_count" => nil,
+        "browser_count" => nil,
+        "ip_count" => nil
+      )
+    end
+
+    it "omits clusters from the search response to avoid N+1 cluster queries" do
+      buyer_email = "cluster-search@example.com"
+      create(:free_purchase, email: buyer_email)
+
+      get :search, params: { query: buyer_email }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["purchases"].first).not_to have_key("clusters")
     end
   end
 


### PR DESCRIPTION
Ref #4989

## What

Extends `Api::Internal::Admin::BaseController#serialize_purchase` so the admin purchase response carries the data fraud reviewers actually need:

- `chargeback_date`, `charge_processor`, `paypal_order_id`
- `ip_address`, `ip_country`, `billing_country`, `card_country`
- `country_mismatches: { billing_vs_ip, billing_vs_card, ip_vs_card }` - case-insensitive comparison, blanks treated as non-mismatches so missing data does not generate false positives
- `card: { bin, type, visual, expiry_month, expiry_year }`
- `dispute` - the latest dispute by `created_at` with state, reason, Stripe ID, and initiated/formalized/won/lost timestamps; `null` when none
- `early_fraud_warning` - Stripe processor ID, fraud type, charge risk level, actionable flag, resolution, resolution message, timestamps; `null` when none
- `affiliate_credit: { amount_cents, fee_cents, basis_points, affiliate_user_id }`; `null` when none
- `clusters: { fingerprint_count, browser_count, ip_count }` on `GET /purchases/:id` only - opt-in via `with_clusters: true`, blank source columns produce `nil` counts

`GET /purchases/:id` now preloads the new associations via `ActiveRecord::Associations::Preloader` before serializing. `GET /purchases/search` switches its `.includes(:link, :seller, :refunds)` to `.includes(*ADMIN_PURCHASE_INCLUDES)` so the search response carries the new fields with no extra queries per row.

## Why

- The admin purchase response was previously price/state/refund-shaped. Fraud triage needs the country trio, card details, dispute and EFW context, and affiliate credit - composing several endpoints to get them defeats the point of having a single purchase read.
- Country mismatch booleans on the server save every caller from reimplementing the comparison and getting the case-insensitivity wrong. Treating blanks as non-mismatches keeps the response honest for purchases where one of the three columns hasn't been populated (free purchases, PayPal flows, etc.).
- Cluster counts are listed in the issue as part of the response extension but they are 3 queries per purchase, which would N+1 the search and list contexts that share the serializer. Opt-in via `with_clusters: true` keeps the show endpoint complete while leaving search/list cheap. PR #10 (lookup by fingerprint/browser/IP) is the right place for cluster-style queries at scale.
- `ADMIN_PURCHASE_INCLUDES` centralizes the preload set so future callers (PR #5020's user purchases list, follow-up endpoints) all stay in sync as the field set grows.



---
This PR was implemented with AI assistance using Claude Opus 4.7 (1M context)