### PR TITLE
Fix self-affiliate sales dropping seller proceeds

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -3133,6 +3133,7 @@ class Purchase < ApplicationRecord
 
     def determine_affiliate_balance_cents
       return 0 if affiliate.nil?
+      return 0 if affiliate.affiliate_user_id == seller_id
 
       affiliate_cents = affiliate_cut * displayed_price_usd_cents
       affiliate_cents -= determine_affiliate_fee_cents

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -6285,6 +6285,31 @@ describe Purchase, :vcr do
     end
   end
 
+  describe "#determine_affiliate_balance_cents" do
+    let(:seller) { create(:user) }
+    let(:product) { create(:product, user: seller, price_cents: 10_00) }
+
+    it "returns 0 when the affiliate user is the seller (self-affiliate)" do
+      global_affiliate = seller.global_affiliate
+      expect(global_affiliate.affiliate_user_id).to eq(seller.id)
+
+      purchase = create(:purchase, link: product, seller: seller, affiliate: global_affiliate)
+
+      expect(purchase.send(:determine_affiliate_balance_cents)).to eq(0)
+      expect(purchase.affiliate_credit_cents).to eq(0)
+    end
+
+    it "credits the affiliate normally when the affiliate user is not the seller" do
+      affiliate_user = create(:user)
+      direct_affiliate = create(:direct_affiliate, seller: seller, affiliate_user: affiliate_user, affiliate_basis_points: 1000, products: [product])
+
+      purchase = create(:purchase, link: product, seller: seller, affiliate: direct_affiliate)
+
+      expect(purchase.send(:determine_affiliate_balance_cents)).to be > 0
+      expect(purchase.affiliate_credit_cents).to be > 0
+    end
+  end
+
   describe "#gift_purchases_cannot_be_on_installment_plans" do
     it "does not allow gift purchases to be on installment plans" do
       purchase = create(:purchase, is_installment_payment: true, installment_plan: create(:product_installment_plan))


### PR DESCRIPTION
## What

For sales where a buyer purchases their own product via their own affiliate link (most commonly a `GlobalAffiliate` referral, where the seller themselves clicks through their own affiliate URL), the seller-proceeds `balance_transaction` is silently dropped. The seller's balance only reflects the small affiliate-commission portion of the sale.

This PR fixes the source of the problem in one line by returning `0` from `Purchase#determine_affiliate_balance_cents` when the affiliate user is the seller.

## Why

**Root cause:** PR #4829 (April 28) added an idempotency guard in `Purchase#increment_sellers_balance!` to safely retry after a `LockWaitTimeout`:

```ruby
if (seller_balance_transaction = balance_transactions.where(user: seller).where.not(balance_id: nil).last)
  self.purchase_success_balance = seller_balance_transaction.balance
  save! if purchase_success_balance_id != seller_balance_transaction.balance_id
  return
end
```

For ordinary sales this is correct. But `increment_affiliates_balance!` runs first (line 1551) and creates a `balance_transaction` for `user: affiliate.affiliate_user`. When `affiliate.affiliate_user_id == seller_id` (a self-affiliate sale), that BT *also* has `user_id == seller_id`. The idempotency guard then matches it, treats it as proof the seller has already been credited, and returns before the seller-proceeds BT is created. The seller loses the net proceeds for every such sale.

**Why this wasn't blocked by PR #4956:** #4956 fixed the `AffiliateRequest` → `DirectAffiliate` path. `GlobalAffiliate` rows are created automatically for every user (`User#after_create :create_global_affiliate!`) and do not go through `AffiliateRequest`, so a self-affiliate scenario is still possible whenever a seller's own global affiliate URL is used to buy their own product.

**Why fix it here:** The bug only manifests because `affiliate_credit_cents > 0` causes `increment_affiliates_balance!` to create a BT in the first place. By returning `0` from `determine_affiliate_balance_cents` when the affiliate is the seller, no affiliate credit is calculated, no affiliate BT is created, the idempotency guard is not tripped, and `payment_cents - affiliate_credit_cents` correctly equals the full net proceeds. The seller receives every dollar they are owed.

This is also the semantically correct behavior — a seller cannot earn a commission on their own sale.

Issue: antiwork/gumroad-private#337

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Claude Opus 4.7 (1M context). Prompts: "what to do next on this issue?", "step 1 (verify in prod)", "create a PR for the fix and assign nyomanjyotisa".

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782883852&installation_id=134400930&pr_number=5340&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5340&signature=f0838620cd43b67fd06a6488431417d302d9cf1a91a046fb2eee0d1f7adf9401"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes seller payout accounting on affiliate-attributed sales; incorrect logic would under- or over-credit balances, though scope is narrow (one guard) and covered by new specs.
> 
> **Overview**
> **Self-affiliate sales** (e.g. a seller buying their own product via their `GlobalAffiliate` link) no longer accrue affiliate credit. `Purchase#determine_affiliate_balance_cents` now returns **0** when `affiliate.affiliate_user_id == seller_id`, so `affiliate_credit_cents` stays zero and the seller balance path is not short-circuited by an affiliate `balance_transaction` on the same user.
> 
> Specs cover **global self-affiliate** (`affiliate_credit_cents` / balance helper) vs a normal **direct affiliate** purchase that still credits commission.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd764f8bd4422c06bc8296c02cf755dbbeda24cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->