### PR TITLE
Fix flaky ES-dependent download page recommendation spec

### DIFF
--- a/spec/requests/download_page/download_page_spec.rb
+++ b/spec/requests/download_page/download_page_spec.rb
@@ -937,6 +937,11 @@ describe("Download Page", type: :system, js: true) do
       rebuild_srpis_cache
       allow_any_instance_of(Link).to receive(:recommendable?).and_return(true)
 
+      # Ensure that Elasticsearch has indexed the products created above before the
+      # recommendation query runs. If the documents are not yet searchable the page
+      # will render without the expected links, causing a flaky failure.
+      Link.import(refresh: true, force: true)
+
       content = create(:product_rich_content, entity: product, description: [{ "type" => RichContent::MORE_LIKE_THIS_NODE_TYPE }])
       purchase = create(:purchase, link: product)
       url_redirect = create(:url_redirect, link: product, purchase:)


### PR DESCRIPTION
## What
Adds `Link.import(refresh: true, force: true)` before visiting the download page in the "more like this" recommendation spec.

## Why
The test at `download_page_spec.rb:934` fails intermittently because it depends on Elasticsearch indexing completing before the page renders. When ES hasn't finished indexing the newly-created products, the recommendation query returns empty results and the assertion `expected to find link "Other Product"` fails.

## How
One line: `Link.import(refresh: true, force: true)` forces an ES index refresh after product creation, ensuring documents are searchable before the page visit. This pattern is used elsewhere in the codebase for ES-dependent specs.

Closes #5217

> [!NOTE]
> This PR was authored with AI assistance (Codex).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782001828&installation_id=134400930&pr_number=5223&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5223&signature=b34bbf09f7545d22e038c33ad2cbfc53f65cbc8204cb5fb968e9865b695316ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->