### PR TITLE
Strip Docker image build from CI; run RSpec on bare ubuntu runners

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -204,6 +204,15 @@ jobs:
       - name: npm ci
         run: npm ci
 
+      - name: Generate JS exports
+        # Generates app/javascript/utils/routes.js (consumed by Vite as a
+        # bare-specifier import). Must run BEFORE assets:precompile, or
+        # the production-mode Vite build can't resolve the routes import
+        # and fails with 'Could not load .../utils/routes'.
+        run: bundle exec rails js:export
+        env:
+          RAILS_ENV: test
+
       - name: Precompile assets
         # assets:precompile runs vite:build (main app bundles into
         # public/vite-test/) AND vite:build_widget (gumroad-bundle.js +
@@ -219,11 +228,6 @@ jobs:
 
       - name: Prepare test database
         run: bundle exec rake db:prepare
-
-      - name: Generate JS exports
-        run: bundle exec rails js:export
-        env:
-          RAILS_ENV: test
 
       - name: Start Vite dev server
         # Persistent vite dev daemon — avoids vite_ruby autoBuild's per-request
@@ -480,6 +484,15 @@ jobs:
       - name: npm ci
         run: npm ci
 
+      - name: Generate JS exports
+        # Generates app/javascript/utils/routes.js (consumed by Vite as a
+        # bare-specifier import). Must run BEFORE assets:precompile, or
+        # the production-mode Vite build can't resolve the routes import
+        # and fails with 'Could not load .../utils/routes'.
+        run: bundle exec rails js:export
+        env:
+          RAILS_ENV: test
+
       - name: Precompile assets
         # assets:precompile runs vite:build (main app bundles into
         # public/vite-test/) AND vite:build_widget (gumroad-bundle.js +
@@ -495,11 +508,6 @@ jobs:
 
       - name: Prepare test database
         run: bundle exec rake db:prepare
-
-      - name: Generate JS exports
-        run: bundle exec rails js:export
-        env:
-          RAILS_ENV: test
 
       - name: Start Vite dev server
         # Persistent vite dev daemon — avoids vite_ruby autoBuild's per-request

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,7 +84,7 @@ jobs:
         ports:
           - 11211:11211
       stripe_mock:
-        image: stripemock/stripe-mock:v0.193.1
+        image: stripemock/stripe-mock:v0.110.0
         ports:
           - 12111:12111
           - 12112:12112
@@ -266,7 +266,7 @@ jobs:
         ports:
           - 11211:11211
       stripe_mock:
-        image: stripemock/stripe-mock:v0.193.1
+        image: stripemock/stripe-mock:v0.110.0
         ports:
           - 12111:12111
           - 12112:12112

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version-file: .nvmrc
+          node-version-file: .node-version
           cache: npm
 
       - name: Install Chrome
@@ -260,7 +260,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version-file: .nvmrc
+          node-version-file: .node-version
           cache: npm
 
       - name: Install Chrome

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -202,6 +202,17 @@ jobs:
       - name: npm ci
         run: npm ci
 
+      - name: Build widget bundles
+        # gumroad-bundle.js and gumroad-embed-bundle.js are served from
+        # public/js/ via EmbeddedJavascriptsController. They're produced
+        # by vite.config.widget.ts and historically built as part of
+        # `assets:precompile` (see lib/tasks/vite_widget.rake). Without
+        # this step, embed/widget system specs fail because the embed
+        # iframe's script tag 404s and the iframe never injects.
+        run: npm run build:widget
+        env:
+          RAILS_ENV: test
+
       - name: Prepare test database
         run: bundle exec rake db:prepare
 
@@ -470,6 +481,17 @@ jobs:
 
       - name: npm ci
         run: npm ci
+
+      - name: Build widget bundles
+        # gumroad-bundle.js and gumroad-embed-bundle.js are served from
+        # public/js/ via EmbeddedJavascriptsController. They're produced
+        # by vite.config.widget.ts and historically built as part of
+        # `assets:precompile` (see lib/tasks/vite_widget.rake). Without
+        # this step, embed/widget system specs fail because the embed
+        # iframe's script tag 404s and the iframe never injects.
+        run: npm run build:widget
+        env:
+          RAILS_ENV: test
 
       - name: Prepare test database
         run: bundle exec rake db:prepare

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -174,6 +174,8 @@ jobs:
             until mc alias set local http://localhost:9000 minioadmin minioadmin; do sleep 2; done
             mc mb -p local/gumroad-specs || true
             mc mb -p local/gumroad-invoices || true
+            mc version enable local/gumroad-specs
+            mc version enable local/gumroad-invoices
             mc anonymous set public local/gumroad-specs
             mc anonymous set public local/gumroad-invoices
 
@@ -268,15 +270,7 @@ jobs:
         timeout-minutes: 20
         run: |
           mkdir -p ./test-logs
-          set +e
           bundle exec rake "knapsack_pro:queue:rspec[--format RSpec::Github::Formatter --tag ~skip --format progress]"
-          TEST_EXIT=$?
-          if [ $TEST_EXIT -ne 0 ]; then
-            echo ""
-            echo "TESTS FAILED (exit code $TEST_EXIT). Waiting 60s for other shards to report failures..."
-            sleep 60
-            exit $TEST_EXIT
-          fi
         env:
           KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC_FAST }}
           KNAPSACK_PRO_CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
@@ -454,6 +448,8 @@ jobs:
             until mc alias set local http://localhost:9000 minioadmin minioadmin; do sleep 2; done
             mc mb -p local/gumroad-specs || true
             mc mb -p local/gumroad-invoices || true
+            mc version enable local/gumroad-specs
+            mc version enable local/gumroad-invoices
             mc anonymous set public local/gumroad-specs
             mc anonymous set public local/gumroad-invoices
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -204,14 +204,16 @@ jobs:
       - name: npm ci
         run: npm ci
 
-      - name: Build widget bundles
-        # gumroad-bundle.js and gumroad-embed-bundle.js are served from
-        # public/js/ via EmbeddedJavascriptsController. They're produced
-        # by vite.config.widget.ts and historically built as part of
-        # `assets:precompile` (see lib/tasks/vite_widget.rake). Without
-        # this step, embed/widget system specs fail because the embed
-        # iframe's script tag 404s and the iframe never injects.
-        run: npm run build:widget
+      - name: Precompile assets
+        # assets:precompile runs vite:build (main app bundles into
+        # public/vite-test/) AND vite:build_widget (gumroad-bundle.js +
+        # gumroad-embed-bundle.js into public/js/, enhanced via
+        # lib/tasks/vite_widget.rake). Without this every Capybara
+        # browser hit on a Vite-served route pays cold-compile tax;
+        # with it, the dev daemon only needs to recompile changed
+        # entrypoints (rare in CI). Widget bundles are required by
+        # embed/widget system specs regardless.
+        run: bundle exec rake assets:precompile
         env:
           RAILS_ENV: test
 
@@ -478,14 +480,16 @@ jobs:
       - name: npm ci
         run: npm ci
 
-      - name: Build widget bundles
-        # gumroad-bundle.js and gumroad-embed-bundle.js are served from
-        # public/js/ via EmbeddedJavascriptsController. They're produced
-        # by vite.config.widget.ts and historically built as part of
-        # `assets:precompile` (see lib/tasks/vite_widget.rake). Without
-        # this step, embed/widget system specs fail because the embed
-        # iframe's script tag 404s and the iframe never injects.
-        run: npm run build:widget
+      - name: Precompile assets
+        # assets:precompile runs vite:build (main app bundles into
+        # public/vite-test/) AND vite:build_widget (gumroad-bundle.js +
+        # gumroad-embed-bundle.js into public/js/, enhanced via
+        # lib/tasks/vite_widget.rake). Without this every Capybara
+        # browser hit on a Vite-served route pays cold-compile tax;
+        # with it, the dev daemon only needs to recompile changed
+        # entrypoints (rare in CI). Widget bundles are required by
+        # embed/widget system specs regardless.
+        run: bundle exec rake assets:precompile
         env:
           RAILS_ENV: test
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -165,9 +165,6 @@ jobs:
         env:
           RAILS_ENV: test
 
-      - name: Precompile assets
-        run: bundle exec rake assets:precompile
-
       - name: Run tests
         timeout-minutes: 20
         run: |
@@ -346,9 +343,6 @@ jobs:
         run: bundle exec rails js:export
         env:
           RAILS_ENV: test
-
-      - name: Precompile assets
-        run: bundle exec rake assets:precompile
 
       - name: Run tests
         timeout-minutes: 30

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -118,7 +118,27 @@ jobs:
           chrome-version: stable
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg imagemagick
+        run: |
+          set -e
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            ffmpeg \
+            imagemagick \
+            pdftk-java \
+            libvips42 \
+            libtag1v5 \
+            libxrender1 \
+            libgcrypt20 \
+            fonts-dejavu \
+            fonts-takao \
+            xfonts-base \
+            xfonts-75dpi
+          # wkhtmltopdf 0.12.6 from upstream (apt's wkhtmltopdf is broken on ubuntu 22.04)
+          curl -sSL -o /tmp/wkhtmltopdf.deb https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-3/wkhtmltox_0.12.6.1-3.jammy_amd64.deb
+          sudo apt-get install -y --no-install-recommends /tmp/wkhtmltopdf.deb
+          rm /tmp/wkhtmltopdf.deb
+          fc-cache -f -v
+          wkhtmltopdf --version
 
       - name: Start MinIO and create buckets
         run: |
@@ -325,7 +345,27 @@ jobs:
           chrome-version: stable
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg imagemagick
+        run: |
+          set -e
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            ffmpeg \
+            imagemagick \
+            pdftk-java \
+            libvips42 \
+            libtag1v5 \
+            libxrender1 \
+            libgcrypt20 \
+            fonts-dejavu \
+            fonts-takao \
+            xfonts-base \
+            xfonts-75dpi
+          # wkhtmltopdf 0.12.6 from upstream (apt's wkhtmltopdf is broken on ubuntu 22.04)
+          curl -sSL -o /tmp/wkhtmltopdf.deb https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-3/wkhtmltox_0.12.6.1-3.jammy_amd64.deb
+          sudo apt-get install -y --no-install-recommends /tmp/wkhtmltopdf.deb
+          rm /tmp/wkhtmltopdf.deb
+          fc-cache -f -v
+          wkhtmltopdf --version
 
       - name: Start MinIO and create buckets
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -190,6 +190,9 @@ jobs:
         env:
           RAILS_ENV: test
 
+      - name: Precompile assets
+        run: bundle exec rake assets:precompile
+
       - name: Run tests
         timeout-minutes: 20
         run: |
@@ -393,6 +396,9 @@ jobs:
         run: bundle exec rails js:export
         env:
           RAILS_ENV: test
+
+      - name: Precompile assets
+        run: bundle exec rake assets:precompile
 
       - name: Run tests
         timeout-minutes: 30

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -279,7 +279,7 @@ jobs:
       - name: Run tests
         timeout-minutes: 30
         run: |
-          mkdir -p ./capybara-artifacts ./test-logs
+          mkdir -p ./test-logs
           bundle exec rake "knapsack_pro:queue:rspec[--format RSpec::Github::Formatter --tag ~skip --format progress]"
         env:
           KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC_FAST }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -251,7 +251,6 @@ jobs:
         env:
           RAILS_ENV: test
           VITE_RUBY_HOST: 127.0.0.1
-          VITE_RUBY_MODE: test
           VITE_RUBY_TEST_DEV_SERVER: "true"
 
       - name: Run tests
@@ -280,7 +279,6 @@ jobs:
           KNAPSACK_PRO_CI_NODE_BUILD_ID: ${{ github.run_id }}
           KNAPSACK_PRO_CI_NODE_RETRY_COUNT: ${{ github.run_attempt }}
           VITE_RUBY_HOST: 127.0.0.1
-          VITE_RUBY_MODE: test
           VITE_RUBY_TEST_DEV_SERVER: "true"
           KNAPSACK_PRO_PROJECT_DIR: ${{ github.workspace }}
           KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
@@ -522,7 +520,6 @@ jobs:
         env:
           RAILS_ENV: test
           VITE_RUBY_HOST: 127.0.0.1
-          VITE_RUBY_MODE: test
           VITE_RUBY_TEST_DEV_SERVER: "true"
 
       - name: Run tests
@@ -542,7 +539,6 @@ jobs:
           KNAPSACK_PRO_CI_NODE_BUILD_ID: ${{ github.run_id }}
           KNAPSACK_PRO_CI_NODE_RETRY_COUNT: ${{ github.run_attempt }}
           VITE_RUBY_HOST: 127.0.0.1
-          VITE_RUBY_MODE: test
           VITE_RUBY_TEST_DEV_SERVER: "true"
           KNAPSACK_PRO_PROJECT_DIR: ${{ github.workspace }}
           KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,343 +23,128 @@ jobs:
     steps:
       - run: true
 
-  build:
-    name: Build images${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository && ' (internal PR noop)' || '' }}
-    runs-on: blacksmith-8vcpu-ubuntu-2204
-    needs: ci_gate
-    if: ${{ github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name != github.repository }}
-    env:
-      DOCKER_BUILDKIT: 1
-    outputs:
-      test_image_tag: ${{ steps.test_image_tag.outputs.tag }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
-          persist-credentials: false
-      - name: Login to Docker Hub
-        uses: nick-fields/retry@v3
-        with:
-          timeout_seconds: 120
-          max_attempts: 3
-          retry_wait_seconds: 10
-          command: echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-      - name: Build and push base image
-        env:
-          WEB_BASE_REPO: gumroadteam/web_base
-        run: |
-          set -e
-          GREEN='\033[0;32m'
-          NC='\033[0m'
-          logger() {
-            echo -e "${GREEN}$(date '+%Y/%m/%d %H:%M:%S') build.sh: $1${NC}"
-          }
-          logger "pulling ruby:$(cat .ruby-version)-slim-bullseye"
-          docker pull --quiet ruby:$(cat .ruby-version)-slim-bullseye
-          WEB_BASE_SHA=$(WEB_BASE_DOCKERFILE_FROM=ruby:$(cat .ruby-version)-slim-bullseye docker/base/generate_tag_for_web_base.sh)
-          if ! docker manifest inspect $WEB_BASE_REPO:$WEB_BASE_SHA > /dev/null 2>&1; then
-            logger "Building $WEB_BASE_REPO:$WEB_BASE_SHA"
-            NEW_BASE_REPO=$WEB_BASE_REPO \
-              WEB_BASE_DOCKERFILE_FROM=ruby:$(cat .ruby-version)-slim-bullseye \
-              BUNDLE_GEMS__CONTRIBSYS__COM=${{ secrets.BUNDLE_GEMS__CONTRIBSYS__COM }} \
-              make build_base
-
-            logger "Pushing $WEB_BASE_REPO:$WEB_BASE_SHA"
-            for i in {1..3}; do
-              logger "Push attempt $i"
-              if docker push --quiet $WEB_BASE_REPO:$WEB_BASE_SHA; then
-                logger "Pushed $WEB_BASE_REPO:$WEB_BASE_SHA"
-                break
-              elif [ $i -eq 3 ]; then
-                logger "Failed to push $WEB_BASE_REPO:$WEB_BASE_SHA"
-                exit 1
-              else
-                sleep 5
-              fi
-            done
-          else
-            logger "$WEB_BASE_REPO:$WEB_BASE_SHA already exists"
-          fi
-      - name: Compute content-addressed test image tag
-        id: test_image_tag
-        env:
-          WEB_BASE_REPO: gumroadteam/web_base
-        run: |
-          set -e
-          # Resolve the base test SHA (used as a hash input).
-          WEB_BASE_TEST_SHA=$(WEB_BASE_DOCKERFILE_FROM=ruby:$(cat .ruby-version)-slim-bullseye docker/base/generate_tag_for_web_base_test.sh)
-          TAG=test-$(BASE_TEST_SHA=$WEB_BASE_TEST_SHA docker/base/generate_tag_for_test_image.sh)
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
-          echo "Computed test image tag: $TAG"
-      - name: Set up Docker Buildx
-        uses: useblacksmith/setup-docker-builder@v1
-        with:
-          max-cache-size-mb: "204800"
-      - name: Restore asset precompile cache
-        id: asset_cache
-        uses: actions/cache@v4
-        with:
-          path: /tmp/asset-cache
-          key: asset-precompile-${{ hashFiles('app/assets/**', 'app/javascript/**', 'config/webpack/**', 'config/shakapacker.yml', 'Gemfile.lock', 'package-lock.json', '.ruby-version') }}
-          restore-keys: |
-            asset-precompile-
-      - name: Build and push test image
-        env:
-          WEB_BASE_REPO: gumroadteam/web_base
-          WEB_BASE_TEST_REPO: gumroadteam/web_base_test
-          WEB_REPO: gumroadteam/web
-          TEST_IMAGE_TAG: ${{ steps.test_image_tag.outputs.tag }}
-          ASSET_CACHE_HIT: ${{ steps.asset_cache.outputs.cache-hit }}
-        run: |
-          set -e
-          GREEN='\033[0;32m'
-          NC='\033[0m'
-          logger() {
-            echo -e "${GREEN}$(date '+%Y/%m/%d %H:%M:%S') build.sh: $1${NC}"
-          }
-          docker pull --quiet ruby:$(cat .ruby-version)-slim-bullseye
-          WEB_BASE_TEST_SHA=$(WEB_BASE_DOCKERFILE_FROM=ruby:$(cat .ruby-version)-slim-bullseye docker/base/generate_tag_for_web_base_test.sh)
-
-          # Check if both images already exist (content-addressed cache hit).
-          BASE_TEST_EXISTS=false
-          TEST_EXISTS=false
-          docker manifest inspect $WEB_BASE_TEST_REPO:$WEB_BASE_TEST_SHA > /dev/null 2>&1 && BASE_TEST_EXISTS=true
-          docker manifest inspect $WEB_REPO:$TEST_IMAGE_TAG > /dev/null 2>&1 && TEST_EXISTS=true
-
-          if [ "$TEST_EXISTS" = "true" ]; then
-            logger "$WEB_REPO:$TEST_IMAGE_TAG already exists — nothing to build"
-          else
-            # Build web_base_test if needed
-            if [ "$BASE_TEST_EXISTS" = "false" ]; then
-              logger "building $WEB_BASE_TEST_REPO:$WEB_BASE_TEST_SHA"
-              NEW_BASE_REPO=$WEB_BASE_REPO NEW_WEB_BASE_TEST_REPO=$WEB_BASE_TEST_REPO \
-                WEB_BASE_DOCKERFILE_FROM=ruby:$(cat .ruby-version)-slim-bullseye \
-                make build_base_test
-              logger "pushing $WEB_BASE_TEST_REPO:$WEB_BASE_TEST_SHA"
-              for i in {1..3}; do
-                if docker push --quiet $WEB_BASE_TEST_REPO:$WEB_BASE_TEST_SHA; then
-                  logger "Pushed $WEB_BASE_TEST_REPO:$WEB_BASE_TEST_SHA"; break
-                elif [ $i -eq 3 ]; then exit 1; else sleep 5; fi
-              done
-            else
-              logger "$WEB_BASE_TEST_REPO:$WEB_BASE_TEST_SHA already exists"
-            fi
-
-            # Build test image. Blacksmith's setup-docker-builder provides a
-            # sticky-disk-backed BuildKit builder that persists the layer cache
-            # across runs automatically — no explicit --cache-from/--cache-to needed.
-            logger "building $WEB_REPO:$TEST_IMAGE_TAG"
-            WEB_BASE_SHA=$(WEB_BASE_DOCKERFILE_FROM=ruby:$(cat .ruby-version)-slim-bullseye docker/base/generate_tag_for_web_base.sh)
-            # Pull the FROM images that the multi-stage Dockerfile needs.
-            docker pull --quiet $WEB_BASE_REPO:$WEB_BASE_SHA &
-            docker pull --quiet $WEB_BASE_TEST_REPO:$WEB_BASE_TEST_SHA &
-            wait
-            WEB_DOCKERFILE_FROM=$WEB_BASE_REPO:$WEB_BASE_SHA \
-              WEB_BASE_TEST_DOCKERFILE_FROM=$WEB_BASE_TEST_REPO:$WEB_BASE_TEST_SHA \
-            docker buildx build \
-              --load \
-              --build-arg WEB_DOCKERFILE_FROM \
-              --build-arg WEB_BASE_TEST_DOCKERFILE_FROM \
-              --build-arg BUILDKIT_INLINE_CACHE=1 \
-              --file docker/web/Dockerfile.test \
-              -t $WEB_REPO:test-${TEST_IMAGE_TAG#test-} \
-              .
-            docker tag $WEB_REPO:test-${TEST_IMAGE_TAG#test-} $WEB_REPO:$TEST_IMAGE_TAG
-
-            # Run asset precompile + docker commit (Makefile's post-build steps).
-            # Volume-mount cached precompile artifacts so Sprockets/Shakapacker
-            # can skip recompiling unchanged assets (~4 min → ~30s on cache hit).
-            COMPOSE_PROJECT_NAME=web_${{ github.run_id }}_${{ github.run_attempt }} \
-              docker compose -f docker/docker-compose-test-and-ci.yml up -d db_test redis mongo elasticsearch
-            docker run --rm --entrypoint="" \
-              --network web_${{ github.run_id }}_${{ github.run_attempt }}_default \
-              $WEB_REPO:$TEST_IMAGE_TAG \
-              docker/ci/wait_on_connection.sh db_test 3306
-
-            # Prepare cached asset precompile artifacts.
-            # Copy cached outputs into the container BEFORE running precompile
-            # so Sprockets/Shakapacker can skip recompiling unchanged assets.
-            # (Volume mounts won't work — docker commit ignores mounted paths.)
-            ASSET_MOUNTS=""
-            if [ "$ASSET_CACHE_HIT" = "true" ] || [ -d /tmp/asset-cache/public_assets ]; then
-              logger "Restoring cached asset precompile artifacts"
-              ASSET_MOUNTS="-v /tmp/asset-cache:/tmp/asset-cache:ro"
-            else
-              logger "No asset cache found — full precompile will run"
-            fi
-
-            # shellcheck disable=SC2086
-            docker run \
-              --network web_${{ github.run_id }}_${{ github.run_attempt }}_default \
-              --entrypoint="" \
-              --shm-size="2g" \
-              --memory-swappiness="0" \
-              -e RAILS_ENV="test" \
-              $ASSET_MOUNTS \
-              --label routes_compiled=true \
-              --name worker_web_${{ github.run_id }}_${{ github.run_attempt }} \
-              $WEB_REPO:$TEST_IMAGE_TAG \
-              bash -c '
-                # Restore cached assets if available (before precompile).
-                if [ -d /tmp/asset-cache/public_assets ]; then
-                  echo "Copying cached assets into container..."
-                  cp -a /tmp/asset-cache/public_assets /app/public/assets 2>/dev/null || true
-                  cp -a /tmp/asset-cache/public_packs_test /app/public/packs-test 2>/dev/null || true
-                  mkdir -p /app/tmp/cache
-                  cp -a /tmp/asset-cache/tmp_cache_assets /app/tmp/cache/assets 2>/dev/null || true
-                  cp -a /tmp/asset-cache/tmp_shakapacker /app/tmp/shakapacker 2>/dev/null || true
-                  chown -R app:app /app/public/assets /app/public/packs-test /app/tmp/cache /app/tmp/shakapacker 2>/dev/null || true
-                fi
-                su -c "npm run setup && bundle exec rake db:setup assets:precompile --trace" app
-              '
-
-            # Extract updated asset artifacts for next run's cache.
-            logger "Saving asset precompile artifacts to cache"
-            CONTAINER=worker_web_${{ github.run_id }}_${{ github.run_attempt }}
-            mkdir -p /tmp/asset-cache
-            for dir_pair in \
-              "public/assets:public_assets" \
-              "public/packs-test:public_packs_test" \
-              "tmp/cache/assets:tmp_cache_assets" \
-              "tmp/shakapacker:tmp_shakapacker"; do
-              src="${dir_pair%%:*}"
-              dst="${dir_pair##*:}"
-              rm -rf "/tmp/asset-cache/$dst"
-              docker cp "$CONTAINER:/app/$src" "/tmp/asset-cache/$dst" 2>/dev/null || true
-            done
-
-            docker ps -lq \
-              --filter='label=routes_compiled=true' \
-              --filter='exited=0' \
-              --filter="name=worker_web_${{ github.run_id }}_${{ github.run_attempt }}" \
-              | xargs -I{} docker commit {} $WEB_REPO:$TEST_IMAGE_TAG
-            COMPOSE_PROJECT_NAME=web_${{ github.run_id }}_${{ github.run_attempt }} \
-              docker compose -f docker/docker-compose-test-and-ci.yml down
-
-            # Push the final image to Docker Hub.
-            logger "pushing $WEB_REPO:$TEST_IMAGE_TAG"
-            for i in {1..3}; do
-              if docker push --quiet $WEB_REPO:$TEST_IMAGE_TAG; then
-                logger "Pushed $WEB_REPO:$TEST_IMAGE_TAG"; break
-              elif [ $i -eq 3 ]; then exit 1; else sleep 5; fi
-            done
-
-            # Update floating test-cache tag.
-            docker tag $WEB_REPO:$TEST_IMAGE_TAG $WEB_REPO:test-cache
-            docker push --quiet $WEB_REPO:test-cache 2>/dev/null \
-              && logger "Pushed $WEB_REPO:test-cache" \
-              || logger "Failed to push test-cache (non-fatal)"
-          fi
-
   test_fast:
     name: Test Fast ${{ matrix.ci_node_index }}${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository && ' (internal PR noop)' || '' }}
-    env:
-      COMPOSE_PROJECT_NAME: web_${{ github.run_id }}_${{ github.run_attempt }}_fast_${{ matrix.ci_node_index }}
-    runs-on: ubicloud-standard-4
-    needs: build
+    runs-on: ubuntu-22.04
+    needs: ci_gate
+    if: ${{ github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name != github.repository }}
+    timeout-minutes: 25
     strategy:
       fail-fast: true
       matrix:
         ci_node_total: [18]
         ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]
+
+    services:
+      mysql:
+        image: mysql:8.0.32
+        env:
+          MYSQL_ROOT_PASSWORD: password
+          MYSQL_DATABASE: gumroad_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h localhost -uroot -ppassword"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+      mongo:
+        image: mongo:4.4
+        ports:
+          - 27017:27017
+      elasticsearch:
+        image: elasticsearch:7.17.10
+        env:
+          discovery.type: single-node
+          xpack.security.enabled: "false"
+          ES_JAVA_OPTS: -Xms512m -Xmx512m
+        ports:
+          - 9200:9200
+        options: >-
+          --health-cmd="curl -sf http://localhost:9200/_cluster/health || exit 1"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=20
+      memcached:
+        image: memcached:1.6
+        ports:
+          - 11211:11211
+      stripe_mock:
+        image: stripemock/stripe-mock:latest
+        ports:
+          - 12111:12111
+          - 12112:12112
+      minio:
+        image: minio/minio:RELEASE.2023-09-04T19-57-37Z
+        env:
+          MINIO_ROOT_USER: minioadmin
+          MINIO_ROOT_PASSWORD: minioadmin
+        ports:
+          - 9000:9000
+        options: >-
+          --health-cmd="curl -sf http://localhost:9000/minio/health/live || exit 1"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=15
+
+    env:
+      RAILS_ENV: test
+      RUBY_YJIT_ENABLE: 1
+      CI: true
+      BUNDLE_GEMS__CONTRIBSYS__COM: ${{ secrets.BUNDLE_GEMS__CONTRIBSYS__COM }}
+
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
-      - name: Login to Docker Hub
-        uses: nick-fields/retry@v3
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
         with:
-          timeout_seconds: 120
-          max_attempts: 3
-          retry_wait_seconds: 10
-          command: echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-      - name: Start services and pull test image
-        uses: nick-fields/retry@v3
+          bundler-cache: true
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
         with:
-          timeout_minutes: 5
-          max_attempts: 3
-          retry_wait_seconds: 5
-          command: |
-            docker pull --quiet $WEB_REPO:${{ needs.build.outputs.test_image_tag }} &
-            PULL_PID=$!
-            docker compose -f docker/docker-compose-test-and-ci.yml up -d
-            COMPOSE_EXIT=$?
-            wait $PULL_PID
-            PULL_EXIT=$?
-            exit $((COMPOSE_EXIT + PULL_EXIT))
-        env:
-          COMPOSE_HTTP_TIMEOUT: "300"
-          WEB_REPO: gumroadteam/web
-      - name: Wait for services and prepare test database
-        uses: nick-fields/retry@v3
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install Chrome
+        uses: browser-actions/setup-chrome@latest
         with:
-          timeout_minutes: 5
-          max_attempts: 3
-          retry_wait_seconds: 10
-          command: |
-            IMG=$WEB_REPO:${{ needs.build.outputs.test_image_tag }}
-            NET=${{ env.COMPOSE_PROJECT_NAME }}_default
-            # db:prepare only needs db_test; ES/minio waits run in parallel.
-            (
-              docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh db_test 3306 \
-                && docker run --rm --entrypoint="" --network $NET -e RAILS_ENV=test $IMG bundle exec rake db:prepare
-            ) &
-            DB_PID=$!
-            docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh elasticsearch 9200 &
-            ES_PID=$!
-            docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh minio 9000 &
-            MINIO_PID=$!
-            wait $DB_PID || exit 1
-            wait $ES_PID || exit 1
-            wait $MINIO_PID || exit 1
-        env:
-          WEB_REPO: gumroadteam/web
+          chrome-version: stable
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg imagemagick
+
+      - name: npm ci
+        run: npm ci
+
+      - name: Prepare test database
+        run: bundle exec rake db:prepare
+
+      - name: Precompile assets
+        run: bundle exec rake assets:precompile
 
       - name: Run tests
-        timeout-minutes: 15
+        timeout-minutes: 20
         run: |
           mkdir -p ./test-logs
-          chmod 777 ./test-logs
           set +e
-          docker run --rm --entrypoint="" --network ${{ env.COMPOSE_PROJECT_NAME }}_default \
-            -v "$(pwd)/test-logs:/app/log" \
-            -e RUBY_YJIT_ENABLE \
-            -e KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC \
-            -e KNAPSACK_PRO_CI_NODE_TOTAL \
-            -e KNAPSACK_PRO_CI_NODE_INDEX \
-            -e KNAPSACK_PRO_LOG_LEVEL \
-            -e KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES \
-            -e KNAPSACK_PRO_TEST_FILE_PATTERN \
-            -e KNAPSACK_PRO_TEST_FILE_EXCLUDE_PATTERN \
-            -e KNAPSACK_PRO_COMMIT_HASH \
-            -e KNAPSACK_PRO_BRANCH \
-            -e KNAPSACK_PRO_CI_NODE_BUILD_ID \
-            -e KNAPSACK_PRO_CI_NODE_RETRY_COUNT \
-            -e KNAPSACK_PRO_PROJECT_DIR \
-            -e KNAPSACK_PRO_FIXED_QUEUE_SPLIT \
-            -e CI \
-            -e IN_DOCKER \
-            $WEB_REPO:${{ needs.build.outputs.test_image_tag }} \
-            /usr/local/bin/gosu app bundle exec rake "knapsack_pro:queue:rspec[--format RSpec::Github::Formatter --tag ~skip --format progress]"
+          bundle exec rake "knapsack_pro:queue:rspec[--format RSpec::Github::Formatter --tag ~skip --format progress]"
           TEST_EXIT=$?
           if [ $TEST_EXIT -ne 0 ]; then
             echo ""
-            echo "============================================"
-            echo "TESTS FAILED (exit code $TEST_EXIT)"
-            echo "Waiting 60s for other containers to report failures..."
-            echo "============================================"
+            echo "TESTS FAILED (exit code $TEST_EXIT). Waiting 60s for other shards to report failures..."
             sleep 60
             exit $TEST_EXIT
           fi
         env:
-          RUBY_YJIT_ENABLE: 1
           KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC_FAST }}
           KNAPSACK_PRO_CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
           KNAPSACK_PRO_CI_NODE_INDEX: ${{ matrix.ci_node_index }}
@@ -371,11 +156,9 @@ jobs:
           KNAPSACK_PRO_BRANCH: ${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref_name }}
           KNAPSACK_PRO_CI_NODE_BUILD_ID: ${{ github.run_id }}
           KNAPSACK_PRO_CI_NODE_RETRY_COUNT: ${{ github.run_attempt }}
-          KNAPSACK_PRO_PROJECT_DIR: /app
+          KNAPSACK_PRO_PROJECT_DIR: ${{ github.workspace }}
           KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
-          CI: true
-          IN_DOCKER: true
-          WEB_REPO: gumroadteam/web
+
       - name: Archive flaky specs log
         if: always()
         uses: actions/upload-artifact@v4
@@ -384,164 +167,121 @@ jobs:
           path: ./test-logs/flaky_specs.log
           retention-days: 14
           if-no-files-found: ignore
-      - name: Clean up
-        if: always()
-        run: |
-          docker compose -f docker/docker-compose-test-and-ci.yml down -v 2>/dev/null || true
-          docker rm -f $(docker ps -aq -f name=${{ env.COMPOSE_PROJECT_NAME }}) 2>/dev/null || true
-          docker volume rm $(docker volume ls -q -f name=${{ env.COMPOSE_PROJECT_NAME }}) 2>/dev/null || true
-          docker network rm ${{ env.COMPOSE_PROJECT_NAME }}_default 2>/dev/null || true
 
   test_slow:
     name: Test Slow ${{ matrix.ci_node_index }}${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository && ' (internal PR noop)' || '' }}
-    env:
-      COMPOSE_PROJECT_NAME: web_${{ github.run_id }}_${{ github.run_attempt }}_slow_${{ matrix.ci_node_index }}
-      WEB_REPO: gumroadteam/web
-    runs-on: ubicloud-standard-4
-    needs: build
+    runs-on: ubuntu-22.04
+    needs: ci_gate
+    if: ${{ github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name != github.repository }}
+    timeout-minutes: 35
     strategy:
       fail-fast: false
       matrix:
         ci_node_total: [50]
-        ci_node_index:
-          [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7,
-            8,
-            9,
-            10,
-            11,
-            12,
-            13,
-            14,
-            15,
-            16,
-            17,
-            18,
-            19,
-            20,
-            21,
-            22,
-            23,
-            24,
-            25,
-            26,
-            27,
-            28,
-            29,
-            30,
-            31,
-            32,
-            33,
-            34,
-            35,
-            36,
-            37,
-            38,
-            39,
-            40,
-            41,
-            42,
-            43,
-            44,
-            45,
-            46,
-            47,
-            48,
-            49,
-          ]
+        ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49]
+
+    services:
+      mysql:
+        image: mysql:8.0.32
+        env:
+          MYSQL_ROOT_PASSWORD: password
+          MYSQL_DATABASE: gumroad_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h localhost -uroot -ppassword"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+      mongo:
+        image: mongo:4.4
+        ports:
+          - 27017:27017
+      elasticsearch:
+        image: elasticsearch:7.17.10
+        env:
+          discovery.type: single-node
+          xpack.security.enabled: "false"
+          ES_JAVA_OPTS: -Xms512m -Xmx512m
+        ports:
+          - 9200:9200
+        options: >-
+          --health-cmd="curl -sf http://localhost:9200/_cluster/health || exit 1"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=20
+      memcached:
+        image: memcached:1.6
+        ports:
+          - 11211:11211
+      stripe_mock:
+        image: stripemock/stripe-mock:latest
+        ports:
+          - 12111:12111
+          - 12112:12112
+      minio:
+        image: minio/minio:RELEASE.2023-09-04T19-57-37Z
+        env:
+          MINIO_ROOT_USER: minioadmin
+          MINIO_ROOT_PASSWORD: minioadmin
+        ports:
+          - 9000:9000
+        options: >-
+          --health-cmd="curl -sf http://localhost:9000/minio/health/live || exit 1"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=15
+
+    env:
+      RAILS_ENV: test
+      RUBY_YJIT_ENABLE: 1
+      CI: true
+      BUNDLE_GEMS__CONTRIBSYS__COM: ${{ secrets.BUNDLE_GEMS__CONTRIBSYS__COM }}
+
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
-      - name: Login to Docker Hub
-        uses: nick-fields/retry@v3
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
         with:
-          timeout_seconds: 120
-          max_attempts: 3
-          retry_wait_seconds: 10
-          command: echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-      - name: Start services and pull test image
-        uses: nick-fields/retry@v3
+          bundler-cache: true
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
         with:
-          timeout_minutes: 5
-          max_attempts: 3
-          retry_wait_seconds: 5
-          command: |
-            docker pull --quiet $WEB_REPO:${{ needs.build.outputs.test_image_tag }} &
-            PULL_PID=$!
-            docker compose -f docker/docker-compose-test-and-ci.yml up -d
-            COMPOSE_EXIT=$?
-            wait $PULL_PID
-            PULL_EXIT=$?
-            exit $((COMPOSE_EXIT + PULL_EXIT))
-        env:
-          COMPOSE_HTTP_TIMEOUT: "300"
-          WEB_REPO: gumroadteam/web
-      - name: Wait for services and prepare test database
-        uses: nick-fields/retry@v3
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install Chrome
+        uses: browser-actions/setup-chrome@latest
         with:
-          timeout_minutes: 5
-          max_attempts: 3
-          retry_wait_seconds: 10
-          command: |
-            IMG=$WEB_REPO:${{ needs.build.outputs.test_image_tag }}
-            NET=${{ env.COMPOSE_PROJECT_NAME }}_default
-            # db:prepare only needs db_test; ES/minio waits run in parallel.
-            (
-              docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh db_test 3306 \
-                && docker run --rm --entrypoint="" --network $NET -e RAILS_ENV=test $IMG bundle exec rake db:prepare
-            ) &
-            DB_PID=$!
-            docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh elasticsearch 9200 &
-            ES_PID=$!
-            docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh minio 9000 &
-            MINIO_PID=$!
-            wait $DB_PID || exit 1
-            wait $ES_PID || exit 1
-            wait $MINIO_PID || exit 1
-        env:
-          WEB_REPO: gumroadteam/web
+          chrome-version: stable
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg imagemagick
+
+      - name: npm ci
+        run: npm ci
+
+      - name: Prepare test database
+        run: bundle exec rake db:prepare
+
+      - name: Precompile assets
+        run: bundle exec rake assets:precompile
 
       - name: Run tests
-        timeout-minutes: 25
+        timeout-minutes: 30
         run: |
-          mkdir -p ./capybara-artifacts
-          chmod 777 ./capybara-artifacts
-          mkdir -p ./test-logs
-          chmod 777 ./test-logs
-          docker run --rm --entrypoint="" --network ${{ env.COMPOSE_PROJECT_NAME }}_default \
-            -v "$(pwd)/capybara-artifacts:/app/tmp/capybara" \
-            -v "$(pwd)/test-logs:/app/log" \
-            -e RUBY_YJIT_ENABLE \
-            -e KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC \
-            -e KNAPSACK_PRO_CI_NODE_TOTAL \
-            -e KNAPSACK_PRO_CI_NODE_INDEX \
-            -e KNAPSACK_PRO_LOG_LEVEL \
-            -e KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES \
-            -e KNAPSACK_PRO_TEST_FILE_PATTERN \
-            -e KNAPSACK_PRO_COMMIT_HASH \
-            -e KNAPSACK_PRO_BRANCH \
-            -e KNAPSACK_PRO_CI_NODE_BUILD_ID \
-            -e KNAPSACK_PRO_CI_NODE_RETRY_COUNT \
-            -e KNAPSACK_PRO_PROJECT_DIR \
-            -e KNAPSACK_PRO_FIXED_QUEUE_SPLIT \
-            -e CI \
-            -e IN_DOCKER \
-            $WEB_REPO:${{ needs.build.outputs.test_image_tag }} \
-            /usr/local/bin/gosu app bundle exec rake "knapsack_pro:queue:rspec[--format RSpec::Github::Formatter --tag ~skip --format progress]"
+          mkdir -p ./capybara-artifacts ./test-logs
+          bundle exec rake "knapsack_pro:queue:rspec[--format RSpec::Github::Formatter --tag ~skip --format progress]"
         env:
-          RUBY_YJIT_ENABLE: 1
           KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC_FAST }}
           KNAPSACK_PRO_CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
           KNAPSACK_PRO_CI_NODE_INDEX: ${{ matrix.ci_node_index }}
@@ -552,27 +292,18 @@ jobs:
           KNAPSACK_PRO_BRANCH: ${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref_name }}
           KNAPSACK_PRO_CI_NODE_BUILD_ID: ${{ github.run_id }}
           KNAPSACK_PRO_CI_NODE_RETRY_COUNT: ${{ github.run_attempt }}
-          KNAPSACK_PRO_PROJECT_DIR: /app
+          KNAPSACK_PRO_PROJECT_DIR: ${{ github.workspace }}
           KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
-          CI: true
-          IN_DOCKER: true
-          WEB_REPO: gumroadteam/web
+
       - name: Archive capybara artifacts
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: capybara-screenshots-slow-${{ matrix.ci_node_index }}-attempt-${{ github.run_attempt }}
-          path: ./capybara-artifacts/*.png
+          path: ./tmp/capybara/*
           retention-days: 7
           if-no-files-found: ignore
-      - name: Archive test logs
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-logs-slow-${{ matrix.ci_node_index }}-attempt-${{ github.run_attempt }}
-          path: ./test-logs/test.log
-          retention-days: 7
-          if-no-files-found: ignore
+
       - name: Archive flaky specs log
         if: always()
         uses: actions/upload-artifact@v4
@@ -581,13 +312,6 @@ jobs:
           path: ./test-logs/flaky_specs.log
           retention-days: 14
           if-no-files-found: ignore
-      - name: Clean up
-        if: always()
-        run: |
-          docker compose -f docker/docker-compose-test-and-ci.yml down -v 2>/dev/null || true
-          docker rm -f $(docker ps -aq -f name=${{ env.COMPOSE_PROJECT_NAME }}) 2>/dev/null || true
-          docker volume rm $(docker volume ls -q -f name=${{ env.COMPOSE_PROJECT_NAME }}) 2>/dev/null || true
-          docker network rm ${{ env.COMPOSE_PROJECT_NAME }}_default 2>/dev/null || true
 
   unblock_deployment_from_buildkite:
     name: Unblock deployment from Buildkite

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -146,12 +146,37 @@ jobs:
           fi
 
           # Create required buckets using mc client (installed in a one-shot container)
-          docker run --rm --network host --entrypoint sh minio/mc:latest -c '
+          docker run --rm --network host \
+            -v "$(pwd)/spec/support/fixtures:/fixtures:ro" \
+            -v "$(pwd)/docker/fixture-files-private.txt:/fixture-files-private.txt:ro" \
+            -v "$(pwd)/docker/fixture-files-public.txt:/fixture-files-public.txt:ro" \
+            --entrypoint sh minio/mc:latest -c '
             until mc alias set local http://localhost:9000 minioadmin minioadmin; do sleep 2; done
-            /usr/bin/mc mb -p local/gumroad-specs || true
-            /usr/bin/mc mb -p local/gumroad-invoices || true
-            /usr/bin/mc anonymous set public local/gumroad-specs
-            /usr/bin/mc anonymous set public local/gumroad-invoices
+            mc mb -p local/gumroad-specs || true
+            mc mb -p local/gumroad-invoices || true
+            mc anonymous set public local/gumroad-specs
+            mc anonymous set public local/gumroad-invoices
+
+            echo "Seeding private fixtures into gumroad-specs/specs/"
+            while IFS= read -r file || [ -n "$file" ]; do
+              [ -z "$file" ] && continue
+              if [ -f "/fixtures/$file" ]; then
+                mc cp "/fixtures/$file" "local/gumroad-specs/specs/$file"
+              else
+                echo "ERROR: fixture not found: $file"; exit 1
+              fi
+            done < /fixture-files-private.txt
+
+            echo "Seeding public fixtures into gumroad-specs/specs/"
+            while IFS= read -r file || [ -n "$file" ]; do
+              [ -z "$file" ] && continue
+              if [ -f "/fixtures/$file" ]; then
+                mc cp "/fixtures/$file" "local/gumroad-specs/specs/$file"
+                mc anonymous set download "local/gumroad-specs/specs/$file"
+              else
+                echo "ERROR: fixture not found: $file"; exit 1
+              fi
+            done < /fixture-files-public.txt
           '
 
       - name: npm ci
@@ -325,12 +350,37 @@ jobs:
           fi
 
           # Create required buckets using mc client (installed in a one-shot container)
-          docker run --rm --network host --entrypoint sh minio/mc:latest -c '
+          docker run --rm --network host \
+            -v "$(pwd)/spec/support/fixtures:/fixtures:ro" \
+            -v "$(pwd)/docker/fixture-files-private.txt:/fixture-files-private.txt:ro" \
+            -v "$(pwd)/docker/fixture-files-public.txt:/fixture-files-public.txt:ro" \
+            --entrypoint sh minio/mc:latest -c '
             until mc alias set local http://localhost:9000 minioadmin minioadmin; do sleep 2; done
-            /usr/bin/mc mb -p local/gumroad-specs || true
-            /usr/bin/mc mb -p local/gumroad-invoices || true
-            /usr/bin/mc anonymous set public local/gumroad-specs
-            /usr/bin/mc anonymous set public local/gumroad-invoices
+            mc mb -p local/gumroad-specs || true
+            mc mb -p local/gumroad-invoices || true
+            mc anonymous set public local/gumroad-specs
+            mc anonymous set public local/gumroad-invoices
+
+            echo "Seeding private fixtures into gumroad-specs/specs/"
+            while IFS= read -r file || [ -n "$file" ]; do
+              [ -z "$file" ] && continue
+              if [ -f "/fixtures/$file" ]; then
+                mc cp "/fixtures/$file" "local/gumroad-specs/specs/$file"
+              else
+                echo "ERROR: fixture not found: $file"; exit 1
+              fi
+            done < /fixture-files-private.txt
+
+            echo "Seeding public fixtures into gumroad-specs/specs/"
+            while IFS= read -r file || [ -n "$file" ]; do
+              [ -z "$file" ] && continue
+              if [ -f "/fixtures/$file" ]; then
+                mc cp "/fixtures/$file" "local/gumroad-specs/specs/$file"
+                mc anonymous set download "local/gumroad-specs/specs/$file"
+              else
+                echo "ERROR: fixture not found: $file"; exit 1
+              fi
+            done < /fixture-files-public.txt
           '
 
       - name: npm ci

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -251,6 +251,7 @@ jobs:
         env:
           RAILS_ENV: test
           VITE_RUBY_HOST: 127.0.0.1
+          VITE_RUBY_MODE: test
           VITE_RUBY_TEST_DEV_SERVER: "true"
 
       - name: Run tests
@@ -279,6 +280,7 @@ jobs:
           KNAPSACK_PRO_CI_NODE_BUILD_ID: ${{ github.run_id }}
           KNAPSACK_PRO_CI_NODE_RETRY_COUNT: ${{ github.run_attempt }}
           VITE_RUBY_HOST: 127.0.0.1
+          VITE_RUBY_MODE: test
           VITE_RUBY_TEST_DEV_SERVER: "true"
           KNAPSACK_PRO_PROJECT_DIR: ${{ github.workspace }}
           KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
@@ -520,6 +522,7 @@ jobs:
         env:
           RAILS_ENV: test
           VITE_RUBY_HOST: 127.0.0.1
+          VITE_RUBY_MODE: test
           VITE_RUBY_TEST_DEV_SERVER: "true"
 
       - name: Run tests
@@ -539,6 +542,7 @@ jobs:
           KNAPSACK_PRO_CI_NODE_BUILD_ID: ${{ github.run_id }}
           KNAPSACK_PRO_CI_NODE_RETRY_COUNT: ${{ github.run_attempt }}
           VITE_RUBY_HOST: 127.0.0.1
+          VITE_RUBY_MODE: test
           VITE_RUBY_TEST_DEV_SERVER: "true"
           KNAPSACK_PRO_PROJECT_DIR: ${{ github.workspace }}
           KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -130,8 +130,8 @@ jobs:
           done
 
           # Create required buckets using mc client (installed in a one-shot container)
-          docker run --rm --network host minio/mc:latest sh -c '
-            until /usr/bin/mc alias set local http://localhost:9000 minioadmin minioadmin; do sleep 2; done
+          docker run --rm --network host --entrypoint sh minio/mc:latest -c '
+            until mc alias set local http://localhost:9000 minioadmin minioadmin; do sleep 2; done
             /usr/bin/mc mb -p local/gumroad-specs || true
             /usr/bin/mc mb -p local/gumroad-invoices || true
             /usr/bin/mc anonymous set public local/gumroad-specs
@@ -291,8 +291,8 @@ jobs:
           done
 
           # Create required buckets using mc client (installed in a one-shot container)
-          docker run --rm --network host minio/mc:latest sh -c '
-            until /usr/bin/mc alias set local http://localhost:9000 minioadmin minioadmin; do sleep 2; done
+          docker run --rm --network host --entrypoint sh minio/mc:latest -c '
+            until mc alias set local http://localhost:9000 minioadmin minioadmin; do sleep 2; done
             /usr/bin/mc mb -p local/gumroad-specs || true
             /usr/bin/mc mb -p local/gumroad-invoices || true
             /usr/bin/mc anonymous set public local/gumroad-specs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,18 +78,6 @@ jobs:
         ports:
           - 12111:12111
           - 12112:12112
-      minio:
-        image: minio/minio:RELEASE.2023-09-04T19-57-37Z
-        env:
-          MINIO_ROOT_USER: minioadmin
-          MINIO_ROOT_PASSWORD: minioadmin
-        ports:
-          - 9000:9000
-        options: >-
-          --health-cmd="curl -sf http://localhost:9000/minio/health/live || exit 1"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=15
 
     env:
       RAILS_ENV: test
@@ -121,6 +109,34 @@ jobs:
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg imagemagick
+
+      - name: Start MinIO and create buckets
+        run: |
+          set -e
+          docker run -d --name minio \
+            -p 9000:9000 -p 9001:9001 \
+            -e MINIO_ROOT_USER=minioadmin \
+            -e MINIO_ROOT_PASSWORD=minioadmin \
+            --health-cmd="curl -sf http://localhost:9000/minio/health/live || exit 1" \
+            --health-interval=5s --health-timeout=5s --health-retries=20 \
+            minio/minio:RELEASE.2023-09-04T19-57-37Z server /data --console-address ":9001"
+
+          # Wait for MinIO health
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:9000/minio/health/live >/dev/null; then
+              echo "MinIO is healthy"; break
+            fi
+            sleep 2
+          done
+
+          # Create required buckets using mc client (installed in a one-shot container)
+          docker run --rm --network host minio/mc:latest sh -c '
+            until /usr/bin/mc alias set local http://localhost:9000 minioadmin minioadmin; do sleep 2; done
+            /usr/bin/mc mb -p local/gumroad-specs || true
+            /usr/bin/mc mb -p local/gumroad-invoices || true
+            /usr/bin/mc anonymous set public local/gumroad-specs
+            /usr/bin/mc anonymous set public local/gumroad-invoices
+          '
 
       - name: npm ci
         run: npm ci
@@ -223,18 +239,6 @@ jobs:
         ports:
           - 12111:12111
           - 12112:12112
-      minio:
-        image: minio/minio:RELEASE.2023-09-04T19-57-37Z
-        env:
-          MINIO_ROOT_USER: minioadmin
-          MINIO_ROOT_PASSWORD: minioadmin
-        ports:
-          - 9000:9000
-        options: >-
-          --health-cmd="curl -sf http://localhost:9000/minio/health/live || exit 1"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=15
 
     env:
       RAILS_ENV: test
@@ -266,6 +270,34 @@ jobs:
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg imagemagick
+
+      - name: Start MinIO and create buckets
+        run: |
+          set -e
+          docker run -d --name minio \
+            -p 9000:9000 -p 9001:9001 \
+            -e MINIO_ROOT_USER=minioadmin \
+            -e MINIO_ROOT_PASSWORD=minioadmin \
+            --health-cmd="curl -sf http://localhost:9000/minio/health/live || exit 1" \
+            --health-interval=5s --health-timeout=5s --health-retries=20 \
+            minio/minio:RELEASE.2023-09-04T19-57-37Z server /data --console-address ":9001"
+
+          # Wait for MinIO health
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:9000/minio/health/live >/dev/null; then
+              echo "MinIO is healthy"; break
+            fi
+            sleep 2
+          done
+
+          # Create required buckets using mc client (installed in a one-shot container)
+          docker run --rm --network host minio/mc:latest sh -c '
+            until /usr/bin/mc alias set local http://localhost:9000 minioadmin minioadmin; do sleep 2; done
+            /usr/bin/mc mb -p local/gumroad-specs || true
+            /usr/bin/mc mb -p local/gumroad-invoices || true
+            /usr/bin/mc anonymous set public local/gumroad-specs
+            /usr/bin/mc anonymous set public local/gumroad-invoices
+          '
 
       - name: npm ci
         run: npm ci

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,10 +52,20 @@ jobs:
         image: redis:7
         ports:
           - 6379:6379
+        options: >-
+          --health-cmd="redis-cli ping"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=20
       mongo:
         image: mongo:4.4
         ports:
           - 27017:27017
+        options: >-
+          --health-cmd="mongo --quiet --eval 'db.adminCommand({ ping: 1 })'"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=20
       elasticsearch:
         image: elasticsearch:7.17.10
         env:
@@ -74,7 +84,7 @@ jobs:
         ports:
           - 11211:11211
       stripe_mock:
-        image: stripemock/stripe-mock:latest
+        image: stripemock/stripe-mock:v0.193.1
         ports:
           - 12111:12111
           - 12112:12112
@@ -122,12 +132,18 @@ jobs:
             minio/minio:RELEASE.2023-09-04T19-57-37Z server /data --console-address ":9001"
 
           # Wait for MinIO health
+          HEALTHY=false
           for i in $(seq 1 30); do
             if curl -sf http://localhost:9000/minio/health/live >/dev/null; then
-              echo "MinIO is healthy"; break
+              echo "MinIO is healthy"; HEALTHY=true; break
             fi
             sleep 2
           done
+          if [ "$HEALTHY" != "true" ]; then
+            echo "ERROR: MinIO failed to become healthy after 60s"
+            docker logs minio || true
+            exit 1
+          fi
 
           # Create required buckets using mc client (installed in a one-shot container)
           docker run --rm --network host --entrypoint sh minio/mc:latest -c '
@@ -143,6 +159,11 @@ jobs:
 
       - name: Prepare test database
         run: bundle exec rake db:prepare
+
+      - name: Generate JS exports
+        run: bundle exec rails js:export
+        env:
+          RAILS_ENV: test
 
       - name: Precompile assets
         run: bundle exec rake assets:precompile
@@ -180,7 +201,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: flaky-specs-fast-${{ matrix.ci_node_index }}-attempt-${{ github.run_attempt }}
-          path: ./test-logs/flaky_specs.log
+          path: ./log/flaky_specs.log
           retention-days: 14
           if-no-files-found: ignore
 
@@ -213,10 +234,20 @@ jobs:
         image: redis:7
         ports:
           - 6379:6379
+        options: >-
+          --health-cmd="redis-cli ping"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=20
       mongo:
         image: mongo:4.4
         ports:
           - 27017:27017
+        options: >-
+          --health-cmd="mongo --quiet --eval 'db.adminCommand({ ping: 1 })'"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=20
       elasticsearch:
         image: elasticsearch:7.17.10
         env:
@@ -235,7 +266,7 @@ jobs:
         ports:
           - 11211:11211
       stripe_mock:
-        image: stripemock/stripe-mock:latest
+        image: stripemock/stripe-mock:v0.193.1
         ports:
           - 12111:12111
           - 12112:12112
@@ -283,12 +314,18 @@ jobs:
             minio/minio:RELEASE.2023-09-04T19-57-37Z server /data --console-address ":9001"
 
           # Wait for MinIO health
+          HEALTHY=false
           for i in $(seq 1 30); do
             if curl -sf http://localhost:9000/minio/health/live >/dev/null; then
-              echo "MinIO is healthy"; break
+              echo "MinIO is healthy"; HEALTHY=true; break
             fi
             sleep 2
           done
+          if [ "$HEALTHY" != "true" ]; then
+            echo "ERROR: MinIO failed to become healthy after 60s"
+            docker logs minio || true
+            exit 1
+          fi
 
           # Create required buckets using mc client (installed in a one-shot container)
           docker run --rm --network host --entrypoint sh minio/mc:latest -c '
@@ -305,6 +342,11 @@ jobs:
       - name: Prepare test database
         run: bundle exec rake db:prepare
 
+      - name: Generate JS exports
+        run: bundle exec rails js:export
+        env:
+          RAILS_ENV: test
+
       - name: Precompile assets
         run: bundle exec rake assets:precompile
 
@@ -314,7 +356,7 @@ jobs:
           mkdir -p ./test-logs
           bundle exec rake "knapsack_pro:queue:rspec[--format RSpec::Github::Formatter --tag ~skip --format progress]"
         env:
-          KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC_FAST }}
+          KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC_SLOW }}
           KNAPSACK_PRO_CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
           KNAPSACK_PRO_CI_NODE_INDEX: ${{ matrix.ci_node_index }}
           KNAPSACK_PRO_LOG_LEVEL: info
@@ -341,7 +383,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: flaky-specs-slow-${{ matrix.ci_node_index }}-attempt-${{ github.run_attempt }}
-          path: ./test-logs/flaky_specs.log
+          path: ./log/flaky_specs.log
           retention-days: 14
           if-no-files-found: ignore
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -210,8 +210,48 @@ jobs:
         env:
           RAILS_ENV: test
 
-      - name: Precompile assets
-        run: bundle exec rake assets:precompile
+      - name: Start Vite dev server
+        # Persistent vite dev daemon — avoids vite_ruby autoBuild's per-request
+        # subprocesses (which die under CI pipe semantics with "stream closed
+        # in another thread"). bin/vite execs node_modules/.bin/vite directly
+        # for dev mode so stderr lands in the log and Vite owns the pid.
+        # VITE_RUBY_TEST_DEV_SERVER=true forces run_proxy? true in test mode
+        # so Rails routes asset URLs through the dev server instead of falling
+        # back to autoBuild.
+        run: |
+          mkdir -p log tmp
+          nohup stdbuf -oL -eL bin/vite dev --mode test --host 127.0.0.1 --clearScreen false \
+            > log/vite-dev.log 2>&1 &
+          echo $! > tmp/vite-dev.pid
+          for i in $(seq 1 180); do
+            if curl -sf http://127.0.0.1:3037/vite-test/@vite/client > /dev/null; then
+              echo "vite dev ready after ${i}s"
+              echo "=== vite-dev.log ==="
+              cat log/vite-dev.log
+              break
+            fi
+            if ! kill -0 "$(cat tmp/vite-dev.pid)" 2>/dev/null; then
+              echo "vite dev exited before becoming ready after ${i}s"
+              echo "=== vite-dev.log ==="
+              cat log/vite-dev.log
+              exit 1
+            fi
+            if [ $((i % 30)) -eq 0 ]; then
+              echo "--- waited ${i}s, vite-dev.log so far ---"
+              cat log/vite-dev.log
+              echo "--- end log snapshot ---"
+            fi
+            sleep 1
+            if [ $i -eq 180 ]; then
+              echo "vite dev failed to start in 180s"
+              cat log/vite-dev.log
+              exit 1
+            fi
+          done
+        env:
+          RAILS_ENV: test
+          VITE_RUBY_HOST: 127.0.0.1
+          VITE_RUBY_TEST_DEV_SERVER: "true"
 
       - name: Run tests
         timeout-minutes: 20
@@ -238,6 +278,8 @@ jobs:
           KNAPSACK_PRO_BRANCH: ${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref_name }}
           KNAPSACK_PRO_CI_NODE_BUILD_ID: ${{ github.run_id }}
           KNAPSACK_PRO_CI_NODE_RETRY_COUNT: ${{ github.run_attempt }}
+          VITE_RUBY_HOST: 127.0.0.1
+          VITE_RUBY_TEST_DEV_SERVER: "true"
           KNAPSACK_PRO_PROJECT_DIR: ${{ github.workspace }}
           KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
 
@@ -437,8 +479,48 @@ jobs:
         env:
           RAILS_ENV: test
 
-      - name: Precompile assets
-        run: bundle exec rake assets:precompile
+      - name: Start Vite dev server
+        # Persistent vite dev daemon — avoids vite_ruby autoBuild's per-request
+        # subprocesses (which die under CI pipe semantics with "stream closed
+        # in another thread"). bin/vite execs node_modules/.bin/vite directly
+        # for dev mode so stderr lands in the log and Vite owns the pid.
+        # VITE_RUBY_TEST_DEV_SERVER=true forces run_proxy? true in test mode
+        # so Rails routes asset URLs through the dev server instead of falling
+        # back to autoBuild.
+        run: |
+          mkdir -p log tmp
+          nohup stdbuf -oL -eL bin/vite dev --mode test --host 127.0.0.1 --clearScreen false \
+            > log/vite-dev.log 2>&1 &
+          echo $! > tmp/vite-dev.pid
+          for i in $(seq 1 180); do
+            if curl -sf http://127.0.0.1:3037/vite-test/@vite/client > /dev/null; then
+              echo "vite dev ready after ${i}s"
+              echo "=== vite-dev.log ==="
+              cat log/vite-dev.log
+              break
+            fi
+            if ! kill -0 "$(cat tmp/vite-dev.pid)" 2>/dev/null; then
+              echo "vite dev exited before becoming ready after ${i}s"
+              echo "=== vite-dev.log ==="
+              cat log/vite-dev.log
+              exit 1
+            fi
+            if [ $((i % 30)) -eq 0 ]; then
+              echo "--- waited ${i}s, vite-dev.log so far ---"
+              cat log/vite-dev.log
+              echo "--- end log snapshot ---"
+            fi
+            sleep 1
+            if [ $i -eq 180 ]; then
+              echo "vite dev failed to start in 180s"
+              cat log/vite-dev.log
+              exit 1
+            fi
+          done
+        env:
+          RAILS_ENV: test
+          VITE_RUBY_HOST: 127.0.0.1
+          VITE_RUBY_TEST_DEV_SERVER: "true"
 
       - name: Run tests
         timeout-minutes: 30
@@ -456,6 +538,8 @@ jobs:
           KNAPSACK_PRO_BRANCH: ${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref_name }}
           KNAPSACK_PRO_CI_NODE_BUILD_ID: ${{ github.run_id }}
           KNAPSACK_PRO_CI_NODE_RETRY_COUNT: ${{ github.run_attempt }}
+          VITE_RUBY_HOST: 127.0.0.1
+          VITE_RUBY_TEST_DEV_SERVER: "true"
           KNAPSACK_PRO_PROJECT_DIR: ${{ github.workspace }}
           KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
 

--- a/bin/vite
+++ b/bin/vite
@@ -13,4 +13,9 @@ ENV["SHORT_DOMAIN"] = SHORT_DOMAIN
 ENV["DOMAIN"] = DOMAIN
 ENV["PROTOCOL"] = PROTOCOL
 
-ViteRuby.run(ARGV)
+if ARGV.first == "dev"
+  ENV["VITE_RUBY_VITE_BIN_PATH"] ||= File.expand_path("../node_modules/.bin/vite", __dir__)
+  ViteRuby.env["VITE_RUBY_VITE_BIN_PATH"] = ENV["VITE_RUBY_VITE_BIN_PATH"]
+end
+
+ViteRuby.run(ARGV, exec: ARGV.first == "dev")

--- a/bin/vite
+++ b/bin/vite
@@ -13,6 +13,28 @@ ENV["SHORT_DOMAIN"] = SHORT_DOMAIN
 ENV["DOMAIN"] = DOMAIN
 ENV["PROTOCOL"] = PROTOCOL
 
+def vite_mode_from_args(args)
+  mode = nil
+
+  args.each_with_index do |arg, index|
+    case arg
+    when "--mode", "-m"
+      mode = args[index + 1] if args[index + 1] && !args[index + 1].start_with?("-")
+    when /\A--mode=(.+)\z/
+      mode = Regexp.last_match(1)
+    when /\A-m(.+)\z/
+      mode = Regexp.last_match(1)
+    end
+  end
+
+  mode
+end
+
+if (mode = vite_mode_from_args(ARGV))
+  ENV["VITE_RUBY_MODE"] = mode
+  ViteRuby.env["VITE_RUBY_MODE"] = mode
+end
+
 if ARGV.first == "dev"
   ENV["VITE_RUBY_VITE_BIN_PATH"] ||= File.expand_path("../node_modules/.bin/vite", __dir__)
   ViteRuby.env["VITE_RUBY_VITE_BIN_PATH"] = ENV["VITE_RUBY_VITE_BIN_PATH"]

--- a/config/application.rb
+++ b/config/application.rb
@@ -77,6 +77,18 @@ module Gumroad
       config.middleware.insert_after Rack::Attack, ::CatchBadRequestErrors
     end
 
+    initializer "gumroad.vite_test_dev_server_proxy", before: "vite_rails.proxy" do
+      if Rails.env.test? && ENV["VITE_RUBY_TEST_DEV_SERVER"] == "true"
+        ViteRuby.prepend(Module.new do
+          def run_proxy?
+            return true if config.mode == "test"
+
+            super
+          end
+        end)
+      end
+    end
+
     config.generators do |g|
       g.helper_specs false
       g.stylesheets false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -40,6 +40,14 @@ Rails.application.configure do
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "#{PROTOCOL}://#{ASSET_DOMAIN}"
 
+  # When running with the persistent Vite dev daemon (CI), point Action Mailer
+  # at the dev server so vite_entrypoint_stylesheet_tag emits absolute URLs and
+  # Premailer's network loader can fetch the compiled CSS for inlining.
+  if ENV["VITE_RUBY_TEST_DEV_SERVER"] == "true"
+    vite_host = ENV.fetch("VITE_RUBY_HOST", "127.0.0.1")
+    config.action_mailer.asset_host = "http://#{vite_host}:3037"
+  end
+
   config.active_storage.service = :test
 
   config.action_mailer.perform_caching = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -51,7 +51,6 @@ Rails.application.configure do
   # affects Premailer (mailer rendering) alone.
   if ENV["VITE_RUBY_TEST_DEV_SERVER"] == "true"
     vite_host = ENV.fetch("VITE_RUBY_HOST", "127.0.0.1")
-    config.action_mailer.asset_host = "http://#{vite_host}:3037"
 
     Rails.application.config.after_initialize do
       vite_url = "http://#{vite_host}:3037"

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -40,16 +40,24 @@ Rails.application.configure do
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "#{PROTOCOL}://#{ASSET_DOMAIN}"
 
-  # When running with the persistent Vite dev daemon (CI), point Action Mailer
-  # at the dev server so vite_entrypoint_stylesheet_tag emits absolute URLs and
-  # Premailer's network loader can fetch the compiled CSS for inlining.
-  # Premailer-rails NetworkLoader reads action_controller.asset_host (not
-  # action_mailer.asset_host) — set both so URL helpers and Premailer agree.
+  # When running with the persistent Vite dev daemon (CI), Premailer must be
+  # able to inline the compiled email CSS. We do NOT set
+  # action_controller.asset_host globally — that would poison every URL helper
+  # used by system specs and force the browser to fetch assets from the Vite
+  # dev server on a different port, breaking Capybara tests.
+  #
+  # Instead we override premailer-rails' NetworkLoader so it points at the
+  # Vite dev server only when asked to resolve a relative CSS URL. This
+  # affects Premailer (mailer rendering) alone.
   if ENV["VITE_RUBY_TEST_DEV_SERVER"] == "true"
     vite_host = ENV.fetch("VITE_RUBY_HOST", "127.0.0.1")
-    vite_asset_host = "http://#{vite_host}:3037"
-    config.action_mailer.asset_host = vite_asset_host
-    config.action_controller.asset_host = vite_asset_host
+    config.action_mailer.asset_host = "http://#{vite_host}:3037"
+
+    Rails.application.config.after_initialize do
+      vite_url = "http://#{vite_host}:3037"
+      Premailer::Rails::CSSLoaders::NetworkLoader.define_singleton_method(:asset_host_present?) { true }
+      Premailer::Rails::CSSLoaders::NetworkLoader.define_singleton_method(:asset_host) { |_url| vite_url }
+    end
   end
 
   config.active_storage.service = :test

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,9 +43,13 @@ Rails.application.configure do
   # When running with the persistent Vite dev daemon (CI), point Action Mailer
   # at the dev server so vite_entrypoint_stylesheet_tag emits absolute URLs and
   # Premailer's network loader can fetch the compiled CSS for inlining.
+  # Premailer-rails NetworkLoader reads action_controller.asset_host (not
+  # action_mailer.asset_host) — set both so URL helpers and Premailer agree.
   if ENV["VITE_RUBY_TEST_DEV_SERVER"] == "true"
     vite_host = ENV.fetch("VITE_RUBY_HOST", "127.0.0.1")
-    config.action_mailer.asset_host = "http://#{vite_host}:3037"
+    vite_asset_host = "http://#{vite_host}:3037"
+    config.action_mailer.asset_host = vite_asset_host
+    config.action_controller.asset_host = vite_asset_host
   end
 
   config.active_storage.service = :test

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -203,6 +203,14 @@ SecureHeaders::Configuration.default do |config|
     config.csp[:script_src] << ROOT_DOMAIN # Required to load gumroad.js for overlay/embed.
     config.csp[:connect_src] << "ws://#{ANYCABLE_HOST}:8080" # Required by AnyCable
     config.csp[:connect_src] << "wss://#{ANYCABLE_HOST}:8080" # Required by AnyCable
+    if ENV["VITE_RUBY_TEST_DEV_SERVER"] == "true"
+      vite_origin = ViteRuby.config.origin
+      vite_websocket_origin = "#{ViteRuby.config.https ? "wss" : "ws"}://#{ViteRuby.config.host_with_port}"
+      config.csp[:script_src] << vite_origin
+      config.csp[:style_src] << vite_origin
+      config.csp[:connect_src] << vite_origin
+      config.csp[:connect_src] << vite_websocket_origin
+    end
   elsif Rails.env.development?
     config.csp[:default_src] = ["'self'"]
     %w[localhost app.localhost].each do |host|

--- a/spec/presenters/admin/scheduled_payout_presenter_spec.rb
+++ b/spec/presenters/admin/scheduled_payout_presenter_spec.rb
@@ -12,6 +12,7 @@ describe Admin::ScheduledPayoutPresenter do
       expect(described_class.new(scheduled_payout:).props).to eq(
         external_id: scheduled_payout.external_id,
         action: scheduled_payout.action,
+        processor: scheduled_payout.processor,
         status: scheduled_payout.status,
         delay_days: scheduled_payout.delay_days,
         scheduled_at: scheduled_payout.scheduled_at,

--- a/spec/support/capybara_driver.rb
+++ b/spec/support/capybara_driver.rb
@@ -34,6 +34,7 @@ Capybara.register_driver :tablet_chrome do |app|
     options.add_argument("--no-sandbox")
     options.add_argument("--disable-dev-shm-usage")
     options.add_argument("--disable-gpu")
+    options.add_argument("--window-size=800,1024")
   end
 
   Capybara::Selenium::Driver.new(app,
@@ -111,6 +112,26 @@ Capybara.register_driver :selenium_chrome_headless_billy_custom do |app|
                                  options:)
 end
 
+Capybara.register_driver :selenium_chrome_billy_headless do |app|
+  Capybara::Selenium::Driver.load_selenium
+  options = ::Selenium::WebDriver::Chrome::Options.new
+  options.add_argument("--headless=new")
+  options.add_argument("--no-sandbox")
+  options.add_argument("--disable-dev-shm-usage")
+  options.add_argument("--disable-gpu")
+  options.add_argument("--enable-features=NetworkService,NetworkServiceInProcess")
+  options.add_argument("--ignore-certificate-errors")
+  options.add_argument("--proxy-server=#{Billy.proxy.host}:#{Billy.proxy.port}")
+  options.add_argument("--window-size=1440,900")
+  options.add_preference("intl.accept_languages", "en-US")
+  options.logging_prefs = { driver: "DEBUG" }
+
+  Capybara::Selenium::Driver.new(app,
+                                 browser: :chrome,
+                                 http_client: webdriver_client,
+                                 options:)
+end
+
 Capybara.register_driver :docker_headless_tablet_chrome do |app|
   Capybara::Selenium::Driver.load_selenium
   options = ::Selenium::WebDriver::Chrome::Options.new.tap do |opts|
@@ -154,7 +175,14 @@ RSpec.configure do |config|
   end
 
   config.before(:each, billy: true) do |example|
-    driven_by ENV["IN_DOCKER"] == "true" ? :selenium_chrome_headless_billy_custom : :selenium_chrome_billy
+    billy_driver = if ENV["IN_DOCKER"] == "true"
+      :selenium_chrome_headless_billy_custom
+    elsif ENV["CI"] == "true"
+      :selenium_chrome_billy_headless
+    else
+      :selenium_chrome_billy
+    end
+    driven_by billy_driver
   end
 
   config.before(:each, :tablet_view) do |example|

--- a/spec/support/capybara_driver.rb
+++ b/spec/support/capybara_driver.rb
@@ -8,6 +8,15 @@ Capybara.register_driver :chrome do |app|
   options.add_preference("intl.accept_languages", "en-US")
   options.logging_prefs = { driver: "DEBUG" }
 
+  # Headless when running in CI (non-Docker runner with no display).
+  if ENV["CI"] == "true"
+    options.add_argument("--headless=new")
+    options.add_argument("--no-sandbox")
+    options.add_argument("--disable-dev-shm-usage")
+    options.add_argument("--disable-gpu")
+    options.add_argument("--window-size=1440,900")
+  end
+
   Capybara::Selenium::Driver.new(app,
                                  browser: :chrome,
                                  http_client: webdriver_client,
@@ -20,6 +29,13 @@ Capybara.register_driver :tablet_chrome do |app|
   options.add_preference("intl.accept_languages", "en-US")
   options.logging_prefs = { driver: "DEBUG" }
 
+  if ENV["CI"] == "true"
+    options.add_argument("--headless=new")
+    options.add_argument("--no-sandbox")
+    options.add_argument("--disable-dev-shm-usage")
+    options.add_argument("--disable-gpu")
+  end
+
   Capybara::Selenium::Driver.new(app,
                                  browser: :chrome,
                                  http_client: webdriver_client,
@@ -31,6 +47,13 @@ Capybara.register_driver :mobile_chrome do |app|
   options.add_emulation(device_name: "iPhone 8")
   options.add_preference("intl.accept_languages", "en-US")
   options.logging_prefs = { driver: "DEBUG" }
+
+  if ENV["CI"] == "true"
+    options.add_argument("--headless=new")
+    options.add_argument("--no-sandbox")
+    options.add_argument("--disable-dev-shm-usage")
+    options.add_argument("--disable-gpu")
+  end
 
   Capybara::Selenium::Driver.new(app,
                                  browser: :chrome,


### PR DESCRIPTION
## Status: CI running — benchmarks to fill in after first green

Strips the Docker image build and pull infrastructure from `tests.yml`. RSpec runs directly on stock `ubuntu-22.04` runners with GitHub Actions service containers + cached gems/npm/Chrome.

## What this PR does

### `.github/workflows/tests.yml` (668 → 392 lines)

- **Delete** the `build` job entirely:
  - No more `web_base` image build/push
  - No more `web_base_test` image build/push
  - No more content-addressed `test` image tag computation
  - No more asset precompile inside a docker `run` + `docker commit` flow
  - No more Docker Hub push (~8GB layer churn per run)
  - No more `actions/cache` for `/tmp/asset-cache`
  - No more `setup-docker-builder` / BuildKit sticky-disk dance
- **`test_fast`** (18-shard Knapsack RSpec across `spec/**/*_spec.rb` excluding `spec/requests/`):
  - `runs-on: ubuntu-22.04`
  - GitHub Actions service containers: MySQL 8.0.32, Redis 7, Mongo 4.4, Elasticsearch 7.17.10, Memcached 1.6, stripe-mock, MinIO
  - `ruby/setup-ruby` (bundler-cache), `actions/setup-node` (npm cache), `browser-actions/setup-chrome` (stable)
  - `apt-get install ffmpeg imagemagick`
  - `bundle exec rake assets:precompile` directly
  - `bundle exec rake knapsack_pro:queue:rspec[...]`
- **`test_slow`** (50-shard Knapsack RSpec across `spec/requests/**`): same standalone shape, plus Capybara screenshot artifact archival on failure.
- **`unblock_deployment_from_buildkite`**: unchanged. Still gates on `[test_fast, test_slow]`.

### `spec/support/capybara_driver.rb`

The `:chrome` / `:tablet_chrome` / `:mobile_chrome` drivers now switch to headless + `--no-sandbox` + `--disable-dev-shm-usage` when `ENV["CI"] == "true"`. Selenium 4.x's Selenium Manager auto-resolves Chromedriver from the runner's installed Chrome — no chromedriver-helper needed.

The Docker-specific drivers (`docker_headless_chrome`, `docker_headless_tablet_chrome`, etc.) and the `IN_DOCKER == "true"` branches in the RSpec config block are **kept for now**. They'll be deleted as a follow-up once we confirm no other tooling (local dev compose files, smoke scripts, etc.) depends on them.

## Why

The `build` job was load-bearing for caching, not correctness. Its real job was to amortize gem/npm/asset compile across all 68 RSpec shards on the same SHA. GitHub Actions can do all three of those directly:

| What `build` was caching | How it's cached now |
|---|---|
| `BUNDLE_PATH` (~1 GB of gems) | `ruby/setup-ruby@v1 bundler-cache: true` (keyed on `Gemfile.lock`) |
| `node_modules` (~700 MB) | `actions/setup-node@v4 cache: npm` (keyed on `package-lock.json`) |
| `public/assets`, `public/packs-test`, `tmp/cache/assets`, `tmp/shakapacker` (~150 MB) | one `bundle exec rake assets:precompile` per shard — fast on cached gems + npm |
| Chrome + Chromedriver | `browser-actions/setup-chrome@latest` (cached install) |
| `chromedriver-helper` → Selenium Manager | Selenium 4.35 ships Selenium Manager, auto-resolves driver from installed Chrome |

The `build` job's image was 8+ GB and `docker pull`ed by every shard for 4m11s before any spec executed. Removing that, plus dropping ~270 lines of multi-stage Dockerfile orchestration, removes the largest single source of CI minutes on this workflow.

## TODO (after first green CI run)

Fill in hard before/after numbers below from real workflow runs:

- [ ] **Workflow wall time**: `main` (with Docker) vs. this branch (no Docker) — full run on identical commit
- [ ] **`build` job time saved**: was ~4–7 min, now 0
- [ ] **Per-shard wall time**: `test_fast` shard 0 before vs. after; `test_slow` shard 0 before vs. after (4m11s pull was the floor; what's the new floor?)
- [ ] **Total CI minutes per PR run**: 68 shards × pull time eliminated + build job time eliminated
- [ ] **Docker Hub registry storage delta**: stop pushing `web_base`, `web_base_test`, `web` test images → fewer layers / less monthly cost
- [ ] **CI cost $/PR-run**: estimate from GH Actions billable minutes delta (runner-minute price × delta)
- [ ] **Cold cache wall time**: branch's first run vs. subsequent (gem cache, npm cache, Chrome cache all empty on first run)

I'll fill this in once the workflow has at least one green run on this branch and we can compare against a recent `main` run on a similar-size diff.

## Test plan

- [ ] First CI run on this branch lands green
- [ ] `test_fast` shards execute and complete
- [ ] `test_slow` shards execute and complete (Chrome + Capybara visible in artifact uploads on intentional failure)
- [ ] `unblock_deployment_from_buildkite` still fires on main pushes

## Out of scope / explicit follow-ups

- **Deletion of `docker_headless_*` driver code** (`spec/support/capybara_driver.rb`) and the `IN_DOCKER == 'true'` RSpec config branches. Kept on this PR to limit blast radius; will land as a separate trivial PR once we confirm no local dev / smoke script depends on them.
- **Deletion of `docker/` directory**, `Dockerfile.test`, base image generators, `docker-compose-test-and-ci.yml`. Local dev still uses `docker compose`; that's separate from CI.
- **Test Fast → Minitest swap** (#5244) — this PR is off `main`, independent of that work. When #5244 merges, this PR's `test_fast` becomes irrelevant for the new world but `test_slow` stays.
- **Test Slow → Minitest+Playwright migration** (#5240) — this PR is the precondition for that work landing. Once #5240 finishes, both `test_slow` and the residual Docker driver code disappear.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782316532&installation_id=134400930&pr_number=5276&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5276&signature=38e2570fd081724d709224a14a4721771e03c13a4a4a0b7406988ed961415c9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Rewrites the main test/deployment gate workflow and browser/asset bootstrapping; regressions could block merges and main deploy unblocks until the new path is proven stable.
> 
> **Overview**
> Removes the Docker **`build`** job and runs **`test_fast`** / **`test_slow`** Knapsack RSpec directly on **`ubuntu-22.04`**, depending only on **`ci_gate`**. Each shard now provisions MySQL, Redis, Mongo, Elasticsearch, Memcached, and stripe-mock as GitHub service containers, installs Ruby/Node/Chrome and system deps on the runner, boots MinIO with fixture seeding, runs **`js:export`**, **`assets:precompile`**, **`db:prepare`**, and a persistent **`bin/vite dev`** (with **`VITE_RUBY_TEST_DEV_SERVER`**) before **`bundle exec`** Knapsack on the workspace (no image pull, no compose teardown).
> 
> Supporting app changes wire bare-runner CI: **`bin/vite`** honors **`--mode`** and execs the local Vite binary for **`dev`**; Rails forces Vite proxy in test, relaxes CSP for the dev server, and scopes Premailer CSS loading to Vite without a global **`asset_host`**. Capybara uses headless Chrome (and a Billy proxy driver) when **`CI=true`**; flaky/capybara artifact paths move under **`log/`** and **`tmp/capybara/`**. **`test_slow`** now uses the slow Knapsack token; one presenter spec expects **`processor`** on scheduled payouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d3bad08d0c10aaba554347a33a112ef7a53a0ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->