### PR TITLE
Fix flaky PurchaseSearchService spec: rescue ES index race condition

### DIFF
--- a/spec/support/elasticsearch.rb
+++ b/spec/support/elasticsearch.rb
@@ -38,6 +38,10 @@ module ElasticsearchHelpers
 
   def index_model_records(model)
     model.import(refresh: true, force: true)
+  rescue Elasticsearch::Transport::Transport::Errors::BadRequest => e
+    raise unless e.message.include?("resource_already_exists_exception")
+
+    model.import(refresh: true)
   end
 end
 


### PR DESCRIPTION
## What

Rescue `resource_already_exists_exception` in the `index_model_records` test helper and retry the import without `force: true`.

## Why

CI run [#26185482866](https://github.com/antiwork/gumroad/actions/runs/26185482866) failed on main with:

```
Elasticsearch::Transport::Transport::Errors::BadRequest:
  [400] {"error":{..."resource_already_exists_exception","reason":"index [purchase-test/...] already exists"...}}
```

The `index_model_records` helper calls `model.import(force: true)` which deletes and recreates the ES index. In parallel CI (knapsack), multiple workers share the same ES index name, causing a race: one worker deletes the index, another creates it first, and the original worker's `create_index!` fails with `resource_already_exists_exception`.

This follows the same rescue pattern already used in `ElasticsearchSetup.create_index` (line 112-118 of the same file).

## Test Results

```
$ bundle exec rspec spec/services/purchase_search_service_spec.rb
39 examples, 0 failures
```

## AI Disclosure

This fix was identified and implemented by Gumclaw (AI assistant).