### PR TITLE
Hide the Rent option on rentable products with no rental price

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -667,7 +667,12 @@ class Link < ApplicationRecord
   end
 
   def rental
-    purchase_type != "buy_only" ? { price_cents: rental_price_cents, rent_only: purchase_type == "rent_only" } : nil
+    return unless rentable?
+
+    price_cents = rental_price_cents
+    return if price_cents.nil?
+
+    { price_cents:, rent_only: rent_only? }
   end
 
   def is_legacy_subscription?

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -645,8 +645,15 @@ describe Link, :vcr do
         expect(product.rental).to eq(price_cents: 200, rent_only: false)
       end
 
-      it "returns nil for a rentable product with no rental price" do
+      it "returns nil for a buy-and-rent product with no rental price" do
         product = create(:product, purchase_type: :buy_and_rent, rental_price_cents: 200)
+        product.prices.alive.is_rental.each(&:mark_deleted!)
+
+        expect(product.reload.rental).to be_nil
+      end
+
+      it "returns nil for a rent-only product with no rental price" do
+        product = create(:product, purchase_type: :rent_only, rental_price_cents: 300)
         product.prices.alive.is_rental.each(&:mark_deleted!)
 
         expect(product.reload.rental).to be_nil

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -629,6 +629,30 @@ describe Link, :vcr do
       end
     end
 
+    describe "#rental" do
+      it "returns nil for a buy-only product" do
+        product = create(:product, purchase_type: :buy_only)
+        expect(product.rental).to be_nil
+      end
+
+      it "returns the price and rent_only flag for a rent-only product" do
+        product = create(:product, purchase_type: :rent_only, rental_price_cents: 300)
+        expect(product.rental).to eq(price_cents: 300, rent_only: true)
+      end
+
+      it "returns the price and rent_only flag for a buy-and-rent product" do
+        product = create(:product, purchase_type: :buy_and_rent, rental_price_cents: 200)
+        expect(product.rental).to eq(price_cents: 200, rent_only: false)
+      end
+
+      it "returns nil for a rentable product with no rental price" do
+        product = create(:product, purchase_type: :buy_and_rent, rental_price_cents: 200)
+        product.prices.alive.is_rental.each(&:mark_deleted!)
+
+        expect(product.reload.rental).to be_nil
+      end
+    end
+
     describe "adding to profile sections" do
       it "adds newly created products to all sections that have add_new_products set" do
         seller = create(:user)

--- a/spec/requests/purchases/product/rentals_spec.rb
+++ b/spec/requests/purchases/product/rentals_spec.rb
@@ -109,6 +109,19 @@ describe("Rentals from product page", type: :system, js: true) do
       expect(UrlRedirect.last.is_rental).to be(true)
     end
 
+    it "hides the rent/buy toggle and still allows buying when a buy_and_rent product has no rental price" do
+      @product.prices.alive.is_rental.each(&:mark_deleted!)
+
+      visit "/l/#{@product.unique_permalink}"
+
+      expect(page).to have_selector("h1", text: "rental test")
+      expect(page).to_not have_radio_button("Rent")
+      expect(page).to_not have_radio_button("Buy")
+
+      add_to_cart(@product)
+      expect(page).to have_cart_item(@product.name)
+    end
+
     describe "rentals and vat" do
       before do
         allow_any_instance_of(ActionDispatch::Request).to receive(:remote_ip).and_return("2.47.255.255") # Italy


### PR DESCRIPTION
Ref antiwork/gumroad-private#421 (narrow fix)

## What

`Link#rental` advertised a rental option for any product whose `purchase_type` isn't `buy_only`, even when the product has no rental price. On the storefront that rendered a "Rent" radio priced at the seller's currency-zero (e.g. A$0) next to "Buy".

Now `Link#rental` returns `nil` when there's no usable rental price, so the rent/buy toggle is omitted and the product behaves as a normal purchase. It still returns the rental details for products that do have a price, so working rentals are unchanged.

## Why

Rentals are soft-deprecated. The product editor no longer exposes a rental price input, so a seller whose product lost its rental price has no way to fix it. A small number of legacy `buy_and_rent` products are in exactly this state and were showing buyers a free, unintended rental.

---

This PR was implemented with AI assistance using Claude Opus 4.7.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782419920&installation_id=134400930&pr_number=5293&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5293&signature=d89db59239476f64c54c8842f4be3776bb4d48ba2f31860f2f04082ed657b585"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to product JSON/rental presentation with broad test coverage; purchase flows for valid rentals are unchanged.
> 
> **Overview**
> **`Link#rental`** no longer exposes rental metadata whenever `purchase_type` isn’t buy-only. It now returns **`nil`** unless the product is **`rentable?`** and has a non-**`nil`** **`rental_price_cents`**, so storefront/API consumers omit the rent/buy toggle instead of showing a zero-priced rent option.
> 
> When rental data is present, the payload still includes **`price_cents`** and **`rent_only`**, now driven by **`rent_only?`** rather than comparing **`purchase_type`** to **`rent_only`**.
> 
> Specs cover **`#rental`** for buy-only, rent-only, buy-and-rent, and missing rental prices, plus a request example that hides Rent/Buy radios but still allows a normal purchase when rental prices were removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8741e23a602c27348d9c37f17e11644729f12b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->