### PR TITLE
Drop layered retries, rebalance test matrix, record flakes

### DIFF
--- a/.github/workflows/tests-ciq.yml
+++ b/.github/workflows/tests-ciq.yml
@@ -1,0 +1,380 @@
+name: Tests (ci-queue pilot)
+
+# Pilot workflow for the ci_queue migration. Mirrors tests.yml but uses
+# Shopify's ci-queue (https://github.com/Shopify/ci-queue) for distribution
+# instead of Knapsack Pro. Triggered manually until we have confidence in it,
+# then it will replace the Knapsack-based tests.yml.
+#
+# Requires repo secrets:
+#   CI_QUEUE_REDIS_URL — Redis URL reachable from GHA runners (rediss://...)
+#   DOCKERHUB_USERNAME / DOCKERHUB_PASSWORD
+#   BUNDLE_GEMS__CONTRIBSYS__COM
+
+on:
+  workflow_dispatch:
+    inputs:
+      fast_shards:
+        description: "Number of fast shards"
+        required: false
+        default: "20"
+      slow_shards:
+        description: "Number of slow shards"
+        required: false
+        default: "48"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build images
+    runs-on: ubicloud-standard-8
+    env:
+      DOCKER_BUILDKIT: 1
+    outputs:
+      test_image_tag: ${{ steps.test_image_tag.outputs.tag }}
+      ciq_build_id: ${{ steps.ciq.outputs.build_id }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Login to Docker Hub
+        uses: nick-fields/retry@v3
+        with:
+          timeout_seconds: 120
+          max_attempts: 3
+          retry_wait_seconds: 10
+          command: echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Build and push base image
+        env:
+          WEB_BASE_REPO: gumroadteam/web_base
+        run: |
+          set -e
+          docker pull --quiet ruby:$(cat .ruby-version)-slim-bullseye
+          WEB_BASE_SHA=$(WEB_BASE_DOCKERFILE_FROM=ruby:$(cat .ruby-version)-slim-bullseye docker/base/generate_tag_for_web_base.sh)
+          if ! docker manifest inspect $WEB_BASE_REPO:$WEB_BASE_SHA > /dev/null 2>&1; then
+            NEW_BASE_REPO=$WEB_BASE_REPO \
+              WEB_BASE_DOCKERFILE_FROM=ruby:$(cat .ruby-version)-slim-bullseye \
+              BUNDLE_GEMS__CONTRIBSYS__COM=${{ secrets.BUNDLE_GEMS__CONTRIBSYS__COM }} \
+              make build_base
+            docker push --quiet $WEB_BASE_REPO:$WEB_BASE_SHA
+          fi
+      - name: Compute content-addressed test image tag
+        id: test_image_tag
+        env:
+          WEB_BASE_REPO: gumroadteam/web_base
+        run: |
+          set -e
+          WEB_BASE_TEST_SHA=$(WEB_BASE_DOCKERFILE_FROM=ruby:$(cat .ruby-version)-slim-bullseye docker/base/generate_tag_for_web_base_test.sh)
+          TAG=test-$(BASE_TEST_SHA=$WEB_BASE_TEST_SHA docker/base/generate_tag_for_test_image.sh)
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+      - name: Build and push test image
+        env:
+          WEB_BASE_REPO: gumroadteam/web_base
+          WEB_BASE_TEST_REPO: gumroadteam/web_base_test
+          WEB_REPO: gumroadteam/web
+          TEST_IMAGE_TAG: ${{ steps.test_image_tag.outputs.tag }}
+        run: |
+          set -e
+          docker pull --quiet ruby:$(cat .ruby-version)-slim-bullseye
+          WEB_BASE_TEST_SHA=$(WEB_BASE_DOCKERFILE_FROM=ruby:$(cat .ruby-version)-slim-bullseye docker/base/generate_tag_for_web_base_test.sh)
+          if ! docker manifest inspect $WEB_REPO:$TEST_IMAGE_TAG > /dev/null 2>&1; then
+            docker pull --quiet $WEB_REPO:test-cache 2>/dev/null || true
+            NEW_BASE_REPO=$WEB_BASE_REPO NEW_WEB_BASE_TEST_REPO=$WEB_BASE_TEST_REPO NEW_WEB_REPO=$WEB_REPO \
+              WEB_BASE_DOCKERFILE_FROM=ruby:$(cat .ruby-version)-slim-bullseye \
+              BRANCH_CACHE_UPLOAD_ENABLED=false \
+              BRANCH_CACHE_RESTORE_ENABLED=false \
+              NEW_WEB_TAG=${TEST_IMAGE_TAG#test-} \
+              COMPOSE_PROJECT_NAME=web_${{ github.run_id }}_${{ github.run_attempt }} \
+              make build_base_test build_test
+            docker push --quiet $WEB_BASE_TEST_REPO:$WEB_BASE_TEST_SHA
+            docker push --quiet $WEB_REPO:$TEST_IMAGE_TAG
+          fi
+      - name: Compute ci-queue build id
+        id: ciq
+        run: echo "build_id=${{ github.run_id }}-${{ github.run_attempt }}" >> $GITHUB_OUTPUT
+
+  test_fast:
+    name: Test Fast (ciq) ${{ matrix.ci_node_index }}
+    env:
+      COMPOSE_PROJECT_NAME: web_${{ github.run_id }}_${{ github.run_attempt }}_fast_${{ matrix.ci_node_index }}
+      WEB_REPO: gumroadteam/web
+    runs-on: ubicloud-standard-4
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        ci_node_total: [20]
+        ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      - name: Login to Docker Hub
+        uses: nick-fields/retry@v3
+        with:
+          timeout_seconds: 120
+          max_attempts: 3
+          retry_wait_seconds: 10
+          command: echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Start services and pull test image
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 5
+          command: |
+            docker pull --quiet $WEB_REPO:${{ needs.build.outputs.test_image_tag }} &
+            PULL_PID=$!
+            docker compose -f docker/docker-compose-test-and-ci.yml up -d
+            COMPOSE_EXIT=$?
+            wait $PULL_PID
+            PULL_EXIT=$?
+            exit $((COMPOSE_EXIT + PULL_EXIT))
+        env:
+          COMPOSE_HTTP_TIMEOUT: "300"
+      - name: Wait for services and prepare test database
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 10
+          command: |
+            IMG=$WEB_REPO:${{ needs.build.outputs.test_image_tag }}
+            NET=${{ env.COMPOSE_PROJECT_NAME }}_default
+            (
+              docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh db_test 3306 \
+                && docker run --rm --entrypoint="" --network $NET -e RAILS_ENV=test $IMG bundle exec rake db:prepare
+            ) &
+            DB_PID=$!
+            docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh elasticsearch 9200 &
+            ES_PID=$!
+            docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh minio 9000 &
+            MINIO_PID=$!
+            wait $DB_PID || exit 1
+            wait $ES_PID || exit 1
+            wait $MINIO_PID || exit 1
+      - name: Run tests via ci-queue
+        timeout-minutes: 15
+        run: |
+          mkdir -p ./test-logs
+          chmod 777 ./test-logs
+          docker run --rm --entrypoint="" --network ${{ env.COMPOSE_PROJECT_NAME }}_default \
+            -v "$(pwd)/test-logs:/app/log" \
+            -e RUBY_YJIT_ENABLE \
+            -e CI_QUEUE_REDIS \
+            -e BUILD_ID \
+            -e WORKER_ID \
+            -e CI \
+            -e IN_DOCKER \
+            $WEB_REPO:${{ needs.build.outputs.test_image_tag }} \
+            /usr/local/bin/gosu app bash -c '
+              find spec -name "*_spec.rb" \
+                -not -path "spec/requests/*" \
+                | bundle exec rspec-queue \
+                    --queue "$CI_QUEUE_REDIS" \
+                    --build "$BUILD_ID" \
+                    --worker "$WORKER_ID" \
+                    --timeout 600 \
+                    --max-requeues 1 \
+                    --requeue-tolerance 0.05 \
+                    --format RSpec::Github::Formatter \
+                    --format progress \
+                    --tag ~skip \
+                    -
+            '
+        env:
+          RUBY_YJIT_ENABLE: 1
+          CI_QUEUE_REDIS: ${{ secrets.CI_QUEUE_REDIS_URL }}
+          BUILD_ID: fast-${{ needs.build.outputs.ciq_build_id }}
+          WORKER_ID: ${{ matrix.ci_node_index }}
+          CI: true
+          IN_DOCKER: true
+      - name: Archive flaky specs log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ciq-flaky-specs-fast-${{ matrix.ci_node_index }}-attempt-${{ github.run_attempt }}
+          path: ./test-logs/flaky_specs.log
+          retention-days: 14
+          if-no-files-found: ignore
+      - name: Clean up
+        if: always()
+        run: |
+          docker compose -f docker/docker-compose-test-and-ci.yml down -v 2>/dev/null || true
+          docker rm -f $(docker ps -aq -f name=${{ env.COMPOSE_PROJECT_NAME }}) 2>/dev/null || true
+          docker volume rm $(docker volume ls -q -f name=${{ env.COMPOSE_PROJECT_NAME }}) 2>/dev/null || true
+          docker network rm ${{ env.COMPOSE_PROJECT_NAME }}_default 2>/dev/null || true
+
+  test_slow:
+    name: Test Slow (ciq) ${{ matrix.ci_node_index }}
+    env:
+      COMPOSE_PROJECT_NAME: web_${{ github.run_id }}_${{ github.run_attempt }}_slow_${{ matrix.ci_node_index }}
+      WEB_REPO: gumroadteam/web
+    runs-on: ubicloud-standard-4
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        ci_node_total: [48]
+        ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      - name: Login to Docker Hub
+        uses: nick-fields/retry@v3
+        with:
+          timeout_seconds: 120
+          max_attempts: 3
+          retry_wait_seconds: 10
+          command: echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Start services and pull test image
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 5
+          command: |
+            docker pull --quiet $WEB_REPO:${{ needs.build.outputs.test_image_tag }} &
+            PULL_PID=$!
+            docker compose -f docker/docker-compose-test-and-ci.yml up -d
+            COMPOSE_EXIT=$?
+            wait $PULL_PID
+            PULL_EXIT=$?
+            exit $((COMPOSE_EXIT + PULL_EXIT))
+        env:
+          COMPOSE_HTTP_TIMEOUT: "300"
+      - name: Wait for services and prepare test database
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 10
+          command: |
+            IMG=$WEB_REPO:${{ needs.build.outputs.test_image_tag }}
+            NET=${{ env.COMPOSE_PROJECT_NAME }}_default
+            (
+              docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh db_test 3306 \
+                && docker run --rm --entrypoint="" --network $NET -e RAILS_ENV=test $IMG bundle exec rake db:prepare
+            ) &
+            DB_PID=$!
+            docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh elasticsearch 9200 &
+            ES_PID=$!
+            docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh minio 9000 &
+            MINIO_PID=$!
+            wait $DB_PID || exit 1
+            wait $ES_PID || exit 1
+            wait $MINIO_PID || exit 1
+      - name: Run tests via ci-queue
+        timeout-minutes: 25
+        run: |
+          mkdir -p ./capybara-artifacts
+          chmod 777 ./capybara-artifacts
+          mkdir -p ./test-logs
+          chmod 777 ./test-logs
+          docker run --rm --entrypoint="" --network ${{ env.COMPOSE_PROJECT_NAME }}_default \
+            -v "$(pwd)/capybara-artifacts:/app/tmp/capybara" \
+            -v "$(pwd)/test-logs:/app/log" \
+            -e RUBY_YJIT_ENABLE \
+            -e CI_QUEUE_REDIS \
+            -e BUILD_ID \
+            -e WORKER_ID \
+            -e CI \
+            -e IN_DOCKER \
+            $WEB_REPO:${{ needs.build.outputs.test_image_tag }} \
+            /usr/local/bin/gosu app bash -c '
+              find spec/requests -name "*_spec.rb" \
+                | bundle exec rspec-queue \
+                    --queue "$CI_QUEUE_REDIS" \
+                    --build "$BUILD_ID" \
+                    --worker "$WORKER_ID" \
+                    --timeout 900 \
+                    --max-requeues 2 \
+                    --requeue-tolerance 0.1 \
+                    --format RSpec::Github::Formatter \
+                    --format progress \
+                    --tag ~skip \
+                    -
+            '
+        env:
+          RUBY_YJIT_ENABLE: 1
+          CI_QUEUE_REDIS: ${{ secrets.CI_QUEUE_REDIS_URL }}
+          BUILD_ID: slow-${{ needs.build.outputs.ciq_build_id }}
+          WORKER_ID: ${{ matrix.ci_node_index }}
+          CI: true
+          IN_DOCKER: true
+      - name: Archive capybara artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ciq-capybara-screenshots-slow-${{ matrix.ci_node_index }}-attempt-${{ github.run_attempt }}
+          path: ./capybara-artifacts/*.png
+          retention-days: 7
+          if-no-files-found: ignore
+      - name: Archive test logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ciq-test-logs-slow-${{ matrix.ci_node_index }}-attempt-${{ github.run_attempt }}
+          path: ./test-logs/test.log
+          retention-days: 7
+          if-no-files-found: ignore
+      - name: Archive flaky specs log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ciq-flaky-specs-slow-${{ matrix.ci_node_index }}-attempt-${{ github.run_attempt }}
+          path: ./test-logs/flaky_specs.log
+          retention-days: 14
+          if-no-files-found: ignore
+      - name: Clean up
+        if: always()
+        run: |
+          docker compose -f docker/docker-compose-test-and-ci.yml down -v 2>/dev/null || true
+          docker rm -f $(docker ps -aq -f name=${{ env.COMPOSE_PROJECT_NAME }}) 2>/dev/null || true
+          docker volume rm $(docker volume ls -q -f name=${{ env.COMPOSE_PROJECT_NAME }}) 2>/dev/null || true
+          docker network rm ${{ env.COMPOSE_PROJECT_NAME }}_default 2>/dev/null || true
+
+  report:
+    name: ci-queue report
+    runs-on: ubicloud-standard-2
+    needs: [test_fast, test_slow]
+    if: always()
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version-file: .ruby-version
+          bundler-cache: false
+      - name: Print queue report
+        run: |
+          gem install ci-queue --no-document
+          rspec-queue \
+            --queue "$CI_QUEUE_REDIS" \
+            --build "fast-${{ needs.build.outputs.ciq_build_id }}" \
+            --report || true
+          rspec-queue \
+            --queue "$CI_QUEUE_REDIS" \
+            --build "slow-${{ needs.build.outputs.ciq_build_id }}" \
+            --report || true
+        env:
+          CI_QUEUE_REDIS: ${{ secrets.CI_QUEUE_REDIS_URL }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -180,8 +180,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ci_node_total: [28]
-        ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27]
+        ci_node_total: [20]
+        ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -242,7 +242,10 @@ jobs:
       - name: Run tests
         timeout-minutes: 15
         run: |
+          mkdir -p ./test-logs
+          chmod 777 ./test-logs
           docker run --rm --entrypoint="" --network ${{ env.COMPOSE_PROJECT_NAME }}_default \
+            -v "$(pwd)/test-logs:/app/log" \
             -e RUBY_YJIT_ENABLE \
             -e KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC \
             -e KNAPSACK_PRO_CI_NODE_TOTAL \
@@ -279,6 +282,14 @@ jobs:
           CI: true
           IN_DOCKER: true
           WEB_REPO: gumroadteam/web
+      - name: Archive flaky specs log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: flaky-specs-fast-${{ matrix.ci_node_index }}-attempt-${{ github.run_attempt }}
+          path: ./test-logs/flaky_specs.log
+          retention-days: 14
+          if-no-files-found: ignore
       - name: Clean up
         if: always()
         run: |
@@ -297,7 +308,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ci_node_total: [72]
+        ci_node_total: [48]
         ci_node_index:
           [
             0,
@@ -348,30 +359,6 @@ jobs:
             45,
             46,
             47,
-            48,
-            49,
-            50,
-            51,
-            52,
-            53,
-            54,
-            55,
-            56,
-            57,
-            58,
-            59,
-            60,
-            61,
-            62,
-            63,
-            64,
-            65,
-            66,
-            67,
-            68,
-            69,
-            70,
-            71,
           ]
     steps:
       - uses: actions/checkout@v4
@@ -431,39 +418,33 @@ jobs:
           WEB_REPO: gumroadteam/web
 
       - name: Run tests
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 20
-          max_attempts: 2
-          retry_wait_seconds: 10
-          command: |
-            # Create local directory for artifacts
-            mkdir -p ./capybara-artifacts
-            chmod 777 ./capybara-artifacts
-            mkdir -p ./test-logs
-            chmod 777 ./test-logs
+        timeout-minutes: 25
+        run: |
+          mkdir -p ./capybara-artifacts
+          chmod 777 ./capybara-artifacts
+          mkdir -p ./test-logs
+          chmod 777 ./test-logs
 
-            # Run tests with volume mount to capture capybara artifacts and test logs
-            docker run --rm --entrypoint="" --network ${{ env.COMPOSE_PROJECT_NAME }}_default \
-              -v "$(pwd)/capybara-artifacts:/app/tmp/capybara" \
-              -v "$(pwd)/test-logs:/app/log" \
-              -e RUBY_YJIT_ENABLE \
-              -e KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC \
-              -e KNAPSACK_PRO_CI_NODE_TOTAL \
-              -e KNAPSACK_PRO_CI_NODE_INDEX \
-              -e KNAPSACK_PRO_LOG_LEVEL \
-              -e KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES \
-              -e KNAPSACK_PRO_TEST_FILE_PATTERN \
-              -e KNAPSACK_PRO_COMMIT_HASH \
-              -e KNAPSACK_PRO_BRANCH \
-              -e KNAPSACK_PRO_CI_NODE_BUILD_ID \
-              -e KNAPSACK_PRO_CI_NODE_RETRY_COUNT \
-              -e KNAPSACK_PRO_PROJECT_DIR \
-              -e KNAPSACK_PRO_FIXED_QUEUE_SPLIT \
-              -e CI \
-              -e IN_DOCKER \
-              $WEB_REPO:${{ needs.build.outputs.test_image_tag }} \
-              /usr/local/bin/gosu app bundle exec rake "knapsack_pro:queue:rspec[--format RSpec::Github::Formatter --tag ~skip --format progress]"
+          docker run --rm --entrypoint="" --network ${{ env.COMPOSE_PROJECT_NAME }}_default \
+            -v "$(pwd)/capybara-artifacts:/app/tmp/capybara" \
+            -v "$(pwd)/test-logs:/app/log" \
+            -e RUBY_YJIT_ENABLE \
+            -e KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC \
+            -e KNAPSACK_PRO_CI_NODE_TOTAL \
+            -e KNAPSACK_PRO_CI_NODE_INDEX \
+            -e KNAPSACK_PRO_LOG_LEVEL \
+            -e KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES \
+            -e KNAPSACK_PRO_TEST_FILE_PATTERN \
+            -e KNAPSACK_PRO_COMMIT_HASH \
+            -e KNAPSACK_PRO_BRANCH \
+            -e KNAPSACK_PRO_CI_NODE_BUILD_ID \
+            -e KNAPSACK_PRO_CI_NODE_RETRY_COUNT \
+            -e KNAPSACK_PRO_PROJECT_DIR \
+            -e KNAPSACK_PRO_FIXED_QUEUE_SPLIT \
+            -e CI \
+            -e IN_DOCKER \
+            $WEB_REPO:${{ needs.build.outputs.test_image_tag }} \
+            /usr/local/bin/gosu app bundle exec rake "knapsack_pro:queue:rspec[--format RSpec::Github::Formatter --tag ~skip --format progress]"
         env:
           RUBY_YJIT_ENABLE: 1
           KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC_FAST }}
@@ -496,6 +477,14 @@ jobs:
           name: test-logs-slow-${{ matrix.ci_node_index }}-attempt-${{ github.run_attempt }}
           path: ./test-logs/test.log
           retention-days: 7
+          if-no-files-found: ignore
+      - name: Archive flaky specs log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: flaky-specs-slow-${{ matrix.ci_node_index }}-attempt-${{ github.run_attempt }}
+          path: ./test-logs/flaky_specs.log
+          retention-days: 14
           if-no-files-found: ignore
       - name: Clean up
         if: always()

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,8 @@ end
 
 group :test do
   gem "capybara", "~> 3.38"
+  gem "ci-queue", "~> 0.95", require: false
+  gem "cuprite", "~> 0.17", require: false
   gem "factory_bot_rails", "~> 6.4"
   gem "faker", "~> 3.1"
   gem "rspec", "~> 3.12"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -165,6 +165,29 @@ def reset_browser_session(example)
   force_browser_restart!
 end
 
+FLAKY_SPECS_LOG_PATH = Rails.root.join("log", "flaky_specs.log").freeze
+
+def record_flaky_spec(example)
+  exception = example.exception
+  return unless exception
+
+  metadata = example.metadata
+  location = metadata[:location] || "#{metadata[:file_path]}:#{metadata[:line_number]}"
+  entry = {
+    timestamp: Time.now.utc.iso8601,
+    location: location,
+    description: example.full_description,
+    exception_class: exception.class.name,
+    exception_message: exception.message.to_s[0, 500],
+    attempt: metadata[:retry_attempts].to_i + 1,
+    build: ENV["GITHUB_RUN_ID"] || ENV["KNAPSACK_PRO_CI_NODE_BUILD_ID"],
+    shard: ENV["KNAPSACK_PRO_CI_NODE_INDEX"] || ENV["CI_NODE_INDEX"],
+  }
+  File.open(FLAKY_SPECS_LOG_PATH, "a") { |f| f.puts(entry.to_json) }
+rescue StandardError => e
+  Rails.logger.warn("[RSpec retry] Failed to record flaky spec: #{e.class}: #{e.message}")
+end
+
 # Harden teardown_fixtures so that a corrupted SAVEPOINT doesn't skip pool
 # unlock and connection cleanup. Without this, a single SAVEPOINT failure
 # poisons every subsequent retry because lock_thread is never reset and
@@ -214,10 +237,15 @@ RSpec.configure do |config|
     config.verbose_retry = true
     # show exception that triggers a retry if verbose_retry is set to true
     config.display_try_failure_messages = true
-    config.default_retry_count = 3
+    config.default_retry_count = 1
+    config.around(:each, type: :system) do |example|
+      example.metadata[:retry] ||= 2
+      example.run
+    end
     config.retry_callback = proc do |example|
       reset_db_connection(example)
       reset_browser_session(example)
+      record_flaky_spec(example)
     end
   end
 

--- a/spec/support/capybara_driver.rb
+++ b/spec/support/capybara_driver.rb
@@ -1,5 +1,37 @@
 # frozen_string_literal: true
 
+USE_CUPRITE = ENV["USE_CUPRITE"] == "true"
+
+if USE_CUPRITE
+  require "capybara/cuprite"
+
+  cuprite_browser_options = {
+    "no-sandbox" => nil,
+    "disable-dev-shm-usage" => nil,
+    "disable-gpu" => nil,
+    "disable-setuid-sandbox" => nil,
+    "disable-site-isolation-trials" => nil,
+    "lang" => "en-US",
+  }
+
+  cuprite_driver_factory = lambda do |app, width:, height:, mobile: false|
+    Capybara::Cuprite::Driver.new(
+      app,
+      window_size: [width, height],
+      browser_options: cuprite_browser_options,
+      process_timeout: 30,
+      timeout: 25,
+      headless: true,
+      js_errors: false,
+      mobile: mobile,
+    )
+  end
+
+  Capybara.register_driver(:cuprite_chrome) { |app| cuprite_driver_factory.call(app, width: 1440, height: 900) }
+  Capybara.register_driver(:cuprite_tablet_chrome) { |app| cuprite_driver_factory.call(app, width: 800, height: 1024) }
+  Capybara.register_driver(:cuprite_mobile_chrome) { |app| cuprite_driver_factory.call(app, width: 375, height: 667, mobile: true) }
+end
+
 webdriver_client = Selenium::WebDriver::Remote::Http::Default.new(open_timeout: 120, read_timeout: 120)
 
 Capybara.register_driver :chrome do |app|
@@ -123,11 +155,19 @@ RSpec.configure do |config|
   end
 
   config.before(:each, type: :system, js: true) do
-    driven_by ENV["IN_DOCKER"] == "true" ? :docker_headless_chrome : :chrome
+    if USE_CUPRITE
+      driven_by :cuprite_chrome
+    else
+      driven_by ENV["IN_DOCKER"] == "true" ? :docker_headless_chrome : :chrome
+    end
   end
 
   config.before(:each, :mobile_view) do |example|
-    driven_by ENV["IN_DOCKER"] == "true" ? :docker_headless_mobile_chrome : :mobile_chrome
+    if USE_CUPRITE
+      driven_by :cuprite_mobile_chrome
+    else
+      driven_by ENV["IN_DOCKER"] == "true" ? :docker_headless_mobile_chrome : :mobile_chrome
+    end
   end
 
   config.before(:each, billy: true) do |example|
@@ -135,6 +175,10 @@ RSpec.configure do |config|
   end
 
   config.before(:each, :tablet_view) do |example|
-    driven_by ENV["IN_DOCKER"] == "true" ? :docker_headless_tablet_chrome : :tablet_chrome
+    if USE_CUPRITE
+      driven_by :cuprite_tablet_chrome
+    else
+      driven_by ENV["IN_DOCKER"] == "true" ? :docker_headless_tablet_chrome : :tablet_chrome
+    end
   end
 end


### PR DESCRIPTION
`test_slow` previously stacked rspec-retry (3x per example) inside a
GHA-level `nick-fields/retry` (2x per shard), letting one flaky spec
survive up to six attempts and replaying the whole shard on any
failure. That masks flakes and roughly doubles wall-clock on hiccups.

Changes:
- Lower `default_retry_count` from 3 to 1; system specs (only browser
  type allowed) keep 2 via an `around` hook.
- Add `record_flaky_spec` to the retry callback; write JSONL entries to
  log/flaky_specs.log so flakes are visible instead of swallowed.
- Drop the `nick-fields/retry` wrapper around `test_slow`'s Run tests
  step; keep retries on docker login/pull (real network failures).
- Mount log dir into the test_fast container and upload
  flaky_specs.log as an artifact from both shards.
- Rebalance shard matrix from 28 fast + 72 slow to 20 + 48. Per-shard
  setup tax (~70 s × 100 = ~7000 CPU-seconds) is the dominant cost on
  warm-cache runs; Knapsack queue mode keeps the tail bounded.