### PR TITLE
Fix flaky embed spec: wait for variant pre-selection

### DIFF
--- a/spec/requests/embed_spec.rb
+++ b/spec/requests/embed_spec.rb
@@ -163,7 +163,7 @@ describe "Embed scenario", type: :system, js: true, mock_easypost: true, retry: 
     visit(embed_page_url)
 
     within_frame do
-      expect(page).to have_radio_button("Blue - Extra Large - Polo", checked: true)
+      expect(page).to have_radio_button("Blue - Extra Large - Polo", checked: true, wait: 15)
       expect(page).to have_field("Quantity", with: 2)
       expect(page).to have_field("Name a fair price", with: 3)
       click_on "Add to cart"


### PR DESCRIPTION
## What
Add `wait: 15` to the embed spec's radio button check for URL-param variant pre-selection.

## Why
The `have_radio_button("Blue - Extra Large - Polo", checked: true)` assertion finds the element but it's not checked yet — the embed iframe needs time to load React, process URL params, and pre-select the variant. With Capybara's default 2s wait, this races and flakes in CI.

CI evidence from [run 26071776092](https://github.com/antiwork/gumroad/actions/runs/26071776092/job/76655323910#step:7:1):
```
expected to find visible radio_button "Blue - Extra Large - Polo" that is checked
but there were no matches. Also found "$0+\nBlue - Extra Large - Polo", which
matched the selector but not all filters. Expected checked true but it wasn't
```

The element is present, the label matches — it just hasn't been checked by React yet when the assertion runs. This is a classic Capybara timing issue with async iframe content.

## How
Same `wait: 15` pattern already used on lines 93 and 118 of this file for other embed assertions that wait on iframe content:
- Line 93: `expect(page).to have_status(text: "$1 off...", wait: 15)`
- Line 118: `expect(page).to have_text("$75", wait: 15)`

## Test results
Spec-only change. The test already has `retry: 2` (line 5) and passed on retry in the linked CI run, confirming the timing nature of the flake.

> [!NOTE]
> This PR was authored with AI assistance.