### PR TITLE
Fix admin stylesheet entrypoint

### DIFF
--- a/app/javascript/entrypoints/admin.ts
+++ b/app/javascript/entrypoints/admin.ts
@@ -5,14 +5,16 @@ import { createRoot } from "react-dom/client";
 import AdminAppWrapper, { GlobalProps } from "../inertia/admin_app_wrapper";
 import Layout from "../layouts/Admin";
 
+import "./admin.scss";
+
 const AdminLayout = (page: React.ReactNode) => React.createElement(Layout, { children: page });
 
 type PageComponent = React.ComponentType & { layout?: (page: React.ReactNode) => React.ReactElement };
 
 const isPageComponent = (value: unknown): value is PageComponent => typeof value === "function";
 
-const tsxPages = import.meta.glob('../pages/**/*.tsx');
-const jsxPages = import.meta.glob('../pages/**/*.jsx');
+const tsxPages = import.meta.glob("../pages/**/*.tsx");
+const jsxPages = import.meta.glob("../pages/**/*.jsx");
 
 const resolvePageComponent = async (name: string): Promise<PageComponent> => {
   const tsxPath = `../pages/${name}.tsx`;


### PR DESCRIPTION
Ref antiwork/gumroad-private/issues/396

## What
- Import `admin.scss` from the admin Vite entrypoint so the admin bundle includes the standalone admin stylesheet.
- Normalize the nearby `import.meta.glob` quote style.

## Why
- The admin page was only getting transitive CSS from the JavaScript bundle, so the real admin styles were omitted from the Vite manifest.
- Keep the admin stylesheet attached to the entrypoint that owns it.
- Refs #3765.

## AI disclosure
- Generated with GPT-5.5 xhigh.
