### PR TITLE
Silently redirect signed-in users from /login and /signup

### DIFF
--- a/app/controllers/concerns/silent_already_signed_in_redirect.rb
+++ b/app/controllers/concerns/silent_already_signed_in_redirect.rb
@@ -5,9 +5,19 @@ module SilentAlreadySignedInRedirect
 
   private
     def require_no_authentication
+      assert_is_devise_resource!
       return unless is_navigational_format?
-      return unless user_signed_in?
+      no_input = devise_mapping.no_input_strategies
 
-      redirect_to after_sign_in_path_for(current_user)
+      authenticated = if no_input.present?
+        args = no_input.dup.push scope: resource_name
+        warden.authenticate?(*args)
+      else
+        warden.authenticated?(resource_name)
+      end
+
+      if authenticated && resource = warden.user(resource_name)
+        redirect_to after_sign_in_path_for(resource)
+      end
     end
 end

--- a/app/controllers/concerns/silent_already_signed_in_redirect.rb
+++ b/app/controllers/concerns/silent_already_signed_in_redirect.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module SilentAlreadySignedInRedirect
+  extend ActiveSupport::Concern
+
+  private
+    def require_no_authentication
+      return unless is_navigational_format?
+      return unless user_signed_in?
+
+      redirect_to after_sign_in_path_for(current_user)
+    end
+end

--- a/app/controllers/logins_controller.rb
+++ b/app/controllers/logins_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class LoginsController < Devise::SessionsController
-  include OauthApplicationConfig, ValidateRecaptcha, InertiaRendering
+  include OauthApplicationConfig, ValidateRecaptcha, InertiaRendering, SilentAlreadySignedInRedirect
 
   include PageMeta::Base
 

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SignupController < Devise::RegistrationsController
-  include OauthApplicationConfig, ValidateRecaptcha, InertiaRendering
+  include OauthApplicationConfig, ValidateRecaptcha, InertiaRendering, SilentAlreadySignedInRedirect
 
   include PageMeta::Base
 

--- a/spec/requests/devise_auth_redirects_spec.rb
+++ b/spec/requests/devise_auth_redirects_spec.rb
@@ -55,26 +55,43 @@ describe "Devise auth path redirects", type: :request do
     end
   end
 
-  describe "GET /login when already signed in" do
+  describe "/login when already signed in" do
     let(:user) { create(:user) }
+    let(:expected_redirect) { dashboard_url(host: VALID_REQUEST_HOSTS.first) }
 
     before { sign_in user }
 
-    it "redirects to the dashboard without 'already signed in' flash" do
+    it "redirects GET to the dashboard without 'already signed in' flash" do
       get "/login"
-      expect(response).to redirect_to(dashboard_url(host: VALID_REQUEST_HOSTS.first))
+      expect(response).to redirect_to(expected_redirect)
+      expect(flash[:alert]).to be_nil
+    end
+
+    it "redirects HTML POST to the dashboard without 'already signed in' flash" do
+      post "/login", params: { user: { login_identifier: user.email, password: "irrelevant" } }
+      expect(response).to redirect_to(expected_redirect)
       expect(flash[:alert]).to be_nil
     end
   end
 
-  describe "GET /signup when already signed in" do
+  describe "/signup when already signed in" do
     let(:user) { create(:user) }
+    let(:expected_redirect) { dashboard_url(host: VALID_REQUEST_HOSTS.first) }
 
     before { sign_in user }
 
-    it "redirects to the dashboard without 'already signed in' flash" do
+    it "redirects GET to the dashboard without 'already signed in' flash" do
       get "/signup"
-      expect(response).to redirect_to(dashboard_url(host: VALID_REQUEST_HOSTS.first))
+      expect(response).to redirect_to(expected_redirect)
+      expect(flash[:alert]).to be_nil
+    end
+
+    it "redirects HTML POST to the dashboard without 'already signed in' flash and without creating a new user" do
+      expect do
+        post "/signup", params: { user: { email: "fresh-#{SecureRandom.hex(4)}@example.com", password: "Password123!" } }
+      end.not_to change(User, :count)
+
+      expect(response).to redirect_to(expected_redirect)
       expect(flash[:alert]).to be_nil
     end
   end

--- a/spec/requests/devise_auth_redirects_spec.rb
+++ b/spec/requests/devise_auth_redirects_spec.rb
@@ -54,4 +54,28 @@ describe "Devise auth path redirects", type: :request do
       expect(response).to redirect_to("/signup?referrer=alice&email=test%40example.com")
     end
   end
+
+  describe "GET /login when already signed in" do
+    let(:user) { create(:user) }
+
+    before { sign_in user }
+
+    it "redirects to the dashboard without 'already signed in' flash" do
+      get "/login"
+      expect(response).to redirect_to(dashboard_url(host: VALID_REQUEST_HOSTS.first))
+      expect(flash[:alert]).to be_nil
+    end
+  end
+
+  describe "GET /signup when already signed in" do
+    let(:user) { create(:user) }
+
+    before { sign_in user }
+
+    it "redirects to the dashboard without 'already signed in' flash" do
+      get "/signup"
+      expect(response).to redirect_to(dashboard_url(host: VALID_REQUEST_HOSTS.first))
+      expect(flash[:alert]).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
## What

Override Devise's inherited \`require_no_authentication\` filter on \`LoginsController\` and \`SignupController\` via a shared concern, so signed-in users hitting \`/login\` or \`/signup\` are silently redirected to the dashboard with no flash.

## Why

#4770 reports that the \"You are already signed in.\" popup still shows on the dashboard. PR #4785 redirected the Devise default paths (\`/users/sign_in\` → \`/login\`, \`/users/sign_up\` → \`/signup\`) at the router level, but the underlying flash trigger lives on the custom controllers themselves: \`LoginsController < Devise::SessionsController\` and \`SignupController < Devise::RegistrationsController\` inherit \`prepend_before_action :require_no_authentication\`, which sets the alert flash and redirects to \`after_sign_in_path_for\`.

The most common trigger is the public marketing site: the \"Start selling\" CTAs on \`home/about.html.erb\`, \`home/saas.html.erb\`, and \`home/shared/_section_cta.html.erb\` hardcode \`signup_path\` regardless of auth state. A signed-in user clicking any of them lands on the dashboard with the popup. The router-level redirect in #4785 doesn't help here — the user goes straight to \`/signup\`, not via \`/users/sign_up\`.

This change closes the hole at the source, so any entry path to \`/login\` or \`/signup\` while signed in (marketing CTA, old bookmark, external link) results in a clean redirect to the dashboard.

Fixes #4770

## Test plan

- [ ] \`bundle exec rspec spec/requests/devise_auth_redirects_spec.rb\` passes (9 examples, including new ones for \`/login\` and \`/signup\` while signed in)
- [ ] Sign in, then visit \`/login\` directly — redirected to dashboard with no popup
- [ ] Sign in, then visit \`/signup\` directly — redirected to dashboard with no popup
- [ ] Sign in, then click \"Start selling\" on gumroad.com — redirected to dashboard with no popup
- [ ] Signed-out user visiting \`/login\` and \`/signup\` still sees those pages normally

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) using Claude Opus 4.7

Prompts:
- \"debug https://github.com/antiwork/gumroad/issues/4770\"
- \"do A create PR and assign me\"

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5367"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782977279&installation_id=134400930&pr_number=5367&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5367&signature=7598e7998acb7dafb3ba2616842ce7ba7becbc4a726eac2a4d2cf6562c63e6b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows Devise’s existing signed-in guard on two auth pages; behavior is covered by request specs and does not change sign-in/sign-up for logged-out users.
> 
> **Overview**
> Adds a shared **`SilentAlreadySignedInRedirect`** concern that overrides Devise’s **`require_no_authentication`** so authenticated users hitting **`/login`** or **`/signup`** are redirected to the post-sign-in path **without** the “You are already signed in.” alert flash.
> 
> **`LoginsController`** and **`SignupController`** include the concern. Request specs assert GET/POST on those routes while signed in redirect to the dashboard with no **`flash[:alert]`**, and that signup POST does not create another user.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56de04359f24718357a9900dfadf23ea11ace70b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->