### PR TITLE
Drop /mobile_minimum_version requirement from :account to :mobile_api

### DIFF
--- a/app/controllers/api/internal/mobile_minimum_versions_controller.rb
+++ b/app/controllers/api/internal/mobile_minimum_versions_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Api::Internal::MobileMinimumVersionsController < Api::Internal::BaseController
-  before_action -> { doorkeeper_authorize! :account }
+  before_action -> { doorkeeper_authorize! :mobile_api }
 
   def show
     # Values for these keys can be set in Rails console to force all mobile app users to upgrade to a specific version.

--- a/spec/controllers/api/internal/mobile_minimum_versions_controller_spec.rb
+++ b/spec/controllers/api/internal/mobile_minimum_versions_controller_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 describe Api::Internal::MobileMinimumVersionsController do
   let(:user) { create(:user) }
   let(:app) { create(:oauth_application, owner: user) }
-  let(:access_token) { create("doorkeeper/access_token", application: app, resource_owner_id: user.id, scopes: "account") }
+  let(:access_token) { create("doorkeeper/access_token", application: app, resource_owner_id: user.id, scopes: "mobile_api") }
 
   describe "GET show" do
     context "with valid access token" do
@@ -31,6 +31,16 @@ describe Api::Internal::MobileMinimumVersionsController do
       end
     end
 
+    context "with a token that predates the :account scope" do
+      let(:access_token) { create("doorkeeper/access_token", application: app, resource_owner_id: user.id, scopes: "mobile_api creator_api") }
+
+      it "authorizes the request so older mobile tokens are not logged out on cold launch" do
+        get :show, params: { access_token: access_token.token }
+
+        expect(response).to be_successful
+      end
+    end
+
     context "without access token" do
       it "returns unauthorized" do
         get :show
@@ -40,7 +50,7 @@ describe Api::Internal::MobileMinimumVersionsController do
     end
 
     context "with wrong scope" do
-      let(:access_token) { create("doorkeeper/access_token", application: app, resource_owner_id: user.id, scopes: "mobile_api") }
+      let(:access_token) { create("doorkeeper/access_token", application: app, resource_owner_id: user.id, scopes: "view_public") }
 
       it "returns forbidden" do
         get :show, params: { access_token: access_token.token }


### PR DESCRIPTION
Closes https://github.com/antiwork/gumroad-mobile/issues/251 https://github.com/antiwork/gumroad-private/issues/410

## What

`Api::Internal::MobileMinimumVersionsController` now authorizes with the `:mobile_api` scope instead of `:account`. The "wrong scope" spec previously asserted that a `mobile_api` token was forbidden — that was literally encoding the bug, so it now uses `view_public`, and there's a new regression spec for the pre-`:account` token case.

## Why

This is the server-side follow-up called out in [gumroad-mobile#252](https://github.com/antiwork/gumroad-mobile/pull/252) — the iOS/Android cold-launch logout loop that grouped to `UnauthorizedError#constructor(lib/request)` in Sentry (`GUMROAD-MOBILE-2D` iOS, ~1,600 users / 5,000 events; `GUMROAD-MOBILE-2A` Android, ~1,400 users / 1,700 events).

The cascade itself was fixed client-side, but the underlying server bug — feature endpoints returning auth failures for older tokens — needed a fix here so it stops appearing at all.

Timeline of how this got into prod:

| Commit | Date | Change |
|---|---|---|
| `14b68a92a` (#3983) | 2026-03-17 | Introduced `:account` optional scope. v2 base controller was updated to auto-accept `:account` alongside any per-endpoint scope, but that override only lives on `Api::V2::BaseController`. |
| `b41807c79` (#4052) | 2026-03-21 | Added `/api/internal/mobile_minimum_version` with `before_action -> { doorkeeper_authorize! :account }`. Four days after `:account` existed — no backfill, and `Api::Internal::BaseController` has no `:account`-OR override. |

OAuth scopes are baked into each access token at grant time (the `oauth_access_tokens.scopes` column stores them as a space-separated string), so a scope added today does not retroactively appear on yesterday's tokens. Tokens issued before clients began requesting `:account` have e.g. `"mobile_api creator_api"` (per `spec/requests/oauth_authorizations_spec.rb:28`), and the legacy native mobile `OauthApplication` does not even allow `:account` in its registered scopes (`db/seeds/030_staging/mobile_oauth_application.rb:9` → `"mobile_api creator_api"`). Cold-start hits to `mobile_minimum_version` from those tokens were rejected by Doorkeeper, and the pre-#252 mobile client treated any auth failure as a dead session.

### Why `:mobile_api` (not a backfill, not `:account`-OR override)

The endpoint returns two global Redis values (`mobile_minimum_version`, `mobile_minimum_update_created_at`) — no PII, no per-user data. `:account` was over-scoped for what it gates. `:mobile_api` is what every other endpoint in `app/controllers/api/mobile/` requires (sessions, devices, feature_flags, purchases, sales, analytics, consumption_analytics, media_locations), and every working mobile token has it. It's the conventional scope for this surface and fixes the bug without touching prod data or shipping a v2-style override into the internal API.



---

🤖 Generated with [Claude Code](https://claude.com/claude-code) using model Claude Opus 4.7 (1M context).


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782289071&installation_id=134400930&pr_number=5267&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5267&signature=c8f9b19f0d59e627b3739e154ad2f8a6ebd7463c34e3814e964f5541acf80ca2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow OAuth scope change on a read-only global config endpoint; aligns with existing mobile controllers and reduces false auth failures.
> 
> **Overview**
> **OAuth scope for `mobile_minimum_version` is switched from `:account` to `:mobile_api`**, aligning this internal cold-launch endpoint with the rest of the mobile API surface.
> 
> Older tokens that only carry `mobile_api` (and never received `:account` at grant time) can read the global Redis minimum-version fields again instead of getting **403**, which was driving mobile cold-launch logout loops.
> 
> Specs now use `mobile_api` for the happy path, assert **`mobile_api creator_api`** tokens still succeed, and treat **`view_public`** as the forbidden-scope case (replacing the previous inverted example).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddd8fd27971e54bb3a66432bd12417fc1563e1af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->