### PR TITLE
Fix Facebook Pixel on receipt page and domain verification meta tag

### DIFF
--- a/app/controllers/concerns/custom_domain_config.rb
+++ b/app/controllers/concerns/custom_domain_config.rb
@@ -17,8 +17,8 @@ module CustomDomainConfig
 
       set_meta_tag(title: @user.try(:name_or_username))
       if @user.enable_verify_domain_third_party_services? && @user.facebook_meta_tag.present?
-        _, content = @user.facebook_meta_tag.match(/content="([^"]+)"/)
-        set_meta_tag(name: "facebook-domain-verification", content:)
+        content = @user.facebook_meta_tag[/content="([^"]+)"/, 1]
+        set_meta_tag(name: "facebook-domain-verification", content:) if content
       end
 
       @body_class = "custom-domain"

--- a/app/javascript/components/DownloadPage/WithContent.tsx
+++ b/app/javascript/components/DownloadPage/WithContent.tsx
@@ -3,8 +3,10 @@ import * as React from "react";
 import typia from "typia";
 
 import { getFolderArchiveDownloadUrl, getProductFileDownloadInfos, saveLastContentPage } from "$app/data/products";
+import { AnalyticsData } from "$app/parsers/product";
 import { RichContent, RichContentPage } from "$app/parsers/richContent";
 import { assertDefined } from "$app/utils/assert";
+import { CurrencyCode, getIsSingleUnitCurrency } from "$app/utils/currency";
 import FileUtils from "$app/utils/file";
 import {
   generatePageIcon,
@@ -12,6 +14,7 @@ import {
   PAGE_ICON_LABELS,
   type PageIconType,
 } from "$app/utils/rich_content_page";
+import { startTrackingForSeller, trackProductEvent } from "$app/utils/user_analytics";
 
 import { Button } from "$app/components/Button";
 import { DiscordButton } from "$app/components/DiscordButton";
@@ -99,15 +102,31 @@ export type ContentProps = {
   community_chat_url: string | null;
 };
 
+export type SellerAnalyticsProps = {
+  seller_id: string;
+  analytics: AnalyticsData;
+  purchase_event: {
+    permalink: string;
+    purchase_external_id: string;
+    product_name: string;
+    value: number;
+    currency: string;
+    quantity: number;
+    tax: string;
+  };
+};
+
 export const WithContent = ({
   content,
   product_has_third_party_analytics,
+  seller_analytics,
   audio_durations,
   latest_media_locations,
   ...props
 }: LayoutProps & {
   content: ContentProps;
   product_has_third_party_analytics: boolean | null;
+  seller_analytics: SellerAnalyticsProps | null;
   audio_durations?: Record<string, FileItem["duration"]> | undefined;
   latest_media_locations?: Record<string, FileItem["latest_media_location"]> | undefined;
 }) => {
@@ -144,6 +163,23 @@ export const WithContent = ({
           location: "receipt",
           purchaseId: props.purchase.id,
         });
+
+      if (seller_analytics) {
+        const { seller_id, analytics, purchase_event } = seller_analytics;
+        startTrackingForSeller(seller_id, analytics);
+        trackProductEvent(seller_id, {
+          action: "purchased",
+          seller_id,
+          permalink: purchase_event.permalink,
+          purchase_external_id: purchase_event.purchase_external_id,
+          product_name: purchase_event.product_name,
+          value: purchase_event.value,
+          valueIsSingleUnit: getIsSingleUnitCurrency(typia.assert<CurrencyCode>(purchase_event.currency)),
+          currency: purchase_event.currency.toUpperCase(),
+          quantity: purchase_event.quantity,
+          tax: purchase_event.tax,
+        });
+      }
     }
   });
   const isDesktop = useIsAboveBreakpoint("lg");

--- a/app/javascript/components/DownloadPage/WithContent.tsx
+++ b/app/javascript/components/DownloadPage/WithContent.tsx
@@ -1,4 +1,5 @@
 import { ArrowLeft, ArrowRight, ListUl } from "@boxicons/react";
+import { router } from "@inertiajs/react";
 import * as React from "react";
 import typia from "typia";
 
@@ -155,7 +156,7 @@ export const WithContent = ({
     if (url.searchParams.get("receipt") === "true" && props.purchase?.email) {
       showAlert(`Your purchase was successful! We sent a receipt to ${props.purchase.email}.`, "success");
       url.searchParams.delete("receipt");
-      window.history.replaceState(window.history.state, "", url.toString());
+      router.replace({ url: url.toString(), preserveState: true, preserveScroll: true });
 
       if (product_has_third_party_analytics && props.purchase.product_permalink)
         addThirdPartyAnalytics({

--- a/app/javascript/pages/Checkout/Show.tsx
+++ b/app/javascript/pages/Checkout/Show.tsx
@@ -520,18 +520,20 @@ const CheckoutIndexPage = () => {
 
       for (const { result, item } of results) {
         if (!result.success) continue;
-        trackProductEvent(item.product.creator.id, {
-          action: "purchased",
-          seller_id: result.seller_id,
-          permalink: result.permalink,
-          purchase_external_id: result.id,
-          currency: result.currency_type.toUpperCase(),
-          product_name: result.name,
-          value: result.non_formatted_price,
-          valueIsSingleUnit: getIsSingleUnitCurrency(typia.assert<CurrencyCode>(result.currency_type)),
-          quantity: result.quantity,
-          tax: result.non_formatted_seller_tax_amount,
-        });
+        if (redirectTo !== "content-page") {
+          trackProductEvent(item.product.creator.id, {
+            action: "purchased",
+            seller_id: result.seller_id,
+            permalink: result.permalink,
+            purchase_external_id: result.id,
+            currency: result.currency_type.toUpperCase(),
+            product_name: result.name,
+            value: result.non_formatted_price,
+            valueIsSingleUnit: getIsSingleUnitCurrency(typia.assert<CurrencyCode>(result.currency_type)),
+            quantity: result.quantity,
+            tax: result.non_formatted_seller_tax_amount,
+          });
+        }
         if (result.has_third_party_analytics && !redirectTo)
           addThirdPartyAnalytics({ permalink: result.permalink, location: "receipt", purchaseId: result.id });
       }

--- a/app/javascript/pages/UrlRedirects/DownloadPage.tsx
+++ b/app/javascript/pages/UrlRedirects/DownloadPage.tsx
@@ -7,11 +7,12 @@ import FileUtils from "$app/utils/file";
 
 import { FileItem } from "$app/components/Download/FileList";
 import { LayoutProps } from "$app/components/DownloadPage/Layout";
-import { ContentProps, WithContent } from "$app/components/DownloadPage/WithContent";
+import { ContentProps, SellerAnalyticsProps, WithContent } from "$app/components/DownloadPage/WithContent";
 
 type PageProps = LayoutProps & {
   content: ContentProps;
   product_has_third_party_analytics: boolean | null;
+  seller_analytics: SellerAnalyticsProps | null;
   audio_durations?: Record<string, FileItem["duration"]>;
   latest_media_locations?: Record<string, FileItem["latest_media_location"]>;
   dropbox_api_key: string | null;

--- a/app/presenters/url_redirect_presenter.rb
+++ b/app/presenters/url_redirect_presenter.rb
@@ -46,6 +46,7 @@ class UrlRedirectPresenter
     {
       content: content_props,
       product_has_third_party_analytics: purchase&.link&.has_third_party_analytics?("receipt"),
+      seller_analytics: seller_analytics_props,
     }.merge(download_page_layout_props).merge(extra_props)
   end
 
@@ -79,6 +80,29 @@ class UrlRedirectPresenter
   end
 
   private
+    def seller_analytics_props
+      return nil unless purchase
+
+      product = purchase.link
+      analytics = product.analytics_data
+      return nil unless analytics[:facebook_pixel_id] || analytics[:google_analytics_id] || analytics[:tiktok_pixel_id]
+
+      currency_type = purchase.displayed_price_currency_type.to_s
+      {
+        seller_id: product.user.external_id,
+        analytics:,
+        purchase_event: {
+          permalink: product.unique_permalink,
+          purchase_external_id: purchase.external_id,
+          product_name: product.name,
+          value: Money.new(purchase.displayed_price_cents, currency_type).cents,
+          currency: currency_type,
+          quantity: purchase.quantity,
+          tax: Money.new(purchase.seller_taxes_in_purchase_currency, currency_type).format(no_cents_if_whole: true, symbol: false),
+        }
+      }
+    end
+
     def download_page_layout_props(email_confirmation_required: false)
       review = purchase&.original_product_review
       call = purchase&.call

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -240,6 +240,38 @@ describe UsersController do
           expect { get :show }.to raise_error(ActionController::RoutingError)
         end
       end
+
+      describe "facebook-domain-verification meta tag" do
+        before do
+          @user = create(:user, username: "fbverify")
+          create(:product, user: @user)
+          CustomDomain.create(domain: "fb-verify.example.com", user: @user)
+          @request.host = "fb-verify.example.com"
+        end
+
+        it "renders the meta tag with the content extracted from the seller's facebook_meta_tag" do
+          @user.update!(
+            enable_verify_domain_third_party_services: true,
+            facebook_meta_tag: '<meta name="facebook-domain-verification" content="abc123verifycode" />'
+          )
+
+          get :show
+
+          expect(response.body).to include('content="abc123verifycode"')
+          expect(response.body).not_to include('<meta name="facebook-domain-verification" inertia=')
+        end
+
+        it "does not render the meta tag when domain verification is disabled" do
+          @user.update!(
+            enable_verify_domain_third_party_services: false,
+            facebook_meta_tag: '<meta name="facebook-domain-verification" content="abc123verifycode" />'
+          )
+
+          get :show
+
+          expect(response.body).not_to include('name="facebook-domain-verification"')
+        end
+      end
     end
 
     context "with user signed in as admin for seller", inertia: true do

--- a/spec/presenters/url_redirect_presenter_spec.rb
+++ b/spec/presenters/url_redirect_presenter_spec.rb
@@ -150,6 +150,7 @@ describe UrlRedirectPresenter do
           avatar_url: @user.avatar_url,
         },
         product_has_third_party_analytics: false,
+        seller_analytics: nil,
         installment: nil,
         purchase: {
           id: @purchase.external_id,


### PR DESCRIPTION
Closes antiwork/gumroad-private#397

## Summary

**Pixel on receipt page:** Load the seller's tracking pixels (FB/GA/TikTok) and fire the `Purchase` event on the receipt page when arriving from a fresh purchase, instead of from Checkout right before `window.location.href` redirect. The redirect was racing with the in-flight pixel request, causing missing Purchase events in Meta Events Manager. Checkout now skips Purchase firing when redirecting to `content-page` to avoid double-fire (library redirects keep firing from Checkout — unchanged).

**Domain verification meta tag:** Fix `_, content = matchdata` in `CustomDomainConfig` — `MatchData` doesn't implement `to_ary`, so multiple-assignment was setting `content` to `nil`, causing the `<meta name="facebook-domain-verification">` tag to render without its `content` attribute.

## Test plan
- [ ] Verify FB Pixel loads on `/d/<id>?receipt=true` (Meta Pixel Helper shows the pixel)
- [ ] Verify `Purchase` event appears in Meta Events Manager after a real purchase
- [ ] Verify GA `purchase` event still fires (seller + Gumroad-internal)
- [ ] Verify TikTok `CompletePayment` still fires
- [ ] Verify library redirects still fire Purchase from Checkout
- [ ] Verify `<meta name="facebook-domain-verification" content="...">` renders correctly on custom-domain pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)