### PR TITLE
Fix flaky discover notices spec — add ES indexing and robust selectors

### DIFF
--- a/spec/requests/products/edit/edit_spec.rb
+++ b/spec/requests/products/edit/edit_spec.rb
@@ -693,14 +693,16 @@ describe("Product Edit Scenario", type: :system, js: true) do
       login_as(recommendable_seller)
 
       expect(recommendable_product.recommendable?).to be(true)
+      index_model_records(Link)
       visit edit_link_path(recommendable_product.unique_permalink) + "/share"
       expect(page).to have_status(text: "#{recommendable_product.name} is listed on Gumroad Discover.")
 
       within(:status, text: "#{recommendable_product.name} is listed on Gumroad Discover.") do
         click_on "View"
       end
-      expect(current_url).to include(UrlService.discover_domain_with_protocol)
-      expect_product_cards_with_names("product 1")
+      expect(page).to have_current_path(/#{Regexp.escape(UrlService.discover_domain_with_protocol)}/, url: true)
+      wait_for_ajax
+      expect(page).to have_link(recommendable_product.name, href: %r{/l/#{recommendable_product.unique_permalink}})
     end
   end
 


### PR DESCRIPTION
## What
Fix flaky spec at `spec/requests/products/edit/edit_spec.rb:681`:
- `"article header"` CSS selector not found — failed on both attempts

## Why
The spec navigates to Discover after clicking "View" but the product isn't indexed in ES yet, so the page has no matching elements.

## Changes
- Added `index_model_records(Link)` before visiting the edit page — ensures ES index is fresh
- Replaced `current_url.include?` with `have_current_path` (Capybara wait-enabled matcher)
- Replaced `expect_product_cards_with_names` with `have_link` (more specific, wait-enabled)

## Test Results
Specs pass locally. These are test-only changes — no production code modified.

---
*This PR was authored with AI assistance (Codex gpt-5.5 + Gumclaw orchestration).*

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782008061&installation_id=134400930&pr_number=5227&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5227&signature=fb50385657be20c20379044a869afd9239b4105d980fa995c42b2d0b3cd8b74e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to a system spec and primarily improve synchronization/selector robustness around Discover navigation and Elasticsearch indexing.
> 
> **Overview**
> Deflakes the `discover notices` system spec by explicitly indexing `Link` records before navigating to the Discover page, ensuring the product is searchable.
> 
> Updates assertions to use Capybara wait-enabled matchers (`have_current_path` with `url: true`, followed by `wait_for_ajax`) and replaces the brittle product-card expectation with a specific `have_link` check for the recommendable product.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7d382eddc5f496a0aa0f5c6b2e461bc2f40e7a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->