### PR TITLE
Fix production checkout redirecting to .apps.staging.gumroad.org

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,7 @@ build_production:
 		-e DATABASE_PASSWORD="password" \
 		-e RAILS_MASTER_KEY=$$RAILS_PRODUCTION_MASTER_KEY \
 		-e DEVISE_SECRET_KEY="sample_secret_key" \
+		-e BUILDKITE_BRANCH=$(BUILDKITE_BRANCH) \
 		-e REVISION=$(NEW_WEB_TAG) \
 		--label assets_compiled=true \
 		$(NEW_WEB_REPO):web-$(NEW_WEB_TAG) \

--- a/docker/web/compile_assets.sh
+++ b/docker/web/compile_assets.sh
@@ -6,8 +6,8 @@ set -e
 
 cd $APP_DIR
 
-# Set CUSTOM_DOMAIN for preview app assets precompilation
-if [[ $BUILDKITE_BRANCH != "main" && $BUILDKITE_BRANCH != comp-assets-* ]]; then
+# Set CUSTOM_DOMAIN for preview app assets precompilation (never for an empty branch)
+if [[ -n $BUILDKITE_BRANCH && $BUILDKITE_BRANCH != "main" && $BUILDKITE_BRANCH != comp-assets-* ]]; then
   base_domain="staging.gumroad.org"
   app_name=$(get_app_name $BUILDKITE_BRANCH)
 


### PR DESCRIPTION
## What

Stops production asset compilation from baking the staging preview domain into the production JS bundle. After build [#12208](https://buildkite.com/gumroad-inc/gumroad/builds/12208/canvas) (commit `a84b39cce`, branch `main`) deployed to production, clicking checkout redirected buyers to `.apps.staging.gumroad.org`.

- `docker/web/compile_assets.sh`: only set `CUSTOM_DOMAIN` when `BUILDKITE_BRANCH` is non-empty (in addition to the existing `!main !comp-assets-*` check).
- `Makefile`: forward `BUILDKITE_BRANCH` into the `build_production` asset container, matching `build_staging`.

## Why

#5356 changed the `CUSTOM_DOMAIN` guard in `docker/web/compile_assets.sh` from an allowlist to a denylist:

```diff
-if [[ $BUILDKITE_BRANCH == deploy-* || $BUILDKITE_BRANCH == devin/* ]]; then
+if [[ $BUILDKITE_BRANCH != "main" && $BUILDKITE_BRANCH != comp-assets-* ]]; then
```

Production assets are compiled by the Makefile `build_production` target, which — unlike `build_staging` (`Makefile:131`) — does **not** forward `BUILDKITE_BRANCH` into the container. So `BUILDKITE_BRANCH` is **empty** during the production asset build.

- The old **allowlist** left `CUSTOM_DOMAIN` unset for an empty branch (`"" == deploy-*` is false) → correct production assets.
- The new **denylist** treats empty as a preview branch (`"" != "main"` and `"" != comp-assets-*` are both true), so it ran:

```bash
app_name=$(get_app_name "")                            # → "" (empty)
export CUSTOM_DOMAIN="${app_name}.apps.staging.gumroad.org"   # → ".apps.staging.gumroad.org"
```

The empty `app_name` is exactly why the leaked domain had a leading dot.

`CUSTOM_DOMAIN` overrides `DOMAIN`/`ROOT_DOMAIN` in `config/domain.rb:80-82` (`DOMAIN = custom_domain || config[:domain]`) and is baked into the precompiled bundle. Product and marketing pages render relative URLs so they were unaffected; checkout builds an **absolute** URL from `ROOT_DOMAIN` and redirected to the staging domain. Rolling production back to the pre-#5356 build restored correct behavior because that build's allowlist left `CUSTOM_DOMAIN` unset.

This PR fixes both sides of the invariant: never bake a custom domain for an unknown (empty) branch, and remove the `build_staging`/`build_production` inconsistency that allowed it.

### Branch truth table after the fix

| `BUILDKITE_BRANCH` | sets `CUSTOM_DOMAIN`? |
| --- | --- |
| `""` (production build container) | no |
| `main` | no |
| `comp-assets-hotfix` | no |
| `deploy-foo` | yes |
| `my-feature` | yes |

## Before/After

Non-user-facing CI/build-config change; behavior is exercised in the build pipeline rather than the UI. The truth table above documents the corrected `CUSTOM_DOMAIN` gating. I'll attach a short walkthrough of the build flow and the leaked-domain repro before merge.

## Test Results

Shell-logic verification of the condition across the relevant branch values (empty / `main` / `comp-assets-*` / `deploy-*` / feature) confirms `CUSTOM_DOMAIN` is only set for genuine preview branches.

---

AI disclosure: drafted with Claude Opus 4.8.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783016876&installation_id=134400930&pr_number=5377&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5377&signature=4e51af22784b7edad7b4c8eed3d63f5748271e5c496301d01f212e98852e5507"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/Makefile and asset-compile guard changes only; they restore correct production domain baking without touching runtime app logic.
> 
> **Overview**
> Fixes production asset builds incorrectly setting **`CUSTOM_DOMAIN`** to `.apps.staging.gumroad.org`, which was baked into the JS bundle and sent checkout to staging.
> 
> **`docker/web/compile_assets.sh`** now requires a **non-empty** `BUILDKITE_BRANCH` before applying the preview-branch rule (still excluding `main` and `comp-assets-*`). An empty branch during production compile no longer exports a bogus staging hostname.
> 
> **`Makefile`** `build_production` now passes **`BUILDKITE_BRANCH`** into the asset container, aligning with `build_staging` so branch-aware logic behaves consistently in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b60d21490e07f87e549920f7d4c3d689492f1f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->