### PR TITLE
Add admin toggle to disable content moderation per product

### DIFF
--- a/app/controllers/admin/links_controller.rb
+++ b/app/controllers/admin/links_controller.rb
@@ -72,6 +72,13 @@ class Admin::LinksController < Admin::BaseController
     render json: { success: true }
   end
 
+  def set_content_moderation_disabled
+    @product.content_moderation_disabled = parse_boolean(params[:disabled])
+    @product.save!
+
+    render json: { success: true }
+  end
+
   def access_product_file
     url_redirect = @product.url_redirects.build
     product_file = ProductFile.find_by_external_id(params[:product_file_id])

--- a/app/javascript/components/Admin/Products/Actions/DisableContentModerationAction.tsx
+++ b/app/javascript/components/Admin/Products/Actions/DisableContentModerationAction.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+import { AdminActionButton } from "$app/components/Admin/ActionButton";
+import { type Product } from "$app/components/Admin/Products/Product";
+
+type DisableContentModerationActionProps = {
+  product: Product;
+};
+
+const DisableContentModerationAction = ({ product }: DisableContentModerationActionProps) =>
+  product.content_moderation_disabled ? (
+    <AdminActionButton
+      url={Routes.set_content_moderation_disabled_admin_product_path(product.external_id, { disabled: "false" })}
+      label="Enable content moderation"
+      loading="Enabling content moderation..."
+      done="Content moderation enabled!"
+      success_message="Content moderation enabled!"
+    />
+  ) : (
+    <AdminActionButton
+      url={Routes.set_content_moderation_disabled_admin_product_path(product.external_id, { disabled: "true" })}
+      label="Disable content moderation"
+      loading="Disabling content moderation..."
+      done="Content moderation disabled!"
+      success_message="Content moderation disabled!"
+    />
+  );
+
+export default DisableContentModerationAction;

--- a/app/javascript/components/Admin/Products/Actions/index.tsx
+++ b/app/javascript/components/Admin/Products/Actions/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import DeleteAction from "$app/components/Admin/Products/Actions/DeleteAction";
+import DisableContentModerationAction from "$app/components/Admin/Products/Actions/DisableContentModerationAction";
 import JoinDiscordAction from "$app/components/Admin/Products/Actions/JoinDiscordAction";
 import MakeAdultAction from "$app/components/Admin/Products/Actions/MakeAdultAction";
 import MarkAsStaffPickedAction from "$app/components/Admin/Products/Actions/MarkAsStaffPickedAction";
@@ -21,6 +22,7 @@ const AdminProductActions = ({ product }: AdminProductActionsProps) => (
       <MakeAdultAction product={product} />
       <MarkAsStaffPickedAction product={product} />
       <UnmarkAsStaffPickedAction product={product} />
+      <DisableContentModerationAction product={product} />
       <JoinDiscordAction product={product} />
     </div>
   </>

--- a/app/javascript/components/Admin/Products/Product.tsx
+++ b/app/javascript/components/Admin/Products/Product.tsx
@@ -46,6 +46,7 @@ export type Product = {
   html_safe_description: string | null;
   alive: boolean;
   is_adult: boolean;
+  content_moderation_disabled: boolean;
   active_integrations: ActiveIntegration[];
   admins_can_mark_as_staff_picked: boolean;
   admins_can_unmark_as_staff_picked: boolean;

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -237,6 +237,8 @@ class Link < ApplicationRecord
   attr_json_data_accessor :main_section_index, default: -> { 0 }
   attr_json_data_accessor :custom_view_content_button_text
   attr_json_data_accessor :custom_receipt_text
+  attr_json_data_accessor :content_moderation_disabled, default: -> { false }
+  alias_method :content_moderation_disabled?, :content_moderation_disabled
 
   scope :alive,                           -> { where(purchase_disabled_at: nil, banned_at: nil, deleted_at: nil) }
   scope :visible,                         -> { where(deleted_at: nil) }

--- a/app/presenters/admin/product_presenter/card.rb
+++ b/app/presenters/admin/product_presenter/card.rb
@@ -32,6 +32,7 @@ class Admin::ProductPresenter::Card
       html_safe_description: product.html_safe_description,
       alive: product.alive?,
       is_adult: product.is_adult?,
+      content_moderation_disabled: product.content_moderation_disabled?,
       active_integrations: format_active_integrations,
       admins_can_mark_as_staff_picked: link_policy.create?,
       admins_can_unmark_as_staff_picked: link_policy.destroy?,

--- a/app/services/content_moderation/moderate_record_service.rb
+++ b/app/services/content_moderation/moderate_record_service.rb
@@ -18,6 +18,7 @@ class ContentModeration::ModerateRecordService
   def check
     return CheckResult.new(passed: true, reasons: []) unless moderation_enabled?
     return CheckResult.new(passed: true, reasons: []) if user&.verified?
+    return CheckResult.new(passed: true, reasons: []) if record_moderation_disabled?
 
     content = extract_content
     return CheckResult.new(passed: true, reasons: []) if content.text.blank? && content.image_urls.empty?
@@ -48,6 +49,10 @@ class ContentModeration::ModerateRecordService
 
     def moderation_enabled?
       Feature.active?(:content_moderation)
+    end
+
+    def record_moderation_disabled?
+      entity_type == :product && record.content_moderation_disabled?
     end
 
     def extract_content

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -91,6 +91,7 @@ namespace :admin do
       post :publish
       delete :unpublish
       post :is_adult
+      post :set_content_moderation_disabled
       get "/file/:product_file_id/access", to: "links#access_product_file", as: :admin_access_product_file
       get :views_count
       get :sales_stats

--- a/spec/controllers/admin/links_controller_spec.rb
+++ b/spec/controllers/admin/links_controller_spec.rb
@@ -172,4 +172,24 @@ describe Admin::LinksController, type: :controller, inertia: true do
       end.to raise_error(ActionController::RoutingError, "Not Found")
     end
   end
+
+  describe "POST set_content_moderation_disabled" do
+    it "toggles content_moderation_disabled on the product" do
+      post :set_content_moderation_disabled, params: { external_id: product.external_id, disabled: "true" }
+
+      expect(response).to be_successful
+      expect(product.reload.content_moderation_disabled?).to be(true)
+
+      post :set_content_moderation_disabled, params: { external_id: product.external_id, disabled: "false" }
+
+      expect(response).to be_successful
+      expect(product.reload.content_moderation_disabled?).to be(false)
+    end
+
+    it "raises a 404 if the product is not found" do
+      expect do
+        post :set_content_moderation_disabled, params: { external_id: "invalid-id", disabled: "true" }
+      end.to raise_error(ActionController::RoutingError, "Not Found")
+    end
+  end
 end

--- a/spec/presenters/admin/product_presenter/card_spec.rb
+++ b/spec/presenters/admin/product_presenter/card_spec.rb
@@ -35,6 +35,7 @@ describe Admin::ProductPresenter::Card do
           html_safe_description: product.html_safe_description,
           alive: product.alive?,
           is_adult: product.is_adult?,
+          content_moderation_disabled: false,
           active_integrations: [],
           admins_can_mark_as_staff_picked: false,
           admins_can_unmark_as_staff_picked: false,

--- a/spec/services/content_moderation/moderate_record_service_spec.rb
+++ b/spec/services/content_moderation/moderate_record_service_spec.rb
@@ -41,6 +41,16 @@ RSpec.describe ContentModeration::ModerateRecordService, :vcr do
       expect(result.reasons).to eq([])
     end
 
+    it "skips moderation for products with content_moderation_disabled set" do
+      product.update!(content_moderation_disabled: true)
+      expect(ContentModeration::ContentExtractor).not_to receive(:new)
+
+      result = described_class.check(product, :product)
+
+      expect(result.passed).to eq(true)
+      expect(result.reasons).to eq([])
+    end
+
     it "returns passed when content is empty" do
       allow_any_instance_of(ContentModeration::ContentExtractor).to receive(:extract_from_product)
         .and_return(ContentModeration::ContentExtractor::Result.new(text: "", image_urls: []))


### PR DESCRIPTION
## What
Adds an admin button on the product page to disable content moderation for a specific product. The flag is stored on the product's `json_data` (no schema change), and `ContentModeration::ModerateRecordService` early-returns when it's set — so both the publish path and the `ModerateProductsJob` batch path skip moderation for that product.

Mirrors the existing `user.verified?` skip introduced in #5024 but at product granularity, for cases where only one product on an otherwise unverified seller's account is hitting false-positive flags.

## Why
Per-seller `verified?` (#5024) and `vip_creator?` are too coarse — sometimes a single legitimate product gets repeatedly flagged (e.g. authorized copyrighted material) on an account we don't want to mark fully verified. Admin needs a per-product override.

Using `json_data` avoids adding a column to `link`s (large table, costly migrations) and follows the same pattern as `sections`, `custom_receipt_text`, etc.

## Files
**Backend**
- `app/models/link.rb` — `attr_json_data_accessor :content_moderation_disabled` + predicate alias
- `app/services/content_moderation/moderate_record_service.rb` — early-return when `record.content_moderation_disabled?` (product entity only)
- `app/controllers/admin/links_controller.rb` — `set_content_moderation_disabled` action
- `config/routes/admin.rb` — `post :set_content_moderation_disabled`
- `app/presenters/admin/product_presenter/card.rb` — exposes the flag

**Frontend**
- `app/javascript/components/Admin/Products/Actions/DisableContentModerationAction.tsx` — new toggle button (mirrors `MakeAdultAction`)
- `app/javascript/components/Admin/Products/Actions/index.tsx` — wires it in
- `app/javascript/components/Admin/Products/Product.tsx` — adds field to `Product` type

**Tests**
- `spec/controllers/admin/links_controller_spec.rb` — toggles flag, 404 path
- `spec/services/content_moderation/moderate_record_service_spec.rb` — skips moderation when flag set
- `spec/presenters/admin/product_presenter/card_spec.rb` — props include the flag

## Test plan
- [ ] Test results: 53 examples, 0 failures locally
- [ ] Deploy to preview; verify admin button toggles on/off and content moderation is bypassed on republish

```
Finished in 19.31 seconds
53 examples, 0 failures
```

## Before / After
Video pending — to be added on the PR before merge.

---

> This PR was authored by Claude Opus 4.7 (1M context). All code was written by AI.