### PR TITLE
Fix spurious Stripe compliance pushes on payments saves

### DIFF
--- a/app/services/update_user_compliance_info.rb
+++ b/app/services/update_user_compliance_info.rb
@@ -74,7 +74,10 @@ class UpdateUserComplianceInfo
       old_compliance_info = current_compliance_info
       compliance_info_changed = compliance_info_changed?(old_compliance_info)
       old_compliance_info.reload if old_compliance_info.persisted? && encrypted_compliance_info_params_present?
-      return { success: true } unless compliance_info_changed
+      unless compliance_info_changed
+        UserComplianceInfoRequest.handle_new_user_compliance_info(old_compliance_info)
+        return { success: true }
+      end
 
       saved, new_compliance_info = if encrypted_compliance_info_params_present?
         dup_and_save_compliance_info(old_compliance_info)

--- a/app/services/update_user_compliance_info.rb
+++ b/app/services/update_user_compliance_info.rb
@@ -23,6 +23,42 @@ class UpdateUserComplianceInfo
     ssn_last_four: "Individual tax id",
     business_tax_id: "Business tax id",
   }.freeze
+  SIMPLE_COMPLIANCE_INFO_FIELDS = %i[
+    first_name
+    last_name
+    first_name_kanji
+    last_name_kanji
+    first_name_kana
+    last_name_kana
+    street_address
+    building_number
+    building_number_kana
+    street_address_kanji
+    street_address_kana
+    city
+    state
+    country
+    zip_code
+    business_name
+    business_name_kanji
+    business_name_kana
+    business_street_address
+    business_building_number
+    business_building_number_kana
+    business_street_address_kanji
+    business_street_address_kana
+    business_city
+    business_state
+    business_country
+    business_zip_code
+    business_type
+    phone
+    business_phone
+    job_title
+    nationality
+    business_vat_id_number
+  ].freeze
+  ENCRYPTED_COMPLIANCE_INFO_FIELDS = %i[individual_tax_id business_tax_id].freeze
 
   def process
     if compliance_params.present?
@@ -38,49 +74,16 @@ class UpdateUserComplianceInfo
       end
 
       old_compliance_info = current_compliance_info
-      saved, new_compliance_info = old_compliance_info.dup_and_save do |new_compliance_info|
-        # if the following fields are submitted and are blank, we don't clear the field for the user
-        new_compliance_info.first_name =              compliance_params[:first_name]              if compliance_params[:first_name].present?
-        new_compliance_info.last_name =               compliance_params[:last_name]               if compliance_params[:last_name].present?
-        new_compliance_info.first_name_kanji =        compliance_params[:first_name_kanji]        if compliance_params[:first_name_kanji].present?
-        new_compliance_info.last_name_kanji =         compliance_params[:last_name_kanji]         if compliance_params[:last_name_kanji].present?
-        new_compliance_info.first_name_kana =         compliance_params[:first_name_kana]         if compliance_params[:first_name_kana].present?
-        new_compliance_info.last_name_kana =          compliance_params[:last_name_kana]          if compliance_params[:last_name_kana].present?
-        new_compliance_info.street_address =          compliance_params[:street_address]          if compliance_params[:street_address].present?
-        new_compliance_info.building_number =         compliance_params[:building_number]         if compliance_params[:building_number].present?
-        new_compliance_info.building_number_kana =    compliance_params[:building_number_kana]    if compliance_params[:building_number_kana].present?
-        new_compliance_info.street_address_kanji =    compliance_params[:street_address_kanji]    if compliance_params[:street_address_kanji].present?
-        new_compliance_info.street_address_kana =     compliance_params[:street_address_kana]     if compliance_params[:street_address_kana].present?
-        new_compliance_info.city =                    compliance_params[:city]                    if compliance_params[:city].present?
-        new_compliance_info.state =                   compliance_params[:state]                   if compliance_params[:state].present?
-        new_compliance_info.country =                 Compliance::Countries.mapping[compliance_params[:country]] if compliance_params[:country].present? && compliance_params[:is_business]
-        new_compliance_info.zip_code =                compliance_params[:zip_code]                if compliance_params[:zip_code].present?
-        new_compliance_info.business_name =           compliance_params[:business_name]           if compliance_params[:business_name].present?
-        new_compliance_info.business_name_kanji =     compliance_params[:business_name_kanji]     if compliance_params[:business_name_kanji].present?
-        new_compliance_info.business_name_kana =      compliance_params[:business_name_kana]      if compliance_params[:business_name_kana].present?
-        new_compliance_info.business_street_address = compliance_params[:business_street_address] if compliance_params[:business_street_address].present?
-        new_compliance_info.business_building_number =      compliance_params[:business_building_number]      if compliance_params[:business_building_number].present?
-        new_compliance_info.business_building_number_kana = compliance_params[:business_building_number_kana] if compliance_params[:business_building_number_kana].present?
-        new_compliance_info.business_street_address_kanji = compliance_params[:business_street_address_kanji] if compliance_params[:business_street_address_kanji].present?
-        new_compliance_info.business_street_address_kana =  compliance_params[:business_street_address_kana]  if compliance_params[:business_street_address_kana].present?
-        new_compliance_info.business_city =           compliance_params[:business_city]           if compliance_params[:business_city].present?
-        new_compliance_info.business_state =          compliance_params[:business_state]          if compliance_params[:business_state].present?
-        new_compliance_info.business_country =        Compliance::Countries.mapping[compliance_params[:business_country]] if compliance_params[:business_country].present? && compliance_params[:is_business]
-        new_compliance_info.business_zip_code =       compliance_params[:business_zip_code]       if compliance_params[:business_zip_code].present?
-        new_compliance_info.business_type =           compliance_params[:business_type]           if compliance_params[:business_type].present?
-        new_compliance_info.is_business =             compliance_params[:is_business]             unless compliance_params[:is_business].nil?
-        new_compliance_info.individual_tax_id =       compliance_params[:ssn_last_four]           if compliance_params[:ssn_last_four].present?
-        new_compliance_info.individual_tax_id =       compliance_params[:individual_tax_id]       if compliance_params[:individual_tax_id].present?
-        if compliance_params[:business_tax_id].present?
-          new_compliance_info.business_tax_id = compliance_params[:business_tax_id].gsub(/\D/, "")
+      compliance_info_changed = compliance_info_changed?(old_compliance_info)
+      old_compliance_info.reload if old_compliance_info.persisted? && encrypted_compliance_info_params_present?
+      return { success: true } unless compliance_info_changed
+
+      saved, new_compliance_info = if encrypted_compliance_info_params_present?
+        dup_and_save_compliance_info(old_compliance_info)
+      else
+        old_compliance_info.dup_and_save do |new_compliance_info|
+          assign_compliance_params(new_compliance_info)
         end
-        new_compliance_info.birthday = Date.new(compliance_params[:dob_year].to_i, compliance_params[:dob_month].to_i, compliance_params[:dob_day].to_i) if compliance_params[:dob_year].present? && compliance_params[:dob_year].to_i > 0
-        new_compliance_info.skip_stripe_job_on_create = true
-        new_compliance_info.phone =                   compliance_params[:phone]                   if compliance_params[:phone].present?
-        new_compliance_info.business_phone =          compliance_params[:business_phone]          if compliance_params[:business_phone].present?
-        new_compliance_info.job_title =               compliance_params[:job_title]               if compliance_params[:job_title].present?
-        new_compliance_info.nationality =             compliance_params[:nationality]             if compliance_params[:nationality].present?
-        new_compliance_info.business_vat_id_number =  compliance_params[:business_vat_id_number]  if compliance_params[:business_vat_id_number].present?
       end
 
       return { success: false, error_message: new_compliance_info.errors.full_messages.to_sentence } unless saved
@@ -105,6 +108,133 @@ class UpdateUserComplianceInfo
   end
 
   private
+    def assign_compliance_params(new_compliance_info)
+      new_compliance_info.first_name =              compliance_params[:first_name]              if compliance_params[:first_name].present?
+      new_compliance_info.last_name =               compliance_params[:last_name]               if compliance_params[:last_name].present?
+      new_compliance_info.first_name_kanji =        compliance_params[:first_name_kanji]        if compliance_params[:first_name_kanji].present?
+      new_compliance_info.last_name_kanji =         compliance_params[:last_name_kanji]         if compliance_params[:last_name_kanji].present?
+      new_compliance_info.first_name_kana =         compliance_params[:first_name_kana]         if compliance_params[:first_name_kana].present?
+      new_compliance_info.last_name_kana =          compliance_params[:last_name_kana]          if compliance_params[:last_name_kana].present?
+      new_compliance_info.street_address =          compliance_params[:street_address]          if compliance_params[:street_address].present?
+      new_compliance_info.building_number =         compliance_params[:building_number]         if compliance_params[:building_number].present?
+      new_compliance_info.building_number_kana =    compliance_params[:building_number_kana]    if compliance_params[:building_number_kana].present?
+      new_compliance_info.street_address_kanji =    compliance_params[:street_address_kanji]    if compliance_params[:street_address_kanji].present?
+      new_compliance_info.street_address_kana =     compliance_params[:street_address_kana]     if compliance_params[:street_address_kana].present?
+      new_compliance_info.city =                    compliance_params[:city]                    if compliance_params[:city].present?
+      new_compliance_info.state =                   compliance_params[:state]                   if compliance_params[:state].present?
+      new_compliance_info.country =                 Compliance::Countries.mapping[compliance_params[:country]] if compliance_params[:country].present? && compliance_params[:is_business]
+      new_compliance_info.zip_code =                compliance_params[:zip_code]                if compliance_params[:zip_code].present?
+      new_compliance_info.business_name =           compliance_params[:business_name]           if compliance_params[:business_name].present?
+      new_compliance_info.business_name_kanji =     compliance_params[:business_name_kanji]     if compliance_params[:business_name_kanji].present?
+      new_compliance_info.business_name_kana =      compliance_params[:business_name_kana]      if compliance_params[:business_name_kana].present?
+      new_compliance_info.business_street_address = compliance_params[:business_street_address] if compliance_params[:business_street_address].present?
+      new_compliance_info.business_building_number =      compliance_params[:business_building_number]      if compliance_params[:business_building_number].present?
+      new_compliance_info.business_building_number_kana = compliance_params[:business_building_number_kana] if compliance_params[:business_building_number_kana].present?
+      new_compliance_info.business_street_address_kanji = compliance_params[:business_street_address_kanji] if compliance_params[:business_street_address_kanji].present?
+      new_compliance_info.business_street_address_kana =  compliance_params[:business_street_address_kana]  if compliance_params[:business_street_address_kana].present?
+      new_compliance_info.business_city =           compliance_params[:business_city]           if compliance_params[:business_city].present?
+      new_compliance_info.business_state =          compliance_params[:business_state]          if compliance_params[:business_state].present?
+      new_compliance_info.business_country =        Compliance::Countries.mapping[compliance_params[:business_country]] if compliance_params[:business_country].present? && compliance_params[:is_business]
+      new_compliance_info.business_zip_code =       compliance_params[:business_zip_code]       if compliance_params[:business_zip_code].present?
+      new_compliance_info.business_type =           compliance_params[:business_type]           if compliance_params[:business_type].present?
+      new_compliance_info.is_business =             compliance_params[:is_business]             unless compliance_params[:is_business].nil?
+      new_compliance_info.individual_tax_id =       compliance_params[:ssn_last_four]           if compliance_params[:ssn_last_four].present?
+      new_compliance_info.individual_tax_id =       compliance_params[:individual_tax_id]       if compliance_params[:individual_tax_id].present?
+      if compliance_params[:business_tax_id].present?
+        new_compliance_info.business_tax_id = compliance_params[:business_tax_id].gsub(/\D/, "")
+      end
+      new_compliance_info.birthday = Date.new(compliance_params[:dob_year].to_i, compliance_params[:dob_month].to_i, compliance_params[:dob_day].to_i) if compliance_params[:dob_year].present? && compliance_params[:dob_year].to_i > 0
+      new_compliance_info.skip_stripe_job_on_create = true
+      new_compliance_info.phone =                   compliance_params[:phone]                   if compliance_params[:phone].present?
+      new_compliance_info.business_phone =          compliance_params[:business_phone]          if compliance_params[:business_phone].present?
+      new_compliance_info.job_title =               compliance_params[:job_title]               if compliance_params[:job_title].present?
+      new_compliance_info.nationality =             compliance_params[:nationality]             if compliance_params[:nationality].present?
+      new_compliance_info.business_vat_id_number =  compliance_params[:business_vat_id_number]  if compliance_params[:business_vat_id_number].present?
+    end
+
+    def dup_and_save_compliance_info(old_compliance_info)
+      new_compliance_info = build_compliance_info_copy(old_compliance_info)
+      saved = nil
+
+      ActiveRecord::Base.transaction do
+        assign_compliance_params(new_compliance_info)
+        saved = old_compliance_info.mark_deleted(validate: false)
+        raise ActiveRecord::Rollback unless saved
+        saved = new_compliance_info.save
+        raise ActiveRecord::Rollback unless saved
+      end
+
+      [saved, new_compliance_info]
+    end
+
+    def build_compliance_info_copy(old_compliance_info)
+      new_compliance_info = old_compliance_info.class.new(
+        old_compliance_info.attributes.except("id", "created_at", "updated_at", "deleted_at", *ENCRYPTED_COMPLIANCE_INFO_FIELDS.map(&:to_s))
+      )
+      ENCRYPTED_COMPLIANCE_INFO_FIELDS.each do |field|
+        value = encrypted_compliance_info_value(old_compliance_info, field)
+        new_compliance_info.public_send("#{field}=", value) if value.present?
+      end
+      new_compliance_info
+    end
+
+    def compliance_info_changed?(old_compliance_info)
+      simple_compliance_info_changed?(old_compliance_info) ||
+        country_changed?(old_compliance_info, :country) ||
+        country_changed?(old_compliance_info, :business_country) ||
+        business_mode_param_changed?(old_compliance_info) ||
+        birthday_changed?(old_compliance_info) ||
+        encrypted_compliance_info_changed?(old_compliance_info)
+    end
+
+    def simple_compliance_info_changed?(old_compliance_info)
+      SIMPLE_COMPLIANCE_INFO_FIELDS.any? do |field|
+        compliance_params[field].present? && compliance_info_value(old_compliance_info, field) != compliance_params[field]
+      end
+    end
+
+    def country_changed?(old_compliance_info, field)
+      compliance_params[field].present? &&
+        compliance_params[:is_business] &&
+        compliance_info_value(old_compliance_info, field) != Compliance::Countries.mapping[compliance_params[field]]
+    end
+
+    def business_mode_param_changed?(old_compliance_info)
+      !compliance_params[:is_business].nil? &&
+        old_compliance_info.is_business != ActiveModel::Type::Boolean.new.cast(compliance_params[:is_business])
+    end
+
+    def birthday_changed?(old_compliance_info)
+      compliance_params[:dob_year].present? &&
+        compliance_params[:dob_year].to_i > 0 &&
+        old_compliance_info.birthday != Date.new(compliance_params[:dob_year].to_i, compliance_params[:dob_month].to_i, compliance_params[:dob_day].to_i)
+    end
+
+    def compliance_info_value(compliance_info, field)
+      compliance_info.public_send(field)
+    end
+
+    def encrypted_compliance_info_changed?(old_compliance_info)
+      submitted_individual_tax_id = compliance_params[:individual_tax_id].presence || compliance_params[:ssn_last_four].presence
+      return true if submitted_individual_tax_id.present? && encrypted_compliance_info_value(old_compliance_info, :individual_tax_id) != submitted_individual_tax_id
+
+      submitted_business_tax_id = compliance_params[:business_tax_id].presence&.gsub(/\D/, "")
+      return true if submitted_business_tax_id.present? && encrypted_compliance_info_value(old_compliance_info, :business_tax_id) != submitted_business_tax_id
+
+      false
+    end
+
+    def encrypted_compliance_info_params_present?
+      compliance_params[:individual_tax_id].present? || compliance_params[:ssn_last_four].present? || compliance_params[:business_tax_id].present?
+    end
+
+    def encrypted_compliance_info_value(compliance_info, field)
+      value = compliance_info.public_send(field)
+      return value.decrypt(GlobalConfig.get("STRONGBOX_GENERAL_PASSWORD")) if ENCRYPTED_COMPLIANCE_INFO_FIELDS.include?(field) && value.is_a?(Strongbox::Lock)
+
+      value
+    end
+
     def po_box_error_message
       ADDRESS_FIELDS_AND_COUNTRY_FALLBACKS.each_key do |address_field|
         next unless should_validate_po_box_for?(address_field)

--- a/app/services/update_user_compliance_info.rb
+++ b/app/services/update_user_compliance_info.rb
@@ -37,7 +37,6 @@ class UpdateUserComplianceInfo
     street_address_kana
     city
     state
-    country
     zip_code
     business_name
     business_name_kanji
@@ -49,7 +48,6 @@ class UpdateUserComplianceInfo
     business_street_address_kana
     business_city
     business_state
-    business_country
     business_zip_code
     business_type
     phone
@@ -195,8 +193,12 @@ class UpdateUserComplianceInfo
 
     def country_changed?(old_compliance_info, field)
       compliance_params[field].present? &&
-        compliance_params[:is_business] &&
+        country_param_will_be_persisted? &&
         compliance_info_value(old_compliance_info, field) != Compliance::Countries.mapping[compliance_params[field]]
+    end
+
+    def country_param_will_be_persisted?
+      !compliance_params[:is_business].nil? && ActiveModel::Type::Boolean.new.cast(compliance_params[:is_business])
     end
 
     def business_mode_param_changed?(old_compliance_info)

--- a/spec/controllers/settings/payments_controller_spec.rb
+++ b/spec/controllers/settings/payments_controller_spec.rb
@@ -282,6 +282,10 @@ describe Settings::PaymentsController, :vcr, type: :controller, inertia: true do
         expect(StripeMerchantAccountManager).not_to have_received(:handle_new_user_compliance_info)
         expect(UserComplianceInfo.count).to eq(initial_compliance_info_count)
         expect(user.reload.alive_user_compliance_info.id).to eq(initial_compliance_info_id)
+        expect(request_1.reload.state).to eq("provided")
+        expect(request_2.reload.state).to eq("requested")
+        expect(request_3.reload.state).to eq("provided")
+        expect(request_4.reload.state).to eq("requested")
         expect(response).to redirect_to(settings_payments_path)
         expect(response).to have_http_status :see_other
       end

--- a/spec/controllers/settings/payments_controller_spec.rb
+++ b/spec/controllers/settings/payments_controller_spec.rb
@@ -204,6 +204,30 @@ describe Settings::PaymentsController, :vcr, type: :controller, inertia: true do
     end
 
     describe "minimum payout threshold" do
+      def create_current_compliance_info_matching_form_params
+        create(
+          :user_compliance_info_empty,
+          user:,
+          first_name: params[:first_name],
+          last_name: params[:last_name],
+          street_address: params[:street_address],
+          city: params[:city],
+          state: params[:state],
+          zip_code: params[:zip_code],
+          country: "United States",
+          is_business: false,
+          individual_tax_id: params[:ssn_last_four],
+          birthday: Date.new(params[:dob_year].to_i, params[:dob_month].to_i, params[:dob_day].to_i),
+          phone: params[:phone],
+        )
+      end
+
+      def enqueue_identity_verification_email_if_compliance_info_is_submitted
+        allow(StripeMerchantAccountManager).to receive(:handle_new_user_compliance_info) do
+          ContactingCreatorMailer.stripe_identity_verification_failed(user.id, "Identity verification failed").deliver_later(queue: "critical")
+        end
+      end
+
       it "updates the payout threshold for valid amounts" do
         expect do
           put :update, params: { payout_threshold_cents: 20_000 }
@@ -221,6 +245,41 @@ describe Settings::PaymentsController, :vcr, type: :controller, inertia: true do
         expect(response).to have_http_status :found
         expect(session[:inertia_errors][:base]).to include("Your payout threshold must be greater than the minimum payout amount")
         expect(user.reload.payout_threshold_cents).to eq(Payouts::MIN_AMOUNT_CENTS)
+      end
+
+      it "does not resubmit unchanged compliance info when only the payout threshold changed" do
+        create_current_compliance_info_matching_form_params
+        enqueue_identity_verification_email_if_compliance_info_is_submitted
+        initial_compliance_info_id = user.alive_user_compliance_info.id
+        initial_compliance_info_count = UserComplianceInfo.count
+
+        expect do
+          put :update, params: { user: params, payout_threshold_cents: 20_000 }
+        end.not_to have_enqueued_mail(ContactingCreatorMailer, :stripe_identity_verification_failed)
+
+        expect(StripeMerchantAccountManager).not_to have_received(:handle_new_user_compliance_info)
+        expect(UserComplianceInfo.count).to eq(initial_compliance_info_count)
+        expect(user.reload.alive_user_compliance_info.id).to eq(initial_compliance_info_id)
+        expect(user.payout_threshold_cents.to_i).to eq(20_000)
+        expect(response).to redirect_to(settings_payments_path)
+        expect(response).to have_http_status :see_other
+      end
+
+      it "does not resubmit identical compliance info" do
+        create_current_compliance_info_matching_form_params
+        enqueue_identity_verification_email_if_compliance_info_is_submitted
+        initial_compliance_info_id = user.alive_user_compliance_info.id
+        initial_compliance_info_count = UserComplianceInfo.count
+
+        expect do
+          put :update, params: { user: params }
+        end.not_to have_enqueued_mail(ContactingCreatorMailer, :stripe_identity_verification_failed)
+
+        expect(StripeMerchantAccountManager).not_to have_received(:handle_new_user_compliance_info)
+        expect(UserComplianceInfo.count).to eq(initial_compliance_info_count)
+        expect(user.reload.alive_user_compliance_info.id).to eq(initial_compliance_info_id)
+        expect(response).to redirect_to(settings_payments_path)
+        expect(response).to have_http_status :see_other
       end
     end
 

--- a/spec/controllers/settings/payments_controller_spec.rb
+++ b/spec/controllers/settings/payments_controller_spec.rb
@@ -228,6 +228,10 @@ describe Settings::PaymentsController, :vcr, type: :controller, inertia: true do
         end
       end
 
+      def payment_form_params
+        params.merge(country: "US", business_country: "US")
+      end
+
       it "updates the payout threshold for valid amounts" do
         expect do
           put :update, params: { payout_threshold_cents: 20_000 }
@@ -254,7 +258,7 @@ describe Settings::PaymentsController, :vcr, type: :controller, inertia: true do
         initial_compliance_info_count = UserComplianceInfo.count
 
         expect do
-          put :update, params: { user: params, payout_threshold_cents: 20_000 }
+          put :update, params: { user: payment_form_params, payout_threshold_cents: 20_000 }
         end.not_to have_enqueued_mail(ContactingCreatorMailer, :stripe_identity_verification_failed)
 
         expect(StripeMerchantAccountManager).not_to have_received(:handle_new_user_compliance_info)
@@ -272,7 +276,7 @@ describe Settings::PaymentsController, :vcr, type: :controller, inertia: true do
         initial_compliance_info_count = UserComplianceInfo.count
 
         expect do
-          put :update, params: { user: params }
+          put :update, params: { user: payment_form_params }
         end.not_to have_enqueued_mail(ContactingCreatorMailer, :stripe_identity_verification_failed)
 
         expect(StripeMerchantAccountManager).not_to have_received(:handle_new_user_compliance_info)

--- a/spec/services/update_user_compliance_info_spec.rb
+++ b/spec/services/update_user_compliance_info_spec.rb
@@ -57,6 +57,7 @@ describe UpdateUserComplianceInfo do
       let!(:compliance_info) { create(:user_compliance_info, user:) }
 
       it "returns success without creating a new compliance info row or submitting it to Stripe" do
+        request = create(:user_compliance_info_request, user:, field_needed: UserComplianceInfoFields::Individual::Address::STREET)
         params = ActionController::Parameters.new(
           first_name: compliance_info.first_name,
           last_name: compliance_info.last_name,
@@ -83,6 +84,7 @@ describe UpdateUserComplianceInfo do
 
         expect(result[:success]).to be true
         expect(user.reload.alive_user_compliance_info.id).to eq(compliance_info.id)
+        expect(request.reload.state).to eq("provided")
       end
     end
 

--- a/spec/services/update_user_compliance_info_spec.rb
+++ b/spec/services/update_user_compliance_info_spec.rb
@@ -64,6 +64,8 @@ describe UpdateUserComplianceInfo do
           city: compliance_info.city,
           state: compliance_info.state,
           zip_code: compliance_info.zip_code,
+          country: compliance_info.country_code,
+          business_country: compliance_info.country_code,
           is_business: false,
           ssn_last_four: "000000000",
           dob_month: compliance_info.birthday.month.to_s,

--- a/spec/services/update_user_compliance_info_spec.rb
+++ b/spec/services/update_user_compliance_info_spec.rb
@@ -53,6 +53,58 @@ describe UpdateUserComplianceInfo do
       end
     end
 
+    context "when submitted compliance values match the current compliance info" do
+      let!(:compliance_info) { create(:user_compliance_info, user:) }
+
+      it "returns success without creating a new compliance info row or submitting it to Stripe" do
+        params = ActionController::Parameters.new(
+          first_name: compliance_info.first_name,
+          last_name: compliance_info.last_name,
+          street_address: compliance_info.street_address,
+          city: compliance_info.city,
+          state: compliance_info.state,
+          zip_code: compliance_info.zip_code,
+          is_business: false,
+          ssn_last_four: "000000000",
+          dob_month: compliance_info.birthday.month.to_s,
+          dob_day: compliance_info.birthday.day.to_s,
+          dob_year: compliance_info.birthday.year.to_s,
+          phone: compliance_info.phone,
+        )
+
+        expect(StripeMerchantAccountManager).not_to receive(:handle_new_user_compliance_info)
+
+        result = nil
+        expect do
+          result = described_class.new(compliance_params: params, user: user).process
+        end.not_to change { UserComplianceInfo.count }
+
+        expect(result[:success]).to be true
+        expect(user.reload.alive_user_compliance_info.id).to eq(compliance_info.id)
+      end
+    end
+
+    context "when submitted compliance values change the current compliance info" do
+      let!(:compliance_info) { create(:user_compliance_info, user:) }
+
+      it "creates a new compliance info row and submits it to Stripe" do
+        params = ActionController::Parameters.new(first_name: "Morgan")
+
+        expect(StripeMerchantAccountManager).to receive(:handle_new_user_compliance_info) do |new_compliance_info|
+          expect(new_compliance_info.first_name).to eq("Morgan")
+        end
+
+        result = nil
+        expect do
+          result = described_class.new(compliance_params: params, user: user).process
+        end.to change { UserComplianceInfo.count }.by(1)
+
+        expect(result[:success]).to be true
+        expect(user.reload.alive_user_compliance_info.first_name).to eq("Morgan")
+        expect(user.alive_user_compliance_info.id).not_to eq(compliance_info.id)
+      end
+    end
+
     context "with a US business that already has a 9-digit business_tax_id saved" do
       let(:us_business_user) do
         create(:user).tap { |u| create(:user_compliance_info_business, user: u) }


### PR DESCRIPTION
## What
- Stop `/settings/payments` saves from resubmitting compliance info to Stripe when the submitted values do not actually change.
- Keep real compliance edits on the existing update path, including encrypted tax ID updates.
- Add regression coverage for no-op saves and real compliance changes.

## Why
- Users were triggering unnecessary Stripe identity checks just by saving unrelated payments settings, which could generate avoidable verification-failed emails.
- Skipping the Stripe call on no-op compliance submissions removes that failure mode without loosening the validation for real edits.

---

This PR was implemented with AI assistance using gpt‑5.5 xhigh and Claude Opus 4.7.