### PR TITLE
Content moderation: stop flagging affiliate recruitment language

### DIFF
--- a/app/services/content_moderation/strategies/prompt_strategy.rb
+++ b/app/services/content_moderation/strategies/prompt_strategy.rb
@@ -25,13 +25,18 @@ class ContentModeration::Strategies::PromptStrategy
     Default: do not flag. Only flag content that is unmistakably spam. When in doubt,
     treat the content as compliant.
 
-    The content you receive comes from one of two surfaces:
+    The content you receive comes from one of three surfaces:
     1. A product listing — description, marketing copy, feature lists, license terms.
     2. A post or email sent to existing subscribers — newsletters, serial fiction,
        daily comics, dialogue-driven storylines, journal entries, or any installment
        of an ongoing subscription where the post itself IS the product the
        subscriber paid for. These posts often contain no marketing copy and no
        reference to a product, because they ARE the product.
+    3. An affiliate recruitment email — the creator is inviting their audience to
+       join the product's affiliate program. These emails will explicitly mention
+       commission rates, earnings, payouts, referral links, and the creator's
+       affiliate program. This is a legitimate, expected use of Gumroad's
+       affiliate feature, not MLM spam.
 
     ALLOW (these are normal Gumroad content, never flag them):
     - Product descriptions, marketing copy, and promotional language
@@ -56,6 +61,13 @@ class ContentModeration::Strategies::PromptStrategy
       written it as part of a story, comic, or newsletter, treat as compliant.
     - Newsletter, journal, or daily-update content with no product description
       and no marketing copy.
+    - Affiliate recruitment emails: phrases like "earn a commission", "earn extra
+      income", "10% commission", "join my affiliate program", "share my product
+      and get paid", "your affiliate link", "monthly payouts", and similar
+      commission/earnings language are normal recruitment copy. Treat as
+      compliant unless paired with classic MLM red flags (multi-level downline
+      structures, guaranteed returns, "no selling required", recruitment over
+      product sales).
 
     Important: this content is extracted from HTML and stripped of structure. You
     will not see images, headings, or layout. For posts/emails the visual content

--- a/spec/services/content_moderation/strategies/prompt_strategy_spec.rb
+++ b/spec/services/content_moderation/strategies/prompt_strategy_spec.rb
@@ -279,6 +279,17 @@ RSpec.describe ContentModeration::Strategies::PromptStrategy, :vcr do
     end
   end
 
+  # Pins the affiliate-recruitment language in SPAM_RULES so a future prompt
+  # refactor can't silently drop the carveout that lets affiliate emails
+  # mention commissions / earnings without being flagged as MLM spam.
+  describe "SPAM_RULES (affiliate recruitment carveout)" do
+    it "tells the model that affiliate recruitment emails are legitimate" do
+      expect(described_class::SPAM_RULES).to include("affiliate recruitment email")
+      expect(described_class::SPAM_RULES).to include("earn a commission")
+      expect(described_class::SPAM_RULES).to include("MLM red flags")
+    end
+  end
+
   def json_chat_response(payload)
     { "choices" => [{ "message" => { "content" => payload.to_json } }] }
   end


### PR DESCRIPTION
## What

Updates `ContentModeration::Strategies::PromptStrategy::SPAM_RULES` to explicitly recognize affiliate-recruitment emails as a legitimate content surface, and to ALLOW the commission / earnings / referral-link phrasing that those emails depend on.

Adds a guardrail spec that pins those phrases in `SPAM_RULES` so a future prompt rewrite can't silently regress the carveout.

## Why

The classifier was flagging standard affiliate-recruitment phrasing — "earn extra income", "earn a commission by recommending my products", "10% commission" — as MLM-style spam. That blocked creators from sending the affiliate-recruitment emails that Posts → Affiliates only is designed for. The reported case (gumroad-private#402) is a 2D animation rigs creator whose first attempt was blocked for "earn extra income"; support advised rewording to "earn a commission by recommending my products" and that rewrite was also blocked.

Affiliate recruitment is a built-in Gumroad feature. The moderator shouldn't be treating its core vocabulary as a violation. The carveout still leaves room to flag the classic MLM red flags (multi-level downline structures, guaranteed returns, "no selling required", recruitment over product sales) so the policy isn't watered down across the board.

## Test plan

- [x] `bin/rspec spec/services/content_moderation/strategies/prompt_strategy_spec.rb` — 17 examples, 0 failures (new guardrail included)
- [ ] Smoke test: send an affiliate recruitment email containing "earn a commission" / "10% commission" / "your affiliate link"
- [ ] Verify a clearly-MLM message ("no selling required, build your downline, guaranteed $5k/month") still gets flagged

Closes antiwork/gumroad-private#402

---

🤖 Assisted by Claude Opus 4.7

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781980216&installation_id=134400930&pr_number=5207&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5207&signature=477433eaee33bcbbf536344fb518bfc2a0cb7da9a6e89a7ff5335e31d7289d7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->