### PR TITLE
Add custom HTML buy e2e

### DIFF
--- a/spec/requests/products/show/custom_html_spec.rb
+++ b/spec/requests/products/show/custom_html_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Custom HTML product page", type: :system, js: true do
+  let(:seller) { create(:user) }
+  let(:product) do
+    create(
+      :product,
+      user: seller,
+      quantity_enabled: true,
+      custom_html: <<~HTML
+        <main>
+          <h1>Custom landing</h1>
+          <button type="button" data-gumroad-action="buy" data-gumroad-quantity="2">Buy from iframe</button>
+        </main>
+      HTML
+    )
+  end
+
+  before do
+    Feature.activate_user(:custom_html_pages, seller)
+  end
+
+  it "navigates from the sandboxed landing iframe to checkout when the buy control is clicked" do
+    visit short_link_path(product)
+
+    expect(page).to have_selector("iframe#gumroad-landing-frame")
+    within_frame(find("iframe#gumroad-landing-frame")) do
+      expect(page).to have_text("Custom landing")
+      click_on "Buy from iframe"
+    end
+
+    expect(page).to have_current_path(/^\/checkout/, wait: 10)
+    within("[role='listitem']", match: :first) do
+      expect(page).to have_text(product.name)
+      expect(page).to have_text("Qty: 2")
+    end
+  end
+end

--- a/spec/requests/products/show/custom_html_spec.rb
+++ b/spec/requests/products/show/custom_html_spec.rb
@@ -32,8 +32,7 @@ describe "Custom HTML product page", type: :system, js: true do
     end
 
     expect(page).to have_current_path(/^\/checkout/, wait: 10)
-    within("[role='listitem']", match: :first) do
-      expect(page).to have_text(product.name)
+    within_cart_item(product.name) do
       expect(page).to have_text("Qty: 2")
     end
   end


### PR DESCRIPTION
Ref #5357

## What
Adds a system spec that exercises a custom HTML product page inside the sandboxed landing iframe and verifies the delegated buy control reaches checkout with the requested quantity.

## Why
The buy bridge is easy to regress because it depends on iframe messaging, the wrapper listener, and checkout params working together. This keeps the production fix covered without adding conditionals around bridge injection.

---

This PR was implemented with AI assistance using gpt-5.5 xhigh.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code, auth, or data-handling impact.
> 
> **Overview**
> Adds a **system (JS) spec** for custom HTML product pages that verifies the full buy path from the sandboxed `#gumroad-landing-frame` iframe through delegated `data-gumroad-action="buy"` / `data-gumroad-quantity` controls to `/checkout` with the expected cart quantity.
> 
> The test enables `:custom_html_pages` for the seller and uses inline custom HTML with a buy button—no application code changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcbf139b5d8932fd261f79525447d8b0f859aec7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->