### PR TITLE
Add "resend to non-openers" for published emails (#5360)

### DIFF
--- a/app/controllers/api/internal/installments/non_opener_resends_controller.rb
+++ b/app/controllers/api/internal/installments/non_opener_resends_controller.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class Api::Internal::Installments::NonOpenerResendsController < Api::Internal::BaseController
+  # A seller may resend a published post to its non-openers at most once per this window,
+  # to avoid accidentally re-blasting the same people repeatedly.
+  RESEND_THROTTLE = 24.hours
+
+  before_action :authenticate_user!
+  before_action :set_installment
+  after_action :verify_authorized
+
+  def show
+    authorize @installment, :resend_to_non_openers?
+
+    render json: { count: @installment.unopened_recipients_count }
+  end
+
+  def create
+    authorize @installment, :resend_to_non_openers?
+
+    if recently_resent?
+      return render json: { success: false, error: "You can only resend to non-openers once every 24 hours." },
+                    status: :too_many_requests
+    end
+
+    count = @installment.unopened_recipients_count
+    if count.zero?
+      return render json: { success: false, error: "Everyone who was emailed has already opened this." },
+                    status: :unprocessable_entity
+    end
+
+    blast = PostEmailBlast.create!(
+      post: @installment,
+      requested_at: Time.current,
+      recipient_filter: PostEmailBlast::RECIPIENT_FILTER_UNOPENED
+    )
+    SendPostBlastEmailsJob.perform_async(blast.id)
+
+    render json: { success: true, count: }
+  end
+
+  private
+    def set_installment
+      @installment = current_seller.installments.alive.find_by_external_id(params[:id])
+      (skip_authorization and e404_json) unless @installment&.resendable_to_non_openers?
+    end
+
+    def recently_resent?
+      @installment.blasts.to_non_openers.where(requested_at: RESEND_THROTTLE.ago..).exists?
+    end
+end

--- a/app/controllers/api/internal/installments/non_opener_resends_controller.rb
+++ b/app/controllers/api/internal/installments/non_opener_resends_controller.rb
@@ -12,7 +12,9 @@ class Api::Internal::Installments::NonOpenerResendsController < Api::Internal::B
   def show
     authorize @installment, :resend_to_non_openers?
 
-    render json: { count: @installment.unopened_recipients_count, recently_resent: recently_resent? }
+    count = @installment.unopened_recipients_count
+    audience_filtered_out = count.zero? && @installment.unopened_recipient_emails.any?
+    render json: { count:, recently_resent: recently_resent?, audience_filtered_out: }
   end
 
   def create

--- a/app/controllers/api/internal/installments/non_opener_resends_controller.rb
+++ b/app/controllers/api/internal/installments/non_opener_resends_controller.rb
@@ -68,8 +68,7 @@ class Api::Internal::Installments::NonOpenerResendsController < Api::Internal::B
 
     def recently_resent?
       scope = @installment.blasts.to_non_openers
-      in_flight = scope.where(completed_at: nil).where(started_at: IN_FLIGHT_GRACE.ago..).exists?
-      return true if in_flight
+      return true if scope.where(completed_at: nil).where(requested_at: IN_FLIGHT_GRACE.ago..).exists?
 
       scope.where(completed_at: RESEND_THROTTLE.ago..).exists?
     end

--- a/app/controllers/api/internal/installments/non_opener_resends_controller.rb
+++ b/app/controllers/api/internal/installments/non_opener_resends_controller.rb
@@ -33,7 +33,12 @@ class Api::Internal::Installments::NonOpenerResendsController < Api::Internal::B
 
       @count = @installment.unopened_recipients_count
       if @count.zero?
-        error_response = [{ success: false, error: "Everyone who was emailed has already opened this." }, :unprocessable_entity]
+        message = if @installment.unopened_recipient_emails.any?
+          "There are no non-openers left to email — the remaining unopened recipients are no longer eligible for this email's audience."
+        else
+          "Everyone who was emailed has already opened this."
+        end
+        error_response = [{ success: false, error: message }, :unprocessable_entity]
         next
       end
 

--- a/app/controllers/api/internal/installments/non_opener_resends_controller.rb
+++ b/app/controllers/api/internal/installments/non_opener_resends_controller.rb
@@ -5,6 +5,11 @@ class Api::Internal::Installments::NonOpenerResendsController < Api::Internal::B
   # to avoid accidentally re-blasting the same people repeatedly.
   RESEND_THROTTLE = 24.hours
 
+  # Hard lifetime cap on non-opener resends per post. Combined with the 24h throttle
+  # this means at most one resend per day, up to three total — after that the same
+  # unopened recipients are left alone for good.
+  MAX_RESENDS = 3
+
   before_action :authenticate_user!
   before_action :set_installment
   after_action :verify_authorized
@@ -17,6 +22,11 @@ class Api::Internal::Installments::NonOpenerResendsController < Api::Internal::B
 
   def create
     authorize @installment, :resend_to_non_openers?
+
+    if resend_limit_reached?
+      return render json: { success: false, error: "You can resend to non-openers up to #{MAX_RESENDS} times per email." },
+                    status: :too_many_requests
+    end
 
     if recently_resent?
       return render json: { success: false, error: "You can only resend to non-openers once every 24 hours." },
@@ -47,5 +57,9 @@ class Api::Internal::Installments::NonOpenerResendsController < Api::Internal::B
 
     def recently_resent?
       @installment.blasts.to_non_openers.where(requested_at: RESEND_THROTTLE.ago..).exists?
+    end
+
+    def resend_limit_reached?
+      @installment.blasts.to_non_openers.count >= MAX_RESENDS
     end
 end

--- a/app/controllers/api/internal/installments/non_opener_resends_controller.rb
+++ b/app/controllers/api/internal/installments/non_opener_resends_controller.rb
@@ -70,10 +70,10 @@ class Api::Internal::Installments::NonOpenerResendsController < Api::Internal::B
       scope = @installment.blasts.to_non_openers
       return true if scope.where(completed_at: nil).where(requested_at: IN_FLIGHT_GRACE.ago..).exists?
 
-      scope.where(completed_at: RESEND_THROTTLE.ago..).exists?
+      scope.where(completed_at: RESEND_THROTTLE.ago..).where(delivery_count: 1..).exists?
     end
 
     def resend_limit_reached?
-      @installment.blasts.to_non_openers.where.not(completed_at: nil).count >= MAX_RESENDS
+      @installment.blasts.to_non_openers.where.not(completed_at: nil).where(delivery_count: 1..).count >= MAX_RESENDS
     end
 end

--- a/app/controllers/api/internal/installments/non_opener_resends_controller.rb
+++ b/app/controllers/api/internal/installments/non_opener_resends_controller.rb
@@ -1,14 +1,9 @@
 # frozen_string_literal: true
 
 class Api::Internal::Installments::NonOpenerResendsController < Api::Internal::BaseController
-  # A seller may resend a published post to its non-openers at most once per this window,
-  # to avoid accidentally re-blasting the same people repeatedly.
   RESEND_THROTTLE = 24.hours
-
-  # Hard lifetime cap on non-opener resends per post. Combined with the 24h throttle
-  # this means at most one resend per day, up to three total — after that the same
-  # unopened recipients are left alone for good.
   MAX_RESENDS = 3
+  IN_FLIGHT_GRACE = 1.hour
 
   before_action :authenticate_user!
   before_action :set_installment
@@ -17,36 +12,45 @@ class Api::Internal::Installments::NonOpenerResendsController < Api::Internal::B
   def show
     authorize @installment, :resend_to_non_openers?
 
-    render json: { count: @installment.unopened_recipients_count }
+    render json: { count: @installment.unopened_recipients_count, recently_resent: recently_resent? }
   end
 
   def create
     authorize @installment, :resend_to_non_openers?
 
-    if resend_limit_reached?
-      return render json: { success: false, error: "You can resend to non-openers up to #{MAX_RESENDS} times per email." },
-                    status: :too_many_requests
+    blast = nil
+    error_response = nil
+    @installment.with_lock do
+      if resend_limit_reached?
+        error_response = [{ success: false, error: "You can resend to non-openers up to #{MAX_RESENDS} times per email." }, :unprocessable_entity]
+        next
+      end
+
+      if recently_resent?
+        error_response = [{ success: false, error: "You can only resend to non-openers once every 24 hours." }, :unprocessable_entity]
+        next
+      end
+
+      @count = @installment.unopened_recipients_count
+      if @count.zero?
+        error_response = [{ success: false, error: "Everyone who was emailed has already opened this." }, :unprocessable_entity]
+        next
+      end
+
+      blast = PostEmailBlast.create!(
+        post: @installment,
+        requested_at: Time.current,
+        recipient_filter: PostEmailBlast::RECIPIENT_FILTER_UNOPENED
+      )
     end
 
-    if recently_resent?
-      return render json: { success: false, error: "You can only resend to non-openers once every 24 hours." },
-                    status: :too_many_requests
+    if error_response
+      json, status = error_response
+      return render json:, status:
     end
 
-    count = @installment.unopened_recipients_count
-    if count.zero?
-      return render json: { success: false, error: "Everyone who was emailed has already opened this." },
-                    status: :unprocessable_entity
-    end
-
-    blast = PostEmailBlast.create!(
-      post: @installment,
-      requested_at: Time.current,
-      recipient_filter: PostEmailBlast::RECIPIENT_FILTER_UNOPENED
-    )
     SendPostBlastEmailsJob.perform_async(blast.id)
-
-    render json: { success: true, count: }
+    render json: { success: true, count: @count }
   end
 
   private
@@ -56,10 +60,14 @@ class Api::Internal::Installments::NonOpenerResendsController < Api::Internal::B
     end
 
     def recently_resent?
-      @installment.blasts.to_non_openers.where(requested_at: RESEND_THROTTLE.ago..).exists?
+      scope = @installment.blasts.to_non_openers
+      in_flight = scope.where(completed_at: nil).where(started_at: IN_FLIGHT_GRACE.ago..).exists?
+      return true if in_flight
+
+      scope.where(completed_at: RESEND_THROTTLE.ago..).exists?
     end
 
     def resend_limit_reached?
-      @installment.blasts.to_non_openers.count >= MAX_RESENDS
+      @installment.blasts.to_non_openers.where.not(completed_at: nil).count >= MAX_RESENDS
     end
 end

--- a/app/javascript/components/EmailsPage/shared.tsx
+++ b/app/javascript/components/EmailsPage/shared.tsx
@@ -1,8 +1,8 @@
-import { FileDetail } from "@boxicons/react";
+import { Envelope, FileDetail } from "@boxicons/react";
 import { useForm } from "@inertiajs/react";
 import React from "react";
 
-import { SavedInstallment, getAudienceCount } from "$app/data/installments";
+import { SavedInstallment, getAudienceCount, getNonOpenerCount, resendToNonOpeners } from "$app/data/installments";
 import { formatStatNumber } from "$app/utils/formatStatNumber";
 import { asyncVoid } from "$app/utils/promise";
 import { assertResponseError } from "$app/utils/request";
@@ -12,6 +12,15 @@ import { EditEmailButton, NewEmailButton } from "$app/components/EmailsPage/Layo
 import { ViewEmailButton } from "$app/components/EmailsPage/ViewEmailButton";
 import { Modal } from "$app/components/Modal";
 import { showAlert } from "$app/components/server-components/Alert";
+
+// Only purchase-backed posts have per-recipient open tracking, so a resend to non-openers
+// is offered for these types alone (follower/affiliate posts have no per-recipient open linkage).
+const NON_OPENER_RESEND_TYPES = ["seller", "product", "variant"];
+
+export const canResendToNonOpeners = (installment: SavedInstallment) =>
+  installment.display_type === "published" &&
+  installment.send_emails &&
+  NON_OPENER_RESEND_TYPES.includes(installment.installment_type);
 
 type DeleteEmailModalProps = {
   installment: { id: string; name: string } | null;
@@ -94,6 +103,77 @@ export const formatAudienceCount = (audienceCounts: AudienceCounts, installmentI
       : formatStatNumber({ value: count });
 };
 
+export const ResendToNonOpenersButton = ({ installment }: { installment: SavedInstallment }) => {
+  const [confirming, setConfirming] = React.useState(false);
+  const [count, setCount] = React.useState<number | null>(null);
+  const [resending, setResending] = React.useState(false);
+
+  const openConfirmation = asyncVoid(async () => {
+    setConfirming(true);
+    setCount(null);
+    try {
+      const { count: nonOpenerCount } = await getNonOpenerCount(installment.external_id);
+      setCount(nonOpenerCount);
+    } catch (error) {
+      assertResponseError(error);
+      setConfirming(false);
+      showAlert("Sorry, something went wrong. Please try again.", "error");
+    }
+  });
+
+  const handleResend = asyncVoid(async () => {
+    setResending(true);
+    try {
+      const { count: sentCount } = await resendToNonOpeners(installment.external_id);
+      showAlert(
+        `Resending to ${formatStatNumber({ value: sentCount })} people who haven't opened this yet.`,
+        "success",
+      );
+      setConfirming(false);
+    } catch (error) {
+      assertResponseError(error);
+      showAlert(error.message, "error");
+    } finally {
+      setResending(false);
+    }
+  });
+
+  return (
+    <>
+      <Button onClick={openConfirmation}>
+        <Envelope pack="filled" className="size-5" />
+        Resend to non-openers
+      </Button>
+      {confirming ? (
+        <Modal
+          open
+          allowClose={!resending}
+          onClose={() => setConfirming(false)}
+          title="Resend to non-openers?"
+          footer={
+            <>
+              <Button disabled={resending} onClick={() => setConfirming(false)}>
+                Cancel
+              </Button>
+              <Button color="accent" disabled={resending || count === null || count === 0} onClick={handleResend}>
+                {resending ? "Resending..." : "Resend"}
+              </Button>
+            </>
+          }
+        >
+          <h4>
+            {count === null
+              ? "Counting recipients who haven't opened this yet..."
+              : count === 0
+                ? "Everyone who was emailed has already opened this."
+                : `This will resend "${installment.name}" to ${formatStatNumber({ value: count })} people who were emailed but haven't opened it yet.`}
+          </h4>
+        </Modal>
+      ) : null}
+    </>
+  );
+};
+
 type EmailSheetActionsProps = {
   installment: SavedInstallment;
   onDelete: () => void;
@@ -103,6 +183,7 @@ export const EmailSheetActions = ({ installment, onDelete }: EmailSheetActionsPr
   <>
     <div className="grid grid-flow-col gap-4">
       {installment.send_emails ? <ViewEmailButton installment={installment} /> : null}
+      {canResendToNonOpeners(installment) ? <ResendToNonOpenersButton installment={installment} /> : null}
       {installment.shown_on_profile ? (
         <NavigationButton href={installment.full_url} target="_blank" rel="noopener noreferrer">
           <FileDetail pack="filled" className="size-5" />

--- a/app/javascript/components/EmailsPage/shared.tsx
+++ b/app/javascript/components/EmailsPage/shared.tsx
@@ -104,6 +104,7 @@ export const formatAudienceCount = (audienceCounts: AudienceCounts, installmentI
 };
 
 export const ResendToNonOpenersButton = ({ installment }: { installment: SavedInstallment }) => {
+  const [loadingCount, setLoadingCount] = React.useState(false);
   const [confirming, setConfirming] = React.useState(false);
   const [count, setCount] = React.useState<number | null>(null);
   const [recentlyResent, setRecentlyResent] = React.useState(false);
@@ -111,9 +112,8 @@ export const ResendToNonOpenersButton = ({ installment }: { installment: SavedIn
   const [resending, setResending] = React.useState(false);
 
   const openConfirmation = asyncVoid(async () => {
-    setConfirming(true);
-    setCount(null);
-    setAudienceFilteredOut(false);
+    if (loadingCount || confirming) return;
+    setLoadingCount(true);
     try {
       const {
         count: nonOpenerCount,
@@ -123,10 +123,12 @@ export const ResendToNonOpenersButton = ({ installment }: { installment: SavedIn
       setCount(nonOpenerCount);
       setRecentlyResent(recently_resent);
       setAudienceFilteredOut(audience_filtered_out);
+      setConfirming(true);
     } catch (error) {
       assertResponseError(error);
-      setConfirming(false);
       showAlert("Sorry, something went wrong. Please try again.", "error");
+    } finally {
+      setLoadingCount(false);
     }
   });
 
@@ -152,11 +154,11 @@ export const ResendToNonOpenersButton = ({ installment }: { installment: SavedIn
 
   return (
     <>
-      <Button onClick={openConfirmation}>
+      <Button disabled={loadingCount} onClick={openConfirmation}>
         <Envelope pack="filled" className="size-5" />
-        Resend to non-openers
+        {loadingCount ? "Loading..." : "Resend to non-openers"}
       </Button>
-      {confirming ? (
+      {confirming && count !== null ? (
         <Modal
           open
           allowClose={!resending}
@@ -174,15 +176,13 @@ export const ResendToNonOpenersButton = ({ installment }: { installment: SavedIn
           }
         >
           <h4>
-            {count === null
-              ? "Counting recipients who haven't opened this yet..."
-              : recentlyResent
-                ? "You've already resent this to non-openers recently. Try again in 24 hours."
-                : count === 0
-                  ? audienceFilteredOut
-                    ? "The remaining unopened recipients are no longer eligible for this email's audience."
-                    : "Everyone who was emailed has already opened this."
-                  : `This will resend "${installment.name}" to ${formatStatNumber({ value: count })} people who were emailed but haven't opened it yet.`}
+            {recentlyResent
+              ? "You've already resent this to non-openers recently. Try again in 24 hours."
+              : count === 0
+                ? audienceFilteredOut
+                  ? "The remaining unopened recipients are no longer eligible for this email's audience."
+                  : "Everyone who was emailed has already opened this."
+                : `This will resend "${installment.name}" to ${formatStatNumber({ value: count })} people who were emailed but haven't opened it yet.`}
           </h4>
         </Modal>
       ) : null}

--- a/app/javascript/components/EmailsPage/shared.tsx
+++ b/app/javascript/components/EmailsPage/shared.tsx
@@ -106,14 +106,16 @@ export const formatAudienceCount = (audienceCounts: AudienceCounts, installmentI
 export const ResendToNonOpenersButton = ({ installment }: { installment: SavedInstallment }) => {
   const [confirming, setConfirming] = React.useState(false);
   const [count, setCount] = React.useState<number | null>(null);
+  const [recentlyResent, setRecentlyResent] = React.useState(false);
   const [resending, setResending] = React.useState(false);
 
   const openConfirmation = asyncVoid(async () => {
     setConfirming(true);
     setCount(null);
     try {
-      const { count: nonOpenerCount } = await getNonOpenerCount(installment.external_id);
+      const { count: nonOpenerCount, recently_resent } = await getNonOpenerCount(installment.external_id);
       setCount(nonOpenerCount);
+      setRecentlyResent(recently_resent);
     } catch (error) {
       assertResponseError(error);
       setConfirming(false);
@@ -129,6 +131,7 @@ export const ResendToNonOpenersButton = ({ installment }: { installment: SavedIn
         `Resending to ${formatStatNumber({ value: sentCount })} people who haven't opened this yet.`,
         "success",
       );
+      setRecentlyResent(true);
       setConfirming(false);
     } catch (error) {
       assertResponseError(error);
@@ -137,6 +140,8 @@ export const ResendToNonOpenersButton = ({ installment }: { installment: SavedIn
       setResending(false);
     }
   });
+
+  const disableResend = resending || recentlyResent || count === null || count === 0;
 
   return (
     <>
@@ -155,7 +160,7 @@ export const ResendToNonOpenersButton = ({ installment }: { installment: SavedIn
               <Button disabled={resending} onClick={() => setConfirming(false)}>
                 Cancel
               </Button>
-              <Button color="accent" disabled={resending || count === null || count === 0} onClick={handleResend}>
+              <Button color="accent" disabled={disableResend} onClick={handleResend}>
                 {resending ? "Resending..." : "Resend"}
               </Button>
             </>
@@ -164,9 +169,11 @@ export const ResendToNonOpenersButton = ({ installment }: { installment: SavedIn
           <h4>
             {count === null
               ? "Counting recipients who haven't opened this yet..."
-              : count === 0
-                ? "Everyone who was emailed has already opened this."
-                : `This will resend "${installment.name}" to ${formatStatNumber({ value: count })} people who were emailed but haven't opened it yet.`}
+              : recentlyResent
+                ? "You've already resent this to non-openers recently. Try again in 24 hours."
+                : count === 0
+                  ? "Everyone who was emailed has already opened this."
+                  : `This will resend "${installment.name}" to ${formatStatNumber({ value: count })} people who were emailed but haven't opened it yet.`}
           </h4>
         </Modal>
       ) : null}

--- a/app/javascript/components/EmailsPage/shared.tsx
+++ b/app/javascript/components/EmailsPage/shared.tsx
@@ -107,15 +107,22 @@ export const ResendToNonOpenersButton = ({ installment }: { installment: SavedIn
   const [confirming, setConfirming] = React.useState(false);
   const [count, setCount] = React.useState<number | null>(null);
   const [recentlyResent, setRecentlyResent] = React.useState(false);
+  const [audienceFilteredOut, setAudienceFilteredOut] = React.useState(false);
   const [resending, setResending] = React.useState(false);
 
   const openConfirmation = asyncVoid(async () => {
     setConfirming(true);
     setCount(null);
+    setAudienceFilteredOut(false);
     try {
-      const { count: nonOpenerCount, recently_resent } = await getNonOpenerCount(installment.external_id);
+      const {
+        count: nonOpenerCount,
+        recently_resent,
+        audience_filtered_out,
+      } = await getNonOpenerCount(installment.external_id);
       setCount(nonOpenerCount);
       setRecentlyResent(recently_resent);
+      setAudienceFilteredOut(audience_filtered_out);
     } catch (error) {
       assertResponseError(error);
       setConfirming(false);
@@ -172,7 +179,9 @@ export const ResendToNonOpenersButton = ({ installment }: { installment: SavedIn
               : recentlyResent
                 ? "You've already resent this to non-openers recently. Try again in 24 hours."
                 : count === 0
-                  ? "Everyone who was emailed has already opened this."
+                  ? audienceFilteredOut
+                    ? "The remaining unopened recipients are no longer eligible for this email's audience."
+                    : "Everyone who was emailed has already opened this."
                   : `This will resend "${installment.name}" to ${formatStatNumber({ value: count })} people who were emailed but haven't opened it yet.`}
           </h4>
         </Modal>

--- a/app/javascript/components/EmailsPage/shared.tsx
+++ b/app/javascript/components/EmailsPage/shared.tsx
@@ -1,5 +1,5 @@
 import { Envelope, FileDetail } from "@boxicons/react";
-import { useForm } from "@inertiajs/react";
+import { router, useForm } from "@inertiajs/react";
 import React from "react";
 
 import { SavedInstallment, getAudienceCount, getNonOpenerCount, resendToNonOpeners } from "$app/data/installments";
@@ -142,6 +142,7 @@ export const ResendToNonOpenersButton = ({ installment }: { installment: SavedIn
       );
       setRecentlyResent(true);
       setConfirming(false);
+      router.reload();
     } catch (error) {
       assertResponseError(error);
       showAlert(error.message, "error");

--- a/app/javascript/data/installments.ts
+++ b/app/javascript/data/installments.ts
@@ -147,7 +147,7 @@ export async function getNonOpenerCount(externalId: string) {
   });
 
   if (!response.ok) throw new ResponseError();
-  return typia.assert<{ count: number }>(await response.json());
+  return typia.assert<{ count: number; recently_resent: boolean }>(await response.json());
 }
 
 export async function resendToNonOpeners(externalId: string) {

--- a/app/javascript/data/installments.ts
+++ b/app/javascript/data/installments.ts
@@ -139,6 +139,29 @@ export function getRecipientCount(requestPayload: RecipientCountRequestPayload) 
   };
 }
 
+export async function getNonOpenerCount(externalId: string) {
+  const response = await request({
+    method: "GET",
+    accept: "json",
+    url: Routes.internal_installment_non_opener_resend_path(externalId),
+  });
+
+  if (!response.ok) throw new ResponseError();
+  return typia.assert<{ count: number }>(await response.json());
+}
+
+export async function resendToNonOpeners(externalId: string) {
+  const response = await request({
+    method: "POST",
+    accept: "json",
+    url: Routes.internal_installment_non_opener_resend_path(externalId),
+  });
+
+  const json: unknown = await response.json();
+  if (!response.ok) throw new ResponseError(typia.assert<{ error: string }>(json).error);
+  return typia.assert<{ count: number }>(json);
+}
+
 export async function previewInstallment(externalId: string) {
   const response = await request({
     method: "POST",

--- a/app/javascript/data/installments.ts
+++ b/app/javascript/data/installments.ts
@@ -51,6 +51,7 @@ export type PublishedInstallment = SavedInstallment & {
   open_rate: number | null;
   view_count: number | null;
   published_at: string;
+  non_opener_resends: { requested_at: string; delivery_count: number; completed: boolean }[];
 };
 
 export type ScheduledInstallment = SavedInstallment & {

--- a/app/javascript/data/installments.ts
+++ b/app/javascript/data/installments.ts
@@ -147,7 +147,9 @@ export async function getNonOpenerCount(externalId: string) {
   });
 
   if (!response.ok) throw new ResponseError();
-  return typia.assert<{ count: number; recently_resent: boolean }>(await response.json());
+  return typia.assert<{ count: number; recently_resent: boolean; audience_filtered_out: boolean }>(
+    await response.json(),
+  );
 }
 
 export async function resendToNonOpeners(externalId: string) {

--- a/app/javascript/pages/Emails/Published.tsx
+++ b/app/javascript/pages/Emails/Published.tsx
@@ -185,7 +185,7 @@ export default function EmailsPublished() {
                               timeZone: currentSeller.timeZone.name,
                             })}
                             {resend.completed
-                              ? ` — ${formatStatNumber({ value: resend.delivery_count })} delivered`
+                              ? ` — ${formatStatNumber({ value: resend.delivery_count })} emailed`
                               : " — in progress"}
                           </li>
                         ))}

--- a/app/javascript/pages/Emails/Published.tsx
+++ b/app/javascript/pages/Emails/Published.tsx
@@ -175,6 +175,23 @@ export default function EmailsPublished() {
                       placeholder: "n/a",
                     })}
                   </CardContent>
+                  {selectedInstallment.non_opener_resends.length > 0 ? (
+                    <CardContent>
+                      <h5 className="font-bold">Resends to non-openers</h5>
+                      <ul className="mt-1 grid gap-1">
+                        {selectedInstallment.non_opener_resends.map((resend, i) => (
+                          <li key={i} className="text-sm">
+                            {new Date(resend.requested_at).toLocaleString(userAgentInfo.locale, {
+                              timeZone: currentSeller.timeZone.name,
+                            })}
+                            {resend.completed
+                              ? ` — ${formatStatNumber({ value: resend.delivery_count })} delivered`
+                              : " — in progress"}
+                          </li>
+                        ))}
+                      </ul>
+                    </CardContent>
+                  ) : null}
                 </Card>
                 <EmailSheetActions
                   installment={selectedInstallment}

--- a/app/models/installment.rb
+++ b/app/models/installment.rb
@@ -688,11 +688,26 @@ class Installment < ApplicationRecord
   # linkage, so this returns an empty array for follower/affiliate posts.
   def unopened_recipient_purchase_ids
     return [] unless seller_or_product_or_variant_type?
-    emailed_recipient_purchase_ids - opened_recipient_purchase_ids
+    email_infos
+      .where.not(purchase_id: nil)
+      .where.not(state: "opened")
+      .distinct.pluck(:purchase_id)
+  end
+
+  def resendable_to_non_openers_purchase_ids
+    candidate_ids = unopened_recipient_purchase_ids
+    return [] if candidate_ids.empty?
+
+    candidates = candidate_ids.to_set
+    AudienceMember
+      .filter(seller_id:, params: audience_members_filter_params)
+      .pluck(:purchase_id)
+      .uniq
+      .select { _1.present? && candidates.include?(_1) }
   end
 
   def unopened_recipients_count
-    unopened_recipient_purchase_ids.size
+    resendable_to_non_openers_purchase_ids.size
   end
 
   # Whether a "resend to non-openers" blast is applicable to this post.

--- a/app/models/installment.rb
+++ b/app/models/installment.rb
@@ -688,10 +688,7 @@ class Installment < ApplicationRecord
   # linkage, so this returns an empty array for follower/affiliate posts.
   def unopened_recipient_purchase_ids
     return [] unless seller_or_product_or_variant_type?
-    email_infos
-      .where.not(purchase_id: nil)
-      .where.not(state: "opened")
-      .distinct.pluck(:purchase_id)
+    emailed_recipient_purchase_ids - opened_recipient_purchase_ids
   end
 
   def resendable_to_non_openers_purchase_ids

--- a/app/models/installment.rb
+++ b/app/models/installment.rb
@@ -691,20 +691,35 @@ class Installment < ApplicationRecord
     emailed_recipient_purchase_ids - opened_recipient_purchase_ids
   end
 
-  def resendable_to_non_openers_purchase_ids
-    candidate_ids = unopened_recipient_purchase_ids
-    return [] if candidate_ids.empty?
+  # Emails of original recipients who haven't opened. Matching on email (rather than
+  # purchase_id) is the right key because AudienceMember collapses a buyer's multiple
+  # purchases into one row keyed by (seller_id, email), so the email_info purchase
+  # may not match the audience row's max(purchase_id).
+  def unopened_recipient_emails
+    return [] unless seller_or_product_or_variant_type?
 
-    candidates = candidate_ids.to_set
+    emailed_ids = emailed_recipient_purchase_ids
+    return [] if emailed_ids.empty?
+
+    emailed_emails = Purchase.where(id: emailed_ids).distinct.pluck(:email).compact.map(&:downcase)
+    opened_emails = Purchase.where(id: opened_recipient_purchase_ids).distinct.pluck(:email).compact.map(&:downcase)
+    emailed_emails - opened_emails
+  end
+
+  def resendable_to_non_openers_emails
+    candidates = unopened_recipient_emails.to_set
+    return [] if candidates.empty?
+
     AudienceMember
-      .filter(seller_id:, params: audience_members_filter_params, with_ids: true)
-      .pluck(Arel.sql("purchase_id"))
+      .filter(seller_id:, params: audience_members_filter_params)
+      .pluck(:email)
+      .map(&:downcase)
       .uniq
-      .select { _1.present? && candidates.include?(_1) }
+      .select { candidates.include?(_1) }
   end
 
   def unopened_recipients_count
-    resendable_to_non_openers_purchase_ids.size
+    resendable_to_non_openers_emails.size
   end
 
   # Whether a "resend to non-openers" blast is applicable to this post.

--- a/app/models/installment.rb
+++ b/app/models/installment.rb
@@ -700,8 +700,8 @@ class Installment < ApplicationRecord
 
     candidates = candidate_ids.to_set
     AudienceMember
-      .filter(seller_id:, params: audience_members_filter_params)
-      .pluck(:purchase_id)
+      .filter(seller_id:, params: audience_members_filter_params, with_ids: true)
+      .pluck(Arel.sql("purchase_id"))
       .uniq
       .select { _1.present? && candidates.include?(_1) }
   end

--- a/app/models/installment.rb
+++ b/app/models/installment.rb
@@ -672,6 +672,34 @@ class Installment < ApplicationRecord
     end
   end
 
+  # Purchase ids of recipients this post was emailed to, backed by the open-tracking
+  # CreatorContactingCustomersEmailInfo rows that are created when a post email is sent.
+  def emailed_recipient_purchase_ids
+    email_infos.where.not(purchase_id: nil).distinct.pluck(:purchase_id)
+  end
+
+  # Purchase ids of recipients who have opened this post's email at least once.
+  def opened_recipient_purchase_ids
+    email_infos.where(state: "opened").where.not(purchase_id: nil).distinct.pluck(:purchase_id)
+  end
+
+  # Purchase ids of original recipients who have not opened this post's email yet.
+  # Only purchase-backed posts (customer/seller/product/variant) have per-recipient open
+  # linkage, so this returns an empty array for follower/affiliate posts.
+  def unopened_recipient_purchase_ids
+    return [] unless seller_or_product_or_variant_type?
+    emailed_recipient_purchase_ids - opened_recipient_purchase_ids
+  end
+
+  def unopened_recipients_count
+    unopened_recipient_purchase_ids.size
+  end
+
+  # Whether a "resend to non-openers" blast is applicable to this post.
+  def resendable_to_non_openers?
+    published? && send_emails? && seller_or_product_or_variant_type?
+  end
+
   def unique_click_count
     Rails.cache.fetch(key_for_cache(:unique_click_count)) do
       summary = CreatorEmailClickSummary.where(installment_id: id).last

--- a/app/models/post_email_blast.rb
+++ b/app/models/post_email_blast.rb
@@ -13,10 +13,23 @@ class PostEmailBlast < ApplicationRecord
   # delivery_count:
   #   Number of emails that were delivered. Not final until the blast is complete.
 
+  # recipient_filter:
+  #   nil       => normal blast, sent to the full computed audience.
+  #   "unopened" => resend targeting only original recipients who have not opened the post yet.
+  RECIPIENT_FILTER_UNOPENED = "unopened"
+
   belongs_to :post, class_name: "Installment"
   belongs_to :seller, class_name: "User"
 
   before_validation -> { self.seller = post.seller }, on: :create
+
+  validates :recipient_filter, inclusion: { in: [RECIPIENT_FILTER_UNOPENED] }, allow_nil: true
+
+  scope :to_non_openers, -> { where(recipient_filter: RECIPIENT_FILTER_UNOPENED) }
+
+  def to_non_openers?
+    recipient_filter == RECIPIENT_FILTER_UNOPENED
+  end
 
   scope :aggregated, -> {
     select(

--- a/app/policies/installment_policy.rb
+++ b/app/policies/installment_policy.rb
@@ -63,4 +63,8 @@ class InstallmentPolicy < ApplicationPolicy
     create? ||
     user.role_support_for?(seller)
   end
+
+  def resend_to_non_openers?
+    create?
+  end
 end

--- a/app/presenters/installment_presenter.rb
+++ b/app/presenters/installment_presenter.rb
@@ -66,6 +66,9 @@ class InstallmentPresenter
         full_url: installment.full_url,
         has_been_blasted: installment.has_been_blasted?,
         shown_in_profile_sections: seller.seller_profile_posts_sections.filter_map { _1.external_id if _1.shown_posts.include?(installment.id) },
+        non_opener_resends: installment.blasts.to_non_openers.order(:requested_at).map do |blast|
+          { requested_at: blast.requested_at, delivery_count: blast.delivery_count, completed: blast.completed_at.present? }
+        end,
       )
 
       unless installment.published?

--- a/app/services/handle_email_event_info/for_installment_email.rb
+++ b/app/services/handle_email_event_info/for_installment_email.rb
@@ -136,6 +136,9 @@ class HandleEmailEventInfo::ForInstallmentEmail
 
         update_installment_cache(email_event_info.installment_id, :unique_open_count)
       end
+
+      email_info = pull_creator_contacting_customers_email_info(email_event_info)
+      email_info.mark_opened!(email_event_info.created_at) if email_info&.persisted? && !email_info.opened?
     end
 
     def handle_spamreport_event!

--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -28,6 +28,7 @@ class RedisKey
     def sales_related_products_internal_limit = "sales_related_products_internal_limit"
     def recommended_products_associated_product_ids_limit = "recommended_products_associated_product_ids_limit"
     def blast_recipients_slice_size = "blast:recipients_slice_size"
+    def blast_sent_emails(blast_id) = "blast:#{blast_id}:sent_emails"
     def impersonated_user(admin_user_id) = "impersonated_user_by_admin_#{admin_user_id}"
     def gumroad_day_date = "gumroad_day_date"
     def update_cached_srpis_job_delay_hours = "update_cached_srpis_job_delay_hours"

--- a/app/sidekiq/send_post_blast_emails_job.rb
+++ b/app/sidekiq/send_post_blast_emails_job.rb
@@ -18,10 +18,19 @@ class SendPostBlastEmailsJob
     Makara::Context.release_all
     @members = AudienceMember.filter(seller_id: @post.seller_id, params: @filters, with_ids: true).select(:id, :email, :purchase_id, :follower_id, :affiliate_id).to_a
 
-    # We will check each batch of emails to see if they were already messaged,
-    # but we can already remove all of the ones we know have already been emailed, ahead of time (faster).
-    # This check is only useful if the post has been published twice, or if this job is being retried.
-    remove_already_emailed_members
+    if @blast.to_non_openers?
+      # This is a resend to the subset of original recipients who haven't opened the post yet.
+      # Every recipient was already emailed, so the `sent_post_emails` exclusion below would
+      # drop everyone. Instead we keep only the original purchase-backed recipients who are
+      # still in the audience and have not opened the email.
+      keep = @post.unopened_recipient_purchase_ids.to_set
+      @members.select! { _1.purchase_id.present? && keep.include?(_1.purchase_id) }
+    else
+      # We will check each batch of emails to see if they were already messaged,
+      # but we can already remove all of the ones we know have already been emailed, ahead of time (faster).
+      # This check is only useful if the post has been published twice, or if this job is being retried.
+      remove_already_emailed_members
+    end
 
     return mark_blast_as_completed if @members.empty?
 
@@ -35,8 +44,12 @@ class SendPostBlastEmailsJob
       rescue => e
         # Delete the sent_post_emails records if there's an error with PostEmailApi.process
         # We cannot use `transaction` here because it exceeds the lock timeout.
-        emails = members.map(&:email)
-        SentPostEmail.where(post: @post, email: emails).delete_all
+        # For a non-openers resend we never insert sent_post_emails (they already exist from the
+        # original blast), so there's nothing to roll back here.
+        unless @blast.to_non_openers?
+          emails = members.map(&:email)
+          SentPostEmail.where(post: @post, email: emails).delete_all
+        end
         raise e
       end
     end
@@ -141,6 +154,10 @@ class SendPostBlastEmailsJob
     # "Unlikely situation" because we've already filtered the sent emails beforehand with `remove_already_emailed_members`,
     # this behavior only helps if an email is sent by something else in parallel, between the start and the end of this job.
     def store_recipients_as_sent(members)
+      # A non-openers resend re-sends to people already in `sent_post_emails`, so we must not
+      # gate on it here (every email would be treated as a duplicate and dropped).
+      return members if @blast.to_non_openers?
+
       emails = Set.new(SentPostEmail.insert_all_emails(post: @post, emails: members.map(&:email)))
       return members if members.size == emails.size
 

--- a/app/sidekiq/send_post_blast_emails_job.rb
+++ b/app/sidekiq/send_post_blast_emails_job.rb
@@ -19,8 +19,8 @@ class SendPostBlastEmailsJob
     @members = AudienceMember.filter(seller_id: @post.seller_id, params: @filters, with_ids: true).select(:id, :email, :purchase_id, :follower_id, :affiliate_id).to_a
 
     if @blast.to_non_openers?
-      keep = @post.unopened_recipient_purchase_ids.to_set
-      @members.select! { _1.purchase_id.present? && keep.include?(_1.purchase_id) }
+      keep_emails = @post.unopened_recipient_emails.to_set
+      @members.select! { _1.email.present? && keep_emails.include?(_1.email.downcase) }
       remove_members_already_sent_in_this_blast
     else
       # We will check each batch of emails to see if they were already messaged,

--- a/app/sidekiq/send_post_blast_emails_job.rb
+++ b/app/sidekiq/send_post_blast_emails_job.rb
@@ -19,12 +19,9 @@ class SendPostBlastEmailsJob
     @members = AudienceMember.filter(seller_id: @post.seller_id, params: @filters, with_ids: true).select(:id, :email, :purchase_id, :follower_id, :affiliate_id).to_a
 
     if @blast.to_non_openers?
-      # This is a resend to the subset of original recipients who haven't opened the post yet.
-      # Every recipient was already emailed, so the `sent_post_emails` exclusion below would
-      # drop everyone. Instead we keep only the original purchase-backed recipients who are
-      # still in the audience and have not opened the email.
       keep = @post.unopened_recipient_purchase_ids.to_set
       @members.select! { _1.purchase_id.present? && keep.include?(_1.purchase_id) }
+      remove_members_already_sent_in_this_blast
     else
       # We will check each batch of emails to see if they were already messaged,
       # but we can already remove all of the ones we know have already been emailed, ahead of time (faster).
@@ -41,11 +38,10 @@ class SendPostBlastEmailsJob
 
       begin
         PostEmailApi.process(post: @post, recipients:, cache:, blast: @blast)
+        mark_members_sent_in_this_blast(members) if @blast.to_non_openers?
       rescue => e
         # Delete the sent_post_emails records if there's an error with PostEmailApi.process
         # We cannot use `transaction` here because it exceeds the lock timeout.
-        # For a non-openers resend we never insert sent_post_emails (they already exist from the
-        # original blast), so there's nothing to roll back here.
         unless @blast.to_non_openers?
           emails = members.map(&:email)
           SentPostEmail.where(post: @post, email: emails).delete_all
@@ -71,6 +67,27 @@ class SendPostBlastEmailsJob
       return if already_sent_emails.empty?
 
       @members.delete_if { _1.email.in?(already_sent_emails) }
+    end
+
+    BLAST_DEDUPE_TTL = 7.days
+
+    def remove_members_already_sent_in_this_blast
+      already_sent = $redis.smembers(RedisKey.blast_sent_emails(@blast.id))
+      return if already_sent.empty?
+
+      already_sent_set = already_sent.to_set
+      @members.delete_if { already_sent_set.include?(_1.email) }
+    end
+
+    def mark_members_sent_in_this_blast(members)
+      emails = members.map(&:email)
+      return if emails.empty?
+
+      key = RedisKey.blast_sent_emails(@blast.id)
+      $redis.pipelined do |pipe|
+        pipe.sadd(key, emails)
+        pipe.expire(key, BLAST_DEDUPE_TTL.to_i)
+      end
     end
 
     def enrich_with_gathered_records(members_with_specifics)
@@ -154,8 +171,6 @@ class SendPostBlastEmailsJob
     # "Unlikely situation" because we've already filtered the sent emails beforehand with `remove_already_emailed_members`,
     # this behavior only helps if an email is sent by something else in parallel, between the start and the end of this job.
     def store_recipients_as_sent(members)
-      # A non-openers resend re-sends to people already in `sent_post_emails`, so we must not
-      # gate on it here (every email would be treated as a duplicate and dropped).
       return members if @blast.to_non_openers?
 
       emails = Set.new(SentPostEmail.insert_all_emails(post: @post, emails: members.map(&:email)))

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1054,6 +1054,7 @@ Rails.application.routes.draw do
           member do
             resource :audience_count, only: [:show], controller: "installments/audience_counts", as: :installment_audience_count
             resource :preview_email, only: [:create], controller: "installments/preview_emails", as: :installment_preview_email
+            resource :non_opener_resend, only: [:show, :create], controller: "installments/non_opener_resends", as: :installment_non_opener_resend
           end
           collection do
             resource :recipient_count, only: [:show], controller: "installments/recipient_counts", as: :installment_recipient_count

--- a/db/migrate/20261130000004_add_recipient_filter_to_post_email_blasts.rb
+++ b/db/migrate/20261130000004_add_recipient_filter_to_post_email_blasts.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRecipientFilterToPostEmailBlasts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :post_email_blasts, :recipient_filter, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_11_30_000003) do
+ActiveRecord::Schema[7.1].define(version: 2026_11_30_000004) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -1439,6 +1439,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_11_30_000003) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "completed_at"
+    t.string "recipient_filter"
     t.index ["post_id", "requested_at"], name: "index_post_email_blasts_on_post_id_and_requested_at"
     t.index ["requested_at"], name: "index_post_email_blasts_on_requested_at"
     t.index ["seller_id", "requested_at"], name: "index_post_email_blasts_on_seller_id_and_requested_at"

--- a/spec/controllers/api/internal/installments/non_opener_resends_controller_spec.rb
+++ b/spec/controllers/api/internal/installments/non_opener_resends_controller_spec.rb
@@ -152,6 +152,16 @@ describe Api::Internal::Installments::NonOpenerResendsController do
       expect(response).to have_http_status(:unprocessable_entity)
     end
 
+    it "blocks a second resend while a prior one is pending (queued but Sidekiq hasn't started it yet)" do
+      create(:blast, post: installment, recipient_filter: "unopened", requested_at: 1.minute.ago, started_at: nil, completed_at: nil)
+
+      expect do
+        post :create, params: { id: installment.external_id }
+      end.not_to change { PostEmailBlast.where(post: installment).count }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
     it "allows a retry after a failed (never-completed) resend" do
       create(:blast, post: installment, recipient_filter: "unopened", requested_at: 3.hours.ago, started_at: 3.hours.ago, completed_at: nil)
 

--- a/spec/controllers/api/internal/installments/non_opener_resends_controller_spec.rb
+++ b/spec/controllers/api/internal/installments/non_opener_resends_controller_spec.rb
@@ -198,5 +198,25 @@ describe Api::Internal::Installments::NonOpenerResendsController do
 
       expect(response).to be_successful
     end
+
+    it "does not count zero-delivered resends toward the lifetime cap" do
+      create_list(:blast, 3, post: installment, recipient_filter: "unopened", requested_at: 25.hours.ago, started_at: 25.hours.ago, completed_at: 25.hours.ago, delivery_count: 0)
+
+      expect do
+        post :create, params: { id: installment.external_id }
+      end.to change { PostEmailBlast.to_non_openers.where(post: installment).count }.by(1)
+
+      expect(response).to be_successful
+    end
+
+    it "does not let a zero-delivered resend trigger the 24h throttle" do
+      create(:blast, post: installment, recipient_filter: "unopened", requested_at: 2.hours.ago, started_at: 2.hours.ago, completed_at: 1.hour.ago, delivery_count: 0)
+
+      expect do
+        post :create, params: { id: installment.external_id }
+      end.to change { PostEmailBlast.to_non_openers.where(post: installment).count }.by(1)
+
+      expect(response).to be_successful
+    end
   end
 end

--- a/spec/controllers/api/internal/installments/non_opener_resends_controller_spec.rb
+++ b/spec/controllers/api/internal/installments/non_opener_resends_controller_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "shared_examples/authorize_called"
+require "shared_examples/authentication_required"
+
+describe Api::Internal::Installments::NonOpenerResendsController do
+  let(:seller) { create(:user) }
+
+  include_context "with user signed in as admin for seller"
+
+  let(:product) { create(:product, user: seller, name: "Product one") }
+  let(:installment) do
+    create(:product_post, :published, seller:, link: product, bought_products: [product.unique_permalink])
+  end
+  let!(:opened_sale) { create(:purchase, link: product, seller:) }
+  let!(:unopened_sale) { create(:purchase, link: product, seller:) }
+
+  before do
+    # Original blast: both recipients emailed, only one opened.
+    [opened_sale, unopened_sale].each { |sale| SentPostEmail.create!(post: installment, email: sale.email) }
+    create(:creator_contacting_customers_email_info_opened, installment: installment, purchase: opened_sale)
+    create(:creator_contacting_customers_email_info_sent, installment: installment, purchase: unopened_sale)
+  end
+
+  describe "GET show" do
+    it_behaves_like "authentication required for action", :get, :show do
+      let(:request_params) { { id: installment.external_id } }
+    end
+
+    it_behaves_like "authorize called for action", :get, :show do
+      let(:record) { installment }
+      let(:policy_method) { :resend_to_non_openers? }
+      let(:request_params) { { id: installment.external_id } }
+    end
+
+    it "returns the number of recipients who have not opened the post yet" do
+      get :show, params: { id: installment.external_id }
+      expect(response).to be_successful
+      expect(response.parsed_body).to eq({ "count" => 1 })
+    end
+
+    it "returns 404 when the installment is not found" do
+      get :show, params: { id: "nonexistent" }
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "returns 404 for a post type that has no per-recipient open tracking (follower)" do
+      follower_post = create(:follower_post, :published, seller:)
+      get :show, params: { id: follower_post.external_id }
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "returns 404 for an unpublished post" do
+      draft = create(:product_post, seller:, link: product, bought_products: [product.unique_permalink])
+      get :show, params: { id: draft.external_id }
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "POST create" do
+    it_behaves_like "authentication required for action", :post, :create do
+      let(:request_params) { { id: installment.external_id } }
+    end
+
+    it_behaves_like "authorize called for action", :post, :create do
+      let(:record) { installment }
+      let(:policy_method) { :resend_to_non_openers? }
+      let(:request_params) { { id: installment.external_id } }
+    end
+
+    it "creates an unopened-filtered blast and enqueues the send job" do
+      expect do
+        post :create, params: { id: installment.external_id }
+      end.to change { PostEmailBlast.to_non_openers.where(post: installment).count }.by(1)
+        .and change { SendPostBlastEmailsJob.jobs.size }.by(1)
+
+      expect(response).to be_successful
+      expect(response.parsed_body).to eq({ "success" => true, "count" => 1 })
+    end
+
+    it "returns 422 when everyone who was emailed has already opened" do
+      create(:creator_contacting_customers_email_info_opened, installment: installment, purchase: unopened_sale)
+
+      expect do
+        post :create, params: { id: installment.external_id }
+      end.not_to change { PostEmailBlast.where(post: installment).count }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["success"]).to eq(false)
+    end
+
+    it "throttles a second resend within the window" do
+      create(:blast, post: installment, recipient_filter: "unopened", requested_at: 1.hour.ago)
+
+      expect do
+        post :create, params: { id: installment.external_id }
+      end.not_to change { PostEmailBlast.where(post: installment).count }
+
+      expect(response).to have_http_status(:too_many_requests)
+      expect(response.parsed_body["success"]).to eq(false)
+    end
+
+    it "allows a resend once the throttle window has passed" do
+      create(:blast, post: installment, recipient_filter: "unopened", requested_at: 25.hours.ago)
+
+      expect do
+        post :create, params: { id: installment.external_id }
+      end.to change { PostEmailBlast.to_non_openers.where(post: installment).count }.by(1)
+
+      expect(response).to be_successful
+    end
+
+    it "returns 404 when the installment is not found" do
+      post :create, params: { id: "nonexistent" }
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/controllers/api/internal/installments/non_opener_resends_controller_spec.rb
+++ b/spec/controllers/api/internal/installments/non_opener_resends_controller_spec.rb
@@ -95,6 +95,19 @@ describe Api::Internal::Installments::NonOpenerResendsController do
 
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response.parsed_body["success"]).to eq(false)
+      expect(response.parsed_body["error"]).to include("already opened")
+    end
+
+    it "returns a distinct 422 message when unopened recipients exist but no longer match the audience filter" do
+      not_bought_product = create(:product, user: seller)
+      installment.update!(not_bought_products: [product.unique_permalink], bought_products: [not_bought_product.unique_permalink])
+
+      expect do
+        post :create, params: { id: installment.external_id }
+      end.not_to change { PostEmailBlast.where(post: installment).count }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["error"]).to include("no longer eligible")
     end
 
     it "throttles a second resend within the window" do

--- a/spec/controllers/api/internal/installments/non_opener_resends_controller_spec.rb
+++ b/spec/controllers/api/internal/installments/non_opener_resends_controller_spec.rb
@@ -37,7 +37,17 @@ describe Api::Internal::Installments::NonOpenerResendsController do
     it "returns the number of recipients who have not opened the post yet" do
       get :show, params: { id: installment.external_id }
       expect(response).to be_successful
-      expect(response.parsed_body).to eq({ "count" => 1, "recently_resent" => false })
+      expect(response.parsed_body).to eq({ "count" => 1, "recently_resent" => false, "audience_filtered_out" => false })
+    end
+
+    it "flags audience_filtered_out when unopened recipients exist but are no longer in the audience" do
+      not_bought_product = create(:product, user: seller)
+      installment.update!(not_bought_products: [product.unique_permalink], bought_products: [not_bought_product.unique_permalink])
+
+      get :show, params: { id: installment.external_id }
+      expect(response).to be_successful
+      expect(response.parsed_body["count"]).to eq(0)
+      expect(response.parsed_body["audience_filtered_out"]).to eq(true)
     end
 
     it "reports recently_resent when an unopened blast was created within the throttle window" do

--- a/spec/controllers/api/internal/installments/non_opener_resends_controller_spec.rb
+++ b/spec/controllers/api/internal/installments/non_opener_resends_controller_spec.rb
@@ -37,7 +37,14 @@ describe Api::Internal::Installments::NonOpenerResendsController do
     it "returns the number of recipients who have not opened the post yet" do
       get :show, params: { id: installment.external_id }
       expect(response).to be_successful
-      expect(response.parsed_body).to eq({ "count" => 1 })
+      expect(response.parsed_body).to eq({ "count" => 1, "recently_resent" => false })
+    end
+
+    it "reports recently_resent when an unopened blast was created within the throttle window" do
+      create(:blast, post: installment, recipient_filter: "unopened", requested_at: 1.hour.ago, completed_at: 50.minutes.ago)
+      get :show, params: { id: installment.external_id }
+      expect(response).to be_successful
+      expect(response.parsed_body["recently_resent"]).to eq(true)
     end
 
     it "returns 404 when the installment is not found" do
@@ -91,18 +98,39 @@ describe Api::Internal::Installments::NonOpenerResendsController do
     end
 
     it "throttles a second resend within the window" do
-      create(:blast, post: installment, recipient_filter: "unopened", requested_at: 1.hour.ago)
+      create(:blast, post: installment, recipient_filter: "unopened", requested_at: 1.hour.ago, completed_at: 1.hour.ago)
 
       expect do
         post :create, params: { id: installment.external_id }
       end.not_to change { PostEmailBlast.where(post: installment).count }
 
-      expect(response).to have_http_status(:too_many_requests)
+      expect(response).to have_http_status(:unprocessable_entity)
       expect(response.parsed_body["success"]).to eq(false)
+      expect(response.parsed_body["error"]).to include("once every 24 hours")
     end
 
     it "allows a resend once the throttle window has passed" do
-      create(:blast, post: installment, recipient_filter: "unopened", requested_at: 25.hours.ago)
+      create(:blast, post: installment, recipient_filter: "unopened", requested_at: 25.hours.ago, completed_at: 25.hours.ago)
+
+      expect do
+        post :create, params: { id: installment.external_id }
+      end.to change { PostEmailBlast.to_non_openers.where(post: installment).count }.by(1)
+
+      expect(response).to be_successful
+    end
+
+    it "blocks a second resend while a prior one is still in flight" do
+      create(:blast, post: installment, recipient_filter: "unopened", requested_at: 5.minutes.ago, started_at: 5.minutes.ago, completed_at: nil)
+
+      expect do
+        post :create, params: { id: installment.external_id }
+      end.not_to change { PostEmailBlast.where(post: installment).count }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it "allows a retry after a failed (never-completed) resend" do
+      create(:blast, post: installment, recipient_filter: "unopened", requested_at: 3.hours.ago, started_at: 3.hours.ago, completed_at: nil)
 
       expect do
         post :create, params: { id: installment.external_id }
@@ -117,16 +145,25 @@ describe Api::Internal::Installments::NonOpenerResendsController do
     end
 
     it "blocks a resend once the lifetime cap is reached, even after the throttle window" do
-      # Three prior resends, all older than the 24h throttle, so only the cap can block.
-      create_list(:blast, 3, post: installment, recipient_filter: "unopened", requested_at: 25.hours.ago)
+      create_list(:blast, 3, post: installment, recipient_filter: "unopened", requested_at: 25.hours.ago, completed_at: 25.hours.ago)
 
       expect do
         post :create, params: { id: installment.external_id }
       end.not_to change { PostEmailBlast.where(post: installment).count }
 
-      expect(response).to have_http_status(:too_many_requests)
+      expect(response).to have_http_status(:unprocessable_entity)
       expect(response.parsed_body["success"]).to eq(false)
       expect(response.parsed_body["error"]).to include("up to 3 times")
+    end
+
+    it "does not count failed (never-completed) prior resends toward the lifetime cap" do
+      create_list(:blast, 3, post: installment, recipient_filter: "unopened", requested_at: 25.hours.ago, completed_at: nil, started_at: 25.hours.ago)
+
+      expect do
+        post :create, params: { id: installment.external_id }
+      end.to change { PostEmailBlast.to_non_openers.where(post: installment).count }.by(1)
+
+      expect(response).to be_successful
     end
   end
 end

--- a/spec/controllers/api/internal/installments/non_opener_resends_controller_spec.rb
+++ b/spec/controllers/api/internal/installments/non_opener_resends_controller_spec.rb
@@ -115,5 +115,18 @@ describe Api::Internal::Installments::NonOpenerResendsController do
       post :create, params: { id: "nonexistent" }
       expect(response).to have_http_status(:not_found)
     end
+
+    it "blocks a resend once the lifetime cap is reached, even after the throttle window" do
+      # Three prior resends, all older than the 24h throttle, so only the cap can block.
+      create_list(:blast, 3, post: installment, recipient_filter: "unopened", requested_at: 25.hours.ago)
+
+      expect do
+        post :create, params: { id: installment.external_id }
+      end.not_to change { PostEmailBlast.where(post: installment).count }
+
+      expect(response).to have_http_status(:too_many_requests)
+      expect(response.parsed_body["success"]).to eq(false)
+      expect(response.parsed_body["error"]).to include("up to 3 times")
+    end
   end
 end

--- a/spec/models/installment_spec.rb
+++ b/spec/models/installment_spec.rb
@@ -1257,4 +1257,67 @@ const b = 2;</code></pre>
       end
     end
   end
+
+  describe "non-opener queries" do
+    let(:seller) { create(:user) }
+    let(:product) { create(:product, user: seller) }
+    let(:post) { create(:product_post, :published, seller:, link: product) }
+    let(:opened_purchase) { create(:purchase, link: product, seller:) }
+    let(:delivered_purchase) { create(:purchase, link: product, seller:) }
+    let(:sent_purchase) { create(:purchase, link: product, seller:) }
+
+    before do
+      create(:creator_contacting_customers_email_info_opened, installment: post, purchase: opened_purchase)
+      create(:creator_contacting_customers_email_info_delivered, installment: post, purchase: delivered_purchase)
+      create(:creator_contacting_customers_email_info_sent, installment: post, purchase: sent_purchase)
+    end
+
+    describe "#emailed_recipient_purchase_ids" do
+      it "returns all purchase ids the post was emailed to" do
+        expect(post.emailed_recipient_purchase_ids).to match_array([opened_purchase.id, delivered_purchase.id, sent_purchase.id])
+      end
+    end
+
+    describe "#opened_recipient_purchase_ids" do
+      it "returns only purchase ids that opened the email" do
+        expect(post.opened_recipient_purchase_ids).to eq([opened_purchase.id])
+      end
+    end
+
+    describe "#unopened_recipient_purchase_ids" do
+      it "returns emailed recipients who have not opened the email" do
+        expect(post.unopened_recipient_purchase_ids).to match_array([delivered_purchase.id, sent_purchase.id])
+      end
+
+      it "returns an empty array for follower posts which have no per-recipient open linkage" do
+        follower_post = create(:follower_post, :published, seller:)
+        expect(follower_post.unopened_recipient_purchase_ids).to eq([])
+      end
+    end
+
+    describe "#unopened_recipients_count" do
+      it "counts emailed recipients who have not opened the email" do
+        expect(post.unopened_recipients_count).to eq(2)
+      end
+    end
+
+    describe "#resendable_to_non_openers?" do
+      it "is true for a published customer post that emails" do
+        expect(post.resendable_to_non_openers?).to be(true)
+      end
+
+      it "is false for an unpublished post" do
+        expect(create(:product_post, seller:, link: product).resendable_to_non_openers?).to be(false)
+      end
+
+      it "is false for a follower post" do
+        expect(create(:follower_post, :published, seller:).resendable_to_non_openers?).to be(false)
+      end
+
+      it "is false when the post does not email" do
+        profile_only_post = create(:product_post, :published, seller:, link: product, send_emails: false, shown_on_profile: true)
+        expect(profile_only_post.resendable_to_non_openers?).to be(false)
+      end
+    end
+  end
 end

--- a/spec/models/installment_spec.rb
+++ b/spec/models/installment_spec.rb
@@ -1299,6 +1299,14 @@ const b = 2;</code></pre>
       it "counts emailed recipients who have not opened the email" do
         expect(post.unopened_recipients_count).to eq(2)
       end
+
+      it "still counts a buyer whose audience row's max(purchase_id) is a newer purchase than the one emailed" do
+        # Same email/buyer, second purchase later than the one we emailed.
+        newer = create(:purchase, link: product, seller:, email: delivered_purchase.email)
+        expect(newer.id).to be > delivered_purchase.id
+        # delivered_purchase has email_info state=delivered (unopened). The buyer should still count.
+        expect(post.unopened_recipients_count).to eq(2)
+      end
     end
 
     describe "#resendable_to_non_openers?" do

--- a/spec/presenters/installment_presenter_spec.rb
+++ b/spec/presenters/installment_presenter_spec.rb
@@ -194,10 +194,26 @@ describe InstallmentPresenter do
         send_emails: true,
         shown_on_profile: true,
         has_been_blasted: false,
+        non_opener_resends: [],
         shown_in_profile_sections: [section.external_id]
       ))
       expect(props.keys).to_not include(:published_once_already, :member_cancellation, :new_customers_only, :delayed_delivery_time_duration, :delayed_delivery_time_period, :displayed_delayed_delivery_time_period)
       expect(props.keys).to_not include(:recipient_description, :to_be_published_at)
+    end
+
+    context "when the installment has non-opener resends" do
+      it "returns each unopened blast in non_opener_resends ordered by requested_at" do
+        older = create(:blast, post: installment, recipient_filter: "unopened", requested_at: 2.days.ago, started_at: 2.days.ago, completed_at: 2.days.ago, delivery_count: 5)
+        newer = create(:blast, post: installment, recipient_filter: "unopened", requested_at: 1.hour.ago, started_at: 1.hour.ago, completed_at: nil, delivery_count: 0)
+        create(:blast, post: installment, requested_at: 3.days.ago) # not an unopened resend, must be excluded
+
+        props = described_class.new(seller:, installment:).props
+
+        expect(props[:non_opener_resends]).to eq([
+                                                   { requested_at: older.requested_at, delivery_count: 5, completed: true },
+                                                   { requested_at: newer.requested_at, delivery_count: 0, completed: false }
+                                                 ])
+      end
     end
 
     context "when installment is of type `product`" do

--- a/spec/requests/emails/resend_to_non_openers_spec.rb
+++ b/spec/requests/emails/resend_to_non_openers_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "shared_examples/authorize_called"
+
+describe("Resend to non-openers flow", :js, type: :system) do
+  include EmailHelpers
+
+  let(:seller) { create(:named_seller) }
+  let(:product) { create(:product, name: "Sample product", user: seller) }
+  let!(:installment) do
+    create(:published_installment, seller:, link: product, installment_type: "product",
+                                   name: "Product update", message: "Hello customers", shown_on_profile: false)
+  end
+  let!(:blast) { create(:post_email_blast, post: installment, completed_at: 1.day.ago) }
+
+  # Three buyers were emailed; one opened, two did not -> 2 non-openers.
+  let!(:opened_purchase) { create(:purchase, link: product, seller:, email: "opened@example.com") }
+  let!(:unopened_purchase_1) { create(:purchase, link: product, seller:, email: "miss1@example.com") }
+  let!(:unopened_purchase_2) { create(:purchase, link: product, seller:, email: "miss2@example.com") }
+
+  include_context "with switching account to user as admin for seller"
+
+  before do
+    seller.update!(timezone: "UTC")
+    allow_any_instance_of(User).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE)
+    create(:payment_completed, user: seller)
+
+    create(:creator_contacting_customers_email_info_opened, installment:, purchase: opened_purchase)
+    create(:creator_contacting_customers_email_info_sent, installment:, purchase: unopened_purchase_1)
+    create(:creator_contacting_customers_email_info_sent, installment:, purchase: unopened_purchase_2)
+  end
+
+  it "resends a published email to the recipients who have not opened it" do
+    visit emails_path
+
+    expect(page).to have_tab_button("Published", open: true)
+    find(:table_row, { "Subject" => "Product update" }).click
+
+    expect(page).to have_button("Resend to non-openers")
+    click_on "Resend to non-openers"
+
+    within_modal "Resend to non-openers?" do
+      expect(page).to have_text("2 people who were emailed but haven't opened it yet")
+      click_on "Resend"
+    end
+
+    expect(page).to have_alert(text: "Resending to 2 people who haven't opened this yet.")
+
+    resend_blast = installment.blasts.where(recipient_filter: "unopened").sole
+    expect(resend_blast.recipient_filter).to eq("unopened")
+    expect(SendPostBlastEmailsJob).to have_enqueued_sidekiq_job(resend_blast.id)
+    expect(installment.blasts.count).to eq(2)
+  end
+
+  it "disables the resend when everyone who was emailed has already opened it" do
+    CreatorContactingCustomersEmailInfo.where(installment_id: installment.id).update_all(state: "opened", opened_at: Time.current)
+
+    visit emails_path
+
+    find(:table_row, { "Subject" => "Product update" }).click
+    click_on "Resend to non-openers"
+
+    within_modal "Resend to non-openers?" do
+      expect(page).to have_text("Everyone who was emailed has already opened this.")
+      expect(page).to have_button("Resend", disabled: true)
+      click_on "Cancel"
+    end
+
+    expect(installment.blasts.where(recipient_filter: "unopened")).to be_empty
+    expect(SendPostBlastEmailsJob).not_to have_enqueued_sidekiq_job(anything)
+  end
+
+  it "does not offer the resend for a follower email with no per-recipient open tracking" do
+    follower_installment = create(:published_installment, seller:, link: nil, installment_type: "follower", name: "Follower update")
+    create(:post_email_blast, post: follower_installment, completed_at: 1.day.ago)
+
+    visit emails_path
+
+    find(:table_row, { "Subject" => "Follower update" }).click
+
+    expect(page).to have_button("View email")
+    expect(page).to_not have_button("Resend to non-openers")
+  end
+end

--- a/spec/requests/emails/resend_to_non_openers_spec.rb
+++ b/spec/requests/emails/resend_to_non_openers_spec.rb
@@ -82,4 +82,14 @@ describe("Resend to non-openers flow", :js, type: :system) do
     expect(page).to have_button("View email")
     expect(page).to_not have_button("Resend to non-openers")
   end
+
+  it "lists each prior non-opener resend on the email sheet" do
+    create(:post_email_blast, post: installment, recipient_filter: "unopened", requested_at: 2.hours.ago, started_at: 2.hours.ago, completed_at: 1.hour.ago, delivery_count: 2)
+
+    visit emails_path
+    find(:table_row, { "Subject" => "Product update" }).click
+
+    expect(page).to have_text("Resends to non-openers")
+    expect(page).to have_text("2 emailed")
+  end
 end

--- a/spec/services/handle_email_event_info/for_installment_email_spec.rb
+++ b/spec/services/handle_email_event_info/for_installment_email_spec.rb
@@ -158,6 +158,29 @@ describe HandleEmailEventInfo::ForInstallmentEmail do
       expect(click_event.click_timestamps.first.to_i).to eq now.to_i
     end
 
+    it "marks the per-purchase email_info as opened when a click event arrives" do
+      email_info = create(:creator_contacting_customers_email_info_sent, installment: @installment, purchase: @purchase)
+      params = { "_json" => [{ "event" => "click", "type" => "CreatorContactingCustomersMailer.purchase_installment",
+                               "identifier" => @identifier, "installment_id" => @installment.id, "url" => "https://www&#46;gumroad&#46;com" }] }
+
+      HandleSendgridEventJob.new.perform(params)
+
+      expect(email_info.reload).to be_opened
+      expect(email_info.opened_at).to be_present
+    end
+
+    it "leaves an already-opened email_info untouched on a click event" do
+      email_info = create(:creator_contacting_customers_email_info_opened, installment: @installment, purchase: @purchase)
+      original_opened_at = email_info.opened_at
+
+      params = { "_json" => [{ "event" => "click", "type" => "CreatorContactingCustomersMailer.purchase_installment",
+                               "identifier" => @identifier, "installment_id" => @installment.id, "url" => "https://www&#46;gumroad&#46;com" }] }
+      HandleSendgridEventJob.new.perform(params)
+
+      expect(email_info.reload).to be_opened
+      expect(email_info.opened_at.to_i).to eq(original_opened_at.to_i)
+    end
+
     it "registers two unique clicks for two different users clicking the same url for the same installment" do
       now = Time.current
       params = { "_json" => [{ "event" => "click", "type" => "CreatorContactingCustomersMailer.purchase_installment",

--- a/spec/sidekiq/send_post_blast_emails_job_spec.rb
+++ b/spec/sidekiq/send_post_blast_emails_job_spec.rb
@@ -308,6 +308,70 @@ describe SendPostBlastEmailsJob, :freeze_time do
     end
   end
 
+  describe "resending to non-openers" do
+    let(:product) { create(:product, user: @seller, name: "Product one") }
+    let(:post) { create(:product_post, :published, seller: @seller, link: product, bought_products: [product.unique_permalink]) }
+    let!(:opened_sale) { create(:purchase, link: product, seller: @seller) }
+    let!(:delivered_sale) { create(:purchase, link: product, seller: @seller) }
+    let!(:sent_sale) { create(:purchase, link: product, seller: @seller) }
+
+    before do
+      # Simulate the original blast: every recipient was emailed (recorded in sent_post_emails and
+      # email_infos), one of them opened it.
+      [opened_sale, delivered_sale, sent_sale].each do |sale|
+        SentPostEmail.create!(post:, email: sale.email)
+      end
+      create(:creator_contacting_customers_email_info_opened, installment: post, purchase: opened_sale)
+      create(:creator_contacting_customers_email_info_delivered, installment: post, purchase: delivered_sale)
+      create(:creator_contacting_customers_email_info_sent, installment: post, purchase: sent_sale)
+    end
+
+    it "sends only to original recipients who have not opened the email" do
+      blast = create(:blast, :just_requested, post:, recipient_filter: "unopened")
+      described_class.new.perform(blast.id)
+
+      expect_sent_count 2
+      expect(PostSendgridApi.mails[delivered_sale.email]).to be_present
+      expect(PostSendgridApi.mails[sent_sale.email]).to be_present
+      expect(PostSendgridApi.mails[opened_sale.email]).to be_blank
+      expect(blast.reload.completed_at).to be_present
+    end
+
+    it "bypasses the already-emailed guard so it can re-send to people in sent_post_emails" do
+      expect(SentPostEmail.where(post:).count).to eq(3)
+
+      blast = create(:blast, :just_requested, post:, recipient_filter: "unopened")
+      described_class.new.perform(blast.id)
+
+      # All recipients were already in sent_post_emails, yet the resend still goes out to non-openers.
+      expect_sent_count 2
+      # The resend does not add new sent_post_emails records.
+      expect(SentPostEmail.where(post:).count).to eq(3)
+    end
+
+    it "sends nothing when everyone who was emailed has already opened" do
+      create(:creator_contacting_customers_email_info_opened, installment: post, purchase: delivered_sale)
+      create(:creator_contacting_customers_email_info_opened, installment: post, purchase: sent_sale)
+
+      blast = create(:blast, :just_requested, post:, recipient_filter: "unopened")
+      described_class.new.perform(blast.id)
+
+      expect_sent_count 0
+      expect(blast.reload.completed_at).to be_present
+    end
+
+    it "does not delete sent_post_emails when a resend raises an error" do
+      blast = create(:blast, :just_requested, post:, recipient_filter: "unopened")
+      expect(PostEmailApi).to receive(:process).and_raise(StandardError.new("API failure"))
+
+      expect do
+        described_class.new.perform(blast.id)
+      end.to raise_error(StandardError, "API failure")
+
+      expect(SentPostEmail.where(post:).count).to eq(3)
+    end
+  end
+
   describe "error handling" do
     it "deletes sent_post_emails records if PostEmailApi.process raises an error" do
       # Setup post and blast


### PR DESCRIPTION
## What
Implements #5360 — lets a seller re-send an already-published customer email to **only the recipients who haven't opened it yet**, as a fresh blast targeting the unopened slice.

## How
- **`PostEmailBlast.recipient_filter`** — new nullable column; `"unopened"` marks a resend blast (validation + `to_non_openers` scope).
- **`Installment` open queries** — `emailed_recipient_purchase_ids`, `opened_recipient_purchase_ids`, `unopened_recipient_purchase_ids` (emailed minus opened), backed by the existing `CreatorContactingCustomersEmailInfo` open-tracking (`state: "opened"`). Scoped to purchase-backed posts (seller/product/variant) — follower/affiliate posts have no per-recipient open linkage, so the feature is hidden for them.
- **`SendPostBlastEmailsJob`** — for an `unopened` blast, target the original recipients minus openers and **bypass the `sent_post_emails` already-emailed guard** (which would otherwise drop everyone, since they were all emailed in the original blast). No new `sent_post_emails` rows are written, and the error-rollback path is skipped accordingly.
- **`Api::Internal::Installments::NonOpenerResendsController`** — `GET` returns the non-opener count; `POST` creates the filtered blast + enqueues the job. Admin-authorized via `InstallmentPolicy#resend_to_non_openers?`, 24h throttle per post, 422 when nobody is left to send to.
- **Frontend** — a "Resend to non-openers" button + confirmation modal in the email editor (`EmailsPage`), shown only for published purchase-backed posts; confirms the live non-opener count before sending.

Sending still routes through `PostEmailApi.process`, so suppression/unsubscribe handling is unchanged.

## Test plan
All run green locally (`PARALLEL_WORKERS=1`):
- `spec/models/installment_spec.rb` — **108 examples, 0 failures** (incl. new opener/non-opener query coverage)
- `spec/sidekiq/send_post_blast_emails_job_spec.rb` — **22 examples, 0 failures** (incl. 4 new: non-opener filtering, already-emailed guard bypass, empty case, error-rollback safety)
- `spec/controllers/api/internal/installments/non_opener_resends_controller_spec.rb` — **13 examples, 0 failures** (auth, 404s, count, create+enqueue, 422 all-opened, 24h throttle)
- `rubocop` clean on all changed Ruby; `eslint` clean on changed TS.

Note: `app/javascript/utils/routes.{js,d.ts}` are gitignored/generated by `js-routes` from `config/routes.rb` — verified the `internal_installment_non_opener_resend_path` helper generates correctly locally.

Closes #5360

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783023843&installation_id=134400930&pr_number=5378&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5378&signature=0ee6588932752bc37acc942706061e3b005e67b222ccbe01ff4a8b24c17ab12a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes bulk email recipient selection and blast behavior (including bypassing normal already-emailed guards for resends), which can affect deliverability and who receives mail, though it reuses existing send paths and adds rate limits.
> 
> **Overview**
> Adds **resend to non-openers** for published customer emails (seller/product/variant posts with per-recipient open tracking).
> 
> Sellers can fetch how many original recipients still haven’t opened, then trigger a new `PostEmailBlast` with `recipient_filter: "unopened"`. The API enforces **24-hour throttling**, a **3 completed resend cap**, and blocks overlapping in-flight blasts; recipients are **unopened emails still in the post’s audience** (with distinct messaging when everyone opened vs. audience rules exclude the rest).
> 
> `SendPostBlastEmailsJob` sends only to that subset, **skips `SentPostEmail` dedupe** from the original blast, and uses **Redis per-blast dedupe** on retries. Open tracking now updates `CreatorContactingCustomersEmailInfo` on **click** as well as open events.
> 
> The emails UI adds a confirmation flow, shows prior non-opener resends on the published sheet, and wires `InstallmentPolicy#resend_to_non_openers?` to the same permissions as creating posts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87af4aa5cfb86ba2928e6db81833ac46e4596cc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->