### PR TITLE
Expose internal scheduled payout creation

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -227,6 +227,7 @@ class Admin::UsersController < Admin::BaseController
       scheduled_payout = @user.scheduled_payouts.create!(
         action: sp_params[:action],
         delay_days: sp_params[:delay_days].presence || 21,
+        processor: sp_params[:action] == "payout" ? @user.current_payout_processor : nil,
         payout_amount_cents: @user.unpaid_balance_cents,
         created_by: current_user
       )

--- a/app/controllers/api/internal/admin/scheduled_payouts_controller.rb
+++ b/app/controllers/api/internal/admin/scheduled_payouts_controller.rb
@@ -3,9 +3,57 @@
 class Api::Internal::Admin::ScheduledPayoutsController < Api::Internal::Admin::BaseController
   DEFAULT_LIMIT = 20
   MAX_LIMIT = 50
-  private_constant :DEFAULT_LIMIT, :MAX_LIMIT
+  DEFAULT_PAYOUT_DELAY_DAYS = 21
+  private_constant :DEFAULT_LIMIT, :MAX_LIMIT, :DEFAULT_PAYOUT_DELAY_DAYS
 
   before_action :fetch_scheduled_payout, only: [:execute, :cancel]
+
+  def create
+    processor = normalized_payout_processor
+    return render json: { success: false, message: "processor is required" }, status: :bad_request if params[:processor].blank?
+    return render json: { success: false, message: "processor must be stripe or paypal" }, status: :bad_request if processor.blank?
+
+    today = current_utc_date
+    payout_date = parse_payout_date_or_render(today)
+    return unless payout_date
+
+    user = find_internal_admin_user_for_write_or_render
+    return unless user
+
+    record_admin_write(action: "scheduled_payouts.create", target: user) do
+      return render json: { success: false, message: "User is not suspended." }, status: :unprocessable_entity unless user.suspended?
+
+      if user.scheduled_payouts.in_progress.exists?
+        return render json: { success: false, message: "User already has a scheduled payout in progress" }, status: :unprocessable_entity
+      end
+
+      delay_days = (payout_date - today).to_i
+      payout_note = build_scheduled_payout_note(user:, payout_date:, delay_days:, processor:, note: params[:note])
+      return render_invalid_scheduled_payout_comment(payout_note) if payout_note.invalid?
+
+      scheduled_payout = nil
+      User.transaction do
+        scheduled_payout = user.scheduled_payouts.create!(
+          action: "payout",
+          delay_days:,
+          scheduled_at: payout_date.in_time_zone("UTC"),
+          processor:,
+          payout_amount_cents: user.unpaid_balance_cents,
+          created_by: Current.admin_actor
+        )
+        payout_note.save!
+      end
+
+      render json: {
+        success: true,
+        user_id: user.external_id,
+        message: "Scheduled payout created",
+        scheduled_payout: serialize_scheduled_payout(scheduled_payout)
+      }
+    rescue ActiveRecord::RecordInvalid => e
+      render json: { success: false, message: e.record.errors.full_messages.to_sentence }, status: :unprocessable_entity
+    end
+  end
 
   def index
     scope = ScheduledPayout.includes(:user, :created_by).order(id: :desc)
@@ -82,6 +130,48 @@ class Api::Internal::Admin::ScheduledPayoutsController < Api::Internal::Admin::B
     def serialize_scheduled_payout(scheduled_payout, enrichment: nil)
       enrichment ||= Admin::ScheduledPayoutEnrichmentService.new([scheduled_payout]).call[scheduled_payout.user_id] || {}
       Admin::ScheduledPayoutPresenter.new(scheduled_payout:, enrichment:).props
+    end
+
+    def normalized_payout_processor
+      processor = params[:processor].to_s.upcase
+      processor if PayoutProcessorType.all.include?(processor)
+    end
+
+    def parse_payout_date_or_render(today)
+      payout_date = if params[:payout_date].present?
+        Date.iso8601(params[:payout_date].to_s)
+      else
+        today + DEFAULT_PAYOUT_DELAY_DAYS
+      end
+
+      if payout_date < today
+        render json: { success: false, message: "payout_date cannot be in the past" }, status: :bad_request
+        return
+      end
+
+      payout_date
+    rescue ArgumentError
+      render json: { success: false, message: "payout_date is invalid" }, status: :bad_request
+      nil
+    end
+
+    def current_utc_date
+      Time.current.utc.to_date
+    end
+
+    def build_scheduled_payout_note(user:, payout_date:, delay_days:, processor:, note:)
+      content = "Scheduled payout via #{processor.downcase} for #{payout_date.in_time_zone("UTC").to_fs(:formatted_date_full_month)} (#{delay_days} day delay)"
+      content += "\nNote: #{note}" if note.present?
+
+      user.comments.new(
+        author_id: current_admin_actor_id,
+        comment_type: Comment::COMMENT_TYPE_PAYOUT_NOTE,
+        content:
+      )
+    end
+
+    def render_invalid_scheduled_payout_comment(comment)
+      render json: { success: false, message: comment.errors.full_messages.to_sentence }, status: :unprocessable_entity
     end
 
     def render_scheduled_payout_error(error)

--- a/app/controllers/api/internal/admin/scheduled_payouts_controller.rb
+++ b/app/controllers/api/internal/admin/scheduled_payouts_controller.rb
@@ -21,28 +21,41 @@ class Api::Internal::Admin::ScheduledPayoutsController < Api::Internal::Admin::B
     return unless user
 
     record_admin_write(action: "scheduled_payouts.create", target: user) do
-      return render json: { success: false, message: "User is not suspended." }, status: :unprocessable_entity unless user.suspended?
-
-      if user.scheduled_payouts.in_progress.exists?
-        return render json: { success: false, message: "User already has a scheduled payout in progress" }, status: :unprocessable_entity
-      end
-
       delay_days = (payout_date - today).to_i
-      payout_note = build_scheduled_payout_note(user:, payout_date:, delay_days:, processor:, note: params[:note])
-      return render_invalid_scheduled_payout_comment(payout_note) if payout_note.invalid?
 
       scheduled_payout = nil
+      failure_message = nil
+
       User.transaction do
-        scheduled_payout = user.scheduled_payouts.create!(
-          action: "payout",
-          delay_days:,
-          scheduled_at: payout_date.in_time_zone("UTC"),
-          processor:,
-          payout_amount_cents: user.unpaid_balance_cents,
-          created_by: Current.admin_actor
-        )
-        payout_note.save!
+        user.lock!
+
+        if !user.suspended?
+          failure_message = "User is not suspended."
+        elsif user.scheduled_payouts.in_progress.exists?
+          failure_message = "User already has a scheduled payout in progress"
+        elsif user.unpaid_balance_cents.to_i <= 0
+          failure_message = "User has no unpaid balance."
+        else
+          payout_note = build_scheduled_payout_note(user:, payout_date:, delay_days:, processor:, note: params[:note])
+          failure_message = payout_note.errors.full_messages.to_sentence if payout_note.invalid?
+
+          if failure_message.blank?
+            scheduled_payout = user.scheduled_payouts.create!(
+              action: "payout",
+              delay_days:,
+              scheduled_at: payout_date.in_time_zone("UTC"),
+              processor:,
+              payout_amount_cents: user.unpaid_balance_cents,
+              created_by: Current.admin_actor
+            )
+            payout_note.save!
+          end
+        end
+
+        raise ActiveRecord::Rollback if failure_message.present?
       end
+
+      return render json: { success: false, message: failure_message }, status: :unprocessable_entity if failure_message.present?
 
       render json: {
         success: true,
@@ -165,13 +178,10 @@ class Api::Internal::Admin::ScheduledPayoutsController < Api::Internal::Admin::B
 
       user.comments.new(
         author_id: current_admin_actor_id,
+        author_name: Current.admin_actor.name,
         comment_type: Comment::COMMENT_TYPE_PAYOUT_NOTE,
         content:
       )
-    end
-
-    def render_invalid_scheduled_payout_comment(comment)
-      render json: { success: false, message: comment.errors.full_messages.to_sentence }, status: :unprocessable_entity
     end
 
     def render_scheduled_payout_error(error)

--- a/app/javascript/pages/Admin/ScheduledPayouts/Index.tsx
+++ b/app/javascript/pages/Admin/ScheduledPayouts/Index.tsx
@@ -19,6 +19,7 @@ type ScheduledPayoutUser = {
 type ScheduledPayout = {
   external_id: string;
   action: "refund" | "payout" | "hold";
+  processor: "PAYPAL" | "STRIPE" | null;
   status: "pending" | "executed" | "cancelled" | "flagged" | "held";
   delay_days: number;
   scheduled_at: string;

--- a/app/models/scheduled_payout.rb
+++ b/app/models/scheduled_payout.rb
@@ -14,6 +14,7 @@ class ScheduledPayout < ApplicationRecord
 
   validates :action, presence: true, inclusion: { in: ACTIONS }
   validates :status, presence: true, inclusion: { in: STATUSES }
+  validates :processor, inclusion: { in: PayoutProcessorType.all }, allow_nil: true
   validates :delay_days, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
   validates :scheduled_at, presence: true
   validates :payout_amount_cents, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
@@ -66,9 +67,10 @@ class ScheduledPayout < ApplicationRecord
 
     if process_payout
       begin
+        payout_processor_type = processor.presence || user.current_payout_processor
         payment, payment_errors = Payouts.create_payment(
           Date.yesterday.to_s,
-          user.current_payout_processor,
+          payout_processor_type,
           user
         )
 
@@ -81,7 +83,7 @@ class ScheduledPayout < ApplicationRecord
           raise "Payout failed: #{error_detail}"
         end
 
-        payout_processor = PayoutProcessorType.get(user.current_payout_processor)
+        payout_processor = PayoutProcessorType.get(payout_processor_type)
         payout_processor.process_payments([payment])
 
         if payment.reload.failed?

--- a/app/presenters/admin/scheduled_payout_presenter.rb
+++ b/app/presenters/admin/scheduled_payout_presenter.rb
@@ -12,6 +12,7 @@ class Admin::ScheduledPayoutPresenter
     {
       external_id: scheduled_payout.external_id,
       action: scheduled_payout.action,
+      processor: scheduled_payout.processor,
       status: scheduled_payout.status,
       delay_days: scheduled_payout.delay_days,
       scheduled_at: scheduled_payout.scheduled_at,

--- a/app/sidekiq/suspend_users_worker.rb
+++ b/app/sidekiq/suspend_users_worker.rb
@@ -28,6 +28,7 @@ class SuspendUsersWorker
       record = user.scheduled_payouts.create!(
         action: scheduled_payout["action"],
         delay_days: scheduled_payout["delay_days"].presence || DEFAULT_SCHEDULED_PAYOUT_DELAY_DAYS,
+        processor: scheduled_payout["action"] == "payout" ? user.current_payout_processor : nil,
         payout_amount_cents: user.unpaid_balance_cents,
         created_by: author
       )

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -361,7 +361,7 @@ Rails.application.routes.draw do
             end
           end
 
-          resources :scheduled_payouts, only: [:index] do
+          resources :scheduled_payouts, only: [:index, :create] do
             member do
               post :execute
               post :cancel

--- a/db/migrate/20261128000000_add_processor_to_scheduled_payouts.rb
+++ b/db/migrate/20261128000000_add_processor_to_scheduled_payouts.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddProcessorToScheduledPayouts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :scheduled_payouts, :processor, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_11_27_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_11_28_000000) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -2018,6 +2018,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_11_27_000000) do
     t.bigint "created_by_id"
     t.datetime "executed_at"
     t.bigint "payout_amount_cents", null: false
+    t.string "processor"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["created_by_id"], name: "index_scheduled_payouts_on_created_by_id"

--- a/spec/controllers/api/internal/admin/scheduled_payouts_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/scheduled_payouts_controller_spec.rb
@@ -14,6 +14,7 @@ describe Api::Internal::Admin::ScheduledPayoutsController do
 
   describe "POST create" do
     let(:suspended_user) { create(:user, user_risk_state: "suspended_for_tos_violation", email: "seller@example.com") }
+    let(:merchant_account) { create(:merchant_account, user: nil) }
 
     include_examples "admin api authorization required", :post, :create, { processor: "stripe", user_id: "missing" }
 
@@ -62,7 +63,6 @@ describe Api::Internal::Admin::ScheduledPayoutsController do
     end
 
     it "creates a scheduled payout for a suspended user with the default payout date" do
-      merchant_account = create(:merchant_account, user: nil)
       create(:balance, user: suspended_user, merchant_account:, amount_cents: 12_345, state: "unpaid")
 
       travel_to Time.utc(2026, 5, 25, 12) do
@@ -100,12 +100,18 @@ describe Api::Internal::Admin::ScheduledPayoutsController do
         )
       )
       payout_note = suspended_user.comments.with_type_payout_note.last
-      expect(payout_note).to have_attributes(author_id: admin_user.id, comment_type: Comment::COMMENT_TYPE_PAYOUT_NOTE)
+      expect(payout_note).to have_attributes(
+        author_id: admin_user.id,
+        author_name: "Risk admin",
+        comment_type: Comment::COMMENT_TYPE_PAYOUT_NOTE
+      )
       expect(payout_note.content).to include("Scheduled payout via stripe for June 15, 2026 (21 day delay)")
       expect(payout_note.content).to include("Appeal window closes before payout.")
     end
 
     it "creates a scheduled payout for an explicit UTC payout date" do
+      create(:balance, user: suspended_user, merchant_account:, amount_cents: 12_345, state: "unpaid")
+
       travel_to Time.utc(2026, 5, 25, 12) do
         post :create, params: {
           user_id: suspended_user.external_id,
@@ -141,7 +147,17 @@ describe Api::Internal::Admin::ScheduledPayoutsController do
       expect(response.parsed_body).to eq({ success: false, message: "User is not suspended." }.as_json)
     end
 
+    it "returns 422 when the user has no unpaid balance" do
+      expect do
+        post :create, params: { user_id: suspended_user.external_id, processor: "stripe" }
+      end.not_to change { ScheduledPayout.count }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body).to eq({ success: false, message: "User has no unpaid balance." }.as_json)
+    end
+
     it "returns 422 when the user has an in-progress scheduled payout" do
+      create(:balance, user: suspended_user, merchant_account:, amount_cents: 12_345, state: "unpaid")
       create(:scheduled_payout, user: suspended_user, status: "pending")
 
       expect do
@@ -153,6 +169,8 @@ describe Api::Internal::Admin::ScheduledPayoutsController do
     end
 
     it "returns 422 without creating a scheduled payout when the note is invalid" do
+      create(:balance, user: suspended_user, merchant_account:, amount_cents: 12_345, state: "unpaid")
+
       expect do
         post :create, params: { user_id: suspended_user.external_id, processor: "stripe", note: "x" * 10_001 }
       end.not_to change { ScheduledPayout.count }
@@ -163,6 +181,8 @@ describe Api::Internal::Admin::ScheduledPayoutsController do
     end
 
     it "writes an admin audit log targeting the suspended user" do
+      create(:balance, user: suspended_user, merchant_account:, amount_cents: 12_345, state: "unpaid")
+
       expect do
         post :create, params: { user_id: suspended_user.external_id, processor: "stripe" }
       end.to change { AdminApiAuditLog.count }.by(1)

--- a/spec/controllers/api/internal/admin/scheduled_payouts_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/scheduled_payouts_controller_spec.rb
@@ -4,10 +4,178 @@ require "spec_helper"
 require "shared_examples/authorized_admin_api_method"
 
 describe Api::Internal::Admin::ScheduledPayoutsController do
+  let(:admin_user) { create(:admin_user, name: "Risk admin") }
   let(:user) { create(:compliant_user) }
+  let(:user_id_required_message) { "user_id is required for mutating admin actions. Use /internal/admin/users/info to look up the user_id by email." }
 
   before do
-    stub_const("GUMROAD_ADMIN_ID", create(:admin_user).id)
+    stub_const("GUMROAD_ADMIN_ID", admin_user.id)
+  end
+
+  describe "POST create" do
+    let(:suspended_user) { create(:user, user_risk_state: "suspended_for_tos_violation", email: "seller@example.com") }
+
+    include_examples "admin api authorization required", :post, :create, { processor: "stripe", user_id: "missing" }
+
+    it "returns 400 when user_id is missing" do
+      post :create, params: { processor: "stripe" }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: user_id_required_message }.as_json)
+    end
+
+    it "returns 404 when the user does not exist" do
+      post :create, params: { user_id: "missing", processor: "stripe" }
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
+    end
+
+    it "returns 400 when processor is missing" do
+      post :create, params: { user_id: suspended_user.external_id }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "processor is required" }.as_json)
+    end
+
+    it "returns 400 when processor is invalid" do
+      post :create, params: { user_id: suspended_user.external_id, processor: "ach" }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "processor must be stripe or paypal" }.as_json)
+    end
+
+    it "returns 400 when payout_date is invalid" do
+      post :create, params: { user_id: suspended_user.external_id, processor: "stripe", payout_date: "not-a-date" }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "payout_date is invalid" }.as_json)
+    end
+
+    it "returns 400 when payout_date is in the past" do
+      travel_to Time.utc(2026, 5, 25, 12) do
+        post :create, params: { user_id: suspended_user.external_id, processor: "stripe", payout_date: "2026-05-24" }
+      end
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "payout_date cannot be in the past" }.as_json)
+    end
+
+    it "creates a scheduled payout for a suspended user with the default payout date" do
+      merchant_account = create(:merchant_account, user: nil)
+      create(:balance, user: suspended_user, merchant_account:, amount_cents: 12_345, state: "unpaid")
+
+      travel_to Time.utc(2026, 5, 25, 12) do
+        expect do
+          post :create, params: {
+            user_id: suspended_user.external_id,
+            processor: "stripe",
+            expected_email: "seller@example.com",
+            note: "Appeal window closes before payout."
+          }
+        end.to change { ScheduledPayout.count }.by(1)
+          .and change { suspended_user.comments.with_type_payout_note.count }.by(1)
+      end
+
+      expect(response).to have_http_status(:ok)
+      scheduled_payout = ScheduledPayout.last
+      expect(scheduled_payout).to have_attributes(
+        user: suspended_user,
+        action: "payout",
+        delay_days: 21,
+        scheduled_at: Time.utc(2026, 6, 15),
+        processor: PayoutProcessorType::STRIPE,
+        payout_amount_cents: 12_345,
+        created_by: admin_user
+      )
+      expect(response.parsed_body).to include(
+        "success" => true,
+        "user_id" => suspended_user.external_id,
+        "message" => "Scheduled payout created",
+        "scheduled_payout" => hash_including(
+          "external_id" => scheduled_payout.external_id,
+          "action" => "payout",
+          "processor" => PayoutProcessorType::STRIPE,
+          "payout_amount_cents" => 12_345
+        )
+      )
+      payout_note = suspended_user.comments.with_type_payout_note.last
+      expect(payout_note).to have_attributes(author_id: admin_user.id, comment_type: Comment::COMMENT_TYPE_PAYOUT_NOTE)
+      expect(payout_note.content).to include("Scheduled payout via stripe for June 15, 2026 (21 day delay)")
+      expect(payout_note.content).to include("Appeal window closes before payout.")
+    end
+
+    it "creates a scheduled payout for an explicit UTC payout date" do
+      travel_to Time.utc(2026, 5, 25, 12) do
+        post :create, params: {
+          user_id: suspended_user.external_id,
+          processor: "paypal",
+          payout_date: "2026-06-01"
+        }
+      end
+
+      expect(response).to have_http_status(:ok)
+      scheduled_payout = ScheduledPayout.last
+      expect(scheduled_payout).to have_attributes(
+        delay_days: 7,
+        scheduled_at: Time.utc(2026, 6, 1),
+        processor: PayoutProcessorType::PAYPAL
+      )
+    end
+
+    it "returns 409 when expected_email does not match" do
+      expect do
+        post :create, params: { user_id: suspended_user.external_id, processor: "stripe", expected_email: "other@example.com" }
+      end.not_to change { ScheduledPayout.count }
+
+      expect(response).to have_http_status(:conflict)
+      expect(response.parsed_body).to eq({ success: false, message: "expected_email does not match the user's current email" }.as_json)
+    end
+
+    it "returns 422 when the user is not suspended" do
+      expect do
+        post :create, params: { user_id: user.external_id, processor: "stripe" }
+      end.not_to change { ScheduledPayout.count }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body).to eq({ success: false, message: "User is not suspended." }.as_json)
+    end
+
+    it "returns 422 when the user has an in-progress scheduled payout" do
+      create(:scheduled_payout, user: suspended_user, status: "pending")
+
+      expect do
+        post :create, params: { user_id: suspended_user.external_id, processor: "stripe" }
+      end.not_to change { ScheduledPayout.count }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body).to eq({ success: false, message: "User already has a scheduled payout in progress" }.as_json)
+    end
+
+    it "returns 422 without creating a scheduled payout when the note is invalid" do
+      expect do
+        post :create, params: { user_id: suspended_user.external_id, processor: "stripe", note: "x" * 10_001 }
+      end.not_to change { ScheduledPayout.count }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["success"]).to be(false)
+      expect(response.parsed_body["message"]).to include("Content is too long")
+    end
+
+    it "writes an admin audit log targeting the suspended user" do
+      expect do
+        post :create, params: { user_id: suspended_user.external_id, processor: "stripe" }
+      end.to change { AdminApiAuditLog.count }.by(1)
+
+      expect(AdminApiAuditLog.last).to have_attributes(
+        action: "scheduled_payouts.create",
+        actor_user_id: admin_user.id,
+        target_type: "User",
+        target_id: suspended_user.id,
+        target_external_id: suspended_user.external_id,
+        response_status: 200
+      )
+    end
   end
 
   describe "GET index" do

--- a/spec/factories/scheduled_payouts.rb
+++ b/spec/factories/scheduled_payouts.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :scheduled_payout do
     user
     action { "payout" }
+    processor { user.current_payout_processor }
     delay_days { 21 }
     scheduled_at { 21.days.from_now }
     status { "pending" }

--- a/spec/factories/scheduled_payouts.rb
+++ b/spec/factories/scheduled_payouts.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :scheduled_payout do
     user
     action { "payout" }
-    processor { user.current_payout_processor }
+    processor { action == "payout" ? user.current_payout_processor : nil }
     delay_days { 21 }
     scheduled_at { 21.days.from_now }
     status { "pending" }

--- a/spec/models/scheduled_payout_spec.rb
+++ b/spec/models/scheduled_payout_spec.rb
@@ -187,6 +187,38 @@ describe ScheduledPayout do
         expect(scheduled_payout.executed_at).to be_present
       end
 
+      it "uses the stored processor when payout executes" do
+        scheduled_payout.update!(processor: PayoutProcessorType::STRIPE)
+        payment = instance_double(Payment, failed?: false, reload: nil)
+        allow(payment).to receive(:reload).and_return(payment)
+        processor = class_double(StripePayoutProcessor, process_payments: nil)
+        expect(Payouts).to receive(:create_payment)
+          .with(Date.yesterday.to_s, PayoutProcessorType::STRIPE, user)
+          .and_return([payment, nil])
+        expect(PayoutProcessorType).to receive(:get).with(PayoutProcessorType::STRIPE).and_return(processor)
+        expect(processor).to receive(:process_payments).with([payment])
+
+        scheduled_payout.execute!
+
+        expect(scheduled_payout.reload.status).to eq("executed")
+      end
+
+      it "falls back to the user's current processor for legacy scheduled payouts" do
+        scheduled_payout.update_column(:processor, nil)
+        payment = instance_double(Payment, failed?: false, reload: nil)
+        allow(payment).to receive(:reload).and_return(payment)
+        processor = class_double(StripePayoutProcessor, process_payments: nil)
+        expect(Payouts).to receive(:create_payment)
+          .with(Date.yesterday.to_s, user.current_payout_processor, user)
+          .and_return([payment, nil])
+        expect(PayoutProcessorType).to receive(:get).with(user.current_payout_processor).and_return(processor)
+        expect(processor).to receive(:process_payments).with([payment])
+
+        scheduled_payout.execute!
+
+        expect(scheduled_payout.reload.status).to eq("executed")
+      end
+
       it "raises if payout fails" do
         payment = instance_double(Payment, failed?: true, errors: double(full_messages: ["Stripe account not found"]))
         allow(payment).to receive(:reload).and_return(payment)

--- a/spec/models/scheduled_payout_spec.rb
+++ b/spec/models/scheduled_payout_spec.rb
@@ -3,6 +3,15 @@
 require "spec_helper"
 
 describe ScheduledPayout do
+  describe "factory defaults" do
+    it "sets processor only for payout actions" do
+      payout = build(:scheduled_payout, action: "payout")
+      expect(payout.processor).to eq(payout.user.current_payout_processor)
+      expect(build(:scheduled_payout, action: "refund").processor).to be_nil
+      expect(build(:scheduled_payout, action: "hold").processor).to be_nil
+    end
+  end
+
   describe "validations" do
     it "is valid with valid attributes" do
       scheduled_payout = build(:scheduled_payout)

--- a/spec/routing/api_internal_admin_contract_spec.rb
+++ b/spec/routing/api_internal_admin_contract_spec.rb
@@ -52,6 +52,23 @@ describe "internal admin API routing" do
     )
   end
 
+  it "routes the scheduled payout write endpoints" do
+    expect(route_for("/internal/admin/scheduled_payouts", :post)).to include(
+      controller: "api/internal/admin/scheduled_payouts",
+      action: "create"
+    )
+    expect(route_for("/internal/admin/scheduled_payouts/abc123/execute", :post)).to include(
+      controller: "api/internal/admin/scheduled_payouts",
+      action: "execute",
+      id: "abc123"
+    )
+    expect(route_for("/internal/admin/scheduled_payouts/abc123/cancel", :post)).to include(
+      controller: "api/internal/admin/scheduled_payouts",
+      action: "cancel",
+      id: "abc123"
+    )
+  end
+
   it "routes the products endpoints" do
     expect(route_for("/internal/admin/products", :get)).to include(controller: "api/internal/admin/products", action: "index")
     expect(route_for("/internal/admin/products/abc123", :get)).to include(controller: "api/internal/admin/products", action: "show", id: "abc123")


### PR DESCRIPTION
Ref #5153

## What

- Added `POST /api/internal/admin/scheduled_payouts` so admins can schedule a payout for a suspended user from the internal API.
- The endpoint validates processor, payout date, suspension state, expected email, and in-progress payout conflicts before creating the record.
- Scheduled payouts now persist the chosen processor and execute with that processor later, while older rows still fall back to the user’s current payout processor.
- The admin UI path that creates scheduled payouts now stores the processor too, so both paths stay consistent.

## Why

- This closes the gap between the CLI and the old admin workflow for delayed payouts after suspension.
- Persisting the processor makes the API honest about which payout rail will be used when the payout eventually executes.

---
This PR was implemented with AI assistance using gpt-5.5 xhigh.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces an admin write path that schedules real-money payouts and changes which payout rail runs at execution time.
> 
> **Overview**
> Adds **`POST /internal/admin/scheduled_payouts`** so admins can schedule a payout for a **suspended** user with a required **Stripe or PayPal** processor, optional **UTC payout date** (default 21 days), optional note, and the usual write guards (`user_id`, `expected_email`, audit log). Creation runs in a locked transaction and rejects non-suspended users, zero balance, and existing in-progress scheduled payouts.
> 
> Scheduled payouts now **persist `processor`** (migration + validation) and **execute** using that value, with a fallback to the user’s current processor for older rows. The same processor is set when scheduling via **admin user actions**, **mass suspend**, and is exposed in the **admin presenter** and scheduled payouts UI types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a864b24ded77991bccf3d69322bf1706f472fa1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->