### PR TITLE
Migrate 39 risky have_alert→interact sites to flash_message

### DIFF
--- a/spec/requests/checkout/form_spec.rb
+++ b/spec/requests/checkout/form_spec.rb
@@ -21,7 +21,7 @@ describe("Checkout form page", type: :system, js: true) do
         expect(page).to have_field("Discount code")
       end
       click_on "Save changes"
-      expect(page).to have_alert(text: "Changes saved!")
+      expect(flash_message).to eq "Changes saved!"
       expect(seller.reload.display_offer_code_field).to eq(true)
 
       visit checkout_form_path
@@ -43,7 +43,7 @@ describe("Checkout form page", type: :system, js: true) do
 
       click_on "Save changes"
       expect(find_field("Label")["aria-invalid"]).to eq "true"
-      expect(page).to have_alert(text: "Please complete all required fields.")
+      expect(flash_message).to eq "Please complete all required fields."
 
       fill_in "Label", with: "You should totally check this - out!"
       in_preview do
@@ -54,12 +54,12 @@ describe("Checkout form page", type: :system, js: true) do
       click_on "Save changes"
       expect(find_field("Label")["aria-invalid"]).to eq "false"
       expect(find_field("Products")["aria-invalid"]).to eq "true"
-      expect(page).to have_alert(text: "Please complete all required fields.")
+      expect(flash_message).to eq "Please complete all required fields."
 
       check "All products"
       click_on "Save changes"
       expect(find_field("Products")["aria-invalid"]).to eq "false"
-      expect(page).to have_alert(text: "Changes saved!")
+      expect(flash_message).to eq "Changes saved!"
       expect(seller.custom_fields.count).to eq(1)
       field = seller.custom_fields.last
       expect(field.name).to eq "You should totally check this - out!"
@@ -79,7 +79,7 @@ describe("Checkout form page", type: :system, js: true) do
       end
       click_on "Save changes"
       expect(find_field("Terms URL")["aria-invalid"]).to eq "false"
-      expect(page).to have_alert(text: "Changes saved!")
+      expect(flash_message).to eq "Changes saved!"
       expect(field.reload.type).to eq "terms"
       expect(field.name).to eq "https://www.gumroad.com"
 
@@ -124,7 +124,7 @@ describe("Checkout form page", type: :system, js: true) do
         expect(page).to_not have_section("Customers who bought this item also bought")
       end
       click_on "Save changes"
-      expect(page).to have_alert(text: "Changes saved!")
+      expect(flash_message).to eq "Changes saved!"
       expect(seller.reload.recommendation_type).to eq(User::RecommendationType::NO_RECOMMENDATIONS)
 
       visit checkout_form_path
@@ -137,7 +137,7 @@ describe("Checkout form page", type: :system, js: true) do
       end
       click_on "Save changes"
       wait_for_ajax
-      expect(page).to have_alert(text: "Changes saved!")
+      expect(flash_message).to eq "Changes saved!"
       expect(seller.reload.recommendation_type).to eq(User::RecommendationType::OWN_PRODUCTS)
 
       choose "Recommend all products and earn a commission with Gumroad Affiliates"
@@ -149,7 +149,7 @@ describe("Checkout form page", type: :system, js: true) do
       end
       click_on "Save changes"
       wait_for_ajax
-      expect(page).to have_alert(text: "Changes saved!")
+      expect(flash_message).to eq "Changes saved!"
       expect(seller.reload.recommendation_type).to eq(User::RecommendationType::GUMROAD_AFFILIATES_PRODUCTS)
 
       choose "Recommend my products and products I'm an affiliate of"

--- a/spec/requests/collaborators_spec.rb
+++ b/spec/requests/collaborators_spec.rb
@@ -207,12 +207,12 @@ describe "Collaborators", type: :system, js: true do
         # invalid email
         fill_in "email", with: "foo"
         click_on "Add collaborator"
-        expect(page).to have_alert(text: "Please enter a valid email")
+        expect(flash_message).to eq "Please enter a valid email"
 
         # no user with that email
         fill_in "email", with: "foo@example.com"
         click_on "Add collaborator"
-        expect(page).to have_alert(text: "The email address isn't associated with a Gumroad account.")
+        expect(flash_message).to eq "The email address isn't associated with a Gumroad account."
 
         # no products selected
         fill_in "email", with: collaborating_user.email
@@ -222,7 +222,7 @@ describe "Collaborators", type: :system, js: true do
           end
         end
         click_on "Add collaborator"
-        expect(page).to have_alert(text: "At least one product must be selected")
+        expect(flash_message).to eq "At least one product must be selected"
 
         # invalid default percent commission
         within find(:table_row, { "Product" => product1.name }) do
@@ -235,7 +235,7 @@ describe "Collaborators", type: :system, js: true do
         within find(:table_row, { "Product" => "All products" }) do
           expect(find("fieldset.danger")).to have_field("Percentage")
         end
-        expect(page).to have_alert(text: "Collaborator cut must be 50% or less")
+        expect(flash_message).to eq "Collaborator cut must be 50% or less"
 
         # invalid product percent commission
         uncheck "All products"
@@ -247,7 +247,7 @@ describe "Collaborators", type: :system, js: true do
         within find(:table_row, { "Product" => product1.name }) do
           expect(find("fieldset.danger")).to have_field("Percentage")
         end
-        expect(page).to have_alert(text: "Collaborator cut must be 50% or less")
+        expect(flash_message).to eq "Collaborator cut must be 50% or less"
         within find(:table_row, { "Product" => product1.name }) do
           fill_in "Percentage", with: 40
           expect(page).not_to have_selector("fieldset.danger")
@@ -257,7 +257,7 @@ describe "Collaborators", type: :system, js: true do
         within find(:table_row, { "Product" => product1.name }) do
           expect(find("fieldset.danger")).to have_field("Percentage")
         end
-        expect(page).to have_alert(text: "Collaborator cut must be 50% or less")
+        expect(flash_message).to eq "Collaborator cut must be 50% or less"
 
         # missing default percent commission
         check "All products"
@@ -268,7 +268,7 @@ describe "Collaborators", type: :system, js: true do
         within find(:table_row, { "Product" => "All products" }) do
           expect(find("fieldset.danger")).to have_field("Percentage")
         end
-        expect(page).to have_alert(text: "Collaborator cut must be 50% or less")
+        expect(flash_message).to eq "Collaborator cut must be 50% or less"
 
         # missing product percent commission
         uncheck "All products"

--- a/spec/requests/customers/customers_spec.rb
+++ b/spec/requests/customers/customers_spec.rb
@@ -703,7 +703,7 @@ describe "Sales page", type: :system, js: true do
           fill_in "Email", with: "newcustomer2@gumroad.com"
           click_on "Save"
         end
-        expect(page).to have_alert(text: "Email updated successfully.")
+        expect(flash_message).to eq "Email updated successfully."
 
         within_section "Email", section_element: :section do
           expect(page).to have_button("Edit")
@@ -716,7 +716,7 @@ describe "Sales page", type: :system, js: true do
 
           uncheck "Receives emails", checked: true
         end
-        expect(page).to have_alert(text: "Your customer will no longer receive your posts.")
+        expect(flash_message).to eq "Your customer will no longer receive your posts."
 
         within_section "Giftee email", section_element: :section do
           expect(page).to have_text("customer1@gumroad.com")
@@ -850,14 +850,14 @@ describe "Sales page", type: :system, js: true do
           click_on "Disable"
         end
         wait_for_ajax
-        expect(page).to have_alert(text: "Changes saved!")
+        expect(flash_message).to eq "Changes saved!"
         expect(purchase2.license.reload.disabled_at).to_not be_nil
 
         within_section "License key", section_element: :section do
           click_on "Enable"
         end
         wait_for_ajax
-        expect(page).to have_alert(text: "Changes saved!")
+        expect(flash_message).to eq "Changes saved!"
         expect(purchase2.license.reload.disabled_at).to be_nil
 
         within_section "Seats", section_element: :section do
@@ -990,7 +990,7 @@ describe "Sales page", type: :system, js: true do
           visit customer_sale_path(purchase1.external_id)
 
           click_on "Resend ping"
-          expect(page).to have_alert(text: "Ping resent.")
+          expect(flash_message).to eq "Ping resent."
           expect(PostToPingEndpointsWorker).to have_enqueued_sidekiq_job(purchase1.id, nil)
 
           visit customer_sale_path(purchase2.external_id)
@@ -998,7 +998,7 @@ describe "Sales page", type: :system, js: true do
             click_on "Resend ping"
           end
           wait_for_ajax
-          expect(page).to have_alert(text: "Ping resent.")
+          expect(flash_message).to eq "Ping resent."
           expect(PostToPingEndpointsWorker).to have_enqueued_sidekiq_job(purchase2.id, nil)
 
           within_section "$0", match: :first do
@@ -1097,7 +1097,7 @@ describe "Sales page", type: :system, js: true do
           end
           wait_for_ajax
         end
-        expect(page).to have_alert(text: "Refund amount cannot be greater than the purchase price.")
+        expect(flash_message).to eq "Refund amount cannot be greater than the purchase price."
 
         within_section "Charges", section_element: :section do
           find_field("2", with: "3").fill_in with: "2"
@@ -1323,7 +1323,7 @@ describe "Sales page", type: :system, js: true do
       it "allows revoking and re-enabling access" do
         visit customer_sale_path(purchase1.external_id)
         click_on "Revoke access"
-        expect(page).to have_alert(text: "Access revoked")
+        expect(flash_message).to eq "Access revoked"
         expect(purchase1.reload.is_access_revoked?).to eq(true)
         click_on "Re-enable access"
         expect(page).to have_alert(text: "Access re-enabled")
@@ -1389,7 +1389,7 @@ describe "Sales page", type: :system, js: true do
             click_on "Confirm refund"
           end
         end
-        expect(page).to have_alert(text: "Refund amount cannot be greater than the purchase price.")
+        expect(flash_message).to eq "Refund amount cannot be greater than the purchase price."
 
         within_section "Refund", section_element: :section do
           fill_in "2", with: "2"
@@ -1568,7 +1568,7 @@ describe "Sales page", type: :system, js: true do
           fill_in "Add a response to the review", with: "Thank you!"
           click_on "Submit"
         end
-        expect(page).to have_alert(text: "Response submitted successfully!")
+        expect(flash_message).to eq "Response submitted successfully!"
         expect(review.response.reload.message).to eq("Thank you!")
 
         within_section "Review" do
@@ -1576,7 +1576,7 @@ describe "Sales page", type: :system, js: true do
           fill_in "Add a response to the review", with: "Thank you, again!"
           click_on "Update"
         end
-        expect(page).to have_alert(text: "Response updated successfully!")
+        expect(flash_message).to eq "Response updated successfully!"
         expect(review.response.reload.message).to eq("Thank you, again!")
 
         within_section "Review" do
@@ -1716,7 +1716,7 @@ describe "Sales page", type: :system, js: true do
 
         fill_in "Call URL", with: "https://zoom.us/j/dumb"
         click_on "Save"
-        expect(page).to have_alert(text: "Call URL updated!")
+        expect(flash_message).to eq "Call URL updated!"
         expect(call_purchase.call.reload.call_url).to eq("https://zoom.us/j/dumb")
 
         visit customer_sale_path(call_purchase.external_id)

--- a/spec/requests/products/edit/rich_text_editor_spec.rb
+++ b/spec/requests/products/edit/rich_text_editor_spec.rb
@@ -334,13 +334,13 @@ describe("Product Edit Rich Text Editor", type: :system, js: true) do
       fill_in "Enter URL", with: ""
       click_on "Add link"
     end
-    expect(page).to have_alert(text: "Please enter a valid URL.")
+    expect(flash_message).to eq "Please enter a valid URL."
 
     expect(page).to_not have_alert(text: "Please enter a valid URL.")
     fill_in "Enter text", with: "An invalid link 2"
     fill_in "Enter URL", with: "/broken:link"
     click_on "Add link"
-    expect(page).to have_alert(text: "Please enter a valid URL.")
+    expect(flash_message).to eq "Please enter a valid URL."
 
     expect(page).to_not have_alert(text: "Please enter a valid URL.")
     fill_in "Enter text", with: "Valid link 1"
@@ -559,14 +559,14 @@ describe("Product Edit Rich Text Editor", type: :system, js: true) do
       attach_file file_fixture("test.pdf") do
         click_on "Insert audio"
       end
-      expect(page).to have_alert(text: "Only audio files are allowed")
+      expect(flash_message).to eq "Only audio files are allowed"
       expect(page).to_not have_embed(name: "test")
 
       # Validate that large files are not allowed
       attach_file file_fixture("big-music-file.mp3") do
         click_on "Insert audio"
       end
-      expect(page).to have_alert(text: "File is too large (max allowed size is 5.0 MB)")
+      expect(flash_message).to eq "File is too large (max allowed size is 5.0 MB)"
       expect(page).to_not have_embed(name: "big-music-file")
 
       # Upload a valid audio file
@@ -788,7 +788,7 @@ describe("Product Edit Rich Text Editor", type: :system, js: true) do
         end
       end
       click_on "Save changes"
-      expect(page).to have_alert(text: "You must add titles to all of your inputs")
+      expect(flash_message).to eq "You must add titles to all of your inputs"
       fill_in "Title", with: "New short answer"
 
       select_disclosure "Insert" do

--- a/spec/requests/settings/payments_spec.rb
+++ b/spec/requests/settings/payments_spec.rb
@@ -172,7 +172,7 @@ describe("Payments Settings Scenario", type: :system, js: true) do
       fill_in("Last 4 digits of SSN", with: "1235")
 
       click_on("Update settings")
-      expect(page).to have_alert("You must use a test bank account number. Try 000123456789 or see more options at https://stripe.com/docs/connect/testing#account-numbers.")
+      expect(flash_message).to eq "You must use a test bank account number. Try 000123456789 or see more options at https://stripe.com/docs/connect/testing#account-numbers."
 
       fill_in("Account number", with: "000123456789")
       fill_in("Confirm account number", with: "000123456789")
@@ -352,7 +352,7 @@ describe("Payments Settings Scenario", type: :system, js: true) do
       click_on "Update settings"
       wait_for_ajax
 
-      expect(page).to have_alert(text: "Thanks! You're all set.")
+      expect(flash_message).to eq "Thanks! You're all set."
       expect(creator.reload.payout_frequency).to eq(User::PayoutSchedule::MONTHLY)
     end
 
@@ -699,7 +699,7 @@ describe("Payments Settings Scenario", type: :system, js: true) do
         expect do
           click_on "Update settings"
           wait_for_ajax
-          expect(page).to have_alert(text: "Thanks! You're all set.")
+          expect(flash_message).to eq "Thanks! You're all set."
         end.to change { @user.alive_user_compliance_info.reload.street_address }.to("123, Smith street")
 
         choose "Business"
@@ -719,7 +719,7 @@ describe("Payments Settings Scenario", type: :system, js: true) do
         expect do
           click_on "Update settings"
           wait_for_ajax
-          expect(page).to have_alert(text: "Thanks! You're all set.")
+          expect(flash_message).to eq "Thanks! You're all set."
           sleep 0.5 # Since the previous Alerts takes time to disappear, checking alert returns early before the api call is complete
         end.to change { @user.alive_user_compliance_info.reload.business_street_address }.to("123 North street")
         find(:css, "input[id$='creator-street-address']").set("po box 123 smith street")
@@ -1254,7 +1254,7 @@ describe("Payments Settings Scenario", type: :system, js: true) do
 
         select("Rio de Janeiro", from: "State")
         click_on("Update settings")
-        expect(page).to have_alert(text: "Thanks! You're all set.")
+        expect(flash_message).to eq "Thanks! You're all set."
       end
 
       it "allows the (non-US based) creator to enter their kyc and paypal email address and it'll save it properly" do
@@ -6569,7 +6569,7 @@ describe("Payments Settings Scenario", type: :system, js: true) do
         end
         click_on "Update settings"
 
-        expect(page).to have_alert(text: "Thanks! You're all set.")
+        expect(flash_message).to eq "Thanks! You're all set."
         expect(user.reload.payouts_paused_by_user?).to be true
 
         refresh
@@ -6711,7 +6711,7 @@ describe("Payments Settings Scenario", type: :system, js: true) do
 
         click_on "Update settings"
 
-        expect(page).to have_alert(text: "Thanks! You're all set.")
+        expect(flash_message).to eq "Thanks! You're all set."
         expect(user.reload.payout_frequency).to eq(User::PayoutSchedule::MONTHLY)
 
         refresh


### PR DESCRIPTION
Stacked on #5095. Migrates the top 5 most-affected spec files (39 of 136 risky sites) to use the new `flash_message` helper. Full rationale and savings estimate in the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)