### PR TITLE
Add admin purchase lookup by fingerprint, browser ID, or IP

### DIFF
--- a/app/controllers/api/internal/admin/base_controller.rb
+++ b/app/controllers/api/internal/admin/base_controller.rb
@@ -216,7 +216,8 @@ class Api::Internal::Admin::BaseController < Api::Internal::BaseController
       {
         id: purchase.external_id_numeric.to_s,
         email: purchase.email,
-        seller_email: purchase.seller_email,
+        seller_email: purchase.seller&.email,
+        seller: serialize_purchase_seller(purchase),
         product_name: purchase.link&.name,
         link_name: purchase.link_name,
         product_id: purchase.link&.external_id_numeric&.to_s,
@@ -255,6 +256,17 @@ class Api::Internal::Admin::BaseController < Api::Internal::BaseController
         visual: purchase.card_visual,
         expiry_month: purchase.card_expiry_month,
         expiry_year: purchase.card_expiry_year,
+      }
+    end
+
+    def serialize_purchase_seller(purchase)
+      seller = purchase.seller
+      return nil if seller.blank?
+
+      {
+        id: seller.external_id,
+        email: seller.email,
+        name: seller.name,
       }
     end
 

--- a/app/controllers/api/internal/admin/purchases_controller.rb
+++ b/app/controllers/api/internal/admin/purchases_controller.rb
@@ -2,9 +2,12 @@
 
 class Api::Internal::Admin::PurchasesController < Api::Internal::Admin::BaseController
   include CurrencyHelper
+  include Api::Internal::Admin::CursorPaginated
 
   MAX_SEARCH_RESULTS = 25
   VALID_PURCHASE_STATUSES = %w[successful failed not_charged chargeback refunded].freeze
+  LOOKUP_FIELDS = %w[stripe_fingerprint browser_guid ip_address].freeze
+  private_constant :LOOKUP_FIELDS
 
   def show
     purchase = fetch_purchase
@@ -40,6 +43,23 @@ class Api::Internal::Admin::PurchasesController < Api::Internal::Admin::BaseCont
     }
   rescue AdminSearchService::InvalidDateError
     render json: { success: false, message: "purchase_date must use YYYY-MM-DD format." }, status: :bad_request
+  end
+
+  def lookup
+    lookup = parse_lookup_params
+    return if lookup.nil?
+
+    records, pagination = paginate_with_cursor(
+      Purchase.where(lookup[:field] => lookup[:value]).includes(*ADMIN_PURCHASE_INCLUDES),
+      order: [[:created_at, :desc], [:id, :desc]]
+    )
+
+    render json: {
+      success: true,
+      lookup:,
+      purchases: records.map { serialize_purchase(_1) },
+      pagination:,
+    }
   end
 
   def resend_receipt
@@ -327,6 +347,22 @@ class Api::Internal::Admin::PurchasesController < Api::Internal::Admin::BaseCont
       end
 
       purchase
+    end
+
+    def parse_lookup_params
+      present = LOOKUP_FIELDS.select { |field| params[field].to_s.strip.present? }
+      if present.empty?
+        render json: { success: false, message: "stripe_fingerprint, browser_guid, or ip_address is required" }, status: :bad_request
+        return nil
+      end
+
+      if present.size > 1
+        render json: { success: false, message: "only one of stripe_fingerprint, browser_guid, ip_address is allowed" }, status: :bad_request
+        return nil
+      end
+
+      field = present.first
+      { field:, value: params[field].to_s.strip }
     end
 
     def fetch_purchase

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -304,6 +304,7 @@ Rails.application.routes.draw do
           resources :purchases, only: [:show] do
             collection do
               get :search
+              get :lookup
               post :resend_all_receipts
               post :reassign
             end

--- a/spec/controllers/api/internal/admin/purchases_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/purchases_controller_spec.rb
@@ -4,6 +4,165 @@ require "spec_helper"
 require "shared_examples/authorized_admin_api_method"
 
 describe Api::Internal::Admin::PurchasesController do
+  describe "GET lookup" do
+    include_examples "admin api authorization required", :get, :lookup
+
+    def lookup_purchase_ids
+      response.parsed_body["purchases"].map { _1["id"] }
+    end
+
+    def create_lookup_purchase(seller, attributes = {})
+      product = create(:product, user: seller)
+      purchase = create(:free_purchase, seller:, link: product)
+      purchase.update_columns(attributes) if attributes.present?
+      purchase
+    end
+
+    def serialized_seller(seller)
+      {
+        "id" => seller.external_id,
+        "email" => seller.email,
+        "name" => seller.name,
+      }
+    end
+
+    it "returns a bad request when no lookup key is provided" do
+      get :lookup
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "stripe_fingerprint, browser_guid, or ip_address is required" }.as_json)
+    end
+
+    it "returns a bad request when the lookup key is blank" do
+      get :lookup, params: { stripe_fingerprint: "" }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "stripe_fingerprint, browser_guid, or ip_address is required" }.as_json)
+    end
+
+    it "returns a bad request when more than one lookup key is provided" do
+      get :lookup, params: { stripe_fingerprint: "fp_shared", ip_address: "203.0.113.7" }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "only one of stripe_fingerprint, browser_guid, ip_address is allowed" }.as_json)
+    end
+
+    it "returns an empty purchase list when the lookup key matches nothing" do
+      get :lookup, params: { stripe_fingerprint: "missing" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(
+        "success" => true,
+        "lookup" => { "field" => "stripe_fingerprint", "value" => "missing" },
+        "purchases" => [],
+        "pagination" => { "next" => nil, "limit" => 20 }
+      )
+    end
+
+    it "returns purchases sharing a stripe fingerprint ordered by created_at and id descending" do
+      first_seller = create(:user, email: "first-seller@example.com", name: "First Seller")
+      second_seller = create(:user, email: "second-seller@example.com", name: "Second Seller")
+      shared_time = 1.hour.ago.change(usec: 0)
+      older = create_lookup_purchase(first_seller, stripe_fingerprint: "fp_shared", created_at: 2.hours.ago)
+      same_time_older_id = create_lookup_purchase(first_seller, stripe_fingerprint: "fp_shared", created_at: shared_time)
+      same_time_newer_id = create_lookup_purchase(second_seller, stripe_fingerprint: "fp_shared", created_at: shared_time)
+      create_lookup_purchase(first_seller, stripe_fingerprint: "fp_shared_suffix", created_at: 30.minutes.ago)
+      create_lookup_purchase(second_seller, stripe_fingerprint: nil, created_at: 15.minutes.ago)
+
+      get :lookup, params: { stripe_fingerprint: " fp_shared " }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["lookup"]).to eq({ "field" => "stripe_fingerprint", "value" => "fp_shared" })
+      expect(lookup_purchase_ids).to eq([same_time_newer_id, same_time_older_id, older].map { _1.external_id_numeric.to_s })
+
+      first_row = response.parsed_body["purchases"].first
+      expect(first_row).to include(
+        "seller_email" => second_seller.email,
+        "seller" => serialized_seller(second_seller)
+      )
+      expect(response.parsed_body["purchases"].map { _1["seller_email"] }).to contain_exactly(first_seller.email, first_seller.email, second_seller.email)
+    end
+
+    it "returns purchases sharing a browser GUID" do
+      seller = create(:user)
+      matching = create_lookup_purchase(seller, browser_guid: "browser-shared")
+      create_lookup_purchase(seller, browser_guid: "browser-other")
+
+      get :lookup, params: { browser_guid: "browser-shared" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["lookup"]).to eq({ "field" => "browser_guid", "value" => "browser-shared" })
+      expect(lookup_purchase_ids).to eq([matching.external_id_numeric.to_s])
+    end
+
+    it "returns purchases sharing an IP address" do
+      seller = create(:user)
+      matching = create_lookup_purchase(seller, ip_address: "203.0.113.7")
+      create_lookup_purchase(seller, ip_address: "198.51.100.4")
+
+      get :lookup, params: { ip_address: "203.0.113.7" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["lookup"]).to eq({ "field" => "ip_address", "value" => "203.0.113.7" })
+      expect(lookup_purchase_ids).to eq([matching.external_id_numeric.to_s])
+    end
+
+    it "paginates lookup results with a cursor" do
+      seller = create(:user)
+      newest = create_lookup_purchase(seller, stripe_fingerprint: "fp_paginated", created_at: 1.hour.ago)
+      middle = create_lookup_purchase(seller, stripe_fingerprint: "fp_paginated", created_at: 2.hours.ago)
+      oldest = create_lookup_purchase(seller, stripe_fingerprint: "fp_paginated", created_at: 3.hours.ago)
+
+      get :lookup, params: { stripe_fingerprint: "fp_paginated", limit: 2 }
+
+      expect(response).to have_http_status(:ok)
+      expect(lookup_purchase_ids).to eq([newest, middle].map { _1.external_id_numeric.to_s })
+      cursor = response.parsed_body["pagination"]["next"]
+      expect(cursor).to be_present
+      expect(response.parsed_body["pagination"]["limit"]).to eq(2)
+
+      get :lookup, params: { stripe_fingerprint: "fp_paginated", limit: 2, cursor: }
+
+      expect(response).to have_http_status(:ok)
+      expect(lookup_purchase_ids).to eq([oldest.external_id_numeric.to_s])
+      expect(response.parsed_body["pagination"]).to eq({ "next" => nil, "limit" => 2 })
+    end
+
+    it "returns a bad request when the cursor is invalid" do
+      get :lookup, params: { stripe_fingerprint: "fp_shared", cursor: "invalid" }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "invalid cursor" }.as_json)
+    end
+
+    it "preloads sellers instead of issuing one query per purchase row" do
+      sellers = 3.times.map { create(:user) }
+      sellers.each do |seller|
+        create_lookup_purchase(seller, stripe_fingerprint: "fp_sellers")
+      end
+
+      seller_ids = sellers.map(&:id)
+      seller_lookup_queries = []
+      counter = lambda do |*, payload|
+        sql = payload[:sql].to_s
+        next if sql.start_with?("INSERT", "UPDATE", "DELETE", "BEGIN", "COMMIT", "SAVEPOINT", "RELEASE")
+        next unless sql.start_with?("SELECT") && sql.include?("`users`")
+        next unless sql.match?(/`users`\.`id` = \d+ LIMIT 1\z/)
+
+        seller_lookup_queries << sql if seller_ids.any? { |id| sql.include?("`id` = #{id} ") }
+      end
+
+      ActiveSupport::Notifications.subscribed(counter, "sql.active_record") do
+        get :lookup, params: { stripe_fingerprint: "fp_sellers" }
+      end
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["purchases"].length).to eq(3)
+      expect(seller_lookup_queries).to be_empty,
+                                       "expected zero per-row SELECTs for sellers, but got:\n#{seller_lookup_queries.join("\n")}"
+    end
+  end
+
   describe "GET search" do
     include_examples "admin api authorization required", :get, :search
 
@@ -246,6 +405,11 @@ describe Api::Internal::Admin::PurchasesController do
         "id" => purchase.external_id_numeric.to_s,
         "email" => "buyer@example.com",
         "seller_email" => purchase.seller_email,
+        "seller" => {
+          "id" => product.user.external_id,
+          "email" => product.user.email,
+          "name" => product.user.name,
+        },
         "product_name" => "Example product",
         "link_name" => purchase.link_name,
         "product_id" => product.external_id_numeric.to_s,
@@ -256,6 +420,19 @@ describe Api::Internal::Admin::PurchasesController do
         "purchase_state" => purchase.purchase_state,
         "refund_status" => nil,
         "receipt_url" => receipt_purchase_url(purchase.external_id, host: UrlService.domain_with_protocol, email: purchase.email)
+      )
+    end
+
+    it "returns nil seller fields when the purchase has no seller" do
+      purchase = create(:free_purchase)
+      purchase.update_columns(seller_id: nil)
+
+      get :show, params: { id: purchase.external_id_numeric }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["purchase"]).to include(
+        "seller_email" => nil,
+        "seller" => nil
       )
     end
 

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -1276,9 +1276,29 @@ describe Api::Internal::Admin::UsersController do
         "id" => purchase.external_id_numeric.to_s,
         "email" => buyer.email,
         "seller_email" => "seller@example.com",
+        "seller" => {
+          "id" => seller.external_id,
+          "email" => "seller@example.com",
+          "name" => seller.name,
+        },
         "product_name" => "Investigation guide",
         "price_cents" => 12_34,
         "purchase_state" => "successful"
+      )
+    end
+
+    it "serializes nil seller fields when a purchase has no seller" do
+      buyer = create(:user, email: "buyer@example.com")
+      purchase = create(:free_purchase, purchaser: buyer, email: buyer.email)
+      purchase.update_columns(seller_id: nil)
+
+      get :purchases, params: { user_id: buyer.external_id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["purchases"].first).to include(
+        "id" => purchase.external_id_numeric.to_s,
+        "seller_email" => nil,
+        "seller" => nil
       )
     end
 


### PR DESCRIPTION
Ref #4989

## What

Adds a new internal admin lookup endpoint for purchases that match a single buyer signal: `stripe_fingerprint`, `browser_guid`, or `ip_address`.

It also expands the shared purchase response with a seller object that includes the seller's external ID, email, and name, while keeping the existing `seller_email` field in place.

## Why

This gives investigators a direct way to follow a buyer cluster across sellers without mixing signals or changing the existing purchase response shape for current callers.

The seller block makes it easier to jump from a purchase cluster to seller-scoped admin tools without breaking existing integrations.

---

This PR was implemented with AI assistance using gpt‑5.5 xhigh.