### PR TITLE
Add PlatformBlock MySQL backing + Mongo→MySQL sync

### DIFF
--- a/app/models/platform_block.rb
+++ b/app/models/platform_block.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class PlatformBlock < ApplicationRecord
+end

--- a/app/services/onetime/sync_platform_blocks_from_mongo.rb
+++ b/app/services/onetime/sync_platform_blocks_from_mongo.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+# Copies BlockedObject documents from Mongo to the MySQL `platform_blocks` table.
+#
+# The app keeps reading/writing Mongo while this runs. Re-run with the
+# `updated_at` watermark from the previous run to pick up changes; the upsert
+# is idempotent on the (object_type, object_value) unique index.
+#
+# Expired records (expires_at <= now) are skipped.
+#
+#   Onetime::SyncPlatformBlocksFromMongo.process
+#   Onetime::SyncPlatformBlocksFromMongo.process(since: Time.parse("2026-05-19 12:00:00 UTC"))
+module Onetime
+  class SyncPlatformBlocksFromMongo
+    BATCH_SIZE = 2_000
+
+    def self.process(since: nil, batch_size: BATCH_SIZE)
+      new(since:, batch_size:).process
+    end
+
+    def initialize(since: nil, batch_size: BATCH_SIZE)
+      @since = since
+      @batch_size = batch_size
+    end
+
+    def process
+      scope = BlockedObject
+        .any_of({ expires_at: nil }, { :expires_at.gt => Time.current })
+        .order_by(updated_at: :asc, _id: :asc)
+        .no_timeout
+      # `>=` (not `>`) so that if a previous run crashed mid-batch, records
+      # sharing the same microsecond `updated_at` as the watermark are not
+      # silently skipped. The upsert is idempotent, so re-processing is safe.
+      scope = scope.where(:updated_at.gte => since) if since
+
+      total = 0
+      last_updated_at = since
+
+      scope.each_slice(batch_size) do |batch|
+        ReplicaLagWatcher.watch
+        upsert_batch(batch)
+        total += batch.size
+        last_updated_at = batch.last.updated_at
+        puts "PlatformBlock sync: #{total} upserted (last updated_at: #{last_updated_at.iso8601(6)})"
+      end
+
+      puts "Done. Upserted #{total} records. To resume from this point: " \
+           "Onetime::SyncPlatformBlocksFromMongo.process(since: Time.parse(\"#{last_updated_at&.iso8601(6)}\"))"
+      last_updated_at
+    end
+
+    private
+      attr_reader :since, :batch_size
+
+      def upsert_batch(batch)
+        now = Time.current
+        rows = batch.map do |obj|
+          {
+            object_type: obj.object_type,
+            object_value: obj.object_value,
+            blocked_at: obj.blocked_at,
+            expires_at: obj.expires_at,
+            blocked_by: obj.blocked_by,
+            created_at: obj.created_at || now,
+            updated_at: obj.updated_at || now,
+          }
+        end
+
+        # `unique_by:` isn't supported by the Makara MySQL adapter, but MySQL's
+        # ON DUPLICATE KEY UPDATE triggers on any unique-index conflict, so the
+        # (object_type, object_value) unique index handles dedup either way.
+        PlatformBlock.upsert_all(
+          rows,
+          update_only: %i[blocked_at expires_at blocked_by updated_at]
+        )
+      end
+  end
+end

--- a/db/migrate/20261127000000_create_platform_blocks.rb
+++ b/db/migrate/20261127000000_create_platform_blocks.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CreatePlatformBlocks < ActiveRecord::Migration[7.1]
+  def change
+    create_table :platform_blocks do |t|
+      t.string :object_type, null: false, limit: 50
+      t.string :object_value, null: false, limit: 320
+      t.datetime :blocked_at, precision: 6
+      t.datetime :expires_at, precision: 6
+      t.bigint :blocked_by
+
+      t.timestamps precision: 6
+
+      t.index [:object_type, :object_value], unique: true, name: "index_platform_blocks_on_type_and_value"
+      t.index :object_value, name: "index_platform_blocks_on_value"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_11_26_000001) do
+ActiveRecord::Schema[7.1].define(version: 2026_11_27_000000) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -1404,6 +1404,18 @@ ActiveRecord::Schema[7.1].define(version: 2026_11_26_000001) do
     t.datetime "updated_at", precision: nil, null: false
     t.index ["balance_id"], name: "index_payments_balances_on_balance_id"
     t.index ["payment_id"], name: "index_payments_balances_on_payment_id"
+  end
+
+  create_table "platform_blocks", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "object_type", limit: 50, null: false
+    t.string "object_value", limit: 320, null: false
+    t.datetime "blocked_at"
+    t.datetime "expires_at"
+    t.bigint "blocked_by"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["object_type", "object_value"], name: "index_platform_blocks_on_type_and_value", unique: true
+    t.index ["object_value"], name: "index_platform_blocks_on_value"
   end
 
   create_table "post_email_blasts", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|

--- a/spec/services/onetime/sync_platform_blocks_from_mongo_spec.rb
+++ b/spec/services/onetime/sync_platform_blocks_from_mongo_spec.rb
@@ -1,0 +1,245 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Onetime::SyncPlatformBlocksFromMongo do
+  before { PlatformBlock.delete_all }
+
+  def silence_stdout
+    original = $stdout
+    $stdout = StringIO.new
+    yield
+  ensure
+    $stdout = original
+  end
+
+  def capture_stdout
+    original = $stdout
+    $stdout = StringIO.new
+    yield
+    $stdout.string
+  ensure
+    $stdout = original
+  end
+
+  describe ".process" do
+    it "copies active records from Mongo to MySQL preserving all fields" do
+      blocked_at = 2.hours.ago
+      expires_at = 1.hour.from_now
+      mongo_record = BlockedObject.create!(
+        object_type: BLOCKED_OBJECT_TYPES[:email],
+        object_value: "blocked@example.com",
+        blocked_at:,
+        expires_at:,
+        blocked_by: 42
+      )
+
+      silence_stdout { described_class.process }
+
+      row = PlatformBlock.find_by!(object_type: BLOCKED_OBJECT_TYPES[:email], object_value: "blocked@example.com")
+      expect(row.blocked_at).to be_within(1.second).of(blocked_at)
+      expect(row.expires_at).to be_within(1.second).of(expires_at)
+      expect(row.blocked_by).to eq(42)
+      expect(row.created_at).to be_within(1.second).of(mongo_record.created_at)
+      expect(row.updated_at).to be_within(1.second).of(mongo_record.updated_at)
+    end
+
+    it "skips records whose expires_at is in the past" do
+      BlockedObject.create!(
+        object_type: BLOCKED_OBJECT_TYPES[:email],
+        object_value: "expired@example.com",
+        blocked_at: 2.days.ago,
+        expires_at: 1.day.ago,
+        blocked_by: nil
+      )
+      BlockedObject.create!(
+        object_type: BLOCKED_OBJECT_TYPES[:email],
+        object_value: "active@example.com",
+        blocked_at: 2.hours.ago,
+        expires_at: 1.hour.from_now,
+        blocked_by: nil
+      )
+
+      silence_stdout { described_class.process }
+
+      expect(PlatformBlock.pluck(:object_value)).to contain_exactly("active@example.com")
+    end
+
+    it "imports records with no expires_at (permanent blocks)" do
+      BlockedObject.create!(
+        object_type: BLOCKED_OBJECT_TYPES[:email_domain],
+        object_value: "example.org",
+        blocked_at: 1.day.ago,
+        expires_at: nil,
+        blocked_by: nil
+      )
+
+      silence_stdout { described_class.process }
+
+      row = PlatformBlock.find_by!(object_value: "example.org")
+      expect(row.expires_at).to be_nil
+    end
+
+    it "imports unblocked tombstones (blocked_at nil and expires_at nil)" do
+      blocked = BlockedObject.create!(
+        object_type: BLOCKED_OBJECT_TYPES[:email],
+        object_value: "tombstone@example.com",
+        blocked_at: 2.hours.ago,
+        expires_at: nil,
+        blocked_by: nil
+      )
+      blocked.unblock!
+
+      silence_stdout { described_class.process }
+
+      row = PlatformBlock.find_by!(object_value: "tombstone@example.com")
+      expect(row.blocked_at).to be_nil
+      expect(row.expires_at).to be_nil
+    end
+
+    it "returns the last updated_at watermark from the run" do
+      mongo_record = BlockedObject.create!(
+        object_type: BLOCKED_OBJECT_TYPES[:email],
+        object_value: "watermark@example.com",
+        blocked_at: 1.hour.ago,
+        expires_at: nil
+      )
+
+      watermark = silence_stdout { described_class.process }
+
+      expect(watermark).to be_within(1.second).of(mongo_record.updated_at)
+    end
+
+    it "returns nil watermark when nothing was synced" do
+      expect(silence_stdout { described_class.process }).to be_nil
+    end
+
+    context "when re-run" do
+      it "is idempotent — re-running produces the same MySQL state" do
+        BlockedObject.create!(
+          object_type: BLOCKED_OBJECT_TYPES[:email],
+          object_value: "idempotent@example.com",
+          blocked_at: 1.hour.ago,
+          expires_at: nil
+        )
+
+        silence_stdout { described_class.process }
+        silence_stdout { described_class.process }
+
+        expect(PlatformBlock.where(object_value: "idempotent@example.com").count).to eq(1)
+      end
+
+      it "does not overwrite created_at on existing rows" do
+        BlockedObject.create!(
+          object_type: BLOCKED_OBJECT_TYPES[:email],
+          object_value: "preserve-created@example.com",
+          blocked_at: 1.hour.ago,
+          expires_at: nil
+        )
+
+        silence_stdout { described_class.process }
+        original_created_at = PlatformBlock.find_by!(object_value: "preserve-created@example.com").created_at
+
+        silence_stdout { described_class.process }
+        expect(PlatformBlock.find_by!(object_value: "preserve-created@example.com").created_at)
+          .to eq(original_created_at)
+      end
+
+      it "propagates updates to blocked_at, expires_at and blocked_by" do
+        mongo_record = BlockedObject.create!(
+          object_type: BLOCKED_OBJECT_TYPES[:email],
+          object_value: "mutating@example.com",
+          blocked_at: 2.hours.ago,
+          expires_at: 1.hour.from_now,
+          blocked_by: 1
+        )
+
+        silence_stdout { described_class.process }
+
+        mongo_record.update!(blocked_by: 99, expires_at: 2.hours.from_now)
+
+        silence_stdout { described_class.process }
+
+        row = PlatformBlock.find_by!(object_value: "mutating@example.com")
+        expect(row.blocked_by).to eq(99)
+        expect(row.expires_at).to be_within(1.second).of(2.hours.from_now)
+      end
+
+      it "propagates Mongo unblock! (nulls blocked_at and expires_at)" do
+        mongo_record = BlockedObject.create!(
+          object_type: BLOCKED_OBJECT_TYPES[:email],
+          object_value: "to-unblock@example.com",
+          blocked_at: 1.hour.ago,
+          expires_at: 1.hour.from_now
+        )
+
+        silence_stdout { described_class.process }
+        mongo_record.unblock!
+
+        silence_stdout { described_class.process }
+
+        row = PlatformBlock.find_by!(object_value: "to-unblock@example.com")
+        expect(row.blocked_at).to be_nil
+        expect(row.expires_at).to be_nil
+      end
+    end
+
+    context "with a since: watermark" do
+      it "syncs only records updated at or after the watermark" do
+        travel_to 3.hours.ago do
+          BlockedObject.create!(
+            object_type: BLOCKED_OBJECT_TYPES[:email],
+            object_value: "older@example.com",
+            blocked_at: Time.current,
+            expires_at: nil
+          )
+        end
+        travel_to 1.hour.ago do
+          BlockedObject.create!(
+            object_type: BLOCKED_OBJECT_TYPES[:email],
+            object_value: "newer@example.com",
+            blocked_at: Time.current,
+            expires_at: nil
+          )
+        end
+
+        silence_stdout { described_class.process(since: 2.hours.ago) }
+
+        expect(PlatformBlock.pluck(:object_value)).to contain_exactly("newer@example.com")
+      end
+
+      it "re-syncs the boundary record (>= semantics, not >)" do
+        boundary = BlockedObject.create!(
+          object_type: BLOCKED_OBJECT_TYPES[:email],
+          object_value: "boundary@example.com",
+          blocked_at: 1.hour.ago,
+          expires_at: nil
+        )
+
+        # Resuming with `since:` equal to the watermark must re-include the
+        # boundary record; otherwise a mid-batch crash would silently skip rows
+        # sharing the same microsecond updated_at.
+        silence_stdout { described_class.process(since: boundary.updated_at) }
+
+        expect(PlatformBlock.find_by(object_value: "boundary@example.com")).to be_present
+      end
+    end
+
+    it "respects batch_size and processes everything across multiple batches" do
+      5.times do |i|
+        BlockedObject.create!(
+          object_type: BLOCKED_OBJECT_TYPES[:email],
+          object_value: "batched-#{i}@example.com",
+          blocked_at: 1.hour.ago,
+          expires_at: nil
+        )
+      end
+
+      output = capture_stdout { described_class.process(batch_size: 2) }
+
+      expect(PlatformBlock.where("object_value LIKE 'batched-%'").count).to eq(5)
+      # 3 batches of size 2, 2, 1 → cumulative log lines printed
+      expect(output.scan(/PlatformBlock sync:/).size).to eq(3)
+    end
+  end
+end


### PR DESCRIPTION
## What

Prepares the move of the Mongo `BlockedObject` admin-fraud collection to MySQL. The app continues to read and write Mongo; this PR only stands up the destination MySQL table, the AR model, and a resumable/idempotent backfill+delta-sync task. Switching reads and writes is a follow-up.

- New `platform_blocks` MySQL table with `UNIQUE(object_type, object_value)` (matches `BlockedObject.block!`'s `find_or_initialize_by(object_type:, object_value:)` natural key) and a secondary index on `object_value` to cover the type-agnostic `BlockedObject.find_object(object_value)` lookups. No FK on `blocked_by`, per project convention. `precision: 6` on timestamps so `updated_at` watermarks match Mongo's microsecond resolution and the delta sync doesn't re-process the same row.
- `PlatformBlock` ActiveRecord model. Coexists with the Mongoid `BlockedObject` during the sync phase; the Mongoid model is deleted at cutover.
- `Onetime::SyncPlatformBlocksFromMongo` — iterates Mongo docs ordered by `(updated_at, _id)` and `upsert_all`s into MySQL with `update_only: [:blocked_at, :expires_at, :blocked_by, :updated_at]` so retries don't disturb `created_at`. Skips already-expired records (no point importing them). `ReplicaLagWatcher.watch` between batches. Resumable via a `since:` watermark; uses `>=` (not `>`) on resume so records sharing the same microsecond `updated_at` as the watermark aren't silently skipped if a previous run crashed mid-batch.

## Why

`blocked_objects` is one of the actively used Mongo collections and the worst-fit for that store: 1.5M rows, point lookups by `object_value`, mutable records (`block!`/`unblock!` upserts and expirations). MySQL is the right home — small, OLTP, mutable, key-value-ish — and moving it lets us close in on retiring the Mongo cluster entirely.

Doing this in two passes (this PR for sync infra; a follow-up for read/write cutover) means production stays on Mongo while we verify the MySQL copy converges, and the cutover PR has a small, reviewable diff.

This replaces the reverted #5131 / #5155 with the naming agreed on in that thread: `PlatformBlock` for the admin platform-wide fraud tool, leaving `SellerBlock` (rename of `BlockedCustomerObject`) for a separate follow-up.

## Operational steps after merge

1. Run migration.
2. Initial backfill: `Onetime::SyncPlatformBlocksFromMongo.process`.
3. Periodically catch up with the printed watermark: `Onetime::SyncPlatformBlocksFromMongo.process(since: Time.parse("..."))`.
4. Once parity is verified, the follow-up PR switches reads/writes to `PlatformBlock` and deletes the Mongoid `BlockedObject`.

## Before/After

No user-facing change. New table and onetime task only — nothing runs automatically. Walkthrough video to be added before marking ready for review.

## Test Results

`bundle exec rspec spec/services/onetime/sync_platform_blocks_from_mongo_spec.rb` — 13 examples, 0 failures. Behavioral coverage for the cutover (switching readers/writers) lands in the follow-up PR; this one is sync infrastructure only.

---

AI disclosure: drafted with Claude Opus 4.7.