### PR TITLE
Add lograge diagnostics for mobile/v2/internal API 401s

### DIFF
--- a/app/modules/lograge_helper.rb
+++ b/app/modules/lograge_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module LogrageHelper
+  MOBILE_API_PATH_PREFIXES = %w[/mobile/ /v2/ /internal/].freeze
+
   def append_info_to_payload(payload)
     super
 
@@ -11,5 +13,14 @@ module LogrageHelper
       "X-Amzn-Trace-Id" => request.headers["HTTP_X_AMZN_TRACE_ID"],
       "X-Revision" => REVISION
     }
+
+    if MOBILE_API_PATH_PREFIXES.any? { |prefix| request.path.start_with?(prefix) }
+      payload[:has_auth] = request.headers["Authorization"].present?
+      payload[:has_mobile_token] = request.params["mobile_token"].present?
+      if defined?(doorkeeper_token) && doorkeeper_token
+        payload[:auth_user_id] = doorkeeper_token.resource_owner_id
+        payload[:auth_token_id] = doorkeeper_token.id
+      end
+    end
   end
 end

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -24,5 +24,9 @@ Rails.application.config.lograge.custom_options = lambda do |event|
     end
   end
 
+  %i[has_auth has_mobile_token auth_user_id auth_token_id].each do |key|
+    params[key] = event.payload[key] if event.payload.key?(key)
+  end
+
   { "params" => params, "headers" => headers, "uuid" => uuid }
 end


### PR DESCRIPTION
## What

Adds four diagnostic fields to lograge output for every request to
\`/mobile/*\`, \`/v2/*\`, \`/internal/*\`:

| Field | Type | Meaning |
|---|---|---|
| \`has_auth\` | bool | Was the \`Authorization\` header sent? |
| \`has_mobile_token\` | bool | Was the \`mobile_token\` URL param sent? |
| \`auth_user_id\` | int / nil | Doorkeeper-resolved user_id (nil if token rejected) |
| \`auth_token_id\` | int / nil | Doorkeeper-resolved \`oauth_access_tokens\` row id (nil if token rejected) |

## Why

We can't currently debug the \`GUMROAD-MOBILE-2D\` / \`GUMROAD-MOBILE-2A\` Sentry cascades (~3K affected users) because the existing lograge output doesn't reveal **which** auth layer rejected the request.

Today the only signal we have for \`/mobile/*\` 401s is:

\`\`\`
method=GET path=/mobile/purchases/search status=401 duration=5.4 ...
\`\`\`

After this PR, the same 401 will read:

\`\`\`
method=GET path=/mobile/purchases/search status=401
  params={remote_ip:\"...\", has_auth:true, has_mobile_token:true, auth_user_id:13075321, auth_token_id:11702118}
\`\`\`

That immediately answers: was a bearer sent? was \`mobile_token\` sent? which token did the server recognize? Bucketing the production 401s by these four fields tells us which fix to ship next:

| Pattern | Diagnosis | Fix location |
|---|---|---|
| \`has_auth=false\` on most 401s | Mobile auth-state race; bearer never reaches server | gumroad-mobile (\`lib/request.ts\`) |
| \`has_mobile_token=false\` on most \`/mobile/*\` 401s | URL builder dropping the param | gumroad-mobile URL helper |
| \`has_auth=true\` but \`auth_token_id=nil\` | Wedge cohort — bearer is a stale/revoked token the keychain holds | gumroad-mobile #252 (already in flight) |
| All true but still 401 | Server-side mystery; needs further investigation | Server |

## Security review

No secret data is logged:

- Not the bearer string
- Not the access_token value
- Not the \`mobile_token\` value
- Not the refresh_token
- Just booleans and integer primary keys

Integer token IDs are visible to anyone with prod console access already. They're not credentials.

## Performance

Zero added DB queries on the success path. \`doorkeeper_token\` is the already-validated, already-cached object Doorkeeper sets during the \`doorkeeper_authorize!\` before_action. We just read its \`.id\` and \`.resource_owner_id\`.

On the failure path (when Doorkeeper rejected the bearer), \`doorkeeper_token\` is nil; we emit nil for those fields without any extra lookup. The combination \`has_auth=true AND auth_token_id=nil\` is itself the diagnostic signal — no need to identify which specific revoked row was sent.

## How to use after deploy

In Kibana (\`logs.gumroad.com\`), once new log lines start landing:

\`\`\`
log:\"path=/mobile\" AND log:\"status=401\" AND log:\"has_auth=false\"
log:\"path=/mobile\" AND log:\"status=401\" AND log:\"has_mobile_token=false\"
log:\"path=/mobile\" AND log:\"status=401\" AND log:\"has_auth=true\" AND log:\"auth_token_id=\"
\`\`\`

One of those will dominate. That answers the question.

## Test plan

- [ ] After deploy, verify new fields appear in \`logs.gumroad.com\` on a successful \`/v2/user\` request (should see \`has_auth=true\` and \`auth_token_id={int}\`)
- [ ] Verify they appear on a failing \`/mobile/purchases/search\` 401 (should see the failure-mode signal)
- [ ] Verify no regression in lograge output for non-mobile paths (they shouldn't get the new fields)
- [ ] Confirm bearer string does NOT appear anywhere in the new log output

Ref: https://github.com/antiwork/gumroad-mobile/pull/251, https://github.com/antiwork/gumroad-mobile/pull/252.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782368835&installation_id=134400930&pr_number=5283&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5283&signature=ccbcf33a0750005f532cd1722d17dc8f596b9539071eac15711309822974716f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change scoped to specific path prefixes; logs booleans and integer IDs, not tokens.
> 
> **Overview**
> Extends **lograge** request logs for **`/mobile/*`**, **`/v2/*`**, and **`/internal/*`** with auth diagnostics to triage mobile API **401**s without logging secrets.
> 
> For those paths only, **`LogrageHelper`** now records whether an **`Authorization`** header and **`mobile_token`** param were present, and—when Doorkeeper already resolved a token—**`auth_user_id`** and **`auth_token_id`**. The **lograge** custom options hook copies those four fields into the logged **`params`** hash when set; other routes are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c30cb185225c90b9fc8b208d5b7d16ba1e75243. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->