### PR TITLE
fix: handle InvalidForeignKey in resized_avatar_url

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -416,7 +416,7 @@ class User < ApplicationRecord
   def resized_avatar_url(size:)
     return ActionController::Base.helpers.image_url("gumroad-default-avatar-5.png") unless avatar.attached?
     cdn_url_for(avatar.variant(resize_to_limit: [size, size]).processed.url)
-  rescue ActiveStorage::FileNotFoundError, Errno::ENOENT => e
+  rescue ActiveStorage::FileNotFoundError, Errno::ENOENT, ActiveRecord::InvalidForeignKey => e
     Rails.logger.warn("User#resized_avatar_url error (#{id}): #{e.class} => #{e.message}")
     ActionController::Base.helpers.image_url("gumroad-default-avatar-5.png")
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1333,6 +1333,17 @@ describe User, :vcr do
           expect(@user.resized_avatar_url(size: 256)).to eq(ActionController::Base.helpers.image_url("gumroad-default-avatar-5.png"))
         end
       end
+
+      context "when avatar blob is deleted but attachment record still exists" do
+        it "returns URL to default avatar" do
+          allow(@user.avatar).to receive(:attached?).and_return(true)
+          allow(@user.avatar).to receive(:variant).and_raise(
+            ActiveRecord::InvalidForeignKey.new("Mysql2::Error: Cannot add or update a child row: a foreign key constraint fails")
+          )
+
+          expect(@user.resized_avatar_url(size: 256)).to eq(ActionController::Base.helpers.image_url("gumroad-default-avatar-5.png"))
+        end
+      end
     end
 
     describe "avatar_url" do


### PR DESCRIPTION
## What

Add `ActiveRecord::InvalidForeignKey` to the rescue clause in `User#resized_avatar_url`.

## Why

Sentry alert [GUMROAD-RP](https://gumroad-to.sentry.io/issues/7498389446/) — `UsersController#subscribe_preview` raises a 500 when a user's `active_storage_blobs` record is deleted but the `active_storage_attachments` record still exists. `avatar.attached?` returns `true`, so the method tries to create a variant record, but the FK constraint on `active_storage_variant_records.blob_id` fails.

The existing rescue handles `ActiveStorage::FileNotFoundError` and `Errno::ENOENT` but not the FK violation. This adds `ActiveRecord::InvalidForeignKey` so the method gracefully falls back to the default avatar.

## Test

New spec: "when avatar blob is deleted but attachment record still exists" — verifies fallback to default avatar on `InvalidForeignKey`. All existing `resized_avatar_url` specs continue to pass.

```
6 examples, 0 failures (2 pre-existing S3-dependent failures excluded)
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781994703&installation_id=134400930&pr_number=5215&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5215&signature=973e4345ec22e214ad072e31a0552deb8701ee33bc680e9157fe8d0c7468b6c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->