### PR TITLE
Fail Buildkite asset push step on errors

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -4,8 +4,19 @@ set -eu
 GREEN="\033[0;32m"
 NC="\033[0m"
 logger() {
-  echo -e "${GREEN}$(date "+%Y/%m/%d %H:%M:%S") ecr-login: $1${NC}"
+  echo -e "${GREEN}$(date "+%Y/%m/%d %H:%M:%S") pre-command: $1${NC}"
 }
+
+logger "Freeing up resources before step"
+logger "Disk usage before cleanup:"
+df -h / /var/lib/docker 2>/dev/null || df -h /
+docker container prune -f >/dev/null 2>&1 || true
+docker volume prune -f >/dev/null 2>&1 || true
+docker network prune -f >/dev/null 2>&1 || true
+docker image prune -f >/dev/null 2>&1 || true
+docker builder prune -f --filter "until=24h" >/dev/null 2>&1 || true
+logger "Disk usage after cleanup:"
+df -h / /var/lib/docker 2>/dev/null || df -h /
 
 logger "Setting up Ruby"
 export PATH="$HOME/.rbenv/bin:$PATH"

--- a/.buildkite/scripts/compile_assets.sh
+++ b/.buildkite/scripts/compile_assets.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -eo pipefail
 
 GREEN='\033[0;32m'
 NC='\033[0m'

--- a/Makefile
+++ b/Makefile
@@ -135,16 +135,16 @@ build_staging:
 		gosu app bash -c "docker/web/compile_assets.sh && $(call remove_spec_folder)"
 	$(DOCKER_CMD) ps -lq --filter='name=$(COMPOSE_PROJECT_NAME)_staging-assets' --filter='label=assets_compiled=true' --filter='exited=0' | xargs -I{} $(DOCKER_CMD) commit {} $(NEW_WEB_REPO):staging-$(NEW_WEB_TAG)
 ifeq ($(PUSH_ASSETS),true)
-	$(DOCKER_CMD) run -d \
-		--entrypoint="bash" \
-		--volume /app \
-		$(NEW_WEB_REPO):staging-$(NEW_WEB_TAG) | xargs -I{} docker run \
-			-e AWS_ACCESS_KEY_ID=$$GUM_AWS_ACCESS_KEY_ID \
-			-e AWS_SECRET_ACCESS_KEY=$$GUM_AWS_SECRET_ACCESS_KEY \
-			-e ASSETS_S3_BUCKET=gumroad-staging-assets \
-			--volumes-from {} \
-			$(AWS_CLI_DOCKER_IMAGE) \
-			sh /app/docker/web/push_assets_to_s3.sh
+	set -e; \
+	container_id=$$($(DOCKER_CMD) run -d --entrypoint="bash" --volume /app $(NEW_WEB_REPO):staging-$(NEW_WEB_TAG)); \
+	trap "$(DOCKER_CMD) rm -f $$container_id >/dev/null 2>&1 || true" EXIT; \
+	$(DOCKER_CMD) run \
+		-e AWS_ACCESS_KEY_ID=$$GUM_AWS_ACCESS_KEY_ID \
+		-e AWS_SECRET_ACCESS_KEY=$$GUM_AWS_SECRET_ACCESS_KEY \
+		-e ASSETS_S3_BUCKET=gumroad-staging-assets \
+		--volumes-from $$container_id \
+		$(AWS_CLI_DOCKER_IMAGE) \
+		sh /app/docker/web/push_assets_to_s3.sh
 endif
 	COMPOSE_PROJECT_NAME=$(COMPOSE_PROJECT_NAME) \
 		$(DOCKER_COMPOSE_CMD) -f docker/docker-compose-test-and-ci.yml down
@@ -175,16 +175,16 @@ build_production:
 		gosu app bash -c "docker/web/compile_assets.sh && $(call remove_spec_folder)"
 	$(DOCKER_CMD) ps -lq --filter='name=$(COMPOSE_PROJECT_NAME)_production-assets' --filter='label=assets_compiled=true' --filter='exited=0' | xargs -I{} $(DOCKER_CMD) commit {} $(NEW_WEB_REPO):production-$(NEW_WEB_TAG)
 ifeq ($(PUSH_ASSETS),true)
-	$(DOCKER_CMD) run -d \
-		--entrypoint="bash" \
-		--volume /app \
-		$(NEW_WEB_REPO):production-$(NEW_WEB_TAG) | xargs -I{} docker run \
-			-e AWS_ACCESS_KEY_ID=$$GUM_AWS_ACCESS_KEY_ID \
-			-e AWS_SECRET_ACCESS_KEY=$$GUM_AWS_SECRET_ACCESS_KEY \
-			-e ASSETS_S3_BUCKET=gumroad-production-assets \
-			--volumes-from {} \
-			$(AWS_CLI_DOCKER_IMAGE) \
-			sh /app/docker/web/push_assets_to_s3.sh
+	set -e; \
+	container_id=$$($(DOCKER_CMD) run -d --entrypoint="bash" --volume /app $(NEW_WEB_REPO):production-$(NEW_WEB_TAG)); \
+	trap "$(DOCKER_CMD) rm -f $$container_id >/dev/null 2>&1 || true" EXIT; \
+	$(DOCKER_CMD) run \
+		-e AWS_ACCESS_KEY_ID=$$GUM_AWS_ACCESS_KEY_ID \
+		-e AWS_SECRET_ACCESS_KEY=$$GUM_AWS_SECRET_ACCESS_KEY \
+		-e ASSETS_S3_BUCKET=gumroad-production-assets \
+		--volumes-from $$container_id \
+		$(AWS_CLI_DOCKER_IMAGE) \
+		sh /app/docker/web/push_assets_to_s3.sh
 endif
 	COMPOSE_PROJECT_NAME=$(COMPOSE_PROJECT_NAME) \
 		$(DOCKER_COMPOSE_CMD) -f docker/docker-compose-test-and-ci.yml down

--- a/docker/web/push_assets_to_s3.sh
+++ b/docker/web/push_assets_to_s3.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eo pipefail
 
 GREEN='\033[0;32m'
 NC='\033[0m' # No Color


### PR DESCRIPTION
## What

Two related changes to make the Buildkite asset-compile step reliable:

1. **Propagate failures.** Fix the asset-push step in `build_staging` / `build_production` so failures during the S3 upload abort the Buildkite step instead of being silently swallowed. Also adds `set -eo pipefail` to `compile_assets.sh` and `push_assets_to_s3.sh`.
2. **Free resources before each step.** Add Docker cleanup to `.buildkite/hooks/pre-command` so every step starts with reclaimed disk.

## Why

### Failures were being swallowed

The asset-push step ran a pipeline of the form:

```sh
docker run -d --entrypoint=bash --volume /app <image> | xargs -I{} docker run ... sh push_assets_to_s3.sh
```

When the first `docker run -d` failed (e.g., the daemon ran out of disk), it printed an error to stderr but emitted no container ID on stdout. `xargs -I{}` then received empty input, ran nothing, and exited 0. The shell pipeline took its exit status from `xargs`, so Make saw success and continued — the image got pushed to ECR with no corresponding assets in S3, while the Buildkite step reported green.

The fix captures the container ID into a variable under `set -e`, so any failure (the launcher container, the AWS CLI container, or the upload script) aborts the Make target and bubbles up through `compile_assets.sh` to fail the Buildkite step. A `trap ... EXIT` removes the temp container on the way out.

`set -eo pipefail` in the shell scripts is defensive: previously `push_assets_to_s3.sh` would still run the second `aws s3 sync` even if the first one failed and would exit 0.

### Pre-step resource cleanup

The triggering failure was `no space left on device` writing to `/var/lib/docker/.../volumes/`. The pre-command hook now prunes before each step:

- `docker container prune` — stopped containers from prior steps
- `docker volume prune` — the bucket that filled up
- `docker network prune` — unused compose networks (`compile_assets.sh` creates one per build)
- `docker image prune` — dangling (untagged) images only; does not touch the `web-<tag>` image needed by the current build
- `docker builder prune --filter "until=24h"` — BuildKit cache older than 24h (keeps recent cache for build-speed hits)

`df -h` is logged before and after so future investigations can see how much was reclaimed.

## Test plan

- [ ] Verify Buildkite "Compile Assets" step turns red when the asset push fails (e.g., by simulating a missing image or invalid S3 bucket on a test branch)
- [ ] Verify the happy path still uploads assets to S3 on a `deploy-*` branch
- [ ] Verify the temp container is removed after the step completes (success and failure)
- [ ] Verify the pre-command hook logs disk usage before/after and does not remove the `web-<tag>` image required by the current step

---

Generated with [Claude Code](https://claude.com/claude-code) using Claude Opus 4.7.