### PR TITLE
Fix Stripe Connect rejection for US business with foreign-resident rep

### DIFF
--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -561,22 +561,28 @@ module StripeMerchantAccountManager
                          })
       end
 
-      # For US accounts, only submit the Personal Tax ID if it's longer than four digits, otherwise the field contains the SSN Last 4.
-      # For non-US accounts, always submit the Personal Tax ID.
-      if personal_tax_id && (country_code != Compliance::Countries::USA.alpha2 || personal_tax_id.length > 4)
-        hash.deep_merge!(id_number: personal_tax_id)
-      end
-
-      # For US accounts, only submit the SSN Last 4 if we have enough digits in the Tax ID to get the last 4.
-      # For non-US accounts, never submit this field, it is for US accounts only.
-      if country_code == Compliance::Countries::USA.alpha2 && personal_tax_id && personal_tax_id.length == 4
-        hash.deep_merge!(ssn_last_4: personal_tax_id.last(4))
+      # `id_number` / `ssn_last_4` are validated by Stripe against the *account* country, not the
+      # representative's. For a US account Stripe expects a 9-digit SSN/ITIN. Submitting a foreign
+      # national ID (e.g. a 10-digit Bangladeshi NID for a foreign-resident US-LLC owner) trips a
+      # "must be 9 digits" rejection. In that case we omit the tax ID so Stripe falls through to the
+      # standard document-verification remediation flow.
+      legal_entity_country_code = user_compliance_info.legal_entity_country_code
+      if personal_tax_id.present?
+        if legal_entity_country_code == Compliance::Countries::USA.alpha2
+          if country_code == Compliance::Countries::USA.alpha2 && personal_tax_id.length == 4
+            hash.deep_merge!(ssn_last_4: personal_tax_id.last(4))
+          elsif personal_tax_id.length == 9
+            hash.deep_merge!(id_number: personal_tax_id)
+          end
+        else
+          hash.deep_merge!(id_number: personal_tax_id)
+        end
       end
 
       if [Compliance::Countries::ARE.alpha2,
           Compliance::Countries::SGP.alpha2,
           Compliance::Countries::BGD.alpha2,
-          Compliance::Countries::PAK.alpha2].include?(user_compliance_info.country_code)
+          Compliance::Countries::PAK.alpha2].include?(legal_entity_country_code)
         hash.deep_merge!(nationality: user_compliance_info.nationality)
       end
 

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -531,6 +531,38 @@ describe StripeMerchantAccountManager, :vcr do
       end
     end
 
+    describe "Bangladesh business with a rep resident outside Bangladesh (person_hash)" do
+      # Reverse direction of the foreign-rep fix: gating nationality on the account country instead
+      # of the rep's residential country also means BGD/SGP/PAK/UAE *accounts* keep submitting
+      # nationality regardless of where the rep lives (Stripe KYC asks for citizenship here, not
+      # residence). Guards against regressing that direction.
+      let(:user_compliance_info) do
+        create(:user_compliance_info_business,
+               user:,
+               first_name: "Imran",
+               last_name: "Choudhury",
+               country: "United States",
+               business_name: "Choudhury Trading Ltd",
+               business_street_address: "Sheikh Mujib Road 14",
+               business_city: "Dhaka",
+               business_state: nil,
+               business_zip_code: "1212",
+               business_country: "Bangladesh",
+               nationality: "BD",
+               individual_tax_id: "12345678901")
+      end
+
+      it "still submits nationality because the Stripe account country (BD) requires it" do
+        person_hash = described_class.send(:person_hash, user_compliance_info, GlobalConfig.get("STRONGBOX_GENERAL_PASSWORD"))
+        expect(person_hash[:nationality]).to eq("BD")
+      end
+
+      it "submits the rep's id_number unchanged since the account is non-US" do
+        person_hash = described_class.send(:person_hash, user_compliance_info, GlobalConfig.get("STRONGBOX_GENERAL_PASSWORD"))
+        expect(person_hash[:id_number]).to eq("12345678901")
+      end
+    end
+
     describe "all info provided of an individual (non-US)" do
       let(:user_compliance_info) { create(:user_compliance_info, user:, zip_code: "M4C 1T2", city: "Toronto", state: nil, country: "Canada") }
       let(:bank_account) { create(:ach_account_stripe_succeed, user:) }

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -481,6 +481,56 @@ describe StripeMerchantAccountManager, :vcr do
       end
     end
 
+    describe "US business with a foreign-resident representative (person_hash)" do
+      # Regression coverage for gumroad-private#441: a US LLC with a Bangladesh-resident
+      # representative could not save settings because we sent the rep's foreign national ID
+      # as person.id_number on a US Stripe Connect account, which Stripe rejects with a
+      # "must be 9 digits" SSN error and our controller surfaces verbatim to the seller.
+      def build_us_llc_with_foreign_rep(individual_tax_id:)
+        create(:user_compliance_info_business,
+               user:,
+               first_name: "Rashed",
+               last_name: "Khan",
+               street_address: "House 12, Road 3",
+               city: "Rajshahi",
+               state: nil,
+               zip_code: "6203",
+               country: "Bangladesh",
+               individual_tax_id:)
+      end
+
+      context "with a non-US tax ID (e.g. Bangladesh national ID)" do
+        let(:user_compliance_info) { build_us_llc_with_foreign_rep(individual_tax_id: "1234567890") }
+
+        let(:person_hash) do
+          described_class.send(:person_hash, user_compliance_info, GlobalConfig.get("STRONGBOX_GENERAL_PASSWORD"))
+        end
+
+        it "omits id_number so Stripe can request document verification instead of rejecting" do
+          expect(person_hash).not_to have_key(:id_number)
+          expect(person_hash).not_to have_key(:ssn_last_4)
+        end
+
+        it "omits nationality because the Stripe account country (US) does not require it" do
+          expect(person_hash).not_to have_key(:nationality)
+        end
+
+        it "still carries the rep's foreign address so Stripe knows where they live" do
+          expect(person_hash[:address]).to include(country: "BD", city: "Rajshahi", postal_code: "6203")
+        end
+      end
+
+      context "with a 9-digit US tax ID (e.g. an ITIN held by a foreign resident)" do
+        let(:user_compliance_info) { build_us_llc_with_foreign_rep(individual_tax_id: "900123456") }
+
+        it "submits the id_number to Stripe so the account can verify without document upload" do
+          person_hash = described_class.send(:person_hash, user_compliance_info, GlobalConfig.get("STRONGBOX_GENERAL_PASSWORD"))
+          expect(person_hash[:id_number]).to eq("900123456")
+          expect(person_hash).not_to have_key(:ssn_last_4)
+        end
+      end
+    end
+
     describe "all info provided of an individual (non-US)" do
       let(:user_compliance_info) { create(:user_compliance_info, user:, zip_code: "M4C 1T2", city: "Toronto", state: nil, country: "Canada") }
       let(:bank_account) { create(:ach_account_stripe_succeed, user:) }


### PR DESCRIPTION
## What

`StripeMerchantAccountManager.person_hash` now gates the representative's `id_number`, `ssn_last_4`, and `nationality` fields on the **Stripe account country** (`legal_entity_country_code`) instead of the representative's country.

| Account | Rep | personal_tax_id | Behavior |
|---|---|---|---|
| US | US | 4 chars | `ssn_last_4` (unchanged) |
| US | US | 9+ chars | `id_number` (unchanged) |
| US | non-US | 9 digits | `id_number` — covers ITIN held by a foreign-resident rep |
| US | non-US | other lengths | **omit** — Stripe falls through to document verification |
| non-US | any | any | `id_number` as-is (unchanged) |

## Why

A US LLC with a foreign-resident representative (e.g. owner living abroad, US bank account, valid EIN) could not save payout settings. Every Update Settings click created a Stripe Connect account and rolled it back ~7 seconds later, surfacing Stripe's verbatim "US tax IDs must have 9 digits" error to the seller.

Root cause: `Stripe::Account.create` succeeded with the US business hash, then `Stripe::Account.create_person` was called with `id_number: <10-digit foreign national ID>`. Stripe applies the account-country's validation to `id_number` — for US accounts that means a 9-digit SSN/ITIN — and rejected the request. `charge_processor_alive_at` was never set on the resulting `merchant_accounts` rows, confirming the failure was on the person-creation step, not account creation.

Gating on the account country matches Stripe's actual contract and matches what the frontend already does for the nationality field. For the foreign-rep case Stripe surfaces a `requirements.currently_due` document-verification requirement, which routes through the existing `payments_controller#remediation` flow (`Stripe::AccountLink` → Stripe-hosted ID upload). The help center has long documented this configuration as supported ("a US LLC needs a US bank account. You can live in another country and use your real home address." — `_13-getting-paid.html.erb:400`); this brings the code in line with the docs.

## Test plan

- [x] Verify locally that the form save no longer creates-and-rolls-back a Stripe account for a US-business / foreign-rep seller
- [x] Confirm the Stripe account ends up in `requirements.currently_due: [individual.verification.document.front]` and the seller is routed to remediation
- [x] Smoke-test an existing US-business / US-rep seller — `id_number` / `ssn_last_4` behavior unchanged
- [x] Smoke-test an existing BD-individual seller — `nationality` still submitted (gate didn't regress)

---

AI disclosure: drafted by Claude Opus 4.7 (1M context).
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782900617&installation_id=134400930&pr_number=5345&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5345&signature=3a16c94e49e3263c6057083d385f2e55ea820c2543a11ab9c4729ac770c8d816"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Stripe Connect KYC payload rules for business representatives; incorrect gating could block onboarding or skip required fields, but behavior is covered by new specs and narrows a known production failure mode.
> 
> **Overview**
> Fixes Stripe Connect **person** creation for US businesses whose representative lives abroad by keying `id_number`, `ssn_last_4`, and `nationality` on **`legal_entity_country_code`** (the Stripe account country), not the rep’s residential country.
> 
> For **US** accounts, only a 4-digit US rep tax ID becomes `ssn_last_4`, and only a **9-digit** value is sent as `id_number`; foreign national IDs (e.g. a 10-digit Bangladesh NID) are **omitted** so Stripe can route sellers through document verification instead of failing with “US tax IDs must have 9 digits.” **Non-US** accounts still send `id_number` unchanged. **`nationality`** is only included when the account country is UAE, Singapore, Bangladesh, or Pakistan—so US LLCs no longer send it for foreign reps, while Bangladesh businesses still do even if the rep’s address is outside Bangladesh.
> 
> Specs cover US LLC + foreign rep (omit tax fields), US LLC + 9-digit ITIN, and Bangladesh business + US-resident rep.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8aac00b59ce8920a6374820e984c99677ad943a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->