### PR TITLE
Stagger LargeSellersUpdateUserBalanceStatsCacheWorker fanout over 1 hour

### DIFF
--- a/app/sidekiq/large_sellers_update_user_balance_stats_cache_worker.rb
+++ b/app/sidekiq/large_sellers_update_user_balance_stats_cache_worker.rb
@@ -5,6 +5,7 @@ class LargeSellersUpdateUserBalanceStatsCacheWorker
   sidekiq_options retry: 1, queue: :low
 
   STAGGER_WINDOW = 1.hour
+  PUSH_BULK_BATCH_SIZE = 1_000
 
   def perform
     user_ids = UserBalanceStatsService.cacheable_users.pluck(:id)
@@ -13,10 +14,13 @@ class LargeSellersUpdateUserBalanceStatsCacheWorker
     delay_step = STAGGER_WINDOW.to_f / user_ids.size
     base_time = Time.current.to_f
 
-    Sidekiq::Client.push_bulk(
-      "class" => UpdateUserBalanceStatsCacheWorker,
-      "args" => user_ids.map { |id| [id] },
-      "at" => user_ids.each_index.map { |i| base_time + (i * delay_step) },
-    )
+    user_ids.each_slice(PUSH_BULK_BATCH_SIZE).with_index do |slice, chunk_index|
+      offset = chunk_index * PUSH_BULK_BATCH_SIZE
+      Sidekiq::Client.push_bulk(
+        "class" => UpdateUserBalanceStatsCacheWorker,
+        "args" => slice.map { |id| [id] },
+        "at" => slice.each_index.map { |i| base_time + ((offset + i) * delay_step) },
+      )
+    end
   end
 end

--- a/app/sidekiq/large_sellers_update_user_balance_stats_cache_worker.rb
+++ b/app/sidekiq/large_sellers_update_user_balance_stats_cache_worker.rb
@@ -4,12 +4,19 @@ class LargeSellersUpdateUserBalanceStatsCacheWorker
   include Sidekiq::Job
   sidekiq_options retry: 1, queue: :low
 
+  STAGGER_WINDOW = 1.hour
+
   def perform
-    user_ids = UserBalanceStatsService.cacheable_users.pluck(:id).map { |el| [el] }
+    user_ids = UserBalanceStatsService.cacheable_users.pluck(:id)
+    return if user_ids.empty?
+
+    delay_step = STAGGER_WINDOW.to_f / user_ids.size
+    base_time = Time.current.to_f
 
     Sidekiq::Client.push_bulk(
       "class" => UpdateUserBalanceStatsCacheWorker,
-      "args" => user_ids,
+      "args" => user_ids.map { |id| [id] },
+      "at" => user_ids.each_index.map { |i| base_time + (i * delay_step) },
     )
   end
 end

--- a/spec/sidekiq/large_sellers_update_user_balance_stats_cache_worker_spec.rb
+++ b/spec/sidekiq/large_sellers_update_user_balance_stats_cache_worker_spec.rb
@@ -8,8 +8,31 @@ describe LargeSellersUpdateUserBalanceStatsCacheWorker do
       ids = create_list(:user, 2).map(&:id)
       expect(UserBalanceStatsService).to receive(:cacheable_users).and_return(User.where(id: ids))
       described_class.new.perform
-      expect(UpdateUserBalanceStatsCacheWorker).to have_enqueued_sidekiq_job(ids[0])
-      expect(UpdateUserBalanceStatsCacheWorker).to have_enqueued_sidekiq_job(ids[1])
+      expect(UpdateUserBalanceStatsCacheWorker.jobs.size).to eq(2)
+      enqueued_ids = UpdateUserBalanceStatsCacheWorker.jobs.map { |job| job["args"].first }
+      expect(enqueued_ids).to match_array(ids)
+    end
+
+    it "staggers the enqueued jobs evenly across STAGGER_WINDOW" do
+      ids = create_list(:user, 4).map(&:id)
+      expect(UserBalanceStatsService).to receive(:cacheable_users).and_return(User.where(id: ids))
+
+      freeze_time do
+        described_class.new.perform
+
+        scheduled_times = UpdateUserBalanceStatsCacheWorker.jobs.map { |job| job["at"] }.sort
+        expected_step = described_class::STAGGER_WINDOW.to_f / ids.size
+        gaps = scheduled_times.each_cons(2).map { |a, b| b - a }
+
+        expect(scheduled_times.first).to be_within(0.01).of(Time.current.to_f)
+        expect(gaps).to all(be_within(0.01).of(expected_step))
+      end
+    end
+
+    it "does nothing when there are no cacheable users" do
+      expect(UserBalanceStatsService).to receive(:cacheable_users).and_return(User.none)
+      described_class.new.perform
+      expect(UpdateUserBalanceStatsCacheWorker.jobs).to be_empty
     end
   end
 end


### PR DESCRIPTION
## What

`LargeSellersUpdateUserBalanceStatsCacheWorker#perform` now spreads its child `UpdateUserBalanceStatsCacheWorker` enqueues linearly across a 1 hour window instead of pushing all of them in at the same instant.

Implementation: `Sidekiq::Client.push_bulk` accepts a per-job `at:` array, so the bulk push is preserved but each child job gets a scheduled execution time `(i / N) * STAGGER_WINDOW` seconds in the future.

## Why

Pingdom alerted on a 502 at `2026-05-26T10:07:29` UTC. The 10:00 UTC slot is shared by:
- `LargeSellersUpdateUserBalanceStatsCacheWorker` (daily)
- `PerformPayoutsUpToDelayDaysAgoWorker` for cross-border Stripe (Tue weekly)
- `CalculateSaleNumbersWorker` (Tue weekly, ~40min)
- `RemoveDeletedFilesFromS3Job` (daily)
- `TriggerCommunityChatRecapRunJob` (daily)

Root cause chain on the master/replica DB:
1. `push_bulk` with no `at:` enqueued ~thousand `UpdateUserBalanceStatsCacheWorker` jobs simultaneously
2. Each child runs `UserBalanceStatsService#generate`, which calls `user.unpaid_balance_cents`, `user.sales_cents_total(after: …)`, etc — multiple SUM aggregations on `purchases` per user
3. Sidekiq workers consumed the jobs in parallel, opening many DB connections; replica connection pool went 39 → 499 (capped at `max_connections`)
4. The same `SUM(purchases.price_cents)` pattern was the top query on the master at the same time (`load 28.79`, top wait event `wait/io/file/innodb/innodb_data_file = 87.63`, `DiskQueueDepth` 2 → 71)
5. Web requests stalled on `ActiveRecord` connection checkout → 502

The previous fix (PR #5251) moved this worker from 08:00 → 10:00 UTC to dodge the daily payouts job. That treated the symptom — the 10:00 slot turned out to be its own contention zone, especially on Tuesdays. The structural problem is the unbounded burst, not the start minute, so this PR throttles the fanout itself.

With ~thousand large sellers and a 1 hour window, child jobs now start ~3.6 s apart (~17/min) instead of all at once. The parent worker still completes in <1 s (it just enqueues), so the cron-tier impact is unchanged. The misleading `# Duration: <1sec` comment in `config/sidekiq_schedule.yml` still applies to the parent and is left as-is.

Considered alternatives:
- **Pick another slot.** Cheap, but the next collision is just waiting for whichever other big job lives there.
- **`sidekiq-throttled` concurrency cap.** Would also work, but adds a gem dependency for a problem solvable with two extra lines.

## Before/After

Non-user-facing — no UI video applicable. The behavioral diff is the queue insertion pattern; see the spec assertions below for the new contract.

## Test Results

```
$ bundle exec rspec spec/sidekiq/large_sellers_update_user_balance_stats_cache_worker_spec.rb
LargeSellersUpdateUserBalanceStatsCacheWorker
  #perform
    queues a job for each cacheable user
    staggers the enqueued jobs evenly across STAGGER_WINDOW
    does nothing when there are no cacheable users

Finished in 0.327 seconds (files took 8.12 seconds to load)
3 examples, 0 failures
```

QA steps for staging:
- [ ] Trigger `LargeSellersUpdateUserBalanceStatsCacheWorker.perform_async` manually
- [ ] Confirm in Sidekiq Web UI that `UpdateUserBalanceStatsCacheWorker` jobs land in the Scheduled set with `at:` timestamps spread up to 1 hour ahead (not all immediately in the `low` queue)
- [ ] Spot-check a few entries to verify the spacing matches `STAGGER_WINDOW / N`

---

🤖 Generated with [Claude Opus 4.7 (1M context)](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782397571&installation_id=134400930&pr_number=5290&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5290&signature=8e5dd500eb1c5ff68f5a1cb07bb35f26d03b0e5d8ed25274c2ad50def2ad1ed4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Operational throttling of background enqueue timing only; no auth, payment, or user-facing API changes.
> 
> **Overview**
> **`LargeSellersUpdateUserBalanceStatsCacheWorker`** no longer enqueues every **`UpdateUserBalanceStatsCacheWorker`** at once. Child jobs are scheduled with **`Sidekiq::Client.push_bulk`** and a per-job **`at:`** array so work is spread evenly over **`STAGGER_WINDOW` (1 hour)**, with **`PUSH_BULK_BATCH_SIZE` (1,000)** slices and an early exit when there are no cacheable users.
> 
> Specs now assert job count and IDs, even spacing of scheduled times, and the empty-user no-op.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f46f4262ba89e87c9c52f1f2f1931d2e7fdb3b8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->