### PR TITLE
Bump schema.rb version to match latest migration

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_11_25_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_11_25_000001) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false


### PR DESCRIPTION
## What

Bumps `db/schema.rb` version from `2026_11_25_000000` to `2026_11_25_000001` so it matches the latest migration timestamp (`20261125000001_add_comment_type_and_created_at_index_to_comments.rb`).

## Why

PR #5035 renamed the comments-index migration from `20261125000000` to `20261125000001` to resolve a timestamp collision, but did not bump the version stamp in `schema.rb`. The index was already present in `schema.rb` and `schema_migrations` already contains `20261125000001` in production, so the only remaining problem is the stale version stamp:

- On CI, `db:schema:load` stamps `schema_migrations` only up through `20261125000000`, leaving `20261125000001` "pending"
- `db:migrate` then tries to run it and fails with `Mysql2::Error: Duplicate key name 'index_comments_on_comment_type_and_created_at'` because the index already exists from `schema:load`

Closes #5039, which proposed making the migration idempotent with `if_not_exists: true`. That works for CI but leaves `schema.rb` at the wrong version, which is misleading — `schema.rb`'s version stamp should reflect the state it actually represents. Bumping the version is the cleaner fix and doesn't add permanent defensive cruft to the migration.

## Test plan

- [ ] `bin/rails db:drop db:create db:schema:load db:migrate` succeeds with no pending migrations
- [ ] CI passes