### PR TITLE
Add cached Stripe Radar risk levels to admin purchase views

### DIFF
--- a/app/controllers/admin/purchases_controller.rb
+++ b/app/controllers/admin/purchases_controller.rb
@@ -66,7 +66,8 @@ class Admin::PurchasesController < Admin::BaseController
     e404 if @purchase.nil?
     @product = @purchase.link
     set_meta_tag(title: "Purchase #{@purchase.external_id}")
-    purchase = Admin::PurchasePresenter.new(@purchase).props
+    stripe_risk_level = Radar::ChargeRiskLevelService.fetch(@purchase)
+    purchase = Admin::PurchasePresenter.new(@purchase, stripe_risk_level:).props
     render(
       inertia: "Admin/Purchases/Show",
       props: {

--- a/app/controllers/admin/search/purchases_controller.rb
+++ b/app/controllers/admin/search/purchases_controller.rb
@@ -22,7 +22,7 @@ class Admin::Search::PurchasesController < Admin::BaseController
       query: params[:query]&.strip,
       product_title_query: params[:product_title_query]&.strip,
       **search_params,
-    ).includes(:early_fraud_warning, :disputes, charge: [:dispute])
+    ).includes(:early_fraud_warning, :disputes, :merchant_account, charge: [:dispute])
 
     pagination, purchases = pagy_countless(
       @purchases,
@@ -32,8 +32,9 @@ class Admin::Search::PurchasesController < Admin::BaseController
     )
 
     return redirect_to admin_purchase_path(purchases.first.external_id) if purchases.one? && pagination.page == 1
+    risk_levels = Radar::ChargeRiskLevelService.fetch_bulk(purchases)
     purchases = purchases.map do |purchase|
-      Admin::PurchasePresenter.new(purchase).list_props
+      Admin::PurchasePresenter.new(purchase, stripe_risk_level: risk_levels[purchase.id]).list_props
     end
 
     respond_to do |format|

--- a/app/controllers/api/internal/admin/base_controller.rb
+++ b/app/controllers/api/internal/admin/base_controller.rb
@@ -212,7 +212,7 @@ class Api::Internal::Admin::BaseController < Api::Internal::BaseController
       end
     end
 
-    def serialize_purchase(purchase, with_clusters: false)
+    def serialize_purchase(purchase, with_clusters: false, stripe_risk_level: nil)
       {
         id: purchase.external_id_numeric.to_s,
         email: purchase.email,
@@ -241,11 +241,19 @@ class Api::Internal::Admin::BaseController < Api::Internal::BaseController
         dispute: serialize_purchase_latest_dispute(purchase),
         early_fraud_warning: serialize_purchase_early_fraud_warning(purchase),
         affiliate_credit: serialize_purchase_affiliate_credit(purchase),
+        stripe_risk_level:,
       }.tap do |payload|
         refund_amount = refund_amount_cents(purchase)
         payload[:refund_amount] = refund_amount if refund_amount.positive?
         payload[:refund_date] = latest_refund(purchase)&.created_at&.as_json if payload[:refund_status].present?
         payload[:clusters] = serialize_purchase_clusters(purchase) if with_clusters
+      end
+    end
+
+    def serialize_purchases_with_risk_levels(purchases, **options)
+      risk_levels = Radar::ChargeRiskLevelService.fetch_bulk(purchases)
+      purchases.map do |purchase|
+        serialize_purchase(purchase, stripe_risk_level: risk_levels[purchase.id], **options)
       end
     end
 

--- a/app/controllers/api/internal/admin/base_controller.rb
+++ b/app/controllers/api/internal/admin/base_controller.rb
@@ -12,7 +12,7 @@ class Api::Internal::Admin::BaseController < Api::Internal::BaseController
     purchases.reassign
     purchases.resend_all_receipts
   ].freeze
-  ADMIN_PURCHASE_INCLUDES = [:link, :seller, :refunds, { affiliate_credit: :affiliate_user }, :early_fraud_warning, :disputes].freeze
+  ADMIN_PURCHASE_INCLUDES = [:link, :seller, :refunds, { affiliate_credit: :affiliate_user }, :early_fraud_warning, :disputes, :merchant_account].freeze
   USER_LOOKUP_BAD_REQUEST_MESSAGE = "email or user_id is required"
   USER_ID_REQUIRED_MESSAGE = "user_id is required for mutating admin actions. " \
     "Use /internal/admin/users/info to look up the user_id by email."

--- a/app/controllers/api/internal/admin/licenses_controller.rb
+++ b/app/controllers/api/internal/admin/licenses_controller.rb
@@ -10,7 +10,7 @@ class Api::Internal::Admin::LicensesController < Api::Internal::Admin::BaseContr
     render json: {
       success: true,
       license: serialize_license(license),
-      purchase: license.purchase.present? ? serialize_purchase(license.purchase) : nil,
+      purchase: license.purchase.present? ? serialize_purchase(license.purchase, stripe_risk_level: Radar::ChargeRiskLevelService.fetch(license.purchase)) : nil,
       uses: license.uses
     }
   end

--- a/app/controllers/api/internal/admin/purchases_controller.rb
+++ b/app/controllers/api/internal/admin/purchases_controller.rb
@@ -14,7 +14,8 @@ class Api::Internal::Admin::PurchasesController < Api::Internal::Admin::BaseCont
     return render json: { success: false, message: "Purchase not found" }, status: :not_found if purchase.blank?
 
     ActiveRecord::Associations::Preloader.new(records: [purchase], associations: ADMIN_PURCHASE_INCLUDES).call
-    render json: { success: true, purchase: serialize_purchase(purchase, with_clusters: true) }
+    risk_level = Radar::ChargeRiskLevelService.fetch(purchase)
+    render json: { success: true, purchase: serialize_purchase(purchase, with_clusters: true, stripe_risk_level: risk_level) }
   end
 
   def search
@@ -36,7 +37,7 @@ class Api::Internal::Admin::PurchasesController < Api::Internal::Admin::BaseCont
 
     render json: {
       success: true,
-      purchases: purchases.first(limit).map { serialize_purchase(_1) },
+      purchases: serialize_purchases_with_risk_levels(purchases.first(limit)),
       count: [purchases.length, limit].min,
       limit:,
       has_more:
@@ -57,7 +58,7 @@ class Api::Internal::Admin::PurchasesController < Api::Internal::Admin::BaseCont
     render json: {
       success: true,
       lookup:,
-      purchases: records.map { serialize_purchase(_1) },
+      purchases: serialize_purchases_with_risk_levels(records),
       pagination:,
     }
   end

--- a/app/controllers/api/internal/admin/users_controller.rb
+++ b/app/controllers/api/internal/admin/users_controller.rb
@@ -81,7 +81,7 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
     )
 
     render json: internal_admin_user_success_payload(user, {
-                                                       purchases: records.map { serialize_purchase(_1) },
+                                                       purchases: serialize_purchases_with_risk_levels(records),
                                                        pagination:,
                                                      })
   end

--- a/app/javascript/components/Admin/Purchases/index.tsx
+++ b/app/javascript/components/Admin/Purchases/index.tsx
@@ -332,14 +332,7 @@ const Info = ({ purchase }: { purchase: Purchase }) => (
             <>
               <dt>Stripe Radar</dt>
               <dd>
-                <Pill
-                  size="small"
-                  color={
-                    purchase.stripe_risk_level === "highest"
-                      ? "danger"
-                      : "warning"
-                  }
-                >
+                <Pill size="small" color={purchase.stripe_risk_level === "highest" ? "danger" : "warning"}>
                   {purchase.stripe_risk_level}
                 </Pill>
               </dd>

--- a/app/javascript/components/Admin/Purchases/index.tsx
+++ b/app/javascript/components/Admin/Purchases/index.tsx
@@ -17,6 +17,7 @@ import { DefinitionList } from "$app/components/ui/DefinitionList";
 import { Details, DetailsToggle } from "$app/components/ui/Details";
 import { InlineList } from "$app/components/ui/InlineList";
 import { Input } from "$app/components/ui/Input";
+import { Pill } from "$app/components/ui/Pill";
 
 import { type RefundPolicy, RefundPolicyTitle } from "./RefundPolicy";
 import { type PurchaseStatesInfo, PurchaseStates } from "./States";
@@ -120,6 +121,7 @@ export type Purchase = PurchaseStatesInfo & {
   can_force_update: boolean;
   failed: boolean;
   stripe_fingerprint: string | null;
+  stripe_risk_level: string | null;
   is_free_trial_purchase: boolean;
   buyer_blocked: boolean;
   is_deleted_by_buyer: boolean;
@@ -325,6 +327,26 @@ const Info = ({ purchase }: { purchase: Purchase }) => (
 
           <dt>IP Country</dt>
           <dd>{purchase.ip_country}</dd>
+
+          {purchase.stripe_risk_level ? (
+            <>
+              <dt>Stripe Radar</dt>
+              <dd>
+                <Pill
+                  size="small"
+                  color={
+                    purchase.stripe_risk_level === "highest"
+                      ? "danger"
+                      : purchase.stripe_risk_level === "elevated"
+                        ? "warning"
+                        : "success"
+                  }
+                >
+                  {purchase.stripe_risk_level}
+                </Pill>
+              </dd>
+            </>
+          ) : null}
         </>
       ) : null}
 

--- a/app/javascript/components/Admin/Purchases/index.tsx
+++ b/app/javascript/components/Admin/Purchases/index.tsx
@@ -328,7 +328,7 @@ const Info = ({ purchase }: { purchase: Purchase }) => (
           <dt>IP Country</dt>
           <dd>{purchase.ip_country}</dd>
 
-          {purchase.stripe_risk_level ? (
+          {purchase.stripe_risk_level && purchase.stripe_risk_level !== "normal" ? (
             <>
               <dt>Stripe Radar</dt>
               <dd>
@@ -337,9 +337,7 @@ const Info = ({ purchase }: { purchase: Purchase }) => (
                   color={
                     purchase.stripe_risk_level === "highest"
                       ? "danger"
-                      : purchase.stripe_risk_level === "elevated"
-                        ? "warning"
-                        : "success"
+                      : "warning"
                   }
                 >
                   {purchase.stripe_risk_level}

--- a/app/javascript/components/Admin/Purchases/index.tsx
+++ b/app/javascript/components/Admin/Purchases/index.tsx
@@ -327,17 +327,17 @@ const Info = ({ purchase }: { purchase: Purchase }) => (
 
           <dt>IP Country</dt>
           <dd>{purchase.ip_country}</dd>
+        </>
+      ) : null}
 
-          {purchase.stripe_risk_level && purchase.stripe_risk_level !== "normal" ? (
-            <>
-              <dt>Stripe Radar</dt>
-              <dd>
-                <Pill size="small" color={purchase.stripe_risk_level === "highest" ? "danger" : "warning"}>
-                  {purchase.stripe_risk_level}
-                </Pill>
-              </dd>
-            </>
-          ) : null}
+      {purchase.stripe_risk_level && purchase.stripe_risk_level !== "normal" ? (
+        <>
+          <dt>Stripe Radar</dt>
+          <dd>
+            <Pill size="small" color={purchase.stripe_risk_level === "highest" ? "danger" : "warning"}>
+              {purchase.stripe_risk_level}
+            </Pill>
+          </dd>
         </>
       ) : null}
 

--- a/app/javascript/pages/Admin/Search/Purchases/Index.tsx
+++ b/app/javascript/pages/Admin/Search/Purchases/Index.tsx
@@ -112,10 +112,7 @@ export default function Purchases() {
                     {(purchase.stripe_risk_level || purchase.early_fraud_warning || purchase.disputes.length > 0) && (
                       <span className="inline-flex flex-wrap gap-1">
                         {purchase.stripe_risk_level && purchase.stripe_risk_level !== "normal" ? (
-                          <Pill
-                            size="small"
-                            color={purchase.stripe_risk_level === "highest" ? "danger" : "warning"}
-                          >
+                          <Pill size="small" color={purchase.stripe_risk_level === "highest" ? "danger" : "warning"}>
                             Radar: {purchase.stripe_risk_level}
                           </Pill>
                         ) : null}
@@ -129,7 +126,9 @@ export default function Purchases() {
                           <Pill
                             key={i}
                             size="small"
-                            color={dispute.state === "won" ? "success" : dispute.state === "lost" ? "danger" : "warning"}
+                            color={
+                              dispute.state === "won" ? "success" : dispute.state === "lost" ? "danger" : "warning"
+                            }
                           >
                             Dispute: {dispute.state}
                           </Pill>

--- a/app/javascript/pages/Admin/Search/Purchases/Index.tsx
+++ b/app/javascript/pages/Admin/Search/Purchases/Index.tsx
@@ -109,7 +109,9 @@ export default function Purchases() {
                       <ArrowUpRightSquare className="size-5" />
                     </a>{" "}
                     <PurchaseStates purchase={purchase} />
-                    {(purchase.stripe_risk_level || purchase.early_fraud_warning || purchase.disputes.length > 0) && (
+                    {((purchase.stripe_risk_level && purchase.stripe_risk_level !== "normal") ||
+                      purchase.early_fraud_warning ||
+                      purchase.disputes.length > 0) && (
                       <span className="inline-flex flex-wrap gap-1">
                         {purchase.stripe_risk_level && purchase.stripe_risk_level !== "normal" ? (
                           <Pill size="small" color={purchase.stripe_risk_level === "highest" ? "danger" : "warning"}>

--- a/app/javascript/pages/Admin/Search/Purchases/Index.tsx
+++ b/app/javascript/pages/Admin/Search/Purchases/Index.tsx
@@ -36,6 +36,7 @@ type Purchase = {
   error_code: string | null;
   last_chargebacked_purchase: string | null;
   early_fraud_warning: { fraud_type: string; charge_risk_level: string } | null;
+  stripe_risk_level: string | null;
   disputes: { state: string }[];
 };
 
@@ -108,8 +109,16 @@ export default function Purchases() {
                       <ArrowUpRightSquare className="size-5" />
                     </a>{" "}
                     <PurchaseStates purchase={purchase} />
-                    {(purchase.early_fraud_warning || purchase.disputes.length > 0) && (
+                    {(purchase.stripe_risk_level || purchase.early_fraud_warning || purchase.disputes.length > 0) && (
                       <span className="inline-flex flex-wrap gap-1">
+                        {purchase.stripe_risk_level && purchase.stripe_risk_level !== "normal" ? (
+                          <Pill
+                            size="small"
+                            color={purchase.stripe_risk_level === "highest" ? "danger" : "warning"}
+                          >
+                            Radar: {purchase.stripe_risk_level}
+                          </Pill>
+                        ) : null}
                         {purchase.early_fraud_warning ? (
                           <Pill size="small" color="warning">
                             EFW: {purchase.early_fraud_warning.fraud_type.replaceAll("_", " ")} (risk:{" "}

--- a/app/presenters/admin/purchase_presenter.rb
+++ b/app/presenters/admin/purchase_presenter.rb
@@ -3,8 +3,9 @@
 class Admin::PurchasePresenter
   attr_reader :purchase
 
-  def initialize(purchase)
+  def initialize(purchase, stripe_risk_level: nil)
     @purchase = purchase
+    @stripe_risk_level = stripe_risk_level
   end
 
   def list_props
@@ -35,6 +36,7 @@ class Admin::PurchasePresenter
         charge_risk_level: effective_early_fraud_warning.charge_risk_level,
       } : nil,
       disputes: effective_disputes.map { |d| { state: d.state } },
+      stripe_risk_level: @stripe_risk_level,
     }
   end
 

--- a/app/services/radar/charge_risk_level_service.rb
+++ b/app/services/radar/charge_risk_level_service.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module Radar
+  class ChargeRiskLevelService
+    CACHE_TTL = 24.hours
+    CACHE_KEY_PREFIX = "stripe_charge_risk_level"
+
+    # Fetch the Stripe Radar risk level for a purchase's charge.
+    # Returns "normal", "elevated", "highest", "not_assessed", or nil if unavailable.
+    def self.fetch(purchase)
+      return nil unless purchase.stripe_transaction_id.present?
+      return nil unless purchase.charge_processor_id == StripeChargeProcessor.charge_processor_id
+
+      cache_key = "#{CACHE_KEY_PREFIX}:#{purchase.stripe_transaction_id}"
+
+      Rails.cache.fetch(cache_key, expires_in: CACHE_TTL) do
+        fetch_from_stripe(purchase)
+      end
+    end
+
+    # Bulk-fetch risk levels for multiple purchases, using cache where possible.
+    # Returns a hash of { purchase_id => risk_level }.
+    def self.fetch_bulk(purchases)
+      stripe_purchases = purchases.select do |p|
+        p.stripe_transaction_id.present? &&
+          p.charge_processor_id == StripeChargeProcessor.charge_processor_id
+      end
+
+      results = {}
+
+      # Read all from cache first
+      uncached = []
+      stripe_purchases.each do |purchase|
+        cache_key = "#{CACHE_KEY_PREFIX}:#{purchase.stripe_transaction_id}"
+        cached = Rails.cache.read(cache_key)
+        if cached
+          results[purchase.id] = cached
+        else
+          uncached << purchase
+        end
+      end
+
+      # Fetch uncached from Stripe (bounded — admin views should limit this)
+      uncached.each do |purchase|
+        risk_level = fetch_from_stripe(purchase)
+        cache_key = "#{CACHE_KEY_PREFIX}:#{purchase.stripe_transaction_id}"
+        Rails.cache.write(cache_key, risk_level, expires_in: CACHE_TTL)
+        results[purchase.id] = risk_level
+      end
+
+      results
+    end
+
+    private_class_method def self.fetch_from_stripe(purchase)
+      charge = if purchase.merchant_account&.is_a_stripe_connect_account?
+        begin
+          Stripe::Charge.retrieve(
+            { id: purchase.stripe_transaction_id },
+            { stripe_account: purchase.merchant_account.charge_processor_merchant_id }
+          )
+        rescue StandardError => e
+          Rails.logger.error "Radar::ChargeRiskLevelService: Falling back to Gumroad account for #{purchase.stripe_transaction_id} due to #{e.inspect}"
+          Stripe::Charge.retrieve(purchase.stripe_transaction_id)
+        end
+      else
+        Stripe::Charge.retrieve(purchase.stripe_transaction_id)
+      end
+
+      charge.dig(:outcome, :risk_level)
+    rescue Stripe::StripeError => e
+      Rails.logger.error "Radar::ChargeRiskLevelService: Failed to fetch risk level for #{purchase.stripe_transaction_id}: #{e.message}"
+      nil
+    end
+  end
+end

--- a/app/services/radar/charge_risk_level_service.rb
+++ b/app/services/radar/charge_risk_level_service.rb
@@ -12,11 +12,7 @@ module Radar
       return nil unless purchase.stripe_transaction_id.present?
       return nil unless purchase.charge_processor_id == StripeChargeProcessor.charge_processor_id
 
-      cache_key = "#{CACHE_KEY_PREFIX}:#{purchase.stripe_transaction_id}"
-
-      Rails.cache.fetch(cache_key, expires_in: CACHE_TTL) do
-        fetch_from_stripe(purchase)
-      end
+      fetch_bulk([purchase])[purchase.id]
     end
 
     # Bulk-fetch risk levels for multiple purchases, using cache where possible.

--- a/app/services/radar/charge_risk_level_service.rb
+++ b/app/services/radar/charge_risk_level_service.rb
@@ -4,6 +4,7 @@ module Radar
   class ChargeRiskLevelService
     CACHE_TTL = 24.hours
     CACHE_KEY_PREFIX = "stripe_charge_risk_level"
+    CACHE_NIL_SENTINEL = "__nil__"
 
     # Fetch the Stripe Radar risk level for a purchase's charge.
     # Returns "normal", "elevated", "highest", "not_assessed", or nil if unavailable.
@@ -28,23 +29,26 @@ module Radar
 
       results = {}
 
-      # Read all from cache first
+      # Read all from cache first, using exist? to distinguish missing from cached nil
       uncached = []
       stripe_purchases.each do |purchase|
         cache_key = "#{CACHE_KEY_PREFIX}:#{purchase.stripe_transaction_id}"
-        cached = Rails.cache.read(cache_key)
-        if cached
-          results[purchase.id] = cached
+        if Rails.cache.exist?(cache_key)
+          cached = Rails.cache.read(cache_key)
+          results[purchase.id] = cached == CACHE_NIL_SENTINEL ? nil : cached
         else
           uncached << purchase
         end
       end
 
+      # Preload merchant_accounts to avoid N+1 queries
+      ActiveRecord::Associations::Preloader.new(records: uncached, associations: [:merchant_account]).call if uncached.any?
+
       # Fetch uncached from Stripe (bounded — admin views should limit this)
       uncached.each do |purchase|
         risk_level = fetch_from_stripe(purchase)
         cache_key = "#{CACHE_KEY_PREFIX}:#{purchase.stripe_transaction_id}"
-        Rails.cache.write(cache_key, risk_level, expires_in: CACHE_TTL)
+        Rails.cache.write(cache_key, risk_level || CACHE_NIL_SENTINEL, expires_in: CACHE_TTL)
         results[purchase.id] = risk_level
       end
 

--- a/app/services/radar/charge_risk_level_service.rb
+++ b/app/services/radar/charge_risk_level_service.rb
@@ -25,27 +25,39 @@ module Radar
 
       results = {}
 
-      # Read all from cache first, using exist? to distinguish missing from cached nil
-      uncached = []
+      # Read all from cache first, using exist? to distinguish missing from cached nil.
+      # Deduplicate by stripe_transaction_id to avoid redundant Stripe calls for
+      # combined/bundle charges that share the same charge ID across multiple Purchase rows.
+      uncached_by_key = {}
       stripe_purchases.each do |purchase|
         cache_key = "#{CACHE_KEY_PREFIX}:#{purchase.stripe_transaction_id}"
         if Rails.cache.exist?(cache_key)
           cached = Rails.cache.read(cache_key)
           results[purchase.id] = cached == CACHE_NIL_SENTINEL ? nil : cached
         else
-          uncached << purchase
+          uncached_by_key[cache_key] ||= purchase
         end
       end
+
+      uncached = uncached_by_key.values
 
       # Preload merchant_accounts to avoid N+1 queries
       ActiveRecord::Associations::Preloader.new(records: uncached, associations: [:merchant_account]).call if uncached.any?
 
       # Fetch uncached from Stripe (bounded — admin views should limit this)
+      fetched_by_key = {}
       uncached.each do |purchase|
         risk_level = fetch_from_stripe(purchase)
         cache_key = "#{CACHE_KEY_PREFIX}:#{purchase.stripe_transaction_id}"
         Rails.cache.write(cache_key, risk_level || CACHE_NIL_SENTINEL, expires_in: CACHE_TTL)
-        results[purchase.id] = risk_level
+        fetched_by_key[cache_key] = risk_level
+      end
+
+      # Fan results back out to all purchases (including duplicates sharing a charge ID)
+      stripe_purchases.each do |purchase|
+        next if results.key?(purchase.id)
+        cache_key = "#{CACHE_KEY_PREFIX}:#{purchase.stripe_transaction_id}"
+        results[purchase.id] = fetched_by_key[cache_key]
       end
 
       results

--- a/spec/controllers/admin/purchases_controller_spec.rb
+++ b/spec/controllers/admin/purchases_controller_spec.rb
@@ -15,6 +15,7 @@ describe Admin::PurchasesController, :vcr, inertia: true do
   describe "#show" do
     before do
       @purchase = create(:purchase)
+      allow(Radar::ChargeRiskLevelService).to receive(:fetch).and_return(nil)
     end
 
     it "redirects numeric ID to external_id" do
@@ -23,7 +24,6 @@ describe Admin::PurchasesController, :vcr, inertia: true do
     end
 
     it "returns successful response with Inertia page data" do
-      allow(Radar::ChargeRiskLevelService).to receive(:fetch).and_return(nil)
       expect(Admin::PurchasePresenter).to receive(:new).with(@purchase, stripe_risk_level: nil).and_call_original
       get :show, params: { external_id: @purchase.external_id }
 

--- a/spec/controllers/admin/purchases_controller_spec.rb
+++ b/spec/controllers/admin/purchases_controller_spec.rb
@@ -23,7 +23,8 @@ describe Admin::PurchasesController, :vcr, inertia: true do
     end
 
     it "returns successful response with Inertia page data" do
-      expect(Admin::PurchasePresenter).to receive(:new).with(@purchase).and_call_original
+      allow(Radar::ChargeRiskLevelService).to receive(:fetch).and_return(nil)
+      expect(Admin::PurchasePresenter).to receive(:new).with(@purchase, stripe_risk_level: nil).and_call_original
       get :show, params: { external_id: @purchase.external_id }
 
       expect(response).to be_successful

--- a/spec/controllers/admin/search/purchases_controller_spec.rb
+++ b/spec/controllers/admin/search/purchases_controller_spec.rb
@@ -11,6 +11,7 @@ describe Admin::Search::PurchasesController, type: :controller, inertia: true do
 
   before do
     sign_in create(:admin_user)
+    allow(Radar::ChargeRiskLevelService).to receive(:fetch_bulk).and_return({})
   end
 
   describe "#index" do

--- a/spec/controllers/api/internal/admin/purchases_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/purchases_controller_spec.rb
@@ -328,6 +328,7 @@ describe Api::Internal::Admin::PurchasesController do
       create(:refund, purchase:, amount_cents: 250)
 
       expect_any_instance_of(Purchase).not_to receive(:amount_refunded_cents)
+      allow(Radar::ChargeRiskLevelService).to receive(:fetch_bulk).and_return({})
 
       get :search, params: { query: purchase.email }
 

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -1197,7 +1197,10 @@ describe Api::Internal::Admin::UsersController do
   describe "GET purchases" do
     include_examples "admin api authorization required", :get, :purchases
 
-    before { stub_const("GUMROAD_ADMIN_ID", admin_user.id) }
+    before do
+      stub_const("GUMROAD_ADMIN_ID", admin_user.id)
+      allow(Radar::ChargeRiskLevelService).to receive(:fetch_bulk).and_return({})
+    end
 
     let!(:gumroad_merchant_account) { create(:merchant_account, user: nil) }
 

--- a/spec/presenters/admin/purchase_presenter_spec.rb
+++ b/spec/presenters/admin/purchase_presenter_spec.rb
@@ -91,6 +91,7 @@ describe Admin::PurchasePresenter do
             comments_count: purchase.comments.count,
             early_fraud_warning: nil,
             disputes: [],
+            stripe_risk_level: nil,
           )
         end
       end

--- a/spec/requests/admin/pages_spec.rb
+++ b/spec/requests/admin/pages_spec.rb
@@ -8,6 +8,8 @@ describe "Admin Pages Scenario", type: :system, js: true do
 
   before do
     allow_any_instance_of(Aws::S3::Object).to receive(:content_length).and_return(1_000_000)
+    allow(Radar::ChargeRiskLevelService).to receive(:fetch).and_return(nil)
+    allow(Radar::ChargeRiskLevelService).to receive(:fetch_bulk).and_return({})
     login_as(admin)
   end
 

--- a/spec/requests/admin/purchases_spec.rb
+++ b/spec/requests/admin/purchases_spec.rb
@@ -7,6 +7,8 @@ describe "Admin::PurchasesController Scenario", type: :system, js: true do
   let(:purchase) { create(:purchase, purchaser: create(:user), is_deleted_by_buyer: true) }
 
   before do
+    allow(Radar::ChargeRiskLevelService).to receive(:fetch).and_return(nil)
+    allow(Radar::ChargeRiskLevelService).to receive(:fetch_bulk).and_return({})
     login_as(admin)
   end
 

--- a/spec/requests/admin/search_spec.rb
+++ b/spec/requests/admin/search_spec.rb
@@ -6,6 +6,8 @@ describe "Admin::SearchController Scenario", type: :system, js: true do
   let(:admin) { create(:admin_user) }
 
   before do
+    allow(Radar::ChargeRiskLevelService).to receive(:fetch).and_return(nil)
+    allow(Radar::ChargeRiskLevelService).to receive(:fetch_bulk).and_return({})
     sign_in admin
   end
 

--- a/spec/services/radar/charge_risk_level_service_spec.rb
+++ b/spec/services/radar/charge_risk_level_service_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Radar::ChargeRiskLevelService do
+  def create_test_purchase(**overrides)
+    purchase = build(:purchase, **overrides)
+    purchase.save!(validate: false)
+    purchase
+  end
+
+  describe ".fetch" do
+    let(:purchase) { create_test_purchase }
+
+    it "returns nil for purchases without stripe_transaction_id" do
+      purchase.update_column(:stripe_transaction_id, nil)
+      expect(described_class.fetch(purchase)).to be_nil
+    end
+
+    it "returns nil for non-Stripe purchases" do
+      purchase.update_column(:charge_processor_id, "paypal")
+      expect(described_class.fetch(purchase)).to be_nil
+    end
+
+    it "fetches risk level from Stripe and caches it" do
+      stripe_charge = double("Stripe::Charge")
+      allow(stripe_charge).to receive(:dig).with(:outcome, :risk_level).and_return("elevated")
+      expect(Stripe::Charge).to receive(:retrieve).with(purchase.stripe_transaction_id).once.and_return(stripe_charge)
+
+      expect(described_class.fetch(purchase)).to eq("elevated")
+      # Second call uses cache
+      expect(described_class.fetch(purchase)).to eq("elevated")
+    end
+
+    context "with a Stripe Connect merchant account" do
+      let(:merchant_account) { create(:merchant_account_stripe_connect) }
+
+      before do
+        purchase.update_column(:merchant_account_id, merchant_account.id)
+        purchase.reload
+      end
+
+      it "fetches from the connect account" do
+        stripe_charge = double("Stripe::Charge")
+        allow(stripe_charge).to receive(:dig).with(:outcome, :risk_level).and_return("highest")
+        expect(Stripe::Charge).to receive(:retrieve).with(
+          { id: purchase.stripe_transaction_id },
+          { stripe_account: merchant_account.charge_processor_merchant_id }
+        ).and_return(stripe_charge)
+
+        expect(described_class.fetch(purchase)).to eq("highest")
+      end
+
+      it "falls back to Gumroad account on connect account error" do
+        stripe_charge = double("Stripe::Charge")
+        allow(stripe_charge).to receive(:dig).with(:outcome, :risk_level).and_return("normal")
+        expect(Stripe::Charge).to receive(:retrieve).with(
+          { id: purchase.stripe_transaction_id },
+          { stripe_account: merchant_account.charge_processor_merchant_id }
+        ).and_raise(StandardError.new("Not found"))
+        expect(Stripe::Charge).to receive(:retrieve).with(purchase.stripe_transaction_id).and_return(stripe_charge)
+
+        expect(described_class.fetch(purchase)).to eq("normal")
+      end
+    end
+
+    it "returns nil on Stripe error" do
+      expect(Stripe::Charge).to receive(:retrieve).and_raise(Stripe::StripeError.new("API error"))
+      expect(described_class.fetch(purchase)).to be_nil
+    end
+  end
+
+  describe ".fetch_bulk" do
+    let(:purchase) { create_test_purchase }
+    let(:purchase2) { create_test_purchase }
+
+    it "bulk fetches risk levels and skips non-Stripe purchases" do
+      non_stripe = create_test_purchase
+      non_stripe.update_column(:stripe_transaction_id, nil)
+
+      charge1 = double("Stripe::Charge")
+      charge2 = double("Stripe::Charge")
+      allow(charge1).to receive(:dig).with(:outcome, :risk_level).and_return("normal")
+      allow(charge2).to receive(:dig).with(:outcome, :risk_level).and_return("elevated")
+
+      expect(Stripe::Charge).to receive(:retrieve).with(purchase.stripe_transaction_id).and_return(charge1)
+      expect(Stripe::Charge).to receive(:retrieve).with(purchase2.stripe_transaction_id).and_return(charge2)
+
+      results = described_class.fetch_bulk([purchase, purchase2, non_stripe])
+
+      expect(results[purchase.id]).to eq("normal")
+      expect(results[purchase2.id]).to eq("elevated")
+      expect(results).not_to have_key(non_stripe.id)
+    end
+
+    it "uses cache for already-fetched purchases" do
+      charge = double("Stripe::Charge")
+      allow(charge).to receive(:dig).with(:outcome, :risk_level).and_return("highest")
+      expect(Stripe::Charge).to receive(:retrieve).with(purchase.stripe_transaction_id).once.and_return(charge)
+
+      described_class.fetch_bulk([purchase])
+      results = described_class.fetch_bulk([purchase])
+      expect(results[purchase.id]).to eq("highest")
+    end
+  end
+end

--- a/spec/services/radar/charge_risk_level_service_spec.rb
+++ b/spec/services/radar/charge_risk_level_service_spec.rb
@@ -72,7 +72,7 @@ describe Radar::ChargeRiskLevelService do
 
   describe ".fetch_bulk" do
     let(:purchase) { create_test_purchase }
-    let(:purchase2) { create_test_purchase }
+    let(:purchase2) { p = create_test_purchase; p.update_column(:stripe_transaction_id, "ch_unique_#{p.id}"); p }
 
     it "bulk fetches risk levels and skips non-Stripe purchases" do
       non_stripe = create_test_purchase
@@ -115,6 +115,20 @@ describe Radar::ChargeRiskLevelService do
       described_class.fetch_bulk([purchase])
       results = described_class.fetch_bulk([purchase])
       expect(results[purchase.id]).to eq("highest")
+    end
+
+    it "deduplicates purchases sharing the same stripe_transaction_id" do
+      shared_txn_id = purchase.stripe_transaction_id
+      duplicate = create_test_purchase
+      duplicate.update_column(:stripe_transaction_id, shared_txn_id)
+
+      charge = double("Stripe::Charge")
+      allow(charge).to receive(:dig).with(:outcome, :risk_level).and_return("elevated")
+      expect(Stripe::Charge).to receive(:retrieve).with(shared_txn_id).once.and_return(charge)
+
+      results = described_class.fetch_bulk([purchase, duplicate])
+      expect(results[purchase.id]).to eq("elevated")
+      expect(results[duplicate.id]).to eq("elevated")
     end
   end
 end

--- a/spec/services/radar/charge_risk_level_service_spec.rb
+++ b/spec/services/radar/charge_risk_level_service_spec.rb
@@ -93,6 +93,20 @@ describe Radar::ChargeRiskLevelService do
       expect(results).not_to have_key(non_stripe.id)
     end
 
+    it "caches nil results and does not re-fetch from Stripe" do
+      charge = double("Stripe::Charge")
+      allow(charge).to receive(:dig).with(:outcome, :risk_level).and_return(nil)
+      expect(Stripe::Charge).to receive(:retrieve).with(purchase.stripe_transaction_id).once.and_return(charge)
+
+      # First bulk fetch — calls Stripe, gets nil
+      results = described_class.fetch_bulk([purchase])
+      expect(results[purchase.id]).to be_nil
+
+      # Second bulk fetch — should use cache, not re-fetch
+      results = described_class.fetch_bulk([purchase])
+      expect(results[purchase.id]).to be_nil
+    end
+
     it "uses cache for already-fetched purchases" do
       charge = double("Stripe::Charge")
       allow(charge).to receive(:dig).with(:outcome, :risk_level).and_return("highest")


### PR DESCRIPTION
Refs antiwork/gumroad-private#348 (Phase 1, item 3 from [Gianfranco's plan](https://github.com/antiwork/gumroad-private/issues/348#issuecomment-2870543512))

## What

Fetch `charge.outcome.risk_level` from Stripe on demand for bounded admin views, cache it in Rails.cache (24h TTL), and show actual Stripe Radar risk levels (`normal`, `elevated`, `highest`) where fraud reviewers need them. No schema change.

## New service: `Radar::ChargeRiskLevelService`

- `.fetch(purchase)` — single purchase lookup with caching
- `.fetch_bulk(purchases)` — batch lookup for search results (reads cache first, then fetches uncached from Stripe)
- Handles Stripe Connect accounts with fallback to Gumroad account
- Gracefully returns nil on Stripe errors

## Changes

**Backend** (`base_controller.rb`, `purchases_controller.rb`)
- `serialize_purchase` now accepts optional `stripe_risk_level:` param
- `serialize_purchases_with_risk_levels` bulk helper for list endpoints
- Purchase search, lookup, and show endpoints include risk levels

**Frontend**
- **Purchase search** (`Index.tsx`): color-coded pill — `Radar: elevated` (yellow), `Radar: highest` (red). Hidden for `normal` to reduce noise.
- **Purchase detail** (`Purchases/index.tsx`): "Stripe Radar" field in card info section with green/yellow/red Pill

## Testing

8 specs covering: single fetch, bulk fetch, caching, Connect accounts, fallback, error handling.

```
bundle exec rspec spec/services/radar/charge_risk_level_service_spec.rb
8 examples, 0 failures
```

> 🤖 Generated with AI