### PR TITLE
Fix Admin::ScheduledPayoutPresenter spec broken on main

### DIFF
--- a/spec/presenters/admin/scheduled_payout_presenter_spec.rb
+++ b/spec/presenters/admin/scheduled_payout_presenter_spec.rb
@@ -12,6 +12,7 @@ describe Admin::ScheduledPayoutPresenter do
       expect(described_class.new(scheduled_payout:).props).to eq(
         external_id: scheduled_payout.external_id,
         action: scheduled_payout.action,
+        processor: scheduled_payout.processor,
         status: scheduled_payout.status,
         delay_days: scheduled_payout.delay_days,
         scheduled_at: scheduled_payout.scheduled_at,


### PR DESCRIPTION
## What

PR #5277 (commit [95a8bd551](https://github.com/antiwork/gumroad/commit/95a8bd551a83fde2e8775db3f5bb5a7b334d9d1c)) added a `:processor` key to `Admin::ScheduledPayoutPresenter#props` but did not update the matching spec. Every CI run on `main` since that merge fails with:

```
Failure/Error: expect(described_class.new(scheduled_payout:).props).to eq(...)
  Diff:
  +:processor => "PAYPAL",
# ./spec/presenters/admin/scheduled_payout_presenter_spec.rb:12
```

## Why

Main is red — every PR branch inherits the failure. This adds the missing `processor:` key to the expected hash so the spec matches the presenter's actual output. **No production code changes.**

## Verification

```
bundle exec rspec spec/presenters/admin/scheduled_payout_presenter_spec.rb
# 2 examples, 0 failures
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782339261&installation_id=134400930&pr_number=5279&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5279&signature=db9f132aebcda1e5685d52e876e7d09c8fe81faaebd7fbab93eb6d14edceb6d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Spec-only change; no runtime behavior is modified.
> 
> **Overview**
> Aligns the **`Admin::ScheduledPayoutPresenter`** `#props` spec with the presenter output after **`processor`** was added to `#props` elsewhere. The example’s expected hash now includes **`processor: scheduled_payout.processor`** so CI on `main` passes again.
> 
> **No application code changes**—test-only fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f19a9259871f0e2430b18dbffd8b78a9cd27ecc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->