### PR TITLE
Use PayPal as source of truth for multi-currency refund amounts

### DIFF
--- a/app/business/payments/charging/charge_processor.rb
+++ b/app/business/payments/charging/charge_processor.rb
@@ -179,13 +179,15 @@ module ChargeProcessor
   def self.refund!(charge_processor_id, charge_id, amount_cents: nil, merchant_account: nil,
                    paypal_order_purchase_unit_refund: nil,
                    reverse_transfer: true,
-                   is_for_fraud: nil)
+                   is_for_fraud: nil,
+                   purchase: nil)
     get_charge_processor(charge_processor_id).refund!(charge_id,
                                                       amount_cents:,
                                                       merchant_account:,
                                                       paypal_order_purchase_unit_refund:,
                                                       reverse_transfer:,
-                                                      is_for_fraud:)
+                                                      is_for_fraud:,
+                                                      purchase:)
   end
 
   # Public: Handles a charge event.

--- a/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
+++ b/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
@@ -724,10 +724,10 @@ class PaypalChargeProcessor
       scale = paypal_cents_scale(purchase_unit.amount&.currency_code)
       total_unit_value = purchase_unit.items.sum { |i| BigDecimal(i.unit_amount.value) * scale * i.quantity.to_i }
       this_item_unit_value = BigDecimal(item.unit_amount.value) * scale * item.quantity.to_i
-      tax_total_value = purchase_unit.amount&.breakdown&.tax_total&.value
-      tax_total = tax_total_value.present? ? BigDecimal(tax_total_value) * scale : BigDecimal(0)
-      this_item_tax_share = total_unit_value.positive? ? (this_item_unit_value * tax_total / total_unit_value) : BigDecimal(0)
-      this_item_full_value_cents = this_item_unit_value + this_item_tax_share
+
+      breakdown_extras = breakdown_extras_cents(purchase_unit.amount&.breakdown, scale)
+      this_item_extras_share = total_unit_value.positive? ? (this_item_unit_value * breakdown_extras / total_unit_value) : BigDecimal(0)
+      this_item_full_value_cents = this_item_unit_value + this_item_extras_share
 
       ratio = if amount_cents.present? && purchase.total_transaction_cents.to_i.positive?
         [BigDecimal(amount_cents) / purchase.total_transaction_cents, BigDecimal(1)].min
@@ -736,6 +736,22 @@ class PaypalChargeProcessor
       end
 
       (this_item_full_value_cents * ratio).floor.to_i
+    end
+
+    # A purchase unit's captured amount equals the sum of its item unit_amounts plus
+    # `tax_total + shipping + handling - discount` from the breakdown. Returning the net
+    # extras lets each item's refund value carry its proportional share of those line items;
+    # without this, refunds on units with shipping/handling/discount would undercount and
+    # PayPal could reject subsequent refunds (or buyers would be short-refunded).
+    def breakdown_extras_cents(breakdown, scale)
+      return BigDecimal(0) if breakdown.blank?
+      additions = %i[tax_total shipping handling].sum(BigDecimal(0)) do |key|
+        value = breakdown.respond_to?(key) ? breakdown.public_send(key)&.value : nil
+        value.present? ? BigDecimal(value) * scale : BigDecimal(0)
+      end
+      discount_value = breakdown.respond_to?(:discount) ? breakdown.discount&.value : nil
+      discount = discount_value.present? ? BigDecimal(discount_value) * scale : BigDecimal(0)
+      additions - discount
     end
 
     def remaining_capture_cents(purchase_unit, capture_id)

--- a/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
+++ b/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
@@ -704,8 +704,8 @@ class PaypalChargeProcessor
     # rounded down to never overshoot the capture.
     def refund_amount_in_merchant_currency_cents(paypal_rest_api, capture_id, amount_cents, merchant_account, purchase)
       if purchase&.paypal_order_id.present?
-        paypal_order = paypal_rest_api.fetch_order(order_id: purchase.paypal_order_id).result
-        purchase_unit = paypal_order.purchase_units.find { |pu| pu.payments&.captures&.any? { |c| c.id == capture_id } }
+        paypal_order = paypal_rest_api.fetch_order(order_id: purchase.paypal_order_id)&.result
+        purchase_unit = paypal_order&.purchase_units&.find { |pu| pu.payments&.captures&.any? { |c| c.id == capture_id } }
         if purchase_unit
           desired = item_refund_cents_from_paypal(purchase_unit, purchase, amount_cents)
           return [desired, remaining_capture_cents(purchase_unit, capture_id)].min if desired
@@ -719,15 +719,15 @@ class PaypalChargeProcessor
       item = purchase_unit.items&.find { |i| i.sku == purchase.link.unique_permalink }
       return nil unless item
 
-      total_unit_value = purchase_unit.items.sum { |i| BigDecimal(i.unit_amount.value) * 100 }
-      this_item_unit_value = BigDecimal(item.unit_amount.value) * 100
+      total_unit_value = purchase_unit.items.sum { |i| BigDecimal(i.unit_amount.value) * 100 * i.quantity.to_i }
+      this_item_unit_value = BigDecimal(item.unit_amount.value) * 100 * item.quantity.to_i
       tax_total_value = purchase_unit.amount&.breakdown&.tax_total&.value
       tax_total = tax_total_value.present? ? BigDecimal(tax_total_value) * 100 : BigDecimal(0)
       this_item_tax_share = total_unit_value.positive? ? (this_item_unit_value * tax_total / total_unit_value) : BigDecimal(0)
       this_item_full_value_cents = this_item_unit_value + this_item_tax_share
 
-      ratio = if amount_cents.present? && purchase.price_cents.to_i.positive?
-        [BigDecimal(amount_cents) / purchase.price_cents, BigDecimal(1)].min
+      ratio = if amount_cents.present? && purchase.total_transaction_cents.to_i.positive?
+        [BigDecimal(amount_cents) / purchase.total_transaction_cents, BigDecimal(1)].min
       else
         BigDecimal(1)
       end

--- a/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
+++ b/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
@@ -716,13 +716,16 @@ class PaypalChargeProcessor
     end
 
     def item_refund_cents_from_paypal(purchase_unit, purchase, amount_cents)
-      item = purchase_unit.items&.find { |i| i.sku == purchase.link.unique_permalink }
+      permalink = purchase.link&.unique_permalink
+      return nil if permalink.blank?
+      item = purchase_unit.items&.find { |i| i.sku == permalink }
       return nil unless item
 
-      total_unit_value = purchase_unit.items.sum { |i| BigDecimal(i.unit_amount.value) * 100 * i.quantity.to_i }
-      this_item_unit_value = BigDecimal(item.unit_amount.value) * 100 * item.quantity.to_i
+      scale = paypal_cents_scale(purchase_unit.amount&.currency_code)
+      total_unit_value = purchase_unit.items.sum { |i| BigDecimal(i.unit_amount.value) * scale * i.quantity.to_i }
+      this_item_unit_value = BigDecimal(item.unit_amount.value) * scale * item.quantity.to_i
       tax_total_value = purchase_unit.amount&.breakdown&.tax_total&.value
-      tax_total = tax_total_value.present? ? BigDecimal(tax_total_value) * 100 : BigDecimal(0)
+      tax_total = tax_total_value.present? ? BigDecimal(tax_total_value) * scale : BigDecimal(0)
       this_item_tax_share = total_unit_value.positive? ? (this_item_unit_value * tax_total / total_unit_value) : BigDecimal(0)
       this_item_full_value_cents = this_item_unit_value + this_item_tax_share
 
@@ -739,9 +742,18 @@ class PaypalChargeProcessor
       capture = purchase_unit.payments.captures.find { |c| c.id == capture_id }
       return 0 unless capture
 
-      captured = (BigDecimal(capture.amount.value) * 100).to_i
-      refunded = (purchase_unit.payments.refunds || []).sum { |r| (BigDecimal(r.amount.value) * 100).to_i }
+      scale = paypal_cents_scale(capture.amount&.currency_code)
+      captured = (BigDecimal(capture.amount.value) * scale).to_i
+      refunded = (purchase_unit.payments.refunds || []).sum { |r| (BigDecimal(r.amount.value) * scale).to_i }
       captured - refunded
+    end
+
+    # PayPal records amounts as decimal strings in the major unit (e.g. "10.59" for GBP £10.59 or
+    # "2141" for JPY ¥2141). To produce a cents-style integer that matches `formatted_amount_for_paypal`
+    # expectations, multiply by 100 for normal currencies and by 1 for zero-decimal currencies
+    # (JPY/TWD/HUF) — matching the asymmetry that `usd_cents_to_currency` already handles.
+    def paypal_cents_scale(currency_code)
+      self.class.is_currency_type_single_unit?(currency_code.to_s.downcase) ? 1 : 100
     end
 
     def self.determine_create_order_error(api_response)

--- a/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
+++ b/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
@@ -315,8 +315,8 @@ class PaypalChargeProcessor
   def self.format_money_floored(money, currency)
     return 0 if money.blank?
     return money if currency.to_s == "usd"
-    rate = get_rate(currency).to_f
-    (BigDecimal(money) * rate).floor.to_i
+    rate = BigDecimal(get_rate(currency).to_s)
+    (BigDecimal(money.to_s) * rate).floor.to_i
   end
 
   def self.formatted_amount_for_paypal(cents, currency)
@@ -724,7 +724,7 @@ class PaypalChargeProcessor
       this_item_tax_share = total_unit_value.positive? ? (this_item_unit_value * tax_total / total_unit_value) : BigDecimal(0)
       this_item_full_value_cents = this_item_unit_value + this_item_tax_share
 
-      ratio = if purchase.price_cents.to_i.positive?
+      ratio = if amount_cents.present? && purchase.price_cents.to_i.positive?
         [BigDecimal(amount_cents) / purchase.price_cents, BigDecimal(1)].min
       else
         BigDecimal(1)

--- a/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
+++ b/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
@@ -316,7 +316,9 @@ class PaypalChargeProcessor
     return 0 if money.blank?
     return money if currency.to_s == "usd"
     rate = BigDecimal(get_rate(currency).to_s)
-    (BigDecimal(money.to_s) * rate).floor.to_i
+    converted = BigDecimal(money.to_s) * rate
+    converted /= 100 if is_currency_type_single_unit?(currency)
+    converted.floor.to_i
   end
 
   def self.formatted_amount_for_paypal(cents, currency)

--- a/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
+++ b/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
@@ -744,8 +744,23 @@ class PaypalChargeProcessor
 
       scale = paypal_cents_scale(capture.amount&.currency_code)
       captured = (BigDecimal(capture.amount.value) * scale).to_i
-      refunded = (purchase_unit.payments.refunds || []).sum { |r| (BigDecimal(r.amount.value) * scale).to_i }
+      refunded = (purchase_unit.payments.refunds || []).sum do |r|
+        next 0 unless refund_belongs_to_capture?(r, capture_id)
+        (BigDecimal(r.amount.value) * scale).to_i
+      end
       captured - refunded
+    end
+
+    # PayPal Orders v2 lists refunds at the purchase-unit level rather than nested under
+    # the specific capture they came from. Each refund's `links` array carries an "up" link
+    # back to the originating capture id; use it to attribute refunds correctly when a
+    # purchase unit has multiple captures. Default to inclusive when links are absent so we
+    # don't drop refunds we can't positively attribute (preserves the single-capture-per-unit
+    # default that older payloads and test fixtures rely on).
+    def refund_belongs_to_capture?(refund, capture_id)
+      links = refund.respond_to?(:links) ? refund.links : nil
+      return true if links.blank?
+      links.any? { |l| l.respond_to?(:href) && l.href.to_s.include?("/captures/#{capture_id}") }
     end
 
     # PayPal records amounts as decimal strings in the major unit (e.g. "10.59" for GBP £10.59 or

--- a/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
+++ b/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
@@ -703,7 +703,7 @@ class PaypalChargeProcessor
     # at the capture's remaining balance. Otherwise falls back to converting the USD amount,
     # rounded down to never overshoot the capture.
     def refund_amount_in_merchant_currency_cents(paypal_rest_api, capture_id, amount_cents, merchant_account, purchase)
-      if purchase&.paypal_order_id.present?
+      if purchase&.paypal_order_id.present? && purchase.respond_to?(:is_part_of_combined_charge?) && purchase.is_part_of_combined_charge?
         paypal_order = paypal_rest_api.fetch_order(order_id: purchase.paypal_order_id)&.result
         purchase_unit = paypal_order&.purchase_units&.find { |pu| pu.payments&.captures&.any? { |c| c.id == capture_id } }
         if purchase_unit

--- a/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
+++ b/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
@@ -309,6 +309,16 @@ class PaypalChargeProcessor
     formatted_amount_for_paypal(usd_cents_to_currency(currency, money), currency)
   end
 
+  # Rounded-down USD-cents → merchant-currency-cents conversion. Used in PayPal refund paths
+  # so cumulative refunds against a single multi-currency capture never exceed the captured
+  # amount due to standard rounding pushing one of the converted values over the truth.
+  def self.format_money_floored(money, currency)
+    return 0 if money.blank?
+    return money if currency.to_s == "usd"
+    rate = get_rate(currency).to_f
+    (BigDecimal(money) * rate).floor.to_i
+  end
+
   def self.formatted_amount_for_paypal(cents, currency)
     amount = Money.new(cents, currency).amount
 
@@ -538,9 +548,9 @@ class PaypalChargeProcessor
     end
   end
 
-  def refund!(charge_id, amount_cents: nil, merchant_account: nil, paypal_order_purchase_unit_refund: nil, **_args)
+  def refund!(charge_id, amount_cents: nil, merchant_account: nil, paypal_order_purchase_unit_refund: nil, purchase: nil, **_args)
     if paypal_order_purchase_unit_refund
-      refund_response = refund_order_purchase_unit!(charge_id, merchant_account, amount_cents)
+      refund_response = refund_order_purchase_unit!(charge_id, merchant_account, amount_cents, purchase:)
       PaypalOrderRefund.new(refund_response, charge_id)
     else
       if amount_cents.nil?
@@ -663,10 +673,18 @@ class PaypalChargeProcessor
     # REFUND_FAILED_INSUFFICIENT_FUNDS (Refund failed due to insufficient funds in your PayPal account)
     #
     # EXTDISPUTE_REFUND_FAILED_INSUFFICIENT_FUNDS (Refund failed due to insufficient funds in seller's PayPal account)
-    def refund_order_purchase_unit!(capture_id, merchant_account, amount_cents)
+    def refund_order_purchase_unit!(capture_id, merchant_account, amount_cents, purchase: nil)
       paypal_rest_api = PaypalRestApi.new
-      api_response = paypal_rest_api.refund(capture_id:, merchant_account:,
-                                            amount: self.class.format_money(amount_cents, merchant_account.currency))
+      refund_amount_cents = refund_amount_in_merchant_currency_cents(paypal_rest_api, capture_id, amount_cents, merchant_account, purchase)
+      if amount_cents.present? && refund_amount_cents <= 0
+        raise ChargeProcessorAlreadyRefundedError, "Capture #{capture_id} has no remaining balance to refund"
+      end
+
+      api_response = paypal_rest_api.refund(
+        capture_id:,
+        merchant_account:,
+        amount: self.class.formatted_amount_for_paypal(refund_amount_cents, merchant_account.currency)
+      )
 
       self.class.log_paypal_api_response("Refund Order Purchase Unit", capture_id, api_response)
       if paypal_rest_api.successful_response?(api_response)
@@ -675,6 +693,53 @@ class PaypalChargeProcessor
         error_message = PaypalChargeProcessor.build_error_message("Failed refund capture id - #{capture_id}", api_response.result.details[0].description)
         raise determine_refund_order_error(api_response), error_message
       end
+    end
+
+    # Returns the refund amount in the merchant account's currency, in cents.
+    # When a `purchase` is provided and the PayPal order can be located, the amount is derived
+    # from PayPal's recorded per-item value (avoiding USD→merchant-currency drift) and capped
+    # at the capture's remaining balance. Otherwise falls back to converting the USD amount,
+    # rounded down to never overshoot the capture.
+    def refund_amount_in_merchant_currency_cents(paypal_rest_api, capture_id, amount_cents, merchant_account, purchase)
+      if purchase&.paypal_order_id.present?
+        paypal_order = paypal_rest_api.fetch_order(order_id: purchase.paypal_order_id).result
+        purchase_unit = paypal_order.purchase_units.find { |pu| pu.payments&.captures&.any? { |c| c.id == capture_id } }
+        if purchase_unit
+          desired = item_refund_cents_from_paypal(purchase_unit, purchase, amount_cents)
+          return [desired, remaining_capture_cents(purchase_unit, capture_id)].min if desired
+        end
+      end
+
+      self.class.format_money_floored(amount_cents, merchant_account.currency)
+    end
+
+    def item_refund_cents_from_paypal(purchase_unit, purchase, amount_cents)
+      item = purchase_unit.items&.find { |i| i.sku == purchase.link.unique_permalink }
+      return nil unless item
+
+      total_unit_value = purchase_unit.items.sum { |i| BigDecimal(i.unit_amount.value) * 100 }
+      this_item_unit_value = BigDecimal(item.unit_amount.value) * 100
+      tax_total_value = purchase_unit.amount&.breakdown&.tax_total&.value
+      tax_total = tax_total_value.present? ? BigDecimal(tax_total_value) * 100 : BigDecimal(0)
+      this_item_tax_share = total_unit_value.positive? ? (this_item_unit_value * tax_total / total_unit_value) : BigDecimal(0)
+      this_item_full_value_cents = this_item_unit_value + this_item_tax_share
+
+      ratio = if purchase.price_cents.to_i.positive?
+        [BigDecimal(amount_cents) / purchase.price_cents, BigDecimal(1)].min
+      else
+        BigDecimal(1)
+      end
+
+      (this_item_full_value_cents * ratio).floor.to_i
+    end
+
+    def remaining_capture_cents(purchase_unit, capture_id)
+      capture = purchase_unit.payments.captures.find { |c| c.id == capture_id }
+      return 0 unless capture
+
+      captured = (BigDecimal(capture.amount.value) * 100).to_i
+      refunded = (purchase_unit.payments.refunds || []).sum { |r| (BigDecimal(r.amount.value) * 100).to_i }
+      captured - refunded
     end
 
     def self.determine_create_order_error(api_response)

--- a/app/modules/purchase/refundable.rb
+++ b/app/modules/purchase/refundable.rb
@@ -88,7 +88,8 @@ class Purchase
                                                 merchant_account:,
                                                 reverse_transfer: !chargedback? || !chargeback_reversed,
                                                 paypal_order_purchase_unit_refund:,
-                                                is_for_fraud:)
+                                                is_for_fraud:,
+                                                purchase: self)
         logger.info("Refunding purchase: #{id} completed with ID: #{charge_refund.id}, Flow of Funds: #{charge_refund.flow_of_funds.to_h}")
         purchase_event = Event.where(purchase_id: id, event_name: "purchase").last
         unless purchase_event.nil?
@@ -292,7 +293,8 @@ class Purchase
                                               amount_cents: gumroad_tax_refundable_cents,
                                               reverse_transfer: false,
                                               merchant_account:,
-                                              paypal_order_purchase_unit_refund: paypal_order_id.present?)
+                                              paypal_order_purchase_unit_refund: paypal_order_id.present?,
+                                              purchase: self)
       logger.info("Refunding purchase: #{id} completed with ID: #{charge_refund.id}, Flow of Funds: #{charge_refund.flow_of_funds.to_h}")
 
       ActiveRecord::Base.transaction do

--- a/spec/business/payments/charging/charge_processor_spec.rb
+++ b/spec/business/payments/charging/charge_processor_spec.rb
@@ -283,7 +283,8 @@ describe ChargeProcessor do
                                                                                              merchant_account: nil,
                                                                                              paypal_order_purchase_unit_refund: nil,
                                                                                              reverse_transfer: true,
-                                                                                             is_for_fraud: nil)
+                                                                                             is_for_fraud: nil,
+                                                                                             purchase: nil)
         ChargeProcessor.refund!(StripeChargeProcessor.charge_processor_id, "charge-id",)
       end
     end
@@ -294,7 +295,8 @@ describe ChargeProcessor do
                                                                                              merchant_account: nil,
                                                                                              paypal_order_purchase_unit_refund: nil,
                                                                                              reverse_transfer: true,
-                                                                                             is_for_fraud: nil)
+                                                                                             is_for_fraud: nil,
+                                                                                             purchase: nil)
         ChargeProcessor.refund!(StripeChargeProcessor.charge_processor_id, "charge-id", amount_cents: 2_00)
       end
     end

--- a/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
@@ -868,6 +868,7 @@ describe PaypalChargeProcessor, :vcr do
           double("Purchase",
                  paypal_order_id:,
                  price_cents: 1346,
+                 total_transaction_cents: 1427,
                  link: double("Link", unique_permalink: "zmuYY"))
         end
 
@@ -876,8 +877,8 @@ describe PaypalChargeProcessor, :vcr do
             purchase_units: [
               OpenStruct.new(
                 items: [
-                  OpenStruct.new(name: "Plating Generator", unit_amount: OpenStruct.new(value: "22.29", currency_code: "GBP"), sku: "BalZT"),
-                  OpenStruct.new(name: "3D Shape Generator", unit_amount: OpenStruct.new(value: "10.00", currency_code: "GBP"), sku: "zmuYY"),
+                  OpenStruct.new(name: "Plating Generator", unit_amount: OpenStruct.new(value: "22.29", currency_code: "GBP"), quantity: 1, sku: "BalZT"),
+                  OpenStruct.new(name: "3D Shape Generator", unit_amount: OpenStruct.new(value: "10.00", currency_code: "GBP"), quantity: 1, sku: "zmuYY"),
                 ],
                 amount: OpenStruct.new(
                   currency_code: "GBP",
@@ -941,16 +942,16 @@ describe PaypalChargeProcessor, :vcr do
           end.to raise_error(ChargeProcessorAlreadyRefundedError, /no remaining balance/)
         end
 
-        it "scales by the refund ratio for partial refunds" do
-          half_amount_cents = 673
+        it "scales by the refund ratio (over gross purchase total) for partial refunds" do
+          half_gross_amount_cents = 713
 
           expect_any_instance_of(PaypalRestApi).to receive(:refund)
-            .with(capture_id:, merchant_account: gbp_merchant_account, amount: 5.30)
+            .with(capture_id:, merchant_account: gbp_merchant_account, amount: 5.29)
             .and_return(OpenStruct.new(status_code: 201,
                                        result: OpenStruct.new(id: "REFUND_ID", status: "COMPLETED")))
 
           subject.refund!(capture_id,
-                          amount_cents: half_amount_cents,
+                          amount_cents: half_gross_amount_cents,
                           merchant_account: gbp_merchant_account,
                           paypal_order_purchase_unit_refund: true,
                           purchase:)
@@ -973,11 +974,59 @@ describe PaypalChargeProcessor, :vcr do
           end.not_to raise_error
         end
 
+        it "multiplies unit_amount by quantity when scoring item values" do
+          quantity_two_order = OpenStruct.new(
+            purchase_units: [OpenStruct.new(
+              items: [OpenStruct.new(unit_amount: OpenStruct.new(value: "10.00", currency_code: "GBP"), quantity: 2, sku: "zmuYY")],
+              amount: OpenStruct.new(currency_code: "GBP", value: "20.00", breakdown: nil),
+              payments: OpenStruct.new(
+                captures: [OpenStruct.new(id: capture_id, amount: OpenStruct.new(value: "20.00", currency_code: "GBP"))],
+                refunds: []
+              )
+            )]
+          )
+          allow_any_instance_of(PaypalRestApi).to receive(:fetch_order)
+            .with(order_id: paypal_order_id)
+            .and_return(OpenStruct.new(result: quantity_two_order))
+
+          expect_any_instance_of(PaypalRestApi).to receive(:refund)
+            .with(capture_id:, merchant_account: gbp_merchant_account, amount: 20.00)
+            .and_return(OpenStruct.new(status_code: 201,
+                                       result: OpenStruct.new(id: "REFUND_ID", status: "COMPLETED")))
+
+          subject.refund!(capture_id,
+                          amount_cents: nil,
+                          merchant_account: gbp_merchant_account,
+                          paypal_order_purchase_unit_refund: true,
+                          purchase:)
+        end
+
+        it "falls back to format_money_floored when fetch_order returns no result (HTTP error)" do
+          allow_any_instance_of(PaypalRestApi).to receive(:fetch_order)
+            .with(order_id: paypal_order_id)
+            .and_return(OpenStruct.new(status_code: 500, result: nil))
+          allow(PaypalChargeProcessor).to receive(:get_rate).with("gbp").and_return("0.7426")
+
+          expect_any_instance_of(PaypalRestApi).to receive(:refund)
+            .with(capture_id:, merchant_account: gbp_merchant_account, amount: 10.59)
+            .and_return(OpenStruct.new(status_code: 201,
+                                       result: OpenStruct.new(id: "REFUND_ID", status: "COMPLETED")))
+
+          expect do
+            subject.refund!(capture_id,
+                            amount_cents: 1427,
+                            merchant_account: gbp_merchant_account,
+                            paypal_order_purchase_unit_refund: true,
+                            purchase:)
+          end.not_to raise_error
+        end
+
         context "when the purchase's product has no matching item in the PayPal order" do
           let(:purchase) do
             double("Purchase",
                    paypal_order_id:,
                    price_cents: 1346,
+                   total_transaction_cents: 1427,
                    link: double("Link", unique_permalink: "no-match"))
           end
 

--- a/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
@@ -1050,6 +1050,52 @@ describe PaypalChargeProcessor, :vcr do
           end
         end
 
+        context "when the purchase_unit has shipping and handling on top of items+tax" do
+          let(:order_with_shipping) do
+            OpenStruct.new(
+              purchase_units: [OpenStruct.new(
+                items: [
+                  OpenStruct.new(unit_amount: OpenStruct.new(value: "22.29", currency_code: "GBP"), quantity: 1, sku: "BalZT"),
+                  OpenStruct.new(unit_amount: OpenStruct.new(value: "10.00", currency_code: "GBP"), quantity: 1, sku: "zmuYY"),
+                ],
+                amount: OpenStruct.new(
+                  currency_code: "GBP",
+                  value: "37.23",
+                  breakdown: OpenStruct.new(
+                    tax_total: OpenStruct.new(value: "1.94", currency_code: "GBP"),
+                    shipping: OpenStruct.new(value: "2.00", currency_code: "GBP"),
+                    handling: OpenStruct.new(value: "1.00", currency_code: "GBP"),
+                    discount: OpenStruct.new(value: "0.00", currency_code: "GBP")
+                  )
+                ),
+                payments: OpenStruct.new(
+                  captures: [OpenStruct.new(id: capture_id, amount: OpenStruct.new(value: "37.23", currency_code: "GBP"))],
+                  refunds: []
+                )
+              )]
+            )
+          end
+
+          before do
+            allow_any_instance_of(PaypalRestApi).to receive(:fetch_order)
+              .with(order_id: paypal_order_id)
+              .and_return(OpenStruct.new(result: order_with_shipping))
+          end
+
+          it "includes the item's proportional share of shipping, handling, and discount in the refund amount" do
+            expect_any_instance_of(PaypalRestApi).to receive(:refund)
+              .with(capture_id:, merchant_account: gbp_merchant_account, amount: 11.52)
+              .and_return(OpenStruct.new(status_code: 201,
+                                         result: OpenStruct.new(id: "REFUND_ID", status: "COMPLETED")))
+
+            subject.refund!(capture_id,
+                            amount_cents: nil,
+                            merchant_account: gbp_merchant_account,
+                            paypal_order_purchase_unit_refund: true,
+                            purchase:)
+          end
+        end
+
         context "when the purchase_unit has multiple captures with their own refunds" do
           let(:other_capture_id) { "OTHER_CAPTURE_XYZ" }
           let(:multi_capture_order) do

--- a/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
@@ -869,6 +869,7 @@ describe PaypalChargeProcessor, :vcr do
                  paypal_order_id:,
                  price_cents: 1346,
                  total_transaction_cents: 1427,
+                 is_part_of_combined_charge?: true,
                  link: double("Link", unique_permalink: "zmuYY"))
         end
 
@@ -1027,6 +1028,7 @@ describe PaypalChargeProcessor, :vcr do
                    paypal_order_id:,
                    price_cents: 1346,
                    total_transaction_cents: 1427,
+                   is_part_of_combined_charge?: true,
                    link: double("Link", unique_permalink: "no-match"))
           end
 

--- a/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
@@ -1022,6 +1022,78 @@ describe PaypalChargeProcessor, :vcr do
           end.not_to raise_error
         end
 
+        context "when the purchase's link is nil" do
+          let(:purchase) do
+            double("Purchase",
+                   paypal_order_id:,
+                   price_cents: 1346,
+                   total_transaction_cents: 1427,
+                   is_part_of_combined_charge?: true,
+                   link: nil)
+          end
+
+          it "falls back to format_money_floored without raising" do
+            allow(PaypalChargeProcessor).to receive(:get_rate).with("gbp").and_return("0.7426")
+
+            expect_any_instance_of(PaypalRestApi).to receive(:refund)
+              .with(capture_id:, merchant_account: gbp_merchant_account, amount: 10.59)
+              .and_return(OpenStruct.new(status_code: 201,
+                                         result: OpenStruct.new(id: "REFUND_ID", status: "COMPLETED")))
+
+            expect do
+              subject.refund!(capture_id,
+                              amount_cents: 1427,
+                              merchant_account: gbp_merchant_account,
+                              paypal_order_purchase_unit_refund: true,
+                              purchase:)
+            end.not_to raise_error
+          end
+        end
+
+        context "when the capture is in a zero-decimal currency (e.g. JPY)" do
+          let(:jpy_merchant_account) { create(:merchant_account_paypal, currency: "jpy", charge_processor_merchant_id: "JPY_MERCHANT") }
+          let(:jpy_capture_id) { "JPY_CAPTURE" }
+          let(:jpy_order) do
+            OpenStruct.new(
+              purchase_units: [OpenStruct.new(
+                items: [OpenStruct.new(unit_amount: OpenStruct.new(value: "2141", currency_code: "JPY"), quantity: 1, sku: "jpY01")],
+                amount: OpenStruct.new(currency_code: "JPY", value: "2141", breakdown: nil),
+                payments: OpenStruct.new(
+                  captures: [OpenStruct.new(id: jpy_capture_id, amount: OpenStruct.new(value: "2141", currency_code: "JPY"))],
+                  refunds: []
+                )
+              )]
+            )
+          end
+          let(:jpy_purchase) do
+            double("Purchase",
+                   paypal_order_id: "JPY_ORDER",
+                   price_cents: 1500,
+                   total_transaction_cents: 1500,
+                   is_part_of_combined_charge?: true,
+                   link: double("Link", unique_permalink: "jpY01"))
+          end
+
+          before do
+            allow_any_instance_of(PaypalRestApi).to receive(:fetch_order)
+              .with(order_id: "JPY_ORDER")
+              .and_return(OpenStruct.new(result: jpy_order))
+          end
+
+          it "treats the PayPal value as already-in-unit (does not multiply by 100)" do
+            expect_any_instance_of(PaypalRestApi).to receive(:refund)
+              .with(capture_id: jpy_capture_id, merchant_account: jpy_merchant_account, amount: 2141)
+              .and_return(OpenStruct.new(status_code: 201,
+                                         result: OpenStruct.new(id: "REFUND_ID", status: "COMPLETED")))
+
+            subject.refund!(jpy_capture_id,
+                            amount_cents: nil,
+                            merchant_account: jpy_merchant_account,
+                            paypal_order_purchase_unit_refund: true,
+                            purchase: jpy_purchase)
+          end
+        end
+
         context "when the purchase's product has no matching item in the PayPal order" do
           let(:purchase) do
             double("Purchase",

--- a/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
@@ -859,6 +859,149 @@ describe PaypalChargeProcessor, :vcr do
           subject.refund!("2CL11631PW424125C", paypal_order_purchase_unit_refund: true, merchant_account:)
         end.to raise_error(ChargeProcessorUnavailableError)
       end
+
+      context "when a purchase context is provided (multi-currency combined-charge refund path)" do
+        let(:gbp_merchant_account) { create(:merchant_account_paypal, currency: "gbp", charge_processor_merchant_id: "MV9KWAJWMZ722") }
+        let(:capture_id) { "5NN998541F917793D" }
+        let(:paypal_order_id) { "0YJ20781U8414554V" }
+        let(:purchase) do
+          double("Purchase",
+                 paypal_order_id:,
+                 price_cents: 1346,
+                 link: double("Link", unique_permalink: "zmuYY"))
+        end
+
+        let(:fake_order) do
+          OpenStruct.new(
+            purchase_units: [
+              OpenStruct.new(
+                items: [
+                  OpenStruct.new(name: "Plating Generator", unit_amount: OpenStruct.new(value: "22.29", currency_code: "GBP"), sku: "BalZT"),
+                  OpenStruct.new(name: "3D Shape Generator", unit_amount: OpenStruct.new(value: "10.00", currency_code: "GBP"), sku: "zmuYY"),
+                ],
+                amount: OpenStruct.new(
+                  currency_code: "GBP",
+                  value: "34.23",
+                  breakdown: OpenStruct.new(tax_total: OpenStruct.new(value: "1.94", currency_code: "GBP"))
+                ),
+                payments: OpenStruct.new(
+                  captures: [OpenStruct.new(id: capture_id, amount: OpenStruct.new(value: "34.23", currency_code: "GBP"))],
+                  refunds: [OpenStruct.new(id: "PRIOR_USD_REFUND", amount: OpenStruct.new(value: "23.64", currency_code: "GBP"))]
+                )
+              )
+            ]
+          )
+        end
+
+        before do
+          allow_any_instance_of(PaypalRestApi).to receive(:fetch_order)
+            .with(order_id: paypal_order_id)
+            .and_return(OpenStruct.new(result: fake_order))
+        end
+
+        it "uses the PayPal-recorded item amount instead of USD→GBP conversion" do
+          expect_any_instance_of(PaypalRestApi).to receive(:refund)
+            .with(capture_id:, merchant_account: gbp_merchant_account, amount: 10.59)
+            .and_return(OpenStruct.new(status_code: 201,
+                                       result: OpenStruct.new(id: "REFUND_ID", status: "COMPLETED")))
+
+          subject.refund!(capture_id,
+                          amount_cents: 1427,
+                          merchant_account: gbp_merchant_account,
+                          paypal_order_purchase_unit_refund: true,
+                          purchase:)
+        end
+
+        it "caps the refund amount at the capture's remaining balance" do
+          allow(fake_order.purchase_units.first.items[1]).to receive(:unit_amount)
+            .and_return(OpenStruct.new(value: "11.00", currency_code: "GBP"))
+
+          expect_any_instance_of(PaypalRestApi).to receive(:refund)
+            .with(capture_id:, merchant_account: gbp_merchant_account, amount: 10.59)
+            .and_return(OpenStruct.new(status_code: 201,
+                                       result: OpenStruct.new(id: "REFUND_ID", status: "COMPLETED")))
+
+          subject.refund!(capture_id,
+                          amount_cents: 1427,
+                          merchant_account: gbp_merchant_account,
+                          paypal_order_purchase_unit_refund: true,
+                          purchase:)
+        end
+
+        it "raises ChargeProcessorAlreadyRefundedError when the capture is fully exhausted" do
+          fake_order.purchase_units.first.payments.refunds <<
+            OpenStruct.new(id: "EXHAUSTING", amount: OpenStruct.new(value: "10.59", currency_code: "GBP"))
+
+          expect do
+            subject.refund!(capture_id,
+                            amount_cents: 1427,
+                            merchant_account: gbp_merchant_account,
+                            paypal_order_purchase_unit_refund: true,
+                            purchase:)
+          end.to raise_error(ChargeProcessorAlreadyRefundedError, /no remaining balance/)
+        end
+
+        it "scales by the refund ratio for partial refunds" do
+          half_amount_cents = 673
+
+          expect_any_instance_of(PaypalRestApi).to receive(:refund)
+            .with(capture_id:, merchant_account: gbp_merchant_account, amount: 5.30)
+            .and_return(OpenStruct.new(status_code: 201,
+                                       result: OpenStruct.new(id: "REFUND_ID", status: "COMPLETED")))
+
+          subject.refund!(capture_id,
+                          amount_cents: half_amount_cents,
+                          merchant_account: gbp_merchant_account,
+                          paypal_order_purchase_unit_refund: true,
+                          purchase:)
+        end
+
+        context "when the purchase's product has no matching item in the PayPal order" do
+          let(:purchase) do
+            double("Purchase",
+                   paypal_order_id:,
+                   price_cents: 1346,
+                   link: double("Link", unique_permalink: "no-match"))
+          end
+
+          it "falls back to USD→GBP conversion with floor (preventing overshoot)" do
+            allow(PaypalChargeProcessor).to receive(:get_rate).with("gbp").and_return("0.7426")
+
+            expect_any_instance_of(PaypalRestApi).to receive(:refund)
+              .with(capture_id:, merchant_account: gbp_merchant_account, amount: 10.59)
+              .and_return(OpenStruct.new(status_code: 201,
+                                         result: OpenStruct.new(id: "REFUND_ID", status: "COMPLETED")))
+
+            subject.refund!(capture_id,
+                            amount_cents: 1427,
+                            merchant_account: gbp_merchant_account,
+                            paypal_order_purchase_unit_refund: true,
+                            purchase:)
+          end
+        end
+      end
+    end
+  end
+
+  describe ".format_money_floored" do
+    it "returns 0 for blank input" do
+      expect(PaypalChargeProcessor.format_money_floored(nil, "gbp")).to eq(0)
+      expect(PaypalChargeProcessor.format_money_floored("", "gbp")).to eq(0)
+    end
+
+    it "passes through USD cents unchanged" do
+      expect(PaypalChargeProcessor.format_money_floored(1427, "usd")).to eq(1427)
+    end
+
+    it "rounds down when converting to non-USD" do
+      allow(PaypalChargeProcessor).to receive(:get_rate).with("gbp").and_return("0.7426")
+      expect(PaypalChargeProcessor.format_money_floored(1427, "gbp")).to eq(1059)
+    end
+
+    it "differs from format_money (.round) on conversions that would round up" do
+      allow(PaypalChargeProcessor).to receive(:get_rate).with("gbp").and_return("0.7435")
+      expect(PaypalChargeProcessor.format_money_floored(1427, "gbp")).to eq(1060)
+      expect(PaypalChargeProcessor.format_money(1427, "gbp")).to eq(10.61)
     end
   end
 

--- a/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
@@ -1020,6 +1020,11 @@ describe PaypalChargeProcessor, :vcr do
       expect(PaypalChargeProcessor.format_money_floored(1427, "gbp")).to eq(1060)
       expect(PaypalChargeProcessor.format_money(1427, "gbp")).to eq(10.61)
     end
+
+    it "divides by 100 for single-unit currencies (matches usd_cents_to_currency for JPY/TWD/HUF)" do
+      allow(PaypalChargeProcessor).to receive(:get_rate).with("jpy").and_return("150.0")
+      expect(PaypalChargeProcessor.format_money_floored(1427, "jpy")).to eq(2140)
+    end
   end
 
   describe ".create_order" do

--- a/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
@@ -1050,6 +1050,50 @@ describe PaypalChargeProcessor, :vcr do
           end
         end
 
+        context "when the purchase_unit has multiple captures with their own refunds" do
+          let(:other_capture_id) { "OTHER_CAPTURE_XYZ" }
+          let(:multi_capture_order) do
+            OpenStruct.new(
+              purchase_units: [OpenStruct.new(
+                items: [OpenStruct.new(unit_amount: OpenStruct.new(value: "10.00", currency_code: "GBP"), quantity: 1, sku: "zmuYY")],
+                amount: OpenStruct.new(currency_code: "GBP", value: "20.00", breakdown: nil),
+                payments: OpenStruct.new(
+                  captures: [
+                    OpenStruct.new(id: capture_id, amount: OpenStruct.new(value: "10.00", currency_code: "GBP")),
+                    OpenStruct.new(id: other_capture_id, amount: OpenStruct.new(value: "10.00", currency_code: "GBP")),
+                  ],
+                  refunds: [
+                    OpenStruct.new(
+                      id: "REFUND_OF_OTHER_CAPTURE",
+                      amount: OpenStruct.new(value: "9.99", currency_code: "GBP"),
+                      links: [OpenStruct.new(rel: "up", href: "https://api.paypal.com/v2/payments/captures/#{other_capture_id}")]
+                    ),
+                  ]
+                )
+              )]
+            )
+          end
+
+          before do
+            allow_any_instance_of(PaypalRestApi).to receive(:fetch_order)
+              .with(order_id: paypal_order_id)
+              .and_return(OpenStruct.new(result: multi_capture_order))
+          end
+
+          it "does not subtract refunds belonging to a different capture from this capture's remaining balance" do
+            expect_any_instance_of(PaypalRestApi).to receive(:refund)
+              .with(capture_id:, merchant_account: gbp_merchant_account, amount: 10.00)
+              .and_return(OpenStruct.new(status_code: 201,
+                                         result: OpenStruct.new(id: "REFUND_ID", status: "COMPLETED")))
+
+            subject.refund!(capture_id,
+                            amount_cents: nil,
+                            merchant_account: gbp_merchant_account,
+                            paypal_order_purchase_unit_refund: true,
+                            purchase:)
+          end
+        end
+
         context "when the capture is in a zero-decimal currency (e.g. JPY)" do
           let(:jpy_merchant_account) { create(:merchant_account_paypal, currency: "jpy", charge_processor_merchant_id: "JPY_MERCHANT") }
           let(:jpy_capture_id) { "JPY_CAPTURE" }

--- a/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
@@ -956,6 +956,23 @@ describe PaypalChargeProcessor, :vcr do
                           purchase:)
         end
 
+        it "treats nil amount_cents as a full refund of the item (does not raise TypeError)" do
+          fake_order.purchase_units.first.payments.refunds.clear
+
+          expect_any_instance_of(PaypalRestApi).to receive(:refund)
+            .with(capture_id:, merchant_account: gbp_merchant_account, amount: 10.60)
+            .and_return(OpenStruct.new(status_code: 201,
+                                       result: OpenStruct.new(id: "REFUND_ID", status: "COMPLETED")))
+
+          expect do
+            subject.refund!(capture_id,
+                            amount_cents: nil,
+                            merchant_account: gbp_merchant_account,
+                            paypal_order_purchase_unit_refund: true,
+                            purchase:)
+          end.not_to raise_error
+        end
+
         context "when the purchase's product has no matching item in the PayPal order" do
           let(:purchase) do
             double("Purchase",

--- a/spec/models/purchase/purchase_refunds_spec.rb
+++ b/spec/models/purchase/purchase_refunds_spec.rb
@@ -356,7 +356,7 @@ describe "PurchaseRefunds", :vcr do
         expect(ChargeProcessor).to receive(:refund!).with(purchase.charge_processor_id, purchase.stripe_transaction_id,
                                                           amount_cents: nil, merchant_account: purchase.merchant_account,
                                                           reverse_transfer: false, paypal_order_purchase_unit_refund: nil,
-                                                          is_for_fraud: false).and_call_original
+                                                          is_for_fraud: false, purchase:).and_call_original
         expect(purchase).to receive(:debit_processor_fee_from_merchant_account!)
 
         purchase.refund_and_save!(create(:admin_user).id)
@@ -555,7 +555,8 @@ describe "PurchaseRefunds", :vcr do
                                                amount_cents: 20,
                                                reverse_transfer: false,
                                                merchant_account: @purchase.merchant_account,
-                                               paypal_order_purchase_unit_refund: false)
+                                               paypal_order_purchase_unit_refund: false,
+                                               purchase: @purchase)
                                          .and_call_original
           expect(@purchase).not_to receive(:debit_processor_fee_from_merchant_account!).and_call_original
 
@@ -601,7 +602,8 @@ describe "PurchaseRefunds", :vcr do
                                                amount_cents: 20,
                                                reverse_transfer: false,
                                                merchant_account: @purchase.merchant_account,
-                                               paypal_order_purchase_unit_refund: false).and_call_original
+                                               paypal_order_purchase_unit_refund: false,
+                                               purchase: @purchase).and_call_original
 
           @purchase.refund_gumroad_taxes!(refunding_user_id: nil)
 
@@ -687,7 +689,8 @@ describe "PurchaseRefunds", :vcr do
                                                    amount_cents: 20,
                                                    reverse_transfer: false,
                                                    merchant_account: @paypal_purchase.merchant_account,
-                                                   paypal_order_purchase_unit_refund: true)
+                                                   paypal_order_purchase_unit_refund: true,
+                                                   purchase: @paypal_purchase)
                                              .and_call_original
               end
 


### PR DESCRIPTION
## What

Threads the originating `Purchase` through `ChargeProcessor.refund!` → `PaypalChargeProcessor#refund!` → `refund_order_purchase_unit!`. When the purchase context is present, the PayPal refund amount is derived directly from PayPal's recorded order data — the item's `unit_amount` + its proportional share of the unit's `tax_total`, scaled by the refund ratio for partial refunds, capped at the capture's remaining balance — instead of converting USD-cents → merchant currency at refund time.

Concrete changes:

- `app/business/payments/charging/charge_processor.rb`: add `purchase:` kwarg to the dispatcher, pass through to the processor.
- `app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb`:
  - `refund!` accepts a `purchase:` kwarg, threads it into `refund_order_purchase_unit!`.
  - `refund_order_purchase_unit!` now computes the merchant-currency cents amount from PayPal's actual order data when `purchase` is present; falls back to a new `format_money_floored` helper otherwise.
  - Raises `ChargeProcessorAlreadyRefundedError` when the capture has no remaining balance and an `amount_cents` was requested (legacy `nil` "full refund" paths preserved).
- `app/modules/purchase/refundable.rb`: pass `purchase: self` from both `ChargeProcessor.refund!` call sites (`refund_and_save!` and `refund_gumroad_taxes!`).
- Specs added for the new path + `format_money_floored` helper; existing dispatcher and PayPal-refund specs updated for the new kwarg.

5 files changed, +225/-11.

## Why

PayPal Orders that capture multiple items in a single combined charge are denominated in the seller's merchant-account currency, regardless of which display currency each item was priced in for the buyer. Refunds previously converted USD-cents → merchant currency via `PaypalChargeProcessor.format_money`'s `.round`, which can overshoot the captured value of a unit by 1p. Concrete failure pattern:

1. Buyer makes a multi-item cart with items in two different display currencies (e.g. one USD, one GBP).
2. The seller's PayPal Connect account is in a single merchant currency (e.g. GBP). PayPal captures both items under one combined charge in that currency.
3. The seller refunds the first item. Our code converts that item's USD-equivalent amount → GBP via `.round`, sending PayPal a value 1p over the item's true captured value. PayPal accepts because the capture as a whole still has enough remaining.
4. The seller refunds the second item. The 1p overshoot from step 3 has consumed part of this item's allowance, so PayPal rejects the refund with `CAPTURE_REFUND_AMOUNT_EXCEEDED`.
5. The failure surfaces silently — `ChargeProcessorInvalidRequestError` is rescued in `refundable.rb:114` without `errors.add`, so the dashboard renders a blank "Something went wrong" message and no refund record is created on Gumroad's side.

Confirmed against a real production multi-currency cart by reading PayPal's order state via their API and walking through the math.

The same conversion path also drifts under FX rate changes between purchase time and refund time. For yearly or long-tail refunds the drift can be multi-percent, producing either hard rejects (overshoot direction) or quietly under-refunded buyers (undershoot direction). A `.floor`-instead-of-`.round` patch would have fixed the overshoot bug class but left the undershoot hole and would still depend on Gumroad's USD-derived conversion math at refund time. The right fix is to stop doing the math in Gumroad and read PayPal's recorded amount instead.

Alternative considered and rejected: storing the merchant-currency capture amount on `Purchase` at capture time. Schema changes to `purchases` are blocked by `CLAUDE.md` ("Do not add, remove, or rename columns on the `purchases` table"). A side table would work but is a bigger architectural change than this PR.

## How the new path computes the amount

```
desired = item.unit_amount + (item.unit_amount / sum_of_all_unit_amounts) × tax_total
        × (refund_amount_cents / purchase.price_cents)  // capped at 1 for full refunds
amount_to_send_to_paypal = min(desired, capture.remaining_balance)
```

`item` is located via `purchase_unit.items.find { sku == purchase.link.unique_permalink }` (we set `sku` to the product permalink at capture creation in `PaypalRestApi#purchase_unit`). When the item can't be located (legacy data, deleted permalink, or some other reason), we fall back to `format_money_floored` (rounds the USD→GBP conversion down so cumulative refunds still never overshoot).


---

This PR was implemented by Claude Opus 4.7 (1M context).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes live refund amount calculation for PayPal Orders combined charges and can under- or over-refund if order/SKU matching or capture balance math is wrong; failures still surface as processor errors on money movement.
> 
> **Overview**
> **PayPal combined-cart refunds** now pass the originating `Purchase` through `ChargeProcessor.refund!` into `PaypalChargeProcessor` so Orders v2 purchase-unit refunds can size amounts from PayPal’s order data instead of rounding USD cents into the seller’s currency at refund time.
> 
> For **combined PayPal charges**, the processor fetches the order, finds the line item by product `sku` (permalink), allocates tax/shipping/handling/discount proportionally, scales partial refunds by `amount_cents / total_transaction_cents`, and caps at **remaining capture balance** (refunds attributed to captures via link `href` when multiple captures exist). If that path cannot run, it uses new **`format_money_floored`** (floor on FX conversion). It raises **`ChargeProcessorAlreadyRefundedError`** when a partial refund is requested but nothing remains on the capture.
> 
> `Purchase::Refundable` passes **`purchase: self`** on both refund entry points; specs cover the new math and dispatcher kwarg.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e229c3f4d3699e3941b7fec2e0e8b9171726cf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->