### PR TITLE
Sync expired BlockedObject rows to PlatformBlock for full history

### DIFF
--- a/app/services/onetime/sync_platform_blocks_from_mongo.rb
+++ b/app/services/onetime/sync_platform_blocks_from_mongo.rb
@@ -6,7 +6,8 @@
 # `updated_at` watermark from the previous run to pick up changes; the upsert
 # is idempotent on the (object_type, object_value) unique index.
 #
-# Expired records (expires_at <= now) are skipped.
+# Every record is copied — including expired ones — so the MySQL table is a
+# full historical mirror of the Mongo collection.
 #
 #   Onetime::SyncPlatformBlocksFromMongo.process
 #   Onetime::SyncPlatformBlocksFromMongo.process(since: Time.parse("2026-05-19 12:00:00 UTC"))
@@ -25,7 +26,6 @@ module Onetime
 
     def process
       scope = BlockedObject
-        .any_of({ expires_at: nil }, { :expires_at.gt => Time.current })
         .order_by(updated_at: :asc, _id: :asc)
         .no_timeout
       # `>=` (not `>`) so that if a previous run crashed mid-batch, records

--- a/spec/services/onetime/sync_platform_blocks_from_mongo_spec.rb
+++ b/spec/services/onetime/sync_platform_blocks_from_mongo_spec.rb
@@ -44,7 +44,7 @@ describe Onetime::SyncPlatformBlocksFromMongo do
       expect(row.updated_at).to be_within(1.second).of(mongo_record.updated_at)
     end
 
-    it "skips records whose expires_at is in the past" do
+    it "imports records whose expires_at is in the past (history)" do
       BlockedObject.create!(
         object_type: BLOCKED_OBJECT_TYPES[:email],
         object_value: "expired@example.com",
@@ -62,7 +62,7 @@ describe Onetime::SyncPlatformBlocksFromMongo do
 
       silence_stdout { described_class.process }
 
-      expect(PlatformBlock.pluck(:object_value)).to contain_exactly("active@example.com")
+      expect(PlatformBlock.pluck(:object_value)).to contain_exactly("expired@example.com", "active@example.com")
     end
 
     it "imports records with no expires_at (permanent blocks)" do


### PR DESCRIPTION
## What

Drop the \`expires_at IS NULL OR expires_at > now\` filter from \`Onetime::SyncPlatformBlocksFromMongo\` so it copies **every** BlockedObject — including expired rows — into \`platform_blocks\`.

On prod right now: ~725k expired records (720k expired IP blocks + 4.8k expired product blocks) are sitting in Mongo but missing from the MySQL mirror.

## Why

These rows are inert under live fraud checks (\`PlatformBlock.active\` still excludes them via \`expires_at\`), so there's no behavioral change. The reason to copy them is audit/history: once \`BlockedObject\` is dropped (planned follow-up to #5165), the only way to answer "was this IP ever blocked, when, by whom" is \`platform_blocks\`. Dropping the filter makes the mirror complete.

The original filter was there to keep the first sync small. Now that the live read/write cutover (#5165) is being prepared, we can afford to bring the rest over in one more pass.

## Rollout

1. Merge this PR.
2. Run on prod console:
   \`\`\`ruby
   Onetime::SyncPlatformBlocksFromMongo.process
   \`\`\`
   Expect ~725k additional rows inserted (most are expired \`ip_address\`).
3. Merge #5165 (the cutover) — its \`PlatformBlock.active\` scope ignores expired rows, so the extra data is transparent to all read paths.

## Test Results

\`\`\`
bundle exec rspec spec/services/onetime/sync_platform_blocks_from_mongo_spec.rb
# => 13 examples, 0 failures
\`\`\`

---

AI disclosure: drafted with Claude Opus 4.7.