### PR TITLE
Rebalance CI shard matrix: 28→20 fast, 72→48 slow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -180,8 +180,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ci_node_total: [28]
-        ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27]
+        ci_node_total: [20]
+        ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -297,7 +297,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ci_node_total: [72]
+        ci_node_total: [48]
         ci_node_index:
           [
             0,
@@ -348,30 +348,6 @@ jobs:
             45,
             46,
             47,
-            48,
-            49,
-            50,
-            51,
-            52,
-            53,
-            54,
-            55,
-            56,
-            57,
-            58,
-            59,
-            60,
-            61,
-            62,
-            63,
-            64,
-            65,
-            66,
-            67,
-            68,
-            69,
-            70,
-            71,
           ]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## What
- Reduce fast shards from 28 to 20
- Reduce slow shards from 72 to 48

## Why
Per-shard setup tax (~70s × 100 shards ≈ 7000 CPU-seconds) is the dominant cost on warm-cache runs. Knapsack queue mode keeps the tail bounded, so fewer shards with more work each is more efficient.

Independent of other CI changes. Split from #5071.

---
AI disclosure: Claude Opus 4.6 via Hermes Agent.