### PR TITLE
Fix missing jQuery global after Vite migration

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -65,7 +65,10 @@ export default defineConfig(({ mode }) => ({
     react(),
     UnpluginTypia({ cache: true }),
     AutoImport({
-      imports: [{ "$app/utils/routes": [["*", "Routes"]] }],
+      imports: [
+        { "$app/utils/routes": [["*", "Routes"]] },
+        { jquery: [["default", "$"], ["default", "jQuery"]] },
+      ],
     }),
     stripCjsExportsPlugin(),
     // Bundle visualizer — only emitted during production builds.


### PR DESCRIPTION
## Problem

All 48 slow tests (request/Capybara specs) fail on main since the Vite migration (#5067) landed.

**Root cause:** The Shakapacker → Vite migration removed webpack's `ProvidePlugin` which injected `$` and `jQuery` globally:
```js
// old webpack config
new webpack.ProvidePlugin({ Routes: "$app/utils/routes", $: "jquery", jQuery: "jquery" })
```

The Vite migration carried over `Routes` via `unplugin-auto-import` but **not jQuery**. This breaks `base_page.ts` (which uses `$(...)` for CSRF setup and AJAX headers), plus analytics files.

## Fix

Add `jquery` to Vite's `AutoImport` plugin config, providing `$` and `jQuery` as global auto-imports — same behavior as webpack's `ProvidePlugin`.

## Bisect

| Commit | CI |
|--------|-----|
| `ae66874d` (Inline hero_parallax.js) | ✅ last green |
| `9019145c` (Remove legacy Sprockets JS #5124) | ❌ first red |
| `8a3d4aaf` (Vite migration #5067) | ❌ |

Fast tests pass; only slow (request/browser) tests fail because they render full pages that load `base.ts` → `base_page.ts` → `$(...)`.