### PR TITLE
Fix settings username display showing fallback instead of persisted value

### DIFF
--- a/app/presenters/profile_presenter.rb
+++ b/app/presenters/profile_presenter.rb
@@ -30,7 +30,7 @@ class ProfilePresenter
     shared_profile_props(seller_custom_domain_url: nil, request:, as_logged_out_user: true).merge(
       {
         profile_settings: {
-          username: seller.username,
+          username: seller.read_attribute(:username).to_s,
           name: seller.name,
           bio: seller.bio,
           font: seller.seller_profile.font,

--- a/spec/presenters/profile_presenter/profile_settings_props_spec.rb
+++ b/spec/presenters/profile_presenter/profile_settings_props_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe ProfilePresenter do
+  describe "#profile_settings_props" do
+    let(:request) { ActionDispatch::TestRequest.create }
+
+    def create_seller!(username:, email:)
+      seller = User.new(
+        username:,
+        email:,
+        password: "-42Q_.c_3628Ca!mW-xTJ8v*",
+        confirmed_at: Time.current,
+        user_risk_state: "not_reviewed",
+        payment_address: email,
+        current_sign_in_ip: "127.0.0.1",
+        last_sign_in_ip: "127.0.0.1",
+        account_created_ip: "127.0.0.1",
+        pre_signup_affiliate_request_processed: true
+      )
+      seller.skip_enabling_two_factor_authentication = true
+      seller.save!
+      seller
+    end
+
+    def profile_settings_for(seller)
+      described_class.new(pundit_user: SellerContext.new(user: seller, seller:), seller:)
+                     .profile_settings_props(request:)[:profile_settings]
+    end
+
+    it "renders the persisted username, not the fallback username" do
+      seller = create_seller!(username: "tommygkendrick", email: "tx-actor@example.com")
+
+      allow(seller).to receive(:username).and_return("txactorexamplecom")
+
+      expect(profile_settings_for(seller)[:username]).to eq("tommygkendrick")
+    end
+
+    it "renders an empty string when the username is nil" do
+      seller = create_seller!(username: nil, email: "foo@example.com")
+
+      expect(profile_settings_for(seller)[:username]).to eq("")
+    end
+  end
+end


### PR DESCRIPTION
Fixes #419

User#username returns a generated fallback (e.g. `user12345`) when the persisted value is blank. The settings page was showing this fallback in the username input, making it look like the user had a username they never set.

Read `read_attribute(:username).to_s` directly so the field shows the real persisted value (or empty when unset).

## Test
```
bundle exec rspec spec/presenters/profile_presenter/profile_settings_props_spec.rb
# 2 examples, 0 failures
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782388739&installation_id=134400930&pr_number=5288&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5288&signature=a82f3d81c906cf8a748f8d8d17a002db66858c540cb81dd3b27b2c5050fa7a22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single presenter field change for settings display only, with focused specs and no auth or persistence logic changes.
> 
> **Overview**
> Fixes profile settings so the username field shows the **stored** `username` column value instead of `User#username`, which substitutes `external_id` when the column is blank.
> 
> `ProfilePresenter#profile_settings_props` now passes `seller.read_attribute(:username).to_s` into `profile_settings`, so unset usernames appear as an empty string rather than a generated fallback.
> 
> Adds presenter specs covering persisted username vs stubbed fallback behavior and nil username → `""`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da8332af9d6870aeb049229425dc98a70a5f7108. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->