### PR TITLE
Add async sales export endpoint

### DIFF
--- a/app/controllers/api/v2/sales_controller.rb
+++ b/app/controllers/api/v2/sales_controller.rb
@@ -2,7 +2,7 @@
 
 class Api::V2::SalesController < Api::V2::BaseController
   include CurrencyHelper
-  before_action(only: [:index, :show]) { doorkeeper_authorize! :view_sales }
+  before_action(only: [:index, :show, :export]) { doorkeeper_authorize! :view_sales }
   before_action(only: [:mark_as_shipped]) { doorkeeper_authorize! :mark_sales_as_shipped }
   before_action(only: [:refund]) { doorkeeper_authorize! :refund_sales, :edit_sales }
   before_action(only: [:resend_receipt]) { doorkeeper_authorize! :edit_sales }
@@ -88,6 +88,19 @@ class Api::V2::SalesController < Api::V2::BaseController
     purchase ? success_with_sale(purchase.as_json(version: 2)) : error_with_sale
   end
 
+  def export
+    filters = export_filters
+    return if performed?
+
+    Exports::PurchaseExportService.export(
+      seller: current_resource_owner,
+      recipient: current_resource_owner,
+      filters:,
+      force_async: true
+    )
+    render_response(true, status: "queued", recipient_email: current_resource_owner.email)
+  end
+
   def mark_as_shipped
     purchase = current_resource_owner.sales.find_by_external_id(params[:id])
 
@@ -150,6 +163,29 @@ class Api::V2::SalesController < Api::V2::BaseController
       sales = sales.where("full_name LIKE ?", "%#{Purchase.sanitize_sql_like(name)}%") if name.present?
       sales = sales.where(id: License.where(serial: license_key.upcase).select(:purchase_id)) if license_key.present?
       sales.order(created_at: :desc, id: :desc)
+    end
+
+    def export_filters
+      filters = {}
+      filters[:start_time] = parse_export_date_param(:from) if params[:from].present?
+      filters[:end_time] = parse_export_date_param(:to) if params[:to].present?
+      return filters if performed?
+
+      if params[:product_id].present?
+        product = current_resource_owner.links.find_by_external_id(params[:product_id])
+        return error_400("Invalid product ID.") if product.nil?
+
+        filters[:product_ids] = [product.external_id]
+      end
+
+      filters
+    end
+
+    def parse_export_date_param(param)
+      Date.strptime(params[param], "%Y-%m-%d")
+      params[param]
+    rescue ArgumentError
+      error_400("Invalid date format provided in field '#{param}'. Dates must be in the format YYYY-MM-DD.")
     end
 
     def set_page # DEPRECATED

--- a/app/controllers/api/v2/sales_controller.rb
+++ b/app/controllers/api/v2/sales_controller.rb
@@ -167,9 +167,14 @@ class Api::V2::SalesController < Api::V2::BaseController
 
     def export_filters
       filters = {}
-      filters[:start_time] = parse_export_date_param(:from) if params[:from].present?
-      filters[:end_time] = parse_export_date_param(:to) if params[:to].present?
-      return filters if performed?
+      if params[:from].present?
+        filters[:start_time] = parse_export_date_param(:from)
+        return filters if performed?
+      end
+      if params[:to].present?
+        filters[:end_time] = parse_export_date_param(:to)
+        return filters if performed?
+      end
 
       if params[:product_id].present?
         product = current_resource_owner.links.find_by_external_id(params[:product_id])

--- a/app/services/exports/purchase_export_service.rb
+++ b/app/services/exports/purchase_export_service.rb
@@ -91,7 +91,7 @@ class Exports::PurchaseExportService
     tempfile
   end
 
-  def self.export(seller:, recipient:, filters: {})
+  def self.export(seller:, recipient:, filters: {}, force_async: false)
     product_ids = Link.by_external_ids(filters[:product_ids]).ids if filters[:product_ids].present?
     variant_ids = BaseVariant.by_external_ids(filters[:variant_ids]).ids if filters[:variant_ids].present?
     start_time = Date.parse(filters[:start_time]).in_time_zone("UTC").beginning_of_day if filters[:start_time].present?
@@ -109,7 +109,7 @@ class Exports::PurchaseExportService
     )
     count = EsClient.count(index: Purchase.index_name, body: { query: search_service.query })["count"]
 
-    if count <= SYNCHRONOUS_EXPORT_THRESHOLD
+    if count <= SYNCHRONOUS_EXPORT_THRESHOLD && !force_async
       records = Purchase.where(id: search_service.process.results.map(&:id))
       Exports::PurchaseExportService.new(records).perform
     else

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,6 +73,7 @@ Rails.application.routes.draw do
           put "enable"
         end
       end
+      post "sales/exports", to: "sales#export"
       resources :sales, only: [:index, :show] do
         member do
           put :mark_as_shipped

--- a/spec/controllers/api/v2/sales_controller_spec.rb
+++ b/spec/controllers/api/v2/sales_controller_spec.rb
@@ -408,6 +408,17 @@ describe Api::V2::SalesController do
         expect(Exports::PurchaseExportService).not_to have_received(:export)
       end
 
+      it "returns a 400 error when both dates are incorrectly formatted" do
+        post :export, params: @params.merge(from: "394293", to: "invalid-date")
+
+        expect(response.code).to eq "400"
+        expect(response.parsed_body).to eq({
+          status: 400,
+          error: "Invalid date format provided in field 'from'. Dates must be in the format YYYY-MM-DD."
+        }.as_json)
+        expect(Exports::PurchaseExportService).not_to have_received(:export)
+      end
+
       it "returns a 400 error if to date format is incorrect" do
         post :export, params: @params.merge(to: "invalid-date")
 
@@ -445,7 +456,7 @@ describe Api::V2::SalesController do
 
     it "grants access with the account scope" do
       token = create("doorkeeper/access_token", application: @app, resource_owner_id: @seller.id, scopes: "account")
-      post :export, params: { access_token: token.token }
+      post :export, params: { access_token: token.token, format: :json }
       expect(response).to be_successful
     end
   end

--- a/spec/controllers/api/v2/sales_controller_spec.rb
+++ b/spec/controllers/api/v2/sales_controller_spec.rb
@@ -349,6 +349,107 @@ describe Api::V2::SalesController do
     end
   end
 
+  describe "POST 'export'" do
+    before do
+      @params = {}
+      allow(Exports::PurchaseExportService).to receive(:export).and_return(false)
+    end
+
+    describe "when logged in with sales scope" do
+      before do
+        @token = create("doorkeeper/access_token", application: @app, resource_owner_id: @seller.id, scopes: "view_sales")
+        @params.merge!(format: :json, access_token: @token.token)
+      end
+
+      it "queues a sales export for the current seller" do
+        post :export, params: @params.merge(from: "2026-01-01", to: "2026-05-21", product_id: @product.external_id)
+
+        expect(response.parsed_body).to eq({
+          success: true,
+          status: "queued",
+          recipient_email: @seller.email
+        }.as_json)
+        expect(Exports::PurchaseExportService).to have_received(:export).with(
+          seller: @seller,
+          recipient: @seller,
+          filters: {
+            start_time: "2026-01-01",
+            end_time: "2026-05-21",
+            product_ids: [@product.external_id]
+          },
+          force_async: true
+        )
+      end
+
+      it "queues a sales export without optional filters" do
+        post :export, params: @params
+
+        expect(response.parsed_body).to eq({
+          success: true,
+          status: "queued",
+          recipient_email: @seller.email
+        }.as_json)
+        expect(Exports::PurchaseExportService).to have_received(:export).with(
+          seller: @seller,
+          recipient: @seller,
+          filters: {},
+          force_async: true
+        )
+      end
+
+      it "returns a 400 error if from date format is incorrect" do
+        post :export, params: @params.merge(from: "394293")
+
+        expect(response.code).to eq "400"
+        expect(response.parsed_body).to eq({
+          status: 400,
+          error: "Invalid date format provided in field 'from'. Dates must be in the format YYYY-MM-DD."
+        }.as_json)
+        expect(Exports::PurchaseExportService).not_to have_received(:export)
+      end
+
+      it "returns a 400 error if to date format is incorrect" do
+        post :export, params: @params.merge(to: "invalid-date")
+
+        expect(response.code).to eq "400"
+        expect(response.parsed_body).to eq({
+          status: 400,
+          error: "Invalid date format provided in field 'to'. Dates must be in the format YYYY-MM-DD."
+        }.as_json)
+        expect(Exports::PurchaseExportService).not_to have_received(:export)
+      end
+
+      it "returns a 400 error if product ID is invalid" do
+        post :export, params: @params.merge(product_id: "invalid base64")
+
+        expect(response.code).to eq "400"
+        expect(response.parsed_body).to eq({
+          status: 400,
+          error: "Invalid product ID."
+        }.as_json)
+        expect(Exports::PurchaseExportService).not_to have_received(:export)
+      end
+    end
+
+    describe "when logged in with public scope" do
+      before do
+        @token = create("doorkeeper/access_token", application: @app, resource_owner_id: @seller.id, scopes: "view_public")
+        @params.merge!(format: :json, access_token: @token.token)
+      end
+
+      it "the response is 403 forbidden for incorrect scope" do
+        post :export, params: @params
+        expect(response.code).to eq "403"
+      end
+    end
+
+    it "grants access with the account scope" do
+      token = create("doorkeeper/access_token", application: @app, resource_owner_id: @seller.id, scopes: "account")
+      post :export, params: { access_token: token.token }
+      expect(response).to be_successful
+    end
+  end
+
   describe "PUT 'mark_as_shipped'" do
     before do
       @product = create(:product, user: @seller)

--- a/spec/services/exports/purchase_export_service_spec.rb
+++ b/spec/services/exports/purchase_export_service_spec.rb
@@ -646,12 +646,29 @@ describe Exports::PurchaseExportService do
     end
   end
 
+  describe ".export" do
+    it "queues the export when async delivery is forced" do
+      seller = create(:user)
+      recipient = create(:user)
+      allow(EsClient).to receive(:count).and_return({ "count" => 1 })
+
+      expect do
+        @result = described_class.export(seller:, recipient:, force_async: true)
+      end.to change(SalesExport, :count).by(1)
+
+      export = SalesExport.last!
+      expect(@result).to eq(false)
+      expect(export.recipient).to eq(recipient)
+      expect(Exports::Sales::CreateAndEnqueueChunksWorker).to have_enqueued_sidekiq_job(export.id)
+    end
+  end
+
   def csv_safe(value)
     return value if value.nil?
     str = value.to_s
     return value if str.empty?
     first = str[0]
-    if first == '+' || first == '-'
+    if first == "+" || first == "-"
       return value if str[1..]&.match?(/\A\d+\.?\d*\z/)
     end
     %w[= @ | % \r \t + -].include?(first) ? "'#{value}" : value


### PR DESCRIPTION
Ref antiwork/gumroad-cli/issues/97

## What
- Adds a `POST /v2/sales/exports` endpoint for CLI-driven sales exports.
- Accepts `from`, `to`, and `product_id`, validates them, and queues the export for email delivery.
- Keeps the existing synchronous export flow intact for the web UI while forcing the API path to run asynchronously.

## Why
- Sellers need a terminal-friendly way to request larger sales exports without waiting on the request cycle.
- Reusing the existing export service keeps the API aligned with the current CSV export behavior instead of introducing a separate export pipeline.

---
This PR was implemented with AI assistance using gpt-5.5 xhigh.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781996144&installation_id=134400930&pr_number=5216&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5216&signature=7db89dbdfa791c8a1dc1e6b1266e2c579e7cb5dbb397fe1163a461954696128c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->