### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/vendor/assets/javascripts/evaporate.cjs
+++ b/vendor/assets/javascripts/evaporate.cjs
@@ -36,7 +36,7 @@ var Evaporate = function(config){
   }
 
 
-  var PENDING = 0, EVAPORATING = 2, COMPLETE = 3, PAUSED = 4, CANCELED = 5, ERROR = 10, ABORTED = 20, ETAG_OF_0_LENGTH_BLOB = '"d41d8cd98f00b204e9800998ecf8427e"';
+  var PENDING = 0, EVAPORATING = 2, COMPLETE = 3, CANCELED = 5, ERROR = 10, ABORTED = 20, ETAG_OF_0_LENGTH_BLOB = '"d41d8cd98f00b204e9800998ecf8427e"';
 
   var _ = this;
   var files = [];


### PR DESCRIPTION
To fix this, remove only the unused constant `PAUSED` from the multi-variable declaration on line 39 in `vendor/assets/javascripts/evaporate.cjs`.

Best single fix without changing behavior:
- Edit the declaration line where status constants are defined.
- Delete `PAUSED = 4,` and leave all other constants unchanged.
- No imports, methods, or additional definitions are needed.

This keeps functional behavior identical while satisfying the static analysis warning and reducing dead code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._