### PR TITLE
fix: handle duplicate slug race condition in SaveInstallmentService

### DIFF
--- a/app/services/save_installment_service.rb
+++ b/app/services/save_installment_service.rb
@@ -56,12 +56,20 @@ class SaveInstallmentService
         installment.link = product_or_variant_type? ? product : nil
         installment.seller = seller
       end
-      if (installment.published? || installment.add_and_validate_filters(installment_attrs, seller)) && installment.save
+      if (installment.published? || installment.add_and_validate_filters(installment_attrs, seller)) && save_with_unique_slug!
         SaveFilesService.perform(installment, product_files_params)
         update_profile_posts_sections!
       else
         @error = installment.errors.full_messages.first
       end
+    end
+
+    def save_with_unique_slug!
+      installment.save
+    rescue ActiveRecord::RecordNotUnique => e
+      raise unless e.message.include?("index_installments_on_slug")
+      installment.slug = "#{installment.slug}-#{SecureRandom.hex(4)}"
+      installment.save
     end
 
     def update_profile_posts_sections!

--- a/spec/services/save_installment_service_spec.rb
+++ b/spec/services/save_installment_service_spec.rb
@@ -544,4 +544,43 @@ describe SaveInstallmentService do
 
     include_examples "updates profile posts sections"
   end
+
+  describe "#save_with_unique_slug!" do
+    it "retries with a unique suffix on ActiveRecord::RecordNotUnique for slug index" do
+      other_seller = create(:user)
+      existing = create(:installment, seller: other_seller, name: "Hello")
+      expect(existing.slug).to eq("hello")
+
+      service = described_class.new(seller:, params: params.deep_merge(installment: { name: "Hello" }), installment: nil, preview_email_recipient:)
+
+      save_call_count = 0
+      allow_any_instance_of(Installment).to receive(:save).and_wrap_original do |original_method|
+        save_call_count += 1
+        if save_call_count == 1
+          original_method.receiver.send(:set_slug)
+          raise ActiveRecord::RecordNotUnique.new("Mysql2::Error: Duplicate entry 'hello' for key 'installments.index_installments_on_slug'")
+        else
+          original_method.call
+        end
+      end
+
+      service.process
+
+      expect(service.error).to be_nil
+      expect(service.installment).to be_persisted
+      expect(service.installment.slug).to include("hello")
+      expect(service.installment.slug).not_to eq("hello")
+    end
+
+    it "re-raises RecordNotUnique for non-slug index violations" do
+      service = described_class.new(seller:, params:, installment: nil, preview_email_recipient:)
+
+      allow_any_instance_of(Installment).to receive(:save).and_raise(
+        ActiveRecord::RecordNotUnique.new("Mysql2::Error: Duplicate entry for key 'installments.some_other_index'")
+      )
+
+      service.process
+      expect(service.error).to include("Duplicate entry")
+    end
+  end
 end


### PR DESCRIPTION
## What

Rescue `ActiveRecord::RecordNotUnique` on the `installments.index_installments_on_slug` unique index in `SaveInstallmentService` and retry with a random hex suffix.

## Why

Sentry alert: `ActiveRecord::RecordNotUnique: Mysql2::Error: Duplicate entry '...' for key 'installments.index_installments_on_slug'` in `EmailsController#create` (high priority, 2 events).

The `Installment` model uses `friendly_id :slug_candidates, use: :slugged` with a global unique DB index on `slug`. FriendlyId resolves slug conflicts at the application level (SELECT then INSERT), but a race condition allows two concurrent requests with the same post name to both pass the uniqueness check, causing the second INSERT to violate the DB constraint.

The `slug_candidates` fallback `[:name, :id]` doesn't help for new records because `:id` is `nil` before the first save.

## How

Added `save_with_unique_slug!` in `SaveInstallmentService` that:
1. Attempts `installment.save` normally
2. On `RecordNotUnique` matching the slug index, appends `-<8 hex chars>` to the slug and retries
3. Re-raises `RecordNotUnique` for any other index violation

This follows the established codebase pattern (e.g. `SentPostEmail`, `SentEmailInfo`, `DevicesController`).

## Test Results

```
bundle exec rspec spec/services/save_installment_service_spec.rb
42 examples, 0 failures
```

## AI Disclosure

Fix authored by Gumclaw (Claude claude-opus-4-6). Identified root cause from Sentry payload, wrote fix and tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781993779&installation_id=134400930&pr_number=5214&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5214&signature=5240dff78bc8653f5860eb7d791b2a1b066fdb04ecd712dc8e04348cdb6ebfae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->