### PR TITLE
Exclude archived products from affiliate dashboard

### DIFF
--- a/app/presenters/affiliated_products_presenter.rb
+++ b/app/presenters/affiliated_products_presenter.rb
@@ -109,6 +109,7 @@ class AffiliatedProductsPresenter
         joins(:affiliate).
         where(affiliate_id: Affiliate.direct_or_global_affiliates.alive.where(affiliate_user_id: user.id).pluck(:id)).
         where(links: { deleted_at: nil, banned_at: nil }).
+        merge(Link.not_archived).
         select(select_columns).
         group(group_by).
         order(order_by)

--- a/spec/presenters/affiliated_products_presenter_spec.rb
+++ b/spec/presenters/affiliated_products_presenter_spec.rb
@@ -550,4 +550,23 @@ describe AffiliatedProductsPresenter do
       expect(described_class.new(seller).affiliated_products_page_props[:archived_tab_visible]).to eq(false)
     end
   end
+
+  describe "#affiliated_products_page_props when the seller archives an affiliated product" do
+    let(:seller) { create(:user) }
+    let(:affiliate_user) { create(:affiliate_user) }
+    let!(:active_product) { create(:product, name: "Active Product", user: seller) }
+    let!(:archived_product) { create(:product, name: "Archived Product", user: seller, archived: true) }
+    let!(:direct_affiliate) do
+      affiliate = create(:direct_affiliate, affiliate_user:, seller:, affiliate_basis_points: 10_00, apply_to_all_products: true)
+      create(:product_affiliate, affiliate:, product: active_product, affiliate_basis_points: 10_00)
+      create(:product_affiliate, affiliate:, product: archived_product, affiliate_basis_points: 10_00)
+      affiliate
+    end
+
+    it "excludes archived products from the affiliated products list" do
+      props = described_class.new(affiliate_user).affiliated_products_page_props
+      product_names = props[:affiliated_products].map { _1[:product_name] }
+      expect(product_names).to contain_exactly("Active Product")
+    end
+  end
 end


### PR DESCRIPTION
## What

Archived products no longer appear on the affiliate dashboard at `/products/affiliated`. Adds `merge(Link.not_archived)` to `AffiliatedProductsPresenter#affiliated_products` so the query mirrors the seller-side affiliates page.

## Why

**Reproduction:**

1. Account A (creator) adds account B as an affiliate for a product.
2. Account A archives that product.
3. Account A's affiliates page no longer lists the product (`DirectAffiliate#products_data` skips archived products without an existing affiliation, and the seller's products listing scopes by `not_archived`).
4. Account B logs in and visits `/products/affiliated` — the archived product still appears.

The presenter filtered `links.deleted_at` and `links.banned_at` but not the `archived` flag. From the affiliate's perspective the product is effectively gone (the creator has stopped selling it), so it should not show up on the dashboard.

---

AI disclosure: Drafted with Claude Opus 4.7 (1M context)