### PR TITLE
Skip cross-border internal transfers below Stripe's destination minimum

### DIFF
--- a/app/business/payments/payouts/payouts.rb
+++ b/app/business/payments/payouts/payouts.rb
@@ -188,14 +188,19 @@ class Payouts
   end
 
   def self.mark_balances_processing(date, processor_type, user)
-    user.unpaid_balances_up_to_date(date).select do |balance|
-      next if !::PayoutProcessorType.get(processor_type).is_balance_payable(balance)
-
-      balance.with_lock do
-        balance.mark_processing!
-      end
-      true
+    payout_processor = ::PayoutProcessorType.get(processor_type)
+    payable_balances = user.unpaid_balances_up_to_date(date).select do |balance|
+      payout_processor.is_balance_payable(balance)
     end
+
+    if payout_processor.respond_to?(:filter_aggregate_payable_balances)
+      payable_balances = payout_processor.filter_aggregate_payable_balances(user, payable_balances)
+    end
+
+    payable_balances.each do |balance|
+      balance.with_lock { balance.mark_processing! }
+    end
+    payable_balances
   end
   private_class_method :mark_balances_processing
 end

--- a/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
+++ b/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
@@ -8,6 +8,13 @@ class StripePayoutProcessor
   MINIMUM_INSTANT_PAYOUT_AMOUNT_CENTS = 100_00
   MAXIMUM_INSTANT_PAYOUT_AMOUNT_CENTS = 9_999_00
 
+  # USD amounts below Stripe's destination-currency minimum get accepted by `Stripe::Transfer.create`
+  # (debiting the platform) but never settle a `balance_transaction` on the destination — funds get
+  # stranded with no error path. Stripe's per-currency minimums top out near $0.55 USD equivalent
+  # for major currencies, so this source-side floor clears them with margin. Source balances under
+  # the floor stay `unpaid` and roll forward to the next cycle.
+  GUMROAD_HELD_USD_MIN_TRANSFER_CENTS = 1_00
+
   # Public: Determines if it's possible for this processor to payout
   # the user by checking that the user has provided us with the
   # information we need to be able to payout with this processor.
@@ -83,6 +90,24 @@ class StripePayoutProcessor
     else
       false
     end
+  end
+
+  # Public: Aggregate-level filter run after `is_balance_payable`. Drops Gumroad-held USD balances
+  # whose summed amount would force a cross-border internal transfer below Stripe's destination
+  # minimum (see `GUMROAD_HELD_USD_MIN_TRANSFER_CENTS`). Skipped balances stay `unpaid` and roll
+  # forward to the next payout. Returns the surviving balances.
+  def self.filter_aggregate_payable_balances(user, balances)
+    return balances if balances.empty?
+
+    merchant_account, balances_held_by_gumroad, _ = get_payout_details(user, balances)
+    return balances if merchant_account.nil?
+    return balances if merchant_account.currency.to_s == Currency::USD
+    return balances if balances_held_by_gumroad.empty?
+
+    total_usd_cents = balances_held_by_gumroad.sum(&:holding_amount_cents)
+    return balances if total_usd_cents >= GUMROAD_HELD_USD_MIN_TRANSFER_CENTS
+
+    balances - balances_held_by_gumroad
   end
 
   # Public: Get the payout destination and categorized balances for a user

--- a/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
+++ b/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
@@ -425,6 +425,121 @@ describe StripePayoutProcessor, :vcr do
     end
   end
 
+  describe "filter_aggregate_payable_balances" do
+    let(:user) { create(:user) }
+    let(:gbp_merchant_account) do
+      create(:merchant_account, user:, charge_processor_id: StripeChargeProcessor.charge_processor_id,
+                                currency: Currency::GBP, country: "GB")
+    end
+    let(:gumroad_merchant_account) do
+      MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id) ||
+        create(:merchant_account, user: nil, charge_processor_id: StripeChargeProcessor.charge_processor_id)
+    end
+    let(:gbp_stripe_balance) do
+      create(:balance, user:, merchant_account: gbp_merchant_account,
+                       holding_currency: Currency::GBP, holding_amount_cents: 1_212_55)
+    end
+
+    context "when total Gumroad-held USD is below the per-currency floor" do
+      let(:tiny_usd_balance) do
+        create(:balance, user:, merchant_account: gumroad_merchant_account,
+                         holding_currency: Currency::USD, holding_amount_cents: 2)
+      end
+
+      before do
+        allow(described_class).to receive(:get_payout_details)
+          .and_return([gbp_merchant_account, [tiny_usd_balance], [gbp_stripe_balance]])
+      end
+
+      it "excludes the Gumroad-held USD balances so they roll forward" do
+        result = described_class.filter_aggregate_payable_balances(user, [gbp_stripe_balance, tiny_usd_balance])
+
+        expect(result).to eq([gbp_stripe_balance])
+      end
+    end
+
+    context "when total Gumroad-held USD clears the floor" do
+      let(:usd_balance_one) do
+        create(:balance, user:, merchant_account: gumroad_merchant_account,
+                         holding_currency: Currency::USD, holding_amount_cents: 60)
+      end
+      let(:usd_balance_two) do
+        create(:balance, user:, merchant_account: gumroad_merchant_account,
+                         holding_currency: Currency::USD, holding_amount_cents: 50)
+      end
+
+      before do
+        allow(described_class).to receive(:get_payout_details)
+          .and_return([gbp_merchant_account, [usd_balance_one, usd_balance_two], [gbp_stripe_balance]])
+      end
+
+      it "keeps every balance so the internal transfer goes through" do
+        result = described_class.filter_aggregate_payable_balances(user, [gbp_stripe_balance, usd_balance_one, usd_balance_two])
+
+        expect(result).to contain_exactly(gbp_stripe_balance, usd_balance_one, usd_balance_two)
+      end
+    end
+
+    context "when the merchant account currency is USD" do
+      let(:usd_merchant_account) do
+        create(:merchant_account, user:, charge_processor_id: StripeChargeProcessor.charge_processor_id, currency: Currency::USD)
+      end
+      let(:tiny_usd_balance) do
+        create(:balance, user:, merchant_account: gumroad_merchant_account,
+                         holding_currency: Currency::USD, holding_amount_cents: 2)
+      end
+
+      before do
+        allow(described_class).to receive(:get_payout_details)
+          .and_return([usd_merchant_account, [tiny_usd_balance], []])
+      end
+
+      it "keeps the balance because no FX conversion is needed" do
+        result = described_class.filter_aggregate_payable_balances(user, [tiny_usd_balance])
+
+        expect(result).to eq([tiny_usd_balance])
+      end
+    end
+
+    context "when no Gumroad-held balances are present" do
+      before do
+        allow(described_class).to receive(:get_payout_details)
+          .and_return([gbp_merchant_account, [], [gbp_stripe_balance]])
+      end
+
+      it "returns the input unchanged" do
+        result = described_class.filter_aggregate_payable_balances(user, [gbp_stripe_balance])
+
+        expect(result).to eq([gbp_stripe_balance])
+      end
+    end
+
+    context "when merchant_account is nil" do
+      let(:orphan_balance) do
+        create(:balance, user:, merchant_account: gumroad_merchant_account,
+                         holding_currency: Currency::USD, holding_amount_cents: 2)
+      end
+
+      before do
+        allow(described_class).to receive(:get_payout_details).and_return([nil, [orphan_balance], []])
+      end
+
+      it "returns the input unchanged so existing nil-merchant handling runs downstream" do
+        result = described_class.filter_aggregate_payable_balances(user, [orphan_balance])
+
+        expect(result).to eq([orphan_balance])
+      end
+    end
+
+    context "when balances is empty" do
+      it "returns the empty array without calling get_payout_details" do
+        expect(described_class).not_to receive(:get_payout_details)
+
+        expect(described_class.filter_aggregate_payable_balances(user, [])).to eq([])
+      end
+    end
+  end
+
   describe "prepare_payment_and_set_amount for Korean bank account" do
     let(:user) { create(:user) }
     let(:bank_account) { create(:korea_bank_account, user:) }


### PR DESCRIPTION
## What

Stops `StripePayoutProcessor.prepare_payment_and_set_amount` from initiating a `Stripe::Transfer` for Gumroad-held USD whose total falls below Stripe's destination-currency minimum (post-FX). The relevant balances stay `unpaid` and roll into the next payout cycle. The user's remaining Stripe-held merchant-currency balances pay out normally.

Implementation:

- `StripePayoutProcessor.filter_aggregate_payable_balances` — new aggregate-level filter that drops Gumroad-held USD balances when their sum is below `GUMROAD_HELD_USD_MIN_TRANSFER_CENTS` (`$1.00`) and the destination merchant currency is non-USD.
- `Payouts.mark_balances_processing` — calls the aggregate filter after the existing per-balance `is_balance_payable` check, via `respond_to?` so PayPal payouts are unaffected.

Closes https://github.com/antiwork/gumroad-private/issues/390.

## Why

The reported UK creator (and ~89 other non-USD creators in the same window) had every payout since mid-April land in `state: failed` with `stripe_transfer_id: NULL` and `failure_reason: NULL`. Investigation showed Stripe was fully operational and the failure was on our side.

Root cause traced to `stripe_payout_processor.rb:164-193`. When `balances_held_by_gumroad.sum > 0`, the code creates a `Stripe::Transfer` to push USD onto the creator's Connect account and then polls `Stripe::Charge.retrieve` for the destination `balance_transaction` to compute the post-FX wire amount. For amounts below Stripe's per-currency minimum **after FX** (e.g., `$0.02 USD → £0.016 GBP < £0.30 minimum`), Stripe books the transfer as `succeeded` on the source side (debiting the platform) but **never emits a destination `balance_transaction`** — the funds become stranded with no error path. Our poll raises after 6 s, the Payment is marked failed, and every retry recreates the same transfer, leaking a small amount of platform balance each time.

This was confirmed by reading the actual Stripe records for the affected creator:

- Platform-side: `tr_…` status `succeeded`, source `balance_transaction.amount = -2 USD`.
- Connect-side: `py_…` status `succeeded`, `balance_transaction = null` (still null 2 days later).
- Connect account: `country: GB`, `default_currency: gbp`, no USD sub-balance — the 2¢ never converted.

The two clean candidate fixes were:

- (a) Refuse to initiate the transfer below a per-currency floor; roll source balances forward.
- (b) Stop depending on `destination_payment.balance_transaction.amount` and use the transfer's own amount.

(b) is unsafe because `payment.amount_cents` is in destination merchant currency, so without the destination `balance_transaction` we have no ledger truth for the post-FX amount, and the platform debit becomes silent shrinkage of creator-owed funds. (a) is the root-cause fix — the bug exists *because* a transfer was initiated that can never settle. This PR ships (a).

`$1.00 USD` was chosen as the source-side floor because Stripe's documented per-currency minimums top out near `$0.55` USD-equivalent across all currencies we settle in. That comfortably clears every documented minimum with room for FX wobble. Source-side comparison avoids depending on FX rate lookup (which fails open in `CurrencyHelper#get_rate`) for the safety floor itself.

Roll-forward semantics are inherited for free from the existing state machine: balances are only marked `paid` when their Payment hits `completed` (`payment.rb:82`), and failed Payments already trigger `mark_balances_as_unpaid` (`payment.rb:77`). Excluded balances are never attached to a Payment, so they stay `unpaid` and re-enter the next cycle via `user.unpaid_balances_up_to_date`.

This PR fixes Mode A (sub-floor amounts → permanently stranded). Mode B (above-floor amounts where Stripe's destination `balance_transaction` takes longer than the current 6 s poll) is a related but separate failure that will be addressed in a follow-up — likely persisting `stripe_internal_transfer_id` before the poll and reconciling asynchronously.

---

This PR was implemented with Claude Opus 4.7 (1M context)