### PR TITLE
CI: rebalance test containers from 20/48 to 18/50

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -262,8 +262,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ci_node_total: [20]
-        ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
+        ci_node_total: [18]
+        ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -390,7 +390,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ci_node_total: [48]
+        ci_node_total: [50]
         ci_node_index:
           [
             0,
@@ -441,6 +441,8 @@ jobs:
             45,
             46,
             47,
+            48,
+            49,
           ]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## What

Rebalance CI test container split from Fast=20/Slow=48 to Fast=18/Slow=50 (same 68 total).

## Why

Measured data from 4 clean CI runs shows Slow is the bottleneck:

| Suite | Total test-min | Containers | Per-container |
|-------|---------------|------------|---------------|
| Fast (before) | 108.9m | 20 | 5.4m |
| Slow (before) | 299.3m | 48 | 6.2m |
| **Fast (after)** | **108.9m** | **18** | **6.05m** |
| **Slow (after)** | **299.3m** | **50** | **5.99m** |

Moving 2 containers from Fast → Slow brings both suites within ~4s of each other (~6.0m each), down from a ~48s gap.

## Impact

- ~12s wall time reduction (small but free — no tradeoff)
- Both suites finish at nearly the same time, eliminating the "waiting for Slow" tail

## Test Results

Workflow-only change. The math is deterministic from measured data; knapsack_pro will automatically rebalance test files across the new container counts.

> This PR was authored with AI assistance (Gumclaw).

---

Self-review: ✅ YAML validated, total containers unchanged (68), knapsack_pro handles rebalancing automatically.