### PR TITLE
ci: bare-metal tests, drop Docker image build/push wrapper

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -297,10 +297,16 @@ jobs:
       - name: Install Chrome and ChromeDriver
         if: steps.chrome-cache.outputs.cache-hit != 'true'
         run: |
+          # Ubicloud runners ship with a newer Chrome preinstalled; remove it
+          # so the pinned 125.x .deb installs cleanly instead of triggering
+          # `Packages were downgraded and -y was used without --allow-downgrades`.
+          sudo apt-get remove -y google-chrome-stable google-chrome || true
           curl --retry 10 --connect-timeout 5 --retry-max-time 60 \
             --output /tmp/google-chrome-stable_${CHROME_VERSION}_amd64.deb \
             "https://public-files.gumroad.com/google-chrome-stable_${CHROME_VERSION}_amd64.deb"
-          sudo apt-get install -y /tmp/google-chrome-stable_${CHROME_VERSION}_amd64.deb
+          sudo apt-get install -y --allow-downgrades /tmp/google-chrome-stable_${CHROME_VERSION}_amd64.deb
+          # Pin so a later apt-get upgrade doesn't bump it under us.
+          sudo apt-mark hold google-chrome-stable
           CHROME_VER_FULL=$(google-chrome --version | sed 's/^Google Chrome //')
           curl --silent --show-error --location --fail --retry 4 --retry-delay 5 \
             --output /tmp/chromedriver_linux64.zip \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request_target' || github.ref != 'refs/heads/main' }}
 
+env:
+  RUBY_YJIT_ENABLE: "1"
+  CHROME_VERSION: "125.0.6422.76-1"
+  # Localhost addressing — the .env.test file already targets 127.0.0.1
+  # for every service, so we just stand up the same services on host ports
+  # and let Rails/Mongoid/ES/Redis/MinIO clients reach them directly.
+
 jobs:
   ci_gate:
     name: CI Gate${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository && ' (internal PR noop)' || '' }}
@@ -23,332 +30,153 @@ jobs:
     steps:
       - run: true
 
-  build:
-    name: Build images${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository && ' (internal PR noop)' || '' }}
-    runs-on: blacksmith-8vcpu-ubuntu-2204
-    needs: ci_gate
-    if: ${{ github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name != github.repository }}
-    env:
-      DOCKER_BUILDKIT: 1
-    outputs:
-      test_image_tag: ${{ steps.test_image_tag.outputs.tag }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
-          persist-credentials: false
-      - name: Login to Docker Hub
-        uses: nick-fields/retry@v3
-        with:
-          timeout_seconds: 120
-          max_attempts: 3
-          retry_wait_seconds: 10
-          command: echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-      - name: Build and push base image
-        env:
-          WEB_BASE_REPO: gumroadteam/web_base
-        run: |
-          set -e
-          GREEN='\033[0;32m'
-          NC='\033[0m'
-          logger() {
-            echo -e "${GREEN}$(date '+%Y/%m/%d %H:%M:%S') build.sh: $1${NC}"
-          }
-          logger "pulling ruby:$(cat .ruby-version)-slim-bullseye"
-          docker pull --quiet ruby:$(cat .ruby-version)-slim-bullseye
-          WEB_BASE_SHA=$(WEB_BASE_DOCKERFILE_FROM=ruby:$(cat .ruby-version)-slim-bullseye docker/base/generate_tag_for_web_base.sh)
-          if ! docker manifest inspect $WEB_BASE_REPO:$WEB_BASE_SHA > /dev/null 2>&1; then
-            logger "Building $WEB_BASE_REPO:$WEB_BASE_SHA"
-            NEW_BASE_REPO=$WEB_BASE_REPO \
-              WEB_BASE_DOCKERFILE_FROM=ruby:$(cat .ruby-version)-slim-bullseye \
-              BUNDLE_GEMS__CONTRIBSYS__COM=${{ secrets.BUNDLE_GEMS__CONTRIBSYS__COM }} \
-              make build_base
-
-            logger "Pushing $WEB_BASE_REPO:$WEB_BASE_SHA"
-            for i in {1..3}; do
-              logger "Push attempt $i"
-              if docker push --quiet $WEB_BASE_REPO:$WEB_BASE_SHA; then
-                logger "Pushed $WEB_BASE_REPO:$WEB_BASE_SHA"
-                break
-              elif [ $i -eq 3 ]; then
-                logger "Failed to push $WEB_BASE_REPO:$WEB_BASE_SHA"
-                exit 1
-              else
-                sleep 5
-              fi
-            done
-          else
-            logger "$WEB_BASE_REPO:$WEB_BASE_SHA already exists"
-          fi
-      - name: Compute content-addressed test image tag
-        id: test_image_tag
-        env:
-          WEB_BASE_REPO: gumroadteam/web_base
-        run: |
-          set -e
-          # Resolve the base test SHA (used as a hash input).
-          WEB_BASE_TEST_SHA=$(WEB_BASE_DOCKERFILE_FROM=ruby:$(cat .ruby-version)-slim-bullseye docker/base/generate_tag_for_web_base_test.sh)
-          TAG=test-$(BASE_TEST_SHA=$WEB_BASE_TEST_SHA docker/base/generate_tag_for_test_image.sh)
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
-          echo "Computed test image tag: $TAG"
-      - name: Set up Docker Buildx
-        uses: useblacksmith/setup-docker-builder@v1
-        with:
-          max-cache-size-mb: "204800"
-      - name: Restore asset precompile cache
-        id: asset_cache
-        uses: actions/cache@v4
-        with:
-          path: /tmp/asset-cache
-          key: asset-precompile-${{ hashFiles('app/assets/**', 'app/javascript/**', 'config/webpack/**', 'config/shakapacker.yml', 'Gemfile.lock', 'package-lock.json', '.ruby-version') }}
-          restore-keys: |
-            asset-precompile-
-      - name: Build and push test image
-        env:
-          WEB_BASE_REPO: gumroadteam/web_base
-          WEB_BASE_TEST_REPO: gumroadteam/web_base_test
-          WEB_REPO: gumroadteam/web
-          TEST_IMAGE_TAG: ${{ steps.test_image_tag.outputs.tag }}
-          ASSET_CACHE_HIT: ${{ steps.asset_cache.outputs.cache-hit }}
-        run: |
-          set -e
-          GREEN='\033[0;32m'
-          NC='\033[0m'
-          logger() {
-            echo -e "${GREEN}$(date '+%Y/%m/%d %H:%M:%S') build.sh: $1${NC}"
-          }
-          docker pull --quiet ruby:$(cat .ruby-version)-slim-bullseye
-          WEB_BASE_TEST_SHA=$(WEB_BASE_DOCKERFILE_FROM=ruby:$(cat .ruby-version)-slim-bullseye docker/base/generate_tag_for_web_base_test.sh)
-
-          # Check if both images already exist (content-addressed cache hit).
-          BASE_TEST_EXISTS=false
-          TEST_EXISTS=false
-          docker manifest inspect $WEB_BASE_TEST_REPO:$WEB_BASE_TEST_SHA > /dev/null 2>&1 && BASE_TEST_EXISTS=true
-          docker manifest inspect $WEB_REPO:$TEST_IMAGE_TAG > /dev/null 2>&1 && TEST_EXISTS=true
-
-          if [ "$TEST_EXISTS" = "true" ]; then
-            logger "$WEB_REPO:$TEST_IMAGE_TAG already exists — nothing to build"
-          else
-            # Build web_base_test if needed
-            if [ "$BASE_TEST_EXISTS" = "false" ]; then
-              logger "building $WEB_BASE_TEST_REPO:$WEB_BASE_TEST_SHA"
-              NEW_BASE_REPO=$WEB_BASE_REPO NEW_WEB_BASE_TEST_REPO=$WEB_BASE_TEST_REPO \
-                WEB_BASE_DOCKERFILE_FROM=ruby:$(cat .ruby-version)-slim-bullseye \
-                make build_base_test
-              logger "pushing $WEB_BASE_TEST_REPO:$WEB_BASE_TEST_SHA"
-              for i in {1..3}; do
-                if docker push --quiet $WEB_BASE_TEST_REPO:$WEB_BASE_TEST_SHA; then
-                  logger "Pushed $WEB_BASE_TEST_REPO:$WEB_BASE_TEST_SHA"; break
-                elif [ $i -eq 3 ]; then exit 1; else sleep 5; fi
-              done
-            else
-              logger "$WEB_BASE_TEST_REPO:$WEB_BASE_TEST_SHA already exists"
-            fi
-
-            # Build test image. Blacksmith's setup-docker-builder provides a
-            # sticky-disk-backed BuildKit builder that persists the layer cache
-            # across runs automatically — no explicit --cache-from/--cache-to needed.
-            logger "building $WEB_REPO:$TEST_IMAGE_TAG"
-            WEB_BASE_SHA=$(WEB_BASE_DOCKERFILE_FROM=ruby:$(cat .ruby-version)-slim-bullseye docker/base/generate_tag_for_web_base.sh)
-            # Pull the FROM images that the multi-stage Dockerfile needs.
-            docker pull --quiet $WEB_BASE_REPO:$WEB_BASE_SHA &
-            docker pull --quiet $WEB_BASE_TEST_REPO:$WEB_BASE_TEST_SHA &
-            wait
-            WEB_DOCKERFILE_FROM=$WEB_BASE_REPO:$WEB_BASE_SHA \
-              WEB_BASE_TEST_DOCKERFILE_FROM=$WEB_BASE_TEST_REPO:$WEB_BASE_TEST_SHA \
-            docker buildx build \
-              --load \
-              --build-arg WEB_DOCKERFILE_FROM \
-              --build-arg WEB_BASE_TEST_DOCKERFILE_FROM \
-              --build-arg BUILDKIT_INLINE_CACHE=1 \
-              --file docker/web/Dockerfile.test \
-              -t $WEB_REPO:test-${TEST_IMAGE_TAG#test-} \
-              .
-            docker tag $WEB_REPO:test-${TEST_IMAGE_TAG#test-} $WEB_REPO:$TEST_IMAGE_TAG
-
-            # Run asset precompile + docker commit (Makefile's post-build steps).
-            # Volume-mount cached precompile artifacts so Sprockets/Shakapacker
-            # can skip recompiling unchanged assets (~4 min → ~30s on cache hit).
-            COMPOSE_PROJECT_NAME=web_${{ github.run_id }}_${{ github.run_attempt }} \
-              docker compose -f docker/docker-compose-test-and-ci.yml up -d db_test redis mongo elasticsearch
-            docker run --rm --entrypoint="" \
-              --network web_${{ github.run_id }}_${{ github.run_attempt }}_default \
-              $WEB_REPO:$TEST_IMAGE_TAG \
-              docker/ci/wait_on_connection.sh db_test 3306
-
-            # Prepare cached asset precompile artifacts.
-            # Copy cached outputs into the container BEFORE running precompile
-            # so Sprockets/Shakapacker can skip recompiling unchanged assets.
-            # (Volume mounts won't work — docker commit ignores mounted paths.)
-            ASSET_MOUNTS=""
-            if [ "$ASSET_CACHE_HIT" = "true" ] || [ -d /tmp/asset-cache/public_assets ]; then
-              logger "Restoring cached asset precompile artifacts"
-              ASSET_MOUNTS="-v /tmp/asset-cache:/tmp/asset-cache:ro"
-            else
-              logger "No asset cache found — full precompile will run"
-            fi
-
-            # shellcheck disable=SC2086
-            docker run \
-              --network web_${{ github.run_id }}_${{ github.run_attempt }}_default \
-              --entrypoint="" \
-              --shm-size="2g" \
-              --memory-swappiness="0" \
-              -e RAILS_ENV="test" \
-              $ASSET_MOUNTS \
-              --label routes_compiled=true \
-              --name worker_web_${{ github.run_id }}_${{ github.run_attempt }} \
-              $WEB_REPO:$TEST_IMAGE_TAG \
-              bash -c '
-                # Restore cached assets if available (before precompile).
-                if [ -d /tmp/asset-cache/public_assets ]; then
-                  echo "Copying cached assets into container..."
-                  cp -a /tmp/asset-cache/public_assets /app/public/assets 2>/dev/null || true
-                  cp -a /tmp/asset-cache/public_packs_test /app/public/packs-test 2>/dev/null || true
-                  mkdir -p /app/tmp/cache
-                  cp -a /tmp/asset-cache/tmp_cache_assets /app/tmp/cache/assets 2>/dev/null || true
-                  cp -a /tmp/asset-cache/tmp_shakapacker /app/tmp/shakapacker 2>/dev/null || true
-                  chown -R app:app /app/public/assets /app/public/packs-test /app/tmp/cache /app/tmp/shakapacker 2>/dev/null || true
-                fi
-                su -c "npm run setup && bundle exec rake db:setup assets:precompile --trace" app
-              '
-
-            # Extract updated asset artifacts for next run's cache.
-            logger "Saving asset precompile artifacts to cache"
-            CONTAINER=worker_web_${{ github.run_id }}_${{ github.run_attempt }}
-            mkdir -p /tmp/asset-cache
-            for dir_pair in \
-              "public/assets:public_assets" \
-              "public/packs-test:public_packs_test" \
-              "tmp/cache/assets:tmp_cache_assets" \
-              "tmp/shakapacker:tmp_shakapacker"; do
-              src="${dir_pair%%:*}"
-              dst="${dir_pair##*:}"
-              rm -rf "/tmp/asset-cache/$dst"
-              docker cp "$CONTAINER:/app/$src" "/tmp/asset-cache/$dst" 2>/dev/null || true
-            done
-
-            docker ps -lq \
-              --filter='label=routes_compiled=true' \
-              --filter='exited=0' \
-              --filter="name=worker_web_${{ github.run_id }}_${{ github.run_attempt }}" \
-              | xargs -I{} docker commit {} $WEB_REPO:$TEST_IMAGE_TAG
-            COMPOSE_PROJECT_NAME=web_${{ github.run_id }}_${{ github.run_attempt }} \
-              docker compose -f docker/docker-compose-test-and-ci.yml down
-
-            # Push the final image to Docker Hub.
-            logger "pushing $WEB_REPO:$TEST_IMAGE_TAG"
-            for i in {1..3}; do
-              if docker push --quiet $WEB_REPO:$TEST_IMAGE_TAG; then
-                logger "Pushed $WEB_REPO:$TEST_IMAGE_TAG"; break
-              elif [ $i -eq 3 ]; then exit 1; else sleep 5; fi
-            done
-
-            # Update floating test-cache tag.
-            docker tag $WEB_REPO:$TEST_IMAGE_TAG $WEB_REPO:test-cache
-            docker push --quiet $WEB_REPO:test-cache 2>/dev/null \
-              && logger "Pushed $WEB_REPO:test-cache" \
-              || logger "Failed to push test-cache (non-fatal)"
-          fi
-
   test_fast:
     name: Test Fast ${{ matrix.ci_node_index }}${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository && ' (internal PR noop)' || '' }}
-    env:
-      COMPOSE_PROJECT_NAME: web_${{ github.run_id }}_${{ github.run_attempt }}_fast_${{ matrix.ci_node_index }}
     runs-on: ubicloud-standard-4
-    needs: build
+    needs: ci_gate
+    if: ${{ github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name != github.repository }}
+    timeout-minutes: 30
     strategy:
       fail-fast: true
       matrix:
         ci_node_total: [18]
         ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]
+
+    services:
+      mysql:
+        image: mysql:8.0.32
+        env:
+          MYSQL_ROOT_PASSWORD: password
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "mysqladmin ping --silent"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+          --tmpfs /var/lib/mysql:size=512M
+
+      redis:
+        image: redis:7.0.7
+        ports:
+          - 6379:6379
+
+      mongo:
+        image: mongo:4.0.19
+        ports:
+          - 27017:27017
+
+      elasticsearch:
+        image: elasticsearch:7.9.3
+        env:
+          discovery.type: single-node
+          ES_JAVA_OPTS: -Xms256m -Xmx256m
+        ports:
+          - 9200:9200
+        options: >-
+          --health-cmd "curl -sf http://localhost:9200/_cluster/health || exit 1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
-      - name: Login to Docker Hub
-        uses: nick-fields/retry@v3
-        with:
-          timeout_seconds: 120
-          max_attempts: 3
-          retry_wait_seconds: 10
-          command: echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-      - name: Start services and pull test image
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 5
-          max_attempts: 3
-          retry_wait_seconds: 5
-          command: |
-            docker pull --quiet $WEB_REPO:${{ needs.build.outputs.test_image_tag }} &
-            PULL_PID=$!
-            docker compose -f docker/docker-compose-test-and-ci.yml up -d
-            COMPOSE_EXIT=$?
-            wait $PULL_PID
-            PULL_EXIT=$?
-            exit $((COMPOSE_EXIT + PULL_EXIT))
-        env:
-          COMPOSE_HTTP_TIMEOUT: "300"
-          WEB_REPO: gumroadteam/web
-      - name: Wait for services and prepare test database
+
+      - name: Install system dependencies
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 5
           max_attempts: 3
           retry_wait_seconds: 10
           command: |
-            IMG=$WEB_REPO:${{ needs.build.outputs.test_image_tag }}
-            NET=${{ env.COMPOSE_PROJECT_NAME }}_default
-            # db:prepare only needs db_test; ES/minio waits run in parallel.
-            (
-              docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh db_test 3306 \
-                && docker run --rm --entrypoint="" --network $NET -e RAILS_ENV=test $IMG bundle exec rake db:prepare
-            ) &
-            DB_PID=$!
-            docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh elasticsearch 9200 &
-            ES_PID=$!
-            docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh minio 9000 &
-            MINIO_PID=$!
-            wait $DB_PID || exit 1
-            wait $ES_PID || exit 1
-            wait $MINIO_PID || exit 1
+            sudo apt-get update -y -qq
+            sudo apt-get install -yq --no-install-recommends \
+              build-essential ca-certificates curl ffmpeg imagemagick jq \
+              libcurl4-openssl-dev liblzma-dev default-libmysqlclient-dev \
+              libssl-dev libtag1-dev libxrender1 libgcrypt20 libvips-dev \
+              libxml2-dev libyaml-dev pdftk percona-toolkit unzip wget \
+              zlib1g-dev fonts-dejavu fonts-wqy-zenhei fonts-wqy-microhei \
+              netcat-openbsd
+            fc-cache -f
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
         env:
-          WEB_REPO: gumroadteam/web
+          BUNDLE_GEMS__CONTRIBSYS__COM: ${{ secrets.BUNDLE_GEMS__CONTRIBSYS__COM }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Restore asset precompile cache
+        id: asset_cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            public/assets
+            public/packs-test
+            tmp/cache/assets
+            tmp/shakapacker
+          key: asset-precompile-${{ hashFiles('app/assets/**', 'app/javascript/**', 'config/webpack/**', 'config/shakapacker.yml', 'Gemfile.lock', 'package-lock.json', '.ruby-version') }}
+          restore-keys: |
+            asset-precompile-
+
+      - name: Copy test env
+        run: cp .env.test .env
+
+      - name: Wait for services and prepare database
+        run: |
+          for i in $(seq 1 60); do
+            mysqladmin ping -h 127.0.0.1 -P 3306 -u root -ppassword --silent && break
+            sleep 1
+          done
+          bundle exec rake db:prepare
+
+      - name: Set up MinIO (S3 fixture buckets)
+        # MinIO doesn't run cleanly as a GitHub Actions service container because
+        # its entrypoint needs the `server` argument. Run as a regular container.
+        run: |
+          docker run -d --rm \
+            -p 9000:9000 -p 9001:9001 \
+            -e MINIO_ROOT_USER=minioadmin \
+            -e MINIO_ROOT_PASSWORD=minioadmin \
+            --name minio \
+            minio/minio:RELEASE.2025-09-07T16-13-09Z \
+            server /data --console-address ":9001"
+          for i in $(seq 1 30); do curl -sf http://localhost:9000/minio/health/ready && break; sleep 1; done
+          docker run --rm --network host minio/mc:RELEASE.2025-08-13T08-35-41Z sh -c '
+            mc alias set myminio http://localhost:9000 minioadmin minioadmin
+            for b in gumroad-specs gumroad-invoices; do
+              mc mb --ignore-existing myminio/$b
+              mc anonymous set public myminio/$b
+              mc version enable myminio/$b
+            done
+          '
+
+      - name: Precompile assets
+        run: |
+          bundle exec rails js:export
+          bundle exec rake assets:precompile --trace
+        env:
+          RAILS_ENV: test
+          NODE_ENV: test
 
       - name: Run tests
         timeout-minutes: 15
         run: |
           mkdir -p ./test-logs
-          chmod 777 ./test-logs
-          docker run --rm --entrypoint="" --network ${{ env.COMPOSE_PROJECT_NAME }}_default \
-            -v "$(pwd)/test-logs:/app/log" \
-            -e RUBY_YJIT_ENABLE \
-            -e KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC \
-            -e KNAPSACK_PRO_CI_NODE_TOTAL \
-            -e KNAPSACK_PRO_CI_NODE_INDEX \
-            -e KNAPSACK_PRO_LOG_LEVEL \
-            -e KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES \
-            -e KNAPSACK_PRO_TEST_FILE_PATTERN \
-            -e KNAPSACK_PRO_TEST_FILE_EXCLUDE_PATTERN \
-            -e KNAPSACK_PRO_COMMIT_HASH \
-            -e KNAPSACK_PRO_BRANCH \
-            -e KNAPSACK_PRO_CI_NODE_BUILD_ID \
-            -e KNAPSACK_PRO_CI_NODE_RETRY_COUNT \
-            -e KNAPSACK_PRO_PROJECT_DIR \
-            -e KNAPSACK_PRO_FIXED_QUEUE_SPLIT \
-            -e CI \
-            -e IN_DOCKER \
-            $WEB_REPO:${{ needs.build.outputs.test_image_tag }} \
-            /usr/local/bin/gosu app bundle exec rake "knapsack_pro:queue:rspec[--format RSpec::Github::Formatter --tag ~skip --format progress]"
+          bundle exec rake "knapsack_pro:queue:rspec[--format RSpec::Github::Formatter --tag ~skip --format progress]"
         env:
-          RUBY_YJIT_ENABLE: 1
+          RAILS_ENV: test
+          NODE_ENV: test
           KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC_FAST }}
           KNAPSACK_PRO_CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
           KNAPSACK_PRO_CI_NODE_INDEX: ${{ matrix.ci_node_index }}
@@ -360,11 +188,10 @@ jobs:
           KNAPSACK_PRO_BRANCH: ${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref_name }}
           KNAPSACK_PRO_CI_NODE_BUILD_ID: ${{ github.run_id }}
           KNAPSACK_PRO_CI_NODE_RETRY_COUNT: ${{ github.run_attempt }}
-          KNAPSACK_PRO_PROJECT_DIR: /app
+          KNAPSACK_PRO_PROJECT_DIR: ${{ github.workspace }}
           KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
           CI: true
-          IN_DOCKER: true
-          WEB_REPO: gumroadteam/web
+
       - name: Archive flaky specs log
         if: always()
         uses: actions/upload-artifact@v4
@@ -373,164 +200,188 @@ jobs:
           path: ./test-logs/flaky_specs.log
           retention-days: 14
           if-no-files-found: ignore
-      - name: Clean up
-        if: always()
-        run: |
-          docker compose -f docker/docker-compose-test-and-ci.yml down -v 2>/dev/null || true
-          docker rm -f $(docker ps -aq -f name=${{ env.COMPOSE_PROJECT_NAME }}) 2>/dev/null || true
-          docker volume rm $(docker volume ls -q -f name=${{ env.COMPOSE_PROJECT_NAME }}) 2>/dev/null || true
-          docker network rm ${{ env.COMPOSE_PROJECT_NAME }}_default 2>/dev/null || true
 
   test_slow:
     name: Test Slow ${{ matrix.ci_node_index }}${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository && ' (internal PR noop)' || '' }}
-    env:
-      COMPOSE_PROJECT_NAME: web_${{ github.run_id }}_${{ github.run_attempt }}_slow_${{ matrix.ci_node_index }}
-      WEB_REPO: gumroadteam/web
     runs-on: ubicloud-standard-4
-    needs: build
+    needs: ci_gate
+    if: ${{ github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name != github.repository }}
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:
         ci_node_total: [50]
         ci_node_index:
-          [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7,
-            8,
-            9,
-            10,
-            11,
-            12,
-            13,
-            14,
-            15,
-            16,
-            17,
-            18,
-            19,
-            20,
-            21,
-            22,
-            23,
-            24,
-            25,
-            26,
-            27,
-            28,
-            29,
-            30,
-            31,
-            32,
-            33,
-            34,
-            35,
-            36,
-            37,
-            38,
-            39,
-            40,
-            41,
-            42,
-            43,
-            44,
-            45,
-            46,
-            47,
-            48,
-            49,
-          ]
+          [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+           20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+           40, 41, 42, 43, 44, 45, 46, 47, 48, 49]
+
+    services:
+      mysql:
+        image: mysql:8.0.32
+        env:
+          MYSQL_ROOT_PASSWORD: password
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "mysqladmin ping --silent"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+          --tmpfs /var/lib/mysql:size=512M
+
+      redis:
+        image: redis:7.0.7
+        ports:
+          - 6379:6379
+
+      mongo:
+        image: mongo:4.0.19
+        ports:
+          - 27017:27017
+
+      elasticsearch:
+        image: elasticsearch:7.9.3
+        env:
+          discovery.type: single-node
+          ES_JAVA_OPTS: -Xms256m -Xmx256m
+        ports:
+          - 9200:9200
+        options: >-
+          --health-cmd "curl -sf http://localhost:9200/_cluster/health || exit 1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
-      - name: Login to Docker Hub
-        uses: nick-fields/retry@v3
-        with:
-          timeout_seconds: 120
-          max_attempts: 3
-          retry_wait_seconds: 10
-          command: echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-      - name: Start services and pull test image
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 5
-          max_attempts: 3
-          retry_wait_seconds: 5
-          command: |
-            docker pull --quiet $WEB_REPO:${{ needs.build.outputs.test_image_tag }} &
-            PULL_PID=$!
-            docker compose -f docker/docker-compose-test-and-ci.yml up -d
-            COMPOSE_EXIT=$?
-            wait $PULL_PID
-            PULL_EXIT=$?
-            exit $((COMPOSE_EXIT + PULL_EXIT))
-        env:
-          COMPOSE_HTTP_TIMEOUT: "300"
-          WEB_REPO: gumroadteam/web
-      - name: Wait for services and prepare test database
+
+      - name: Install system dependencies
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 5
           max_attempts: 3
           retry_wait_seconds: 10
           command: |
-            IMG=$WEB_REPO:${{ needs.build.outputs.test_image_tag }}
-            NET=${{ env.COMPOSE_PROJECT_NAME }}_default
-            # db:prepare only needs db_test; ES/minio waits run in parallel.
-            (
-              docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh db_test 3306 \
-                && docker run --rm --entrypoint="" --network $NET -e RAILS_ENV=test $IMG bundle exec rake db:prepare
-            ) &
-            DB_PID=$!
-            docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh elasticsearch 9200 &
-            ES_PID=$!
-            docker run --rm --entrypoint="" --network $NET $IMG docker/ci/wait_on_connection.sh minio 9000 &
-            MINIO_PID=$!
-            wait $DB_PID || exit 1
-            wait $ES_PID || exit 1
-            wait $MINIO_PID || exit 1
+            sudo apt-get update -y -qq
+            sudo apt-get install -yq --no-install-recommends \
+              build-essential ca-certificates curl ffmpeg imagemagick jq \
+              libcurl4-openssl-dev liblzma-dev default-libmysqlclient-dev \
+              libssl-dev libtag1-dev libxrender1 libgcrypt20 libvips-dev \
+              libxml2-dev libyaml-dev pdftk percona-toolkit unzip wget \
+              zlib1g-dev fonts-dejavu fonts-wqy-zenhei fonts-wqy-microhei \
+              netcat-openbsd
+
+            # wkhtmltopdf — used to render HTML to PDF in some specs.
+            wget --quiet https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz -O /tmp/wkhtml.tar.xz
+            tar xf /tmp/wkhtml.tar.xz -C /tmp
+            sudo cp /tmp/wkhtmltox/bin/wkhtmltopdf /usr/local/bin/wkhtmltopdf
+            sudo chmod +x /usr/local/bin/wkhtmltopdf
+
+            fc-cache -f
+
+      - name: Cache Chrome and ChromeDriver
+        id: chrome-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            /opt/google/chrome
+            /usr/local/bin/chromedriver
+            /usr/bin/google-chrome
+            /usr/bin/google-chrome-stable
+          key: chrome-${{ env.CHROME_VERSION }}
+
+      - name: Install Chrome and ChromeDriver
+        if: steps.chrome-cache.outputs.cache-hit != 'true'
+        run: |
+          curl --retry 10 --connect-timeout 5 --retry-max-time 60 \
+            --output /tmp/google-chrome-stable_${CHROME_VERSION}_amd64.deb \
+            "https://public-files.gumroad.com/google-chrome-stable_${CHROME_VERSION}_amd64.deb"
+          sudo apt-get install -y /tmp/google-chrome-stable_${CHROME_VERSION}_amd64.deb
+          CHROME_VER_FULL=$(google-chrome --version | sed 's/^Google Chrome //')
+          curl --silent --show-error --location --fail --retry 4 --retry-delay 5 \
+            --output /tmp/chromedriver_linux64.zip \
+            "https://storage.googleapis.com/chrome-for-testing-public/$CHROME_VER_FULL/linux64/chromedriver-linux64.zip"
+          cd /tmp && unzip chromedriver_linux64.zip
+          sudo mv chromedriver-linux64/chromedriver /usr/local/bin/chromedriver
+          sudo chmod +x /usr/local/bin/chromedriver
+          chromedriver --version
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
         env:
-          WEB_REPO: gumroadteam/web
+          BUNDLE_GEMS__CONTRIBSYS__COM: ${{ secrets.BUNDLE_GEMS__CONTRIBSYS__COM }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Restore asset precompile cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            public/assets
+            public/packs-test
+            tmp/cache/assets
+            tmp/shakapacker
+          key: asset-precompile-${{ hashFiles('app/assets/**', 'app/javascript/**', 'config/webpack/**', 'config/shakapacker.yml', 'Gemfile.lock', 'package-lock.json', '.ruby-version') }}
+          restore-keys: |
+            asset-precompile-
+
+      - name: Copy test env
+        run: cp .env.test .env
+
+      - name: Wait for services and prepare database
+        run: |
+          for i in $(seq 1 60); do
+            mysqladmin ping -h 127.0.0.1 -P 3306 -u root -ppassword --silent && break
+            sleep 1
+          done
+          bundle exec rake db:prepare
+
+      - name: Set up MinIO (S3 fixture buckets)
+        run: |
+          docker run -d --rm \
+            -p 9000:9000 -p 9001:9001 \
+            -e MINIO_ROOT_USER=minioadmin \
+            -e MINIO_ROOT_PASSWORD=minioadmin \
+            --name minio \
+            minio/minio:RELEASE.2025-09-07T16-13-09Z \
+            server /data --console-address ":9001"
+          for i in $(seq 1 30); do curl -sf http://localhost:9000/minio/health/ready && break; sleep 1; done
+          docker run --rm --network host minio/mc:RELEASE.2025-08-13T08-35-41Z sh -c '
+            mc alias set myminio http://localhost:9000 minioadmin minioadmin
+            for b in gumroad-specs gumroad-invoices; do
+              mc mb --ignore-existing myminio/$b
+              mc anonymous set public myminio/$b
+              mc version enable myminio/$b
+            done
+          '
+
+      - name: Precompile assets
+        run: |
+          bundle exec rails js:export
+          bundle exec rake assets:precompile --trace
+        env:
+          RAILS_ENV: test
+          NODE_ENV: test
 
       - name: Run tests
         timeout-minutes: 25
         run: |
-          mkdir -p ./capybara-artifacts
-          chmod 777 ./capybara-artifacts
-          mkdir -p ./test-logs
-          chmod 777 ./test-logs
-          docker run --rm --entrypoint="" --network ${{ env.COMPOSE_PROJECT_NAME }}_default \
-            -v "$(pwd)/capybara-artifacts:/app/tmp/capybara" \
-            -v "$(pwd)/test-logs:/app/log" \
-            -e RUBY_YJIT_ENABLE \
-            -e KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC \
-            -e KNAPSACK_PRO_CI_NODE_TOTAL \
-            -e KNAPSACK_PRO_CI_NODE_INDEX \
-            -e KNAPSACK_PRO_LOG_LEVEL \
-            -e KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES \
-            -e KNAPSACK_PRO_TEST_FILE_PATTERN \
-            -e KNAPSACK_PRO_COMMIT_HASH \
-            -e KNAPSACK_PRO_BRANCH \
-            -e KNAPSACK_PRO_CI_NODE_BUILD_ID \
-            -e KNAPSACK_PRO_CI_NODE_RETRY_COUNT \
-            -e KNAPSACK_PRO_PROJECT_DIR \
-            -e KNAPSACK_PRO_FIXED_QUEUE_SPLIT \
-            -e CI \
-            -e IN_DOCKER \
-            $WEB_REPO:${{ needs.build.outputs.test_image_tag }} \
-            /usr/local/bin/gosu app bundle exec rake "knapsack_pro:queue:rspec[--format RSpec::Github::Formatter --tag ~skip --format progress]"
+          mkdir -p ./capybara-artifacts ./test-logs
+          bundle exec rake "knapsack_pro:queue:rspec[--format RSpec::Github::Formatter --tag ~skip --format progress]"
         env:
-          RUBY_YJIT_ENABLE: 1
+          RAILS_ENV: test
+          NODE_ENV: test
           KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC_FAST }}
           KNAPSACK_PRO_CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
           KNAPSACK_PRO_CI_NODE_INDEX: ${{ matrix.ci_node_index }}
@@ -541,11 +392,10 @@ jobs:
           KNAPSACK_PRO_BRANCH: ${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref_name }}
           KNAPSACK_PRO_CI_NODE_BUILD_ID: ${{ github.run_id }}
           KNAPSACK_PRO_CI_NODE_RETRY_COUNT: ${{ github.run_attempt }}
-          KNAPSACK_PRO_PROJECT_DIR: /app
+          KNAPSACK_PRO_PROJECT_DIR: ${{ github.workspace }}
           KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
           CI: true
-          IN_DOCKER: true
-          WEB_REPO: gumroadteam/web
+
       - name: Archive capybara artifacts
         if: failure()
         uses: actions/upload-artifact@v4
@@ -554,6 +404,7 @@ jobs:
           path: ./capybara-artifacts/*.png
           retention-days: 7
           if-no-files-found: ignore
+
       - name: Archive test logs
         if: failure()
         uses: actions/upload-artifact@v4
@@ -562,6 +413,7 @@ jobs:
           path: ./test-logs/test.log
           retention-days: 7
           if-no-files-found: ignore
+
       - name: Archive flaky specs log
         if: always()
         uses: actions/upload-artifact@v4
@@ -570,13 +422,6 @@ jobs:
           path: ./test-logs/flaky_specs.log
           retention-days: 14
           if-no-files-found: ignore
-      - name: Clean up
-        if: always()
-        run: |
-          docker compose -f docker/docker-compose-test-and-ci.yml down -v 2>/dev/null || true
-          docker rm -f $(docker ps -aq -f name=${{ env.COMPOSE_PROJECT_NAME }}) 2>/dev/null || true
-          docker volume rm $(docker volume ls -q -f name=${{ env.COMPOSE_PROJECT_NAME }}) 2>/dev/null || true
-          docker network rm ${{ env.COMPOSE_PROJECT_NAME }}_default 2>/dev/null || true
 
   unblock_deployment_from_buildkite:
     name: Unblock deployment from Buildkite
@@ -605,11 +450,9 @@ jobs:
             fi
 
             echo "Looking for Buildkite build for commit $COMMIT_SHA on pipeline $ORG_SLUG/$PIPELINE_SLUG..."
-            # Fetch builds for the specific commit, including jobs
             BUILD_DATA=$(curl -s -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
               "https://api.buildkite.com/v2/organizations/$ORG_SLUG/pipelines/$PIPELINE_SLUG/builds?commit=$COMMIT_SHA&include_retried_jobs=true")
 
-            # Extract the latest build number that is currently blocked for this commit
             BUILD_NUMBER=$(echo "$BUILD_DATA" | jq -r --arg commit "$COMMIT_SHA" '[.[] | select(.commit == $commit and .blocked == true)] | sort_by(.created_at) | last | .number // empty')
 
             if [ -z "$BUILD_NUMBER" ]; then
@@ -618,11 +461,9 @@ jobs:
             fi
 
             echo "Found blocked Buildkite build number: $BUILD_NUMBER. Fetching job details..."
-            # Fetch detailed data for the specific build to get job IDs
             BUILD_DETAIL_DATA=$(curl -s -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
                "https://api.buildkite.com/v2/organizations/$ORG_SLUG/pipelines/$PIPELINE_SLUG/builds/$BUILD_NUMBER")
 
-            # Extract the job ID for the block step with key "require-approval"
             BLOCK_JOB_ID=$(echo "$BUILD_DETAIL_DATA" | jq -r '.jobs[] | select(.type == "manual" and .step_key == "require-approval") | .id // empty')
 
             if [ -z "$BLOCK_JOB_ID" ]; then
@@ -631,23 +472,20 @@ jobs:
             fi
 
             echo "Found block job ID: $BLOCK_JOB_ID for build $BUILD_NUMBER. Attempting to unblock job..."
-            # Send the unblock request using PUT to the job-specific endpoint
             RESPONSE_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X PUT \
               -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
               -H "Content-Type: application/json" \
               -d '{}' \
               "https://api.buildkite.com/v2/organizations/$ORG_SLUG/pipelines/$PIPELINE_SLUG/builds/$BUILD_NUMBER/jobs/$BLOCK_JOB_ID/unblock")
 
-            # Check the response code
             if [ "$RESPONSE_CODE" -ge 200 ] && [ "$RESPONSE_CODE" -lt 300 ]; then
               echo "Successfully sent unblock request for job $BLOCK_JOB_ID in build $BUILD_NUMBER. Response code: $RESPONSE_CODE"
             else
               echo "Error sending unblock request for job $BLOCK_JOB_ID in build $BUILD_NUMBER. Response code: $RESPONSE_CODE"
-              # Attempt to fetch error details from Buildkite if available
               ERROR_DETAILS=$(curl -s -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
                 "https://api.buildkite.com/v2/organizations/$ORG_SLUG/pipelines/$PIPELINE_SLUG/builds/$BUILD_NUMBER/jobs/$BLOCK_JOB_ID")
               echo "API Response details for failed unblock: $ERROR_DETAILS"
-              exit 1 # Exit with error if the API call failed
+              exit 1
             fi
         env:
           UNBLOCK_DEPLOYMENT: ${{ secrets.UNBLOCK_DEPLOYMENT_FROM_BUILDKITE }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -152,7 +152,7 @@ jobs:
             minio/minio:RELEASE.2025-09-07T16-13-09Z \
             server /data --console-address ":9001"
           for i in $(seq 1 30); do curl -sf http://localhost:9000/minio/health/ready && break; sleep 1; done
-          docker run --rm --network host minio/mc:RELEASE.2025-08-13T08-35-41Z sh -c '
+          docker run --rm --network host --entrypoint sh minio/mc:RELEASE.2025-08-13T08-35-41Z -c '
             mc alias set myminio http://localhost:9000 minioadmin minioadmin
             for b in gumroad-specs gumroad-invoices; do
               mc mb --ignore-existing myminio/$b
@@ -363,7 +363,7 @@ jobs:
             minio/minio:RELEASE.2025-09-07T16-13-09Z \
             server /data --console-address ":9001"
           for i in $(seq 1 30); do curl -sf http://localhost:9000/minio/health/ready && break; sleep 1; done
-          docker run --rm --network host minio/mc:RELEASE.2025-08-13T08-35-41Z sh -c '
+          docker run --rm --network host --entrypoint sh minio/mc:RELEASE.2025-08-13T08-35-41Z -c '
             mc alias set myminio http://localhost:9000 minioadmin minioadmin
             for b in gumroad-specs gumroad-invoices; do
               mc mb --ignore-existing myminio/$b

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -307,7 +307,12 @@ jobs:
           sudo apt-get install -y --allow-downgrades /tmp/google-chrome-stable_${CHROME_VERSION}_amd64.deb
           # Pin so a later apt-get upgrade doesn't bump it under us.
           sudo apt-mark hold google-chrome-stable
-          CHROME_VER_FULL=$(google-chrome --version | sed 's/^Google Chrome //')
+          CHROME_VERSION_OUTPUT=$(google-chrome --version)
+          CHROME_VER_FULL=$(echo "$CHROME_VERSION_OUTPUT" | grep -oE '[0-9]+(\.[0-9]+){3}' | head -n 1)
+          if [ -z "$CHROME_VER_FULL" ]; then
+            echo "Unable to parse Chrome version from: $CHROME_VERSION_OUTPUT"
+            exit 1
+          fi
           curl --silent --show-error --location --fail --retry 4 --retry-delay 5 \
             --output /tmp/chromedriver_linux64.zip \
             "https://storage.googleapis.com/chrome-for-testing-public/$CHROME_VER_FULL/linux64/chromedriver-linux64.zip"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -114,7 +114,12 @@ jobs:
           cache: npm
 
       - name: Install npm dependencies
-        run: npm ci
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 10
+          command: npm ci
 
       - name: Restore asset precompile cache
         id: asset_cache
@@ -333,7 +338,12 @@ jobs:
           cache: npm
 
       - name: Install npm dependencies
-        run: npm ci
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 10
+          command: npm ci
 
       - name: Restore asset precompile cache
         uses: actions/cache@v4


### PR DESCRIPTION
## Why

The current CI builds 3 Docker images (`web_base`, `web_base_test`, `web`) on every push from a single big runner, pushes them to Docker Hub, then 68 test shards each Docker-pull the multi-GB image before they can do anything. That's ~3–5 min of upfront build work plus ~30–60s of per-shard pull latency, before we even talk to Knapsack Pro.

Flexile dropped its Docker wrapper a few weeks ago and gets meaningful wins from running bare-metal. This applies the same pattern to Gumroad.

## What

Switch `tests.yml` to bare-metal:
- Each shard does `apt-get install` for system deps (build-essential, imagemagick, vips, mysql client, ffmpeg, fonts, etc.)
- `ruby/setup-ruby@v1 bundler-cache: true` handles Ruby + cached gems
- `actions/setup-node@v4 cache: npm` handles Node + cached npm
- MySQL / Redis / Mongo / Elasticsearch run as native GitHub service containers
- MinIO runs as a one-shot `docker run -d` (its entrypoint takes args, doesn't fit the services schema)
- Chrome + ChromeDriver pinned to `125.0.6422.76-1` (matching the prior Dockerfile), cached
- Asset precompile cache survives across runs (same key as before)

Removed:
- The entire `build` job and its asset-precompile-then-docker-commit dance
- Docker Hub login in every shard
- `gumroadteam/web_base`, `/web_base_test`, `/web` image flow
- `docker/docker-compose-test-and-ci.yml` orchestration (still keeping the file for now — used by local dev)
- `docker run --entrypoint=…` wrapper around rake/rspec
- `/usr/local/bin/gosu app` indirection
- Container teardown step

Kept everything else: 18-shard Test Fast / 50-shard Test Slow, Knapsack Pro queue mode, flaky-spec logs, Buildkite deploy-unblock downstream.

## Tradeoffs

- **Each shard pays the apt/bundle/npm setup cost** (~90s with warm caches) instead of pulling a pre-baked image (~30–60s). Roughly a wash, but with much less moving infrastructure.
- **No more Docker Hub dependency** for CI — one less external SaaS to depend on, no more rate-limit risk.
- **Bare-metal flakes** may surface differently than container flakes (file permission edges, port collisions). Expected to be minimal because `.env.test` already uses `localhost` everywhere.

## Validation

Draft until at least one full CI run passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5315"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782555311&installation_id=134400930&pr_number=5315&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5315&signature=01342ae2492eadddd7cbeff2c8476affe3885de27efe3668ba9d5e43c1a8c248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->