### PR TITLE
Add related users endpoint for admin investigations

### DIFF
--- a/app/controllers/api/internal/admin/users_controller.rb
+++ b/app/controllers/api/internal/admin/users_controller.rb
@@ -540,8 +540,8 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
 
       values = raw.split(",").map(&:strip).reject(&:blank?).uniq
       invalid = values - Admin::RelatedUsersService::VALID_SIGNALS
-      if invalid.any?
-        render json: { success: false, message: "signals contains invalid value: #{invalid.first}" }, status: :bad_request
+      if values.empty? || invalid.any?
+        render json: { success: false, message: "signals contains invalid value: #{invalid.first || raw}" }, status: :bad_request
         return nil
       end
 

--- a/app/controllers/api/internal/admin/users_controller.rb
+++ b/app/controllers/api/internal/admin/users_controller.rb
@@ -86,6 +86,23 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
                                                      })
   end
 
+  def related
+    user = find_internal_admin_user_for_read_or_render(include_deleted: true)
+    return unless user
+
+    signals = parse_related_signals
+    return if signals.nil?
+
+    result = Admin::RelatedUsersService.new(user, signals:, limit: related_limit).call
+
+    render json: internal_admin_user_success_payload(user, {
+                                                       signals_evaluated: result.signals_evaluated,
+                                                       per_signal_limit: result.per_signal_limit,
+                                                       related_users: result.related_users,
+                                                       truncated: result.truncated,
+                                                     })
+  end
+
   def suspension
     user = find_internal_admin_user_for_read_or_render
     return unless user
@@ -515,6 +532,27 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
       end
 
       values
+    end
+
+    def parse_related_signals
+      raw = params[:signals].to_s
+      return Admin::RelatedUsersService::VALID_SIGNALS if raw.blank?
+
+      values = raw.split(",").map(&:strip).reject(&:blank?).uniq
+      invalid = values - Admin::RelatedUsersService::VALID_SIGNALS
+      if invalid.any?
+        render json: { success: false, message: "signals contains invalid value: #{invalid.first}" }, status: :bad_request
+        return nil
+      end
+
+      values
+    end
+
+    def related_limit
+      raw = Integer(params[:limit], exception: false)
+      return Admin::RelatedUsersService::DEFAULT_LIMIT if raw.nil? || raw <= 0
+
+      [raw, Admin::RelatedUsersService::MAX_LIMIT].min
     end
 
     def purchases_scope(user, filters)

--- a/app/services/admin/related_users_service.rb
+++ b/app/services/admin/related_users_service.rb
@@ -81,6 +81,7 @@ class Admin::RelatedUsersService
       rows = User
         .where("account_created_ip IN (:ips) OR current_sign_in_ip IN (:ips) OR last_sign_in_ip IN (:ips)", ips: target_ips)
         .where.not(id: @target.id)
+        .order(updated_at: :desc, id: :desc)
         .limit(@limit + 1)
         .pluck(:id, :account_created_ip, :current_sign_in_ip, :last_sign_in_ip)
 
@@ -108,6 +109,7 @@ class Admin::RelatedUsersService
       ids = User
         .where(payment_address: @target.payment_address)
         .where.not(id: @target.id)
+        .order(updated_at: :desc, id: :desc)
         .limit(@limit + 1)
         .pluck(:id)
 
@@ -122,6 +124,7 @@ class Admin::RelatedUsersService
         .joins(:credit_card)
         .where(credit_cards: { stripe_fingerprint: target_fingerprint })
         .where.not(id: @target.id)
+        .order(updated_at: :desc, id: :desc)
         .limit(@limit + 1)
         .pluck(:id)
 

--- a/app/services/admin/related_users_service.rb
+++ b/app/services/admin/related_users_service.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+class Admin::RelatedUsersService
+  DEFAULT_LIMIT = 50
+  MAX_LIMIT = 50
+  VALID_SIGNALS = %w[ip payment_address card_fingerprint].freeze
+  IP_COLUMNS = %i[account_created_ip current_sign_in_ip last_sign_in_ip].freeze
+  private_constant :IP_COLUMNS
+
+  Result = Struct.new(:signals_evaluated, :per_signal_limit, :related_users, :truncated, keyword_init: true)
+  Relation = Struct.new(:user_id, :signal, :shared_value, :via, keyword_init: true)
+  private_constant :Relation
+
+  def initialize(user, signals: VALID_SIGNALS, limit: DEFAULT_LIMIT)
+    @target = user
+    @signals = Array(signals).map(&:to_s) & VALID_SIGNALS
+    @limit = limit.to_i.clamp(1, MAX_LIMIT)
+  end
+
+  def call
+    evaluated = []
+    truncated = {}
+    relations = []
+
+    if @signals.include?("ip")
+      evaluated << "ip" if target_ips.any?
+      signal_relations, signal_truncated = ip_relations
+      relations.concat(signal_relations)
+      truncated["ip"] = signal_truncated
+    end
+
+    if @signals.include?("payment_address")
+      if @target.payment_address.present?
+        evaluated << "payment_address"
+        signal_relations, signal_truncated = payment_address_relations
+        relations.concat(signal_relations)
+        truncated["payment_address"] = signal_truncated
+      else
+        truncated["payment_address"] = false
+      end
+    end
+
+    if @signals.include?("card_fingerprint")
+      if target_fingerprint.present?
+        evaluated << "card_fingerprint"
+        signal_relations, signal_truncated = card_fingerprint_relations
+        relations.concat(signal_relations)
+        truncated["card_fingerprint"] = signal_truncated
+      else
+        truncated["card_fingerprint"] = false
+      end
+    end
+
+    Result.new(
+      signals_evaluated: evaluated,
+      per_signal_limit: @limit,
+      related_users: dedup_and_rank(relations),
+      truncated:
+    )
+  end
+
+  private
+    def target_ips
+      @target_ips ||= IP_COLUMNS.map { @target.public_send(_1) }.compact_blank.uniq
+    end
+
+    def target_ip_columns_by_value
+      @target_ip_columns_by_value ||= IP_COLUMNS.each_with_object(Hash.new { |hash, value| hash[value] = [] }) do |column, result|
+        value = @target.public_send(column)
+        result[value] << column.to_s if value.present?
+      end
+    end
+
+    def target_fingerprint
+      @target_fingerprint ||= @target.credit_card&.stripe_fingerprint
+    end
+
+    def ip_relations
+      return [[], false] if target_ips.empty?
+
+      rows = User
+        .where("account_created_ip IN (:ips) OR current_sign_in_ip IN (:ips) OR last_sign_in_ip IN (:ips)", ips: target_ips)
+        .where.not(id: @target.id)
+        .limit(@limit + 1)
+        .pluck(:id, :account_created_ip, :current_sign_in_ip, :last_sign_in_ip)
+
+      truncated = rows.length > @limit
+      grouped = rows.first(@limit).each_with_object({}) do |(user_id, account_created_ip, current_sign_in_ip, last_sign_in_ip), result|
+        candidate_values = {
+          "account_created_ip" => account_created_ip,
+          "current_sign_in_ip" => current_sign_in_ip,
+          "last_sign_in_ip" => last_sign_in_ip,
+        }
+
+        candidate_values.each do |column, value|
+          next unless target_ip_columns_by_value.key?(value)
+
+          relation = result[[user_id, value]] ||= Relation.new(user_id:, signal: "ip", shared_value: value, via: [])
+          relation.via.concat(target_ip_columns_by_value[value])
+          relation.via << column
+        end
+      end
+
+      [grouped.values.each { _1.via = _1.via.uniq.sort_by { |column| IP_COLUMNS.map(&:to_s).index(column) } }, truncated]
+    end
+
+    def payment_address_relations
+      ids = User
+        .where(payment_address: @target.payment_address)
+        .where.not(id: @target.id)
+        .limit(@limit + 1)
+        .pluck(:id)
+
+      [
+        ids.first(@limit).map { Relation.new(user_id: _1, signal: "payment_address", shared_value: @target.payment_address, via: nil) },
+        ids.length > @limit,
+      ]
+    end
+
+    def card_fingerprint_relations
+      ids = User
+        .joins(:credit_card)
+        .where(credit_cards: { stripe_fingerprint: target_fingerprint })
+        .where.not(id: @target.id)
+        .limit(@limit + 1)
+        .pluck(:id)
+
+      [
+        ids.first(@limit).map { Relation.new(user_id: _1, signal: "card_fingerprint", shared_value: nil, via: nil) },
+        ids.length > @limit,
+      ]
+    end
+
+    def dedup_and_rank(relations)
+      relations_by_user_id = relations.group_by(&:user_id)
+      return [] if relations_by_user_id.empty?
+
+      users_by_id = User.where(id: relations_by_user_id.keys).index_by(&:id)
+      last_status_changed_at_by_user_id = last_status_changed_at_by_user_id(users_by_id.keys)
+
+      users_by_id.values
+        .sort_by { |user| [-relations_by_user_id[user.id].map(&:signal).uniq.length, -user.updated_at.to_i, -user.id] }
+        .map do |user|
+          {
+            id: user.external_id,
+            email: user.email,
+            name: user.name,
+            deleted_at: user.deleted_at&.as_json,
+            risk_state: Admin::UserRiskStatePresenter.new(user, last_status_changed_at: last_status_changed_at_by_user_id[user.id]).props,
+            relations: relations_by_user_id[user.id].map { serialize_relation(_1) },
+          }
+        end
+    end
+
+    def last_status_changed_at_by_user_id(user_ids)
+      Comment
+        .where(
+          commentable_type: User.name,
+          commentable_id: user_ids,
+          comment_type: Admin::UserRiskStatePresenter::RISK_STATE_COMMENT_TYPES
+        )
+        .group(:commentable_id)
+        .maximum(:created_at)
+    end
+
+    def serialize_relation(relation)
+      {
+        signal: relation.signal,
+        shared_value: relation.shared_value,
+      }.tap do |payload|
+        payload[:via] = relation.via if relation.via.present?
+      end
+    end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -331,6 +331,7 @@ Rails.application.routes.draw do
               get :comments
               get :compliance_info
               get :purchases
+              get :related
               get :suspension
               post :reset_password
               post :update_email

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -1528,6 +1528,173 @@ describe Api::Internal::Admin::UsersController do
     include_examples "supports user lookup by user_id", :purchases, method: :get
   end
 
+  describe "GET related" do
+    include_examples "admin api authorization required", :get, :related
+
+    before { stub_const("GUMROAD_ADMIN_ID", admin_user.id) }
+
+    def credit_card_with_fingerprint(fingerprint)
+      CreditCard.create!(
+        stripe_fingerprint: fingerprint,
+        visual: "**** **** **** 4242",
+        card_type: CardType::VISA,
+        stripe_customer_id: "cus_#{SecureRandom.hex(6)}",
+        expiry_month: 12,
+        expiry_year: 2030,
+        charge_processor_id: StripeChargeProcessor.charge_processor_id
+      )
+    end
+
+    def related_user_payload(user)
+      response.parsed_body["related_users"].find { _1["id"] == user.external_id }
+    end
+
+    it "returns bad request when neither user_id nor email is provided" do
+      get :related
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "email or user_id is required" }.as_json)
+    end
+
+    it "returns not found when the user does not exist" do
+      get :related, params: { user_id: "missing" }
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
+    end
+
+    it "rejects unknown signal values" do
+      user = create(:user)
+
+      get :related, params: { user_id: user.external_id, signals: "ip,bogus" }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "signals contains invalid value: bogus" }.as_json)
+    end
+
+    it "returns the full default-signals response" do
+      target = create(:user,
+                      account_created_ip: "1.2.3.4",
+                      current_sign_in_ip: nil,
+                      last_sign_in_ip: nil,
+                      payment_address: "shared-payment@example.com",
+                      credit_card: credit_card_with_fingerprint("fp_shared"))
+      ip_match = create(:user, account_created_ip: "1.2.3.4", current_sign_in_ip: nil, last_sign_in_ip: nil, payment_address: nil)
+      payment_match = create(:user, account_created_ip: nil, current_sign_in_ip: nil, last_sign_in_ip: nil, payment_address: "shared-payment@example.com")
+      card_match = create(:user, account_created_ip: nil, current_sign_in_ip: nil, last_sign_in_ip: nil, payment_address: nil, credit_card: credit_card_with_fingerprint("fp_shared"))
+
+      get :related, params: { user_id: target.external_id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(
+        "success" => true,
+        "user_id" => target.external_id,
+        "signals_evaluated" => %w[ip payment_address card_fingerprint],
+        "per_signal_limit" => 50,
+        "truncated" => {
+          "ip" => false,
+          "payment_address" => false,
+          "card_fingerprint" => false,
+        }
+      )
+      expect(response.parsed_body["related_users"].map { _1["id"] }).to contain_exactly(ip_match.external_id, payment_match.external_id, card_match.external_id)
+      expect(related_user_payload(ip_match)["relations"]).to contain_exactly(
+        {
+          "signal" => "ip",
+          "shared_value" => "1.2.3.4",
+          "via" => ["account_created_ip"],
+        }
+      )
+      expect(related_user_payload(payment_match)["relations"]).to eq([
+                                                                       {
+                                                                         "signal" => "payment_address",
+                                                                         "shared_value" => "shared-payment@example.com",
+                                                                       }
+                                                                     ])
+      expect(related_user_payload(card_match)["relations"]).to eq([
+                                                                    {
+                                                                      "signal" => "card_fingerprint",
+                                                                      "shared_value" => nil,
+                                                                    }
+                                                                  ])
+    end
+
+    it "scopes related users to the requested signals" do
+      target = create(:user, account_created_ip: "1.2.3.4", current_sign_in_ip: nil, last_sign_in_ip: nil, payment_address: "shared-payment@example.com")
+      ip_match = create(:user, account_created_ip: "1.2.3.4", current_sign_in_ip: nil, last_sign_in_ip: nil, payment_address: nil)
+      payment_match = create(:user, account_created_ip: nil, current_sign_in_ip: nil, last_sign_in_ip: nil, payment_address: "shared-payment@example.com")
+
+      get :related, params: { user_id: target.external_id, signals: "ip" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["signals_evaluated"]).to eq(["ip"])
+      expect(response.parsed_body["related_users"].map { _1["id"] }).to eq([ip_match.external_id])
+      expect(response.parsed_body["related_users"].map { _1["id"] }).not_to include(payment_match.external_id)
+    end
+
+    it "applies the per-signal limit and reports truncation" do
+      target = create(:user, account_created_ip: "1.2.3.4", current_sign_in_ip: nil, last_sign_in_ip: nil, payment_address: nil)
+      create_list(:user, 3, account_created_ip: "1.2.3.4", current_sign_in_ip: nil, last_sign_in_ip: nil, payment_address: nil)
+
+      get :related, params: { user_id: target.external_id, signals: "ip", limit: 1 }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["per_signal_limit"]).to eq(1)
+      expect(response.parsed_body["related_users"].length).to eq(1)
+      expect(response.parsed_body["truncated"]).to eq("ip" => true)
+    end
+
+    it "includes each related user's risk state" do
+      target = create(:user, account_created_ip: "1.2.3.4", current_sign_in_ip: nil, last_sign_in_ip: nil, payment_address: nil)
+      related = create(:user, account_created_ip: "1.2.3.4", current_sign_in_ip: nil, last_sign_in_ip: nil, payment_address: nil, user_risk_state: "suspended_for_fraud")
+      create(:comment, commentable: related, comment_type: Comment::COMMENT_TYPE_SUSPENDED, created_at: 1.hour.ago)
+
+      get :related, params: { user_id: target.external_id, signals: "ip" }
+
+      expect(response).to have_http_status(:ok)
+      expect(related_user_payload(related)["risk_state"]).to eq(Admin::UserRiskStatePresenter.new(related).props.as_json)
+    end
+
+    it "keeps related user enrichment queries bounded" do
+      target = create(:user,
+                      account_created_ip: "1.2.3.4",
+                      current_sign_in_ip: nil,
+                      last_sign_in_ip: nil,
+                      payment_address: "shared-payment@example.com",
+                      credit_card: credit_card_with_fingerprint("fp_shared"))
+      5.times do
+        related = create(:user,
+                         account_created_ip: "1.2.3.4",
+                         current_sign_in_ip: nil,
+                         last_sign_in_ip: nil,
+                         payment_address: "shared-payment@example.com",
+                         credit_card: credit_card_with_fingerprint("fp_shared"))
+        create(:comment, commentable: related, comment_type: Comment::COMMENT_TYPE_SUSPENDED)
+      end
+
+      select_queries = []
+      counter = lambda do |*, payload|
+        sql = payload[:sql].to_s.squish
+        next if payload[:name] == "SCHEMA"
+        next unless sql.start_with?("SELECT")
+        next if sql.include?("`admin_api_tokens`")
+        next if sql.include?("`oauth_access_tokens`")
+
+        select_queries << sql
+      end
+
+      ActiveSupport::Notifications.subscribed(counter, "sql.active_record") do
+        get :related, params: { user_id: target.external_id }
+      end
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["related_users"].length).to eq(5)
+      expect(select_queries.length).to be <= 8, "expected at most 8 SELECTs but got #{select_queries.length}:\n#{select_queries.join("\n")}"
+    end
+
+    include_examples "supports user lookup by user_id", :related, method: :get
+  end
+
   describe "GET suspension" do
     include_examples "admin api authorization required", :get, :suspension
 

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -1572,6 +1572,15 @@ describe Api::Internal::Admin::UsersController do
       expect(response.parsed_body).to eq({ success: false, message: "signals contains invalid value: bogus" }.as_json)
     end
 
+    it "rejects a comma-only signals value" do
+      user = create(:user)
+
+      get :related, params: { user_id: user.external_id, signals: ",,," }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "signals contains invalid value: ,,," }.as_json)
+    end
+
     it "returns the full default-signals response" do
       target = create(:user,
                       account_created_ip: "1.2.3.4",

--- a/spec/services/admin/related_users_service_benchmark_spec.rb
+++ b/spec/services/admin/related_users_service_benchmark_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "benchmark"
+
+describe Admin::RelatedUsersService, :benchmark do
+  def credit_card_with_fingerprint(fingerprint)
+    CreditCard.create!(
+      stripe_fingerprint: fingerprint,
+      visual: "**** **** **** 4242",
+      card_type: CardType::VISA,
+      stripe_customer_id: "cus_#{SecureRandom.hex(6)}",
+      expiry_month: 12,
+      expiry_year: 2030,
+      charge_processor_id: StripeChargeProcessor.charge_processor_id
+    )
+  end
+
+  it "runs the related-users lookup under 500ms with realistic fan-out; run with bundle exec rspec --tag benchmark spec/services/admin/related_users_service_benchmark_spec.rb" do
+    target = create(:user,
+                    account_created_ip: "1.2.3.4",
+                    current_sign_in_ip: "5.6.7.8",
+                    last_sign_in_ip: nil,
+                    payment_address: "benchmark-payment@example.com",
+                    credit_card: credit_card_with_fingerprint("fp_benchmark"))
+
+    200.times do |index|
+      create(:user,
+             account_created_ip: "198.51.100.#{index % 250}",
+             current_sign_in_ip: nil,
+             last_sign_in_ip: nil,
+             payment_address: "unrelated-#{index}@example.com")
+    end
+
+    create_list(:user, 200, account_created_ip: "1.2.3.4", current_sign_in_ip: nil, last_sign_in_ip: nil, payment_address: nil)
+    create_list(:user, 200, account_created_ip: nil, current_sign_in_ip: nil, last_sign_in_ip: nil, payment_address: "benchmark-payment@example.com")
+
+    200.times do
+      create(:user,
+             account_created_ip: nil,
+             current_sign_in_ip: nil,
+             last_sign_in_ip: nil,
+             payment_address: nil,
+             credit_card: credit_card_with_fingerprint("fp_benchmark"))
+    end
+
+    described_class.new(target).call
+    duration = Benchmark.realtime { described_class.new(target).call }
+    RSpec.configuration.reporter.message("Related users benchmark: #{(duration * 1000).round(1)}ms")
+
+    expect(duration).to be < 0.5
+  end
+end

--- a/spec/services/admin/related_users_service_spec.rb
+++ b/spec/services/admin/related_users_service_spec.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Admin::RelatedUsersService do
+  def credit_card_with_fingerprint(fingerprint)
+    CreditCard.create!(
+      stripe_fingerprint: fingerprint,
+      visual: "**** **** **** 4242",
+      card_type: CardType::VISA,
+      stripe_customer_id: "cus_#{SecureRandom.hex(6)}",
+      expiry_month: 12,
+      expiry_year: 2030,
+      charge_processor_id: StripeChargeProcessor.charge_processor_id
+    )
+  end
+
+  def related_user_payload(result, user)
+    result.related_users.find { _1[:id] == user.external_id }
+  end
+
+  it "returns users sharing any target IP with the matching columns" do
+    target = create(:user, account_created_ip: nil, current_sign_in_ip: "1.2.3.4", last_sign_in_ip: nil, payment_address: nil)
+    created_ip_match = create(:user, account_created_ip: "1.2.3.4", current_sign_in_ip: nil, last_sign_in_ip: nil, payment_address: nil)
+    last_ip_match = create(:user, account_created_ip: nil, current_sign_in_ip: nil, last_sign_in_ip: "1.2.3.4", payment_address: nil)
+    create(:user, account_created_ip: nil, current_sign_in_ip: nil, last_sign_in_ip: "5.6.7.8", payment_address: nil)
+
+    result = described_class.new(target, signals: ["ip"]).call
+
+    expect(result.signals_evaluated).to eq(["ip"])
+    expect(result.related_users.map { _1[:id] }).to contain_exactly(created_ip_match.external_id, last_ip_match.external_id)
+    expect(related_user_payload(result, created_ip_match)[:relations]).to contain_exactly(
+      signal: "ip",
+      shared_value: "1.2.3.4",
+      via: ["account_created_ip", "current_sign_in_ip"]
+    )
+    expect(related_user_payload(result, last_ip_match)[:relations]).to contain_exactly(
+      signal: "ip",
+      shared_value: "1.2.3.4",
+      via: ["current_sign_in_ip", "last_sign_in_ip"]
+    )
+  end
+
+  it "aggregates IP via columns for a related user matching the same shared value multiple ways" do
+    target = create(:user, account_created_ip: "1.2.3.4", current_sign_in_ip: nil, last_sign_in_ip: nil, payment_address: nil)
+    related = create(:user, account_created_ip: "1.2.3.4", current_sign_in_ip: "1.2.3.4", last_sign_in_ip: nil, payment_address: nil)
+
+    result = described_class.new(target, signals: ["ip"]).call
+
+    expect(related_user_payload(result, related)[:relations]).to contain_exactly(
+      signal: "ip",
+      shared_value: "1.2.3.4",
+      via: ["account_created_ip", "current_sign_in_ip"]
+    )
+  end
+
+  it "returns users sharing the target payment address" do
+    target = create(:user, payment_address: "shared-payment@example.com")
+    related = create(:user, payment_address: "shared-payment@example.com")
+    create(:user, payment_address: "other-payment@example.com")
+
+    result = described_class.new(target, signals: ["payment_address"]).call
+
+    expect(result.signals_evaluated).to eq(["payment_address"])
+    expect(result.related_users.map { _1[:id] }).to eq([related.external_id])
+    expect(result.related_users.first[:relations]).to eq([
+                                                           {
+                                                             signal: "payment_address",
+                                                             shared_value: "shared-payment@example.com",
+                                                           }
+                                                         ])
+  end
+
+  it "skips payment address when the target has no payment address" do
+    target = create(:user, payment_address: nil)
+    create(:user, payment_address: nil)
+
+    result = described_class.new(target, signals: ["payment_address"]).call
+
+    expect(result.signals_evaluated).to eq([])
+    expect(result.related_users).to eq([])
+    expect(result.truncated).to eq("payment_address" => false)
+  end
+
+  it "returns users sharing the target card fingerprint without exposing the fingerprint value" do
+    target = create(:user, payment_address: nil, credit_card: credit_card_with_fingerprint("fp_shared"))
+    first_related = create(:user, payment_address: nil, credit_card: credit_card_with_fingerprint("fp_shared"))
+    second_related = create(:user, payment_address: nil, credit_card: credit_card_with_fingerprint("fp_shared"))
+    create(:user, payment_address: nil, credit_card: credit_card_with_fingerprint("fp_other"))
+
+    result = described_class.new(target, signals: ["card_fingerprint"]).call
+
+    expect(result.signals_evaluated).to eq(["card_fingerprint"])
+    expect(result.related_users.map { _1[:id] }).to contain_exactly(first_related.external_id, second_related.external_id)
+    expect(result.related_users.flat_map { _1[:relations] }).to all(eq(signal: "card_fingerprint", shared_value: nil))
+  end
+
+  it "skips card fingerprint when the target has no credit card" do
+    target = create(:user, payment_address: nil, credit_card: nil)
+
+    result = described_class.new(target, signals: ["card_fingerprint"]).call
+
+    expect(result.signals_evaluated).to eq([])
+    expect(result.related_users).to eq([])
+    expect(result.truncated).to eq("card_fingerprint" => false)
+  end
+
+  it "deduplicates by user and ranks users matching more distinct signals first" do
+    target = create(:user, account_created_ip: "1.2.3.4", current_sign_in_ip: nil, last_sign_in_ip: nil, payment_address: "shared@example.com")
+    multi_signal = create(:user, account_created_ip: "1.2.3.4", current_sign_in_ip: nil, last_sign_in_ip: nil, payment_address: "shared@example.com", updated_at: 2.days.ago)
+    single_signal = create(:user, account_created_ip: "1.2.3.4", current_sign_in_ip: nil, last_sign_in_ip: nil, payment_address: "other@example.com", updated_at: 1.hour.ago)
+
+    result = described_class.new(target, signals: %w[ip payment_address]).call
+
+    expect(result.related_users.map { _1[:id] }).to eq([multi_signal.external_id, single_signal.external_id])
+    expect(result.related_users.first[:relations].map { _1[:signal] }).to contain_exactly("ip", "payment_address")
+  end
+
+  it "caps each signal and reports truncation" do
+    target = create(:user, account_created_ip: "1.2.3.4", current_sign_in_ip: nil, last_sign_in_ip: nil, payment_address: nil)
+    create_list(:user, 3, account_created_ip: "1.2.3.4", current_sign_in_ip: nil, last_sign_in_ip: nil, payment_address: nil)
+
+    result = described_class.new(target, signals: ["ip"], limit: 2).call
+
+    expect(result.related_users.length).to eq(2)
+    expect(result.truncated).to eq("ip" => true)
+  end
+
+  it "excludes the target user from related users" do
+    target = create(:user, account_created_ip: "1.2.3.4", current_sign_in_ip: nil, last_sign_in_ip: nil, payment_address: "shared@example.com", credit_card: credit_card_with_fingerprint("fp_shared"))
+
+    result = described_class.new(target).call
+
+    expect(result.related_users).to eq([])
+  end
+
+  it "includes soft-deleted related users with deletion state exposed" do
+    target = create(:user, account_created_ip: "1.2.3.4", current_sign_in_ip: nil, last_sign_in_ip: nil, payment_address: nil)
+    deleted = create(:user, :deleted, account_created_ip: "1.2.3.4", current_sign_in_ip: nil, last_sign_in_ip: nil, payment_address: nil)
+
+    result = described_class.new(target, signals: ["ip"]).call
+
+    expect(related_user_payload(result, deleted)).to include(
+      id: deleted.external_id,
+      deleted_at: deleted.deleted_at.as_json
+    )
+  end
+
+  it "returns empty results when the target has no related signal values" do
+    target = create(:user, account_created_ip: nil, current_sign_in_ip: nil, last_sign_in_ip: nil, payment_address: nil, credit_card: nil)
+
+    result = described_class.new(target).call
+
+    expect(result.signals_evaluated).to eq([])
+    expect(result.related_users).to eq([])
+    expect(result.truncated).to eq(
+      "ip" => false,
+      "payment_address" => false,
+      "card_fingerprint" => false
+    )
+  end
+end

--- a/spec/services/admin/related_users_service_spec.rb
+++ b/spec/services/admin/related_users_service_spec.rb
@@ -116,14 +116,43 @@ describe Admin::RelatedUsersService do
     expect(result.related_users.first[:relations].map { _1[:signal] }).to contain_exactly("ip", "payment_address")
   end
 
-  it "caps each signal and reports truncation" do
+  it "caps the IP signal to the most recently updated matches and reports truncation" do
     target = create(:user, account_created_ip: "1.2.3.4", current_sign_in_ip: nil, last_sign_in_ip: nil, payment_address: nil)
-    create_list(:user, 3, account_created_ip: "1.2.3.4", current_sign_in_ip: nil, last_sign_in_ip: nil, payment_address: nil)
+    oldest = create(:user, account_created_ip: "1.2.3.4", current_sign_in_ip: nil, last_sign_in_ip: nil, payment_address: nil, updated_at: 3.days.ago)
+    middle = create(:user, account_created_ip: "1.2.3.4", current_sign_in_ip: nil, last_sign_in_ip: nil, payment_address: nil, updated_at: 2.days.ago)
+    newest = create(:user, account_created_ip: "1.2.3.4", current_sign_in_ip: nil, last_sign_in_ip: nil, payment_address: nil, updated_at: 1.day.ago)
 
     result = described_class.new(target, signals: ["ip"], limit: 2).call
 
-    expect(result.related_users.length).to eq(2)
+    expect(result.related_users.map { _1[:id] }).to eq([newest.external_id, middle.external_id])
+    expect(result.related_users.map { _1[:id] }).not_to include(oldest.external_id)
     expect(result.truncated).to eq("ip" => true)
+  end
+
+  it "caps the payment address signal to the most recently updated matches" do
+    target = create(:user, payment_address: "shared-payment@example.com")
+    oldest = create(:user, payment_address: "shared-payment@example.com", updated_at: 3.days.ago)
+    middle = create(:user, payment_address: "shared-payment@example.com", updated_at: 2.days.ago)
+    newest = create(:user, payment_address: "shared-payment@example.com", updated_at: 1.day.ago)
+
+    result = described_class.new(target, signals: ["payment_address"], limit: 2).call
+
+    expect(result.related_users.map { _1[:id] }).to eq([newest.external_id, middle.external_id])
+    expect(result.related_users.map { _1[:id] }).not_to include(oldest.external_id)
+    expect(result.truncated).to eq("payment_address" => true)
+  end
+
+  it "caps the card fingerprint signal to the most recently updated matches" do
+    target = create(:user, payment_address: nil, credit_card: credit_card_with_fingerprint("fp_shared"))
+    oldest = create(:user, payment_address: nil, credit_card: credit_card_with_fingerprint("fp_shared"), updated_at: 3.days.ago)
+    middle = create(:user, payment_address: nil, credit_card: credit_card_with_fingerprint("fp_shared"), updated_at: 2.days.ago)
+    newest = create(:user, payment_address: nil, credit_card: credit_card_with_fingerprint("fp_shared"), updated_at: 1.day.ago)
+
+    result = described_class.new(target, signals: ["card_fingerprint"], limit: 2).call
+
+    expect(result.related_users.map { _1[:id] }).to eq([newest.external_id, middle.external_id])
+    expect(result.related_users.map { _1[:id] }).not_to include(oldest.external_id)
+    expect(result.truncated).to eq("card_fingerprint" => true)
   end
 
   it "excludes the target user from related users" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -205,6 +205,7 @@ RSpec.configure do |config|
   config.raise_errors_for_deprecations!
   config.use_transactional_fixtures = true
   config.filter_run_when_matching :focus
+  config.filter_run_excluding benchmark: true unless config.inclusion_filter.rules.key?(:benchmark)
   config.example_status_persistence_file_path = Rails.root.join("tmp", "rspec_status.txt").to_s
   config.include ActiveSupport::Testing::TimeHelpers
 


### PR DESCRIPTION
Ref #4989

## What
- Adds `GET /internal/admin/users/related` so admins can find users linked by shared IP, payment address, or card fingerprint.
- Returns a deduplicated, ranked list with per-signal relation details, truncation flags, and inline risk state.
- Keeps the response capped per signal and skips signals that do not apply to the target user.

## Why
- This gives investigators a single read path for the most common related-user checks without adding schema changes.
- The endpoint is built around indexed lookups and explicit caps so it stays fast and predictable under fan-out.

---

This PR was implemented with AI assistance using gpt‑5.5 xhigh.