### PR TITLE
Remove XQuartz from README test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ RAILS_ENV=test bin/rails js:export  # generate JS constants for the test environ
 
 ### Integration tests
 
-Integration specs use Capybara with Selenium driving Chrome. Install Chrome from [google.com/chrome](https://www.google.com/chrome/) — Selenium Manager handles chromedriver automatically.
+Integration specs use Capybara with Selenium driving Chrome. Install Chrome from [google.com/chrome](https://www.google.com/chrome/).
 
 See [docs/testing.md](docs/testing.md) for details on preventing flaky specs, VCR cassettes, debugging widgets, and purchase testing with Stripe/PayPal.
 

--- a/README.md
+++ b/README.md
@@ -241,11 +241,7 @@ RAILS_ENV=test bin/rails js:export  # generate JS constants for the test environ
 
 ### Integration tests
 
-Integration specs use Capybara with Selenium (Chrome). On macOS, install XQuartz:
-
-```shell
-brew install xquartz
-```
+Integration specs use Capybara with Selenium driving Chrome. Install Chrome from [google.com/chrome](https://www.google.com/chrome/) — Selenium Manager handles chromedriver automatically.
 
 See [docs/testing.md](docs/testing.md) for details on preventing flaky specs, VCR cassettes, debugging widgets, and purchase testing with Stripe/PayPal.
 


### PR DESCRIPTION
## What

Drop the `brew install xquartz` step from the README's Integration tests section. Replace it with a pointer to install Chrome itself.

## Why

XQuartz provides X11 — it was needed in the old days when Selenium drove Firefox/Chromium through an X11 server on macOS. Modern Chrome and chromedriver on macOS use native Cocoa windowing, so XQuartz is no longer required. A clean Mac with no XQuartz installed (no `/Applications/XQuartz.app`, `which xquartz` empty, `DISPLAY` unset) runs the integration suite without issue.

The instruction was a stale carryover from #5034, which surfaced it from `docs/testing.md` into the top-level README. Sending new contributors through an unnecessary install step is friction. Selenium Manager (bundled with `selenium-webdriver`) auto-resolves chromedriver, so the only real prerequisite on macOS is Chrome.

`docs/testing.md` still has the same outdated XQuartz note (lines 79–85); leaving that for a follow-up to keep this PR focused on the README.

## Before / after

Before:

> Integration specs use Capybara with Selenium (Chrome). On macOS, install XQuartz:
>
> ```shell
> brew install xquartz
> ```

After:

> Integration specs use Capybara with Selenium driving Chrome. Install Chrome from [google.com/chrome](https://www.google.com/chrome/) — Selenium Manager handles chromedriver automatically.

## Test plan

- [x] Confirmed local Mac has no XQuartz installed yet runs `bin/rspec` integration specs successfully
- [ ] Reviewer: skim the rendered README section on GitHub

---

AI disclosure: drafted with Claude Opus 4.7 (1M context).