### PR TITLE
Cache healthcheck purchases count for 30 seconds

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -27,7 +27,9 @@ class HealthcheckController < ApplicationController
 
   def purchases
     threshold = $redis.get(RedisKey.min_successful_purchases_in_last_10_minutes)
-    count = Purchase.successful.where(created_at: 10.minutes.ago..Time.current).count
+    count = Rails.cache.fetch("healthcheck:purchases:successful_last_10_minutes", expires_in: 30.seconds) do
+      Purchase.successful.where(created_at: 10.minutes.ago..Time.current).count
+    end
     healthy = threshold.present? && count >= threshold.to_i
     status = healthy ? :ok : :service_unavailable
 


### PR DESCRIPTION
## What

Wrap the count query in `HealthcheckController#purchases` with a 30-second `Rails.cache.fetch`, so repeated hits to `/healthcheck/purchases` reuse the cached value instead of re-running `Purchase.successful.where(created_at: 10.minutes.ago..Time.current).count` against the database each time.

## Why

The endpoint is polled frequently by external monitoring, but the underlying signal — successful purchases in the last 10 minutes — only needs to be fresh enough to detect a sustained drop. A 30-second TTL keeps detection responsive while removing redundant counts against the purchases table.

## Test plan

- [ ] First request to `/healthcheck/purchases` issues the count query; subsequent requests within 30s do not
- [ ] After the cache expires, the next request re-issues the query
- [ ] Healthy/unhealthy status still reflects the threshold from `RedisKey.min_successful_purchases_in_last_10_minutes`

---

AI disclosure: drafted with Claude Opus 4.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781978352&installation_id=134400930&pr_number=5203&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5203&signature=2458935b2a7833977b42c4cab41c87f7b4e90b60c6b0d39e2b9b9e59afda02bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->