### PR TITLE
CI: pin build job to Blacksmith runner

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
 
   build:
     name: Build images${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository && ' (internal PR noop)' || '' }}
-    runs-on: ${{ fromJSON(vars.CI_BUILD_RUNNER || '["blacksmith-8vcpu-ubuntu-2204"]') }}
+    runs-on: blacksmith-8vcpu-ubuntu-2204
     needs: ci_gate
     if: ${{ github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name != github.repository }}
     env:


### PR DESCRIPTION
## What

Drop the `CI_BUILD_RUNNER` repo-variable override on the `build` job and pin `runs-on` directly to `blacksmith-8vcpu-ubuntu-2204`.

## Why

The previous PR kept the override as an escape hatch while we verified the Blacksmith cutover. Now that the cutover is confirmed working, the indirection adds no value — pinning `runs-on` makes the workflow easier to read and removes a runtime dependency on a repo variable that could be edited unintentionally.

If we ever need to flip back, it's a one-line edit, same as flipping the variable.

## Before / After

CI-only change. The PR's own CI run is the walkthrough — the `Build images` job should land on a Blacksmith runner unconditionally.

## Test Results

Verified by this PR's own `Build images` job.

---

AI disclosure: drafted with Claude Opus 4.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781976963&installation_id=134400930&pr_number=5201&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5201&signature=7f60cec310fd2498ae30dade88c9c33ab0e9305d54fcd69aa90c8ae18ff894a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->