### PR TITLE
Store Walks App Attest challenges in $redis instead of Rails.cache

### DIFF
--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -46,6 +46,7 @@ class RedisKey
     def seller_age_threshold_days = "seller_age_threshold_days"
     def sales_report_jobs = "sales_report_jobs"
     def acme_challenge(token) = "acme_challenge:#{token}"
+    def walks_app_attest_challenge(challenge) = "walks_app_attest_challenge:#{challenge}"
     def unreviewed_users_data = "admin:unreviewed_users_data"
     def unreviewed_users_cutoff_date = "admin:unreviewed_users_cutoff_date"
     def paypal_topup_needed = "paypal:topup_needed"

--- a/app/services/walks_app_attest_challenge.rb
+++ b/app/services/walks_app_attest_challenge.rb
@@ -5,31 +5,30 @@
 # attestation/assertion and hashes it (together with the request body, on
 # assertions) into the clientDataHash that DCAppAttestService signs over.
 #
-# Stored in Rails.cache (Redis) because:
-#  - The data is ephemeral (5-minute TTL).
-#  - We don't want this hot, short-lived churn on MySQL.
-#  - `delete` is the atomic consume primitive we need for single-use.
+# Stored in `$redis` (not Rails.cache, which is Memcached in production and can
+# evict keys before their TTL under memory pressure — a dropped challenge fails
+# the request as `invalid_challenge`). `$redis` is the same store the analogous
+# single-use ACME challenge tokens use. `SETEX` issues the nonce; `DEL`'s
+# return value (1 iff the key existed) is the atomic consume primitive that
+# guarantees single-use even under concurrent requests.
 class WalksAppAttestChallenge
   TTL = 5.minutes
-  PREFIX = "walks:app_attest:chal:"
 
   class << self
     def issue!
       SecureRandom.urlsafe_base64(32).tap do |challenge|
-        Rails.cache.write(cache_key(challenge), "1", expires_in: TTL)
+        $redis.setex(RedisKey.walks_app_attest_challenge(challenge), TTL.to_i, "1")
       end
     end
 
     # Returns true if the challenge existed and was deleted (single-use), false
-    # otherwise. Treats blank input as miss.
+    # otherwise. `DEL` returns the number of keys it removed, so a positive
+    # count means this caller is the one that consumed the nonce. Treats blank
+    # input as a miss.
     def consume!(challenge)
       return false if challenge.blank?
-      !!Rails.cache.delete(cache_key(challenge))
+      deleted_count = $redis.del(RedisKey.walks_app_attest_challenge(challenge))
+      deleted_count.positive?
     end
-
-    private
-      def cache_key(challenge)
-        "#{PREFIX}#{challenge}"
-      end
   end
 end

--- a/spec/services/walks_app_attest_challenge_spec.rb
+++ b/spec/services/walks_app_attest_challenge_spec.rb
@@ -4,10 +4,12 @@ require "spec_helper"
 
 describe WalksAppAttestChallenge do
   describe ".issue!" do
-    it "issues a 32+ char url-safe string and writes it to the cache" do
+    it "issues a 32+ char url-safe string and writes it to redis with a TTL" do
       challenge = described_class.issue!
       expect(challenge).to match(/\A[A-Za-z0-9_-]{30,}\z/)
-      expect(Rails.cache.read("#{described_class::PREFIX}#{challenge}")).to eq("1")
+      key = RedisKey.walks_app_attest_challenge(challenge)
+      expect($redis.get(key)).to eq("1")
+      expect($redis.ttl(key)).to be_within(5).of(described_class::TTL.to_i)
     end
 
     it "produces a distinct challenge on each call" do
@@ -21,7 +23,7 @@ describe WalksAppAttestChallenge do
     it "deletes the challenge and returns true the first time" do
       challenge = described_class.issue!
       expect(described_class.consume!(challenge)).to be(true)
-      expect(Rails.cache.read("#{described_class::PREFIX}#{challenge}")).to be_nil
+      expect($redis.get(RedisKey.walks_app_attest_challenge(challenge))).to be_nil
     end
 
     it "returns false on second consume" do


### PR DESCRIPTION
## What

Moves the single-use Apple App Attest challenge nonces (Gumroad Walks) out of `Rails.cache` and into `$redis`:

- `WalksAppAttestChallenge#issue!` → `$redis.setex(RedisKey.walks_app_attest_challenge(challenge), TTL.to_i, "1")`
- `WalksAppAttestChallenge#consume!` → deletes the key and returns whether `DEL` removed one (`deleted_count.positive?`)
- Adds a `RedisKey.walks_app_attest_challenge` helper, next to the existing `acme_challenge` one
- Drops the now-unused `PREFIX` constant

## Why

The nonces were stored in `Rails.cache`, which is **Memcached** in production. Memcached is a bounded LRU and can evict keys before their TTL under memory pressure. If a challenge is evicted in the (normally few-second) window between being issued and consumed, `consume!` finds nothing and the request is rejected as `invalid_assertion` — a spurious, hard-to-reproduce failure that correlates with cache load rather than anything in the request.

`$redis` is a real Redis instance the app already treats as a reliable store, and it's the exact store the analogous single-use **ACME challenge** tokens use (`$redis.setex`/`$redis.del` with `RedisKey.acme_challenge`), so this follows existing convention.

`DEL`'s return value (the count of keys removed) is also a stronger consume primitive than the previous `Rails.cache.delete` boolean: under concurrent requests, exactly one caller gets a positive count, which guarantees single-use atomically.

This is a reliability fix only — replay protection is unchanged, since it also rests on the monotonic per-key counter (`WalksAppAttestKey#advance_counter!`) and the unique `key_id` on attestation.

> Note: if `REDIS_HOST`'s `maxmemory-policy` is `allkeys-lru`, Redis can still evict under pressure (lower risk than Memcached, but worth confirming it's `noeviction`/`volatile-ttl`).

## Test Results

```
bundle exec rspec spec/services/walks_app_attest_challenge_spec.rb
6 examples, 0 failures

bundle exec rspec spec/services/walks_app_attest_verifier_spec.rb \
  spec/controllers/api/v2/walks/app_attest/challenges_controller_spec.rb
20 examples, 0 failures
```

rubocop: clean on all changed files. The challenge spec was updated to assert against `$redis`/`RedisKey` (incl. a TTL check); the verifier/controller specs use the public `issue!`/`consume!` API and were unaffected.

---

🤖 AI disclosure: drafted with Claude Opus 4.7 (1M context).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782488674&installation_id=134400930&pr_number=5304&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5304&signature=e41c9660c4c5ce9a6107ff9c95acbf66ad81d712bf996f343f7ebfe6dc54f341"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small storage-backend swap for ephemeral nonces; behavior and security model unchanged, with specs updated.
> 
> **Overview**
> Walks **App Attest** single-use challenge nonces now live in **`$redis`** via **`RedisKey.walks_app_attest_challenge`**, using **`SETEX`** on issue and **`DEL`** (positive delete count) on consume, instead of **`Rails.cache`** (Memcached in production).
> 
> This mirrors the existing **ACME** challenge pattern and avoids early eviction under cache pressure, which could cause spurious **`invalid_challenge`** failures between issue and consume. Specs assert Redis storage and TTL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3da03148de914b786f3c7e54fd9873a2feaa8b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->