### PR TITLE
Fix Angola IBAN validation that blocks valid 25-char Angolan IBANs

### DIFF
--- a/app/models/angola_bank_account.rb
+++ b/app/models/angola_bank_account.rb
@@ -48,7 +48,9 @@ class AngolaBankAccount < BankAccount
       decrypted = account_number_decrypted.to_s
       return if decrypted.empty?
       cleaned = decrypted.strip.gsub(/[ -]/, "")
-      self.account_number = cleaned if cleaned != decrypted
+      return if cleaned == decrypted
+      self.account_number = cleaned
+      self.account_number_last_four = cleaned.last(4)
     end
 
     def validate_bank_code

--- a/app/models/angola_bank_account.rb
+++ b/app/models/angola_bank_account.rb
@@ -6,10 +6,13 @@ class AngolaBankAccount < BankAccount
   BANK_CODE_FORMAT_REGEX = /^([0-9a-zA-Z]){8,11}$/
   private_constant :BANK_CODE_FORMAT_REGEX
 
+  ACCOUNT_NUMBER_FORMAT_REGEX = /\AAO[0-9]{23}\z/
+  private_constant :ACCOUNT_NUMBER_FORMAT_REGEX
+
   alias_attribute :bank_code, :bank_number
 
   validate :validate_bank_code
-  validate :validate_account_number, if: -> { Rails.env.production? }
+  validate :validate_account_number
 
   def routing_number
     "#{bank_code}"
@@ -46,7 +49,7 @@ class AngolaBankAccount < BankAccount
     end
 
     def validate_account_number
-      return if Ibandit::IBAN.new(account_number_decrypted).valid?
+      return if ACCOUNT_NUMBER_FORMAT_REGEX.match?(account_number_decrypted.to_s.gsub(/[ -]/, ""))
       errors.add :base, "The account number is invalid."
     end
 end

--- a/app/models/angola_bank_account.rb
+++ b/app/models/angola_bank_account.rb
@@ -11,6 +11,7 @@ class AngolaBankAccount < BankAccount
 
   alias_attribute :bank_code, :bank_number
 
+  before_validation :normalize_account_number
   validate :validate_bank_code
   validate :validate_account_number
 
@@ -43,13 +44,20 @@ class AngolaBankAccount < BankAccount
   end
 
   private
+    def normalize_account_number
+      decrypted = account_number_decrypted.to_s
+      return if decrypted.empty?
+      cleaned = decrypted.strip.gsub(/[ -]/, "")
+      self.account_number = cleaned if cleaned != decrypted
+    end
+
     def validate_bank_code
       return if BANK_CODE_FORMAT_REGEX.match?(bank_code)
       errors.add :base, "The bank code is invalid."
     end
 
     def validate_account_number
-      return if ACCOUNT_NUMBER_FORMAT_REGEX.match?(account_number_decrypted.to_s.gsub(/[ -]/, ""))
+      return if ACCOUNT_NUMBER_FORMAT_REGEX.match?(account_number_decrypted)
       errors.add :base, "The account number is invalid."
     end
 end

--- a/app/models/angola_bank_account.rb
+++ b/app/models/angola_bank_account.rb
@@ -59,7 +59,7 @@ class AngolaBankAccount < BankAccount
     end
 
     def validate_account_number
-      return if ACCOUNT_NUMBER_FORMAT_REGEX.match?(account_number_decrypted)
+      return if ACCOUNT_NUMBER_FORMAT_REGEX.match?(account_number_decrypted.to_s)
       errors.add :base, "The account number is invalid."
     end
 end

--- a/spec/models/angola_bank_account_spec.rb
+++ b/spec/models/angola_bank_account_spec.rb
@@ -43,4 +43,31 @@ describe AngolaBankAccount do
       expect(build(:angola_bank_account, bank_code: "AAAAAOAOXXXX")).not_to be_valid
     end
   end
+
+  describe "#validate_account_number" do
+    it "allows records that match the required account number regex" do
+      expect(build(:angola_bank_account)).to be_valid
+      expect(build(:angola_bank_account, account_number: "AO06004400006729503010102")).to be_valid
+
+      ao_bank_account = build(:angola_bank_account, account_number: "AO12345")
+      expect(ao_bank_account).not_to be_valid
+      expect(ao_bank_account.errors.full_messages.to_sentence).to eq("The account number is invalid.")
+
+      ao_bank_account = build(:angola_bank_account, account_number: "DE61109010140000071219812874")
+      expect(ao_bank_account).not_to be_valid
+      expect(ao_bank_account.errors.full_messages.to_sentence).to eq("The account number is invalid.")
+
+      ao_bank_account = build(:angola_bank_account, account_number: "06004400006729503010102")
+      expect(ao_bank_account).not_to be_valid
+      expect(ao_bank_account.errors.full_messages.to_sentence).to eq("The account number is invalid.")
+    end
+
+    it "accepts an IBAN with spaces between groups" do
+      expect(build(:angola_bank_account, account_number: "AO06 0044 0000 6729 5030 1010 2")).to be_valid
+    end
+
+    it "accepts an IBAN with dashes between groups" do
+      expect(build(:angola_bank_account, account_number: "AO06-0044-0000-6729-5030-1010-2")).to be_valid
+    end
+  end
 end

--- a/spec/models/angola_bank_account_spec.rb
+++ b/spec/models/angola_bank_account_spec.rb
@@ -89,5 +89,14 @@ describe AngolaBankAccount do
       ba.valid?
       expect(ba.send(:account_number_decrypted)).to eq("AO06004400006729503010102")
     end
+
+    it "updates account_number_last_four to match the normalized value so the masked display is correct" do
+      ba = build(:angola_bank_account,
+                 account_number: "AO06 0044 0000 6729 5030 1010 2",
+                 account_number_last_four: "10 2") # what UpdatePayoutMethod would persist pre-normalization
+      ba.valid?
+      expect(ba.account_number_last_four).to eq("0102")
+      expect(ba.account_number_visual).to eq("AO******0102")
+    end
   end
 end

--- a/spec/models/angola_bank_account_spec.rb
+++ b/spec/models/angola_bank_account_spec.rb
@@ -70,4 +70,24 @@ describe AngolaBankAccount do
       expect(build(:angola_bank_account, account_number: "AO06-0044-0000-6729-5030-1010-2")).to be_valid
     end
   end
+
+  describe "normalization" do
+    it "strips spaces from the saved account number so the value Stripe receives is clean" do
+      ba = build(:angola_bank_account, account_number: "AO06 0044 0000 6729 5030 1010 2")
+      ba.valid?
+      expect(ba.send(:account_number_decrypted)).to eq("AO06004400006729503010102")
+    end
+
+    it "strips dashes from the saved account number" do
+      ba = build(:angola_bank_account, account_number: "AO06-0044-0000-6729-5030-1010-2")
+      ba.valid?
+      expect(ba.send(:account_number_decrypted)).to eq("AO06004400006729503010102")
+    end
+
+    it "strips leading and trailing whitespace" do
+      ba = build(:angola_bank_account, account_number: "  AO06004400006729503010102  ")
+      ba.valid?
+      expect(ba.send(:account_number_decrypted)).to eq("AO06004400006729503010102")
+    end
+  end
 end


### PR DESCRIPTION
## What

`AngolaBankAccount#validate_account_number` uses `Ibandit::IBAN.valid?` to validate IBANs, gated to `Rails.env.production?`. Replace it with an explicit `ACCOUNT_NUMBER_FORMAT_REGEX = /\AAO[0-9]{23}\z/` (matching the Madagascar/Oman pattern from #5005 and #489), strip whitespace and dashes before matching, drop the production-only gate so dev/test exercise the same path as prod, and add a `before_validation` callback that normalizes the saved account_number so the downstream Stripe call receives a clean value.

## Why

Ibandit 1.26.1's `SUPPORTED_COUNTRY_CODES` does not include `AO`. As a result `Ibandit::IBAN.new("AO06004400006729503010102").valid?` returns `false` — even for the IBAN that Stripe explicitly documents as the AO test account number. Because the validation is gated to `Rails.env.production?`, the existing spec passes (validation is skipped) but production silently rejects every Angolan IBAN.

The production data backs this up. Of 129 all-time `AngolaBankAccount` records (11 alive), only 1 has actually been linked to Stripe (`stripe_bank_account_id` is set). The other 95% use foreign BICs (Wise `TRWIBEB1XXX`, Portuguese `BAPAPTPLXXX`, etc.) because that's the only way users find to get the local validation to pass. The 7 records that did use an actual Angolan BIC are mostly soft-deleted, presumably because they couldn't push to Stripe and the user gave up.

Closes #5246. The issue's symptom (Angolan sellers can't onboard with Angolan banks) is real, but the diagnosis points at the wrong line: `BANK_CODE_FORMAT_REGEX = /^([0-9a-zA-Z]){8,11}$/` validates the BIC/SWIFT field, which is correctly 8–11 alphanumeric per ISO 9362. The 25-char IBAN goes into a separate `account_number` field, validated by `validate_account_number` — and that's where the bug is.

I verified the Stripe schema against the real test API (41 calls):

| Scenario | Stripe response |
|---|---|
| Current: IBAN in `account_number` + BIC `AAAAAOAOXXX` in `routing_number` | Account created, external account attached, `last4=0102` |
| Only IBAN, no `routing_number` (issue's proposal #1) | `Missing required param: bank_account[routing_number]` |
| 4-digit bank code as `routing_number` (issue's proposal #2) | `Invalid routing number for AO. The number must contain both the bank code and the branch code` |
| IBAN in `routing_number` | Same `routing_number_invalid` |

So the current schema is what Stripe requires; the fix is purely in the local validation.



---

🤖 Generated with [Claude Opus 4.7](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes payout onboarding validation for Angola and alters persisted account numbers via normalization; scope is limited to one bank account model but affects seller payout setup.
> 
> **Overview**
> **Angolan payout accounts** were rejected in production because `Ibandit::IBAN` does not support country code `AO`, while dev/test skipped `validate_account_number` entirely.
> 
> `AngolaBankAccount` now validates `account_number` with **`/\AAO[0-9]{23}\z/`** (25-character AO IBAN), runs that check in **all environments**, and **normalizes** input on save by stripping spaces/dashes and trimming whitespace so Stripe gets a compact IBAN and **`account_number_last_four`** stays aligned with the masked display.
> 
> Specs cover valid/invalid IBANs, spaced/dashed input, and normalization behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0da199aa62460eead18245fae7c4cc7c66fe4132. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->