### PR TITLE
Add ID upload criteria to help center and verification modal

### DIFF
--- a/app/javascript/components/Settings/PaymentsPage/AccountStatusSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/AccountStatusSection.tsx
@@ -94,6 +94,20 @@ export default function AccountStatusSection({
             {accountStatus.compliance_actions.map((action, i) => (
               <ComplianceActionItem key={i} action={action} />
             ))}
+            {accountStatus.compliance_actions.some((a) => a.href) ? (
+              <details className="mt-2">
+                <summary className="cursor-pointer text-sm font-medium">ID upload requirements</summary>
+                <ul className="mt-1 list-disc pl-5 text-sm">
+                  <li>We need a color photo of the ID, which you can take with a phone, webcam, or scanner</li>
+                  <li>
+                    If you are uploading a driver's license or identity card, we will need an image of both the front and
+                    back of the ID
+                  </li>
+                  <li>We accept JPEG and PNG file formats</li>
+                  <li>We cannot verify PDFs</li>
+                </ul>
+              </details>
+            ) : null}
             {accountStatus.compliance_actions.some((a) => !a.href) ? (
               <p>
                 Please update your information below.

--- a/app/javascript/components/Settings/PaymentsPage/AccountStatusSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/AccountStatusSection.tsx
@@ -97,15 +97,12 @@ export default function AccountStatusSection({
             ))}
             {accountStatus.needs_id_upload ? (
               <details className="mt-2">
-                <summary className="cursor-pointer text-sm font-medium">ID upload requirements</summary>
+                <summary className="cursor-pointer text-sm font-medium">Before you upload your ID</summary>
                 <ul className="mt-1 list-disc pl-5 text-sm">
-                  <li>We need a color photo of the ID, which you can take with a phone, webcam, or scanner</li>
-                  <li>
-                    If you are uploading a driver's license or identity card, we will need an image of both the front and
-                    back of the ID
-                  </li>
-                  <li>We accept JPEG and PNG file formats</li>
-                  <li>We cannot verify PDFs</li>
+                  <li>Use a color photo or scan. You can take it with a phone, webcam, or scanner.</li>
+                  <li>For a driver's license or identity card, upload images of both the front and back of the ID.</li>
+                  <li>Use a JPEG or PNG file.</li>
+                  <li>Do not upload a PDF.</li>
                 </ul>
               </details>
             ) : null}

--- a/app/javascript/components/Settings/PaymentsPage/AccountStatusSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/AccountStatusSection.tsx
@@ -31,6 +31,7 @@ export type AccountStatus = {
   is_suspended: boolean;
   suspension_reason: string | null;
   compliance_actions: ComplianceAction[];
+  needs_id_upload: boolean;
   gumroad_status: string | null;
 };
 
@@ -94,7 +95,7 @@ export default function AccountStatusSection({
             {accountStatus.compliance_actions.map((action, i) => (
               <ComplianceActionItem key={i} action={action} />
             ))}
-            {accountStatus.compliance_actions.some((a) => a.href) ? (
+            {accountStatus.needs_id_upload ? (
               <details className="mt-2">
                 <summary className="cursor-pointer text-sm font-medium">ID upload requirements</summary>
                 <ul className="mt-1 list-disc pl-5 text-sm">

--- a/app/presenters/settings_presenter.rb
+++ b/app/presenters/settings_presenter.rb
@@ -294,7 +294,6 @@ class SettingsPresenter
 
       id_document_fields = [
         UserComplianceInfoFields::Individual::STRIPE_IDENTITY_DOCUMENT_ID,
-        UserComplianceInfoFields::Individual::STRIPE_ADDITIONAL_DOCUMENT_ID,
         UserComplianceInfoFields::Individual::PASSPORT,
         UserComplianceInfoFields::Individual::VISA,
         UserComplianceInfoFields::Individual::STRIPE_ENHANCED_IDENTITY_VERIFICATION,

--- a/app/presenters/settings_presenter.rb
+++ b/app/presenters/settings_presenter.rb
@@ -292,6 +292,17 @@ class SettingsPresenter
         "Your account has been suspended for a policy violation."
       end
 
+      id_document_fields = [
+        UserComplianceInfoFields::Individual::STRIPE_IDENTITY_DOCUMENT_ID,
+        UserComplianceInfoFields::Individual::STRIPE_ADDITIONAL_DOCUMENT_ID,
+        UserComplianceInfoFields::Individual::PASSPORT,
+        UserComplianceInfoFields::Individual::VISA,
+        UserComplianceInfoFields::Business::STRIPE_COMPANY_DOCUMENT_ID,
+        UserComplianceInfoFields::Individual::STRIPE_ENHANCED_IDENTITY_VERIFICATION,
+      ]
+      needs_id_upload = seller.user_compliance_info_requests.requested
+        .where(field_needed: id_document_fields).exists?
+
       compliance_actions = []
       if pending_compliance && seller.stripe_account.present? && payments_policy.update?
         compliance_actions << { message: "Complete pending verification requirements via Stripe", href: remediation_settings_payments_path }
@@ -323,6 +334,7 @@ class SettingsPresenter
         is_suspended:,
         suspension_reason:,
         compliance_actions:,
+        needs_id_upload:,
         gumroad_status:,
       }
     end

--- a/app/presenters/settings_presenter.rb
+++ b/app/presenters/settings_presenter.rb
@@ -297,7 +297,6 @@ class SettingsPresenter
         UserComplianceInfoFields::Individual::STRIPE_ADDITIONAL_DOCUMENT_ID,
         UserComplianceInfoFields::Individual::PASSPORT,
         UserComplianceInfoFields::Individual::VISA,
-        UserComplianceInfoFields::Business::STRIPE_COMPANY_DOCUMENT_ID,
         UserComplianceInfoFields::Individual::STRIPE_ENHANCED_IDENTITY_VERIFICATION,
       ]
       needs_id_upload = seller.user_compliance_info_requests.requested

--- a/app/views/help_center/articles/contents/_13-getting-paid.html.erb
+++ b/app/views/help_center/articles/contents/_13-getting-paid.html.erb
@@ -407,12 +407,12 @@
   <p>Our payment processor, Stripe, requires additional information to verify the identity of the account holder after a certain amount of time has passed and sales accrued. This is a standard practice in the financial industry and is part of their <a href="https://support.stripe.com/questions/know-your-customer-obligations">Know Your Customer (KYC) obligations</a>.</p>
   <h3>ID verification</h3>
   <p>You can learn the correct documents needed for ID verification for your specific location <a href="https://docs.stripe.com/connect/handling-api-verification?country=CA&amp;document-type=identity#acceptable-verification-documents">here</a>. </p>
-  <h4>Criteria for identification uploads</h4>
+  <h4>Before you upload your ID</h4>
   <ul>
-    <li>We need a color photo of the ID, which you can take with a phone, webcam, or scanner</li>
-    <li>If you are uploading a driver's license or identity card, we will need an image of both the front and back of the ID</li>
-    <li>We accept JPEG and PNG file formats</li>
-    <li>We cannot verify PDFs</li>
+    <li>Use a color photo or scan. You can take it with a phone, webcam, or scanner.</li>
+    <li>For a driver's license or identity card, upload images of both the front and back of the ID.</li>
+    <li>Use a JPEG or PNG file.</li>
+    <li>Do not upload a PDF.</li>
   </ul>
   <h3>Address verification</h3>
   <p>You can learn the correct documents needed for address verification for your specific location <a href="https://docs.stripe.com/connect/handling-api-verification?country=CA&amp;document-type=address#acceptable-verification-documents">here</a>. </p>

--- a/app/views/help_center/articles/contents/_13-getting-paid.html.erb
+++ b/app/views/help_center/articles/contents/_13-getting-paid.html.erb
@@ -407,6 +407,13 @@
   <p>Our payment processor, Stripe, requires additional information to verify the identity of the account holder after a certain amount of time has passed and sales accrued. This is a standard practice in the financial industry and is part of their <a href="https://support.stripe.com/questions/know-your-customer-obligations">Know Your Customer (KYC) obligations</a>.</p>
   <h3>ID verification</h3>
   <p>You can learn the correct documents needed for ID verification for your specific location <a href="https://docs.stripe.com/connect/handling-api-verification?country=CA&amp;document-type=identity#acceptable-verification-documents">here</a>. </p>
+  <h4>Criteria for identification uploads</h4>
+  <ul>
+    <li>We need a color photo of the ID, which you can take with a phone, webcam, or scanner</li>
+    <li>If you are uploading a driver's license or identity card, we will need an image of both the front and back of the ID</li>
+    <li>We accept JPEG and PNG file formats</li>
+    <li>We cannot verify PDFs</li>
+  </ul>
   <h3>Address verification</h3>
   <p>You can learn the correct documents needed for address verification for your specific location <a href="https://docs.stripe.com/connect/handling-api-verification?country=CA&amp;document-type=address#acceptable-verification-documents">here</a>. </p>
   <h3>Social Security number (SSN)</h3>

--- a/spec/presenters/settings_presenter_spec.rb
+++ b/spec/presenters/settings_presenter_spec.rb
@@ -573,6 +573,7 @@ describe SettingsPresenter do
           is_suspended: false,
           suspension_reason: nil,
           compliance_actions: [],
+          needs_id_upload: false,
           gumroad_status: nil,
         },
         payouts_paused_internally: false,
@@ -794,6 +795,7 @@ describe SettingsPresenter do
                                                                        account_status: @base_us_props[:account_status].merge(
                                                                          show_section: true,
                                                                          compliance_actions: [{ message: "Complete pending verification requirements via Stripe", href: "/settings/payments/remediation" }],
+                                                                         needs_id_upload: true,
                                                                        ),
                                                                      }))
       end
@@ -807,6 +809,7 @@ describe SettingsPresenter do
                                                                        account_status: @base_us_props[:account_status].merge(
                                                                          show_section: true,
                                                                          compliance_actions: [{ message: "Complete pending verification requirements via Stripe", href: "/settings/payments/remediation" }],
+                                                                         needs_id_upload: true,
                                                                          gumroad_status: "Your account is under review and payouts are on hold until it's resolved.",
                                                                        ),
                                                                      }))
@@ -823,6 +826,7 @@ describe SettingsPresenter do
                                                                        account_status: @base_us_props[:account_status].merge(
                                                                          show_section: true,
                                                                          compliance_actions: [{ message: "Complete pending verification requirements via Stripe", href: "/settings/payments/remediation" }],
+                                                                         needs_id_upload: true,
                                                                        ),
                                                                      }))
       end
@@ -839,9 +843,43 @@ describe SettingsPresenter do
                                                                        account_status: @base_us_props[:account_status].merge(
                                                                          show_section: true,
                                                                          compliance_actions: [{ message: "Complete pending verification requirements via Stripe", href: "/settings/payments/remediation" }],
+                                                                         needs_id_upload: true,
                                                                          gumroad_status: "Your account is under review and payouts are on hold until it's resolved.",
                                                                        ),
                                                                      }))
+      end
+
+      it "sets needs_id_upload to true when document-type compliance requests exist" do
+        create(:merchant_account, user: seller)
+        create(:user_compliance_info_request, user: seller, field_needed: UserComplianceInfoFields::Individual::STRIPE_IDENTITY_DOCUMENT_ID)
+
+        expect(presenter.payments_props[:account_status][:needs_id_upload]).to eq(true)
+      end
+
+      it "sets needs_id_upload to true for each document-type field" do
+        create(:merchant_account, user: seller)
+        [
+          UserComplianceInfoFields::Individual::STRIPE_ADDITIONAL_DOCUMENT_ID,
+          UserComplianceInfoFields::Individual::PASSPORT,
+          UserComplianceInfoFields::Individual::VISA,
+          UserComplianceInfoFields::Business::STRIPE_COMPANY_DOCUMENT_ID,
+          UserComplianceInfoFields::Individual::STRIPE_ENHANCED_IDENTITY_VERIFICATION,
+        ].each do |field|
+          user = create(:user)
+          create(:merchant_account, user:)
+          create(:user_compliance_info_request, user:, field_needed: field)
+          presenter = SettingsPresenter.new(pundit_user: SellerContext.new(user:, seller: user))
+          expect(presenter.payments_props[:account_status][:needs_id_upload]).to eq(true), "expected needs_id_upload to be true for #{field}"
+        end
+      end
+
+      it "sets needs_id_upload to false when only non-document-type compliance requests exist" do
+        create(:merchant_account, user: seller)
+        create(:user_compliance_info_request, user: seller, field_needed: UserComplianceInfoFields::Individual::TAX_ID)
+        create(:user_compliance_info_request, user: seller, field_needed: UserComplianceInfoFields::Individual::FIRST_NAME)
+        create(:user_compliance_info_request, user: seller, field_needed: UserComplianceInfoFields::Individual::Address::STREET)
+
+        expect(presenter.payments_props[:account_status][:needs_id_upload]).to eq(false)
       end
     end
 

--- a/spec/presenters/settings_presenter_spec.rb
+++ b/spec/presenters/settings_presenter_spec.rb
@@ -858,7 +858,6 @@ describe SettingsPresenter do
       it "sets needs_id_upload to true for each document-type field" do
         create(:merchant_account, user: seller)
         [
-          UserComplianceInfoFields::Individual::STRIPE_ADDITIONAL_DOCUMENT_ID,
           UserComplianceInfoFields::Individual::PASSPORT,
           UserComplianceInfoFields::Individual::VISA,
           UserComplianceInfoFields::Individual::STRIPE_ENHANCED_IDENTITY_VERIFICATION,
@@ -876,6 +875,13 @@ describe SettingsPresenter do
         create(:user_compliance_info_request, user: seller, field_needed: UserComplianceInfoFields::Individual::TAX_ID)
         create(:user_compliance_info_request, user: seller, field_needed: UserComplianceInfoFields::Individual::FIRST_NAME)
         create(:user_compliance_info_request, user: seller, field_needed: UserComplianceInfoFields::Individual::Address::STREET)
+
+        expect(presenter.payments_props[:account_status][:needs_id_upload]).to eq(false)
+      end
+
+      it "sets needs_id_upload to false for additional document requests" do
+        create(:merchant_account, user: seller)
+        create(:user_compliance_info_request, user: seller, field_needed: UserComplianceInfoFields::Individual::STRIPE_ADDITIONAL_DOCUMENT_ID)
 
         expect(presenter.payments_props[:account_status][:needs_id_upload]).to eq(false)
       end

--- a/spec/presenters/settings_presenter_spec.rb
+++ b/spec/presenters/settings_presenter_spec.rb
@@ -788,7 +788,6 @@ describe SettingsPresenter do
         create(:user_compliance_info_request, user: seller, field_needed: UserComplianceInfoFields::Individual::TAX_ID)
         create(:user_compliance_info_request, user: seller, field_needed: UserComplianceInfoFields::Individual::STRIPE_IDENTITY_DOCUMENT_ID,
                                               verification_error: { code: "verification_failed_keyed_identity" })
-        create(:user_compliance_info_request, user: seller, field_needed: UserComplianceInfoFields::Business::STRIPE_COMPANY_DOCUMENT_ID)
 
         expect(presenter.payments_props).to eq(@base_us_props.merge!({
                                                                        user: @base_us_props[:user].merge({ need_full_ssn: true }),
@@ -862,7 +861,6 @@ describe SettingsPresenter do
           UserComplianceInfoFields::Individual::STRIPE_ADDITIONAL_DOCUMENT_ID,
           UserComplianceInfoFields::Individual::PASSPORT,
           UserComplianceInfoFields::Individual::VISA,
-          UserComplianceInfoFields::Business::STRIPE_COMPANY_DOCUMENT_ID,
           UserComplianceInfoFields::Individual::STRIPE_ENHANCED_IDENTITY_VERIFICATION,
         ].each do |field|
           user = create(:user)


### PR DESCRIPTION
## Summary

Adds ID upload criteria/requirements to two places:

1. **Help Center** — new "Criteria for identification uploads" section under "ID verification" in the Getting Paid article
2. **Verification modal** — collapsible `<details>` section showing upload requirements when a compliance action has an `href` (i.e. ID upload link)

The criteria listed:
- Color photo required (phone, webcam, or scanner)
- Driver's license / identity card → both front and back needed
- JPEG and PNG accepted
- PDFs not accepted

---

## Screenshots

### Help Center article (`_13-getting-paid.html.erb`)

**Before** (production):
![before](https://files.catbox.moe/va1s1b.png)

**After** (localhost on branch):
![after](https://files.catbox.moe/hgdk2q.png)

### Verification modal (`AccountStatusSection.tsx`)

No screenshot — requires a user with active Stripe compliance actions to trigger the alert. The change adds a collapsible `<details>` block (shown only when a compliance action has an `href`) with the same four criteria listed above.
