### PR TITLE
Fix missing images/fonts in prod: sync public/images and public/fonts to S3

### DIFF
--- a/docker/web/push_assets_to_s3.sh
+++ b/docker/web/push_assets_to_s3.sh
@@ -15,3 +15,11 @@ logger "Done uploading public/vite to S3"
 logger "Uploading public/js to S3"
 aws s3 sync /app/public/js s3://${ASSETS_S3_BUCKET}/js --acl public-read --cache-control max-age=300,public
 logger "Done uploading public/js to S3"
+
+logger "Uploading public/images to S3"
+aws s3 sync /app/public/images s3://${ASSETS_S3_BUCKET}/images --acl public-read --cache-control max-age=300,public
+logger "Done uploading public/images to S3"
+
+logger "Uploading public/fonts to S3"
+aws s3 sync /app/public/fonts s3://${ASSETS_S3_BUCKET}/fonts --acl public-read --cache-control max-age=31536000,public
+logger "Done uploading public/fonts to S3"


### PR DESCRIPTION
## What

Add `aws s3 sync` for `/app/public/images` and `/app/public/fonts` in `docker/web/push_assets_to_s3.sh`. These are the two directories where #5152 placed images and fonts when it deprecated Sprockets.

## Why

After [#5152](https://github.com/antiwork/gumroad/pull/5152) moved ~460 images and 13 fonts out of `app/assets/` (which Sprockets used to compile into `public/assets/`) and into `public/images/` and `public/fonts/`, the S3 push script wasn't updated to upload the new locations. It still only syncs `public/vite` and `public/js`:

```bash
aws s3 sync /app/public/vite s3://${ASSETS_S3_BUCKET}/vite ...
aws s3 sync /app/public/js   s3://${ASSETS_S3_BUCKET}/js   ...
```

[#5154](https://github.com/antiwork/gumroad/pull/5154) only removed the now-dead `public/assets` sync — it did not add the missing image/font syncs.

In production, `config.asset_host = https://assets.gumroad.com`, which is a CloudFront → S3 distribution. So `image_tag \"about/coin-1.svg\"` renders as `<img src=\"https://assets.gumroad.com/images/about/coin-1.svg\">`, and CSS-referenced fonts (e.g. `url(/fonts/ABCFavorit-Regular.woff2)`) also resolve against `assets.gumroad.com` because the bundled CSS is itself served from that host. Since neither directory is in S3, both return 403 from CloudFront, and the homepage renders with all images broken and the default serif fallback font.

**Verification** (current `main`, before this fix):

```
GET https://assets.gumroad.com/images/about/coin-1.svg            → 403 (CloudFront)
GET https://assets.gumroad.com/fonts/ABCFavorit-Regular.woff2     → 403 (CloudFront)
GET https://assets.gumroad.com/vite/.vite/manifest.json           → 200
```

Vite/JS sync still works; only images and fonts are missing.

### Cache-control choices

| Path             | max-age      | Reason                                                                                             |
| ---------------- | ------------ | -------------------------------------------------------------------------------------------------- |
| `public/images`  | `300, public`        | Matches the existing `js` sync. Filenames aren't fingerprinted post-Sprockets, so we need short TTLs to invalidate on update. |
| `public/fonts`   | `31536000, public`   | Fonts rarely change and are large. Not `immutable` since filenames aren't fingerprinted, but a year is fine. |

`--delete` intentionally omitted, matching the conservative behavior of the existing `js`/`vite` syncs.

## Before/After

CI/infra-only change; no runtime code path is touched.

**Before:** broken images and default serif font on gumroad.com (see screenshot in the linked issue/conversation).

**After:** S3 will contain `images/` and `fonts/` prefixes after the next post-merge `:gear: Compile Assets` build. Production then serves them via the existing CloudFront distribution. I'll attach a screenshot of the production homepage rendering correctly once this deploys.

## Test plan

- [ ] Merge to `main` and confirm the next `:gear: Compile Assets` (parallel job 1, production) logs `Done uploading public/images to S3` and `Done uploading public/fonts to S3` and exits 0.
- [ ] After the next production deploy, confirm `curl -I https://assets.gumroad.com/images/about/coin-1.svg` returns 200 and the homepage at https://gumroad.com renders with images and the ABC Favorit font.

---

🤖 AI disclosure: Authored by Claude Opus 4.7 (1M context).