### PR TITLE
Fix flaky cart persistence spec: wait for new cart after checkout

### DIFF
--- a/spec/requests/checkout/cart_spec.rb
+++ b/spec/requests/checkout/cart_spec.rb
@@ -181,7 +181,8 @@ describe "Checkout cart", :js, type: :system do
         expect(user_cart.reload).to be_deleted
         expect(user_cart.email).to eq(buyer.email)
         expect(user_cart.order_id).to eq(Order.last.id)
-        new_buyer_cart = buyer.reload.alive_cart
+        poll_until { buyer.reload.alive_cart.present? }
+        new_buyer_cart = buyer.alive_cart
         expect(new_buyer_cart.browser_guid).to eq(user_cart.browser_guid)
         expect(new_buyer_cart.alive_cart_products.count).to eq(0)
 


### PR DESCRIPTION
## What

Wait for the buyer's new alive cart to exist before asserting on it in the cart persistence spec.

## Why

`spec/requests/checkout/cart_spec.rb:171` was flaky on CI ([run #26182962884](https://github.com/antiwork/gumroad/actions/runs/26182962884)). After checkout, the new alive cart is created asynchronously. The test accessed `buyer.reload.alive_cart` immediately, which returned `nil` intermittently — causing `NoMethodError: undefined method 'browser_guid' for nil`.

The fix uses the existing `poll_until` helper (already used at lines 176, 195, and 220 in the same file) to wait for the cart to be present before asserting.

## Test Results

Cannot run this system spec locally (requires MinIO on port 9000), but the fix follows the exact same `poll_until` pattern used throughout this spec file for identical async-cart-creation waits.

## AI Disclosure

This fix was generated by Gumclaw (AI agent) in response to a CI failure webhook.