### PR TITLE
Fix CLI onboarding tile link

### DIFF
--- a/app/javascript/components/DashboardPage.tsx
+++ b/app/javascript/components/DashboardPage.tsx
@@ -79,8 +79,6 @@ type GettingStartedItemType = {
   link: string;
   IconComponent: React.ComponentType<GettingStartedIconProps>;
   description: string;
-  target?: string;
-  rel?: string;
 };
 
 const GETTING_STARTED_ITEMS: GettingStartedItemType[] = [
@@ -136,11 +134,9 @@ const GETTING_STARTED_ITEMS: GettingStartedItemType[] = [
   {
     name: "Command line",
     getCompleted: (stats) => !!stats.used_cli,
-    link: "https://github.com/antiwork/gumroad-cli",
+    link: `${Routes.api_path()}#api-cli`,
     IconComponent: CliIcon,
     description: "Use Gumroad via the command line interface.",
-    target: "_blank",
-    rel: "noreferrer",
   },
 ];
 
@@ -151,8 +147,6 @@ type GettingStartedItemProps = {
   link: string;
   IconComponent: React.ComponentType<GettingStartedIconProps>;
   description: string;
-  target?: string;
-  rel?: string;
 };
 
 const Greeter = () => (
@@ -175,8 +169,6 @@ const GettingStartedItem = ({
   IconComponent,
   description,
   minimized,
-  target,
-  rel,
 }: GettingStartedItemProps) => {
   const commonClasses = "relative";
 
@@ -214,14 +206,7 @@ const GettingStartedItem = ({
   }
 
   return (
-    <NavigationButton
-      color="filled"
-      href={link}
-      className={commonClasses}
-      data-status="pending"
-      target={target}
-      rel={rel}
-    >
+    <NavigationButton color="filled" href={link} className={commonClasses} data-status="pending">
       {content}
     </NavigationButton>
   );
@@ -429,8 +414,6 @@ export const DashboardPage = ({
                     IconComponent={item.IconComponent}
                     description={item.description}
                     minimized={gettingStartedMinimized}
-                    {...(item.target !== undefined ? { target: item.target } : {})}
-                    {...(item.rel !== undefined ? { rel: item.rel } : {})}
                   />
                 ))}
               </div>


### PR DESCRIPTION
## What

Updates the dashboard getting started "Command line" tile to link to Gumroad's API docs CLI section (`/api#api-cli`) instead of the GitHub repository.

Also removes the now-unused `target`/`rel` plumbing that was only needed while the tile was an external link.

## Why

Follow-up to #5043 after Sahil's review feedback: a gumroad.com page is a better onboarding destination than sending creators directly to GitHub. The existing API docs page already has a dedicated Command line section with install and getting-started details, so the dashboard tile can point there.

## Before/After

No visible layout change. Before, clicking the tile opened `https://github.com/antiwork/gumroad-cli` in a new tab. After, clicking it navigates to `/api#api-cli` on gumroad.com.

Video not included: this is a one-link follow-up to already-merged PR #5043 and the visual tile itself is unchanged.

## Test Results

- `npm run lint-fast -- app/javascript/components/DashboardPage.tsx --max-warnings 0 --no-warn-ignored` ✅
- `npx tsc --noEmit -p .` blocked by existing baseline TypeScript config error on clean `origin/main`: `TS2688: Cannot find type definition file for 'vite/client'`
- `bin/test-confidence` blocked by provider overload: `Opus planning test execution... failed (empty response); Response: Overloaded`

---

AI disclosure: Claude Opus 4.7 addressed the review feedback for PR #5043, inspected the existing `/api#api-cli` route/section, made the link cleanup, and ran the verification commands above.