### PR TITLE
Remove .cursorrules (Cursor reads AGENTS.md now)

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,1 +1,0 @@
-See CONTRIBUTING.md for development guidelines


### PR DESCRIPTION
Cursor now reads `AGENTS.md` (and `.cursor/rules/*.mdc`) instead of the legacy `.cursorrules` file. See https://cursor.com/docs/rules.

This removes the deprecated config so we don't have duplicated/conflicting agent guidance.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>