### PR TITLE
Add dedicated Gumroad Walks privacy policy at /walks/privacy (App Review 5.1.1/5.1.2)

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -55,6 +55,16 @@ class HomeController < ApplicationController
     set_meta_tag(property: "og:url", content: privacy_url)
   end
 
+  def walks_privacy
+    set_meta_tag(title: "Gumroad Walks privacy policy")
+    set_meta_tag(name: "description", content: "How the Gumroad Walks app collects, uses, and shares your data, including voice audio and transcripts sent to AI service providers.")
+    set_meta_tag(tag_name: "link", rel: "canonical", href: walks_privacy_url, head_key: "canonical")
+    set_meta_tag(property: "og:title", value: "Gumroad Walks privacy policy")
+    set_meta_tag(property: "og:description", value: "How the Gumroad Walks app collects, uses, and shares your data, including voice audio and transcripts sent to AI service providers.")
+    set_meta_tag(property: "og:type", value: "website")
+    set_meta_tag(property: "og:url", content: walks_privacy_url)
+  end
+
   def prohibited
     set_meta_tag(title: "Prohibited products on Gumroad")
     set_meta_tag(name: "description", content: "Understand what products and activities are not allowed on Gumroad to comply with our policies.")

--- a/app/views/home/walks_privacy.html.erb
+++ b/app/views/home/walks_privacy.html.erb
@@ -1,6 +1,6 @@
 <%= render "home/shared/header",
   bg_color: "pink",
-  title: "Gumroad Walks Privacy Policy",
+  title: "Gumroad Walks privacy policy",
   description: "Last revised: June 2, 2026" %>
 
 <div class="max-w-6xl px-8 lg:px-[4vw] py-12 md:py-20 mx-auto space-y-16 text-lg">

--- a/app/views/home/walks_privacy.html.erb
+++ b/app/views/home/walks_privacy.html.erb
@@ -1,0 +1,83 @@
+<%= render "home/shared/header",
+  bg_color: "pink",
+  title: "Gumroad Walks Privacy Policy",
+  description: "Last revised: June 2, 2026" %>
+
+<div class="max-w-6xl px-8 lg:px-[4vw] py-12 md:py-20 mx-auto space-y-16 text-lg">
+  <div>
+    <p class="pb-8">This Privacy Policy describes how the <strong>Gumroad Walks</strong> mobile app ("Walks," "we," "us") collects, uses, and shares your information. It is specific to the Walks app. Gumroad's general <a href="/privacy" class="text-pink underline">Privacy Policy</a> also applies; where this policy and the general policy differ for the Walks app, this policy controls.</p>
+    <p>Walks turns a walking conversation into a publishable product. During a walk, the app interviews you by voice and afterward drafts a product (such as a book, course, or podcast) from what you said. Delivering those features requires sending your voice and the resulting transcript to third-party artificial intelligence (AI) providers, as described below. We ask for your permission inside the app before any of this happens.</p>
+  </div>
+
+  <div>
+    <h2 class="text-5xl lg:text-7xl font-medium pb-6">1. What data we collect</h2>
+    <ul class="list-disc my-6 pl-4 [&>li]:leading-8 space-y-2">
+      <li><strong>Voice audio.</strong> The audio captured by your device's microphone while you are in an active walk session.</li>
+      <li><strong>Transcript.</strong> The text transcription of that audio, including both your responses and the interviewer's prompts.</li>
+      <li><strong>Derived product content.</strong> The draft product generated from your session — for example, a title, description, chapters, and price.</li>
+      <li><strong>Walk metadata.</strong> Session details such as duration, timestamps, and the topic you chose, stored on your device.</li>
+      <li><strong>Account / publishing data.</strong> If you choose to publish a product, the Gumroad account authorization you grant (via Gumroad OAuth) and the product you publish. Connecting a Gumroad account is optional and only needed to publish.</li>
+      <li><strong>Diagnostics.</strong> Crash and error reports (via Sentry) to keep the app reliable.</li>
+    </ul>
+    <p>Walks does <strong>not</strong> require you to create an account or log in to record a walk, review it, or generate a draft.</p>
+  </div>
+
+  <div>
+    <h2 class="text-5xl lg:text-7xl font-medium pb-6">2. How we collect it</h2>
+    <ul class="list-disc my-6 pl-4 [&>li]:leading-8 space-y-2">
+      <li><strong>Microphone audio</strong> is captured only while you are in an active walk session that you started, and only after you have (a) agreed to the in-app AI disclosure and (b) granted iOS microphone permission. We do not record audio in the background or outside of a session.</li>
+      <li><strong>The transcript and draft content</strong> are produced from that audio in real time during the session.</li>
+      <li><strong>Diagnostics</strong> are collected automatically when an error or crash occurs.</li>
+    </ul>
+  </div>
+
+  <div>
+    <h2 class="text-5xl lg:text-7xl font-medium pb-6">3. How we use it</h2>
+    <p class="pb-8">We use the data we collect <strong>solely to provide the app's features to you</strong>: to transcribe your speech, conduct the interactive interview, generate a draft product you can review and edit, and — if you choose — publish that product to your Gumroad store. We use diagnostics only to maintain and improve reliability.</p>
+    <p>We do <strong>not</strong> sell your data, use it for advertising, or use it to train our own AI models.</p>
+  </div>
+
+  <div>
+    <h2 class="text-5xl lg:text-7xl font-medium pb-6">4. Who we share it with</h2>
+    <p class="pb-8">To provide Walks's core features, we send your voice audio and transcript to third-party AI service providers. Your data is transmitted to them through Gumroad's own servers (our servers hold the API credentials; your device does not). We currently use:</p>
+    <ul class="list-disc my-6 pl-4 [&>li]:leading-8 space-y-2">
+      <li><strong>OpenAI</strong> — receives your <strong>voice audio</strong> (and its transcript) to power the real-time voice interview. Governed by OpenAI's privacy policy: <a href="https://openai.com/policies/privacy-policy" target="_blank" rel="noopener" class="text-pink underline">openai.com/policies/privacy-policy</a>.</li>
+      <li><strong>Anthropic</strong> — receives your <strong>transcript</strong> to generate the draft product. Governed by Anthropic's privacy policy: <a href="https://www.anthropic.com/legal/privacy" target="_blank" rel="noopener" class="text-pink underline">anthropic.com/legal/privacy</a>.</li>
+    </ul>
+    <p class="pb-8">Each provider processes this data under contract solely to provide the service to us, and is contractually required to provide the <strong>same or equal level of protection</strong> for your data as set out in this Privacy Policy.</p>
+    <p>We also use <strong>Sentry</strong> for crash/error diagnostics, <strong>Apple</strong> (App Attest and StoreKit) to verify the app and process subscriptions, and — only if you choose to publish — <strong>Gumroad</strong> to host the product you create. We otherwise share data only as described in Gumroad's general <a href="/privacy" class="text-pink underline">Privacy Policy</a> (for example, to comply with law).</p>
+  </div>
+
+  <div>
+    <h2 class="text-5xl lg:text-7xl font-medium pb-6">5. Your permission and your choices</h2>
+    <ul class="list-disc my-6 pl-4 [&>li]:leading-8 space-y-2">
+      <li><strong>We ask first.</strong> Before any audio or transcript is collected or sent, Walks shows a clear in-app disclosure that identifies what is sent and to whom (OpenAI and Anthropic), and asks for your permission. You can decline.</li>
+      <li><strong>You control the microphone.</strong> You can grant or revoke microphone access at any time in iOS Settings. Revoking it will prevent recording.</li>
+      <li><strong>You can stop.</strong> You can end a session at any time, and you can delete walks from within the app.</li>
+      <li><strong>Connecting Gumroad is optional.</strong> You only authorize a Gumroad account if you choose to publish a product; you can disconnect it at any time in the app.</li>
+    </ul>
+  </div>
+
+  <div>
+    <h2 class="text-5xl lg:text-7xl font-medium pb-6">6. Retention and deletion</h2>
+    <p class="pb-8">We retain your data only as long as necessary to provide the features described here and to meet legal, accounting, or reporting requirements. Walks you record are stored on your device and can be deleted by you in the app.</p>
+    <p>You may request deletion of data associated with you by contacting <a href="mailto:support@gumroad.com" class="text-pink underline">support@gumroad.com</a>. The retention and rights provisions of Gumroad's general <a href="/privacy" class="text-pink underline">Privacy Policy</a>, including rights for users in the European Union and California, also apply.</p>
+  </div>
+
+  <div>
+    <h2 class="text-5xl lg:text-7xl font-medium pb-6">7. Children</h2>
+    <p>Walks is not directed to children under 13 (or the minimum age required in your jurisdiction), and we do not knowingly collect their personal information.</p>
+  </div>
+
+  <div>
+    <h2 class="text-5xl lg:text-7xl font-medium pb-6">8. Changes to this policy</h2>
+    <p>We may update this Privacy Policy from time to time. If we make material changes, we will update the "Last revised" date above and, where appropriate, notify you in the app or in the app store listing. Your continued use of Walks after an update means you accept the revised policy.</p>
+  </div>
+
+  <div>
+    <h2 class="text-5xl lg:text-7xl font-medium pb-6">9. Contact us</h2>
+    <p>If you have any questions about this Privacy Policy or how Walks handles your data, email us at <a href="mailto:support@gumroad.com" class="text-pink underline">support@gumroad.com</a>.</p>
+  </div>
+</div>
+
+<%= render "home/shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -418,6 +418,7 @@ Rails.application.routes.draw do
     get "/terms", to: "home#terms"
     get "/prohibited", to: "home#prohibited"
     get "/privacy", to: "home#privacy"
+    get "/walks/privacy", to: "home#walks_privacy"
     get "/taxes", to: redirect("/pricing", status: 301)
     get "/hackathon", to: "home#hackathon"
     get "/small-bets", to: "home#small_bets"


### PR DESCRIPTION
## What
Adds a **Walks-specific privacy policy** served at `gumroad.com/walks/privacy`:
- New route `/walks/privacy` → `home#walks_privacy`
- New view `app/views/home/walks_privacy.html.erb` (same header/footer chrome as `/privacy`)

The page is scoped to exactly what the Walks app does and hits every Apple requirement head-on, in plain language:
- **What** we collect (voice audio, transcript, derived draft, walk metadata, optional Gumroad publishing auth, diagnostics)
- **How** (mic only during an active session, after in-app consent + iOS permission)
- **All uses** (transcribe, interview, draft, optionally publish — explicitly **not** ads or model-training)
- **Who it's shared with** — **OpenAI** (voice) and **Anthropic** (transcript) via Gumroad's servers, under contract with equal-protection terms; plus Sentry, Apple, and (only if publishing) Gumroad
- Consent, retention, deletion, children, contact

## Why
This is the stronger fix for the Walks App Review rejection under **5.1.1(i)** and **5.1.2(i)** — a focused, app-specific policy is clearer to users and reviewers than the general policy. It becomes the **App Store Connect Privacy Policy URL** for Walks and is the source of truth mirrored by the in-app privacy screen (added in a separate antiwork/gumroad-walks PR alongside the in-app AI consent gate).

## Relationship to #5374
#5374 added an AI-processors section to the **general** `/privacy` policy. This PR adds the **dedicated Walks** page (which cross-links to the general policy). They're complementary — but if you'd rather have a single source, we can land this one and close #5374 (or keep both). Your call.

## Test plan
- `walks_privacy_path`/`_url` helper resolves (verified via `rails runner`).
- ERB compiles cleanly (`ERB.new(...).src`); bare-renderer Devise/Warden error is environmental and reproduces identically on the existing `/privacy` page, so it's not introduced here.
- Visual: page renders with the same chrome/styling as `/privacy`.

## Risk
Additive static page + one route + one controller action. No existing behavior touched.

Co-authored-by: Sahil Lavingia <sahil@gumroad.com>
🤖 Authored with AI assistance (Claude Opus 4.8).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783006632&installation_id=134400930&pr_number=5375&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5375&signature=fe4510c8e716e1bc58d7f814b17c6d9ac1d6edd626893fcc36f8dfe65fbb0bc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive static marketing/legal page, one route, and one controller action; no changes to auth, payments, or existing `/privacy` behavior.
> 
> **Overview**
> Adds a **Gumroad Walks–specific privacy policy** at **`/walks/privacy`**, intended for App Store Connect and App Review (5.1.1/5.1.2).
> 
> Wiring is minimal: a new **`get "/walks/privacy"`** route under `GumroadDomainConstraint`, a **`HomeController#walks_privacy`** action that sets title/description/canonical/OG meta tags (same pattern as **`#privacy`**), and a new **`walks_privacy.html.erb`** view using the existing home header/footer chrome.
> 
> The page text is new content—not a tweak to **`/privacy`**—and spells out Walks data (voice, transcript, drafts, optional Gumroad publish), collection (session + in-app consent + mic permission), use (features only, no ads/training), and sharing (**OpenAI**, **Anthropic**, Sentry, Apple, optional Gumroad), with cross-links to the general **`/privacy`** policy where it applies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 474abb610f7fddd69a76dadc70572a0fa097b9c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->