### PR TITLE
Update Ireland e-publication VAT rate to 0%

### DIFF
--- a/db/seeds/020_development_staging/eu_tax_rates.rb
+++ b/db/seeds/020_development_staging/eu_tax_rates.rb
@@ -45,7 +45,7 @@ ZipTaxRate.find_or_create_by(country: "FR", flags: 2).update(combined_rate: 0.05
 ZipTaxRate.find_or_create_by(country: "DE", flags: 2).update(combined_rate: 0.07) # Germany
 ZipTaxRate.find_or_create_by(country: "GR", flags: 2).update(combined_rate: 0.06) # Greece
 ZipTaxRate.find_or_create_by(country: "HU", flags: 2).update(combined_rate: 0.27) # Hungary
-ZipTaxRate.find_or_create_by(country: "IE", flags: 2).update(combined_rate: 0.09) # Ireland
+ZipTaxRate.find_or_create_by(country: "IE", flags: 2).update(combined_rate: 0.00) # Ireland
 ZipTaxRate.find_or_create_by(country: "IT", flags: 2).update(combined_rate: 0.04) # Italy
 ZipTaxRate.find_or_create_by(country: "LV", flags: 2).update(combined_rate: 0.21) # Latvia
 ZipTaxRate.find_or_create_by(country: "LT", flags: 2).update(combined_rate: 0.21) # Lithuania


### PR DESCRIPTION
Fixes antiwork/gumroad-private#375

## What

Updates the Ireland e-publication VAT rate in the EU tax-rate seeds from 9% to 0%. Production (`ZipTaxRate` ID 51206) was updated separately via Rails console. This PR keeps dev/staging seeds in line so a re-seed doesn't silently revert the rate.

## Why

Ireland zero-rated VAT on e-publications effective 2024-01-01 ([Revenue.ie](https://www.revenue.ie/en/tax-professionals/tdm/value-added-tax/part03-taxable-transactions-goods-ica-services/Services/electronic-publications.pdf)). No code change needed. `SalesTaxCalculator` already returns the `country: "IE", flags: 2` row for IE buyers on e-publication products, so a `combined_rate` of 0 propagates through to zero VAT.

---

This PR was implemented with AI assistance using Claude Opus 4.7.