### PR TITLE
Improve Stripe verification failure emails for clarity and trust

### DIFF
--- a/app/mailers/contacting_creator_mailer.rb
+++ b/app/mailers/contacting_creator_mailer.rb
@@ -348,14 +348,14 @@ class ContactingCreatorMailer < ApplicationMailer
   def stripe_document_verification_failed(user_id, error_message)
     @seller = User.find(user_id)
     return do_not_send unless @seller.account_active?
-    @subject = "[Action Required] Document Verification Failed"
+    @subject = "[Action Required] Stripe needs an updated document"
     @error_message = error_message
   end
 
   def stripe_identity_verification_failed(user_id, error_message)
     @seller = User.find(user_id)
     return do_not_send unless @seller.account_active?
-    @subject = "[Action Required] Identity Verification Failed"
+    @subject = "[Action Required] Stripe needs updated identity information"
     @error_message = error_message
   end
 

--- a/app/views/contacting_creator_mailer/stripe_document_verification_failed.html.erb
+++ b/app/views/contacting_creator_mailer/stripe_document_verification_failed.html.erb
@@ -1,9 +1,9 @@
 <div>
-  <p>Sorry about this! We ran into the following issue when trying to verify the document you uploaded on your payout settings page:</p>
+  <p>Stripe, our payment processor, was unable to verify a document you uploaded on your payout settings. This is a standard compliance check — no action was taken on your account.</p>
+  <p>Here's what Stripe reported:</p>
   <p>
     <i><%= @error_message %></i>
   </p>
-  <p>Please upload a valid document at:</p>
-  <p><%= link_to("Provide your information", settings_payments_url, class: "button primary") %></p>
-  <p>Or you can click here: <%= link_to settings_payments_url, settings_payments_url %></p>
+  <p>To fix this, visit your payout settings and upload a valid document. You can navigate there directly at <strong>gumroad.com/settings/payments</strong> — no need to click the link in this email if you're unsure.</p>
+  <p><%= link_to("Go to payout settings", settings_payments_url, class: "button primary") %></p>
 </div>

--- a/app/views/contacting_creator_mailer/stripe_identity_verification_failed.html.erb
+++ b/app/views/contacting_creator_mailer/stripe_identity_verification_failed.html.erb
@@ -1,9 +1,9 @@
 <div>
-  <p>Sorry about this! We ran into the following issue when trying to verify the information entered on your payout settings page:</p>
+  <p>Stripe, our payment processor, was unable to verify some of the identity information on your payout settings. This is a standard compliance check — no action was taken on your account.</p>
+  <p>Here's what Stripe reported:</p>
   <p>
     <i><%= @error_message %></i>
   </p>
-  <p>Please make any required changes at:</p>
-  <p><%= link_to("Provide your information", settings_payments_url, class: "button primary") %></p>
-  <p>Or you can click here: <%= link_to(settings_payments_url, settings_payments_url) %></p>
+  <p>To fix this, visit your payout settings and update the relevant information. You can navigate there directly at <strong>gumroad.com/settings/payments</strong> — no need to click the link in this email if you're unsure.</p>
+  <p><%= link_to("Go to payout settings", settings_payments_url, class: "button primary") %></p>
 </div>

--- a/lib/mailer_previews/contacting_creator_mailer_preview.rb
+++ b/lib/mailer_previews/contacting_creator_mailer_preview.rb
@@ -132,7 +132,7 @@ class ContactingCreatorMailerPreview < ActionMailer::Preview
   end
 
   def stripe_identity_verification_failed
-    ContactingCreatorMailer.stripe_document_verification_failed(User.last&.id, "The country of the business address provided does not match the country of the account. Businesses must be located in the same country as the account.")
+    ContactingCreatorMailer.stripe_identity_verification_failed(User.last&.id, "The country of the business address provided does not match the country of the account. Businesses must be located in the same country as the account.")
   end
 
   def singapore_identity_verification_reminder

--- a/spec/mailers/contacting_creator_mailer_spec.rb
+++ b/spec/mailers/contacting_creator_mailer_spec.rb
@@ -1714,10 +1714,10 @@ describe ContactingCreatorMailer do
       mail = ContactingCreatorMailer.stripe_document_verification_failed(creator.id, stripe_error_reason)
 
       expect(mail.to).to eq [creator.email]
-      expect(mail.subject).to eq "[Action Required] Document Verification Failed"
-      expect(mail.body.encoded).to include "Sorry about this! We ran into the following issue when trying to verify the document you uploaded on your payout settings page:"
+      expect(mail.subject).to eq "[Action Required] Stripe needs an updated document"
+      expect(mail.body.encoded).to include "Stripe, our payment processor, was unable to verify a document"
       expect(mail.body.encoded).to include stripe_error_reason
-      expect(mail.body.encoded).to include "Please upload a valid document at:"
+      expect(mail.body.encoded).to include "gumroad.com/settings/payments"
       expect(mail.body.encoded).to include settings_payments_url
     end
   end
@@ -1730,10 +1730,10 @@ describe ContactingCreatorMailer do
       mail = ContactingCreatorMailer.stripe_identity_verification_failed(creator.id, stripe_error_reason)
 
       expect(mail.to).to eq [creator.email]
-      expect(mail.subject).to eq "[Action Required] Identity Verification Failed"
-      expect(mail.body.encoded).to include "Sorry about this! We ran into the following issue when trying to verify the information entered on your payout settings page:"
+      expect(mail.subject).to eq "[Action Required] Stripe needs updated identity information"
+      expect(mail.body.encoded).to include "Stripe, our payment processor, was unable to verify some of the identity information"
       expect(mail.body.encoded).to include stripe_error_reason
-      expect(mail.body.encoded).to include "Please make any required changes at:"
+      expect(mail.body.encoded).to include "gumroad.com/settings/payments"
       expect(mail.body.encoded).to include settings_payments_url
     end
   end


### PR DESCRIPTION
Closes #5028

## Problem

Creators receive 'Identity Verification Failed' emails out of the blue and think they're phishing. The old emails:
- Said 'Sorry about this!' with a vague error and a button — classic phishing pattern
- Never mentioned Stripe or explained why verification was triggered
- Didn't tell creators what specifically to fix

## Changes

**Subjects** — less alarming, names Stripe as the source:
- `[Action Required] Identity Verification Failed` → `[Action Required] Stripe needs updated identity information`
- `[Action Required] Document Verification Failed` → `[Action Required] Stripe needs an updated document`

**Body** — explains what's happening, builds trust:
- Opens with 'Stripe, our payment processor' so creators know where this comes from
- States it's a standard compliance check and no action was taken on their account
- Shows the Stripe error under 'Here's what Stripe reported:'
- Includes the plain-text URL (`gumroad.com/settings/payments`) so creators can navigate directly without clicking the email link

**Bug fix**: mailer preview for `stripe_identity_verification_failed` was calling `stripe_document_verification_failed`

## Before/After

**Before (identity):**
> Sorry about this! We ran into the following issue when trying to verify the information entered on your payout settings page:
> *We were unable to find information based on the data entered...*
> Please make any required changes at: [Provide your information]

**After (identity):**
> Stripe, our payment processor, was unable to verify some of the identity information on your payout settings. This is a standard compliance check — no action was taken on your account.
> Here's what Stripe reported:
> *We were unable to find information based on the data entered...*
> To fix this, visit your payout settings and update the relevant information. You can navigate there directly at **gumroad.com/settings/payments** — no need to click the link in this email if you're unsure.
> [Go to payout settings]

> 🤖 Generated with AI