### PR TITLE
Allow iframely.net iframes in product descriptions

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1396,7 +1396,8 @@ class Link < ApplicationRecord
         if %w[strong b em u s h1 h2 h3 h4 h5 h6 pre code ul ol li hr blockquote p a figure figcaption img div span iframe script br upsell-card public-file-embed review-card].exclude?(node.name) && !node.text?
           node.remove
         elsif node.name == "iframe"
-          if node["src"].present? && (URI.parse(node["src"]) rescue nil)&.host == "cdn.iframe.ly"
+          iframe_host = (URI.parse(node["src"]) rescue nil)&.host if node["src"].present?
+          if %w[cdn.iframe.ly iframely.net].include?(iframe_host)
             node.attributes.each do |attr|
               node.remove_attribute(attr.first) unless %w[src frameborder allowfullscreen scrolling allow style].include?(attr.first)
             end

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -88,6 +88,7 @@ SecureHeaders::Configuration.default do |config|
 
       # oembeds - rich text editor
       "iframe.ly",
+      "iframely.net",
 
       # helper widget
       "help.gumroad.com",

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -3855,6 +3855,22 @@ describe Link, :vcr do
       end
     end
 
+    context "when description contains an iframely.net iframe" do
+      let(:product) { create(:product, description: "<iframe src=\"https://iframely.net/api/iframe?url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DzumvXpa7kGY&key=31708e31\" allowfullscreen></iframe>") }
+
+      it "keeps the iframe" do
+        expect(product.html_safe_description).to include("iframely.net/api/iframe")
+      end
+    end
+
+    context "when description contains an iframe from an untrusted host" do
+      let(:product) { create(:product, description: "before<iframe src=\"https://evil.example.com/embed\"></iframe>after") }
+
+      it "removes the iframe" do
+        expect(product.html_safe_description).to eq("beforeafter")
+      end
+    end
+
     context "when description contains a script from an untrusted source" do
       let(:product) { create(:product, description: "some text<script src='https://untrusted.example.com/script.js'></script>evil script") }
 


### PR DESCRIPTION
## Summary
- Iframely's oEmbed response now points its `<iframe src>` at `iframely.net/api/iframe` rather than `cdn.iframe.ly/api/iframe`. Our description sanitizer (`app/models/link.rb#description_scrubber`) only allowlisted `cdn.iframe.ly`, so iframes produced by the editor's "Insert Video" button were stripped at render time — sellers saw their video disappear from the public product page.
- Adds `iframely.net` to the sanitizer's iframe-host allowlist and to the CSP `frame-src` list.

## What
- `app/models/link.rb` — convert the iframe-host check to a small allowlist; both `cdn.iframe.ly` (legacy, still used by some saved descriptions) and `iframely.net` (current Iframely embed host) are accepted.
- `config/initializers/secure_headers.rb` — add `iframely.net` to CSP `frame-src` so the browser will actually load the iframe once the sanitizer keeps it.
- `spec/models/link_spec.rb` — add `html_safe_description` specs for both an `iframely.net` iframe (kept) and an untrusted-host iframe (removed). The `iframely.net` spec was verified to fail on `main` without the sanitizer change.

## Why
The Iframely API key (`MediaEmbed.tsx:147`) is fine — `iframe.ly/api/oembed` returns HTTP 200 with our key. What changed is the iframe URL inside the oEmbed response: Iframely's player is now hosted on `iframely.net`, a domain we never allowlisted. So the sanitizer ran and removed the iframe before the description ever reached the browser. This matches the "host is not authorized" / missing-video reports referenced in `antiwork/gumroad-private#367` (the diagnosis in that issue points at our API key, but the key itself isn't the problem — only the host allowlist).

No data backfill needed; the scrubber runs at render time, so existing descriptions start rendering again on deploy.

## Before/After
Video TODO before merge.
- **Before:** product page (e.g. `https://mikkalab.gumroad.com/l/captionanimatorpro`) shows the description text but the video block is gone — DOM has no iframe at all.
- **After:** iframe is preserved, browser loads the Iframely player, video renders.

## Test plan
- [ ] Edit a product, click "Insert Video" in the rich-text editor, paste a YouTube URL, save → on the public product page the video renders.
- [ ] Open a product whose description already contains an `iframely.net` iframe (e.g. `mikkalab/captionanimatorpro`) → video renders without any data change.
- [ ] An iframe with an arbitrary host (`<iframe src="https://evil.example.com">`) added via a description payload is still stripped.
- [ ] No CSP violations in the browser console on a product page with an embedded video.

## Test Results
`bundle exec rspec spec/models/link_spec.rb` — 6 examples, 0 failures across `html_safe_description` sanitizer specs. Verified the new `iframely.net iframe` spec fails on `main` without the `link.rb` change.

---

AI disclosure: Implemented with Claude Opus 4.7 (1M context). The agent investigated a reported broken video embed on a live product, used a read-only production console to inspect the saved description HTML, traced the Iframely oEmbed response shape, identified the gap between the sanitizer/CSP allowlist and Iframely's current embed host, and wrote the fix and specs.