### PR TITLE
Promote Gumroad CLI on the public API docs page

### DIFF
--- a/app/javascript/components/ApiDocumentation/CommandLine.tsx
+++ b/app/javascript/components/ApiDocumentation/CommandLine.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+import { Card, CardContent } from "$app/components/ui/Card";
+import CodeSnippet from "$app/components/ui/CodeSnippet";
+
+export const CommandLine = () => (
+  <Card id="api-cli">
+    <CardContent>
+      <h2 className="grow">Command line</h2>
+    </CardContent>
+    <CardContent>
+      <div className="flex grow flex-col gap-4">
+        <p>
+          Prefer a terminal? The{" "}
+          <a href="https://github.com/antiwork/gumroad-cli" target="_blank" rel="noopener noreferrer">
+            Gumroad CLI
+          </a>{" "}
+          wraps every endpoint below and is built for humans and AI agents alike.
+        </p>
+        <CodeSnippet caption="Install with Homebrew">brew install antiwork/cli/gumroad</CodeSnippet>
+        <CodeSnippet caption="Or run the install script">
+          curl -fsSL https://gumroad.com/install-cli.sh | bash
+        </CodeSnippet>
+        <p>
+          Each endpoint below shows the matching <code>gumroad</code> invocation next to its cURL example. Run{" "}
+          <code>gumroad &lt;command&gt; --help</code> for the full list of flags.
+        </p>
+      </div>
+    </CardContent>
+  </Card>
+);

--- a/app/javascript/components/ApiDocumentation/Endpoints/CustomFields.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/CustomFields.tsx
@@ -112,7 +112,8 @@ export const UpdateCustomField = () => (
     </CodeSnippet>
     <CodeSnippet caption="Gumroad CLI">
       {`gumroad custom-fields update --product A-m3CDDC5dlrSdKZp0RFhA== \\
-  --name "phone number"`}
+  --name "phone number" \\
+  --required=false`}
     </CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{

--- a/app/javascript/components/ApiDocumentation/Endpoints/CustomFields.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/CustomFields.tsx
@@ -43,6 +43,7 @@ export const GetCustomFields = () => (
   -d "access_token=ACCESS_TOKEN" \\
   -X GET`}
     </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">gumroad custom-fields list --product A-m3CDDC5dlrSdKZp0RFhA==</CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,
@@ -74,6 +75,11 @@ export const CreateCustomField = () => (
   -d "required=true" \\
   -X POST`}
     </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">
+      {`gumroad custom-fields create --product A-m3CDDC5dlrSdKZp0RFhA== \\
+  --name "phone number" \\
+  --required`}
+    </CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,
@@ -104,6 +110,10 @@ export const UpdateCustomField = () => (
   -d "name=phone number" \\
   -X PUT`}
     </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">
+      {`gumroad custom-fields update --product A-m3CDDC5dlrSdKZp0RFhA== \\
+  --name "phone number"`}
+    </CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,
@@ -126,6 +136,10 @@ export const DeleteCustomField = () => (
       {`curl https://api.gumroad.com/v2/products/A-m3CDDC5dlrSdKZp0RFhA==/custom_fields/phone%20number \\
   -d "access_token=ACCESS_TOKEN" \\
   -X DELETE`}
+    </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">
+      {`gumroad custom-fields delete --product A-m3CDDC5dlrSdKZp0RFhA== \\
+  --name "phone number"`}
     </CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{

--- a/app/javascript/components/ApiDocumentation/Endpoints/Files.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/Files.tsx
@@ -34,6 +34,11 @@ export const FilesOverview = () => (
         this <code>upload_id</code>. Call abort again while you see <code>accepted</code>; stop when you see{" "}
         <code>already_gone</code>.
       </p>
+      <p>
+        The CLI collapses all four steps into a single command and prints the canonical <code>file_url</code> you can
+        attach to a product:
+      </p>
+      <CodeSnippet caption="Gumroad CLI">gumroad files upload ./course.pdf</CodeSnippet>
     </div>
   </CardContent>
 );
@@ -125,6 +130,10 @@ export const CompleteFile = () => (
   -d 'parts[][etag]="9b2cf535f27731c974343645a3985328"' \\
   -X POST`}
     </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">
+      {`# replay an ambiguous complete from a recovery manifest written by 'gumroad files upload'
+gumroad files complete --recovery err.json`}
+    </CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,
@@ -166,6 +175,11 @@ export const AbortFile = () => (
   -d "key=attachments/A-m3CDDC5dlrSdKZp0RFhA==/9f2c1b7d6e4a/original/course.pdf" \\
   -X POST`}
     </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">
+      {`gumroad files abort \\
+  --upload-id ibZBv_75gd9o.uPYmGbJ5JjxqK4_VsP3... \\
+  --key attachments/A-m3CDDC5dlrSdKZp0RFhA==/9f2c1b7d6e4a/original/course.pdf`}
+    </CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,
@@ -202,6 +216,12 @@ export const AttachFile = () => (
   -d "files[][url]=https://gumroad-specials.s3.amazonaws.com/attachments/A-m3CDDC5dlrSdKZp0RFhA==/9f2c1b7d6e4a/original/course.pdf" \\
   -X POST`}
       </CodeSnippet>
+      <CodeSnippet caption="Gumroad CLI (upload + attach in one call)">
+        {`gumroad products create --type digital \\
+  --name "My product" \\
+  --price 5.00 \\
+  --file ./course.pdf`}
+      </CodeSnippet>
       <p>
         <strong>
           <code>files</code> on <code>PUT /v2/products/:id</code> is a full replacement
@@ -219,6 +239,9 @@ export const AttachFile = () => (
   -d "files[][url]=https://gumroad-specials.s3.amazonaws.com/attachments/A-m3CDDC5dlrSdKZp0RFhA==/bbbb2222/original/existing2.pdf" \\
   -d "files[][url]=https://gumroad-specials.s3.amazonaws.com/attachments/A-m3CDDC5dlrSdKZp0RFhA==/9f2c1b7d6e4a/original/course.pdf" \\
   -X PUT`}
+      </CodeSnippet>
+      <CodeSnippet caption="Gumroad CLI (append a file, keep existing attachments)">
+        gumroad products update PRODUCT_ID --file ./course.pdf
       </CodeSnippet>
       <p>
         Save the canonical <code>file_url</code> on your side. <code>GET /v2/products/:id</code> returns a time-limited

--- a/app/javascript/components/ApiDocumentation/Endpoints/Files.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/Files.tsx
@@ -130,9 +130,8 @@ export const CompleteFile = () => (
   -d 'parts[][etag]="9b2cf535f27731c974343645a3985328"' \\
   -X POST`}
     </CodeSnippet>
-    <CodeSnippet caption="Gumroad CLI">
-      {`# replay an ambiguous complete from a recovery manifest written by 'gumroad files upload'
-gumroad files complete --recovery err.json`}
+    <CodeSnippet caption="Gumroad CLI (replay from recovery manifest)">
+      gumroad files complete --recovery err.json
     </CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{

--- a/app/javascript/components/ApiDocumentation/Endpoints/Licenses.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/Licenses.tsx
@@ -36,6 +36,10 @@ export const VerifyLicense = () => (
   -d "license_key=A1B2C3D4-E5F60718-9ABCDEF0-1234ABCD" \\
   -X POST`}
     </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">
+      {`echo "A1B2C3D4-E5F60718-9ABCDEF0-1234ABCD" | gumroad licenses verify \\
+  --product 32-nPAicqbLj8B_WswVlMw==`}
+    </CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,
@@ -98,6 +102,10 @@ export const EnableLicense = () => (
   -d "product_id=32-nPAicqbLj8B_WswVlMw==" \\
   -d "license_key=A1B2C3D4-E5F60718-9ABCDEF0-1234ABCD" \\
   -X PUT`}
+    </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">
+      {`echo "A1B2C3D4-E5F60718-9ABCDEF0-1234ABCD" | gumroad licenses enable \\
+  --product 32-nPAicqbLj8B_WswVlMw==`}
     </CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
@@ -162,6 +170,10 @@ export const DisableLicense = () => (
   -d "license_key=A1B2C3D4-E5F60718-9ABCDEF0-1234ABCD" \\
   -X PUT`}
     </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">
+      {`echo "A1B2C3D4-E5F60718-9ABCDEF0-1234ABCD" | gumroad licenses disable \\
+  --product 32-nPAicqbLj8B_WswVlMw==`}
+    </CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,
@@ -224,6 +236,10 @@ export const DecrementUsesCount = () => (
   -d "product_id=32-nPAicqbLj8B_WswVlMw==" \\
   -d "license_key=A1B2C3D4-E5F60718-9ABCDEF0-1234ABCD" \\
   -X PUT`}
+    </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">
+      {`echo "A1B2C3D4-E5F60718-9ABCDEF0-1234ABCD" | gumroad licenses decrement \\
+  --product 32-nPAicqbLj8B_WswVlMw==`}
     </CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
@@ -291,6 +307,10 @@ export const RotateLicense = () => (
   -d "product_id=32-nPAicqbLj8B_WswVlMw==" \\
   -d "license_key=A1B2C3D4-E5F60718-9ABCDEF0-1234ABCD" \\
   -X PUT`}
+    </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">
+      {`echo "A1B2C3D4-E5F60718-9ABCDEF0-1234ABCD" | gumroad licenses rotate \\
+  --product 32-nPAicqbLj8B_WswVlMw==`}
     </CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{

--- a/app/javascript/components/ApiDocumentation/Endpoints/OfferCodes.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/OfferCodes.tsx
@@ -43,6 +43,7 @@ export const GetOfferCodes = () => (
   -d "access_token=ACCESS_TOKEN" \\
   -X GET`}
     </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">gumroad offer-codes list --product A-m3CDDC5dlrSdKZp0RFhA==</CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,
@@ -79,6 +80,10 @@ export const GetOfferCode = () => (
   -d "name=1OFF" \\
   -d "amount_cents=100" \\
   -X GET`}
+    </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">
+      {`gumroad offer-codes view bfi_30HLgGWL8H2wo_Gzlg== \\
+  --product A-m3CDDC5dlrSdKZp0RFhA==`}
     </CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
@@ -117,6 +122,11 @@ export const CreateOfferCode = () => (
   -d "offer_type=cents" \\
   -X POST`}
     </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">
+      {`gumroad offer-codes create --product A-m3CDDC5dlrSdKZp0RFhA== \\
+  --name 1OFF \\
+  --amount 1.00`}
+    </CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,
@@ -149,6 +159,11 @@ export const UpdateOfferCode = () => (
   -d "max_purchase_count=10" \\
   -X PUT`}
     </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">
+      {`gumroad offer-codes update bfi_30HLgGWL8H2wo_Gzlg== \\
+  --product A-m3CDDC5dlrSdKZp0RFhA== \\
+  --max-purchase-count 10`}
+    </CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,
@@ -174,6 +189,10 @@ export const DeleteOfferCode = () => (
       {`curl https://api.gumroad.com/v2/products/A-m3CDDC5dlrSdKZp0RFhA==/offer_codes/bfi_30HLgGWL8H2wo_Gzlg== \\
   -d "access_token=ACCESS_TOKEN" \\
   -X DELETE`}
+    </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">
+      {`gumroad offer-codes delete bfi_30HLgGWL8H2wo_Gzlg== \\
+  --product A-m3CDDC5dlrSdKZp0RFhA==`}
     </CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{

--- a/app/javascript/components/ApiDocumentation/Endpoints/Payouts.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/Payouts.tsx
@@ -79,6 +79,7 @@ export const GetPayouts = () => (
   -d "after=2020-09-03" \\
   -X GET`}
     </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">gumroad payouts list --before 2021-09-03 --after 2020-09-03</CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,
@@ -158,6 +159,7 @@ export const GetPayout = () => (
   -d "include_transactions=true" \\
   -X GET`}
     </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">gumroad payouts view fEGTaEpuKDsnDvf_MfecTA==</CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,
@@ -269,6 +271,7 @@ export const GetUpcomingPayouts = () => (
   -d "include_transactions=true" \\
   -X GET`}
     </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">gumroad payouts upcoming</CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,

--- a/app/javascript/components/ApiDocumentation/Endpoints/Products.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/Products.tsx
@@ -65,6 +65,7 @@ export const GetProducts = () => (
   -d "access_token=ACCESS_TOKEN" \\
   -X GET`}
     </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">gumroad products list</CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,
@@ -142,6 +143,7 @@ export const GetProduct = () => (
   -d "access_token=ACCESS_TOKEN" \\
   -X GET`}
     </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">gumroad products view A-m3CDDC5dlrSdKZp0RFhA==</CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,
@@ -271,6 +273,12 @@ export const CreateProduct = () => (
   -d "price_currency_type=usd" \\
   -X POST`}
     </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">
+      {`gumroad products create --type digital \\
+  --name "Pencil Icon PSD" \\
+  --price 1.00 \\
+  --currency usd`}
+    </CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,
@@ -348,6 +356,11 @@ export const UpdateProduct = () => (
   -d "max_purchase_count=100" \\
   -X PUT`}
     </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">
+      {`gumroad products update A-m3CDDC5dlrSdKZp0RFhA== \\
+  --name "Pencil Icon PSD v2" \\
+  --max-purchase-count 100`}
+    </CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,
@@ -379,6 +392,7 @@ export const DeleteProduct = () => (
   -d "access_token=ACCESS_TOKEN" \\
   -X DELETE`}
     </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">gumroad products delete A-m3CDDC5dlrSdKZp0RFhA==</CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,
@@ -396,6 +410,7 @@ export const EnableProduct = () => (
   -d "access_token=ACCESS_TOKEN" \\
   -X PUT`}
     </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">gumroad products publish A-m3CDDC5dlrSdKZp0RFhA==</CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,
@@ -473,6 +488,7 @@ export const DisableProduct = () => (
   -d "access_token=ACCESS_TOKEN" \\
   -X PUT`}
     </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">gumroad products unpublish A-m3CDDC5dlrSdKZp0RFhA==</CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,

--- a/app/javascript/components/ApiDocumentation/Endpoints/ResourceSubscriptions.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/ResourceSubscriptions.tsx
@@ -180,6 +180,10 @@ export const CreateResourceSubscription = () => (
   -d "post_url=https://postatmebro.com" \\
   -X PUT`}
     </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">
+      {`gumroad webhooks create --resource sale \\
+  --url https://postatmebro.com`}
+    </CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,
@@ -222,6 +226,7 @@ export const GetResourceSubscriptions = () => (
   -d "resource_name=sale" \\
   -X GET`}
     </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">gumroad webhooks list --resource sale</CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,
@@ -246,6 +251,7 @@ export const DeleteResourceSubscription = () => (
   -d "access_token=ACCESS_TOKEN" \\
   -X DELETE`}
     </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">gumroad webhooks delete G_-mnBf9b1j9A7a4ub4nFQ==</CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,

--- a/app/javascript/components/ApiDocumentation/Endpoints/Sales.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/Sales.tsx
@@ -60,6 +60,13 @@ export const GetSales = () => (
   -d "license_key=83DB262A-C19D3B06-A5235A6B-8C079166" \\
   -X GET`}
     </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">
+      {`gumroad sales list --all \\
+  --before 2021-09-03 \\
+  --after 2020-09-03 \\
+  --product bfi_30HLgGWL8H2wo_Gzlg== \\
+  --email calvin@example.com`}
+    </CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,
@@ -148,6 +155,7 @@ export const GetSale = () => (
   -d "access_token=ACCESS_TOKEN" \\
   -X GET`}
     </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">gumroad sales view FO8TXN-dvxYabdavG97Y-Q==</CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,
@@ -239,6 +247,10 @@ export const MarkSaleAsShipped = () => (
   -d "access_token=ACCESS_TOKEN" \\
   -d "tracking_url=https://www.shippingcompany.com/track/t123" \\
   -X PUT`}
+    </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">
+      {`gumroad sales ship A-m3CDDC5dlrSdKZp0RFhA== \\
+  --tracking-url https://www.shippingcompany.com/track/t123`}
     </CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
@@ -337,6 +349,7 @@ export const RefundSale = () => (
   -d "amount_cents=200" \\
   -X PUT`}
     </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">gumroad sales refund A-m3CDDC5dlrSdKZp0RFhA== --amount 2.00</CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,
@@ -411,6 +424,7 @@ export const ResendReceipt = () => (
   -d "access_token=ACCESS_TOKEN" \\
   -X POST`}
     </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">gumroad sales resend-receipt A-m3CDDC5dlrSdKZp0RFhA==</CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success": true

--- a/app/javascript/components/ApiDocumentation/Endpoints/Sales.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/Sales.tsx
@@ -65,7 +65,7 @@ export const GetSales = () => (
   --before 2021-09-03 \\
   --after 2020-09-03 \\
   --product bfi_30HLgGWL8H2wo_Gzlg== \\
-  --email calvin@example.com`}
+  --email calvin@gumroad.com`}
     </CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{

--- a/app/javascript/components/ApiDocumentation/Endpoints/Subscribers.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/Subscribers.tsx
@@ -69,6 +69,10 @@ export const GetSubscribers = () => (
   -d "email=calvin@gumroad.com" \\
   -X GET`}
     </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">
+      {`gumroad subscribers list --product 0ssD7adjRklGBjS5cwlWPq== \\
+  --email calvin@example.com`}
+    </CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success":true,
@@ -119,6 +123,7 @@ export const GetSubscriber = () => (
   -d "access_token=ACCESS_TOKEN" \\
   -X GET`}
     </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">gumroad subscribers view P5ppE6H8XIjy2JSCgUhbAw==</CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success":true,

--- a/app/javascript/components/ApiDocumentation/Endpoints/Subscribers.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/Subscribers.tsx
@@ -71,7 +71,7 @@ export const GetSubscribers = () => (
     </CodeSnippet>
     <CodeSnippet caption="Gumroad CLI">
       {`gumroad subscribers list --product 0ssD7adjRklGBjS5cwlWPq== \\
-  --email calvin@example.com`}
+  --email calvin@gumroad.com`}
     </CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{

--- a/app/javascript/components/ApiDocumentation/Endpoints/User.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/User.tsx
@@ -19,6 +19,7 @@ export const GetUser = () => (
   -d "access_token=ACCESS_TOKEN" \\
   -X GET`}
     </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">gumroad user</CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,

--- a/app/javascript/components/ApiDocumentation/Endpoints/Variants.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/Variants.tsx
@@ -52,6 +52,10 @@ export const CreateVariantCategory = () => (
   -d "title=colors" \\
   -X POST`}
     </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">
+      {`gumroad variant-categories create --product A-m3CDDC5dlrSdKZp0RFhA== \\
+  --title colors`}
+    </CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,
@@ -75,6 +79,10 @@ export const GetVariantCategory = () => (
       {`curl https://api.gumroad.com/v2/products/A-m3CDDC5dlrSdKZp0RFhA==/variant_categories/mN7CdHiwHaR9FlxKvF-n-g== \\
   -d "access_token=ACCESS_TOKEN" \\
   -X GET`}
+    </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">
+      {`gumroad variant-categories view mN7CdHiwHaR9FlxKvF-n-g== \\
+  --product A-m3CDDC5dlrSdKZp0RFhA==`}
     </CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
@@ -105,6 +113,11 @@ export const UpdateVariantCategory = () => (
   -d "title=sizes" \\
   -X PUT`}
     </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">
+      {`gumroad variant-categories update mN7CdHiwHaR9FlxKvF-n-g== \\
+  --product A-m3CDDC5dlrSdKZp0RFhA== \\
+  --title sizes`}
+    </CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,
@@ -127,6 +140,10 @@ export const DeleteVariantCategory = () => (
       {`curl https://api.gumroad.com/v2/products/A-m3CDDC5dlrSdKZp0RFhA==/variant_categories/mN7CdHiwHaR9FlxKvF-n-g== \\
   -d "access_token=ACCESS_TOKEN" \\
   -X DELETE`}
+    </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">
+      {`gumroad variant-categories delete mN7CdHiwHaR9FlxKvF-n-g== \\
+  --product A-m3CDDC5dlrSdKZp0RFhA==`}
     </CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
@@ -159,6 +176,7 @@ export const GetVariantCategories = () => (
   -d "access_token=ACCESS_TOKEN" \\
   -X GET`}
     </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">gumroad variant-categories list --product A-m3CDDC5dlrSdKZp0RFhA==</CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,
@@ -190,6 +208,12 @@ export const CreateVariant = () => (
   -d "name=red" \\
   -d "price_difference_cents=250"`}
     </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">
+      {`gumroad variants create --product A-m3CDDC5dlrSdKZp0RFhA== \\
+  --category mN7CdHiwHaR9FlxKvF-n-g== \\
+  --name red \\
+  --price-difference 2.50`}
+    </CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,
@@ -215,6 +239,11 @@ export const GetVariant = () => (
       {`curl https://api.gumroad.com/v2/products/A-m3CDDC5dlrSdKZp0RFhA==/variant_categories/mN7CdHiwHaR9FlxKvF-n-g==/variants/kuaXCPHTmRuoK13rNGVbxg== \\
   -d "access_token=ACCESS_TOKEN" \\
   -X GET`}
+    </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">
+      {`gumroad variants view kuaXCPHTmRuoK13rNGVbxg== \\
+  --product A-m3CDDC5dlrSdKZp0RFhA== \\
+  --category mN7CdHiwHaR9FlxKvF-n-g==`}
     </CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
@@ -249,6 +278,12 @@ export const UpdateVariant = () => (
   -d "price_difference_cents=150" \\
   -X PUT`}
     </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">
+      {`gumroad variants update kuaXCPHTmRuoK13rNGVbxg== \\
+  --product A-m3CDDC5dlrSdKZp0RFhA== \\
+  --category mN7CdHiwHaR9FlxKvF-n-g== \\
+  --price-difference 1.50`}
+    </CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
   "success": true,
@@ -273,6 +308,11 @@ export const DeleteVariant = () => (
       {`curl https://api.gumroad.com/v2/products/A-m3CDDC5dlrSdKZp0RFhA==/variant_categories/mN7CdHiwHaR9FlxKvF-n-g==/variants/kuaXCPHTmRuoK13rNGVbxg== \\
   -d "access_token=ACCESS_TOKEN" \\
   -X DELETE`}
+    </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">
+      {`gumroad variants delete kuaXCPHTmRuoK13rNGVbxg== \\
+  --product A-m3CDDC5dlrSdKZp0RFhA== \\
+  --category mN7CdHiwHaR9FlxKvF-n-g==`}
     </CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{
@@ -304,6 +344,10 @@ export const GetVariants = () => (
       {`curl https://api.gumroad.com/v2/products/A-m3CDDC5dlrSdKZp0RFhA==/variant_categories/mN7CdHiwHaR9FlxKvF-n-g==/variants \\
   -d "access_token=ACCESS_TOKEN" \\
   -X GET`}
+    </CodeSnippet>
+    <CodeSnippet caption="Gumroad CLI">
+      {`gumroad variants list --product A-m3CDDC5dlrSdKZp0RFhA== \\
+  --category mN7CdHiwHaR9FlxKvF-n-g==`}
     </CodeSnippet>
     <CodeSnippet caption="Example response:">
       {`{

--- a/app/javascript/components/ApiDocumentation/Navigation.tsx
+++ b/app/javascript/components/ApiDocumentation/Navigation.tsx
@@ -8,6 +8,9 @@ export const Navigation = () => (
   >
     <menu className="grid list-none gap-3">
       <li>
+        <a href="#api-cli">Command line</a>
+      </li>
+      <li>
         <a href="#api-intro">Introduction</a>
       </li>
       <li>

--- a/app/javascript/pages/Public/Api.tsx
+++ b/app/javascript/pages/Public/Api.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import { ApiResource } from "$app/components/ApiDocumentation/ApiResource";
 import { Authentication } from "$app/components/ApiDocumentation/Authentication";
+import { CommandLine } from "$app/components/ApiDocumentation/CommandLine";
 import { CreateCover, DeleteCover } from "$app/components/ApiDocumentation/Endpoints/Covers";
 import {
   GetCustomFields,
@@ -78,6 +79,7 @@ export default function Api() {
           <div className="grid grid-cols-1 items-start gap-x-16 gap-y-8 lg:grid-cols-[var(--grid-cols-sidebar)]">
             <Navigation />
             <article className="grid gap-8">
+              <CommandLine />
               <Introduction />
               <Authentication />
               <Scopes />


### PR DESCRIPTION
Step 3 of #4995

## What

Surfaces the [Gumroad CLI](https://github.com/antiwork/gumroad-cli) on the public API docs at `/api`. Adds a "Command line" card at the top of the page with the Homebrew install command and a link to the CLI repo, a matching sidebar entry, and a `gumroad ...` snippet next to every cURL example where a direct CLI command exists: Products, Sales, Subscribers, Licenses, Payouts, Offer codes, Custom fields, User, Variants, Files, and Resource subscriptions (which map to `gumroad webhooks`). 

Endpoints with no CLI surface (Covers, Earnings, Tax forms, and the low-level `POST /files/presign`) are left untouched.

## Why

The API docs page didn't mention the CLI at all. Putting the equivalent invocation next to each REST example lets readers pick the CLI without leaving the page. Resource subscriptions and webhooks are the same concept under different names, so the CLI snippet uses the CLI's `webhooks` naming alongside the REST `resource_subscriptions` example.

## Screenshots

**New Command line section**
<img width="2930" height="1430" alt="CleanShot 2026-05-12 at 17 26 42@2x" src="https://github.com/user-attachments/assets/83b38797-c375-4c8c-8851-0ccfe0db93e1" />

**Snippet example**
<img width="2930" height="1814" alt="CleanShot 2026-05-12 at 17 27 13@2x" src="https://github.com/user-attachments/assets/64171b59-7d25-403f-a303-f72f8ae05169" />

---

This PR was implemented with AI assistance using Claude Opus 4.7.