### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/app/javascript/components/ProductEdit/ContentTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/index.tsx
@@ -55,7 +55,7 @@ import { Modal } from "$app/components/Modal";
 import { Popover, PopoverClose, PopoverContent, PopoverTrigger } from "$app/components/Popover";
 import { FileEmbedGroup } from "$app/components/ProductEdit/ContentTab/FileEmbedGroup";
 import { Layout } from "$app/components/ProductEdit/Layout";
-import { ExistingFileEntry, FileEntry, useProductEditContext, Variant } from "$app/components/ProductEdit/state";
+import { ExistingFileEntry, FileEntry, useProductEditContext } from "$app/components/ProductEdit/state";
 import { ReviewForm } from "$app/components/ReviewForm";
 import {
   baseEditorOptions,


### PR DESCRIPTION
The correct fix is to remove `Variant` from the named import list in `app/javascript/components/ProductEdit/ContentTab/index.tsx` without changing runtime behavior. Since this is an unused import, deleting only that symbol is the minimal, safest change.

Specifically:
- Edit the import on line 58.
- Change:
  `import { ExistingFileEntry, FileEntry, useProductEditContext, Variant } from "$app/components/ProductEdit/state";`
- To:
  `import { ExistingFileEntry, FileEntry, useProductEditContext } from "$app/components/ProductEdit/state";`

No additional imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._