### PR TITLE
Fix flaky cart persistence specs: replace Timeout.timeout with PollWait

### DIFF
--- a/spec/requests/checkout/cart_spec.rb
+++ b/spec/requests/checkout/cart_spec.rb
@@ -140,13 +140,7 @@ describe "Checkout cart", :js, type: :system do
     end
 
     describe "cart persistence" do
-      let(:wait_timeout) { 60 }
-
-      def poll_until(timeout: wait_timeout)
-        Timeout.timeout(timeout) do
-          sleep 0.1 until yield
-        end
-      end
+      let(:wait) { PollWait.new(timeout: 60) }
 
       context "when adding a product with a discount code" do
         let(:offer_code) { create(:percentage_offer_code, code: "get-it-for-free", amount_percentage: 100, products: [@product], user: @product.user) }
@@ -173,7 +167,7 @@ describe "Checkout cart", :js, type: :system do
         login_as buyer
         visit @product.long_url
         add_to_cart(@product)
-        poll_until { buyer.reload.alive_cart.present? }
+        wait.until { buyer.reload.alive_cart.present? }
         user_cart = Cart.alive.sole
         expect(user_cart.user).to eq(buyer)
         expect(user_cart.alive_cart_products.sole.product_id).to eq(@product.id)
@@ -181,7 +175,7 @@ describe "Checkout cart", :js, type: :system do
         expect(user_cart.reload).to be_deleted
         expect(user_cart.email).to eq(buyer.email)
         expect(user_cart.order_id).to eq(Order.last.id)
-        poll_until { buyer.reload.alive_cart.present? }
+        wait.until { buyer.reload.alive_cart.present? }
         new_buyer_cart = buyer.alive_cart
         expect(new_buyer_cart.browser_guid).to eq(user_cart.browser_guid)
         expect(new_buyer_cart.alive_cart_products.count).to eq(0)
@@ -193,7 +187,7 @@ describe "Checkout cart", :js, type: :system do
 
         visit @membership_product.long_url
         add_to_cart(@membership_product, recurrence: "Yearly", option: @membership_product.variants.first.name)
-        poll_until { Cart.alive.count == 2 }
+        wait.until { Cart.alive.count == 2 }
         guest_cart = Cart.last
         expect(guest_cart).to be_alive
         expect(guest_cart.user).to be_nil
@@ -218,7 +212,7 @@ describe "Checkout cart", :js, type: :system do
 
         add_to_cart(@membership_product, recurrence: "Yearly", option: @membership_product.variant_categories.first.variants.first.name)
 
-        poll_until { buyer.reload.alive_cart.present? && buyer.alive_cart.cart_products.exists? }
+        wait.until { buyer.reload.alive_cart.present? && buyer.alive_cart.cart_products.exists? }
 
         cart = buyer.alive_cart
         cart_product = cart.cart_products.sole
@@ -237,7 +231,7 @@ describe "Checkout cart", :js, type: :system do
           end
         end
 
-        poll_until { cart_product.reload.deleted? }
+        wait.until { cart_product.reload.deleted? }
 
         new_cart_product = cart.cart_products.alive.sole
 
@@ -249,7 +243,7 @@ describe "Checkout cart", :js, type: :system do
         visit @product.long_url
         add_to_cart(@product)
 
-        poll_until { cart.cart_products.alive.count == 2 }
+        wait.until { cart.cart_products.alive.count == 2 }
         expect(cart.cart_products.alive.first.product).to eq @membership_product
         expect(cart.cart_products.alive.second.product).to eq @product
 
@@ -257,7 +251,7 @@ describe "Checkout cart", :js, type: :system do
 
         expect(cart.reload).to be_deleted
         # A new empty cart is created after checkout
-        poll_until { buyer.reload.alive_cart.present? }
+        wait.until { buyer.reload.alive_cart.present? }
         expect(buyer.alive_cart.cart_products).to be_empty
       end
 
@@ -276,7 +270,7 @@ describe "Checkout cart", :js, type: :system do
         end
         expect(page).to have_link("View content")
 
-        poll_until { buyer.carts.count == 2 }
+        wait.until { buyer.carts.count == 2 }
 
         expect(buyer.alive_cart.cart_products.sole.product).to eq @product
 
@@ -294,7 +288,7 @@ describe "Checkout cart", :js, type: :system do
 
         visit @membership_product.long_url
         add_to_cart(@membership_product, recurrence: "Yearly", option: @membership_product.variants.first.name)
-        poll_until { Cart.alive.count == 2 }
+        wait.until { Cart.alive.count == 2 }
         guest_cart = Cart.alive.last
         expect(guest_cart.user).to be_nil
         expect(guest_cart.alive_cart_products.count).to eq(1)
@@ -323,7 +317,7 @@ describe "Checkout cart", :js, type: :system do
             login_as buyer
             visit product1.long_url
             click_on text: "I want this!"
-            poll_until { buyer.reload.alive_cart.present? }
+            wait.until { buyer.reload.alive_cart.present? }
             create_list(:cart_product, 49, cart: buyer.alive_cart)
           end
 
@@ -366,7 +360,7 @@ describe "Checkout cart", :js, type: :system do
               product2 = create(:product, name: "Product 2")
               visit product2.long_url
               add_to_cart(product2)
-              poll_until { Cart.alive.count == 2 }
+              wait.until { Cart.alive.count == 2 }
               guest_cart = Cart.alive.last
 
               visit checkout_path(cart_id: user_cart.secure_external_id(scope: "cart_login"))


### PR DESCRIPTION
## What
Replace the hand-rolled `poll_until` helper in `spec/requests/checkout/cart_spec.rb` with the existing `PollWait` class (from `spec/support/poll_wait.rb`), using a 60s timeout.

## Why
The cart persistence specs at line 214 ("creates and updates a cart during checkout for a logged-in user") failed all 3 rspec-retry attempts with `execution expired` in [run #26238740552](https://github.com/antiwork/gumroad/actions/runs/26238740552). The triggering commit (`a6c27205` — removing `.cursorrules`) didn't touch any app or spec code, confirming this is a pre-existing timing flake.

The root cause: `poll_until` wraps `Timeout.timeout` around a `sleep 0.1` loop. em-synchrony patches `Kernel#sleep`, which can swallow the timeout signal — the backtrace confirms the timeout fires inside `em-synchrony/kernel.rb:24`. This causes the spec to hang for the full timeout on each retry attempt (3 × ~79s = 235s total).

`PollWait` uses monotonic-clock deadline checking (`Process.clock_gettime(CLOCK_MONOTONIC)`) instead of `Timeout.timeout`, making it immune to em-synchrony's sleep patching. It also polls at 0.5s intervals instead of 0.1s, reducing CPU churn.

## Test Results
`ruby -c spec/requests/checkout/cart_spec.rb` → Syntax OK. Cannot run system specs locally (requires MinIO), but the change is a drop-in replacement using an existing, well-tested helper with no behavioral change.

## AI Disclosure
This PR was authored by Gumclaw (AI agent) investigating CI failure on main.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781976492&installation_id=134400930&pr_number=5198&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5198&signature=2f7c14d1c556d30950d4e21e78da6a00a2eee276460589214b614fb712ad5f51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->