### PR TITLE
Fix flaky purchase_spec timing tolerance for InvalidateProductCacheWorker

### DIFF
--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -3144,7 +3144,10 @@ describe Purchase, :vcr do
 
     it "schedules a sidekiq job to invalidate the product's cache in 1 minute" do
       @purchase.mark_successful!
-      expect(InvalidateProductCacheWorker).to have_enqueued_sidekiq_job(@purchase.link.id).in(1.minute)
+      expect(InvalidateProductCacheWorker.jobs.size).to eq(1)
+      job = InvalidateProductCacheWorker.jobs.last
+      expect(job["args"]).to eq([@purchase.link.id])
+      expect(job["at"]).to be_within(1.second).of(1.minute.from_now.to_f)
     end
   end
 
@@ -3169,7 +3172,10 @@ describe Purchase, :vcr do
       @product.update_column(:max_purchase_count, 10)
 
       @purchase.update_balance_and_mark_successful!
-      expect(InvalidateProductCacheWorker).to have_enqueued_sidekiq_job(@purchase.link.id).in(1.minute)
+      expect(InvalidateProductCacheWorker.jobs.size).to eq(1)
+      job = InvalidateProductCacheWorker.jobs.last
+      expect(job["args"]).to eq([@purchase.link.id])
+      expect(job["at"]).to be_within(1.second).of(1.minute.from_now.to_f)
     end
 
     it "sets updated_at on the sku" do


### PR DESCRIPTION
## What

Replace the exact-equality `have_enqueued_sidekiq_job(...).in(1.minute)` assertions in two `purchase_spec.rb` tests with direct job inspection that allows a 1-second tolerance on the scheduled `at` time.

- `spec/models/purchase_spec.rb:3146` — "schedules a sidekiq job to invalidate the product's cache in 1 minute"
- `spec/models/purchase_spec.rb:3174` — "schedules a sidekiq job to invalidate the product's cache on inventory change in 1 minute"

## Why

`rspec-sidekiq` 5's `.in(duration)` chain computes the expected `at` as `Time.now.to_f + duration` **at matcher-evaluation time** and then does an exact equality check against the job's recorded `at` (captured at enqueue time, a few milliseconds earlier). Any sub-millisecond drift between those two `Time.now` reads fails the assertion.

The recent CI failure shows exactly that: expected `1779197354`, got `1779197353.988344` — a 12 ms gap.

Considered using `freeze_time` to make both reads identical, but inspecting the enqueued job directly with `be_within(1.second)` is closer to what the spec actually means ("scheduled roughly a minute from now") and still catches real regressions (e.g. if someone changed the delay to 5 minutes). The `.jobs.size`/`.args` checks also make the assertion fail loudly if the worker's argument shape ever changes, instead of silently matching the wrong job.

## Before/After

Non-user-facing test fix. No video — change is isolated to RSpec assertions; behavior of `InvalidateProductCacheWorker` is unchanged.

## Test Results

Both specs pass locally:

```
bundle exec rspec spec/models/purchase_spec.rb \
  -e "schedules a sidekiq job to invalidate the product's cache in 1 minute" \
  -e "schedules a sidekiq job to invalidate the product's cache on inventory change in 1 minute"
```

Reverting just the spec change reproduces the flake (the eq check on `at` fails when `Time.now` advances between enqueue and assertion).

---

AI disclosure: written with Claude Opus 4.7. Prompts: pasted the failing RSpec output and asked to "fix flaky spec by allowing some variance", then "open PR".