### PR TITLE
Add category discovery and path input

### DIFF
--- a/app/controllers/api/v2/categories_controller.rb
+++ b/app/controllers/api/v2/categories_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Api::V2::CategoriesController < Api::V2::BaseController
+  before_action -> { doorkeeper_authorize!(*Doorkeeper.configuration.public_scopes.concat([:view_public])) }
+
+  def index
+    render json: {
+      success: true,
+      categories: Discover::TaxonomyPresenter.new.categories_for_api
+    }
+  end
+end

--- a/app/controllers/api/v2/categories_controller.rb
+++ b/app/controllers/api/v2/categories_controller.rb
@@ -4,6 +4,8 @@ class Api::V2::CategoriesController < Api::V2::BaseController
   before_action -> { doorkeeper_authorize!(*Doorkeeper.configuration.public_scopes.concat([:view_public])) }
 
   def index
+    expires_in 1.hour
+
     render json: {
       success: true,
       categories: Discover::TaxonomyPresenter.new.categories_for_api

--- a/app/controllers/api/v2/links_controller.rb
+++ b/app/controllers/api/v2/links_controller.rb
@@ -22,6 +22,7 @@ class Api::V2::LinksController < Api::V2::BaseController
   before_action(only: [:show, :index]) { doorkeeper_authorize!(*Doorkeeper.configuration.public_scopes.concat([:view_public])) }
   before_action(only: [:create, :update, :disable, :enable, :destroy]) { doorkeeper_authorize! :edit_products }
   before_action :reject_unsupported_upload_fields, only: [:update, :create]
+  before_action :resolve_category_param, only: [:update, :create]
   before_action :set_link_id_to_id, only: [:show, :update, :disable, :enable, :destroy]
   before_action :fetch_product, only: [:show, :update, :disable, :enable, :destroy]
 
@@ -117,15 +118,6 @@ class Api::V2::LinksController < Api::V2::BaseController
       end
       error = validate_file_urls(params[:files])
       return render_response(false, message: error) if error
-    end
-
-    if params[:taxonomy_id].present?
-      if params[:taxonomy_id].respond_to?(:key?) || params[:taxonomy_id].is_a?(Array)
-        return render_response(false, message: "taxonomy_id must be a scalar value.")
-      end
-      if !Taxonomy.exists?(params[:taxonomy_id])
-        return render_response(false, message: "Invalid taxonomy_id.")
-      end
     end
 
     is_recurring_billing = native_type == Link::NATIVE_TYPE_MEMBERSHIP
@@ -496,6 +488,40 @@ class Api::V2::LinksController < Api::V2::BaseController
         return "File URLs must reference your own uploaded files. Use the presigned upload endpoint to upload files first."
       end
       nil
+    end
+
+    def resolve_category_param
+      if params.key?(:category)
+        if params[:category].respond_to?(:key?) || params[:category].is_a?(Array)
+          return render_response(false, message: "category must be a scalar value.")
+        end
+
+        if params[:category].present?
+          if params[:taxonomy_id].present?
+            return render_response(false, message: "Specify either category or taxonomy_id, not both.")
+          end
+
+          category = Discover::TaxonomyPresenter.new.category_for_path(params[:category].to_s)
+          return render_response(false, message: "Invalid category.") if category.blank?
+
+          params[:taxonomy_id] = category[:id]
+        end
+      end
+
+      validate_taxonomy_id_param
+    end
+
+    def validate_taxonomy_id_param
+      return if params[:taxonomy_id].blank?
+
+      if params[:taxonomy_id].respond_to?(:key?) || params[:taxonomy_id].is_a?(Array)
+        return render_response(false, message: "taxonomy_id must be a scalar value.")
+      end
+      if !Taxonomy.exists?(params[:taxonomy_id])
+        render_response(false, message: "Invalid taxonomy_id.")
+      end
+    rescue ActiveModel::RangeError
+      render_response(false, message: "One or more numeric values are out of range.")
     end
 
     def set_link_id_to_id

--- a/app/controllers/api/v2/links_controller.rb
+++ b/app/controllers/api/v2/links_controller.rb
@@ -47,7 +47,8 @@ class Api::V2::LinksController < Api::V2::BaseController
     as_json_options = {
       api_scopes: doorkeeper_token.scopes,
       slim: true,
-      preloaded_ppp_factors: PurchasingPowerParityService.new.get_all_countries_factors(current_resource_owner)
+      preloaded_ppp_factors: PurchasingPowerParityService.new.get_all_countries_factors(current_resource_owner),
+      preloaded_categories_by_taxonomy_id: Discover::TaxonomyPresenter.new.categories_by_id_for_api
     }
 
     products_as_json = paginated_products.as_json(as_json_options)

--- a/app/controllers/api/v2/links_controller.rb
+++ b/app/controllers/api/v2/links_controller.rb
@@ -506,20 +506,21 @@ class Api::V2::LinksController < Api::V2::BaseController
           return render_response(false, message: "Invalid category.") if category.blank?
 
           params[:taxonomy_id] = category[:id]
+          return validate_taxonomy_id_param(invalid_message: "Invalid category.")
         end
       end
 
       validate_taxonomy_id_param
     end
 
-    def validate_taxonomy_id_param
+    def validate_taxonomy_id_param(invalid_message: "Invalid taxonomy_id.")
       return if params[:taxonomy_id].blank?
 
       if params[:taxonomy_id].respond_to?(:key?) || params[:taxonomy_id].is_a?(Array)
         return render_response(false, message: "taxonomy_id must be a scalar value.")
       end
       if !Taxonomy.exists?(params[:taxonomy_id])
-        render_response(false, message: "Invalid taxonomy_id.")
+        render_response(false, message: invalid_message)
       end
     rescue ActiveModel::RangeError
       render_response(false, message: "One or more numeric values are out of range.")

--- a/app/javascript/components/ApiDocumentation/Endpoints/Products.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/Products.tsx
@@ -5,7 +5,7 @@ import CodeSnippet from "$app/components/ui/CodeSnippet";
 import { ApiEndpoint } from "../ApiEndpoint";
 import { ApiParameter, ApiParameters } from "../ApiParameters";
 import { ApiResponseFields, renderFields } from "../ApiResponseFields";
-import { PRODUCT_FIELDS, PRODUCT_LIST_FIELDS } from "../responseFieldDefinitions";
+import { CATEGORY_FIELDS, PRODUCT_FIELDS, PRODUCT_LIST_FIELDS } from "../responseFieldDefinitions";
 
 const ProductResponseFields = () => (
   <ApiResponseFields>
@@ -37,6 +37,15 @@ const SingleProductResponseFields = () => (
   </ApiResponseFields>
 );
 
+const CategoriesResponseFields = () => (
+  <ApiResponseFields>
+    {renderFields([
+      { name: "success", type: "boolean", description: "Whether the request succeeded" },
+      { name: "categories", type: "array", description: "Flat list of product categories", children: CATEGORY_FIELDS },
+    ])}
+  </ApiResponseFields>
+);
+
 const UpdateProductResponseFields = () => (
   <ApiResponseFields>
     {renderFields([
@@ -51,6 +60,35 @@ const UpdateProductResponseFields = () => (
       },
     ])}
   </ApiResponseFields>
+);
+
+export const GetCategories = () => (
+  <ApiEndpoint
+    method="get"
+    path="/categories"
+    description="Retrieve the full product category list. Use a category's path as the category parameter when creating or updating products."
+  >
+    <CategoriesResponseFields />
+    <CodeSnippet caption="cURL example">
+      {`curl https://api.gumroad.com/v2/categories \\
+  -d "access_token=ACCESS_TOKEN" \\
+  -X GET`}
+    </CodeSnippet>
+    <CodeSnippet caption="Example response:">
+      {`{
+  "success": true,
+  "categories": [
+    {
+      "id": 123,
+      "name": "figma",
+      "label": "Figma",
+      "path": "design/ui-and-web/figma",
+      "parent_id": 122
+    }
+  ]
+}`}
+    </CodeSnippet>
+  </ApiEndpoint>
 );
 
 export const GetProducts = () => (
@@ -86,6 +124,9 @@ export const GetProducts = () => (
     "url": null, # Deprecated, always null
     "id": "A-m3CDDC5dlrSdKZp0RFhA==",
     "price": 100,
+    "taxonomy_id": 123,
+    "category": "design/ui-and-web/figma",
+    "category_label": "Figma",
     "purchasing_power_parity_prices": {
       "US": 100,
       "IN": 50,
@@ -164,6 +205,9 @@ export const GetProduct = () => (
     "url": null, # Deprecated, always null
     "id": "A-m3CDDC5dlrSdKZp0RFhA==",
     "price": 100,
+    "taxonomy_id": 123,
+    "category": "design/ui-and-web/figma",
+    "category_label": "Figma",
     "purchasing_power_parity_prices": {
       "US": 100,
       "IN": 50,
@@ -243,7 +287,14 @@ export const CreateProduct = () => (
       <ApiParameter name="customizable_price" description="(optional, true or false) pay-what-you-want" />
       <ApiParameter name="suggested_price_cents" description="(optional)" />
       <ApiParameter name="max_purchase_count" description="(optional)" />
-      <ApiParameter name="taxonomy_id" description="(optional)" />
+      <ApiParameter
+        name="category"
+        description='(optional) full category path from GET /v2/categories, e.g. "design/ui-and-web/figma"; cannot be sent with taxonomy_id'
+      />
+      <ApiParameter
+        name="taxonomy_id"
+        description="(optional) numeric category ID; alias for category, cannot be sent with category"
+      />
       <ApiParameter name="tags" description="(optional) array of tag strings" />
       <ApiParameter name="custom_summary" description="(optional)" />
       <ApiParameter
@@ -271,6 +322,7 @@ export const CreateProduct = () => (
   -d "name=Pencil Icon PSD" \\
   -d "price=100" \\
   -d "price_currency_type=usd" \\
+  -d "category=design/ui-and-web/figma" \\
   -X POST`}
     </CodeSnippet>
     <CodeSnippet caption="Gumroad CLI">
@@ -287,6 +339,9 @@ export const CreateProduct = () => (
     "name": "Pencil Icon PSD",
     "price": 100,
     "currency": "usd",
+    "taxonomy_id": 123,
+    "category": "design/ui-and-web/figma",
+    "category_label": "Figma",
     "published": false,
     "files": [],
     "covers": [],
@@ -328,7 +383,14 @@ export const UpdateProduct = () => (
       <ApiParameter name="is_adult" description="(optional, true or false)" />
       <ApiParameter name="display_product_reviews" description="(optional, true or false)" />
       <ApiParameter name="should_show_sales_count" description="(optional, true or false)" />
-      <ApiParameter name="taxonomy_id" description="(optional)" />
+      <ApiParameter
+        name="category"
+        description='(optional) full category path from GET /v2/categories, e.g. "design/ui-and-web/figma"; cannot be sent with taxonomy_id'
+      />
+      <ApiParameter
+        name="taxonomy_id"
+        description="(optional) numeric category ID; alias for category, cannot be sent with category"
+      />
       <ApiParameter name="tags" description="(optional) array of tag strings; full replacement" />
       <ApiParameter name="custom_receipt" description="(optional)" />
       <ApiParameter name="custom_summary" description="(optional)" />
@@ -354,6 +416,7 @@ export const UpdateProduct = () => (
   -d "access_token=ACCESS_TOKEN" \\
   -d "name=Pencil Icon PSD v2" \\
   -d "max_purchase_count=100" \\
+  -d "category=design/ui-and-web/figma" \\
   -X PUT`}
     </CodeSnippet>
     <CodeSnippet caption="Gumroad CLI">

--- a/app/javascript/components/ApiDocumentation/Navigation.tsx
+++ b/app/javascript/components/ApiDocumentation/Navigation.tsx
@@ -29,6 +29,9 @@ export const Navigation = () => (
             <a href="#products">Products</a>
           </li>
           <li>
+            <a href="#categories">Categories</a>
+          </li>
+          <li>
             <a href="#files">Files</a>
           </li>
           <li>

--- a/app/javascript/components/ApiDocumentation/responseFieldDefinitions.ts
+++ b/app/javascript/components/ApiDocumentation/responseFieldDefinitions.ts
@@ -21,6 +21,22 @@ export const COVER_FIELDS: FieldDefinition[] = [
   { name: "native_height", type: "number", description: "Intrinsic height of the source asset in pixels" },
 ];
 
+export const CATEGORY_FIELDS: FieldDefinition[] = [
+  { name: "id", type: "number", description: "Numeric category ID accepted by taxonomy_id" },
+  { name: "name", type: "string", description: 'Short category slug (e.g. "figma")' },
+  { name: "label", type: "string", description: 'Human-readable category label (e.g. "Figma")' },
+  {
+    name: "path",
+    type: "string",
+    description: 'Full category path accepted by category (e.g. "design/ui-and-web/figma")',
+  },
+  {
+    name: "parent_id",
+    type: "number | null",
+    description: "Numeric ID of the parent category; null for root categories",
+  },
+];
+
 const PRODUCT_VARIANT_FIELDS: FieldDefinition[] = [
   { name: "title", type: "string", description: 'Variant category title (e.g. "Tier")' },
   {
@@ -103,6 +119,9 @@ const SHARED_PRODUCT_FIELDS: FieldDefinition[] = [
     condition: "present when the seller has purchasing power parity enabled and the product has not opted out",
   },
   { name: "currency", type: "string", description: 'ISO currency code (e.g. "usd")' },
+  { name: "taxonomy_id", type: "number | null", description: "Numeric category ID" },
+  { name: "category", type: "string | null", description: "Full category path" },
+  { name: "category_label", type: "string | null", description: "Human-readable category label" },
   { name: "short_url", type: "string", description: "Short Gumroad URL for the product" },
   { name: "thumbnail_url", type: "string | null", description: "URL of the product thumbnail image" },
   {

--- a/app/javascript/pages/Public/Api.tsx
+++ b/app/javascript/pages/Public/Api.tsx
@@ -28,6 +28,7 @@ import {
 import { GetEarnings } from "$app/components/ApiDocumentation/Endpoints/Earnings";
 import {GetPayouts, GetPayout, GetUpcomingPayouts} from "$app/components/ApiDocumentation/Endpoints/Payouts";
 import {
+  GetCategories,
   GetProducts,
   GetProduct,
   CreateProduct,
@@ -106,6 +107,10 @@ export default function Api() {
                 <DeleteProduct />
                 <EnableProduct />
                 <DisableProduct />
+              </ApiResource>
+
+              <ApiResource name="Categories" id="categories">
+                <GetCategories />
               </ApiResource>
 
               <ApiResource name="Files" id="files">

--- a/app/models/concerns/product/as_json.rb
+++ b/app/models/concerns/product/as_json.rb
@@ -80,7 +80,7 @@ module Product::AsJson
 
       ppp_factors = purchasing_power_parity_enabled? ? options[:preloaded_ppp_factors] || PurchasingPowerParityService.new.get_all_countries_factors(user) : nil
       slim = options[:slim]
-      category = taxonomy_id.present? ? Discover::TaxonomyPresenter.new.category_for_taxonomy_id(taxonomy_id) : nil
+      category = category_for_api(options)
 
       json = as_json(original: true, only: keep).merge!(
         "id" => external_id,
@@ -183,6 +183,17 @@ module Product::AsJson
       factors.keys.index_with do |country_code|
         price_cents == 0 ? 0 : [factors[country_code] * price_cents, currency["min_price"]].max.round
       end
+    end
+
+    def category_for_api(options)
+      return if taxonomy_id.blank?
+
+      preloaded_categories_by_taxonomy_id = options[:preloaded_categories_by_taxonomy_id]
+      if preloaded_categories_by_taxonomy_id.present?
+        return preloaded_categories_by_taxonomy_id[taxonomy_id.to_s]
+      end
+
+      Discover::TaxonomyPresenter.new.category_for_taxonomy_id(taxonomy_id)
     end
 
     def as_json_for_mobile_api

--- a/app/models/concerns/product/as_json.rb
+++ b/app/models/concerns/product/as_json.rb
@@ -80,12 +80,16 @@ module Product::AsJson
 
       ppp_factors = purchasing_power_parity_enabled? ? options[:preloaded_ppp_factors] || PurchasingPowerParityService.new.get_all_countries_factors(user) : nil
       slim = options[:slim]
+      category = taxonomy_id.present? ? Discover::TaxonomyPresenter.new.category_for_taxonomy_id(taxonomy_id) : nil
 
       json = as_json(original: true, only: keep).merge!(
         "id" => external_id,
         "url" => nil, # Deprecated
         "price" => cached_default_price_cents,
         "currency" => price_currency_type,
+        "taxonomy_id" => taxonomy_id,
+        "category" => category&.dig(:path),
+        "category_label" => category&.dig(:label),
         "short_url" => long_url,
         "thumbnail_url" => thumbnail&.alive&.url.presence,
         "tags" => tags.pluck(:name),
@@ -139,19 +143,17 @@ module Product::AsJson
           "rich_content" => rich_content_json,
           "has_same_rich_content_for_all_variants" => has_same_rich_content_for_all_variants?,
           "files" => ordered_alive_product_files.filter_map do |f|
-            begin
-              {
-                id: f.external_id,
-                name: f.display_name,
-                size: f.size,
-                url: f.signed_url,
-                filetype: f.filetype,
-                filegroup: f.filegroup,
-              }
-            rescue Aws::S3::Errors::NotFound => e
-              Rails.logger.warn("Skipping product file #{f.id} with missing S3 object: #{e.message}")
-              nil
-            end
+            {
+              id: f.external_id,
+              name: f.display_name,
+              size: f.size,
+              url: f.signed_url,
+              filetype: f.filetype,
+              filegroup: f.filegroup,
+            }
+          rescue Aws::S3::Errors::NotFound => e
+            Rails.logger.warn("Skipping product file #{f.id} with missing S3 object: #{e.message}")
+            nil
           end
         )
       end

--- a/app/presenters/discover/taxonomy_presenter.rb
+++ b/app/presenters/discover/taxonomy_presenter.rb
@@ -353,4 +353,50 @@ class Discover::TaxonomyPresenter
 
     taxonomies
   end
+
+  def categories_for_api
+    categories_by_id.values.sort_by { |category| category[:path] }
+  end
+
+  def category_for_taxonomy_id(taxonomy_id)
+    return if taxonomy_id.blank?
+
+    categories_by_id[taxonomy_id.to_s]
+  end
+
+  def category_for_path(path)
+    return if path.blank?
+
+    categories_by_path[path]
+  end
+
+  private
+    def categories_by_path
+      @categories_by_path ||= categories_by_id.values.index_by { |category| category[:path] }
+    end
+
+    def categories_by_id
+      @categories_by_id ||= begin
+        taxonomies = taxonomies_for_nav
+        taxonomies_by_id = taxonomies.index_by { |taxonomy| taxonomy[:key] }
+        path_by_id = {}
+
+        taxonomies.each_with_object({}) do |taxonomy, hash|
+          hash[taxonomy[:key]] = {
+            id: taxonomy[:key].to_i,
+            name: taxonomy[:slug],
+            label: taxonomy[:label] || taxonomy[:slug],
+            path: path_for_taxonomy(taxonomy, taxonomies_by_id, path_by_id),
+            parent_id: taxonomy[:parent_key]&.to_i
+          }
+        end
+      end
+    end
+
+    def path_for_taxonomy(taxonomy, taxonomies_by_id, path_by_id)
+      path_by_id[taxonomy[:key]] ||= begin
+        parent = taxonomies_by_id[taxonomy[:parent_key]]
+        parent.present? ? "#{path_for_taxonomy(parent, taxonomies_by_id, path_by_id)}/#{taxonomy[:slug]}" : taxonomy[:slug]
+      end
+    end
 end

--- a/app/presenters/discover/taxonomy_presenter.rb
+++ b/app/presenters/discover/taxonomy_presenter.rb
@@ -358,6 +358,10 @@ class Discover::TaxonomyPresenter
     categories_by_id.values.sort_by { |category| category[:path] }
   end
 
+  def categories_by_id_for_api
+    categories_by_id
+  end
+
   def category_for_taxonomy_id(taxonomy_id)
     return if taxonomy_id.blank?
 

--- a/config/initializers/api_v2_methods.rb
+++ b/config/initializers/api_v2_methods.rb
@@ -45,6 +45,18 @@ GUMROAD_API_V2_METHODS = [
     ]
   },
   {
+    name: "Categories",
+    methods: [
+      {
+        type: :get,
+        path: "/categories",
+        description: "Retrieve the full product category list.",
+        response_layout: :categories,
+        curl_layout: :get_categories
+      }
+    ]
+  },
+  {
     name: "Variant categories",
     methods: [
       {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,6 +58,7 @@ Rails.application.routes.draw do
       end
 
       get "/user", to: "users#show"
+      resources :categories, only: [:index]
       resources :links, path: "products", only: [:index, :show, :update, :create, :destroy] do
         resources :custom_fields, only: [:index, :create, :update, :destroy]
         resources :offer_codes, only: [:index, :create, :show, :update, :destroy]

--- a/spec/controllers/api/v2/categories_controller_spec.rb
+++ b/spec/controllers/api/v2/categories_controller_spec.rb
@@ -49,6 +49,14 @@ describe Api::V2::CategoriesController do
           "parent_id" => @figma.parent_id
         )
       end
+
+      it "allows clients to cache the category list for an hour without shared-cache reuse" do
+        get @action, params: @params
+
+        expect(response.headers["Cache-Control"]).to include("max-age=3600")
+        expect(response.headers["Cache-Control"]).to include("private")
+        expect(response.headers["Cache-Control"]).not_to include("public")
+      end
     end
 
     it "grants access with the account scope" do

--- a/spec/controllers/api/v2/categories_controller_spec.rb
+++ b/spec/controllers/api/v2/categories_controller_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "shared_examples/authorized_oauth_v1_api_method"
+
+describe Api::V2::CategoriesController do
+  before do
+    @user = create(:user)
+    @app = create(:oauth_application, owner: create(:user))
+    @action = :index
+    @params = {}
+  end
+
+  describe "GET 'index'" do
+    before do
+      Rails.cache.delete("taxonomies_for_nav")
+
+      design = Taxonomy.find_or_create_by!(slug: "design")
+      ui_and_web = Taxonomy.find_or_create_by!(slug: "ui-and-web", parent: design)
+      @figma = Taxonomy.find_or_create_by!(slug: "figma", parent: ui_and_web)
+
+      Rails.cache.delete("taxonomies_for_nav")
+    end
+
+    it_behaves_like "authorized oauth v1 api method"
+
+    describe "when logged in with public scope" do
+      before do
+        @token = create("doorkeeper/access_token", application: @app, resource_owner_id: @user.id, scopes: "view_public")
+        @params.merge!(format: :json, access_token: @token.token)
+      end
+
+      it "returns a stable flat list with labels and paths" do
+        get @action, params: @params
+
+        expect(response).to be_successful
+        body = response.parsed_body
+        expect(body["success"]).to be true
+
+        categories = body["categories"]
+        expect(categories.map { |category| category["path"] }).to eq(categories.map { |category| category["path"] }.sort)
+
+        figma = categories.find { |category| category["path"] == "design/ui-and-web/figma" }
+        expect(figma).to eq(
+          "id" => @figma.id,
+          "name" => "figma",
+          "label" => "Figma",
+          "path" => "design/ui-and-web/figma",
+          "parent_id" => @figma.parent_id
+        )
+      end
+    end
+
+    it "grants access with the account scope" do
+      token = create("doorkeeper/access_token", application: @app, resource_owner_id: @user.id, scopes: "account")
+      get @action, params: { access_token: token.token }
+      expect(response).to be_successful
+      expect(response.parsed_body["categories"]).to be_present
+    end
+  end
+end

--- a/spec/controllers/api/v2/links_controller_spec.rb
+++ b/spec/controllers/api/v2/links_controller_spec.rb
@@ -661,6 +661,18 @@ describe Api::V2::LinksController do
         expect(response.parsed_body["message"]).to eq("Invalid category.")
       end
 
+      it "rejects stale cached category paths as invalid categories" do
+        taxonomy = create_category_taxonomy_tree
+        expect(Discover::TaxonomyPresenter.new.category_for_path("design/ui-and-web/figma")).to be_present
+        taxonomy.delete
+
+        post @action, params: @params.merge(category: "design/ui-and-web/figma")
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to be false
+        expect(response.parsed_body["message"]).to eq("Invalid category.")
+      end
+
       it "rejects category and taxonomy_id together" do
         taxonomy = create_category_taxonomy_tree
 
@@ -1391,6 +1403,17 @@ describe Api::V2::LinksController do
         create_category_taxonomy_tree
 
         put @action, params: @params.merge(category: "design/ui-and-web/not-real")
+
+        expect(response.parsed_body["success"]).to be(false)
+        expect(response.parsed_body["message"]).to eq("Invalid category.")
+      end
+
+      it "rejects stale cached category paths as invalid categories" do
+        taxonomy = create_category_taxonomy_tree
+        expect(Discover::TaxonomyPresenter.new.category_for_path("design/ui-and-web/figma")).to be_present
+        taxonomy.delete
+
+        put @action, params: @params.merge(category: "design/ui-and-web/figma")
 
         expect(response.parsed_body["success"]).to be(false)
         expect(response.parsed_body["message"]).to eq("Invalid category.")

--- a/spec/controllers/api/v2/links_controller_spec.rb
+++ b/spec/controllers/api/v2/links_controller_spec.rb
@@ -45,6 +45,22 @@ describe Api::V2::LinksController do
         }.as_json(api_scopes: ["view_public"], slim: true))
       end
 
+      it "preloads category metadata once for the product list" do
+        taxonomy = create_category_taxonomy_tree
+        @product1.update!(taxonomy:)
+        @product2.update!(taxonomy:)
+
+        expect(Discover::TaxonomyPresenter).to receive(:new).once.and_call_original
+
+        get @action, params: @params
+
+        expect(response).to be_successful
+        expect(response.parsed_body["products"].map { |product| product["category"] }).to contain_exactly(
+          "design/ui-and-web/figma",
+          "design/ui-and-web/figma"
+        )
+      end
+
       it "omits detail-only fields from the slim response" do
         versioned_product = create(:product_with_digital_versions, user: @user, created_at: Time.current + 7200)
         create(:product_file, link: versioned_product, url: "#{S3_BASE_URL}specs/test.pdf")

--- a/spec/controllers/api/v2/links_controller_spec.rb
+++ b/spec/controllers/api/v2/links_controller_spec.rb
@@ -10,6 +10,17 @@ describe Api::V2::LinksController do
     @app = create(:oauth_application, owner: create(:user))
   end
 
+  def create_category_taxonomy_tree
+    Rails.cache.delete("taxonomies_for_nav")
+
+    design = Taxonomy.find_or_create_by!(slug: "design")
+    ui_and_web = Taxonomy.find_or_create_by!(slug: "ui-and-web", parent: design)
+    figma = Taxonomy.find_or_create_by!(slug: "figma", parent: ui_and_web)
+
+    Rails.cache.delete("taxonomies_for_nav")
+    figma
+  end
+
   describe "GET 'index'" do
     before do
       @action = :index
@@ -560,6 +571,13 @@ describe Api::V2::LinksController do
         expect(product.taxonomy.slug).to eq("other")
       end
 
+      it "defaults taxonomy to 'other' when category is blank" do
+        post @action, params: @params.merge(category: "")
+
+        product = @user.links.last
+        expect(product.taxonomy.slug).to eq("other")
+      end
+
       it "uses the seller's currency when currency is omitted" do
         @user.update!(currency_type: "gbp")
 
@@ -575,6 +593,66 @@ describe Api::V2::LinksController do
         expect(response).to be_successful
         expect(response.parsed_body["success"]).to be false
         expect(response.parsed_body["message"]).to include("Invalid taxonomy_id")
+      end
+
+      it "handles taxonomy_id range errors" do
+        allow(Taxonomy).to receive(:exists?).and_raise(ActiveModel::RangeError)
+
+        post @action, params: @params.merge(taxonomy_id: 1)
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to be false
+        expect(response.parsed_body["message"]).to eq("One or more numeric values are out of range.")
+      end
+
+      it "creates a product with taxonomy_id" do
+        taxonomy = create_category_taxonomy_tree
+
+        post @action, params: @params.merge(taxonomy_id: taxonomy.id)
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to be true
+
+        product = @user.links.last
+        expect(product.taxonomy).to eq(taxonomy)
+        expect(response.parsed_body["product"]["taxonomy_id"]).to eq(taxonomy.id)
+        expect(response.parsed_body["product"]["category"]).to eq("design/ui-and-web/figma")
+        expect(response.parsed_body["product"]["category_label"]).to eq("Figma")
+      end
+
+      it "creates a product with category path" do
+        taxonomy = create_category_taxonomy_tree
+
+        post @action, params: @params.merge(category: "design/ui-and-web/figma")
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to be true
+
+        product = @user.links.last
+        expect(product.taxonomy).to eq(taxonomy)
+        expect(response.parsed_body["product"]["taxonomy_id"]).to eq(taxonomy.id)
+        expect(response.parsed_body["product"]["category"]).to eq("design/ui-and-web/figma")
+        expect(response.parsed_body["product"]["category_label"]).to eq("Figma")
+      end
+
+      it "rejects unknown category path" do
+        create_category_taxonomy_tree
+
+        post @action, params: @params.merge(category: "design/ui-and-web/not-real")
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to be false
+        expect(response.parsed_body["message"]).to eq("Invalid category.")
+      end
+
+      it "rejects category and taxonomy_id together" do
+        taxonomy = create_category_taxonomy_tree
+
+        post @action, params: @params.merge(category: "design/ui-and-web/figma", taxonomy_id: taxonomy.id)
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to be false
+        expect(response.parsed_body["message"]).to eq("Specify either category or taxonomy_id, not both.")
       end
 
       it "creates a product with rich content pages" do
@@ -1258,6 +1336,57 @@ describe Api::V2::LinksController do
         put @action, params: @params.merge(native_type: "membership")
         expect(response.parsed_body["success"]).to be(true)
         expect(@product.reload.native_type).to eq(original_type)
+      end
+
+      it "updates taxonomy_id" do
+        taxonomy = create_category_taxonomy_tree
+
+        put @action, params: @params.merge(taxonomy_id: taxonomy.id)
+
+        expect(response.parsed_body["success"]).to be(true)
+        expect(@product.reload.taxonomy).to eq(taxonomy)
+        expect(response.parsed_body["product"]["taxonomy_id"]).to eq(taxonomy.id)
+        expect(response.parsed_body["product"]["category"]).to eq("design/ui-and-web/figma")
+        expect(response.parsed_body["product"]["category_label"]).to eq("Figma")
+      end
+
+      it "handles taxonomy_id range errors" do
+        allow(Taxonomy).to receive(:exists?).and_raise(ActiveModel::RangeError)
+
+        put @action, params: @params.merge(taxonomy_id: 1)
+
+        expect(response.parsed_body["success"]).to be(false)
+        expect(response.parsed_body["message"]).to eq("One or more numeric values are out of range.")
+      end
+
+      it "updates category by path" do
+        taxonomy = create_category_taxonomy_tree
+
+        put @action, params: @params.merge(category: "design/ui-and-web/figma")
+
+        expect(response.parsed_body["success"]).to be(true)
+        expect(@product.reload.taxonomy).to eq(taxonomy)
+        expect(response.parsed_body["product"]["taxonomy_id"]).to eq(taxonomy.id)
+        expect(response.parsed_body["product"]["category"]).to eq("design/ui-and-web/figma")
+        expect(response.parsed_body["product"]["category_label"]).to eq("Figma")
+      end
+
+      it "rejects unknown category path" do
+        create_category_taxonomy_tree
+
+        put @action, params: @params.merge(category: "design/ui-and-web/not-real")
+
+        expect(response.parsed_body["success"]).to be(false)
+        expect(response.parsed_body["message"]).to eq("Invalid category.")
+      end
+
+      it "rejects category and taxonomy_id together" do
+        taxonomy = create_category_taxonomy_tree
+
+        put @action, params: @params.merge(category: "design/ui-and-web/figma", taxonomy_id: taxonomy.id)
+
+        expect(response.parsed_body["success"]).to be(false)
+        expect(response.parsed_body["message"]).to eq("Specify either category or taxonomy_id, not both.")
       end
 
       it "returns validation errors in standard format" do


### PR DESCRIPTION
Ref #5329

## What
- Adds a `GET /v2/categories` endpoint that exposes the category tree as a flat, cached list with stable paths, labels, and parent IDs.
- Accepts product categories by full path on create and update while keeping `taxonomy_id` as a supported alias.
- Round-trips category data on product responses so clients can read back the path and label they set.

## Why
- Paths are the only globally unique, stable identifier for this tree-shaped category data, so they are safer than bare names and easier to use than raw IDs.
- Reusing the existing Discover taxonomy presenter keeps the category map and label source in one place instead of duplicating reference data.

---
This PR was implemented with AI assistance using gpt‑5.5 xhigh.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands the public v2 API and changes product create/update validation and serialization; stale cached category paths after taxonomy deletes are explicitly guarded in tests but remain an operational edge case.
> 
> **Overview**
> Adds **`GET /v2/categories`**, returning a flat, **private 1-hour cacheable** list of categories (`id`, `name`, `label`, `path`, `parent_id`) built from **`Discover::TaxonomyPresenter`**.
> 
> Product **create/update** now accept an optional **`category`** full path (e.g. `design/ui-and-web/figma`) that maps to **`taxonomy_id`**, with validation that **`category` and `taxonomy_id` are not both sent**, plus clearer errors for invalid paths and numeric range issues. Product **JSON** adds **`taxonomy_id`**, **`category`**, and **`category_label`**, with **preloaded category metadata** on **`GET /v2/products`** to avoid N+1 lookups.
> 
> Public **API docs** and **`api_v2_methods`** are updated accordingly; specs cover the new endpoint and category round-trips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3409c319afffc3b51f07f16e37c65ad1e50c38d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->