### PR TITLE
Add app-owned Vivero preview compose runtime

### DIFF
--- a/docker/docker-compose-vivero-preview.yml
+++ b/docker/docker-compose-vivero-preview.yml
@@ -1,0 +1,107 @@
+# Vivero preview runtime for Gumroad.
+#
+# Vivero references this single app-owned Compose service and overlays only
+# preview labels, networking, and dynamic loopback ports. Keep Gumroad runtime
+# images, env contracts, dependency services, volumes, setup, and boot behavior
+# here instead of copying them into vivero.yml.
+
+services:
+  db_test:
+    extends:
+      file: docker-compose-test-and-ci.yml
+      service: db_test
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h 127.0.0.1 -uroot -ppassword --silent"]
+      interval: 2s
+      timeout: 2s
+      retries: 60
+
+  redis:
+    extends:
+      file: docker-compose-test-and-ci.yml
+      service: redis
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli ping | grep PONG"]
+      interval: 2s
+      timeout: 2s
+      retries: 60
+
+  mongo:
+    extends:
+      file: docker-compose-test-and-ci.yml
+      service: mongo
+    healthcheck:
+      test: ["CMD-SHELL", "mongo --quiet --eval 'db.runCommand({ ping: 1 }).ok' | grep 1"]
+      interval: 2s
+      timeout: 2s
+      retries: 60
+
+  elasticsearch:
+    extends:
+      file: docker-compose-test-and-ci.yml
+      service: elasticsearch
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:9200 >/dev/null"]
+      interval: 2s
+      timeout: 2s
+      retries: 90
+
+  memcached:
+    extends:
+      file: docker-compose-test-and-ci.yml
+      service: memcached
+
+  gumroad-web:
+    image: ${GUMROAD_VIVERO_WEB_IMAGE:-vivero/gumroad-dev-runtime:3.4.3-node22}
+    working_dir: /app
+    command: ./docker/web/vivero_preview.sh
+    environment:
+      APP_DIR: /app
+      BUNDLE_PATH: /bundle_path
+      DATABASE_HOST: db_test
+      DATABASE_NAME: gumroad_development
+      DATABASE_PORT: "3306"
+      DATABASE_USERNAME: root
+      DATABASE_PASSWORD: password
+      DISABLE_SPRING: "1"
+      ELASTICSEARCH_HOST: http://elasticsearch:9200
+      GRPC_RUBY_BUILD_PROCS: "4"
+      IN_DOCKER: "true"
+      MEMCACHE_SERVERS: memcached
+      MONGO_DATABASE_URL: mongo:27017
+      MONGO_SECONDARY_DATABASE_URL: mongo:27017
+      MONGO_DATABASE_NAME: gumroad_log_development
+      MONGO_DATABASE_USERNAME: username
+      MONGO_DATABASE_PASSWORD: password
+      MONGO_REPLICA_SET: empty_replica_set
+      PORT: "3310"
+      PUPPETEER_SKIP_DOWNLOAD: "true"
+      RACK_ATTACK_REDIS_HOST: redis:6379/3
+      RACK_ENV: development
+      RAILS_ENV: development
+      REDIS_HOST: redis:6379/0
+      RPUSH_REDIS_HOST: redis:6379/2
+      SIDEKIQ_REDIS_HOST: redis:6379/1
+      SKIP_NATIVE_MYSQL_RECONNECT: "true"
+    volumes:
+      - ..:/app
+      - bundle_path:/bundle_path
+      - node_modules:/app/node_modules
+    depends_on:
+      db_test:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      mongo:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
+      memcached:
+        condition: service_started
+
+volumes:
+  bundle_path:
+  node_modules:
+  redis_data:
+  mongo_data:
+  minio_data:

--- a/docker/web/vivero_preview.sh
+++ b/docker/web/vivero_preview.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "${APP_DIR:-/app}"
+
+export PORT="${PORT:-3310}"
+export PUPPETEER_SKIP_DOWNLOAD="${PUPPETEER_SKIP_DOWNLOAD:-true}"
+
+rm -f tmp/pids/server.pid
+
+bundle check || bundle install
+bundle exec rails db:prepare
+bundle exec rails runner 'load Rails.root.join("db/seeds/020_development_staging/gumroad_posts.rb") unless User.exists?(username: "gumroad")'
+
+npm install
+bundle exec rails js:export
+npm run build || test -f public/packs/manifest.json
+
+bundle exec rails runner 'DevTools.delete_all_indices_and_reindex_all'
+
+exec bundle exec rails server -b 0.0.0.0 -p "$PORT"


### PR DESCRIPTION
## Summary
- add an app-owned Compose runtime for Vivero previews
- extend Gumroad's existing test/CI backing services and add a single gumroad-web service
- move preview bootstrap/setup/boot behavior into Gumroad-owned docker/web/vivero_preview.sh

## Verification
- docker compose -f docker/docker-compose-vivero-preview.yml config --quiet
- bash -n docker/web/vivero_preview.sh
- vivero preview up gumroad-main --id main-thin --wait --timeout 15m --public
- vivero preview up gumroad-main --id main --wait --timeout 15m --public
- vivero preview smoke preview:main
- public URL returned HTTP 200 with no localhost origin leaks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782312451&installation_id=134400930&pr_number=5274&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5274&signature=22fad147d53dd89ba5e122d6465072ba360205704664754a004624f285b314ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New preview-only Docker and shell bootstrap; no production app logic, auth, or payment paths changed.
> 
> **Overview**
> Adds an **app-owned Docker Compose stack** for Vivero PR previews so runtime images, env, backing services, and boot logic live in Gumroad instead of being duplicated in Vivero’s config.
> 
> `docker/docker-compose-vivero-preview.yml` **extends** the existing test/CI services (`db_test`, Redis, Mongo, Elasticsearch, Memcached) and adds stricter **healthchecks** plus a single **`gumroad-web`** service (dev runtime image, repo mount, dependency `depends_on` with healthy conditions). Vivero is expected to overlay only labels, networking, and ports on top of this file.
> 
> `docker/web/vivero_preview.sh` is the **preview entrypoint**: install gems, `db:prepare`, optional dev seed, `npm install` / JS build, full Elasticsearch reindex via `DevTools`, then `rails server` on `PORT` (default 3310).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a89974b18e69a153b1ccab670fbe36486f4bc3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->