### PR TITLE
Add GDPR Erase Buyer button on admin purchase page

### DIFF
--- a/app/controllers/admin/purchases_controller.rb
+++ b/app/controllers/admin/purchases_controller.rb
@@ -161,12 +161,14 @@ class Admin::PurchasesController < Admin::BaseController
       return render json: { success: false, message: "This purchase has already been anonymized." }
     end
 
-    result = GdprBuyerErasureService.new(email, performed_by: current_user).perform!
-    render json: { success: true, counts: result[:counts], anonymized_to: result[:anonymized_to] }
-  rescue ArgumentError => e
-    render json: { success: false, message: e.message }
-  rescue => e
-    render json: { success: false, message: "Erasure failed: #{e.message}" }
+    begin
+      result = GdprBuyerErasureService.new(email, performed_by: current_user).perform!
+      render json: { success: true, counts: result[:counts], anonymized_to: result[:anonymized_to] }
+    rescue ArgumentError => e
+      render json: { success: false, message: e.message }
+    rescue => e
+      render json: { success: false, message: "Erasure failed: #{e.message}" }
+    end
   end
 
   private

--- a/app/controllers/admin/purchases_controller.rb
+++ b/app/controllers/admin/purchases_controller.rb
@@ -2,7 +2,7 @@
 
 class Admin::PurchasesController < Admin::BaseController
   before_action :fetch_purchase, only: %i[cancel_subscription refund refund_for_fraud refund_taxes_only resend_receipt
-                                          show sync_status_with_charge_processor block_buyer unblock_buyer undelete update_giftee_email]
+                                          show sync_status_with_charge_processor block_buyer unblock_buyer undelete update_giftee_email gdpr_erase_buyer]
 
   def cancel_subscription
     if @purchase.subscription
@@ -151,6 +151,22 @@ class Admin::PurchasesController < Admin::BaseController
         }
       end
     end
+  end
+
+  def gdpr_erase_buyer
+    e404 if @purchase.nil?
+
+    email = @purchase.email
+    if email.blank? || email.ends_with?("@#{GdprDataErasureService::ANONYMIZED_EMAIL_DOMAIN}")
+      return render json: { success: false, message: "This purchase has already been anonymized." }
+    end
+
+    result = GdprBuyerErasureService.new(email, performed_by: current_user).perform!
+    render json: { success: true, counts: result[:counts], anonymized_to: result[:anonymized_to] }
+  rescue ArgumentError => e
+    render json: { success: false, message: e.message }
+  rescue => e
+    render json: { success: false, message: "Erasure failed: #{e.message}" }
   end
 
   private

--- a/app/javascript/components/Admin/Purchases/index.tsx
+++ b/app/javascript/components/Admin/Purchases/index.tsx
@@ -126,6 +126,7 @@ export type Purchase = PurchaseStatesInfo & {
   buyer_blocked: boolean;
   is_deleted_by_buyer: boolean;
   is_guest_buyer: boolean;
+  is_buyer_email_anonymized: boolean;
   comments_count: number;
 };
 
@@ -651,7 +652,7 @@ const ActionButtons = ({ purchase }: { purchase: Purchase }) => (
         success_message="Undeleted!"
       />
     ) : null}
-    {purchase.is_guest_buyer && !purchase.email?.endsWith("@deleted.gumroad.com") ? (
+    {purchase.is_guest_buyer && !purchase.is_buyer_email_anonymized ? (
       <AdminActionButton
         label="GDPR Erase Buyer"
         url={Routes.gdpr_erase_buyer_admin_purchase_path(purchase.external_id)}

--- a/app/javascript/components/Admin/Purchases/index.tsx
+++ b/app/javascript/components/Admin/Purchases/index.tsx
@@ -125,6 +125,7 @@ export type Purchase = PurchaseStatesInfo & {
   is_free_trial_purchase: boolean;
   buyer_blocked: boolean;
   is_deleted_by_buyer: boolean;
+  is_guest_buyer: boolean;
   comments_count: number;
 };
 
@@ -650,13 +651,13 @@ const ActionButtons = ({ purchase }: { purchase: Purchase }) => (
         success_message="Undeleted!"
       />
     ) : null}
-    {!purchase.email?.includes("@deleted.gumroad.com") ? (
+    {purchase.is_guest_buyer && !purchase.email?.endsWith("@deleted.gumroad.com") ? (
       <AdminActionButton
         label="GDPR Erase Buyer"
         url={Routes.gdpr_erase_buyer_admin_purchase_path(purchase.external_id)}
         loading="Erasing buyer PII..."
         done="Buyer PII erased!"
-        confirm_message="⚠️ GDPR ERASURE — This will permanently anonymize ALL PII for this buyer's email across ALL purchases and related tables. This cannot be undone. Proceed?"
+        confirm_message="GDPR ERASURE: This permanently anonymizes ALL PII for this buyer's email across ALL purchases and related tables. This cannot be undone. Proceed?"
         success_message="Buyer PII erased across all tables!"
       />
     ) : null}

--- a/app/javascript/components/Admin/Purchases/index.tsx
+++ b/app/javascript/components/Admin/Purchases/index.tsx
@@ -650,6 +650,16 @@ const ActionButtons = ({ purchase }: { purchase: Purchase }) => (
         success_message="Undeleted!"
       />
     ) : null}
+    {!purchase.email?.includes("@deleted.gumroad.com") ? (
+      <AdminActionButton
+        label="GDPR Erase Buyer"
+        url={Routes.gdpr_erase_buyer_admin_purchase_path(purchase.external_id)}
+        loading="Erasing buyer PII..."
+        done="Buyer PII erased!"
+        confirm_message="⚠️ GDPR ERASURE — This will permanently anonymize ALL PII for this buyer's email across ALL purchases and related tables. This cannot be undone. Proceed?"
+        success_message="Buyer PII erased across all tables!"
+      />
+    ) : null}
     {purchase.successful ? (
       <Button asChild size="sm">
         <a href={Routes.receipt_purchase_path(purchase.external_id)} target="_blank" rel="noopener noreferrer">

--- a/app/presenters/admin/purchase_presenter.rb
+++ b/app/presenters/admin/purchase_presenter.rb
@@ -136,6 +136,7 @@ class Admin::PurchasePresenter
                        is_free_trial_purchase: purchase.is_free_trial_purchase?,
                        buyer_blocked: purchase.buyer_blocked?,
                        is_deleted_by_buyer: purchase.is_deleted_by_buyer?,
+                       is_guest_buyer: purchase.purchaser_id.nil?,
                        comments_count: purchase.comments.count,
                      })
   end

--- a/app/presenters/admin/purchase_presenter.rb
+++ b/app/presenters/admin/purchase_presenter.rb
@@ -137,6 +137,7 @@ class Admin::PurchasePresenter
                        buyer_blocked: purchase.buyer_blocked?,
                        is_deleted_by_buyer: purchase.is_deleted_by_buyer?,
                        is_guest_buyer: purchase.purchaser_id.nil?,
+                       is_buyer_email_anonymized: purchase.email.to_s.ends_with?("@#{GdprDataErasureService::ANONYMIZED_EMAIL_DOMAIN}"),
                        comments_count: purchase.comments.count,
                      })
   end

--- a/app/services/gdpr_buyer_erasure_service.rb
+++ b/app/services/gdpr_buyer_erasure_service.rb
@@ -103,9 +103,14 @@ class GdprBuyerErasureService
         email: nil,
         ip_address: nil,
         ip_country: nil,
+        ip_state: nil,
+        billing_zip: nil,
+        card_type: nil,
         card_visual: nil,
         fingerprint: nil,
-        billing_zip: nil,
+        browser_fingerprint: nil,
+        browser_plugins: nil,
+        browser_guid: nil,
       )
     end
 

--- a/app/services/gdpr_buyer_erasure_service.rb
+++ b/app/services/gdpr_buyer_erasure_service.rb
@@ -153,9 +153,20 @@ class GdprBuyerErasureService
     end
 
     def anonymize_blocked_customer_objects!
-      counts[:blocked_customer_objects] = BlockedCustomerObject.where(buyer_email: email).update_all(
+      fingerprint_block_count = BlockedCustomerObject.where(buyer_email: email).update_all(
         buyer_email: @anonymized_email,
       )
+
+      email_object_type = BlockedCustomerObject::SUPPORTED_OBJECT_TYPES[:email]
+      conflict_seller_ids = BlockedCustomerObject.where(object_type: email_object_type, object_value: @anonymized_email).pluck(:seller_id)
+      if conflict_seller_ids.any?
+        BlockedCustomerObject.where(object_type: email_object_type, object_value: email, seller_id: conflict_seller_ids).delete_all
+      end
+      email_block_count = BlockedCustomerObject.where(object_type: email_object_type, object_value: email).update_all(
+        object_value: @anonymized_email,
+      )
+
+      counts[:blocked_customer_objects] = fingerprint_block_count + email_block_count
     end
 
     def anonymize_signup_events!

--- a/app/services/gdpr_buyer_erasure_service.rb
+++ b/app/services/gdpr_buyer_erasure_service.rb
@@ -60,7 +60,7 @@ class GdprBuyerErasureService
   rescue ArgumentError
     raise
   rescue => e
-    Rails.logger.error("GDPR buyer erasure failed for #{email}: #{e.message}")
+    Rails.logger.error("GDPR buyer erasure failed for #{@anonymized_email || '[no anonymized email yet]'}: #{e.message}")
     raise
   end
 
@@ -155,22 +155,21 @@ class GdprBuyerErasureService
 
     def anonymize_blocked_customer_objects!
       email_object_type = BlockedCustomerObject::SUPPORTED_OBJECT_TYPES[:email]
-      fingerprint_object_type = BlockedCustomerObject::SUPPORTED_OBJECT_TYPES[:charge_processor_fingerprint]
-
-      fingerprint_block_count = BlockedCustomerObject.where(
-        object_type: fingerprint_object_type,
-        buyer_email: email
-      ).update_all(buyer_email: @anonymized_email)
 
       conflict_seller_ids = BlockedCustomerObject.where(object_type: email_object_type, object_value: @anonymized_email).pluck(:seller_id)
       if conflict_seller_ids.any?
         BlockedCustomerObject.where(object_type: email_object_type, object_value: email, seller_id: conflict_seller_ids).delete_all
       end
-      email_block_count = BlockedCustomerObject.where(object_type: email_object_type, object_value: email).update_all(
-        object_value: @anonymized_email,
-      )
 
-      counts[:blocked_customer_objects] = fingerprint_block_count + email_block_count
+      affected_ids = BlockedCustomerObject.where(buyer_email: email)
+                                          .or(BlockedCustomerObject.where(object_type: email_object_type, object_value: email))
+                                          .distinct
+                                          .pluck(:id)
+
+      BlockedCustomerObject.where(id: affected_ids, buyer_email: email).update_all(buyer_email: @anonymized_email)
+      BlockedCustomerObject.where(id: affected_ids, object_type: email_object_type, object_value: email).update_all(object_value: @anonymized_email)
+
+      counts[:blocked_customer_objects] = affected_ids.size
     end
 
     def anonymize_signup_events!
@@ -289,7 +288,7 @@ class GdprBuyerErasureService
                    "Performed by #{performed_by.email}."
         )
       rescue => e
-        Rails.logger.error("GDPR buyer erasure log failed for #{email} on seller #{seller_id}: #{e.message}")
+        Rails.logger.error("GDPR buyer erasure log failed for #{@anonymized_email} on seller #{seller_id}: #{e.message}")
       end
     end
 end

--- a/app/services/gdpr_buyer_erasure_service.rb
+++ b/app/services/gdpr_buyer_erasure_service.rb
@@ -1,0 +1,243 @@
+# frozen_string_literal: true
+
+# Anonymizes all buyer PII for a given email address across all tables.
+# Designed for guest buyers who have no User record — triggered from the
+# admin purchase page. Also callable from Rails console:
+#
+#   GdprBuyerErasureService.new("buyer@example.com", performed_by: User.find(ADMIN_ID)).perform!
+#
+class GdprBuyerErasureService
+  ANONYMIZED_EMAIL_DOMAIN = GdprDataErasureService::ANONYMIZED_EMAIL_DOMAIN
+  ANONYMIZED_NAME = GdprDataErasureService::ANONYMIZED_NAME
+  ANONYMIZED_VALUE = GdprDataErasureService::ANONYMIZED_VALUE
+
+  attr_reader :email, :performed_by, :counts
+
+  def initialize(email, performed_by:)
+    @email = email.to_s.strip.downcase
+    @performed_by = performed_by
+    @counts = Hash.new(0)
+  end
+
+  def perform!
+    raise ArgumentError, "Email is required" if email.blank?
+
+    # If this email belongs to a registered user, use the full account erasure instead.
+    if (user = User.alive.find_by(email: email))
+      raise ArgumentError, "This email belongs to user ##{user.id} (#{user.username}). Use GdprDataErasureService for account holders."
+    end
+
+    anonymized_email = generate_anonymized_email
+
+    ActiveRecord::Base.transaction do
+      anonymize_purchases!(anonymized_email)
+      anonymize_events!
+      anonymize_audience_members!(anonymized_email)
+      anonymize_followers!(anonymized_email)
+      anonymize_carts!(anonymized_email)
+      anonymize_gifts!(anonymized_email)
+      anonymize_imported_customers!(anonymized_email)
+      anonymize_sent_post_emails!(anonymized_email)
+      anonymize_blocked_customer_objects!(anonymized_email)
+      anonymize_signup_events!
+      anonymize_service_charges!
+      anonymize_charges!
+      anonymize_dispute_evidences!
+      anonymize_purchase_custom_fields!
+      anonymize_credit_cards!
+      log_erasure!
+    end
+
+    { success: true, email: email, anonymized_to: anonymized_email, counts: counts }
+  rescue => e
+    Rails.logger.error("GDPR buyer erasure failed for #{email}: #{e.message}")
+    raise
+  end
+
+  private
+    def generate_anonymized_email
+      digest = Digest::SHA256.hexdigest(email)[0..11]
+      "buyer-#{digest}@#{ANONYMIZED_EMAIL_DOMAIN}"
+    end
+
+    def anonymize_purchases!(anonymized_email)
+      # Collect credit card IDs before anonymizing
+      purchase_credit_card_ids = Purchase.where(email: email).where.not(credit_card_id: nil).distinct.pluck(:credit_card_id)
+      @credit_card_ids_from_purchases = purchase_credit_card_ids
+
+      counts[:purchases] = Purchase.where(email: email).update_all(
+        email: anonymized_email,
+        full_name: ANONYMIZED_NAME,
+        street_address: nil,
+        city: nil,
+        state: nil,
+        zip_code: nil,
+        country: nil,
+        ip_address: nil,
+        ip_country: nil,
+        ip_state: nil,
+        browser_guid: nil,
+        stripe_fingerprint: nil,
+        stripe_card_id: nil,
+        card_type: nil,
+        card_visual: nil,
+        card_bin: nil,
+        card_country: nil,
+        card_expiry_month: nil,
+        card_expiry_year: nil,
+        credit_card_zipcode: nil,
+        session_id: nil,
+        referrer: nil,
+        custom_fields: nil,
+      )
+    end
+
+    def anonymize_events!
+      counts[:events] = Event.where(email: email).update_all(
+        email: nil,
+        ip_address: nil,
+        ip_country: nil,
+        card_visual: nil,
+        fingerprint: nil,
+        billing_zip: nil,
+      )
+    end
+
+    def anonymize_audience_members!(anonymized_email)
+      counts[:audience_members] = AudienceMember.where(email: email).update_all(
+        email: anonymized_email,
+        details: nil,
+      )
+    end
+
+    def anonymize_followers!(anonymized_email)
+      counts[:followers] = Follower.where(email: email).update_all(
+        email: anonymized_email,
+      )
+    end
+
+    def anonymize_carts!(anonymized_email)
+      counts[:carts] = Cart.where(email: email).update_all(
+        email: anonymized_email,
+        ip_address: nil,
+        browser_guid: nil,
+      )
+    end
+
+    def anonymize_gifts!(anonymized_email)
+      counts[:gifts_as_giftee] = Gift.where(giftee_email: email).update_all(giftee_email: anonymized_email)
+      counts[:gifts_as_gifter] = Gift.where(gifter_email: email).update_all(gifter_email: anonymized_email)
+    end
+
+    def anonymize_imported_customers!(anonymized_email)
+      counts[:imported_customers] = ImportedCustomer.where(email: email).update_all(
+        email: anonymized_email,
+      )
+    end
+
+    def anonymize_sent_post_emails!(anonymized_email)
+      counts[:sent_post_emails] = SentPostEmail.where(email: email).update_all(
+        email: anonymized_email,
+      )
+    end
+
+    def anonymize_blocked_customer_objects!(anonymized_email)
+      counts[:blocked_customer_objects] = BlockedCustomerObject.where(buyer_email: email).update_all(
+        buyer_email: anonymized_email,
+      )
+    end
+
+    def anonymize_signup_events!
+      counts[:signup_events] = SignupEvent.where(email: email).update_all(
+        email: nil,
+        ip_address: nil,
+        ip_country: nil,
+        ip_state: nil,
+        billing_zip: nil,
+        card_type: nil,
+        card_visual: nil,
+        fingerprint: nil,
+        browser_fingerprint: nil,
+        browser_plugins: nil,
+        browser_guid: nil,
+      )
+    end
+
+    def anonymize_service_charges!
+      # ServiceCharge is linked to User, not email. Guest buyers have no
+      # User record, so there are no service charges to anonymize.
+    end
+
+    def anonymize_charges!
+      purchase_ids = Purchase.where(email: generate_anonymized_email).pluck(:id)
+      return if purchase_ids.empty?
+
+      charge_ids = ChargePurchase.where(purchase_id: purchase_ids).distinct.pluck(:charge_id)
+      return if charge_ids.empty?
+
+      counts[:charges] = Charge.where(id: charge_ids).update_all(
+        payment_method_fingerprint: nil,
+      )
+    end
+
+    def anonymize_dispute_evidences!
+      counts[:dispute_evidences] = DisputeEvidence.where(customer_email: email).update_all(
+        customer_email: nil,
+        customer_name: nil,
+        customer_purchase_ip: nil,
+        billing_address: nil,
+        shipping_address: nil,
+      )
+    end
+
+    def anonymize_purchase_custom_fields!
+      purchase_ids = Purchase.where(email: generate_anonymized_email).pluck(:id)
+      return if purchase_ids.empty?
+
+      counts[:purchase_custom_fields] = PurchaseCustomField.where(purchase_id: purchase_ids).update_all(
+        value: ANONYMIZED_VALUE,
+      )
+    end
+
+    def anonymize_credit_cards!
+      credit_card_ids = @credit_card_ids_from_purchases || []
+      return if credit_card_ids.empty?
+
+      # Only anonymize credit cards not owned by any user (guest cards)
+      user_owned_ids = User.where(credit_card_id: credit_card_ids).pluck(:credit_card_id)
+      guest_card_ids = credit_card_ids - user_owned_ids
+      return if guest_card_ids.empty?
+
+      counts[:credit_cards] = CreditCard.where(id: guest_card_ids).update_all(
+        card_type: ANONYMIZED_VALUE,
+        visual: ANONYMIZED_VALUE,
+        card_bin: nil,
+        card_country: nil,
+        expiry_month: nil,
+        expiry_year: nil,
+        stripe_fingerprint: nil,
+        stripe_card_id: nil,
+        stripe_customer_id: nil,
+        braintree_customer_id: nil,
+        paypal_billing_agreement_id: nil,
+        processor_payment_method_id: nil,
+        funding_type: nil,
+        json_data: nil,
+      )
+    end
+
+    def log_erasure!
+      # Log on each seller whose purchases were affected
+      seller_ids = Purchase.where(email: generate_anonymized_email).distinct.pluck(:seller_id)
+      seller_ids.each do |seller_id|
+        User.find_by(id: seller_id)&.comments&.create!(
+          author_id: performed_by.id,
+          author_name: performed_by.name || performed_by.email,
+          comment_type: Comment::COMMENT_TYPE_NOTE,
+          content: "GDPR buyer erasure performed for a guest buyer. " \
+                   "All buyer PII anonymized across #{counts.values.sum} records. " \
+                   "Performed by #{performed_by.email}."
+        )
+      end
+    end
+end

--- a/app/services/gdpr_buyer_erasure_service.rb
+++ b/app/services/gdpr_buyer_erasure_service.rb
@@ -49,6 +49,8 @@ class GdprBuyerErasureService
     log_erasure!
 
     { success: true, email: email, anonymized_to: @anonymized_email, counts: counts }
+  rescue ArgumentError
+    raise
   rescue => e
     Rails.logger.error("GDPR buyer erasure failed for #{email}: #{e.message}")
     raise
@@ -100,6 +102,8 @@ class GdprBuyerErasureService
     end
 
     def anonymize_audience_members!
+      conflict_seller_ids = AudienceMember.where(email: @anonymized_email).pluck(:seller_id)
+      AudienceMember.where(email: email, seller_id: conflict_seller_ids).delete_all if conflict_seller_ids.any?
       counts[:audience_members] = AudienceMember.where(email: email).update_all(
         email: @anonymized_email,
         details: nil,
@@ -107,6 +111,8 @@ class GdprBuyerErasureService
     end
 
     def anonymize_followers!
+      conflict_followed_ids = Follower.where(email: @anonymized_email).pluck(:followed_id)
+      Follower.where(email: email, followed_id: conflict_followed_ids).delete_all if conflict_followed_ids.any?
       counts[:followers] = Follower.where(email: email).update_all(
         email: @anonymized_email,
       )
@@ -132,6 +138,8 @@ class GdprBuyerErasureService
     end
 
     def anonymize_sent_post_emails!
+      conflict_post_ids = SentPostEmail.where(email: @anonymized_email).pluck(:post_id)
+      SentPostEmail.where(email: email, post_id: conflict_post_ids).delete_all if conflict_post_ids.any?
       counts[:sent_post_emails] = SentPostEmail.where(email: email).update_all(
         email: @anonymized_email,
       )
@@ -200,7 +208,12 @@ class GdprBuyerErasureService
       return if @credit_card_ids.empty?
 
       user_owned_ids = User.where(credit_card_id: @credit_card_ids).pluck(:credit_card_id)
-      guest_card_ids = @credit_card_ids - user_owned_ids
+      shared_with_other_buyers_ids = Purchase
+        .where(credit_card_id: @credit_card_ids)
+        .where.not(id: @purchase_ids)
+        .distinct
+        .pluck(:credit_card_id)
+      guest_card_ids = @credit_card_ids - user_owned_ids - shared_with_other_buyers_ids
       return if guest_card_ids.empty?
 
       counts[:credit_cards] = CreditCard.where(id: guest_card_ids).update_all(

--- a/app/services/gdpr_buyer_erasure_service.rb
+++ b/app/services/gdpr_buyer_erasure_service.rb
@@ -290,5 +290,7 @@ class GdprBuyerErasureService
       rescue => e
         Rails.logger.error("GDPR buyer erasure log failed for #{@anonymized_email} on seller #{seller_id}: #{e.message}")
       end
+    rescue => e
+      Rails.logger.error("GDPR buyer erasure log_erasure! unexpected failure for #{@anonymized_email}: #{e.message}")
     end
 end

--- a/app/services/gdpr_buyer_erasure_service.rb
+++ b/app/services/gdpr_buyer_erasure_service.rb
@@ -1,11 +1,5 @@
 # frozen_string_literal: true
 
-# Anonymizes all buyer PII for a given email address across all tables.
-# Designed for guest buyers who have no User record — triggered from the
-# admin purchase page. Also callable from Rails console:
-#
-#   GdprBuyerErasureService.new("buyer@example.com", performed_by: User.find(ADMIN_ID)).perform!
-#
 class GdprBuyerErasureService
   ANONYMIZED_EMAIL_DOMAIN = GdprDataErasureService::ANONYMIZED_EMAIL_DOMAIN
   ANONYMIZED_NAME = GdprDataErasureService::ANONYMIZED_NAME
@@ -22,33 +16,39 @@ class GdprBuyerErasureService
   def perform!
     raise ArgumentError, "Email is required" if email.blank?
 
-    # If this email belongs to a registered user, use the full account erasure instead.
-    if (user = User.alive.find_by(email: email))
-      raise ArgumentError, "This email belongs to user ##{user.id} (#{user.username}). Use GdprDataErasureService for account holders."
+    if (user = User.find_by(email: email))
+      raise ArgumentError, "This email belongs to user ##{user.id}. Use GdprDataErasureService for account holders."
     end
 
-    anonymized_email = generate_anonymized_email
+    @anonymized_email = generate_anonymized_email
+    purchases = Purchase.where(email: email)
+    @purchase_ids = purchases.pluck(:id)
+    @credit_card_ids = purchases.where.not(credit_card_id: nil).distinct.pluck(:credit_card_id)
+    @browser_guids = purchases.where.not(browser_guid: nil).distinct.pluck(:browser_guid)
+    @seller_ids = purchases.distinct.pluck(:seller_id)
 
     ActiveRecord::Base.transaction do
-      anonymize_purchases!(anonymized_email)
+      anonymize_purchases!
       anonymize_events!
-      anonymize_audience_members!(anonymized_email)
-      anonymize_followers!(anonymized_email)
-      anonymize_carts!(anonymized_email)
-      anonymize_gifts!(anonymized_email)
-      anonymize_imported_customers!(anonymized_email)
-      anonymize_sent_post_emails!(anonymized_email)
-      anonymize_blocked_customer_objects!(anonymized_email)
+      anonymize_audience_members!
+      anonymize_followers!
+      anonymize_carts!
+      anonymize_gifts!
+      anonymize_imported_customers!
+      anonymize_sent_post_emails!
+      anonymize_blocked_customer_objects!
       anonymize_signup_events!
-      anonymize_service_charges!
       anonymize_charges!
       anonymize_dispute_evidences!
       anonymize_purchase_custom_fields!
       anonymize_credit_cards!
-      log_erasure!
+      anonymize_discover_searches!
+      anonymize_utm_link_visits!
     end
 
-    { success: true, email: email, anonymized_to: anonymized_email, counts: counts }
+    log_erasure!
+
+    { success: true, email: email, anonymized_to: @anonymized_email, counts: counts }
   rescue => e
     Rails.logger.error("GDPR buyer erasure failed for #{email}: #{e.message}")
     raise
@@ -60,13 +60,9 @@ class GdprBuyerErasureService
       "buyer-#{digest}@#{ANONYMIZED_EMAIL_DOMAIN}"
     end
 
-    def anonymize_purchases!(anonymized_email)
-      # Collect credit card IDs before anonymizing
-      purchase_credit_card_ids = Purchase.where(email: email).where.not(credit_card_id: nil).distinct.pluck(:credit_card_id)
-      @credit_card_ids_from_purchases = purchase_credit_card_ids
-
-      counts[:purchases] = Purchase.where(email: email).update_all(
-        email: anonymized_email,
+    def anonymize_purchases!
+      counts[:purchases] = Purchase.where(id: @purchase_ids).update_all(
+        email: @anonymized_email,
         full_name: ANONYMIZED_NAME,
         street_address: nil,
         city: nil,
@@ -103,47 +99,47 @@ class GdprBuyerErasureService
       )
     end
 
-    def anonymize_audience_members!(anonymized_email)
+    def anonymize_audience_members!
       counts[:audience_members] = AudienceMember.where(email: email).update_all(
-        email: anonymized_email,
+        email: @anonymized_email,
         details: nil,
       )
     end
 
-    def anonymize_followers!(anonymized_email)
+    def anonymize_followers!
       counts[:followers] = Follower.where(email: email).update_all(
-        email: anonymized_email,
+        email: @anonymized_email,
       )
     end
 
-    def anonymize_carts!(anonymized_email)
+    def anonymize_carts!
       counts[:carts] = Cart.where(email: email).update_all(
-        email: anonymized_email,
+        email: @anonymized_email,
         ip_address: nil,
         browser_guid: nil,
       )
     end
 
-    def anonymize_gifts!(anonymized_email)
-      counts[:gifts_as_giftee] = Gift.where(giftee_email: email).update_all(giftee_email: anonymized_email)
-      counts[:gifts_as_gifter] = Gift.where(gifter_email: email).update_all(gifter_email: anonymized_email)
+    def anonymize_gifts!
+      counts[:gifts_as_giftee] = Gift.where(giftee_email: email).update_all(giftee_email: @anonymized_email)
+      counts[:gifts_as_gifter] = Gift.where(gifter_email: email).update_all(gifter_email: @anonymized_email)
     end
 
-    def anonymize_imported_customers!(anonymized_email)
+    def anonymize_imported_customers!
       counts[:imported_customers] = ImportedCustomer.where(email: email).update_all(
-        email: anonymized_email,
+        email: @anonymized_email,
       )
     end
 
-    def anonymize_sent_post_emails!(anonymized_email)
+    def anonymize_sent_post_emails!
       counts[:sent_post_emails] = SentPostEmail.where(email: email).update_all(
-        email: anonymized_email,
+        email: @anonymized_email,
       )
     end
 
-    def anonymize_blocked_customer_objects!(anonymized_email)
+    def anonymize_blocked_customer_objects!
       counts[:blocked_customer_objects] = BlockedCustomerObject.where(buyer_email: email).update_all(
-        buyer_email: anonymized_email,
+        buyer_email: @anonymized_email,
       )
     end
 
@@ -163,19 +159,21 @@ class GdprBuyerErasureService
       )
     end
 
-    def anonymize_service_charges!
-      # ServiceCharge is linked to User, not email. Guest buyers have no
-      # User record, so there are no service charges to anonymize.
-    end
-
     def anonymize_charges!
-      purchase_ids = Purchase.where(email: generate_anonymized_email).pluck(:id)
-      return if purchase_ids.empty?
+      return if @purchase_ids.empty?
 
-      charge_ids = ChargePurchase.where(purchase_id: purchase_ids).distinct.pluck(:charge_id)
+      charge_ids = ChargePurchase.where(purchase_id: @purchase_ids).distinct.pluck(:charge_id)
       return if charge_ids.empty?
 
-      counts[:charges] = Charge.where(id: charge_ids).update_all(
+      shared_charge_ids = ChargePurchase
+        .where(charge_id: charge_ids)
+        .where.not(purchase_id: @purchase_ids)
+        .distinct
+        .pluck(:charge_id)
+      exclusive_charge_ids = charge_ids - shared_charge_ids
+      return if exclusive_charge_ids.empty?
+
+      counts[:charges] = Charge.where(id: exclusive_charge_ids).update_all(
         payment_method_fingerprint: nil,
       )
     end
@@ -191,21 +189,18 @@ class GdprBuyerErasureService
     end
 
     def anonymize_purchase_custom_fields!
-      purchase_ids = Purchase.where(email: generate_anonymized_email).pluck(:id)
-      return if purchase_ids.empty?
+      return if @purchase_ids.empty?
 
-      counts[:purchase_custom_fields] = PurchaseCustomField.where(purchase_id: purchase_ids).update_all(
+      counts[:purchase_custom_fields] = PurchaseCustomField.where(purchase_id: @purchase_ids).update_all(
         value: ANONYMIZED_VALUE,
       )
     end
 
     def anonymize_credit_cards!
-      credit_card_ids = @credit_card_ids_from_purchases || []
-      return if credit_card_ids.empty?
+      return if @credit_card_ids.empty?
 
-      # Only anonymize credit cards not owned by any user (guest cards)
-      user_owned_ids = User.where(credit_card_id: credit_card_ids).pluck(:credit_card_id)
-      guest_card_ids = credit_card_ids - user_owned_ids
+      user_owned_ids = User.where(credit_card_id: @credit_card_ids).pluck(:credit_card_id)
+      guest_card_ids = @credit_card_ids - user_owned_ids
       return if guest_card_ids.empty?
 
       counts[:credit_cards] = CreditCard.where(id: guest_card_ids).update_all(
@@ -226,11 +221,31 @@ class GdprBuyerErasureService
       )
     end
 
+    def anonymize_discover_searches!
+      return if @browser_guids.empty?
+
+      counts[:discover_searches] = DiscoverSearch.where(browser_guid: @browser_guids).update_all(
+        ip_address: nil,
+        browser_guid: nil,
+      )
+    end
+
+    def anonymize_utm_link_visits!
+      return if @browser_guids.empty?
+
+      counts[:utm_link_visits] = UtmLinkVisit.where(browser_guid: @browser_guids).update_all(
+        ip_address: ANONYMIZED_VALUE,
+        browser_guid: ANONYMIZED_VALUE,
+        user_agent: nil,
+      )
+    end
+
     def log_erasure!
-      # Log on each seller whose purchases were affected
-      seller_ids = Purchase.where(email: generate_anonymized_email).distinct.pluck(:seller_id)
-      seller_ids.each do |seller_id|
-        User.find_by(id: seller_id)&.comments&.create!(
+      @seller_ids.each do |seller_id|
+        seller = User.find_by(id: seller_id)
+        next unless seller
+
+        seller.comments.create!(
           author_id: performed_by.id,
           author_name: performed_by.name || performed_by.email,
           comment_type: Comment::COMMENT_TYPE_NOTE,
@@ -239,5 +254,7 @@ class GdprBuyerErasureService
                    "Performed by #{performed_by.email}."
         )
       end
+    rescue => e
+      Rails.logger.error("GDPR buyer erasure log failed for #{email}: #{e.message}")
     end
 end

--- a/app/services/gdpr_buyer_erasure_service.rb
+++ b/app/services/gdpr_buyer_erasure_service.rb
@@ -20,11 +20,18 @@ class GdprBuyerErasureService
       raise ArgumentError, "This email belongs to user ##{user.id}. Use GdprDataErasureService for account holders."
     end
 
+    registered_purchase_count = Purchase.where(email: email).where.not(purchaser_id: nil).count
+    if registered_purchase_count > 0
+      raise ArgumentError, "This email is associated with #{registered_purchase_count} purchase(s) belonging to registered users. Erase those account holders with GdprDataErasureService first."
+    end
+
     @anonymized_email = generate_anonymized_email
-    purchases = Purchase.where(email: email)
+    purchases = Purchase.where(email: email, purchaser_id: nil)
     @purchase_ids = purchases.pluck(:id)
     @credit_card_ids = purchases.where.not(credit_card_id: nil).distinct.pluck(:credit_card_id)
-    @browser_guids = purchases.where.not(browser_guid: nil).distinct.pluck(:browser_guid)
+    candidate_browser_guids = purchases.where.not(browser_guid: nil).distinct.pluck(:browser_guid)
+    shared_browser_guids = candidate_browser_guids.any? ? Purchase.where(browser_guid: candidate_browser_guids).where.not(id: @purchase_ids).distinct.pluck(:browser_guid) : []
+    @browser_guids = candidate_browser_guids - shared_browser_guids
     @seller_ids = purchases.distinct.pluck(:seller_id)
 
     ActiveRecord::Base.transaction do
@@ -266,8 +273,8 @@ class GdprBuyerErasureService
                    "All buyer PII anonymized across #{counts.values.sum} records. " \
                    "Performed by #{performed_by.email}."
         )
+      rescue => e
+        Rails.logger.error("GDPR buyer erasure log failed for #{email} on seller #{seller_id}: #{e.message}")
       end
-    rescue => e
-      Rails.logger.error("GDPR buyer erasure log failed for #{email}: #{e.message}")
     end
 end

--- a/app/services/gdpr_buyer_erasure_service.rb
+++ b/app/services/gdpr_buyer_erasure_service.rb
@@ -26,15 +26,16 @@ class GdprBuyerErasureService
     end
 
     @anonymized_email = generate_anonymized_email
-    purchases = Purchase.where(email: email, purchaser_id: nil)
-    @purchase_ids = purchases.pluck(:id)
-    @credit_card_ids = purchases.where.not(credit_card_id: nil).distinct.pluck(:credit_card_id)
-    candidate_browser_guids = purchases.where.not(browser_guid: nil).distinct.pluck(:browser_guid)
-    shared_browser_guids = candidate_browser_guids.any? ? Purchase.where(browser_guid: candidate_browser_guids).where.not(id: @purchase_ids).distinct.pluck(:browser_guid) : []
-    @browser_guids = candidate_browser_guids - shared_browser_guids
-    @seller_ids = purchases.distinct.pluck(:seller_id)
 
     ActiveRecord::Base.transaction do
+      purchases = Purchase.where(email: email, purchaser_id: nil)
+      @purchase_ids = purchases.pluck(:id)
+      @credit_card_ids = purchases.where.not(credit_card_id: nil).distinct.pluck(:credit_card_id)
+      candidate_browser_guids = purchases.where.not(browser_guid: nil).distinct.pluck(:browser_guid)
+      shared_browser_guids = candidate_browser_guids.any? ? Purchase.where(browser_guid: candidate_browser_guids).where.not(id: @purchase_ids).distinct.pluck(:browser_guid) : []
+      @browser_guids = candidate_browser_guids - shared_browser_guids
+      @seller_ids = purchases.distinct.pluck(:seller_id)
+
       anonymize_purchases!
       anonymize_events!
       anonymize_audience_members!
@@ -65,7 +66,7 @@ class GdprBuyerErasureService
 
   private
     def generate_anonymized_email
-      digest = Digest::SHA256.hexdigest(email)[0..11]
+      digest = OpenSSL::HMAC.hexdigest("SHA256", Rails.application.secret_key_base, email)[0..15]
       "buyer-#{digest}@#{ANONYMIZED_EMAIL_DOMAIN}"
     end
 
@@ -153,11 +154,14 @@ class GdprBuyerErasureService
     end
 
     def anonymize_blocked_customer_objects!
-      fingerprint_block_count = BlockedCustomerObject.where(buyer_email: email).update_all(
-        buyer_email: @anonymized_email,
-      )
-
       email_object_type = BlockedCustomerObject::SUPPORTED_OBJECT_TYPES[:email]
+      fingerprint_object_type = BlockedCustomerObject::SUPPORTED_OBJECT_TYPES[:charge_processor_fingerprint]
+
+      fingerprint_block_count = BlockedCustomerObject.where(
+        object_type: fingerprint_object_type,
+        buyer_email: email
+      ).update_all(buyer_email: @anonymized_email)
+
       conflict_seller_ids = BlockedCustomerObject.where(object_type: email_object_type, object_value: @anonymized_email).pluck(:seller_id)
       if conflict_seller_ids.any?
         BlockedCustomerObject.where(object_type: email_object_type, object_value: email, seller_id: conflict_seller_ids).delete_all

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -133,6 +133,7 @@ namespace :admin do
       post :block_buyer
       post :unblock_buyer
       post :undelete
+      post :gdpr_erase_buyer
     end
   end
 

--- a/spec/presenters/admin/purchase_presenter_spec.rb
+++ b/spec/presenters/admin/purchase_presenter_spec.rb
@@ -88,11 +88,38 @@ describe Admin::PurchasePresenter do
             is_free_trial_purchase: purchase.is_free_trial_purchase?,
             buyer_blocked: purchase.buyer_blocked?,
             is_deleted_by_buyer: purchase.is_deleted_by_buyer?,
+            is_guest_buyer: purchase.purchaser_id.nil?,
+            is_buyer_email_anonymized: false,
             comments_count: purchase.comments.count,
             early_fraud_warning: nil,
             disputes: [],
             stripe_risk_level: nil,
           )
+        end
+      end
+
+      context "when the buyer email is already anonymized" do
+        let(:purchase) { create(:free_purchase, link: product, seller: seller, purchaser: nil).tap { |p| p.update_columns(email: "buyer-abc@deleted.gumroad.com") } }
+
+        it "exposes is_buyer_email_anonymized as true" do
+          expect(props[:is_buyer_email_anonymized]).to be(true)
+        end
+      end
+
+      context "when the purchase is a guest buyer" do
+        let(:purchase) { create(:free_purchase, link: product, seller: seller, purchaser: nil) }
+
+        it "exposes is_guest_buyer as true" do
+          expect(props[:is_guest_buyer]).to be(true)
+        end
+      end
+
+      context "when the purchase has a registered buyer" do
+        let(:buyer) { create(:user) }
+        let(:purchase) { create(:free_purchase, link: product, seller: seller, purchaser: buyer) }
+
+        it "exposes is_guest_buyer as false" do
+          expect(props[:is_guest_buyer]).to be(false)
         end
       end
 

--- a/spec/services/gdpr_buyer_erasure_service_spec.rb
+++ b/spec/services/gdpr_buyer_erasure_service_spec.rb
@@ -95,6 +95,39 @@ describe GdprBuyerErasureService do
         expect(unrelated_purchase.email).to eq("other@example.com")
       end
 
+      it "anonymizes all PII columns on matching events rows" do
+        event = Event.new(
+          email: buyer_email,
+          ip_address: "9.9.9.9",
+          ip_country: "US",
+          ip_state: "NY",
+          billing_zip: "11111",
+          card_type: "visa",
+          card_visual: "**** 4242",
+          fingerprint: "fp_event",
+          browser_fingerprint: "bfp_event",
+          browser_plugins: "Flash, Java",
+          browser_guid: "guid_event",
+          event_name: "purchase",
+        )
+        event.save!(validate: false)
+
+        described_class.new(buyer_email, performed_by: admin).perform!
+
+        event.reload
+        expect(event.email).to be_nil
+        expect(event.ip_address).to be_nil
+        expect(event.ip_country).to be_nil
+        expect(event.ip_state).to be_nil
+        expect(event.billing_zip).to be_nil
+        expect(event.card_type).to be_nil
+        expect(event.card_visual).to be_nil
+        expect(event.fingerprint).to be_nil
+        expect(event.browser_fingerprint).to be_nil
+        expect(event.browser_plugins).to be_nil
+        expect(event.browser_guid).to be_nil
+      end
+
       it "anonymizes followers by email" do
         follower = Follower.create!(email: buyer_email, user: purchase1.seller)
 

--- a/spec/services/gdpr_buyer_erasure_service_spec.rb
+++ b/spec/services/gdpr_buyer_erasure_service_spec.rb
@@ -21,6 +21,11 @@ describe GdprBuyerErasureService do
       expect { described_class.new("deleted-user@example.com", performed_by: admin).perform! }.to raise_error(ArgumentError, /Use GdprDataErasureService/)
     end
 
+    it "does not log validation failures as erasure failures" do
+      expect(Rails.logger).not_to receive(:error).with(/GDPR buyer erasure failed/)
+      expect { described_class.new("", performed_by: admin).perform! }.to raise_error(ArgumentError)
+    end
+
     context "with guest buyer data" do
       let!(:purchase1) do
         create(:free_purchase, email: buyer_email, purchaser: nil).tap do |p|
@@ -146,6 +151,23 @@ describe GdprBuyerErasureService do
         end
       end
 
+      describe "second erasure after a fresh purchase under the same email" do
+        it "merges duplicate audience_members without violating the unique index" do
+          seller = purchase1.seller
+          anonymized = described_class.new(buyer_email, performed_by: admin).send(:generate_anonymized_email)
+          AudienceMember.where(seller: seller, email: [buyer_email, anonymized]).delete_all
+          existing_anonymized = AudienceMember.new(seller: seller, email: anonymized, details: { purchases: [{ id: 1 }] })
+          existing_anonymized.save!(validate: false)
+          fresh = AudienceMember.new(seller: seller, email: buyer_email, details: { purchases: [{ id: 2 }] })
+          fresh.save!(validate: false)
+
+          expect { described_class.new(buyer_email, performed_by: admin).perform! }.not_to raise_error
+          expect(AudienceMember.where(seller: seller, email: buyer_email).count).to eq(0)
+          expect(AudienceMember.where(id: existing_anonymized.id)).to exist
+          expect(AudienceMember.where(id: fresh.id)).not_to exist
+        end
+      end
+
       describe "credit cards" do
         it "anonymizes guest credit cards but leaves user-owned cards untouched" do
           guest_card = CreditCard.new(visual: "**** 1111", card_type: "visa", stripe_fingerprint: "fp_guest")
@@ -161,6 +183,19 @@ describe GdprBuyerErasureService do
 
           expect(guest_card.reload.visual).to eq("[redacted]")
           expect(owned_card.reload.visual).to eq("**** 2222")
+        end
+
+        it "does not anonymize a credit card also used by another buyer's purchase" do
+          shared_card = CreditCard.new(visual: "**** 9999", card_type: "visa", stripe_fingerprint: "fp_shared")
+          shared_card.save!(validate: false)
+
+          purchase1.update_columns(credit_card_id: shared_card.id)
+          other_buyer_purchase = create(:free_purchase, email: "other-guest@example.com", purchaser: nil)
+          other_buyer_purchase.update_columns(credit_card_id: shared_card.id)
+
+          described_class.new(buyer_email, performed_by: admin).perform!
+
+          expect(shared_card.reload.visual).to eq("**** 9999")
         end
       end
     end

--- a/spec/services/gdpr_buyer_erasure_service_spec.rb
+++ b/spec/services/gdpr_buyer_erasure_service_spec.rb
@@ -26,6 +26,19 @@ describe GdprBuyerErasureService do
       expect { described_class.new("", performed_by: admin).perform! }.to raise_error(ArgumentError)
     end
 
+    it "does not log the original buyer email in plaintext when the erasure fails" do
+      buyer_email = "leak-check@example.com"
+      create(:free_purchase, email: buyer_email, purchaser: nil)
+      allow(Purchase).to receive(:where).and_call_original
+      allow_any_instance_of(ActiveRecord::Relation).to receive(:update_all).and_raise(StandardError, "boom")
+      logged = []
+      allow(Rails.logger).to receive(:error) { |msg| logged << msg }
+
+      expect { described_class.new(buyer_email, performed_by: admin).perform! }.to raise_error(StandardError)
+
+      expect(logged.join("\n")).not_to include(buyer_email)
+    end
+
     it "raises when any purchase under this email belongs to a registered user" do
       registered_buyer = create(:user)
       purchase = create(:free_purchase, email: "mixed-owner@example.com", purchaser: nil)
@@ -169,6 +182,24 @@ describe GdprBuyerErasureService do
         described_class.new(buyer_email, performed_by: admin).perform!
 
         expect(block.reload.object_value).to end_with("@deleted.gumroad.com")
+      end
+
+      it "anonymizes buyer_email on email-type blocked_customer_objects that have it populated" do
+        seller = purchase1.seller
+        block = BlockedCustomerObject.new(
+          seller: seller,
+          object_type: BlockedCustomerObject::SUPPORTED_OBJECT_TYPES[:email],
+          object_value: buyer_email,
+          buyer_email: buyer_email,
+          blocked_at: Time.current
+        )
+        block.save!(validate: false)
+
+        described_class.new(buyer_email, performed_by: admin).perform!
+
+        block.reload
+        expect(block.object_value).to end_with("@deleted.gumroad.com")
+        expect(block.buyer_email).to end_with("@deleted.gumroad.com")
       end
 
       it "does not count email-type blocked_customer_objects under the fingerprint scope" do

--- a/spec/services/gdpr_buyer_erasure_service_spec.rb
+++ b/spec/services/gdpr_buyer_erasure_service_spec.rb
@@ -157,6 +157,14 @@ describe GdprBuyerErasureService do
         expect(purchase1.full_name).to eq("[deleted]")
       end
 
+      it "swallows unexpected log_erasure! failures so a logging hiccup is not reported as a failed erasure" do
+        service = described_class.new(buyer_email, performed_by: admin)
+        service.instance_variable_set(:@anonymized_email, "buyer-test@deleted.gumroad.com")
+        service.instance_variable_set(:@seller_ids, nil)
+
+        expect { service.send(:log_erasure!) }.not_to raise_error
+      end
+
       it "continues logging on other sellers when one seller's comment fails" do
         other_purchase = create(:free_purchase, email: buyer_email, purchaser: nil)
         seller_a = purchase1.seller

--- a/spec/services/gdpr_buyer_erasure_service_spec.rb
+++ b/spec/services/gdpr_buyer_erasure_service_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe GdprBuyerErasureService do
+  let(:admin) { create(:user, is_team_member: true) }
+  let(:buyer_email) { "guest-buyer@example.com" }
+
+  describe "#perform!" do
+    it "raises when email is blank" do
+      expect { described_class.new("", performed_by: admin).perform! }.to raise_error(ArgumentError, /Email is required/)
+    end
+
+    it "raises when email belongs to a registered user" do
+      create(:user, email: "registered@example.com")
+      expect { described_class.new("registered@example.com", performed_by: admin).perform! }.to raise_error(ArgumentError, /Use GdprDataErasureService/)
+    end
+
+    context "with guest buyer data" do
+      let!(:purchase1) do
+        create(:free_purchase, email: buyer_email, purchaser: nil).tap do |p|
+          p.update_columns(
+            full_name: "Jane Doe",
+            ip_address: "1.2.3.4",
+            street_address: "123 Main St",
+            city: "NYC",
+            state: "NY",
+            zip_code: "10001",
+            country: "US",
+            stripe_fingerprint: "fp_123",
+            card_visual: "**** 4242",
+            card_bin: "424242",
+            custom_fields: '{"phone": "555-1234"}',
+          )
+        end
+      end
+      let!(:purchase2) do
+        create(:free_purchase, email: buyer_email, purchaser: nil).tap do |p|
+          p.update_columns(full_name: "Jane Doe", ip_address: "1.2.3.5")
+        end
+      end
+      let!(:unrelated_purchase) { create(:free_purchase, email: "other@example.com", purchaser: nil) }
+
+      it "anonymizes all purchases matching the email" do
+        result = described_class.new(buyer_email, performed_by: admin).perform!
+
+        expect(result[:success]).to be(true)
+        expect(result[:counts][:purchases]).to eq(2)
+
+        purchase1.reload
+        expect(purchase1.email).to end_with("@deleted.gumroad.com")
+        expect(purchase1.full_name).to eq("[deleted]")
+        expect(purchase1.ip_address).to be_nil
+        expect(purchase1.street_address).to be_nil
+        expect(purchase1.city).to be_nil
+        expect(purchase1.stripe_fingerprint).to be_nil
+        expect(purchase1.card_visual).to be_nil
+        expect(purchase1.card_bin).to be_nil
+        expect(purchase1.custom_fields).to be_blank
+
+        unrelated_purchase.reload
+        expect(unrelated_purchase.email).to eq("other@example.com")
+      end
+
+      it "anonymizes followers by email" do
+        follower = Follower.create!(email: buyer_email, user: purchase1.seller)
+
+        described_class.new(buyer_email, performed_by: admin).perform!
+
+        follower.reload
+        expect(follower.email).to end_with("@deleted.gumroad.com")
+      end
+
+      it "anonymizes carts by email" do
+        cart = Cart.create!(email: buyer_email, ip_address: "5.6.7.8", browser_guid: "abc123", user: purchase1.seller)
+
+        described_class.new(buyer_email, performed_by: admin).perform!
+
+        cart.reload
+        expect(cart.email).to end_with("@deleted.gumroad.com")
+        expect(cart.ip_address).to be_nil
+        expect(cart.browser_guid).to be_nil
+      end
+
+      it "logs erasure on affected sellers" do
+        described_class.new(buyer_email, performed_by: admin).perform!
+
+        seller = purchase1.seller.reload
+        comment = seller.comments.last
+        expect(comment.content).to include("GDPR buyer erasure")
+        expect(comment.author_id).to eq(admin.id)
+      end
+
+      it "generates a deterministic anonymized email" do
+        result = described_class.new(buyer_email, performed_by: admin).perform!
+
+        expect(result[:anonymized_to]).to start_with("buyer-")
+        expect(result[:anonymized_to]).to end_with("@deleted.gumroad.com")
+      end
+
+      it "does not touch purchases with different emails" do
+        described_class.new(buyer_email, performed_by: admin).perform!
+
+        unrelated_purchase.reload
+        expect(unrelated_purchase.full_name).not_to eq("[deleted]")
+      end
+    end
+  end
+end

--- a/spec/services/gdpr_buyer_erasure_service_spec.rb
+++ b/spec/services/gdpr_buyer_erasure_service_spec.rb
@@ -118,6 +118,14 @@ describe GdprBuyerErasureService do
         expect(result[:anonymized_to]).to end_with("@deleted.gumroad.com")
       end
 
+      it "uses HMAC keyed on secret_key_base, not a plain truncated SHA256 of the email" do
+        service = described_class.new(buyer_email, performed_by: admin)
+        anonymized = service.send(:generate_anonymized_email)
+        plain_sha_truncated = Digest::SHA256.hexdigest(buyer_email)[0..11]
+        expect(anonymized).not_to include(plain_sha_truncated)
+        expect(anonymized).to include(OpenSSL::HMAC.hexdigest("SHA256", Rails.application.secret_key_base, buyer_email)[0..15])
+      end
+
       it "does not touch purchases with different emails" do
         described_class.new(buyer_email, performed_by: admin).perform!
 
@@ -161,6 +169,25 @@ describe GdprBuyerErasureService do
         described_class.new(buyer_email, performed_by: admin).perform!
 
         expect(block.reload.object_value).to end_with("@deleted.gumroad.com")
+      end
+
+      it "does not count email-type blocked_customer_objects under the fingerprint scope" do
+        seller = purchase1.seller
+        # An email-type row that happens to have buyer_email set should not be
+        # counted twice when we tally fingerprint-type vs email-type updates.
+        email_row = BlockedCustomerObject.new(
+          seller: seller,
+          object_type: BlockedCustomerObject::SUPPORTED_OBJECT_TYPES[:email],
+          object_value: buyer_email,
+          buyer_email: buyer_email,
+          blocked_at: Time.current
+        )
+        email_row.save!(validate: false)
+
+        result = described_class.new(buyer_email, performed_by: admin).perform!
+
+        # One row touched once (object_value updated), not double-counted.
+        expect(result[:counts][:blocked_customer_objects]).to eq(1)
       end
 
       it "anonymizes fingerprint-type blocked_customer_objects via buyer_email" do

--- a/spec/services/gdpr_buyer_erasure_service_spec.rb
+++ b/spec/services/gdpr_buyer_erasure_service_spec.rb
@@ -26,6 +26,15 @@ describe GdprBuyerErasureService do
       expect { described_class.new("", performed_by: admin).perform! }.to raise_error(ArgumentError)
     end
 
+    it "raises when any purchase under this email belongs to a registered user" do
+      registered_buyer = create(:user)
+      purchase = create(:free_purchase, email: "mixed-owner@example.com", purchaser: nil)
+      purchase.update_columns(purchaser_id: registered_buyer.id)
+      expect { described_class.new("mixed-owner@example.com", performed_by: admin).perform! }
+        .to raise_error(ArgumentError, /belonging to registered users/)
+      expect(purchase.reload.email).to eq("mixed-owner@example.com")
+    end
+
     context "with guest buyer data" do
       let!(:purchase1) do
         create(:free_purchase, email: buyer_email, purchaser: nil).tap do |p|
@@ -125,6 +134,33 @@ describe GdprBuyerErasureService do
         purchase1.reload
         expect(purchase1.email).to end_with("@deleted.gumroad.com")
         expect(purchase1.full_name).to eq("[deleted]")
+      end
+
+      it "continues logging on other sellers when one seller's comment fails" do
+        other_purchase = create(:free_purchase, email: buyer_email, purchaser: nil)
+        seller_a = purchase1.seller
+        seller_b = other_purchase.seller
+
+        allow(User).to receive(:find_by).and_call_original
+        allow(User).to receive(:find_by).with(id: seller_a.id).and_raise(StandardError, "boom")
+
+        described_class.new(buyer_email, performed_by: admin).perform!
+
+        expect(seller_b.reload.comments.where("content LIKE ?", "%GDPR buyer erasure%")).to exist
+      end
+
+      it "does not anonymize discover_searches whose browser_guid is also used by another buyer's purchase" do
+        shared_guid = "shared-guid-#{SecureRandom.hex(4)}"
+        purchase1.update_columns(browser_guid: shared_guid)
+        other_buyer_purchase = create(:free_purchase, email: "other-guest@example.com", purchaser: nil)
+        other_buyer_purchase.update_columns(browser_guid: shared_guid)
+        search = DiscoverSearch.create!(browser_guid: shared_guid, ip_address: "9.9.9.9")
+
+        described_class.new(buyer_email, performed_by: admin).perform!
+
+        search.reload
+        expect(search.browser_guid).to eq(shared_guid)
+        expect(search.ip_address).to eq("9.9.9.9")
       end
 
       describe "charges with shared purchases across buyers" do

--- a/spec/services/gdpr_buyer_erasure_service_spec.rb
+++ b/spec/services/gdpr_buyer_erasure_service_spec.rb
@@ -11,9 +11,14 @@ describe GdprBuyerErasureService do
       expect { described_class.new("", performed_by: admin).perform! }.to raise_error(ArgumentError, /Email is required/)
     end
 
-    it "raises when email belongs to a registered user" do
+    it "raises when email belongs to an active registered user" do
       create(:user, email: "registered@example.com")
       expect { described_class.new("registered@example.com", performed_by: admin).perform! }.to raise_error(ArgumentError, /Use GdprDataErasureService/)
+    end
+
+    it "raises when email belongs to a soft-deleted registered user" do
+      create(:user, email: "deleted-user@example.com", deleted_at: Time.current)
+      expect { described_class.new("deleted-user@example.com", performed_by: admin).perform! }.to raise_error(ArgumentError, /Use GdprDataErasureService/)
     end
 
     context "with guest buyer data" do
@@ -30,13 +35,14 @@ describe GdprBuyerErasureService do
             stripe_fingerprint: "fp_123",
             card_visual: "**** 4242",
             card_bin: "424242",
+            browser_guid: "guid-1",
             custom_fields: '{"phone": "555-1234"}',
           )
         end
       end
       let!(:purchase2) do
         create(:free_purchase, email: buyer_email, purchaser: nil).tap do |p|
-          p.update_columns(full_name: "Jane Doe", ip_address: "1.2.3.5")
+          p.update_columns(full_name: "Jane Doe", ip_address: "1.2.3.5", browser_guid: "guid-2")
         end
       end
       let!(:unrelated_purchase) { create(:free_purchase, email: "other@example.com", purchaser: nil) }
@@ -103,6 +109,59 @@ describe GdprBuyerErasureService do
 
         unrelated_purchase.reload
         expect(unrelated_purchase.full_name).not_to eq("[deleted]")
+      end
+
+      it "completes the erasure even if logging fails" do
+        allow(User).to receive(:find_by).and_call_original
+        allow(User).to receive(:find_by).with(id: purchase1.seller_id).and_raise(StandardError, "log failure")
+
+        expect { described_class.new(buyer_email, performed_by: admin).perform! }.not_to raise_error
+
+        purchase1.reload
+        expect(purchase1.email).to end_with("@deleted.gumroad.com")
+        expect(purchase1.full_name).to eq("[deleted]")
+      end
+
+      describe "charges with shared purchases across buyers" do
+        let!(:other_buyer_purchase) { create(:free_purchase, email: "other@example.com", purchaser: nil) }
+
+        it "nullifies fingerprint on charges whose purchases are all owned by the erased buyer" do
+          charge = create(:charge, payment_method_fingerprint: "fp_exclusive")
+          ChargePurchase.create!(charge: charge, purchase: purchase1)
+          ChargePurchase.create!(charge: charge, purchase: purchase2)
+
+          described_class.new(buyer_email, performed_by: admin).perform!
+
+          expect(charge.reload.payment_method_fingerprint).to be_nil
+        end
+
+        it "leaves fingerprint untouched on charges shared with another buyer's purchase" do
+          shared_charge = create(:charge, payment_method_fingerprint: "fp_shared")
+          ChargePurchase.create!(charge: shared_charge, purchase: purchase1)
+          ChargePurchase.create!(charge: shared_charge, purchase: other_buyer_purchase)
+
+          described_class.new(buyer_email, performed_by: admin).perform!
+
+          expect(shared_charge.reload.payment_method_fingerprint).to eq("fp_shared")
+        end
+      end
+
+      describe "credit cards" do
+        it "anonymizes guest credit cards but leaves user-owned cards untouched" do
+          guest_card = CreditCard.new(visual: "**** 1111", card_type: "visa", stripe_fingerprint: "fp_guest")
+          guest_card.save!(validate: false)
+          owned_card = CreditCard.new(visual: "**** 2222", card_type: "visa", stripe_fingerprint: "fp_owned")
+          owned_card.save!(validate: false)
+          User.find(create(:user).id).update_columns(credit_card_id: owned_card.id)
+
+          purchase1.update_columns(credit_card_id: guest_card.id)
+          purchase2.update_columns(credit_card_id: owned_card.id)
+
+          described_class.new(buyer_email, performed_by: admin).perform!
+
+          expect(guest_card.reload.visual).to eq("[redacted]")
+          expect(owned_card.reload.visual).to eq("**** 2222")
+        end
       end
     end
   end

--- a/spec/services/gdpr_buyer_erasure_service_spec.rb
+++ b/spec/services/gdpr_buyer_erasure_service_spec.rb
@@ -149,6 +149,57 @@ describe GdprBuyerErasureService do
         expect(seller_b.reload.comments.where("content LIKE ?", "%GDPR buyer erasure%")).to exist
       end
 
+      it "anonymizes email-type blocked_customer_objects" do
+        seller = purchase1.seller
+        block = BlockedCustomerObject.create!(
+          seller: seller,
+          object_type: BlockedCustomerObject::SUPPORTED_OBJECT_TYPES[:email],
+          object_value: buyer_email,
+          blocked_at: Time.current
+        )
+
+        described_class.new(buyer_email, performed_by: admin).perform!
+
+        expect(block.reload.object_value).to end_with("@deleted.gumroad.com")
+      end
+
+      it "anonymizes fingerprint-type blocked_customer_objects via buyer_email" do
+        seller = purchase1.seller
+        block = BlockedCustomerObject.create!(
+          seller: seller,
+          object_type: BlockedCustomerObject::SUPPORTED_OBJECT_TYPES[:charge_processor_fingerprint],
+          object_value: "fp_xyz",
+          buyer_email: buyer_email,
+          blocked_at: Time.current
+        )
+
+        described_class.new(buyer_email, performed_by: admin).perform!
+
+        expect(block.reload.buyer_email).to end_with("@deleted.gumroad.com")
+        expect(block.object_value).to eq("fp_xyz")
+      end
+
+      it "merges duplicate email-type blocked_customer_objects when an anonymized row already exists" do
+        seller = purchase1.seller
+        anonymized = described_class.new(buyer_email, performed_by: admin).send(:generate_anonymized_email)
+        existing_anonymized = BlockedCustomerObject.create!(
+          seller: seller,
+          object_type: BlockedCustomerObject::SUPPORTED_OBJECT_TYPES[:email],
+          object_value: anonymized,
+          blocked_at: Time.current
+        )
+        fresh = BlockedCustomerObject.create!(
+          seller: seller,
+          object_type: BlockedCustomerObject::SUPPORTED_OBJECT_TYPES[:email],
+          object_value: buyer_email,
+          blocked_at: Time.current
+        )
+
+        expect { described_class.new(buyer_email, performed_by: admin).perform! }.not_to raise_error
+        expect(BlockedCustomerObject.where(id: existing_anonymized.id)).to exist
+        expect(BlockedCustomerObject.where(id: fresh.id)).not_to exist
+      end
+
       it "does not anonymize discover_searches whose browser_guid is also used by another buyer's purchase" do
         shared_guid = "shared-guid-#{SecureRandom.hex(4)}"
         purchase1.update_columns(browser_guid: shared_guid)


### PR DESCRIPTION
## What

Adds a "GDPR Erase Buyer" button on the admin purchase page for guest buyers who have no User record. When a guest buyer files a GDPR Art. 17 erasure request, admins can now anonymize their PII directly from the purchase page.

## Why

Previously, GDPR erasure required a User record (`GdprDataErasureService`). Guest buyers who purchased without creating a Gumroad account had no erasure path — their data couldn't be anonymized through any admin interface.

## How

### New: `GdprBuyerErasureService`
Takes a buyer email and anonymizes ALL PII across 15+ tables:
- **purchases** — email, name, address, IP, card details, fingerprints, custom fields
- **events, signup_events** — email, IP, fingerprints
- **audience_members, followers, imported_customers, sent_post_emails** — email
- **carts** — email, IP, browser_guid
- **gifts** — giftee/gifter email
- **blocked_customer_objects** — buyer_email
- **dispute_evidences** — customer email, name, addresses
- **purchase_custom_fields** — free-text values
- **credit_cards** — card details, processor IDs (guest cards only)
- **charges** — payment_method_fingerprint (via charge_purchases join)

Generates a deterministic anonymized email (`buyer-<sha256>@deleted.gumroad.com`). Logs erasure as a comment on each affected seller's account.

### UI
Button appears on admin purchase page below Block/Unblock buyer. Hidden when email is already anonymized. Shows confirmation dialog before proceeding.

### Also callable from Rails console:
```ruby
GdprBuyerErasureService.new('buyer@example.com', performed_by: User.find(ADMIN_ID)).perform!
```

## Test Results
8 examples, 0 failures (local)

Closes #5202

---
*This PR was authored by Gumclaw (AI agent). All code reviewed before submission.*

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781993598&installation_id=134400930&pr_number=5213&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5213&signature=b9866b7f5a9088f2fd35c3e010e00ccc703e968b1a8a6ff942c3404e2b4f3405"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it introduces an admin-triggered, irreversible anonymization workflow that bulk-updates PII across many tables (via `update_all`) and affects multiple purchases for the same email; mistakes could cause unintended data loss or partial erasure.
> 
> **Overview**
> Adds an admin-only `gdpr_erase_buyer` action on purchases and a new `GdprBuyerErasureService` to anonymize guest-buyer PII by email across purchases and related records (events, audience/followers, carts, gifts, dispute evidence, custom fields, charge fingerprints, credit cards, etc.), using a deterministic HMAC-based anonymized email and recording per-seller audit comments.
> 
> Updates the admin purchase presenter/UI to expose `is_guest_buyer` and `is_buyer_email_anonymized` and show a **“GDPR Erase Buyer”** button only for non-anonymized guest purchases, wiring it via a new admin route and adding specs for the presenter flags and erasure behavior/edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce6275ec4de8f1bf36d4661861bd04eabcce1c37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->