### PR TITLE
Add internal admin TOS suspension endpoint

### DIFF
--- a/app/controllers/api/internal/admin/users_controller.rb
+++ b/app/controllers/api/internal/admin/users_controller.rb
@@ -249,7 +249,7 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
         return render json: internal_admin_user_success_payload(user, status: "already_suspended", message: "User is already suspended for fraud")
       end
 
-      suspension_note = build_suspension_note(user) if params[:suspension_note].present?
+      suspension_note = build_suspension_note(user, content: params[:suspension_note]) if params[:suspension_note].present?
       return render_invalid_comment(suspension_note) if suspension_note&.invalid?
 
       user.suspend_for_fraud!(author_id: current_admin_actor_id)
@@ -272,7 +272,7 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
                                                                 })
       end
 
-      suspension_note = build_suspension_note(user, params[:note]) if params[:note].present?
+      suspension_note = build_suspension_note(user, content: params[:suspension_note]) if params[:suspension_note].present?
       return render_invalid_comment(suspension_note) if suspension_note&.invalid?
 
       user.suspend_for_tos_violation!(author_id: current_admin_actor_id)
@@ -721,7 +721,7 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
       )
     end
 
-    def build_suspension_note(user, content = params[:suspension_note])
+    def build_suspension_note(user, content:)
       user.comments.new(
         author_id: current_admin_actor_id,
         comment_type: Comment::COMMENT_TYPE_SUSPENSION_NOTE,

--- a/app/controllers/api/internal/admin/users_controller.rb
+++ b/app/controllers/api/internal/admin/users_controller.rb
@@ -260,6 +260,32 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
     end
   end
 
+  def suspend_for_tos_violation
+    user = find_internal_admin_user_for_write_or_render
+    return unless user
+
+    record_admin_write(action: "users.suspend_for_tos_violation", target: user) do
+      if user.suspended_for_tos_violation?
+        return render json: internal_admin_user_success_payload(user, {
+                                                                  status: "already_suspended",
+                                                                  message: "User is already suspended for a policy violation"
+                                                                })
+      end
+
+      suspension_note = build_suspension_note(user, params[:note]) if params[:note].present?
+      return render_invalid_comment(suspension_note) if suspension_note&.invalid?
+
+      user.suspend_for_tos_violation!(author_id: current_admin_actor_id)
+      suspension_note&.save!
+      render json: internal_admin_user_success_payload(user, {
+                                                         status: "suspended_for_tos_violation",
+                                                         message: "User suspended for a policy violation"
+                                                       })
+    rescue StateMachines::InvalidTransition => e
+      render json: { success: false, message: e.message }, status: :unprocessable_entity
+    end
+  end
+
   def watch
     return render json: { success: false, message: "revenue_threshold is required" }, status: :bad_request if params[:revenue_threshold].blank?
 
@@ -695,11 +721,11 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
       )
     end
 
-    def build_suspension_note(user)
+    def build_suspension_note(user, content = params[:suspension_note])
       user.comments.new(
         author_id: current_admin_actor_id,
         comment_type: Comment::COMMENT_TYPE_SUSPENSION_NOTE,
-        content: params[:suspension_note]
+        content:
       )
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -345,6 +345,7 @@ Rails.application.routes.draw do
               post :create_comment
               post :mark_compliant
               post :suspend_for_fraud
+              post :suspend_for_tos_violation
               post :watch
               post :update_watch
               post :unwatch

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -2574,7 +2574,7 @@ describe Api::Internal::Admin::UsersController do
 
     it "creates an extra suspension note when one is provided" do
       expect do
-        post :suspend_for_tos_violation, params: { user_id: user.external_id, note: "DMCA takedown notice confirmed" }
+        post :suspend_for_tos_violation, params: { user_id: user.external_id, suspension_note: "DMCA takedown notice confirmed" }
       end.to change { user.comments.reload.count }.by(2)
 
       expect(response).to have_http_status(:ok)
@@ -2588,7 +2588,7 @@ describe Api::Internal::Admin::UsersController do
 
     it "returns 422 without suspending the user when the note is invalid" do
       expect do
-        post :suspend_for_tos_violation, params: { user_id: user.external_id, note: "x" * 10_001 }
+        post :suspend_for_tos_violation, params: { user_id: user.external_id, suspension_note: "x" * 10_001 }
       end.not_to change { user.comments.reload.count }
 
       expect(response).to have_http_status(:unprocessable_entity)
@@ -2601,7 +2601,7 @@ describe Api::Internal::Admin::UsersController do
       user.update!(user_risk_state: "suspended_for_tos_violation")
 
       expect do
-        post :suspend_for_tos_violation, params: { user_id: user.external_id, note: "Retry" }
+        post :suspend_for_tos_violation, params: { user_id: user.external_id, suspension_note: "Retry" }
       end.not_to change { user.comments.reload.count }
 
       expect(response).to have_http_status(:ok)

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -898,7 +898,7 @@ describe Api::Internal::Admin::UsersController do
       user = create(:user)
       matching = create(:comment, commentable: user, comment_type: Comment::COMMENT_TYPE_NOTE)
       create(:comment, commentable: create(:user), comment_type: Comment::COMMENT_TYPE_NOTE)
-      create(:comment, commentable: create(:purchase), comment_type: Comment::COMMENT_TYPE_NOTE)
+      create(:comment, commentable: create(:product), comment_type: Comment::COMMENT_TYPE_NOTE)
 
       get :comments, params: { user_id: user.external_id }
 
@@ -2513,6 +2513,131 @@ describe Api::Internal::Admin::UsersController do
     include_examples "requires user_id for user mutation", :suspend_for_fraud
     include_examples "supports user lookup by user_id", :suspend_for_fraud, build_user: -> { create(:compliant_user) }
     include_examples "checks expected_email for user mutation", :suspend_for_fraud, build_user: -> { create(:compliant_user) }
+  end
+
+  describe "POST suspend_for_tos_violation" do
+    let(:user) { create(:compliant_user, email: "seller@example.com") }
+
+    include_examples "admin api authorization required", :post, :suspend_for_tos_violation
+
+    it "returns 400 when user_id is missing" do
+      post :suspend_for_tos_violation
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: user_id_required_message }.as_json)
+    end
+
+    it "returns 404 when the user does not exist" do
+      post :suspend_for_tos_violation, params: { user_id: "missing" }
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
+    end
+
+    it "suspends the user for a policy violation and creates an audit comment attributed to the admin actor" do
+      expect do
+        post :suspend_for_tos_violation, params: { user_id: user.external_id }
+      end.to change { user.comments.reload.count }.by(1)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq({
+        success: true,
+        user_id: user.external_id,
+        status: "suspended_for_tos_violation",
+        message: "User suspended for a policy violation"
+      }.as_json)
+      expect(user.reload).to be_suspended_for_tos_violation
+      expect(user).not_to be_suspended_for_fraud
+
+      comment = user.comments.last
+      expect(comment).to have_attributes(
+        author_id: admin_user.id,
+        comment_type: Comment::COMMENT_TYPE_SUSPENDED
+      )
+      expect(comment.content).to include("Suspended for a policy violation")
+    end
+
+    it "records the admin API audit log with the TOS suspension action key" do
+      expect do
+        post :suspend_for_tos_violation, params: { user_id: user.external_id }
+      end.to change { AdminApiAuditLog.count }.by(1)
+
+      expect(response).to have_http_status(:ok)
+      expect(AdminApiAuditLog.last).to have_attributes(
+        action: "users.suspend_for_tos_violation",
+        actor_user_id: admin_user.id,
+        target_type: "User",
+        target_id: user.id,
+        response_status: 200
+      )
+    end
+
+    it "creates an extra suspension note when one is provided" do
+      expect do
+        post :suspend_for_tos_violation, params: { user_id: user.external_id, note: "DMCA takedown notice confirmed" }
+      end.to change { user.comments.reload.count }.by(2)
+
+      expect(response).to have_http_status(:ok)
+      note = user.comments.find_by!(comment_type: Comment::COMMENT_TYPE_SUSPENSION_NOTE)
+      expect(note).to have_attributes(
+        author_id: admin_user.id,
+        comment_type: Comment::COMMENT_TYPE_SUSPENSION_NOTE,
+        content: "DMCA takedown notice confirmed"
+      )
+    end
+
+    it "returns 422 without suspending the user when the note is invalid" do
+      expect do
+        post :suspend_for_tos_violation, params: { user_id: user.external_id, note: "x" * 10_001 }
+      end.not_to change { user.comments.reload.count }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["success"]).to be(false)
+      expect(response.parsed_body["message"]).to include("Content is too long")
+      expect(user.reload).to be_compliant
+    end
+
+    it "returns success without creating another comment when the user is already suspended for a policy violation" do
+      user.update!(user_risk_state: "suspended_for_tos_violation")
+
+      expect do
+        post :suspend_for_tos_violation, params: { user_id: user.external_id, note: "Retry" }
+      end.not_to change { user.comments.reload.count }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq({
+        success: true,
+        user_id: user.external_id,
+        status: "already_suspended",
+        message: "User is already suspended for a policy violation"
+      }.as_json)
+    end
+
+    it "returns 422 when the user is suspended for fraud" do
+      user.update!(user_risk_state: "suspended_for_fraud")
+
+      expect do
+        post :suspend_for_tos_violation, params: { user_id: user.external_id }
+      end.not_to change { user.comments.reload.count }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["success"]).to be(false)
+      expect(user.reload).to be_suspended_for_fraud
+    end
+
+    it "returns 422 when the state machine rejects the suspension" do
+      user.update!(verified: true)
+
+      post :suspend_for_tos_violation, params: { user_id: user.external_id }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["success"]).to be(false)
+      expect(user.reload).to be_compliant
+    end
+
+    include_examples "requires user_id for user mutation", :suspend_for_tos_violation
+    include_examples "supports user lookup by user_id", :suspend_for_tos_violation, build_user: -> { create(:compliant_user) }
+    include_examples "checks expected_email for user mutation", :suspend_for_tos_violation, build_user: -> { create(:compliant_user) }
   end
 
   describe "POST watch" do

--- a/spec/routing/api_internal_admin_contract_spec.rb
+++ b/spec/routing/api_internal_admin_contract_spec.rb
@@ -34,6 +34,17 @@ describe "internal admin API routing" do
     expect(route_for("/internal/admin/users/unwatch", :post)).to include(controller: "api/internal/admin/users", action: "unwatch")
   end
 
+  it "routes the user suspension write endpoints" do
+    expect(route_for("/internal/admin/users/suspend_for_fraud", :post)).to include(
+      controller: "api/internal/admin/users",
+      action: "suspend_for_fraud"
+    )
+    expect(route_for("/internal/admin/users/suspend_for_tos_violation", :post)).to include(
+      controller: "api/internal/admin/users",
+      action: "suspend_for_tos_violation"
+    )
+  end
+
   it "routes the products endpoints" do
     expect(route_for("/internal/admin/products", :get)).to include(controller: "api/internal/admin/products", action: "index")
     expect(route_for("/internal/admin/products/abc123", :get)).to include(controller: "api/internal/admin/products", action: "show", id: "abc123")


### PR DESCRIPTION
Ref #5153

## What
- Adds `POST /internal/admin/users/suspend_for_tos_violation` for internal admin use.
- Suspends a user for a policy violation, records the admin audit action, and returns a status/message aligned to policy-violation language.
- Accepts an optional suspension note and preserves the existing user lookup and expected-email safeguards.

## Why
- This gives admins a dedicated TOS-suspension action instead of reusing the fraud flow.
- Separating the endpoint keeps the response shape and audit trail explicit, which makes the API easier for downstream callers to use correctly.

---
This PR was implemented with AI assistance using gpt-5.5 xhigh.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces a new admin write path that transitions user risk state to suspended_for_tos_violation; incorrect use directly affects account access and enforcement.
> 
> **Overview**
> Adds **`POST /internal/admin/users/suspend_for_tos_violation`** so internal admins can suspend sellers for policy violations separately from the fraud path, with policy-specific status/messages and audit action **`users.suspend_for_tos_violation`**.
> 
> The new action mirrors **`suspend_for_fraud`**: optional **`suspension_note`**, idempotent **already suspended** handling, invalid-note **422**s, and state-machine rejection handling. **`build_suspension_note`** now takes note text via a **`content:`** keyword (fraud path updated too).
> 
> Routing and contract specs cover both suspension write endpoints; controller specs add full coverage for the TOS flow (audit log, notes, cross-reason conflicts). A comments spec fixture switches from purchase to product commentables.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ae2b167886272e80c5fc08d395c58d971c934c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->