### PR TITLE
Add unpaid balance refund admin endpoints

### DIFF
--- a/app/controllers/api/internal/admin/users_controller.rb
+++ b/app/controllers/api/internal/admin/users_controller.rb
@@ -131,6 +131,13 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
                                                      })
   end
 
+  def unpaid_balance
+    user = find_internal_admin_user_for_read_or_render
+    return unless user
+
+    render json: internal_admin_user_success_payload(user, unpaid_balance_payload(RefundUnpaidPurchasesWorker.unpaid_balance_summary_for(user)))
+  end
+
   def reset_password
     user = find_internal_admin_user_for_write_or_render
     return unless user
@@ -320,6 +327,51 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
                                                        })
     rescue StateMachines::InvalidTransition => e
       render json: { success: false, message: e.message }, status: :unprocessable_entity
+    end
+  end
+
+  def refund_balance
+    return render_internal_admin_user_id_required if params[:user_id].blank?
+    return render json: { success: false, message: "expected_email is required" }, status: :bad_request if params[:expected_email].blank?
+
+    expected_purchase_count = parse_non_negative_integer_param(:expected_purchase_count)
+    return if performed?
+
+    expected_total_amount_cents = parse_non_negative_integer_param(:expected_total_amount_cents)
+    return if performed?
+
+    user = find_internal_admin_user_for_write_or_render
+    return unless user
+
+    unless user.suspended?
+      return render json: { success: false, message: "User must be suspended to refund unpaid purchases" }, status: :unprocessable_entity
+    end
+
+    current_summary = RefundUnpaidPurchasesWorker.unpaid_balance_summary_for(user)
+    unless unpaid_balance_summary_matches?(current_summary, expected_purchase_count:, expected_total_amount_cents:)
+      payload = {
+        success: false,
+        message: "Expected unpaid balance does not match current unpaid balance",
+        current: unpaid_balance_payload(current_summary)
+      }
+      return render json: internal_admin_user_success_payload(user, payload), status: :conflict
+    end
+
+    record_admin_write(action: "users.refund_balance", target: user) do
+      job_id = RefundUnpaidPurchasesWorker.perform_async(user.id, current_admin_actor_id)
+      if job_id.blank?
+        payload = {
+          success: false,
+          message: "Refund balance is already queued or running",
+          current: unpaid_balance_payload(current_summary)
+        }
+        return render json: internal_admin_user_success_payload(user, payload), status: :conflict
+      end
+
+      render json: internal_admin_user_success_payload(user, {
+        status: "queued",
+        message: "Refund balance queued",
+      }.merge(unpaid_balance_payload(current_summary)))
     end
   end
 
@@ -780,6 +832,35 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
 
     def flag_for_tos_violation_comment_content(product)
       "Flagged for a policy violation by #{Current.admin_actor.name_or_username} on #{Time.current.to_fs(:formatted_date_full_month)} for product named '#{product.name}'"
+    end
+
+    def parse_non_negative_integer_param(name)
+      raw = params[name]
+      if raw.blank?
+        render json: { success: false, message: "#{name} is required" }, status: :bad_request
+        return
+      end
+
+      value = raw.to_s
+      unless value.match?(/\A\d+\z/)
+        render json: { success: false, message: "#{name} must be a non-negative integer" }, status: :bad_request
+        return
+      end
+
+      value.to_i
+    end
+
+    def unpaid_balance_summary_matches?(summary, expected_purchase_count:, expected_total_amount_cents:)
+      summary[:count] == expected_purchase_count && summary[:total_amount_cents] == expected_total_amount_cents
+    end
+
+    def unpaid_balance_payload(summary)
+      {
+        count: summary[:count],
+        total: summary[:total_amount_cents],
+        total_amount_cents: summary[:total_amount_cents],
+        currency: summary[:currency]
+      }
     end
 
     def parse_threshold_cents(raw)

--- a/app/sidekiq/refund_unpaid_purchases_worker.rb
+++ b/app/sidekiq/refund_unpaid_purchases_worker.rb
@@ -2,14 +2,27 @@
 
 class RefundUnpaidPurchasesWorker
   include Sidekiq::Job
-  sidekiq_options retry: 1, queue: :default
+  sidekiq_options retry: 1, queue: :default, lock: :until_executed
+
+  def self.unpaid_purchases_for(user)
+    unpaid_balance_ids = user.balances.unpaid.select(:id)
+    user.sales.where(purchase_success_balance_id: unpaid_balance_ids).successful.not_fully_refunded
+  end
+
+  def self.unpaid_balance_summary_for(user)
+    purchases = unpaid_purchases_for(user).includes(:refunds).to_a
+    {
+      count: purchases.size,
+      total_amount_cents: purchases.sum(&:gross_amount_refundable_cents),
+      currency: Currency::USD
+    }
+  end
 
   def perform(user_id, admin_user_id)
     user = User.find(user_id)
     return unless user.suspended?
 
-    unpaid_balance_ids = user.balances.unpaid.ids
-    user.sales.where(purchase_success_balance_id: unpaid_balance_ids).successful.not_fully_refunded.ids.each do |purchase_id|
+    self.class.unpaid_purchases_for(user).ids.each do |purchase_id|
       RefundPurchaseWorker.perform_async(purchase_id, admin_user_id)
     end
 

--- a/app/sidekiq/refund_unpaid_purchases_worker.rb
+++ b/app/sidekiq/refund_unpaid_purchases_worker.rb
@@ -4,16 +4,29 @@ class RefundUnpaidPurchasesWorker
   include Sidekiq::Job
   sidekiq_options retry: 1, queue: :default, lock: :until_executed
 
+  def self.lock_args(args)
+    [args.first]
+  end
+
   def self.unpaid_purchases_for(user)
     unpaid_balance_ids = user.balances.unpaid.select(:id)
     user.sales.where(purchase_success_balance_id: unpaid_balance_ids).successful.not_fully_refunded
   end
 
   def self.unpaid_balance_summary_for(user)
-    purchases = unpaid_purchases_for(user).includes(:refunds).to_a
+    refundable_amounts = unpaid_purchases_for(user)
+      .left_joins(:refunds)
+      .group("purchases.id", "purchases.price_cents", "purchases.gumroad_tax_cents")
+      .pluck(Arel.sql(
+               "COALESCE(purchases.price_cents, 0) + " \
+               "COALESCE(purchases.gumroad_tax_cents, 0) - " \
+               "COALESCE(SUM(refunds.amount_cents), 0) - " \
+               "COALESCE(SUM(refunds.gumroad_tax_cents), 0)"
+             ))
+
     {
-      count: purchases.size,
-      total_amount_cents: purchases.sum(&:gross_amount_refundable_cents),
+      count: refundable_amounts.size,
+      total_amount_cents: refundable_amounts.sum,
       currency: Currency::USD
     }
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -339,6 +339,7 @@ Rails.application.routes.draw do
               get :radar_stats
               get :related
               get :suspension
+              get :unpaid_balance
               post :reset_password
               post :update_email
               post :two_factor_authentication
@@ -347,6 +348,7 @@ Rails.application.routes.draw do
               post :suspend_for_fraud
               post :suspend_for_tos_violation
               post :flag_for_tos_violation
+              post :refund_balance
               post :watch
               post :update_watch
               post :unwatch

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -1967,6 +1967,212 @@ describe Api::Internal::Admin::UsersController do
     include_examples "supports user lookup by user_id", :suspension, method: :get, build_user: -> { create(:compliant_user) }
   end
 
+  describe "GET unpaid_balance" do
+    include_examples "admin api authorization required", :get, :unpaid_balance
+
+    let!(:gumroad_merchant_account) { create(:merchant_account, user: nil) }
+    let(:user) { create(:tos_user, email: "seller@example.com") }
+    let(:product) { create(:product, user:) }
+
+    def create_purchase_for_unpaid_balance(seller:, product:, balance:, price_cents:, gumroad_tax_cents: 0, **attributes)
+      create(:purchase,
+             {
+               seller:,
+               link: product,
+               purchase_success_balance: balance,
+               price_cents:,
+               gumroad_tax_cents:,
+               total_transaction_cents: price_cents + gumroad_tax_cents
+             }.merge(attributes))
+    end
+
+    it "returns count and total for refundable purchases on unpaid balances" do
+      unpaid_balance = create(:balance, user:)
+      matching_purchase = create_purchase_for_unpaid_balance(seller: user, product:, balance: unpaid_balance, price_cents: 15_00, gumroad_tax_cents: 2_00)
+      create(:refund, purchase: matching_purchase, amount_cents: 5_00, gumroad_tax_cents: 1_00)
+
+      paid_balance = create(:balance, user:)
+      paid_balance.mark_processing!
+      paid_balance.mark_paid!
+      create_purchase_for_unpaid_balance(seller: user, product:, balance: paid_balance, price_cents: 20_00)
+      create(:purchase, seller: user, link: product, price_cents: 30_00, purchase_success_balance: nil)
+      create_purchase_for_unpaid_balance(seller: user, product:, balance: unpaid_balance, price_cents: 40_00, stripe_refunded: true)
+      other_user = create(:tos_user)
+      create_purchase_for_unpaid_balance(seller: other_user, product: create(:product, user: other_user), balance: create(:balance, user: other_user), price_cents: 50_00)
+
+      get :unpaid_balance, params: { user_id: user.external_id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq({
+        success: true,
+        user_id: user.external_id,
+        count: 1,
+        total: 11_00,
+        total_amount_cents: 11_00,
+        currency: "usd"
+      }.as_json)
+    end
+
+    it "returns zero totals when no purchases match the refund worker query" do
+      get :unpaid_balance, params: { user_id: user.external_id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq({
+        success: true,
+        user_id: user.external_id,
+        count: 0,
+        total: 0,
+        total_amount_cents: 0,
+        currency: "usd"
+      }.as_json)
+    end
+
+    it "returns a bad request when user lookup params are missing" do
+      get :unpaid_balance
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "email or user_id is required" }.as_json)
+    end
+
+    it "does not write an admin audit log" do
+      expect do
+        get :unpaid_balance, params: { user_id: user.external_id }
+      end.not_to change { AdminApiAuditLog.count }
+    end
+
+    include_examples "supports user lookup by user_id", :unpaid_balance, method: :get, build_user: -> { create(:tos_user) }
+  end
+
+  describe "POST refund_balance" do
+    let!(:gumroad_merchant_account) { create(:merchant_account, user: nil) }
+    let(:user) { create(:tos_user, email: "seller@example.com") }
+    let(:balance) { create(:balance, user:) }
+    let(:product) { create(:product, user:) }
+    let!(:purchase) do
+      create(:purchase,
+             seller: user,
+             link: product,
+             purchase_success_balance: balance,
+             price_cents: 12_34,
+             gumroad_tax_cents: 1_00,
+             total_transaction_cents: 13_34)
+    end
+
+    include_examples "admin api authorization required", :post, :refund_balance, {
+      user_id: "missing",
+      expected_email: "seller@example.com",
+      expected_purchase_count: 0,
+      expected_total_amount_cents: 0
+    }
+
+    def refund_balance_params(user, overrides = {})
+      summary = RefundUnpaidPurchasesWorker.unpaid_balance_summary_for(user)
+      {
+        user_id: user.external_id,
+        expected_email: user.email,
+        expected_purchase_count: summary[:count],
+        expected_total_amount_cents: summary[:total_amount_cents]
+      }.merge(overrides)
+    end
+
+    it "returns 400 when user_id is missing" do
+      post :refund_balance, params: {
+        expected_email: user.email,
+        expected_purchase_count: 1,
+        expected_total_amount_cents: 13_34
+      }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: user_id_required_message }.as_json)
+    end
+
+    it "returns 400 when expected_email is missing" do
+      post :refund_balance, params: refund_balance_params(user).except(:expected_email)
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "expected_email is required" }.as_json)
+    end
+
+    it "returns 400 when expected_purchase_count is missing" do
+      post :refund_balance, params: refund_balance_params(user).except(:expected_purchase_count)
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "expected_purchase_count is required" }.as_json)
+    end
+
+    it "returns 400 when an expected value is not a non-negative integer" do
+      post :refund_balance, params: refund_balance_params(user, expected_total_amount_cents: "12.34")
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "expected_total_amount_cents must be a non-negative integer" }.as_json)
+    end
+
+    it "returns 422 when the user is not suspended" do
+      user.update!(user_risk_state: "compliant")
+
+      expect do
+        post :refund_balance, params: refund_balance_params(user)
+      end.not_to change { RefundUnpaidPurchasesWorker.jobs.size }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body).to eq({ success: false, message: "User must be suspended to refund unpaid purchases" }.as_json)
+    end
+
+    it "returns 409 with current values when the expected count or total is stale" do
+      expect do
+        post :refund_balance, params: refund_balance_params(user, expected_total_amount_cents: 1)
+      end.not_to change { RefundUnpaidPurchasesWorker.jobs.size }
+
+      expect(response).to have_http_status(:conflict)
+      expect(response.parsed_body).to eq({
+        success: false,
+        user_id: user.external_id,
+        message: "Expected unpaid balance does not match current unpaid balance",
+        current: {
+          count: 1,
+          total: 13_34,
+          total_amount_cents: 13_34,
+          currency: "usd"
+        }
+      }.as_json)
+    end
+
+    it "enqueues a refund worker when the expected values match" do
+      expect do
+        post :refund_balance, params: refund_balance_params(user)
+      end.to change { RefundUnpaidPurchasesWorker.jobs.size }.by(1)
+        .and change { AdminApiAuditLog.count }.by(1)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq({
+        success: true,
+        user_id: user.external_id,
+        status: "queued",
+        message: "Refund balance queued",
+        count: 1,
+        total: 13_34,
+        total_amount_cents: 13_34,
+        currency: "usd"
+      }.as_json)
+      expect(RefundUnpaidPurchasesWorker).to have_enqueued_sidekiq_job(user.id, admin_user.id)
+      expect(AdminApiAuditLog.last).to have_attributes(
+        action: "users.refund_balance",
+        actor_user_id: admin_user.id,
+        target_type: "User",
+        target_id: user.id,
+        response_status: 200
+      )
+    end
+
+    include_examples "requires user_id for user mutation",
+                     :refund_balance,
+                     extra_params: { expected_email: "seller@example.com", expected_purchase_count: 0, expected_total_amount_cents: 0 }
+    include_examples "checks expected_email for user mutation",
+                     :refund_balance,
+                     build_user: -> { create(:tos_user) },
+                     extra_params: { expected_purchase_count: 0, expected_total_amount_cents: 0 }
+  end
+
   describe "POST reset_password" do
     let(:user) { create(:user) }
 

--- a/spec/routing/api_internal_admin_contract_spec.rb
+++ b/spec/routing/api_internal_admin_contract_spec.rb
@@ -21,11 +21,16 @@ describe "internal admin API routing" do
     expect(route_for("/internal/admin/users/radar_stats", :get)).to include(controller: "api/internal/admin/users", action: "radar_stats")
     expect(route_for("/internal/admin/users/related", :get)).to include(controller: "api/internal/admin/users", action: "related")
     expect(route_for("/internal/admin/users/suspension", :get)).to include(controller: "api/internal/admin/users", action: "suspension")
+    expect(route_for("/internal/admin/users/unpaid_balance", :get)).to include(controller: "api/internal/admin/users", action: "unpaid_balance")
     expect(route_for("/internal/admin/payouts", :get)).to include(controller: "api/internal/admin/payouts", action: "index")
   end
 
   it "routes the precise refund endpoint" do
     expect(route_for("/internal/admin/purchases/123/refund", :post)).to include(controller: "api/internal/admin/purchases", action: "refund", id: "123")
+  end
+
+  it "routes the user refund balance write endpoint" do
+    expect(route_for("/internal/admin/users/refund_balance", :post)).to include(controller: "api/internal/admin/users", action: "refund_balance")
   end
 
   it "routes the user watchlist write endpoints" do

--- a/spec/sidekiq/refund_unpaid_purchases_worker_spec.rb
+++ b/spec/sidekiq/refund_unpaid_purchases_worker_spec.rb
@@ -3,8 +3,13 @@
 require "spec_helper"
 
 describe RefundUnpaidPurchasesWorker, :vcr do
+  it "uses a unique execution lock" do
+    expect(described_class.sidekiq_options["lock"]).to eq(:until_executed)
+  end
+
   describe "#perform" do
     before do
+      create(:merchant_account, user: nil)
       @admin_user = create(:admin_user)
       @purchase = create(:purchase_in_progress, chargeable: create(:chargeable))
       @purchase.process!

--- a/spec/sidekiq/refund_unpaid_purchases_worker_spec.rb
+++ b/spec/sidekiq/refund_unpaid_purchases_worker_spec.rb
@@ -7,6 +7,37 @@ describe RefundUnpaidPurchasesWorker, :vcr do
     expect(described_class.sidekiq_options["lock"]).to eq(:until_executed)
   end
 
+  it "locks by user id only" do
+    expect(described_class.lock_args([123, 456])).to eq([123])
+  end
+
+  describe ".unpaid_balance_summary_for" do
+    it "computes refundable totals without calling per-purchase refundable helpers" do
+      create(:merchant_account, user: nil)
+      user = create(:tos_user)
+      product = create(:product, user:)
+      balance = create(:balance, user:)
+      purchase = create(:purchase,
+                        seller: user,
+                        link: product,
+                        purchase_success_balance: balance,
+                        price_cents: 15_00,
+                        gumroad_tax_cents: 2_00,
+                        total_transaction_cents: 17_00)
+      create(:refund, purchase:, amount_cents: 5_00, gumroad_tax_cents: 1_00)
+
+      expect_any_instance_of(Purchase).not_to receive(:gross_amount_refundable_cents)
+      expect(ActiveRecord::Base.connection).not_to receive(:stick_to_primary!)
+
+      expected_summary = {
+        count: 1,
+        total_amount_cents: 11_00,
+        currency: "usd"
+      }
+      expect(described_class.unpaid_balance_summary_for(user)).to eq(expected_summary)
+    end
+  end
+
   describe "#perform" do
     before do
       create(:merchant_account, user: nil)


### PR DESCRIPTION
Ref #5153

## What

Adds internal admin support for previewing a suspended seller’s unpaid balance and queueing a refund pass against that snapshot.

The refund path now checks the user is suspended, requires the caller to confirm the current unpaid purchase count and amount, and returns `409` if the preview is stale.

## Why

This closes the gap between the CLI and the existing admin workflow for fraud-style balance refunds. It keeps the refund action tied to current state so admins do not act on a stale preview.

---
This PR was implemented with AI assistance using gpt-5.5 xhigh.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Triggers bulk purchase refunds tied to seller balances and requires strict preview matching; mistakes or race conditions could refund the wrong amount or duplicate work despite the per-user job lock.
> 
> **Overview**
> Adds internal admin APIs to **preview** and **queue** refunds against a suspended seller’s unpaid-balance snapshot, aligning the HTTP admin flow with the existing CLI-style balance refund path.
> 
> **GET `unpaid_balance`** returns refundable purchase count and total cents (plus currency) using the same selection logic as the refund worker. **POST `refund_balance`** requires the user to be suspended, mandatory `expected_email`, and non-negative integer `expected_purchase_count` / `expected_total_amount_cents`; it returns **409** with current totals when the preview is stale or when a per-user refund job is already queued/running, otherwise enqueues `RefundUnpaidPurchasesWorker` under audit action `users.refund_balance`.
> 
> `RefundUnpaidPurchasesWorker` now centralizes unpaid purchase scoping and computes the preview total via SQL (price + tax minus prior refunds) instead of per-purchase helpers, and adds a **Sidekiq unique lock** keyed by user id so duplicate refund passes cannot run in parallel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b5182e96b2ac9b85bc7041ff94f3c651c31c35e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->