### PR TITLE
Add URL support for product thumbnails

### DIFF
--- a/app/controllers/api/v2/thumbnails_controller.rb
+++ b/app/controllers/api/v2/thumbnails_controller.rb
@@ -27,7 +27,7 @@ class Api::V2::ThumbnailsController < Api::V2::BaseController
     end
   rescue ActiveSupport::MessageVerifier::InvalidSignature, ActiveRecord::RecordNotFound
     render_response(false, message: "The signed_blob_id is invalid or expired.")
-  rescue URI::InvalidURIError, Addressable::URI::InvalidURIError, SsrfFilter::CRLFInjection, SsrfFilter::InvalidUriScheme, SsrfFilter::PrivateIPAddress
+  rescue URI::InvalidURIError, Addressable::URI::InvalidURIError, SsrfFilter::CRLFInjection, SsrfFilter::InvalidUriScheme, SsrfFilter::PrivateIPAddress, SsrfFilter::TooManyRedirects, SsrfFilter::UnresolvedHostname
     render status: :bad_request, json: { success: false, message: "Please provide a valid public image URL." }
   rescue Thumbnail::RemoteFileTooLarge
     render_response(false, message: "Could not process your thumbnail, please upload an image with size smaller than 5 MB.")

--- a/app/controllers/api/v2/thumbnails_controller.rb
+++ b/app/controllers/api/v2/thumbnails_controller.rb
@@ -29,6 +29,8 @@ class Api::V2::ThumbnailsController < Api::V2::BaseController
     render_response(false, message: "The signed_blob_id is invalid or expired.")
   rescue URI::InvalidURIError, Addressable::URI::InvalidURIError, SsrfFilter::CRLFInjection, SsrfFilter::InvalidUriScheme, SsrfFilter::PrivateIPAddress
     render status: :bad_request, json: { success: false, message: "Please provide a valid public image URL." }
+  rescue Thumbnail::RemoteFileTooLarge
+    render_response(false, message: "Could not process your thumbnail, please upload an image with size smaller than 5 MB.")
   rescue ActiveRecord::InvalidForeignKey, ActiveStorage::FileNotFoundError, *INTERNET_EXCEPTIONS
     render_response(false, message: "Could not process your thumbnail, please try again.")
   end

--- a/app/controllers/api/v2/thumbnails_controller.rb
+++ b/app/controllers/api/v2/thumbnails_controller.rb
@@ -5,13 +5,19 @@ class Api::V2::ThumbnailsController < Api::V2::BaseController
   before_action :fetch_product
 
   def create
-    return render_response(false, message: "Please provide a signed_blob_id.") if params[:signed_blob_id].blank?
-
     thumbnail = @product.thumbnail || @product.build_thumbnail
     thumbnail.unsplash_url = nil
     thumbnail.deleted_at = nil
-    thumbnail.file.attach(params[:signed_blob_id])
-    thumbnail.file.analyze
+
+    if params[:signed_blob_id].present?
+      thumbnail.file.attach(params[:signed_blob_id])
+    elsif params[:url].present?
+      thumbnail.url = params[:url]
+    else
+      return render_response(false, message: "Please provide a signed_blob_id or url.")
+    end
+
+    thumbnail.file.analyze if thumbnail.file.attached? && !thumbnail.file.analyzed?
 
     if thumbnail.save
       render_response(true, thumbnail: thumbnail)
@@ -21,6 +27,8 @@ class Api::V2::ThumbnailsController < Api::V2::BaseController
     end
   rescue ActiveSupport::MessageVerifier::InvalidSignature, ActiveRecord::RecordNotFound
     render_response(false, message: "The signed_blob_id is invalid or expired.")
+  rescue URI::InvalidURIError, Addressable::URI::InvalidURIError, SsrfFilter::CRLFInjection, SsrfFilter::InvalidUriScheme, SsrfFilter::PrivateIPAddress
+    render status: :bad_request, json: { success: false, message: "Please provide a valid public image URL." }
   rescue ActiveRecord::InvalidForeignKey, ActiveStorage::FileNotFoundError, *INTERNET_EXCEPTIONS
     render_response(false, message: "Could not process your thumbnail, please try again.")
   end

--- a/app/javascript/components/ApiDocumentation/Endpoints/Thumbnails.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/Thumbnails.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+
+import CodeSnippet from "$app/components/ui/CodeSnippet";
+
+import { ApiEndpoint } from "../ApiEndpoint";
+import { ApiParameter, ApiParameters } from "../ApiParameters";
+import { ApiResponseFields, renderFields } from "../ApiResponseFields";
+import { THUMBNAIL_FIELDS } from "../responseFieldDefinitions";
+
+const ThumbnailResponseFields = () => (
+  <ApiResponseFields>
+    {renderFields([
+      { name: "success", type: "boolean", description: "Whether the request succeeded" },
+      {
+        name: "thumbnail",
+        type: "object | null",
+        description: "The product thumbnail; null after deletion",
+        children: THUMBNAIL_FIELDS,
+      },
+    ])}
+  </ApiResponseFields>
+);
+
+export const CreateThumbnail = () => (
+  <ApiEndpoint
+    method="post"
+    path="/products/:product_id/thumbnail"
+    description={
+      <>
+        Set a product thumbnail from a signed upload or publicly accessible image URL. URL thumbnails are downloaded and
+        stored by Gumroad, so the URL must be reachable over HTTP(S) and cannot be a private or pre-signed upload URL.
+        Thumbnail images must be square, at least 600x600px, smaller than 5 MB, and in JPG, PNG, or GIF format. Requires
+        the <code>edit_products</code> scope.
+      </>
+    }
+  >
+    <ApiParameters>
+      <ApiParameter
+        name="signed_blob_id"
+        description="(required unless url is provided; signed ID from a direct upload)"
+      />
+      <ApiParameter
+        name="url"
+        description="(required unless signed_blob_id is provided; a publicly accessible image URL)"
+      />
+    </ApiParameters>
+    <ThumbnailResponseFields />
+    <CodeSnippet caption="cURL example">
+      {`curl https://api.gumroad.com/v2/products/A-m3CDDC5dlrSdKZp0RFhA==/thumbnail \\
+  -d "access_token=ACCESS_TOKEN" \\
+  -d "url=https://example.com/thumbnail.png" \\
+  -X POST`}
+    </CodeSnippet>
+    <CodeSnippet caption="Example response:">
+      {`{
+  "success": true,
+  "thumbnail": {
+    "url": "https://public-files.gumroad.com/variants/72iaezqqthnj1350mdc618namqki/f2f9c6fc18a80b8bafa38f3562360c0e42507f1c0052dcb708593f7efa3bdab8",
+    "guid": "abc123"
+  }
+}`}
+    </CodeSnippet>
+  </ApiEndpoint>
+);
+
+export const DeleteThumbnail = () => (
+  <ApiEndpoint
+    method="delete"
+    path="/products/:product_id/thumbnail"
+    description={
+      <>
+        Delete a product thumbnail. Requires the <code>edit_products</code> scope.
+      </>
+    }
+  >
+    <ThumbnailResponseFields />
+    <CodeSnippet caption="cURL example">
+      {`curl https://api.gumroad.com/v2/products/A-m3CDDC5dlrSdKZp0RFhA==/thumbnail \\
+  -d "access_token=ACCESS_TOKEN" \\
+  -X DELETE`}
+    </CodeSnippet>
+    <CodeSnippet caption="Example response:">
+      {`{
+  "success": true,
+  "thumbnail": null
+}`}
+    </CodeSnippet>
+  </ApiEndpoint>
+);

--- a/app/javascript/components/ApiDocumentation/Navigation.tsx
+++ b/app/javascript/components/ApiDocumentation/Navigation.tsx
@@ -35,6 +35,9 @@ export const Navigation = () => (
             <a href="#covers">Covers</a>
           </li>
           <li>
+            <a href="#thumbnails">Thumbnails</a>
+          </li>
+          <li>
             <a href="#variant-categories">Variant categories</a>
           </li>
           <li>

--- a/app/javascript/components/ApiDocumentation/responseFieldDefinitions.ts
+++ b/app/javascript/components/ApiDocumentation/responseFieldDefinitions.ts
@@ -21,6 +21,11 @@ export const COVER_FIELDS: FieldDefinition[] = [
   { name: "native_height", type: "number", description: "Intrinsic height of the source asset in pixels" },
 ];
 
+export const THUMBNAIL_FIELDS: FieldDefinition[] = [
+  { name: "url", type: "string", description: "CDN URL of the product thumbnail image" },
+  { name: "guid", type: "string", description: "Unique identifier for the thumbnail" },
+];
+
 const PRODUCT_VARIANT_FIELDS: FieldDefinition[] = [
   { name: "title", type: "string", description: 'Variant category title (e.g. "Tier")' },
   {

--- a/app/javascript/pages/Public/Api.tsx
+++ b/app/javascript/pages/Public/Api.tsx
@@ -5,63 +5,70 @@ import { Authentication } from "$app/components/ApiDocumentation/Authentication"
 import { CommandLine } from "$app/components/ApiDocumentation/CommandLine";
 import { CreateCover, DeleteCover } from "$app/components/ApiDocumentation/Endpoints/Covers";
 import {
-  GetCustomFields,
   CreateCustomField,
-  UpdateCustomField,
   DeleteCustomField,
+  GetCustomFields,
+  UpdateCustomField,
 } from "$app/components/ApiDocumentation/Endpoints/CustomFields";
-import { FilesOverview, PresignFile, CompleteFile, AbortFile, AttachFile } from "$app/components/ApiDocumentation/Endpoints/Files";
+import { GetEarnings } from "$app/components/ApiDocumentation/Endpoints/Earnings";
 import {
-  VerifyLicense,
-  EnableLicense,
-  DisableLicense,
+  AbortFile,
+  AttachFile,
+  CompleteFile,
+  FilesOverview,
+  PresignFile,
+} from "$app/components/ApiDocumentation/Endpoints/Files";
+import {
   DecrementUsesCount,
+  DisableLicense,
+  EnableLicense,
   RotateLicense,
+  VerifyLicense,
 } from "$app/components/ApiDocumentation/Endpoints/Licenses";
 import {
-  GetOfferCodes,
-  GetOfferCode,
   CreateOfferCode,
-  UpdateOfferCode,
   DeleteOfferCode,
+  GetOfferCode,
+  GetOfferCodes,
+  UpdateOfferCode,
 } from "$app/components/ApiDocumentation/Endpoints/OfferCodes";
-import { GetEarnings } from "$app/components/ApiDocumentation/Endpoints/Earnings";
-import {GetPayouts, GetPayout, GetUpcomingPayouts} from "$app/components/ApiDocumentation/Endpoints/Payouts";
+import { GetPayout, GetPayouts, GetUpcomingPayouts } from "$app/components/ApiDocumentation/Endpoints/Payouts";
 import {
-  GetProducts,
-  GetProduct,
   CreateProduct,
-  UpdateProduct,
   DeleteProduct,
-  EnableProduct,
   DisableProduct,
+  EnableProduct,
+  GetProduct,
+  GetProducts,
+  UpdateProduct,
 } from "$app/components/ApiDocumentation/Endpoints/Products";
 import {
   CreateResourceSubscription,
-  GetResourceSubscriptions,
   DeleteResourceSubscription,
+  GetResourceSubscriptions,
 } from "$app/components/ApiDocumentation/Endpoints/ResourceSubscriptions";
 import {
-  GetSales,
-  GetSale,
   MarkSaleAsShipped,
   RefundSale,
   ResendReceipt,
+  GetSale,
+  GetSales,
 } from "$app/components/ApiDocumentation/Endpoints/Sales";
 import { GetSubscribers, GetSubscriber } from "$app/components/ApiDocumentation/Endpoints/Subscribers";
 import { GetTaxForms, DownloadTaxForm } from "$app/components/ApiDocumentation/Endpoints/TaxForms";
+import { CreateThumbnail, DeleteThumbnail } from "$app/components/ApiDocumentation/Endpoints/Thumbnails";
 import { GetUser } from "$app/components/ApiDocumentation/Endpoints/User";
 import {
-  CreateVariantCategory,
-  GetVariantCategory,
-  UpdateVariantCategory,
-  DeleteVariantCategory,
-  GetVariantCategories,
   CreateVariant,
-  GetVariant,
-  UpdateVariant,
+  CreateVariantCategory,
   DeleteVariant,
+  DeleteVariantCategory,
+  GetVariant,
+  GetVariantCategories,
+  GetVariantCategory,
   GetVariants,
+  UpdateVariant,
+  UpdateVariantCategory,
 } from "$app/components/ApiDocumentation/Endpoints/Variants";
 import { Errors } from "$app/components/ApiDocumentation/Errors";
 import { Introduction } from "$app/components/ApiDocumentation/Introduction";
@@ -119,6 +126,11 @@ export default function Api() {
               <ApiResource name="Covers" id="covers">
                 <CreateCover />
                 <DeleteCover />
+              </ApiResource>
+
+              <ApiResource name="Thumbnails" id="thumbnails">
+                <CreateThumbnail />
+                <DeleteThumbnail />
               </ApiResource>
 
               <ApiResource name="Variant categories" id="variant-categories">

--- a/app/models/thumbnail.rb
+++ b/app/models/thumbnail.rb
@@ -7,6 +7,7 @@ class Thumbnail < ApplicationRecord
   DISPLAY_THUMBNAIL_DIMENSION = 600
   MAX_FILE_SIZE = 5.megabytes
   ALLOW_CONTENT_TYPES = /jpeg|gif|png|jpg/i
+  RemoteFileTooLarge = Class.new(StandardError)
 
   belongs_to :product, class_name: "Link", optional: true
 
@@ -46,13 +47,28 @@ class Thumbnail < ApplicationRecord
     raise URI::InvalidURIError.new("URL must include a valid host") if new_uri.host.blank?
     new_url = new_uri.to_s
 
-    response = SsrfFilter.get(new_url)
+    blob = nil
     tempfile = Tempfile.new(binmode: true)
-    tempfile.write(response.body)
-    tempfile.rewind
-    blob = ActiveStorage::Blob.create_and_upload!(io: tempfile,
-                                                  filename: File.basename(new_url),
-                                                  content_type: response.content_type)
+    begin
+      downloaded_byte_size = 0
+      response = SsrfFilter.get(new_url) do |http_response|
+        raise RemoteFileTooLarge if http_response["content-length"].to_i > MAX_FILE_SIZE
+
+        write_file = !http_response.is_a?(Net::HTTPRedirection)
+        http_response.read_body do |chunk|
+          raise RemoteFileTooLarge if downloaded_byte_size + chunk.bytesize > MAX_FILE_SIZE
+
+          tempfile.write(chunk) if write_file
+          downloaded_byte_size += chunk.bytesize
+        end
+      end
+      tempfile.rewind
+      blob = ActiveStorage::Blob.create_and_upload!(io: tempfile,
+                                                    filename: File.basename(new_url),
+                                                    content_type: response.content_type)
+    ensure
+      tempfile.close!
+    end
     self.unsplash_url = nil
     file.attach(blob.signed_id)
     file.analyze

--- a/app/models/thumbnail.rb
+++ b/app/models/thumbnail.rb
@@ -52,18 +52,20 @@ class Thumbnail < ApplicationRecord
     blob = nil
     tempfile = Tempfile.new(binmode: true)
     begin
-      downloaded_byte_size = 0
       response = SsrfFilter.get(new_url) do |http_response|
         raise RemoteFileTooLarge if http_response["content-length"].to_i > MAX_FILE_SIZE
 
-        write_file = !http_response.is_a?(Net::HTTPRedirection)
+        write_file = http_response.is_a?(Net::HTTPSuccess)
+        response_byte_size = 0
         http_response.read_body do |chunk|
-          raise RemoteFileTooLarge if downloaded_byte_size + chunk.bytesize > MAX_FILE_SIZE
+          response_byte_size += chunk.bytesize
+          raise RemoteFileTooLarge if response_byte_size > MAX_FILE_SIZE
 
           tempfile.write(chunk) if write_file
-          downloaded_byte_size += chunk.bytesize
         end
       end
+      raise ActiveStorage::FileNotFoundError unless response.is_a?(Net::HTTPSuccess)
+
       tempfile.rewind
       blob = ActiveStorage::Blob.create_and_upload!(io: tempfile,
                                                     filename: filename,

--- a/app/models/thumbnail.rb
+++ b/app/models/thumbnail.rb
@@ -46,6 +46,8 @@ class Thumbnail < ApplicationRecord
     raise URI::InvalidURIError.new("URL '#{new_url}' is not a web url") unless new_uri.scheme.in?(["http", "https"])
     raise URI::InvalidURIError.new("URL must include a valid host") if new_uri.host.blank?
     new_url = new_uri.to_s
+    filename = File.basename(new_uri.path)
+    filename = "thumbnail" if filename.blank? || filename == "/"
 
     blob = nil
     tempfile = Tempfile.new(binmode: true)
@@ -64,14 +66,17 @@ class Thumbnail < ApplicationRecord
       end
       tempfile.rewind
       blob = ActiveStorage::Blob.create_and_upload!(io: tempfile,
-                                                    filename: File.basename(new_url),
+                                                    filename: filename,
                                                     content_type: response.content_type)
+      blob.analyze
+      self.unsplash_url = nil
+      file.attach(blob.signed_id)
+    rescue
+      blob&.purge
+      raise
     ensure
       tempfile.close!
     end
-    self.unsplash_url = nil
-    file.attach(blob.signed_id)
-    file.analyze
   end
 
   def url(variant: :default)

--- a/app/models/thumbnail.rb
+++ b/app/models/thumbnail.rb
@@ -37,6 +37,27 @@ class Thumbnail < ApplicationRecord
     alive? ? self : nil
   end
 
+  def url=(new_url)
+    new_url = new_url.to_s
+    new_url = "https:#{new_url}" if new_url.starts_with?("//")
+    new_url = Addressable::URI.escape(new_url) unless URI::ABS_URI.match?(new_url)
+    new_uri = URI.parse(new_url)
+    raise URI::InvalidURIError.new("URL '#{new_url}' is not a web url") unless new_uri.scheme.in?(["http", "https"])
+    raise URI::InvalidURIError.new("URL must include a valid host") if new_uri.host.blank?
+    new_url = new_uri.to_s
+
+    response = SsrfFilter.get(new_url)
+    tempfile = Tempfile.new(binmode: true)
+    tempfile.write(response.body)
+    tempfile.rewind
+    blob = ActiveStorage::Blob.create_and_upload!(io: tempfile,
+                                                  filename: File.basename(new_url),
+                                                  content_type: response.content_type)
+    self.unsplash_url = nil
+    file.attach(blob.signed_id)
+    file.analyze
+  end
+
   def url(variant: :default)
     return unsplash_url if unsplash_url.present?
     return unless file.attached?

--- a/spec/controllers/api/v2/thumbnails_controller_spec.rb
+++ b/spec/controllers/api/v2/thumbnails_controller_spec.rb
@@ -198,6 +198,26 @@ describe Api::V2::ThumbnailsController do
         expect(@product.reload.thumbnail).to be_nil
       end
 
+      it "does not count discarded redirect response bodies against the final image size" do
+        url = "https://example.com/redirecting-thumbnail.png"
+        redirect_response = remote_file_response("blah.txt", "text/plain", chunks: ["a" * Thumbnail::MAX_FILE_SIZE], redirect: true)
+        final_response = remote_file_response("smilie.png", "image/png")
+        allow(SsrfFilter).to receive(:get).with(url) do |&block|
+          block.call(redirect_response)
+          block.call(final_response)
+          final_response
+        end
+
+        post @action, params: @params.merge(url:)
+
+        expect(response).to be_successful
+        body = response.parsed_body
+        expect(body["success"]).to be(true)
+        expect(@product.reload.thumbnail).to be_alive
+        expect(@product.thumbnail.file.blob.filename.to_s).to eq("redirecting-thumbnail.png")
+        expect(@product.thumbnail.file.blob.byte_size).to eq(File.size(Rails.root.join("spec", "support", "fixtures", "smilie.png")))
+      end
+
       it "purges the downloaded blob and keeps the existing thumbnail when analysis fails" do
         existing = create(:thumbnail, product: @product)
         old_blob = existing.file.blob
@@ -213,6 +233,20 @@ describe Api::V2::ThumbnailsController do
         expect(body["success"]).to be(false)
         expect(body["message"]).to eq("Could not process your thumbnail, please try again.")
         expect(@product.reload.thumbnail.file.blob).to eq(old_blob)
+      end
+
+      it "returns processing errors for non-success remote responses without creating a blob" do
+        url = "https://example.com/not-found.png"
+        stub_remote_file(url, "blah.txt", "text/html", response_class: Net::HTTPNotFound)
+
+        expect do
+          post @action, params: @params.merge(url:)
+        end.not_to change { ActiveStorage::Blob.count }
+
+        body = response.parsed_body
+        expect(body["success"]).to be(false)
+        expect(body["message"]).to eq("Could not process your thumbnail, please try again.")
+        expect(@product.reload.thumbnail).to be_nil
       end
 
       it "returns processing errors for non-image remote files" do
@@ -367,18 +401,21 @@ describe Api::V2::ThumbnailsController do
     end
   end
 
-  def stub_remote_file(url, fixture_name, content_type, content_length: nil, chunks: nil)
-    response = remote_file_response(fixture_name, content_type, content_length:, chunks:)
+  def stub_remote_file(url, fixture_name, content_type, content_length: nil, chunks: nil, response_class: Net::HTTPOK)
+    response = remote_file_response(fixture_name, content_type, content_length:, chunks:, response_class:)
 
     allow(SsrfFilter).to receive(:get).with(url).and_yield(response).and_return(response)
   end
 
-  def remote_file_response(fixture_name, content_type, content_length: nil, chunks: nil, redirect: false)
-    response_class = redirect ? Net::HTTPRedirection : Object
+  def remote_file_response(fixture_name, content_type, content_length: nil, chunks: nil, response_class: Net::HTTPOK, redirect: false)
+    response_class = Net::HTTPRedirection if redirect
 
     Class.new(response_class) do
       define_method(:initialize) do |fixture_name, content_type, content_length, chunks|
-        super("1.1", "302", "Found") if redirect
+        if is_a?(Net::HTTPResponse)
+          code = redirect ? "302" : Net::HTTPResponse::CODE_TO_OBJ.key(response_class)
+          super("1.1", code, code)
+        end
 
         @body = File.binread(Rails.root.join("spec", "support", "fixtures", fixture_name))
         @content_type = content_type

--- a/spec/controllers/api/v2/thumbnails_controller_spec.rb
+++ b/spec/controllers/api/v2/thumbnails_controller_spec.rb
@@ -42,6 +42,24 @@ describe Api::V2::ThumbnailsController do
         expect(@product.reload.thumbnail).to be_alive
       end
 
+      it "attaches a thumbnail from a URL" do
+        url = "https://example.com/thumbnail.png"
+        stub_remote_file(url, "smilie.png", "image/png")
+
+        post @action, params: @params.merge(url:)
+
+        expect(response).to be_successful
+        body = response.parsed_body
+        expect(body["success"]).to be(true)
+        expect(body["thumbnail"]["url"]).to be_present
+        expect(body["thumbnail"]["guid"]).to be_present
+        expect(@product.reload.thumbnail).to be_alive
+        expect(@product.thumbnail.file.blob.filename.to_s).to eq("thumbnail.png")
+        expect(@product.thumbnail.file.blob.metadata.slice("width", "height")).to eq("width" => 1006, "height" => 1006)
+        expect(@product.thumbnail.unsplash_url).to be_nil
+        expect(SsrfFilter).to have_received(:get).with(url)
+      end
+
       it "replaces an existing thumbnail" do
         existing = create(:thumbnail, product: @product)
         old_guid = existing.guid
@@ -61,6 +79,25 @@ describe Api::V2::ThumbnailsController do
         expect(@product.thumbnail).to be_alive
       end
 
+      it "replaces an existing thumbnail from a URL" do
+        existing = create(:thumbnail, product: @product)
+        old_guid = existing.guid
+        old_blob = existing.file.blob
+        url = "https://example.com/replacement.png"
+        stub_remote_file(url, "smilie.png", "image/png")
+
+        expect do
+          post @action, params: @params.merge(url:)
+        end.not_to change { Thumbnail.count }
+
+        expect(response).to be_successful
+        body = response.parsed_body
+        expect(body["success"]).to be(true)
+        expect(@product.reload.thumbnail.guid).to eq(old_guid)
+        expect(@product.thumbnail.file.blob).not_to eq(old_blob)
+        expect(@product.thumbnail.file.blob.filename.to_s).to eq("replacement.png")
+      end
+
       it "returns validation errors for invalid files" do
         blob = ActiveStorage::Blob.create_and_upload!(
           io: Rack::Test::UploadedFile.new(Rails.root.join("spec", "support", "fixtures", "kFDzu.png"), "image/png"),
@@ -75,12 +112,62 @@ describe Api::V2::ThumbnailsController do
         expect(body["message"]).to be_present
       end
 
-      it "returns error when signed_blob_id is not provided" do
+      it "returns validation errors for too-small remote files" do
+        url = "https://example.com/small.png"
+        stub_remote_file(url, "test-small.png", "image/png")
+
+        post @action, params: @params.merge(url:)
+
+        body = response.parsed_body
+        expect(body["success"]).to be(false)
+        expect(body["message"]).to eq("Could not process your thumbnail, please try again.")
+        expect(@product.reload.thumbnail).to be_nil
+      end
+
+      it "returns validation errors for non-square remote files" do
+        url = "https://example.com/non-square.png"
+        stub_remote_file(url, "kFDzu.png", "image/png")
+
+        post @action, params: @params.merge(url:)
+
+        body = response.parsed_body
+        expect(body["success"]).to be(false)
+        expect(body["message"]).to eq("Please upload a square thumbnail.")
+        expect(@product.reload.thumbnail).to be_nil
+      end
+
+      it "returns validation errors for oversized remote files and purges the downloaded blob" do
+        url = "https://example.com/large.jpeg"
+        stub_remote_file(url, "error_file.jpeg", "image/jpeg")
+
+        expect do
+          post @action, params: @params.merge(url:)
+        end.not_to change { ActiveStorage::Blob.count }
+
+        body = response.parsed_body
+        expect(body["success"]).to be(false)
+        expect(body["message"]).to eq("Could not process your thumbnail, please upload an image with size smaller than 5 MB.")
+        expect(@product.reload.thumbnail).to be_nil
+      end
+
+      it "returns processing errors for non-image remote files" do
+        url = "https://example.com/not-image.txt"
+        stub_remote_file(url, "blah.txt", "text/plain")
+
+        post @action, params: @params.merge(url:)
+
+        body = response.parsed_body
+        expect(body["success"]).to be(false)
+        expect(body["message"]).to eq("Could not process your thumbnail, please try again.")
+        expect(@product.reload.thumbnail).to be_nil
+      end
+
+      it "returns error when neither signed_blob_id nor url is provided" do
         post @action, params: @params
 
         body = response.parsed_body
         expect(body["success"]).to be(false)
-        expect(body["message"]).to eq("Please provide a signed_blob_id.")
+        expect(body["message"]).to eq("Please provide a signed_blob_id or url.")
       end
 
       it "returns error for invalid signed_blob_id" do
@@ -89,6 +176,38 @@ describe Api::V2::ThumbnailsController do
         body = response.parsed_body
         expect(body["success"]).to be(false)
         expect(body["message"]).to eq("The signed_blob_id is invalid or expired.")
+      end
+
+      it "returns error for invalid URLs" do
+        post @action, params: @params.merge(url: "ftp://example.com/thumbnail.png")
+
+        expect(response).to have_http_status(:bad_request)
+        body = response.parsed_body
+        expect(body["success"]).to be(false)
+        expect(body["message"]).to eq("Please provide a valid public image URL.")
+      end
+
+      it "returns error for blocked internal URLs" do
+        url = "http://127.0.0.1/thumbnail.png"
+        allow(SsrfFilter).to receive(:get).with(url).and_raise(SsrfFilter::PrivateIPAddress)
+
+        post @action, params: @params.merge(url:)
+
+        expect(response).to have_http_status(:bad_request)
+        body = response.parsed_body
+        expect(body["success"]).to be(false)
+        expect(body["message"]).to eq("Please provide a valid public image URL.")
+      end
+
+      it "returns processing errors when the remote file cannot be downloaded" do
+        url = "https://example.com/missing.png"
+        allow(SsrfFilter).to receive(:get).with(url).and_raise(SocketError)
+
+        post @action, params: @params.merge(url:)
+
+        body = response.parsed_body
+        expect(body["success"]).to be(false)
+        expect(body["message"]).to eq("Could not process your thumbnail, please try again.")
       end
 
       it "revives a previously deleted thumbnail" do
@@ -157,5 +276,14 @@ describe Api::V2::ThumbnailsController do
         expect(body["message"]).to eq("The thumbnail was not found.")
       end
     end
+  end
+
+  def stub_remote_file(url, fixture_name, content_type)
+    allow(SsrfFilter).to receive(:get).with(url).and_return(
+      Struct.new(:body, :content_type).new(
+        File.binread(Rails.root.join("spec", "support", "fixtures", fixture_name)),
+        content_type
+      )
+    )
   end
 end

--- a/spec/controllers/api/v2/thumbnails_controller_spec.rb
+++ b/spec/controllers/api/v2/thumbnails_controller_spec.rb
@@ -43,7 +43,7 @@ describe Api::V2::ThumbnailsController do
       end
 
       it "attaches a thumbnail from a URL" do
-        url = "https://example.com/thumbnail.png"
+        url = "https://example.com/assets/thumbnail.png?token=abc&w=600"
         stub_remote_file(url, "smilie.png", "image/png")
 
         post @action, params: @params.merge(url:)
@@ -198,6 +198,23 @@ describe Api::V2::ThumbnailsController do
         expect(@product.reload.thumbnail).to be_nil
       end
 
+      it "purges the downloaded blob and keeps the existing thumbnail when analysis fails" do
+        existing = create(:thumbnail, product: @product)
+        old_blob = existing.file.blob
+        url = "https://example.com/thumbnail.png"
+        stub_remote_file(url, "smilie.png", "image/png")
+        allow_any_instance_of(ActiveStorage::Blob).to receive(:analyze).and_raise(Net::ReadTimeout)
+
+        expect do
+          post @action, params: @params.merge(url:)
+        end.not_to change { ActiveStorage::Blob.count }
+
+        body = response.parsed_body
+        expect(body["success"]).to be(false)
+        expect(body["message"]).to eq("Could not process your thumbnail, please try again.")
+        expect(@product.reload.thumbnail.file.blob).to eq(old_blob)
+      end
+
       it "returns processing errors for non-image remote files" do
         url = "https://example.com/not-image.txt"
         stub_remote_file(url, "blah.txt", "text/plain")
@@ -228,6 +245,30 @@ describe Api::V2::ThumbnailsController do
 
       it "returns error for invalid URLs" do
         post @action, params: @params.merge(url: "ftp://example.com/thumbnail.png")
+
+        expect(response).to have_http_status(:bad_request)
+        body = response.parsed_body
+        expect(body["success"]).to be(false)
+        expect(body["message"]).to eq("Please provide a valid public image URL.")
+      end
+
+      it "returns error for unresolved URLs" do
+        url = "https://nonexistent.example.com/thumbnail.png"
+        allow(SsrfFilter).to receive(:get).with(url).and_raise(SsrfFilter::UnresolvedHostname)
+
+        post @action, params: @params.merge(url:)
+
+        expect(response).to have_http_status(:bad_request)
+        body = response.parsed_body
+        expect(body["success"]).to be(false)
+        expect(body["message"]).to eq("Please provide a valid public image URL.")
+      end
+
+      it "returns error for URLs with too many redirects" do
+        url = "https://example.com/redirect-loop.png"
+        allow(SsrfFilter).to receive(:get).with(url).and_raise(SsrfFilter::TooManyRedirects)
+
+        post @action, params: @params.merge(url:)
 
         expect(response).to have_http_status(:bad_request)
         body = response.parsed_body

--- a/spec/controllers/api/v2/thumbnails_controller_spec.rb
+++ b/spec/controllers/api/v2/thumbnails_controller_spec.rb
@@ -150,6 +150,54 @@ describe Api::V2::ThumbnailsController do
         expect(@product.reload.thumbnail).to be_nil
       end
 
+      it "rejects remote files with content length above the thumbnail limit before creating a blob" do
+        url = "https://example.com/large.jpeg"
+        stub_remote_file(url, "smilie.png", "image/jpeg", content_length: Thumbnail::MAX_FILE_SIZE + 1)
+
+        expect do
+          post @action, params: @params.merge(url:)
+        end.not_to change { ActiveStorage::Blob.count }
+
+        body = response.parsed_body
+        expect(body["success"]).to be(false)
+        expect(body["message"]).to eq("Could not process your thumbnail, please upload an image with size smaller than 5 MB.")
+        expect(@product.reload.thumbnail).to be_nil
+      end
+
+      it "stops downloading remote files when the streamed body exceeds the thumbnail limit" do
+        url = "https://example.com/large.jpeg"
+        stub_remote_file(url, "smilie.png", "image/jpeg", chunks: ["a" * Thumbnail::MAX_FILE_SIZE, "a"])
+
+        expect do
+          post @action, params: @params.merge(url:)
+        end.not_to change { ActiveStorage::Blob.count }
+
+        body = response.parsed_body
+        expect(body["success"]).to be(false)
+        expect(body["message"]).to eq("Could not process your thumbnail, please upload an image with size smaller than 5 MB.")
+        expect(@product.reload.thumbnail).to be_nil
+      end
+
+      it "stops downloading redirect response bodies when they exceed the thumbnail limit" do
+        url = "https://example.com/redirecting-thumbnail.png"
+        redirect_response = remote_file_response("blah.txt", "text/plain", chunks: ["a" * Thumbnail::MAX_FILE_SIZE, "a"], redirect: true)
+        final_response = remote_file_response("smilie.png", "image/png")
+        allow(SsrfFilter).to receive(:get).with(url) do |&block|
+          block.call(redirect_response)
+          block.call(final_response)
+          final_response
+        end
+
+        expect do
+          post @action, params: @params.merge(url:)
+        end.not_to change { ActiveStorage::Blob.count }
+
+        body = response.parsed_body
+        expect(body["success"]).to be(false)
+        expect(body["message"]).to eq("Could not process your thumbnail, please upload an image with size smaller than 5 MB.")
+        expect(@product.reload.thumbnail).to be_nil
+      end
+
       it "returns processing errors for non-image remote files" do
         url = "https://example.com/not-image.txt"
         stub_remote_file(url, "blah.txt", "text/plain")
@@ -278,12 +326,34 @@ describe Api::V2::ThumbnailsController do
     end
   end
 
-  def stub_remote_file(url, fixture_name, content_type)
-    allow(SsrfFilter).to receive(:get).with(url).and_return(
-      Struct.new(:body, :content_type).new(
-        File.binread(Rails.root.join("spec", "support", "fixtures", fixture_name)),
-        content_type
-      )
-    )
+  def stub_remote_file(url, fixture_name, content_type, content_length: nil, chunks: nil)
+    response = remote_file_response(fixture_name, content_type, content_length:, chunks:)
+
+    allow(SsrfFilter).to receive(:get).with(url).and_yield(response).and_return(response)
+  end
+
+  def remote_file_response(fixture_name, content_type, content_length: nil, chunks: nil, redirect: false)
+    response_class = redirect ? Net::HTTPRedirection : Object
+
+    Class.new(response_class) do
+      define_method(:initialize) do |fixture_name, content_type, content_length, chunks|
+        super("1.1", "302", "Found") if redirect
+
+        @body = File.binread(Rails.root.join("spec", "support", "fixtures", fixture_name))
+        @content_type = content_type
+        @content_length = content_length
+        @chunks = chunks
+      end
+
+      attr_reader :content_type
+
+      def [](header)
+        @content_length if header.downcase == "content-length"
+      end
+
+      def read_body
+        (@chunks || [@body]).each { yield _1 }
+      end
+    end.new(fixture_name, content_type, content_length, chunks)
   end
 end


### PR DESCRIPTION
Ref #5328

## What
- Let `POST /v2/products/:id/thumbnail` accept either `signed_blob_id` or `url`.
- Download URL-based thumbnails server-side, store them in Gumroad storage, and run the existing thumbnail validations before save.
- Keep the response shape the same and return clear errors for invalid URLs, private hosts, download failures, and missing input.
- Document the thumbnail endpoint in the API reference so it matches the existing covers flow.

## Why
- This removes the file-upload-only limit without changing the endpoint, scope, or response contract.
- Downloading and attaching the image keeps validation and CDN delivery consistent with uploaded thumbnails, instead of hot-linking fragile remote URLs.

---

This PR was implemented with AI assistance using gpt-5.5 xhigh.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds server-side fetching of user-supplied URLs (SSRF-filtered but still a sensitive path) and new download/size-limit logic; mitigated by extensive specs and alignment with existing cover URL handling.
> 
> **Overview**
> **POST `/v2/products/:id/thumbnail`** now accepts either `signed_blob_id` or a public `url`, with clearer errors when neither is provided.
> 
> For URL input, the server downloads the image via **`SsrfFilter`** (HTTP/HTTPS only, size-capped at 5 MB), stores it in Active Storage, and runs the same thumbnail validations as uploads. The API returns **400** for invalid/private/unresolvable URLs and dedicated messages for oversized downloads; analysis runs only when a file is attached.
> 
> The public API reference adds **Thumbnails** create/delete docs (parameters, constraints, examples). Controller specs cover URL success, replacement, validation failures, SSRF/size limits, redirects, and blob cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 391b7804ad8d0bf2d92605f0e31d9c2b4955559c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->