### PR TITLE
Fix duplicate index migration breaking all CI

### DIFF
--- a/db/migrate/20261125000001_add_comment_type_and_created_at_index_to_comments.rb
+++ b/db/migrate/20261125000001_add_comment_type_and_created_at_index_to_comments.rb
@@ -4,6 +4,7 @@ class AddCommentTypeAndCreatedAtIndexToComments < ActiveRecord::Migration[7.1]
   def change
     add_index :comments,
               [:comment_type, :commentable_type, :created_at, :commentable_id],
-              name: "index_comments_on_comment_type_and_created_at"
+              name: "index_comments_on_comment_type_and_created_at",
+              if_not_exists: true
   end
 end


### PR DESCRIPTION
The `index_comments_on_comment_type_and_created_at` index already exists in production (present in schema.rb), so `db:migrate` fails with `Mysql2::Error: Duplicate key name`. This is breaking **every test shard on main**.

Fix: add `if_not_exists: true` to make the migration idempotent.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>