### PR TITLE
Set unique tag per Android push to stop tray collapse

### DIFF
--- a/app/services/push_notification_service/android.rb
+++ b/app/services/push_notification_service/android.rb
@@ -45,7 +45,7 @@ module PushNotificationService
         notification.notification = notification_args
 
         if consumer_app?
-          notification.data = data.merge(tag:, message: title)
+          notification.data = data.merge("tag" => tag, "message" => title)
         end
 
         notification.save!

--- a/app/services/push_notification_service/android.rb
+++ b/app/services/push_notification_service/android.rb
@@ -26,7 +26,8 @@ module PushNotificationService
       end
 
       def send_notification
-        notification_args = { title:, body:, icon: "notification_icon" }.compact
+        tag = notification_tag
+        notification_args = { title:, body:, icon: "notification_icon", tag: }.compact
 
         notification = Rpush::Fcm::Notification.new
         notification.app = app
@@ -37,15 +38,26 @@ module PushNotificationService
         if @sound.present?
           notification.sound = @sound
           notification_args[:channel_id] = "Purchases"
+        else
+          notification_args[:channel_id] = "default"
         end
 
         notification.notification = notification_args
 
         if consumer_app?
-          notification.data = data.merge(message: title)
+          notification.data = data.merge(tag:, message: title)
         end
 
         notification.save!
+      end
+
+      def notification_tag
+        data["tag"].presence ||
+          data["installment_id"].presence ||
+          data["purchase_id"].presence ||
+          data["subscription_id"].presence ||
+          data["follower_id"].presence ||
+          SecureRandom.uuid
       end
 
       def creator_app?

--- a/spec/services/push_notification_service/android_spec.rb
+++ b/spec/services/push_notification_service/android_spec.rb
@@ -29,7 +29,7 @@ describe PushNotificationService::Android do
         expect(notification).to receive(:notification=).with(
           { title: title, body: body, icon: "notification_icon", tag: "abcd1234", channel_id: "Purchases" }
         )
-        expect(notification).to receive(:data=).with({ "purchase_id" => "abcd1234", tag: "abcd1234", message: title })
+        expect(notification).to receive(:data=).with({ "purchase_id" => "abcd1234", "tag" => "abcd1234", "message" => title })
         expect(notification).to receive(:save!)
 
         PushNotificationService::Android.new(device_token: device_token, title: title, body: body, data: data, app_type: Device::APP_TYPES[:consumer], sound: sound).process
@@ -55,7 +55,7 @@ describe PushNotificationService::Android do
         expect(notification).to receive(:notification=).with(
           { title: title, body: body, icon: "notification_icon", tag: "post-xyz", channel_id: "default" }
         )
-        expect(notification).to receive(:data=).with({ "installment_id" => "post-xyz", tag: "post-xyz", message: title })
+        expect(notification).to receive(:data=).with({ "installment_id" => "post-xyz", "tag" => "post-xyz", "message" => title })
         expect(notification).to receive(:save!)
 
         PushNotificationService::Android.new(device_token: device_token, title: title, body: body, data: data, app_type: Device::APP_TYPES[:consumer]).process
@@ -91,27 +91,27 @@ describe PushNotificationService::Android do
       it "prefers an explicit data['tag']" do
         payload = capture_payload(data: { "tag" => "explicit", "installment_id" => "fallback" })
         expect(payload[:notification][:tag]).to eq("explicit")
-        expect(payload[:data][:tag]).to eq("explicit")
+        expect(payload[:data]["tag"]).to eq("explicit")
       end
 
       it "uses installment_id when no explicit tag is set" do
         payload = capture_payload(data: { "installment_id" => "post-1", "purchase_id" => "buy-1" })
         expect(payload[:notification][:tag]).to eq("post-1")
-        expect(payload[:data][:tag]).to eq("post-1")
+        expect(payload[:data]["tag"]).to eq("post-1")
       end
 
       it "falls back through purchase_id, subscription_id, follower_id" do
-        expect(capture_payload(data: { "purchase_id" => "p1" })[:data][:tag]).to eq("p1")
-        expect(capture_payload(data: { "subscription_id" => "s1" })[:data][:tag]).to eq("s1")
-        expect(capture_payload(data: { "follower_id" => "f1" })[:data][:tag]).to eq("f1")
+        expect(capture_payload(data: { "purchase_id" => "p1" })[:data]["tag"]).to eq("p1")
+        expect(capture_payload(data: { "subscription_id" => "s1" })[:data]["tag"]).to eq("s1")
+        expect(capture_payload(data: { "follower_id" => "f1" })[:data]["tag"]).to eq("f1")
       end
 
       it "generates unique tags per message when no identifier is provided" do
         first = capture_payload(data: {})
         second = capture_payload(data: {})
-        expect(first[:data][:tag]).to be_present
-        expect(second[:data][:tag]).to be_present
-        expect(first[:data][:tag]).not_to eq(second[:data][:tag])
+        expect(first[:data]["tag"]).to be_present
+        expect(second[:data]["tag"]).to be_present
+        expect(first[:data]["tag"]).not_to eq(second[:data]["tag"])
       end
 
       it "emits distinct tags for two news-update pushes about different installments" do
@@ -119,7 +119,7 @@ describe PushNotificationService::Android do
         second = capture_payload(data: { "installment_id" => "post-b" })
         expect(first[:notification][:tag]).to eq("post-a")
         expect(second[:notification][:tag]).to eq("post-b")
-        expect(first[:data][:tag]).not_to eq(second[:data][:tag])
+        expect(first[:data]["tag"]).not_to eq(second[:data]["tag"])
       end
     end
   end

--- a/spec/services/push_notification_service/android_spec.rb
+++ b/spec/services/push_notification_service/android_spec.rb
@@ -9,7 +9,7 @@ describe PushNotificationService::Android do
 
   describe "consumer app" do
     context "when notification sound is passed" do
-      it "creates a FCM notification with sound" do
+      it "creates a FCM notification with sound and the Purchases channel" do
         app = double("fcm_app")
         allow(PushNotificationService::Android).to receive(:consumer_app).and_return(app)
 
@@ -17,6 +17,7 @@ describe PushNotificationService::Android do
         title = "Test"
         body = "Test body"
         sound = Device::NOTIFICATION_SOUNDS[:sale]
+        data = { "purchase_id" => "abcd1234" }
 
         notification = double("fcm_notification")
         expect(Rpush::Fcm::Notification).to receive(:new).and_return(notification)
@@ -25,22 +26,25 @@ describe PushNotificationService::Android do
         expect(notification).to receive(:device_token=).with(device_token)
         expect(notification).to receive(:content_available=).with(true)
         expect(notification).to receive(:sound=).with(sound)
-        expect(notification).to receive(:notification=).with({ title: title, body: body, icon: "notification_icon", channel_id: "Purchases" })
-        expect(notification).to receive(:data=).with({ message: title })
+        expect(notification).to receive(:notification=).with(
+          { title: title, body: body, icon: "notification_icon", tag: "abcd1234", channel_id: "Purchases" }
+        )
+        expect(notification).to receive(:data=).with({ "purchase_id" => "abcd1234", tag: "abcd1234", message: title })
         expect(notification).to receive(:save!)
 
-        PushNotificationService::Android.new(device_token: device_token, title: title, body: body, app_type: Device::APP_TYPES[:consumer], sound: sound).process
+        PushNotificationService::Android.new(device_token: device_token, title: title, body: body, data: data, app_type: Device::APP_TYPES[:consumer], sound: sound).process
       end
     end
 
     context "when notification sound is not passed" do
-      it "creates a FCM notification without sound" do
+      it "creates a FCM notification without sound and the default channel" do
         app = double("fcm_app")
         allow(PushNotificationService::Android).to receive(:consumer_app).and_return(app)
 
         device_token = "ABC"
         title = "Test"
         body = "Test body"
+        data = { "installment_id" => "post-xyz" }
 
         notification = double("fcm_notification")
         expect(Rpush::Fcm::Notification).to receive(:new).and_return(notification)
@@ -48,12 +52,85 @@ describe PushNotificationService::Android do
         expect(notification).to receive(:alert=).with(title)
         expect(notification).to receive(:device_token=).with(device_token)
         expect(notification).to receive(:content_available=).with(true)
-        expect(notification).to receive(:notification=).with({ title: title, body: body, icon: "notification_icon" })
-        expect(notification).to receive(:data=).with({ message: title })
+        expect(notification).to receive(:notification=).with(
+          { title: title, body: body, icon: "notification_icon", tag: "post-xyz", channel_id: "default" }
+        )
+        expect(notification).to receive(:data=).with({ "installment_id" => "post-xyz", tag: "post-xyz", message: title })
         expect(notification).to receive(:save!)
 
-        PushNotificationService::Android.new(device_token: device_token, title: title, body: body, app_type: Device::APP_TYPES[:consumer]).process
+        PushNotificationService::Android.new(device_token: device_token, title: title, body: body, data: data, app_type: Device::APP_TYPES[:consumer]).process
       end
+    end
+
+    describe "tag derivation" do
+      let(:device_token) { "ABC" }
+      let(:title) { "Test" }
+      let(:body) { "Test body" }
+
+      def capture_payload(data:)
+        captured = {}
+        notification = instance_double(Rpush::Fcm::Notification)
+        allow(notification).to receive(:app=)
+        allow(notification).to receive(:alert=)
+        allow(notification).to receive(:device_token=)
+        allow(notification).to receive(:content_available=)
+        allow(notification).to receive(:sound=)
+        allow(notification).to receive(:notification=) { |args| captured[:notification] = args }
+        allow(notification).to receive(:data=) { |args| captured[:data] = args }
+        allow(notification).to receive(:save!)
+        allow(Rpush::Fcm::Notification).to receive(:new).and_return(notification)
+        allow(PushNotificationService::Android).to receive(:consumer_app).and_return(double("fcm_app"))
+
+        PushNotificationService::Android.new(
+          device_token: device_token, title: title, body: body, data: data, app_type: Device::APP_TYPES[:consumer]
+        ).process
+
+        captured
+      end
+
+      it "prefers an explicit data['tag']" do
+        payload = capture_payload(data: { "tag" => "explicit", "installment_id" => "fallback" })
+        expect(payload[:notification][:tag]).to eq("explicit")
+        expect(payload[:data][:tag]).to eq("explicit")
+      end
+
+      it "uses installment_id when no explicit tag is set" do
+        payload = capture_payload(data: { "installment_id" => "post-1", "purchase_id" => "buy-1" })
+        expect(payload[:notification][:tag]).to eq("post-1")
+        expect(payload[:data][:tag]).to eq("post-1")
+      end
+
+      it "falls back through purchase_id, subscription_id, follower_id" do
+        expect(capture_payload(data: { "purchase_id" => "p1" })[:data][:tag]).to eq("p1")
+        expect(capture_payload(data: { "subscription_id" => "s1" })[:data][:tag]).to eq("s1")
+        expect(capture_payload(data: { "follower_id" => "f1" })[:data][:tag]).to eq("f1")
+      end
+
+      it "generates unique tags per message when no identifier is provided" do
+        first = capture_payload(data: {})
+        second = capture_payload(data: {})
+        expect(first[:data][:tag]).to be_present
+        expect(second[:data][:tag]).to be_present
+        expect(first[:data][:tag]).not_to eq(second[:data][:tag])
+      end
+
+      it "emits distinct tags for two news-update pushes about different installments" do
+        first = capture_payload(data: { "installment_id" => "post-a" })
+        second = capture_payload(data: { "installment_id" => "post-b" })
+        expect(first[:notification][:tag]).to eq("post-a")
+        expect(second[:notification][:tag]).to eq("post-b")
+        expect(first[:data][:tag]).not_to eq(second[:data][:tag])
+      end
+    end
+  end
+
+  describe "creator app" do
+    it "does not send a notification" do
+      expect(Rpush::Fcm::Notification).not_to receive(:new)
+
+      PushNotificationService::Android.new(
+        device_token: "ABC", title: "Test", body: "Body", app_type: Device::APP_TYPES[:creator]
+      ).process
     end
   end
 end


### PR DESCRIPTION
## What

When the consumer Android app received multiple pending news-update push notifications, tapping any one of them appeared to clear all of the others. This PR fixes the dispatcher so each FCM message carries a stable, unique Android notification tag.

Changes in `app/services/push_notification_service/android.rb`:

- Derive a `tag` from the data payload — `installment_id` for posts, then falling through `purchase_id` → `subscription_id` → `follower_id`, with `SecureRandom.uuid` as a last-resort fallback so we never emit a payload without a tag.
- Inject the tag into **both** spots that matter on Android:
  - `android.notification.tag` (background path — Firebase SDK auto-displays from the system tray).
  - `data["tag"]` (foreground path — `expo-notifications`' `FirebaseMessagingDelegate` reads it as the notification identifier; see `node_modules/expo-notifications/.../FirebaseMessagingDelegate.kt:128-130`).
- Set `channel_id` explicitly to match the channels the consumer app declares in `components/use-push-notifications.ts:48-58`: `default` for news updates, `Purchases` (existing) for sale pings.

## Why

The buyer report came in via Helper (https://help.gumroad.com/all?id=4f6ad9fcb90a01bce65aa80c8c188297) and was filed in the mobile repo as antiwork/gumroad-mobile#257 (sub-bug 1b).

Two relevant facts about Android delivery in this stack:

1. The consumer app registers a **native FCM token** (`Notifications.getDevicePushTokenAsync()` — not `getExpoPushTokenAsync`), and the backend dispatches via Rpush FCM directly. There is no Expo Push HTTP API in the loop.
2. On Android, when the FCM payload includes a `notification` block, the system displays it directly while the app is in the background — `onMessageReceived` is **not** called. The system uses `android.notification.tag` to dedupe/replace; if it's unset, multiple pending pings can collapse into a single tray slot. So what the buyer saw as "all cleared" was actually a single replaced notification — tapping it dismissed the only thing visible. Hypothesis A from the investigation.

When the app *is* in the foreground, `ExpoFirebaseMessagingService.onMessageReceived` fires and the delegate keys the notification identifier off `remoteMessage.data["tag"] ?? messageId ?? UUID` — and `ExpoPresentationDelegate.getNotifyId` returns a constant. So `data["tag"]` is the other field that matters. Setting both covers both delivery paths.

Stable identifiers (e.g. `installment.external_id`) mean two pushes about different posts get distinct tray slots, while a re-delivery of the same post replaces cleanly instead of stacking.


---

AI disclosure: drafted with Claude Opus 4.7 (1M context).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782391659&installation_id=134400930&pr_number=5289&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5289&signature=56541826acb8149c32ddaa44e2dc90b478237d0c3ccb9a54da9be36e285807c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to consumer Android push payload shaping; no auth or payment logic, with behavior covered by expanded service specs.
> 
> **Overview**
> Consumer Android FCM pushes now include a **stable `tag`** on both the system notification payload and `data["tag"]`, derived from explicit `data["tag"]` or entity ids (`installment_id`, `purchase_id`, etc., else a random UUID). That stops unrelated notifications from collapsing into one tray slot (and fixes the “tapping one clears the rest” behavior).
> 
> Non-sale pushes also set **`channel_id` to `default`** when no sound is present (sale pings still use `Purchases`). Specs cover tag precedence, per-message uniqueness, channel/tag expectations, and that creator app still skips FCM.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 849b2665c78223df793944ab464cbd2f610f57aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->