### PR TITLE
Fix TS build errors: restore Variant import removed by #5104

### DIFF
--- a/app/javascript/components/ProductEdit/ContentTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/index.tsx
@@ -55,7 +55,7 @@ import { Modal } from "$app/components/Modal";
 import { Popover, PopoverClose, PopoverContent, PopoverTrigger } from "$app/components/Popover";
 import { FileEmbedGroup } from "$app/components/ProductEdit/ContentTab/FileEmbedGroup";
 import { Layout } from "$app/components/ProductEdit/Layout";
-import { ExistingFileEntry, FileEntry, useProductEditContext } from "$app/components/ProductEdit/state";
+import { ExistingFileEntry, FileEntry, useProductEditContext, Variant } from "$app/components/ProductEdit/state";
 import { ReviewForm } from "$app/components/ReviewForm";
 import {
   baseEditorOptions,
@@ -1210,7 +1210,7 @@ export const ContentTab = () => {
                                     (product.has_same_rich_content_for_all_variants
                                       ? product.rich_content
                                       : item.rich_content
-                                    ).reduce<Date | null>((acc, item) => {
+                                    ).reduce<Date | null>((acc: Date | null, item: { updated_at: string }) => {
                                       const date = parseISO(item.updated_at);
                                       return acc && acc > date ? acc : date;
                                     }, null) ?? new Date(),


### PR DESCRIPTION
## What
Restore the Variant type import and add explicit types to a reduce callback in ProductEdit/ContentTab/index.tsx.

## Why
PR #5104 removed the Variant import, but it is still used as a type parameter in ComboBox<Variant> on line 1175. The reduce callback also needs explicit parameter types for strict mode.

These cause 3 webpack TypeScript errors (TS2304, TS7006 x2). The errors were latent — content-addressed Docker image caching meant no fresh webpack build had been triggered on CI since the change was merged.

## AI Disclosure
This PR was authored with AI assistance (Gumclaw/Hermes).