### PR TITLE
Add account refund policy API

### DIFF
--- a/app/controllers/api/v2/refund_policies_controller.rb
+++ b/app/controllers/api/v2/refund_policies_controller.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+class Api::V2::RefundPoliciesController < Api::V2::BaseController
+  REFUND_PERIOD_ALLOWED_VALUES = %w[none 7 14 30 183].freeze
+  REFUND_PERIOD_VALUES = {
+    "none" => 0,
+    "0" => 0,
+    "7" => 7,
+    "14" => 14,
+    "30" => 30,
+    "183" => 183,
+  }.freeze
+  ACCOUNT_LEVEL_REFUND_POLICY_NOT_IN_EFFECT_MESSAGE = "The account-level refund policy is not in effect for this seller."
+
+  before_action(only: [:show]) { doorkeeper_authorize!(*Doorkeeper.configuration.public_scopes.concat([:view_public])) }
+  before_action(only: [:update]) { doorkeeper_authorize! :edit_products }
+
+  def show
+    success_with_object(:refund_policy, serialized_refund_policy)
+  end
+
+  def update
+    return render_response(false, message: ACCOUNT_LEVEL_REFUND_POLICY_NOT_IN_EFFECT_MESSAGE) unless current_resource_owner.account_level_refund_policy_enabled?
+
+    refund_policy = current_resource_owner.refund_policy
+    if refund_policy.update(refund_policy_params)
+      success_with_object(:refund_policy, serialized_refund_policy)
+    else
+      render_response(false, message: refund_policy_error_message(refund_policy))
+    end
+  end
+
+  private
+    def refund_policy_params
+      permitted_params = { max_refund_period_in_days: REFUND_PERIOD_VALUES[params[:refund_period].to_s] }
+      permitted_params[:fine_print] = params[:fine_print] if params.key?(:fine_print)
+      permitted_params
+    end
+
+    def refund_policy_error_message(refund_policy)
+      return "Refund period must be one of: #{REFUND_PERIOD_ALLOWED_VALUES.join(', ')}." if refund_policy.errors.of_kind?(:max_refund_period_in_days, :inclusion)
+
+      refund_policy.errors.full_messages.to_sentence
+    end
+
+    def serialized_refund_policy
+      refund_policy = current_resource_owner.refund_policy
+      {
+        refund_period: serialized_refund_period(refund_policy),
+        title: refund_policy.title,
+        fine_print: refund_policy.fine_print,
+        in_effect: current_resource_owner.account_level_refund_policy_enabled?,
+      }
+    end
+
+    def serialized_refund_period(refund_policy)
+      refund_policy.max_refund_period_in_days.zero? ? "none" : refund_policy.max_refund_period_in_days.to_s
+    end
+end

--- a/app/controllers/api/v2/refund_policies_controller.rb
+++ b/app/controllers/api/v2/refund_policies_controller.rb
@@ -4,7 +4,6 @@ class Api::V2::RefundPoliciesController < Api::V2::BaseController
   REFUND_PERIOD_ALLOWED_VALUES = %w[none 7 14 30 183].freeze
   REFUND_PERIOD_VALUES = {
     "none" => 0,
-    "0" => 0,
     "7" => 7,
     "14" => 14,
     "30" => 30,
@@ -21,6 +20,7 @@ class Api::V2::RefundPoliciesController < Api::V2::BaseController
 
   def update
     return render_response(false, message: ACCOUNT_LEVEL_REFUND_POLICY_NOT_IN_EFFECT_MESSAGE) unless current_resource_owner.account_level_refund_policy_enabled?
+    return render_response(false, message: "Refund period is required.") if params[:refund_period].blank?
 
     refund_policy = current_resource_owner.refund_policy
     if refund_policy.update(refund_policy_params)

--- a/app/javascript/components/ApiDocumentation/Endpoints/RefundPolicy.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/RefundPolicy.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+
+import CodeSnippet from "$app/components/ui/CodeSnippet";
+
+import { ApiEndpoint } from "../ApiEndpoint";
+import { ApiParameter, ApiParameters } from "../ApiParameters";
+import { ApiResponseFields, FieldDefinition, renderFields } from "../ApiResponseFields";
+
+const REFUND_POLICY_FIELDS: FieldDefinition[] = [
+  { name: "refund_period", type: "string", description: 'One of "none", "7", "14", "30", or "183"' },
+  { name: "title", type: "string", description: "Display title derived from the refund period" },
+  { name: "fine_print", type: "string | null", description: "Optional fine print, with HTML stripped" },
+  {
+    name: "in_effect",
+    type: "boolean",
+    description: "Whether this account-level refund policy is currently shown to buyers",
+  },
+];
+
+export const GetRefundPolicy = () => (
+  <ApiEndpoint method="get" path="/refund_policy" description="Retrieve the account-level refund policy.">
+    <ApiResponseFields>
+      {renderFields([
+        { name: "success", type: "boolean", description: "Whether the request succeeded" },
+        {
+          name: "refund_policy",
+          type: "object",
+          description: "The account-level refund policy",
+          children: REFUND_POLICY_FIELDS,
+        },
+      ])}
+    </ApiResponseFields>
+    <CodeSnippet caption="cURL example">
+      {`curl https://api.gumroad.com/v2/refund_policy \\
+  -d "access_token=ACCESS_TOKEN" \\
+  -X GET`}
+    </CodeSnippet>
+    <CodeSnippet caption="Example response:">
+      {`{
+  "success": true,
+  "refund_policy": {
+    "refund_period": "30",
+    "title": "30-day money back guarantee",
+    "fine_print": "Refund requests are reviewed within 2 business days.",
+    "in_effect": true
+  }
+}`}
+    </CodeSnippet>
+  </ApiEndpoint>
+);
+
+export const UpdateRefundPolicy = () => (
+  <ApiEndpoint
+    method="put"
+    path="/refund_policy"
+    description="Update the account-level refund policy. Requires the edit_products scope. Updates are rejected when the account-level policy is not in effect for the seller."
+  >
+    <ApiParameters>
+      <ApiParameter name="refund_period" description='Required. One of "none", "7", "14", "30", or "183".' />
+      <ApiParameter
+        name="fine_print"
+        description="Optional. Max 3000 characters. HTML is stripped. Send an empty value to clear it."
+      />
+    </ApiParameters>
+    <ApiResponseFields>
+      {renderFields([
+        { name: "success", type: "boolean", description: "Whether the request succeeded" },
+        {
+          name: "refund_policy",
+          type: "object",
+          description: "The updated account-level refund policy",
+          children: REFUND_POLICY_FIELDS,
+        },
+      ])}
+    </ApiResponseFields>
+    <CodeSnippet caption="cURL example">
+      {`curl https://api.gumroad.com/v2/refund_policy \\
+  -d "access_token=ACCESS_TOKEN" \\
+  -d "refund_period=30" \\
+  -d "fine_print=Refund requests are reviewed within 2 business days." \\
+  -X PUT`}
+    </CodeSnippet>
+    <CodeSnippet caption="Example response:">
+      {`{
+  "success": true,
+  "refund_policy": {
+    "refund_period": "30",
+    "title": "30-day money back guarantee",
+    "fine_print": "Refund requests are reviewed within 2 business days.",
+    "in_effect": true
+  }
+}`}
+    </CodeSnippet>
+  </ApiEndpoint>
+);

--- a/app/javascript/components/ApiDocumentation/Navigation.tsx
+++ b/app/javascript/components/ApiDocumentation/Navigation.tsx
@@ -53,6 +53,9 @@ export const Navigation = () => (
             <a href="#user">User</a>
           </li>
           <li>
+            <a href="#refund-policy">Refund policy</a>
+          </li>
+          <li>
             <a href="#resource-subscriptions">Resource subscriptions</a>
           </li>
           <li>

--- a/app/javascript/pages/Public/Api.tsx
+++ b/app/javascript/pages/Public/Api.tsx
@@ -43,6 +43,7 @@ import {
   GetProducts,
   UpdateProduct,
 } from "$app/components/ApiDocumentation/Endpoints/Products";
+import { GetRefundPolicy, UpdateRefundPolicy } from "$app/components/ApiDocumentation/Endpoints/RefundPolicy";
 import {
   CreateResourceSubscription,
   DeleteResourceSubscription,
@@ -168,6 +169,11 @@ export default function Api() {
 
               <ApiResource name="User" id="user">
                 <GetUser />
+              </ApiResource>
+
+              <ApiResource name="Refund policy" id="refund-policy">
+                <GetRefundPolicy />
+                <UpdateRefundPolicy />
               </ApiResource>
 
               <ApiResource name="Resource subscriptions" id="resource-subscriptions">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,7 @@ Rails.application.routes.draw do
 
       get "/user", to: "users#show"
       resources :categories, only: [:index]
+      resource :refund_policy, only: [:show, :update], controller: :refund_policies
       resources :links, path: "products", only: [:index, :show, :update, :create, :destroy] do
         resources :custom_fields, only: [:index, :create, :update, :destroy]
         resources :offer_codes, only: [:index, :create, :show, :update, :destroy]

--- a/spec/controllers/api/v2/refund_policies_controller_spec.rb
+++ b/spec/controllers/api/v2/refund_policies_controller_spec.rb
@@ -112,6 +112,30 @@ describe Api::V2::RefundPoliciesController do
         expect(seller.refund_policy.reload.max_refund_period_in_days).to eq(30)
       end
 
+      it "rejects undocumented numeric zero as a refund period" do
+        seller.refund_policy.update!(max_refund_period_in_days: 30)
+
+        put :update, params: { access_token: token.token, refund_period: "0" }
+
+        expect(response.parsed_body).to eq(
+          "success" => false,
+          "message" => "Refund period must be one of: none, 7, 14, 30, 183."
+        )
+        expect(seller.refund_policy.reload.max_refund_period_in_days).to eq(30)
+      end
+
+      it "rejects a missing refund period" do
+        seller.refund_policy.update!(max_refund_period_in_days: 30)
+
+        put :update, params: { access_token: token.token }
+
+        expect(response.parsed_body).to eq(
+          "success" => false,
+          "message" => "Refund period is required."
+        )
+        expect(seller.refund_policy.reload.max_refund_period_in_days).to eq(30)
+      end
+
       it "rejects fine print over 3000 characters" do
         seller.refund_policy.update!(max_refund_period_in_days: 30, fine_print: "Existing fine print")
 

--- a/spec/controllers/api/v2/refund_policies_controller_spec.rb
+++ b/spec/controllers/api/v2/refund_policies_controller_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Api::V2::RefundPoliciesController do
+  let(:seller) { create(:user) }
+  let(:app) { create(:oauth_application, owner: create(:user)) }
+
+  describe "GET 'show'" do
+    context "without a token" do
+      it "returns 401" do
+        get :show
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context "with a valid token" do
+      let(:token) { create("doorkeeper/access_token", application: app, resource_owner_id: seller.id, scopes: "view_public") }
+
+      it "returns the current refund policy" do
+        seller.refund_policy.update!(max_refund_period_in_days: 30, fine_print: "Refund requests are reviewed within 2 business days.")
+
+        get :show, params: { access_token: token.token }
+
+        expect(response.parsed_body).to eq(
+          "success" => true,
+          "refund_policy" => {
+            "refund_period" => "30",
+            "title" => "30-day money back guarantee",
+            "fine_print" => "Refund requests are reviewed within 2 business days.",
+            "in_effect" => true,
+          }
+        )
+      end
+
+      it "reports when the account-level refund policy is not in effect" do
+        seller.update!(refund_policy_enabled: false)
+
+        get :show, params: { access_token: token.token }
+
+        expect(response.parsed_body["success"]).to be(true)
+        expect(response.parsed_body["refund_policy"]["in_effect"]).to be(false)
+      end
+    end
+  end
+
+  describe "PUT 'update'" do
+    context "without a token" do
+      it "returns 401" do
+        put :update, params: { refund_period: "30" }
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context "with a token missing edit_products scope" do
+      let(:token) { create("doorkeeper/access_token", application: app, resource_owner_id: seller.id, scopes: "view_public view_sales") }
+
+      it "returns 403" do
+        put :update, params: { access_token: token.token, refund_period: "30" }
+        expect(response.status).to eq(403)
+      end
+    end
+
+    context "with edit_products scope" do
+      let(:token) { create("doorkeeper/access_token", application: app, resource_owner_id: seller.id, scopes: "edit_products") }
+
+      it "updates the refund period and fine print" do
+        seller.refund_policy.update!(max_refund_period_in_days: 0)
+
+        put :update, params: { access_token: token.token, refund_period: "30", fine_print: "Refund requests are reviewed within 2 business days." }
+
+        refund_policy = seller.refund_policy.reload
+        expect(refund_policy.max_refund_period_in_days).to eq(30)
+        expect(refund_policy.fine_print).to eq("Refund requests are reviewed within 2 business days.")
+        expect(response.parsed_body).to eq(
+          "success" => true,
+          "refund_policy" => {
+            "refund_period" => "30",
+            "title" => "30-day money back guarantee",
+            "fine_print" => "Refund requests are reviewed within 2 business days.",
+            "in_effect" => true,
+          }
+        )
+      end
+
+      it "updates the refund period to none" do
+        seller.refund_policy.update!(max_refund_period_in_days: 30)
+
+        put :update, params: { access_token: token.token, refund_period: "none" }
+
+        expect(seller.refund_policy.reload.max_refund_period_in_days).to eq(0)
+        expect(response.parsed_body).to eq(
+          "success" => true,
+          "refund_policy" => {
+            "refund_period" => "none",
+            "title" => "No refunds allowed",
+            "fine_print" => nil,
+            "in_effect" => true,
+          }
+        )
+      end
+
+      it "rejects an invalid refund period with the allowed values" do
+        seller.refund_policy.update!(max_refund_period_in_days: 30)
+
+        put :update, params: { access_token: token.token, refund_period: "365" }
+
+        expect(response.parsed_body).to eq(
+          "success" => false,
+          "message" => "Refund period must be one of: none, 7, 14, 30, 183."
+        )
+        expect(seller.refund_policy.reload.max_refund_period_in_days).to eq(30)
+      end
+
+      it "rejects fine print over 3000 characters" do
+        seller.refund_policy.update!(max_refund_period_in_days: 30, fine_print: "Existing fine print")
+
+        put :update, params: { access_token: token.token, refund_period: "14", fine_print: "a" * 3001 }
+
+        expect(response.parsed_body).to eq(
+          "success" => false,
+          "message" => "Fine print is too long (maximum is 3000 characters)"
+        )
+        refund_policy = seller.refund_policy.reload
+        expect(refund_policy.max_refund_period_in_days).to eq(30)
+        expect(refund_policy.fine_print).to eq("Existing fine print")
+      end
+
+      it "strips HTML from fine print" do
+        put :update, params: { access_token: token.token, refund_period: "14", fine_print: "<p>Refunds <strong>approved</strong></p>" }
+
+        refund_policy = seller.refund_policy.reload
+        expect(refund_policy.max_refund_period_in_days).to eq(14)
+        expect(refund_policy.fine_print).to eq("Refunds approved")
+        expect(response.parsed_body["refund_policy"]["fine_print"]).to eq("Refunds approved")
+      end
+
+      it "rejects updates when the account-level refund policy is not in effect" do
+        seller.update!(refund_policy_enabled: false)
+        seller.refund_policy.update!(max_refund_period_in_days: 30, fine_print: "Existing fine print")
+
+        put :update, params: { access_token: token.token, refund_period: "7", fine_print: "Updated fine print" }
+
+        expect(response.parsed_body).to eq(
+          "success" => false,
+          "message" => "The account-level refund policy is not in effect for this seller."
+        )
+        refund_policy = seller.refund_policy.reload
+        expect(refund_policy.max_refund_period_in_days).to eq(30)
+        expect(refund_policy.fine_print).to eq("Existing fine print")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ref #5330

## What
- Adds `GET` and `PUT /v2/refund_policy` for a seller’s account-level refund policy.
- Returns the current period, derived title, fine print, and whether the account-level policy is in effect.
- Lets authorized clients update the policy with the allowed refund periods and fine print, while rejecting writes when the account-level policy is not active for that seller.
- Documents the new endpoints in the API reference.

## Why
- Refund policy is a store-wide setting, so the API needs to expose the same resource sellers already manage in Settings.
- Reusing the existing refund policy model keeps validation and sanitization behavior consistent instead of duplicating business rules.

---
This PR was implemented with AI assistance using gpt‑5.5 xhigh.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes buyer-facing refund terms via API using existing model rules; writes are gated on account-level policy being in effect and edit_products scope.
> 
> **Overview**
> Adds **public API v2** support for a seller’s **account-level refund policy** via `GET` and `PUT /v2/refund_policy`, wired through a new `RefundPoliciesController` and a singular route under `api_routes`.
> 
> **Read** returns `refund_period` (allowed strings `none`, `7`, `14`, `30`, `183`), derived `title`, `fine_print`, and `in_effect` (whether the account-level policy is active for buyers). **Update** requires the `edit_products` scope, maps `refund_period` to the existing model’s day count, optionally updates `fine_print` (with model validation and HTML stripping), and **rejects writes** when the account-level policy is not in effect or when the period is missing/invalid.
> 
> The **API reference** gains a Refund policy section (nav + `GetRefundPolicy` / `UpdateRefundPolicy` docs). **Controller specs** cover auth, scopes, happy paths, validation, and the not-in-effect guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb1c200c055030b27a28c116227c5c975d11a5c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->