### PR TITLE
Tighten Dominican Republic bank code validation to exactly 3 digits

### DIFF
--- a/app/javascript/components/Settings/PaymentsPage/BankAccountSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/BankAccountSection.tsx
@@ -1734,36 +1734,24 @@ const BankAccountSection = ({
                   />
                 </Fieldset>
               ) : user.country_code === "DO" ? (
-                <>
-                  <Fieldset state={errorFieldNames.has("bank_code") ? "danger" : undefined}>
-                    <FieldsetTitle>
-                      <Label htmlFor={`${uid}-bank-code`}>Bank code</Label>
-                    </FieldsetTitle>
-                    <Input
-                      type="text"
-                      id={`${uid}-bank-code`}
-                      placeholder="021"
-                      maxLength={3}
-                      required
-                      disabled={isFormDisabled}
-                      aria-invalid={errorFieldNames.has("bank_code")}
-                      onChange={(evt) => updateBankAccount({ bank_code: evt.target.value })}
-                    />
-                  </Fieldset>
-                  <Fieldset state={errorFieldNames.has("branch_code") ? "danger" : undefined}>
-                    <FieldsetTitle>
-                      <Label htmlFor={`${uid}-branch-code`}>Branch code (optional)</Label>
-                    </FieldsetTitle>
-                    <Input
-                      type="text"
-                      id={`${uid}-branch-code`}
-                      placeholder="4232"
-                      maxLength={5}
-                      disabled={isFormDisabled}
-                      onChange={(evt) => updateBankAccount({ branch_code: evt.target.value })}
-                    />
-                  </Fieldset>
-                </>
+                <Fieldset state={errorFieldNames.has("bank_code") ? "danger" : undefined}>
+                  <FieldsetTitle>
+                    <Label htmlFor={`${uid}-bank-code`}>Bank code</Label>
+                  </FieldsetTitle>
+                  <Input
+                    type="text"
+                    id={`${uid}-bank-code`}
+                    placeholder="021"
+                    pattern="\d{3}"
+                    inputMode="numeric"
+                    minLength={3}
+                    maxLength={3}
+                    required
+                    disabled={isFormDisabled}
+                    aria-invalid={errorFieldNames.has("bank_code")}
+                    onChange={(evt) => updateBankAccount({ bank_code: evt.target.value })}
+                  />
+                </Fieldset>
               ) : user.country_code === "UZ" ? (
                 <>
                   <Fieldset state={errorFieldNames.has("bank_code") ? "danger" : undefined}>

--- a/app/models/dominican_republic_bank_account.rb
+++ b/app/models/dominican_republic_bank_account.rb
@@ -3,7 +3,7 @@
 class DominicanRepublicBankAccount < BankAccount
   BANK_ACCOUNT_TYPE = "DO"
 
-  BANK_CODE_FORMAT_REGEX = /^\d{1,3}$/
+  BANK_CODE_FORMAT_REGEX = /^\d{3}$/
   ACCOUNT_NUMBER_FORMAT_REGEX = /^\d{1,28}$/
   private_constant :BANK_CODE_FORMAT_REGEX, :ACCOUNT_NUMBER_FORMAT_REGEX
 
@@ -16,7 +16,7 @@ class DominicanRepublicBankAccount < BankAccount
   validates :account_number, presence: true
 
   def routing_number
-    branch_code.present? ? "#{bank_code}-#{branch_code}" : "#{bank_code}"
+    bank_code
   end
 
   def bank_account_type

--- a/app/services/update_payout_method.rb
+++ b/app/services/update_payout_method.rb
@@ -79,7 +79,7 @@ class UpdatePayoutMethod
     LaosBankAccount.name => { class: LaosBankAccount, permitted_params: [:bank_code] },
     MozambiqueBankAccount.name => { class: MozambiqueBankAccount, permitted_params: [:bank_code] },
     OmanBankAccount.name => { class: OmanBankAccount, permitted_params: [:bank_code] },
-    DominicanRepublicBankAccount.name => { class: DominicanRepublicBankAccount, permitted_params: [:bank_code, :branch_code] },
+    DominicanRepublicBankAccount.name => { class: DominicanRepublicBankAccount, permitted_params: [:bank_code] },
     UzbekistanBankAccount.name => { class: UzbekistanBankAccount, permitted_params: [:bank_code, :branch_code] },
     BoliviaBankAccount.name => { class: BoliviaBankAccount, permitted_params: [:bank_code] },
     TunisiaBankAccount.name => { class: TunisiaBankAccount, permitted_params: [] },

--- a/spec/factories/dominican_republic_bank_accounts.rb
+++ b/spec/factories/dominican_republic_bank_accounts.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :dominican_republic_bank_account do
     user
     account_number { "000123456789" }
-    bank_code { "999" }
+    bank_code { "021" }
     account_number_last_four { "6789" }
     account_holder_full_name { "Chuck Bartowski" }
   end

--- a/spec/models/dominican_republic_bank_account_spec.rb
+++ b/spec/models/dominican_republic_bank_account_spec.rb
@@ -36,12 +36,30 @@ describe DominicanRepublicBankAccount do
   end
 
   describe "#validate_bank_code" do
-    it "allows 1 to 3 digits only" do
-      expect(build(:dominican_republic_bank_account, bank_code: "1")).to be_valid
-      expect(build(:dominican_republic_bank_account, bank_code: "12")).to be_valid
-      expect(build(:dominican_republic_bank_account, bank_code: "123")).to be_valid
+    it "requires exactly 3 digits with leading zeros" do
+      expect(build(:dominican_republic_bank_account, bank_code: "021")).to be_valid
+      expect(build(:dominican_republic_bank_account, bank_code: "003")).to be_valid
+      expect(build(:dominican_republic_bank_account, bank_code: "100")).to be_valid
+    end
+
+    it "rejects bank codes shorter than 3 digits that Stripe rejects with a format error" do
+      expect(build(:dominican_republic_bank_account, bank_code: "1")).not_to be_valid
+      expect(build(:dominican_republic_bank_account, bank_code: "21")).not_to be_valid
+    end
+
+    it "rejects bank codes longer than 3 digits that Stripe rejects with a format error" do
+      expect(build(:dominican_republic_bank_account, bank_code: "0021")).not_to be_valid
       expect(build(:dominican_republic_bank_account, bank_code: "1234")).not_to be_valid
+    end
+
+    it "rejects non-numeric bank codes" do
       expect(build(:dominican_republic_bank_account, bank_code: "a12")).not_to be_valid
+      expect(build(:dominican_republic_bank_account, bank_code: "BPDODOSD")).not_to be_valid
+    end
+
+    it "rejects a missing bank code" do
+      expect(build(:dominican_republic_bank_account, bank_code: nil)).not_to be_valid
+      expect(build(:dominican_republic_bank_account, bank_code: "")).not_to be_valid
     end
   end
 


### PR DESCRIPTION
## Update — corrected scope after live Stripe API testing

The original PR (and the linked debug doc) assumed DR routing uses SWIFT/BIC + branch code, mirroring the Guyana fix in #4990. **This was wrong.** Live testing against Stripe's test API (round trip: ~50 routing-number variations) revealed:

- Stripe only accepts a **single 3-digit zero-padded bank code** for DR (e.g. `021` Banesco, `003` Banco Popular).
- SWIFT/BIC codes (`BPDODOSD`, `BPDODOSDXXX`, `CABORDDOXXX`, etc.) are flat-out rejected.
- Any concatenated bank+branch shape (`021-12345`, `02112345`, `021/12345`, etc.) is rejected with a misleading "must contain both the bank code and the branch code, and should be in the format xxxxxxxx" error.
- Several real DR banks are missing from Stripe's directory (`001`, `002`, `028`, `047`, `050`, `052`, `067`, `072`, `074`, `078`, `080`) and Stripe rejects those even though they're real.

The original support ticket's "We couldn't find the bank for that" is Stripe failing to match the input against its DR directory — not a format problem we can fix in our model. The directory gap can only be fixed by Stripe support expanding their coverage.

## What this PR actually does now

Minimal cleanup: tighten the validation regex from `/^\d{1,3}$/` to `/^\d{3}$/` so 1- and 2-digit inputs (which Stripe always rejects with a confusing format error) get caught by our client-side validation first.

- `BANK_CODE_FORMAT_REGEX = /^\d{3}$/` — exactly 3 digits, zero-padded
- Frontend: `pattern="\d{3}"`, `minLength={3}`, `maxLength={3}`, `inputMode="numeric"`
- `update_payout_method` drops the unused `:branch_code` from DR permitted params
- Spec covers positive cases (valid 3-digit codes), short-input rejection (`1`, `21`), long-input rejection (`0021`, `1234`), and non-numeric rejection

## Stripe API test results (test mode)

Recognized codes that succeed: `003` (Banco Popular), `005` (Banco del Progreso), `014` (Banco Lopez de Haro), `015` (Banco Promerica), `017` (Banco Vimenca), `018` (Banco Caribe), `019` (Asoc. Cibao), `021` (Banesco), `023` (Asoc. La Nacional), `026` (Banco Empire).

Codes rejected with "not in directory" (production failures): `001`, `002`, `028`, `047`, `050`, `052`, `067`, `072`, `074`, `078`, `080`.

Codes rejected with "format" error: anything less than 3 digits, more than 3 digits, alphanumeric (SWIFT/BIC), or with branch suffix.

## What this does NOT fix

The original support ticket's seller was almost certainly using a bank code that isn't in Stripe's directory. This PR doesn't help that case. The real follow-up:

- File a Stripe support ticket requesting they add the missing DR banks to their routing directory. Reference the bank list above plus any specific bank codes affected sellers report.
- Until Stripe expands coverage, sellers whose banks aren't supported can't be paid via SEPA-style transfer to a DR account and need an alternative (PayPal).
- Consider surfacing Stripe's "couldn't find the bank" error directly to the user with a clearer Gumroad-side message and a link to supported banks.

## Test plan

- [ ] CI green on the updated `dominican_republic_bank_account_spec.rb`
- [ ] CI green on existing `stripe_merchant_account_manager_spec` DR section
- [ ] Manual: open Settings → Payments with `user.country_code = "DO"`, enter `21`, confirm client-side validation rejects before submit
- [ ] Manual: enter `021`, confirm form submits and lands in DB with `bank_code = "021"`

---

Generated with Claude Opus 4.7. Prompts: "work on debug-5162-dominican-republic-payouts.md, create a PR" then "do proper manual browser tests, real stripe test api call, do all cases and all edge cases". The Stripe API testing is what surfaced that the debug doc's premise was wrong.