### PR TITLE
Temporarily disable Rack::Attack throttles on Gumroad Walks endpoints

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -140,20 +140,25 @@ class Rack::Attack
     #
     # Both `/api/v2/walks/...` (gumroad.com) and `/v2/walks/...` (api.gumroad.com)
     # need throttles since `api_routes` is mounted under both prefixes.
-    throttle_by_ip path: "/api/v2/walks/realtime_tokens", method: :post, requests: 5, period: 1.hour, max_level: 1
-    throttle_by_ip path: "/v2/walks/realtime_tokens",     method: :post, requests: 5, period: 1.hour, max_level: 1
-    throttle_by_ip path: "/api/v2/walks/synthesis",       method: :post, requests: 5, period: 1.hour, max_level: 1
-    throttle_by_ip path: "/v2/walks/synthesis",           method: :post, requests: 5, period: 1.hour, max_level: 1
+    # Temporarily relaxed while debugging the App Attest reinstall flow, where a
+    # fresh install can burn the 3/hr attestation cap during repeated testing
+    # and get a 429 the client surfaces as "attestation rejected." Restored in a
+    # follow-up once the reinstall bug is fixed — these cap OpenAI/Anthropic
+    # spend and prevent attested-key fan-out.
+    # throttle_by_ip path: "/api/v2/walks/realtime_tokens", method: :post, requests: 5, period: 1.hour, max_level: 1
+    # throttle_by_ip path: "/v2/walks/realtime_tokens",     method: :post, requests: 5, period: 1.hour, max_level: 1
+    # throttle_by_ip path: "/api/v2/walks/synthesis",       method: :post, requests: 5, period: 1.hour, max_level: 1
+    # throttle_by_ip path: "/v2/walks/synthesis",           method: :post, requests: 5, period: 1.hour, max_level: 1
 
     # App Attest bootstrap. `attestations` is genuinely once-per-install on the
     # happy path; cap at 3/IP/hr so a single corporate NAT can recover from
     # transient failures but a botnet can't fan out attested keys.
     # `challenges` is one-per-request on every walks call + once per
     # attestation, so it needs more headroom.
-    throttle_by_ip path: "/api/v2/walks/app_attest/attestations", method: :post, requests: 3,  period: 1.hour, max_level: 1
-    throttle_by_ip path: "/v2/walks/app_attest/attestations",     method: :post, requests: 3,  period: 1.hour, max_level: 1
-    throttle_by_ip path: "/api/v2/walks/app_attest/challenges",   method: :post, requests: 60, period: 1.hour, max_level: 1
-    throttle_by_ip path: "/v2/walks/app_attest/challenges",       method: :post, requests: 60, period: 1.hour, max_level: 1
+    # throttle_by_ip path: "/api/v2/walks/app_attest/attestations", method: :post, requests: 3,  period: 1.hour, max_level: 1
+    # throttle_by_ip path: "/v2/walks/app_attest/attestations",     method: :post, requests: 3,  period: 1.hour, max_level: 1
+    # throttle_by_ip path: "/api/v2/walks/app_attest/challenges",   method: :post, requests: 60, period: 1.hour, max_level: 1
+    # throttle_by_ip path: "/v2/walks/app_attest/challenges",       method: :post, requests: 60, period: 1.hour, max_level: 1
   end
 
   throttle_by_ip path: "/",                               requests: 60, period: 30.seconds # Initial: 120rpm, Max: 600 requests/9 hours


### PR DESCRIPTION
## What

Comments out the eight Rack::Attack throttle rules scoped to the Gumroad Walks endpoints in `config/initializers/rack_attack.rb`:

- `/api/v2/walks/realtime_tokens` + `/v2/walks/realtime_tokens` (5/hr)
- `/api/v2/walks/synthesis` + `/v2/walks/synthesis` (5/hr)
- `/api/v2/walks/app_attest/attestations` + `/v2/walks/app_attest/attestations` (3/hr)
- `/api/v2/walks/app_attest/challenges` + `/v2/walks/app_attest/challenges` (60/hr)

Every other throttle (login, signup, password reset, follow-spam, etc.) is left in place.

## Why

The App Attest reinstall flow trips the 3/hour cap on the attestations endpoint during repeated TestFlight testing. A fresh install generates a new Secure Enclave key and re-attests; after three attempts within the hour the limiter returns `429`, which the iOS client reports as "Gumroad rejected this device's attestation." Production logs confirmed the pattern — three `status=201` attestations followed by a run of `[Rack::Attack][Blocked]` entries on `/api/v2/walks/app_attest/attestations` from a single IP.

Disabling only these rules unblocks end-to-end testing of the attestation + free-walk flow without weakening brute-force protection elsewhere.

This is intentionally temporary. The rules cap per-IP OpenAI (realtime tokens) and Anthropic (synthesis) spend and limit attested-key fan-out, so they will be restored in a follow-up once the underlying reinstall issue is fixed.

## Test Results

Config-only change (commented-out throttle declarations); no behavior to unit-test. Verified the file still parses and the remaining rules are unchanged.

---

🤖 AI disclosure: drafted with Claude Opus 4.7 (1M context).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782486590&installation_id=134400930&pr_number=5303&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5303&signature=4a2f7e2ca17ed9bcd2855081fbcda59a881dce563f5d181dce340315d93b8baa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->