### PR TITLE
Fix flaky cart_spec: replace Timeout.timeout with monotonic clock polling

### DIFF
--- a/spec/requests/checkout/cart_spec.rb
+++ b/spec/requests/checkout/cart_spec.rb
@@ -140,11 +140,14 @@ describe "Checkout cart", :js, type: :system do
     end
 
     describe "cart persistence" do
-      let(:wait_timeout) { 30 }
+      let(:wait_timeout) { ENV["CI"] ? 45 : 30 }
 
       def poll_until(timeout: wait_timeout)
-        Timeout.timeout(timeout) do
-          sleep 0.1 until yield
+        deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+        loop do
+          return if yield
+          raise Timeout::Error, "execution expired after #{timeout}s" if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+          sleep 0.2
         end
       end
 


### PR DESCRIPTION
## What
Replace `Timeout.timeout` with a monotonic clock polling loop in `cart_spec.rb`'s `poll_until` helper, and increase CI timeout from 30s to 45s.

## Why
`cart_spec.rb:214` ("creates and updates a cart during checkout for a logged-in user") keeps timing out on CI — failed again on run [#26215843823](https://github.com/antiwork/gumroad/actions/runs/26215843823) with `execution expired` on all 3 retries (145s total). The previous fix (#5173) bumped timeout from 15s→30s but wasn't enough.

Root causes:
1. **`Timeout.timeout` is unsafe** — it raises via `Thread#raise` which can interrupt mid-ActiveRecord query or mid-`sleep`, causing unpredictable behavior on slow CI runners
2. **30s wasn't enough** — this test has 5 sequential `poll_until` calls that compound on slow CI runners

Changes:
- Replace `Timeout.timeout` block with `Process.clock_gettime(CLOCK_MONOTONIC)` deadline loop — safe, no thread interruption
- Increase CI timeout to 45s via `ENV['CI']` check (local stays at 30s)
- Increase sleep interval from 0.1s to 0.2s to reduce CPU churn

## Test Results
Cannot run this specific system spec locally (requires AWS S3 cassettes and VCR setup not available in local env). The change is purely in polling mechanics — no test logic changes.

## AI Disclosure
This PR was created by Gumclaw (AI agent) to fix a flaky CI spec.