### PR TITLE
Fix flaky embed affiliate specs — add waits and polling

### DIFF
--- a/spec/requests/embed_spec.rb
+++ b/spec/requests/embed_spec.rb
@@ -10,6 +10,14 @@ describe "Embed scenario", type: :system, js: true, mock_easypost: true, retry: 
   let(:product) { create(:physical_product) }
   let!(:js_nonce) { SecureRandom.base64(32).chomp }
 
+  def expect_affiliate_credit_to_be_created(&block)
+    affiliate_credit_count = AffiliateCredit.count
+
+    block.call
+
+    wait_until_true(sleep_interval: 0.1) { AffiliateCredit.count == affiliate_credit_count + 1 }
+  end
+
   it "accepts product URL" do
     product = create(:product)
 
@@ -29,9 +37,9 @@ describe "Embed scenario", type: :system, js: true, mock_easypost: true, retry: 
 
     within_embed_frame { click_on "Add to cart" }
 
-    expect do
+    expect_affiliate_credit_to_be_created do
       check_out(pwyw_product, email: nil)
-    end.to change { AffiliateCredit.count }.from(0).to(1)
+    end
 
     purchase = pwyw_product.sales.successful.last
     expect(purchase.email).to eq("john@test.com")
@@ -48,13 +56,14 @@ describe "Embed scenario", type: :system, js: true, mock_easypost: true, retry: 
     visit(create_embed_page(pwyw_product, url: "#{direct_affiliate.referral_url_for_product(pwyw_product)}?", outbound: false))
 
     within_embed_frame do
+      expect(page).to have_field("Name a fair price", wait: 15)
       fill_in "Name a fair price", with: 75
       click_on "Add to cart"
     end
 
-    expect do
+    expect_affiliate_credit_to_be_created do
       check_out(pwyw_product)
-    end.to change { AffiliateCredit.count }.from(0).to(1)
+    end
 
     purchase = pwyw_product.sales.successful.last
     expect(purchase.email).to eq("test@gumroad.com")
@@ -116,12 +125,13 @@ describe "Embed scenario", type: :system, js: true, mock_easypost: true, retry: 
 
       within_embed_frame do
         expect(page).to have_text("$75", wait: 15)
+        expect(page).to have_link("Add to cart", href: /affiliate_id=#{direct_affiliate.external_id_numeric}/, wait: 15)
         click_on "Add to cart"
       end
 
-      expect do
+      expect_affiliate_credit_to_be_created do
         check_out(product)
-      end.to change { AffiliateCredit.count }.by(1)
+      end
 
       purchase = product.sales.successful.last.reload
       expect(purchase.affiliate_credit.affiliate).to eq(direct_affiliate)

--- a/spec/support/embed_helpers.rb
+++ b/spec/support/embed_helpers.rb
@@ -8,8 +8,11 @@ module EmbedHelpers
   # Wait for the Gumroad embed iframe to be injected by gumroad-embed.js before entering it.
   # Bare `within_frame` does not retry and fails instantly when the iframe hasn't loaded yet.
   def within_embed_frame(wait: 15, &block)
-    expect(page).to have_selector("iframe", wait:)
-    within_frame(&block)
+    iframe = find("iframe", wait:)
+    within_frame(iframe) do
+      expect(page).to have_selector("#app > *", wait:)
+      block.call
+    end
   end
 
   def create_embed_page(product, template_name: "embed_page.html.erb", url: nil, gumroad_params: nil, outbound: true, insert_anchor_tag: true, custom_domain_base_uri: nil, query_params: {})


### PR DESCRIPTION
## What
Fix 2 flaky specs in `spec/requests/embed_spec.rb`:
- Line 43: `"Name a fair price"` field not found — timing issue, page not fully loaded
- Line 114: `AffiliateCredit.count` not changing — race condition in credit creation

## Why
These specs fail intermittently in CI due to timing issues.

## Changes
- New `expect_affiliate_credit_to_be_created` helper that polls with `wait_until_true` instead of instant `change { }.by(1)`
- Added `have_field("Name a fair price", wait: 15)` before `fill_in` — waits for React render
- Improved `within_embed_frame` to find specific iframe and wait for `#app > *` inside it before yielding

## Test Results
Specs pass locally. These are test-only changes — no production code modified.

---
*This PR was authored with AI assistance (Codex gpt-5.5 + Gumclaw orchestration).*

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782008031&installation_id=134400930&pr_number=5225&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5225&signature=8ba9e1e7c43fc63d46493dc307258ba73929bdcc8619bf9e03b7b6cee750d179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that add explicit waits/polling to reduce timing-related flakiness, without modifying production behavior.
> 
> **Overview**
> Stabilizes flaky embed affiliate system specs by replacing immediate `change { AffiliateCredit.count }` assertions with a polling helper (`expect_affiliate_credit_to_be_created`) that waits for async credit creation.
> 
> Improves embed UI timing by making `within_embed_frame` wait for the iframe and `#app` content before yielding, and adds explicit waits for critical elements (e.g., "Name a fair price" and an affiliate-parameterized "Add to cart" link) prior to interaction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ee47125e5a3beca67c16d461127d0476782f4f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->