### PR TITLE
[codex] Add checkout timeout to CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,9 @@ jobs:
     outputs:
       test_image_tag: ${{ steps.test_image_tag.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out repository
+        uses: actions/checkout@v4
+        timeout-minutes: 5
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
@@ -266,7 +268,9 @@ jobs:
         ci_node_total: [18]
         ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out repository
+        uses: actions/checkout@v4
+        timeout-minutes: 5
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
@@ -446,7 +450,9 @@ jobs:
             49,
           ]
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out repository
+        uses: actions/checkout@v4
+        timeout-minutes: 5
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false


### PR DESCRIPTION
## Summary

Adds a 5-minute timeout to each `actions/checkout@v4` step in the Tests workflow.

## Why

Some CI shards can hang inside checkout before app setup or tests begin. The existing test-step timeouts do not apply to checkout, so those hangs can keep a run alive for much longer than useful.

## Validation

- Parsed `.github/workflows/tests.yml` with Ruby YAML
- Verified this branch contains only `.github/workflows/tests.yml` changes

## Notes

This branch is separate from `buyer-currency-display`, so pushing it does not cancel that branch's current CI run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782574613&installation_id=134400930&pr_number=5318&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5318&signature=e6a5e275735060859bc6a8ffdc9e6ea0ebbfeafb8ba0593de9a2d77c0875370a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change with no application, auth, or data-path impact.
> 
> **Overview**
> Adds a **5-minute** step timeout and an explicit **Check out repository** name on every `actions/checkout@v4` step in the Tests workflow (`build`, `test_fast`, and `test_slow`).
> 
> That caps how long a shard can sit in checkout before tests or image work start, so a stuck fetch does not hold the whole job until the default job timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e2dd79355528ccbcb284f090939f729b8caff0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->