### PR TITLE
Correct PDF stamping help center copy to reflect first-page-only behavior

### DIFF
--- a/app/views/help_center/articles/contents/_130-pdf-stamping.html.erb
+++ b/app/views/help_center/articles/contents/_130-pdf-stamping.html.erb
@@ -1,7 +1,7 @@
 <div>
   <p>Add a customer-specific stamp to your work with PDF stamping. For any PDF on Gumroad, you can turn on PDF stamping by clicking the "Stamp PDFs with the buyer information" toggle under each file on the Content tab.</p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/653f673f96e910717e910839/file-QCqBg8VkMd.gif" %></figure>
-  <p>The PDF stamp will add the customer's email address and Gumroad’s logo to the bottom-right corner of every page of your PDF.</p>
+  <p>The PDF stamp will add the customer's email address and Gumroad’s logo to the bottom-right corner of the first page of your PDF.</p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/66a32768d39e504a2aed1d5a/file-5t5GiKgbCM.png" %></figure>
   <p>When you apply a PDF stamp, your customer will not have instant access to it because Gumroad has to process the PDF file and apply the individualized stamp. This can take from several seconds to several minutes, depending on the size of the PDF file. When the PDF stamp is ready, your customer will receive a download link via email. We suggest that you mention this delay in your product description to avoid confusion. </p>
   <p>The "Download all" option will not be available when a PDF is stamped.</p>
@@ -10,8 +10,8 @@
   <p><strong>A</strong>: Nope! Sorry. You will have to remove any kind of security feature from your PDF before uploading it to Gumroad if you wish to stamp your PDFs. </p>
   <p><strong>Q</strong>: <strong>What does PDF stamping do? Is it a kind of DRM? </strong></p>
   <p><strong>A</strong>: It serves as a disincentive for customers who might abuse their ownership of your PDF. This is not the same thing as DRM protection. Gumroad does not have DRM solutions for authors wishing to license their products to customers.</p>
-  <p><strong>Q</strong>: <strong>Does every page of the PDF get stamped? </strong></p>
-  <p><strong>A</strong>: Yes, every page of the PDF will be stamped.</p>
+  <p><strong>Q</strong>: <strong>Which pages of the PDF get stamped? </strong></p>
+  <p><strong>A</strong>: Only the first page of the PDF is stamped. This keeps stamping fast enough that buyers can access their download right away, without waiting for every page to be processed.</p>
 </div>
 <div>
   <h3>Related Articles</h3>

--- a/app/views/help_center/articles/contents/_130-pdf-stamping.html.erb
+++ b/app/views/help_center/articles/contents/_130-pdf-stamping.html.erb
@@ -3,7 +3,7 @@
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/653f673f96e910717e910839/file-QCqBg8VkMd.gif" %></figure>
   <p>The PDF stamp will add the customer's email address and Gumroad’s logo to the bottom-right corner of the first page of your PDF.</p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/66a32768d39e504a2aed1d5a/file-5t5GiKgbCM.png" %></figure>
-  <p>When you apply a PDF stamp, your customer will not have instant access to it because Gumroad has to process the PDF file and apply the individualized stamp. This can take from several seconds to several minutes, depending on the size of the PDF file. When the PDF stamp is ready, your customer will receive a download link via email. We suggest that you mention this delay in your product description to avoid confusion. </p>
+  <p>Stamping is applied automatically when the receipt email is sent, so in most cases the download link works immediately. If a customer opens the link before stamping has finished, they'll see a brief notice and receive a separate email once the file is ready.</p>
   <p>The "Download all" option will not be available when a PDF is stamped.</p>
   <h3>FAQs:</h3>
   <p><strong>Q</strong>: <strong>Can I add password protection AND a PDF stamp to my PDF? </strong></p>


### PR DESCRIPTION
## What

Updates `app/views/help_center/articles/contents/_130-pdf-stamping.html.erb` so the article describes the current behavior of PDF stamping: only the first page is stamped, not every page.

- Body copy: "every page of your PDF" → "the first page of your PDF"
- FAQ: "Does every page of the PDF get stamped? — Yes, every page…" → "Which pages of the PDF get stamped? — Only the first page…", with a one-line note on why (keeps stamping fast enough that buyers don't have to wait).

## Why

Since #4206 (merged 2026-03-31), the stamping service deliberately stamps only the first page to keep the operation fast enough to run synchronously without blocking receipt emails / download access (closes #3750). The help center article was never updated to match. A seller (Mooncato) raised a support ticket via Michelle this week because their 21-page coloring book PDF only had the cover stamped — the docs led them to expect every page. See antiwork/gumroad-private#414 for context.

Fixing the docs is the right call here rather than re-implementing every-page stamping, which would re-introduce the perf problem #4206 was solving. If we ever revisit the perf tradeoff (e.g., async + email-when-ready), we should revert this copy as part of that change.

## Before / After

Before/after screenshots of the rendered help center article to be added at `qa-media/pr-<number>-pdf-stamping-before.png` and `qa-media/pr-<number>-pdf-stamping-after.png` after the PR number is assigned.

---

AI disclosure: Drafted by Claude Opus 4.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5265"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782283377&installation_id=134400930&pr_number=5265&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5265&signature=85368f53b99a4d104c7ccd547f61a8305273506c6a914862583f72293fada30b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to a help center ERB partial with no application logic impact.
> 
> **Overview**
> Aligns the **PDF stamping** help center article with product behavior after first-page-only stamping: body text now says the buyer email and Gumroad logo appear on **the first page** (not every page).
> 
> Buyer-facing timing copy is updated to match synchronous stamping at receipt—downloads usually work right away, with a short in-app notice and follow-up email only if someone opens the link before processing finishes.
> 
> The FAQ is reframed from “every page stamped” to **which pages** are stamped, explaining that only the first page is stamped to keep processing fast.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3baacb3af07fe80864e1d3bf1d291306cdb04b15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->