### PR TITLE
Fix Vite CDN asset base

### DIFF
--- a/config/vite.json
+++ b/config/vite.json
@@ -13,7 +13,12 @@
     "publicOutputDir": "vite-test",
     "port": 3037
   },
+  "staging": {
+    "assetHost": "https://staging-assets.gumroad.com",
+    "publicOutputDir": "vite"
+  },
   "production": {
+    "assetHost": "https://assets.gumroad.com",
     "publicOutputDir": "vite"
   }
 }


### PR DESCRIPTION
Ref: production Vite asset outage
Related: #5152

## What

This PR sets explicit Vite asset hosts for staging and production so production-built chunks preload JS and CSS from the asset CDN instead of from the app host.

The direct-load failure was caused by emitted Vite runtime URLs like `/vite/assets/...`. On `gumroad.com`, those requests returned HTML/404 responses, so CSS preloads failed strict MIME checks and dynamic chunks aborted. The same assets existed on the CDN.

## Why

This became visible after `9b74cdd06` / #5152 removed Sprockets. `5f9c47ebe76e` was a good production tag with Vite present but Sprockets still owning the asset precompile environment setup. After Sprockets removal, the local task graph is:

```text
assets:precompile
  vite:install_dependencies
  vite:build_all
  vite:build_widget
```

`vite:install_dependencies` runs before the Rails `environment` prerequisite reached through `vite:verify_install`, which lets Vite initialize from `config/vite.json` before Rails has applied `config.asset_host`. Without an explicit Vite asset host, production and staging fall back to `/vite/`.

Keeping the fix in `config/vite.json` makes the Vite build self-contained for the environments that publish assets to CDN hosts, instead of relying on Rails environment initialization order.

## Evidence

Git history points to the Sprockets removal boundary:

```text
5f9c47ebe  Skip cross-border internal transfers below Stripe's destination minimum (#5150)
9b74cdd06  Deprecate Sprockets: move images/fonts to public/, remove gem (#5152)
```

Local Vite config reproduction:

```text
origin/main production base: /vite/
origin/main staging base: /vite/

fix branch production base: https://assets.gumroad.com/vite/
fix branch staging base: https://staging-assets.gumroad.com/vite/
```

A real production Vite build on this branch succeeded. Inspecting the emitted `public/vite/assets/*.js` files showed CDN asset URLs and no bad `"/vite/"` preload helper.

## Test Results

Ran targeted local verification:

```bash
npm run setup
npx vite build --mode production
rg '"/vite/"' public/vite/assets --glob '*.js'
```

The build completed successfully, and the final grep returned no matches.

---

This PR was implemented with AI assistance using gpt-5.5 xhigh.
