### PR TITLE
Fix flaky tiered membership offer codes spec

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -48,6 +48,7 @@ class SubscriptionsController < ApplicationController
     def check_can_manage
       (@subscription = Subscription.find_by_external_id(params[:id])) || e404
       e404 if @subscription.ended?
+      e404 if @subscription.original_purchase.nil?
       e404 if @subscription.is_installment_plan? && @subscription.charges_completed?
       cookie = cookies.encrypted[@subscription.cookie_key]
       return if cookie.present? && ActiveSupport::SecurityUtils.secure_compare(cookie, @subscription.external_id)


### PR DESCRIPTION
## What
Add a nil guard for `original_purchase` in `SubscriptionsController#check_can_manage`.

## Why
The `tiered_membership_offer_codes_spec.rb:150` test intermittently fails in CI with:

```
NoMethodError: undefined method 'deep_symbolize_keys' for nil
# .../inertia_rails/renderer.rb:91:in 'InertiaRails::Renderer#merge_props'
# ./app/controllers/subscriptions_controller.rb:42:in 'SubscriptionsController#manage'
```

`CheckoutPresenter#subscription_manager_props` returns `nil` when `subscription.original_purchase` is nil (line 166 guard clause). The controller passes this nil as `props:` to `render inertia:`, which crashes on `nil.deep_symbolize_keys`.

The scoped `has_one :original_purchase` association (filtered by flag bits) intermittently fails to load in the Puma server thread during system tests — a classic CI timing/connection visibility race.

A subscription without an `original_purchase` is invalid state, so returning 404 is the correct behavior. The spec already has `retry: 2`, so on retry the association loads correctly and the test passes.

CI run: https://github.com/antiwork/gumroad/actions/runs/26184821891

## Test Results
```
bundle exec rspec spec/requests/subscription/tiered_membership_offer_codes_spec.rb
17 examples, 0 failures (line 150 test passed)
```
(One unrelated local flake on line 17 due to VCR cassette — passed on isolated rerun.)

## AI Disclosure
This fix was identified and implemented by Gumclaw (AI agent) monitoring CI failures.