### PR TITLE
Stop forcing Stripe Connect representative to 100% ownership

### DIFF
--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -210,12 +210,21 @@ module StripeMerchantAccountManager
   end
 
   def self.update_person(user, stripe_account, last_user_compliance_info_id, passphrase)
-    stripe_person = Stripe::Account.list_persons(stripe_account.id)["data"].last
+    stripe_persons = Stripe::Account.list_persons(stripe_account.id)["data"]
+    stripe_person = find_stripe_representative_person(stripe_persons)
+    return if stripe_person.nil?
+
     last_user_compliance_info = UserComplianceInfo.find_by_external_id(last_user_compliance_info_id)
     user_compliance_info = user.alive_user_compliance_info
 
     current_attributes = person_hash(user_compliance_info, passphrase)
-    current_attributes.deep_merge!(relationship: { representative: true, owner: true, title: user_compliance_info.job_title.presence || DEFAULT_RELATIONSHIP_TITLE, percent_ownership: 100 })
+    relationship_attributes = {
+      representative: true,
+      owner: true,
+      title: user_compliance_info.job_title.presence || DEFAULT_RELATIONSHIP_TITLE
+    }
+    relationship_attributes[:percent_ownership] = 100 unless other_beneficial_owners_present?(stripe_persons, stripe_person)
+    current_attributes.deep_merge!(relationship: relationship_attributes)
     diff_attributes = current_attributes
     last_attributes = person_hash(last_user_compliance_info, passphrase)
 
@@ -232,6 +241,16 @@ module StripeMerchantAccountManager
     end
 
     Stripe::Account.update_person(stripe_account.id, stripe_person.id, diff_attributes)
+  end
+
+  def self.find_stripe_representative_person(stripe_persons)
+    stripe_persons.find { |person| person[:relationship]&.[](:representative) } || stripe_persons.last
+  end
+
+  def self.other_beneficial_owners_present?(stripe_persons, representative_person)
+    stripe_persons.any? do |person|
+      person.id != representative_person.id && person[:relationship]&.[](:owner)
+    end
   end
 
   def self.get_diff_attributes(current_attributes, last_attributes)

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -11680,4 +11680,163 @@ describe StripeMerchantAccountManager, :vcr do
       end
     end
   end
+
+  describe ".find_stripe_representative_person" do
+    let(:representative) do
+      Stripe::Person.construct_from(id: "person_rep", relationship: { representative: true, owner: true })
+    end
+    let(:co_owner) do
+      Stripe::Person.construct_from(id: "person_co_owner", relationship: { representative: false, owner: true })
+    end
+    let(:no_relationship_person) do
+      Stripe::Person.construct_from(id: "person_unknown")
+    end
+
+    it "returns the person flagged as representative" do
+      expect(described_class.find_stripe_representative_person([co_owner, representative])).to eq(representative)
+    end
+
+    it "falls back to the last person when no representative is set" do
+      expect(described_class.find_stripe_representative_person([no_relationship_person, co_owner])).to eq(co_owner)
+    end
+
+    it "returns nil for an empty list" do
+      expect(described_class.find_stripe_representative_person([])).to be_nil
+    end
+  end
+
+  describe ".other_beneficial_owners_present?" do
+    let(:representative) do
+      Stripe::Person.construct_from(id: "person_rep", relationship: { representative: true, owner: true })
+    end
+
+    it "returns false when only the representative is an owner" do
+      director_only = Stripe::Person.construct_from(
+        id: "person_director", relationship: { representative: false, owner: false, director: true }
+      )
+      expect(described_class.other_beneficial_owners_present?([representative, director_only], representative)).to eq(false)
+    end
+
+    it "returns true when at least one other person is flagged as an owner" do
+      co_owner = Stripe::Person.construct_from(
+        id: "person_co_owner", relationship: { representative: false, owner: true }
+      )
+      expect(described_class.other_beneficial_owners_present?([representative, co_owner], representative)).to eq(true)
+    end
+  end
+
+  describe ".update_person" do
+    let(:user) { create(:user, email: "rep@example.com") }
+    let(:user_compliance_info) { create(:user_compliance_info_business, user:) }
+    let(:stripe_account) { Stripe::Account.construct_from(id: "acct_multi_owner_123") }
+
+    let(:representative_person) do
+      Stripe::Person.construct_from(
+        id: "person_representative",
+        object: "person",
+        account: stripe_account.id,
+        relationship: { representative: true, owner: true, percent_ownership: 33.33 }
+      )
+    end
+    let(:co_director_owner) do
+      Stripe::Person.construct_from(
+        id: "person_co_director",
+        object: "person",
+        account: stripe_account.id,
+        relationship: { representative: false, owner: true, percent_ownership: 33.33 }
+      )
+    end
+    let(:third_owner) do
+      Stripe::Person.construct_from(
+        id: "person_third_owner",
+        object: "person",
+        account: stripe_account.id,
+        relationship: { representative: false, owner: true, percent_ownership: 33.34 }
+      )
+    end
+
+    before { user_compliance_info }
+
+    context "with multiple beneficial owners on the Stripe account" do
+      before do
+        expect(Stripe::Account).to receive(:list_persons)
+          .with(stripe_account.id)
+          .and_return("data" => [co_director_owner, representative_person, third_owner])
+      end
+
+      it "updates the representative person rather than the last person returned by Stripe" do
+        expect(Stripe::Account).to receive(:update_person)
+          .with(stripe_account.id, representative_person.id, anything)
+          .and_return(true)
+
+        described_class.update_person(user, stripe_account, nil, "1234")
+      end
+
+      it "omits percent_ownership so Stripe preserves the existing owner split" do
+        captured_attributes = nil
+        expect(Stripe::Account).to receive(:update_person) do |_account_id, _person_id, attributes|
+          captured_attributes = attributes
+          true
+        end
+
+        described_class.update_person(user, stripe_account, nil, "1234")
+
+        expect(captured_attributes[:relationship]).to include(representative: true, owner: true)
+        expect(captured_attributes[:relationship]).not_to have_key(:percent_ownership)
+      end
+    end
+
+    context "with only the representative on the Stripe account" do
+      it "sets percent_ownership to 100 (current behavior for single-owner accounts)" do
+        expect(Stripe::Account).to receive(:list_persons)
+          .with(stripe_account.id)
+          .and_return("data" => [representative_person])
+
+        captured_attributes = nil
+        expect(Stripe::Account).to receive(:update_person) do |_account_id, _person_id, attributes|
+          captured_attributes = attributes
+          true
+        end
+
+        described_class.update_person(user, stripe_account, nil, "1234")
+
+        expect(captured_attributes[:relationship]).to include(representative: true, owner: true, percent_ownership: 100)
+      end
+    end
+
+    context "with a representative plus a non-owner director on the Stripe account" do
+      it "still sets percent_ownership to 100 because no other beneficial owners exist" do
+        director_only = Stripe::Person.construct_from(
+          id: "person_director_only",
+          object: "person",
+          account: stripe_account.id,
+          relationship: { representative: false, owner: false, director: true }
+        )
+        expect(Stripe::Account).to receive(:list_persons)
+          .with(stripe_account.id)
+          .and_return("data" => [representative_person, director_only])
+
+        captured_attributes = nil
+        expect(Stripe::Account).to receive(:update_person) do |_account_id, _person_id, attributes|
+          captured_attributes = attributes
+          true
+        end
+
+        described_class.update_person(user, stripe_account, nil, "1234")
+
+        expect(captured_attributes[:relationship]).to include(representative: true, owner: true, percent_ownership: 100)
+      end
+    end
+
+    context "when Stripe returns no persons for the account" do
+      it "returns early without calling update_person" do
+        expect(Stripe::Account).to receive(:list_persons)
+          .with(stripe_account.id)
+          .and_return("data" => [])
+        expect(Stripe::Account).not_to receive(:update_person)
+
+        described_class.update_person(user, stripe_account, nil, "1234")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What

`StripeMerchantAccountManager#update_person` had two latent bugs that surfaced for sellers whose Stripe Connect compliance flow recorded additional beneficial owners (typical of UK/EU Ltd companies with multiple directors):

1. It selected the person to update via `Stripe::Account.list_persons(...)["data"].last` — an arbitrary choice that did not necessarily match the user tied to the Gumroad account.
2. It hard-coded `relationship.percent_ownership: 100` on every update. When Stripe had already split ownership across multiple persons (e.g. 33.33% × 3 directors), pushing the representative to 100% drove the total above 100% and Stripe rejected the update with:

   > The total combined ownership of the company would exceed 100 percent.

The rejection was caught in `Settings::PaymentsController#update_user_compliance_info` and persisted as a `note` Comment on the user. So every time an affected seller resubmitted their Settings → Payments form, a fresh "exceed 100%" admin note was created — even when their Stripe account was already fully verified (`charges_enabled`, `payouts_enabled` both `true`, no `requirements.currently_due`).

The fix in [stripe_merchant_account_manager.rb#L212-L255](https://github.com/antiwork/gumroad/blob/fix-stripe-update-person-multi-owner/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb#L212-L255):

- Picks the person flagged `relationship.representative = true`, falling back to the previous `list_persons.last` behavior when no representative is present (preserves behavior for older accounts and existing test stubs).
- Only sets `percent_ownership: 100` when no other person on the Stripe account is flagged as an owner. When other beneficial owners exist, the representative's existing Stripe-side percentage is left untouched.
- Returns early if Stripe returns zero persons, instead of crashing on `nil.id`.

Two new private helpers — `find_stripe_representative_person` and `other_beneficial_owners_present?` — keep the logic out of the main flow and individually testable.

`create_account` is intentionally not changed: at account creation there is always exactly one person, so the existing `percent_ownership: 100` is correct there.

## Why

A real production seller (UK Ltd with three director-owners at 33.33% each, Stripe account fully verified) had 20+ identical "exceed 100%" admin notes accrue over the past three weeks because they kept opening Settings → Payments to "fix" something Stripe support had told them to fix in our app. The Stripe account itself was healthy — the error was entirely generated by us re-submitting `percent_ownership: 100` on every Gumroad-side update — but the admin notes spooked first-line support into routing the ticket as a Stripe-side problem, and Stripe Support correctly bounced it back to Gumroad.

The fix is minimal and conservative: behavior is unchanged for single-owner accounts (which is what Gumroad's Payments UI models today), and the multi-owner case stops producing false-positive errors. Sellers with multi-director companies no longer need to coordinate with Stripe Support — they can update their compliance details on Gumroad without triggering the phantom error.



---

This PR was implemented with Claude Opus 4.7 (1M context)
