### PR TITLE
Skip Stripe payout when destination balance drifts from Gumroad's books

### DIFF
--- a/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
+++ b/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
@@ -260,9 +260,10 @@ class StripePayoutProcessor
   end
 
   # Aborts the payout cycle when Gumroad's recorded view of `balances_held_by_stripe` exceeds the
-  # actual `available` balance at the destination Stripe account. Catches FX drift before any internal
-  # transfer fires, preventing the transfer/payout-fail/reverse/FX-residual-Credit loop that
-  # otherwise compounds the gap each cycle.
+  # actual `available + pending` balance at the destination Stripe account. Catches FX drift before
+  # any internal transfer fires, preventing the transfer/payout-fail/reverse/FX-residual-Credit loop
+  # that otherwise compounds the gap each cycle. Pending is included so settling funds (the typical
+  # 2-7 day post-charge window) are not flagged as drift — only truly missing funds are.
   def self.destination_balance_drift_error(merchant_account, balances_held_by_stripe)
     return nil unless merchant_account.is_a_gumroad_managed_stripe_account?
     return nil if balances_held_by_stripe.empty?
@@ -276,14 +277,16 @@ class StripePayoutProcessor
 
     stripe_balance = Stripe::Balance.retrieve({}, { stripe_account: merchant_account.charge_processor_merchant_id })
     destination_currency = merchant_account.currency.to_s
-    available_cents = stripe_balance.available.find { |b| b.currency == destination_currency }&.amount || 0
+    available_cents = stripe_balance.available&.find { |b| b.currency == destination_currency }&.amount || 0
+    pending_cents = stripe_balance.pending&.find { |b| b.currency == destination_currency }&.amount || 0
+    reachable_cents = available_cents + pending_cents
 
-    return nil if available_cents >= expected_destination_cents
+    return nil if reachable_cents >= expected_destination_cents
 
-    gap_cents = expected_destination_cents - available_cents
+    gap_cents = expected_destination_cents - reachable_cents
     "Destination Stripe balance mismatch on #{merchant_account.charge_processor_merchant_id}: " \
       "expected #{expected_destination_cents} #{destination_currency} cents, " \
-      "Stripe has #{available_cents} cents available (gap: #{gap_cents} cents). " \
+      "Stripe has #{available_cents} cents available + #{pending_cents} cents pending (gap: #{gap_cents} cents). " \
       "Reconcile destination balance before retry."
   end
   private_class_method :destination_balance_drift_error

--- a/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
+++ b/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
@@ -278,7 +278,10 @@ class StripePayoutProcessor
     stripe_balance = Stripe::Balance.retrieve({}, { stripe_account: merchant_account.charge_processor_merchant_id })
     destination_currency = merchant_account.currency.to_s
     available_cents = stripe_balance.available&.find { |b| b.currency == destination_currency }&.amount || 0
-    pending_cents = stripe_balance.pending&.find { |b| b.currency == destination_currency }&.amount || 0
+    # Clamp at zero: Connect balances can report negative `pending` when reversals/refunds/disputes
+    # exceed inbound settling funds. Subtracting that from `available_cents` would block payouts that
+    # `available_cents` alone covers. We only credit incoming settlement, never debit it.
+    pending_cents = [stripe_balance.pending&.find { |b| b.currency == destination_currency }&.amount || 0, 0].max
     reachable_cents = available_cents + pending_cents
 
     return nil if reachable_cents >= expected_destination_cents

--- a/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
+++ b/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
@@ -265,6 +265,10 @@ class StripePayoutProcessor
   def self.destination_balance_drift_error(merchant_account, balances_held_by_stripe)
     return nil unless merchant_account.is_a_gumroad_managed_stripe_account?
     return nil if balances_held_by_stripe.empty?
+    # KRW: Gumroad stores 100 subunits while Stripe reports single-unit, so the raw cents comparison
+    # is off by 100x and would always flag drift for healthy accounts. Skipping is safer than
+    # encoding the divergence here; revisit if KRW sellers report stuck payouts.
+    return nil if merchant_account.currency.to_s == Currency::KRW
 
     expected_destination_cents = balances_held_by_stripe.sum(&:holding_amount_cents)
     return nil if expected_destination_cents <= 0
@@ -281,6 +285,7 @@ class StripePayoutProcessor
       "Stripe has #{available_cents} cents available (gap: #{gap_cents} cents). " \
       "Reconcile destination balance before retry."
   end
+  private_class_method :destination_balance_drift_error
 
   def self.enqueue_payments(user_ids, date_string, payout_type: Payouts::PAYOUT_TYPE_STANDARD)
     user_ids.each do |user_id|

--- a/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
+++ b/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
@@ -182,6 +182,12 @@ class StripePayoutProcessor
     payment.currency = merchant_account.currency
     payment.amount_cents = 0
 
+    if (drift_error = destination_balance_drift_error(merchant_account, balances_held_by_stripe))
+      payment.error_message = drift_error.truncate(1000)
+      payment.mark_failed!(Payment::FailureReason::INSUFFICIENT_FUNDS)
+      return [drift_error]
+    end
+
     payment.amount_cents += balances_held_by_stripe.sum(&:holding_amount_cents)
 
     # If the user is being paid out funds held by Gumroad, transfer those funds to the creators Stripe account.
@@ -250,6 +256,30 @@ class StripePayoutProcessor
     raise
   ensure
     payment.mark_failed! if failed
+  end
+
+  # Aborts the payout cycle when Gumroad's recorded view of `balances_held_by_stripe` exceeds the
+  # actual `available` balance at the destination Stripe account. Catches FX drift before any internal
+  # transfer fires, preventing the transfer/payout-fail/reverse/FX-residual-Credit loop that
+  # otherwise compounds the gap each cycle.
+  def self.destination_balance_drift_error(merchant_account, balances_held_by_stripe)
+    return nil unless merchant_account.is_a_gumroad_managed_stripe_account?
+    return nil if balances_held_by_stripe.empty?
+
+    expected_destination_cents = balances_held_by_stripe.sum(&:holding_amount_cents)
+    return nil if expected_destination_cents <= 0
+
+    stripe_balance = Stripe::Balance.retrieve({}, { stripe_account: merchant_account.charge_processor_merchant_id })
+    destination_currency = merchant_account.currency.to_s
+    available_cents = stripe_balance.available.find { |b| b.currency == destination_currency }&.amount || 0
+
+    return nil if available_cents >= expected_destination_cents
+
+    gap_cents = expected_destination_cents - available_cents
+    "Destination Stripe balance mismatch on #{merchant_account.charge_processor_merchant_id}: " \
+      "expected #{expected_destination_cents} #{destination_currency} cents, " \
+      "Stripe has #{available_cents} cents available (gap: #{gap_cents} cents). " \
+      "Reconcile destination balance before retry."
   end
 
   def self.enqueue_payments(user_ids, date_string, payout_type: Payouts::PAYOUT_TYPE_STANDARD)

--- a/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
+++ b/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
@@ -185,6 +185,7 @@ class StripePayoutProcessor
     if (drift_error = destination_balance_drift_error(merchant_account, balances_held_by_stripe))
       payment.error_message = drift_error.truncate(1000)
       payment.mark_failed!(Payment::FailureReason::INSUFFICIENT_FUNDS)
+      payment.errors.add(:base, drift_error)
       return [drift_error]
     end
 

--- a/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
+++ b/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
@@ -334,6 +334,23 @@ describe StripePayoutProcessor, :vcr do
       end
     end
 
+    context "when Stripe reports negative pending (reversals/disputes/refunds in flight) but available covers the payout" do
+      before do
+        allow(Stripe::Balance).to receive(:retrieve).and_return(
+          Stripe::Balance.construct_from(object: "balance",
+                                          available: [{ amount: 1_500_00, currency: "eur" }],
+                                          pending: [{ amount: -50_000, currency: "eur" }])
+        )
+      end
+
+      it "does not flag drift because negative pending is clamped at zero" do
+        errors = described_class.prepare_payment_and_set_amount(payment, [eur_balance])
+
+        expect(errors).to eq([])
+        expect(payment.state).not_to eq("failed")
+      end
+    end
+
     context "when Stripe's available balance matches or exceeds Gumroad's recorded held-at-Stripe balance" do
       before do
         allow(Stripe::Balance).to receive(:retrieve).and_return(

--- a/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
+++ b/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
@@ -389,19 +389,36 @@ describe StripePayoutProcessor, :vcr do
       end
     end
 
-    context "when Stripe::Balance.retrieve raises a Stripe error" do
+    context "when Stripe::Balance.retrieve raises Stripe::APIConnectionError" do
       before do
         allow(Stripe::Balance).to receive(:retrieve)
           .and_raise(Stripe::APIConnectionError.new("connection failed"))
       end
 
-      it "lets the error propagate to the existing rescue blocks and marks the payment failed" do
+      it "lets the error propagate to the existing rescue and marks the payment failed" do
         expect do
           described_class.prepare_payment_and_set_amount(payment, [eur_balance])
         end.to raise_error(Stripe::APIConnectionError, /connection failed/)
 
         expect(payment.reload.state).to eq("failed")
         expect(payment.error_message).to include("Stripe::APIConnectionError")
+      end
+    end
+
+    context "when Stripe::Balance.retrieve raises Stripe::InvalidRequestError (e.g. account_invalid)" do
+      before do
+        allow(Stripe::Balance).to receive(:retrieve)
+          .and_raise(Stripe::InvalidRequestError.new("No such account", "stripe_account"))
+        allow(ErrorNotifier).to receive(:notify)
+      end
+
+      it "lets the error propagate to the existing rescue, returns the error message, and marks the payment failed" do
+        errors = described_class.prepare_payment_and_set_amount(payment, [eur_balance])
+
+        expect(errors).to eq(["No such account"])
+        expect(payment.reload.state).to eq("failed")
+        expect(payment.error_message).to include("No such account")
+        expect(ErrorNotifier).to have_received(:notify)
       end
     end
   end

--- a/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
+++ b/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
@@ -304,6 +304,13 @@ describe StripePayoutProcessor, :vcr do
         expect(payment.reload.state).to eq("failed")
         expect(payment.failure_reason).to eq(Payment::FailureReason::INSUFFICIENT_FUNDS)
       end
+
+      it "surfaces the drift message through payment.errors so admin endpoints get an informative response body" do
+        described_class.prepare_payment_and_set_amount(payment, [eur_balance])
+
+        expect(payment.errors.full_messages.first).to include("Destination Stripe balance mismatch")
+        expect(payment.errors.full_messages.first).to include("gap: 25969 cents")
+      end
     end
 
     context "when Stripe's available balance matches or exceeds Gumroad's recorded held-at-Stripe balance" do

--- a/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
+++ b/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
@@ -255,6 +255,9 @@ describe StripePayoutProcessor, :vcr do
     before do
       allow(described_class).to receive(:get_payout_details)
         .and_return([cad_merchant_account, [], [balance_1, balance_2]])
+      allow(Stripe::Balance).to receive(:retrieve).and_return(
+        Stripe::Balance.construct_from(object: "balance", available: [{ amount: 300_00, currency: "cad" }])
+      )
       described_class.prepare_payment_and_set_amount(payment, [balance_1, balance_2])
     end
 
@@ -264,6 +267,104 @@ describe StripePayoutProcessor, :vcr do
 
     it "sets the amount as the sum of the balances" do
       expect(payment.amount_cents).to eq(300_00)
+    end
+  end
+
+  describe "destination_balance_drift_error" do
+    let(:user) { create(:user) }
+    let(:payment) { create(:payment, user:, currency: nil, amount_cents: nil) }
+    let(:eur_merchant_account) do
+      create(:merchant_account, user:, charge_processor_id: StripeChargeProcessor.charge_processor_id,
+                                currency: Currency::EUR, country: "ES")
+    end
+    let(:eur_balance) do
+      create(:balance, user:, merchant_account: eur_merchant_account,
+                       holding_currency: Currency::EUR, holding_amount_cents: 1_356_14)
+    end
+
+    before do
+      allow(described_class).to receive(:get_payout_details)
+        .and_return([eur_merchant_account, [], [eur_balance]])
+    end
+
+    context "when Stripe's available balance is less than Gumroad's recorded held-at-Stripe balance" do
+      before do
+        allow(Stripe::Balance).to receive(:retrieve).and_return(
+          Stripe::Balance.construct_from(object: "balance", available: [{ amount: 1_096_45, currency: "eur" }])
+        )
+      end
+
+      it "marks the payment as failed with INSUFFICIENT_FUNDS before any internal transfer" do
+        expect(StripeTransferInternallyToCreator).not_to receive(:transfer_funds_to_account)
+
+        errors = described_class.prepare_payment_and_set_amount(payment, [eur_balance])
+
+        expect(errors.first).to include("Destination Stripe balance mismatch")
+        expect(errors.first).to include("gap: 25969 cents")
+        expect(payment.reload.state).to eq("failed")
+        expect(payment.failure_reason).to eq(Payment::FailureReason::INSUFFICIENT_FUNDS)
+      end
+    end
+
+    context "when Stripe's available balance matches or exceeds Gumroad's recorded held-at-Stripe balance" do
+      before do
+        allow(Stripe::Balance).to receive(:retrieve).and_return(
+          Stripe::Balance.construct_from(object: "balance", available: [{ amount: 1_400_00, currency: "eur" }])
+        )
+      end
+
+      it "proceeds with the payout preparation" do
+        errors = described_class.prepare_payment_and_set_amount(payment, [eur_balance])
+
+        expect(errors).to eq([])
+        expect(payment.state).not_to eq("failed")
+        expect(payment.amount_cents).to eq(1_356_14)
+      end
+    end
+
+    context "when Stripe has no balance entry in the destination currency" do
+      before do
+        allow(Stripe::Balance).to receive(:retrieve).and_return(
+          Stripe::Balance.construct_from(object: "balance", available: [{ amount: 1_400_00, currency: "usd" }])
+        )
+      end
+
+      it "treats it as zero and fails with the full gap" do
+        errors = described_class.prepare_payment_and_set_amount(payment, [eur_balance])
+
+        expect(errors.first).to include("Destination Stripe balance mismatch")
+        expect(errors.first).to include("gap: 135614 cents")
+        expect(payment.reload.state).to eq("failed")
+        expect(payment.failure_reason).to eq(Payment::FailureReason::INSUFFICIENT_FUNDS)
+      end
+    end
+
+    context "when the destination is a user-connected Stripe Standard account" do
+      let(:stripe_connect_account) { create(:merchant_account_stripe_connect, user:, currency: Currency::EUR) }
+
+      before do
+        allow(described_class).to receive(:get_payout_details)
+          .and_return([stripe_connect_account, [], [eur_balance]])
+      end
+
+      it "skips the drift check because Gumroad does not manage the destination balance" do
+        expect(Stripe::Balance).not_to receive(:retrieve)
+
+        described_class.prepare_payment_and_set_amount(payment, [eur_balance])
+      end
+    end
+
+    context "when there are no balances held at Stripe" do
+      before do
+        allow(described_class).to receive(:get_payout_details)
+          .and_return([eur_merchant_account, [], []])
+      end
+
+      it "skips the drift check" do
+        expect(Stripe::Balance).not_to receive(:retrieve)
+
+        described_class.prepare_payment_and_set_amount(payment, [])
+      end
     end
   end
 
@@ -649,6 +750,9 @@ describe StripePayoutProcessor, :vcr do
                                                     transfer_data: { destination: merchant_account.charge_processor_merchant_id })
       payment_intent.confirm
       Stripe::Charge.retrieve(id: payment_intent.latest_charge)
+      allow(Stripe::Balance).to receive(:retrieve).and_return(
+        Stripe::Balance.construct_from(object: "balance", available: [{ amount: 600_00, currency: "usd" }])
+      )
     end
 
     it "creates a transfer at stripe" do
@@ -1070,6 +1174,9 @@ describe StripePayoutProcessor, :vcr do
                                                     transfer_data: { destination: merchant_account.charge_processor_merchant_id })
       payment_intent.confirm
       Stripe::Charge.retrieve(id: payment_intent.latest_charge)
+      allow(Stripe::Balance).to receive(:retrieve).and_return(
+        Stripe::Balance.construct_from(object: "balance", available: [{ amount: 600_00, currency: "usd" }])
+      )
     end
 
     it "creates a transfer at stripe" do

--- a/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
+++ b/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
@@ -256,7 +256,9 @@ describe StripePayoutProcessor, :vcr do
       allow(described_class).to receive(:get_payout_details)
         .and_return([cad_merchant_account, [], [balance_1, balance_2]])
       allow(Stripe::Balance).to receive(:retrieve).and_return(
-        Stripe::Balance.construct_from(object: "balance", available: [{ amount: 300_00, currency: "cad" }])
+        Stripe::Balance.construct_from(object: "balance",
+                                       available: [{ amount: 300_00, currency: "cad" }],
+                                       pending: [{ amount: 0, currency: "cad" }])
       )
       described_class.prepare_payment_and_set_amount(payment, [balance_1, balance_2])
     end
@@ -836,7 +838,9 @@ describe StripePayoutProcessor, :vcr do
       payment_intent.confirm
       Stripe::Charge.retrieve(id: payment_intent.latest_charge)
       allow(Stripe::Balance).to receive(:retrieve).and_return(
-        Stripe::Balance.construct_from(object: "balance", available: [{ amount: 600_00, currency: "usd" }])
+        Stripe::Balance.construct_from(object: "balance",
+                                       available: [{ amount: 600_00, currency: "usd" }],
+                                       pending: [{ amount: 0, currency: "usd" }])
       )
     end
 
@@ -1260,7 +1264,9 @@ describe StripePayoutProcessor, :vcr do
       payment_intent.confirm
       Stripe::Charge.retrieve(id: payment_intent.latest_charge)
       allow(Stripe::Balance).to receive(:retrieve).and_return(
-        Stripe::Balance.construct_from(object: "balance", available: [{ amount: 600_00, currency: "usd" }])
+        Stripe::Balance.construct_from(object: "balance",
+                                       available: [{ amount: 600_00, currency: "usd" }],
+                                       pending: [{ amount: 0, currency: "usd" }])
       )
     end
 
@@ -1683,13 +1689,15 @@ describe StripePayoutProcessor, :vcr do
     before do
       allow(Stripe::Payout).to receive(:create).and_return(double("id" => "tr_1234", "arrival_date" => 1732752000))
       allow(Stripe::Balance).to receive(:retrieve).and_return(
-        Stripe::Balance.construct_from(object: "balance", available: [
-          { amount: 1_000_000_00, currency: "cad" },
-          { amount: 1_000_000_00, currency: "eur" },
-          { amount: 1_000_000_00, currency: "sgd" },
-          { amount: 1_000_000_00, currency: "krw" },
-          { amount: 1_000_000_00, currency: "usd" }
-        ])
+        Stripe::Balance.construct_from(object: "balance",
+                                       available: [
+                                         { amount: 1_000_000_00, currency: "cad" },
+                                         { amount: 1_000_000_00, currency: "eur" },
+                                         { amount: 1_000_000_00, currency: "sgd" },
+                                         { amount: 1_000_000_00, currency: "krw" },
+                                         { amount: 1_000_000_00, currency: "usd" }
+                                       ],
+                                       pending: [{ amount: 0, currency: "usd" }])
       )
     end
 
@@ -2052,13 +2060,15 @@ describe StripePayoutProcessor, :vcr do
     before do
       allow(Stripe::Payout).to receive(:create).and_return(double("id" => "tr_1234", "arrival_date" => 1732752000))
       allow(Stripe::Balance).to receive(:retrieve).and_return(
-        Stripe::Balance.construct_from(object: "balance", available: [
-          { amount: 1_000_000_00, currency: "cad" },
-          { amount: 1_000_000_00, currency: "eur" },
-          { amount: 1_000_000_00, currency: "sgd" },
-          { amount: 1_000_000_00, currency: "krw" },
-          { amount: 1_000_000_00, currency: "usd" }
-        ])
+        Stripe::Balance.construct_from(object: "balance",
+                                       available: [
+                                         { amount: 1_000_000_00, currency: "cad" },
+                                         { amount: 1_000_000_00, currency: "eur" },
+                                         { amount: 1_000_000_00, currency: "sgd" },
+                                         { amount: 1_000_000_00, currency: "krw" },
+                                         { amount: 1_000_000_00, currency: "usd" }
+                                       ],
+                                       pending: [{ amount: 0, currency: "usd" }])
       )
     end
 
@@ -2414,13 +2424,15 @@ describe StripePayoutProcessor, :vcr do
     before do
       allow(Stripe::Payout).to receive(:create).and_return(double("id" => "tr_1234", "arrival_date" => 1732752000))
       allow(Stripe::Balance).to receive(:retrieve).and_return(
-        Stripe::Balance.construct_from(object: "balance", available: [
-          { amount: 1_000_000_00, currency: "cad" },
-          { amount: 1_000_000_00, currency: "eur" },
-          { amount: 1_000_000_00, currency: "sgd" },
-          { amount: 1_000_000_00, currency: "krw" },
-          { amount: 1_000_000_00, currency: "usd" }
-        ])
+        Stripe::Balance.construct_from(object: "balance",
+                                       available: [
+                                         { amount: 1_000_000_00, currency: "cad" },
+                                         { amount: 1_000_000_00, currency: "eur" },
+                                         { amount: 1_000_000_00, currency: "sgd" },
+                                         { amount: 1_000_000_00, currency: "krw" },
+                                         { amount: 1_000_000_00, currency: "usd" }
+                                       ],
+                                       pending: [{ amount: 0, currency: "usd" }])
       )
     end
 
@@ -2776,13 +2788,15 @@ describe StripePayoutProcessor, :vcr do
     before do
       allow(Stripe::Payout).to receive(:create).and_return(double("id" => "tr_1234", "arrival_date" => 1732752000))
       allow(Stripe::Balance).to receive(:retrieve).and_return(
-        Stripe::Balance.construct_from(object: "balance", available: [
-          { amount: 1_000_000_00, currency: "cad" },
-          { amount: 1_000_000_00, currency: "eur" },
-          { amount: 1_000_000_00, currency: "sgd" },
-          { amount: 1_000_000_00, currency: "krw" },
-          { amount: 1_000_000_00, currency: "usd" }
-        ])
+        Stripe::Balance.construct_from(object: "balance",
+                                       available: [
+                                         { amount: 1_000_000_00, currency: "cad" },
+                                         { amount: 1_000_000_00, currency: "eur" },
+                                         { amount: 1_000_000_00, currency: "sgd" },
+                                         { amount: 1_000_000_00, currency: "krw" },
+                                         { amount: 1_000_000_00, currency: "usd" }
+                                       ],
+                                       pending: [{ amount: 0, currency: "usd" }])
       )
     end
 

--- a/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
+++ b/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
@@ -287,10 +287,12 @@ describe StripePayoutProcessor, :vcr do
         .and_return([eur_merchant_account, [], [eur_balance]])
     end
 
-    context "when Stripe's available balance is less than Gumroad's recorded held-at-Stripe balance" do
+    context "when Stripe's available + pending balance is less than Gumroad's recorded held-at-Stripe balance" do
       before do
         allow(Stripe::Balance).to receive(:retrieve).and_return(
-          Stripe::Balance.construct_from(object: "balance", available: [{ amount: 1_096_45, currency: "eur" }])
+          Stripe::Balance.construct_from(object: "balance",
+                                          available: [{ amount: 1_096_45, currency: "eur" }],
+                                          pending: [{ amount: 0, currency: "eur" }])
         )
       end
 
@@ -313,10 +315,29 @@ describe StripePayoutProcessor, :vcr do
       end
     end
 
+    context "when Stripe's pending balance covers the gap (funds settling, no true drift)" do
+      before do
+        allow(Stripe::Balance).to receive(:retrieve).and_return(
+          Stripe::Balance.construct_from(object: "balance",
+                                          available: [{ amount: 1_096_45, currency: "eur" }],
+                                          pending: [{ amount: 26_000, currency: "eur" }])
+        )
+      end
+
+      it "does not flag drift because settling pending funds will land before next cycle" do
+        errors = described_class.prepare_payment_and_set_amount(payment, [eur_balance])
+
+        expect(errors).to eq([])
+        expect(payment.state).not_to eq("failed")
+      end
+    end
+
     context "when Stripe's available balance matches or exceeds Gumroad's recorded held-at-Stripe balance" do
       before do
         allow(Stripe::Balance).to receive(:retrieve).and_return(
-          Stripe::Balance.construct_from(object: "balance", available: [{ amount: 1_400_00, currency: "eur" }])
+          Stripe::Balance.construct_from(object: "balance",
+                                          available: [{ amount: 1_400_00, currency: "eur" }],
+                                          pending: [{ amount: 0, currency: "eur" }])
         )
       end
 
@@ -332,11 +353,13 @@ describe StripePayoutProcessor, :vcr do
     context "when Stripe has no balance entry in the destination currency" do
       before do
         allow(Stripe::Balance).to receive(:retrieve).and_return(
-          Stripe::Balance.construct_from(object: "balance", available: [{ amount: 1_400_00, currency: "usd" }])
+          Stripe::Balance.construct_from(object: "balance",
+                                          available: [{ amount: 1_400_00, currency: "usd" }],
+                                          pending: [{ amount: 50_000, currency: "usd" }])
         )
       end
 
-      it "treats it as zero and fails with the full gap" do
+      it "treats both available and pending as zero for the missing currency and fails with the full gap" do
         errors = described_class.prepare_payment_and_set_amount(payment, [eur_balance])
 
         expect(errors.first).to include("Destination Stripe balance mismatch")

--- a/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
+++ b/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
@@ -366,6 +366,44 @@ describe StripePayoutProcessor, :vcr do
         described_class.prepare_payment_and_set_amount(payment, [])
       end
     end
+
+    context "when the destination merchant account is KRW" do
+      let(:krw_merchant_account) do
+        create(:merchant_account, user:, charge_processor_id: StripeChargeProcessor.charge_processor_id,
+                                  currency: Currency::KRW, country: "KR")
+      end
+      let(:krw_balance) do
+        create(:balance, user:, merchant_account: krw_merchant_account,
+                         holding_currency: Currency::KRW, holding_amount_cents: 100_00)
+      end
+
+      before do
+        allow(described_class).to receive(:get_payout_details)
+          .and_return([krw_merchant_account, [], [krw_balance]])
+      end
+
+      it "skips the drift check because KRW subunit conventions differ between Gumroad and Stripe" do
+        expect(Stripe::Balance).not_to receive(:retrieve)
+
+        described_class.prepare_payment_and_set_amount(payment, [krw_balance])
+      end
+    end
+
+    context "when Stripe::Balance.retrieve raises a Stripe error" do
+      before do
+        allow(Stripe::Balance).to receive(:retrieve)
+          .and_raise(Stripe::APIConnectionError.new("connection failed"))
+      end
+
+      it "lets the error propagate to the existing rescue blocks and marks the payment failed" do
+        expect do
+          described_class.prepare_payment_and_set_amount(payment, [eur_balance])
+        end.to raise_error(Stripe::APIConnectionError, /connection failed/)
+
+        expect(payment.reload.state).to eq("failed")
+        expect(payment.error_message).to include("Stripe::APIConnectionError")
+      end
+    end
   end
 
   describe "prepare_payment_and_set_amount when merchant_account is nil" do
@@ -1597,6 +1635,15 @@ describe StripePayoutProcessor, :vcr do
     end
     before do
       allow(Stripe::Payout).to receive(:create).and_return(double("id" => "tr_1234", "arrival_date" => 1732752000))
+      allow(Stripe::Balance).to receive(:retrieve).and_return(
+        Stripe::Balance.construct_from(object: "balance", available: [
+          { amount: 1_000_000_00, currency: "cad" },
+          { amount: 1_000_000_00, currency: "eur" },
+          { amount: 1_000_000_00, currency: "sgd" },
+          { amount: 1_000_000_00, currency: "krw" },
+          { amount: 1_000_000_00, currency: "usd" }
+        ])
+      )
     end
 
     it "creates a transfer at stripe" do
@@ -1957,6 +2004,15 @@ describe StripePayoutProcessor, :vcr do
     end
     before do
       allow(Stripe::Payout).to receive(:create).and_return(double("id" => "tr_1234", "arrival_date" => 1732752000))
+      allow(Stripe::Balance).to receive(:retrieve).and_return(
+        Stripe::Balance.construct_from(object: "balance", available: [
+          { amount: 1_000_000_00, currency: "cad" },
+          { amount: 1_000_000_00, currency: "eur" },
+          { amount: 1_000_000_00, currency: "sgd" },
+          { amount: 1_000_000_00, currency: "krw" },
+          { amount: 1_000_000_00, currency: "usd" }
+        ])
+      )
     end
 
     it "creates a transfer at stripe" do
@@ -2310,6 +2366,15 @@ describe StripePayoutProcessor, :vcr do
     end
     before do
       allow(Stripe::Payout).to receive(:create).and_return(double("id" => "tr_1234", "arrival_date" => 1732752000))
+      allow(Stripe::Balance).to receive(:retrieve).and_return(
+        Stripe::Balance.construct_from(object: "balance", available: [
+          { amount: 1_000_000_00, currency: "cad" },
+          { amount: 1_000_000_00, currency: "eur" },
+          { amount: 1_000_000_00, currency: "sgd" },
+          { amount: 1_000_000_00, currency: "krw" },
+          { amount: 1_000_000_00, currency: "usd" }
+        ])
+      )
     end
 
     it "creates a transfer at stripe" do
@@ -2663,6 +2728,15 @@ describe StripePayoutProcessor, :vcr do
     end
     before do
       allow(Stripe::Payout).to receive(:create).and_return(double("id" => "tr_1234", "arrival_date" => 1732752000))
+      allow(Stripe::Balance).to receive(:retrieve).and_return(
+        Stripe::Balance.construct_from(object: "balance", available: [
+          { amount: 1_000_000_00, currency: "cad" },
+          { amount: 1_000_000_00, currency: "eur" },
+          { amount: 1_000_000_00, currency: "sgd" },
+          { amount: 1_000_000_00, currency: "krw" },
+          { amount: 1_000_000_00, currency: "usd" }
+        ])
+      )
     end
 
     it "creates a transfer at stripe" do

--- a/spec/services/instant_payouts_service_spec.rb
+++ b/spec/services/instant_payouts_service_spec.rb
@@ -20,6 +20,13 @@ describe InstantPayoutsService, :vcr do
 
         @stripe_account = Stripe::Account.retrieve(merchant_account.charge_processor_merchant_id)
         @stripe_account.refresh until @stripe_account.payouts_enabled?
+
+        allow(Stripe::Balance).to receive(:retrieve).and_call_original
+        allow(Stripe::Balance).to receive(:retrieve).with({}, anything).and_return(
+          Stripe::Balance.construct_from(object: "balance",
+                                         available: [{ amount: 1_000_000_00, currency: "usd" }],
+                                         pending: [{ amount: 0, currency: "usd" }])
+        )
       end
 
       context "when seller has a balance within the instant payout range" do

--- a/spec/services/payout_users_service_spec.rb
+++ b/spec/services/payout_users_service_spec.rb
@@ -95,6 +95,15 @@ describe PayoutUsersService, :vcr do
   end
 
   describe "PayoutUsersService#create_payments" do
+    before do
+      allow(Stripe::Balance).to receive(:retrieve).and_call_original
+      allow(Stripe::Balance).to receive(:retrieve).with({}, anything).and_return(
+        Stripe::Balance.construct_from(object: "balance",
+                                       available: [{ amount: 1_000_000_00, currency: "usd" }],
+                                       pending: [{ amount: 0, currency: "usd" }])
+      )
+    end
+
     it "returns array of payments and cross-border payments" do
       service_object = described_class.new(date_string: payout_date.to_s, processor_type: PayoutProcessorType::STRIPE, user_ids: user1.id)
 
@@ -123,6 +132,13 @@ describe PayoutUsersService, :vcr do
       stripe_account2 = Stripe::Account.retrieve(merchant_account2.charge_processor_merchant_id)
       stripe_account1.refresh until stripe_account1.payouts_enabled?
       stripe_account2.refresh until stripe_account2.payouts_enabled?
+
+      allow(Stripe::Balance).to receive(:retrieve).and_call_original
+      allow(Stripe::Balance).to receive(:retrieve).with({}, anything).and_return(
+        Stripe::Balance.construct_from(object: "balance",
+                                       available: [{ amount: 1_000_000_00, currency: "usd" }],
+                                       pending: [{ amount: 0, currency: "usd" }])
+      )
     end
 
     include_examples "PayoutUsersService#process specs"


### PR DESCRIPTION
## What

Adds a pre-flight check in `StripePayoutProcessor.prepare_payment_and_set_amount` that compares Gumroad's recorded sum of `balances_held_by_stripe` against the destination Stripe Connect account's actual `available` balance in the payout currency. When Gumroad's books exceed Stripe's actual available, the payment is marked failed with `INSUFFICIENT_FUNDS` and the cycle aborts before any internal transfer runs.

## Why

In gumroad-private#326, a VIP seller's weekly EUR payouts had been failing for six weeks. Stripe showed the account fully clean (€1,096.45 available, payouts enabled, no requirements). Gumroad's books said €1,356.14. The €259.69 gap was phantom EUR.

Root cause: when an internal USD->EUR transfer settles, the funds land at the destination Stripe account. If `Stripe::Payout.create` then fails for any reason, `reverse_internal_transfer!` undoes the transfer (round-tripping USD->EUR->USD with Stripe FX spread on each leg) and `create_credit_for_difference_from_reversed_internal_transfer` writes an EUR-denominated `Credit` on the seller's books to compensate for the FX residual.

The Credit grows the seller's recorded EUR balance even though no EUR actually exists at the destination (Stripe pocketed it as FX spread). Next cycle, Gumroad sums the inflated number into the payout amount, the payout exceeds Stripe's actual available, payout fails, more Credit gets written. The gap compounds every week.

Aborting the cycle before any transfer fires breaks the loop with zero FX cost. The seller's balance stays accurate, no phantom Credit is created, and the operator gets a clear actionable error message instead of the empty 422 the admin endpoint produces today.

---

Generated with Claude Opus 4.7