### PR TITLE
Fix flaky blockable_spec: freeze time around block! and assertion

### DIFF
--- a/spec/models/concerns/purchase/blockable_spec.rb
+++ b/spec/models/concerns/purchase/blockable_spec.rb
@@ -379,24 +379,22 @@ describe Purchase::Blockable do
           end
 
           context "when the ip_address is already blocked" do
-            before do
-              @expires_in = BlockedObject::IP_ADDRESS_BLOCKING_DURATION_IN_MONTHS.months
-
-              BlockedObject.block!(
-                BLOCKED_OBJECT_TYPES[:ip_address],
-                @purchase.ip_address,
-                nil,
-                expires_in: @expires_in
-              )
-            end
-
             it "doesn't overwrite the previous ip_address block" do
-              travel_to(Time.current) do
+              freeze_time do
+                expires_in = BlockedObject::IP_ADDRESS_BLOCKING_DURATION_IN_MONTHS.months
+
+                BlockedObject.block!(
+                  BLOCKED_OBJECT_TYPES[:ip_address],
+                  @purchase.ip_address,
+                  nil,
+                  expires_in:
+                )
+
                 expect do
                   @purchase.mark_failed!
                 end.not_to change { BlockedObject.count }
 
-                expect(BlockedObject.ip_address.find_active_object(@purchase.ip_address).expires_at.to_i).to eq @expires_in.from_now.to_i
+                expect(BlockedObject.ip_address.find_active_object(@purchase.ip_address).expires_at.to_i).to eq expires_in.from_now.to_i
               end
             end
           end


### PR DESCRIPTION
## What

Fix flaky spec at `spec/models/concerns/purchase/blockable_spec.rb:393` — `Purchase::Blockable#mark_failed doesn't overwrite the previous ip_address block`.

## Why

The test was intermittently failing because `BlockedObject.block!` in the `before` block captured wall-clock time T1 for `expires_at`, but `travel_to(Time.current)` in the `it` block froze at T2 (slightly later). The assertion compared `expires_at` (T1 + 6 months) against `expires_in.from_now` (T2 + 6 months) — off by 1 second when they straddled a second boundary.

CI failure: https://github.com/antiwork/gumroad/actions/runs/26130679451/job/76856102020

## How

Moved `BlockedObject.block!` from the `before` block into the `it` block, wrapped in `freeze_time` so both the block creation and the assertion share the same frozen instant. Same pattern used in #5130 (subscription send_delay flake).

## Before/After

**Before:** `before` block runs `block!` at wall-clock T1, `travel_to(Time.current)` freezes at T2 → 1-second mismatch possible.

**After:** Single `freeze_time` block wraps both `block!` and assertion → deterministic.

## Test Results

Cannot run locally (Docker CI only), but the fix is a proven pattern from #5130.

## Self-Review

- [x] Root cause identified: wall-clock drift between `before` and `travel_to`
- [x] Fix uses `freeze_time` (single frozen context) instead of nested `travel_to`
- [x] No behavior change — only test timing stabilized

---

> This PR was authored with AI assistance (Gumclaw/Hermes Agent).