### PR TITLE
Accept Sandbox StoreKit JWS on production for Walks ProSub (fixes recording blocked by paywall)

### DIFF
--- a/app/services/app_store_walks_jws_verifier.rb
+++ b/app/services/app_store_walks_jws_verifier.rb
@@ -5,7 +5,15 @@
 class AppStoreWalksJwsVerifier
   PRODUCT_ID = "ProSub"
   BUNDLE_ID = "com.gumroad.walks"
-  ENVIRONMENT = Rails.env.production? ? "Production" : "Sandbox"
+  # Accepted StoreKit environments per Rails env. A production backend must
+  # accept *both* "Production" and "Sandbox": TestFlight builds and sandbox
+  # Apple IDs always produce Sandbox-signed transactions yet talk to the
+  # production API, so hard-pinning to "Production" rejected every internal
+  # tester's valid ProSub JWS — they fell through to the consumed free-trial
+  # path and got a 402 → paywall → recording never started. Apple explicitly
+  # recommends not pinning verification to the server's own environment for
+  # exactly this reason. Non-production backends only ever see Sandbox.
+  ACCEPTED_ENVIRONMENTS = Rails.env.production? ? %w[Production Sandbox].freeze : %w[Sandbox].freeze
   APPLE_ROOT_CA_PATH = Rails.root.join("config", "certs", "AppleRootCA-G3.pem")
 
   Result = Struct.new(:valid?, :expires_at, :product_id, :original_transaction_id, :error, keyword_init: true)
@@ -49,7 +57,7 @@ class AppStoreWalksJwsVerifier
         expires_at && expires_at > Time.current &&
         product_id == PRODUCT_ID &&
         bundle_id == BUNDLE_ID &&
-        environment == ENVIRONMENT
+        ACCEPTED_ENVIRONMENTS.include?(environment)
 
       Result.new(
         valid?: ok,

--- a/spec/services/app_store_walks_jws_verifier_spec.rb
+++ b/spec/services/app_store_walks_jws_verifier_spec.rb
@@ -188,7 +188,7 @@ describe AppStoreWalksJwsVerifier do
         expect(result.valid?).to be(false)
       end
 
-      it "rejects a subscription from the wrong environment" do
+      it "rejects a Production-signed subscription in a non-production env (test env accepts only Sandbox)" do
         result = described_class.verify(make_jws({
           productId: "ProSub",
           bundleId: "com.gumroad.walks",
@@ -196,6 +196,50 @@ describe AppStoreWalksJwsVerifier do
           expiresDate: (Time.current.to_i + 86_400) * 1000,
         }))
         expect(result.valid?).to be(false)
+      end
+
+      it "rejects an unknown environment value" do
+        result = described_class.verify(make_jws({
+          productId: "ProSub",
+          bundleId: "com.gumroad.walks",
+          environment: "Xcode",
+          expiresDate: (Time.current.to_i + 86_400) * 1000,
+        }))
+        expect(result.valid?).to be(false)
+      end
+
+      context "on a production backend (accepts both Production and Sandbox)" do
+        before { stub_const("AppStoreWalksJwsVerifier::ACCEPTED_ENVIRONMENTS", %w[Production Sandbox]) }
+
+        it "accepts a Production-signed ProSub subscription" do
+          result = described_class.verify(make_jws({
+            productId: "ProSub",
+            bundleId: "com.gumroad.walks",
+            environment: "Production",
+            expiresDate: (Time.current.to_i + 86_400) * 1000,
+          }))
+          expect(result.valid?).to be(true)
+        end
+
+        it "accepts a Sandbox-signed ProSub subscription (TestFlight / sandbox tester on prod)" do
+          result = described_class.verify(make_jws({
+            productId: "ProSub",
+            bundleId: "com.gumroad.walks",
+            environment: "Sandbox",
+            expiresDate: (Time.current.to_i + 86_400) * 1000,
+          }))
+          expect(result.valid?).to be(true)
+        end
+
+        it "still rejects an unknown environment value" do
+          result = described_class.verify(make_jws({
+            productId: "ProSub",
+            bundleId: "com.gumroad.walks",
+            environment: "Xcode",
+            expiresDate: (Time.current.to_i + 86_400) * 1000,
+          }))
+          expect(result.valid?).to be(false)
+        end
       end
     end
   end


### PR DESCRIPTION
## What

The Walks "record a walk" flow is gated by `WalksEntitlement`, which verifies an Apple-signed StoreKit transaction JWS for the `ProSub` subscription via `AppStoreWalksJwsVerifier`. The verifier hard-pinned the accepted StoreKit `environment` to the server's own Rails env:

```ruby
ENVIRONMENT = Rails.env.production? ? "Production" : "Sandbox"
# ...
environment == ENVIRONMENT
```

**TestFlight builds and sandbox Apple IDs always produce `Sandbox`-signed transactions, even though they hit the production API.** So on prod, a tester's valid ProSub JWS was rejected → the request fell through to the already-consumed one-free-walk path → backend returned `402 subscription_required` → the iOS app set `paywallRequired = true` and the walk never started. This is the reported "recording a walk isn't working — maybe a JWT/subscription issue," and it hit every internal tester (@slavingia, @ershad, @gianfrancopiana) even with an active subscription.

## Fix

Accept **both** `Production` and `Sandbox` on a production backend; non-production backends continue to accept `Sandbox` only. Unknown environment values are still rejected. This is Apple's documented guidance — verification should not be pinned to the server's own environment, precisely because TestFlight/sandbox purchases are Sandbox-signed against prod.

```ruby
ACCEPTED_ENVIRONMENTS = Rails.env.production? ? %w[Production Sandbox].freeze : %w[Sandbox].freeze
# ...
ACCEPTED_ENVIRONMENTS.include?(environment)
```

All other entitlement conditions are unchanged (not revoked, not expired, `productId == "ProSub"`, `bundleId == "com.gumroad.walks"`).

## Tests

`spec/services/app_store_walks_jws_verifier_spec.rb`:
- Renamed the existing "wrong environment" test to clarify non-prod accepts only Sandbox.
- Added rejection of an unknown environment value.
- Added a `production backend` context (`stub_const ACCEPTED_ENVIRONMENTS`) proving it accepts **both** Production- and Sandbox-signed ProSub, and still rejects junk environments.

Note: the 11 happy-path examples (pre-existing) can't run locally on macOS — the spec's cert fixture does `k.private_key = nil`, which raises `pkeys are immutable on OpenSSL 3.0`. This fails identically on a clean `origin/main` checkout, so it's a pre-existing macOS/OpenSSL-3.0 limitation, not introduced here. **CI (Linux OpenSSL) is the source of truth** for the happy-path branches. The 10 cheap-rejection tests pass locally; the new logic is also unit-verified standalone.

## Risk

Low and one-directional: this *widens* what's accepted on prod (Sandbox in addition to Production) only for the `ProSub` product + correct bundle + unexpired + cert-chain-anchored-at-Apple-Root-CA-G3. It does not weaken the chain/signature/product/bundle/expiry checks. Worst case is a sandbox tester getting Pro access on prod, which is the intended behavior for internal testing.

## Verify in prod after deploy

Confirm the live 402s clear: a tester with an active sub should get a `200` from `POST /api/v2/walks/realtime_tokens` and the walk should start. If a 402 persists, capture the logged `WalksAppAttest assertion rejected: <reason>` line — that would indicate the secondary App Attest path, not JWS.

Refs: antiwork/gumroad-walks#18

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782925957&installation_id=134400930&pr_number=5350&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5350&signature=80cb588e726ac4776d37bfef40bc1468f7fba1e3b748915d7c8e65a3ac0d6fcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only widens allowed `environment` values on prod for already chain-verified ProSub tokens; signature, product, bundle, and expiry checks are unchanged.
> 
> **Overview**
> **Production Walks ProSub verification** no longer requires the StoreKit JWS `environment` to match the Rails environment. `AppStoreWalksJwsVerifier` replaces a single `ENVIRONMENT` with `ACCEPTED_ENVIRONMENTS`: on production, both `Production` and `Sandbox` are allowed; elsewhere, only `Sandbox`. Entitlement still requires the same product, bundle, expiry, revocation, and cert chain checks.
> 
> This fixes TestFlight and sandbox Apple IDs hitting the production API with **Sandbox**-signed transactions, which were rejected and led to `402 subscription_required` and blocked recording.
> 
> Specs rename the old “wrong environment” case, add rejection for unknown environments, and add a stubbed production-backend context that accepts both Production- and Sandbox-signed ProSub JWS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2820f633e94d6e077c90ce786dbbebd67598cd7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->