### PR TITLE
Disable password-manager autofill on profile username field

### DIFF
--- a/app/javascript/pages/Settings/Profile/Show.tsx
+++ b/app/javascript/pages/Settings/Profile/Show.tsx
@@ -115,6 +115,10 @@ export default function SettingsPage() {
               <Input
                 id={`${uid}-username`}
                 type="text"
+                autoComplete="off"
+                data-1p-ignore="true"
+                data-lpignore="true"
+                data-form-type="other"
                 disabled={!loggedInUser?.policies.settings_profile.update_username}
                 value={profileSettings.username}
                 onChange={(evt) =>


### PR DESCRIPTION
Fixes antiwork/gumroad-private#419

## What

The username field on **Settings → Profile** could be overwritten by password-manager autofill. When a manager filled the saved login (an email) into the field, its `onChange` handler stripped the non-alphanumeric characters — e.g. `you@example.com` → `youexamplecom` — so sellers saw a username they never set and a "View your profile at" link to a storefront that doesn't exist.

This marks the field as not-autofillable: `autoComplete="off"` plus the documented opt-outs for 1Password (`data-1p-ignore`), LastPass (`data-lpignore`), and Dashlane (`data-form-type="other"`).

## Why

The value looked broken, but storefronts kept working fine. Sellers thought their public URL had changed. The bug only affects what you see on screen; the username in the database is correct.

`autoComplete="off"` alone isn't enough: 1Password and others use `autocomplete` only to identify fields, not to decide whether to fill, so each manager needs its own opt-out. A username is a public handle, so managers should never target it. (A prior change, #5288, only affected the blank-username case and didn't address this.)

---

This PR was implemented with AI assistance using Claude Opus 4.7.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single UI attribute change on one settings field; no auth, API, or persistence changes.
> 
> **Overview**
> Adds **autofill and password-manager opt-outs** on the Settings → Profile **username** `Input` (`autoComplete="off"` plus 1Password, LastPass, and Dashlane data attributes) so saved logins are not injected into a field that **sanitizes** input to lowercase alphanumeric-only—avoiding misleading on-screen usernames and storefront preview links without changing save logic or stored values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b05a3de32b1434202df6a3c51811f425f3052b11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->