### PR TITLE
Fix flaky cart_spec: increase poll_until timeout from 15s to 30s

### DIFF
--- a/spec/requests/checkout/cart_spec.rb
+++ b/spec/requests/checkout/cart_spec.rb
@@ -140,7 +140,7 @@ describe "Checkout cart", :js, type: :system do
     end
 
     describe "cart persistence" do
-      let(:wait_timeout) { 15 }
+      let(:wait_timeout) { 30 }
 
       def poll_until(timeout: wait_timeout)
         Timeout.timeout(timeout) do


### PR DESCRIPTION
## What
Increase the `wait_timeout` for the cart persistence `poll_until` helper from 15s to 30s in `spec/requests/checkout/cart_spec.rb`.

## Why
The test at line 214 (*creates and updates a cart during checkout for a logged-in user*) failed in CI run [#26193513727](https://github.com/antiwork/gumroad/actions/runs/26193513727) with `Timeout::Error: execution expired`. The CI node was under heavy load — the single test took 98s wall time on a node running 105 examples. The 15s `poll_until` timeout is too tight for slow CI runners.

The triggering commit (`b864f0b`) only touched `spec/support/elasticsearch.rb` (unrelated ES race condition fix), confirming this is a flaky timeout, not a regression.

## Fix
Double the timeout to 30s. This only affects the failure path — passing tests complete well under 15s, so there's no impact on normal suite runtime.

## Test Results
Cannot run this system spec locally (requires minio on port 9000), but the fix is a simple timeout constant increase with no behavioral change.

## AI Disclosure
This PR was generated by Gumclaw (AI agent) investigating a CI failure.