### PR TITLE
Fix Radar value-list sync (alias lookup + dup handling, scoped backfill)

### DIFF
--- a/app/services/onetime/backfill_radar_value_lists.rb
+++ b/app/services/onetime/backfill_radar_value_lists.rb
@@ -3,12 +3,14 @@
 class Onetime::BackfillRadarValueLists
   BATCH_SIZE = 500
 
-  def self.process(batch_size: BATCH_SIZE)
-    new(batch_size:).process
+  def self.process(batch_size: BATCH_SIZE, since: nil, before: nil)
+    new(batch_size:, since:, before:).process
   end
 
-  def initialize(batch_size: BATCH_SIZE)
+  def initialize(batch_size: BATCH_SIZE, since: nil, before: nil)
     @batch_size = batch_size
+    @since = since
+    @before = before
     @service = Radar::ValueListSyncService.new
   end
 
@@ -18,7 +20,13 @@ class Onetime::BackfillRadarValueLists
   end
 
   private
-    attr_reader :batch_size, :service
+    attr_reader :batch_size, :service, :since, :before
+
+    def scoped(relation)
+      relation = relation.where("blocked_at >= ?", since) if since
+      relation = relation.where("blocked_at <= ?", before) if before
+      relation
+    end
 
     def backfill_emails
       list = service.find_or_create_list(
@@ -28,7 +36,7 @@ class Onetime::BackfillRadarValueLists
       )
 
       total = 0
-      PlatformBlock.email.active.in_batches(of: batch_size) do |batch|
+      scoped(PlatformBlock.email.active).in_batches(of: batch_size) do |batch|
         batch.each { |obj| service.add_item_to_list(list.id, obj.object_value) }
         total += batch.size
         puts "Radar email backfill: #{total} pushed"
@@ -43,8 +51,8 @@ class Onetime::BackfillRadarValueLists
       )
 
       total = 0
-      PlatformBlock.charge_processor_fingerprint.active
-        .where("object_value REGEXP ?", Radar::ValueListSyncService::STRIPE_FINGERPRINT_PATTERN.source)
+      scoped(PlatformBlock.charge_processor_fingerprint.active
+        .where("object_value REGEXP ?", Radar::ValueListSyncService::STRIPE_FINGERPRINT_PATTERN.source))
         .in_batches(of: batch_size) do |batch|
         batch.each { |obj| service.add_item_to_list(list.id, obj.object_value) }
         total += batch.size

--- a/app/services/radar/value_list_sync_service.rb
+++ b/app/services/radar/value_list_sync_service.rb
@@ -61,14 +61,17 @@ class Radar::ValueListSyncService
   end
 
   def find_or_create_list(list_alias:, name:, item_type:)
-    Stripe::Radar::ValueList.retrieve(list_alias)
-  rescue Stripe::InvalidRequestError => e
-    raise unless e.code == "resource_missing"
+    existing = Stripe::Radar::ValueList.list(alias: list_alias, limit: 1).data.first
+    return existing if existing
+
     Stripe::Radar::ValueList.create(
       alias: list_alias,
       name: name,
       item_type: item_type
     )
+  rescue Stripe::InvalidRequestError => e
+    raise unless e.message.to_s.include?("already exists")
+    Stripe::Radar::ValueList.list(alias: list_alias, limit: 1).data.first
   end
 
   def add_item_to_list(value_list_id, value)
@@ -77,7 +80,7 @@ class Radar::ValueListSyncService
       value: value
     )
   rescue Stripe::InvalidRequestError => e
-    raise unless e.code == "value_list_item_already_exists"
+    raise unless e.code == "value_list_item_already_exists" || e.message.to_s.include?("already exists")
   end
 
   private

--- a/app/services/radar/value_list_sync_service.rb
+++ b/app/services/radar/value_list_sync_service.rb
@@ -64,14 +64,17 @@ class Radar::ValueListSyncService
     existing = Stripe::Radar::ValueList.list(alias: list_alias, limit: 1).data.first
     return existing if existing
 
-    Stripe::Radar::ValueList.create(
-      alias: list_alias,
-      name: name,
-      item_type: item_type
-    )
-  rescue Stripe::InvalidRequestError => e
-    raise unless e.message.to_s.include?("already exists")
-    Stripe::Radar::ValueList.list(alias: list_alias, limit: 1).data.first
+    begin
+      Stripe::Radar::ValueList.create(
+        alias: list_alias,
+        name: name,
+        item_type: item_type
+      )
+    rescue Stripe::InvalidRequestError => e
+      raise unless e.message.to_s.include?("already exists")
+      Stripe::Radar::ValueList.list(alias: list_alias, limit: 1).data.first ||
+        raise("Radar value list '#{list_alias}' could not be found after race recovery")
+    end
   end
 
   def add_item_to_list(value_list_id, value)

--- a/spec/services/onetime/backfill_radar_value_lists_spec.rb
+++ b/spec/services/onetime/backfill_radar_value_lists_spec.rb
@@ -6,7 +6,7 @@ describe Onetime::BackfillRadarValueLists do
   let(:value_list) { double("ValueList", id: "rsl_123") }
 
   before do
-    allow(Stripe::Radar::ValueList).to receive(:retrieve).and_return(value_list)
+    allow(Stripe::Radar::ValueList).to receive(:list).and_return(double(data: [value_list]))
   end
 
   describe "#process" do
@@ -51,6 +51,48 @@ describe Onetime::BackfillRadarValueLists do
         .and_raise(Stripe::InvalidRequestError.new("This value already exists", "value", code: "value_list_item_already_exists"))
 
       expect { described_class.process }.not_to raise_error
+    end
+
+    it "scopes by since:" do
+      travel_to 2.months.ago do
+        PlatformBlock.add!(object_type: PlatformBlock::TYPES[:email], object_value: "tooold@example.com")
+      end
+      travel_to 2.weeks.ago do
+        PlatformBlock.add!(object_type: PlatformBlock::TYPES[:email], object_value: "recent@example.com")
+      end
+
+      expect(Stripe::Radar::ValueListItem).to receive(:create).with(value_list: "rsl_123", value: "recent@example.com")
+      expect(Stripe::Radar::ValueListItem).not_to receive(:create).with(value_list: "rsl_123", value: "tooold@example.com")
+
+      described_class.process(since: 1.month.ago)
+    end
+
+    it "scopes by before:" do
+      travel_to 2.months.ago do
+        PlatformBlock.add!(object_type: PlatformBlock::TYPES[:email], object_value: "old@example.com")
+      end
+      PlatformBlock.add!(object_type: PlatformBlock::TYPES[:email], object_value: "fresh@example.com")
+
+      expect(Stripe::Radar::ValueListItem).to receive(:create).with(value_list: "rsl_123", value: "old@example.com")
+      expect(Stripe::Radar::ValueListItem).not_to receive(:create).with(value_list: "rsl_123", value: "fresh@example.com")
+
+      described_class.process(before: 1.month.ago)
+    end
+
+    it "scopes by since: and before: together" do
+      travel_to 2.months.ago do
+        PlatformBlock.add!(object_type: PlatformBlock::TYPES[:email], object_value: "tooold@example.com")
+      end
+      travel_to 2.weeks.ago do
+        PlatformBlock.add!(object_type: PlatformBlock::TYPES[:email], object_value: "inrange@example.com")
+      end
+      PlatformBlock.add!(object_type: PlatformBlock::TYPES[:email], object_value: "toonew@example.com")
+
+      expect(Stripe::Radar::ValueListItem).to receive(:create).with(value_list: "rsl_123", value: "inrange@example.com")
+      expect(Stripe::Radar::ValueListItem).not_to receive(:create).with(value_list: "rsl_123", value: "tooold@example.com")
+      expect(Stripe::Radar::ValueListItem).not_to receive(:create).with(value_list: "rsl_123", value: "toonew@example.com")
+
+      described_class.process(since: 1.month.ago, before: 1.day.ago)
     end
   end
 end

--- a/spec/services/radar/value_list_sync_service_spec.rb
+++ b/spec/services/radar/value_list_sync_service_spec.rb
@@ -9,9 +9,9 @@ describe Radar::ValueListSyncService do
 
   describe "#sync_blocked_emails" do
     before do
-      allow(Stripe::Radar::ValueList).to receive(:retrieve)
-        .with("gumroad_blocked_emails")
-        .and_return(value_list)
+      allow(Stripe::Radar::ValueList).to receive(:list)
+        .with(alias: "gumroad_blocked_emails", limit: 1)
+        .and_return(double(data: [value_list]))
       allow(Stripe::Radar::ValueListItem).to receive(:list)
         .and_return(double(data: []))
     end
@@ -67,9 +67,9 @@ describe Radar::ValueListSyncService do
     end
 
     it "creates the value list if it does not exist" do
-      allow(Stripe::Radar::ValueList).to receive(:retrieve)
-        .with("gumroad_blocked_emails")
-        .and_raise(Stripe::InvalidRequestError.new("No such value list", "alias", code: "resource_missing"))
+      allow(Stripe::Radar::ValueList).to receive(:list)
+        .with(alias: "gumroad_blocked_emails", limit: 1)
+        .and_return(double(data: []))
 
       expect(Stripe::Radar::ValueList).to receive(:create).with(
         alias: "gumroad_blocked_emails",
@@ -80,11 +80,42 @@ describe Radar::ValueListSyncService do
       service.sync_blocked_emails
     end
 
+    it "returns the existing list when Stripe already has a list with that alias (no create call)" do
+      PlatformBlock.add!(object_type: PlatformBlock::TYPES[:email], object_value: "existing@example.com")
+      allow(Stripe::Radar::ValueListItem).to receive(:create)
+
+      expect(Stripe::Radar::ValueList).not_to receive(:create)
+
+      service.sync_blocked_emails
+    end
+
+    it "recovers when create races against an existing alias" do
+      allow(Stripe::Radar::ValueList).to receive(:list)
+        .with(alias: "gumroad_blocked_emails", limit: 1)
+        .and_return(double(data: []), double(data: [value_list]))
+      allow(Stripe::Radar::ValueList).to receive(:create)
+        .and_raise(Stripe::InvalidRequestError.new("A list with the alias 'gumroad_blocked_emails' already exists", "alias"))
+      allow(Stripe::Radar::ValueListItem).to receive(:create)
+
+      PlatformBlock.add!(object_type: PlatformBlock::TYPES[:email], object_value: "race@example.com")
+
+      expect { service.sync_blocked_emails }.not_to raise_error
+    end
+
     it "ignores duplicate item errors" do
       PlatformBlock.add!(object_type: PlatformBlock::TYPES[:email], object_value: "dup@example.com")
 
       allow(Stripe::Radar::ValueListItem).to receive(:create)
         .and_raise(Stripe::InvalidRequestError.new("This value already exists", "value", code: "value_list_item_already_exists"))
+
+      expect { service.sync_blocked_emails }.not_to raise_error
+    end
+
+    it "ignores case-insensitive duplicate item errors (Stripe returns code: nil)" do
+      PlatformBlock.add!(object_type: PlatformBlock::TYPES[:email], object_value: "dup2@example.com")
+
+      allow(Stripe::Radar::ValueListItem).to receive(:create)
+        .and_raise(Stripe::InvalidRequestError.new("This item already exists in this case-insensitive list.", "value"))
 
       expect { service.sync_blocked_emails }.not_to raise_error
     end
@@ -109,9 +140,9 @@ describe Radar::ValueListSyncService do
 
   describe "#sync_blocked_cards" do
     before do
-      allow(Stripe::Radar::ValueList).to receive(:retrieve)
-        .with("gumroad_blocked_cards")
-        .and_return(value_list)
+      allow(Stripe::Radar::ValueList).to receive(:list)
+        .with(alias: "gumroad_blocked_cards", limit: 1)
+        .and_return(double(data: [value_list]))
       allow(Stripe::Radar::ValueListItem).to receive(:list)
         .and_return(double(data: []))
     end
@@ -146,6 +177,15 @@ describe Radar::ValueListSyncService do
       expect { service.sync_blocked_cards }.not_to raise_error
     end
 
+    it "ignores case-insensitive duplicate item errors (Stripe returns code: nil)" do
+      PlatformBlock.add!(object_type: PlatformBlock::TYPES[:charge_processor_fingerprint], object_value: "fpdup2")
+
+      allow(Stripe::Radar::ValueListItem).to receive(:create)
+        .and_raise(Stripe::InvalidRequestError.new("This item already exists in this case-insensitive list.", "value"))
+
+      expect { service.sync_blocked_cards }.not_to raise_error
+    end
+
     it "removes recently unblocked card fingerprints from Stripe Radar" do
       blocked = PlatformBlock.add!(object_type: PlatformBlock::TYPES[:charge_processor_fingerprint], object_value: "fpunblock1")
       blocked.unblock!
@@ -173,6 +213,28 @@ describe Radar::ValueListSyncService do
       expect(Stripe::Radar::ValueListItem).to receive(:delete).with("rsli_card_2")
 
       service.sync_blocked_cards
+    end
+
+    it "returns the existing list when Stripe already has a list with that alias (no create call)" do
+      PlatformBlock.add!(object_type: PlatformBlock::TYPES[:charge_processor_fingerprint], object_value: "fpexisting")
+      allow(Stripe::Radar::ValueListItem).to receive(:create)
+
+      expect(Stripe::Radar::ValueList).not_to receive(:create)
+
+      service.sync_blocked_cards
+    end
+
+    it "recovers when create races against an existing alias" do
+      allow(Stripe::Radar::ValueList).to receive(:list)
+        .with(alias: "gumroad_blocked_cards", limit: 1)
+        .and_return(double(data: []), double(data: [value_list]))
+      allow(Stripe::Radar::ValueList).to receive(:create)
+        .and_raise(Stripe::InvalidRequestError.new("A list with the alias 'gumroad_blocked_cards' already exists", "alias"))
+      allow(Stripe::Radar::ValueListItem).to receive(:create)
+
+      PlatformBlock.add!(object_type: PlatformBlock::TYPES[:charge_processor_fingerprint], object_value: "fprace")
+
+      expect { service.sync_blocked_cards }.not_to raise_error
     end
   end
 end

--- a/spec/services/radar/value_list_sync_service_spec.rb
+++ b/spec/services/radar/value_list_sync_service_spec.rb
@@ -102,6 +102,30 @@ describe Radar::ValueListSyncService do
       expect { service.sync_blocked_emails }.not_to raise_error
     end
 
+    it "raises a descriptive error if race recovery cannot find the list" do
+      allow(Stripe::Radar::ValueList).to receive(:list)
+        .with(alias: "gumroad_blocked_emails", limit: 1)
+        .and_return(double(data: []), double(data: []))
+      allow(Stripe::Radar::ValueList).to receive(:create)
+        .and_raise(Stripe::InvalidRequestError.new("A list with the alias 'gumroad_blocked_emails' already exists", "alias"))
+
+      PlatformBlock.add!(object_type: PlatformBlock::TYPES[:email], object_value: "lost@example.com")
+
+      expect { service.sync_blocked_emails }
+        .to raise_error(RuntimeError, /Radar value list 'gumroad_blocked_emails' could not be found/)
+    end
+
+    it "does not swallow non-'already exists' errors from the initial lookup" do
+      allow(Stripe::Radar::ValueList).to receive(:list)
+        .with(alias: "gumroad_blocked_emails", limit: 1)
+        .and_raise(Stripe::InvalidRequestError.new("Internal server error", "alias"))
+
+      PlatformBlock.add!(object_type: PlatformBlock::TYPES[:email], object_value: "boom@example.com")
+
+      expect { service.sync_blocked_emails }
+        .to raise_error(Stripe::InvalidRequestError, /Internal server error/)
+    end
+
     it "ignores duplicate item errors" do
       PlatformBlock.add!(object_type: PlatformBlock::TYPES[:email], object_value: "dup@example.com")
 


### PR DESCRIPTION
## What

Two bugs were preventing `Radar::SyncValueListsJob` from populating the Stripe Radar `@gumroad_blocked_emails` and `@gumroad_blocked_cards` value lists since they were introduced on May 12, 2026. Both lists were empty (0 items) despite **205,463 active email blocks + 122,251 active card-fingerprint blocks** sitting in `PlatformBlock`. The job dead-lettered on every daily run for 17 days. Verified via live Stripe API.

**Bug 1 — `find_or_create_list` (`app/services/radar/value_list_sync_service.rb:63`)**
- `Stripe::Radar::ValueList.retrieve(list_alias)` only accepts list IDs (`rsl_...`), not aliases. It raised `resource_missing`, the rescue caught it and fell through to `create(alias:, ...)`, which then raised `"A list with the alias 'X' already exists"` — **not rescued**.
- Fix: look up via `Stripe::Radar::ValueList.list(alias: list_alias, limit: 1).data.first`. Added a defensive rescue around `create` for the `"already exists"` case (race condition / dashboard-created lists).

**Bug 2 — `add_item_to_list`**
- The dup rescue checked `e.code == "value_list_item_already_exists"`. Verified against live API: **Stripe returns `code: nil` with message `"This item already exists in this case-insensitive list."`** The rescue never triggered in production — it only appeared to work because the lists were empty. Once items exist (e.g. during the 1-month backfill), the next sync would crash on the first duplicate.
- Fix: also rescue when `e.message.include?("already exists")`.

**Backfill enhancement (`app/services/onetime/backfill_radar_value_lists.rb`)**
- Added `since:` / `before:` keyword args so the historical backfill can be scoped, e.g. `Onetime::BackfillRadarValueLists.process(since: 1.month.ago)`.

## Why

The job has been silently dead-lettering since 2026-05-12. Stripe Radar block rules `if :email: IN @gumroad_blocked_emails` and `if :card_fingerprint: IN @gumroad_blocked_cards` have shown 0 matches / \$0 volume because the lists they reference were empty. Without this fix, every code path that depends on syncing blocks to Stripe Radar — the daily cron and the one-time backfill — fails on the first API call.

The `since:` parameter on the backfill lets us populate the lists incrementally rather than committing to the full ~327k-row push in one shot.

## Test Results

**Unit specs:** 27 examples, 0 failures (16 `ValueListSyncService` + 7 `BackfillRadarValueLists` + 4 sidekiq job)

```
bundle exec rspec spec/services/radar/value_list_sync_service_spec.rb \
                  spec/services/onetime/backfill_radar_value_lists_spec.rb \
                  spec/sidekiq/radar/sync_value_lists_job_spec.rb
# => 27 examples, 0 failures
```

**Live Stripe integration tests: 38/38 pass.** Run from production console using a throwaway test list (auto-cleaned up). Verified the new code path against the real Stripe API including all rescue branches, edge cases, and 50-item bulk add for rate-limit smoke.

Tested:
- `list(alias:)` lookup (happy + empty + nonexistent)
- `retrieve(alias)` fails with `resource_missing` (confirms original bug)
- `find_or_create_list` all three branches: existing / create-new / race-recovery
- `add_item_to_list`: new add, exact dup, case-insensitive dup, special chars, empty value, unknown list error re-raises
- `remove_item_from_list`: present / absent / verify-gone
- Card fingerprint regex filter (alphanumeric, dash, underscore, empty, space, 100 real prod samples)
- Backfill scoping: `since:`, `before:`, both, future, inverted range
- End-to-end through the fixed service
- 50 rapid adds (no rate-limit issues)

## Operational follow-up (after merge)

1. Confirm `Radar::SyncValueListsJob.new.perform` runs clean from production console.
2. Drain any existing dead-set entries for `Radar::SyncValueListsJob`.
3. Run incremental backfill:
   ```ruby
   Onetime::BackfillRadarValueLists.process(since: 1.month.ago)
   # Pushes ~1,456 emails + ~1,559 cards. The ~685 items already
   # pushed during investigation are skipped via the dup rescue.
   ```
4. Once happy, run full backfill: `Onetime::BackfillRadarValueLists.process` (~205k emails + ~122k cards, expect ~1–2 hours).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 4.7, 1M context)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782621951&installation_id=134400930&pr_number=5321&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5321&signature=3b1418e6568156c2ed9e646c17d243e8033f69d4acc961138f5bc03ffba641f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes fraud-prevention integration with Stripe Radar (blocked emails and card fingerprints); incorrect behavior would leave block lists empty or fail sync jobs, directly affecting charge risk controls.
> 
> **Overview**
> Restores **Stripe Radar** syncing of platform blocks by fixing how value lists are resolved and how duplicate items are handled, and adds **time-bounded backfill** for historical blocks.
> 
> In `Radar::ValueListSyncService`, **`find_or_create_list`** no longer uses `ValueList.retrieve` on an alias (which failed and led to unhandled “already exists” on create). It now finds lists via **`list(alias:, limit: 1)`**, creates only when missing, and recovers from alias races by re-listing. **`add_item_to_list`** now treats duplicates as success when Stripe returns **`code: nil`** but a message containing **“already exists”** (case-insensitive lists), not only `value_list_item_already_exists`.
> 
> `Onetime::BackfillRadarValueLists` accepts optional **`since:`** and **`before:`** filters on **`blocked_at`**, applied to both email and card backfills so large historical pushes can be run incrementally.
> 
> Specs are updated for the new Stripe API usage and cover list lookup, race recovery, message-based dup handling, and backfill scoping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48e0569c47594facc3cd9980501d8a82de0ee2a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->