### PR TITLE
Fix "Contact support" links on payments settings (#5098)

### DIFF
--- a/app/javascript/components/Settings/PaymentsPage/AccountStatusSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/AccountStatusSection.tsx
@@ -2,13 +2,11 @@ import * as React from "react";
 
 import { Alert } from "$app/components/ui/Alert";
 
-const HELP_URL = "https://help.gumroad.com";
-
 const SupportLink = () => (
   <>
     {" "}
     If you have questions,{" "}
-    <a href={HELP_URL} className="underline">
+    <a href={Routes.help_center_root_path()} className="underline">
       contact support
     </a>
     .

--- a/spec/requests/settings/payments_spec.rb
+++ b/spec/requests/settings/payments_spec.rb
@@ -6554,7 +6554,7 @@ describe("Payments Settings Scenario", type: :system, js: true) do
 
         within_section "Account status", section_element: :section do
           expect(page).to have_text("Please provide your tax ID.")
-          expect(page).to have_link("contact support", href: "https://help.gumroad.com")
+          expect(page).to have_link("contact support", href: help_center_root_path)
           expect(page).not_to have_text("Action needed")
         end
       end


### PR DESCRIPTION
## What

The `SupportLink` in `AccountStatusSection.tsx` rendered every "contact support" link on the payments settings page as a link to `https://help.gumroad.com`. That URL is the Helper admin interface — after #5038 removed the embedded Helper widget, sellers clicking the link landed on a login page they can't authenticate against (causing "user not found" errors when they typed their email).

This change routes the link to the in-app help center (`/help`) via `Routes.help_center_root_path()`, matching the pattern already used elsewhere (e.g. the navbar footer and the marketing footer). It affects every status banner on the payments settings page:

- Account suspension notice
- Stripe-paused payouts
- Admin-paused payouts
- System-paused (security review) payouts
- Compliance action alerts
- Gumroad status alerts

The matching link assertion in `spec/requests/settings/payments_spec.rb` is updated to the new URL.

## Why

The current link sends sellers to a dead end. The help center is the supported entry point for getting help — and unlike a `mailto:` link, it keeps users in-app where they can search articles before contacting support if they still need to.

## Before / After

| | Before | After |
| --- | --- | --- |
| "Contact support" link | `https://help.gumroad.com` (Helper admin login) | `/help` (Gumroad Help Center) |

## Test plan

- [ ] Visit `/settings/payments` as a user with a pending compliance action
- [ ] Confirm the "contact support" link in the Account status banner navigates to `/help`
- [ ] Run `bundle exec rspec spec/requests/settings/payments_spec.rb -e "renders compliance actions as direct linked instructions"`

Fixes #5098

---

AI disclosure: drafted with Claude Opus 4.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)