### PR TITLE
Show selected/total products count in profile editor

### DIFF
--- a/app/javascript/components/Profile/EditSections.tsx
+++ b/app/javascript/components/Profile/EditSections.tsx
@@ -452,6 +452,7 @@ const ProductsSectionView = ({ section }: { section: ProductsSection }) => {
     [JSON.stringify(section.shown_products), section.default_product_sort],
   );
   const selectedProductsCount = state.products.filter((product) => section.shown_products.includes(product.id)).length;
+  const totalProductsCount = state.products.length;
 
   return (
     <SectionLayout
@@ -460,7 +461,7 @@ const ProductsSectionView = ({ section }: { section: ProductsSection }) => {
         <EditorSubmenu
           key="0"
           heading="Products"
-          text={`${selectedProductsCount} ${selectedProductsCount === 1 ? "product" : "products"}`}
+          text={`${selectedProductsCount}/${totalProductsCount} ${totalProductsCount === 1 ? "product" : "products"}`}
         >
           <ProductsSettings section={section} />
         </EditorSubmenu>,


### PR DESCRIPTION
## What

Changes the profile editor Products section menu from showing `0 products` to `0/67 products` (selected/total), so creators can see there are products available to select.

**Before:** `Products — 0 products` → looks like there are no products
**After:** `Products — 0/67 products` → clear that 67 products are available to select

## Why

Creators were confused by "0 products" — they thought the system found no products in their account and never clicked through to select them. A creator spent a week in support unable to get products on her profile because of this.

Fixes antiwork/gumroad-private#361

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>