### PR TITLE
Update Claude Code Review trigger to '@claude review once'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ Resolve conflicts locally before pushing. PRs with stale branches will not be me
 
 ### Code review
 
-Claude Code Review is set to manual mode. After opening a PR, request a review by posting a `@claude review` comment on the PR. This triggers an AI-powered review of your changes — it won't run automatically.
+Claude Code Review is set to manual mode. After opening a PR, request a review by posting a `@claude review once` comment on the PR. This triggers an AI-powered review of your changes — it won't run automatically.
 
 ### Before pushing
 


### PR DESCRIPTION
## What
Update Claude Code Review trigger from `@claude review` to `@claude review once` in CONTRIBUTING.md.

## Why
`@claude review once` is the preferred invocation — it triggers a single review pass without re-reviewing on subsequent pushes.

---
*This PR was created by Gumclaw 🤖*