### PR TITLE
Add paginated admin user comments read API

### DIFF
--- a/app/controllers/api/internal/admin/users_controller.rb
+++ b/app/controllers/api/internal/admin/users_controller.rb
@@ -10,6 +10,10 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
     @valid_purchase_states ||= Purchase.state_machines[:purchase_state].states.map { _1.name.to_s }.freeze
   end
 
+  def self.valid_comment_types
+    @valid_comment_types ||= Comment.constants.grep(/^COMMENT_TYPE_/).map { Comment.const_get(_1) }.freeze
+  end
+
   def info
     user = find_internal_admin_user_for_read_or_render(include_deleted: true)
     return unless user
@@ -43,6 +47,24 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
     render json: internal_admin_user_success_payload(user, {
                                                        compliance_info: serialize_compliance_info(user.alive_user_compliance_info),
                                                        info_requests: open_compliance_info_requests(user).map { serialize_compliance_info_request(_1) },
+                                                     })
+  end
+
+  def comments
+    user = find_internal_admin_user_for_read_or_render(include_deleted: true)
+    return unless user
+
+    comment_types = parse_comment_types
+    return if comment_types.nil?
+
+    records, pagination = paginate_with_cursor(
+      comments_scope(user, comment_types),
+      order: [[:created_at, :desc], [:id, :desc]]
+    )
+
+    render json: internal_admin_user_success_payload(user, {
+                                                       comments: records.map { serialize_comment(_1) },
+                                                       pagination:,
                                                      })
   end
 
@@ -283,6 +305,12 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
       scope.includes(product_affiliates: :product)
     end
 
+    def comments_scope(user, comment_types)
+      scope = user.comments.includes(:author)
+      scope = scope.where(comment_type: comment_types) if comment_types.any?
+      scope
+    end
+
     def sellers_by_id_for(affiliates, direction)
       return {} unless direction == "received"
 
@@ -475,6 +503,20 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
       nil
     end
 
+    def parse_comment_types
+      raw = params[:comment_type].to_s
+      return [] if raw.blank?
+
+      values = raw.split(",").map(&:strip).reject(&:blank?)
+      invalid = values - self.class.valid_comment_types
+      if invalid.any?
+        render json: { success: false, message: "comment_type contains invalid value: #{invalid.first}" }, status: :bad_request
+        return nil
+      end
+
+      values
+    end
+
     def purchases_scope(user, filters)
       scope = Purchase.where(purchaser_id: user.id)
       scope = scope.or(Purchase.where(email: user.email)) if user.email.present?
@@ -586,7 +628,9 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
         author_name: comment.author_name.presence || comment.author&.name || "System",
         content: comment.content,
         comment_type: comment.comment_type,
-        created_at: comment.created_at.iso8601
+        created_at: comment.created_at.iso8601,
+        deleted_at: comment.deleted_at&.iso8601,
+        alive: comment.alive?
       }
     end
 

--- a/app/controllers/api/internal/admin/users_controller.rb
+++ b/app/controllers/api/internal/admin/users_controller.rb
@@ -509,8 +509,8 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
 
       values = raw.split(",").map(&:strip).reject(&:blank?)
       invalid = values - self.class.valid_comment_types
-      if invalid.any?
-        render json: { success: false, message: "comment_type contains invalid value: #{invalid.first}" }, status: :bad_request
+      if values.empty? || invalid.any?
+        render json: { success: false, message: "comment_type contains invalid value: #{invalid.first || raw}" }, status: :bad_request
         return nil
       end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -328,6 +328,7 @@ Rails.application.routes.draw do
             collection do
               get :info
               get :affiliates
+              get :comments
               get :compliance_info
               get :purchases
               get :suspension

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -743,6 +743,218 @@ describe Api::Internal::Admin::UsersController do
     include_examples "supports user lookup by user_id", :affiliates, method: :get, extra_params: { direction: "granted" }
   end
 
+  describe "GET comments" do
+    include_examples "admin api authorization required", :get, :comments
+
+    before { stub_const("GUMROAD_ADMIN_ID", admin_user.id) }
+
+    def comment_ids
+      response.parsed_body["comments"].map { _1["id"] }
+    end
+
+    it "returns bad request when neither user_id nor email is provided" do
+      get :comments
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "email or user_id is required" }.as_json)
+    end
+
+    it "returns not found when the user does not exist" do
+      get :comments, params: { user_id: "missing" }
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
+    end
+
+    it "returns an empty list with cursor pagination metadata" do
+      user = create(:user)
+
+      get :comments, params: { user_id: user.external_id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(
+        "success" => true,
+        "user_id" => user.external_id,
+        "comments" => [],
+        "pagination" => { "next" => nil, "limit" => 20 }
+      )
+    end
+
+    it "looks up soft-deleted users" do
+      user = create(:user, :deleted)
+
+      get :comments, params: { user_id: user.external_id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["user_id"]).to eq(user.external_id)
+    end
+
+    it "lists comments for the user ordered by created_at and id descending" do
+      user = create(:user)
+      timestamp = 1.hour.ago.change(usec: 0)
+      older = create(:comment, commentable: user, author: admin_user, author_name: "Older Admin", comment_type: Comment::COMMENT_TYPE_NOTE, content: "Older note", created_at: 2.hours.ago)
+      first_same_time = create(:comment, commentable: user, author: admin_user, author_name: "First Admin", comment_type: Comment::COMMENT_TYPE_NOTE, content: "First note", created_at: timestamp)
+      second_same_time = create(:comment, commentable: user, author: admin_user, author_name: "Second Admin", comment_type: Comment::COMMENT_TYPE_SUSPENSION_NOTE, content: "Second note", created_at: timestamp)
+
+      get :comments, params: { user_id: user.external_id }
+
+      expect(response).to have_http_status(:ok)
+      expect(comment_ids).to eq([second_same_time.external_id, first_same_time.external_id, older.external_id])
+      expect(response.parsed_body["comments"].first).to include(
+        "id" => second_same_time.external_id,
+        "author_name" => "Second Admin",
+        "content" => "Second note",
+        "comment_type" => Comment::COMMENT_TYPE_SUSPENSION_NOTE,
+        "created_at" => second_same_time.created_at.iso8601,
+        "deleted_at" => nil,
+        "alive" => true
+      )
+    end
+
+    it "falls back to the author name and then System when the snapshot is blank" do
+      user = create(:user)
+      author = create(:admin_user, name: "Riley Admin")
+      snapshot = create(:comment, commentable: user, author:, author_name: "Snapshot Name", comment_type: Comment::COMMENT_TYPE_NOTE)
+      author_fallback = create(:comment, commentable: user, author:, author_name: nil, comment_type: Comment::COMMENT_TYPE_NOTE)
+      system_fallback = create(:comment, commentable: user, author:, author_name: "Temporary", comment_type: Comment::COMMENT_TYPE_NOTE)
+      system_fallback.update_columns(author_id: nil, author_name: nil)
+
+      get :comments, params: { user_id: user.external_id }
+
+      payloads = response.parsed_body["comments"].index_by { _1["id"] }
+      expect(payloads[snapshot.external_id]["author_name"]).to eq("Snapshot Name")
+      expect(payloads[author_fallback.external_id]["author_name"]).to eq("Riley Admin")
+      expect(payloads[system_fallback.external_id]["author_name"]).to eq("System")
+    end
+
+    it "filters to a single comment_type" do
+      user = create(:user)
+      note = create(:comment, commentable: user, comment_type: Comment::COMMENT_TYPE_NOTE)
+      create(:comment, commentable: user, comment_type: Comment::COMMENT_TYPE_SUSPENSION_NOTE)
+
+      get :comments, params: { user_id: user.external_id, comment_type: "note" }
+
+      expect(response).to have_http_status(:ok)
+      expect(comment_ids).to eq([note.external_id])
+    end
+
+    it "filters to multiple comment types from a comma-separated list" do
+      user = create(:user)
+      note = create(:comment, commentable: user, comment_type: Comment::COMMENT_TYPE_NOTE, created_at: 2.hours.ago)
+      suspension_note = create(:comment, commentable: user, comment_type: Comment::COMMENT_TYPE_SUSPENSION_NOTE, created_at: 1.hour.ago)
+      create(:comment, commentable: user, comment_type: Comment::COMMENT_TYPE_FLAGGED, created_at: 30.minutes.ago)
+
+      get :comments, params: { user_id: user.external_id, comment_type: "note,suspension_note" }
+
+      expect(response).to have_http_status(:ok)
+      expect(comment_ids).to eq([suspension_note.external_id, note.external_id])
+    end
+
+    it "rejects an unknown comment_type value" do
+      user = create(:user)
+
+      get :comments, params: { user_id: user.external_id, comment_type: "bogus" }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "comment_type contains invalid value: bogus" }.as_json)
+    end
+
+    it "rejects a comma-separated comment_type list with any invalid value" do
+      user = create(:user)
+
+      get :comments, params: { user_id: user.external_id, comment_type: "note,bogus" }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "comment_type contains invalid value: bogus" }.as_json)
+    end
+
+    it "includes soft-deleted comments with deletion state exposed" do
+      user = create(:user)
+      deleted_comment = create(:comment, commentable: user, comment_type: Comment::COMMENT_TYPE_NOTE)
+      deleted_comment.mark_deleted!
+
+      get :comments, params: { user_id: user.external_id }
+
+      expect(response).to have_http_status(:ok)
+      payload = response.parsed_body["comments"].first
+      expect(payload).to include(
+        "id" => deleted_comment.external_id,
+        "alive" => false,
+        "deleted_at" => deleted_comment.reload.deleted_at.iso8601
+      )
+    end
+
+    it "scopes results to the requested user and excludes comments on other records" do
+      user = create(:user)
+      matching = create(:comment, commentable: user, comment_type: Comment::COMMENT_TYPE_NOTE)
+      create(:comment, commentable: create(:user), comment_type: Comment::COMMENT_TYPE_NOTE)
+      create(:comment, commentable: create(:purchase), comment_type: Comment::COMMENT_TYPE_NOTE)
+
+      get :comments, params: { user_id: user.external_id }
+
+      expect(response).to have_http_status(:ok)
+      expect(comment_ids).to eq([matching.external_id])
+    end
+
+    it "paginates comments with a cursor" do
+      user = create(:user)
+      newest = create(:comment, commentable: user, comment_type: Comment::COMMENT_TYPE_NOTE, created_at: 1.hour.ago)
+      middle = create(:comment, commentable: user, comment_type: Comment::COMMENT_TYPE_NOTE, created_at: 2.hours.ago)
+      oldest = create(:comment, commentable: user, comment_type: Comment::COMMENT_TYPE_NOTE, created_at: 3.hours.ago)
+
+      get :comments, params: { user_id: user.external_id, limit: 2 }
+
+      expect(response).to have_http_status(:ok)
+      expect(comment_ids).to eq([newest.external_id, middle.external_id])
+      cursor = response.parsed_body["pagination"]["next"]
+      expect(cursor).to be_present
+      expect(response.parsed_body["pagination"]["limit"]).to eq(2)
+
+      get :comments, params: { user_id: user.external_id, limit: 2, cursor: }
+
+      expect(response).to have_http_status(:ok)
+      expect(comment_ids).to eq([oldest.external_id])
+      expect(response.parsed_body["pagination"]).to eq({ "next" => nil, "limit" => 2 })
+    end
+
+    it "returns bad request when the cursor is invalid" do
+      user = create(:user)
+
+      get :comments, params: { user_id: user.external_id, cursor: "invalid" }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "invalid cursor" }.as_json)
+    end
+
+    it "preloads authors instead of issuing one query per comment" do
+      user = create(:user)
+      3.times do |index|
+        author = create(:admin_user, name: "Admin #{index}")
+        create(:comment, commentable: user, author:, author_name: nil, comment_type: Comment::COMMENT_TYPE_NOTE)
+      end
+      select_queries = []
+      counter = lambda do |*, payload|
+        sql = payload[:sql].to_s.squish
+        next if payload[:name] == "SCHEMA"
+        next unless sql.start_with?("SELECT")
+        next if sql.include?("`admin_api_tokens`")
+        next if sql.include?("`oauth_access_tokens`")
+
+        select_queries << sql
+      end
+
+      ActiveSupport::Notifications.subscribed(counter, "sql.active_record") do
+        get :comments, params: { user_id: user.external_id }
+      end
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["comments"].length).to eq(3)
+      expect(select_queries.length).to be <= 4, "expected at most 4 SELECTs but got #{select_queries.length}:\n#{select_queries.join("\n")}"
+    end
+
+    include_examples "supports user lookup by user_id", :comments, method: :get
+  end
+
   describe "GET compliance_info" do
     include_examples "admin api authorization required", :get, :compliance_info
 
@@ -1642,7 +1854,12 @@ describe Api::Internal::Admin::UsersController do
       expect(response.parsed_body["success"]).to be(true)
       expect(response.parsed_body["user_id"]).to eq(user.external_id)
       comment_data = response.parsed_body["comment"]
-      expect(comment_data).to include("content" => "An admin note", "comment_type" => Comment::COMMENT_TYPE_NOTE)
+      expect(comment_data).to include(
+        "content" => "An admin note",
+        "comment_type" => Comment::COMMENT_TYPE_NOTE,
+        "deleted_at" => nil,
+        "alive" => true
+      )
       expect(comment_data["id"]).to be_present
       expect(user.comments.last.author_id).to eq(admin_user.id)
     end

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -868,6 +868,16 @@ describe Api::Internal::Admin::UsersController do
       expect(response.parsed_body).to eq({ success: false, message: "comment_type contains invalid value: bogus" }.as_json)
     end
 
+    it "rejects a comma-only comment_type value instead of silently returning all comments" do
+      user = create(:user)
+      create(:comment, commentable: user, comment_type: Comment::COMMENT_TYPE_NOTE)
+
+      get :comments, params: { user_id: user.external_id, comment_type: "," }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "comment_type contains invalid value: ," }.as_json)
+    end
+
     it "includes soft-deleted comments with deletion state exposed" do
       user = create(:user)
       deleted_comment = create(:comment, commentable: user, comment_type: Comment::COMMENT_TYPE_NOTE)


### PR DESCRIPTION
Ref #4989

## What

Added a new internal admin endpoint to list a user’s comments with cursor pagination and optional `comment_type` filtering.
- Returns soft-deleted comments so investigators can see the full history.
- Reuses the shared comment serializer and now includes `deleted_at` and `alive` in both read and write responses.
- Validates comment types strictly and returns a clear 400 when a requested type is invalid.

## Why

This gives fraud reviewers a read path for the existing admin comments workflow without changing the write API.
- Keeps the response shape consistent across comment endpoints.
- Uses the same cursor pagination pattern as the other user-scoped admin reads.
- Preserves soft-deleted records so no history is lost during investigations.

---
This PR was implemented with AI assistance using gpt‑5.5 xhigh.