### PR TITLE
Fix flaky embed specs: wait for iframe before entering it

### DIFF
--- a/spec/requests/embed_spec.rb
+++ b/spec/requests/embed_spec.rb
@@ -15,7 +15,7 @@ describe "Embed scenario", type: :system, js: true, mock_easypost: true, retry: 
 
     visit(create_embed_page(product, url: product.long_url, gumroad_params: "&email=sam@test.com", outbound: false))
 
-    within_frame { click_on "Add to cart" }
+    within_embed_frame { click_on "Add to cart" }
 
     check_out(product)
   end
@@ -27,7 +27,7 @@ describe "Embed scenario", type: :system, js: true, mock_easypost: true, retry: 
 
     visit(create_embed_page(pwyw_product, url: "#{direct_affiliate.referral_url_for_product(pwyw_product)}?email=john@test.com", gumroad_params: "&price=75", outbound: false))
 
-    within_frame { click_on "Add to cart" }
+    within_embed_frame { click_on "Add to cart" }
 
     expect do
       check_out(pwyw_product, email: nil)
@@ -47,7 +47,7 @@ describe "Embed scenario", type: :system, js: true, mock_easypost: true, retry: 
 
     visit(create_embed_page(pwyw_product, url: "#{direct_affiliate.referral_url_for_product(pwyw_product)}?", outbound: false))
 
-    within_frame do
+    within_embed_frame do
       fill_in "Name a fair price", with: 75
       click_on "Add to cart"
     end
@@ -68,7 +68,7 @@ describe "Embed scenario", type: :system, js: true, mock_easypost: true, retry: 
 
     visit(create_embed_page(product, url: short_link_url(product, host: "#{PROTOCOL}://#{DOMAIN}"), outbound: false))
 
-    within_frame { click_on "Add to cart" }
+    within_embed_frame { click_on "Add to cart" }
 
     check_out(product)
   end
@@ -78,7 +78,7 @@ describe "Embed scenario", type: :system, js: true, mock_easypost: true, retry: 
 
     visit(create_embed_page(product, insert_anchor_tag: false, outbound: false))
 
-    within_frame { click_on "Add to cart" }
+    within_embed_frame { click_on "Add to cart" }
 
     check_out(product)
   end
@@ -89,7 +89,7 @@ describe "Embed scenario", type: :system, js: true, mock_easypost: true, retry: 
     it "applies the discount code" do
       visit(create_embed_page(product, url: "#{product.long_url}/#{offer_code.code}", outbound: false))
 
-      within_frame do
+      within_embed_frame do
         expect(page).to have_status(text: "$1 off will be applied at checkout (Code SXSW)", wait: 15)
         click_on "Add to cart"
       end
@@ -114,7 +114,7 @@ describe "Embed scenario", type: :system, js: true, mock_easypost: true, retry: 
     it "successfully credits the affiliate commission for the product bought using its affiliated product URL" do
       visit(create_embed_page(product, url: direct_affiliate.referral_url_for_product(product), outbound: false))
 
-      within_frame do
+      within_embed_frame do
         expect(page).to have_text("$75", wait: 15)
         click_on "Add to cart"
       end
@@ -132,7 +132,7 @@ describe "Embed scenario", type: :system, js: true, mock_easypost: true, retry: 
       it "successfully credits the affiliate commission for the product bought from a page that contains '#{query_param}' query parameter" do
         visit(create_embed_page(product, url: short_link_url(product, host: UrlService.domain_with_protocol), outbound: false, query_params: { query_param => direct_affiliate.external_id_numeric }))
 
-        within_frame { click_on "Add to cart" }
+        within_embed_frame { click_on "Add to cart" }
 
         check_out(product)
 
@@ -162,7 +162,7 @@ describe "Embed scenario", type: :system, js: true, mock_easypost: true, retry: 
     embed_page_url = create_embed_page(physical_skus_product, template_name: "embed_page.html.erb", outbound: false, gumroad_params: "quantity=2&price=3&Age=21&Gender=Male&option=#{physical_skus_product.skus.find_by(name: "Blue - Extra Large - Polo").external_id}")
     visit(embed_page_url)
 
-    within_frame do
+    within_embed_frame do
       expect(page).to have_radio_button("Blue - Extra Large - Polo", checked: true)
       expect(page).to have_field("Quantity", with: 2)
       expect(page).to have_field("Name a fair price", with: 3)

--- a/spec/support/embed_helpers.rb
+++ b/spec/support/embed_helpers.rb
@@ -5,6 +5,13 @@ module EmbedHelpers
     Dir.glob(Rails.root.join("public", "embed_spec_page_*.html")).each { |f| File.delete(f) }
   end
 
+  # Wait for the Gumroad embed iframe to be injected by gumroad-embed.js before entering it.
+  # Bare `within_frame` does not retry and fails instantly when the iframe hasn't loaded yet.
+  def within_embed_frame(wait: 15, &block)
+    expect(page).to have_selector("iframe", wait:)
+    within_frame(&block)
+  end
+
   def create_embed_page(product, template_name: "embed_page.html.erb", url: nil, gumroad_params: nil, outbound: true, insert_anchor_tag: true, custom_domain_base_uri: nil, query_params: {})
     template = Rails.root.join("spec", "support", "fixtures", template_name)
     filename = Rails.root.join("public", "embed_spec_page_#{product.unique_permalink}.html")


### PR DESCRIPTION
## What
Add a `within_embed_frame` helper to `EmbedHelpers` that waits for the embed iframe to appear before entering it, and replace all bare `within_frame` calls in `embed_spec.rb`.

## Why
`within_frame` does not retry — it fails instantly when the iframe hasn't been injected yet. The embed page loads `gumroad-embed.js` which dynamically creates the iframe, and under CI load this can take several seconds. When the JS hasn't finished executing, `within_frame` raises `Capybara::ElementNotFound: Unable to find frame`.

CI evidence from [run 26181766383](https://github.com/antiwork/gumroad/actions/runs/26181766383) (job `Test Slow 27`):
```
1st Try error in ./spec/requests/embed_spec.rb:114:
```
The triggering commit (`66aec96` — S3 sync script change) touches zero runtime code, confirming this is a timing flake.

## How
- New `within_embed_frame(wait: 15)` helper in `spec/support/embed_helpers.rb` — calls `expect(page).to have_selector("iframe", wait:)` before `within_frame`, giving the embed JS up to 15 seconds to inject the iframe
- Same pattern already used for Stripe iframes in `checkout_helpers.rb:212`
- All 9 `within_frame` calls in `embed_spec.rb` replaced with `within_embed_frame`

## Test results
Spec-only change. Cannot run locally (embed JS requires Docker build), but the pattern is proven by the existing Stripe iframe waits and the spec already has `retry: 2` (line 5) as a safety net.

> [!NOTE]
> This PR was authored with AI assistance.