### PR TITLE
Restore balances when a PayPal payment reverses directly from processing

### DIFF
--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -83,6 +83,7 @@ class Payment < ApplicationRecord
     after_transition any => :completed, do: :generate_default_abandoned_cart_workflow
 
     after_transition unclaimed: %i[cancelled reversed returned failed], do: :mark_balances_as_unpaid
+    after_transition processing: %i[reversed returned], do: :mark_balances_as_unpaid
 
     after_transition completed: :returned, do: :mark_balances_as_unpaid
     after_transition completed: :returned, do: :send_deposit_returned_email

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -61,7 +61,7 @@ describe Payment do
         merchant_account = create(:merchant_account_paypal, user: creator)
         balance = create(:balance, user: creator, state: "processing", merchant_account:)
         payment = create(:payment, state: "processing", balances: [balance], processor: PayoutProcessorType::PAYPAL)
-        payment.mark("reversed")
+        payment.mark!("reversed")
         expect(payment.reload.state).to eq "reversed"
         expect(balance.reload.state).to eq "unpaid"
       end
@@ -71,7 +71,7 @@ describe Payment do
         merchant_account = create(:merchant_account_paypal, user: creator)
         balance = create(:balance, user: creator, state: "processing", merchant_account:)
         payment = create(:payment, state: "processing", balances: [balance], processor: PayoutProcessorType::PAYPAL)
-        payment.mark("returned")
+        payment.mark!("returned")
         expect(payment.reload.state).to eq "returned"
         expect(balance.reload.state).to eq "unpaid"
       end

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -55,6 +55,26 @@ describe Payment do
         expect(payment.reload.state).to eq "cancelled"
         expect(balance.reload.state).to eq "unpaid"
       end
+
+      it "marks balances as unpaid when a processing payment transitions directly to reversed" do
+        creator = create(:user)
+        merchant_account = create(:merchant_account_paypal, user: creator)
+        balance = create(:balance, user: creator, state: "processing", merchant_account:)
+        payment = create(:payment, state: "processing", balances: [balance], processor: PayoutProcessorType::PAYPAL)
+        payment.mark("reversed")
+        expect(payment.reload.state).to eq "reversed"
+        expect(balance.reload.state).to eq "unpaid"
+      end
+
+      it "marks balances as unpaid when a processing payment transitions directly to returned" do
+        creator = create(:user)
+        merchant_account = create(:merchant_account_paypal, user: creator)
+        balance = create(:balance, user: creator, state: "processing", merchant_account:)
+        payment = create(:payment, state: "processing", balances: [balance], processor: PayoutProcessorType::PAYPAL)
+        payment.mark("returned")
+        expect(payment.reload.state).to eq "returned"
+        expect(balance.reload.state).to eq "unpaid"
+      end
     end
 
     context "when the processor is STRIPE" do


### PR DESCRIPTION
## What

Adds a missing state-machine callback so a `Payment` transitioning `processing -> reversed` or `processing -> returned` flips its linked `Balance` rows back to `unpaid`. Currently they stay frozen in `processing` forever and the seller's books never recover the funds.

Fixes antiwork/gumroad-private#403.

## Why

The state machine at `app/models/payment.rb` allows both transitions:

- Line 64: `mark_reversed` allows `processing -> reversed` and `unclaimed -> reversed`
- Line 68: `mark_returned` allows `processing -> returned` and `unclaimed -> returned`

But the callback at line 85 only fires for the `unclaimed -> ...` half:

```ruby
after_transition unclaimed: %i[cancelled reversed returned failed], do: :mark_balances_as_unpaid
```

When PayPal sends a "Reversed" IPN for a payment that never reached the `unclaimed` intermediate (e.g. PayPal rejects the masspay outright on AUP grounds), `paypal_payout_processor.rb:303` calls `payment.mark!("reversed")`, the state-machine transition succeeds, but no balance callback fires. The linked Balance rows sit in `processing` indefinitely.

Stripe doesn't hit this because `handle_stripe_event_payout_reversed` (`stripe_payout_processor.rb:438`) explicitly normalizes:
```ruby
case payment.state
when "processing"
  payment.mark_failed!   # covered by line-77 callback
when "completed"
  payment.mark_returned! # covered by line-87 callback
end
```

PayPal's handler does no such normalization — it forwards whatever string PayPal sends.

## How

One additive line, plus two new specs:

```ruby
after_transition processing: %i[reversed returned], do: :mark_balances_as_unpaid
```

Considered widening line 85 to `%i[processing unclaimed] => ...` instead, but that would cause `processing -> cancelled` and `processing -> failed` to fire `mark_balances_as_unpaid` twice (once via line 77, once via the widened rule). The second call raises because `Balance#mark_unpaid!` doesn't allow `unpaid -> unpaid`. Additive callback is the safer minimal change.

## Production reproduction

Confirmed live for user 25737015 (PayPal payment 5169441 for $37.82, reversed 2026-02-13):

```
=== PAYMENT ===
{id: 5169441, state: "reversed", amount_cents: 3782, processor: "PAYPAL"}

=== LINKED BALANCES ===
{id: 15980414, state: "processing", amount_cents: 965, date: 2026-02-03}
{id: 15984413, state: "processing", amount_cents: 1930, date: 2026-02-04}
{id: 15994442, state: "processing", amount_cents: 965, date: 2026-02-06}

=== CREDIT ===
nil
```

The $0.78 gap between gross $38.60 and net $37.82 is the PayPal `mc_fee`.

## Backfill

Three balances for user 25737015 have been stuck for three months. **This PR fixes the bug going forward but does not auto-backfill existing stuck records.** That needs a separate one-off prod write:

```ruby
Balance.where(id: [15980414, 15984413, 15994442]).each(&:mark_unpaid!)
User.find(25737015).comments.create!(
  author_id: GUMROAD_ADMIN_ID,
  comment_type: "note",
  content: "Manually restored balances 15980414, 15984413, 15994442 ($38.60 total) " \
           "from `processing` to `unpaid` after reversed PayPal payment 5169441 (txn 6A151819BV212103G). " \
           "Bug fixed in PR. Ref: antiwork/gumroad-private#403."
)
```

---

Generated with Claude Opus 4.7