### PR TITLE
Fix asset push: drop dead public/assets sync after Sprockets removal

### DIFF
--- a/docker/web/push_assets_to_s3.sh
+++ b/docker/web/push_assets_to_s3.sh
@@ -8,10 +8,6 @@ logger() {
   echo -e "${GREEN}$DT docker_asset_compile.sh: $1${NC}"
 }
 
-logger "Uploading public/assets to S3"
-aws s3 sync /app/public/assets s3://${ASSETS_S3_BUCKET}/assets --acl public-read --cache-control max-age=31536000,immutable
-logger "Done uploading public/assets to S3"
-
 logger "Uploading public/vite to S3"
 aws s3 sync /app/public/vite s3://${ASSETS_S3_BUCKET}/vite --acl public-read --cache-control max-age=31536000,immutable
 logger "Done uploading public/vite to S3"


### PR DESCRIPTION
## What

Remove the legacy `aws s3 sync /app/public/assets …` line from `docker/web/push_assets_to_s3.sh`.

## Why

Sprockets and `app/assets/` were retired in #5152. `rake assets:precompile` now runs only Vite Ruby, which writes to `public/vite/` and `public/js/` — `/app/public/assets` is never created in the build container.

The first push to `main` after that merge ([build 10317](https://buildkite.com/gumroad-inc/gumroad/builds/10317)) failed in the production asset step:

```
The user-provided path /app/public/assets does not exist.
make: *** [Makefile:159: build_production] Error 255
```

`set -eo pipefail` then aborts the script before `public/vite` and `public/js` are uploaded — so the entire S3 push is skipped and production deploys off `main` are blocked. #5152 retired the Sprockets pipeline but didn't update this script; this PR finishes that cleanup.

The migration PR (#5067) didn't hit this because Sprockets still produced `public/assets/` at that point.

## Before/After

CI-only change with no runtime behavior. The S3 push step on `main` builds will go from exit 2 → exit 0, with `public/vite/` and `public/js/` actually reaching S3. No video — there is no UI surface to record, and the broken step doesn't run on PR branches built off this branch (the production push only runs on the post-merge `main` build), so the fix is verified by reading the build log.

## Test plan

- [ ] Merge to `main` and confirm the next `:gear: Compile Assets` (parallel job 1, production) reaches `Done uploading public/js to S3` and exits 0.
- [ ] Confirm production deploy unblocks (build 10317 was the first failure; once green, downstream `:rocket: Deploy to Production` can run).

---

🤖 AI disclosure: drafted with Claude Opus 4.7 (1M context). Prompts: investigation of Buildkite build 10317 and request to send a PR with the fix.