### PR TITLE
Fix flaky embed specs — increase within_embed_frame wait to 30s

### DIFF
--- a/spec/support/embed_helpers.rb
+++ b/spec/support/embed_helpers.rb
@@ -7,7 +7,7 @@ module EmbedHelpers
 
   # Wait for the Gumroad embed iframe to be injected by gumroad-embed.js before entering it.
   # Bare `within_frame` does not retry and fails instantly when the iframe hasn't loaded yet.
-  def within_embed_frame(wait: 15, &block)
+  def within_embed_frame(wait: 30, &block)
     iframe = find("iframe", wait:)
     within_frame(iframe) do
       expect(page).to have_selector("#app > *", wait:)


### PR DESCRIPTION
## What

Increase the default `wait` timeout in `within_embed_frame` from 15s to 30s.

## Why

`embed_spec.rb:31` ("accepts affiliated product URL with query params") failed on CI run [26265813185](https://github.com/antiwork/gumroad/actions/runs/26265813185) — both the first attempt and the rspec-retry.

The error was `expected to find css "#app > *" but there were no matches` — the embed iframe was injected by `gumroad-embed.js` but the React app inside it didn't mount within 15s.

The adjacent test (`embed_spec.rb:21`) passed in 15.2s — barely under the 15s wire — confirming the CI runner was simply slow. The affiliated test creates more DB records (affiliate_user, direct_affiliate, pwyw_product) so the iframe content takes longer to render.

## Fix

Bump the default `wait:` from 15s → 30s in `within_embed_frame`. This cascades to both the `find("iframe")` and the `#app > *` selector check, giving slow CI runners enough headroom.

## Test Results

Cannot run embed specs locally (widget bundle domain mismatch), but the fix is a simple timeout increase with no behavioral change. All other callers use the default or pass explicit waits that remain unchanged.

## AI Disclosure

This PR was authored by Gumclaw (AI agent).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782014215&installation_id=134400930&pr_number=5228&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5228&signature=6c58cec04406c7c476a2f19eb62e8b86ab03ba453f899a6ee3c6d0de664f1158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-helper-only timeout change intended to reduce CI flakiness; main impact is potentially slower failures when the embed never loads.
> 
> **Overview**
> Increases the default `within_embed_frame` wait timeout from 15s to 30s so embed specs allow more time for the iframe and `#app` content to load, reducing CI flakiness on slow runners.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf0d1472ae3da904e1cd2dc1f33ff97299eb3a18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->