### PR TITLE
CI: let test_slow run the full suite on failure

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -399,7 +399,7 @@ jobs:
     runs-on: ubicloud-standard-4
     needs: build
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         ci_node_total: [50]
         ci_node_index:
@@ -519,7 +519,6 @@ jobs:
           chmod 777 ./capybara-artifacts
           mkdir -p ./test-logs
           chmod 777 ./test-logs
-          set +e
           docker run --rm --entrypoint="" --network ${{ env.COMPOSE_PROJECT_NAME }}_default \
             -v "$(pwd)/capybara-artifacts:/app/tmp/capybara" \
             -v "$(pwd)/test-logs:/app/log" \
@@ -540,16 +539,6 @@ jobs:
             -e IN_DOCKER \
             $WEB_REPO:${{ needs.build.outputs.test_image_tag }} \
             /usr/local/bin/gosu app bundle exec rake "knapsack_pro:queue:rspec[--format RSpec::Github::Formatter --tag ~skip --format progress]"
-          TEST_EXIT=$?
-          if [ $TEST_EXIT -ne 0 ]; then
-            echo ""
-            echo "============================================"
-            echo "TESTS FAILED (exit code $TEST_EXIT)"
-            echo "Waiting 60s for other containers to report failures..."
-            echo "============================================"
-            sleep 60
-            exit $TEST_EXIT
-          fi
         env:
           RUBY_YJIT_ENABLE: 1
           KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC_FAST }}
@@ -567,14 +556,6 @@ jobs:
           CI: true
           IN_DOCKER: true
           WEB_REPO: gumroadteam/web
-      - name: Cancel workflow on failure
-        if: failure()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const { owner, repo } = context.repo;
-            console.log(`Cancelling workflow run ${context.runId} to stop all test containers...`);
-            await github.rest.actions.cancelWorkflowRun({ owner, repo, run_id: context.runId });
       - name: Archive capybara artifacts
         if: failure()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## What

In `.github/workflows/tests.yml`, the `test_slow` job currently aborts the entire workflow the moment any of its 50 matrix shards fails:

- `strategy.fail-fast: true` cancels sibling matrix shards on first failure.
- A trailing `actions/github-script` step calls `cancelWorkflowRun` to tear down the rest of the run.
- A 60s `sleep` before exiting existed only to give peer containers a brief window to report before being cancelled.

This PR flips `fail-fast` back to `false` (its value prior to #5143) and removes the explicit `cancelWorkflowRun` step and the now-unnecessary `sleep`. `test_fast` is left as-is.

## Why

Cancelling on first failure surfaces only one (often arbitrary) failing shard per run. With ~50 slow shards, fixing a batch of failures becomes a serial pull-push-wait loop: fix the first reported failure, rerun, discover the next one, repeat.

Letting every shard run to completion exposes the full set of failures in a single CI run, so they can be triaged and fixed together. The tradeoff is a small amount of extra CI time on failing runs, which we accept in exchange for far fewer round-trips when stabilizing the suite.

## Test plan

- [ ] Open a PR with an intentional failure in a slow spec and confirm all 50 `Test Slow` shards run to completion (not cancelled), and that the workflow is reported as failed.
- [ ] Confirm `test_fast` behavior is unchanged.

---

AI disclosure: drafted with Claude Opus 4.7.