### PR TITLE
Fix for Useless assignment to local variable

### DIFF
--- a/app/javascript/components/ComboBox.tsx
+++ b/app/javascript/components/ComboBox.tsx
@@ -55,7 +55,7 @@ export const ComboBox = <Option extends unknown>({
   const itemRefs: (HTMLElement | null)[] = [];
 
   const moveCursor = (from: number, by: number) => {
-    let i = from;
+    let i: number;
     do {
       i = (from + by) % options.length;
       if (!itemRefs[i]?.inert) {

--- a/app/javascript/components/ComboBox.tsx
+++ b/app/javascript/components/ComboBox.tsx
@@ -55,9 +55,9 @@ export const ComboBox = <Option extends unknown>({
   const itemRefs: (HTMLElement | null)[] = [];
 
   const moveCursor = (from: number, by: number) => {
-    let i: number;
+    let i = from;
     do {
-      i = (from + by) % options.length;
+      i = ((i + by) % options.length + options.length) % options.length;
       if (!itemRefs[i]?.inert) {
         setFocusedOptionIndex(i);
         break;


### PR DESCRIPTION
The best fix is to declare `i` without an initial value and keep the existing loop logic unchanged.  
In `app/javascript/components/ComboBox.tsx`, update the `moveCursor` function so `i` is declared as `let i: number;` instead of `let i = from;`. This removes the dead store while preserving functionality.

No new imports, helper methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._