### PR TITLE
Restore --json --jq filter on products page url in landing prompt

### DIFF
--- a/app/javascript/components/ProductEdit/ShareTab/LandingPageEditor.tsx
+++ b/app/javascript/components/ProductEdit/ShareTab/LandingPageEditor.tsx
@@ -55,7 +55,7 @@ For a pay-what-you-want product where the buyer should name their OWN price on t
 Then preview, publish, and verify it with the Gumroad CLI:
 - Run the real server-side sanitizer WITHOUT publishing and read what it changed: gumroad products page preview ${uniquePermalink} ./landing.html --json --no-input --non-interactive — inspect .sanitization_report. If it stripped tags or attributes your page needs (a buy element, an <input>, a <script>), fix the HTML and preview again. Do this until the report is clean so you never publish a broken page.
 - Publish (or update) the page once preview is clean: gumroad products page publish ${uniquePermalink} ./landing.html --json --no-input --non-interactive — .sanitization_report reflects what actually shipped.
-- Confirm it's live and find the public URL: gumroad products page url ${uniquePermalink} --no-input --non-interactive
+- Confirm it's live and find the public URL: gumroad products page url ${uniquePermalink} --json --jq '.product.landing_url' --no-input --non-interactive
 - Remove the landing page and restore the default product page: gumroad products page clear ${uniquePermalink} --yes --json --no-input --non-interactive
 
 If the gumroad CLI isn't installed: brew install antiwork/cli/gumroad (or curl -fsSL https://gumroad.com/install-cli.sh | bash), then run gumroad auth login.`;


### PR DESCRIPTION
## What

Restore `--json --jq '.product.landing_url'` on the `products page url` command in the landing-page agent prompt.

## Why

[#5372](https://github.com/antiwork/gumroad/pull/5372) dropped the filter on a mistaken read of the CLI. `products page url` honors `--json`/`--jq` via the shared JSON fast-path (`RunDecoded` prints the raw product GET response before the bare-URL callback), so the filter works — and keeps `--json` consistent with every other command in the prompt.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5373"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783005962&installation_id=134400930&pr_number=5373&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5373&signature=5e0a146002b8738972d03ca3789508d0a8b2c10eb524568e1621a8a023f36208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-string change to seller-facing AI agent documentation; no runtime product or checkout behavior.
> 
> **Overview**
> Updates the **Copy prompt** agent instructions in `LandingPageEditor` so the post-publish verification step again uses `gumroad products page url` with **`--json --jq '.product.landing_url'`**, matching the other CLI examples in the prompt and yielding only the public URL instead of full JSON output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d79352e89bbd11211a02b4f6083f38146ad22c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->