### PR TITLE
Drop nick-fields/retry from test_slow, upload flaky log artifacts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -242,7 +242,10 @@ jobs:
       - name: Run tests
         timeout-minutes: 15
         run: |
+          mkdir -p ./test-logs
+          chmod 777 ./test-logs
           docker run --rm --entrypoint="" --network ${{ env.COMPOSE_PROJECT_NAME }}_default \
+            -v "$(pwd)/test-logs:/app/log" \
             -e RUBY_YJIT_ENABLE \
             -e KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC \
             -e KNAPSACK_PRO_CI_NODE_TOTAL \
@@ -279,6 +282,14 @@ jobs:
           CI: true
           IN_DOCKER: true
           WEB_REPO: gumroadteam/web
+      - name: Archive flaky specs log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: flaky-specs-fast-${{ matrix.ci_node_index }}-attempt-${{ github.run_attempt }}
+          path: ./test-logs/flaky_specs.log
+          retention-days: 14
+          if-no-files-found: ignore
       - name: Clean up
         if: always()
         run: |
@@ -431,39 +442,33 @@ jobs:
           WEB_REPO: gumroadteam/web
 
       - name: Run tests
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 20
-          max_attempts: 2
-          retry_wait_seconds: 10
-          command: |
-            # Create local directory for artifacts
-            mkdir -p ./capybara-artifacts
-            chmod 777 ./capybara-artifacts
-            mkdir -p ./test-logs
-            chmod 777 ./test-logs
+        timeout-minutes: 25
+        run: |
+          mkdir -p ./capybara-artifacts
+          chmod 777 ./capybara-artifacts
+          mkdir -p ./test-logs
+          chmod 777 ./test-logs
 
-            # Run tests with volume mount to capture capybara artifacts and test logs
-            docker run --rm --entrypoint="" --network ${{ env.COMPOSE_PROJECT_NAME }}_default \
-              -v "$(pwd)/capybara-artifacts:/app/tmp/capybara" \
-              -v "$(pwd)/test-logs:/app/log" \
-              -e RUBY_YJIT_ENABLE \
-              -e KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC \
-              -e KNAPSACK_PRO_CI_NODE_TOTAL \
-              -e KNAPSACK_PRO_CI_NODE_INDEX \
-              -e KNAPSACK_PRO_LOG_LEVEL \
-              -e KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES \
-              -e KNAPSACK_PRO_TEST_FILE_PATTERN \
-              -e KNAPSACK_PRO_COMMIT_HASH \
-              -e KNAPSACK_PRO_BRANCH \
-              -e KNAPSACK_PRO_CI_NODE_BUILD_ID \
-              -e KNAPSACK_PRO_CI_NODE_RETRY_COUNT \
-              -e KNAPSACK_PRO_PROJECT_DIR \
-              -e KNAPSACK_PRO_FIXED_QUEUE_SPLIT \
-              -e CI \
-              -e IN_DOCKER \
-              $WEB_REPO:${{ needs.build.outputs.test_image_tag }} \
-              /usr/local/bin/gosu app bundle exec rake "knapsack_pro:queue:rspec[--format RSpec::Github::Formatter --tag ~skip --format progress]"
+          docker run --rm --entrypoint="" --network ${{ env.COMPOSE_PROJECT_NAME }}_default \
+            -v "$(pwd)/capybara-artifacts:/app/tmp/capybara" \
+            -v "$(pwd)/test-logs:/app/log" \
+            -e RUBY_YJIT_ENABLE \
+            -e KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC \
+            -e KNAPSACK_PRO_CI_NODE_TOTAL \
+            -e KNAPSACK_PRO_CI_NODE_INDEX \
+            -e KNAPSACK_PRO_LOG_LEVEL \
+            -e KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES \
+            -e KNAPSACK_PRO_TEST_FILE_PATTERN \
+            -e KNAPSACK_PRO_COMMIT_HASH \
+            -e KNAPSACK_PRO_BRANCH \
+            -e KNAPSACK_PRO_CI_NODE_BUILD_ID \
+            -e KNAPSACK_PRO_CI_NODE_RETRY_COUNT \
+            -e KNAPSACK_PRO_PROJECT_DIR \
+            -e KNAPSACK_PRO_FIXED_QUEUE_SPLIT \
+            -e CI \
+            -e IN_DOCKER \
+            $WEB_REPO:${{ needs.build.outputs.test_image_tag }} \
+            /usr/local/bin/gosu app bundle exec rake "knapsack_pro:queue:rspec[--format RSpec::Github::Formatter --tag ~skip --format progress]"
         env:
           RUBY_YJIT_ENABLE: 1
           KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC_FAST }}
@@ -496,6 +501,14 @@ jobs:
           name: test-logs-slow-${{ matrix.ci_node_index }}-attempt-${{ github.run_attempt }}
           path: ./test-logs/test.log
           retention-days: 7
+          if-no-files-found: ignore
+      - name: Archive flaky specs log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: flaky-specs-slow-${{ matrix.ci_node_index }}-attempt-${{ github.run_attempt }}
+          path: ./test-logs/flaky_specs.log
+          retention-days: 14
           if-no-files-found: ignore
       - name: Clean up
         if: always()


### PR DESCRIPTION
## What
- Remove `nick-fields/retry` wrapper from test_slow Run tests step
- Mount log dir into test_fast container
- Upload `flaky_specs.log` as artifact from both fast and slow shards

## Why
test_slow stacked rspec-retry inside GHA-level nick-fields/retry (2x per shard), letting one flaky spec survive up to 6 attempts and replaying the whole shard on any failure. This masks flakes and roughly doubles wall-clock on hiccups.

Depends on #5072 for the `record_flaky_spec` callback.
Split from #5071.

---
AI disclosure: Claude Opus 4.6 via Hermes Agent.