### PR TITLE
Fix flaky tiered membership offer codes specs — add surcharge waits

### DIFF
--- a/spec/requests/subscription/tiered_membership_offer_codes_spec.rb
+++ b/spec/requests/subscription/tiered_membership_offer_codes_spec.rb
@@ -36,7 +36,9 @@ describe "Tiered Membership Offer code Spec", type: :system, js: true, retry: 2 
 
       choose @lower_tier.name
 
+      wait_for_checkout_surcharges_loaded
       expect(page).not_to have_text "You'll be charged"
+      expect(page).to have_button("Update membership", disabled: false)
 
       expect do
         click_on "Update membership"
@@ -62,6 +64,10 @@ describe "Tiered Membership Offer code Spec", type: :system, js: true, retry: 2 
       visit "/subscriptions/#{@subscription.external_id}/manage?token=#{@subscription.token}"
 
       fill_in "Seats", with: 2
+      wait_for_checkout_surcharges_loaded
+      expect(page).to have_text "You'll be charged US$5.35"
+      expect(page).to have_button("Update membership", disabled: false)
+
       click_on "Update membership"
       wait_for_ajax
       expect(page).to have_alert(text: "Your membership has been updated.")
@@ -75,6 +81,10 @@ describe "Tiered Membership Offer code Spec", type: :system, js: true, retry: 2 
       visit "/subscriptions/#{@subscription.external_id}/manage?token=#{@subscription.token}"
 
       fill_in "Seats", with: 1
+      wait_for_checkout_surcharges_loaded
+      expect(page).not_to have_text "You'll be charged"
+      expect(page).to have_button("Update membership", disabled: false)
+
       click_on "Update membership"
       wait_for_ajax
       expect(page).to have_alert(text: "Your membership will be updated at the end of your current billing cycle.")
@@ -180,6 +190,10 @@ describe "Tiered Membership Offer code Spec", type: :system, js: true, retry: 2 
         visit "/subscriptions/#{@subscription.external_id}/manage?token=#{@subscription.token}"
 
         fill_in "Seats", with: 2
+        wait_for_checkout_surcharges_loaded
+        expect(page).to have_text "You'll be charged US$10.05"
+        expect(page).to have_button("Update membership", disabled: false)
+
         click_on "Update membership"
         wait_for_ajax
         expect(page).to have_alert(text: "Your membership has been updated.")
@@ -193,6 +207,10 @@ describe "Tiered Membership Offer code Spec", type: :system, js: true, retry: 2 
         visit "/subscriptions/#{@subscription.external_id}/manage?token=#{@subscription.token}"
 
         fill_in "Seats", with: 1
+        wait_for_checkout_surcharges_loaded
+        expect(page).not_to have_text "You'll be charged"
+        expect(page).to have_button("Update membership", disabled: false)
+
         click_on "Update membership"
         wait_for_ajax
         expect(page).to have_alert(text: "Your membership will be updated at the end of your current billing cycle.")


### PR DESCRIPTION
## What
Fix 2 flaky specs in `spec/requests/subscription/tiered_membership_offer_codes_spec.rb`:
- Line 34: `undefined method deep_symbolize_keys for nil` — API response not ready
- Line 61: `"Your membership has been updated."` alert not found — timing issue

## Why
These specs fail intermittently in CI because they click "Update membership" before checkout surcharges finish loading.

## Changes
- Added `wait_for_checkout_surcharges_loaded` before clicking update
- Added `expect(page).to have_button("Update membership", disabled: false)` checks
- Added price text assertions to confirm the page is ready before interaction

## Test Results
Specs pass locally. These are test-only changes — no production code modified.

---
*This PR was authored with AI assistance (Codex gpt-5.5 + Gumclaw orchestration).*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to system specs, adding explicit waits/assertions to avoid timing-related CI flakes without modifying production behavior.
> 
> **Overview**
> Makes `tiered_membership_offer_codes_spec.rb` less flaky by waiting for checkout surcharge recalculations to finish before submitting membership changes.
> 
> The affected upgrade/downgrade and seat-change scenarios now call `wait_for_checkout_surcharges_loaded` and assert the expected charge blurb and that the "Update membership" button is enabled before clicking, reducing race conditions around async pricing updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae859fb2e7b6bb6e19d2196d0a17b100a6eafec1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782008059&installation_id=134400930&pr_number=5226&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5226&signature=b326347480d627d402d68319d995dbbd3c75aa447cd58c2f27ec752099576bb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->