### PR TITLE
Update embed spec for renamed widget bundle

### DIFF
--- a/spec/controllers/embedded_javascripts_controller_spec.rb
+++ b/spec/controllers/embedded_javascripts_controller_spec.rb
@@ -24,7 +24,7 @@ describe EmbeddedJavascriptsController do
     it "returns the correct js" do
       get :embed, format: :js
 
-      expect(response.body).to include("/js/gumroad-embed.js")
+      expect(response.body).to include("/js/gumroad-embed-bundle.js")
     end
   end
 end


### PR DESCRIPTION
## What

`spec/controllers/embedded_javascripts_controller_spec.rb` — update the `embed` example to assert the renamed bundle filename `/js/gumroad-embed-bundle.js`.

## Why

[851068ea](https://github.com/antiwork/gumroad/commit/851068ea) renamed the embed bundle from `gumroad-embed.js` to `gumroad-embed-bundle.js` so it no longer matches the `script[src*='/js/gumroad.js']` selector used by the widget. The controller side was updated; this spec was not, so [run 25937970419 / job 76250312763](https://github.com/antiwork/gumroad/actions/runs/25937970419/job/76250312763?pr=5067) fails with:

> expected `\"…/js/gumroad-embed-bundle.js…\"` to include `\"/js/gumroad-embed.js\"`

This is not a flake — it's a real spec drift from the rename. Updating the expectation makes the spec follow the controller.

## Test Results

Single-character expectation update. The other example in the file (`overlay`) is unaffected because it already asserts the renamed `gumroad-bundle.js` path indirectly via the selector literal that remains in the template.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) — model: Claude Opus 4.7 (1M context). Prompt: \"fix spec meanwhile: <CI link> claude left same comment\".