### PR TITLE
Gate preview app deploys behind Buildkite approval for every branch

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,13 @@
 steps:
+  - block: "Approval required for preview app deployment"
+    key: require-preview-approval
+    branches: "!main !comp-assets-*"
+    prompt: "Provision and deploy a preview app for this branch?"
+    blocked_state: running
+
   - label: ":docker: Build Base Image"
     key: build-base-image
-    branches: "main deploy-* comp-assets-*"
+    depends_on: require-preview-approval
     command: ".buildkite/scripts/build_base.sh"
     timeout_in_minutes: 60
     plugins:
@@ -13,7 +19,6 @@ steps:
     key: build-web-image
     command: ".buildkite/scripts/build_web.sh"
     depends_on: build-base-image
-    branches: "main deploy-* comp-assets-*"
     timeout_in_minutes: 25
     plugins:
       - docker-login#v3.0.0:
@@ -23,7 +28,6 @@ steps:
   - label: ":gear: Compile Assets"
     key: compile-assets
     depends_on: build-web-image
-    branches: "main deploy-* comp-assets-*"
     command: ".buildkite/scripts/compile_assets.sh"
     artifact_paths: "log/**/*"
     parallelism: 2
@@ -37,10 +41,10 @@ steps:
           username: gumroad
           password-env: QUAY_PASSWORD
 
-  - label: ":rocket: Deploy Branch App"
-    key: build-and-deploy-branch
+  - label: ":rocket: Deploy Preview App"
+    key: build-and-deploy-preview
     depends_on: compile-assets
-    branches: "deploy-*"
+    branches: "!main !comp-assets-*"
     command: ".buildkite/scripts/deploy_branch.sh"
     timeout_in_minutes: 45
     plugins:

--- a/.buildkite/scripts/compile_assets.sh
+++ b/.buildkite/scripts/compile_assets.sh
@@ -75,7 +75,7 @@ if [[ $BUILDKITE_PARALLEL_JOB = 0 && $BUILDKITE_BRANCH != "main" ]]; then
   push_image staging || exit 1
 fi
 
-if [[ $BUILDKITE_PARALLEL_JOB = 1 && ! $BUILDKITE_BRANCH =~ ^(deploy-.*|devin/.*)$ ]]; then
+if [[ $BUILDKITE_PARALLEL_JOB = 1 && ( $BUILDKITE_BRANCH == "main" || $BUILDKITE_BRANCH == comp-assets-* ) ]]; then
   logger "Building production assets"
   docker rm production-assets || :
   COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME}_production \

--- a/.buildkite/scripts/deploy_branch.sh
+++ b/.buildkite/scripts/deploy_branch.sh
@@ -7,7 +7,7 @@ logger() {
   echo -e "${GREEN}$(date "+%Y/%m/%d %H:%M:%S") deploy_branch.sh: $1${NC}"
 }
 
-# Build branch app nginx image
+# Build preview app nginx image
 AWS_BRANCH_APP_NGINX_REPO=${ECR_REGISTRY}/gumroad/branch_app_nginx
 REVISION=${BUILDKITE_COMMIT}
 
@@ -54,8 +54,8 @@ else
   logger "Image $AWS_BRANCH_APP_NGINX_REPO:$BRANCH_APP_NGINX_TAG already exists"
 fi
 
-# Deploy branch app
-logger "Starting branch app deployment"
+# Deploy preview app
+logger "Starting preview app deployment"
 
 # Install Nomad
 source .buildkite/scripts/install_nomad.sh
@@ -68,7 +68,7 @@ copy_secrets
 BRANCH=${BUILDKITE_BRANCH}
 DEPLOY_TAG="staging-${WEB_TAG}"
 
-logger "Deploying branch app for ${BRANCH} with tag ${DEPLOY_TAG}"
+logger "Deploying preview app for ${BRANCH} with tag ${DEPLOY_TAG}"
 
 # Ensure necessary directories exist with proper permissions
 logger "Creating required directories"
@@ -76,7 +76,7 @@ sudo mkdir -p nomad/staging/certs
 sudo mkdir -p nomad/certs
 sudo chown -R buildkite-agent:buildkite-agent nomad/
 
-# Deploy branch app
+# Deploy preview app
 cd nomad/staging/deploy_branch
 BRANCH=$BRANCH \
   DEPLOY_TAG=$DEPLOY_TAG \

--- a/app/business/payments/charging/implementations/stripe/stripe_charge_radar_processor.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge_radar_processor.rb
@@ -41,7 +41,7 @@ module StripeChargeRadarProcessor
     ProcessEarlyFraudWarningJob.perform_async(early_fraud_warning.id)
   rescue ActiveRecord::RecordNotFound => e
     # Ignore for non-production environments, as the purchase could have been done on one of the many
-    # environments (one of engineer's local, staging, branch app, etc)
+    # environments (one of engineer's local, staging, preview app, etc)
     return unless Rails.env.production?
     # An event that has the `account` attribute is associated with a Stripe Connect account
     # If the purchase cannot be found, it's most likely because it wasn't done on the platform

--- a/config/domain.rb
+++ b/config/domain.rb
@@ -93,7 +93,7 @@ ANYCABLE_HOST           = config[:anycable_host]
 if custom_domain
   VALID_REQUEST_HOSTS << custom_domain
   VALID_API_REQUEST_HOSTS << "api.#{custom_domain}"
-  VALID_API_REQUEST_HOSTS << custom_domain if ENV["BRANCH_DEPLOYMENT"].present? # Allow CORS to branch-apps's root domain
+  VALID_API_REQUEST_HOSTS << custom_domain if ENV["BRANCH_DEPLOYMENT"].present? # Allow CORS to preview app's root domain
   VALID_CORS_ORIGINS << custom_domain
   DISCOVER_DOMAIN = custom_domain
   VALID_DISCOVER_REQUEST_HOST = custom_domain

--- a/docker/web/compile_assets.sh
+++ b/docker/web/compile_assets.sh
@@ -6,8 +6,8 @@ set -e
 
 cd $APP_DIR
 
-# Set CUSTOM_DOMAIN for branch app assets precompilation
-if [[ $BUILDKITE_BRANCH == deploy-* || $BUILDKITE_BRANCH == devin/* ]]; then
+# Set CUSTOM_DOMAIN for preview app assets precompilation
+if [[ $BUILDKITE_BRANCH != "main" && $BUILDKITE_BRANCH != comp-assets-* ]]; then
   base_domain="staging.gumroad.org"
   app_name=$(get_app_name $BUILDKITE_BRANCH)
 

--- a/docker/web/server.sh
+++ b/docker/web/server.sh
@@ -15,7 +15,7 @@ consul_put() {
 # Set default value for port
 export PORT=3000
 
-# Send notification to Slack on branch app deployment
+# Send notification to Slack on preview app deployment
 if [[ $BRANCH_DEPLOYMENT == "true" ]]; then
   if [[ ! -z "$NOMAD_HOST_PORT_puma" ]]; then
     export PORT=$NOMAD_HOST_PORT_puma

--- a/docker/web/server.sh
+++ b/docker/web/server.sh
@@ -15,7 +15,7 @@ consul_put() {
 # Set default value for port
 export PORT=3000
 
-# Send notification to Slack on preview app deployment
+# For preview apps, use the Nomad-allocated port and register the app's address in consul for routing
 if [[ $BRANCH_DEPLOYMENT == "true" ]]; then
   if [[ ! -z "$NOMAD_HOST_PORT_puma" ]]; then
     export PORT=$NOMAD_HOST_PORT_puma

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -186,6 +186,6 @@ $ nomad run sidekiq_worker.nomad
 
 ## Deploying to a preview app
 
-You can deploy a branch-specific deployment (aka preview app) from any branch except `main` and `comp-assets-*`. Pushing the branch starts a Buildkite build that waits at the "Approval required for preview app deployment" block; unblock it in Buildkite to provision and deploy the preview app. Nothing is built or provisioned until you approve, and there is no automated approval.
+You can deploy a preview app from any branch except `main` and `comp-assets-*`. Pushing the branch starts a Buildkite build that waits at the "Approval required for preview app deployment" block; unblock it in Buildkite to provision and deploy the preview app. Nothing is built or provisioned until you approve, and there is no automated approval.
 
 Deployments will be deleted automatically when the associated branches are deleted in the repository.

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -10,7 +10,7 @@
   - [When deployment goes bad](#when-deployment-goes-bad)
   - [Logs](#logs)
   - [Hotfixing workers only](#hotfixing-workers-only)
-- [Deploying to a branch app](#deploying-to-a-branch-app)
+- [Deploying to a preview app](#deploying-to-a-preview-app)
 - [Deploying to staging](#deploying-to-staging)
 
 ---
@@ -184,8 +184,8 @@ $ dotenv -f ../.env erb sidekiq_worker.nomad.erb > sidekiq_worker.nomad
 $ nomad run sidekiq_worker.nomad
 ```
 
-## Deploying to a branch app
+## Deploying to a preview app
 
-You can deploy a branch-specific deployment (aka branch app) by prefixing the branch name with `deploy-`, e.g., `deploy-bundle-share`.
+You can deploy a branch-specific deployment (aka preview app) from any branch except `main` and `comp-assets-*`. Pushing the branch starts a Buildkite build that waits at the "Approval required for preview app deployment" block; unblock it in Buildkite to provision and deploy the preview app. Nothing is built or provisioned until you approve, and there is no automated approval.
 
 Deployments will be deleted automatically when the associated branches are deleted in the repository.


### PR DESCRIPTION
## What

Preview apps (formerly "branch apps") were only built and deployed for `deploy-*` branches, and the deploy ran **automatically** with no approval. This PR:

- **Enables preview app deployment for every branch** except `main` and `comp-assets-*` (the deploy step's filter goes from `deploy-*` to `!main !comp-assets-*`). The `deploy-` branch prefix is no longer required — any branch can deploy a preview app.
- **Adds a manual Buildkite block step** — *"Approval required for preview app deployment"* — that gates the whole build → deploy chain. It mirrors the existing production approval block (same `blocked_state: running`). No preview app is built or provisioned until someone unblocks the build in Buildkite. No automated approval.
- **Renames the human-readable "branch app" terminology to "preview app"** across labels, prompts, comments, and docs.

The new block is placed **ahead of the build steps** (`build-base-image` now `depends_on` it), so pushing a branch doesn't kick off expensive image builds or asset compilation on its own — nothing runs until the build is approved.

## Why

Today only `deploy-*` branches get a preview environment, so testing any other branch end-to-end means renaming/pushing a `deploy-*` branch. Opening this up to every branch removes that friction, while the approval gate keeps it on-demand — matching how production deploys already ask for permission.

### `main` and `comp-assets-*` flows are unchanged

The preview block and deploy step are scoped to `branches: "!main !comp-assets-*"`, so on those branches the block is filtered out of the build. Per [Buildkite's dependency docs](https://buildkite.com/docs/pipelines/configure/dependencies#dependencies-and-conditionals), when a `depends_on` target is excluded by a branch filter the dependency is ignored and the dependent step still runs. So `build-base-image` runs immediately and the existing flows are untouched:

- **`main`:** build → "Approval required for production deployment" → deploy to production *(unchanged)*
- **`comp-assets-*`:** build automatically, no deploy *(unchanged)*
- **any other branch:** "Approval required for preview app deployment" → build → deploy preview app

### Asset builds follow the same scope

- `docker/web/compile_assets.sh` set `CUSTOM_DOMAIN` only for `deploy-*`/`devin/*` branches. With preview apps now on every branch, an arbitrary branch would precompile assets with the wrong domain. The condition is broadened to "any branch except `main` and `comp-assets-*`"; `get_app_name` already handles non-`deploy-` branch names.
- `.buildkite/scripts/compile_assets.sh` now builds **production** assets only for `main` and `comp-assets-*`. Preview branches build **staging** assets only — the same behavior `deploy-*`/`devin/*` already had, now extended to every preview branch (and it avoids wasting time building production assets for previews).

### Terminology

Only human-readable strings are renamed. Infrastructure identifiers are intentionally left unchanged because they are contracts with live infra: the `gumroad/branch_app_nginx` ECR repo, the `nomad/staging/deploy_branch` job dir, the `BRANCH_DEPLOYMENT` env var, the `branch-app-` Elasticsearch index prefix, and the `branch_app_nginx` Makefile target/image. A full identifier rename is a coordinated infra migration and is out of scope here. The matching wording change in the deployment repo: antiwork/gumroad-deployment#30.

## Before/After

CI-config + terminology change; no user-facing UI. Behavior is exercised in the Buildkite UI:

- **Before:** a push to a non-`deploy-*` branch ran no preview pipeline; `deploy-*` branches deployed automatically.
- **After:** a push to any branch except `main`/`comp-assets-*` starts a build that waits at the "Approval required for preview app deployment" block until manually unblocked, then builds and deploys the preview app.

QA: push this branch, confirm the Buildkite build pauses at the new block, unblock it, and verify the preview app builds and deploys. Confirm `main` (production approval still gates deploy) and `comp-assets-*` (builds automatically, no preview block) are unaffected.

---

AI disclosure: drafted with Claude Opus 4.8.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI/deploy behavior for every non-main branch (approval gating, broader preview deploys, and asset precompile domain rules), which can affect staging asset pushes and preview URL correctness if mis-scoped.
> 
> **Overview**
> **Preview apps** replace the old `deploy-*`-only **branch app** flow: any branch except `main` and `comp-assets-*` can deploy, but only after a new Buildkite **manual approval** block. That block sits **before** image builds (`build-base-image` depends on it), so pushes no longer start expensive builds until someone unblocks. Branch filters are removed from the shared build/compile steps; the deploy step is renamed to **Deploy Preview App** and scoped with `!main !comp-assets-*`.
> 
> **Asset compilation** is aligned with the wider preview scope: `docker/web/compile_assets.sh` sets `CUSTOM_DOMAIN` for every non-`main`, non-`comp-assets-*` branch (not just `deploy-*` / `devin/*`), and `.buildkite/scripts/compile_assets.sh` builds **production** assets only on `main` and `comp-assets-*` (preview branches stay staging-only).
> 
> Human-facing **“branch app” → “preview app”** wording updates appear in deploy scripts, `docs/deploying.md`, and a few comments (`config/domain.rb`, Stripe radar, `docker/web/server.sh`). Infra identifiers (`BRANCH_DEPLOYMENT`, ECR/nginx paths, etc.) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4e24953912e967854bc4fcdaedc54672e23de63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->