### PR TITLE
Fix custom landing page agent prompt to match shipped CLI and buy-button contract

### DIFF
--- a/app/javascript/components/ProductEdit/ShareTab/LandingPageEditor.tsx
+++ b/app/javascript/components/ProductEdit/ShareTab/LandingPageEditor.tsx
@@ -41,23 +41,23 @@ Example buy buttons:
   <a data-gumroad-action="buy" data-gumroad-option="Pro" data-gumroad-recurrence="yearly">Buy Pro – $99/year</a>
   <button data-gumroad-action="buy" data-gumroad-quantity="2">Buy 2 seats</button>
 
-For a pay-what-you-want product where the buyer should name their OWN price on the page, render a price <input> and post the chosen amount to checkout yourself (do NOT put data-gumroad-action="buy" on this button — Gumroad would overwrite your click handler with the fixed-price one). The page is allowed to post a "gumroad:checkout" message to its parent with any of: option, quantity, price, recurrence. An empty price falls back to Gumroad's own price-entry step, so there is no dead end:
-  <input id="gr-price" type="number" min="0" placeholder="9.99" />
-  <button id="gr-buy">I want this</button>
-  <noscript><a data-gumroad-action="buy">I want this</a></noscript>
+For a pay-what-you-want product where the buyer should name their OWN price on the page, render a price <input> and post the chosen amount to checkout yourself (do NOT put data-gumroad-action="buy" on this button — Gumroad's delegated buy handler would intercept it before your custom price is added). The page is allowed to post a "gumroad:checkout" message to its parent with any of: variant, quantity, price, recurrence. Use variant for a variant/version/tier name. An empty price falls back to Gumroad's own price-entry step, so there is no dead end:
+  <input id="gr-price" type="number" min="0" step="0.01" placeholder="9.99" />
+  <button id="gr-buy" type="button">I want this</button>
   <script>
-    document.getElementById("gr-buy").onclick = function () {
+    document.getElementById("gr-buy").addEventListener("click", function () {
       var v = (document.getElementById("gr-price").value || "").trim(), params = {};
       if (v !== "") { var n = parseFloat(v); if (!isNaN(n) && n >= 0) params.price = String(n); }
       parent.postMessage({ type: "gumroad:checkout", params: params }, "*");
-    };
+    });
   </script>
 
 Then publish it with the Gumroad CLI:
-- Publish (or update) the page: gumroad products update ${uniquePermalink} --custom-html ./landing.html --json --non-interactive
-- Preview the request without sending it: add --dry-run to the command above.
-- Remove the landing page and restore the default product page: gumroad products update ${uniquePermalink} --custom-html '' --json --non-interactive
-- Confirm it's live and find the public URL: gumroad products view ${uniquePermalink} --json
+- Preview the local request without publishing: gumroad products update ${uniquePermalink} --custom-html ./landing.html --dry-run --json --no-input --non-interactive
+- Publish (or update) the page: gumroad products update ${uniquePermalink} --custom-html ./landing.html --json --no-input --non-interactive
+- Inspect .result.sanitization_report in the publish response; if Gumroad removed tags or attributes, edit and publish again.
+- Remove the landing page and restore the default product page: gumroad products update ${uniquePermalink} --custom-html '' --json --no-input --non-interactive
+- Confirm it's live and find the public URL: gumroad products view ${uniquePermalink} --json --jq '.product.landing_url' --no-input --non-interactive
 
 If the gumroad CLI isn't installed: brew install antiwork/cli/gumroad (or curl -fsSL https://gumroad.com/install-cli.sh | bash), then run gumroad auth login.`;
 

--- a/app/javascript/components/ProductEdit/ShareTab/LandingPageEditor.tsx
+++ b/app/javascript/components/ProductEdit/ShareTab/LandingPageEditor.tsx
@@ -24,6 +24,8 @@ export const LandingPageEditor = () => {
 
 Design a unique, conversion-focused page tailored to this product — fully responsive, accessible, and supporting light and dark mode. Save it as one self-contained file, landing.html. The page is sanitized and runs sandboxed: inline CSS/JS (animations, scroll effects, modals) and a Tailwind CDN work. For images and media, use only your product's own assets (run gumroad products view ${uniquePermalink} for its cover and thumbnail URLs), inline data: URIs, or CSS — external image/media hosts are blocked, and the page can't fetch external URLs or read the buyer's account.
 
+IMPORTANT: a custom landing page REPLACES the entire product page, including the native price and "I want this!" button. Your HTML must include at least one buy element (see below) or the product becomes unpurchasable. Always end by loading the live page and clicking through to checkout to confirm the buy flow works.
+
 Mark live values and buy buttons with data attributes that Gumroad fills in server-side:
 - data-gumroad-field="name|price|description" — interpolated with the product's current values.
 - data-gumroad-action="buy" — wired up to launch the Gumroad checkout. Use on any element (<a>, <button>, <div>).
@@ -31,7 +33,7 @@ Mark live values and buy buttons with data attributes that Gumroad fills in serv
 For products with selection state, set the choice directly on the buy element so the checkout opens pre-selected (an invalid value silently falls back to the product defaults — it won't break the page):
 - data-gumroad-option="<variant name>" — for products with variants/versions/tiers.
 - data-gumroad-quantity="<integer>" — for products with quantity enabled.
-- data-gumroad-price="<decimal>" — for pay-what-you-want products (major units, e.g. "9.99").
+- data-gumroad-price="<decimal>" — for pay-what-you-want products (major units, e.g. "9.99"). This sets ONE fixed price and sends the buyer straight to checkout.
 - data-gumroad-recurrence="monthly|quarterly|biannually|yearly|every_two_years" — for membership/subscription products.
 
 Example buy buttons:
@@ -39,10 +41,23 @@ Example buy buttons:
   <a data-gumroad-action="buy" data-gumroad-option="Pro" data-gumroad-recurrence="yearly">Buy Pro – $99/year</a>
   <button data-gumroad-action="buy" data-gumroad-quantity="2">Buy 2 seats</button>
 
+For a pay-what-you-want product where the buyer should name their OWN price on the page, render a price <input> and post the chosen amount to checkout yourself (do NOT put data-gumroad-action="buy" on this button — Gumroad would overwrite your click handler with the fixed-price one). The page is allowed to post a "gumroad:checkout" message to its parent with any of: option, quantity, price, recurrence. An empty price falls back to Gumroad's own price-entry step, so there is no dead end:
+  <input id="gr-price" type="number" min="0" placeholder="9.99" />
+  <button id="gr-buy">I want this</button>
+  <noscript><a data-gumroad-action="buy">I want this</a></noscript>
+  <script>
+    document.getElementById("gr-buy").onclick = function () {
+      var v = (document.getElementById("gr-price").value || "").trim(), params = {};
+      if (v !== "") { var n = parseFloat(v); if (!isNaN(n) && n >= 0) params.price = String(n); }
+      parent.postMessage({ type: "gumroad:checkout", params: params }, "*");
+    };
+  </script>
+
 Then publish it with the Gumroad CLI:
-- Preview without publishing (check the sanitization report first): gumroad products page preview ${uniquePermalink} ./landing.html --json --no-input
-- Publish: gumroad products page push ${uniquePermalink} ./landing.html --json --no-input
-- Print the live URL: gumroad products page url ${uniquePermalink} --json --no-input
+- Publish (or update) the page: gumroad products update ${uniquePermalink} --custom-html ./landing.html --json --non-interactive
+- Preview the request without sending it: add --dry-run to the command above.
+- Remove the landing page and restore the default product page: gumroad products update ${uniquePermalink} --custom-html '' --json --non-interactive
+- Confirm it's live and find the public URL: gumroad products view ${uniquePermalink} --json
 
 If the gumroad CLI isn't installed: brew install antiwork/cli/gumroad (or curl -fsSL https://gumroad.com/install-cli.sh | bash), then run gumroad auth login.`;
 


### PR DESCRIPTION
## What

Updates the Share-tab "Copy prompt" agent prompt (`LandingPageEditor.tsx`) so it matches the CLI that actually ships and the real buy-button contract.

Three changes to the prompt text:

1. **Correct the publish commands.** The prompt instructed `gumroad products page preview|push|url ...`, none of which exist. The shipped command for publishing a landing page is `gumroad products update <id> --custom-html ./landing.html` (#121). The prompt now uses it, plus `--custom-html ''` to clear the page and `--dry-run` to preview the request, and `gumroad products view <id>` to confirm it's live.

2. **Warn that a custom page removes the native buy button.** A custom landing page replaces the entire product page — including the native price bar and "I want this!" button. If the HTML has no buy element, the product becomes silently unpurchasable. The prompt now states this and tells the agent to load the live page and click through to checkout to verify.

3. **Document the buyer-entered PWYW pattern.** `data-gumroad-price` sets one fixed price, which is wrong for a $0+ pay-what-you-want product where the buyer should name their own amount. The prompt now shows the supported pattern: a price `<input>` plus a button that posts `{type:"gumroad:checkout", params:{price}}` to the parent wrapper (and a `<noscript>` fallback). It explains not to put `data-gumroad-action="buy"` on that button, since the interpolator would overwrite the custom click handler with the fixed-price one.

## Why

Agents handed the old prompt hit "unknown command" on the `products page` trio and fell back to hand-rolling the raw v2 API, with no guidance on the buy-button requirement — which produces a good-looking page that can't be purchased. The two contract details added here (full-page replacement, and how a buyer-named price reaches checkout) are the two things most likely to ship broken.

The PWYW message contract is verified against production source, not invented:
- `LinksController#custom_html_wrapper_document` listens for `{type:"gumroad:checkout", params}` and forwards the whitelisted keys `["variant","option","quantity","price","recurrence"]` to `?wanted=true`.
- `LandingPagePreview` uses the same allowed-keys list for the editor preview.

The prompt snippet only uses keys from that whitelist, so what the prompt teaches and what the wrapper accepts stay in sync.

## Test plan

- Prompt text only — no component logic or types change; the `agentPrompt` template literal still renders in the "Copy prompt" button and the "Show prompt" `<details>`.
- No test snapshots the prompt string, so no spec updates are needed.
- Manually verified the documented flow end-to-end on a live product: `products update --custom-html` publishes the page; a price input posting `{type:"gumroad:checkout", params:{price:"25"}}` lands on `/checkout` at US$25; an empty price falls back to the native price-entry step; `--custom-html ''` restores the default page.

---

AI disclosure: drafted with Claude Opus 4.7. Prompt: update the Share-tab landing-page agent prompt to match how the CLI actually works after the `--custom-html` flag shipped, add the missing buy-button requirement, and document the pay-what-you-want buyer-input pattern that feeds checkout.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5363"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782957926&installation_id=134400930&pr_number=5363&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5363&signature=6d6e8bcefe132b0d2ebf7db4370c3efea777cf6aa6c1c9628c32a101abedd1de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change to the agent prompt template; no runtime product-edit or checkout logic is modified.
> 
> **Overview**
> Updates the Share-tab **Copy prompt** string in `LandingPageEditor.tsx` so AI agents get instructions that match the shipped Gumroad CLI and custom landing-page purchase behavior.
> 
> The prompt now uses **`gumroad products update … --custom-html`** (with `--dry-run`, clear via empty `--custom-html`, and live URL via `products view`) instead of non-existent **`products page`** commands. It adds an **IMPORTANT** note that custom HTML **replaces** the default product page and must include at least one buy path, with a reminder to verify checkout on the live page.
> 
> It clarifies **`data-gumroad-price`** as a single fixed PWYW amount, and documents buyer-entered PWYW via a price input and **`parent.postMessage({ type: "gumroad:checkout", params })`** without **`data-gumroad-action="buy"`** on that control.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa6a736307de658cd0b7390c203ab44c9bd03e90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->