### PR TITLE
Update rich text editor specs for iframely.net URLs

### DIFF
--- a/spec/requests/products/edit/rich_text_editor_spec.rb
+++ b/spec/requests/products/edit/rich_text_editor_spec.rb
@@ -396,7 +396,7 @@ describe("Product Edit Rich Text Editor", type: :system, js: true) do
     sleep 1
     expect(rich_text_editor_input.find("iframe")[:src]).to include "1380521414818557955"
     save_change
-    expect(@product.reload.description).to include "iframe.ly/api/iframe?app=1&amp;url=#{CGI.escape("https://twitter.com/gumroad/status/1380521414818557955")}"
+    expect(@product.reload.description).to include "iframely.net/api/iframe?app=1&amp;url=#{CGI.escape("https://twitter.com/gumroad/status/1380521414818557955")}"
   end
 
   it "supports button embeds" do
@@ -533,7 +533,7 @@ describe("Product Edit Rich Text Editor", type: :system, js: true) do
       end
       sleep 0.5 # wait for the editor to update the content
       escaped_url = CGI.escape(tweet_url)
-      iframely_base = "https://cdn.iframe.ly/api/iframe"
+      iframely_base = "https://iframely.net/api/iframe"
 
       expect(rich_text_editor_input.find("iframe")[:src]).to include(iframely_base)
       expect(rich_text_editor_input.find("iframe")[:src]).to include("url=#{escaped_url}")


### PR DESCRIPTION
## What

Updates two specs in `spec/requests/products/edit/rich_text_editor_spec.rb` to expect `iframely.net` URLs instead of the legacy `iframe.ly` / `cdn.iframe.ly` URLs:

- `supports twitter embeds` (line 385)
- `Dynamic product content editor supports embedding tweets` (line 522)

## Why

Follow-up to #5050, which switched the rich text editor's embed URLs to `iframely.net`. The system specs still asserted the old domains and would fail after that change.

## Test results

```
$ bundle exec rspec spec/requests/products/edit/rich_text_editor_spec.rb:385 spec/requests/products/edit/rich_text_editor_spec.rb:522
..
Finished in 10.94 seconds (files took 3.57 seconds to load)
2 examples, 0 failures
```

---

AI disclosure: written with Claude Opus 4.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)