### PR TITLE
Skip content moderation for verified sellers

### DIFF
--- a/app/services/content_moderation/moderate_record_service.rb
+++ b/app/services/content_moderation/moderate_record_service.rb
@@ -17,6 +17,7 @@ class ContentModeration::ModerateRecordService
 
   def check
     return CheckResult.new(passed: true, reasons: []) unless moderation_enabled?
+    return CheckResult.new(passed: true, reasons: []) if user&.verified?
 
     content = extract_content
     return CheckResult.new(passed: true, reasons: []) if content.text.blank? && content.image_urls.empty?

--- a/spec/services/content_moderation/moderate_record_service_spec.rb
+++ b/spec/services/content_moderation/moderate_record_service_spec.rb
@@ -31,6 +31,16 @@ RSpec.describe ContentModeration::ModerateRecordService, :vcr do
       expect(result.reasons).to eq([])
     end
 
+    it "skips moderation for verified sellers" do
+      seller.update!(verified: true)
+      expect(ContentModeration::ContentExtractor).not_to receive(:new)
+
+      result = described_class.check(product, :product)
+
+      expect(result.passed).to eq(true)
+      expect(result.reasons).to eq([])
+    end
+
     it "returns passed when content is empty" do
       allow_any_instance_of(ContentModeration::ContentExtractor).to receive(:extract_from_product)
         .and_return(ContentModeration::ContentExtractor::Result.new(text: "", image_urls: []))


### PR DESCRIPTION
**1-line change + test.** Verified sellers skip content moderation entirely.

## Problem
Verified sellers (reviewed by admin) still run through Iffy moderation on every product/post publish. This causes false positive blocks — e.g. a copyright mismatch flagging a legitimately authorized book (gumroad-private#357).

## Fix
Add `return CheckResult.new(passed: true, reasons: []) if user&.verified?` at the top of `ModerateRecordService#check`. This is in the service layer so all callers benefit:
- Product publish (`link.rb`)
- Post publish (`installment.rb`)  
- Batch moderation (`ModerateProductsJob`)

Existing `vip_creator?` skip in the model validations remains as belt-and-suspenders.

## Files
- `app/services/content_moderation/moderate_record_service.rb` — +1 line
- `spec/services/content_moderation/moderate_record_service_spec.rb` — +10 lines (new test)

## Test
```
13 examples, 0 failures
```

Ref antiwork/gumroad-private#357

> This PR was authored by Gumclaw (AI agent). All code was written by AI.