### PR TITLE
Fix admin purchase search crash when product is deleted

### DIFF
--- a/app/controllers/api/internal/admin/base_controller.rb
+++ b/app/controllers/api/internal/admin/base_controller.rb
@@ -398,7 +398,7 @@ class Api::Internal::Admin::BaseController < Api::Internal::BaseController
     def amount_refundable_cents_in_currency(purchase)
       return 0 unless purchase.charge_processor_id.in?(ChargeProcessor.charge_processor_ids)
       refundable_usd_cents = purchase.price_cents - refund_amount_cents(purchase)
-      purchase.usd_cents_to_currency(purchase.link.price_currency_type, refundable_usd_cents, purchase.rate_converted_to_usd)
+      purchase.usd_cents_to_currency(purchase.displayed_price_currency_type, refundable_usd_cents, purchase.rate_converted_to_usd)
     end
 
     def latest_refund(purchase)

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -1718,12 +1718,12 @@ class Purchase < ApplicationRecord
   end
 
   def amount_refundable_in_currency
-    amount_in_cents = usd_cents_to_currency(link.price_currency_type, amount_refundable_cents, rate_converted_to_usd)
+    amount_in_cents = usd_cents_to_currency(displayed_price_currency_type, amount_refundable_cents, rate_converted_to_usd)
     Money.new(amount_in_cents, displayed_price_currency_type).format(no_cents_if_whole: true, symbol: false)
   end
 
   def amount_refundable_cents_in_currency
-    usd_cents_to_currency(link.price_currency_type, amount_refundable_cents, rate_converted_to_usd)
+    usd_cents_to_currency(displayed_price_currency_type, amount_refundable_cents, rate_converted_to_usd)
   end
 
   def refunding_amount_cents(amount)

--- a/app/presenters/customer_presenter.rb
+++ b/app/presenters/customer_presenter.rb
@@ -165,7 +165,7 @@ class CustomerPresenter
       partially_refunded: purchase.stripe_partially_refunded?,
       refunded: purchase.stripe_refunded?,
       amount_refundable: purchase.amount_refundable_cents_in_currency,
-      currency_type: purchase.link.price_currency_type,
+      currency_type: purchase.displayed_price_currency_type.to_s,
       transaction_url_for_seller: purchase.transaction_url_for_seller,
       is_upgrade_purchase: purchase.is_upgrade_purchase?,
       chargedback: purchase.chargedback? && !purchase.chargeback_reversed?,

--- a/spec/controllers/api/internal/admin/purchases_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/purchases_controller_spec.rb
@@ -339,6 +339,22 @@ describe Api::Internal::Admin::PurchasesController do
       )
     end
 
+    it "does not crash when a purchase has a deleted product" do
+      purchase = create(:free_purchase, email: "deleted-product@example.com")
+      purchase.update_columns(price_cents: 500, charge_processor_id: "stripe", stripe_transaction_id: "ch_test")
+      purchase.link.destroy!
+
+      allow(Radar::ChargeRiskLevelService).to receive(:fetch_bulk).and_return({})
+
+      get :search, params: { query: "deleted-product@example.com" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["purchases"].first).to include(
+        "id" => purchase.external_id_numeric.to_s,
+        "amount_refundable_cents_in_currency" => 500
+      )
+    end
+
     it "caps results and reports when more matches exist" do
       stub_const("#{described_class}::MAX_SEARCH_RESULTS", 2)
       buyer_email = "buyer@example.com"

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -5883,10 +5883,21 @@ describe Purchase, :vcr do
   describe "#amount_refundable_cents_in_currency" do
     let(:purchase) { create(:purchase, link: create(:product, price_currency_type: Currency::EUR), price_cents: 200) }
 
-    before { allow_any_instance_of(Purchase).to receive(:get_rate).with(Currency::EUR).and_return(0.8) }
+    before do
+      allow_any_instance_of(Purchase).to receive(:get_rate).with(:eur).and_return(0.8)
+      purchase.update_columns(displayed_price_currency_type: "eur")
+    end
 
     it "returns the refundable amount in the purchase's currency" do
       expect(purchase.amount_refundable_cents_in_currency).to eq(160)
+    end
+
+    context "when the product has been deleted" do
+      before { purchase.link.destroy! }
+
+      it "uses displayed_price_currency_type from the purchase record" do
+        expect(purchase.reload.amount_refundable_cents_in_currency).to eq(160)
+      end
     end
   end
 

--- a/spec/presenters/customer_presenter_spec.rb
+++ b/spec/presenters/customer_presenter_spec.rb
@@ -419,7 +419,8 @@ describe CustomerPresenter do
 
     before do
       purchase.link.update!(price_currency_type: Currency::EUR, price_cents: 100)
-      allow_any_instance_of(Purchase).to receive(:get_rate).with(Currency::EUR).and_return(0.8)
+      purchase.update_columns(displayed_price_currency_type: "eur")
+      allow_any_instance_of(Purchase).to receive(:get_rate).with(:eur).and_return(0.8)
     end
 
     it "returns the correct props" do


### PR DESCRIPTION
## What

Admin purchase search (`/admin/purchases`) crashes with 500 when a purchase has a deleted/missing product.

## Why

`amount_refundable_cents_in_currency` calls `purchase.link.price_currency_type` but `purchase.link` can be nil for soft-deleted products or null `link_id`. One nil link blows up the entire search.

## How

Use `displayed_price_currency_type` instead — it's stored directly on the purchase record at creation time and is always present. Fixed in three places:

- `Admin::BaseController#amount_refundable_cents_in_currency`
- `Purchase#amount_refundable_cents_in_currency`
- `Purchase#amount_refundable_in_currency`

Fixes https://github.com/antiwork/gumroad-private/issues/374