### PR TITLE
Retry transient TaxJar connection errors in US states sales-tax report

### DIFF
--- a/app/sidekiq/create_us_states_sales_summary_report_job.rb
+++ b/app/sidekiq/create_us_states_sales_summary_report_job.rb
@@ -108,7 +108,7 @@ class CreateUsStatesSalesSummaryReportJob
                                                   sales_tax_dollars:,
                                                   unit_price_dollars:)
             end
-          rescue Taxjar::Error::GatewayTimeout, Taxjar::Error::InternalServerError => e
+          rescue Taxjar::Error::GatewayTimeout, *TaxjarErrors::SERVER => e
             retries += 1
             if retries < 3
               Rails.logger.info("CreateUsStatesSalesSummaryReportJob: TaxJar error for purchase with external ID #{purchase.external_id}. Retry attempt #{retries}/3. #{e.class}: #{e.message}")

--- a/config/initializers/004_constants.rb
+++ b/config/initializers/004_constants.rb
@@ -71,7 +71,8 @@ DENYLIST = %w[ a about account activate add admin administrator api app apps
 INTERNET_EXCEPTIONS = [SocketError, Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::ENETUNREACH, Errno::EHOSTUNREACH,
                        Errno::EADDRNOTAVAIL, EOFError, URI::InvalidURIError, Addressable::URI::InvalidURIError,
                        Timeout::Error, Net::HTTPBadResponse, Net::OpenTimeout, Net::ReadTimeout, OpenURI::HTTPError,
-                       OpenSSL::SSL::SSLError, Faraday::ConnectionFailed, SsrfFilter::Error].freeze
+                       OpenSSL::SSL::SSLError, Faraday::ConnectionFailed, SsrfFilter::Error,
+                       HTTP::ConnectionError, HTTP::TimeoutError].freeze
 
 FILE_REGEX = {
   archive: /rar|zip|tar/i,

--- a/spec/sidekiq/create_us_states_sales_summary_report_job_spec.rb
+++ b/spec/sidekiq/create_us_states_sales_summary_report_job_spec.rb
@@ -107,6 +107,24 @@ describe CreateUsStatesSalesSummaryReportJob do
       expect(@purchase7.purchase_taxjar_info).to be_present
     end
 
+    it "retries and completes the report when TaxJar raises a transient connection error" do
+      expect(s3_bucket_double).to receive(:object).ordered.and_return(@s3_object)
+
+      raised = false
+      allow_any_instance_of(TaxjarApi).to receive(:create_order_transaction).and_wrap_original do |original, **kwargs|
+        unless raised
+          raised = true
+          raise HTTP::ConnectionError, "failed to connect: Connection reset by peer - SSL_connect"
+        end
+        original.call(**kwargs)
+      end
+      allow_any_instance_of(described_class).to receive(:sleep)
+
+      expect { described_class.new.perform(subdivision_codes, month, year) }.not_to raise_error
+
+      expect(InternalNotificationWorker).to have_enqueued_sidekiq_job("payments", "US Sales Tax Summary Report", anything, "green")
+    end
+
     it "creates a summary CSV file with correct totals for each state without submitting transactions to TaxJar when push_to_taxjar is false" do
       expect(s3_bucket_double).to receive(:object).ordered.and_return(@s3_object)
       expect_any_instance_of(TaxjarApi).not_to receive(:create_order_transaction)

--- a/spec/support/fixtures/vcr_cassettes/CreateUsStatesSalesSummaryReportJob/happy_case/retries_and_completes_the_report_when_TaxJar_raises_a_transient_connection_error.yml
+++ b/spec/support/fixtures/vcr_cassettes/CreateUsStatesSalesSummaryReportJob/happy_case/retries_and_completes_the_report_when_TaxJar_raises_a_transient_connection_error.yml
@@ -1,0 +1,6142 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_yxiuHufM0f1JcR","request_duration_ms":0}}'
+      Idempotency-Key:
+      - 1141627a-5079-4c0b-b6e3-ce853c517b2c
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel Version 24.6.0: Mon
+        Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041 arm64","hostname":"Ershads-MacBook-Pro-office.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 02 Jun 2026 13:12:02 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK;
+        report-to csp
+      Idempotency-Key:
+      - 1141627a-5079-4c0b-b6e3-ce853c517b2c
+      Original-Request:
+      - req_HM8b8ChgNEAjN2
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"
+      Request-Id:
+      - req_HM8b8ChgNEAjN2
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-04-22.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1Tds6wIBOqvOFDrfvtjiRuKz",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 6,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1780405922,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1Tds6wIBOqvOFDrfvtjiRuKz
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_HM8b8ChgNEAjN2","request_duration_ms":312}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel Version 24.6.0: Mon
+        Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041 arm64","hostname":"Ershads-MacBook-Pro-office.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 02 Jun 2026 13:12:03 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"
+      Request-Id:
+      - req_hX0lfyjt4mHvsv
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-04-22.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1Tds6wIBOqvOFDrfvtjiRuKz",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 6,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1780405922,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.sandbox.taxjar.com/v2/taxes
+    body:
+      encoding: UTF-8
+      string: '{"from_country":"US","from_state":"CA","from_zip":"94104","to_country":"US","to_state":"WA","to_zip":"98121","shipping":0.0,"line_items":[{"quantity":1,"unit_price":100.0,"discount":0,"product_tax_code":"31000"}],"nexus_addresses":[{"country":"US","state":"WA"}]}'
+    headers:
+      User-Agent:
+      - 'TaxJar/Ruby (Darwin Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel
+        Version 24.6.0: Mon Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041
+        arm64; ruby 3.4.3-p32; OpenSSL 3.6.2 7 Apr 2026) taxjar-ruby/3.0.4'
+      Authorization:
+      - Bearer <TAXJAR_API_KEY>
+      X-Api-Version:
+      - '2022-01-24'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+      Host:
+      - api.sandbox.taxjar.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1491'
+      Connection:
+      - close
+      Date:
+      - Tue, 02 Jun 2026 13:12:03 GMT
+      X-Amzn-Trace-Id:
+      - Root=1-6a1ed6a3-116411b35edd756535e3d3f7
+      X-Amzn-Requestid:
+      - 4adcb745-b286-404b-8d7d-c9a6b3d32d31
+      Access-Control-Allow-Origin:
+      - https://developers.taxjar.com
+      X-Amz-Apigw-Id:
+      - eVZ5lGHcIAMEOTw=
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 f37cb654f276fda4bb4d719cefa4c758.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - JFK50-P9
+      X-Amz-Cf-Id:
+      - LP-8WkEPis6xTvtl8l5vwBppiefoeKGgX4Gr7UVNLCoSeRq9oUNFvg==
+    body:
+      encoding: UTF-8
+      string: '{"tax":{"rate":0.1055,"freight_taxable":true,"tax_source":"destination","shipping":0.0,"taxable_amount":100.0,"jurisdictions":{"state":"WA","city":"SEATTLE","country":"US","county":"KING"},"breakdown":{"line_items":[{"id":"1","tax_collectable":10.55,"taxable_amount":100.0,"combined_tax_rate":0.1055,"state_taxable_amount":100.0,"county_taxable_amount":100.0,"city_taxable_amount":100.0,"special_district_taxable_amount":100.0,"city_tax_rate":0.0125,"county_tax_rate":0.005,"special_tax_rate":0.023,"special_district_amount":2.3,"city_amount":1.25,"county_amount":0.5,"state_amount":6.5,"state_sales_tax_rate":0.065}],"shipping":{"tax_collectable":0.0,"taxable_amount":0.0,"combined_tax_rate":0.1055,"state_taxable_amount":0.0,"county_taxable_amount":0.0,"city_taxable_amount":0.0,"city_tax_rate":0.0125,"county_tax_rate":0.005,"special_tax_rate":0.023,"special_district_amount":0.0,"special_taxable_amount":0.0,"city_amount":0.0,"county_amount":0.0,"state_amount":0.0,"state_sales_tax_rate":0.065},"tax_collectable":10.55,"taxable_amount":100.0,"combined_tax_rate":0.1055,"state_taxable_amount":100.0,"state_tax_collectable":6.5,"county_taxable_amount":100.0,"county_tax_collectable":0.5,"city_taxable_amount":100.0,"city_tax_collectable":1.25,"special_district_taxable_amount":100.0,"special_district_tax_collectable":2.3,"city_tax_rate":0.0125,"county_tax_rate":0.005,"special_tax_rate":0.023,"state_tax_rate":0.065},"has_nexus":true,"amount_to_collect":10.55,"order_total_amount":100.0}}'
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=11055&currency=usd&description=You+bought+http%3A%2F%2Fedgar953e8f1b2.test.gumroad.com%3A31337%2Fl%2Fd%21&metadata[purchase]=PH9MZRiDkh_gD1YVEZY2YA%3D%3D&transfer_group=26&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1Tds6wIBOqvOFDrfvtjiRuKz&statement_descriptor_suffix=edgar953e8f1b2
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_hX0lfyjt4mHvsv","request_duration_ms":167}}'
+      Idempotency-Key:
+      - 5a09a563-89f9-4e6f-9eef-6b22db819ea4
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel Version 24.6.0: Mon
+        Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041 arm64","hostname":"Ershads-MacBook-Pro-office.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 02 Jun 2026 13:12:04 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1640'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK;
+        report-to csp
+      Idempotency-Key:
+      - 5a09a563-89f9-4e6f-9eef-6b22db819ea4
+      Original-Request:
+      - req_B5doxLMKLVkYRH
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"
+      Request-Id:
+      - req_B5doxLMKLVkYRH
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-04-22.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3Tds6xIBOqvOFDrf1DWKDxs2",
+          "object": "payment_intent",
+          "amount": 11055,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 11055,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3Tds6xIBOqvOFDrf1DWKDxs2_secret_xeuYGdbvleHuPNRUIHbCOitn2",
+          "confirmation_method": "automatic",
+          "created": 1780405923,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgar953e8f1b2.test.gumroad.com:31337/l/d!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3Tds6xIBOqvOFDrf160SY15G",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "PH9MZRiDkh_gD1YVEZY2YA=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1Tds6wIBOqvOFDrfvtjiRuKz",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar953e8f1b2",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "26"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3Tds6xIBOqvOFDrf160SY15G?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_B5doxLMKLVkYRH","request_duration_ms":909}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel Version 24.6.0: Mon
+        Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041 arm64","hostname":"Ershads-MacBook-Pro-office.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 02 Jun 2026 13:12:04 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3804'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"
+      Request-Id:
+      - req_vrtqB2BR8JVO3Z
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-04-22.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3Tds6xIBOqvOFDrf160SY15G",
+          "object": "charge",
+          "amount": 11055,
+          "amount_captured": 11055,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3Tds6xIBOqvOFDrf1MczA7da",
+            "object": "balance_transaction",
+            "amount": 11055,
+            "available_on": 1780963200,
+            "balance_type": "payments",
+            "created": 1780405923,
+            "currency": "usd",
+            "description": "You bought http://edgar953e8f1b2.test.gumroad.com:31337/l/d!",
+            "exchange_rate": null,
+            "fee": 351,
+            "fee_details": [
+              {
+                "amount": 351,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 10704,
+            "reporting_category": "charge",
+            "source": "ch_3Tds6xIBOqvOFDrf160SY15G",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR953E8F1B2",
+          "captured": true,
+          "created": 1780405923,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar953e8f1b2.test.gumroad.com:31337/l/d!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "PH9MZRiDkh_gD1YVEZY2YA=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 37,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3Tds6xIBOqvOFDrf1DWKDxs2",
+          "payment_method": "pm_1Tds6wIBOqvOFDrfvtjiRuKz",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 11055,
+              "authorization_code": "109082",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 6,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 11055,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKKSt-9AGMgaFz-aT0JA6LBZ8gWzleA8JtqecBcU2o6_wS24AAWNVgKS5CYa-3WnmKkR7_6v6fSZ_pg3l",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar953e8f1b2",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "26"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_vrtqB2BR8JVO3Z","request_duration_ms":379}}'
+      Idempotency-Key:
+      - 2797af13-a450-41bb-a778-15c38e7ad42b
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel Version 24.6.0: Mon
+        Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041 arm64","hostname":"Ershads-MacBook-Pro-office.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 02 Jun 2026 13:12:04 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK;
+        report-to csp
+      Idempotency-Key:
+      - 2797af13-a450-41bb-a778-15c38e7ad42b
+      Original-Request:
+      - req_f1mvkxpyXT87hS
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"
+      Request-Id:
+      - req_f1mvkxpyXT87hS
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-04-22.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1Tds6yIBOqvOFDrfPsIg1dsQ",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 6,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1780405924,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1Tds6yIBOqvOFDrfPsIg1dsQ
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_f1mvkxpyXT87hS","request_duration_ms":235}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel Version 24.6.0: Mon
+        Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041 arm64","hostname":"Ershads-MacBook-Pro-office.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 02 Jun 2026 13:12:05 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"
+      Request-Id:
+      - req_9u8ucTxM8kUCwL
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-04-22.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1Tds6yIBOqvOFDrfPsIg1dsQ",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 6,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1780405924,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.sandbox.taxjar.com/v2/taxes
+    body:
+      encoding: UTF-8
+      string: '{"from_country":"US","from_state":"CA","from_zip":"94104","to_country":"US","to_state":"WI","to_zip":"53703","shipping":0.0,"line_items":[{"quantity":1,"unit_price":100.0,"discount":0,"product_tax_code":"31000"}],"nexus_addresses":[{"country":"US","state":"WI"}]}'
+    headers:
+      User-Agent:
+      - 'TaxJar/Ruby (Darwin Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel
+        Version 24.6.0: Mon Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041
+        arm64; ruby 3.4.3-p32; OpenSSL 3.6.2 7 Apr 2026) taxjar-ruby/3.0.4'
+      Authorization:
+      - Bearer <TAXJAR_API_KEY>
+      X-Api-Version:
+      - '2022-01-24'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+      Host:
+      - api.sandbox.taxjar.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1460'
+      Connection:
+      - close
+      Date:
+      - Tue, 02 Jun 2026 13:12:05 GMT
+      X-Amzn-Trace-Id:
+      - Root=1-6a1ed6a5-4a6b73ef329149ca1946cbbc
+      X-Amzn-Requestid:
+      - 3ac895c7-da23-4d39-bc52-ad3994c7d97f
+      Access-Control-Allow-Origin:
+      - https://developers.taxjar.com
+      X-Amz-Apigw-Id:
+      - eVZ56GAuoAMEFRA=
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 e770ad1d5cbd97118591a2a170c4e66c.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - JFK50-P9
+      X-Amz-Cf-Id:
+      - I3qn9ghDNzvT0YpENAIVtZ-TCTZ7BNZ1AW_38W7TVpWQF9ThK8clQQ==
+    body:
+      encoding: UTF-8
+      string: '{"tax":{"rate":0.055,"freight_taxable":true,"tax_source":"destination","shipping":0.0,"taxable_amount":100.0,"jurisdictions":{"state":"WI","city":"MADISON","country":"US","county":"DANE
+        COUNTY"},"breakdown":{"line_items":[{"id":"1","tax_collectable":5.5,"taxable_amount":100.0,"combined_tax_rate":0.055,"state_taxable_amount":100.0,"county_taxable_amount":100.0,"city_taxable_amount":0.0,"special_district_taxable_amount":0.0,"city_tax_rate":0.0,"county_tax_rate":0.005,"special_tax_rate":0.0,"special_district_amount":0.0,"city_amount":0.0,"county_amount":0.5,"state_amount":5.0,"state_sales_tax_rate":0.05}],"shipping":{"tax_collectable":0.0,"taxable_amount":0.0,"combined_tax_rate":0.055,"state_taxable_amount":0.0,"county_taxable_amount":0.0,"city_taxable_amount":0.0,"city_tax_rate":0.0,"county_tax_rate":0.005,"special_tax_rate":0.0,"special_district_amount":0.0,"special_taxable_amount":0.0,"city_amount":0.0,"county_amount":0.0,"state_amount":0.0,"state_sales_tax_rate":0.05},"tax_collectable":5.5,"taxable_amount":100.0,"combined_tax_rate":0.055,"state_taxable_amount":100.0,"state_tax_collectable":5.0,"county_taxable_amount":100.0,"county_tax_collectable":0.5,"city_taxable_amount":0.0,"city_tax_collectable":0.0,"special_district_taxable_amount":0.0,"special_district_tax_collectable":0.0,"city_tax_rate":0.0,"county_tax_rate":0.005,"special_tax_rate":0.0,"state_tax_rate":0.05},"has_nexus":true,"amount_to_collect":5.5,"order_total_amount":100.0}}'
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=10550&currency=usd&description=You+bought+http%3A%2F%2Fedgar953e8f1b2.test.gumroad.com%3A31337%2Fl%2Fd%21&metadata[purchase]=OVEhZclDfjf9OENvGvQwGw%3D%3D&transfer_group=27&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1Tds6yIBOqvOFDrfPsIg1dsQ&statement_descriptor_suffix=edgar953e8f1b2
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_9u8ucTxM8kUCwL","request_duration_ms":179}}'
+      Idempotency-Key:
+      - 6e5ea05b-f45a-4ac1-bca6-47e5e098238c
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel Version 24.6.0: Mon
+        Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041 arm64","hostname":"Ershads-MacBook-Pro-office.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 02 Jun 2026 13:12:06 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1640'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK;
+        report-to csp
+      Idempotency-Key:
+      - 6e5ea05b-f45a-4ac1-bca6-47e5e098238c
+      Original-Request:
+      - req_QuuVOOy1Agj9pf
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"
+      Request-Id:
+      - req_QuuVOOy1Agj9pf
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-04-22.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3Tds6zIBOqvOFDrf1XHZaCB0",
+          "object": "payment_intent",
+          "amount": 10550,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 10550,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3Tds6zIBOqvOFDrf1XHZaCB0_secret_iiqXpFQUlKSvPFCMmj8V0cN5i",
+          "confirmation_method": "automatic",
+          "created": 1780405925,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgar953e8f1b2.test.gumroad.com:31337/l/d!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3Tds6zIBOqvOFDrf1kcs108q",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "OVEhZclDfjf9OENvGvQwGw=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1Tds6yIBOqvOFDrfPsIg1dsQ",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar953e8f1b2",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "27"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3Tds6zIBOqvOFDrf1kcs108q?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_QuuVOOy1Agj9pf","request_duration_ms":1258}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel Version 24.6.0: Mon
+        Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041 arm64","hostname":"Ershads-MacBook-Pro-office.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 02 Jun 2026 13:12:07 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3803'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"
+      Request-Id:
+      - req_4QvkmJ8XgiQiI6
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-04-22.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3Tds6zIBOqvOFDrf1kcs108q",
+          "object": "charge",
+          "amount": 10550,
+          "amount_captured": 10550,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3Tds6zIBOqvOFDrf1ovLeezy",
+            "object": "balance_transaction",
+            "amount": 10550,
+            "available_on": 1780963200,
+            "balance_type": "payments",
+            "created": 1780405925,
+            "currency": "usd",
+            "description": "You bought http://edgar953e8f1b2.test.gumroad.com:31337/l/d!",
+            "exchange_rate": null,
+            "fee": 336,
+            "fee_details": [
+              {
+                "amount": 336,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 10214,
+            "reporting_category": "charge",
+            "source": "ch_3Tds6zIBOqvOFDrf1kcs108q",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR953E8F1B2",
+          "captured": true,
+          "created": 1780405925,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar953e8f1b2.test.gumroad.com:31337/l/d!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "OVEhZclDfjf9OENvGvQwGw=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 9,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3Tds6zIBOqvOFDrf1XHZaCB0",
+          "payment_method": "pm_1Tds6yIBOqvOFDrfPsIg1dsQ",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 10550,
+              "authorization_code": "623325",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 6,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 10550,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKKet-9AGMgYMZe6zRNg6LBZfg43TCzNqmzdWj8MxphkaioRWbXHrRpnAtRTVSMrJzAXe6lsHEaZxFhMn",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar953e8f1b2",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "27"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_4QvkmJ8XgiQiI6","request_duration_ms":662}}'
+      Idempotency-Key:
+      - 533d4d30-68ef-4dad-a8a7-a839e866d8a0
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel Version 24.6.0: Mon
+        Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041 arm64","hostname":"Ershads-MacBook-Pro-office.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 02 Jun 2026 13:12:07 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK;
+        report-to csp
+      Idempotency-Key:
+      - 533d4d30-68ef-4dad-a8a7-a839e866d8a0
+      Original-Request:
+      - req_Szw0icLIV4jGoo
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"
+      Request-Id:
+      - req_Szw0icLIV4jGoo
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-04-22.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1Tds71IBOqvOFDrffZHIthII",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 6,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1780405927,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1Tds71IBOqvOFDrffZHIthII
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_Szw0icLIV4jGoo","request_duration_ms":213}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel Version 24.6.0: Mon
+        Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041 arm64","hostname":"Ershads-MacBook-Pro-office.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 02 Jun 2026 13:12:07 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"
+      Request-Id:
+      - req_n3Fbz83uCkRESb
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-04-22.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1Tds71IBOqvOFDrffZHIthII",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 6,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1780405927,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.sandbox.taxjar.com/v2/taxes
+    body:
+      encoding: UTF-8
+      string: '{"from_country":"US","from_state":"CA","from_zip":"94104","to_country":"US","to_state":"WA","to_zip":"98184","shipping":0.0,"line_items":[{"quantity":1,"unit_price":100.0,"discount":0,"product_tax_code":"31000"}],"nexus_addresses":[{"country":"US","state":"WA"}]}'
+    headers:
+      User-Agent:
+      - 'TaxJar/Ruby (Darwin Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel
+        Version 24.6.0: Mon Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041
+        arm64; ruby 3.4.3-p32; OpenSSL 3.6.2 7 Apr 2026) taxjar-ruby/3.0.4'
+      Authorization:
+      - Bearer <TAXJAR_API_KEY>
+      X-Api-Version:
+      - '2022-01-24'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+      Host:
+      - api.sandbox.taxjar.com
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '91'
+      Connection:
+      - close
+      Date:
+      - Tue, 02 Jun 2026 13:12:08 GMT
+      X-Amzn-Trace-Id:
+      - Root=1-6a1ed6a8-15ecd0b5062142ee5bbf5023
+      X-Amzn-Requestid:
+      - fbd0c9b9-c827-4d06-927b-d6d7a1c6d135
+      X-Amz-Apigw-Id:
+      - eVZ6UE4KIAMEU5A=
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 35f02b3211065bf08280b7b1b4bbd0ce.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - JFK50-P9
+      X-Amz-Cf-Id:
+      - rtJO0Crv1AwBxjW7e5z7FlxKHxIuOxSOwfcmhtvg2XKv7pkl2LXSbQ==
+    body:
+      encoding: UTF-8
+      string: '{"detail":"to_zip 98184 is not used within to_state WA","status":400,"error":"Bad
+        Request"}'
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=10000&currency=usd&description=You+bought+http%3A%2F%2Fedgar953e8f1b2.test.gumroad.com%3A31337%2Fl%2Fd%21&metadata[purchase]=AwEjZNQ0GmyQvPECHqt63g%3D%3D&transfer_group=28&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1Tds71IBOqvOFDrffZHIthII&statement_descriptor_suffix=edgar953e8f1b2
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_n3Fbz83uCkRESb","request_duration_ms":168}}'
+      Idempotency-Key:
+      - 0b10b70d-e685-4c9f-8a20-b88fbd5c8b00
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel Version 24.6.0: Mon
+        Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041 arm64","hostname":"Ershads-MacBook-Pro-office.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 02 Jun 2026 13:12:09 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1640'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK;
+        report-to csp
+      Idempotency-Key:
+      - 0b10b70d-e685-4c9f-8a20-b88fbd5c8b00
+      Original-Request:
+      - req_NSS0hEEXpzlijq
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"
+      Request-Id:
+      - req_NSS0hEEXpzlijq
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-04-22.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3Tds72IBOqvOFDrf0knEZZEo",
+          "object": "payment_intent",
+          "amount": 10000,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 10000,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3Tds72IBOqvOFDrf0knEZZEo_secret_MXAqaxgSSjSt7FqdyJsFTEMdc",
+          "confirmation_method": "automatic",
+          "created": 1780405928,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgar953e8f1b2.test.gumroad.com:31337/l/d!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3Tds72IBOqvOFDrf0cEmvvhT",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "AwEjZNQ0GmyQvPECHqt63g=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1Tds71IBOqvOFDrffZHIthII",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar953e8f1b2",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "28"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3Tds72IBOqvOFDrf0cEmvvhT?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_NSS0hEEXpzlijq","request_duration_ms":991}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel Version 24.6.0: Mon
+        Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041 arm64","hostname":"Ershads-MacBook-Pro-office.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 02 Jun 2026 13:12:09 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3803'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"
+      Request-Id:
+      - req_NPy43XrkUdT9j4
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-04-22.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3Tds72IBOqvOFDrf0cEmvvhT",
+          "object": "charge",
+          "amount": 10000,
+          "amount_captured": 10000,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3Tds72IBOqvOFDrf02EjiqTg",
+            "object": "balance_transaction",
+            "amount": 10000,
+            "available_on": 1780963200,
+            "balance_type": "payments",
+            "created": 1780405928,
+            "currency": "usd",
+            "description": "You bought http://edgar953e8f1b2.test.gumroad.com:31337/l/d!",
+            "exchange_rate": null,
+            "fee": 320,
+            "fee_details": [
+              {
+                "amount": 320,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 9680,
+            "reporting_category": "charge",
+            "source": "ch_3Tds72IBOqvOFDrf0cEmvvhT",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR953E8F1B2",
+          "captured": true,
+          "created": 1780405928,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar953e8f1b2.test.gumroad.com:31337/l/d!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "AwEjZNQ0GmyQvPECHqt63g=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 41,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3Tds72IBOqvOFDrf0knEZZEo",
+          "payment_method": "pm_1Tds71IBOqvOFDrffZHIthII",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 10000,
+              "authorization_code": "998678",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 6,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 10000,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKKmt-9AGMgYiEhLgWoc6LBZi7lCJrORsEWXQeWkvT5xpjegVdtWOgQfM0tb2m-asJcL_iBp25U51ehuP",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar953e8f1b2",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "28"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_NPy43XrkUdT9j4","request_duration_ms":318}}'
+      Idempotency-Key:
+      - f06d2e8d-d29e-4363-8b60-50de37c0d482
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel Version 24.6.0: Mon
+        Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041 arm64","hostname":"Ershads-MacBook-Pro-office.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 02 Jun 2026 13:12:09 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK;
+        report-to csp
+      Idempotency-Key:
+      - f06d2e8d-d29e-4363-8b60-50de37c0d482
+      Original-Request:
+      - req_BkyOwgYmdydW1Z
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"
+      Request-Id:
+      - req_BkyOwgYmdydW1Z
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-04-22.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1Tds73IBOqvOFDrf2Yex8ixY",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 6,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1780405929,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1Tds73IBOqvOFDrf2Yex8ixY
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_BkyOwgYmdydW1Z","request_duration_ms":203}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel Version 24.6.0: Mon
+        Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041 arm64","hostname":"Ershads-MacBook-Pro-office.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 02 Jun 2026 13:12:10 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"
+      Request-Id:
+      - req_uhWqg2K0MM6fBt
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-04-22.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1Tds73IBOqvOFDrf2Yex8ixY",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 6,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1780405929,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.sandbox.taxjar.com/v2/taxes
+    body:
+      encoding: UTF-8
+      string: '{"from_country":"US","from_state":"CA","from_zip":"94104","to_country":"US","to_state":"WA","to_zip":"98612","shipping":0.0,"line_items":[{"quantity":1,"unit_price":100.0,"discount":0,"product_tax_code":"31000"}],"nexus_addresses":[{"country":"US","state":"WA"}]}'
+    headers:
+      User-Agent:
+      - 'TaxJar/Ruby (Darwin Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel
+        Version 24.6.0: Mon Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041
+        arm64; ruby 3.4.3-p32; OpenSSL 3.6.2 7 Apr 2026) taxjar-ruby/3.0.4'
+      Authorization:
+      - Bearer <TAXJAR_API_KEY>
+      X-Api-Version:
+      - '2022-01-24'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+      Host:
+      - api.sandbox.taxjar.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1470'
+      Connection:
+      - close
+      Date:
+      - Tue, 02 Jun 2026 13:12:10 GMT
+      X-Amzn-Trace-Id:
+      - Root=1-6a1ed6aa-1f4f1c05732e06a8219ad4db
+      X-Amzn-Requestid:
+      - d4de3f1d-85e6-4d82-8b6b-bcca527fd089
+      Access-Control-Allow-Origin:
+      - https://developers.taxjar.com
+      X-Amz-Apigw-Id:
+      - eVZ6rHSkIAMETPQ=
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 a00c6c8eb0312a56ca49e4663e1ea3d4.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - JFK50-P9
+      X-Amz-Cf-Id:
+      - beOR60HCI-nnztmkMWlVcpCGqhRTfGrMiqvHDpIkH_7FZv0Vgtl8ow==
+    body:
+      encoding: UTF-8
+      string: '{"tax":{"rate":0.078,"freight_taxable":true,"tax_source":"destination","shipping":0.0,"taxable_amount":100.0,"jurisdictions":{"state":"WA","city":"CATHLAMET","country":"US","county":"WAHKIAKUM"},"breakdown":{"line_items":[{"id":"1","tax_collectable":7.8,"taxable_amount":100.0,"combined_tax_rate":0.078,"state_taxable_amount":100.0,"county_taxable_amount":100.0,"city_taxable_amount":100.0,"special_district_taxable_amount":0.0,"city_tax_rate":0.01,"county_tax_rate":0.003,"special_tax_rate":0.0,"special_district_amount":0.0,"city_amount":1.0,"county_amount":0.3,"state_amount":6.5,"state_sales_tax_rate":0.065}],"shipping":{"tax_collectable":0.0,"taxable_amount":0.0,"combined_tax_rate":0.078,"state_taxable_amount":0.0,"county_taxable_amount":0.0,"city_taxable_amount":0.0,"city_tax_rate":0.01,"county_tax_rate":0.003,"special_tax_rate":0.0,"special_district_amount":0.0,"special_taxable_amount":0.0,"city_amount":0.0,"county_amount":0.0,"state_amount":0.0,"state_sales_tax_rate":0.065},"tax_collectable":7.8,"taxable_amount":100.0,"combined_tax_rate":0.078,"state_taxable_amount":100.0,"state_tax_collectable":6.5,"county_taxable_amount":100.0,"county_tax_collectable":0.3,"city_taxable_amount":100.0,"city_tax_collectable":1.0,"special_district_taxable_amount":0.0,"special_district_tax_collectable":0.0,"city_tax_rate":0.01,"county_tax_rate":0.003,"special_tax_rate":0.0,"state_tax_rate":0.065},"has_nexus":true,"amount_to_collect":7.8,"order_total_amount":100.0}}'
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=10780&currency=usd&description=You+bought+http%3A%2F%2Fedgar953e8f1b2.test.gumroad.com%3A31337%2Fl%2Fd%21&metadata[purchase]=wIfssDxlK0ZKxrUDzkea2g%3D%3D&transfer_group=29&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1Tds73IBOqvOFDrf2Yex8ixY&statement_descriptor_suffix=edgar953e8f1b2
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_uhWqg2K0MM6fBt","request_duration_ms":443}}'
+      Idempotency-Key:
+      - 595841b2-bd0b-4bfe-a8aa-3195faeee77d
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel Version 24.6.0: Mon
+        Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041 arm64","hostname":"Ershads-MacBook-Pro-office.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 02 Jun 2026 13:12:11 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1640'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK;
+        report-to csp
+      Idempotency-Key:
+      - 595841b2-bd0b-4bfe-a8aa-3195faeee77d
+      Original-Request:
+      - req_KL2STlewrklM9v
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"
+      Request-Id:
+      - req_KL2STlewrklM9v
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-04-22.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3Tds74IBOqvOFDrf12bQ60mj",
+          "object": "payment_intent",
+          "amount": 10780,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 10780,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3Tds74IBOqvOFDrf12bQ60mj_secret_rcBZHCyvUaXW2ldkDmIrPVvWV",
+          "confirmation_method": "automatic",
+          "created": 1780405930,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgar953e8f1b2.test.gumroad.com:31337/l/d!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3Tds74IBOqvOFDrf1YAjCWTG",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "wIfssDxlK0ZKxrUDzkea2g=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1Tds73IBOqvOFDrf2Yex8ixY",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar953e8f1b2",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "29"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3Tds74IBOqvOFDrf1YAjCWTG?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_KL2STlewrklM9v","request_duration_ms":961}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel Version 24.6.0: Mon
+        Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041 arm64","hostname":"Ershads-MacBook-Pro-office.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 02 Jun 2026 13:12:11 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3804'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"
+      Request-Id:
+      - req_eCgx9ZoCJIBLGR
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-04-22.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3Tds74IBOqvOFDrf1YAjCWTG",
+          "object": "charge",
+          "amount": 10780,
+          "amount_captured": 10780,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3Tds74IBOqvOFDrf1KUb9C4b",
+            "object": "balance_transaction",
+            "amount": 10780,
+            "available_on": 1780963200,
+            "balance_type": "payments",
+            "created": 1780405930,
+            "currency": "usd",
+            "description": "You bought http://edgar953e8f1b2.test.gumroad.com:31337/l/d!",
+            "exchange_rate": null,
+            "fee": 343,
+            "fee_details": [
+              {
+                "amount": 343,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 10437,
+            "reporting_category": "charge",
+            "source": "ch_3Tds74IBOqvOFDrf1YAjCWTG",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR953E8F1B2",
+          "captured": true,
+          "created": 1780405930,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar953e8f1b2.test.gumroad.com:31337/l/d!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "wIfssDxlK0ZKxrUDzkea2g=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 24,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3Tds74IBOqvOFDrf12bQ60mj",
+          "payment_method": "pm_1Tds73IBOqvOFDrf2Yex8ixY",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 10780,
+              "authorization_code": "933680",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 6,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 10780,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKKut-9AGMgbNGBbhVTM6LBbquqwUveDEgSQUquc3ZotViVBoFGD9egOE5O7fYVZkAs_UigIgeyfRuZA_",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar953e8f1b2",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "29"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_eCgx9ZoCJIBLGR","request_duration_ms":398}}'
+      Idempotency-Key:
+      - c18e21f9-8627-4fe8-b95b-1d145ffb7ded
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel Version 24.6.0: Mon
+        Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041 arm64","hostname":"Ershads-MacBook-Pro-office.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 02 Jun 2026 13:12:12 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK;
+        report-to csp
+      Idempotency-Key:
+      - c18e21f9-8627-4fe8-b95b-1d145ffb7ded
+      Original-Request:
+      - req_j9dUsUr04RKKfH
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"
+      Request-Id:
+      - req_j9dUsUr04RKKfH
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-04-22.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1Tds75IBOqvOFDrfDidqcvq5",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 6,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1780405932,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1Tds75IBOqvOFDrfDidqcvq5
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_j9dUsUr04RKKfH","request_duration_ms":235}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel Version 24.6.0: Mon
+        Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041 arm64","hostname":"Ershads-MacBook-Pro-office.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 02 Jun 2026 13:12:12 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"
+      Request-Id:
+      - req_NO7Eg8JfM0KLdt
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-04-22.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1Tds75IBOqvOFDrfDidqcvq5",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 6,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1780405932,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.sandbox.taxjar.com/v2/taxes
+    body:
+      encoding: UTF-8
+      string: '{"from_country":"US","from_state":"CA","from_zip":"94104","to_country":"US","to_state":"PA","to_zip":"19464","shipping":0.0,"line_items":[{"quantity":1,"unit_price":100.0,"discount":0,"product_tax_code":"31000"}],"nexus_addresses":[{"country":"US","state":"PA"}]}'
+    headers:
+      User-Agent:
+      - 'TaxJar/Ruby (Darwin Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel
+        Version 24.6.0: Mon Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041
+        arm64; ruby 3.4.3-p32; OpenSSL 3.6.2 7 Apr 2026) taxjar-ruby/3.0.4'
+      Authorization:
+      - Bearer <TAXJAR_API_KEY>
+      X-Api-Version:
+      - '2022-01-24'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+      Host:
+      - api.sandbox.taxjar.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1437'
+      Connection:
+      - close
+      Date:
+      - Tue, 02 Jun 2026 13:12:12 GMT
+      X-Amzn-Trace-Id:
+      - Root=1-6a1ed6ac-750f0b2079f3130c4b4370fb
+      X-Amzn-Requestid:
+      - bbc1f344-f8ab-433e-bb38-94eec273b8a3
+      Access-Control-Allow-Origin:
+      - https://developers.taxjar.com
+      X-Amz-Apigw-Id:
+      - eVZ7AFBPIAMEkcw=
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 35f02b3211065bf08280b7b1b4bbd0ce.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - JFK50-P9
+      X-Amz-Cf-Id:
+      - TapKpvhLp4oJN2sThnEutGNCRIPVV_O-a0HMRMYgPQahWDwO9algGQ==
+    body:
+      encoding: UTF-8
+      string: '{"tax":{"rate":0.06,"freight_taxable":true,"tax_source":"origin","shipping":0.0,"taxable_amount":100.0,"jurisdictions":{"state":"PA","city":"POTTSTOWN","country":"US","county":"BERKS"},"breakdown":{"line_items":[{"id":"1","tax_collectable":6.0,"taxable_amount":100.0,"combined_tax_rate":0.06,"special_district_amount":0.0,"special_tax_rate":0.0,"state_taxable_amount":100.0,"county_taxable_amount":0.0,"city_taxable_amount":0.0,"special_district_taxable_amount":0.0,"city_tax_rate":0.0,"county_tax_rate":0.0,"city_amount":0.0,"county_amount":0.0,"state_amount":6.0,"state_sales_tax_rate":0.06}],"shipping":{"tax_collectable":0.0,"taxable_amount":0.0,"combined_tax_rate":0.06,"special_district_amount":0.0,"special_tax_rate":0.0,"special_taxable_amount":0.0,"state_taxable_amount":0.0,"county_taxable_amount":0.0,"city_taxable_amount":0.0,"city_tax_rate":0.0,"county_tax_rate":0.0,"city_amount":0.0,"county_amount":0.0,"state_amount":0.0,"state_sales_tax_rate":0.06},"tax_collectable":6.0,"taxable_amount":100.0,"combined_tax_rate":0.06,"special_tax_rate":0.0,"state_taxable_amount":100.0,"state_tax_collectable":6.0,"county_taxable_amount":0.0,"county_tax_collectable":0.0,"city_taxable_amount":0.0,"city_tax_collectable":0.0,"special_district_taxable_amount":0.0,"special_district_tax_collectable":0.0,"city_tax_rate":0.0,"county_tax_rate":0.0,"state_tax_rate":0.06},"has_nexus":true,"amount_to_collect":6.0,"order_total_amount":100.0}}'
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=10600&currency=usd&description=You+bought+http%3A%2F%2Fedgar953e8f1b2.test.gumroad.com%3A31337%2Fl%2Fd%21&metadata[purchase]=HypNI43kvmE-ZOitENgCDw%3D%3D&transfer_group=30&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1Tds75IBOqvOFDrfDidqcvq5&statement_descriptor_suffix=edgar953e8f1b2
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_NO7Eg8JfM0KLdt","request_duration_ms":178}}'
+      Idempotency-Key:
+      - 3f09638f-badc-4c85-8f14-d5e9fb810b2d
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel Version 24.6.0: Mon
+        Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041 arm64","hostname":"Ershads-MacBook-Pro-office.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 02 Jun 2026 13:12:13 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1640'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK;
+        report-to csp
+      Idempotency-Key:
+      - 3f09638f-badc-4c85-8f14-d5e9fb810b2d
+      Original-Request:
+      - req_aORtZirAk3odRT
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"
+      Request-Id:
+      - req_aORtZirAk3odRT
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-04-22.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3Tds76IBOqvOFDrf0EK5ArAy",
+          "object": "payment_intent",
+          "amount": 10600,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 10600,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3Tds76IBOqvOFDrf0EK5ArAy_secret_zvIigoPqTlkivGzz01ENxtKtQ",
+          "confirmation_method": "automatic",
+          "created": 1780405932,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgar953e8f1b2.test.gumroad.com:31337/l/d!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3Tds76IBOqvOFDrf0rV89X4H",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "HypNI43kvmE-ZOitENgCDw=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1Tds75IBOqvOFDrfDidqcvq5",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar953e8f1b2",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "30"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3Tds76IBOqvOFDrf0rV89X4H?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_aORtZirAk3odRT","request_duration_ms":970}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel Version 24.6.0: Mon
+        Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041 arm64","hostname":"Ershads-MacBook-Pro-office.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 02 Jun 2026 13:12:13 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3804'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"
+      Request-Id:
+      - req_atS1ttsXx1Tv5K
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-04-22.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3Tds76IBOqvOFDrf0rV89X4H",
+          "object": "charge",
+          "amount": 10600,
+          "amount_captured": 10600,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3Tds76IBOqvOFDrf0dPOpqps",
+            "object": "balance_transaction",
+            "amount": 10600,
+            "available_on": 1780963200,
+            "balance_type": "payments",
+            "created": 1780405932,
+            "currency": "usd",
+            "description": "You bought http://edgar953e8f1b2.test.gumroad.com:31337/l/d!",
+            "exchange_rate": null,
+            "fee": 337,
+            "fee_details": [
+              {
+                "amount": 337,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 10263,
+            "reporting_category": "charge",
+            "source": "ch_3Tds76IBOqvOFDrf0rV89X4H",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR953E8F1B2",
+          "captured": true,
+          "created": 1780405932,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar953e8f1b2.test.gumroad.com:31337/l/d!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "HypNI43kvmE-ZOitENgCDw=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 17,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3Tds76IBOqvOFDrf0EK5ArAy",
+          "payment_method": "pm_1Tds75IBOqvOFDrfDidqcvq5",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 10600,
+              "authorization_code": "917543",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 6,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 10600,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKK2t-9AGMgaH26TozFc6LBZ18-RNbFXIDwcBs-8tpM5rjcJ7pZHrN5FY_0xxBVrIwhCd2fw5-QgDcOOx",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar953e8f1b2",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "30"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_atS1ttsXx1Tv5K","request_duration_ms":409}}'
+      Idempotency-Key:
+      - 96c870b8-3678-4f03-9193-a9977ecee9fb
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel Version 24.6.0: Mon
+        Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041 arm64","hostname":"Ershads-MacBook-Pro-office.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 02 Jun 2026 13:12:14 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK;
+        report-to csp
+      Idempotency-Key:
+      - 96c870b8-3678-4f03-9193-a9977ecee9fb
+      Original-Request:
+      - req_fY5t8RqWmapKyP
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"
+      Request-Id:
+      - req_fY5t8RqWmapKyP
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-04-22.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1Tds78IBOqvOFDrf5yT7dQLq",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 6,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1780405934,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1Tds78IBOqvOFDrf5yT7dQLq
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_fY5t8RqWmapKyP","request_duration_ms":200}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel Version 24.6.0: Mon
+        Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041 arm64","hostname":"Ershads-MacBook-Pro-office.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 02 Jun 2026 13:12:14 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"
+      Request-Id:
+      - req_cXLi29u97FRdgd
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-04-22.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1Tds78IBOqvOFDrf5yT7dQLq",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 6,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1780405934,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.sandbox.taxjar.com/v2/taxes
+    body:
+      encoding: UTF-8
+      string: '{"from_country":"US","from_state":"CA","from_zip":"94104","to_country":"US","to_state":"WA","to_zip":"98121","shipping":0.0,"line_items":[{"quantity":3,"unit_price":100.0,"discount":0,"product_tax_code":"31000"}],"nexus_addresses":[{"country":"US","state":"WA"}]}'
+    headers:
+      User-Agent:
+      - 'TaxJar/Ruby (Darwin Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel
+        Version 24.6.0: Mon Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041
+        arm64; ruby 3.4.3-p32; OpenSSL 3.6.2 7 Apr 2026) taxjar-ruby/3.0.4'
+      Authorization:
+      - Bearer <TAXJAR_API_KEY>
+      X-Api-Version:
+      - '2022-01-24'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+      Host:
+      - api.sandbox.taxjar.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1493'
+      Connection:
+      - close
+      Date:
+      - Tue, 02 Jun 2026 13:12:14 GMT
+      X-Amzn-Trace-Id:
+      - Root=1-6a1ed6ae-01f0eb977a61614436ff9856
+      X-Amzn-Requestid:
+      - cc19d965-fdb6-40ae-82d0-efcbbd63422f
+      Access-Control-Allow-Origin:
+      - https://developers.taxjar.com
+      X-Amz-Apigw-Id:
+      - eVZ7VEeJoAMEMag=
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 4405d33bb955e52261d91331153980de.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - JFK50-P9
+      X-Amz-Cf-Id:
+      - MPo-MUiDAP9HRCbL9rWqU0hrIcFSdRp29enYNudlB-FI4iHtmvf6Sw==
+    body:
+      encoding: UTF-8
+      string: '{"tax":{"rate":0.1055,"freight_taxable":true,"tax_source":"destination","shipping":0.0,"taxable_amount":300.0,"jurisdictions":{"state":"WA","city":"SEATTLE","country":"US","county":"KING"},"breakdown":{"line_items":[{"id":"1","tax_collectable":31.65,"taxable_amount":300.0,"combined_tax_rate":0.1055,"state_taxable_amount":300.0,"county_taxable_amount":300.0,"city_taxable_amount":300.0,"special_district_taxable_amount":300.0,"city_tax_rate":0.0125,"county_tax_rate":0.005,"special_tax_rate":0.023,"special_district_amount":6.9,"city_amount":3.75,"county_amount":1.5,"state_amount":19.5,"state_sales_tax_rate":0.065}],"shipping":{"tax_collectable":0.0,"taxable_amount":0.0,"combined_tax_rate":0.1055,"state_taxable_amount":0.0,"county_taxable_amount":0.0,"city_taxable_amount":0.0,"city_tax_rate":0.0125,"county_tax_rate":0.005,"special_tax_rate":0.023,"special_district_amount":0.0,"special_taxable_amount":0.0,"city_amount":0.0,"county_amount":0.0,"state_amount":0.0,"state_sales_tax_rate":0.065},"tax_collectable":31.65,"taxable_amount":300.0,"combined_tax_rate":0.1055,"state_taxable_amount":300.0,"state_tax_collectable":19.5,"county_taxable_amount":300.0,"county_tax_collectable":1.5,"city_taxable_amount":300.0,"city_tax_collectable":3.75,"special_district_taxable_amount":300.0,"special_district_tax_collectable":6.9,"city_tax_rate":0.0125,"county_tax_rate":0.005,"special_tax_rate":0.023,"state_tax_rate":0.065},"has_nexus":true,"amount_to_collect":31.65,"order_total_amount":300.0}}'
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=33165&currency=usd&description=You+bought+http%3A%2F%2Fedgar953e8f1b2.test.gumroad.com%3A31337%2Fl%2Fd%21&metadata[purchase]=8X5YAI7PSmVbyj0eTlwrpg%3D%3D&transfer_group=31&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1Tds78IBOqvOFDrf5yT7dQLq&statement_descriptor_suffix=edgar953e8f1b2
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_cXLi29u97FRdgd","request_duration_ms":204}}'
+      Idempotency-Key:
+      - b1698e78-9ff3-4781-a99d-14d434a3ba94
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel Version 24.6.0: Mon
+        Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041 arm64","hostname":"Ershads-MacBook-Pro-office.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 02 Jun 2026 13:12:15 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1640'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK;
+        report-to csp
+      Idempotency-Key:
+      - b1698e78-9ff3-4781-a99d-14d434a3ba94
+      Original-Request:
+      - req_rjqj22xdx5UZMj
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"
+      Request-Id:
+      - req_rjqj22xdx5UZMj
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-04-22.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3Tds78IBOqvOFDrf0wMHwdf6",
+          "object": "payment_intent",
+          "amount": 33165,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 33165,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3Tds78IBOqvOFDrf0wMHwdf6_secret_jywd2cu305BxKGkP0M7eWo1Yf",
+          "confirmation_method": "automatic",
+          "created": 1780405934,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgar953e8f1b2.test.gumroad.com:31337/l/d!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3Tds78IBOqvOFDrf0OH1JJqH",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "8X5YAI7PSmVbyj0eTlwrpg=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1Tds78IBOqvOFDrf5yT7dQLq",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar953e8f1b2",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "31"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3Tds78IBOqvOFDrf0OH1JJqH?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_rjqj22xdx5UZMj","request_duration_ms":980}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel Version 24.6.0: Mon
+        Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041 arm64","hostname":"Ershads-MacBook-Pro-office.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 02 Jun 2026 13:12:15 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3804'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"
+      Request-Id:
+      - req_4hSDwaB0kyBp0Z
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-04-22.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3Tds78IBOqvOFDrf0OH1JJqH",
+          "object": "charge",
+          "amount": 33165,
+          "amount_captured": 33165,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3Tds78IBOqvOFDrf076XXyNT",
+            "object": "balance_transaction",
+            "amount": 33165,
+            "available_on": 1780963200,
+            "balance_type": "payments",
+            "created": 1780405934,
+            "currency": "usd",
+            "description": "You bought http://edgar953e8f1b2.test.gumroad.com:31337/l/d!",
+            "exchange_rate": null,
+            "fee": 992,
+            "fee_details": [
+              {
+                "amount": 992,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 32173,
+            "reporting_category": "charge",
+            "source": "ch_3Tds78IBOqvOFDrf0OH1JJqH",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR953E8F1B2",
+          "captured": true,
+          "created": 1780405934,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar953e8f1b2.test.gumroad.com:31337/l/d!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "8X5YAI7PSmVbyj0eTlwrpg=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 22,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3Tds78IBOqvOFDrf0wMHwdf6",
+          "payment_method": "pm_1Tds78IBOqvOFDrf5yT7dQLq",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 33165,
+              "authorization_code": "443743",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 6,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 33165,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKK-t-9AGMgYbYicemdc6LBbXRF8Z4xL_AgG-nV12Bws8h3OqjiKTsM03DKVEVgJGDG5ApFlt1kWhEnFz",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar953e8f1b2",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "31"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_4hSDwaB0kyBp0Z","request_duration_ms":332}}'
+      Idempotency-Key:
+      - bb3679bc-a0be-47ad-b1b1-677def09c7b2
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel Version 24.6.0: Mon
+        Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041 arm64","hostname":"Ershads-MacBook-Pro-office.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 02 Jun 2026 13:12:16 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK;
+        report-to csp
+      Idempotency-Key:
+      - bb3679bc-a0be-47ad-b1b1-677def09c7b2
+      Original-Request:
+      - req_DZBD2gYHXeLMt2
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"
+      Request-Id:
+      - req_DZBD2gYHXeLMt2
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-04-22.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1Tds7AIBOqvOFDrft3Grn6Jo",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 6,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1780405936,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1Tds7AIBOqvOFDrft3Grn6Jo
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_DZBD2gYHXeLMt2","request_duration_ms":257}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel Version 24.6.0: Mon
+        Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041 arm64","hostname":"Ershads-MacBook-Pro-office.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 02 Jun 2026 13:12:16 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"
+      Request-Id:
+      - req_GuM3LnCCWofn7F
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-04-22.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1Tds7AIBOqvOFDrft3Grn6Jo",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 6,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1780405936,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.sandbox.taxjar.com/v2/taxes
+    body:
+      encoding: UTF-8
+      string: '{"from_country":"US","from_state":"CA","from_zip":"94104","to_country":"US","to_state":"WI","to_zip":"53202","shipping":0.0,"line_items":[{"quantity":1,"unit_price":100.0,"discount":0,"product_tax_code":"31000"}],"nexus_addresses":[{"country":"US","state":"WI"}]}'
+    headers:
+      User-Agent:
+      - 'TaxJar/Ruby (Darwin Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel
+        Version 24.6.0: Mon Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041
+        arm64; ruby 3.4.3-p32; OpenSSL 3.6.2 7 Apr 2026) taxjar-ruby/3.0.4'
+      Authorization:
+      - Bearer <TAXJAR_API_KEY>
+      X-Api-Version:
+      - '2022-01-24'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+      Host:
+      - api.sandbox.taxjar.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1474'
+      Connection:
+      - close
+      Date:
+      - Tue, 02 Jun 2026 13:12:16 GMT
+      X-Amzn-Trace-Id:
+      - Root=1-6a1ed6b0-76d45b5049bcef1066f84b13
+      X-Amzn-Requestid:
+      - ff6ee03a-0ed5-4ab5-acc0-a2869f716c48
+      Access-Control-Allow-Origin:
+      - https://developers.taxjar.com
+      X-Amz-Apigw-Id:
+      - eVZ7pEw4IAMEIaw=
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 f945e6d653577aeade801c7da9322cba.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - JFK50-P9
+      X-Amz-Cf-Id:
+      - 6CX-hVB0W1OIHBg2UIyES2EQeSEy4MmnydveX4--dtGOrWUJ6wjuyA==
+    body:
+      encoding: UTF-8
+      string: '{"tax":{"rate":0.079,"freight_taxable":true,"tax_source":"destination","shipping":0.0,"taxable_amount":100.0,"jurisdictions":{"state":"WI","city":"MILWAUKEE","country":"US","county":"MILWAUKEE
+        COUNTY"},"breakdown":{"line_items":[{"id":"1","tax_collectable":7.9,"taxable_amount":100.0,"combined_tax_rate":0.079,"special_district_amount":0.0,"special_tax_rate":0.0,"state_taxable_amount":100.0,"county_taxable_amount":100.0,"city_taxable_amount":100.0,"special_district_taxable_amount":0.0,"city_tax_rate":0.02,"county_tax_rate":0.009,"city_amount":2.0,"county_amount":0.9,"state_amount":5.0,"state_sales_tax_rate":0.05}],"shipping":{"tax_collectable":0.0,"taxable_amount":0.0,"combined_tax_rate":0.079,"special_district_amount":0.0,"special_tax_rate":0.0,"special_taxable_amount":0.0,"state_taxable_amount":0.0,"county_taxable_amount":0.0,"city_taxable_amount":0.0,"city_tax_rate":0.02,"county_tax_rate":0.009,"city_amount":0.0,"county_amount":0.0,"state_amount":0.0,"state_sales_tax_rate":0.05},"tax_collectable":7.9,"taxable_amount":100.0,"combined_tax_rate":0.079,"special_tax_rate":0.0,"state_taxable_amount":100.0,"state_tax_collectable":5.0,"county_taxable_amount":100.0,"county_tax_collectable":0.9,"city_taxable_amount":100.0,"city_tax_collectable":2.0,"special_district_taxable_amount":0.0,"special_district_tax_collectable":0.0,"city_tax_rate":0.02,"county_tax_rate":0.009,"state_tax_rate":0.05},"has_nexus":true,"amount_to_collect":7.9,"order_total_amount":100.0}}'
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=10790&currency=usd&description=You+bought+http%3A%2F%2Fedgar953e8f1b2.test.gumroad.com%3A31337%2Fl%2Fd%21&metadata[purchase]=uQx2kx9_lhwvd_0G1RmdkQ%3D%3D&transfer_group=32&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1Tds7AIBOqvOFDrft3Grn6Jo&statement_descriptor_suffix=edgar953e8f1b2
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_GuM3LnCCWofn7F","request_duration_ms":187}}'
+      Idempotency-Key:
+      - 4000f07c-6dd9-475b-b767-e3aeb44e67e8
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel Version 24.6.0: Mon
+        Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041 arm64","hostname":"Ershads-MacBook-Pro-office.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 02 Jun 2026 13:12:17 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1640'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK;
+        report-to csp
+      Idempotency-Key:
+      - 4000f07c-6dd9-475b-b767-e3aeb44e67e8
+      Original-Request:
+      - req_P6SVlZULwaUX1b
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"
+      Request-Id:
+      - req_P6SVlZULwaUX1b
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-04-22.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3Tds7AIBOqvOFDrf1uagmbB6",
+          "object": "payment_intent",
+          "amount": 10790,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 10790,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3Tds7AIBOqvOFDrf1uagmbB6_secret_4BTMcSscRhn8JL1XuohqUsDsb",
+          "confirmation_method": "automatic",
+          "created": 1780405936,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgar953e8f1b2.test.gumroad.com:31337/l/d!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3Tds7AIBOqvOFDrf1U6HpatA",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "uQx2kx9_lhwvd_0G1RmdkQ=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1Tds7AIBOqvOFDrft3Grn6Jo",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar953e8f1b2",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "32"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3Tds7AIBOqvOFDrf1U6HpatA?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_P6SVlZULwaUX1b","request_duration_ms":1178}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel Version 24.6.0: Mon
+        Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041 arm64","hostname":"Ershads-MacBook-Pro-office.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 02 Jun 2026 13:12:18 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3803'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"
+      Request-Id:
+      - req_mwNIO3O3dxdbLq
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-04-22.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3Tds7AIBOqvOFDrf1U6HpatA",
+          "object": "charge",
+          "amount": 10790,
+          "amount_captured": 10790,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3Tds7AIBOqvOFDrf1ne4NsnO",
+            "object": "balance_transaction",
+            "amount": 10790,
+            "available_on": 1780963200,
+            "balance_type": "payments",
+            "created": 1780405936,
+            "currency": "usd",
+            "description": "You bought http://edgar953e8f1b2.test.gumroad.com:31337/l/d!",
+            "exchange_rate": null,
+            "fee": 343,
+            "fee_details": [
+              {
+                "amount": 343,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 10447,
+            "reporting_category": "charge",
+            "source": "ch_3Tds7AIBOqvOFDrf1U6HpatA",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR953E8F1B2",
+          "captured": true,
+          "created": 1780405936,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar953e8f1b2.test.gumroad.com:31337/l/d!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "uQx2kx9_lhwvd_0G1RmdkQ=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 7,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3Tds7AIBOqvOFDrf1uagmbB6",
+          "payment_method": "pm_1Tds7AIBOqvOFDrft3Grn6Jo",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 10790,
+              "authorization_code": "506165",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 6,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 10790,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKLKt-9AGMgajew6A6CA6LBZJA5W9sevBKVUB5Exe81673TgZesKUe-pDtBX5NaPwGDcufr5ySsge7hmA",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar953e8f1b2",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "32"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_mwNIO3O3dxdbLq","request_duration_ms":326}}'
+      Idempotency-Key:
+      - 0011ecc2-e73e-41ed-afd6-ddcedc20e6c4
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel Version 24.6.0: Mon
+        Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041 arm64","hostname":"Ershads-MacBook-Pro-office.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 02 Jun 2026 13:12:18 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK;
+        report-to csp
+      Idempotency-Key:
+      - 0011ecc2-e73e-41ed-afd6-ddcedc20e6c4
+      Original-Request:
+      - req_kzs5rTyr8OePmG
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"
+      Request-Id:
+      - req_kzs5rTyr8OePmG
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-04-22.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1Tds7CIBOqvOFDrffnq8PicW",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 6,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1780405938,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1Tds7CIBOqvOFDrffnq8PicW
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_kzs5rTyr8OePmG","request_duration_ms":248}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel Version 24.6.0: Mon
+        Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041 arm64","hostname":"Ershads-MacBook-Pro-office.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 02 Jun 2026 13:12:18 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"
+      Request-Id:
+      - req_mNvz3sVc0ydhIL
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-04-22.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1Tds7CIBOqvOFDrffnq8PicW",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 6,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1780405938,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.sandbox.taxjar.com/v2/taxes
+    body:
+      encoding: UTF-8
+      string: '{"from_country":"US","from_state":"CA","from_zip":"94104","to_country":"US","to_state":"WA","to_zip":"98604","shipping":0.0,"line_items":[{"quantity":1,"unit_price":100.0,"discount":0,"product_tax_code":"31000"}],"nexus_addresses":[{"country":"US","state":"WA"}]}'
+    headers:
+      User-Agent:
+      - 'TaxJar/Ruby (Darwin Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel
+        Version 24.6.0: Mon Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041
+        arm64; ruby 3.4.3-p32; OpenSSL 3.6.2 7 Apr 2026) taxjar-ruby/3.0.4'
+      Authorization:
+      - Bearer <TAXJAR_API_KEY>
+      X-Api-Version:
+      - '2022-01-24'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+      Host:
+      - api.sandbox.taxjar.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1483'
+      Connection:
+      - close
+      Date:
+      - Tue, 02 Jun 2026 13:12:18 GMT
+      X-Amzn-Trace-Id:
+      - Root=1-6a1ed6b2-795289a84eb860a1434744e8
+      X-Amzn-Requestid:
+      - 0527c527-116c-4835-901a-574db0650d88
+      Access-Control-Allow-Origin:
+      - https://developers.taxjar.com
+      X-Amz-Apigw-Id:
+      - eVZ7_GUioAMEvuw=
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 35f02b3211065bf08280b7b1b4bbd0ce.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - JFK50-P9
+      X-Amz-Cf-Id:
+      - uNuTno09JdNdIY8B3LfhaDqMLERDPuOU5MfrP1eA25QT1v2QMwloGw==
+    body:
+      encoding: UTF-8
+      string: '{"tax":{"rate":0.089,"freight_taxable":true,"tax_source":"destination","shipping":0.0,"taxable_amount":100.0,"jurisdictions":{"state":"WA","city":"BATTLE
+        GROUND","country":"US","county":"CLARK"},"breakdown":{"line_items":[{"id":"1","tax_collectable":8.9,"taxable_amount":100.0,"combined_tax_rate":0.089,"state_taxable_amount":100.0,"county_taxable_amount":100.0,"city_taxable_amount":100.0,"special_district_taxable_amount":100.0,"city_tax_rate":0.012,"county_tax_rate":0.005,"special_tax_rate":0.007,"special_district_amount":0.7,"city_amount":1.2,"county_amount":0.5,"state_amount":6.5,"state_sales_tax_rate":0.065}],"shipping":{"tax_collectable":0.0,"taxable_amount":0.0,"combined_tax_rate":0.089,"state_taxable_amount":0.0,"county_taxable_amount":0.0,"city_taxable_amount":0.0,"city_tax_rate":0.012,"county_tax_rate":0.005,"special_tax_rate":0.007,"special_district_amount":0.0,"special_taxable_amount":0.0,"city_amount":0.0,"county_amount":0.0,"state_amount":0.0,"state_sales_tax_rate":0.065},"tax_collectable":8.9,"taxable_amount":100.0,"combined_tax_rate":0.089,"state_taxable_amount":100.0,"state_tax_collectable":6.5,"county_taxable_amount":100.0,"county_tax_collectable":0.5,"city_taxable_amount":100.0,"city_tax_collectable":1.2,"special_district_taxable_amount":100.0,"special_district_tax_collectable":0.7,"city_tax_rate":0.012,"county_tax_rate":0.005,"special_tax_rate":0.007,"state_tax_rate":0.065},"has_nexus":true,"amount_to_collect":8.9,"order_total_amount":100.0}}'
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=10890&currency=usd&description=You+bought+http%3A%2F%2Fedgar953e8f1b2.test.gumroad.com%3A31337%2Fl%2Fd%21&metadata[purchase]=sxJWZRv05w6znNnH_mygmg%3D%3D&transfer_group=33&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1Tds7CIBOqvOFDrffnq8PicW&statement_descriptor_suffix=edgar953e8f1b2
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_mNvz3sVc0ydhIL","request_duration_ms":208}}'
+      Idempotency-Key:
+      - f2cee3dc-9053-4853-85b7-cbd3849bf47d
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel Version 24.6.0: Mon
+        Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041 arm64","hostname":"Ershads-MacBook-Pro-office.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 02 Jun 2026 13:12:19 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1640'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK;
+        report-to csp
+      Idempotency-Key:
+      - f2cee3dc-9053-4853-85b7-cbd3849bf47d
+      Original-Request:
+      - req_pmhch6R8ACOcek
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"
+      Request-Id:
+      - req_pmhch6R8ACOcek
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-04-22.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3Tds7CIBOqvOFDrf0A4rjJ3K",
+          "object": "payment_intent",
+          "amount": 10890,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 10890,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3Tds7CIBOqvOFDrf0A4rjJ3K_secret_7Xymcmd1UP9WqCrRek9SiRRGt",
+          "confirmation_method": "automatic",
+          "created": 1780405938,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgar953e8f1b2.test.gumroad.com:31337/l/d!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3Tds7CIBOqvOFDrf0AwhLpU9",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "sxJWZRv05w6znNnH_mygmg=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1Tds7CIBOqvOFDrffnq8PicW",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar953e8f1b2",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "33"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3Tds7CIBOqvOFDrf0AwhLpU9?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_pmhch6R8ACOcek","request_duration_ms":1023}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel Version 24.6.0: Mon
+        Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041 arm64","hostname":"Ershads-MacBook-Pro-office.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 02 Jun 2026 13:12:20 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3804'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=cXra0cvmgHGx5k8h4iFQU_xm5bb7maLezXijOJURHAPbd4cUTlbe04WzdgmisXb7BNXX1Mp32DQpuRkK&t=1"
+      Request-Id:
+      - req_Q3hhmAdaHfURvV
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-04-22.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3Tds7CIBOqvOFDrf0AwhLpU9",
+          "object": "charge",
+          "amount": 10890,
+          "amount_captured": 10890,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3Tds7CIBOqvOFDrf01PAWkBs",
+            "object": "balance_transaction",
+            "amount": 10890,
+            "available_on": 1780963200,
+            "balance_type": "payments",
+            "created": 1780405939,
+            "currency": "usd",
+            "description": "You bought http://edgar953e8f1b2.test.gumroad.com:31337/l/d!",
+            "exchange_rate": null,
+            "fee": 346,
+            "fee_details": [
+              {
+                "amount": 346,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 10544,
+            "reporting_category": "charge",
+            "source": "ch_3Tds7CIBOqvOFDrf0AwhLpU9",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR953E8F1B2",
+          "captured": true,
+          "created": 1780405939,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar953e8f1b2.test.gumroad.com:31337/l/d!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "sxJWZRv05w6znNnH_mygmg=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 24,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3Tds7CIBOqvOFDrf0A4rjJ3K",
+          "payment_method": "pm_1Tds7CIBOqvOFDrffnq8PicW",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 10890,
+              "authorization_code": "393101",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 6,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 10890,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKLOt-9AGMgYGhcedsCo6LBac67P0xC55cO73EYKbBtNiQIsHArjSZTPDTct7YgapTKYJy1x9mYvXwfO0",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar953e8f1b2",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "33"
+        }
+  recorded_at: Wed, 10 Aug 2022 00:00:00 GMT
+- request:
+    method: post
+    uri: https://api.sandbox.taxjar.com/v2/transactions/orders
+    body:
+      encoding: UTF-8
+      string: '{"transaction_id":"PH9MZRiDkh_gD1YVEZY2YA==","transaction_date":"2022-08-10T00:00:00Z","provider":"api","from_country":"US","from_state":"CA","from_zip":"94104","to_country":"US","to_state":"WA","to_zip":"98121","amount":100.0,"shipping":0.0,"sales_tax":10.55,"line_items":[{"quantity":1,"unit_price":100.0,"sales_tax":10.55,"product_tax_code":"31000"}]}'
+    headers:
+      User-Agent:
+      - 'TaxJar/Ruby (Darwin Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel
+        Version 24.6.0: Mon Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041
+        arm64; ruby 3.4.3-p32; OpenSSL 3.6.2 7 Apr 2026) taxjar-ruby/3.0.4'
+      Authorization:
+      - Bearer <TAXJAR_API_KEY>
+      X-Api-Version:
+      - '2022-01-24'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+      Host:
+      - api.sandbox.taxjar.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '605'
+      Connection:
+      - close
+      Date:
+      - Tue, 02 Jun 2026 13:12:20 GMT
+      X-Amzn-Trace-Id:
+      - Root=1-6a1ed6b4-50d969a03144e1756a3a41d9
+      X-Amzn-Requestid:
+      - b9beaf9e-ea4e-4722-9081-d5a22b6c228b
+      X-Amz-Apigw-Id:
+      - eVZ8OGRCIAMEYZA=
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 96514100085c5a3055b3debbca21d95c.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - JFK50-P9
+      X-Amz-Cf-Id:
+      - rj1N2c7oLAFU_uRoRsp3SCVN9m0WW6lBBow6hovNPUlz7aA46c6j8Q==
+    body:
+      encoding: UTF-8
+      string: '{"order":{"transaction_reference_id":null,"to_zip":"98121","to_street":null,"to_state":"WA","to_country":"US","to_city":null,"from_zip":"94104","from_street":null,"from_state":"CA","from_country":"US","from_city":null,"customer_id":null,"transaction_date":"2022-08-10T00:00:00.000Z","exemption_type":null,"shipping":"0.0","line_items":[{"product_identifier":null,"discount":"0.0","unit_price":"100.0","quantity":1,"product_tax_code":"31000","sales_tax":"10.55","description":null,"id":0}],"user_id":126159,"sales_tax":"10.55","provider":"api","transaction_id":"PH9MZRiDkh_gD1YVEZY2YA==","amount":"100.0"}}'
+  recorded_at: Tue, 02 Jun 2026 13:12:20 GMT
+- request:
+    method: post
+    uri: https://api.sandbox.taxjar.com/v2/transactions/orders
+    body:
+      encoding: UTF-8
+      string: '{"transaction_id":"AwEjZNQ0GmyQvPECHqt63g==","transaction_date":"2022-08-10T00:00:00Z","provider":"api","from_country":"US","from_state":"CA","from_zip":"94104","to_country":"US","to_state":"WA","to_zip":"98184","amount":100.0,"shipping":0.0,"sales_tax":0.0,"line_items":[{"quantity":1,"unit_price":100.0,"sales_tax":0.0,"product_tax_code":"31000"}]}'
+    headers:
+      User-Agent:
+      - 'TaxJar/Ruby (Darwin Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel
+        Version 24.6.0: Mon Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041
+        arm64; ruby 3.4.3-p32; OpenSSL 3.6.2 7 Apr 2026) taxjar-ruby/3.0.4'
+      Authorization:
+      - Bearer <TAXJAR_API_KEY>
+      X-Api-Version:
+      - '2022-01-24'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+      Host:
+      - api.sandbox.taxjar.com
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '91'
+      Connection:
+      - close
+      Date:
+      - Tue, 02 Jun 2026 13:12:20 GMT
+      X-Amzn-Trace-Id:
+      - Root=1-6a1ed6b4-3e20194d563b9d7456317a18
+      X-Amzn-Requestid:
+      - 90ac0f59-d5d2-491d-9ce4-27ccf3a57823
+      X-Amz-Apigw-Id:
+      - eVZ8PERyIAMErzQ=
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 038e573b31ba7cbc11f601ef11abb8f6.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - JFK50-P9
+      X-Amz-Cf-Id:
+      - 2vDWpZqBP9Qrw4PpHoCTkS4JrnoQGmE5LXQ-cPEdAP3lTB_UZJfJVA==
+    body:
+      encoding: UTF-8
+      string: '{"detail":"to_zip 98184 is not used within to_state WA","status":400,"error":"Bad
+        Request"}'
+  recorded_at: Tue, 02 Jun 2026 13:12:20 GMT
+- request:
+    method: post
+    uri: https://api.sandbox.taxjar.com/v2/transactions/orders
+    body:
+      encoding: UTF-8
+      string: '{"transaction_id":"wIfssDxlK0ZKxrUDzkea2g==","transaction_date":"2022-08-10T00:00:00Z","provider":"api","from_country":"US","from_state":"CA","from_zip":"94104","to_country":"US","to_state":"WA","to_zip":"98612","amount":100.0,"shipping":0.0,"sales_tax":7.8,"line_items":[{"quantity":1,"unit_price":100.0,"sales_tax":7.8,"product_tax_code":"31000"}]}'
+    headers:
+      User-Agent:
+      - 'TaxJar/Ruby (Darwin Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel
+        Version 24.6.0: Mon Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041
+        arm64; ruby 3.4.3-p32; OpenSSL 3.6.2 7 Apr 2026) taxjar-ruby/3.0.4'
+      Authorization:
+      - Bearer <TAXJAR_API_KEY>
+      X-Api-Version:
+      - '2022-01-24'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+      Host:
+      - api.sandbox.taxjar.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '601'
+      Connection:
+      - close
+      Date:
+      - Tue, 02 Jun 2026 13:12:20 GMT
+      X-Amzn-Trace-Id:
+      - Root=1-6a1ed6b4-53eab5ad2888fbbd2caa0ca6
+      X-Amzn-Requestid:
+      - 33077e9e-2ac7-4564-b42d-7418bbffb468
+      X-Amz-Apigw-Id:
+      - eVZ8QHGboAMEbdA=
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 10ba2918c339c40dc987fef4e0ca1954.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - JFK50-P9
+      X-Amz-Cf-Id:
+      - 81nDdQrLlmoAFKWK3GlHUfSX6olArIUjxAEMcNJoJ5zZO7Y4vweLeg==
+    body:
+      encoding: UTF-8
+      string: '{"order":{"transaction_reference_id":null,"to_zip":"98612","to_street":null,"to_state":"WA","to_country":"US","to_city":null,"from_zip":"94104","from_street":null,"from_state":"CA","from_country":"US","from_city":null,"customer_id":null,"transaction_date":"2022-08-10T00:00:00.000Z","exemption_type":null,"shipping":"0.0","line_items":[{"product_identifier":null,"discount":"0.0","unit_price":"100.0","quantity":1,"product_tax_code":"31000","sales_tax":"7.8","description":null,"id":0}],"user_id":126159,"sales_tax":"7.8","provider":"api","transaction_id":"wIfssDxlK0ZKxrUDzkea2g==","amount":"100.0"}}'
+  recorded_at: Tue, 02 Jun 2026 13:12:20 GMT
+- request:
+    method: post
+    uri: https://api.sandbox.taxjar.com/v2/transactions/orders
+    body:
+      encoding: UTF-8
+      string: '{"transaction_id":"8X5YAI7PSmVbyj0eTlwrpg==","transaction_date":"2022-08-10T00:00:00Z","provider":"api","from_country":"US","from_state":"CA","from_zip":"94104","to_country":"US","to_state":"WA","to_zip":"98121","amount":300.0,"shipping":0.0,"sales_tax":31.65,"line_items":[{"quantity":3,"unit_price":100.0,"sales_tax":31.65,"product_tax_code":"31000"}]}'
+    headers:
+      User-Agent:
+      - 'TaxJar/Ruby (Darwin Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel
+        Version 24.6.0: Mon Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041
+        arm64; ruby 3.4.3-p32; OpenSSL 3.6.2 7 Apr 2026) taxjar-ruby/3.0.4'
+      Authorization:
+      - Bearer <TAXJAR_API_KEY>
+      X-Api-Version:
+      - '2022-01-24'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+      Host:
+      - api.sandbox.taxjar.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '605'
+      Connection:
+      - close
+      Date:
+      - Tue, 02 Jun 2026 13:12:20 GMT
+      X-Amzn-Trace-Id:
+      - Root=1-6a1ed6b4-000a65c479d5378307958368
+      X-Amzn-Requestid:
+      - 1dcf254b-16a6-4c45-bf8c-86245c8f1970
+      X-Amz-Apigw-Id:
+      - eVZ8RFXtIAMEiuQ=
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 35be33ade0277c30a9cd9f9886b7151e.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - JFK50-P9
+      X-Amz-Cf-Id:
+      - JZPRr7b6z-YF94qjoz14TuIzcO7ghoL2kTBKm47AMjpntLQX4SzzYg==
+    body:
+      encoding: UTF-8
+      string: '{"order":{"transaction_reference_id":null,"to_zip":"98121","to_street":null,"to_state":"WA","to_country":"US","to_city":null,"from_zip":"94104","from_street":null,"from_state":"CA","from_country":"US","from_city":null,"customer_id":null,"transaction_date":"2022-08-10T00:00:00.000Z","exemption_type":null,"shipping":"0.0","line_items":[{"product_identifier":null,"discount":"0.0","unit_price":"100.0","quantity":3,"sales_tax":"31.65","product_tax_code":"31000","description":null,"id":0}],"user_id":126159,"sales_tax":"31.65","provider":"api","transaction_id":"8X5YAI7PSmVbyj0eTlwrpg==","amount":"300.0"}}'
+  recorded_at: Tue, 02 Jun 2026 13:12:20 GMT
+- request:
+    method: post
+    uri: https://api.sandbox.taxjar.com/v2/transactions/orders
+    body:
+      encoding: UTF-8
+      string: '{"transaction_id":"sxJWZRv05w6znNnH_mygmg==","transaction_date":"2022-08-10T00:00:00Z","provider":"api","from_country":"US","from_state":"CA","from_zip":"94104","to_country":"US","to_state":"WA","to_zip":"98604","amount":72.17,"shipping":0.0,"sales_tax":6.73,"line_items":[{"quantity":1,"unit_price":72.17,"sales_tax":6.73,"product_tax_code":"31000"}]}'
+    headers:
+      User-Agent:
+      - 'TaxJar/Ruby (Darwin Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel
+        Version 24.6.0: Mon Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041
+        arm64; ruby 3.4.3-p32; OpenSSL 3.6.2 7 Apr 2026) taxjar-ruby/3.0.4'
+      Authorization:
+      - Bearer <TAXJAR_API_KEY>
+      X-Api-Version:
+      - '2022-01-24'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+      Host:
+      - api.sandbox.taxjar.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '603'
+      Connection:
+      - close
+      Date:
+      - Tue, 02 Jun 2026 13:12:20 GMT
+      X-Amzn-Trace-Id:
+      - Root=1-6a1ed6b4-223afc7f7dee194904cc33a9
+      X-Amzn-Requestid:
+      - 21c92476-a4e1-409c-8f3f-c09554640b86
+      X-Amz-Apigw-Id:
+      - eVZ8SG4GIAMEVcw=
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 96514100085c5a3055b3debbca21d95c.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - JFK50-P9
+      X-Amz-Cf-Id:
+      - V0-ra7lFiuCSVoH88ctOKE94paG6ub8JLjP6dy6tTXQ8XI1GicomGw==
+    body:
+      encoding: UTF-8
+      string: '{"order":{"transaction_reference_id":null,"to_zip":"98604","to_street":null,"to_state":"WA","to_country":"US","to_city":null,"from_zip":"94104","from_street":null,"from_state":"CA","from_country":"US","from_city":null,"customer_id":null,"transaction_date":"2022-08-10T00:00:00.000Z","exemption_type":null,"shipping":"0.0","line_items":[{"product_identifier":null,"discount":"0.0","unit_price":"72.17","quantity":1,"product_tax_code":"31000","sales_tax":"6.73","description":null,"id":0}],"user_id":126159,"sales_tax":"6.73","provider":"api","transaction_id":"sxJWZRv05w6znNnH_mygmg==","amount":"72.17"}}'
+  recorded_at: Tue, 02 Jun 2026 13:12:20 GMT
+- request:
+    method: post
+    uri: https://api.sandbox.taxjar.com/v2/transactions/orders
+    body:
+      encoding: UTF-8
+      string: '{"transaction_id":"OMqMgvq2ppgKjkhDH2ofsQ==","transaction_date":"2022-08-10T00:00:00Z","provider":"api","from_country":"US","from_state":"CA","from_zip":"94104","to_country":"US","to_state":"WA","to_zip":"98612","amount":100.0,"shipping":0.0,"sales_tax":6.5,"line_items":[{"quantity":1,"unit_price":100.0,"sales_tax":6.5,"product_tax_code":"31000"}]}'
+    headers:
+      User-Agent:
+      - 'TaxJar/Ruby (Darwin Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel
+        Version 24.6.0: Mon Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041
+        arm64; ruby 3.4.3-p32; OpenSSL 3.6.2 7 Apr 2026) taxjar-ruby/3.0.4'
+      Authorization:
+      - Bearer <TAXJAR_API_KEY>
+      X-Api-Version:
+      - '2022-01-24'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+      Host:
+      - api.sandbox.taxjar.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '601'
+      Connection:
+      - close
+      Date:
+      - Tue, 02 Jun 2026 13:12:20 GMT
+      X-Amzn-Trace-Id:
+      - Root=1-6a1ed6b4-2a414c2b3aba40ac0e3030bc
+      X-Amzn-Requestid:
+      - b6d86a44-85f5-4d7c-a5d6-ed589267b25e
+      X-Amz-Apigw-Id:
+      - eVZ8UHhMoAMELDg=
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 dc7aeefd8f9f1132c56cbdea9095671e.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - JFK50-P9
+      X-Amz-Cf-Id:
+      - oAcbCTbHYBsh4_D1gr9FmVt30zrJUDFIPxeMW1rPUfChKw0KNO9l6g==
+    body:
+      encoding: UTF-8
+      string: '{"order":{"transaction_reference_id":null,"to_zip":"98612","to_street":null,"to_state":"WA","to_country":"US","to_city":null,"from_zip":"94104","from_street":null,"from_state":"CA","from_country":"US","from_city":null,"customer_id":null,"transaction_date":"2022-08-10T00:00:00.000Z","exemption_type":null,"shipping":"0.0","line_items":[{"product_identifier":null,"discount":"0.0","unit_price":"100.0","quantity":1,"product_tax_code":"31000","sales_tax":"6.5","description":null,"id":0}],"user_id":126159,"sales_tax":"6.5","provider":"api","transaction_id":"OMqMgvq2ppgKjkhDH2ofsQ==","amount":"100.0"}}'
+  recorded_at: Tue, 02 Jun 2026 13:12:20 GMT
+- request:
+    method: post
+    uri: https://api.sandbox.taxjar.com/v2/transactions/orders
+    body:
+      encoding: UTF-8
+      string: '{"transaction_id":"OVEhZclDfjf9OENvGvQwGw==","transaction_date":"2022-08-10T00:00:00Z","provider":"api","from_country":"US","from_state":"CA","from_zip":"94104","to_country":"US","to_state":"WI","to_zip":"53703","amount":100.0,"shipping":0.0,"sales_tax":5.5,"line_items":[{"quantity":1,"unit_price":100.0,"sales_tax":5.5,"product_tax_code":"31000"}]}'
+    headers:
+      User-Agent:
+      - 'TaxJar/Ruby (Darwin Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel
+        Version 24.6.0: Mon Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041
+        arm64; ruby 3.4.3-p32; OpenSSL 3.6.2 7 Apr 2026) taxjar-ruby/3.0.4'
+      Authorization:
+      - Bearer <TAXJAR_API_KEY>
+      X-Api-Version:
+      - '2022-01-24'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+      Host:
+      - api.sandbox.taxjar.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '601'
+      Connection:
+      - close
+      Date:
+      - Tue, 02 Jun 2026 13:12:20 GMT
+      X-Amzn-Trace-Id:
+      - Root=1-6a1ed6b4-0b19a7c70a6d79ac65ed6712
+      X-Amzn-Requestid:
+      - 8f882121-605b-4766-94d1-b78f76329c4a
+      X-Amz-Apigw-Id:
+      - eVZ8VEZ1oAMEsmw=
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 e9b24567d1b1c671d2e8099ba5c0bca4.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - JFK50-P9
+      X-Amz-Cf-Id:
+      - IIAOqoHsEi6ikcgG4-B9oBqiV6jTx0Ff2OeMsD2eE62iv9SkHW3hCA==
+    body:
+      encoding: UTF-8
+      string: '{"order":{"transaction_reference_id":null,"to_zip":"53703","to_street":null,"to_state":"WI","to_country":"US","to_city":null,"from_zip":"94104","from_street":null,"from_state":"CA","from_country":"US","from_city":null,"customer_id":null,"transaction_date":"2022-08-10T00:00:00.000Z","exemption_type":null,"shipping":"0.0","line_items":[{"product_identifier":null,"discount":"0.0","unit_price":"100.0","quantity":1,"product_tax_code":"31000","sales_tax":"5.5","description":null,"id":0}],"user_id":126159,"sales_tax":"5.5","provider":"api","transaction_id":"OVEhZclDfjf9OENvGvQwGw==","amount":"100.0"}}'
+  recorded_at: Tue, 02 Jun 2026 13:12:20 GMT
+- request:
+    method: post
+    uri: https://api.sandbox.taxjar.com/v2/transactions/orders
+    body:
+      encoding: UTF-8
+      string: '{"transaction_id":"uQx2kx9_lhwvd_0G1RmdkQ==","transaction_date":"2022-08-10T00:00:00Z","provider":"api","from_country":"US","from_state":"CA","from_zip":"94104","to_country":"US","to_state":"WI","to_zip":"53202","amount":100.0,"shipping":0.0,"sales_tax":7.9,"line_items":[{"quantity":1,"unit_price":100.0,"sales_tax":7.9,"product_tax_code":"31000"}]}'
+    headers:
+      User-Agent:
+      - 'TaxJar/Ruby (Darwin Ershads-MacBook-Pro-office.local 24.6.0 Darwin Kernel
+        Version 24.6.0: Mon Jul 14 11:30:40 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6041
+        arm64; ruby 3.4.3-p32; OpenSSL 3.6.2 7 Apr 2026) taxjar-ruby/3.0.4'
+      Authorization:
+      - Bearer <TAXJAR_API_KEY>
+      X-Api-Version:
+      - '2022-01-24'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+      Host:
+      - api.sandbox.taxjar.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '601'
+      Connection:
+      - close
+      Date:
+      - Tue, 02 Jun 2026 13:12:21 GMT
+      X-Amzn-Trace-Id:
+      - Root=1-6a1ed6b5-6b2dc8cf61ee90e900ebff84
+      X-Amzn-Requestid:
+      - 0d663009-8e34-46f4-af17-3bceea313799
+      X-Amz-Apigw-Id:
+      - eVZ8WH1iIAMEs5w=
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 98c618da1ae9747c519f885d3d24b9a8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - JFK50-P9
+      X-Amz-Cf-Id:
+      - xjy0YOUYi-hl75qH4e4BRnVEC8NFJNnHirsfvf4UX52QqETTZiSKXg==
+    body:
+      encoding: UTF-8
+      string: '{"order":{"transaction_reference_id":null,"to_zip":"53202","to_street":null,"to_state":"WI","to_country":"US","to_city":null,"from_zip":"94104","from_street":null,"from_state":"CA","from_country":"US","from_city":null,"customer_id":null,"transaction_date":"2022-08-10T00:00:00.000Z","exemption_type":null,"shipping":"0.0","line_items":[{"product_identifier":null,"discount":"0.0","unit_price":"100.0","quantity":1,"sales_tax":"7.9","product_tax_code":"31000","description":null,"id":0}],"user_id":126159,"sales_tax":"7.9","provider":"api","transaction_id":"uQx2kx9_lhwvd_0G1RmdkQ==","amount":"100.0"}}'
+  recorded_at: Tue, 02 Jun 2026 13:12:21 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
## What

`CreateUsStatesSalesSummaryReportJob` aborted the entire multi-state sales-tax report when TaxJar returned a transient connection error (e.g. an SSL connection reset mid-run), discarding progress after potentially thousands of purchases had already been pushed.

This fixes two layered gaps:

- **Report job retry loop was too narrow.** The per-purchase retry only rescued `Taxjar::Error::GatewayTimeout` and `Taxjar::Error::InternalServerError`, so connection-level failures propagated and aborted the run. It now retries the full transient set: `Taxjar::Error::GatewayTimeout, *TaxjarErrors::SERVER`.
- **`HTTP::ConnectionError` was never classified as a connection error.** The underlying `Errno::ECONNRESET` *is* in `INTERNET_EXCEPTIONS`, but `taxjar-ruby` (via the `http` gem) wraps it in `HTTP::ConnectionError` before it surfaces. Because `HTTP::ConnectionError` wasn't in `INTERNET_EXCEPTIONS`, `TaxjarApi#with_caching`'s `*TaxjarErrors::SERVER` rescue never matched and the error escaped uncaught. Added `HTTP::ConnectionError` and `HTTP::TimeoutError` to `INTERNET_EXCEPTIONS`.

Adds a regression test that simulates a transient `HTTP::ConnectionError` from TaxJar and asserts the report still completes.

## Why

The report is generated by re-pushing transactions to TaxJar one purchase at a time. Transient connection resets to a third-party API are expected and should be retried, not treated as fatal — today a single blip discards a long-running job's progress. The classification gap is broader than this job: `TaxjarApi#calculate_tax_for_order` is called during real-time checkout tax calculation, so the same wrapped connection error could escape uncaught there too. Adding `HTTP::ConnectionError` to `INTERNET_EXCEPTIONS` fixes the root classification, and broadening the job's retry covers the specific report failure.

Closes antiwork/gumroad-private#457

## Before/After

_Non-user-facing (background job + error classification). Walkthrough video of the report job and TaxJar error handling to follow._

## Test Results

- New regression test + existing happy-case pass
- `spec/business/sales_tax/taxjar/taxjar_api_spec.rb` — 8 examples, 0 failures
- Confirmed the new test fails when the retry fix is reverted (valid regression)
- `rubocop -a` clean on all changed files

---

🤖 AI disclosure: drafted with Claude Opus 4.8 (1M context).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5370"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782998123&installation_id=134400930&pr_number=5370&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5370&signature=3d9552341a5421c853091ab24f59759a737fcedac8800f547825f533ba2653f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted error classification and retry behavior for third-party TaxJar calls; no auth, payment capture, or schema changes.
> 
> **Overview**
> Transient TaxJar/network failures no longer abort the multi-state **US sales tax summary** job after partial progress.
> 
> `CreateUsStatesSalesSummaryReportJob` now retries per-purchase pushes on **`Taxjar::Error::GatewayTimeout`** and the full **`TaxjarErrors::SERVER`** set (not only internal server errors), so wrapped connection issues are retried up to three times before failing.
> 
> **`INTERNET_EXCEPTIONS`** now includes **`HTTP::ConnectionError`** and **`HTTP::TimeoutError`**, so errors from the `http` gem are treated as connection failures inside **`TaxjarErrors::SERVER`** (e.g. checkout tax via **`TaxjarApi`**). A spec asserts the report still finishes after a simulated transient **`HTTP::ConnectionError`** on the first **`create_order_transaction`** call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f15ea735a653e7f8f671c0035889140607fddab5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->