### PR TITLE
Native Playwright test infrastructure (null driver pattern)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ end
 
 group :test do
   gem "capybara", "~> 3.38"
+  gem "playwright-ruby-client", "~> 1.60"
   gem "factory_bot_rails", "~> 6.4"
   gem "faker", "~> 3.1"
   gem "rspec", "~> 3.12"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -693,6 +693,10 @@ GEM
       ttfunk
     pdfkit (0.8.7.3)
     phony (2.20.12)
+    playwright-ruby-client (1.60.0)
+      base64
+      concurrent-ruby (>= 1.1.6)
+      mime-types (>= 3.0)
     pp (0.6.3)
       prettyprint
     prawn (2.5.0)
@@ -1201,6 +1205,7 @@ DEPENDENCIES
   pdf-reader (~> 2.11)
   pdfkit (~> 0.8)
   phony (~> 2.20)
+  playwright-ruby-client (~> 1.60)
   prawn (~> 2.4)
   premailer-rails (~> 1.12)
   private_address_check (~> 0.5)

--- a/spec/support/playwright_native.rb
+++ b/spec/support/playwright_native.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+# Infrastructure for native Playwright specs (no Capybara DSL).
+#
+# Usage: tag specs with `driver: :playwright` to get a fresh BrowserContext
+# per test with `@playwright_page` available.
+#
+# Example:
+#   describe "Login flow", driver: :playwright do
+#     it "signs in" do
+#       page = @playwright_page
+#       page.goto("/login")
+#       page.get_by_label("Email").fill("user@example.com")
+#       page.get_by_label("Password").fill("secret")
+#       page.get_by_role("button", name: "Log in").click
+#       expect(page.get_by_text("Dashboard")).to be_visible
+#     end
+#   end
+#
+# Benefits over Capybara DSL:
+# - Native Playwright auto-waiting (no more sleep/wait_for_ajax)
+# - get_by_role, get_by_label, get_by_text selectors
+# - Built-in assertions (to_be_visible, to_have_text, etc.)
+# - No stale element errors
+# - Screenshot/video recording per-test
+# - Network interception via page.route
+
+require "capybara"
+require "playwright"
+require "playwright/test"
+
+# Null driver: tells Capybara to boot the Rails server without
+# actually providing a browser — we manage that ourselves via Playwright.
+class CapybaraNullDriver < Capybara::Driver::Base
+  def needs_server?
+    true
+  end
+end
+
+Capybara.register_driver(:playwright_null) { CapybaraNullDriver.new }
+
+# Shared browser singleton — launched once per suite, one BrowserContext per test.
+module PlaywrightTestBrowser
+  class << self
+    attr_reader :browser, :playwright_instance
+
+    def start!
+      @fiber = Fiber.new do
+        Playwright.create(playwright_cli_executable_path: playwright_cli_path) do |playwright|
+          @playwright_instance = playwright
+          browser = playwright.chromium.launch(
+            headless: ENV["HEADLESS"] != "false",
+            args: [
+              "--disable-gpu",
+              "--no-sandbox",
+              "--disable-setuid-sandbox",
+              "--disable-dev-shm-usage",
+            ],
+          )
+          Fiber.yield(browser)
+          browser.close
+        end
+      end
+      @browser = @fiber.resume
+    end
+
+    def stop!
+      @fiber&.resume
+    end
+
+    private
+
+    def playwright_cli_path
+      local = File.join(Dir.pwd, "node_modules", ".bin", "playwright")
+      File.exist?(local) ? local : "playwright"
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.before(:suite) do
+    PlaywrightTestBrowser.start!
+  end
+
+  config.after(:suite) do
+    PlaywrightTestBrowser.stop!
+  end
+
+  config.around(:each, driver: :playwright) do |example|
+    Capybara.current_driver = :playwright_null
+
+    # Boot the Rails test server and get its URL
+    base_url = Capybara.current_session.server.base_url
+
+    PlaywrightTestBrowser.browser.new_context(
+      baseURL: base_url,
+      viewport: { width: 1440, height: 900 },
+      ignoreHTTPSErrors: true,
+      locale: "en-US",
+    ) do |context|
+      @playwright_page = context.new_page
+      @playwright_context = context
+      example.run
+    end
+  end
+end
+
+# Helper module included in playwright-driver specs
+module PlaywrightHelpers
+  # Sign in by posting to the Devise session endpoint directly,
+  # then transferring the session cookie to the Playwright browser.
+  def playwright_login_as(user, page: @playwright_page)
+    # Use Warden's test helper to set the cookie via a direct request
+    base_url = Capybara.current_session.server.base_url
+
+    # Navigate to a lightweight page first to establish the domain
+    page.goto("/")
+
+    # Post login credentials via Playwright
+    page.goto("/login")
+    page.get_by_label("Email").fill(user.email)
+    page.get_by_label("Password").fill(user.password || "password")
+    page.get_by_role("button", name: "Log in").click
+
+    # Wait for redirect to complete
+    page.wait_for_url("**/")
+  end
+
+  # Assert text is visible on the page (with auto-wait)
+  def expect_text(text, page: @playwright_page)
+    expect(page.get_by_text(text)).to be_visible
+  end
+
+  # Assert text is NOT visible
+  def expect_no_text(text, page: @playwright_page)
+    expect(page.get_by_text(text)).not_to be_visible
+  end
+
+  # Take a screenshot on failure
+  def save_playwright_screenshot(name)
+    path = Rails.root.join("tmp", "screenshots", "#{name}.png")
+    FileUtils.mkdir_p(File.dirname(path))
+    @playwright_page&.screenshot(path: path.to_s)
+    path
+  end
+end
+
+RSpec.configure do |config|
+  config.include PlaywrightHelpers, driver: :playwright
+  config.include Playwright::Test::Matchers, driver: :playwright
+
+  # Auto-screenshot on failure
+  config.after(:each, driver: :playwright) do |example|
+    if example.exception && @playwright_page
+      name = example.full_description.parameterize.truncate(200)
+      path = save_playwright_screenshot(name)
+      example.metadata[:playwright_screenshot] = path.to_s
+    end
+  end
+end

--- a/spec/system/settings/password_spec.rb
+++ b/spec/system/settings/password_spec.rb
@@ -1,0 +1,229 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Native Playwright version of spec/requests/settings/password_spec.rb
+#
+# Uses playwright-ruby-client directly instead of Capybara DSL.
+# Benefits:
+# - Native auto-waiting (no sleep/retry)
+# - get_by_label, get_by_role selectors
+# - No stale element errors
+# - Cleaner, more readable test code
+describe("Password Settings", driver: :playwright) do
+  let(:compromised_password) { "password" }
+  let(:not_compromised_password) { SecureRandom.hex(24) }
+
+  def page
+    @playwright_page
+  end
+
+  def login_via_browser(user)
+    page.goto("/login")
+    page.get_by_label("Email").fill(user.email)
+    page.locator("input[type='password']").fill(user.password)
+    page.get_by_role("button", name: "Login").click
+    # Wait for successful login — we should land on a page with the main nav
+    page.locator("nav[aria-label='Main']").wait_for(state: "visible", timeout: 15_000)
+  end
+
+  def alert_text
+    page.locator("[role='alert']").text_content
+  end
+
+  def expect_alert(text:)
+    expect(page.locator("[role='alert']")).to have_text(text)
+  end
+
+  context "when logged in using social login provider" do
+    let(:user) { create(:user, provider: :facebook, password: "-42Q_.c_3628Ca!mW-xTJ8v*") }
+
+    it "doesn't allow setting a new password with a value that was found in the password breaches" do
+      login_via_browser(user)
+      page.goto("/settings/password")
+
+      # Social login users don't see "Old password"
+      expect(page.get_by_label("Old password").count).to eq(0)
+
+      page.get_by_label("Add password").fill(compromised_password)
+
+      vcr_turned_on do
+        VCR.use_cassette("Add Password-with a compromised password") do
+          with_real_pwned_password_check do
+            page.get_by_role("button", name: "Change password").click
+            expect_alert(
+              text: "New password has previously appeared in a data breach as per haveibeenpwned.com and should never be used. Please choose something harder to guess.",
+            )
+          end
+        end
+      end
+    end
+
+    it "allows setting a new password with a value that was not found in the password breaches" do
+      login_via_browser(user)
+      page.goto("/settings/password")
+
+      expect(page.get_by_label("Old password").count).to eq(0)
+
+      page.get_by_label("Add password").fill(not_compromised_password)
+
+      vcr_turned_on do
+        VCR.use_cassette("Add Password-with a not compromised password") do
+          with_real_pwned_password_check do
+            page.get_by_role("button", name: "Change password").click
+            expect_alert(text: "You have successfully changed your password.")
+          end
+        end
+      end
+    end
+  end
+
+  context "when not logged in using social provider" do
+    let(:user) { create(:user) }
+
+    it "validates the new password length" do
+      login_via_browser(user)
+      page.goto("/settings/password")
+
+      # Too short
+      page.get_by_label("Old password").fill(user.password)
+      page.get_by_label("New password").fill("123")
+      encrypted_before = user.reload.encrypted_password
+      page.get_by_role("button", name: "Change password").click
+      expect_alert(text: "Your new password is too short.")
+      expect(user.reload.encrypted_password).to eq(encrypted_before)
+
+      # Minimum length (4 chars)
+      page.get_by_label("New password").fill("1234")
+      page.get_by_role("button", name: "Change password").click
+      expect_alert(text: "You have successfully changed your password.")
+      expect(user.reload.encrypted_password).not_to eq(encrypted_before)
+
+      # Too long (128 chars)
+      encrypted_before = user.reload.encrypted_password
+      page.get_by_label("Old password").fill("1234")
+      page.get_by_label("New password").fill("*" * 128)
+      page.get_by_role("button", name: "Change password").click
+      expect_alert(text: "Your new password is too long.")
+      expect(user.reload.encrypted_password).to eq(encrypted_before)
+
+      # Max length (127 chars)
+      page.get_by_label("Old password").fill("1234")
+      page.get_by_label("New password").fill("*" * 127)
+      page.get_by_role("button", name: "Change password").click
+      expect_alert(text: "You have successfully changed your password.")
+      expect(user.reload.encrypted_password).not_to eq(encrypted_before)
+    end
+
+    it "doesn't allow changing the password with a value that was found in the password breaches" do
+      login_via_browser(user)
+      page.goto("/settings/password")
+
+      page.get_by_label("Old password").fill(user.password)
+      page.get_by_label("New password").fill(compromised_password)
+
+      vcr_turned_on do
+        VCR.use_cassette("Add Password-with a compromised password") do
+          with_real_pwned_password_check do
+            page.get_by_role("button", name: "Change password").click
+            expect_alert(
+              text: "New password has previously appeared in a data breach as per haveibeenpwned.com and should never be used. Please choose something harder to guess.",
+            )
+          end
+        end
+      end
+    end
+
+    it "allows changing the password with a value that was not found in the password breaches" do
+      login_via_browser(user)
+      page.goto("/settings/password")
+
+      page.get_by_label("Old password").fill(user.password)
+      page.get_by_label("New password").fill(not_compromised_password)
+
+      vcr_turned_on do
+        VCR.use_cassette("Add Password-with a not compromised password") do
+          with_real_pwned_password_check do
+            page.get_by_role("button", name: "Change password").click
+            expect_alert(text: "You have successfully changed your password.")
+          end
+        end
+      end
+    end
+  end
+
+  describe "two-factor authentication section" do
+    let(:user) { create(:user) }
+
+    context "when feature flag is active" do
+      before do
+        Feature.activate(:authenticator_2fa)
+      end
+
+      it "displays authenticator app status" do
+        login_via_browser(user)
+        page.goto("/settings/password")
+
+        expect(page.get_by_text("Two-factor authentication")).to be_visible
+        expect(page.get_by_text("Authenticator app")).to be_visible
+        expect(page.get_by_role("button", name: "Set up")).to be_visible
+      end
+
+      it "allows setting up and then removing the authenticator app" do
+        login_via_browser(user)
+        page.goto("/settings/password")
+
+        page.get_by_role("button", name: "Set up").click
+        expect(page.get_by_text("Scan this QR code")).to be_visible
+        expect(page.locator("[data-testid='qr-code']")).to be_visible
+
+        credential = user.reload.totp_credential
+        expect(credential).to be_present
+        expect(credential).not_to be_confirmed
+
+        page.get_by_label("Enter the code from your authenticator app").fill(credential.otp_code)
+        page.get_by_role("button", name: "Verify").click
+
+        expect(page.get_by_text("Save these codes")).to be_visible
+        expect(credential.reload).to be_confirmed
+
+        page.get_by_role("button", name: "Done").click
+        expect(page.get_by_role("button", name: "Remove")).to be_visible
+
+        page.get_by_role("button", name: "Remove").click
+        expect(page.get_by_role("button", name: "Set up")).to be_visible
+        expect(user.reload.totp_credential).to be_nil
+      end
+
+      context "when authenticator app is enabled" do
+        before do
+          create(:totp_credential, :with_recovery_codes, user:)
+        end
+
+        it "allows regenerating recovery codes" do
+          login_via_browser(user)
+          page.goto("/settings/password")
+
+          page.get_by_role("button", name: "Regenerate recovery codes").click
+
+          expect(page.get_by_text("Save these codes")).to be_visible
+          expect(page.get_by_role("button", name: "Copy all")).to be_visible
+          expect(page.get_by_role("button", name: "Download")).to be_visible
+
+          page.get_by_role("button", name: "Done").click
+          expect(page.get_by_text("Save these codes")).not_to be_visible
+        end
+      end
+    end
+
+    context "when feature flag is not active" do
+      it "does not display the two-factor authentication section" do
+        login_via_browser(user)
+        page.goto("/settings/password")
+
+        expect(page.get_by_text("Two-factor authentication").count).to eq(0)
+        expect(page.get_by_text("Authenticator app").count).to eq(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What
Add `playwright-ruby-client` with the null driver pattern for writing end-to-end tests using Playwright's native API directly — no Capybara DSL.

## Why
[Playwright is less flaky than Selenium](https://justin.searls.co/links/2024-08-29-why-playwright-is-less-flaky-than-selenium/) — native auto-waiting, semantic selectors (`get_by_role`, `get_by_label`), and better error messages with call logs.

Capybara's DSL layer introduces its own timing issues and selector ambiguity. By using Playwright directly, we get cleaner tests and leverage the full Playwright API (network interception, tracing, video recording).

## Architecture

**Null driver pattern** (from [official guide](https://playwright-ruby-client.vercel.app/docs/article/guides/rails_integration_with_null_driver)):
- `CapybaraNullDriver`: tells Capybara to boot the Rails test server without providing a browser
- `PlaywrightTestBrowser`: shared browser singleton launched once per suite (Fiber-based lifecycle)
- Each test gets a fresh `BrowserContext` (equivalent to new incognito window)
- Tag specs with `driver: :playwright` to opt in

**Stays RSpec** — not switching to Minitest. The infrastructure integrates with our existing RSpec setup, factories, VCR, and spec_helper.

## Pilot Spec
Converted `spec/requests/settings/password_spec.rb` → `spec/system/settings/password_spec.rb`

Before (Capybara DSL):
```ruby
fill_in('Old password', with: user.password)
fill_in('New password', with: '123')
click_on('Change password')
expect(page).to have_alert(text: 'Your new password is too short.')
```

After (native Playwright):
```ruby
page.get_by_label('Old password').fill(user.password)
page.get_by_label('New password').fill('123')
page.get_by_role('button', name: 'Change password').click
expect(page.locator("[role='alert']")).to have_text('Your new password is too short.')
```

## Status
- Infrastructure: ✅ working
- Pilot spec: 3/9 passing, remaining need VCR/WebMock integration work (VCR cassettes don't intercept Playwright's HTTP — only WebMock stubs in the test process)
- New specs in `spec/system/` — existing Capybara specs untouched

## Files
| File | What |
|------|------|
| `Gemfile` | Add `playwright-ruby-client (~> 1.60)` |
| `spec/support/playwright_native.rb` | Null driver, shared browser, helpers, matchers |
| `spec/system/settings/password_spec.rb` | Pilot conversion |

---
*This PR was authored with AI assistance (Gumclaw). I have reviewed and tested the changes.*

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782000615&installation_id=134400930&pr_number=5221&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5221&signature=a1d84608f45e7f91b33b3411cf790a96cc7999aa9f96ebbecf1a86644baa8404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->