### PR TITLE
Fix flaky installments_helper_spec HTML escaping

### DIFF
--- a/spec/helpers/installments_helper_spec.rb
+++ b/spec/helpers/installments_helper_spec.rb
@@ -11,7 +11,7 @@ describe InstallmentsHelper do
 
     context "when url is missing" do
       it "displays the post title as plain text" do
-        is_expected.to eq("<span class=\"title\">#{post.subject}</span>")
+        is_expected.to eq("<span class=\"title\">#{ERB::Util.html_escape(post.subject)}</span>")
       end
     end
 
@@ -19,7 +19,7 @@ describe InstallmentsHelper do
       let(:url) { "https://example.com/p/#{post.slug}" }
 
       it "displays the post title as an anchor tag" do
-        is_expected.to eq("<a target=\"_blank\" class=\"title\" href=\"#{url}\">#{post.subject}</a>")
+        is_expected.to eq("<a target=\"_blank\" class=\"title\" href=\"#{url}\">#{ERB::Util.html_escape(post.subject)}</a>")
       end
     end
   end


### PR DESCRIPTION
## What
Fix flaky `InstallmentsHelper#post_title_displayable` spec.

## Why
`content_tag` and `link_to` HTML-escape their content. When `Faker::Book.title` generates a title containing an apostrophe (e.g. "The Soldier's Art"), the helper outputs `&#39;` but the spec compared against the raw `'` character — causing intermittent failures depending on which random title Faker picks.

## Changes
Wrap `post.subject` with `ERB::Util.html_escape` in both spec assertions to match what the helper actually produces.

## Test Results
```
2 examples, 0 failures
```

## AI Disclosure
This PR was authored with AI assistance (Gumclaw).

---
- [x] Self-review
- [x] Specs pass locally
- [x] Lint clean