### PR TITLE
Fix Walks App Attest assertion verification (double-hash)

### DIFF
--- a/app/services/walks_app_attest_verifier.rb
+++ b/app/services/walks_app_attest_verifier.rb
@@ -125,15 +125,19 @@ class WalksAppAttestVerifier
       return fail_result(:bad_assertion) unless signature.is_a?(String) && authenticator_data.is_a?(String)
 
       client_data_hash = OpenSSL::Digest::SHA256.digest(challenge.to_s + request_body.to_s)
-      # Apple signs with kSecKeyAlgorithmECDSASignatureMessageX962SHA256, which
-      # hashes the input internally before ECDSA. The "input" given to the
-      # Secure Enclave is `authenticatorData || clientDataHash`, so the signed
-      # digest is exactly `nonce = SHA256(authenticatorData || clientDataHash)`.
-      # Ruby's `dsa_verify_asn1(digest, sig)` is raw ECDSA verify (no further
-      # hashing), so we pass `nonce` directly — NOT `SHA256(nonce)`. Apple's
-      # CryptoKit reference does the same: `publicKey.isValidSignature(sig, for: nonce)`.
+      # Apple's App Attest assertion: the Secure Enclave is handed
+      # `nonce = SHA256(authenticatorData || clientDataHash)` and signs it with
+      # ES256, which hashes its input *again* with SHA256 before the ECDSA
+      # operation. So the value actually signed is `SHA256(nonce)`. Apple's
+      # CryptoKit reference, `publicKey.isValidSignature(sig, for: nonce)`,
+      # passes `nonce` as a message (DataProtocol), so CryptoKit hashes it
+      # before verifying — it does NOT treat `nonce` as a pre-computed digest.
+      # `dsa_verify_asn1(digest, sig)` is a raw ECDSA verify with no hashing, so
+      # we must pass `SHA256(nonce)`. Verifying against `nonce` directly is the
+      # classic App Attest mistake and rejects every genuine assertion.
       nonce = OpenSSL::Digest::SHA256.digest(authenticator_data + client_data_hash)
-      return fail_result(:bad_signature) unless key.public_key_ec.dsa_verify_asn1(nonce, signature)
+      signed_digest = OpenSSL::Digest::SHA256.digest(nonce)
+      return fail_result(:bad_signature) unless key.public_key_ec.dsa_verify_asn1(signed_digest, signature)
 
       parsed = parse_auth_data(authenticator_data, expect_attestation: false)
       return fail_result(:bad_auth_data) unless parsed

--- a/spec/services/walks_app_attest_verifier_spec.rb
+++ b/spec/services/walks_app_attest_verifier_spec.rb
@@ -103,13 +103,14 @@ describe WalksAppAttestVerifier do
     def build_assertion(counter:, challenge:, body: request_body, rp_id_hash: app_id_hash)
       auth_data = rp_id_hash + [0].pack("C") + [counter].pack("N")
       client_data_hash = OpenSSL::Digest::SHA256.digest(challenge + body)
-      # Mirror Apple's kSecKeyAlgorithmECDSASignatureMessageX962SHA256: the
-      # Secure Enclave hashes the input internally, so it signs over `nonce`
-      # (= SHA256(authData || clientDataHash)) directly. Ruby's
-      # `dsa_sign_asn1(digest)` is raw ECDSA sign, so pass `nonce` — NOT a
-      # second SHA256 — to match what a real iPhone produces.
+      # Reproduce what a real iPhone produces. Apple hands the Secure Enclave
+      # `nonce = SHA256(authData || clientDataHash)` and signs it with ES256,
+      # which hashes that input *again* with SHA256 before ECDSA — so the value
+      # actually signed is `SHA256(nonce)`. `dsa_sign_asn1(digest)` is a raw
+      # ECDSA sign with no hashing, so pass `SHA256(nonce)`. (Verified against a
+      # live device assertion: signing `nonce` directly does NOT match.)
       nonce = OpenSSL::Digest::SHA256.digest(auth_data + client_data_hash)
-      signature = ec_key.dsa_sign_asn1(nonce)
+      signature = ec_key.dsa_sign_asn1(OpenSSL::Digest::SHA256.digest(nonce))
       cbor = CBOR.encode("signature" => signature, "authenticatorData" => auth_data)
       Base64.strict_encode64(cbor)
     end


### PR DESCRIPTION
## What

`WalksAppAttestVerifier.assert` verified the assertion signature against `nonce = SHA256(authenticatorData ‖ clientDataHash)` using `dsa_verify_asn1(nonce, signature)` — a raw ECDSA verify with no hashing. Apple's Secure Enclave actually signs **`SHA256(nonce)`** (ES256 hashes its input again before the ECDSA op; CryptoKit's `isValidSignature(_:for:)` passes `nonce` as a message and hashes it). So the verifier compared the signature to the wrong digest and rejected **every** genuine assertion as `bad_signature`.

Fix: hash once more and verify against `SHA256(nonce)`.

## Impact

Every walks API call (`realtime_tokens`, `synthesis`) from a physical device returned `402`, which the iOS app renders as a subscription paywall. No device could start a walk via the App Attest free-walk path. Attestation was unaffected — it validates a certificate chain and the nonce cert-extension, not an ECDSA signature — which is why attestation succeeded while assertion always failed.

## How it was found

Captured a live assertion (keyId, challenge, body, signature) from a device and replayed verification offline. `clientDataHash` reconstructed correctly and the stored public key provably matched the keyId (`SHA256(octets) == keyId`), yet the signature failed against `nonce`. An independent `openssl` check (validated on a known-good signature) **accepted the same signature over `SHA256(nonce)`**, confirming the double hash.

## Test

The spec's `build_assertion` helper shared the same single-hash assumption, so the fixture and the buggy verifier agreed and the test passed against incorrect behavior. Updated it to sign `SHA256(nonce)`, matching a real device. All 18 examples pass, including the tamper / replayed-challenge / unknown-key / wrong-rpId negatives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5308"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782498586&installation_id=134400930&pr_number=5308&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5308&signature=ff7e860f65a41de383b53488f27100bd1bbcb0872350302d46e20541a04f5dc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes cryptographic verification on the walks App Attest path; a mistake would reject all devices or weaken assertion checks, though scope is limited to assertion (not attestation) and tests were aligned to live device behavior.
> 
> **Overview**
> Fixes **App Attest assertion** verification so per-request walks API calls from real devices stop failing with `bad_signature`.
> 
> `WalksAppAttestVerifier.assert` now ECDSA-verifies against **`SHA256(nonce)`** (where `nonce = SHA256(authenticatorData ‖ clientDataHash)`), matching Apple’s ES256 / CryptoKit behavior, instead of verifying against `nonce` directly via raw `dsa_verify_asn1`. Comments in the verifier document the double-hash rationale.
> 
> The spec **`build_assertion`** helper is updated to sign `SHA256(nonce)` so tests match a live device; previously the fixture and verifier shared the same wrong assumption and passed while production rejected every genuine assertion (e.g. walks APIs returning **402** / paywall).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cde5ade32365c9989506cd9e9a7cfc3cca24188. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->