### PR TITLE
Replace Open Exchange Rates with Stripe FX Quotes API

### DIFF
--- a/app/helpers/currency_helper.rb
+++ b/app/helpers/currency_helper.rb
@@ -34,13 +34,18 @@ module CurrencyHelper
   end
 
   def query_rate(currency_type)
-    JSON.parse(URI.open(CURRENCY_SOURCE).read)["rates"][currency_type]
-  rescue StandardError
-    currency_namespace.get(currency_type.to_s)
+    formatted_currency = currency_type.to_s.upcase
+    return backup_rate(formatted_currency) unless use_stripe_fx_quotes?
+    return backup_rate(formatted_currency) unless stripe_fx_supported_currency_choice?(formatted_currency)
+
+    stripe_fx_rates([formatted_currency])[formatted_currency] || backup_rate(formatted_currency)
+  rescue Stripe::StripeError => e
+    notify_stripe_fx_quote_error(e, currencies: [formatted_currency])
+    backup_rate(formatted_currency)
   end
 
   def get_rate(currency_type)
-    return "1.0" if currency_type.to_s == "usd" # Getting around an open exchange jankiness
+    return "1.0" if currency_type.to_s == "usd"
     formatted_currency = currency_type.to_s.upcase
     rate = currency_namespace.get(formatted_currency.to_s)
     if rate && rate.to_f > 0
@@ -52,8 +57,63 @@ module CurrencyHelper
     end
   end
 
+  def backup_currency_rates
+    JSON.parse(File.read(BACKUP_CURRENCY_RATES_PATH))["rates"]
+  end
+
+  def backup_rate(currency_type)
+    backup_currency_rates[currency_type.to_s.upcase]
+  end
+
+  def use_stripe_fx_quotes?
+    !Rails.env.development? && !Rails.env.test?
+  end
+
+  def stripe_fx_supported_currency_choice?(currency_type)
+    STRIPE_FX_CURRENCY_CHOICES.include?(currency_type.to_s.upcase)
+  end
+
+  def stripe_fx_rates(currency_types)
+    currencies = Array(currency_types).map { _1.to_s.upcase }.uniq
+    supported_currencies = (currencies & STRIPE_FX_CURRENCY_CHOICES) - ["USD"]
+    return {} if supported_currencies.empty?
+
+    quote = Stripe::FxQuote.create(
+      to_currency: "usd",
+      from_currencies: supported_currencies.map(&:downcase),
+      lock_duration: "none"
+    )
+
+    supported_currencies.index_with { stripe_fx_rate_from_quote(quote, _1) }.compact
+  end
+
+  def stripe_fx_rate_from_quote(quote, currency_type)
+    rate = stripe_fx_quote_rates(quote)&.[](currency_type.to_s.downcase)
+    exchange_rate = stripe_fx_attribute(rate, "exchange_rate")
+    return if exchange_rate.blank? || BigDecimal(exchange_rate.to_s) <= 0
+
+    (1 / BigDecimal(exchange_rate.to_s)).to_f
+  end
+
+  def stripe_fx_quote_rates(quote)
+    stripe_fx_attribute(quote, "rates")
+  end
+
+  def stripe_fx_attribute(object, key)
+    return if object.blank?
+    return object[key] if object.respond_to?(:[]) && object[key].present?
+    return object[key.to_sym] if object.respond_to?(:[]) && object[key.to_sym].present?
+
+    object.public_send(key) if object.respond_to?(key)
+  end
+
+  def notify_stripe_fx_quote_error(error, currencies:)
+    Rails.logger.warn("Stripe FX Quotes API failed for #{currencies.join(', ')}: #{error.class} - #{error.message}")
+    ErrorNotifier.notify(error, currencies:) { |report| report.severity = "warning" }
+  end
+
   def get_usd_cents(currency_type, quantity, rate: nil)
-    return quantity if currency_type.to_s == "usd" # Getting around an open exchange jankiness
+    return quantity if currency_type.to_s == "usd"
     rate = get_rate(currency_type) if rate.nil?
     converted = BigDecimal(quantity) / rate.to_f
     if is_currency_type_single_unit?(currency_type)
@@ -69,7 +129,7 @@ module CurrencyHelper
   # quantity - amount in USD cents
   # rate - optional. Uses this as the conversion rate instead of looking up by currency_type if present.
   def usd_cents_to_currency(currency_type, quantity, rate = nil)
-    return quantity if currency_type.to_s == "usd" # Getting around an open exchange jankiness
+    return quantity if currency_type.to_s == "usd"
     conversion_rate = rate.present? ? rate.to_f : get_rate(currency_type).to_f
     converted = BigDecimal(quantity) * conversion_rate
     if is_currency_type_single_unit?(currency_type)

--- a/app/sidekiq/update_currencies_worker.rb
+++ b/app/sidekiq/update_currencies_worker.rb
@@ -6,10 +6,30 @@ class UpdateCurrenciesWorker
   sidekiq_options retry: 5, queue: :default
 
   def perform
-    rates = JSON.parse(URI.open(CURRENCY_SOURCE).read)["rates"]
-
-    rates.each do |currency, rate|
+    rates_for_cache.each do |currency, rate|
       currency_namespace.set(currency.to_s, rate)
     end
   end
+
+  private
+    def rates_for_cache
+      return backup_rates_for_currency_choices unless use_stripe_fx_quotes?
+
+      backup_rates_for_currency_choices.merge(stripe_fx_rates(currency_choice_codes))
+    rescue Stripe::StripeError => e
+      notify_stripe_fx_quote_error(e, currencies: stripe_fx_currency_choice_codes)
+      backup_rates_for_currency_choices
+    end
+
+    def backup_rates_for_currency_choices
+      backup_currency_rates.slice(*currency_choice_codes)
+    end
+
+    def currency_choice_codes
+      CURRENCY_CHOICES.keys.map { _1.to_s.upcase }
+    end
+
+    def stripe_fx_currency_choice_codes
+      (currency_choice_codes & STRIPE_FX_CURRENCY_CHOICES) - ["USD"]
+    end
 end

--- a/config/initializers/currency.rb
+++ b/config/initializers/currency.rb
@@ -1,12 +1,35 @@
 # frozen_string_literal: true
 
-OPEN_EXCHANGE_RATES_API_BASE_URL = "https://openexchangerates.org/api"
-OPEN_EXCHANGE_RATE_KEY           = GlobalConfig.get("OPEN_EXCHANGE_RATES_APP_ID")
+CURRENCY_CHOICES = HashWithIndifferentAccess.new(
+  JSON.load_file(Rails.root.join("config/currencies.json").to_s)["currencies"]
+)
+BACKUP_CURRENCY_RATES_PATH = Rails.root.join("lib/currency/backup_rates.json").to_s
+STRIPE_FX_QUOTES_API_VERSION = "2025-07-30.preview"
+STRIPE_FX_SUPPORTED_CURRENCIES = %w[
+  AED AUD AWG BBD BHD BMD BSD CAD CHF DKK EUR GBP HKD IDR INR
+  JOD JPY KWD MYR NZD OMR PAB RON SAR SEK SGD THB USD XCD YER
+  AFN ALL AMD ANG AOA AZN BAM BDT BIF BND BOB BRL BWP BZD CLP
+  CNY COP CRC CVE CZK DJF DOP DZD FKP GEL GIP GMD GNF GTQ GYD
+  HNL HTG HUF ILS ISK JMD KES KGS KHR KRW KYD KZT LKR LRD MAD
+  MDL MGA MKD MNT MOP MUR MVR MXN MZN NAD NOK NPR PEN PHP PKR
+  PLN PYG QAR RSD RWF SHP STD TJS TND TRY TTD TWD TZS UAH UGX
+  UYU UZS VND XAF XOF XPF ZAR ZMW
+].freeze
+STRIPE_FX_CURRENCY_CHOICES = (CURRENCY_CHOICES.keys.map { _1.to_s.upcase } & STRIPE_FX_SUPPORTED_CURRENCIES).freeze
 
-CURRENCY_SOURCE = if Rails.env.development? || Rails.env.test?
-  "#{Rails.root}/lib/currency/backup_rates.json"
-else
-  "#{OPEN_EXCHANGE_RATES_API_BASE_URL}/latest.json?app_id=#{OPEN_EXCHANGE_RATE_KEY}"
+unless defined?(Stripe::FxQuote)
+  module Stripe
+    class FxQuote
+      def self.create(params = {}, opts = {})
+        response = Stripe.raw_request(
+          :post,
+          "/v1/fx_quotes",
+          params,
+          { stripe_version: ::STRIPE_FX_QUOTES_API_VERSION }.merge(opts)
+        )
+
+        Stripe.deserialize(response.http_body)
+      end
+    end
+  end
 end
-
-CURRENCY_CHOICES = HashWithIndifferentAccess.new(JSON.load_file("#{Rails.root}/config/currencies.json")["currencies"])

--- a/spec/helpers/currency_helper_spec.rb
+++ b/spec/helpers/currency_helper_spec.rb
@@ -4,9 +4,49 @@ require "spec_helper"
 
 describe CurrencyHelper do
   describe "#get_rate" do
+    def enable_stripe_fx_quotes
+      allow(Rails.env).to receive(:development?).and_return(false)
+      allow(Rails.env).to receive(:test?).and_return(false)
+    end
+
     it "returns the correct value" do
       expect(get_rate("JPY")).to eq "78.3932"
       expect(get_rate("GBP")).to eq "0.652571"
+    end
+
+    it "returns the cached value when present" do
+      currency_namespace.set("JPY", "149.25")
+
+      expect(Stripe::FxQuote).not_to receive(:create)
+      expect(get_rate("JPY")).to eq "149.25"
+    end
+
+    it "fetches a Stripe FX quote and caches it when Redis is empty" do
+      enable_stripe_fx_quotes
+      quote = { "rates" => { "eur" => { "exchange_rate" => 1.25 } } }
+
+      expect(Stripe::FxQuote).to receive(:create).with(
+        to_currency: "usd",
+        from_currencies: ["eur"],
+        lock_duration: "none"
+      ).and_return(quote)
+
+      expect(get_rate("EUR")).to eq "0.8"
+      expect(currency_namespace.get("EUR")).to eq "0.8"
+    end
+
+    it "returns the backup rate when Stripe FX quotes fail" do
+      enable_stripe_fx_quotes
+      error = Stripe::APIError.new("Stripe is down")
+      report = instance_double(ErrorNotifier::SentryReportAdapter)
+
+      allow(Stripe::FxQuote).to receive(:create).and_raise(error)
+      expect(Rails.logger).to receive(:warn).with(/Stripe FX Quotes API failed/)
+      expect(report).to receive(:severity=).with("warning")
+      expect(ErrorNotifier).to receive(:notify).with(error, currencies: ["EUR"]).and_yield(report)
+
+      expect(get_rate("EUR")).to eq "0.81127"
+      expect(currency_namespace.get("EUR")).to eq "0.81127"
     end
   end
 

--- a/spec/sidekiq/update_currencies_worker_spec.rb
+++ b/spec/sidekiq/update_currencies_worker_spec.rb
@@ -2,20 +2,60 @@
 
 require "spec_helper"
 
-describe UpdateCurrenciesWorker, :vcr do
+describe UpdateCurrenciesWorker do
   describe "#perform" do
-    before do
-      @worker_instance = described_class.new
+    let(:worker) { described_class.new }
+
+    def enable_stripe_fx_quotes
+      allow(Rails.env).to receive(:development?).and_return(false)
+      allow(Rails.env).to receive(:test?).and_return(false)
     end
 
-    it "updates currencies for current date" do
-      @worker_instance.currency_namespace.set("AUD", "0.1111")
-      expect(@worker_instance.get_rate("AUD")).to eq("0.1111")
+    it "updates currencies from the backup rates in test" do
+      worker.currency_namespace.set("AUD", "0.1111")
+      expect(worker.get_rate("AUD")).to eq("0.1111")
 
-      @worker_instance.perform
+      worker.perform
 
-      # In test this is a fixed rate read from a file
-      expect(@worker_instance.get_rate("AUD")).to eq("0.969509")
+      expect(worker.get_rate("AUD")).to eq("0.969509")
+    end
+
+    it "populates Redis with Stripe FX quote rates" do
+      enable_stripe_fx_quotes
+      quote = {
+        "rates" => {
+          "aud" => { "exchange_rate" => 0.5 },
+          "eur" => { "exchange_rate" => 1.25 },
+        },
+      }
+
+      expect(Stripe::FxQuote).to receive(:create).with(
+        to_currency: "usd",
+        from_currencies: match_array((STRIPE_FX_CURRENCY_CHOICES - ["USD"]).map(&:downcase)),
+        lock_duration: "none"
+      ).and_return(quote)
+
+      worker.perform
+
+      expect(worker.currency_namespace.get("AUD")).to eq("2.0")
+      expect(worker.currency_namespace.get("EUR")).to eq("0.8")
+      expect(worker.currency_namespace.get("USD")).to eq("1")
+    end
+
+    it "falls back to backup rates when Stripe FX quotes fail" do
+      enable_stripe_fx_quotes
+      error = Stripe::RateLimitError.new("rate limited")
+      report = instance_double(ErrorNotifier::SentryReportAdapter)
+
+      allow(Stripe::FxQuote).to receive(:create).and_raise(error)
+      expect(Rails.logger).to receive(:warn).with(/Stripe FX Quotes API failed/)
+      expect(report).to receive(:severity=).with("warning")
+      expect(ErrorNotifier).to receive(:notify)
+        .with(error, currencies: match_array(STRIPE_FX_CURRENCY_CHOICES - ["USD"]))
+        .and_yield(report)
+
+      expect { worker.perform }.not_to raise_error
+      expect(worker.currency_namespace.get("AUD")).to eq("0.969509")
     end
   end
 end


### PR DESCRIPTION
## What

Swaps currency rate updates from Open Exchange Rates to Stripe FX Quotes with `lock_duration: none`, keeping the Redis rate shape unchanged for downstream callers.

The existing `backup_rates.json` remains the development and test source, and production falls back to those static rates when Stripe FX Quotes fails or does not return a supported currency.

## Why

Stripe is the exchange engine used for charges, so using Stripe FX Quotes keeps cached conversion rates closer to the rates that actually apply at settlement. This also removes a paid vendor dependency and the Open Exchange Rates API key from the live currency update path.

## Fallback

If Stripe FX Quotes returns an error or rate limit response, the worker and inline `get_rate` fallback log a warning, notify Sentry at warning severity, and use `lib/currency/backup_rates.json` without re-raising.

## Risk

Stripe documents FX Quotes as a preview service, so availability and supported currencies can change. The static backup file remains in place to handle availability gaps.

## Follow-up

Once Stripe FX Quotes is GA, drop the `backup_rates.json` production fallback. Separately, update `Purchase.rate_converted_to_usd` to use a charge-time quote with `lock_duration: hour`.

## Ops

After the remaining out-of-scope Open Exchange Rates references are removed, cancel the Open Exchange Rates subscription and delete the `OPEN_EXCHANGE_RATES_APP_ID` production secret.

---

This PR was implemented with AI assistance using GPT-5.

Prompts used:

- "Swap Open Exchange Rates for Stripe FX Quotes API"

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782355892&installation_id=134400930&pr_number=5282&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5282&signature=60a17eb016cda1f98c873eed97bd64a9c6f526cbb80b7122670cc3341ea95d37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches payment-adjacent conversion rates and depends on a preview Stripe API, though failures degrade to static backup rates with monitoring.
> 
> **Overview**
> **Production currency rates** now come from **Stripe FX Quotes** (`lock_duration: none`) instead of Open Exchange Rates. Dev/test still use `lib/currency/backup_rates.json`; production uses that file when Stripe fails or a currency is outside the supported list.
> 
> `CurrencyHelper#query_rate` and `UpdateCurrenciesWorker` fetch quotes (with a thin `Stripe::FxQuote` wrapper on preview API `2025-07-30`), invert exchange rates into the same Redis shape callers already expect, and on `Stripe::StripeError` log, notify Sentry at warning severity, and fall back without raising. Open Exchange config and `CURRENCY_SOURCE` are removed from `config/initializers/currency.rb`.
> 
> Specs replace VCR with stubbed Stripe paths for cache hits, successful quotes, and failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef386dc2d5329f192f33cbdb7ff4ce29fe7a92bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->