### PR TITLE
Add purchases healthcheck endpoint

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -25,6 +25,15 @@ class HealthcheckController < ApplicationController
     render plain: "PayPal balance: #{message}", status:
   end
 
+  def purchases
+    threshold = $redis.get(RedisKey.min_successful_purchases_in_last_10_minutes)
+    count = Purchase.successful.where(created_at: 10.minutes.ago..Time.current).count
+    healthy = threshold.present? && count >= threshold.to_i
+    status = healthy ? :ok : :service_unavailable
+
+    render plain: "Purchases: #{status}", status:
+  end
+
   SIDEKIQ_QUEUE_LIMITS = { critical: 12_000, default: 300_000 }
   SIDEKIQ_RETRIES_LIMIT = 20_000
   private_constant :SIDEKIQ_QUEUE_LIMITS, :SIDEKIQ_RETRIES_LIMIT

--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -49,6 +49,7 @@ class RedisKey
     def unreviewed_users_data = "admin:unreviewed_users_data"
     def unreviewed_users_cutoff_date = "admin:unreviewed_users_cutoff_date"
     def paypal_topup_needed = "paypal:topup_needed"
+    def min_successful_purchases_in_last_10_minutes = "healthcheck:min_successful_purchases_in_last_10_minutes"
     def email_router_fallback(user_id) = "email_router_fallback:#{user_id}"
     def mobile_minimum_version = "mobile:minimum_version"
     def mobile_minimum_update_created_at = "mobile:minimum_update_created_at"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
   get "/healthcheck" => "healthcheck#index"
   get "/healthcheck/sidekiq" => "healthcheck#sidekiq"
   get "/healthcheck/paypal_balance" => "healthcheck#paypal_balance"
+  get "/healthcheck/purchases" => "healthcheck#purchases"
 
   use_doorkeeper do
     controllers applications: "oauth/applications"

--- a/spec/controllers/healthcheck_controller_spec.rb
+++ b/spec/controllers/healthcheck_controller_spec.rb
@@ -108,4 +108,63 @@ describe HealthcheckController do
       end
     end
   end
+
+  describe "GET 'purchases'" do
+    let(:redis_key) { RedisKey.min_successful_purchases_in_last_10_minutes }
+
+    after { $redis.del(redis_key) }
+
+    context "when the successful purchases count meets the threshold" do
+      before do
+        $redis.set(redis_key, 2)
+        create_list(:purchase, 2, purchase_state: "successful", created_at: 5.minutes.ago)
+      end
+
+      it "returns HTTP success" do
+        get :purchases
+
+        expect(response.status).to eq(200)
+        expect(response.body).to eq("Purchases: ok")
+      end
+    end
+
+    context "when the successful purchases count is below the threshold" do
+      before do
+        $redis.set(redis_key, 5)
+        create_list(:purchase, 2, purchase_state: "successful", created_at: 5.minutes.ago)
+      end
+
+      it "returns HTTP service_unavailable" do
+        get :purchases
+
+        expect(response.status).to eq(503)
+        expect(response.body).to eq("Purchases: service_unavailable")
+      end
+    end
+
+    context "when successful purchases are older than 10 minutes" do
+      before do
+        $redis.set(redis_key, 1)
+        create(:purchase, purchase_state: "successful", created_at: 15.minutes.ago)
+      end
+
+      it "ignores them and returns HTTP service_unavailable" do
+        get :purchases
+
+        expect(response.status).to eq(503)
+        expect(response.body).to eq("Purchases: service_unavailable")
+      end
+    end
+
+    context "when the Redis threshold is not set" do
+      before { $redis.del(redis_key) }
+
+      it "returns HTTP service_unavailable" do
+        get :purchases
+
+        expect(response.status).to eq(503)
+        expect(response.body).to eq("Purchases: service_unavailable")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What

Adds a new healthcheck endpoint to detect drops in purchase traffic.

- `GET /healthcheck/purchases` — returns `200 OK` when the count of successful purchases in the last 10 minutes is at or above a Redis-configured threshold, otherwise `503 Service Unavailable`.
- `RedisKey.min_successful_purchases_in_last_10_minutes` stores the threshold. Set with `$redis.set(RedisKey.min_successful_purchases_in_last_10_minutes, N)` in the prod console.
- Response body is intentionally `Purchases: ok` / `Purchases: service_unavailable` — it does not expose the actual count or threshold, since the endpoint is public.
- An unset threshold is treated as unhealthy so a missing/cleared Redis key is surfaced by the check rather than silently passing.

## Why

Catches anomalous drops in purchase volume (broken checkout, payment provider outage, etc.) by surfacing them through the same healthcheck mechanism we already wire to monitoring (alongside `/healthcheck/sidekiq` and `/healthcheck/paypal_balance`). Keeping the threshold in Redis lets us tune it without a deploy.

## Test Results

```
HealthcheckController GET 'purchases'
  when the successful purchases count meets the threshold
    returns HTTP success
  when the successful purchases count is below the threshold
    returns HTTP service_unavailable
  when successful purchases are older than 10 minutes
    ignores them and returns HTTP service_unavailable
  when the Redis threshold is not set
    returns HTTP service_unavailable

Finished in 0.71 seconds
4 examples, 0 failures
```

## Test plan

- [ ] Set a high threshold in prod Redis (e.g. `$redis.set(RedisKey.min_successful_purchases_in_last_10_minutes, 999999)`) and confirm `/healthcheck/purchases` returns 503.
- [ ] Set a low/realistic threshold and confirm it returns 200.
- [ ] Confirm response body does not leak the count or threshold.

---

AI disclosure: drafted with Claude Opus 4.7.