### PR TITLE
Fall back to seller refund policy when no per-purchase snapshot exists

### DIFF
--- a/app/controllers/api/internal/admin/purchases_controller.rb
+++ b/app/controllers/api/internal/admin/purchases_controller.rb
@@ -161,7 +161,7 @@ class Api::Internal::Admin::PurchasesController < Api::Internal::Admin::BaseCont
           return render json: { success: false, message: "Purchase is outside of the refund policy timeframe" }, status: :unprocessable_entity
         end
 
-        if purchase.purchase_refund_policy&.fine_print.present?
+        if purchase.effective_refund_policy&.fine_print.present?
           return render json: { success: false, message: "This product has specific refund conditions that require seller review" }, status: :unprocessable_entity
         end
       end

--- a/app/controllers/api/internal/helper/purchases_controller.rb
+++ b/app/controllers/api/internal/helper/purchases_controller.rb
@@ -110,7 +110,7 @@ class Api::Internal::Helper::PurchasesController < Api::Internal::Helper::BaseCo
       return render json: { success: false, message: "Purchase is outside of the refund policy timeframe" }, status: :unprocessable_entity
     end
 
-    if purchase.purchase_refund_policy&.fine_print.present?
+    if purchase.effective_refund_policy&.fine_print.present?
       return render json: { success: false, message: "This product has specific refund conditions that require seller review" }, status: :unprocessable_entity
     end
 

--- a/app/modules/purchase/refundable.rb
+++ b/app/modules/purchase/refundable.rb
@@ -349,13 +349,17 @@ class Purchase
     return false unless successful? || gift_receiver_purchase_successful? || not_charged?
     return false if refunded? || chargedback?
 
-    refund_policy = purchase_refund_policy
+    refund_policy = effective_refund_policy
     return false unless refund_policy.present?
 
     max_days = refund_policy.max_refund_period_in_days
     return false if max_days.nil? || max_days <= 0
 
     created_at > max_days.days.ago
+  end
+
+  def effective_refund_policy
+    purchase_refund_policy || seller&.refund_policy
   end
 
   private

--- a/spec/controllers/api/internal/admin/purchases_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/purchases_controller_spec.rb
@@ -926,6 +926,37 @@ describe Api::Internal::Admin::PurchasesController do
         expect(response.parsed_body["message"]).to eq(Purchase::Refundable::ACTIVE_DISPUTE_REFUND_ERROR_MESSAGE)
       end
 
+      context "when no per-purchase refund policy row exists but the seller has an account-level policy" do
+        before do
+          allow(purchase).to receive(:within_refund_policy_timeframe?).and_call_original
+          allow(purchase).to receive(:purchase_refund_policy).and_return(nil)
+          allow(purchase).to receive(:successful?).and_return(true)
+          allow(purchase).to receive(:refunded?).and_return(false)
+          allow(purchase).to receive(:chargedback?).and_return(false)
+          purchase.seller.refund_policy.update!(max_refund_period_in_days: 30, fine_print: nil)
+          purchase.created_at = 1.day.ago
+        end
+
+        it "honors the seller policy timeframe and refunds without force" do
+          expect(purchase).to receive(:refund!).with(refunding_user_id: admin_user.id, amount: nil).and_return(true)
+
+          post :refund, params: params
+
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body["success"]).to be(true)
+        end
+
+        it "returns 422 when outside the seller policy timeframe" do
+          purchase.created_at = 31.days.ago
+
+          post :refund, params: params
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.parsed_body["success"]).to be(false)
+          expect(response.parsed_body["message"]).to eq("Purchase is outside of the refund policy timeframe")
+        end
+      end
+
       context "with cancel_subscription=true" do
         let(:subscription) { instance_double(Subscription, deactivated?: false, cancelled_at: nil, price: nil) }
 

--- a/spec/controllers/api/internal/helper/purchases_controller_spec.rb
+++ b/spec/controllers/api/internal/helper/purchases_controller_spec.rb
@@ -429,14 +429,14 @@ describe Api::Internal::Helper::PurchasesController, :vcr do
 
     let(:purchase) { instance_double(Purchase, id: 1, email: "test@example.com", external_id_numeric: 1) }
     let(:params) { { purchase_id: "12345", email: "test@example.com" } }
-    let(:purchase_refund_policy) { double("PurchaseRefundPolicy", fine_print: nil) }
+    let(:refund_policy) { double("RefundPolicy", fine_print: nil) }
 
     before do
       stub_const("GUMROAD_ADMIN_ID", admin_user.id)
 
       allow(Purchase).to receive(:find_by_external_id_numeric).with(12345).and_return(purchase)
       allow(purchase).to receive(:within_refund_policy_timeframe?).and_return(true)
-      allow(purchase).to receive(:purchase_refund_policy).and_return(purchase_refund_policy)
+      allow(purchase).to receive(:effective_refund_policy).and_return(refund_policy)
       allow(purchase).to receive(:refund_and_save!).with(admin_user.id).and_return(true)
     end
 
@@ -461,7 +461,18 @@ describe Api::Internal::Helper::PurchasesController, :vcr do
 
       it "returns an error when fine print exists" do
         allow(purchase).to receive(:within_refund_policy_timeframe?).and_return(true)
-        allow(purchase_refund_policy).to receive(:fine_print).and_return("Some fine print")
+        allow(refund_policy).to receive(:fine_print).and_return("Some fine print")
+
+        post :auto_refund_purchase, params: params
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(JSON.parse(response.body)["success"]).to eq(false)
+        expect(JSON.parse(response.body)["message"]).to eq("This product has specific refund conditions that require seller review")
+      end
+
+      it "surfaces fine print from the seller policy when no per-purchase policy exists" do
+        seller_policy = double("SellerRefundPolicy", fine_print: "Manual review required")
+        allow(purchase).to receive(:effective_refund_policy).and_return(seller_policy)
 
         post :auto_refund_purchase, params: params
 
@@ -472,7 +483,7 @@ describe Api::Internal::Helper::PurchasesController, :vcr do
 
       it "returns an error if the refund fails" do
         allow(purchase).to receive(:within_refund_policy_timeframe?).and_return(true)
-        allow(purchase_refund_policy).to receive(:fine_print).and_return(nil)
+        allow(refund_policy).to receive(:fine_print).and_return(nil)
 
         allow(purchase).to receive(:refund_and_save!).with(admin_user.id).and_return(false)
 

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -6363,12 +6363,44 @@ describe Purchase, :vcr do
       end
     end
 
-    context "when there is no refund policy" do
+    context "when there is no per-purchase or seller refund policy" do
       it "returns false" do
         allow(purchase).to receive(:successful?).and_return(true)
         allow(purchase).to receive(:refunded?).and_return(false)
         allow(purchase).to receive(:chargedback?).and_return(false)
         allow(purchase).to receive(:purchase_refund_policy).and_return(nil)
+        allow(purchase.seller).to receive(:refund_policy).and_return(nil)
+
+        expect(purchase.within_refund_policy_timeframe?).to be false
+      end
+    end
+
+    context "when the per-purchase policy is missing but the seller has an account-level policy" do
+      let(:seller_refund_policy) { purchase.seller.refund_policy }
+
+      before do
+        seller_refund_policy.update!(max_refund_period_in_days: 30)
+        allow(purchase).to receive(:successful?).and_return(true)
+        allow(purchase).to receive(:refunded?).and_return(false)
+        allow(purchase).to receive(:chargedback?).and_return(false)
+        allow(purchase).to receive(:purchase_refund_policy).and_return(nil)
+      end
+
+      it "honors the seller policy when within the timeframe" do
+        purchase.created_at = 5.days.ago
+
+        expect(purchase.within_refund_policy_timeframe?).to be true
+      end
+
+      it "returns false when outside the seller policy timeframe" do
+        purchase.created_at = 35.days.ago
+
+        expect(purchase.within_refund_policy_timeframe?).to be false
+      end
+
+      it "returns false when the seller policy has a non-positive max period" do
+        seller_refund_policy.update!(max_refund_period_in_days: 0)
+        purchase.created_at = 5.days.ago
 
         expect(purchase.within_refund_policy_timeframe?).to be false
       end


### PR DESCRIPTION
## What

`Purchase#within_refund_policy_timeframe?` now falls back to the seller's account-level refund policy when no `PurchaseRefundPolicy` snapshot row exists on the purchase. The admin and helper refund endpoints' fine-print gate also routes through a new `Purchase#effective_refund_policy` helper so seller-level fine print is respected the same way.

Concrete changes:

- `app/modules/purchase/refundable.rb`: add `effective_refund_policy` and use it from `within_refund_policy_timeframe?` (falls back to `seller&.refund_policy` when the per-purchase snapshot is nil).
- `app/controllers/api/internal/admin/purchases_controller.rb`, `app/controllers/api/internal/helper/purchases_controller.rb`: the fine-print check now reads `purchase.effective_refund_policy&.fine_print` so the seller's account-level fine print also blocks unforced refunds.
- Specs updated for the new behavior, with regression coverage in the model and admin controller that fails when this change is reverted.

## Why

The global Flipper flag `seller_refund_policy_disabled_for_all` is currently on in production (confirmed against the read replica). That makes `User#account_level_refund_policy_enabled?` return false for every seller, so `Purchase::CreateService` takes neither the account-level nor the product-level branch in `app/services/purchase/create_service.rb:47-59` and **never builds a `PurchaseRefundPolicy` row** for new purchases. Existing recent purchases on the affected sellers' products confirm this — none of them have a snapshot row.

`Purchase#within_refund_policy_timeframe?` then sees `refund_policy = purchase_refund_policy` resolve to nil and returns false. Both admin and helper refund controllers turn that into "Purchase is outside of the refund policy timeframe", which is misleading: the real condition is "no policy attached at all". This is the bug surfaced in antiwork/gumroad-private#440 — a 1-day-old purchase against a 30-day seller policy was rejected, and admins had to fall back to `--force`.

The seller still has a `SellerRefundPolicy` row (auto-created via `User#after_create :create_refund_policy!`) that records the timeframe and any fine print they agreed to. Falling back to that row keeps the seller's stated terms enforceable when no snapshot was captured, instead of refusing every refund. `--force` continues to bypass both the timeframe and fine-print gates, so existing escape hatches for admins keep working unchanged.

Alternative considered: removing the timeframe check entirely from the admin/helper paths, or making "no policy" mean "open". Rejected — the seller's `SellerRefundPolicy` is the authoritative source for their agreed-upon timeframe even when the per-purchase snapshot is missing, so honoring it is more conservative and matches what buyers see on the checkout page.

---

This PR was implemented by Claude Opus 4.7 (1M context)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5341"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782886105&installation_id=134400930&pr_number=5341&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5341&signature=81bb5d7bc5747a967ea4ddbf96d4f88f1b51fe182b724ecf354868d15d85218e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how admin and helper APIs decide refund eligibility (timeframe and fine print), which is money-adjacent but scoped and covered by regression specs; per-purchase snapshots still take precedence when present.
> 
> **Overview**
> Adds **`Purchase#effective_refund_policy`**, using the per-purchase snapshot when present and otherwise the seller’s account-level **`SellerRefundPolicy`**. **`within_refund_policy_timeframe?`** and the admin/helper refund **fine-print** checks now use that helper instead of **`purchase_refund_policy` alone**.
> 
> Recent purchases with **no** `PurchaseRefundPolicy` row (e.g. when account-level policy creation is disabled globally) were treated as outside policy and blocked normal refunds; they now honor the seller’s configured window and fine print. **`--force`** behavior is unchanged. Specs cover seller-policy fallback for timeframe, fine print, and admin auto-refund.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1f8e25cd404c7c184640c169585c7a475c66bdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->