### PR TITLE
Fix timing flakes in subscription, cart, and admin specs

### DIFF
--- a/spec/models/purchase/purchase_subscription_spec.rb
+++ b/spec/models/purchase/purchase_subscription_spec.rb
@@ -161,7 +161,8 @@ describe "PurchaseSubscription", :vcr do
               freeze_time do
                 @purchase.update_balance_and_mark_successful!
 
-                expect(RecurringChargeWorker).to have_enqueued_sidekiq_job(@subscription.id).at(1.year.from_now)
+                expect(RecurringChargeWorker).to have_enqueued_sidekiq_job(@subscription.id)
+                expect(RecurringChargeWorker.jobs.last["at"]).to be_within(2).of(1.year.from_now.to_f)
               end
             end
           end
@@ -180,7 +181,8 @@ describe "PurchaseSubscription", :vcr do
               freeze_time do
                 @purchase.update_balance_and_mark_successful!
 
-                expect(RecurringChargeWorker).to have_enqueued_sidekiq_job(@subscription.id).at(3.months.from_now)
+                expect(RecurringChargeWorker).to have_enqueued_sidekiq_job(@subscription.id)
+                expect(RecurringChargeWorker.jobs.last["at"]).to be_within(2).of(3.months.from_now.to_f)
               end
             end
           end
@@ -199,7 +201,8 @@ describe "PurchaseSubscription", :vcr do
               freeze_time do
                 @purchase.update_balance_and_mark_successful!
 
-                expect(RecurringChargeWorker).to have_enqueued_sidekiq_job(@subscription.id).at(6.months.from_now)
+                expect(RecurringChargeWorker).to have_enqueued_sidekiq_job(@subscription.id)
+                expect(RecurringChargeWorker.jobs.last["at"]).to be_within(2).of(6.months.from_now.to_f)
               end
             end
           end
@@ -218,7 +221,8 @@ describe "PurchaseSubscription", :vcr do
               freeze_time do
                 @purchase.update_balance_and_mark_successful!
 
-                expect(RecurringChargeWorker).to have_enqueued_sidekiq_job(@subscription.id).at(2.years.from_now)
+                expect(RecurringChargeWorker).to have_enqueued_sidekiq_job(@subscription.id)
+                expect(RecurringChargeWorker.jobs.last["at"]).to be_within(2).of(2.years.from_now.to_f)
               end
             end
           end

--- a/spec/requests/admin/pages_spec.rb
+++ b/spec/requests/admin/pages_spec.rb
@@ -132,9 +132,10 @@ describe "Admin Pages Scenario", type: :system, js: true do
       expect(page).to have_text("product #29")
       expect(page).to have_text("product #28")
       expect(page).not_to have_text("product #0")
-      first("main").scroll_to :bottom
-
-      expect(page).to have_text("product #0")
+      find("main").scroll_to :bottom
+      # IntersectionObserver needs time to fire after scroll, then AJAX
+      # loads the next page. Use Capybara's built-in retry with longer wait.
+      expect(page).to have_text("product #0", wait: 10)
     end
   end
 

--- a/spec/requests/checkout/cart_spec.rb
+++ b/spec/requests/checkout/cart_spec.rb
@@ -140,7 +140,7 @@ describe "Checkout cart", :js, type: :system do
     end
 
     describe "cart persistence" do
-      let(:wait_timeout) { 10 }
+      let(:wait_timeout) { 15 }
 
       def poll_until(timeout: wait_timeout)
         Timeout.timeout(timeout) do


### PR DESCRIPTION
## What

Fixes 3 recurring flaky specs found across open PRs.

## Why

These timing-sensitive tests fail intermittently in CI, blocking unrelated PRs.

## Changes

### 1. `purchase_subscription_spec.rb` — off-by-1 timestamp flake
The `.at()` Sidekiq matcher does exact float comparison, which can differ by a fraction of a second from the independently computed expected time. Adds `be_within(2).of()` tolerance while keeping the explicit expected durations (`1.year.from_now`, `3.months.from_now`, `6.months.from_now`, `2.years.from_now`) visible in the assertions.

### 2. `checkout/cart_spec.rb` — timeout on cart persistence
Increases `poll_until` timeout from 10s to 15s. CI runners under load need more time for cart AJAX persistence round-trips.

### 3. `admin/pages_spec.rb` — infinite scroll not loading
- Uses `find('main')` instead of `first('main')` (more explicit)
- Gives IntersectionObserver-driven infinite scroll a 10s Capybara wait instead of expecting immediate text appearance after `scroll_to :bottom`

## Test results
These are test-only changes — no production code modified.

---
*This PR was created by Gumclaw 🤖*