### PR TITLE
CI: drop 60s sleep on test failure in Fast job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -327,7 +327,6 @@ jobs:
         run: |
           mkdir -p ./test-logs
           chmod 777 ./test-logs
-          set +e
           docker run --rm --entrypoint="" --network ${{ env.COMPOSE_PROJECT_NAME }}_default \
             -v "$(pwd)/test-logs:/app/log" \
             -e RUBY_YJIT_ENABLE \
@@ -348,16 +347,6 @@ jobs:
             -e IN_DOCKER \
             $WEB_REPO:${{ needs.build.outputs.test_image_tag }} \
             /usr/local/bin/gosu app bundle exec rake "knapsack_pro:queue:rspec[--format RSpec::Github::Formatter --tag ~skip --format progress]"
-          TEST_EXIT=$?
-          if [ $TEST_EXIT -ne 0 ]; then
-            echo ""
-            echo "============================================"
-            echo "TESTS FAILED (exit code $TEST_EXIT)"
-            echo "Waiting 60s for other containers to report failures..."
-            echo "============================================"
-            sleep 60
-            exit $TEST_EXIT
-          fi
         env:
           RUBY_YJIT_ENABLE: 1
           KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC_FAST }}


### PR DESCRIPTION
## What

The Fast test job currently wraps `bundle exec rake knapsack_pro:queue:rspec` in a shell block that captures the exit code, prints a banner, and **sleeps 60 seconds** before re-exiting non-zero:

```yaml
set +e
docker run ... rake knapsack_pro:queue:rspec ...
TEST_EXIT=$?
if [ $TEST_EXIT -ne 0 ]; then
  echo 'TESTS FAILED ... Waiting 60s for other containers to report failures...'
  sleep 60
  exit $TEST_EXIT
fi
```

This PR removes the wrapper. The exit code flows through naturally and the step fails immediately on rspec exit \`!= 0\`.

## Why

The 60s sleep was intended to delay job exit so peer shards could surface their own failures before a fast-failing job triggered the workflow's `cancel-in-progress`. In practice it just makes red runs 60s longer per shard and delays feedback. GitHub Actions surfaces peer-shard failures independently; no artificial wait is needed.

The **Slow** test job already runs the same rake invocation directly without this wrapper, so this PR aligns both jobs on the same pattern.

## Diff

```diff
-          set +e
           docker run ... \
             ... \
             rake knapsack_pro:queue:rspec ...
-          TEST_EXIT=$?
-          if [ $TEST_EXIT -ne 0 ]; then
-            echo 'TESTS FAILED (exit code $TEST_EXIT)'
-            echo 'Waiting 60s for other containers to report failures...'
-            sleep 60
-            exit $TEST_EXIT
-          fi
```

One file, one hunk, –11 LOC.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782339421&installation_id=134400930&pr_number=5280&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5280&signature=66da723981d96db972817b0249be866f72a1eb3505f145555bb684c1be2b0bbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to failure timing; test command and matrix behavior are unchanged.
> 
> **Overview**
> Removes the **Fast** test job shell wrapper around `knapsack_pro:queue:rspec` that used `set +e`, captured the exit code, printed a failure banner, and **slept 60 seconds** before re-exiting. The step now runs `docker run … rake knapsack_pro:queue:rspec` directly so a failing shard fails immediately, matching the **Slow** job pattern.
> 
> Failed runs should finish up to ~60s sooner per failing matrix node, with no change to how tests are invoked or which specs run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46118ff7d1317352ed627fabbcda57010e897a38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->