### PR TITLE
Fix embed spec flakiness root cause — gate within_embed_frame on React hydration (#5218)

### DIFF
--- a/spec/requests/embed_spec.rb
+++ b/spec/requests/embed_spec.rb
@@ -56,7 +56,7 @@ describe "Embed scenario", type: :system, js: true, mock_easypost: true, retry: 
     visit(create_embed_page(pwyw_product, url: "#{direct_affiliate.referral_url_for_product(pwyw_product)}?", outbound: false))
 
     within_embed_frame do
-      expect(page).to have_field("Name a fair price", wait: 15)
+      expect(page).to have_field("Name a fair price")
       fill_in "Name a fair price", with: 75
       click_on "Add to cart"
     end
@@ -99,7 +99,7 @@ describe "Embed scenario", type: :system, js: true, mock_easypost: true, retry: 
       visit(create_embed_page(product, url: "#{product.long_url}/#{offer_code.code}", outbound: false))
 
       within_embed_frame do
-        expect(page).to have_status(text: "$1 off will be applied at checkout (Code SXSW)", wait: 15)
+        expect(page).to have_status(text: "$1 off will be applied at checkout (Code SXSW)")
         click_on "Add to cart"
       end
 
@@ -124,8 +124,8 @@ describe "Embed scenario", type: :system, js: true, mock_easypost: true, retry: 
       visit(create_embed_page(product, url: direct_affiliate.referral_url_for_product(product), outbound: false))
 
       within_embed_frame do
-        expect(page).to have_text("$75", wait: 15)
-        expect(page).to have_link("Add to cart", href: /affiliate_id=#{direct_affiliate.external_id_numeric}/, wait: 15)
+        expect(page).to have_text("$75")
+        expect(page).to have_link("Add to cart", href: /affiliate_id=#{direct_affiliate.external_id_numeric}/)
         click_on "Add to cart"
       end
 

--- a/spec/support/embed_helpers.rb
+++ b/spec/support/embed_helpers.rb
@@ -5,12 +5,20 @@ module EmbedHelpers
     Dir.glob(Rails.root.join("public", "embed_spec_page_*.html")).each { |f| File.delete(f) }
   end
 
-  # Wait for the Gumroad embed iframe to be injected by gumroad-embed.js before entering it.
+  # Wait for the Gumroad embed iframe to be injected by gumroad-embed.js before entering it,
+  # then wait for the embedded React app to finish hydrating before yielding.
+  #
   # Bare `within_frame` does not retry and fails instantly when the iframe hasn't loaded yet.
-  def within_embed_frame(wait: 30, &block)
+  # The previous gate (`#app > *`) only proved that *some* child node existed under `#app`,
+  # which happens before React hydrates and renders the product UI — so any assertion the
+  # caller made inside the block was racing the hydration. Waiting for the "Add to cart"
+  # action (rendered by Product/Layout.tsx once hydrated; an `<a>` styled as a button when
+  # `cart: true`, hence the link_or_button selector) is a real hydration signal and removes
+  # the need for long `wait:` overrides on subsequent assertions.
+  def within_embed_frame(wait: Capybara.default_max_wait_time, &block)
     iframe = find("iframe", wait:)
     within_frame(iframe) do
-      expect(page).to have_selector("#app > *", wait:)
+      expect(page).to have_selector(:link_or_button, "Add to cart", wait:)
       block.call
     end
   end


### PR DESCRIPTION
## What

Replace the `#app > *` hydration gate in `within_embed_frame` with a real React-hydration signal (`have_selector(:link_or_button, "Add to cart")`), and drop the now-redundant `wait: 15` overrides on three assertions inside `within_embed_frame` blocks in `spec/requests/embed_spec.rb`.

Follow-up to #5228, which only bumped the per-matcher wait from 15s → 30s. Per Sahil on #5218: *"Or fix the root cause so we don't need any wait? 15 seconds is a lot."*

## Why

The `#app > *` selector matches as soon as **any** child node exists under `#app` — which happens before React has finished hydrating and rendering the product UI. The discount code IS in the server props (not async-fetched), so the discount-status alert renders the instant hydration completes, but the helper was yielding control back to the test block before that point. Under CI load, `expect(page).to have_status(...)` then raced hydration and would intermittently time out — even at `wait: 30`.

`Add to cart` is a much better gate: it's rendered by `Product/Layout.tsx` only after React mounts (it's an `<a>` styled as a button when `cart: true`, hence the `:link_or_button` selector). Once it appears, the rest of the product DOM — including the discount status alert and price text — is also present.

With the proper gate in place, the per-matcher `wait: 15` overrides become noise. Capybara's default 25s retry covers anything genuinely slow.

## Verification

Ran the previously flaky example `spec/requests/embed_spec.rb:99` ('discount code in URL applies the discount code') 10× in a row locally:

```
=== Run 1 ===  Finished in 5.87 seconds. 1 example, 0 failures
=== Run 2 ===  Finished in 6.47 seconds. 1 example, 0 failures
=== Run 3 ===  Finished in 6.40 seconds. 1 example, 0 failures
=== Run 4 ===  Finished in 5.98 seconds. 1 example, 0 failures
=== Run 5 ===  Finished in 6.21 seconds. 1 example, 0 failures
=== Run 6 ===  Finished in 6.02 seconds. 1 example, 0 failures
=== Run 7 ===  Finished in 6.48 seconds. 1 example, 0 failures
=== Run 8 ===  Finished in 5.78 seconds. 1 example, 0 failures
=== Run 9 ===  Finished in 6.13 seconds. 1 example, 0 failures
=== Run 10 === Finished in 6.31 seconds. 1 example, 0 failures
```

10/10 pass, every run 5.7–6.5s. No flake, no wait padding.

Closes #5218.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782026382&installation_id=134400930&pr_number=5230&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5230&signature=3108969e134ed2ddbc705903e59c7c4c9cf4302ba15b2acf0772c3637ad90a4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to test helpers/specs and only adjust synchronization/wait conditions, not production behavior.
> 
> **Overview**
> Improves embed system test reliability by updating `within_embed_frame` to wait for a real post-hydration UI signal (`:link_or_button` "Add to cart") instead of the earlier `#app > *` selector.
> 
> With the stronger gating in place, removes the redundant per-expectation `wait: 15` overrides in `spec/requests/embed_spec.rb` assertions inside `within_embed_frame` blocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c569d25faf7b7dc8026f012b8024cbaad91366d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->