### PR TITLE
Fix for Useless assignment to local variable

### DIFF
--- a/app/javascript/pages/Products/New.tsx
+++ b/app/javascript/pages/Products/New.tsx
@@ -237,7 +237,6 @@ const NewProductPage = () => {
       form.setError("link.price_range", "is required");
       if (!hasFocused) {
         priceInputRef.current?.focus();
-        hasFocused = true;
       }
       hasErrors = true;
     } else {


### PR DESCRIPTION
The best fix is to remove the unused assignment `hasFocused = true` at line 240 while keeping the focus call itself.  
In `app/javascript/pages/Products/New.tsx`, inside `saveProduct`, in the `if (form.data.link.price_range.trim() === "")` block, keep:

- the `if (!hasFocused)` guard
- `priceInputRef.current?.focus();`

and delete only the redundant `hasFocused = true;` line in that block. No imports, new methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._