### PR TITLE
Run Price Checker backfill durably in Sidekiq with tuned throughput

### DIFF
--- a/app/services/onetime/backfill_price_checker_index_fields.rb
+++ b/app/services/onetime/backfill_price_checker_index_fields.rb
@@ -2,8 +2,9 @@
 
 module Onetime
   class BackfillPriceCheckerIndexFields
-    SCROLL_SIZE = 1_000
+    SCROLL_SIZE = 5_000
     SCROLL_SORT = ["_doc"].freeze
+    JOB_INTERVAL_SECONDS = 10
     ATTRIBUTES_TO_UPDATE = %w[price_currency_type customizable_price native_type].freeze
 
     def self.process
@@ -20,7 +21,7 @@ module Onetime
         _source: false,
       )
 
-      minute_offset = 0
+      seconds_offset = 0
       loop do
         hits = response.dig("hits", "hits") || []
         break if hits.empty?
@@ -30,9 +31,9 @@ module Onetime
           "class" => SendToElasticsearchWorker,
           "args" => args,
           "queue" => "low",
-          "at" => minute_offset.minutes.from_now.to_i,
+          "at" => seconds_offset.seconds.from_now.to_i,
         )
-        minute_offset += 1
+        seconds_offset += JOB_INTERVAL_SECONDS
 
         response = EsClient.scroll(scroll_id: response["_scroll_id"], scroll: "1m")
       end

--- a/app/sidekiq/backfill_price_checker_index_fields_job.rb
+++ b/app/sidekiq/backfill_price_checker_index_fields_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class BackfillPriceCheckerIndexFieldsJob
+  include Sidekiq::Job
+  sidekiq_options retry: 0, queue: :low, lock: :until_executed
+
+  def perform
+    Onetime::BackfillPriceCheckerIndexFields.process
+  end
+end

--- a/spec/sidekiq/backfill_price_checker_index_fields_job_spec.rb
+++ b/spec/sidekiq/backfill_price_checker_index_fields_job_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe BackfillPriceCheckerIndexFieldsJob do
+  it "delegates to Onetime::BackfillPriceCheckerIndexFields.process" do
+    expect(Onetime::BackfillPriceCheckerIndexFields).to receive(:process)
+    described_class.new.perform
+  end
+end


### PR DESCRIPTION
Follow-up to #4945.

## What

Two changes to the Price Checker backfill that shipped in #4945:

- Wraps `Onetime::BackfillPriceCheckerIndexFields.process` in a new `BackfillPriceCheckerIndexFieldsJob` (`queue: :low`, `retry: 0`, `lock: :until_executed`). Operators kick off the backfill with `BackfillPriceCheckerIndexFieldsJob.perform_async` — no live Rails console needed, no risk of accidental double-runs.
- Tunes the scroll loop: scroll batch 1000 → 5000, stagger 1 minute → 10 seconds (new `JOB_INTERVAL_SECONDS` constant). Scheduled-job rate moves from 16.67/sec to 500/sec; the enqueue tail drops from ~8.6 days to ~7 hours.

## Why

The merged backfill schedules `SendToElasticsearchWorker` jobs spread across 8.6 days of `at:` offsets and depends on the operator's SSH session staying alive for the full enqueue loop. Any disconnect drops the remaining work; re-running starts over from the top, so partial duplicates pile up in Redis.

Wrapping it in a Sidekiq job moves durability to Sidekiq itself. One fire-and-forget call instead of a long console session. The unique-jobs lock prevents accidental concurrent runs.

The throughput tune lands on 500/sec. Workers process `low` behind `critical` and `default` per [docker/web/sidekiq_worker.sh](docker/web/sidekiq_worker.sh), so realistic drain is in the low hundreds/sec. Pushing the scheduled rate past that just inflates the Redis scheduled set without speeding total completion. 500/sec is the breathing-room upper bound — same total wall-clock as 1000/sec would give, with ~half the peak Redis memory.

Considered a more invasive alternative: iterating MySQL with `find_in_batches` and writing ES via `_bulk` directly, skipping Sidekiq entirely. It would be faster (~1.7 hours) but bypasses `ProductIndexingService`, the canonical indexing path.

---

This PR was implemented with AI assistance using Claude Opus 4.7.