### PR TITLE
Fix blank Admin::Users::Show for accounts with no email

### DIFF
--- a/app/javascript/components/Admin/Users/ChangeEmail.tsx
+++ b/app/javascript/components/Admin/Users/ChangeEmail.tsx
@@ -28,7 +28,12 @@ const AdminUserChangeEmail = ({ user }: AdminUserChangeEmailProps) => (
         {(isLoading) => (
           <Fieldset>
             <div className="grid grid-cols-[1fr_auto] gap-3">
-              <Input type="email" name="update_email[email_address]" placeholder={user.email} required />
+              <Input
+                type="email"
+                name="update_email[email_address]"
+                placeholder={user.email ?? "No email on file"}
+                required
+              />
               <Button type="submit" disabled={isLoading}>
                 {isLoading ? "Updating..." : "Update email"}
               </Button>

--- a/app/javascript/components/Admin/Users/User.tsx
+++ b/app/javascript/components/Admin/Users/User.tsx
@@ -65,15 +65,15 @@ export type RecentEfw = {
 
 export type User = {
   external_id: string;
-  email: string;
+  email: string | null;
   support_email?: string | null;
   name: string | null;
   avatar_url: string;
   username: string;
   profile_url: string;
-  form_email: string;
+  form_email: string | null;
   blocked_by_form_email_object: PlatformBlock | null;
-  form_email_domain: string;
+  form_email_domain: string | null;
   blocked_by_form_email_domain_object: PlatformBlock | null;
   subdomain_with_protocol: string;
   custom_fee_per_thousand: number | null;

--- a/spec/presenters/admin/user_presenter/card_spec.rb
+++ b/spec/presenters/admin/user_presenter/card_spec.rb
@@ -47,6 +47,21 @@ describe Admin::UserPresenter::Card do
       end
     end
 
+    describe "email fields when user has no email" do
+      let(:user) do
+        user = create(:user, provider: :twitter, twitter_user_id: "123", twitter_handle: "throwaway")
+        user.update_columns(email: nil, unconfirmed_email: nil)
+        user.reload
+      end
+
+      it "returns nil for email-derived fields without raising" do
+        expect(props[:email]).to be_nil
+        expect(props[:form_email]).to be_nil
+        expect(props[:form_email_domain]).to be_nil
+        expect(props[:support_email]).to be_nil
+      end
+    end
+
     describe "blocking information" do
       context "when user is not blocked by form_email" do
         it "returns nil for blocked_by_form_email_object" do


### PR DESCRIPTION
## What

`/admin/users/<id>` renders an empty page for users whose `email` is `NULL`. The Inertia page (`app/javascript/pages/Admin/Users/Show.tsx`) calls `typia.assert<PageProps>` on the props passed in by `Admin::UserPresenter::Card`. The TS `User` type declares `email`, `form_email`, and `form_email_domain` as non-nullable `string`, but the presenter passes through whatever `user.form_email` returns — which is `nil` when both `email` and `unconfirmed_email` are nil. `typia.assert` throws, React renders nothing, and support is left without a way to manage the account in the admin UI.

This only affects the Inertia admin page; the CLI admin path is unaffected because it doesn't go through the React component.

## Why

Widening the schema is the minimum-scope fix that restores the admin page for these accounts. The TypeScript type is the only thing claiming these fields are non-nullable — the backend has always treated them as nullable, and the underlying `users.email` column is nullable.

The root cause of the NULL emails themselves (some OAuth providers don't populate `email` on signup) is a separate, larger change tracked in the linked issue. Fixing the admin UI is a prerequisite to triaging those accounts at all.

## Changes

- `app/javascript/components/Admin/Users/User.tsx`: widen `email`, `form_email`, `form_email_domain` to `string | null`.
- `app/javascript/components/Admin/Users/ChangeEmail.tsx`: fall back to a placeholder string when `user.email` is null so the form input renders.
- `spec/presenters/admin/user_presenter/card_spec.rb`: add a regression case asserting the presenter returns nil for email fields when the user has no email, without raising.

## Test plan

- [x] `bundle exec rspec spec/presenters/admin/user_presenter/card_spec.rb` (13 examples, 0 failures)
- [x] `npx eslint` against the changed and adjacent admin user components (clean)
- [ ] Reviewer: load `/admin/users/<id>` against a NULL-email account in a preview app and confirm the page renders with the email block hidden and the rest of the user card intact

## Related

Refs antiwork/gumroad-private#418

---

AI disclosure: drafted with Claude Opus 4.7.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type/schema alignment and a UI placeholder only; no auth, payout, or email-update API behavior changes in this diff.
> 
> **Overview**
> Fixes a **blank** `/admin/users/:id` Inertia page when a user has no `email` / `unconfirmed_email`. The presenter already sent `nil` for email-related fields, but the admin `User` type required non-null strings, so **`typia.assert` on page props threw** and React rendered nothing.
> 
> The PR **aligns TypeScript with the backend** by typing `email`, `form_email`, and `form_email_domain` as `string | null`, and uses a **"No email on file"** placeholder on the change-email input when `user.email` is null. A presenter spec asserts nil email fields for OAuth-style users without raising.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b7c4bb58121caa06c29c56816eccb96f94e9658. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782413962&installation_id=134400930&pr_number=5291&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5291&signature=3dc74a851ee3fda7b1dddc5e10002295bbfbbdf25960bbbce486ddaefd0939b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->