### PR TITLE
Fix CLI onboarding link to gumroad.com page

### DIFF
--- a/app/javascript/components/DashboardPage.tsx
+++ b/app/javascript/components/DashboardPage.tsx
@@ -136,11 +136,7 @@ const GETTING_STARTED_ITEMS: GettingStartedItemType[] = [
   {
     name: "Command line",
     getCompleted: (stats) => !!stats.used_cli,
-    // Points to /api#api-cli (the existing API page's CLI section) instead of
-    // a dedicated /cli page to avoid duplicating content.
     link: "/api#api-cli",
-    target: "_blank",
-    rel: "noopener noreferrer",
     IconComponent: CliIcon,
     description: "Use Gumroad via the command line interface.",
   },
@@ -153,8 +149,6 @@ type GettingStartedItemProps = {
   link: string;
   IconComponent: React.ComponentType<GettingStartedIconProps>;
   description: string;
-  target?: string;
-  rel?: string;
 };
 
 const Greeter = () => (
@@ -177,8 +171,6 @@ const GettingStartedItem = ({
   IconComponent,
   description,
   minimized,
-  target,
-  rel,
 }: GettingStartedItemProps) => {
   const commonClasses = "relative";
 
@@ -216,14 +208,7 @@ const GettingStartedItem = ({
   }
 
   return (
-    <NavigationButton
-      color="filled"
-      href={link}
-      target={target}
-      rel={rel}
-      className={commonClasses}
-      data-status="pending"
-    >
+    <NavigationButton color="filled" href={link} className={commonClasses} data-status="pending">
       {content}
     </NavigationButton>
   );

--- a/app/javascript/components/DashboardPage.tsx
+++ b/app/javascript/components/DashboardPage.tsx
@@ -79,8 +79,6 @@ type GettingStartedItemType = {
   link: string;
   IconComponent: React.ComponentType<GettingStartedIconProps>;
   description: string;
-  target?: string;
-  rel?: string;
 };
 
 const GETTING_STARTED_ITEMS: GettingStartedItemType[] = [
@@ -136,11 +134,9 @@ const GETTING_STARTED_ITEMS: GettingStartedItemType[] = [
   {
     name: "Command line",
     getCompleted: (stats) => !!stats.used_cli,
-    link: "https://github.com/antiwork/gumroad-cli",
+    link: "/api#api-cli",
     IconComponent: CliIcon,
     description: "Use Gumroad via the command line interface.",
-    target: "_blank",
-    rel: "noreferrer",
   },
 ];
 
@@ -151,8 +147,6 @@ type GettingStartedItemProps = {
   link: string;
   IconComponent: React.ComponentType<GettingStartedIconProps>;
   description: string;
-  target?: string;
-  rel?: string;
 };
 
 const Greeter = () => (
@@ -175,8 +169,6 @@ const GettingStartedItem = ({
   IconComponent,
   description,
   minimized,
-  target,
-  rel,
 }: GettingStartedItemProps) => {
   const commonClasses = "relative";
 
@@ -214,14 +206,7 @@ const GettingStartedItem = ({
   }
 
   return (
-    <NavigationButton
-      color="filled"
-      href={link}
-      className={commonClasses}
-      data-status="pending"
-      target={target}
-      rel={rel}
-    >
+    <NavigationButton color="filled" href={link} className={commonClasses} data-status="pending">
       {content}
     </NavigationButton>
   );
@@ -429,8 +414,6 @@ export const DashboardPage = ({
                     IconComponent={item.IconComponent}
                     description={item.description}
                     minimized={gettingStartedMinimized}
-                    {...(item.target !== undefined ? { target: item.target } : {})}
-                    {...(item.rel !== undefined ? { rel: item.rel } : {})}
                   />
                 ))}
               </div>

--- a/app/javascript/components/DashboardPage.tsx
+++ b/app/javascript/components/DashboardPage.tsx
@@ -79,6 +79,8 @@ type GettingStartedItemType = {
   link: string;
   IconComponent: React.ComponentType<GettingStartedIconProps>;
   description: string;
+  target?: string;
+  rel?: string;
 };
 
 const GETTING_STARTED_ITEMS: GettingStartedItemType[] = [
@@ -134,7 +136,11 @@ const GETTING_STARTED_ITEMS: GettingStartedItemType[] = [
   {
     name: "Command line",
     getCompleted: (stats) => !!stats.used_cli,
+    // Points to /api#api-cli (the existing API page's CLI section) instead of
+    // a dedicated /cli page to avoid duplicating content.
     link: "/api#api-cli",
+    target: "_blank",
+    rel: "noopener noreferrer",
     IconComponent: CliIcon,
     description: "Use Gumroad via the command line interface.",
   },
@@ -147,6 +153,8 @@ type GettingStartedItemProps = {
   link: string;
   IconComponent: React.ComponentType<GettingStartedIconProps>;
   description: string;
+  target?: string;
+  rel?: string;
 };
 
 const Greeter = () => (
@@ -169,6 +177,8 @@ const GettingStartedItem = ({
   IconComponent,
   description,
   minimized,
+  target,
+  rel,
 }: GettingStartedItemProps) => {
   const commonClasses = "relative";
 
@@ -206,7 +216,14 @@ const GettingStartedItem = ({
   }
 
   return (
-    <NavigationButton color="filled" href={link} className={commonClasses} data-status="pending">
+    <NavigationButton
+      color="filled"
+      href={link}
+      target={target}
+      rel={rel}
+      className={commonClasses}
+      data-status="pending"
+    >
       {content}
     </NavigationButton>
   );
@@ -408,11 +425,8 @@ export const DashboardPage = ({
                 {GETTING_STARTED_ITEMS.map((item) => (
                   <GettingStartedItem
                     key={item.name}
-                    name={item.name}
+                    {...item}
                     completed={item.getCompleted(getting_started_stats)}
-                    link={item.link}
-                    IconComponent={item.IconComponent}
-                    description={item.description}
                     minimized={gettingStartedMinimized}
                   />
                 ))}


### PR DESCRIPTION
## What

Follow-up to #5043: the dashboard "Command line" getting started tile now links to `/api#api-cli` instead of the GitHub repository. Because it is now an internal Gumroad page link, it no longer opens in a new tab.

## Why

Sahil asked for the tile to point to a page on gumroad.com. `/api#api-cli` already lands on Gumroad's API page at the Command line section with CLI install instructions, so this avoids adding a duplicate `/cli` page.

## Before/After

No visual change. This only changes the click target for the existing Command line tile.

- Before: `https://github.com/antiwork/gumroad-cli`
- After: `/api#api-cli`

## Test Results

- Passed: static check that `DashboardPage.tsx` uses `/api#api-cli`, no longer includes `https://github.com/antiwork/gumroad-cli`, and removed the external-link attributes from the Command line tile.
- Attempted: `bin/test-confidence` twice. Both attempts failed before running tests because the model planning call returned `Overloaded`.
- Attempted: `npx eslint --fix app/javascript/components/DashboardPage.tsx`. It fails on current `main`-level `Routes` global typing errors in this file; using a literal `/api#api-cli` avoids adding a new `Routes` lint error for this change.
- Attempted: `npx tsc --noEmit --pretty`. It fails on current `main` with `TS2688: Cannot find type definition file for 'vite/client'`.

---

This PR was implemented with AI assistance using Claude Opus 4.7.

Prompts used:

- "work kanban task t_9e4799df"
