### PR TITLE
Fix stale cart email persisting after account email change

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -30,7 +30,7 @@ class CheckoutController < ApplicationController
       cart = Cart.fetch_by(user: logged_in_user, browser_guid:) || Cart.new(user: logged_in_user, browser_guid:)
       cart.ip_address = request.remote_ip
       cart.browser_guid = browser_guid
-      cart.email = update_permitted_params[:email].presence || logged_in_user&.email
+      cart.email = logged_in_user&.email || update_permitted_params[:email].presence
       cart.return_url = update_permitted_params[:returnUrl]
       cart.reject_ppp_discount = update_permitted_params[:rejectPppDiscount] || false
       cart.discount_codes = update_permitted_params[:discountCodes].to_a.map { { code: _1[:code], fromUrl: _1[:fromUrl] } }

--- a/app/javascript/pages/Checkout/Show.tsx
+++ b/app/javascript/pages/Checkout/Show.tsx
@@ -167,7 +167,7 @@ const CheckoutIndexPage = () => {
   } = typia.assert<CheckoutIndexPageProps>(usePage().props);
 
   const user = useLoggedInUser();
-  const email = props.cart?.email ?? user?.email ?? "";
+  const email = user?.email ?? props.cart?.email ?? "";
   const cartForm = useForm<{ cart: CartState }>(() => {
     const initialCart = clear_cart ? newCartState() : (props.cart ?? newCartState());
     const url = new URL(window.location.href);

--- a/spec/controllers/checkout_controller_spec.rb
+++ b/spec/controllers/checkout_controller_spec.rb
@@ -296,7 +296,7 @@ describe CheckoutController, type: :controller, inertia: true do
 
         cart = controller.logged_in_user.alive_cart
         expect(cart).to have_attributes(
-          email: "john@example.com",
+          email: seller.email,
           return_url: "https://example.com",
           reject_ppp_discount: false,
           discount_codes: [{ "code" => "BLACKFRIDAY", "fromUrl" => false }]
@@ -404,6 +404,15 @@ describe CheckoutController, type: :controller, inertia: true do
           accepted_offer_details: { "original_product_id" => product3.external_id, "original_variant_id" => nil },
           pay_in_installments: true
         )
+      end
+
+      it "forces the cart email to the signed-in user's email regardless of the submitted email" do
+        cart = create(:cart, user: seller, email: "stale@example.com")
+
+        patch :update, params: { cart: { email: "stale@example.com", items: [], discountCodes: [] } }, as: :json
+
+        expect(response).to have_http_status(:see_other)
+        expect(cart.reload.email).to eq(seller.email)
       end
 
       it "updates `browser_guid` with the value of the `_gumroad_guid` cookie" do


### PR DESCRIPTION
Fixes https://github.com/antiwork/gumroad-private/issues/385

## What

When a buyer's account email is changed, the checkout page keeps showing — and using — their old email. New purchases get recorded under the old email and receipts go to the wrong address.

This PR makes two server-authoritative changes so that a signed-in buyer's `users.email` always wins on checkout:

- **`app/javascript/pages/Checkout/Show.tsx:170`** — flip the priority so `user.email` is preferred over the cart's stored email when a user is logged in.
- **`app/controllers/checkout_controller.rb:33`** — in `#update`, when `logged_in_user` is present, set `cart.email = logged_in_user.email` unconditionally. The form value is only used for guest checkouts.

## Why

`update_alive_cart_email` (added in #2706) syncs `cart.email` whenever `users.email` changes — but only for changes that happen **after** that PR shipped (2026-01-06). Users whose email was changed earlier still have stale `cart.email` rows.

The bug then self-perpetuates:

1. `Show.tsx:170` reads `cart.email` first, so the stale value renders in the disabled input.
2. The user can't fix it themselves — the field is `disabled` when logged in (PaymentForm.tsx:345).
3. On every checkout visit, the frontend resubmits the stale email and `checkout_controller#update` does `cart.email = update_permitted_params[:email].presence || logged_in_user&.email`, overwriting the cart with itself.
4. At purchase time, `purchases_controller.rb:199` writes `@purchase.email = params[:email]`, so receipts go to the old address.

Treating `cart.email` as buyer-identity data owned by the server (not the form) closes all four steps with a two-line change. Per CONTRIBUTING.md, identity-bound business state belongs in Rails, not the frontend.

## Alternatives considered

- **Force re-sync via callback on read** (e.g. on `CartPresenter`): doesn't help guests and adds a write to every checkout render.
- **One-time backfill script**: would heal existing stale rows, but doesn't prevent future drift if any path slips past the `saved_change_to_email?` callback (e.g. raw SQL fixes, future OAuth flows). The controller-side guard makes that class of bug impossible, regardless of how `users.email` was changed.

A backfill task may still be worth running as a follow-up to clean up already-stuck carts ahead of the next checkout visit; left out of this PR to keep it small.

## Before / After

| | Before | After |
| --- | --- | --- |
| `users.email` changes, `carts.email` not synced (pre-#2706 user) | Checkout shows old email; purchases recorded under old email | Checkout shows current `users.email`; cart and purchase get the right email |
| Signed-in buyer submits a different email | Cart accepts submitted email | Cart ignores submitted email, uses `logged_in_user.email` |
| Guest checkout | Unchanged | Unchanged |

Verified in production for the reported user (id 17598551): `users.email = aringunness@gmail.com`, `alive_cart.email = salarikan@gmail.com` — exactly the scenario this fix handles. With this change, their next checkout visit overwrites the stale cart email with the correct one.

## Test plan

- [x] `bundle exec rspec spec/controllers/checkout_controller_spec.rb -e "PATCH update"` — all 15 specs pass, including a new spec that submits a stale email while signed in and asserts the cart ends up with the user's email.
- [ ] Manual: log in, set `cart.email` to a value that differs from `users.email` (e.g. via the rails console), visit `/checkout`, confirm the page shows `users.email` and a test purchase records `users.email`.
- [ ] Manual: guest checkout still uses the email entered in the form.

---

AI disclosure: implemented with Claude Opus 4.7. Prompts directed the agent to investigate the linked issue, identify root cause, propose a fix, and implement it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)