### PR TITLE
Skip check_suspended when impersonating a user

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,7 +32,7 @@ class ApplicationController < ActionController::Base
   before_action :redirect_to_custom_subdomain
 
   before_action :set_signup_referrer, if: -> { logged_in_user.nil? }
-  before_action :check_suspended, if: -> { logged_in_user.present? && logged_in_user.suspended? && !request.get? && !request.head? }
+  before_action :check_suspended, if: -> { logged_in_user.present? && logged_in_user.suspended? && !impersonating? && !request.get? && !request.head? }
 
   before_action :set_gumroad_guid
 

--- a/spec/requests/admin/impersonate_spec.rb
+++ b/spec/requests/admin/impersonate_spec.rb
@@ -28,6 +28,11 @@ describe "Impersonate", type: :system, js: true do
     impersonate_and_verify(seller, seller.merchant_accounts.sole.charge_processor_merchant_id)
   end
 
+  it "impersonates and unimpersonates a suspended seller" do
+    seller.update!(user_risk_state: "suspended_for_fraud")
+    impersonate_and_verify(seller, seller.email)
+  end
+
   def impersonate_and_verify(seller, identifier)
     visit "/admin"
     fill_in "Enter user email, username, or Stripe account ID", with: identifier


### PR DESCRIPTION
## What
Adds `!impersonating?` to the `check_suspended` before_action predicate so the suspension check is skipped entirely during admin impersonation.

## Why
Admins who impersonate a suspended user get stuck — the Unbecome button sends a DELETE to `admin_unimpersonate_path`, which is blocked by `check_suspended` because it evaluates against the impersonated user (`logged_in_user`), not the admin. The only escape is logging out entirely.

The response comes back as `{ success: false, error_message: "...suspended..." }` but the frontend expects `{ redirect_to: string }` — typia.assert throws, the catch branch fires a generic error toast, and the Redis impersonation key (7-day TTL) is never cleared.

## How
One-line change: add `!impersonating?` (already a helper on the Impersonate concern) to the `check_suspended` condition. This means:
- Admins can always Unbecome from a suspended user
- Admins can perform any mutation while impersonating (the admin's own suspension state is what should gate mutations, not the impersonated user's)

## Test
Added system spec: impersonate a suspended seller → verify Unbecome works and returns to admin page.

Closes antiwork/gumroad-private#401

> [!NOTE]
> This PR was authored with AI assistance.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782001734&installation_id=134400930&pr_number=5222&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5222&signature=c8f8963700b3d077ae5757f42fe158dee58a2eb74517044bd3474b6b98415301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes a global suspension guard to be skipped during admin impersonation, which affects authorization of all non-GET/HEAD requests while impersonating. Risk is limited but could unintentionally permit mutations that were previously blocked for suspended accounts.
> 
> **Overview**
> Fixes admin impersonation getting stuck on suspended accounts by updating `ApplicationController` to *not run* `check_suspended` when `impersonating?` is true (for non-GET/HEAD requests).
> 
> Adds a system spec covering impersonating a `suspended_for_fraud` seller and verifying that **Unbecome** succeeds and returns to the admin page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4966abefd71160d21f83415348895e55986026cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->