### PR TITLE
Allow mobile sales export auth

### DIFF
--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -319,7 +319,11 @@ class PurchasesController < ApplicationController
       return unless mobile_export_token_matches?
 
       doorkeeper_authorize! :creator_api
-      sign_in current_api_user if current_api_user.present?
+      return if performed?
+      return if current_api_user.blank?
+
+      sign_in current_api_user
+      @_current_seller = current_api_user
     end
 
     def mobile_export_token_matches?

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -21,6 +21,7 @@ class PurchasesController < ApplicationController
     confirm subscribe unsubscribe receipt resend_receipt
     update_subscription charge_preorder confirm_receipt_email
   ].freeze
+  before_action :authenticate_mobile_export!, only: :export
   before_action :authenticate_user!, except: PUBLIC_ACTIONS
   after_action :verify_authorized, except: PUBLIC_ACTIONS
 
@@ -312,6 +313,23 @@ class PurchasesController < ApplicationController
   end
 
   protected
+    def authenticate_mobile_export!
+      return if user_signed_in?
+      return if params[:access_token].blank?
+      return unless mobile_export_token_matches?
+
+      doorkeeper_authorize! :creator_api
+      sign_in current_api_user if current_api_user.present?
+    end
+
+    def mobile_export_token_matches?
+      mobile_token = params[:mobile_token].to_s
+      expected_token = Api::Mobile::BaseController::MOBILE_TOKEN
+
+      mobile_token.bytesize == expected_token.bytesize &&
+        ActiveSupport::SecurityUtils.secure_compare(mobile_token, expected_token)
+    end
+
     def verify_current_seller_is_seller_for_purchase
       e404_json if @purchase.nil? || @purchase.seller != current_seller
     end

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -6,4 +6,5 @@
 # Use this to limit dissemination of sensitive information.
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
 Rails.application.config.filter_parameters += %i[password cc_number number expiry_date cc_expiry cvc account_number account_number_repeated passphrase
-                                                 chargeable tax_id individual_tax_id business_tax_id ssn_first_three ssn_middle_two ssn_last_four]
+                                                 chargeable tax_id individual_tax_id business_tax_id ssn_first_three ssn_middle_two ssn_last_four
+                                                 access_token mobile_token]

--- a/spec/controllers/purchases_controller_spec.rb
+++ b/spec/controllers/purchases_controller_spec.rb
@@ -863,6 +863,38 @@ describe PurchasesController, :vcr do
       end
     end
 
+    describe "GET export with mobile authentication" do
+      let(:oauth_app) { create(:oauth_application, owner: seller) }
+      let(:access_token) do
+        create("doorkeeper/access_token", application: oauth_app, resource_owner_id: seller.id, scopes: "creator_api")
+      end
+      let(:tempfile) do
+        Tempfile.new(["sales", ".csv"]).tap do |file|
+          file.write("id\n")
+          file.rewind
+        end
+      end
+
+      before do
+        sign_out(user_with_role_for_seller)
+        allow(Exports::PurchaseExportService).to receive(:export).and_return(tempfile)
+      end
+
+      after do
+        tempfile.close!
+      end
+
+      it "uses the mobile token to export sales" do
+        get :export, params: {
+          access_token: access_token.token,
+          mobile_token: Api::Mobile::BaseController::MOBILE_TOKEN
+        }
+
+        expect(response).to be_successful
+        expect(Exports::PurchaseExportService).to have_received(:export).with(hash_including(seller:, recipient: seller))
+      end
+    end
+
     describe "PUT revoke_access" do
       let(:product) { create(:product, user: seller) }
       let(:purchase) { create(:purchase, link: product, seller:) }

--- a/spec/controllers/purchases_controller_spec.rb
+++ b/spec/controllers/purchases_controller_spec.rb
@@ -893,6 +893,43 @@ describe PurchasesController, :vcr do
         expect(response).to be_successful
         expect(Exports::PurchaseExportService).to have_received(:export).with(hash_including(seller:, recipient: seller))
       end
+
+      context "when the token does not have the creator_api scope" do
+        let(:access_token) do
+          create("doorkeeper/access_token", application: oauth_app, resource_owner_id: seller.id, scopes: "mobile_api")
+        end
+
+        it "does not sign in the token owner" do
+          expect(controller).not_to receive(:sign_in)
+
+          get :export, params: {
+            access_token: access_token.token,
+            mobile_token: Api::Mobile::BaseController::MOBILE_TOKEN
+          }
+
+          expect(response).to have_http_status(:forbidden)
+          expect(Exports::PurchaseExportService).not_to have_received(:export)
+        end
+      end
+
+      context "when the browser has a stale seller switch cookie" do
+        let(:other_seller) { create(:user) }
+
+        before do
+          create(:team_membership, user: seller, seller: other_seller, role: TeamMembership::ROLE_ADMIN)
+          cookies.encrypted[:current_seller_id] = other_seller.id
+        end
+
+        it "exports the mobile token owner's sales" do
+          get :export, params: {
+            access_token: access_token.token,
+            mobile_token: Api::Mobile::BaseController::MOBILE_TOKEN
+          }
+
+          expect(response).to be_successful
+          expect(Exports::PurchaseExportService).to have_received(:export).with(hash_including(seller:, recipient: seller))
+        end
+      end
     end
 
     describe "PUT revoke_access" do


### PR DESCRIPTION
Ref #5115

Sibling mobile PR: [antiwork/gumroad-mobile#248](https://github.com/antiwork/gumroad-mobile/pull/248)

## What

This lets the existing sales export route accept a valid mobile creator OAuth token and mobile token before the normal web login check.

The export action still uses the existing seller authorization and export behavior after authentication succeeds.

## Why

The mobile app opens the export in the browser, which does not share the app OAuth session. The sibling mobile PR can pass app auth to `/purchases/export`, but the web route also needs to consume that handoff so sellers reach the CSV download instead of the login page.

This keeps the existing export URL and mirrors the mobile web handoff pattern used elsewhere.

---

This PR was implemented with AI assistance using gpt‑5.5 xhigh.