### PR TITLE
Add product section writes to the v2 API

### DIFF
--- a/app/controllers/api/v2/product_sections_controller.rb
+++ b/app/controllers/api/v2/product_sections_controller.rb
@@ -4,7 +4,7 @@ class Api::V2::ProductSectionsController < Api::V2::BaseController
   PRODUCT_SECTION_TYPE = "products"
   DEFAULT_PRODUCT_SECTION_ATTRIBUTES = {
     default_product_sort: "page_layout",
-    shown_products: [],
+    shown_products: [].freeze,
     show_filters: false,
     add_new_products: false,
   }.freeze
@@ -75,7 +75,7 @@ class Api::V2::ProductSectionsController < Api::V2::BaseController
     end
 
     def product_section_attributes(with_defaults:)
-      attributes = with_defaults ? DEFAULT_PRODUCT_SECTION_ATTRIBUTES.dup : {}
+      attributes = with_defaults ? DEFAULT_PRODUCT_SECTION_ATTRIBUTES.deep_dup : {}
       attributes[:header] = params[:header] if params.key?(:header)
       attributes[:hide_header] = boolean_param(:hide_header) if params.key?(:hide_header)
       attributes[:default_product_sort] = params[:default_product_sort] if params.key?(:default_product_sort)
@@ -99,12 +99,13 @@ class Api::V2::ProductSectionsController < Api::V2::BaseController
         raise InvalidProductSectionParams, "shown_products must reference your own product IDs."
       end
 
-      found_product_ids = current_resource_owner.products.where(id: product_ids.uniq).ids
-      if product_ids.uniq.sort != found_product_ids.sort
+      unique_product_ids = product_ids.uniq
+      found_product_ids = current_resource_owner.products.where(id: unique_product_ids).ids
+      if unique_product_ids.sort != found_product_ids.sort
         raise InvalidProductSectionParams, "shown_products must reference your own product IDs."
       end
 
-      product_ids
+      unique_product_ids
     end
 
     def boolean_param(key)
@@ -140,8 +141,8 @@ class Api::V2::ProductSectionsController < Api::V2::BaseController
       success_with_object(:section, section ? Api::ProductSectionsPresenter.new(@product, sections: [section]).props.sole : nil)
     end
 
-    def error_with_section(section = nil)
-      error_with_object(:section, section)
+    def error_with_section
+      error_with_object(:section, nil)
     end
 
     def record_error_message(error)

--- a/app/controllers/api/v2/product_sections_controller.rb
+++ b/app/controllers/api/v2/product_sections_controller.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+class Api::V2::ProductSectionsController < Api::V2::BaseController
+  PRODUCT_SECTION_TYPE = "products"
+  DEFAULT_PRODUCT_SECTION_ATTRIBUTES = {
+    default_product_sort: "page_layout",
+    shown_products: [],
+    show_filters: false,
+    add_new_products: false,
+  }.freeze
+
+  before_action(only: [:create, :update, :destroy]) { doorkeeper_authorize! :edit_products }
+  before_action :fetch_product
+  before_action :fetch_section, only: %i[update destroy]
+
+  def create
+    return unsupported_section_type(:created) if params[:type] != PRODUCT_SECTION_TYPE
+
+    section_attributes = product_section_attributes(with_defaults: true).merge(
+      type: SellerProfileProductsSection.name,
+      seller: current_resource_owner
+    )
+
+    ActiveRecord::Base.transaction do
+      @product.lock!
+      @section = @product.seller_profile_sections.create!(section_attributes)
+      @product.update!(sections: ordered_section_ids + [@section.id])
+    end
+
+    success_with_section(@section)
+  rescue InvalidProductSectionParams => e
+    render_response(false, message: e.message)
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => e
+    render_response(false, message: record_error_message(e))
+  end
+
+  def update
+    return unsupported_section_type(:updated) unless product_section?
+    return unsupported_section_type(:updated) if params.key?(:type) && params[:type] != PRODUCT_SECTION_TYPE
+
+    @section.update!(product_section_attributes(with_defaults: false))
+
+    success_with_section(@section)
+  rescue InvalidProductSectionParams => e
+    render_response(false, message: e.message)
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => e
+    render_response(false, message: record_error_message(e))
+  end
+
+  def destroy
+    return unsupported_section_type(:deleted) unless product_section?
+
+    ActiveRecord::Base.transaction do
+      @product.lock!
+      section_ids = ordered_section_ids
+      updated_section_ids = section_ids - [@section.id]
+      @product.update!(
+        sections: updated_section_ids,
+        main_section_index: adjusted_main_section_index(section_ids.index(@section.id), updated_section_ids.length)
+      )
+      @section.destroy!
+    end
+
+    success_with_section
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved, ActiveRecord::RecordNotDestroyed => e
+    render_response(false, message: record_error_message(e))
+  end
+
+  private
+    class InvalidProductSectionParams < StandardError; end
+
+    def fetch_section
+      @section = @product.seller_profile_sections.find_by_external_id(params[:id])
+      error_with_section if @section.nil?
+    end
+
+    def product_section_attributes(with_defaults:)
+      attributes = with_defaults ? DEFAULT_PRODUCT_SECTION_ATTRIBUTES.dup : {}
+      attributes[:header] = params[:header] if params.key?(:header)
+      attributes[:hide_header] = boolean_param(:hide_header) if params.key?(:hide_header)
+      attributes[:default_product_sort] = params[:default_product_sort] if params.key?(:default_product_sort)
+      attributes[:shown_products] = shown_product_ids if params.key?(:shown_products)
+      attributes[:show_filters] = boolean_param(:show_filters) if params.key?(:show_filters)
+      attributes[:add_new_products] = boolean_param(:add_new_products) if params.key?(:add_new_products)
+      attributes
+    end
+
+    def shown_product_ids
+      shown_products = params[:shown_products]
+      raise InvalidProductSectionParams, "shown_products must reference your own product IDs." unless shown_products.is_a?(Array)
+
+      product_ids = shown_products.map do |external_id|
+        raise InvalidProductSectionParams, "shown_products must reference your own product IDs." unless external_id.respond_to?(:to_str)
+
+        Link.from_external_id(external_id)
+      end
+
+      if product_ids.any?(&:blank?)
+        raise InvalidProductSectionParams, "shown_products must reference your own product IDs."
+      end
+
+      found_product_ids = current_resource_owner.products.where(id: product_ids.uniq).ids
+      if product_ids.uniq.sort != found_product_ids.sort
+        raise InvalidProductSectionParams, "shown_products must reference your own product IDs."
+      end
+
+      product_ids
+    end
+
+    def boolean_param(key)
+      case params[key]
+      when true, "true", "1", 1
+        true
+      when false, "false", "0", 0
+        false
+      else
+        raise InvalidProductSectionParams, "#{key} must be true or false."
+      end
+    end
+
+    def ordered_section_ids
+      Array(@product.sections).map(&:to_i)
+    end
+
+    def adjusted_main_section_index(deleted_section_index, section_count)
+      index = (@product.main_section_index || 0).to_i
+      index -= 1 if deleted_section_index && deleted_section_index < index
+      [[index, 0].max, section_count].min
+    end
+
+    def product_section?
+      @section.is_a?(SellerProfileProductsSection)
+    end
+
+    def unsupported_section_type(action)
+      render_response(false, message: "Only product-listing sections can be #{action} via the API right now.")
+    end
+
+    def success_with_section(section = nil)
+      success_with_object(:section, section ? Api::ProductSectionsPresenter.new(@product, sections: [section]).props.sole : nil)
+    end
+
+    def error_with_section(section = nil)
+      error_with_object(:section, section)
+    end
+
+    def record_error_message(error)
+      error.record.errors.full_messages.presence&.to_sentence || error.message
+    end
+end

--- a/app/presenters/api/product_sections_presenter.rb
+++ b/app/presenters/api/product_sections_presenter.rb
@@ -10,9 +10,9 @@ class Api::ProductSectionsPresenter
     "SellerProfileSubscribeSection" => "subscribe",
   }.freeze
 
-  def initialize(product)
+  def initialize(product, sections: nil)
     @product = product
-    @sections = ordered_sections
+    @sections = sections || ordered_sections
     @product_external_ids_by_id = build_product_external_ids_by_id
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,7 @@ Rails.application.routes.draw do
       resource :refund_policy, only: [:show, :update], controller: :refund_policies
       resources :links, path: "products", only: [:index, :show, :update, :create, :destroy] do
         resources :custom_fields, only: [:index, :create, :update, :destroy]
+        resources :sections, only: [:create, :update, :destroy], controller: "product_sections"
         resources :offer_codes, only: [:index, :create, :show, :update, :destroy]
         resources :variant_categories, only: [:index, :create, :show, :update, :destroy] do
           resources :variants, only: [:index, :create, :show, :update, :destroy]

--- a/spec/controllers/api/v2/product_sections_controller_spec.rb
+++ b/spec/controllers/api/v2/product_sections_controller_spec.rb
@@ -78,6 +78,24 @@ describe Api::V2::ProductSectionsController do
         )
       end
 
+      it "does not share default shown_products between created sections" do
+        post @action, params: { link_id: @product.external_id, type: "products", access_token: @token.token }
+        @product.seller_profile_sections.sole.shown_products << @shown_product1.id
+
+        post @action, params: { link_id: @product.external_id, type: "products", access_token: @token.token }
+
+        expect(response.parsed_body["section"]["shown_products"]).to eq([])
+        expect(@product.seller_profile_sections.order(:id).last.shown_products).to eq([])
+      end
+
+      it "deduplicates shown_products while preserving their first-seen order" do
+        post @action, params: @params.merge(shown_products: [@shown_product2.external_id, @shown_product1.external_id, @shown_product2.external_id])
+
+        section = @product.seller_profile_sections.sole
+        expect(section.shown_products).to eq([@shown_product2.id, @shown_product1.id])
+        expect(response.parsed_body["section"]["shown_products"]).to eq([@shown_product2.external_id, @shown_product1.external_id])
+      end
+
       it "rejects shown_products that are not the seller's products" do
         foreign_product = create(:product)
 
@@ -169,6 +187,13 @@ describe Api::V2::ProductSectionsController do
           "show_filters" => true,
           "add_new_products" => false
         )
+      end
+
+      it "deduplicates shown_products when updating" do
+        put @action, params: @params.merge(shown_products: [@new_product.external_id, @old_product.external_id, @new_product.external_id])
+
+        expect(@section.reload.shown_products).to eq([@new_product.id, @old_product.id])
+        expect(response.parsed_body["section"]["shown_products"]).to eq([@new_product.external_id, @old_product.external_id])
       end
 
       it "rejects unsupported section type changes" do

--- a/spec/controllers/api/v2/product_sections_controller_spec.rb
+++ b/spec/controllers/api/v2/product_sections_controller_spec.rb
@@ -1,0 +1,264 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "shared_examples/authorized_oauth_v1_api_method"
+
+describe Api::V2::ProductSectionsController do
+  before do
+    @user = create(:user)
+    @app = create(:oauth_application, owner: create(:user))
+    @product = create(:product, user: @user)
+  end
+
+  describe "POST 'create'" do
+    before do
+      @action = :create
+      @shown_product1 = create(:product, user: @user)
+      @shown_product2 = create(:product, user: @user)
+      @params = {
+        link_id: @product.external_id,
+        type: "products",
+        header: "Featured picks",
+        hide_header: false,
+        shown_products: [@shown_product2.external_id, @shown_product1.external_id],
+        default_product_sort: "highest_rated",
+        show_filters: true,
+        add_new_products: false,
+      }
+    end
+
+    it_behaves_like "authorized oauth v1 api method"
+    it_behaves_like "authorized oauth v1 api method only for edit_products scope"
+
+    describe "when logged in with edit_products scope" do
+      before do
+        @token = create("doorkeeper/access_token", application: @app, resource_owner_id: @user.id, scopes: "edit_products")
+        @params.merge!(access_token: @token.token)
+      end
+
+      it "creates a product section, appends it to the product order, and returns the serialized section" do
+        expect do
+          post @action, params: @params
+        end.to change { @product.seller_profile_sections.count }.by(1)
+
+        section = @product.seller_profile_sections.sole
+        expect(section).to be_a(SellerProfileProductsSection)
+        expect(section.seller).to eq(@user)
+        expect(@product.reload.sections).to eq([section.id])
+        expect(response.parsed_body["section"]).to eq(
+          {
+            "id" => section.external_id,
+            "type" => "products",
+            "header" => "Featured picks",
+            "hide_header" => false,
+            "shown_products" => [@shown_product2.external_id, @shown_product1.external_id],
+            "default_product_sort" => "highest_rated",
+            "show_filters" => true,
+            "add_new_products" => false,
+          }
+        )
+        expect(@product.as_json(api_scopes: ["edit_products"])["sections"].sole).to eq(response.parsed_body["section"])
+      end
+
+      it "applies product section defaults when fields are omitted" do
+        post @action, params: { link_id: @product.external_id, type: "products", access_token: @token.token }
+
+        section = @product.seller_profile_sections.sole
+        expect(response.parsed_body["section"]).to eq(
+          {
+            "id" => section.external_id,
+            "type" => "products",
+            "header" => "",
+            "hide_header" => false,
+            "shown_products" => [],
+            "default_product_sort" => "page_layout",
+            "show_filters" => false,
+            "add_new_products" => false,
+          }
+        )
+      end
+
+      it "rejects shown_products that are not the seller's products" do
+        foreign_product = create(:product)
+
+        post @action, params: @params.merge(shown_products: [foreign_product.external_id])
+
+        expect(response.parsed_body).to eq(
+          {
+            "success" => false,
+            "message" => "shown_products must reference your own product IDs.",
+          }
+        )
+        expect(@product.reload.seller_profile_sections).to be_empty
+        expect(@product.sections).to eq([])
+      end
+
+      it "rejects unknown shown_products" do
+        post @action, params: @params.merge(shown_products: [ObfuscateIds.encrypt(999_999_999)])
+
+        expect(response.parsed_body).to eq(
+          {
+            "success" => false,
+            "message" => "shown_products must reference your own product IDs.",
+          }
+        )
+      end
+
+      it "rejects unsupported section types" do
+        post @action, params: @params.merge(type: "rich_text")
+
+        expect(response.parsed_body).to eq(
+          {
+            "success" => false,
+            "message" => "Only product-listing sections can be created via the API right now.",
+          }
+        )
+        expect(@product.reload.seller_profile_sections).to be_empty
+      end
+    end
+  end
+
+  describe "PUT 'update'" do
+    before do
+      @old_product = create(:product, user: @user)
+      @new_product = create(:product, user: @user)
+      @section = create(:seller_profile_products_section, seller: @user, product: @product, shown_products: [@old_product.id])
+      @other_section = create(:seller_profile_rich_text_section, seller: @user, product: @product)
+      @product.update!(sections: [@other_section.id, @section.id])
+      @action = :update
+      @params = {
+        link_id: @product.external_id,
+        id: @section.external_id,
+        header: "Updated picks",
+        hide_header: true,
+        shown_products: [@new_product.external_id],
+        default_product_sort: "price_asc",
+        show_filters: true,
+        add_new_products: false,
+      }
+    end
+
+    it_behaves_like "authorized oauth v1 api method"
+    it_behaves_like "authorized oauth v1 api method only for edit_products scope"
+
+    describe "when logged in with edit_products scope" do
+      before do
+        @token = create("doorkeeper/access_token", application: @app, resource_owner_id: @user.id, scopes: "edit_products")
+        @params.merge!(access_token: @token.token)
+      end
+
+      it "updates product section fields without changing product section order" do
+        put @action, params: @params
+
+        expect(@product.reload.sections).to eq([@other_section.id, @section.id])
+        expect(@section.reload).to have_attributes(
+          header: "Updated picks",
+          shown_products: [@new_product.id],
+          default_product_sort: "price_asc",
+          show_filters: true,
+          add_new_products: false
+        )
+        expect(@section.hide_header?).to be(true)
+        expect(response.parsed_body["section"]).to include(
+          "id" => @section.external_id,
+          "type" => "products",
+          "header" => "Updated picks",
+          "hide_header" => true,
+          "shown_products" => [@new_product.external_id],
+          "default_product_sort" => "price_asc",
+          "show_filters" => true,
+          "add_new_products" => false
+        )
+      end
+
+      it "rejects unsupported section type changes" do
+        put @action, params: @params.merge(type: "rich_text")
+
+        expect(response.parsed_body).to eq(
+          {
+            "success" => false,
+            "message" => "Only product-listing sections can be updated via the API right now.",
+          }
+        )
+        expect(@section.reload.header).to be_nil
+      end
+
+      it "does not update sections from another product" do
+        other_product = create(:product, user: @user)
+        other_section = create(:seller_profile_products_section, seller: @user, product: other_product)
+
+        put @action, params: @params.merge(id: other_section.external_id)
+
+        expect(response.parsed_body).to eq(
+          {
+            "success" => false,
+            "message" => "The section was not found.",
+          }
+        )
+        expect(other_section.reload.header).to be_nil
+      end
+    end
+  end
+
+  describe "DELETE 'destroy'" do
+    before do
+      @section = create(:seller_profile_products_section, seller: @user, product: @product)
+      @other_section = create(:seller_profile_rich_text_section, seller: @user, product: @product)
+      @product.update!(sections: [@other_section.id, @section.id])
+      @action = :destroy
+      @params = {
+        link_id: @product.external_id,
+        id: @section.external_id,
+      }
+    end
+
+    it_behaves_like "authorized oauth v1 api method"
+    it_behaves_like "authorized oauth v1 api method only for edit_products scope"
+
+    describe "when logged in with edit_products scope" do
+      before do
+        @token = create("doorkeeper/access_token", application: @app, resource_owner_id: @user.id, scopes: "edit_products")
+        @params.merge!(access_token: @token.token)
+      end
+
+      it "removes the section from product order and destroys the section" do
+        delete @action, params: @params
+
+        expect(response.parsed_body).to eq(
+          {
+            "success" => true,
+            "message" => "The section was deleted successfully.",
+          }
+        )
+        expect(@product.reload.sections).to eq([@other_section.id])
+        expect(SellerProfileSection.exists?(@section.id)).to be(false)
+      end
+
+      it "moves main_section_index back when deleting a section before the main product block" do
+        @product.update!(sections: [@section.id, @other_section.id], main_section_index: 1)
+
+        delete @action, params: @params
+
+        expect(@product.reload).to have_attributes(
+          sections: [@other_section.id],
+          main_section_index: 0
+        )
+      end
+
+      it "does not destroy sections from another product" do
+        other_product = create(:product, user: @user)
+        other_section = create(:seller_profile_products_section, seller: @user, product: other_product)
+
+        delete @action, params: @params.merge(id: other_section.external_id)
+
+        expect(response.parsed_body).to eq(
+          {
+            "success" => false,
+            "message" => "The section was not found.",
+          }
+        )
+        expect(SellerProfileSection.exists?(other_section.id)).to be(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ref antiwork/gumroad-cli#101

## What

Adds v2 API support for creating, updating, and deleting product-listing sections on a product. The endpoints return the same section shape used by product show responses, validate product ownership and supported fields, and keep section ordering plus main product placement consistent.

## Why

API clients need to manage product page product-listing sections without exposing dashboard-only contracts for rich text, posts, wishlists, or subscribe sections. Keeping writes scoped to product-listing sections preserves the narrow public contract established by the read-only section API while still enabling the CLI workflow.

---

This PR was implemented with AI assistance using gpt‑5.5 xhigh.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New authenticated product-page mutation surface with transactional section ordering; scope is limited to listing sections and ownership checks on shown_products.
> 
> **Overview**
> Adds **v2 API write endpoints** for **product-listing** (`type: products`) sections nested under `/products/:link_id/sections` — **create**, **update**, and **destroy** — gated by the **`edit_products`** OAuth scope.
> 
> **Create** appends a new `SellerProfileProductsSection` to the product’s `sections` order inside a locked transaction and returns the same serialized `section` shape as product reads. **Update** patches listing fields without reordering sections. **Destroy** removes the section from `sections`, adjusts **`main_section_index`** when a section before the main block is deleted, then deletes the record. Writes reject other section types and validate **`shown_products`** as the seller’s own product external IDs (deduped, order preserved). **`Api::ProductSectionsPresenter`** now accepts an optional **`sections:`** subset for single-section responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3d24680f80499b1c1aa0d792141c6ca5506bf4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->