### PR TITLE
Add internal admin endpoint to flag a user for a policy violation

### DIFF
--- a/app/controllers/api/internal/admin/users_controller.rb
+++ b/app/controllers/api/internal/admin/users_controller.rb
@@ -286,6 +286,43 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
     end
   end
 
+  def flag_for_tos_violation
+    return render json: { success: false, message: "product_id is required" }, status: :bad_request if params[:product_id].blank?
+
+    user = find_internal_admin_user_for_write_or_render
+    return unless user
+
+    product = find_internal_admin_product_or_render
+    return unless product
+
+    unless product.user_id == user.id
+      return render json: { success: false, message: "Product does not belong to user" }, status: :unprocessable_entity
+    end
+
+    record_admin_write(action: "users.flag_for_tos_violation", target: user) do
+      if user.flagged_for_tos_violation?
+        return render json: internal_admin_user_success_payload(user, {
+                                                                  product_id: product.external_id,
+                                                                  status: "already_flagged",
+                                                                  message: "User is already flagged for a policy violation"
+                                                                })
+      end
+
+      user.flag_for_tos_violation!(
+        author_id: current_admin_actor_id,
+        product_id: product.id,
+        content: flag_for_tos_violation_comment_content(product)
+      )
+      render json: internal_admin_user_success_payload(user, {
+                                                         product_id: product.external_id,
+                                                         status: "flagged_for_tos_violation",
+                                                         message: "User flagged for a policy violation"
+                                                       })
+    rescue StateMachines::InvalidTransition => e
+      render json: { success: false, message: e.message }, status: :unprocessable_entity
+    end
+  end
+
   def watch
     return render json: { success: false, message: "revenue_threshold is required" }, status: :bad_request if params[:revenue_threshold].blank?
 
@@ -731,6 +768,18 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
 
     def render_invalid_comment(comment)
       render json: { success: false, message: comment.errors.full_messages.to_sentence }, status: :unprocessable_entity
+    end
+
+    def find_internal_admin_product_or_render
+      product = Link.find_by_external_id(params[:product_id])
+      return product if product.present?
+
+      render json: { success: false, message: "Product not found" }, status: :not_found
+      nil
+    end
+
+    def flag_for_tos_violation_comment_content(product)
+      "Flagged for a policy violation on #{Time.current.to_fs(:formatted_date_full_month)} for a product named '#{product.name}'"
     end
 
     def parse_threshold_cents(raw)

--- a/app/controllers/api/internal/admin/users_controller.rb
+++ b/app/controllers/api/internal/admin/users_controller.rb
@@ -771,7 +771,7 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
     end
 
     def find_internal_admin_product_or_render
-      product = Link.find_by_external_id(params[:product_id])
+      product = Link.alive.find_by_external_id(params[:product_id])
       return product if product.present?
 
       render json: { success: false, message: "Product not found" }, status: :not_found
@@ -779,7 +779,7 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
     end
 
     def flag_for_tos_violation_comment_content(product)
-      "Flagged for a policy violation on #{Time.current.to_fs(:formatted_date_full_month)} for a product named '#{product.name}'"
+      "Flagged for a policy violation by #{Current.admin_actor.name_or_username} on #{Time.current.to_fs(:formatted_date_full_month)} for product named '#{product.name}'"
     end
 
     def parse_threshold_cents(raw)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -346,6 +346,7 @@ Rails.application.routes.draw do
               post :mark_compliant
               post :suspend_for_fraud
               post :suspend_for_tos_violation
+              post :flag_for_tos_violation
               post :watch
               post :update_watch
               post :unwatch

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -2640,6 +2640,139 @@ describe Api::Internal::Admin::UsersController do
     include_examples "checks expected_email for user mutation", :suspend_for_tos_violation, build_user: -> { create(:compliant_user) }
   end
 
+  describe "POST flag_for_tos_violation" do
+    let(:user) { create(:compliant_user, email: "seller@example.com") }
+    let(:product) { create(:product, user:, name: "Policy problem guide") }
+
+    include_examples "admin api authorization required", :post, :flag_for_tos_violation, { product_id: "missing" }
+
+    it "returns 400 when user_id is missing" do
+      post :flag_for_tos_violation, params: { product_id: product.external_id }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: user_id_required_message }.as_json)
+    end
+
+    it "returns 400 when product_id is missing" do
+      post :flag_for_tos_violation, params: { user_id: user.external_id }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "product_id is required" }.as_json)
+    end
+
+    it "returns 404 when the user does not exist" do
+      post :flag_for_tos_violation, params: { user_id: "missing", product_id: product.external_id }
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
+    end
+
+    it "returns 404 when the product does not exist" do
+      post :flag_for_tos_violation, params: { user_id: user.external_id, product_id: "missing" }
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body).to eq({ success: false, message: "Product not found" }.as_json)
+    end
+
+    it "returns 422 without flagging the user when the product belongs to another user" do
+      other_product = create(:product)
+
+      expect do
+        post :flag_for_tos_violation, params: { user_id: user.external_id, product_id: other_product.external_id }
+      end.not_to change { user.comments.reload.count }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body).to eq({ success: false, message: "Product does not belong to user" }.as_json)
+      expect(user.reload).to be_compliant
+    end
+
+    it "flags the user for a policy violation and creates user and product comments attributed to the admin actor" do
+      expect do
+        post :flag_for_tos_violation, params: { user_id: user.external_id, product_id: product.external_id }
+      end.to change { user.comments.reload.count }.by(1)
+        .and change { product.comments.reload.count }.by(1)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq({
+        success: true,
+        user_id: user.external_id,
+        product_id: product.external_id,
+        status: "flagged_for_tos_violation",
+        message: "User flagged for a policy violation"
+      }.as_json)
+      expect(user.reload).to be_flagged_for_tos_violation
+
+      user_comment = user.comments.last
+      expect(user_comment).to have_attributes(
+        author_id: admin_user.id,
+        comment_type: Comment::COMMENT_TYPE_FLAGGED,
+        content: include("Flagged for a policy violation")
+      )
+      expect(user_comment.content).to include("Policy problem guide")
+
+      product_comment = product.comments.last
+      expect(product_comment).to have_attributes(
+        author_id: admin_user.id,
+        comment_type: "flagged",
+        content: user_comment.content
+      )
+    end
+
+    it "records the admin API audit log with the TOS flag action key" do
+      expect do
+        post :flag_for_tos_violation, params: { user_id: user.external_id, product_id: product.external_id }
+      end.to change { AdminApiAuditLog.count }.by(1)
+
+      expect(response).to have_http_status(:ok)
+      expect(AdminApiAuditLog.last).to have_attributes(
+        action: "users.flag_for_tos_violation",
+        actor_user_id: admin_user.id,
+        target_type: "User",
+        target_id: user.id,
+        response_status: 200
+      )
+    end
+
+    it "returns success without creating another comment when the user is already flagged for a policy violation" do
+      user.flag_for_tos_violation!(author_id: admin_user.id, product_id: product.id)
+
+      expect do
+        post :flag_for_tos_violation, params: { user_id: user.external_id, product_id: product.external_id }
+      end.not_to change { user.comments.reload.count }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq({
+        success: true,
+        user_id: user.external_id,
+        product_id: product.external_id,
+        status: "already_flagged",
+        message: "User is already flagged for a policy violation"
+      }.as_json)
+    end
+
+    it "returns 422 when the state machine rejects the flag" do
+      user.update!(verified: true)
+
+      post :flag_for_tos_violation, params: { user_id: user.external_id, product_id: product.external_id }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["success"]).to be(false)
+      expect(user.reload).to be_compliant
+    end
+
+    it "rejects mismatched expected_email without mutating the user" do
+      expect do
+        post :flag_for_tos_violation, params: { user_id: user.external_id, product_id: product.external_id, expected_email: "other@example.com" }
+      end.not_to change { user.comments.reload.count }
+
+      expect(response).to have_http_status(:conflict)
+      expect(response.parsed_body).to eq({ success: false, message: "expected_email does not match the user's current email" }.as_json)
+      expect(user.reload).to be_compliant
+    end
+
+    include_examples "requires user_id for user mutation", :flag_for_tos_violation, extra_params: { product_id: "missing" }
+  end
+
   describe "POST watch" do
     let(:user) { create(:user) }
 

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -2674,6 +2674,21 @@ describe Api::Internal::Admin::UsersController do
       expect(response.parsed_body).to eq({ success: false, message: "Product not found" }.as_json)
     end
 
+    it "returns 404 when the product is not alive" do
+      deleted_product = create(:product, user:)
+      deleted_product.mark_deleted!
+      banned_product = create(:product, user:, banned_at: 1.day.ago)
+      purchase_disabled_product = create(:product, user:, purchase_disabled_at: 1.day.ago)
+
+      [deleted_product, banned_product, purchase_disabled_product].each do |inactive_product|
+        post :flag_for_tos_violation, params: { user_id: user.external_id, product_id: inactive_product.external_id }
+
+        expect(response).to have_http_status(:not_found)
+        expect(response.parsed_body).to eq({ success: false, message: "Product not found" }.as_json)
+        expect(user.reload).to be_compliant
+      end
+    end
+
     it "returns 422 without flagging the user when the product belongs to another user" do
       other_product = create(:product)
 
@@ -2709,6 +2724,7 @@ describe Api::Internal::Admin::UsersController do
         content: include("Flagged for a policy violation")
       )
       expect(user_comment.content).to include("Policy problem guide")
+      expect(user_comment.content).to include("by #{admin_user.name_or_username}")
 
       product_comment = product.comments.last
       expect(product_comment).to have_attributes(

--- a/spec/routing/api_internal_admin_contract_spec.rb
+++ b/spec/routing/api_internal_admin_contract_spec.rb
@@ -45,6 +45,13 @@ describe "internal admin API routing" do
     )
   end
 
+  it "routes the user policy-violation flag write endpoint" do
+    expect(route_for("/internal/admin/users/flag_for_tos_violation", :post)).to include(
+      controller: "api/internal/admin/users",
+      action: "flag_for_tos_violation"
+    )
+  end
+
   it "routes the products endpoints" do
     expect(route_for("/internal/admin/products", :get)).to include(controller: "api/internal/admin/products", action: "index")
     expect(route_for("/internal/admin/products/abc123", :get)).to include(controller: "api/internal/admin/products", action: "show", id: "abc123")


### PR DESCRIPTION
Ref #5153

## What

- Adds `POST /internal/admin/users/flag_for_tos_violation` so admins can flag a seller for a policy violation with a specific product.
- Requires both `user_id` and `product_id`, checks that the product belongs to that user, and returns clear errors for missing or mismatched data.
- Reuses the existing risk-state transition so the user and product comments stay consistent with the rest of the admin flow.

## Why

- The admin flow needs a separate action for flagging a seller before suspension, with product-level context and ownership checks.
- Keeping the validation and audit entry on the API side prevents the wrong seller or stale product from being flagged.

---

This PR was implemented with AI assistance using gpt-5.5 xhigh.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new admin write that changes seller risk state and creates audit comments; mitigated by product ownership checks, alive-product lookup, and reuse of the existing state machine, but it does not mirror the web admin flow’s product unpublish/delete side effects.
> 
> **Overview**
> Adds **`POST /internal/admin/users/flag_for_tos_violation`** so internal admin tools can flag a seller for a policy violation **before** suspension, with a specific **alive** product in context.
> 
> The action requires **`user_id`** and **`product_id`**, resolves the product via `Link.alive`, returns **422** if the product does not belong to that user, and is **idempotent** when the user is already flagged (`already_flagged`). On success it calls the existing **`flag_for_tos_violation!`** risk transition (admin actor, product id, standardized comment text), returns **`product_id`** in the JSON payload, and records **`users.flag_for_tos_violation`** in the admin API audit log. It follows the same guardrails as other user mutations (**`expected_email`**, state-machine errors).
> 
> Routing and a routing contract spec cover the new path; controller specs exercise validation, ownership, inactive products, comments on user and product, audit logging, and duplicate flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b2ea7b7e039ca0bcf88eede4ee0abd9eec96d98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->