### PR TITLE
Add CLI badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@
   <a href="https://gumroad.com">Gumroad</a> is an e-commerce platform that enables creators to sell products directly to consumers. This repository contains the source code for the Gumroad web application.
 </p>
 
+<p align="center">
+  <a href="https://github.com/antiwork/gumroad-cli">
+    <img src="https://img.shields.io/badge/CLI-gumroad--cli-FF90E8?style=for-the-badge" alt="Gumroad CLI">
+  </a>
+</p>
+
 ## Table of Contents
 
 - [Getting Started](#getting-started)


### PR DESCRIPTION
Ref #4995

## What

Adds a centered shields.io badge to the top of `README.md` linking from the main `antiwork/gumroad` repo to [`antiwork/gumroad-cli`](https://github.com/antiwork/gumroad-cli). Brand-pink (`#FF90E8`), placed between the description paragraph and the table of contents.

## Why

Step 4 of #4995 ("Promote CLI") calls for a "CLI badge/link in the main gumroad repo README" to funnel the repo's 9K stars toward the CLI.

Picked shields.io style over a plain text-link row or callout because the badge reads as a visible "we ship a CLI" signal at a glance without taking much vertical space.

## Screenshot

<img width="2134" height="1456" alt="CleanShot 2026-05-12 at 16 54 12@2x" src="https://github.com/user-attachments/assets/11fa6db2-7abb-49a1-b571-86dd261d9268" />

---

🤖 Generated with [Claude Opus 4.7.