### PR TITLE
Fix "Use a different card" button submitting the form

### DIFF
--- a/app/javascript/components/Checkout/CreditCardInput.tsx
+++ b/app/javascript/components/Checkout/CreditCardInput.tsx
@@ -41,6 +41,7 @@ export const CreditCardInput = ({
         <Label>Card information</Label>
         {savedCreditCard ? (
           <button
+            type="button"
             className="cursor-pointer font-normal underline all-unset"
             disabled={disabled}
             onClick={() => setUseSavedCard(!useSavedCard)}


### PR DESCRIPTION
Closes antiwork/gumroad-private#399

## Summary

The toggle `<button>` inside `CreditCardInput` is missing `type="button"`, so it defaults to `type="submit"`. When this component is rendered inside the Settings → Payments `<form>`, clicking "Use a different card?" submits the whole form: the card-entry UI flashes for a moment, then the page reloads back to the top and the user never gets to enter their new card.

## Fix
One-line: add `type="button"` to the toggle.

Subscription manage flows aren't affected (CreditCardInput sits in a non-form context there), which is why existing specs that click this button continue to work.

## Test plan
- [x] On Settings → Payments with a saved card, click "Use a different card?" — page should NOT reload and the Stripe card input should remain visible
- [x] Subscription manage page's "Use a different card?" still works (covered by existing specs in `spec/requests/subscription/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)