### PR TITLE
Index email columns scanned by GDPR buyer erasure

### DIFF
--- a/db/migrate/20261201000000_add_email_indexes_for_gdpr_buyer_erasure.rb
+++ b/db/migrate/20261201000000_add_email_indexes_for_gdpr_buyer_erasure.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AddEmailIndexesForGdprBuyerErasure < ActiveRecord::Migration[7.1]
+  # GdprBuyerErasureService anonymizes guest-buyer PII by querying these tables
+  # on their email column. Without an index, the UPDATE on `events`/`signup_events`
+  # (very large, write-heavy tables) does a full table scan and locks every row it
+  # scans, contending with concurrent inserts until innodb_lock_wait_timeout fires
+  # ("Lock wait timeout exceeded"). Indexing the lookup columns turns these into
+  # narrow seeks that lock only the matching rows.
+  def change
+    add_index :events, :email, name: "index_events_on_email"
+    add_index :signup_events, :email, name: "index_signup_events_on_email"
+    add_index :dispute_evidences, :customer_email, name: "index_dispute_evidences_on_customer_email"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_11_30_000003) do
+ActiveRecord::Schema[7.1].define(version: 2026_12_01_000000) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -836,6 +836,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_11_30_000003) do
     t.string "error_message"
     t.text "access_activity_log"
     t.text "reason_for_winning"
+    t.index ["customer_email"], name: "index_dispute_evidences_on_customer_email"
     t.index ["dispute_id"], name: "index_dispute_evidences_on_dispute_id", unique: true
     t.index ["resolved_at"], name: "index_dispute_evidences_on_resolved_at"
   end
@@ -941,6 +942,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_11_30_000003) do
     t.integer "service_charge_id"
     t.index ["browser_guid"], name: "index_events_on_browser_guid"
     t.index ["created_at"], name: "index_events_on_created_at"
+    t.index ["email"], name: "index_events_on_email"
     t.index ["event_name", "link_id", "created_at"], name: "index_events_on_event_name_and_link_id"
     t.index ["ip_address"], name: "index_events_on_ip_address"
     t.index ["link_id"], name: "index_events_on_link_id"
@@ -2201,6 +2203,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_11_30_000003) do
     t.index ["ip_address"], name: "index_events_on_ip_address"
     t.index ["user_id"], name: "index_events_on_user_id"
     t.index ["visit_id"], name: "index_events_on_visit_id"
+    t.index ["email"], name: "index_signup_events_on_email"
   end
 
   create_table "skus_variants", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|

--- a/spec/db/gdpr_buyer_erasure_indexes_spec.rb
+++ b/spec/db/gdpr_buyer_erasure_indexes_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# GdprBuyerErasureService anonymizes guest-buyer PII with `update_all` queries
+# keyed on the email column of each table. On the large, write-heavy `events`
+# and `signup_events` tables, a missing index forced a full-table scan that
+# locked every scanned row and contended with concurrent inserts until
+# innodb_lock_wait_timeout fired ("Lock wait timeout exceeded"). These indexes
+# keep the erasure a narrow seek. See issue #438.
+describe "GDPR buyer erasure lookup indexes" do
+  let(:connection) { ActiveRecord::Base.connection }
+
+  {
+    events: :email,
+    signup_events: :email,
+    dispute_evidences: :customer_email,
+  }.each do |table, column|
+    it "has an index on #{table}.#{column} so erasure does not full-scan the table" do
+      expect(connection.index_exists?(table, column)).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds indexes on the three email columns that `GdprBuyerErasureService` queries but that were unindexed:

- `events.email`
- `signup_events.email`
- `dispute_evidences.customer_email`

## Why

The "GDPR Erase Buyer" button (shipped in #5202) calls `GdprBuyerErasureService`, which anonymizes guest-buyer PII with `update_all` queries keyed on each table's email column. Auditing every email-scoped table the service touches, three lacked an index on the lookup column — and two of them (`events`, `signup_events`) are among the largest, most write-heavy tables in the app.

**Root cause:** without an index, `Event.where(email:).update_all(...)` runs as a full-table-scan `UPDATE`. InnoDB locks *every row the scan touches*, not just the matched rows. On a table taking constant concurrent inserts, that scan blocks on locks those inserts hold until `innodb_lock_wait_timeout` (~30s) fires:

```
Mysql2::Error::TimeoutError: Lock wait timeout exceeded; try restarting transaction
```

The transaction never commits, so the buyer's data is left un-erased — exactly the behavior reported. It surfaced now because this was the first erasure run against a guest purchase, on a ~12-year-old record whose email predates any indexing of these columns. The single wrapping transaction compounded it by holding those locks across all 16 anonymization steps.

**Fix:** indexing the lookup columns turns each `update_all` from a whole-table lock into a narrow seek that locks only the matching rows, removing the contention. The erasure stays in one transaction — the index removes the reason it was slow, so there's no need to trade away atomicity. The other ten email-scoped tables the service touches (`purchases`, `audience_members`, `carts`, etc.) were already indexed.

Note: none of the new indexes are on `users` or `purchases`, per the CONTRIBUTING.md prohibition on schema/index changes to those tables.

## Test Results

`spec/db/gdpr_buyer_erasure_indexes_spec.rb` is added as a regression guard asserting the three indexes exist — it fails if this migration is reverted. (A functional erasure spec can't catch a missing index, since query *results* are identical with or without it; only performance/locking differs.)

I was unable to run the migration or suite locally (no MySQL available in my environment and a Ruby version mismatch), so test execution and the migration run need to happen in CI / a preview deploy. `bin/test-confidence` and lint should be run before merge.

## Video

This is a non-user-facing DB/migration change with no UI surface to demo. The behavioral change is the absence of the lock-wait timeout, which only reproduces against production-scale `events`/`signup_events` tables and can't be meaningfully captured in a local screen recording. Walkthrough of the affected path: admin → guest purchase → "GDPR Erase Buyer" → `Admin::PurchasesController#gdpr_erase_buyer` → `GdprBuyerErasureService#perform!` → `anonymize_events!` / `anonymize_signup_events!` (the previously-unindexed `update_all` calls).

Closes the "GDPR Erase Buyer" timeout reported in antiwork/gumroad-private#438.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

AI disclosure: Written by Claude Opus 4.8 (1M context). Prompt: "investigate and fix this: https://github.com/antiwork/gumroad-private/issues/438", followed by "open PR".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds indexes on large, write-heavy tables (events, signup_events), which can lengthen migration deploy time and briefly affect write throughput during index builds, but avoids operational failure of GDPR erasure.
> 
> **Overview**
> Adds database indexes on the email lookup columns used by **GDPR buyer erasure** so guest-buyer anonymization no longer full-scans huge tables.
> 
> A new migration indexes `events.email`, `signup_events.email`, and `dispute_evidences.customer_email`, with `schema.rb` updated to match. Without these, `GdprBuyerErasureService` `update_all` calls on `events` and `signup_events` could scan the whole table, hold broad row locks, and hit **InnoDB lock wait timeouts** under concurrent writes—leaving erasure incomplete.
> 
> A regression spec asserts all three indexes exist so reverting the migration is caught in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c615a51bc2594480f6dea0a54eb552a165d2a773. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5348"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782916431&installation_id=134400930&pr_number=5348&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5348&signature=22d7846260f4d243099a07ebde1a22624140a1d2634eed8519712299da7891d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->