### PR TITLE
Fix custom HTML buy bridge

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -983,6 +983,21 @@ class LinksController < ApplicationController
           </head>
           <body>
             #{custom_html}
+            <script data-cfasync="false">
+              document.addEventListener("click", function (e) {
+                var target = e.target;
+                var buyButton = target && target.closest ? target.closest('[data-gumroad-action="buy"]') : null;
+                if (!buyButton) return;
+                e.preventDefault();
+
+                var params = {};
+                try {
+                  params = JSON.parse(buyButton.dataset.gumroadCheckoutParams || "{}");
+                } catch (_e) {}
+
+                parent.postMessage({type:"gumroad:checkout",params:params},"*");
+              }, true);
+            </script>
           </body>
         </html>
       HTML
@@ -1033,7 +1048,7 @@ class LinksController < ApplicationController
               title="#{title}"
               sandbox="allow-scripts allow-forms"
             ></iframe>
-            <script nonce="#{ERB::Util.h(nonce)}">
+            <script nonce="#{ERB::Util.h(nonce)}" data-cfasync="false">
               var frame = document.getElementById("gumroad-landing-frame");
               var BASE_CHECKOUT = #{checkout_url_js};
               // Whitelist the selection-state keys the checkout already accepts on the

--- a/app/services/pages/interpolator.rb
+++ b/app/services/pages/interpolator.rb
@@ -10,9 +10,6 @@ class Pages::Interpolator
     "description" => ->(product) { ActionView::Base.full_sanitizer.sanitize(product.description.to_s) }
   }.freeze
 
-  BUY_BUTTON_ONCLICK_JS = "parent.postMessage({type:'gumroad:checkout',params:JSON.parse(this.dataset.gumroadCheckoutParams||'{}')},'*');return false;"
-  private_constant :BUY_BUTTON_ONCLICK_JS
-
   def self.interpolate(html, product:)
     return html if html.blank?
 
@@ -23,17 +20,11 @@ class Pages::Interpolator
       node.inner_html = ERB::Util.h(handler.call(product)) if handler
     end
 
-    # The iframe sandbox omits top-navigation, so the buy button can't
-    # navigate the buyer's tab itself. It messages the wrapper, which owns the
-    # checkout URL it will navigate to. `return false` stops an anchor (or a
-    # button inside a form) from navigating/submitting the iframe to a dead
-    # checkout-in-iframe. Match any element, not just <a>, so an agent-authored
-    # <button>/<div> buy control still gets wired up instead of silently dying.
-    #
     # The selection params (variant/quantity/PWYW price/recurrence) are
     # validated server-side and serialized into a JSON data attribute the
-    # onclick reads at click time, so a typo in the agent's HTML falls back
-    # to the product's default checkout instead of breaking the buyer's view.
+    # iframe's delegated checkout handler reads at click time, so a typo in the
+    # agent's HTML falls back to the product's default checkout instead of
+    # breaking the buyer's view.
     # Build the validator once so the product-derived lookups (variant names,
     # allowed recurrences) are memoized across every buy button on the page,
     # not re-queried per element.
@@ -41,7 +32,6 @@ class Pages::Interpolator
     fragment.css('[data-gumroad-action="buy"]').each do |node|
       selection = buy_button_validator.validate(node)
       node["data-gumroad-checkout-params"] = selection.to_json
-      node["onclick"] = BUY_BUTTON_ONCLICK_JS
       if node.name == "a"
         query = Rack::Utils.build_query({ wanted: true }.merge(selection))
         node["href"] = "/l/#{product.unique_permalink}?#{query}"

--- a/spec/controllers/links_controller_custom_html_spec.rb
+++ b/spec/controllers/links_controller_custom_html_spec.rb
@@ -43,8 +43,10 @@ describe LinksController, :vcr, type: :controller do
       expect(response.body).to include('e.data.type === "gumroad:checkout"')
       expect(response.body).to include('e.origin !== "null"')
       # Script carries a nonce — script-src has no 'unsafe-inline', so without
-      # it the listener would be CSP-blocked in the browser.
-      expect(response.body).to match(/<script nonce="[^"]+">/)
+      # it the listener would be CSP-blocked in the browser. It also opts out of
+      # Rocket Loader so Cloudflare doesn't rewrite the inline handler and drop
+      # the nonce before the browser sees it.
+      expect(response.body).to match(/<script nonce="[^"]+" data-cfasync="false">/)
       # Only our own iframe can trigger checkout — gate on e.source so an
       # embedding page can't drive the navigation.
       expect(response.body).to include("e.source !== frame.contentWindow")
@@ -175,6 +177,19 @@ describe LinksController, :vcr, type: :controller do
       expect(response.body).to include(">#{product.name}<")
       expect(response.body).not_to include(">placeholder<")
       expect(response.body).to include(%(href="/l/#{product.unique_permalink}?wanted=true"))
+    end
+
+    it "serves a Rocket Loader-safe delegated checkout bridge" do
+      product.update!(custom_html: %(<button data-gumroad-action="buy">Buy</button>))
+
+      get :landing_iframe_content, params: { id: product.unique_permalink }
+
+      expect(response.body).to include(%(<script data-cfasync="false">))
+      expect(response.body).to include(%(target.closest('[data-gumroad-action="buy"]')))
+      expect(response.body).to include("e.preventDefault();")
+      expect(response.body).not_to include("stopImmediatePropagation")
+      expect(response.body).to include(%(parent.postMessage({type:"gumroad:checkout",params:params},"*");))
+      expect(response.body).not_to include("onclick=")
     end
   end
 

--- a/spec/services/pages/interpolator_spec.rb
+++ b/spec/services/pages/interpolator_spec.rb
@@ -32,15 +32,14 @@ describe Pages::Interpolator do
       expect(result).not_to include("<strong>")
     end
 
-    it "wires <a data-gumroad-action='buy'> to message the wrapper instead of navigating itself" do
+    it "prepares <a data-gumroad-action='buy'> for the delegated checkout bridge" do
       html = %(<a data-gumroad-action="buy" href="#">Buy</a>)
 
       result = described_class.interpolate(html, product: product)
 
       expect(result).to include(%(href="/l/#{product.unique_permalink}?wanted=true"))
-      expect(result).to include("type:'gumroad:checkout'")
-      expect(result).to include("this.dataset.gumroadCheckoutParams")
-      expect(result).to include("return false")
+      expect(result).to include(%(data-gumroad-checkout-params="{}"))
+      expect(result).not_to include("onclick")
     end
 
     it "leaves unknown field markers untouched (graceful fallback)" do
@@ -89,14 +88,13 @@ describe Pages::Interpolator do
       expect(described_class.interpolate(nil, product: product)).to be_nil
     end
 
-    it "wires non-anchor buy elements via onclick without converting them to anchors" do
+    it "prepares non-anchor buy elements without converting them to anchors" do
       html = %(<button data-gumroad-action="buy">Buy</button>)
 
       result = described_class.interpolate(html, product: product)
 
-      expect(result).to include("type:'gumroad:checkout'")
-      expect(result).to include("this.dataset.gumroadCheckoutParams")
-      expect(result).to include("return false")
+      expect(result).to include(%(data-gumroad-checkout-params="{}"))
+      expect(result).not_to include("onclick")
       expect(result).to include("<button")
       expect(result).not_to include("<a")
       expect(result).not_to include("href=")


### PR DESCRIPTION
## What

Fixes custom HTML buy buttons by moving checkout click handling out of per-element inline `onclick` attributes and into a Gumroad-owned delegated handler in the landing iframe. The wrapper and iframe bridge scripts opt out of Cloudflare Rocket Loader so CSP and nonce handling stay intact.

Validated with the focused custom HTML controller, interpolator, and CSP specs.

## Why

Rocket Loader was rewriting inline handlers and wrapper scripts in production, while the custom HTML CSP blocked Rocket Loader. That left `data-gumroad-action="buy"` controls rendered but inert. Keeping the bridge in first-party code preserves the sandboxed iframe model and the existing server-side checkout validation.

---

This PR was implemented with AI assistance using gpt‑5.5 xhigh.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes buyer-facing custom HTML checkout wiring (click handling and Cloudflare script behavior) but keeps the same postMessage contract and server-side param validation.
> 
> **Overview**
> Custom HTML **buy** controls no longer get per-element inline `onclick` handlers from `Pages::Interpolator`; they only receive validated `data-gumroad-checkout-params` (and anchor `href`s as before).
> 
> Checkout clicks are handled by a **Gumroad-owned delegated script** injected into the landing iframe document, which `postMessage`s `{type:"gumroad:checkout", params:…}` to the parent wrapper—same protocol as before, but without seller inline JS driving checkout.
> 
> Both the iframe bridge and the wrapper’s checkout listener scripts add **`data-cfasync="false"`** so Cloudflare Rocket Loader doesn’t rewrite them and break CSP nonces / leave buy buttons inert in production.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de4c3fa043677c4cf2ffea73643253aeb72f3892. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->