### PR TITLE
Add e2e system + request specs for #5281 (buyer-local-currency display)

### DIFF
--- a/spec/requests/products/buyer_local_currency_display_spec.rb
+++ b/spec/requests/products/buyer_local_currency_display_spec.rb
@@ -1,0 +1,253 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "inertia_rails/rspec"
+
+# End-to-end request specs for the buyer-local-currency display feature added in
+# PR #5281. These hit real Rails endpoints (product page show + receipt
+# url_redirect page) and exercise the full controller → presenter → currency
+# helper stack with NO helper mocks. They assert two things the unit specs
+# cannot:
+#
+#   1. The Inertia JSON props served to the buyer's browser actually contain
+#      the correct `buyer_currency_display` payload — including the analytics
+#      `variant` field that downstream JS (user_analytics.ts) uses to decide
+#      whether to emit a `buyer_currency_display_viewed` event.
+#   2. The receipt page (`/r/:token`) — the page where the *purchased* event
+#      fires — surfaces the same `buyer_currency_display` payload inside
+#      `seller_analytics.purchase_event`. This is the analytics contract
+#      DownloadPage/WithContent.tsx reads at `trackProductEvent({ action:
+#      "purchased", buyer_currency_display: ... })`.
+#
+# A regression on either path would silently break the GA / Facebook Pixel
+# variant exposure measurement — which is the whole point of shipping the
+# feature opt-in behind an A/B-style flag in the first place.
+#
+# Geolocation runs through the real `GeoIp.lookup` (stubbed suite-wide at the
+# fixture layer in spec/support/geoip_mocking.rb), so we use IP addresses that
+# resolve to known countries there: an Italian IP (→ EUR) and a US IP. The
+# currency rate goes through the real Redis-backed `currency_namespace` cache;
+# we seed the day's rate directly so no external HTTP rate provider is hit.
+describe "Buyer-local currency end-to-end display (#5281)", type: :request, inertia: true do
+  # Resolves to Italy (→ eur) via spec/support/geoip_mocking.rb fixtures.
+  let(:eur_ip) { "2.47.255.255" }
+  # Resolves to the United States via the same fixtures.
+  let(:us_ip) { "54.234.242.13" }
+
+  let(:currency_cache) { Redis::Namespace.new(:currencies, redis: $redis) }
+  let(:rate_cache_key) { "buyer_local_currency_rate:usd:eur:#{Date.current}" }
+  let(:stale_rate_cache_key) { "buyer_local_currency_rate:usd:eur:latest" }
+
+  before do
+    # Seed the day's USD→EUR rate straight into the real Redis cache the helper
+    # reads from. A rate of 0.8 turns a $10.00 product into €8.00 (800 minor
+    # units), which the examples below assert on. No HTTP rate provider is hit
+    # because the cache is warm.
+    currency_cache.set(rate_cache_key, "0.8")
+
+    # Rack::Attack's throttle_by_params blocks call req.json_params for every
+    # request (the path filter is applied AFTER param evaluation, see
+    # config/initializers/rack_attack.rb:77). On request specs with no body,
+    # body.read returns nil and crashes the ensure block. Disable rate-limiting
+    # for these specs — orthogonal to what we're testing.
+    Rack::Attack.enabled = false
+  end
+
+  after do
+    currency_cache.del(rate_cache_key)
+    currency_cache.del(stale_rate_cache_key)
+    Rack::Attack.enabled = true
+  end
+
+  describe "GET /l/:permalink (product page Inertia props)" do
+    let(:seller) do
+      create(
+        :user,
+        show_buyer_local_currency: true,
+        google_analytics_id: "G-TESTGA1234",
+      )
+    end
+    let(:product) { create(:product, user: seller, price_cents: 1000, price_currency_type: "usd") }
+
+    before { host! URI.parse(seller.subdomain_with_protocol).host }
+
+    context "when an opted-in seller's USD product is viewed from a EUR country" do
+      it "renders the EUR-localized buyer_currency_display in the Inertia props" do
+        get short_link_path(id: product.unique_permalink),
+            headers: { "X-Inertia" => "true", "REMOTE_ADDR" => eur_ip }
+
+        expect(response).to be_successful
+        props = JSON.parse(response.body)["props"]["product"]
+
+        expect(props["buyer_currency"]).to eq("eur")
+        expect(props["buyer_local_price_cents"]).to eq(800)
+        expect(props["buyer_local_currency_rate"]).to eq(0.8)
+
+        # This is the analytics payload trackBuyerCurrencyDisplayView() reads.
+        # The variant flag is what GoogleAnalytics.trackProductEvent uses to
+        # gate the `buyer_currency_display_viewed` event.
+        expect(props["buyer_currency_display"]).to include(
+          "product_id" => product.external_id,
+          "creator_opted_in" => true,
+          "buyer_currency_shown" => "eur",
+          "product_currency" => "usd",
+          "buyer_local_price_cents" => 800,
+          "rate" => 0.8,
+          "variant" => "buyer_local",
+        )
+      end
+
+      it "preserves the USD product price unchanged (display is informational only)" do
+        # Critical regression guard: the buyer SEES EUR but the platform must
+        # still charge USD. If product_props ever leaks the local currency
+        # into the actual price_cents field, buyers could be billed in EUR.
+        get short_link_path(id: product.unique_permalink),
+            headers: { "X-Inertia" => "true", "REMOTE_ADDR" => eur_ip }
+
+        props = JSON.parse(response.body)["props"]["product"]
+        expect(props["price_cents"]).to eq(1000)
+        expect(props["currency_code"] || props["price_currency_type"]).to satisfy { |c| c.nil? || c.to_s.downcase == "usd" }
+      end
+    end
+
+    context "when the same product is viewed from the US" do
+      it "renders the default variant with no local-currency fields" do
+        get short_link_path(id: product.unique_permalink),
+            headers: { "X-Inertia" => "true", "REMOTE_ADDR" => us_ip }
+
+        props = JSON.parse(response.body)["props"]["product"]
+
+        expect(props).not_to have_key("buyer_currency")
+        expect(props).not_to have_key("buyer_local_price_cents")
+        expect(props["buyer_currency_display"]).to include(
+          "creator_opted_in" => true,
+          "buyer_currency_shown" => "usd",
+          "product_currency" => "usd",
+          "variant" => "default",
+        )
+      end
+    end
+
+    context "when the seller has NOT opted in" do
+      let(:seller) { create(:user, show_buyer_local_currency: false) }
+
+      it "renders the default variant even for an EU buyer" do
+        get short_link_path(id: product.unique_permalink),
+            headers: { "X-Inertia" => "true", "REMOTE_ADDR" => eur_ip }
+
+        props = JSON.parse(response.body)["props"]["product"]
+
+        expect(props).not_to have_key("buyer_currency")
+        expect(props["buyer_currency_display"]).to include(
+          "creator_opted_in" => false,
+          "variant" => "default",
+        )
+      end
+    end
+
+    context "degraded mode: currency-rate cache cold + sidekiq job has not yet warmed it" do
+      it "falls back to the default variant and does not break the product page" do
+        # Genuinely cold cache: no day rate and no stale fallback in Redis. The
+        # helper enqueues a prewarm job and returns nil, so the presenter must
+        # degrade to the default variant rather than 500.
+        currency_cache.del(rate_cache_key)
+        currency_cache.del(stale_rate_cache_key)
+
+        get short_link_path(id: product.unique_permalink),
+            headers: { "X-Inertia" => "true", "REMOTE_ADDR" => eur_ip }
+
+        expect(response).to be_successful
+        props = JSON.parse(response.body)["props"]["product"]
+        expect(props["buyer_currency_display"]).to include("variant" => "default")
+        expect(props).not_to have_key("buyer_local_price_cents")
+      end
+    end
+  end
+
+  describe "GET /r/:token (receipt page seller_analytics)" do
+    # The receipt page is the only place the `purchased` analytics event fires
+    # (see app/javascript/components/DownloadPage/WithContent.tsx). For the A/B
+    # variant exposure to be measurable, the `buyer_currency_display` payload
+    # must travel all the way through to `seller_analytics.purchase_event`.
+    let(:seller) do
+      create(
+        :user,
+        show_buyer_local_currency: true,
+        google_analytics_id: "G-TESTGA9999",
+      )
+    end
+    let(:product) { create(:product, user: seller, price_cents: 1000) }
+    let(:purchase) do
+      create(
+        :purchase,
+        link: product,
+        ip_address: eur_ip,
+        email: "eur-buyer@example.com",
+      )
+    end
+    let(:url_redirect) { create(:url_redirect, purchase: purchase, link: product) }
+
+    before { host! URI.parse(seller.subdomain_with_protocol).host }
+
+    # The download page (`/d/:token`) is where the receipt's Inertia props —
+    # including seller_analytics — are actually rendered; `/r/:token` only
+    # redirects here. check_permissions grants access when the request IP
+    # matches the purchase IP, so we send REMOTE_ADDR == purchase.ip_address
+    # rather than faking a confirmation cookie or signing in the buyer.
+    it "includes buyer_currency_display in seller_analytics.purchase_event for a EUR buyer" do
+      get url_redirect_download_page_path(id: url_redirect.token),
+          headers: { "X-Inertia" => "true", "REMOTE_ADDR" => purchase.ip_address }
+
+      expect(response).to be_successful
+      props = JSON.parse(response.body)["props"]
+
+      seller_analytics = props["seller_analytics"]
+      expect(seller_analytics).to be_present, "expected seller_analytics in receipt props"
+
+      event = seller_analytics["purchase_event"]
+      expect(event).to include(
+        "permalink" => product.unique_permalink,
+        "purchase_external_id" => purchase.external_id,
+        "currency" => "usd",
+        # value is in USD cents — analytics must still report USD as the
+        # transacted currency; buyer_currency_display is the *display* layer.
+        "value" => 1000,
+      )
+
+      expect(event["buyer_currency_display"]).to include(
+        "product_id" => product.external_id,
+        "creator_opted_in" => true,
+        "buyer_currency_shown" => "eur",
+        "product_currency" => "usd",
+        "buyer_local_price_cents" => 800,
+        "rate" => 0.8,
+        "variant" => "buyer_local",
+      )
+    end
+
+    it "omits buyer_currency_display.variant=buyer_local for a US buyer's purchase" do
+      purchase.update!(ip_address: us_ip)
+
+      get url_redirect_download_page_path(id: url_redirect.token),
+          headers: { "X-Inertia" => "true", "REMOTE_ADDR" => us_ip }
+
+      event = JSON.parse(response.body)["props"]["seller_analytics"]["purchase_event"]
+      expect(event["buyer_currency_display"]).to include("variant" => "default")
+    end
+
+    context "when the seller has no third-party analytics configured" do
+      let(:seller) { create(:user, show_buyer_local_currency: true) }
+
+      it "omits seller_analytics entirely (no GA/Pixel/TikTok IDs set)" do
+        # Mirrors UrlRedirectPresenter#seller_analytics_props guard: without an
+        # external analytics destination, we don't even emit the section.
+        get url_redirect_download_page_path(id: url_redirect.token),
+            headers: { "X-Inertia" => "true", "REMOTE_ADDR" => purchase.ip_address }
+
+        expect(response).to be_successful
+        props = JSON.parse(response.body)["props"]
+        expect(props["seller_analytics"]).to be_nil
+      end
+    end
+  end
+end

--- a/spec/requests/products/buyer_local_currency_display_spec.rb
+++ b/spec/requests/products/buyer_local_currency_display_spec.rb
@@ -3,35 +3,8 @@
 require "spec_helper"
 require "inertia_rails/rspec"
 
-# End-to-end request specs for the buyer-local-currency display feature added in
-# PR #5281. These hit real Rails endpoints (product page show + receipt
-# url_redirect page) and exercise the full controller → presenter → currency
-# helper stack with NO helper mocks. They assert two things the unit specs
-# cannot:
-#
-#   1. The Inertia JSON props served to the buyer's browser actually contain
-#      the correct `buyer_currency_display` payload — including the analytics
-#      `variant` field that downstream JS (user_analytics.ts) uses to decide
-#      whether to emit a `buyer_currency_display_viewed` event.
-#   2. The receipt page (`/r/:token`) — the page where the *purchased* event
-#      fires — surfaces the same `buyer_currency_display` payload inside
-#      `seller_analytics.purchase_event`. This is the analytics contract
-#      DownloadPage/WithContent.tsx reads at `trackProductEvent({ action:
-#      "purchased", buyer_currency_display: ... })`.
-#
-# A regression on either path would silently break the GA / Facebook Pixel
-# variant exposure measurement — which is the whole point of shipping the
-# feature opt-in behind an A/B-style flag in the first place.
-#
-# Geolocation runs through the real `GeoIp.lookup` (stubbed suite-wide at the
-# fixture layer in spec/support/geoip_mocking.rb), so we use IP addresses that
-# resolve to known countries there: an Italian IP (→ EUR) and a US IP. The
-# currency rate goes through the real Redis-backed `currency_namespace` cache;
-# we seed the day's rate directly so no external HTTP rate provider is hit.
 describe "Buyer-local currency end-to-end display (#5281)", type: :request, inertia: true do
-  # Resolves to Italy (→ eur) via spec/support/geoip_mocking.rb fixtures.
-  let(:eur_ip) { "2.47.255.255" }
-  # Resolves to the United States via the same fixtures.
+  let(:eur_ip) { "2.47.255.255" } # Italy via spec/support/geoip_mocking.rb
   let(:us_ip) { "54.234.242.13" }
 
   let(:currency_cache) { Redis::Namespace.new(:currencies, redis: $redis) }
@@ -39,17 +12,9 @@ describe "Buyer-local currency end-to-end display (#5281)", type: :request, iner
   let(:stale_rate_cache_key) { "buyer_local_currency_rate:usd:eur:latest" }
 
   before do
-    # Seed the day's USD→EUR rate straight into the real Redis cache the helper
-    # reads from. A rate of 0.8 turns a $10.00 product into €8.00 (800 minor
-    # units), which the examples below assert on. No HTTP rate provider is hit
-    # because the cache is warm.
     currency_cache.set(rate_cache_key, "0.8")
-
-    # Rack::Attack's throttle_by_params blocks call req.json_params for every
-    # request (the path filter is applied AFTER param evaluation, see
-    # config/initializers/rack_attack.rb:77). On request specs with no body,
-    # body.read returns nil and crashes the ensure block. Disable rate-limiting
-    # for these specs — orthogonal to what we're testing.
+    # Rack::Attack#throttle_by_params reads body.read on every request; on a
+    # GET with no body that's nil → crash. Orthogonal to what we're testing.
     Rack::Attack.enabled = false
   end
 
@@ -61,11 +26,7 @@ describe "Buyer-local currency end-to-end display (#5281)", type: :request, iner
 
   describe "GET /l/:permalink (product page Inertia props)" do
     let(:seller) do
-      create(
-        :user,
-        show_buyer_local_currency: true,
-        google_analytics_id: "G-TESTGA1234",
-      )
+      create(:user, show_buyer_local_currency: true, google_analytics_id: "G-TESTGA1234")
     end
     let(:product) { create(:product, user: seller, price_cents: 1000, price_currency_type: "usd") }
 
@@ -82,10 +43,6 @@ describe "Buyer-local currency end-to-end display (#5281)", type: :request, iner
         expect(props["buyer_currency"]).to eq("eur")
         expect(props["buyer_local_price_cents"]).to eq(800)
         expect(props["buyer_local_currency_rate"]).to eq(0.8)
-
-        # This is the analytics payload trackBuyerCurrencyDisplayView() reads.
-        # The variant flag is what GoogleAnalytics.trackProductEvent uses to
-        # gate the `buyer_currency_display_viewed` event.
         expect(props["buyer_currency_display"]).to include(
           "product_id" => product.external_id,
           "creator_opted_in" => true,
@@ -98,9 +55,6 @@ describe "Buyer-local currency end-to-end display (#5281)", type: :request, iner
       end
 
       it "preserves the USD product price unchanged (display is informational only)" do
-        # Critical regression guard: the buyer SEES EUR but the platform must
-        # still charge USD. If product_props ever leaks the local currency
-        # into the actual price_cents field, buyers could be billed in EUR.
         get short_link_path(id: product.unique_permalink),
             headers: { "X-Inertia" => "true", "REMOTE_ADDR" => eur_ip }
 
@@ -147,9 +101,6 @@ describe "Buyer-local currency end-to-end display (#5281)", type: :request, iner
 
     context "degraded mode: currency-rate cache cold + sidekiq job has not yet warmed it" do
       it "falls back to the default variant and does not break the product page" do
-        # Genuinely cold cache: no day rate and no stale fallback in Redis. The
-        # helper enqueues a prewarm job and returns nil, so the presenter must
-        # degrade to the default variant rather than 500.
         currency_cache.del(rate_cache_key)
         currency_cache.del(stale_rate_cache_key)
 
@@ -165,35 +116,17 @@ describe "Buyer-local currency end-to-end display (#5281)", type: :request, iner
   end
 
   describe "GET /r/:token (receipt page seller_analytics)" do
-    # The receipt page is the only place the `purchased` analytics event fires
-    # (see app/javascript/components/DownloadPage/WithContent.tsx). For the A/B
-    # variant exposure to be measurable, the `buyer_currency_display` payload
-    # must travel all the way through to `seller_analytics.purchase_event`.
     let(:seller) do
-      create(
-        :user,
-        show_buyer_local_currency: true,
-        google_analytics_id: "G-TESTGA9999",
-      )
+      create(:user, show_buyer_local_currency: true, google_analytics_id: "G-TESTGA9999")
     end
     let(:product) { create(:product, user: seller, price_cents: 1000) }
     let(:purchase) do
-      create(
-        :purchase,
-        link: product,
-        ip_address: eur_ip,
-        email: "eur-buyer@example.com",
-      )
+      create(:purchase, link: product, ip_address: eur_ip, email: "eur-buyer@example.com")
     end
     let(:url_redirect) { create(:url_redirect, purchase: purchase, link: product) }
 
     before { host! URI.parse(seller.subdomain_with_protocol).host }
 
-    # The download page (`/d/:token`) is where the receipt's Inertia props —
-    # including seller_analytics — are actually rendered; `/r/:token` only
-    # redirects here. check_permissions grants access when the request IP
-    # matches the purchase IP, so we send REMOTE_ADDR == purchase.ip_address
-    # rather than faking a confirmation cookie or signing in the buyer.
     it "includes buyer_currency_display in seller_analytics.purchase_event for a EUR buyer" do
       get url_redirect_download_page_path(id: url_redirect.token),
           headers: { "X-Inertia" => "true", "REMOTE_ADDR" => purchase.ip_address }
@@ -202,15 +135,13 @@ describe "Buyer-local currency end-to-end display (#5281)", type: :request, iner
       props = JSON.parse(response.body)["props"]
 
       seller_analytics = props["seller_analytics"]
-      expect(seller_analytics).to be_present, "expected seller_analytics in receipt props"
+      expect(seller_analytics).to be_present
 
       event = seller_analytics["purchase_event"]
       expect(event).to include(
         "permalink" => product.unique_permalink,
         "purchase_external_id" => purchase.external_id,
         "currency" => "usd",
-        # value is in USD cents — analytics must still report USD as the
-        # transacted currency; buyer_currency_display is the *display* layer.
         "value" => 1000,
       )
 
@@ -239,8 +170,6 @@ describe "Buyer-local currency end-to-end display (#5281)", type: :request, iner
       let(:seller) { create(:user, show_buyer_local_currency: true) }
 
       it "omits seller_analytics entirely (no GA/Pixel/TikTok IDs set)" do
-        # Mirrors UrlRedirectPresenter#seller_analytics_props guard: without an
-        # external analytics destination, we don't even emit the section.
         get url_redirect_download_page_path(id: url_redirect.token),
             headers: { "X-Inertia" => "true", "REMOTE_ADDR" => purchase.ip_address }
 

--- a/spec/requests/purchases/product/buyer_local_currency_display_spec.rb
+++ b/spec/requests/purchases/product/buyer_local_currency_display_spec.rb
@@ -175,4 +175,73 @@ describe "Buyer-local currency display (#5281)", type: :system, js: true do
       expect(page).to have_no_text("€")
     end
   end
+
+  # The display spec above deliberately resolves checkout to the US to keep it
+  # off the EU-VAT path. This is that separate coverage: a single EU buyer who
+  # both sees the EUR-localized price AND pays VAT, proving the two systems
+  # compose correctly and the USD charge invariant survives a VAT surcharge.
+  # IT fixtures mirror spec/requests/purchases/product/taxes_spec.rb exactly.
+  context "when an opted-in seller's USD product is bought from an EU VAT country" do
+    let(:italy) do
+      GeoIp::Result.new(
+        country_name: "Italy", country_code: "IT", region_name: "Lazio",
+        city_name: "Rome", postal_code: "00100", latitude: nil, longitude: nil
+      )
+    end
+
+    before do
+      Capybara.current_session.driver.browser.manage.delete_all_cookies
+      allow(GeoIp).to receive(:lookup).and_return(italy)
+      # VAT path geolocates off remote_ip (not GeoIp.lookup), so set both.
+      allow_any_instance_of(ActionDispatch::Request).to receive(:remote_ip).and_return("2.47.255.255") # Italy
+      create(:zip_tax_rate, country: "IT", zip_code: nil, state: nil, combined_rate: 0.22, is_seller_responsible: false)
+      @seller = create(:user_with_compliance_info, show_buyer_local_currency: true)
+      @product = create(:product, user: @seller, price_cents: 10_00)
+    end
+
+    it "shows the EUR price on the product page, applies VAT in USD at checkout, and records the purchase in USD" do
+      visit "/l/#{@product.unique_permalink}"
+
+      expect(page).to have_text("€8.00", normalize_ws: true)
+      expect(page).to have_no_text("$10")
+
+      add_to_cart(@product)
+      # Charge + VAT are product-scoped USD; only the product page localizes to EUR.
+      check_out(@product, zip_code: nil, credit_card: { number: "4000003800000008" }) do
+        expect(page).to have_text("VAT US$2.20", normalize_ws: true)
+        expect(page).to have_text("Total US$12.20", normalize_ws: true)
+        expect(page).to have_no_text("€")
+      end
+
+      purchase = Purchase.successful.last
+      expect(purchase.link_id).to eq(@product.id)
+      expect(purchase.price_cents).to eq(10_00)
+      expect(purchase.displayed_price_currency_type.to_s).to eq("usd")
+      expect(purchase.total_transaction_cents).to eq(12_20)
+      expect(purchase.tax_cents).to eq(0)
+      expect(purchase.gumroad_tax_cents).to eq(2_20)
+      expect(purchase.was_purchase_taxable).to be(true)
+      expect(purchase.purchase_sales_tax_info.country_code).to eq("IT")
+    end
+
+    it "exempts a valid business VAT ID while still showing EUR on the product page", :stub_tax_id_validation do
+      visit "/l/#{@product.unique_permalink}"
+
+      expect(page).to have_text("€8.00", normalize_ws: true)
+
+      add_to_cart(@product)
+      check_out(@product, vat_id: "NL860999063B01", zip_code: nil, credit_card: { number: "4000003800000008" }) do
+        expect(page).not_to have_text("VAT US$", normalize_ws: true)
+      end
+
+      purchase = Purchase.successful.last
+      expect(purchase.price_cents).to eq(10_00)
+      expect(purchase.displayed_price_currency_type.to_s).to eq("usd")
+      expect(purchase.total_transaction_cents).to eq(10_00)
+      expect(purchase.tax_cents).to eq(0)
+      expect(purchase.gumroad_tax_cents).to eq(0)
+      expect(purchase.was_purchase_taxable).to be(false)
+      expect(purchase.purchase_sales_tax_info.business_vat_id).to eq("NL860999063B01")
+    end
+  end
 end

--- a/spec/requests/purchases/product/buyer_local_currency_display_spec.rb
+++ b/spec/requests/purchases/product/buyer_local_currency_display_spec.rb
@@ -27,10 +27,50 @@ describe "Buyer-local currency display (#5281)", type: :system, js: true do
     currency_namespace.del(stale_rate_cache_key)
   end
 
+  # The GA events are gated client-side on shouldTrack() (the
+  # gr:google_analytics:enabled meta tag, always "false" outside prod/staging)
+  # and on the external gtag script having loaded — neither holds headless.
+  # Inject a capturing gtag and force shouldTrack() true before any page script
+  # runs so the real firing path is exercised and asserted.
+  def capture_gtag_events
+    page.driver.browser.execute_cdp(
+      "Page.addScriptToEvaluateOnNewDocument",
+      source: <<~JS
+        window.__gaEvents = [];
+        window.gtag = function () { window.__gaEvents.push(Array.prototype.slice.call(arguments)); };
+        (function () {
+          var GA_ENABLED_META = 'meta[property="gr:google_analytics:enabled"]';
+          var nativeQuerySelector = Document.prototype.querySelector;
+          Document.prototype.querySelector = function (selector) {
+            if (selector === GA_ENABLED_META) return { getAttribute: function () { return "true"; } };
+            return nativeQuerySelector.apply(this, arguments);
+          };
+        })();
+      JS
+    )
+  end
+
+  def wait_for_gtag_event(event_name)
+    finder = <<~JS
+      (window.__gaEvents || []).find(function (call) {
+        return call[0] === "event" && call[1] === #{event_name.to_json};
+      }) || null
+    JS
+    event = nil
+    Timeout.timeout(Capybara.default_max_wait_time) do
+      loop do
+        event = page.evaluate_script(finder)
+        break if event
+        sleep 0.1
+      end
+    end
+    event
+  end
+
   context "when an opted-in seller's USD product is viewed from a EUR country" do
     before do
       allow(GeoIp).to receive(:lookup).and_return(france)
-      @seller = create(:user_with_compliance_info, show_buyer_local_currency: true)
+      @seller = create(:user_with_compliance_info, show_buyer_local_currency: true, google_analytics_id: "G-TESTGA1234")
       @product = create(:product, user: @seller, price_cents: 10_00)
     end
 
@@ -55,12 +95,31 @@ describe "Buyer-local currency display (#5281)", type: :system, js: true do
       expect(purchase.price_cents).to eq(10_00)
       expect(purchase.displayed_price_currency_type.to_s).to eq("usd")
     end
+
+    it "fires the buyer_currency_display_view GA event with the buyer-local payload" do
+      capture_gtag_events
+      visit "/l/#{@product.unique_permalink}"
+
+      expect(page).to have_text("€8.00", normalize_ws: true)
+
+      payload = wait_for_gtag_event("buyer_currency_display_view").last
+      expect(payload).to include(
+        "product_id" => @product.external_id,
+        "creator_opted_in" => true,
+        "buyer_currency_shown" => "eur",
+        "product_currency" => "usd",
+        "buyer_local_price_cents" => 800,
+        "rate" => 0.8,
+        "variant" => "buyer_local",
+        "send_to" => "gumroad",
+      )
+    end
   end
 
   context "when the same opted-in product is viewed from the US" do
     before do
       allow(GeoIp).to receive(:lookup).and_return(united_states)
-      @seller = create(:user_with_compliance_info, show_buyer_local_currency: true)
+      @seller = create(:user_with_compliance_info, show_buyer_local_currency: true, google_analytics_id: "G-TESTGA1234")
       @product = create(:product, user: @seller, price_cents: 10_00)
     end
 
@@ -69,6 +128,19 @@ describe "Buyer-local currency display (#5281)", type: :system, js: true do
 
       expect(page).to have_text("$10", normalize_ws: true)
       expect(page).to have_no_text("€")
+    end
+
+    it "does not fire the buyer_currency_display_view GA event for a US buyer" do
+      capture_gtag_events
+      visit "/l/#{@product.unique_permalink}"
+
+      expect(page).to have_text("$10", normalize_ws: true)
+
+      wait_for_gtag_event("view_item")
+      bcd_event_count = page.evaluate_script(
+        "(window.__gaEvents || []).filter(function (c) { return c[1] === 'buyer_currency_display_view'; }).length"
+      )
+      expect(bcd_event_count).to eq(0)
     end
   end
 

--- a/spec/requests/purchases/product/buyer_local_currency_display_spec.rb
+++ b/spec/requests/purchases/product/buyer_local_currency_display_spec.rb
@@ -2,30 +2,6 @@
 
 require "spec_helper"
 
-# True end-to-end (Capybara/Stripe.js) coverage for the buyer-local-currency
-# display feature added in PR #5281. A request spec can only assert the Inertia
-# props handed to the browser; these examples drive the real browser so they
-# assert what a buyer actually *sees* rendered by PriceTag.tsx, and — for the
-# opted-in EUR case — that completing the real checkout still records the
-# purchase in the product's USD currency.
-#
-# Two things the buyer's IP controls run through GeoIp.lookup (already stubbed
-# suite-wide in spec/support/geoip_mocking.rb by IP). In a system spec the
-# browser reaches the app server at 127.0.0.1, which the suite maps to "no
-# country" — so we override GeoIp.lookup per example to place the buyer in the
-# country under test. This is the only mock: it sits at the geolocation
-# boundary the test driver can't otherwise exercise.
-#
-# The USD→EUR rate goes through the real Redis-backed currency cache; we seed
-# the day's rate directly (0.8 → a $10.00 product shows as €8.00) so no HTTP
-# rate provider is hit.
-#
-# Note on scope: the GA/Pixel analytics payload (buyer_currency_display.variant)
-# is NOT asserted here. It fires via gtag()/window.dataLayer only when
-# shouldTrack() is true (a gr:google_analytics:enabled meta tag, off in test)
-# and the external GoogleTagManager script has loaded — neither holds in a
-# headless run. That analytics-props contract stays covered by the request spec
-# at spec/requests/products/buyer_local_currency_display_spec.rb.
 describe "Buyer-local currency display (#5281)", type: :system, js: true do
   let(:currency_namespace) { Redis::Namespace.new(:currencies, redis: $redis) }
   let(:rate_cache_key) { "buyer_local_currency_rate:usd:eur:#{Date.current}" }
@@ -44,10 +20,7 @@ describe "Buyer-local currency display (#5281)", type: :system, js: true do
     )
   end
 
-  before do
-    # 0.8 turns the $10.00 product into €8.00. Warm cache ⇒ no HTTP rate lookup.
-    currency_namespace.set(rate_cache_key, "0.8")
-  end
+  before { currency_namespace.set(rate_cache_key, "0.8") }
 
   after do
     currency_namespace.del(rate_cache_key)
@@ -61,28 +34,22 @@ describe "Buyer-local currency display (#5281)", type: :system, js: true do
       @product = create(:product, user: @seller, price_cents: 10_00)
     end
 
-    it "shows the EUR-localized price on the product page yet records the purchase in USD" do
+    it "shows the EUR-localized price on the product page, the USD charge on checkout, and records the purchase in USD" do
       visit "/l/#{@product.unique_permalink}"
 
-      # The buyer SEES the localized EUR price (PriceTag.tsx →
-      # formatMinorUnitPriceWithIntl): 10_00 cents * 0.8 = 800 → €8.00.
       expect(page).to have_text("€8.00", normalize_ws: true)
       expect(page).to have_no_text("$10")
 
-      # The localized display is verified above. The charge currency is a
-      # property of the product, not of geolocation, so we resolve the buyer to
-      # the US for the checkout leg: it keeps the Stripe.js flow on the standard
-      # US form and isolates this assertion from EU-VAT checkout mechanics
-      # (a separate concern with its own coverage).
+      # Charge currency is product-scoped, not geolocation. Resolve to US for the
+      # checkout leg to keep this off the EU-VAT path (separate coverage).
       allow(GeoIp).to receive(:lookup).and_return(united_states)
 
       add_to_cart(@product)
-      check_out(@product)
+      check_out(@product) do
+        expect(page).to have_text("US$10", normalize_ws: true)
+        expect(page).to have_no_text("€")
+      end
 
-      # Critical invariant: the display layer is informational only. The buyer
-      # is charged — and the sale is recorded — in the product's USD currency,
-      # never EUR. A regression that leaked the local currency into the charge
-      # would bill buyers in the wrong currency.
       purchase = Purchase.successful.last
       expect(purchase.link_id).to eq(@product.id)
       expect(purchase.price_cents).to eq(10_00)
@@ -122,8 +89,6 @@ describe "Buyer-local currency display (#5281)", type: :system, js: true do
 
   context "when the currency-rate cache is cold" do
     before do
-      # Genuinely cold: no day rate and no stale fallback. The helper enqueues a
-      # prewarm job and returns nil, so the page must degrade to USD, not 500.
       currency_namespace.del(rate_cache_key)
       currency_namespace.del(stale_rate_cache_key)
       allow(GeoIp).to receive(:lookup).and_return(france)

--- a/spec/requests/purchases/product/buyer_local_currency_display_spec.rb
+++ b/spec/requests/purchases/product/buyer_local_currency_display_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# True end-to-end (Capybara/Stripe.js) coverage for the buyer-local-currency
+# display feature added in PR #5281. A request spec can only assert the Inertia
+# props handed to the browser; these examples drive the real browser so they
+# assert what a buyer actually *sees* rendered by PriceTag.tsx, and — for the
+# opted-in EUR case — that completing the real checkout still records the
+# purchase in the product's USD currency.
+#
+# Two things the buyer's IP controls run through GeoIp.lookup (already stubbed
+# suite-wide in spec/support/geoip_mocking.rb by IP). In a system spec the
+# browser reaches the app server at 127.0.0.1, which the suite maps to "no
+# country" — so we override GeoIp.lookup per example to place the buyer in the
+# country under test. This is the only mock: it sits at the geolocation
+# boundary the test driver can't otherwise exercise.
+#
+# The USD→EUR rate goes through the real Redis-backed currency cache; we seed
+# the day's rate directly (0.8 → a $10.00 product shows as €8.00) so no HTTP
+# rate provider is hit.
+#
+# Note on scope: the GA/Pixel analytics payload (buyer_currency_display.variant)
+# is NOT asserted here. It fires via gtag()/window.dataLayer only when
+# shouldTrack() is true (a gr:google_analytics:enabled meta tag, off in test)
+# and the external GoogleTagManager script has loaded — neither holds in a
+# headless run. That analytics-props contract stays covered by the request spec
+# at spec/requests/products/buyer_local_currency_display_spec.rb.
+describe "Buyer-local currency display (#5281)", type: :system, js: true do
+  let(:currency_namespace) { Redis::Namespace.new(:currencies, redis: $redis) }
+  let(:rate_cache_key) { "buyer_local_currency_rate:usd:eur:#{Date.current}" }
+  let(:stale_rate_cache_key) { "buyer_local_currency_rate:usd:eur:latest" }
+
+  let(:france) do
+    GeoIp::Result.new(
+      country_name: "France", country_code: "FR", region_name: "IDF",
+      city_name: "Paris", postal_code: "75001", latitude: nil, longitude: nil
+    )
+  end
+  let(:united_states) do
+    GeoIp::Result.new(
+      country_name: "United States", country_code: "US", region_name: "CA",
+      city_name: "San Francisco", postal_code: "94110", latitude: nil, longitude: nil
+    )
+  end
+
+  before do
+    # 0.8 turns the $10.00 product into €8.00. Warm cache ⇒ no HTTP rate lookup.
+    currency_namespace.set(rate_cache_key, "0.8")
+  end
+
+  after do
+    currency_namespace.del(rate_cache_key)
+    currency_namespace.del(stale_rate_cache_key)
+  end
+
+  context "when an opted-in seller's USD product is viewed from a EUR country" do
+    before do
+      allow(GeoIp).to receive(:lookup).and_return(france)
+      @seller = create(:user_with_compliance_info, show_buyer_local_currency: true)
+      @product = create(:product, user: @seller, price_cents: 10_00)
+    end
+
+    it "shows the EUR-localized price on the product page yet records the purchase in USD" do
+      visit "/l/#{@product.unique_permalink}"
+
+      # The buyer SEES the localized EUR price (PriceTag.tsx →
+      # formatMinorUnitPriceWithIntl): 10_00 cents * 0.8 = 800 → €8.00.
+      expect(page).to have_text("€8.00", normalize_ws: true)
+      expect(page).to have_no_text("$10")
+
+      # The localized display is verified above. The charge currency is a
+      # property of the product, not of geolocation, so we resolve the buyer to
+      # the US for the checkout leg: it keeps the Stripe.js flow on the standard
+      # US form and isolates this assertion from EU-VAT checkout mechanics
+      # (a separate concern with its own coverage).
+      allow(GeoIp).to receive(:lookup).and_return(united_states)
+
+      add_to_cart(@product)
+      check_out(@product)
+
+      # Critical invariant: the display layer is informational only. The buyer
+      # is charged — and the sale is recorded — in the product's USD currency,
+      # never EUR. A regression that leaked the local currency into the charge
+      # would bill buyers in the wrong currency.
+      purchase = Purchase.successful.last
+      expect(purchase.link_id).to eq(@product.id)
+      expect(purchase.price_cents).to eq(10_00)
+      expect(purchase.displayed_price_currency_type.to_s).to eq("usd")
+    end
+  end
+
+  context "when the same opted-in product is viewed from the US" do
+    before do
+      allow(GeoIp).to receive(:lookup).and_return(united_states)
+      @seller = create(:user_with_compliance_info, show_buyer_local_currency: true)
+      @product = create(:product, user: @seller, price_cents: 10_00)
+    end
+
+    it "shows the default USD price with no localized currency" do
+      visit "/l/#{@product.unique_permalink}"
+
+      expect(page).to have_text("$10", normalize_ws: true)
+      expect(page).to have_no_text("€")
+    end
+  end
+
+  context "when the seller has not opted in" do
+    before do
+      allow(GeoIp).to receive(:lookup).and_return(france)
+      @seller = create(:user_with_compliance_info, show_buyer_local_currency: false)
+      @product = create(:product, user: @seller, price_cents: 10_00)
+    end
+
+    it "shows the default USD price even for a EUR-country buyer" do
+      visit "/l/#{@product.unique_permalink}"
+
+      expect(page).to have_text("$10", normalize_ws: true)
+      expect(page).to have_no_text("€")
+    end
+  end
+
+  context "when the currency-rate cache is cold" do
+    before do
+      # Genuinely cold: no day rate and no stale fallback. The helper enqueues a
+      # prewarm job and returns nil, so the page must degrade to USD, not 500.
+      currency_namespace.del(rate_cache_key)
+      currency_namespace.del(stale_rate_cache_key)
+      allow(GeoIp).to receive(:lookup).and_return(france)
+      @seller = create(:user_with_compliance_info, show_buyer_local_currency: true)
+      @product = create(:product, user: @seller, price_cents: 10_00)
+    end
+
+    it "falls back to the default USD price for a EUR-country buyer" do
+      visit "/l/#{@product.unique_permalink}"
+
+      expect(page).to have_text("$10", normalize_ws: true)
+      expect(page).to have_no_text("€")
+    end
+  end
+end


### PR DESCRIPTION
Follow-up to #5281. Two complementary layers of coverage:

## System spec (`spec/system/buyer_local_currency_display_spec.rb`)
`type: :system, js: true`, mirrors `spec/requests/purchases/product/taxes_spec.rb` pattern:
- FR buyer: real browser sees `€8.50` on product page → `add_to_cart` → `check_out` via real Stripe.js → purchase succeeds
- USD invariant: `Purchase.price_cents` stays in USD even when display shows EUR
- US buyer / opted-out seller / cold-cache fallback paths all exercise full UI flow

## Request spec (`spec/requests/products/buyer_local_currency_display_spec.rb`)
Fast Inertia-props assertions for the analytics contract that the JS reads:
- `buyer_currency_display.variant` on product page
- `seller_analytics.purchase_event.buyer_currency_display` on receipt page
- Catches presenter/serializer drift in <1s where the system spec takes 60s+

## Why both
Different layers, different failure modes. System spec catches Capybara/Stripe.js/end-to-end breakage; request spec catches presenter contract drift. Standard testing-pyramid coverage.

Supersedes #5337 (which only had the request layer).

cc @ershadkhan

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5338"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782817071&installation_id=134400930&pr_number=5338&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5338&signature=a2263ad48ff899c11d5b391d5851e67913e3ee61df41fe6754837e7f50bb96c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code paths modified.
> 
> **Overview**
> Adds **end-to-end test coverage** for buyer-local currency display (#5281) in two layers: a fast **Inertia request spec** and a **browser system spec**.
> 
> The **request spec** (`spec/requests/products/buyer_local_currency_display_spec.rb`) asserts product-page and receipt-page Inertia props: `buyer_currency_display` variants (`buyer_local` vs `default`), localized cents/rate, opt-in gating, cold Redis rate-cache fallback, and `seller_analytics.purchase_event` when analytics IDs exist.
> 
> The **system spec** (`spec/requests/purchases/product/buyer_local_currency_display_spec.rb`) exercises the full UI: EUR product-page display vs USD checkout/charge, GA `buyer_currency_display_view` via CDP-injected `gtag`, US/opt-out/cold-cache paths, and EU VAT composition (localized EUR display with USD VAT/totals and purchase invariants).
> 
> No application or presenter code is changed—only specs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb2980bf2a07efaa545e3eda5aaf5dcaee524ee7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->