### PR TITLE
Fix 3 flaky specs: membership price updates, workflows presenter, sync stuck payouts

### DIFF
--- a/spec/presenters/workflows_presenter_spec.rb
+++ b/spec/presenters/workflows_presenter_spec.rb
@@ -8,8 +8,8 @@ describe WorkflowsPresenter do
     let(:product) { create(:product, user: seller) }
     let!(:workflow1) { create(:workflow, link: product, seller:, workflow_type: Workflow::FOLLOWER_TYPE, created_at: 1.day.ago) }
     let!(:_workflow2) { create(:workflow, link: nil, seller:, workflow_type: Workflow::SELLER_TYPE, deleted_at: DateTime.current) }
-    let!(:workflow3) { create(:workflow, link: product, seller:) }
-    let!(:workflow4) { create(:workflow, link: nil, seller:, workflow_type: Workflow::SELLER_TYPE) }
+    let!(:workflow3) { create(:workflow, link: product, seller:, created_at: 1.hour.ago) }
+    let!(:workflow4) { create(:workflow, link: nil, seller:, workflow_type: Workflow::SELLER_TYPE, created_at: 2.hours.ago) }
 
     it "returns alive workflows ordered by created at descending" do
       result = described_class.new(seller:).workflows_props

--- a/spec/sidekiq/schedule_membership_price_updates_job_spec.rb
+++ b/spec/sidekiq/schedule_membership_price_updates_job_spec.rb
@@ -157,8 +157,8 @@ describe ScheduleMembershipPriceUpdatesJob do
           end
 
           it "deletes existing plan changes for product price changes, but not user-initiated plan changes" do
+            for_price_change = create(:subscription_plan_change, subscription: disabled_subscription, for_product_price_change: true, created_at: 1.minute.ago)
             by_user = create(:subscription_plan_change, subscription: disabled_subscription, tier: enabled_tier, perceived_price_cents: new_price - 1)
-            for_price_change = create(:subscription_plan_change, subscription: disabled_subscription, for_product_price_change: true)
 
             described_class.new.perform(enabled_tier.id)
 

--- a/spec/sidekiq/sync_stuck_payouts_job_spec.rb
+++ b/spec/sidekiq/sync_stuck_payouts_job_spec.rb
@@ -123,17 +123,18 @@ describe SyncStuckPayoutsJob do
       end
 
       it "syncs Stripe payouts stuck in creating with Stripe IDs to their actual status" do
+        arrival_timestamp = 1.day.ago.to_i
         payment = create(:payment, processor: PayoutProcessorType::STRIPE, state: "creating",
                                    stripe_transfer_id: "po_creating", stripe_connect_account_id: "acct_creating",
                                    created_at: 3.days.ago)
 
-        stripe_payout = { "status" => "paid", "arrival_date" => 1.day.ago.to_i }
+        stripe_payout = { "status" => "paid", "arrival_date" => arrival_timestamp }
         allow(Stripe::Payout).to receive(:retrieve).with("po_creating", { stripe_account: "acct_creating" }).and_return(stripe_payout)
 
         described_class.new.perform(PayoutProcessorType::STRIPE)
 
         expect(payment.reload.state).to eq("completed")
-        expect(payment.arrival_date).to eq(1.day.ago.to_i)
+        expect(payment.arrival_date).to eq(arrival_timestamp)
       end
 
       it "does not sync Stripe payouts still in creating under 24 hours" do
@@ -227,7 +228,7 @@ describe SyncStuckPayoutsJob do
         payment = create(:payment, processor: PayoutProcessorType::STRIPE, state: "processing",
                                    stripe_transfer_id: "po_today", stripe_connect_account_id: "acct_today",
                                    created_at: 2.days.ago)
-        payment.update!(arrival_date: Date.current.beginning_of_day.to_i)
+        payment.update!(arrival_date: Time.current.middle_of_day.to_i)
 
         expect(Stripe::Payout).not_to receive(:retrieve)
 


### PR DESCRIPTION
## What
Fix three flaky/timezone-dependent spec failures.

## Why

### 1. `schedule_membership_price_updates_job_spec` (CI flake)
Two `SubscriptionPlanChange` records created back-to-back share the same `created_at`. The `latest_plan_change` association uses `order(created_at: :desc)` — when timestamps tie, MySQL returns either one. If the wrong record wins, `for_tier?` fails and the subscription is skipped.

**Fix:** Create `for_price_change` first with `created_at: 1.minute.ago` so `by_user` is always the latest.

### 2. `workflows_presenter_spec` (CI flake)
`workflow3` and `workflow4` had no explicit `created_at`, getting identical timestamps. `order(created_at: DESC)` is non-deterministic with ties.

**Fix:** Give each an explicit `created_at` (1.hour.ago, 2.hours.ago).

### 3. `sync_stuck_payouts_job_spec` (two issues)
- **Timestamp drift:** `1.day.ago.to_i` evaluated twice (stub + assertion) can cross a second boundary, differing by 1. **Fix:** Capture once in a local variable.
- **Timezone-dependent failure:** `Date.current.beginning_of_day.to_i` (midnight UTC) can appear as yesterday when MySQL `FROM_UNIXTIME` uses a different timezone. **Fix:** Use `Time.current.middle_of_day.to_i` (noon UTC).

## Test Results
```
19 examples, 0 failures (workflows_presenter + sync_stuck_payouts)
16 examples, 0 failures (schedule_membership_price_updates)
```

## AI Disclosure
This PR was authored with AI assistance (Gumclaw/Hermes).