### PR TITLE
Log Walks App Attest assertion failure reason

### DIFF
--- a/app/controllers/concerns/walks_entitlement.rb
+++ b/app/controllers/concerns/walks_entitlement.rb
@@ -54,7 +54,10 @@ module WalksEntitlement
       key_id    = request.headers["X-App-Attest-KeyId"].to_s.presence
       assertion = request.headers["X-App-Attest-Assertion"].to_s.presence
       challenge = request.headers["X-App-Attest-Challenge"].to_s.presence
-      return nil if key_id.nil? || assertion.nil? || challenge.nil?
+      if key_id.nil? || assertion.nil? || challenge.nil?
+        Rails.logger.warn("WalksAppAttest assertion rejected: missing_headers")
+        return nil
+      end
 
       result = WalksAppAttestVerifier.assert(
         key_id: key_id,
@@ -62,7 +65,14 @@ module WalksEntitlement
         challenge: challenge,
         request_body: request.raw_post,
       )
-      result.valid? ? result.key : nil
+      return result.key if result.valid?
+
+      # The verifier's specific failure symbol (e.g. bad_signature vs
+      # invalid_challenge) is otherwise discarded here — log it so a 402 on
+      # the walks endpoints can be diagnosed without a client-side capture.
+      # Mirrors the attestations controller, which already logs its reason.
+      Rails.logger.warn("WalksAppAttest assertion rejected: #{result.error}")
+      nil
     end
 
     def valid_jws?


### PR DESCRIPTION
## What

`WalksEntitlement#verify_app_attest_assertion` returned the attested key or `nil`, discarding `WalksAppAttestVerifier::Result#error`. When an assertion fails, the request becomes a generic `402` and the specific failure symbol (`bad_signature`, `invalid_challenge`, `unknown_key`, …) is lost — it can't be recovered from logs without instrumenting the iOS client.

This adds a `Rails.logger.warn` of the rejection reason on both failure paths:
- missing `X-App-Attest-*` headers → `missing_headers`
- a failed `WalksAppAttestVerifier.assert` → the verifier's `result.error`

This mirrors `Api::V2::Walks::AppAttest::AttestationsController`, which already logs its rejection reason. Logging only — the entitlement decision is unchanged.

## Why

Production shows every `api/v2/walks/realtime_tokens` request returning `402` while attestation registration succeeds (keys are created with `environment=production`, but all have `counter=0` / `last_used_at=nil`, so no assertion has ever verified). The attest-succeeds / assert-always-fails split points at an assertion-specific failure, but the exact symbol is currently unobservable because it's discarded here.

With this logging in place, a single failing request reveals whether the cause is signature verification, challenge consumption, or an unknown key — without a client-side debug build.

## Test plan
- [ ] Deploy, trigger a walk that 402s, and confirm the rejection reason appears in logs.
- [ ] Confirm a successful assertion still issues a token (no behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782494051&installation_id=134400930&pr_number=5305&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5305&signature=f0a9136f3a4d411fc3eb46713dda02b9c8506121e0327b2ccfc4956d3e667841"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change on walks entitlement; no auth decision or API response changes.
> 
> **Overview**
> Adds **observability** when App Attest assertions fail on paid walks endpoints (`WalksEntitlement#verify_app_attest_assertion`). Missing `X-App-Attest-*` headers now log `missing_headers`; failed `WalksAppAttestVerifier.assert` calls log the verifier’s `result.error` (e.g. `bad_signature`, `invalid_challenge`) instead of returning `nil` silently. **Entitlement behavior is unchanged**—clients still get the same `402` with `invalid_assertion`; only server logs gain the failure symbol, aligned with `AttestationsController`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdc144048acc95714df27d78d55d802ced20e119. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->