### PR TITLE
CI: fix early-fail showing 'cancelled' instead of 'failed'

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: read
-  actions: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.event.pull_request.number || github.ref }}
@@ -376,14 +375,6 @@ jobs:
           CI: true
           IN_DOCKER: true
           WEB_REPO: gumroadteam/web
-      - name: Cancel workflow on failure
-        if: failure()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const { owner, repo } = context.repo;
-            console.log(`Cancelling workflow run ${context.runId} to stop all test containers...`);
-            await github.rest.actions.cancelWorkflowRun({ owner, repo, run_id: context.runId });
       - name: Archive flaky specs log
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## What

Remove the `cancelWorkflowRun()` step from CI so failed test containers show as **failed** (red ✗) instead of **cancelled** (grey ⊘).

## Why

The `cancelWorkflowRun()` API call (added in #5143) cancels the entire workflow run — including the container that detected the failure. GitHub marks it as "cancelled" before the job can finish with a "failed" status, losing the failure information in the UI.

## How

- Remove the `Cancel workflow on failure` step from both `test_fast` and `test_slow`
- Remove the now-unnecessary `actions: write` permission
- `fail-fast: true` (from #5143) still handles cancelling sibling containers within each matrix
- The 60s grace period (from #5143) is unchanged

## Tradeoff

We lose cross-matrix cancellation — a `test_fast` failure won't stop `test_slow` containers and vice versa. But `fail-fast: true` still stops siblings within the same matrix, and the failing container correctly shows as **failed** with full RSpec output.

> This PR was authored with AI assistance (Gumclaw).