### PR TITLE
Warn when custom HTML lacks a buy affordance

### DIFF
--- a/app/controllers/api/v2/links_controller.rb
+++ b/app/controllers/api/v2/links_controller.rb
@@ -12,6 +12,8 @@ class Api::V2::LinksController < Api::V2::BaseController
   ]).freeze
 
   RESULTS_PER_PAGE = 10
+  MISSING_BUY_AFFORDANCE_WARNING = "The custom landing page does not include a buy element, so buyers may not be able to purchase this product. " \
+                                   'Add an element with data-gumroad-action="buy" or post a gumroad:checkout message.'
 
   SHOW_PRODUCT_ASSOCIATIONS = (BASE_PRODUCT_ASSOCIATIONS + [
     :page,
@@ -424,8 +426,13 @@ class Api::V2::LinksController < Api::V2::BaseController
     end
 
     additional_info = params.key?(:custom_html) ? { previous_custom_html: previous_custom_html, sanitization_report: sanitization_report } : {}
-    offer_code_warning = check_offer_code_validity
-    additional_info[:warning] = offer_code_warning if offer_code_warning
+    warnings = [check_offer_code_validity]
+    if params[:custom_html].present?
+      # Profiles share the sanitizer, so buy-affordance warnings stay in the product API.
+      warnings << custom_html_buy_affordance_warning(@product.custom_html)
+    end
+    warning = warnings.compact.join(" ").presence
+    additional_info[:warning] = warning if warning
     success_with_object(:product, @product, additional_info)
   end
 
@@ -479,7 +486,10 @@ class Api::V2::LinksController < Api::V2::BaseController
     if errors.any?
       render_response(false, message: errors.map(&:full_message).to_sentence, sanitization_report: result.report)
     else
-      render_response(true, custom_html: sanitized, sanitization_report: result.report)
+      additional_info = { custom_html: sanitized, sanitization_report: result.report }
+      warning = custom_html_buy_affordance_warning(sanitized)
+      additional_info[:warning] = warning if warning
+      render_response(true, additional_info)
     end
   end
 
@@ -490,6 +500,12 @@ class Api::V2::LinksController < Api::V2::BaseController
 
     def error_with_product(product = nil)
       error_with_object(:product, product)
+    end
+
+    def custom_html_buy_affordance_warning(html)
+      return unless Pages::BuyAffordance.missing?(html)
+
+      MISSING_BUY_AFFORDANCE_WARNING
     end
 
     # Reject oversized HTML before the sanitizer parses it. Page validates the

--- a/app/javascript/components/ApiDocumentation/Endpoints/Products.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/Products.tsx
@@ -55,8 +55,8 @@ const UpdateProductResponseFields = () => (
         name: "warning",
         type: "string",
         description:
-          "Warning about offer codes that became invalid for the product (currency mismatch or below minimum price).",
-        condition: "present when at least one offer code is invalid after the update",
+          "Warning about offer codes that became invalid for the product, or custom HTML that has no buy element.",
+        condition: "present when there is an advisory warning after the update",
       },
     ])}
   </ApiResponseFields>
@@ -83,6 +83,10 @@ const CustomHtmlDocumentation = () => (
       </li>
       <li>
         Both <code>PUT</code> and preview return a <code>sanitization_report</code> listing what was stripped.
+      </li>
+      <li>
+        Both <code>PUT</code> and preview return a top-level <code>warning</code> if the custom HTML has no{" "}
+        <code>data-gumroad-action="buy"</code> element or <code>gumroad:checkout</code> postMessage.
       </li>
       <li>
         A successful <code>PUT</code> also returns <code>previous_custom_html</code> (the prior value, for one-step

--- a/app/javascript/components/ProductEdit/ShareTab/LandingPageEditor.tsx
+++ b/app/javascript/components/ProductEdit/ShareTab/LandingPageEditor.tsx
@@ -54,6 +54,7 @@ For a pay-what-you-want product where the buyer should name their OWN price on t
 
 Then preview, publish, and verify it with the Gumroad CLI:
 - Run the real server-side sanitizer WITHOUT publishing and read what it changed: gumroad products page preview ${uniquePermalink} ./landing.html --json --no-input --non-interactive — inspect .sanitization_report. If it stripped tags or attributes your page needs (a buy element, an <input>, a <script>), fix the HTML and preview again. Do this until the report is clean so you never publish a broken page.
+- Also inspect the top-level .warning from preview/publish. If it says the page has no buy element, add data-gumroad-action="buy" or a gumroad:checkout postMessage before publishing.
 - Publish (or update) the page once preview is clean: gumroad products page publish ${uniquePermalink} ./landing.html --json --no-input --non-interactive — .sanitization_report reflects what actually shipped.
 - Confirm it's live and find the public URL: gumroad products page url ${uniquePermalink} --json --jq '.product.landing_url' --no-input --non-interactive
 - Remove the landing page and restore the default product page: gumroad products page clear ${uniquePermalink} --yes --json --no-input --non-interactive

--- a/app/services/pages/buy_affordance.rb
+++ b/app/services/pages/buy_affordance.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class Pages::BuyAffordance
+  BUY_SELECTOR = '[data-gumroad-action="buy"]'
+  CHECKOUT_MESSAGE = "gumroad:checkout"
+
+  def self.missing?(html)
+    new(html).missing?
+  end
+
+  def initialize(html)
+    @html = html.to_s
+  end
+
+  def missing?
+    return false if @html.blank?
+
+    Loofah.fragment(@html).css(BUY_SELECTOR).empty? && !@html.include?(CHECKOUT_MESSAGE)
+  end
+end

--- a/spec/controllers/api/v2/links_controller_custom_html_spec.rb
+++ b/spec/controllers/api/v2/links_controller_custom_html_spec.rb
@@ -184,6 +184,35 @@ describe Api::V2::LinksController do
       expect(report["removed_attributes"]).to include(a_hash_including("attribute" => "href", "reason" => "javascript: URL blocked"))
     end
 
+    it "returns a warning when custom HTML has no buy affordance" do
+      put :update, params: { format: :json, access_token: @token.token, id: @product.external_id, custom_html: "<section><h1>Landing page</h1></section>" }
+
+      body = JSON.parse(response.body)
+      expect(body["success"]).to be(true)
+      expect(body["warning"]).to include("does not include a buy element")
+    end
+
+    it "does not return the buy warning when custom HTML has a buy element" do
+      put :update, params: { format: :json, access_token: @token.token, id: @product.external_id, custom_html: %(<section><a data-gumroad-action="buy">Buy now</a></section>) }
+
+      body = JSON.parse(response.body)
+      expect(body["success"]).to be(true)
+      expect(body).not_to have_key("warning")
+    end
+
+    it "joins offer-code and buy-affordance warnings in the existing warning string" do
+      @product.update!(price_cents: 2_00)
+      create(:offer_code, user: @user, products: [@product], code: "SAVE100", amount_cents: 1_00, currency_type: @product.price_currency_type)
+
+      put :update, params: { format: :json, access_token: @token.token, id: @product.external_id, price: 1_50, custom_html: "<section><h1>Landing page</h1></section>" }
+
+      body = JSON.parse(response.body)
+      expect(body["success"]).to be(true)
+      expect(body["warning"]).to be_a(String)
+      expect(body["warning"]).to include("SAVE100")
+      expect(body["warning"]).to include("does not include a buy element")
+    end
+
     it "applies custom_html alongside other attribute changes without choking on the row lock" do
       put :update, params: { format: :json, access_token: @token.token, id: @product.external_id, name: "Renamed", custom_html: "<section>Combined update</section>" }
 
@@ -288,6 +317,15 @@ describe Api::V2::LinksController do
       expect(body["custom_html"]).to include("<h1>Keep</h1>")
       expect(body["sanitization_report"]["total_removed"]).to eq(1)
       expect(body["sanitization_report"]["removed_tags"].first["reason"]).to eq("script src host not allowed")
+    end
+
+    it "returns a warning when the previewed custom HTML has no buy affordance" do
+      post :preview_custom_html, params: { format: :json, access_token: @token.token, id: @product.external_id, custom_html: "<section><h1>Landing page</h1></section>" }
+
+      body = JSON.parse(response.body)
+      expect(body["success"]).to be(true)
+      expect(body["warning"]).to include("does not include a buy element")
+      expect(@product.reload.custom_html).to be_nil
     end
   end
 

--- a/spec/services/pages/buy_affordance_spec.rb
+++ b/spec/services/pages/buy_affordance_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Pages::BuyAffordance do
+  describe ".missing?" do
+    it "returns false when the HTML has a data-gumroad-action buy element" do
+      html = %(<section><a data-gumroad-action="buy">Buy now</a></section>)
+
+      expect(described_class.missing?(html)).to be(false)
+    end
+
+    it "returns false when the HTML posts the gumroad checkout message" do
+      html = %(<script>parent.postMessage({ type: "gumroad:checkout" }, "*");</script>)
+
+      expect(described_class.missing?(html)).to be(false)
+    end
+
+    it "returns true when the HTML has no buy affordance" do
+      html = %(<section><h1>Landing page</h1><p>No checkout path.</p></section>)
+
+      expect(described_class.missing?(html)).to be(true)
+    end
+
+    it "returns true when the buy element existed only before sanitization stripped it" do
+      html = %(<section><custom-buy data-gumroad-action="buy">Buy</custom-buy><p>Details</p></section>)
+      sanitized = Ai::PageSanitizer.sanitize(html)
+
+      expect(sanitized).to include("<p>Details</p>")
+      expect(sanitized).not_to include("data-gumroad-action")
+      expect(described_class.missing?(sanitized)).to be(true)
+    end
+
+    it "returns false for blank HTML" do
+      expect(described_class.missing?(nil)).to be(false)
+      expect(described_class.missing?("")).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
Closes #5365

## What
- Add an advisory warning when custom HTML pages have no buy affordance.
- Surface that warning in both `update` and `preview_custom_html`, alongside the existing offer-code warning.
- Update the landing-page prompt and API docs so agents and humans look at the new top-level `warning` field.

## Why
- A custom landing page without a purchase path makes the product effectively unbuyable.
- This keeps the check product-scoped while still allowing the shared sanitizer path to stay reusable for profiles and future page types.

---

This PR was implemented with AI assistance using gpt-5.5 xhigh.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Advisory-only API warnings on custom HTML publish/preview; no auth or blocking behavior changes, though ignored warnings could leave products unpurchasable.
> 
> **Overview**
> Adds an **advisory** top-level `warning` when custom product landing HTML has no checkout path—neither a `data-gumroad-action="buy"` element nor a `gumroad:checkout` postMessage (via new `Pages::BuyAffordance`).
> 
> **Product API:** `PUT` update (when `custom_html` is present) and `POST preview_custom_html` now attach this warning alongside the existing invalid-offer-code warning (combined into one string). Saves still succeed.
> 
> **Docs & UX:** API docs and the Share tab agent prompt tell builders to check `.warning` after preview/publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eaf9c04f938d69a8438973d6bf160f6baf239ca8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->