### PR TITLE
Fix flaky StreamingUrlsController spec

### DIFF
--- a/spec/controllers/product_review_videos/streaming_urls_controller_spec.rb
+++ b/spec/controllers/product_review_videos/streaming_urls_controller_spec.rb
@@ -17,20 +17,22 @@ RSpec.describe ProductReviewVideos::StreamingUrlsController, type: :controller d
       before { product_review_video.approved! }
 
       it "returns the correct media URLs" do
-        get :index, params: {
-          product_review_video_id: product_review_video.external_id
-        }, format: :json
+        freeze_time do
+          get :index, params: {
+            product_review_video_id: product_review_video.external_id
+          }, format: :json
 
-        expect(response).to have_http_status(:ok)
-        expect(response.parsed_body[:streaming_urls]).to eq(
-          [
-            product_review_video_stream_path(
-              product_review_video.external_id,
-              format: :smil
-            ),
-            product_review_video.video_file.signed_download_url
-          ]
-        )
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body[:streaming_urls]).to eq(
+            [
+              product_review_video_stream_path(
+                product_review_video.external_id,
+                format: :smil
+              ),
+              product_review_video.video_file.signed_download_url
+            ]
+          )
+        end
       end
     end
 


### PR DESCRIPTION
## What

`spec/controllers/product_review_videos/streaming_urls_controller_spec.rb` — wrap the "returns the correct media URLs" example in `freeze_time` so the controller and the expectation compute the S3 presigned URL at the same instant.

## Why

The example compared `response.parsed_body[:streaming_urls]` against a freshly-generated `product_review_video.video_file.signed_download_url`. Both calls produce S3 presigned URLs that embed `X-Amz-Date` and a derived `X-Amz-Signature`. When the two invocations straddled a one-second boundary, the signatures differed and the `eq` match failed.

That's exactly the failure observed in [run 25937754416 / job 76249432382](https://github.com/antiwork/gumroad/actions/runs/25937754416/job/76249432382): identical S3 paths, mismatched `X-Amz-Signature` suffixes (`d87ca9…` vs `7bdebd…`).

`freeze_time` is the lightest fix that preserves the assertion's intent — stubbing `signed_download_url` would make the test tautological (it exists specifically to verify the controller surfaces the right URL).

## Test Results

The change is a `freeze_time` wrapper around the existing request and expectation; no production code touched. The other examples in the file are unaffected.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) — model: Claude Opus 4.7 (1M context). Prompt: "fix this flakey spec plz in a new branch - <CI link>".