### PR TITLE
CI: switch build job to Blacksmith with sticky-disk Docker cache

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
 
   build:
     name: Build images${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository && ' (internal PR noop)' || '' }}
-    runs-on: ${{ fromJSON(vars.CI_BUILD_RUNNER || '["ubicloud-standard-8"]') }}
+    runs-on: ${{ fromJSON(vars.CI_BUILD_RUNNER || '["blacksmith-8vcpu-ubuntu-2204"]') }}
     needs: ci_gate
     if: ${{ github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name != github.repository }}
     env:
@@ -95,7 +95,9 @@ jobs:
           echo "tag=$TAG" >> $GITHUB_OUTPUT
           echo "Computed test image tag: $TAG"
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: useblacksmith/setup-docker-builder@v1
+        with:
+          max-cache-size-mb: "204800"
       - name: Restore asset precompile cache
         id: asset_cache
         uses: actions/cache@v4
@@ -146,9 +148,10 @@ jobs:
               logger "$WEB_BASE_TEST_REPO:$WEB_BASE_TEST_SHA already exists"
             fi
 
-            # Build test image using GHA cache instead of pulling test-cache
-            # from Docker Hub (~3 min saved by avoiding the registry round-trip).
-            logger "building $WEB_REPO:$TEST_IMAGE_TAG (with GHA cache)"
+            # Build test image. Blacksmith's setup-docker-builder provides a
+            # sticky-disk-backed BuildKit builder that persists the layer cache
+            # across runs automatically — no explicit --cache-from/--cache-to needed.
+            logger "building $WEB_REPO:$TEST_IMAGE_TAG"
             WEB_BASE_SHA=$(WEB_BASE_DOCKERFILE_FROM=ruby:$(cat .ruby-version)-slim-bullseye docker/base/generate_tag_for_web_base.sh)
             # Pull the FROM images that the multi-stage Dockerfile needs.
             docker pull --quiet $WEB_BASE_REPO:$WEB_BASE_SHA &
@@ -158,8 +161,6 @@ jobs:
               WEB_BASE_TEST_DOCKERFILE_FROM=$WEB_BASE_TEST_REPO:$WEB_BASE_TEST_SHA \
             docker buildx build \
               --load \
-              --cache-from type=gha,scope=test-image \
-              --cache-to type=gha,mode=max,scope=test-image \
               --build-arg WEB_DOCKERFILE_FROM \
               --build-arg WEB_BASE_TEST_DOCKERFILE_FROM \
               --build-arg BUILDKIT_INLINE_CACHE=1 \


### PR DESCRIPTION
## What

- Switch the `build` job runner default from `ubicloud-standard-8` to `blacksmith-8vcpu-ubuntu-2204` (same vCPU count). The `vars.CI_BUILD_RUNNER` override is preserved so we can flip back without a code change.
- Replace `docker/setup-buildx-action@v3` with `useblacksmith/setup-docker-builder@v1`, configured with `max-cache-size-mb: 204800` (200 GB).
- Drop `--cache-from type=gha,scope=test-image` / `--cache-to type=gha,mode=max,scope=test-image` from the test-image `docker buildx build`.

## Why

Blacksmith's `setup-docker-builder` action registers a BuildKit builder backed by a sticky disk that persists the local layer cache across CI runs. Once that's in place, the GHA cache export/import is redundant — and mixing the two adds an extra serialize/upload round-trip on every build that the sticky disk already handles natively. 200 GB gives plenty of headroom for the test-image working set while still bounding growth so Blacksmith evicts oldest layers automatically.

Only the `build` job moves; `ci_gate`, `test_fast`, `test_slow`, and `unblock_deployment_from_buildkite` stay on Ubicloud for now (those don't build Docker images, so the cache story doesn't apply).

## Before / After

CI-only change with no user-facing surface — the PR's own CI run is the walkthrough. Worth comparing the `Build images` job duration against a recent main run to confirm the sticky-disk cache is being hit.

## Test Results

This PR exercises itself: the `build` job in this PR's CI run is the test. On a cold cache the first run will be slower than steady state; subsequent runs on the branch should show the sticky-disk hit.

---

AI disclosure: drafted with Claude Opus 4.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781976834&installation_id=134400930&pr_number=5200&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5200&signature=fa60118b17ca167d5c22e7d7718fb130fbeb9c47b8481a5d039dfe87f5f9071b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->