### PR TITLE
Fix EIN validation firing on Update Settings with saved tax IDs

### DIFF
--- a/app/javascript/components/Settings/PaymentsPage/AccountDetailsSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/AccountDetailsSection.tsx
@@ -80,6 +80,18 @@ const AccountDetailsSection = ({
     if (user.business_tax_id_entered) setIsEditingBusinessTaxId(false);
   }, [saveCounter]);
 
+  React.useEffect(() => {
+    if (!isEditingIndividualTaxId && complianceInfo.individual_tax_id) {
+      updateComplianceInfo({ individual_tax_id: null });
+    }
+  }, [isEditingIndividualTaxId]);
+
+  React.useEffect(() => {
+    if (!isEditingBusinessTaxId && complianceInfo.business_tax_id) {
+      updateComplianceInfo({ business_tax_id: null });
+    }
+  }, [isEditingBusinessTaxId]);
+
   const formatPhoneNumber = (phoneNumber: string, country_code: string | null): string => {
     const countryCode: CountryCode = typia.assert<CountryCode>(country_code);
     return parsePhoneNumberFromString(phoneNumber, countryCode)?.format("E.164") ?? phoneNumber;

--- a/app/services/update_user_compliance_info.rb
+++ b/app/services/update_user_compliance_info.rb
@@ -18,6 +18,7 @@ class UpdateUserComplianceInfo
   end
 
   MAX_ENCRYPTED_FIELD_LENGTH = 200
+  MASKED_TAX_ID_PATTERN = /[\u2022*]/
   ENCRYPTED_FIELD_LABELS = {
     individual_tax_id: "Individual tax id",
     ssn_last_four: "Individual tax id",
@@ -90,7 +91,7 @@ class UpdateUserComplianceInfo
       return { success: false, error_message: new_compliance_info.errors.full_messages.to_sentence } unless saved
 
       if new_compliance_info.is_business && new_compliance_info.legal_entity_country_code == "US" &&
-          compliance_params[:business_tax_id].present? && new_compliance_info.business_tax_id.length != 9
+          submitted_tax_id_for(:business_tax_id).present? && new_compliance_info.business_tax_id.length != 9
         return { success: false, error_message: "US business tax IDs (EIN) must have 9 digits." }
       end
 
@@ -139,11 +140,11 @@ class UpdateUserComplianceInfo
       new_compliance_info.business_zip_code =       compliance_params[:business_zip_code]       if compliance_params[:business_zip_code].present?
       new_compliance_info.business_type =           compliance_params[:business_type]           if compliance_params[:business_type].present?
       new_compliance_info.is_business =             compliance_params[:is_business]             unless compliance_params[:is_business].nil?
-      new_compliance_info.individual_tax_id =       compliance_params[:ssn_last_four]           if compliance_params[:ssn_last_four].present?
-      new_compliance_info.individual_tax_id =       compliance_params[:individual_tax_id]       if compliance_params[:individual_tax_id].present?
-      if compliance_params[:business_tax_id].present?
+      new_compliance_info.individual_tax_id =       submitted_tax_id_for(:ssn_last_four)        if submitted_tax_id_for(:ssn_last_four).present?
+      new_compliance_info.individual_tax_id =       submitted_tax_id_for(:individual_tax_id)    if submitted_tax_id_for(:individual_tax_id).present?
+      if submitted_tax_id_for(:business_tax_id).present?
         new_compliance_info.business_tax_id = normalize_business_tax_id(
-          compliance_params[:business_tax_id],
+          submitted_tax_id_for(:business_tax_id),
           country_code: new_compliance_info.legal_entity_country_code,
         )
       end
@@ -223,16 +224,23 @@ class UpdateUserComplianceInfo
     end
 
     def encrypted_compliance_info_changed?(old_compliance_info)
-      submitted_individual_tax_id = compliance_params[:individual_tax_id].presence || compliance_params[:ssn_last_four].presence
+      submitted_individual_tax_id = submitted_tax_id_for(:individual_tax_id).presence || submitted_tax_id_for(:ssn_last_four).presence
       return true if submitted_individual_tax_id.present? && encrypted_compliance_info_value(old_compliance_info, :individual_tax_id) != submitted_individual_tax_id
 
       submitted_business_tax_id = normalize_business_tax_id(
-        compliance_params[:business_tax_id],
+        submitted_tax_id_for(:business_tax_id),
         country_code: old_compliance_info.legal_entity_country_code,
       )
       return true if submitted_business_tax_id.present? && encrypted_compliance_info_value(old_compliance_info, :business_tax_id) != submitted_business_tax_id
 
       false
+    end
+
+    def submitted_tax_id_for(field)
+      value = compliance_params[field]
+      return nil if value.blank?
+      return nil if value.to_s.match?(MASKED_TAX_ID_PATTERN)
+      value
     end
 
     def normalize_business_tax_id(value, country_code:)
@@ -242,7 +250,7 @@ class UpdateUserComplianceInfo
     end
 
     def encrypted_compliance_info_params_present?
-      compliance_params[:individual_tax_id].present? || compliance_params[:ssn_last_four].present? || compliance_params[:business_tax_id].present?
+      submitted_tax_id_for(:individual_tax_id).present? || submitted_tax_id_for(:ssn_last_four).present? || submitted_tax_id_for(:business_tax_id).present?
     end
 
     def encrypted_compliance_info_value(compliance_info, field)

--- a/spec/services/update_user_compliance_info_spec.rb
+++ b/spec/services/update_user_compliance_info_spec.rb
@@ -148,6 +148,31 @@ describe UpdateUserComplianceInfo do
 
         expect(result[:success]).to be true
       end
+
+      it "ignores a masked business_tax_id resubmission (containing bullet characters)" do
+        params = ActionController::Parameters.new(
+          is_business: true,
+          business_street_address: "456 Updated Street",
+          business_tax_id: "\u2022\u2022-\u2022\u2022\u2022\u20221234",
+        )
+
+        result = described_class.new(compliance_params: params, user: us_business_user).process
+
+        expect(result[:success]).to be true
+        expect(us_business_user.alive_user_compliance_info.business_street_address).to eq("456 Updated Street")
+      end
+
+      it "ignores a masked individual_tax_id resubmission (containing asterisks)" do
+        params = ActionController::Parameters.new(
+          is_business: true,
+          business_street_address: "456 Updated Street",
+          individual_tax_id: "***-**-1234",
+        )
+
+        result = described_class.new(compliance_params: params, user: us_business_user).process
+
+        expect(result[:success]).to be true
+      end
     end
 
     context "with a non-US business" do


### PR DESCRIPTION
Closes antiwork/gumroad-private#400

## Summary

US business creators with a saved EIN were hitting "US business tax IDs (EIN) must have 9 digits." on a routine "Update Settings" click, blocking Stripe Connect onboarding. PR #4924 added a gate on `compliance_params[:business_tax_id].present?` but two cases still slipped through:

1. **Stale form state** — After a successful save, the `useEffect` on `saveCounter` only resets the `isEditingBusinessTaxId` toggle, not the form data. A previously-typed tax-id value persists in `form.data.user.business_tax_id` and gets resubmitted on the next click.
2. **Masked display values** — If the masked display string (`••-•••9717`) ever reaches the backend, `normalize_business_tax_id` strips it to the last 4 digits and the length check fires.

## Fix
- **Frontend** (`AccountDetailsSection.tsx`): clear `business_tax_id` / `individual_tax_id` from form state when the user exits edit mode (`isEditing*` flips to `false`).
- **Backend** (`update_user_compliance_info.rb`): new `submitted_tax_id_for(field)` helper returns `nil` for values containing mask characters (`•` U+2022 or `*`). Used by `assign_compliance_params`, `encrypted_compliance_info_changed?`, `encrypted_compliance_info_params_present?`, and the EIN length gate.

## Test plan
- [x] New spec: ignores a masked business_tax_id resubmission (bullets)
- [x] New spec: ignores a masked individual_tax_id resubmission (asterisks)
- [x] Existing spec: still rejects a too-short business_tax_id submitted in the same request
- [x] Existing spec: still accepts a 9-digit business_tax_id with formatting
- [x] Manually verify clicking "Update Settings" with saved EIN no longer errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)