### PR TITLE
Fix flaky admin infinite scroll test: scrollIntoView instead of scrollTo

### DIFF
--- a/spec/requests/admin/pages_spec.rb
+++ b/spec/requests/admin/pages_spec.rb
@@ -132,15 +132,14 @@ describe "Admin Pages Scenario", type: :system, js: true do
       expect(page).to have_text("product #29")
       expect(page).to have_text("product #28")
       expect(page).not_to have_text("product #0")
-      # IntersectionObserver needs the sentinel to enter the viewport.
-      # Use window.scrollTo to ensure the full page scrolls, not just an
-      # element's overflow. Repeat — CI runners can be slow to fire the
-      # observer callback and complete the AJAX fetch.
-      5.times do
-        page.execute_script("window.scrollTo(0, document.body.scrollHeight)")
-        break if page.has_text?("product #0", wait: 5)
-      end
-      expect(page).to have_text("product #0", wait: 20)
+      # Scroll the WhenVisible sentinel (renders a LoadingSpinner with
+      # role="progressbar") directly into view so the IntersectionObserver
+      # fires reliably — window.scrollTo(0, document.body.scrollHeight) is
+      # racy because scrollHeight can be stale on slow CI runners.
+      page.execute_script(<<~JS)
+        document.querySelector('[role="progressbar"]')?.scrollIntoView({ block: 'center' });
+      JS
+      expect(page).to have_text("product #0", wait: 30)
     end
   end
 


### PR DESCRIPTION
## What
Replace `window.scrollTo(0, document.body.scrollHeight)` with `scrollIntoView()` on the sentinel element in the admin purchase search infinite scroll test.

## Why
This test has been flaking on CI repeatedly ([run 26171025261](https://github.com/antiwork/gumroad/actions/runs/26171025261)). PR #5139 bumped retry count and timeouts but the root cause remained: `scrollTo(0, document.body.scrollHeight)` is racy because `scrollHeight` can be stale when the page hasn't fully laid out on slow CI runners, so the Inertia `WhenVisible` sentinel (which uses `IntersectionObserver`) never enters the viewport.

The fix scrolls the sentinel element itself (`LoadingSpinner` with `role="progressbar"`) directly into view with `scrollIntoView({ block: 'center' })`, which deterministically triggers the observer regardless of layout timing.

## Test Results
Cannot run locally — all specs in the `Search` context require Stripe test keys for the `let(:purchase)` factory. CI will validate.

## AI Disclosure
This fix was authored by Gumclaw (AI agent) investigating CI run 26171025261.