### PR TITLE
Expose product sections in v2 product responses

### DIFF
--- a/app/controllers/api/v2/links_controller.rb
+++ b/app/controllers/api/v2/links_controller.rb
@@ -16,6 +16,7 @@ class Api::V2::LinksController < Api::V2::BaseController
   SHOW_PRODUCT_ASSOCIATIONS = (BASE_PRODUCT_ASSOCIATIONS + [
     :page,
     :ordered_alive_product_files,
+    :seller_profile_sections,
     :alive_rich_contents,
     { variant_categories_alive: [{ alive_variants: :alive_rich_contents }] },
   ]).freeze

--- a/app/models/concerns/product/as_json.rb
+++ b/app/models/concerns/product/as_json.rb
@@ -144,6 +144,8 @@ module Product::AsJson
           "custom_html" => custom_html,
           "rich_content" => rich_content_json,
           "has_same_rich_content_for_all_variants" => has_same_rich_content_for_all_variants?,
+          "main_section_index" => main_section_index || 0,
+          "sections" => Api::ProductSectionsPresenter.new(self).props,
           "files" => ordered_alive_product_files.filter_map do |f|
             {
               id: f.external_id,

--- a/app/presenters/api/product_sections_presenter.rb
+++ b/app/presenters/api/product_sections_presenter.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+class Api::ProductSectionsPresenter
+  SECTION_TYPES = {
+    "SellerProfileProductsSection" => "products",
+    "SellerProfileFeaturedProductSection" => "featured_product",
+    "SellerProfileRichTextSection" => "rich_text",
+    "SellerProfilePostsSection" => "posts",
+    "SellerProfileWishlistsSection" => "wishlists",
+    "SellerProfileSubscribeSection" => "subscribe",
+  }.freeze
+
+  def initialize(product)
+    @product = product
+    @sections = ordered_sections
+    @product_external_ids_by_id = build_product_external_ids_by_id
+  end
+
+  def props
+    sections.map { serialize(_1) }
+  end
+
+  private
+    attr_reader :product, :sections, :product_external_ids_by_id
+
+    def ordered_sections
+      sections_by_id = product.seller_profile_sections.index_by(&:id)
+
+      Array(product.sections).filter_map do |section_id|
+        sections_by_id[section_id] || sections_by_id[section_id.to_i]
+      end
+    end
+
+    def build_product_external_ids_by_id
+      product_ids = sections.flat_map do |section|
+        case section
+        when SellerProfileProductsSection
+          section.shown_products
+        when SellerProfileFeaturedProductSection
+          section.featured_product_id
+        end
+      end.compact.uniq
+
+      return {} if product_ids.empty?
+
+      Link.where(user_id: product.user_id, id: product_ids).index_by(&:id).transform_values(&:external_id)
+    end
+
+    def serialize(section)
+      payload = {
+        "id" => section.external_id,
+        "type" => SECTION_TYPES.fetch(section.type),
+        "header" => section.header || "",
+        "hide_header" => section.hide_header?,
+      }
+
+      case section
+      when SellerProfileProductsSection
+        payload.merge!(
+          "shown_products" => section.shown_products.filter_map { product_external_ids_by_id[_1] },
+          "default_product_sort" => section.default_product_sort,
+          "show_filters" => section.show_filters,
+          "add_new_products" => section.add_new_products,
+        )
+      when SellerProfileFeaturedProductSection
+        payload.merge!("featured_product" => product_external_ids_by_id[section.featured_product_id])
+      end
+
+      payload
+    end
+end

--- a/app/presenters/api/product_sections_presenter.rb
+++ b/app/presenters/api/product_sections_presenter.rb
@@ -49,7 +49,7 @@ class Api::ProductSectionsPresenter
     def serialize(section)
       payload = {
         "id" => section.external_id,
-        "type" => SECTION_TYPES.fetch(section.type),
+        "type" => type_for(section),
         "header" => section.header || "",
         "hide_header" => section.hide_header?,
       }
@@ -63,9 +63,16 @@ class Api::ProductSectionsPresenter
           "add_new_products" => section.add_new_products,
         )
       when SellerProfileFeaturedProductSection
-        payload.merge!("featured_product" => product_external_ids_by_id[section.featured_product_id])
+        featured_product_external_id = product_external_ids_by_id[section.featured_product_id]
+        payload.merge!("featured_product" => featured_product_external_id) if featured_product_external_id.present?
       end
 
       payload
+    end
+
+    def type_for(section)
+      SECTION_TYPES.fetch(section.type) do
+        section.type.to_s.delete_prefix("SellerProfile").delete_suffix("Section").underscore
+      end
     end
 end

--- a/spec/controllers/api/v2/links_controller_spec.rb
+++ b/spec/controllers/api/v2/links_controller_spec.rb
@@ -66,6 +66,8 @@ describe Api::V2::LinksController do
         create(:product_file, link: versioned_product, url: "#{S3_BASE_URL}specs/test.pdf")
         create(:rich_content, entity: versioned_product, description: [{ "type" => "paragraph", "content" => [{ "type" => "text", "text" => "hello" }] }])
         create(:rich_content, entity: versioned_product.alive_variants.first, description: [{ "type" => "paragraph", "content" => [{ "type" => "text", "text" => "variant" }] }])
+        section = create(:seller_profile_rich_text_section, seller: @user, product: versioned_product)
+        versioned_product.update!(sections: [section.id])
 
         get @action, params: @params
 
@@ -74,6 +76,8 @@ describe Api::V2::LinksController do
         expect(product).not_to have_key("rich_content")
         expect(product).not_to have_key("has_same_rich_content_for_all_variants")
         expect(product).not_to have_key("files")
+        expect(product).not_to have_key("main_section_index")
+        expect(product).not_to have_key("sections")
         expect(product["variants"].first["options"].first).not_to have_key("rich_content")
       end
 
@@ -993,6 +997,119 @@ describe Api::V2::LinksController do
         first_option = options.find { |o| o["rich_content"].any? }
         expect(first_option).to be_present
         expect(first_option["rich_content"].first["description"]).to eq({ "type" => "doc", "content" => [{ "type" => "paragraph", "content" => [{ "type" => "text", "text" => "variant content" }] }] })
+      end
+
+      it "includes an empty sections array and main_section_index for products with no sections" do
+        get :show, params: @params
+
+        product = response.parsed_body["product"]
+        expect(product["sections"]).to eq([])
+        expect(product["main_section_index"]).to eq(0)
+      end
+
+      it "returns sections in the product display order with main_section_index" do
+        first_section = create(:seller_profile_rich_text_section, seller: @user, product: @product, header: "First")
+        second_section = create(:seller_profile_rich_text_section, seller: @user, product: @product, header: "Second")
+        @product.update!(sections: [second_section.id, first_section.id], main_section_index: 1)
+
+        get :show, params: @params
+
+        product = response.parsed_body["product"]
+        expect(product["main_section_index"]).to eq(1)
+        expect(product["sections"].map { _1["id"] }).to eq([second_section.external_id, first_section.external_id])
+        expect(product["sections"].map { _1["type"] }).to eq(["rich_text", "rich_text"])
+      end
+
+      it "reorders sections when product.sections changes" do
+        first_section = create(:seller_profile_rich_text_section, seller: @user, product: @product, header: "First")
+        second_section = create(:seller_profile_rich_text_section, seller: @user, product: @product, header: "Second")
+        @product.update!(sections: [first_section.id, second_section.id])
+
+        get :show, params: @params
+        expect(response.parsed_body["product"]["sections"].map { _1["id"] }).to eq([first_section.external_id, second_section.external_id])
+
+        @product.update!(sections: [second_section.id, first_section.id])
+
+        get :show, params: @params
+        expect(response.parsed_body["product"]["sections"].map { _1["id"] }).to eq([second_section.external_id, first_section.external_id])
+      end
+
+      it "serializes product sections with shown product external IDs and display settings" do
+        shown_product1 = create(:product, user: @user)
+        shown_product2 = create(:product, user: @user)
+        section = create(
+          :seller_profile_products_section,
+          seller: @user,
+          product: @product,
+          header: "Featured picks",
+          shown_products: [shown_product2.id, shown_product1.id],
+          default_product_sort: "highest_rated",
+          show_filters: true,
+          add_new_products: false
+        )
+        @product.update!(sections: [section.id])
+
+        get :show, params: @params
+
+        expect(response.parsed_body["product"]["sections"].sole).to eq(
+          {
+            "id" => section.external_id,
+            "type" => "products",
+            "header" => "Featured picks",
+            "hide_header" => false,
+            "shown_products" => [shown_product2.external_id, shown_product1.external_id],
+            "default_product_sort" => "highest_rated",
+            "show_filters" => true,
+            "add_new_products" => false,
+          }
+        )
+      end
+
+      it "serializes featured product sections with the featured product external ID" do
+        featured_product = create(:product, user: @user)
+        section = create(
+          :seller_profile_featured_product_section,
+          seller: @user,
+          product: @product,
+          header: "Don't miss this",
+          featured_product_id: featured_product.id
+        )
+        @product.update!(sections: [section.id])
+
+        get :show, params: @params
+
+        expect(response.parsed_body["product"]["sections"].sole).to eq(
+          {
+            "id" => section.external_id,
+            "type" => "featured_product",
+            "header" => "Don't miss this",
+            "hide_header" => false,
+            "featured_product" => featured_product.external_id,
+          }
+        )
+      end
+
+      it "serializes non-scoped section types with only the common fields" do
+        section = create(
+          :seller_profile_rich_text_section,
+          seller: @user,
+          product: @product,
+          header: "About",
+          hide_header: true,
+          text: { "type" => "doc", "content" => [{ "type" => "paragraph" }] }
+        )
+        @product.update!(sections: [section.id])
+
+        get :show, params: @params
+
+        expect(response.parsed_body["product"]["sections"].sole).to eq(
+          {
+            "id" => section.external_id,
+            "type" => "rich_text",
+            "header" => "About",
+            "hide_header" => true,
+          }
+        )
       end
     end
 

--- a/spec/controllers/api/v2/links_controller_spec.rb
+++ b/spec/controllers/api/v2/links_controller_spec.rb
@@ -1089,6 +1089,23 @@ describe Api::V2::LinksController do
         )
       end
 
+      it "omits featured_product when the referenced product is not owned by the seller" do
+        other_seller_product = create(:product)
+        section = create(
+          :seller_profile_featured_product_section,
+          seller: @user,
+          product: @product,
+          featured_product_id: other_seller_product.id
+        )
+        @product.update!(sections: [section.id])
+
+        get :show, params: @params
+
+        serialized_section = response.parsed_body["product"]["sections"].sole
+        expect(serialized_section["type"]).to eq("featured_product")
+        expect(serialized_section).not_to have_key("featured_product")
+      end
+
       it "serializes non-scoped section types with only the common fields" do
         section = create(
           :seller_profile_rich_text_section,
@@ -1110,6 +1127,16 @@ describe Api::V2::LinksController do
             "hide_header" => true,
           }
         )
+      end
+
+      it "falls back to friendly type strings for unmapped section classes" do
+        stub_const("Api::ProductSectionsPresenter::SECTION_TYPES", {})
+        section = create(:seller_profile_rich_text_section, seller: @user, product: @product)
+        @product.update!(sections: [section.id])
+
+        get :show, params: @params
+
+        expect(response.parsed_body["product"]["sections"].sole["type"]).to eq("rich_text")
       end
     end
 


### PR DESCRIPTION
Ref antiwork/gumroad-cli#101

## What

Adds product page sections to `GET /v2/products/:id`.

The response now includes `main_section_index` and an ordered `sections` array for full product responses. Product-listing and featured-product sections include their relevant product references as v2 product IDs. Other section types return only the common fields so the API does not commit to unsupported rich-text, posts, wishlist, or subscribe contracts yet.

## Why

The CLI needs a read path before it can safely add section-management commands. Product sections are not inline JSON content; they are ordered section records with type-specific data and raw product references.

This keeps this PR read-only and small while establishing the public response shape future write endpoints can build on.

---

This PR was implemented with AI assistance using GPT-5.5 xhigh.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only API expansion with seller-scoped product ID resolution; no write paths or auth changes.
> 
> **Overview**
> **Full v2 product responses** (`GET /v2/products/:id`, non-slim) now expose **`main_section_index`** and an ordered **`sections`** array so clients can read product page layout without write APIs yet.
> 
> A new **`Api::ProductSectionsPresenter`** builds each section from `product.sections` order with common fields (`id`, `type`, `header`, `hide_header`). **Products** sections add `shown_products` (v2 external IDs), sort/filter flags, and **featured_product** sections add `featured_product` when the target belongs to the seller—otherwise that key is omitted. Other section types (e.g. rich text) stay minimal so the API does not promise full content for posts, wishlists, or subscribe yet.
> 
> **`SHOW_PRODUCT_ASSOCIATIONS`** preloads `:seller_profile_sections` for show. **Slim index** responses still omit `sections` and `main_section_index`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2f28d864eb83335ea30a6094848df447d6ba495. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->