### PR TITLE
Fix silent subscription renewal failures on plan-change application

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -319,9 +319,9 @@ class Purchase < ApplicationRecord
   # this ensures preorders that require shipping at a later date will pass this validation
   %w[full_name street_address country state zip_code city].each do |f|
     validates f.to_sym, presence: true, on: :create,
-                        if: -> { link.is_physical || (link.require_shipping? && !is_recurring_subscription_charge && !is_preorder_charge?) }
+                        if: -> { !is_applying_plan_change && (link.is_physical || (link.require_shipping? && !is_recurring_subscription_charge && !is_preorder_charge?)) }
     validates f.to_sym, presence: true, on: :update,
-                        if: -> { is_updated_original_subscription_purchase && (link.is_physical || link.require_shipping?) && !is_recurring_subscription_charge && !is_preorder_charge? }
+                        if: -> { !is_applying_plan_change && is_updated_original_subscription_purchase && (link.is_physical || link.require_shipping?) && !is_recurring_subscription_charge && !is_preorder_charge? }
   end
   validates :call, presence: true, if: -> { link.native_type == Link::NATIVE_TYPE_CALL }
   validates_inclusion_of :recommender_model_name, in: RecommendedProductsService::MODELS, allow_nil: true

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -1201,13 +1201,27 @@ describe Purchase, :vcr do
   end
 
   context "when is_applying_plan_change is true on a require_shipping product" do
-    it "skips address presence validations so plan-change application can proceed for legacy subscribers without an address" do
+    it "skips address presence validations on :create so plan-change application can proceed for legacy subscribers without an address" do
       purchase = build(:purchase,
                        street_address: nil, full_name: nil, country: nil, state: nil, city: nil, zip_code: nil,
                        link: create(:product, require_shipping: true))
       purchase.is_applying_plan_change = true
 
       expect(purchase).to be_valid
+      %i[full_name street_address country state city zip_code].each do |field|
+        expect(purchase.errors[field]).to be_empty
+      end
+    end
+
+    it "skips address presence validations on :update so later updates to the placeholder purchase don't fail" do
+      purchase = build(:purchase,
+                       street_address: nil, full_name: nil, country: nil, state: nil, city: nil, zip_code: nil,
+                       link: create(:product, require_shipping: true))
+      purchase.is_updated_original_subscription_purchase = true
+      purchase.save!(validate: false)
+      purchase.is_applying_plan_change = true
+
+      expect(purchase.valid?(:update)).to be true
       %i[full_name street_address country state city zip_code].each do |field|
         expect(purchase.errors[field]).to be_empty
       end

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -1200,6 +1200,20 @@ describe Purchase, :vcr do
     end
   end
 
+  context "when is_applying_plan_change is true on a require_shipping product" do
+    it "skips address presence validations so plan-change application can proceed for legacy subscribers without an address" do
+      purchase = build(:purchase,
+                       street_address: nil, full_name: nil, country: nil, state: nil, city: nil, zip_code: nil,
+                       link: create(:product, require_shipping: true))
+      purchase.is_applying_plan_change = true
+
+      expect(purchase).to be_valid
+      %i[full_name street_address country state city zip_code].each do |field|
+        expect(purchase.errors[field]).to be_empty
+      end
+    end
+  end
+
   describe "limiting # of sales for a link" do
     let(:user) { create(:user) }
     let(:link) { create(:product, max_purchase_count: 1) }


### PR DESCRIPTION
## What

Add `!is_applying_plan_change` to the two `full_name`/`street_address`/`country`/`state`/`city`/`zip_code` presence validations in `app/models/purchase.rb:320-325`, so the placeholder original-subscription purchase built by `Subscription#update_current_plan!` is not blocked by missing address fields when applying a `subscription_plan_change` for a `require_shipping` product.

Single-line model change, 14 lines of regression spec.

## Why

`RecurringChargeWorker` (`app/sidekiq/recurring_charge_worker.rb:35-61`) applies any pending `subscription_plan_change` before charging the renewal. The way it applies the change is by calling `Subscription#update_current_plan!`, which builds a *new* original subscription purchase as a placeholder for the new tier/price (`app/models/subscription.rb:507-523`):

```ruby
new_purchase.is_original_subscription_purchase = true
new_purchase.is_updated_original_subscription_purchase = true
new_purchase.is_applying_plan_change = is_applying_plan_change  # true from RecurringChargeWorker
```

For a product with `require_shipping = true`, the `on: :create` and `on: :update` presence validations at `app/models/purchase.rb:320-325` both fire on that placeholder. `is_recurring_subscription_charge` is false (because `is_original_subscription_purchase = true`), so the existing escape hatch for normal renewals doesn't apply. The placeholder copies `street_address` etc. from the prior `original_purchase` via `Subscription#build_purchase` — but if the subscriber joined *before* the seller toggled `require_shipping` on the product, those fields are nil. The placeholder fails validation, `update_current_plan!` raises `Subscription::UpdateFailed`, and `RecurringChargeWorker` silently rescues and returns at line 51-54:

```ruby
rescue Subscription::UpdateFailed => e
  Rails.logger.info("RecurringChargeWorker#perform(#{subscription_id}) failed: #{e.class} (#{e.message})")
  return
end
```

`subscription.charge!` is never reached, so no Purchase row is created in any state — not `successful`, not `failed`, not `in_progress`. The plan_change row stays `applied=false`. The next time the worker fires (via `FindSubscriptionsWithMissingChargeWorker` or a re-enqueue), it hits the same path and silently returns again. Renewals are lost without any visible failure.

This is the root cause of antiwork/gumroad-private#439: Purveyor Press is a tiered membership where DIGITAL + PRINT ships physical newsletters and DIGITAL ONLY is digital. Because `require_shipping` is enabled at the product level, every subscriber's renewal — including DIGITAL ONLY subscribers like Lara Cunningham — is subject to address validation. The seller's May 12 price change queued `subscription_plan_change` rows on ~100 subs; every renewal due after that date hit the validation and was silently dropped.

Confirmed against production by running a transactional dry-run of `subscription.update_current_plan!(..., is_applying_plan_change: true)` on sub 2539542:

```
UpdateFailed: Street address can't be blank
```

There is already precedent for `is_applying_plan_change` short-circuiting validations that don't apply to a tier/price swap on an in-flight subscription: `perceived_price_cents_matches_price_cents` (`app/models/purchase.rb:3720`) and the minimum-price logic at line 1438 both do the same thing. The placeholder purchase is never actually charged — it's a marker for the new pricing — so enforcing address presence on it has no business meaning.

Alternative considered: copy the buyer's address from somewhere else (e.g., their User profile) onto the placeholder. Rejected — the buyer never provided one, and `Purchase` is the wrong place to invent address data. The placeholder doesn't ship anything either way; future renewal charges will skip the validation via `is_recurring_subscription_charge`, and subscriber-driven plan changes from the dashboard already require a real address entry. The plan-change application path is the only one that legitimately needs the bypass.

## How to unblock the seven affected subscribers after this ships

Once merged and deployed, re-enqueue the worker for each affected sub:

```ruby
[2539542, 2522686, 2540481, 2540519, 2541254, 2543917, 2540539].each do |sid|
  RecurringChargeWorker.perform_async(sid, true)
end
```

Until then, manually re-enqueueing hits the same failing path.


---

This PR was implemented by Claude Opus 4.7 (1M context)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5342"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782886762&installation_id=134400930&pr_number=5342&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5342&signature=53669602713a5efd668487ea3baaebc19d6f3de3c19fb2162df01da4cd745e67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow conditional bypass for an internal plan-change path; normal purchases and updates still enforce shipping fields when required.
> 
> **Overview**
> **Subscription plan changes** on products with **`require_shipping`** were failing when the placeholder original purchase had no address (e.g. subscribers who joined before shipping was required). **`RecurringChargeWorker`** could then bail on `Subscription::UpdateFailed` and never charge renewals.
> 
> This PR adds **`!is_applying_plan_change`** to the **`Purchase`** create/update presence validations for **`full_name`**, **`street_address`**, **`country`**, **`state`**, **`city`**, and **`zip_code`**, aligned with other plan-change bypasses like **`perceived_price_cents_matches_price_cents`**. Normal checkout and subscriber-driven updates still require addresses when shipping applies.
> 
> Specs cover **`:create`** and **`:update`** with **`is_applying_plan_change`** set and blank address fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1db73f264d372d50eb2ebba84c33ce047999705. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->