### PR TITLE
Hide review edit on deleted products

### DIFF
--- a/app/controllers/product_reviews_controller.rb
+++ b/app/controllers/product_reviews_controller.rb
@@ -5,7 +5,7 @@ class ProductReviewsController < ApplicationController
 
   PER_PAGE = 10
 
-  before_action :fetch_product, only: [:set]
+  before_action :fetch_visible_product, only: [:set]
 
   def index
     product = Link.find_by_external_id(permitted_params[:product_id])
@@ -80,6 +80,13 @@ class ProductReviewsController < ApplicationController
       render json: { success: false, message: e.message }
     rescue StandardError
       render json: { success: false, message: "Sorry, something went wrong." }
+    end
+
+    def fetch_visible_product
+      @product = Link.fetch(params[:link_id])
+      unless @product
+        render json: { success: false, message: "Sorry, this product was removed by the seller." }
+      end
     end
 
     def permitted_params

--- a/app/javascript/components/DownloadPage/Layout.tsx
+++ b/app/javascript/components/DownloadPage/Layout.tsx
@@ -60,6 +60,7 @@ export type LayoutProps = {
     product_long_url: string | null;
     created_at: string;
     allows_review: boolean;
+    product_available: boolean;
     disable_reviews_after_year: boolean;
     review: Review | null;
     membership: {
@@ -112,11 +113,15 @@ export const Layout = ({
   const receiptPurchaseId = purchase?.bundle_purchase_id ?? purchase?.id;
 
   const disabledStatus =
-    purchase && differenceInYears(new Date(), parseISO(purchase.created_at)) >= 1 && purchase.disable_reviews_after_year
-      ? "Reviews may not be created or modified for this product 1 year after purchase."
-      : purchase?.membership?.in_free_trial
-        ? "Reviews are not allowed during the free trial period."
-        : null;
+    purchase && !purchase.product_available
+      ? "Removed by the seller"
+      : purchase &&
+          differenceInYears(new Date(), parseISO(purchase.created_at)) >= 1 &&
+          purchase.disable_reviews_after_year
+        ? "Reviews may not be created or modified for this product 1 year after purchase."
+        : purchase?.membership?.in_free_trial
+          ? "Reviews are not allowed during the free trial period."
+          : null;
 
   const settings = is_mobile_app_web_view ? null : (
     <>

--- a/app/javascript/components/ProductsPage/ProductIconCell.tsx
+++ b/app/javascript/components/ProductsPage/ProductIconCell.tsx
@@ -8,19 +8,20 @@ export const ProductIconCell = ({
   thumbnail,
   placeholder = <Image pack="filled" className="size-5" />,
 }: {
-  href: string;
+  href?: string;
   thumbnail: string | null;
   placeholder?: React.ReactNode;
-}) => (
-  <TableCell hideLabel className="text-center text-xl lg:w-20 lg:min-w-20 lg:border-r lg:border-border lg:p-0">
-    <a href={href}>
-      {thumbnail ? (
-        <div className="lg:h-20 lg:overflow-hidden">
-          <img className="max-w-20 lg:size-full lg:object-cover" role="presentation" src={thumbnail} />
-        </div>
-      ) : (
-        placeholder
-      )}
-    </a>
-  </TableCell>
-);
+}) => {
+  const content = thumbnail ? (
+    <div className="lg:h-20 lg:overflow-hidden">
+      <img className="max-w-20 lg:size-full lg:object-cover" role="presentation" src={thumbnail} />
+    </div>
+  ) : (
+    placeholder
+  );
+  return (
+    <TableCell hideLabel className="text-center text-xl lg:w-20 lg:min-w-20 lg:border-r lg:border-border lg:p-0">
+      {href ? <a href={href}>{content}</a> : content}
+    </TableCell>
+  );
+};

--- a/app/javascript/components/ReviewForm.tsx
+++ b/app/javascript/components/ReviewForm.tsx
@@ -321,9 +321,11 @@ export const ReviewForm = React.forwardRef<
     );
 
     const reviewButton = viewing ? (
-      <Button onClick={() => setFormState("editing")} disabled={disabled} key="edit" type="button">
-        Edit
-      </Button>
+      disabled ? null : (
+        <Button onClick={() => setFormState("editing")} key="edit" type="button">
+          Edit
+        </Button>
+      )
     ) : (
       <Button color="primary" disabled={disabled || !readyToSubmit} key="submit" type="submit">
         {review ? "Update review" : "Post review"}

--- a/app/javascript/components/ReviewForm.tsx
+++ b/app/javascript/components/ReviewForm.tsx
@@ -321,7 +321,7 @@ export const ReviewForm = React.forwardRef<
     );
 
     const reviewButton = viewing ? (
-      <Button onClick={() => setFormState("editing")} key="edit" type="button">
+      <Button onClick={() => setFormState("editing")} disabled={disabled} key="edit" type="button">
         Edit
       </Button>
     ) : (

--- a/app/javascript/pages/Reviews/Index.tsx
+++ b/app/javascript/pages/Reviews/Index.tsx
@@ -69,15 +69,19 @@ const Row = ({ review, onChange }: { review: Review; onChange: (review: Review) 
   return (
     <TableRow>
       <ProductIconCell
-        href={review.product.url}
+        href={review.product.available ? review.product.url : undefined}
         thumbnail={review.product.thumbnail_url ?? null}
         placeholder={<img src={nativeTypeThumbnails[`./${review.product.native_type}.svg`]} />}
       />
       <TableCell className="break-words">
         <div>
-          <a href={review.product.url} target="_blank" rel="noreferrer">
+          {review.product.available ? (
+            <a href={review.product.url} target="_blank" rel="noreferrer">
+              <h4>{review.product.name}</h4>
+            </a>
+          ) : (
             <h4>{review.product.name}</h4>
-          </a>
+          )}
           By{" "}
           <a href={review.product.seller.url} target="_blank" rel="noreferrer">
             {review.product.seller.name}

--- a/app/javascript/pages/Reviews/Index.tsx
+++ b/app/javascript/pages/Reviews/Index.tsx
@@ -16,6 +16,7 @@ import { Card } from "$app/components/ui/Card";
 import { Placeholder, PlaceholderImage } from "$app/components/ui/Placeholder";
 import { Table, TableBody, TableCaption, TableCell, TableRow } from "$app/components/ui/Table";
 import { useOnChange } from "$app/components/useOnChange";
+import { WithTooltip } from "$app/components/WithTooltip";
 
 import placeholderImage from "$assets/images/placeholders/reviews.png";
 
@@ -34,6 +35,7 @@ type Product = {
   permalink: string;
   thumbnail_url: string | null;
   native_type: ProductNativeType;
+  available: boolean;
   seller: {
     name: string;
     url: string;
@@ -91,27 +93,35 @@ const Row = ({ review, onChange }: { review: Review; onChange: (review: Review) 
       <TableCell className="break-words">{review.message ? `"${review.message}"` : null}</TableCell>
       <TableCell>
         <div className="flex flex-wrap gap-3 lg:justify-end">
-          <Popover open={isEditing} onOpenChange={setIsEditing}>
-            <PopoverAnchor>
-              <PopoverTrigger aria-label="Edit" asChild>
-                <Button size="icon">
-                  <Pencil className="size-5" />
-                </Button>
-              </PopoverTrigger>
-            </PopoverAnchor>
-            <PopoverContent sideOffset={4} className="border-0 p-0 shadow-none" usePortal>
-              <Card>
-                <ReviewForm
-                  permalink={review.product.permalink}
-                  purchaseId={review.purchase_id}
-                  purchaseEmailDigest={review.purchase_email_digest}
-                  review={review}
-                  onChange={(newReview) => onChange({ ...review, ...newReview })}
-                  className="flex flex-wrap items-center justify-between gap-4 p-4"
-                />
-              </Card>
-            </PopoverContent>
-          </Popover>
+          {review.product.available ? (
+            <Popover open={isEditing} onOpenChange={setIsEditing}>
+              <PopoverAnchor>
+                <PopoverTrigger aria-label="Edit" asChild>
+                  <Button size="icon">
+                    <Pencil className="size-5" />
+                  </Button>
+                </PopoverTrigger>
+              </PopoverAnchor>
+              <PopoverContent sideOffset={4} className="border-0 p-0 shadow-none" usePortal>
+                <Card>
+                  <ReviewForm
+                    permalink={review.product.permalink}
+                    purchaseId={review.purchase_id}
+                    purchaseEmailDigest={review.purchase_email_digest}
+                    review={review}
+                    onChange={(newReview) => onChange({ ...review, ...newReview })}
+                    className="flex flex-wrap items-center justify-between gap-4 p-4"
+                  />
+                </Card>
+              </PopoverContent>
+            </Popover>
+          ) : (
+            <WithTooltip tip="Removed by the seller" position="left">
+              <Button size="icon" aria-label="Edit" disabled>
+                <Pencil className="size-5" />
+              </Button>
+            </WithTooltip>
+          )}
         </div>
       </TableCell>
     </TableRow>

--- a/app/presenters/reviews_presenter.rb
+++ b/app/presenters/reviews_presenter.rb
@@ -9,7 +9,7 @@ class ReviewsPresenter
 
   def reviews_props
     {
-      reviews: user.product_reviews.includes(:editable_video).map do |review|
+      reviews: user.product_reviews.includes(:editable_video, :purchase, link: [:user, :thumbnail_alive]).map do |review|
         product = review.link
         ProductReviewPresenter.new(review).review_form_props.merge(
           id: review.external_id,
@@ -18,7 +18,7 @@ class ReviewsPresenter
           product: product_props(product),
         )
       end,
-      purchases: user.purchases.allowing_reviews_to_be_counted.where.missing(:product_review).order(created_at: :desc).filter_map do |purchase|
+      purchases: user.purchases.allowing_reviews_to_be_counted.where.missing(:product_review).joins(:link).merge(Link.visible).preload(:seller, link: [:user, :thumbnail_alive]).order(created_at: :desc).filter_map do |purchase|
         if !purchase.seller.disable_reviews_after_year? || purchase.created_at > 1.year.ago
           product = purchase.link
           {
@@ -40,6 +40,7 @@ class ReviewsPresenter
         permalink: product.unique_permalink,
         thumbnail_url: product.thumbnail_alive&.url,
         native_type: product.native_type,
+        available: !product.deleted?,
         seller: {
           name: seller.display_name,
           url: seller.profile_url,

--- a/app/presenters/url_redirect_presenter.rb
+++ b/app/presenters/url_redirect_presenter.rb
@@ -129,6 +129,7 @@ class UrlRedirectPresenter
           variant_name: purchase.variant_names&.join(", "),
           product_long_url: purchase.link&.long_url,
           allows_review: purchase.allows_review?,
+          product_available: !purchase.link&.deleted?,
           disable_reviews_after_year: purchase.seller.disable_reviews_after_year?,
           review: review.present? ? ProductReviewPresenter.new(review).review_form_props : nil,
           membership: purchase.subscription.present? ? {

--- a/spec/controllers/product_reviews_controller_spec.rb
+++ b/spec/controllers/product_reviews_controller_spec.rb
@@ -189,6 +189,41 @@ describe ProductReviewsController do
         expect(review.reload.rating).to eq(2)
       end
     end
+
+    context "when the product has been deleted" do
+      before { product.update!(deleted_at: 1.day.ago) }
+
+      it "rejects updating an existing review with a JSON error" do
+        review = create(:product_review, purchase: purchase, rating: 2)
+        put :set, params: valid_params
+
+        expect(response.parsed_body["success"]).to eq(false)
+        expect(response.parsed_body["message"]).to eq("Sorry, this product was removed by the seller.")
+        expect(review.reload.rating).to eq(2)
+      end
+
+      it "rejects creating a new review with a JSON error" do
+        put :set, params: valid_params
+
+        expect(response.parsed_body["success"]).to eq(false)
+        expect(response.parsed_body["message"]).to eq("Sorry, this product was removed by the seller.")
+        expect(purchase.reload.product_review).to be_nil
+      end
+    end
+
+    %i[banned_at purchase_disabled_at].each do |attribute|
+      context "when the product has #{attribute} set but is not deleted" do
+        before { product.update!(attribute => 1.day.ago) }
+
+        it "still allows updating an existing review — only deleted products are blocked" do
+          review = create(:product_review, purchase: purchase, rating: 2)
+          put :set, params: valid_params.merge(rating: 5)
+
+          expect(response.parsed_body["success"]).to eq(true)
+          expect(review.reload.rating).to eq(5)
+        end
+      end
+    end
   end
 
   describe "#index" do

--- a/spec/presenters/reviews_presenter_spec.rb
+++ b/spec/presenters/reviews_presenter_spec.rb
@@ -40,6 +40,7 @@ describe ReviewsPresenter do
                 permalink: reviews.first.link.unique_permalink,
                 thumbnail_url: thumbnail.url,
                 native_type: "digital",
+                available: true,
                 seller: {
                   name: "Seller",
                   url: seller.profile_url,
@@ -56,6 +57,7 @@ describe ReviewsPresenter do
                 permalink: reviews.second.link.unique_permalink,
                 thumbnail_url: nil,
                 native_type: "digital",
+                available: true,
                 seller: {
                   name: "Seller",
                   url: seller.profile_url,
@@ -72,6 +74,7 @@ describe ReviewsPresenter do
                 permalink: reviews.third.link.unique_permalink,
                 thumbnail_url: nil,
                 native_type: "digital",
+                available: true,
                 seller: {
                   name: "Seller",
                   url: seller.profile_url,
@@ -89,6 +92,7 @@ describe ReviewsPresenter do
                 permalink: product2.unique_permalink,
                 thumbnail_url: nil,
                 native_type: "digital",
+                available: true,
                 seller: {
                   name: "Seller",
                   url: seller.profile_url,
@@ -104,6 +108,7 @@ describe ReviewsPresenter do
                 permalink: product1.unique_permalink,
                 thumbnail_url: thumbnail1.url,
                 native_type: "digital",
+                available: true,
                 seller: {
                   name: "Seller",
                   url: seller.profile_url,
@@ -113,6 +118,52 @@ describe ReviewsPresenter do
           ],
         }
       )
+    end
+
+    context "when the reviewed product has been deleted" do
+      let!(:deleted_product) { create(:product, deleted_at: 1.day.ago) }
+      let!(:review_on_deleted_product) do
+        purchase = create(:purchase, purchaser: user, link: deleted_product)
+        create(:product_review, purchase: purchase, link: deleted_product)
+      end
+
+      it "marks the product unavailable so the edit UI can be hidden" do
+        review_props = presenter.reviews_props[:reviews].find { |r| r[:id] == review_on_deleted_product.external_id }
+        expect(review_props[:product][:available]).to be(false)
+      end
+    end
+
+    context "when a purchase awaiting review is for a deleted product" do
+      let!(:deleted_product) { create(:product, deleted_at: 1.day.ago) }
+      let!(:purchase_on_deleted_product) { create(:purchase, purchaser: user, link: deleted_product) }
+
+      it "omits it from the purchases-awaiting-review list" do
+        expect(presenter.reviews_props[:purchases].map { |p| p[:id] }).not_to include(purchase_on_deleted_product.external_id)
+      end
+    end
+
+    %i[banned_at purchase_disabled_at].each do |attribute|
+      context "when the reviewed product has #{attribute} set but is not deleted" do
+        let!(:product_with_attr) { create(:product, attribute => 1.day.ago) }
+        let!(:review_on_product) do
+          purchase = create(:purchase, purchaser: user, link: product_with_attr)
+          create(:product_review, purchase: purchase, link: product_with_attr)
+        end
+
+        it "still marks the product available — only deleted_at blocks the edit UI" do
+          review_props = presenter.reviews_props[:reviews].find { |r| r[:id] == review_on_product.external_id }
+          expect(review_props[:product][:available]).to be(true)
+        end
+      end
+
+      context "when a purchase awaiting review has #{attribute} set on its product but is not deleted" do
+        let!(:product_with_attr) { create(:product, attribute => 1.day.ago) }
+        let!(:purchase_on_product) { create(:purchase, purchaser: user, link: product_with_attr) }
+
+        it "keeps it in the purchases-awaiting-review list" do
+          expect(presenter.reviews_props[:purchases].map { |p| p[:id] }).to include(purchase_on_product.external_id)
+        end
+      end
     end
   end
 end

--- a/spec/presenters/url_redirect_presenter_spec.rb
+++ b/spec/presenters/url_redirect_presenter_spec.rb
@@ -166,6 +166,7 @@ describe UrlRedirectPresenter do
           variant_name: nil,
           product_permalink: @product.unique_permalink,
           allows_review: true,
+          product_available: true,
           disable_reviews_after_year: false,
           review: nil,
           membership: nil,
@@ -603,6 +604,7 @@ describe UrlRedirectPresenter do
           product_permalink: @product.unique_permalink,
           product_long_url: @product.long_url,
           allows_review: true,
+          product_available: true,
           disable_reviews_after_year: true,
           review: nil,
           membership: {


### PR DESCRIPTION
Fixes antiwork/gumroad-private#398

## What

When a buyer tries to update a review on a deleted product, the "Update review" button silently does nothing and the rating reverts on refresh.

The Reviews page now hides the Edit button for deleted products and shows "This product is no longer available". Deleted products are also dropped from the "awaiting review" list, and the endpoint returns a clean JSON error for stale pages that still reach it.

## Why

When a product gets deleted, the controller throws a routing error that Rails serves as HTML 404. The frontend expects JSON, so it can't parse the response, and the error never surfaces to the user. Hiding the UI makes sense here. Deleted products have no public page anyway, and the JSON error prevents stale pages from causing problems.

## Screenshots

**Library page – product deleted by seller**
<img width="2880" height="1464" alt="image" src="https://github.com/user-attachments/assets/bba4d96d-fd93-4a44-bf29-3e121cf34d1c" />

**Download page – product deleted by seller**
<img width="2880" height="1464" alt="image" src="https://github.com/user-attachments/assets/9000eb02-e17b-4987-942e-dbb633f0b839" />

---

This PR was implemented with AI assistance using Claude Opus 4.7 and gpt‑5.5 xhigh

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781988202&installation_id=134400930&pr_number=5212&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5212&signature=c1d124e25482fd0594826a9d3f3000164cb89f51eefd252a61e06e1ce70505b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->