### PR TITLE
Unblock Puerto Rico sellers by onboarding them onto US-side Stripe Connect

### DIFF
--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -50,6 +50,7 @@ module StripeMerchantAccountManager
       raise MerchantRegistrationUserNotReadyError.new(user.id, "does not have a legal entity country") if country_code.blank?
       raise MerchantRegistrationUserNotReadyError.new(user.id, "is not supported yet") if NEW_ACCOUNT_CREATION_BLOCKED_COUNTRIES.include?(country_code)
       country = Country.new(country_code)
+      stripe_country_code = country.stripe_country_code
 
       currency = country.payout_currency
       raise MerchantRegistrationUserNotReadyError.new(user.id, "has no default currency defined for it's legal entity's country") if currency.blank?
@@ -63,7 +64,7 @@ module StripeMerchantAccountManager
       account_params = {
         type: "custom",
         requested_capabilities: capabilities,
-        country: country_code,
+        country: stripe_country_code,
         default_currency: currency
       }
       account_params.deep_merge!(account_hash(user, tos_agreement, user_compliance_info, passphrase:))
@@ -71,7 +72,7 @@ module StripeMerchantAccountManager
 
       merchant_account = MerchantAccount.create!(
         user:,
-        country: country_code,
+        country: stripe_country_code,
         currency:,
         charge_processor_id: StripeChargeProcessor.charge_processor_id
       )
@@ -142,11 +143,12 @@ module StripeMerchantAccountManager
 
     last_attributes = account_hash(user, nil, last_user_compliance_info, passphrase:)
     current_attributes = account_hash(user, tos_agreement, user_compliance_info, passphrase:)
+    stripe_country_code = Country.new(user_compliance_info.legal_entity_country_code).stripe_country_code
     last_attributes[:metadata] = {}
     last_attributes[:business_profile] = {}
     if user_compliance_info.is_business?
       last_attributes.delete(:individual)
-      if last_attributes[:company].present? && user_compliance_info.country_code == Compliance::Countries::USA.alpha2
+      if last_attributes[:company].present? && stripe_country_code == Compliance::Countries::USA.alpha2
         last_attributes[:company][:structure] = nil
       end
       last_attributes.delete(:business_type) if user_compliance_info.country_code == Compliance::Countries::CAN.alpha2
@@ -177,7 +179,7 @@ module StripeMerchantAccountManager
 
     if last_user_compliance_info&.is_business? && user_compliance_info.is_individual?
       # Clear structure first - Stripe rejects company[structure] when business_type is "individual"
-      if last_user_compliance_info.country_code == Compliance::Countries::USA.alpha2 &&
+      if Country.new(last_user_compliance_info.legal_entity_country_code).stripe_country_code == Compliance::Countries::USA.alpha2 &&
         last_user_compliance_info.business_type == UserComplianceInfo::BusinessTypes::SOLE_PROPRIETORSHIP
         Stripe::Account.update(stripe_account.id, { company: { structure: "" } })
       end
@@ -189,7 +191,7 @@ module StripeMerchantAccountManager
 
     # Only set structure for US accounts
     if user_compliance_info.is_business? &&
-      user_compliance_info.country_code == Compliance::Countries::USA.alpha2 &&
+      stripe_country_code == Compliance::Countries::USA.alpha2 &&
       user_compliance_info.business_type == UserComplianceInfo::BusinessTypes::SOLE_PROPRIETORSHIP
       diff_attributes[:company] ||= {}
       diff_attributes[:company][:structure] = user_compliance_info.business_type
@@ -497,6 +499,7 @@ module StripeMerchantAccountManager
   def self.person_hash(user_compliance_info, passphrase)
     if user_compliance_info
       personal_tax_id = user_compliance_info.individual_tax_id.decrypt(passphrase)
+      stripe_country_code = Country.new(user_compliance_info.country_code).stripe_country_code
 
       hash = {
         first_name: user_compliance_info.first_name,
@@ -540,20 +543,20 @@ module StripeMerchantAccountManager
                              city: user_compliance_info.city,
                              state: user_compliance_info.state,
                              postal_code: user_compliance_info.zip_code,
-                             country: user_compliance_info.country_code
+                             country: stripe_country_code
                            },
                          })
       end
 
       # For US accounts, only submit the Personal Tax ID if it's longer than four digits, otherwise the field contains the SSN Last 4.
       # For non-US accounts, always submit the Personal Tax ID.
-      if personal_tax_id && (user_compliance_info.country_code != Compliance::Countries::USA.alpha2 || personal_tax_id.length > 4)
+      if personal_tax_id && (stripe_country_code != Compliance::Countries::USA.alpha2 || personal_tax_id.length > 4)
         hash.deep_merge!(id_number: personal_tax_id)
       end
 
       # For US accounts, only submit the SSN Last 4 if we have enough digits in the Tax ID to get the last 4.
       # For non-US accounts, never submit this field, it is for US accounts only.
-      if user_compliance_info.country_code == Compliance::Countries::USA.alpha2 && personal_tax_id && personal_tax_id.length == 4
+      if stripe_country_code == Compliance::Countries::USA.alpha2 && personal_tax_id && personal_tax_id.length == 4
         hash.deep_merge!(ssn_last_4: personal_tax_id.last(4))
       end
 

--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -575,6 +575,7 @@ module StripeMerchantAccountManager
     return unless user_compliance_info.present?
 
     business_tax_id = user_compliance_info.business_tax_id.decrypt(passphrase)
+    stripe_country_code = Country.new(user_compliance_info.legal_entity_country_code).stripe_country_code
     hash = {
       company: {
         name: user_compliance_info.business_name.presence,
@@ -584,7 +585,7 @@ module StripeMerchantAccountManager
           city: user_compliance_info.legal_entity_city,
           state: user_compliance_info.legal_entity_state,
           postal_code: user_compliance_info.legal_entity_zip_code,
-          country: user_compliance_info.legal_entity_country_code
+          country: stripe_country_code
         },
         tax_id: business_tax_id.presence,
         phone: user_compliance_info.business_phone,

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -86,10 +86,22 @@ class Country
   ].freeze
   private_constant :CROSS_BORDER_PAYOUTS_COUNTRIES
 
+  # Stripe does not accept its own ISO codes for US territories on Connect accounts: a Puerto Rico
+  # seller must be onboarded as `country: "US"`. We keep the seller's true country in their
+  # compliance info; this mapping is only applied for Stripe-API-facing fields.
+  TERRITORY_TO_PARENT_COUNTRY = {
+    Compliance::Countries::PRI.alpha2 => Compliance::Countries::USA.alpha2,
+  }.freeze
+  private_constant :TERRITORY_TO_PARENT_COUNTRY
+
   attr_reader :alpha2_code
 
   def initialize(country_code)
     @alpha2_code = country_code
+  end
+
+  def stripe_country_code
+    TERRITORY_TO_PARENT_COUNTRY[alpha2_code] || alpha2_code
   end
 
   def supports_stripe_cross_border_payouts?
@@ -108,7 +120,8 @@ class Country
 
   def default_currency
     case alpha2_code
-    when Compliance::Countries::USA.alpha2
+    when Compliance::Countries::USA.alpha2,
+        Compliance::Countries::PRI.alpha2
       Currency::USD
     when Compliance::Countries::CAN.alpha2
       Currency::CAD

--- a/app/modules/user/compliance.rb
+++ b/app/modules/user/compliance.rb
@@ -127,6 +127,7 @@ module User::Compliance
     Compliance::Countries::MAC,
     Compliance::Countries::BEN,
     Compliance::Countries::CIV,
+    Compliance::Countries::PRI,
   ].concat(EUROPEAN_COUNTRIES).freeze
 
   SUPPORTED_COUNTRIES_HAVING_STATES = [

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -8627,6 +8627,55 @@ describe StripeMerchantAccountManager, :vcr do
         end
       end
     end
+
+    describe "Puerto Rico seller onboarded onto a US-side Stripe Connect account" do
+      let(:user_compliance_info) do
+        create(:user_compliance_info, user:,
+                                      country: "Puerto Rico", state: "PR", city: "San Juan", zip_code: "00921")
+      end
+      let(:bank_account) { create(:ach_account_stripe_succeed, user:) }
+      let(:tos_agreement) { create(:tos_agreement, user:) }
+      let(:stripe_account_stub) do
+        external_account = instance_double("Stripe::BankAccount", id: "ba_stub", fingerprint: "fp_stub")
+        external_accounts = instance_double("Stripe::ListObject")
+        allow(external_accounts).to receive(:first).and_return(external_account)
+        stripe_account = instance_double("Stripe::Account", id: "acct_pr_stub", external_accounts:)
+        allow(stripe_account).to receive(:[]).with("metadata").and_return({ "user_compliance_info_id" => user_compliance_info.external_id })
+        allow(stripe_account).to receive(:capabilities).and_return(double(keys: []))
+        stripe_account
+      end
+
+      before do
+        user_compliance_info
+        bank_account
+        tos_agreement
+        allow(Stripe::Account).to receive(:create).and_return(stripe_account_stub)
+        allow(CheckPaymentAddressWorker).to receive(:perform_async)
+        allow(DefaultAbandonedCartWorkflowGeneratorService).to receive(:new).and_return(double(generate: nil))
+      end
+
+      it "sends country: 'US' to Stripe and stores the merchant account with country 'US'" do
+        merchant_account = subject.create_account(user, passphrase: "1234")
+
+        expect(Stripe::Account).to have_received(:create) do |params|
+          expect(params[:country]).to eq("US")
+          expect(params[:default_currency]).to eq(Currency::USD)
+          expect(params[:individual][:address][:country]).to eq("US")
+        end
+        expect(merchant_account.country).to eq("US")
+        expect(merchant_account.currency).to eq(Currency::USD)
+      end
+
+      it "follows US SSN semantics when submitting the personal tax ID" do
+        subject.create_account(user, passphrase: "1234")
+
+        expect(Stripe::Account).to have_received(:create) do |params|
+          # 9-digit SSN: id_number is sent (US semantics: full SSN under id_number)
+          expect(params[:individual][:id_number]).to eq("000000000")
+          expect(params[:individual]).not_to have_key(:ssn_last_4)
+        end
+      end
+    end
   end
 
   describe "#update_account" do

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -8636,10 +8636,10 @@ describe StripeMerchantAccountManager, :vcr do
       let(:bank_account) { create(:ach_account_stripe_succeed, user:) }
       let(:tos_agreement) { create(:tos_agreement, user:) }
       let(:stripe_account_stub) do
-        external_account = instance_double("Stripe::BankAccount", id: "ba_stub", fingerprint: "fp_stub")
-        external_accounts = instance_double("Stripe::ListObject")
+        external_account = double("Stripe::BankAccount", id: "ba_stub", fingerprint: "fp_stub")
+        external_accounts = double("Stripe::ListObject")
         allow(external_accounts).to receive(:first).and_return(external_account)
-        stripe_account = instance_double("Stripe::Account", id: "acct_pr_stub", external_accounts:)
+        stripe_account = double("Stripe::Account", id: "acct_pr_stub", external_accounts:)
         allow(stripe_account).to receive(:[]).with("metadata").and_return({ "user_compliance_info_id" => user_compliance_info.external_id })
         allow(stripe_account).to receive(:capabilities).and_return(double(keys: []))
         stripe_account

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -8684,6 +8684,12 @@ describe StripeMerchantAccountManager, :vcr do
                                                  business_city: "San Juan", business_zip_code: "00921")
         end
 
+        before do
+          # Business sellers also trigger Stripe::Account.create_person for the representative;
+          # stub it so the test doesn't make an unhandled HTTP request.
+          allow(Stripe::Account).to receive(:create_person).and_return(double("Stripe::Person", id: "person_stub"))
+        end
+
         it "remaps company.address.country to US so Stripe accepts the business address" do
           subject.create_account(user, passphrase: "1234")
 

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -8675,6 +8675,25 @@ describe StripeMerchantAccountManager, :vcr do
           expect(params[:individual]).not_to have_key(:ssn_last_4)
         end
       end
+
+      describe "Puerto Rico business seller" do
+        let(:user_compliance_info) do
+          create(:user_compliance_info_business, user:,
+                                                 country: "Puerto Rico", state: "PR", city: "San Juan", zip_code: "00921",
+                                                 business_country: "Puerto Rico", business_state: "PR",
+                                                 business_city: "San Juan", business_zip_code: "00921")
+        end
+
+        it "remaps company.address.country to US so Stripe accepts the business address" do
+          subject.create_account(user, passphrase: "1234")
+
+          expect(Stripe::Account).to have_received(:create) do |params|
+            # Stripe rejects with "Address for business must match account country" if these differ
+            expect(params[:country]).to eq("US")
+            expect(params[:company][:address][:country]).to eq("US")
+          end
+        end
+      end
     end
   end
 

--- a/spec/models/country_spec.rb
+++ b/spec/models/country_spec.rb
@@ -286,9 +286,23 @@ describe Country do
     end
   end
 
+  describe "#stripe_country_code" do
+    it "maps US territory ISO codes to their parent country code expected by Stripe" do
+      expect(Country.new("PR").stripe_country_code).to eq "US"
+    end
+
+    it "passes through every other country code unchanged" do
+      expect(Country.new("US").stripe_country_code).to eq "US"
+      expect(Country.new("GB").stripe_country_code).to eq "GB"
+      expect(Country.new("JP").stripe_country_code).to eq "JP"
+      expect(Country.new("VN").stripe_country_code).to eq "VN"
+    end
+  end
+
   describe "#default_currency" do
     it "returns the currency which is set as default currency for all the accounts from the country" do
       expect(Country.new("US").default_currency).to eq Currency::USD
+      expect(Country.new("PR").default_currency).to eq Currency::USD
       expect(Country.new("GB").default_currency).to eq Currency::GBP
       expect(Country.new("AU").default_currency).to eq Currency::AUD
       expect(Country.new("FR").default_currency).to eq Currency::EUR
@@ -385,6 +399,7 @@ describe Country do
   describe "#payout_currency" do
     it "returns the currency which is used for sending stripe payouts to the country" do
       expect(Country.new("US").payout_currency).to eq Currency::USD
+      expect(Country.new("PR").payout_currency).to eq Currency::USD
       expect(Country.new("GB").payout_currency).to eq Currency::GBP
       expect(Country.new("AU").payout_currency).to eq Currency::AUD
       expect(Country.new("FR").payout_currency).to eq Currency::EUR

--- a/spec/modules/user/compliance_spec.rb
+++ b/spec/modules/user/compliance_spec.rb
@@ -29,6 +29,12 @@ describe User::Compliance do
       end
     end
 
+    it "returns true for Puerto Rico creators (onboarded as US-side Stripe accounts)" do
+      creator = create(:user)
+      create(:user_compliance_info_empty, user: creator, country: "Puerto Rico")
+      expect(creator.native_payouts_supported?).to be true
+    end
+
     it "returns false for other countries" do
       venezuela_user = create(:user)
       create(:user_compliance_info_empty, user: venezuela_user, country: "Venezuela")


### PR DESCRIPTION
## What

Puerto Rico sellers (992 in prod today, several new signups this week) can now select Stripe as a payout option and complete Connect onboarding. Their compliance country stays `PR`; their Stripe Connect account is created as a US-side managed account because Stripe does not accept `country: \"PR\"` on `Stripe::Account.create`.

Implementation:

- `app/modules/user/compliance.rb` — add `Compliance::Countries::PRI` to `SUPPORTED_COUNTRIES`. → `user.native_payouts_supported?` returns true for PR, so the settings UI shows the Stripe option (settings_presenter.rb:347).
- `app/models/country.rb` — new `Country#stripe_country_code` helper that maps `PR → US` (and is a no-op for every other ISO code); add USD as PR's `default_currency`. → `Country.new(\"PR\").payout_currency` is now `\"usd\"`, so the `currency.blank?` precondition in `create_account` no longer raises.
- `app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb` — derive `stripe_country_code` once per call and use it for the Stripe-bound fields: `Stripe::Account.create(country:)`, `MerchantAccount.country` (so it matches the Stripe-side country and existing `merchant_account.country == \"US\"` checks in `credit.rb`/`stripe_charge_processor.rb` correctly include PR sellers), `person_hash`'s `address.country`, the US-only SSN vs `id_number` gating, and the US sole-proprietorship structure guards in `update_account`.

Closes https://github.com/antiwork/gumroad-private/issues/394.

## Why

Investigation against prod found 992 PR sellers (968 individuals + 24 businesses) with `UserComplianceInfo.country: \"Puerto Rico\"`, with new signups landing this week. Every one of them currently hits a three-layer catch-22:

1. `Compliance::Countries::PRI` was missing from `SUPPORTED_COUNTRIES`, so `User#native_payouts_supported?` returned `false` and the settings UI hid the Stripe payout path entirely. Only PayPal was offered.
2. PayPal payouts require \$100 lifetime earnings before activation, but PR sellers can't earn anything without a payout method attached. → catch-22.
3. The naive \"just add PR to the list\" fix surfaced in the issue body would have replaced the blocker with a new failure mode: `Country.new(\"PR\").default_currency` was `nil`, so `StripeMerchantAccountManager.create_account` raised `MerchantRegistrationUserNotReadyError(\"has no default currency...\")` at `stripe_merchant_account_manager.rb:55`. Even past that, `Stripe::Account.create(country: \"PR\", ...)` would fail at Stripe's API since Stripe treats PR sellers as US for Connect (PR uses US ABA routing numbers, US-style SSNs, FDIC-insured banks, and US state code `PR`).

The chosen approach keeps the user's true country (`PR`) in their compliance info — important for tax reporting and future PR-specific business logic — and applies the `PR → US` mapping only at Stripe-API boundaries via a single `Country#stripe_country_code` helper. The `MerchantAccount.country` column tracks the Stripe-side country code (matching what `merchant_account_manager.rb:725` syncs to from `stripe_account[\"country\"]`), so all existing `merchant_account.country == \"US\"` branches in `credit.rb` and `stripe_charge_processor.rb` apply correctly to PR sellers.

The `TERRITORY_TO_PARENT_COUNTRY` constant is intentionally small (PR only) for now. The same Stripe-Connect-treats-them-as-US dynamic applies to American Samoa, Guam, Northern Mariana Islands, and US Virgin Islands, but the support ticket and observed prod data only cover PR — extending coverage to other US territories is a follow-up if/when those tickets arrive.

---

This PR was implemented with Claude Opus 4.7 (1M context).