### PR TITLE
Point landing page prompt at products page CLI commands

### DIFF
--- a/app/javascript/components/ApiDocumentation/Endpoints/Products.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/Products.tsx
@@ -103,7 +103,7 @@ const CustomHtmlDocumentation = () => (
     </CodeSnippet>
     <CodeSnippet caption="Gumroad CLI">
       {`gumroad products page preview <permalink> ./landing.html
-gumroad products page push <permalink> ./landing.html`}
+gumroad products page publish <permalink> ./landing.html`}
     </CodeSnippet>
     <p>
       Your HTML is sanitized — disallowed tags and attributes are stripped — then served inside a sandboxed iframe (

--- a/app/javascript/components/ProductEdit/ShareTab/LandingPageEditor.tsx
+++ b/app/javascript/components/ProductEdit/ShareTab/LandingPageEditor.tsx
@@ -52,12 +52,11 @@ For a pay-what-you-want product where the buyer should name their OWN price on t
     });
   </script>
 
-Then publish it with the Gumroad CLI:
-- Preview the local request without publishing: gumroad products update ${uniquePermalink} --custom-html ./landing.html --dry-run --json --no-input --non-interactive
-- Publish (or update) the page: gumroad products update ${uniquePermalink} --custom-html ./landing.html --json --no-input --non-interactive
-- Inspect .result.sanitization_report in the publish response; if Gumroad removed tags or attributes, edit and publish again.
-- Remove the landing page and restore the default product page: gumroad products update ${uniquePermalink} --custom-html '' --json --no-input --non-interactive
-- Confirm it's live and find the public URL: gumroad products view ${uniquePermalink} --json --jq '.product.landing_url' --no-input --non-interactive
+Then preview, publish, and verify it with the Gumroad CLI:
+- Run the real server-side sanitizer WITHOUT publishing and read what it changed: gumroad products page preview ${uniquePermalink} ./landing.html --json --no-input --non-interactive — inspect .sanitization_report. If it stripped tags or attributes your page needs (a buy element, an <input>, a <script>), fix the HTML and preview again. Do this until the report is clean so you never publish a broken page.
+- Publish (or update) the page once preview is clean: gumroad products page publish ${uniquePermalink} ./landing.html --json --no-input --non-interactive — .sanitization_report reflects what actually shipped.
+- Confirm it's live and find the public URL: gumroad products page url ${uniquePermalink} --json --jq '.product.landing_url' --no-input --non-interactive
+- Remove the landing page and restore the default product page: gumroad products page clear ${uniquePermalink} --yes --json --no-input --non-interactive
 
 If the gumroad CLI isn't installed: brew install antiwork/cli/gumroad (or curl -fsSL https://gumroad.com/install-cli.sh | bash), then run gumroad auth login.`;
 

--- a/app/javascript/components/ProductEdit/ShareTab/LandingPageEditor.tsx
+++ b/app/javascript/components/ProductEdit/ShareTab/LandingPageEditor.tsx
@@ -55,7 +55,7 @@ For a pay-what-you-want product where the buyer should name their OWN price on t
 Then preview, publish, and verify it with the Gumroad CLI:
 - Run the real server-side sanitizer WITHOUT publishing and read what it changed: gumroad products page preview ${uniquePermalink} ./landing.html --json --no-input --non-interactive — inspect .sanitization_report. If it stripped tags or attributes your page needs (a buy element, an <input>, a <script>), fix the HTML and preview again. Do this until the report is clean so you never publish a broken page.
 - Publish (or update) the page once preview is clean: gumroad products page publish ${uniquePermalink} ./landing.html --json --no-input --non-interactive — .sanitization_report reflects what actually shipped.
-- Confirm it's live and find the public URL: gumroad products page url ${uniquePermalink} --json --jq '.product.landing_url' --no-input --non-interactive
+- Confirm it's live and find the public URL: gumroad products page url ${uniquePermalink} --no-input --non-interactive
 - Remove the landing page and restore the default product page: gumroad products page clear ${uniquePermalink} --yes --json --no-input --non-interactive
 
 If the gumroad CLI isn't installed: brew install antiwork/cli/gumroad (or curl -fsSL https://gumroad.com/install-cli.sh | bash), then run gumroad auth login.`;


### PR DESCRIPTION
Fixes #5364

## What

Points the Share-tab agent prompt (and the custom-HTML API docs) at the `products page` CLI commands that shipped in [gumroad-cli#127](https://github.com/antiwork/gumroad-cli/pull/127): `preview`, `publish`, `url`, and `clear`. The key addition is `gumroad products page preview`, which runs the real server-side sanitizer without publishing and returns a `.sanitization_report` — the prompt now has the agent fix the HTML until that report is clean before going live. Also fixes the API docs snippet, which referenced a non-existent `products page push` (the verb is `publish`).

## Why

[#5363](https://github.com/antiwork/gumroad/pull/5363) used `products update --custom-html` because the `products page` namespace didn't exist yet. That flow had no way to see what the sanitizer stripped until after publishing — the deploy-and-discover loop #5364 describes, where a stripped buy element silently breaks the live page. `preview` exposes the report beforehand, turning "publish and discover" into "preview and fix once."

---

This PR was implemented with AI assistance using Claude Opus 4.8.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only changes to API documentation and the Share-tab agent prompt; no product, auth, or checkout logic changes.
> 
> **Overview**
> Updates **custom HTML landing page** guidance so sellers and agents use the **`gumroad products page`** CLI instead of **`products update --custom-html`**.
> 
> In **Share tab** (`LandingPageEditor`), the copied agent prompt now walks through **`page preview`** (server sanitizer + `.sanitization_report` before go-live), **`page publish`**, **`page url`**, and **`page clear`**, replacing the old dry-run/update/view/jq flow.
> 
> In **API docs** (`Products.tsx`), the CLI example fixes a bad verb: **`page push`** → **`page publish`**, alongside **`page preview`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc4f31645e4cb040f094e6af94c0db38e643dfde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->