### PR TITLE
Fix flaky switch_controller_spec timing tolerance

### DIFF
--- a/spec/controllers/sellers/switch_controller_spec.rb
+++ b/spec/controllers/sellers/switch_controller_spec.rb
@@ -19,7 +19,7 @@ describe Sellers::SwitchController do
       it "doesn't set cookie" do
         post :create, params: { team_membership_id: "foo" }
 
-        expect(cookies.encrypted[:current_seller_id]). to eq(nil)
+        expect(cookies.encrypted[:current_seller_id]).to eq(nil)
         expect(response).to have_http_status(:no_content)
       end
     end
@@ -30,9 +30,8 @@ describe Sellers::SwitchController do
       it "sets cookie and updates last_accessed_at" do
         post :create, params: { team_membership_id: team_membership.external_id.to_s }
 
-        expect(cookies.encrypted[:current_seller_id]). to eq(seller.id)
-        puts team_membership.last_accessed_at
-        expect(team_membership.reload.last_accessed_at).to be_within(1.second).of(Time.current)
+        expect(cookies.encrypted[:current_seller_id]).to eq(seller.id)
+        expect(team_membership.reload.last_accessed_at).to be_within(2.seconds).of(Time.current)
         expect(response).to have_http_status(:no_content)
       end
 
@@ -44,7 +43,7 @@ describe Sellers::SwitchController do
         it "doesn't set cookie" do
           post :create, params: { team_membership_id: team_membership.external_id.to_s }
 
-          expect(cookies.encrypted[:current_seller_id]). to eq(nil)
+          expect(cookies.encrypted[:current_seller_id]).to eq(nil)
           expect(response).to have_http_status(:no_content)
         end
       end


### PR DESCRIPTION
## What
Fix flaky `Sellers::SwitchController` spec that intermittently fails in CI.

## Why
The spec checks `last_accessed_at` is within 1 second of `Time.current`, but CI occasionally exceeds this by milliseconds:
```
expected 2026-05-16 10:17:26.000000000 +0000 to be within 1 of 2026-05-16 10:17:27.000338716 +0000
```
The timestamp was only 0.3ms past the 1-second boundary.

## Changes
- Widen `be_within` tolerance from `1.second` to `2.seconds` — still validates the timestamp is recent without being brittle
- Remove stray `puts` debug statement left in the spec
- Fix minor whitespace issues (`expect(). to` → `expect().to`)

## Test Results
```
4 examples, 0 failures
```

## AI Disclosure
This PR was authored with AI assistance (Gumclaw).

---
- [x] Self-review
- [x] Specs pass locally
- [x] Lint clean