### PR TITLE
Update knapsack_pro from 7.8.0 to 10.0.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ end
 group :development, :test do
   gem "bundler"
   gem "dotenv-rails", "~> 2.8"
-  gem "knapsack_pro", "~> 7.0"
+  gem "knapsack_pro", "~> 10.0"
   gem "pry-byebug", "~> 3.10"
   gem "pry-rails", "~> 0.3", require: "pry-rails/console"
   gem "rubocop", "~> 1.79", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -498,8 +498,9 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
-    knapsack_pro (7.8.0)
+    knapsack_pro (10.0.1)
       rake
+      thor (~> 1.4)
     koala (3.6.0)
       addressable
       base64
@@ -1164,7 +1165,7 @@ DEPENDENCIES
   json-schema (~> 5.0)
   json_matchers (~> 0.11)
   kaminari (~> 1.2)
-  knapsack_pro (~> 7.0)
+  knapsack_pro (~> 10.0)
   koala (~> 3.3)
   lograge (~> 0.12)
   makara (= 0.6.0.pre)


### PR DESCRIPTION
## What

Bumps the `knapsack_pro` gem from **7.8.0 → 10.0.1** (the latest release).

- `Gemfile`: `gem "knapsack_pro", "~> 7.0"` → `"~> 10.0"`
- `Gemfile.lock`: `knapsack_pro 7.8.0` → `10.0.1` (adds a `thor (~> 1.4)` dependency edge; `thor 1.4.0` was already resolved, so no new top-level gem)

## Why

The Knapsack Pro dashboard flags the Gumroad RSpec client (v7.8.0) as **outdated** — both the "Fast Specs" and "Slow specs" test suites run on it, and Flexile is already on v10.0.1. Staying current keeps us on supported queue-mode behavior and bug/perf fixes.

The 7 → 10 jump is **config-compatible** for this repo — I reviewed every major's breaking changes against our setup:

| Version | Breaking change | Impact here |
|---------|-----------------|-------------|
| v8 | `KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES` defaults to `true` | None — already set `true` explicitly in `tests.yml` |
| v9 | Requires Ruby ≥ 3.0; removed internal `KNAPSACK_PRO_MODE`; log format change | None — repo is on Ruby 3.4.3; `KNAPSACK_PRO_MODE` unused |
| v10 | New optional `KNAPSACK_PRO_TEST_QUEUE_ID` (only matters if *overriding* the branch) | None — inside our Docker CI, `GITHUB_ACTIONS` isn't passed in, so knapsack derives the queue ID from `[KNAPSACK_PRO_CI_NODE_TOTAL, KNAPSACK_PRO_BRANCH, KNAPSACK_PRO_COMMIT_HASH]`, all of which are already set. The optional var is not needed. |

Verified against the installed v10 gem that every API and rake task this repo depends on still exists:
- `KnapsackPro::Adapters::RSpecAdapter.bind` (`spec/spec_helper.rb`)
- `KnapsackPro::Hooks::Queue.before_queue` / `after_queue` (`spec/support/puffing_billy.rb`)
- `knapsack_pro:rspec` and `knapsack_pro:queue:rspec` rake tasks (`docker/web/rspec.sh`, `.github/workflows/tests.yml`)

No code or CI/workflow changes are required.

## Before/After

Non-user-facing (CI test-runner tooling). 📹 _Video walkthrough to be added._

## Test Results

The real validation is the CI RSpec run (Fast Specs + Slow specs) on this PR — those jobs exercise the new client end-to-end via `knapsack_pro:queue:rspec`. Local `bundle install` couldn't complete in my sandbox (unrelated pre-existing unbuilt native gems), but `bundle lock --update=knapsack_pro` resolved cleanly and the v10 gem loads with all required APIs present.

---

🤖 AI disclosure: This PR was prepared with Claude Opus 4.7 (Claude Code). Prompt: "update gumroad to latest knapsack pro" → "open PR". The agent located the gem in the Gemfile, checked the latest version, reviewed the v8/v9/v10 changelogs against this repo's config and Ruby version, updated the Gemfile + lockfile, verified the v10 gem's APIs/rake tasks/queue-ID derivation, and opened this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump for dev/test CI tooling; no application or workflow edits in the diff.
> 
> **Overview**
> Bumps the **Knapsack Pro** CI test-splitting gem from **7.8.0** to **10.0.1** by changing `knapsack_pro` in the `Gemfile` from `~> 7.0` to `~> 10.0` and refreshing `Gemfile.lock`. The lockfile now records an explicit **`thor (~> 1.4)`** dependency on the gem (no new top-level gem beyond what was already resolved).
> 
> There are **no** changes to RSpec setup, rake tasks, or GitHub Actions workflows—CI still runs `knapsack_pro:queue:rspec` with the same env vars.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8e5f20ef1a3de914ab1b03e3b6a13cd57f7a494. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782497357&installation_id=134400930&pr_number=5306&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5306&signature=91cbf8080f3f2c35937fd417a5359053b5ea538958d9b35222249b98983b9f94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->