### PR TITLE
Extend admin product response with fraud-investigation fields

### DIFF
--- a/app/controllers/api/internal/admin/products_controller.rb
+++ b/app/controllers/api/internal/admin/products_controller.rb
@@ -8,8 +8,15 @@ class Api::Internal::Admin::ProductsController < Api::Internal::Admin::BaseContr
   SELLER_LOOKUP_BAD_REQUEST_MESSAGE = "email or external_id is required"
   RECENT_CHARGEBACK_WINDOW_DAYS = 90
   NON_GLOBAL_AFFILIATE_TYPES = [DirectAffiliate.name, Collaborator.name].freeze
+  TAXONOMY_ANCESTRY_SQL = <<~SQL.squish.freeze
+    SELECT h.descendant_id, t.slug
+    FROM taxonomy_hierarchies h
+    INNER JOIN taxonomies t ON t.id = h.ancestor_id
+    WHERE h.descendant_id IN (?)
+    ORDER BY h.descendant_id, h.generations DESC
+  SQL
   private_constant :DEFAULT_PER_PAGE, :MAX_PER_PAGE, :SELLER_LOOKUP_BAD_REQUEST_MESSAGE,
-                   :RECENT_CHARGEBACK_WINDOW_DAYS, :NON_GLOBAL_AFFILIATE_TYPES
+                   :RECENT_CHARGEBACK_WINDOW_DAYS, :NON_GLOBAL_AFFILIATE_TYPES, :TAXONOMY_ANCESTRY_SQL
 
   def index
     if params[:email].blank? && params[:external_id].blank?
@@ -24,19 +31,24 @@ class Api::Internal::Admin::ProductsController < Api::Internal::Admin::BaseContr
       .order(Admin::Users::ListPaginatedProducts::PRODUCTS_ORDER)
 
     pagination, paginated = pagy(products, page: requested_page, limit: per_page, overflow: :empty_page)
+    ancestry_paths = taxonomy_ancestry_paths_for(paginated)
 
     render json: {
       success: true,
-      products: paginated.map { serialize_product(_1) },
+      products: paginated.map { serialize_product(_1, ancestry_paths:) },
       pagination: PagyPresenter.new(pagination).metadata
     }
   end
 
   def show
-    product = Link.find_by_external_id(params[:id])
+    product = Link
+      .includes(:product_files, :display_asset_previews, :taxonomy, product_affiliates: { affiliate: :affiliate_user })
+      .find_by_external_id(params[:id])
     return render json: { success: false, message: "Product not found" }, status: :not_found if product.blank?
 
-    render json: { success: true, product: serialize_product(product, with_fraud_context: true) }
+    ancestry_paths = taxonomy_ancestry_paths_for([product])
+
+    render json: { success: true, product: serialize_product(product, with_fraud_context: true, ancestry_paths:) }
   end
 
   private
@@ -63,7 +75,7 @@ class Api::Internal::Admin::ProductsController < Api::Internal::Admin::BaseContr
       [params[:page].to_i, 1].max
     end
 
-    def serialize_product(product, with_fraud_context: false)
+    def serialize_product(product, with_fraud_context: false, ancestry_paths: {})
       payload = {
         id: product.external_id,
         name: product.name,
@@ -80,7 +92,7 @@ class Api::Internal::Admin::ProductsController < Api::Internal::Admin::BaseContr
         alive: product.alive?,
         is_adult: product.is_adult?,
         bad_card_counter: product.bad_card_counter,
-        taxonomy: serialize_product_taxonomy(product.taxonomy),
+        taxonomy: serialize_product_taxonomy(product.taxonomy, ancestry_paths:),
         seller: {
           id: product.user&.external_id,
           email: product.user&.email
@@ -92,14 +104,25 @@ class Api::Internal::Admin::ProductsController < Api::Internal::Admin::BaseContr
       payload
     end
 
-    def serialize_product_taxonomy(taxonomy)
+    def serialize_product_taxonomy(taxonomy, ancestry_paths:)
       return nil if taxonomy.nil?
 
       {
         id: taxonomy.id.to_s,
         slug: taxonomy.slug,
-        ancestry_path: taxonomy.ancestry_path,
+        ancestry_path: ancestry_paths[taxonomy.id] || [taxonomy.slug],
       }
+    end
+
+    def taxonomy_ancestry_paths_for(products)
+      taxonomy_ids = products.filter_map(&:taxonomy_id).uniq
+      return {} if taxonomy_ids.empty?
+
+      sql = ActiveRecord::Base.sanitize_sql_array([TAXONOMY_ANCESTRY_SQL, taxonomy_ids])
+      rows = ActiveRecord::Base.connection.select_rows(sql)
+      rows.each_with_object({}) do |(descendant_id, slug), hash|
+        (hash[descendant_id] ||= []) << slug
+      end
     end
 
     def serialize_product_affiliates(product)
@@ -122,6 +145,8 @@ class Api::Internal::Admin::ProductsController < Api::Internal::Admin::BaseContr
         },
         basis_points: basis_points,
         destination_url: product_affiliate.destination_url,
+        alive: affiliate.alive?,
+        deleted_at: affiliate.deleted_at&.as_json,
       }
     end
 
@@ -131,7 +156,9 @@ class Api::Internal::Admin::ProductsController < Api::Internal::Admin::BaseContr
       payload = { window_days: RECENT_CHARGEBACK_WINDOW_DAYS, successful_count:, chargedback_count: 0, rate: nil }
       return payload if successful_count.zero?
 
-      chargedback_count = Purchase.chargedback.where(link_id: product.id).where("purchases.created_at >= ?", window).count
+      chargedback_count = Purchase.chargedback.not_chargeback_reversed
+        .where(link_id: product.id)
+        .where("purchases.created_at >= ?", window).count
       payload.merge(chargedback_count:, rate: (chargedback_count.to_f / successful_count).round(4))
     end
 

--- a/app/controllers/api/internal/admin/products_controller.rb
+++ b/app/controllers/api/internal/admin/products_controller.rb
@@ -6,7 +6,10 @@ class Api::Internal::Admin::ProductsController < Api::Internal::Admin::BaseContr
   DEFAULT_PER_PAGE = Admin::Users::ListPaginatedProducts::PRODUCTS_PER_PAGE
   MAX_PER_PAGE = 100
   SELLER_LOOKUP_BAD_REQUEST_MESSAGE = "email or external_id is required"
-  private_constant :DEFAULT_PER_PAGE, :MAX_PER_PAGE, :SELLER_LOOKUP_BAD_REQUEST_MESSAGE
+  RECENT_CHARGEBACK_WINDOW_DAYS = 90
+  NON_GLOBAL_AFFILIATE_TYPES = [DirectAffiliate.name, Collaborator.name].freeze
+  private_constant :DEFAULT_PER_PAGE, :MAX_PER_PAGE, :SELLER_LOOKUP_BAD_REQUEST_MESSAGE,
+                   :RECENT_CHARGEBACK_WINDOW_DAYS, :NON_GLOBAL_AFFILIATE_TYPES
 
   def index
     if params[:email].blank? && params[:external_id].blank?
@@ -17,7 +20,7 @@ class Api::Internal::Admin::ProductsController < Api::Internal::Admin::BaseContr
     return unless user
 
     products = user.products
-      .includes(:product_files, :display_asset_previews)
+      .includes(:product_files, :display_asset_previews, :taxonomy, product_affiliates: { affiliate: :affiliate_user })
       .order(Admin::Users::ListPaginatedProducts::PRODUCTS_ORDER)
 
     pagination, paginated = pagy(products, page: requested_page, limit: per_page, overflow: :empty_page)
@@ -33,7 +36,7 @@ class Api::Internal::Admin::ProductsController < Api::Internal::Admin::BaseContr
     product = Link.find_by_external_id(params[:id])
     return render json: { success: false, message: "Product not found" }, status: :not_found if product.blank?
 
-    render json: { success: true, product: serialize_product(product) }
+    render json: { success: true, product: serialize_product(product, with_fraud_context: true) }
   end
 
   private
@@ -60,8 +63,8 @@ class Api::Internal::Admin::ProductsController < Api::Internal::Admin::BaseContr
       [params[:page].to_i, 1].max
     end
 
-    def serialize_product(product)
-      {
+    def serialize_product(product, with_fraud_context: false)
+      payload = {
         id: product.external_id,
         name: product.name,
         description: product.description,
@@ -72,14 +75,64 @@ class Api::Internal::Admin::ProductsController < Api::Internal::Admin::BaseContr
         preview_url: product.preview_url,
         created_at: product.created_at.iso8601,
         deleted_at: product.deleted_at&.iso8601,
+        banned_at: product.banned_at&.iso8601,
+        purchase_disabled_at: product.purchase_disabled_at&.iso8601,
         alive: product.alive?,
         is_adult: product.is_adult?,
+        bad_card_counter: product.bad_card_counter,
+        taxonomy: serialize_product_taxonomy(product.taxonomy),
         seller: {
           id: product.user&.external_id,
           email: product.user&.email
         },
+        affiliates: serialize_product_affiliates(product),
         files: product.product_files.sort_by { |f| [f.position.nil? ? 0 : 1, f.position.to_i, f.id] }.map { serialize_file(_1) }
       }
+      payload[:recent_chargeback_rate] = recent_chargeback_rate(product) if with_fraud_context
+      payload
+    end
+
+    def serialize_product_taxonomy(taxonomy)
+      return nil if taxonomy.nil?
+
+      {
+        id: taxonomy.id.to_s,
+        slug: taxonomy.slug,
+        ancestry_path: taxonomy.ancestry_path,
+      }
+    end
+
+    def serialize_product_affiliates(product)
+      affiliates = product.product_affiliates.to_a.select do |pa|
+        NON_GLOBAL_AFFILIATE_TYPES.include?(pa.affiliate&.type)
+      end
+      affiliates.sort_by(&:id).map { serialize_product_affiliate(_1) }
+    end
+
+    def serialize_product_affiliate(product_affiliate)
+      affiliate = product_affiliate.affiliate
+      basis_points = product_affiliate.affiliate_basis_points || affiliate.affiliate_basis_points
+      affiliate_user = affiliate.affiliate_user
+      {
+        id: affiliate.external_id,
+        type: affiliate.type,
+        affiliate_user: affiliate_user && {
+          id: affiliate_user.external_id,
+          email: affiliate_user.email,
+        },
+        basis_points: basis_points,
+        destination_url: product_affiliate.destination_url,
+      }
+    end
+
+    def recent_chargeback_rate(product)
+      window = RECENT_CHARGEBACK_WINDOW_DAYS.days.ago
+      successful_count = Purchase.successful.where(link_id: product.id).where("purchases.created_at >= ?", window).count
+      payload = { window_days: RECENT_CHARGEBACK_WINDOW_DAYS, successful_count:, chargedback_count: 0, rate: nil }
+      return payload if successful_count.zero?
+
+      chargedback_count = Purchase.chargedback.where(link_id: product.id).where("purchases.created_at >= ?", window).count
+      payload.merge(chargedback_count:, rate: (chargedback_count.to_f / successful_count).round(4))
     end
 
     def serialize_file(file)

--- a/app/controllers/api/internal/admin/products_controller.rb
+++ b/app/controllers/api/internal/admin/products_controller.rb
@@ -153,6 +153,7 @@ class Api::Internal::Admin::ProductsController < Api::Internal::Admin::BaseContr
     def recent_chargeback_rate(product)
       window = RECENT_CHARGEBACK_WINDOW_DAYS.days.ago
       base = Purchase.not_is_bundle_product_purchase
+        .not_fully_refunded
         .where(link_id: product.id)
         .where("purchases.created_at >= ?", window)
 

--- a/app/controllers/api/internal/admin/products_controller.rb
+++ b/app/controllers/api/internal/admin/products_controller.rb
@@ -152,13 +152,15 @@ class Api::Internal::Admin::ProductsController < Api::Internal::Admin::BaseContr
 
     def recent_chargeback_rate(product)
       window = RECENT_CHARGEBACK_WINDOW_DAYS.days.ago
-      successful_count = Purchase.successful.where(link_id: product.id).where("purchases.created_at >= ?", window).count
+      base = Purchase.not_is_bundle_product_purchase
+        .where(link_id: product.id)
+        .where("purchases.created_at >= ?", window)
+
+      successful_count = base.successful.count
       payload = { window_days: RECENT_CHARGEBACK_WINDOW_DAYS, successful_count:, chargedback_count: 0, rate: nil }
       return payload if successful_count.zero?
 
-      chargedback_count = Purchase.chargedback.not_chargeback_reversed
-        .where(link_id: product.id)
-        .where("purchases.created_at >= ?", window).count
+      chargedback_count = base.chargedback.not_chargeback_reversed.count
       payload.merge(chargedback_count:, rate: (chargedback_count.to_f / successful_count).round(4))
     end
 

--- a/spec/controllers/api/internal/admin/products_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/products_controller_spec.rb
@@ -312,5 +312,158 @@ describe Api::Internal::Admin::ProductsController do
       expect(payload["id"]).to eq(file.external_id)
       expect(payload["deleted_at"]).to be_present
     end
+
+    it "exposes banned_at and purchase_disabled_at when set, nil when not" do
+      banned = create(:product, user: seller, banned_at: 1.day.ago)
+      banned.update_column(:purchase_disabled_at, 2.days.ago)
+      clean = create(:product, user: seller)
+
+      get :show, params: { id: banned.external_id }
+      expect(response.parsed_body["product"]).to include(
+        "banned_at" => banned.banned_at.iso8601,
+        "purchase_disabled_at" => banned.purchase_disabled_at.iso8601,
+        "alive" => false
+      )
+
+      get :show, params: { id: clean.external_id }
+      expect(response.parsed_body["product"]).to include(
+        "banned_at" => nil,
+        "purchase_disabled_at" => nil
+      )
+    end
+
+    it "returns the bad-card counter value as stored on the product" do
+      product = create(:product, user: seller)
+      product.update_column(:bad_card_counter, 7)
+
+      get :show, params: { id: product.external_id }
+
+      expect(response.parsed_body["product"]["bad_card_counter"]).to eq(7)
+    end
+
+    it "returns the taxonomy slug and ancestry path when assigned" do
+      root = Taxonomy.create!(slug: "physical-goods")
+      child = Taxonomy.create!(slug: "books", parent: root)
+      product = create(:product, user: seller, taxonomy: child)
+
+      get :show, params: { id: product.external_id }
+
+      expect(response.parsed_body["product"]["taxonomy"]).to eq(
+        "id" => child.id.to_s,
+        "slug" => "books",
+        "ancestry_path" => ["physical-goods", "books"]
+      )
+    end
+
+    it "returns null taxonomy when none is assigned" do
+      product = create(:product, user: seller, taxonomy: nil)
+
+      get :show, params: { id: product.external_id }
+
+      expect(response.parsed_body["product"]["taxonomy"]).to be_nil
+    end
+
+    it "lists attached direct affiliates with the fallback basis points from the parent affiliate" do
+      product = create(:product, user: seller, name: "Direct affiliate product")
+      direct_user = create(:user, email: "direct@example.com")
+      direct = create(:direct_affiliate, seller:, affiliate_user: direct_user, affiliate_basis_points: 1500, products: [product])
+      ProductAffiliate.find_by!(affiliate: direct, product:).update!(affiliate_basis_points: nil, destination_url: "https://example.com/d")
+
+      get :show, params: { id: product.external_id }
+
+      payload = response.parsed_body["product"]["affiliates"]
+      expect(payload.length).to eq(1)
+      expect(payload.first).to include(
+        "id" => direct.external_id,
+        "type" => "DirectAffiliate",
+        "basis_points" => 1500,
+        "destination_url" => "https://example.com/d"
+      )
+      expect(payload.first["affiliate_user"]).to eq(
+        "id" => direct_user.external_id,
+        "email" => "direct@example.com"
+      )
+    end
+
+    it "lists collaborators with per-product basis-point overrides" do
+      product = create(:product, user: seller, name: "Collab product")
+      collab_user = create(:user, email: "collab@example.com")
+      collab = create(:collaborator, seller:, affiliate_user: collab_user, apply_to_all_products: false, affiliate_basis_points: 2000)
+      create(:product_affiliate, affiliate: collab, product:, affiliate_basis_points: 2500)
+
+      get :show, params: { id: product.external_id }
+
+      payload = response.parsed_body["product"]["affiliates"]
+      expect(payload.length).to eq(1)
+      expect(payload.first).to include(
+        "id" => collab.external_id,
+        "type" => "Collaborator",
+        "basis_points" => 2500
+      )
+    end
+
+    it "excludes global affiliates from the attached affiliates list" do
+      product = create(:product, user: seller)
+      direct_user = create(:user)
+      direct = create(:direct_affiliate, seller:, affiliate_user: direct_user, products: [product])
+      global = create(:user).global_affiliate
+      create(:product_affiliate, affiliate: global, product:)
+
+      get :show, params: { id: product.external_id }
+
+      expect(response.parsed_body["product"]["affiliates"].map { _1["id"] }).to eq([direct.external_id])
+    end
+
+    it "returns an empty affiliates list when none are attached" do
+      product = create(:product, user: seller)
+
+      get :show, params: { id: product.external_id }
+
+      expect(response.parsed_body["product"]["affiliates"]).to eq([])
+    end
+
+    it "computes recent_chargeback_rate over a 90 day window from successful sales" do
+      create(:merchant_account, user: nil)
+      product = create(:product, user: seller)
+      4.times { create(:purchase, link: product, seller:, created_at: 10.days.ago) }
+      chargedback = create(:purchase, link: product, seller:, created_at: 5.days.ago)
+      chargedback.update_column(:chargeback_date, 4.days.ago)
+      stale_chargeback = create(:purchase, link: product, seller:, created_at: 100.days.ago)
+      stale_chargeback.update_column(:chargeback_date, 95.days.ago)
+
+      get :show, params: { id: product.external_id }
+
+      expect(response.parsed_body["product"]["recent_chargeback_rate"]).to eq(
+        "window_days" => 90,
+        "successful_count" => 5,
+        "chargedback_count" => 1,
+        "rate" => 0.2
+      )
+    end
+
+    it "returns a recent_chargeback_rate with nil rate when there are no recent successful purchases" do
+      product = create(:product, user: seller)
+
+      get :show, params: { id: product.external_id }
+
+      expect(response.parsed_body["product"]["recent_chargeback_rate"]).to eq(
+        "window_days" => 90,
+        "successful_count" => 0,
+        "chargedback_count" => 0,
+        "rate" => nil
+      )
+    end
+
+    it "omits recent_chargeback_rate from index rows to keep the listing cheap" do
+      create(:merchant_account, user: nil)
+      product = create(:product, user: seller)
+      create(:purchase, link: product, seller:)
+
+      get :index, params: { external_id: seller.external_id }
+
+      expect(response).to have_http_status(:ok)
+      row = response.parsed_body["products"].find { _1["id"] == product.external_id }
+      expect(row).not_to have_key("recent_chargeback_rate")
+    end
   end
 end

--- a/spec/controllers/api/internal/admin/products_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/products_controller_spec.rb
@@ -145,6 +145,33 @@ describe Api::Internal::Admin::ProductsController do
       expect(product_files_queries.first).to include("IN (")
     end
 
+    it "resolves taxonomy ancestry with a single batched query across distinct taxonomies" do
+      root = Taxonomy.create!(slug: "root")
+      branch_a = Taxonomy.create!(slug: "branch-a", parent: root)
+      branch_b = Taxonomy.create!(slug: "branch-b", parent: root)
+      branch_c = Taxonomy.create!(slug: "branch-c", parent: root)
+      create(:product, user: seller, taxonomy: branch_a)
+      create(:product, user: seller, taxonomy: branch_b)
+      create(:product, user: seller, taxonomy: branch_c)
+
+      hierarchy_queries = []
+      counter = lambda do |*, payload|
+        sql = payload[:sql].to_s
+        next if sql.start_with?("INSERT", "UPDATE", "DELETE", "BEGIN", "COMMIT", "SAVEPOINT", "RELEASE")
+        hierarchy_queries << sql if sql.include?("taxonomy_hierarchies") && sql.start_with?("SELECT")
+      end
+
+      ActiveSupport::Notifications.subscribed(counter, "sql.active_record") do
+        get :index, params: { email: seller.email }
+      end
+
+      expect(response).to have_http_status(:ok)
+      paths = response.parsed_body["products"].map { _1["taxonomy"]["ancestry_path"] }
+      expect(paths).to contain_exactly(["root", "branch-a"], ["root", "branch-b"], ["root", "branch-c"])
+      expect(hierarchy_queries.length).to eq(1),
+                                          "expected one batched taxonomy_hierarchies SELECT but got #{hierarchy_queries.length}:\n#{hierarchy_queries.join("\n")}"
+    end
+
     it "exposes file metadata including soft-deleted files" do
       product = create(:product, user: seller)
       alive_file = create(:readable_document, link: product, display_name: "Big guide", size: 1_048_576)
@@ -377,11 +404,30 @@ describe Api::Internal::Admin::ProductsController do
         "id" => direct.external_id,
         "type" => "DirectAffiliate",
         "basis_points" => 1500,
-        "destination_url" => "https://example.com/d"
+        "destination_url" => "https://example.com/d",
+        "alive" => true,
+        "deleted_at" => nil
       )
       expect(payload.first["affiliate_user"]).to eq(
         "id" => direct_user.external_id,
         "email" => "direct@example.com"
+      )
+    end
+
+    it "surfaces soft-deleted affiliates with their lifecycle state so reviewers see recently removed ones" do
+      product = create(:product, user: seller)
+      direct_user = create(:user)
+      deleted_at = 1.day.ago
+      direct = create(:direct_affiliate, seller:, affiliate_user: direct_user, products: [product])
+      direct.update!(deleted_at:)
+
+      get :show, params: { id: product.external_id }
+
+      payload = response.parsed_body["product"]["affiliates"].first
+      expect(payload).to include(
+        "id" => direct.external_id,
+        "alive" => false,
+        "deleted_at" => deleted_at.as_json
       )
     end
 
@@ -439,6 +485,24 @@ describe Api::Internal::Admin::ProductsController do
         "chargedback_count" => 1,
         "rate" => 0.2
       )
+    end
+
+    it "excludes reversed chargebacks from recent_chargeback_rate, matching the rest of the fraud-signal stack" do
+      create(:merchant_account, user: nil)
+      product = create(:product, user: seller)
+      4.times { create(:purchase, link: product, seller:, created_at: 10.days.ago) }
+      lost = create(:purchase, link: product, seller:, created_at: 5.days.ago)
+      lost.update_columns(chargeback_date: 4.days.ago)
+      reversed = create(:purchase, link: product, seller:, created_at: 6.days.ago)
+      reversed.update_columns(chargeback_date: 5.days.ago)
+      reversed.update!(chargeback_reversed: true)
+
+      get :show, params: { id: product.external_id }
+
+      payload = response.parsed_body["product"]["recent_chargeback_rate"]
+      expect(payload["successful_count"]).to eq(6)
+      expect(payload["chargedback_count"]).to eq(1)
+      expect(payload["rate"]).to eq((1.0 / 6).round(4))
     end
 
     it "returns a recent_chargeback_rate with nil rate when there are no recent successful purchases" do

--- a/spec/controllers/api/internal/admin/products_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/products_controller_spec.rb
@@ -505,6 +505,21 @@ describe Api::Internal::Admin::ProductsController do
       expect(payload["rate"]).to eq((1.0 / 6).round(4))
     end
 
+    it "excludes bundle sub-purchases from both successful_count and chargedback_count" do
+      create(:merchant_account, user: nil)
+      product = create(:product, user: seller)
+      3.times { create(:purchase, link: product, seller:, created_at: 10.days.ago) }
+      bundle_sub = create(:purchase, link: product, seller:, created_at: 8.days.ago, price_cents: 0)
+      bundle_sub.update!(is_bundle_product_purchase: true)
+
+      get :show, params: { id: product.external_id }
+
+      payload = response.parsed_body["product"]["recent_chargeback_rate"]
+      expect(payload["successful_count"]).to eq(3)
+      expect(payload["chargedback_count"]).to eq(0)
+      expect(payload["rate"]).to be_nil.or eq(0.0)
+    end
+
     it "returns a recent_chargeback_rate with nil rate when there are no recent successful purchases" do
       product = create(:product, user: seller)
 


### PR DESCRIPTION
Ref #4989

## What

Extends `Api::Internal::Admin::ProductsController#serialize_product` with the fields fraud reviewers need to read off a single product response:

- `banned_at`, `purchase_disabled_at` - ISO 8601 datetimes, `nil` when not set
- `bad_card_counter` - integer from the `links.bad_card_counter` column
- `taxonomy: { id, slug, ancestry_path }` - `ancestry_path` is the slug array root → leaf via `taxonomy.ancestry_path` (provided by `has_closure_tree`); `nil` when unassigned
- `affiliates` - list of attached direct affiliates and collaborators, filtered the same way as the user-affiliates endpoint (`[DirectAffiliate.name, Collaborator.name]`). Each row carries `id`, `type`, `affiliate_user: { id, email }`, effective `basis_points` (per-product override falls back to the parent affiliate's), and `destination_url`
- `recent_chargeback_rate: { window_days: 90, successful_count, chargedback_count, rate }` - **show only**, opt-in via `with_fraud_context: true` to keep the index endpoint cheap. `rate` is `nil` when there were no recent successful sales

Index now `.includes(:taxonomy, product_affiliates: { affiliate: :affiliate_user })` so the new fields do not N+1 across paginated rows.

## Why

- The admin product response was previously product-card-shaped. Fraud triage needs the lifecycle dates (banned, purchase-disabled), the bad-card signal, the taxonomy for category-based heuristics, and the attached-affiliate graph - composing several endpoints to get them defeats the point of having a single product read.
- `recent_chargeback_rate` is the only expensive new field (2 COUNT queries per product). The same pattern from #5022 applies: gate cluster-style cost behind a kwarg so show stays informative and index stays cheap. PR #10 (lookup endpoint) is the right place for cluster-style queries at scale.
- The non-global affiliate filter matches the user-affiliates endpoint (PR #5008) so callers see consistent affiliate shape across the user-side and product-side reads. Global affiliates aren't useful in this view since they're an implicit relationship for every product.
- The 90 day chargeback window matches industry convention for issuer-issued EFW/dispute lag. The response carries `window_days` so the contract is self-documenting.



---
This PR was implemented with AI assistance using Claude Opus 4.7 (1M context).