### PR TITLE
Sync stripe_disabled_reason from Stripe in remediation rescue

### DIFF
--- a/app/controllers/settings/payments_controller.rb
+++ b/app/controllers/settings/payments_controller.rb
@@ -169,9 +169,7 @@ class Settings::PaymentsController < Settings::BaseController
                                              type: "account_update",
                                            }).url, allow_other_host: true
   rescue Stripe::InvalidRequestError => e
-    if e.message.include?("has been rejected") && current_seller.stripe_account.stripe_disabled_reason.blank?
-      current_seller.stripe_account.update!(stripe_disabled_reason: "rejected.other")
-    end
+    sync_stripe_disabled_reason(current_seller.stripe_account) if current_seller.stripe_account.stripe_disabled_reason.blank?
     ErrorNotifier.notify(e, context: { user_id: current_seller.id })
     redirect_to settings_payments_path, alert: "We couldn't open the verification page. Please contact support."
   end
@@ -248,5 +246,12 @@ class Settings::PaymentsController < Settings::BaseController
 
     def current_seller_policy
       [:settings, :payments, current_seller]
+    end
+
+    def sync_stripe_disabled_reason(merchant_account)
+      stripe_account = Stripe::Account.retrieve(merchant_account.charge_processor_merchant_id)
+      disabled_reason = stripe_account["requirements"]["disabled_reason"]
+      merchant_account.update!(stripe_disabled_reason: disabled_reason) if disabled_reason.present?
+    rescue Stripe::StripeError, ActiveRecord::ActiveRecordError
     end
 end

--- a/app/services/onetime/backfill_stripe_disabled_reason.rb
+++ b/app/services/onetime/backfill_stripe_disabled_reason.rb
@@ -24,7 +24,7 @@ module Onetime
         return if merchant_account.is_a_stripe_connect_account?
 
         stripe_account = Stripe::Account.retrieve(merchant_account.charge_processor_merchant_id)
-        disabled_reason = stripe_account["requirements"]&.dig("disabled_reason")
+        disabled_reason = stripe_account["requirements"]["disabled_reason"]
         return if merchant_account.stripe_disabled_reason == disabled_reason
 
         merchant_account.update!(stripe_disabled_reason: disabled_reason)

--- a/spec/controllers/settings/payments_controller_spec.rb
+++ b/spec/controllers/settings/payments_controller_spec.rb
@@ -1943,7 +1943,7 @@ describe Settings::PaymentsController, :vcr, type: :controller, inertia: true do
       expect(response.location).to match(Regexp.new("https://connect.stripe.com/setup/c/#{stripe_connect_account_id}/"))
     end
 
-    context "when the Stripe account has been permanently rejected" do
+    context "when Stripe::AccountLink.create raises Stripe::InvalidRequestError" do
       let!(:merchant_account) { create(:merchant_account, user:, charge_processor_merchant_id: "acct_rejected") }
       let!(:compliance_request) { create(:user_compliance_info_request, user:, field_needed: UserComplianceInfoFields::Individual::TAX_ID) }
 
@@ -1953,7 +1953,18 @@ describe Settings::PaymentsController, :vcr, type: :controller, inertia: true do
         )
       end
 
+      def stub_stripe_account_retrieve(disabled_reason:)
+        allow(Stripe::Account).to receive(:retrieve).with("acct_rejected").and_return(
+          Stripe::Account.construct_from(
+            id: "acct_rejected",
+            object: "account",
+            requirements: { "disabled_reason" => disabled_reason, "currently_due" => [], "past_due" => [] }
+          )
+        )
+      end
+
       it "redirects back to settings with an alert instead of raising" do
+        stub_stripe_account_retrieve(disabled_reason: "rejected.listed")
         expect(ErrorNotifier).to receive(:notify).with(instance_of(Stripe::InvalidRequestError), context: { user_id: user.id })
 
         get :remediation
@@ -1962,18 +1973,53 @@ describe Settings::PaymentsController, :vcr, type: :controller, inertia: true do
         expect(flash[:alert]).to eq("We couldn't open the verification page. Please contact support.")
       end
 
-      it "records rejected.other on the merchant account so the rejection alert renders on the next page load" do
-        get :remediation
-
-        expect(merchant_account.reload.stripe_disabled_reason).to eq("rejected.other")
-      end
-
-      it "does not overwrite an existing stripe_disabled_reason" do
-        merchant_account.update!(stripe_disabled_reason: "rejected.listed")
+      it "records the disabled_reason returned by Stripe so the rejection alert renders on the next page load" do
+        stub_stripe_account_retrieve(disabled_reason: "rejected.listed")
 
         get :remediation
 
         expect(merchant_account.reload.stripe_disabled_reason).to eq("rejected.listed")
+      end
+
+      it "records the disabled_reason even when the Stripe error message does not contain 'has been rejected'" do
+        allow(Stripe::AccountLink).to receive(:create).and_raise(
+          Stripe::InvalidRequestError.new("This account cannot be onboarded.", nil)
+        )
+        stub_stripe_account_retrieve(disabled_reason: "rejected.fraud")
+
+        get :remediation
+
+        expect(merchant_account.reload.stripe_disabled_reason).to eq("rejected.fraud")
+      end
+
+      it "does not overwrite an existing stripe_disabled_reason" do
+        merchant_account.update!(stripe_disabled_reason: "rejected.listed")
+        expect(Stripe::Account).not_to receive(:retrieve)
+
+        get :remediation
+
+        expect(merchant_account.reload.stripe_disabled_reason).to eq("rejected.listed")
+      end
+
+      it "does not write a disabled_reason when Stripe returns none" do
+        stub_stripe_account_retrieve(disabled_reason: nil)
+
+        get :remediation
+
+        expect(merchant_account.reload.stripe_disabled_reason).to be_nil
+      end
+
+      it "still redirects when Stripe::Account.retrieve itself raises" do
+        allow(Stripe::Account).to receive(:retrieve).with("acct_rejected").and_raise(
+          Stripe::APIConnectionError.new("Stripe is down")
+        )
+        expect(ErrorNotifier).to receive(:notify).with(instance_of(Stripe::InvalidRequestError), context: { user_id: user.id })
+
+        get :remediation
+
+        expect(response).to redirect_to(settings_payments_path)
+        expect(flash[:alert]).to eq("We couldn't open the verification page. Please contact support.")
+        expect(merchant_account.reload.stripe_disabled_reason).to be_nil
       end
     end
   end

--- a/spec/services/onetime/backfill_stripe_disabled_reason_spec.rb
+++ b/spec/services/onetime/backfill_stripe_disabled_reason_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Onetime::BackfillStripeDisabledReason do
+  describe ".process" do
+    def stub_stripe_account(account_id, disabled_reason:)
+      allow(Stripe::Account).to receive(:retrieve).with(account_id).and_return(
+        Stripe::Account.construct_from(
+          id: account_id,
+          object: "account",
+          requirements: { "disabled_reason" => disabled_reason }
+        )
+      )
+    end
+
+    it "writes the disabled_reason returned by Stripe onto the merchant account" do
+      merchant_account = create(:merchant_account, charge_processor_merchant_id: "acct_one")
+      stub_stripe_account("acct_one", disabled_reason: "rejected.listed")
+
+      described_class.process
+
+      expect(merchant_account.reload.stripe_disabled_reason).to eq("rejected.listed")
+    end
+
+    it "clears the disabled_reason when Stripe no longer reports one" do
+      merchant_account = create(:merchant_account, charge_processor_merchant_id: "acct_two", stripe_disabled_reason: "rejected.other")
+      stub_stripe_account("acct_two", disabled_reason: nil)
+
+      described_class.process
+
+      expect(merchant_account.reload.stripe_disabled_reason).to be_nil
+    end
+
+    it "skips Stripe Connect accounts" do
+      merchant_account = create(:merchant_account, charge_processor_merchant_id: "acct_three")
+      merchant_account.update!(json_data: merchant_account.json_data.deep_merge("meta" => { "stripe_connect" => "true" }))
+      expect(Stripe::Account).not_to receive(:retrieve)
+
+      described_class.process
+
+      expect(merchant_account.reload.stripe_disabled_reason).to be_nil
+    end
+
+    it "leaves the value untouched when it already matches what Stripe reports" do
+      merchant_account = create(:merchant_account, charge_processor_merchant_id: "acct_four", stripe_disabled_reason: "rejected.listed")
+      stub_stripe_account("acct_four", disabled_reason: "rejected.listed")
+      expect_any_instance_of(MerchantAccount).not_to receive(:update!)
+
+      described_class.process
+
+      expect(merchant_account.reload.stripe_disabled_reason).to eq("rejected.listed")
+    end
+
+    it "skips merchant accounts whose Stripe::Account.retrieve raises and continues with the rest" do
+      bad = create(:merchant_account, charge_processor_merchant_id: "acct_bad")
+      good = create(:merchant_account, charge_processor_merchant_id: "acct_good")
+      allow(Stripe::Account).to receive(:retrieve).with("acct_bad").and_raise(Stripe::APIConnectionError.new("nope"))
+      stub_stripe_account("acct_good", disabled_reason: "rejected.fraud")
+
+      expect { described_class.process }.not_to raise_error
+
+      expect(bad.reload.stripe_disabled_reason).to be_nil
+      expect(good.reload.stripe_disabled_reason).to eq("rejected.fraud")
+    end
+  end
+end


### PR DESCRIPTION
Ref antiwork/gumroad-private#393

## What

Two paths exist to populate `stripe_disabled_reason` when the webhook missed it: the remediation rescue (real-time, when a seller clicks the link) and `Onetime::BackfillStripeDisabledReason` (bulk, run from a console). Both were broken.

- The rescue used a substring match in Stripe's error wording. Other wordings silently no-op'd, the warning banner kept rendering, and affected sellers got stuck clicking it forever.
- The backfill called `.dig` on a `Stripe::StripeObject`, which raises `NoMethodError` and aborts on the first account.

Both now use the same bracket-access read against `Stripe::Account.retrieve`. Specs added for the backfill (there were none).

## Why

Stripe's own account state is the source of truth, not the wording of its error messages, and the bulk path needed to actually work so we can clear the existing backlog of affected sellers rather than wait for each to re-engage.

No UI changes — both fixes make the existing rejection banner reliably reached for every `rejected.*` variant.

## Follow-up

Run `Onetime::BackfillStripeDisabledReason.process` from a prod console after this merges to clear the existing backlog.

---

This PR was implemented with AI assistance using Claude Opus 4.7.