### PR TITLE
Drop "saucy" from adult-keyword filter

### DIFF
--- a/app/services/adult_keyword_detector.rb
+++ b/app/services/adult_keyword_detector.rb
@@ -11,7 +11,7 @@ class AdultKeywordDetector
        "pinup", "impregnation", "gagged", "hentai", "squirt", "orgasm", "virginkiller", "abdl", "crotch",
        "breast inflation", "ahri", "granblue", "lingerie",
        "boudoir", "kink", "shibari", "gutpunch", "gutpunching", "abs punch", "necro",
-       "vibrator", "fetish", "nsfw", "saucy", "footjob", "joi"].join("|") +
+       "vibrator", "fetish", "nsfw", "footjob", "joi"].join("|") +
     ")\\b"
   ).freeze
 

--- a/spec/services/adult_keyword_detector_spec.rb
+++ b/spec/services/adult_keyword_detector_spec.rb
@@ -19,7 +19,9 @@ describe AdultKeywordDetector do
      "small fuéta",
      "Yuri Gagarin was a great astronaut",
      "Tentacle Monster Hat",
-     "ns fw"].each do |text|
+     "ns fw",
+     "Signature Seerie Episode 12 - Saucy",
+     "a saucy magic trick"].each do |text|
       expect(described_class.adult?(text)).to eq(false)
     end
   end


### PR DESCRIPTION
## What

Removes `saucy` from `AdultKeywordDetector::ADULT_KEYWORD_REGEX`. Adds two non-adult fixtures to the spec — the exact product name from the support ticket and a generic "saucy magic trick" phrase — so the regression has a guard.

## Why

`Saucy` is a common English word with predominantly non-sexual meanings (cheeky, bold, also literally "containing sauce") and was producing false positives that blocked legitimate products from publishing.

The reported case (`gumroad-private#404`) is a $3.6k-revenue magic-trick creator whose product is named `Signature Seerie Episode 12 - Saucy` (a sauce-sachet trick). Removing all uses of the word from the description didn't clear the flag because the product name and slug also tokenize through the detector, and the name can't be changed for a published product. The creator has been blocked for 30 days with a launch on May 23.

Every other word in the list is explicit and unambiguous; `saucy` was the only general-vocabulary outlier.

## Test plan

- [x] `bin/rspec spec/services/adult_keyword_detector_spec.rb` — 2 examples, 0 failures
- [ ] Smoke test: publish a product containing "saucy" in the name/description

Closes antiwork/gumroad-private#404

---

🤖 Assisted by Claude Opus 4.7

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781980027&installation_id=134400930&pr_number=5206&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5206&signature=0ae2cffe7cbeeb07587040db68fcc7333e121d18b077fc551f70ab5e8f0eab31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->