### PR TITLE
Fix admin Stripe Transfer ID link to navigate to the payout

### DIFF
--- a/app/business/payments/utilities/stripe_url.rb
+++ b/app/business/payments/utilities/stripe_url.rb
@@ -10,7 +10,10 @@ module StripeUrl
   end
 
   def self.transfer_url(transfer_id, account_id: nil)
-    [base_url(account_id:), "transfers", transfer_id].join("/")
+    segments = [base_url]
+    segments += ["connect", "view-as", account_id] if account_id
+    segments += ["payouts", transfer_id]
+    segments.join("/")
   end
 
   def self.charge_url(charge_id)

--- a/app/business/payments/utilities/stripe_url.rb
+++ b/app/business/payments/utilities/stripe_url.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 module StripeUrl
+  # Stripe dashboard workspace id for the Gumroad platform account; required as the
+  # first path segment for deep links — Stripe redirects to the dashboard home otherwise.
+  DASHBOARD_WORKSPACE_ID = "9e1RjUNIyYGpA9Cfh3RmQxxTzb1aakpE"
+
   def self.dashboard_url(account_id: nil)
     [base_url(account_id:), "dashboard"].join("/")
   end
@@ -10,14 +14,11 @@ module StripeUrl
   end
 
   def self.transfer_url(transfer_id, account_id: nil)
-    if account_id
-      segments = ["https://dashboard.stripe.com", "connect", "view-as", account_id]
-      segments << "test" unless Rails.env.production?
-      segments += ["payouts", transfer_id]
-      segments.join("/")
-    else
-      [base_url, "payouts", transfer_id].join("/")
-    end
+    segments = ["https://dashboard.stripe.com", DASHBOARD_WORKSPACE_ID]
+    segments += ["connect", "view-as", account_id] if account_id
+    segments << "test" unless Rails.env.production?
+    segments += ["payouts", transfer_id]
+    segments.join("/")
   end
 
   def self.charge_url(charge_id)

--- a/app/business/payments/utilities/stripe_url.rb
+++ b/app/business/payments/utilities/stripe_url.rb
@@ -10,10 +10,14 @@ module StripeUrl
   end
 
   def self.transfer_url(transfer_id, account_id: nil)
-    segments = [base_url]
-    segments += ["connect", "view-as", account_id] if account_id
-    segments += ["payouts", transfer_id]
-    segments.join("/")
+    if account_id
+      segments = ["https://dashboard.stripe.com", "connect", "view-as", account_id]
+      segments << "test" unless Rails.env.production?
+      segments += ["payouts", transfer_id]
+      segments.join("/")
+    else
+      [base_url, "payouts", transfer_id].join("/")
+    end
   end
 
   def self.charge_url(charge_id)

--- a/spec/business/payments/utilities/stripe_url_spec.rb
+++ b/spec/business/payments/utilities/stripe_url_spec.rb
@@ -46,4 +46,38 @@ describe StripeUrl do
       end
     end
   end
+
+  describe "transfer_url" do
+    describe "production" do
+      before do
+        allow(Rails.env).to receive(:production?).and_return(true)
+      end
+
+      after do
+        allow(Rails.env).to receive(:production?).and_call_original
+      end
+
+      it "returns a connected-account payout url when account_id is provided" do
+        expect(described_class.transfer_url("po_123", account_id: "acct_456"))
+          .to eq("https://dashboard.stripe.com/connect/view-as/acct_456/payouts/po_123")
+      end
+
+      it "returns a platform payout url when account_id is not provided" do
+        expect(described_class.transfer_url("po_123"))
+          .to eq("https://dashboard.stripe.com/payouts/po_123")
+      end
+    end
+
+    describe "not production" do
+      it "returns a test-mode connected-account payout url when account_id is provided" do
+        expect(described_class.transfer_url("po_123", account_id: "acct_456"))
+          .to eq("https://dashboard.stripe.com/test/connect/view-as/acct_456/payouts/po_123")
+      end
+
+      it "returns a test-mode platform payout url when account_id is not provided" do
+        expect(described_class.transfer_url("po_123"))
+          .to eq("https://dashboard.stripe.com/test/payouts/po_123")
+      end
+    end
+  end
 end

--- a/spec/business/payments/utilities/stripe_url_spec.rb
+++ b/spec/business/payments/utilities/stripe_url_spec.rb
@@ -48,6 +48,8 @@ describe StripeUrl do
   end
 
   describe "transfer_url" do
+    let(:workspace) { StripeUrl::DASHBOARD_WORKSPACE_ID }
+
     describe "production" do
       before do
         allow(Rails.env).to receive(:production?).and_return(true)
@@ -57,26 +59,26 @@ describe StripeUrl do
         allow(Rails.env).to receive(:production?).and_call_original
       end
 
-      it "returns a connected-account payout url when account_id is provided" do
+      it "returns a workspace-prefixed connected-account payout url when account_id is provided" do
         expect(described_class.transfer_url("po_123", account_id: "acct_456"))
-          .to eq("https://dashboard.stripe.com/connect/view-as/acct_456/payouts/po_123")
+          .to eq("https://dashboard.stripe.com/#{workspace}/connect/view-as/acct_456/payouts/po_123")
       end
 
-      it "returns a platform payout url when account_id is not provided" do
+      it "returns a workspace-prefixed platform payout url when account_id is not provided" do
         expect(described_class.transfer_url("po_123"))
-          .to eq("https://dashboard.stripe.com/payouts/po_123")
+          .to eq("https://dashboard.stripe.com/#{workspace}/payouts/po_123")
       end
     end
 
     describe "not production" do
-      it "returns a test-mode connected-account payout url with /test/ scoped inside the view-as context" do
+      it "puts /test/ inside the view-as scope for connected-account payouts" do
         expect(described_class.transfer_url("po_123", account_id: "acct_456"))
-          .to eq("https://dashboard.stripe.com/connect/view-as/acct_456/test/payouts/po_123")
+          .to eq("https://dashboard.stripe.com/#{workspace}/connect/view-as/acct_456/test/payouts/po_123")
       end
 
-      it "returns a test-mode platform payout url when account_id is not provided" do
+      it "puts /test/ between the workspace and /payouts/ for platform payouts" do
         expect(described_class.transfer_url("po_123"))
-          .to eq("https://dashboard.stripe.com/test/payouts/po_123")
+          .to eq("https://dashboard.stripe.com/#{workspace}/test/payouts/po_123")
       end
     end
   end

--- a/spec/business/payments/utilities/stripe_url_spec.rb
+++ b/spec/business/payments/utilities/stripe_url_spec.rb
@@ -69,9 +69,9 @@ describe StripeUrl do
     end
 
     describe "not production" do
-      it "returns a test-mode connected-account payout url when account_id is provided" do
+      it "returns a test-mode connected-account payout url with /test/ scoped inside the view-as context" do
         expect(described_class.transfer_url("po_123", account_id: "acct_456"))
-          .to eq("https://dashboard.stripe.com/test/connect/view-as/acct_456/payouts/po_123")
+          .to eq("https://dashboard.stripe.com/connect/view-as/acct_456/test/payouts/po_123")
       end
 
       it "returns a test-mode platform payout url when account_id is not provided" do


### PR DESCRIPTION
Fixes antiwork/gumroad-private#412

## What

The "Stripe Transfer ID" link on `Admin > Payouts` opened the Stripe dashboard home instead of the payout. Rewrote `StripeUrl.transfer_url` to emit a URL Stripe's dashboard will actually resolve.

```
Before (non-prod): https://dashboard.stripe.com/<acct>/test/transfers/<po>
After  (non-prod): https://dashboard.stripe.com/<workspace>/connect/view-as/<acct>/test/payouts/<po>
                    └── for platform-only payouts (no acct): ──/<workspace>/test/payouts/<po>
```

`<workspace>` is `DASHBOARD_WORKSPACE_ID`, a new module-level constant in `StripeUrl`.

## Why

Three independent things were wrong:

1. **Wrong resource.** The column is named `stripe_transfer_id` for historical reasons, but the value stored is actually a `Stripe::Payout.id` (`po_…`), set from `Stripe::Payout.create(...).id` in `StripePayoutProcessor#perform_payment` (`app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb:349`). Hitting `/transfers/<po_…>` doesn't resolve to anything because the ID doesn't live under that resource.
2. **Wrong account-scoping slot.** The connected `acct_…` was placed immediately after the domain. That URL slot is reserved for the platform's own dashboard workspace, not for connected accounts. To view a connected account's resource, the path is `/connect/view-as/<acct>/…`.
3. **Workspace prefix required for deep links.** Empirically, Stripe's dashboard drops session-less deep links to the home page or "Could not load the connected account." Testing with a real test-mode connected payout, the only URL shape that opens the specific payout is `dashboard.stripe.com/<workspace>/connect/view-as/<acct>/test/payouts/<po>` — the 32-char workspace id is non-negotiable. It's account-scoped (same value for every admin on Gumroad's Stripe account, same value in test and live), so hardcoding it keeps the URL builder self-contained without per-environment env vars. The constant carries a comment so future maintainers don't strip it back out.

The bug reporter's suggested format (`/<session>/connect/view-as/<acct>/payouts/<po>`) was correct in structure but used `<session>` as a placeholder; the actual session segment is the workspace id described above, and the test-mode `/test/` segment lives **inside** the view-as scope, not at the workspace level.

Renaming the underlying `stripe_transfer_id` column is intentionally out of scope — `payments`-adjacent schema churn isn't worth it for a UI label.

## After


https://github.com/user-attachments/assets/7ecf57a2-ab57-4dad-8471-d7eda0d5ac75


---

Generated with Claude Opus 4.7 (1M context).