### PR TITLE
Add a sales summary API endpoint

### DIFF
--- a/app/controllers/api/v2/sales_controller.rb
+++ b/app/controllers/api/v2/sales_controller.rb
@@ -2,7 +2,7 @@
 
 class Api::V2::SalesController < Api::V2::BaseController
   include CurrencyHelper
-  before_action(only: [:index, :show, :export]) { doorkeeper_authorize! :view_sales }
+  before_action(only: [:index, :show, :export, :summary]) { doorkeeper_authorize! :view_sales }
   before_action(only: [:mark_as_shipped]) { doorkeeper_authorize! :mark_sales_as_shipped }
   before_action(only: [:refund]) { doorkeeper_authorize! :refund_sales, :edit_sales }
   before_action(only: [:resend_receipt]) { doorkeeper_authorize! :edit_sales }
@@ -101,6 +101,13 @@ class Api::V2::SalesController < Api::V2::BaseController
     render_response(true, status: "queued", recipient_email: current_resource_owner.email)
   end
 
+  def summary
+    summary_params = sales_summary_params
+    return if performed?
+
+    render_response(true, Api::V2::SalesSummary.new(seller: current_resource_owner, **summary_params))
+  end
+
   def mark_as_shipped
     purchase = current_resource_owner.sales.find_by_external_id(params[:id])
 
@@ -189,6 +196,32 @@ class Api::V2::SalesController < Api::V2::BaseController
     def parse_export_date_param(param)
       Date.strptime(params[param], "%Y-%m-%d")
       params[param]
+    rescue ArgumentError
+      error_400("Invalid date format provided in field '#{param}'. Dates must be in the format YYYY-MM-DD.")
+    end
+
+    def sales_summary_params
+      group_by = params[:group_by].presence
+      if group_by.present? && Api::V2::SalesSummary::VALID_GROUPS.exclude?(group_by)
+        return error_400("Invalid group_by. Valid values are: #{Api::V2::SalesSummary::VALID_GROUPS.join(', ')}.")
+      end
+
+      from = parse_summary_date_param(:from) if params[:from].present?
+      return if performed?
+
+      to = params[:to].present? ? parse_summary_date_param(:to) : ActiveSupport::TimeZone[current_resource_owner.timezone].today
+      return if performed?
+
+      from ||= to - 29
+
+      return error_400("'from' must be on or before 'to'.") if from > to
+      return error_400("Date range cannot exceed #{AnalyticsController::MAX_DATE_RANGE_DAYS} days.") if (to - from).to_i > AnalyticsController::MAX_DATE_RANGE_DAYS
+
+      { from:, to:, group_by: }
+    end
+
+    def parse_summary_date_param(param)
+      Date.strptime(params[param], "%Y-%m-%d")
     rescue ArgumentError
       error_400("Invalid date format provided in field '#{param}'. Dates must be in the format YYYY-MM-DD.")
     end

--- a/app/services/api/v2/sales_summary.rb
+++ b/app/services/api/v2/sales_summary.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+class Api::V2::SalesSummary
+  VALID_GROUPS = %w[product day week month].freeze
+
+  def initialize(seller:, from:, to:, group_by: nil)
+    @seller = seller
+    @from = from
+    @to = to
+    @group_by = group_by
+  end
+
+  def as_json(*)
+    result = summary_from_search
+    result.merge!(
+      currency: Currency::USD,
+      from: @from.to_s,
+      to: @to.to_s,
+    )
+    result[:breakdown] = breakdown if @group_by.present?
+    result
+  end
+
+  private
+    def summary_from_search
+      search_result = PurchaseSearchService.search(base_search_options.merge(track_total_hits: true, aggs: metric_aggs))
+      summary_from_result(search_result.results.total, search_result.aggregations)
+    end
+
+    def breakdown
+      buckets = paginated_breakdown_buckets
+      @products_by_id = @seller.links.where(id: buckets.map { _1["key"]["product_id"].to_i }.uniq).index_by(&:id) if @group_by == "product"
+      items = buckets.map { breakdown_item(_1) }
+      return items.sort_by { [-_1[:gross_cents], _1[:label].to_s] } if @group_by == "product"
+
+      items.sort_by { _1[:key] }
+    end
+
+    def paginated_breakdown_buckets
+      after_key = nil
+      body = breakdown_body
+      buckets = []
+
+      loop do
+        body[:aggs][:breakdown][:composite][:after] = after_key if after_key
+        response = Purchase.search(body).aggregations.breakdown
+        buckets += response.buckets
+        break if response.buckets.size < ES_MAX_BUCKET_SIZE
+
+        after_key = response["after_key"]
+      end
+
+      buckets
+    end
+
+    def breakdown_body
+      {
+        query: PurchaseSearchService.new(base_search_options).query,
+        size: 0,
+        aggs: {
+          breakdown: {
+            composite: { size: ES_MAX_BUCKET_SIZE, sources: breakdown_sources },
+            aggs: metric_aggs
+          }
+        }
+      }
+    end
+
+    def base_search_options
+      Purchase::CHARGED_SALES_SEARCH_OPTIONS.merge(
+        seller: @seller,
+        exclude_refunded: false,
+        exclude_unreversed_chargedback: false,
+        created_on_or_after: CreatorAnalytics::DateQuery.day_start(@from, timezone: @seller.timezone),
+        created_before: CreatorAnalytics::DateQuery.day_start(@to + 1.day, timezone: @seller.timezone),
+        size: 0,
+      )
+    end
+
+    def metric_aggs
+      {
+        gross_cents: { sum: { field: "price_cents" } },
+        refunded_cents: { sum: { field: "amount_refunded_cents" } },
+        refunded_units: { filter: { range: { amount_refunded_cents: { gt: 0 } } } },
+      }
+    end
+
+    def breakdown_sources
+      case @group_by
+      when "product"
+        [{ product_id: { terms: { field: "product_id" } } }]
+      when "day", "week", "month"
+        [{ date: { date_histogram: { time_zone: @seller.timezone_id, field: "created_at", calendar_interval: @group_by, format: date_format } } }]
+      end
+    end
+
+    def date_format
+      @group_by == "month" ? "yyyy-MM" : "yyyy-MM-dd"
+    end
+
+    def breakdown_item(bucket)
+      item = summary_from_result(bucket["doc_count"], bucket)
+      if @group_by == "product"
+        product = products_by_id[bucket["key"]["product_id"].to_i]
+        item.merge(key: product&.external_id || bucket["key"]["product_id"].to_s, label: product&.name)
+      else
+        item.merge(key: bucket["key"]["date"], label: bucket["key"]["date"])
+      end
+    end
+
+    def summary_from_result(units, aggregation)
+      gross_cents = aggregation["gross_cents"]["value"].to_i
+      refunded_cents = aggregation["refunded_cents"]["value"].to_i
+      {
+        gross_cents:,
+        net_cents: gross_cents - refunded_cents,
+        units:,
+        refunded_cents:,
+        refunded_units: aggregation["refunded_units"]["doc_count"],
+      }
+    end
+
+    def products_by_id
+      @products_by_id ||= {}
+    end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,6 +74,7 @@ Rails.application.routes.draw do
         end
       end
       post "sales/exports", to: "sales#export"
+      get "sales/summary", to: "sales#summary"
       resources :sales, only: [:index, :show] do
         member do
           put :mark_as_shipped

--- a/spec/controllers/api/v2/sales_controller_spec.rb
+++ b/spec/controllers/api/v2/sales_controller_spec.rb
@@ -510,7 +510,7 @@ describe Api::V2::SalesController do
         )
       end
 
-      it "uses the requested end date when only from is provided" do
+      it "defaults the end date to today in the seller's timezone when only from is provided" do
         travel_to(Time.utc(2026, 5, 21, 12)) do
           get :summary, params: @params.merge(from: "2026-05-01")
         end

--- a/spec/controllers/api/v2/sales_controller_spec.rb
+++ b/spec/controllers/api/v2/sales_controller_spec.rb
@@ -461,6 +461,132 @@ describe Api::V2::SalesController do
     end
   end
 
+  describe "GET 'summary'" do
+    before do
+      @params = {}
+      @summary = {
+        gross_cents: 0,
+        net_cents: 0,
+        units: 0,
+        refunded_cents: 0,
+        refunded_units: 0,
+        currency: "usd",
+        from: "2026-04-22",
+        to: "2026-05-21"
+      }
+      allow(Api::V2::SalesSummary).to receive(:new).and_return(@summary)
+    end
+
+    describe "when logged in with sales scope" do
+      before do
+        @token = create("doorkeeper/access_token", application: @app, resource_owner_id: @seller.id, scopes: "view_sales")
+        @params.merge!(format: :json, access_token: @token.token)
+      end
+
+      it "returns a sales summary for the requested date range and grouping" do
+        get :summary, params: @params.merge(from: "2026-01-01", to: "2026-05-21", group_by: "month")
+
+        expect(response.parsed_body).to eq({ success: true }.merge(@summary).as_json)
+        expect(Api::V2::SalesSummary).to have_received(:new).with(
+          seller: @seller,
+          from: Date.new(2026, 1, 1),
+          to: Date.new(2026, 5, 21),
+          group_by: "month"
+        )
+      end
+
+      it "defaults to the last 30 days in the seller's timezone" do
+        @seller.update!(timezone: "Tokyo")
+
+        travel_to(Time.utc(2026, 5, 21, 18)) do
+          get :summary, params: @params
+        end
+
+        expect(Api::V2::SalesSummary).to have_received(:new).with(
+          seller: @seller,
+          from: Date.new(2026, 4, 23),
+          to: Date.new(2026, 5, 22),
+          group_by: nil
+        )
+      end
+
+      it "uses the requested end date when only from is provided" do
+        travel_to(Time.utc(2026, 5, 21, 12)) do
+          get :summary, params: @params.merge(from: "2026-05-01")
+        end
+
+        expect(Api::V2::SalesSummary).to have_received(:new).with(
+          seller: @seller,
+          from: Date.new(2026, 5, 1),
+          to: Date.new(2026, 5, 21),
+          group_by: nil
+        )
+      end
+
+      it "returns a 400 error if from date format is incorrect" do
+        get :summary, params: @params.merge(from: "394293")
+
+        expect(response.code).to eq "400"
+        expect(response.parsed_body).to eq({
+          status: 400,
+          error: "Invalid date format provided in field 'from'. Dates must be in the format YYYY-MM-DD."
+        }.as_json)
+        expect(Api::V2::SalesSummary).not_to have_received(:new)
+      end
+
+      it "returns a 400 error if from is after to" do
+        get :summary, params: @params.merge(from: "2026-05-22", to: "2026-05-21")
+
+        expect(response.code).to eq "400"
+        expect(response.parsed_body).to eq({
+          status: 400,
+          error: "'from' must be on or before 'to'."
+        }.as_json)
+        expect(Api::V2::SalesSummary).not_to have_received(:new)
+      end
+
+      it "returns a 400 error if date range is too wide" do
+        get :summary, params: @params.merge(from: "2025-01-01", to: "2026-05-21")
+
+        expect(response.code).to eq "400"
+        expect(response.parsed_body).to eq({
+          status: 400,
+          error: "Date range cannot exceed 366 days."
+        }.as_json)
+        expect(Api::V2::SalesSummary).not_to have_received(:new)
+      end
+
+      it "returns a 400 error if group_by is invalid" do
+        get :summary, params: @params.merge(group_by: "email")
+
+        expect(response.code).to eq "400"
+        expect(response.parsed_body).to eq({
+          status: 400,
+          error: "Invalid group_by. Valid values are: product, day, week, month."
+        }.as_json)
+        expect(Api::V2::SalesSummary).not_to have_received(:new)
+      end
+    end
+
+    describe "when logged in with public scope" do
+      before do
+        @token = create("doorkeeper/access_token", application: @app, resource_owner_id: @seller.id, scopes: "view_public")
+        @params.merge!(format: :json, access_token: @token.token)
+      end
+
+      it "the response is 403 forbidden for incorrect scope" do
+        get :summary, params: @params
+        expect(response.code).to eq "403"
+      end
+    end
+
+    it "grants access with the account scope" do
+      token = create("doorkeeper/access_token", application: @app, resource_owner_id: @seller.id, scopes: "account")
+      get :summary, params: { access_token: token.token, format: :json }
+      expect(response).to be_successful
+    end
+  end
+
   describe "PUT 'mark_as_shipped'" do
     before do
       @product = create(:product, user: @seller)

--- a/spec/services/api/v2/sales_summary_spec.rb
+++ b/spec/services/api/v2/sales_summary_spec.rb
@@ -66,6 +66,22 @@ describe Api::V2::SalesSummary do
                                        ])
     end
 
+    it "paginates breakdown buckets" do
+      stub_const("#{described_class}::ES_MAX_BUCKET_SIZE", 2)
+      seller = create(:user, timezone: "UTC")
+      products = create_list(:product, 3, user: seller, price_cents: 10_00)
+      products.each do |product|
+        create(:purchase, link: product, price_cents: 10_00, created_at: Time.utc(2026, 1, 1, 12))
+      end
+      index_model_records(Purchase)
+
+      expect(Purchase).to receive(:search).exactly(3).times.and_call_original
+
+      result = described_class.new(seller:, from: Date.new(2026, 1, 1), to: Date.new(2026, 1, 31), group_by: "product").as_json
+
+      expect(result[:breakdown].map { _1[:key] }).to match_array(products.map(&:external_id))
+    end
+
     it "groups date breakdowns in the seller's timezone" do
       seller = create(:user, timezone: "Pacific Time (US & Canada)")
       product = create(:product, user: seller, price_cents: 10_00)

--- a/spec/services/api/v2/sales_summary_spec.rb
+++ b/spec/services/api/v2/sales_summary_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Api::V2::SalesSummary do
+  describe "#as_json" do
+    it "returns totals for the requested date range" do
+      seller = create(:user, timezone: "UTC")
+      product = create(:product, user: seller, price_cents: 10_00)
+      create(:purchase, link: product, price_cents: 10_00, created_at: Time.utc(2026, 1, 1, 12))
+      create(:purchase, link: product, price_cents: 20_00, created_at: Time.utc(2026, 1, 2, 12))
+      partially_refunded_purchase = create(:purchase, link: product, price_cents: 30_00, created_at: Time.utc(2026, 1, 3, 12))
+      partially_refunded_purchase.refund_partial_purchase!(5_00, seller.id)
+      create(:refunded_purchase, link: product, price_cents: 40_00, created_at: Time.utc(2026, 1, 3, 12))
+      create(:purchase, link: product, price_cents: 50_00, created_at: Time.utc(2026, 2, 1, 12))
+      create(:failed_purchase, link: product, price_cents: 60_00, created_at: Time.utc(2026, 1, 2, 12))
+      create(:purchase, :gift_receiver, link: product, price_cents: 70_00, created_at: Time.utc(2026, 1, 2, 12))
+      create(:purchase, price_cents: 80_00, created_at: Time.utc(2026, 1, 2, 12))
+      index_model_records(Purchase)
+
+      result = described_class.new(seller:, from: Date.new(2026, 1, 1), to: Date.new(2026, 1, 31)).as_json
+
+      expect(result).to eq(
+        gross_cents: 100_00,
+        net_cents: 55_00,
+        units: 4,
+        refunded_cents: 45_00,
+        refunded_units: 2,
+        currency: "usd",
+        from: "2026-01-01",
+        to: "2026-01-31",
+      )
+    end
+
+    it "returns product breakdowns sorted by gross sales" do
+      seller = create(:user, timezone: "UTC")
+      product = create(:product, user: seller, name: "Small product", price_cents: 10_00)
+      larger_product = create(:product, user: seller, name: "Large product", price_cents: 20_00)
+      create(:purchase, link: product, price_cents: 10_00, created_at: Time.utc(2026, 1, 1, 12))
+      create(:purchase, link: larger_product, price_cents: 20_00, created_at: Time.utc(2026, 1, 2, 12))
+      partially_refunded_purchase = create(:purchase, link: larger_product, price_cents: 30_00, created_at: Time.utc(2026, 1, 3, 12))
+      partially_refunded_purchase.refund_partial_purchase!(5_00, seller.id)
+      index_model_records(Purchase)
+
+      result = described_class.new(seller:, from: Date.new(2026, 1, 1), to: Date.new(2026, 1, 31), group_by: "product").as_json
+
+      expect(result[:breakdown]).to eq([
+                                         {
+                                           key: larger_product.external_id,
+                                           label: "Large product",
+                                           gross_cents: 50_00,
+                                           net_cents: 45_00,
+                                           units: 2,
+                                           refunded_cents: 5_00,
+                                           refunded_units: 1,
+                                         },
+                                         {
+                                           key: product.external_id,
+                                           label: "Small product",
+                                           gross_cents: 10_00,
+                                           net_cents: 10_00,
+                                           units: 1,
+                                           refunded_cents: 0,
+                                           refunded_units: 0,
+                                         }
+                                       ])
+    end
+
+    it "groups date breakdowns in the seller's timezone" do
+      seller = create(:user, timezone: "Pacific Time (US & Canada)")
+      product = create(:product, user: seller, price_cents: 10_00)
+      create(:purchase, link: product, price_cents: 10_00, created_at: Time.utc(2026, 5, 21, 6, 30))
+      create(:purchase, link: product, price_cents: 20_00, created_at: Time.utc(2026, 5, 21, 8, 0))
+      index_model_records(Purchase)
+
+      result = described_class.new(seller:, from: Date.new(2026, 5, 20), to: Date.new(2026, 5, 21), group_by: "day").as_json
+
+      expect(result[:breakdown]).to eq([
+                                         {
+                                           key: "2026-05-20",
+                                           label: "2026-05-20",
+                                           gross_cents: 10_00,
+                                           net_cents: 10_00,
+                                           units: 1,
+                                           refunded_cents: 0,
+                                           refunded_units: 0,
+                                         },
+                                         {
+                                           key: "2026-05-21",
+                                           label: "2026-05-21",
+                                           gross_cents: 20_00,
+                                           net_cents: 20_00,
+                                           units: 1,
+                                           refunded_cents: 0,
+                                           refunded_units: 0,
+                                         }
+                                       ])
+    end
+
+    it "groups monthly breakdowns" do
+      seller = create(:user, timezone: "UTC")
+      product = create(:product, user: seller, price_cents: 10_00)
+      create(:purchase, link: product, price_cents: 10_00, created_at: Time.utc(2026, 1, 31, 12))
+      create(:purchase, link: product, price_cents: 20_00, created_at: Time.utc(2026, 2, 1, 12))
+      index_model_records(Purchase)
+
+      result = described_class.new(seller:, from: Date.new(2026, 1, 1), to: Date.new(2026, 2, 28), group_by: "month").as_json
+
+      expect(result[:breakdown].pluck(:key)).to eq(["2026-01", "2026-02"])
+    end
+
+    it "groups weekly breakdowns" do
+      seller = create(:user, timezone: "UTC")
+      product = create(:product, user: seller, price_cents: 10_00)
+      create(:purchase, link: product, price_cents: 10_00, created_at: Time.utc(2026, 1, 7, 12))
+      create(:purchase, link: product, price_cents: 20_00, created_at: Time.utc(2026, 1, 12, 12))
+      index_model_records(Purchase)
+
+      result = described_class.new(seller:, from: Date.new(2026, 1, 1), to: Date.new(2026, 1, 31), group_by: "week").as_json
+
+      expect(result[:breakdown].pluck(:key)).to eq(["2026-01-05", "2026-01-12"])
+    end
+  end
+end


### PR DESCRIPTION
Ref antiwork/gumroad-cli/issues/97

## What

This PR adds a sales summary endpoint that returns an aggregated view of sales for the current account. It gives clients a simpler way to fetch the totals they need without assembling the data themselves.

## Why

This reduces duplicate client-side logic and makes the sales data easier to consume in one request. It also keeps the API response focused on the summary view the product needs.

---

This PR was implemented with AI assistance using gpt‑5.5 xhigh.