### PR TITLE
Fix flaky StrippedFields spec

### DIFF
--- a/spec/models/concerns/stripped_fields_spec.rb
+++ b/spec/models/concerns/stripped_fields_spec.rb
@@ -2,18 +2,31 @@
 
 require "spec_helper"
 
-ActiveRecord::Schema.define do
-  create_table :test_fields, temporary: true, force: true do |t|
-    t.string :name
-    t.string :email
-    t.string :description
-    t.string :sql
-    t.string :code
-  end
-end
-
 describe StrippedFields do
+  # Use a non-temporary table to avoid connection-scoped lifetime issues.
+  # Temporary tables are lost when the DB connection is recycled, which can
+  # happen between file load time and test execution in parallel CI.
+  before(:all) do
+    ActiveRecord::Schema.define do
+      create_table :stripped_fields_test, force: true do |t|
+        t.string :name
+        t.string :email
+        t.string :description
+        t.string :sql
+        t.string :code
+      end
+    end
+  end
+
+  after(:all) do
+    ActiveRecord::Schema.define do
+      drop_table :stripped_fields_test, if_exists: true
+    end
+  end
+
   class TestField < ApplicationRecord
+    self.table_name = "stripped_fields_test"
+
     include StrippedFields
 
     stripped_fields :name, :email, transform: ->(v) { v.upcase }


### PR DESCRIPTION
The test used a temporary table created at file load time. Temporary tables are connection-scoped in MySQL — if the connection pool recycles between load time and test execution (common under heavy parallel CI), the table disappears and `TestField.new` hits a statement timeout.

Fix: use a regular table created in `before(:all)` with `after(:all)` cleanup, and explicitly set `table_name` on the model.

Failure: https://github.com/antiwork/gumroad/actions/runs/25835354881/job/75910411473#step:7:1