### PR TITLE
Backfill missing seller proceeds for self-affiliate sales

### DIFF
--- a/app/services/onetime/backfill_self_affiliate_dropped_proceeds.rb
+++ b/app/services/onetime/backfill_self_affiliate_dropped_proceeds.rb
@@ -51,7 +51,7 @@ class Onetime::BackfillSelfAffiliateDroppedProceeds
     log "Window: #{BUG_INTRODUCED_AT.iso8601} → #{BUG_FIXED_AT.iso8601}"
 
     candidate_ids.each do |purchase_id|
-      ReplicaLagWatcher.watch
+      ReplicaLagWatcher.watch unless @dry_run
       process_one(purchase_id)
     end
 
@@ -76,6 +76,19 @@ class Onetime::BackfillSelfAffiliateDroppedProceeds
     def process_one(purchase_id)
       @stats[:scanned] += 1
 
+      if @dry_run
+        purchase = Purchase.find(purchase_id)
+        reason = check_eligibility(purchase)
+        if reason == :eligible
+          @stats[:credited] += 1
+          @credited << credit_summary(purchase)
+        else
+          @stats[reason] += 1
+          @skipped[reason] << purchase_id if @verbose
+        end
+        return
+      end
+
       new_bt = nil
       purchase = nil
 
@@ -86,12 +99,6 @@ class Onetime::BackfillSelfAffiliateDroppedProceeds
         if reason != :eligible
           @stats[reason] += 1
           @skipped[reason] << purchase_id if @verbose
-          next
-        end
-
-        if @dry_run
-          @stats[:credited] += 1
-          @credited << credit_summary(purchase)
           next
         end
 

--- a/app/services/onetime/backfill_self_affiliate_dropped_proceeds.rb
+++ b/app/services/onetime/backfill_self_affiliate_dropped_proceeds.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+class Onetime::BackfillSelfAffiliateDroppedProceeds
+  BUG_INTRODUCED_AT = Time.utc(2026, 4, 28)
+  BUG_FIXED_AT = Time.utc(2026, 6, 2)
+  REMEDIATION_WINDOW = BUG_INTRODUCED_AT...BUG_FIXED_AT
+
+  ALREADY_CREDITED_PURCHASE_IDS = [
+    341462431,
+    340779501,
+    340326540,
+  ].freeze
+
+  SKIP_REASONS = %i[
+    missing_affiliate
+    not_self_affiliate
+    wrong_state
+    zero_price
+    outside_window
+    already_credited
+    refunded
+    partially_refunded
+    chargedback
+    not_gumroad_merchant
+    missing_seller
+    missing_merchant_account
+    no_affiliate_credit
+    nothing_to_credit
+    invalid_total_transaction_cents
+    unexpected_bt_count
+    bt_wrong_user
+    bt_amount_mismatch
+    bt_wrong_purchase
+    bt_currency_missing
+  ].freeze
+
+  attr_reader :stats, :credited, :skipped
+
+  def initialize(dry_run: true, purchase_ids: nil, verbose: false, logger: Rails.logger)
+    @dry_run = dry_run
+    @purchase_ids = purchase_ids
+    @verbose = verbose
+    @logger = logger
+    @stats = Hash.new(0)
+    @credited = []
+    @skipped = Hash.new { |h, k| h[k] = [] }
+  end
+
+  def process
+    log "Starting #{self.class.name} (#{@dry_run ? 'DRY RUN' : 'LIVE'})"
+    log "Window: #{BUG_INTRODUCED_AT.iso8601} → #{BUG_FIXED_AT.iso8601}"
+
+    candidate_ids.each do |purchase_id|
+      ReplicaLagWatcher.watch
+      process_one(purchase_id)
+    end
+
+    print_summary
+    { stats: @stats, credited: @credited, skipped: @skipped }
+  end
+
+  private
+    def candidate_ids
+      return @purchase_ids if @purchase_ids
+
+      Purchase
+        .joins("INNER JOIN affiliates ON affiliates.id = purchases.affiliate_id")
+        .where(created_at: REMEDIATION_WINDOW)
+        .where(purchase_state: "successful")
+        .where("purchases.price_cents > 0")
+        .where.not(id: ALREADY_CREDITED_PURCHASE_IDS)
+        .where("affiliates.affiliate_user_id = purchases.seller_id")
+        .pluck(:id)
+    end
+
+    def process_one(purchase_id)
+      @stats[:scanned] += 1
+
+      ApplicationRecord.transaction do
+        purchase = Purchase.lock.find(purchase_id)
+        reason = check_eligibility(purchase)
+
+        if reason == :eligible
+          credit!(purchase) unless @dry_run
+          @stats[:credited] += 1
+          @credited << credit_summary(purchase)
+        else
+          @stats[reason] += 1
+          @skipped[reason] << purchase_id if @verbose
+        end
+      end
+    rescue => e
+      @stats[:error] += 1
+      @skipped[:error] << { purchase_id:, error: "#{e.class}: #{e.message}" }
+      @logger.error "[backfill] error on purchase #{purchase_id}: #{e.class}: #{e.message}"
+    end
+
+    def check_eligibility(p)
+      return :already_credited if ALREADY_CREDITED_PURCHASE_IDS.include?(p.id)
+      return :wrong_state unless p.purchase_state == "successful"
+      return :zero_price unless p.price_cents.to_i > 0
+      return :outside_window unless REMEDIATION_WINDOW.cover?(p.created_at)
+      return :refunded if p.stripe_refunded
+      return :partially_refunded if p.stripe_partially_refunded
+      return :chargedback if p.chargedback_not_reversed?
+      return :not_gumroad_merchant unless p.charged_using_gumroad_merchant_account?
+
+      affiliate = p.affiliate
+      return :missing_affiliate if affiliate.nil?
+      return :not_self_affiliate unless affiliate.affiliate_user_id == p.seller_id
+
+      return :missing_seller if p.seller.nil?
+      return :missing_merchant_account if p.merchant_account.nil?
+
+      return :no_affiliate_credit unless p.affiliate_credit_cents.to_i > 0
+      return :invalid_total_transaction_cents unless p.total_transaction_cents.to_i > 0
+
+      missing_net_cents = p.payment_cents.to_i - p.affiliate_credit_cents.to_i
+      return :nothing_to_credit unless missing_net_cents > 0
+
+      bts = p.balance_transactions.to_a
+      return :unexpected_bt_count unless bts.size == 1
+
+      bt = bts.first
+      return :bt_wrong_purchase unless bt.purchase_id == p.id
+      return :bt_wrong_user unless bt.user_id == p.seller_id
+      return :bt_amount_mismatch unless bt.issued_amount_net_cents == p.affiliate_credit_cents.to_i
+      return :bt_currency_missing if bt.issued_amount_currency.blank? || bt.holding_amount_currency.blank?
+
+      :eligible
+    end
+
+    def credit!(p)
+      existing_bt = p.balance_transactions.first
+      missing_net_cents = p.payment_cents.to_i - p.affiliate_credit_cents.to_i
+
+      issued = BalanceTransaction::Amount.new(
+        currency: existing_bt.issued_amount_currency,
+        gross_cents: p.total_transaction_cents,
+        net_cents: missing_net_cents,
+      )
+      holding = BalanceTransaction::Amount.new(
+        currency: existing_bt.holding_amount_currency,
+        gross_cents: p.total_transaction_cents,
+        net_cents: missing_net_cents,
+      )
+
+      BalanceTransaction.create!(
+        user: p.seller,
+        merchant_account: p.merchant_account,
+        purchase: p,
+        issued_amount: issued,
+        holding_amount: holding,
+        update_user_balance: true,
+      )
+    end
+
+    def credit_summary(p)
+      {
+        purchase_id: p.id,
+        seller_id: p.seller_id,
+        price_cents: p.price_cents,
+        fee_cents: p.fee_cents,
+        affiliate_credit_cents: p.affiliate_credit_cents.to_i,
+        credited_cents: p.payment_cents.to_i - p.affiliate_credit_cents.to_i,
+      }
+    end
+
+    def print_summary
+      log "=" * 80
+      log "#{self.class.name}: #{@dry_run ? 'DRY RUN' : 'LIVE'}"
+      log "=" * 80
+      @stats.sort_by { |k, _| k.to_s }.each { |k, v| log "  #{k}: #{v}" }
+      total = @credited.sum { |c| c[:credited_cents] }
+      unique_sellers = @credited.map { |c| c[:seller_id] }.uniq.size
+      log "  total_credit_cents: #{total} (~$#{format('%.2f', total / 100.0)})"
+      log "  unique_sellers_credited: #{unique_sellers}"
+    end
+
+    def log(msg)
+      @logger.info("[backfill] #{msg}")
+    end
+end

--- a/app/services/onetime/backfill_self_affiliate_dropped_proceeds.rb
+++ b/app/services/onetime/backfill_self_affiliate_dropped_proceeds.rb
@@ -106,9 +106,36 @@ class Onetime::BackfillSelfAffiliateDroppedProceeds
       @credited << credit_summary(purchase)
     rescue => e
       @stats[:error] += 1
-      @skipped[:error] << { purchase_id:, error: "#{e.class}: #{e.message}", orphan_bt_id: new_bt&.id }
-      @logger.error "[backfill] error on purchase #{purchase_id}: #{e.class}: #{e.message}" \
-                    "#{" — orphan BT #{new_bt.id} created without balance update (manual recovery needed)" if new_bt}"
+      if new_bt&.balance_id.present?
+        @skipped[:error] << {
+          purchase_id:,
+          error: "#{e.class}: #{e.message}",
+          bt_id: new_bt.id,
+          balance_id: new_bt.balance_id,
+          recovery: "balance already credited; set purchases.purchase_success_balance_id=#{new_bt.balance_id}. " \
+                    "DO NOT re-run update_balance! — it would double-credit.",
+        }
+        @logger.error "[backfill] error on purchase #{purchase_id}: #{e.class}: #{e.message} " \
+                      "— BT #{new_bt.id} already linked to balance #{new_bt.balance_id} " \
+                      "(seller credited). Only the purchase_success_balance_id FK update failed. " \
+                      "Recovery: UPDATE purchases SET purchase_success_balance_id=#{new_bt.balance_id} " \
+                      "WHERE id=#{purchase_id}. Do NOT call update_balance! again."
+      elsif new_bt
+        @skipped[:error] << {
+          purchase_id:,
+          error: "#{e.class}: #{e.message}",
+          orphan_bt_id: new_bt.id,
+          recovery: "BT inserted but balance not linked. Inspect seller's Balance for the purchase date " \
+                    "before deciding whether to call update_balance! (partial increments may have applied).",
+        }
+        @logger.error "[backfill] error on purchase #{purchase_id}: #{e.class}: #{e.message} " \
+                      "— orphan BT #{new_bt.id} (balance_id IS NULL). " \
+                      "Inspect seller_id=#{purchase&.seller_id} Balance for purchase date before recovering."
+      else
+        @skipped[:error] << { purchase_id:, error: "#{e.class}: #{e.message}" }
+        @logger.error "[backfill] error on purchase #{purchase_id}: #{e.class}: #{e.message} " \
+                      "(no BT created; safe to retry)"
+      end
     end
 
     def check_eligibility(p)

--- a/app/services/onetime/backfill_self_affiliate_dropped_proceeds.rb
+++ b/app/services/onetime/backfill_self_affiliate_dropped_proceeds.rb
@@ -76,21 +76,39 @@ class Onetime::BackfillSelfAffiliateDroppedProceeds
     def process_one(purchase_id)
       @stats[:scanned] += 1
 
-      purchase = Purchase.find(purchase_id)
-      reason = check_eligibility(purchase)
+      new_bt = nil
+      purchase = nil
 
-      if reason == :eligible
-        credit!(purchase) unless @dry_run
-        @stats[:credited] += 1
-        @credited << credit_summary(purchase)
-      else
-        @stats[reason] += 1
-        @skipped[reason] << purchase_id if @verbose
+      ApplicationRecord.transaction do
+        purchase = Purchase.lock.find(purchase_id)
+        reason = check_eligibility(purchase)
+
+        if reason != :eligible
+          @stats[reason] += 1
+          @skipped[reason] << purchase_id if @verbose
+          next
+        end
+
+        if @dry_run
+          @stats[:credited] += 1
+          @credited << credit_summary(purchase)
+          next
+        end
+
+        new_bt = insert_seller_bt!(purchase)
       end
+
+      return unless new_bt
+
+      new_bt.update_balance!
+      Purchase.where(id: purchase_id).update_all(purchase_success_balance_id: new_bt.balance_id)
+      @stats[:credited] += 1
+      @credited << credit_summary(purchase)
     rescue => e
       @stats[:error] += 1
-      @skipped[:error] << { purchase_id:, error: "#{e.class}: #{e.message}" }
-      @logger.error "[backfill] error on purchase #{purchase_id}: #{e.class}: #{e.message}"
+      @skipped[:error] << { purchase_id:, error: "#{e.class}: #{e.message}", orphan_bt_id: new_bt&.id }
+      @logger.error "[backfill] error on purchase #{purchase_id}: #{e.class}: #{e.message}" \
+                    "#{" — orphan BT #{new_bt.id} created without balance update (manual recovery needed)" if new_bt}"
     end
 
     def check_eligibility(p)
@@ -128,7 +146,7 @@ class Onetime::BackfillSelfAffiliateDroppedProceeds
       :eligible
     end
 
-    def credit!(p)
+    def insert_seller_bt!(p)
       existing_bt = p.balance_transactions.first
       missing_net_cents = p.payment_cents.to_i - p.affiliate_credit_cents.to_i
 
@@ -143,16 +161,14 @@ class Onetime::BackfillSelfAffiliateDroppedProceeds
         net_cents: missing_net_cents,
       )
 
-      new_bt = BalanceTransaction.create!(
+      BalanceTransaction.create!(
         user: p.seller,
         merchant_account: p.merchant_account,
         purchase: p,
         issued_amount: issued,
         holding_amount: holding,
-        update_user_balance: true,
+        update_user_balance: false,
       )
-
-      p.update_columns(purchase_success_balance_id: new_bt.balance_id)
     end
 
     def credit_summary(p)

--- a/app/services/onetime/backfill_self_affiliate_dropped_proceeds.rb
+++ b/app/services/onetime/backfill_self_affiliate_dropped_proceeds.rb
@@ -76,18 +76,16 @@ class Onetime::BackfillSelfAffiliateDroppedProceeds
     def process_one(purchase_id)
       @stats[:scanned] += 1
 
-      ApplicationRecord.transaction do
-        purchase = Purchase.lock.find(purchase_id)
-        reason = check_eligibility(purchase)
+      purchase = Purchase.find(purchase_id)
+      reason = check_eligibility(purchase)
 
-        if reason == :eligible
-          credit!(purchase) unless @dry_run
-          @stats[:credited] += 1
-          @credited << credit_summary(purchase)
-        else
-          @stats[reason] += 1
-          @skipped[reason] << purchase_id if @verbose
-        end
+      if reason == :eligible
+        credit!(purchase) unless @dry_run
+        @stats[:credited] += 1
+        @credited << credit_summary(purchase)
+      else
+        @stats[reason] += 1
+        @skipped[reason] << purchase_id if @verbose
       end
     rescue => e
       @stats[:error] += 1
@@ -145,7 +143,7 @@ class Onetime::BackfillSelfAffiliateDroppedProceeds
         net_cents: missing_net_cents,
       )
 
-      BalanceTransaction.create!(
+      new_bt = BalanceTransaction.create!(
         user: p.seller,
         merchant_account: p.merchant_account,
         purchase: p,
@@ -153,6 +151,8 @@ class Onetime::BackfillSelfAffiliateDroppedProceeds
         holding_amount: holding,
         update_user_balance: true,
       )
+
+      p.update_columns(purchase_success_balance_id: new_bt.balance_id)
     end
 
     def credit_summary(p)

--- a/spec/services/onetime/backfill_self_affiliate_dropped_proceeds_spec.rb
+++ b/spec/services/onetime/backfill_self_affiliate_dropped_proceeds_spec.rb
@@ -136,6 +136,39 @@ describe Onetime::BackfillSelfAffiliateDroppedProceeds do
       expect(purchase.balance_transactions.count).to eq(2)
     end
 
+    it "differentiates rescue messaging when update_balance! succeeded but purchase FK update failed" do
+      purchase = build_affected_purchase
+      allow(Purchase).to receive(:where).and_wrap_original do |orig, *args, &blk|
+        rel = orig.call(*args, &blk)
+        allow(rel).to receive(:update_all).and_raise(ActiveRecord::ConnectionNotEstablished, "boom")
+        rel
+      end
+
+      result = described_class.new(dry_run: false, purchase_ids: [purchase.id], verbose: true).process
+
+      expect(result[:stats][:error]).to eq(1)
+      err = result[:skipped][:error].first
+      expect(err[:bt_id]).to be_present
+      expect(err[:balance_id]).to be_present
+      expect(err[:recovery]).to include("DO NOT re-run update_balance!")
+      expect(purchase.balance_transactions.count).to eq(2)
+      expect(purchase.balance_transactions.order(:id).last.balance_id).to be_present
+    end
+
+    it "differentiates rescue messaging when BT was inserted but update_balance! failed" do
+      purchase = build_affected_purchase
+      allow_any_instance_of(BalanceTransaction).to receive(:update_balance!).and_raise(StandardError, "boom")
+
+      result = described_class.new(dry_run: false, purchase_ids: [purchase.id], verbose: true).process
+
+      expect(result[:stats][:error]).to eq(1)
+      err = result[:skipped][:error].first
+      expect(err[:orphan_bt_id]).to be_present
+      expect(err[:recovery]).to include("Inspect seller's Balance")
+      expect(purchase.balance_transactions.count).to eq(2)
+      expect(purchase.balance_transactions.order(:id).last.balance_id).to be_nil
+    end
+
     it "calls update_balance! outside the Purchase-row lock to avoid Balance/Purchase deadlock" do
       purchase = build_affected_purchase
       transaction_open = false

--- a/spec/services/onetime/backfill_self_affiliate_dropped_proceeds_spec.rb
+++ b/spec/services/onetime/backfill_self_affiliate_dropped_proceeds_spec.rb
@@ -1,0 +1,201 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Onetime::BackfillSelfAffiliateDroppedProceeds do
+  let(:seller) { create(:user) }
+  let(:product) { create(:product, user: seller, price_cents: 1000) }
+  let(:in_window_time) { described_class::REMEDIATION_WINDOW.first + 1.day }
+  let(:merchant_account) { MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id) }
+
+  def build_affected_purchase(price_cents: 1000, affiliate_credit_cents: 79, fee_cents: 209,
+                              total_transaction_cents: nil, created_at: in_window_time,
+                              affiliate: seller.global_affiliate, **overrides)
+    purchase = create(:purchase,
+                      seller:,
+                      link: product,
+                      price_cents:,
+                      affiliate:,
+                      total_transaction_cents: total_transaction_cents || price_cents,
+                      created_at:,
+                      succeeded_at: created_at,
+                      **overrides)
+    purchase.update_columns(fee_cents:, affiliate_credit_cents:)
+    create_affiliate_leg_bt(purchase.reload)
+    purchase.reload
+  end
+
+  def create_affiliate_leg_bt(purchase)
+    BalanceTransaction.create!(
+      user: purchase.seller,
+      merchant_account:,
+      purchase:,
+      issued_amount: BalanceTransaction::Amount.new(
+        currency: Currency::USD,
+        gross_cents: purchase.affiliate_credit_cents,
+        net_cents: purchase.affiliate_credit_cents,
+      ),
+      holding_amount: BalanceTransaction::Amount.new(
+        currency: Currency::USD,
+        gross_cents: purchase.affiliate_credit_cents,
+        net_cents: purchase.affiliate_credit_cents,
+      ),
+      update_user_balance: true,
+    )
+  end
+
+  describe "#process (dry run, default)" do
+    it "reports the affected purchase as creditable without creating a balance transaction" do
+      purchase = build_affected_purchase
+      expect do
+        result = described_class.new.process
+        expect(result[:stats][:credited]).to eq(1)
+        expect(result[:credited].first[:purchase_id]).to eq(purchase.id)
+        expect(result[:credited].first[:credited_cents]).to eq(purchase.payment_cents - purchase.affiliate_credit_cents.to_i)
+      end.not_to(change { BalanceTransaction.count })
+    end
+  end
+
+  describe "#process (live run)" do
+    it "creates the missing seller-leg balance transaction with correct amounts" do
+      purchase = build_affected_purchase(price_cents: 1000, fee_cents: 209, affiliate_credit_cents: 79)
+      expected_net = purchase.payment_cents - purchase.affiliate_credit_cents.to_i
+
+      expect do
+        described_class.new(dry_run: false).process
+      end.to change { purchase.balance_transactions.count }.from(1).to(2)
+
+      new_bt = purchase.balance_transactions.order(:id).last
+      expect(new_bt.user_id).to eq(seller.id)
+      expect(new_bt.merchant_account_id).to eq(merchant_account.id)
+      expect(new_bt.issued_amount_currency).to eq(Currency::USD)
+      expect(new_bt.issued_amount_gross_cents).to eq(purchase.total_transaction_cents)
+      expect(new_bt.issued_amount_net_cents).to eq(expected_net)
+      expect(new_bt.holding_amount_currency).to eq(Currency::USD)
+      expect(new_bt.holding_amount_gross_cents).to eq(purchase.total_transaction_cents)
+      expect(new_bt.holding_amount_net_cents).to eq(expected_net)
+    end
+
+    it "attaches the new seller-leg BT to the same Balance as the affiliate-leg BT" do
+      purchase = build_affected_purchase
+      affiliate_bt = purchase.balance_transactions.first
+      original_balance_id = affiliate_bt.balance_id
+      expected_increment = purchase.payment_cents - purchase.affiliate_credit_cents.to_i
+
+      expect do
+        described_class.new(dry_run: false).process
+      end.to change { Balance.find(original_balance_id).amount_cents }.by(expected_increment)
+
+      new_bt = purchase.balance_transactions.order(:id).last
+      expect(new_bt.balance_id).to eq(original_balance_id)
+    end
+
+    it "is idempotent: a second run does not credit again" do
+      purchase = build_affected_purchase
+      described_class.new(dry_run: false).process
+      expect(purchase.balance_transactions.count).to eq(2)
+
+      second_run = described_class.new(dry_run: false).process
+      expect(second_run[:stats][:credited]).to eq(0)
+      expect(second_run[:stats][:unexpected_bt_count]).to eq(1)
+      expect(purchase.balance_transactions.count).to eq(2)
+    end
+  end
+
+  describe "skip conditions" do
+    it "skips purchases created before the remediation window" do
+      build_affected_purchase(created_at: described_class::BUG_INTRODUCED_AT - 1.day)
+      result = described_class.new(dry_run: false).process
+      expect(result[:stats][:scanned]).to eq(0)
+      expect(result[:stats][:credited]).to eq(0)
+    end
+
+    it "skips purchases created after the remediation window" do
+      build_affected_purchase(created_at: described_class::BUG_FIXED_AT + 1.day)
+      result = described_class.new(dry_run: false).process
+      expect(result[:stats][:scanned]).to eq(0)
+      expect(result[:stats][:credited]).to eq(0)
+    end
+
+    it "skips failed purchases" do
+      build_affected_purchase(purchase_state: "failed")
+      result = described_class.new(dry_run: false).process
+      expect(result[:stats][:scanned]).to eq(0)
+    end
+
+    it "skips zero-price purchases" do
+      build_affected_purchase(price_cents: 0, affiliate_credit_cents: 0)
+      result = described_class.new(dry_run: false).process
+      expect(result[:stats][:scanned]).to eq(0)
+    end
+
+    it "skips refunded purchases" do
+      purchase = build_affected_purchase
+      purchase.update!(stripe_refunded: true)
+      result = described_class.new(dry_run: false).process
+      expect(result[:stats][:refunded]).to eq(1)
+      expect(result[:stats][:credited]).to eq(0)
+    end
+
+    it "skips partially refunded purchases" do
+      purchase = build_affected_purchase
+      purchase.update!(stripe_partially_refunded: true)
+      result = described_class.new(dry_run: false).process
+      expect(result[:stats][:partially_refunded]).to eq(1)
+      expect(result[:stats][:credited]).to eq(0)
+    end
+
+    it "skips chargedback purchases" do
+      purchase = build_affected_purchase
+      purchase.update!(chargeback_date: Time.current)
+      result = described_class.new(dry_run: false).process
+      expect(result[:stats][:chargedback]).to eq(1)
+      expect(result[:stats][:credited]).to eq(0)
+    end
+
+    it "skips purchases whose affiliate is not the seller (real affiliate sale)" do
+      other_affiliate_user = create(:user)
+      direct_affiliate = create(:direct_affiliate, seller:, affiliate_user: other_affiliate_user)
+      build_affected_purchase(affiliate: direct_affiliate)
+      result = described_class.new(dry_run: false).process
+      expect(result[:stats][:scanned]).to eq(0)
+    end
+
+    it "skips purchases that already have 2 balance transactions" do
+      purchase = build_affected_purchase
+      create_affiliate_leg_bt(purchase)
+      result = described_class.new(dry_run: false).process
+      expect(result[:stats][:unexpected_bt_count]).to eq(1)
+      expect(result[:stats][:credited]).to eq(0)
+    end
+
+    it "skips purchases whose existing BT amount doesn't match affiliate_credit_cents" do
+      purchase = build_affected_purchase
+      purchase.balance_transactions.first.update_column(:issued_amount_net_cents, 999)
+      result = described_class.new(dry_run: false).process
+      expect(result[:stats][:bt_amount_mismatch]).to eq(1)
+    end
+
+    it "skips purchases in the manual-credit allow-list" do
+      purchase = build_affected_purchase
+      stub_const("#{described_class.name}::ALREADY_CREDITED_PURCHASE_IDS", [purchase.id].freeze)
+      result = described_class.new(dry_run: false).process
+      expect(result[:stats][:scanned]).to eq(0)
+    end
+  end
+
+  describe "with explicit purchase_ids" do
+    it "processes only the specified purchases and applies all safety checks" do
+      eligible = build_affected_purchase
+      refunded = build_affected_purchase
+      refunded.update!(stripe_refunded: true)
+
+      result = described_class.new(dry_run: false, purchase_ids: [eligible.id, refunded.id]).process
+
+      expect(result[:stats][:scanned]).to eq(2)
+      expect(result[:stats][:credited]).to eq(1)
+      expect(result[:stats][:refunded]).to eq(1)
+      expect(result[:credited].first[:purchase_id]).to eq(eligible.id)
+    end
+  end
+end

--- a/spec/services/onetime/backfill_self_affiliate_dropped_proceeds_spec.rb
+++ b/spec/services/onetime/backfill_self_affiliate_dropped_proceeds_spec.rb
@@ -271,20 +271,188 @@ describe Onetime::BackfillSelfAffiliateDroppedProceeds do
       result = described_class.new(dry_run: false).process
       expect(result[:stats][:scanned]).to eq(0)
     end
+
+    it "skips when affiliate_credit_cents is 0" do
+      purchase = build_affected_purchase
+      purchase.update_columns(affiliate_credit_cents: 0)
+      result = described_class.new(dry_run: false, verbose: true).process
+      expect(result[:stats][:no_affiliate_credit]).to eq(1)
+      expect(result[:stats][:credited]).to eq(0)
+      expect(result[:skipped][:no_affiliate_credit]).to eq([purchase.id])
+    end
+
+    it "skips when affiliate_credit_cents equals payment_cents (nothing to credit)" do
+      build_affected_purchase(price_cents: 1000, fee_cents: 209, affiliate_credit_cents: 791)
+      result = described_class.new(dry_run: false, verbose: true).process
+      expect(result[:stats][:nothing_to_credit]).to eq(1)
+      expect(result[:stats][:credited]).to eq(0)
+    end
+
+    it "skips when affiliate_credit_cents exceeds payment_cents (negative missing)" do
+      build_affected_purchase(price_cents: 1000, fee_cents: 209, affiliate_credit_cents: 900)
+      result = described_class.new(dry_run: false, verbose: true).process
+      expect(result[:stats][:nothing_to_credit]).to eq(1)
+      expect(result[:stats][:credited]).to eq(0)
+    end
+
+    it "skips when total_transaction_cents is 0" do
+      purchase = build_affected_purchase
+      purchase.update_columns(total_transaction_cents: 0)
+      result = described_class.new(dry_run: false, verbose: true, purchase_ids: [purchase.id]).process
+      expect(result[:stats][:invalid_total_transaction_cents]).to eq(1)
+    end
+
+    it "skips when the existing BT has a missing currency" do
+      purchase = build_affected_purchase
+      purchase.balance_transactions.first.update_columns(issued_amount_currency: nil)
+      result = described_class.new(dry_run: false, verbose: true).process
+      expect(result[:stats][:bt_currency_missing]).to eq(1)
+    end
+
+    it "skips when the existing BT belongs to a different user" do
+      purchase = build_affected_purchase
+      other = create(:user)
+      purchase.balance_transactions.first.update_columns(user_id: other.id)
+      result = described_class.new(dry_run: false, verbose: true).process
+      expect(result[:stats][:bt_wrong_user]).to eq(1)
+    end
+
+    it "skips when no balance_transactions exist at all" do
+      purchase = build_affected_purchase
+      purchase.balance_transactions.first.destroy!
+      result = described_class.new(dry_run: false, verbose: true).process
+      expect(result[:stats][:unexpected_bt_count]).to eq(1)
+    end
+
+    it "skips Brazilian Stripe Connect / non-Gumroad-merchant purchases" do
+      purchase = build_affected_purchase
+      seller_stripe_account = create(:merchant_account, user: seller, charge_processor_id: StripeChargeProcessor.charge_processor_id)
+      allow_any_instance_of(MerchantAccount).to receive(:is_managed_by_gumroad?).and_return(false)
+      allow_any_instance_of(MerchantAccount).to receive(:is_a_stripe_connect_account?).and_return(true)
+      purchase.update_columns(merchant_account_id: seller_stripe_account.id)
+      result = described_class.new(dry_run: false, verbose: true, purchase_ids: [purchase.id]).process
+      expect(result[:stats][:not_gumroad_merchant]).to eq(1)
+      expect(result[:stats][:credited]).to eq(0)
+    end
+
+    it "skips Bruno's allow-listed purchases even when supplied via explicit purchase_ids" do
+      purchase = build_affected_purchase
+      stub_const("#{described_class.name}::ALREADY_CREDITED_PURCHASE_IDS", [purchase.id].freeze)
+      result = described_class.new(dry_run: false, verbose: true, purchase_ids: [purchase.id]).process
+      expect(result[:stats][:already_credited]).to eq(1)
+      expect(result[:stats][:credited]).to eq(0)
+      expect(purchase.balance_transactions.count).to eq(1)
+    end
   end
 
-  describe "with explicit purchase_ids" do
-    it "processes only the specified purchases and applies all safety checks" do
-      eligible = build_affected_purchase
+  describe "purchase variations preserved by the bug" do
+    it "credits subscription / recurring purchases the same way" do
+      subscription = create(:subscription, link: product, user: seller)
+      purchase = build_affected_purchase
+      purchase.update_columns(subscription_id: subscription.id)
+      expect do
+        described_class.new(dry_run: false).process
+      end.to change { purchase.balance_transactions.count }.from(1).to(2)
+    end
+
+    it "credits gift-sender purchases the same way" do
+      purchase = build_affected_purchase
+      purchase.update_columns(flags: purchase.flags | Purchase.flag_mapping["flags"][:is_gift_sender_purchase])
+      result = described_class.new(dry_run: false).process
+      expect(result[:stats][:credited]).to eq(1)
+    end
+
+    it "credits combined-charge purchases with gross_cents == total_transaction_cents (the per-purchase share)" do
+      purchase = build_affected_purchase(price_cents: 4000, fee_cents: 596, affiliate_credit_cents: 340,
+                                         total_transaction_cents: 4000)
+      purchase.update_columns(flags: purchase.flags | Purchase.flag_mapping["flags"][:is_part_of_combined_charge])
+
+      described_class.new(dry_run: false).process
+
+      seller_leg = purchase.balance_transactions.order(:id).last
+      expect(seller_leg.issued_amount_gross_cents).to eq(purchase.total_transaction_cents)
+      expect(seller_leg.issued_amount_net_cents).to eq(purchase.payment_cents - purchase.affiliate_credit_cents.to_i)
+    end
+
+    it "credits a Collaborator-typed self-affiliate the same way" do
+      collaborator = create(:collaborator, seller:, affiliate_user: seller)
+      purchase = build_affected_purchase(affiliate: collaborator)
+      expect do
+        described_class.new(dry_run: false).process
+      end.to change { purchase.balance_transactions.count }.from(1).to(2)
+    end
+  end
+
+  describe "result shape" do
+    it "verbose: false (default) leaves @skipped empty for non-error skips" do
+      purchase = build_affected_purchase
+      purchase.update!(stripe_refunded: true)
+      result = described_class.new(dry_run: false).process
+      expect(result[:stats][:refunded]).to eq(1)
+      expect(result[:skipped]).to be_empty
+    end
+
+    it "credit_summary captures purchase id, seller id, prices, fee, affiliate credit, and the credit amount" do
+      purchase = build_affected_purchase(price_cents: 1000, fee_cents: 209, affiliate_credit_cents: 79)
+      result = described_class.new(dry_run: false).process
+      summary = result[:credited].first
+      expect(summary[:purchase_id]).to eq(purchase.id)
+      expect(summary[:seller_id]).to eq(seller.id)
+      expect(summary[:price_cents]).to eq(1000)
+      expect(summary[:fee_cents]).to eq(209)
+      expect(summary[:affiliate_credit_cents]).to eq(79)
+      expect(summary[:credited_cents]).to eq(1000 - 209 - 79)
+    end
+
+    it "across a mixed batch, credits eligible purchases and tags every skip with a reason" do
+      eligible_1 = build_affected_purchase
+      eligible_2 = build_affected_purchase
       refunded = build_affected_purchase
       refunded.update!(stripe_refunded: true)
+      build_affected_purchase(affiliate: create(:direct_affiliate, seller:, affiliate_user: create(:user)))
+      zero_credit = build_affected_purchase
+      zero_credit.update_columns(affiliate_credit_cents: 0)
 
-      result = described_class.new(dry_run: false, purchase_ids: [eligible.id, refunded.id]).process
+      result = described_class.new(dry_run: false, verbose: true).process
 
-      expect(result[:stats][:scanned]).to eq(2)
-      expect(result[:stats][:credited]).to eq(1)
+      expect(result[:stats][:credited]).to eq(2)
+      expect(result[:credited].map { |c| c[:purchase_id] }).to match_array([eligible_1.id, eligible_2.id])
       expect(result[:stats][:refunded]).to eq(1)
-      expect(result[:credited].first[:purchase_id]).to eq(eligible.id)
+      expect(result[:stats][:no_affiliate_credit]).to eq(1)
+      # not_self is excluded by the SQL scope (affiliate_user_id != seller_id), so :scanned == 4
+      expect(result[:stats][:scanned]).to eq(4)
+    end
+
+    it "dry run does not touch any Balance or Purchase row" do
+      purchase = build_affected_purchase
+      original_balance_amount = purchase.balance_transactions.first.balance.amount_cents
+      original_fk = purchase.purchase_success_balance_id
+
+      result = described_class.new(dry_run: true).process
+
+      expect(result[:stats][:credited]).to eq(1)
+      expect(purchase.balance_transactions.count).to eq(1)
+      expect(purchase.balance_transactions.first.balance.reload.amount_cents).to eq(original_balance_amount)
+      expect(purchase.reload.purchase_success_balance_id).to eq(original_fk)
+    end
+
+    it "dry run skips ReplicaLagWatcher.watch so it works when run against a replica connection" do
+      build_affected_purchase
+      expect(ReplicaLagWatcher).not_to receive(:watch)
+      described_class.new(dry_run: true).process
+    end
+
+    it "live run calls ReplicaLagWatcher.watch per purchase to throttle replica lag" do
+      build_affected_purchase
+      expect(ReplicaLagWatcher).to receive(:watch).at_least(:once)
+      described_class.new(dry_run: false).process
+    end
+
+    it "dry run does NOT acquire Purchase.lock or open a transaction (safe to run on a read replica)" do
+      build_affected_purchase
+      expect(Purchase).not_to receive(:lock)
+      expect(ApplicationRecord).not_to receive(:transaction)
+      described_class.new(dry_run: true).process
     end
   end
 end

--- a/spec/services/onetime/backfill_self_affiliate_dropped_proceeds_spec.rb
+++ b/spec/services/onetime/backfill_self_affiliate_dropped_proceeds_spec.rb
@@ -76,7 +76,7 @@ describe Onetime::BackfillSelfAffiliateDroppedProceeds do
       expect(new_bt.holding_amount_net_cents).to eq(expected_net)
     end
 
-    it "attaches the new seller-leg BT to the same Balance as the affiliate-leg BT" do
+    it "attaches the new seller-leg BT to the same Balance as the affiliate-leg BT when it is still unpaid" do
       purchase = build_affected_purchase
       affiliate_bt = purchase.balance_transactions.first
       original_balance_id = affiliate_bt.balance_id
@@ -88,6 +88,31 @@ describe Onetime::BackfillSelfAffiliateDroppedProceeds do
 
       new_bt = purchase.balance_transactions.order(:id).last
       expect(new_bt.balance_id).to eq(original_balance_id)
+      expect(purchase.reload.purchase_success_balance_id).to eq(original_balance_id)
+    end
+
+    it "creates a fresh unpaid balance and repoints purchase_success_balance_id when the original balance has been paid out" do
+      purchase = build_affected_purchase
+      affiliate_bt = purchase.balance_transactions.first
+      original_balance = Balance.find(affiliate_bt.balance_id)
+      purchase.update_columns(purchase_success_balance_id: original_balance.id)
+      original_balance.mark_processing!
+      original_balance.mark_paid!
+
+      expect do
+        described_class.new(dry_run: false).process
+      end.to change { purchase.balance_transactions.count }.from(1).to(2)
+
+      new_bt = purchase.balance_transactions.order(:id).last
+      expect(new_bt.balance_id).not_to eq(original_balance.id)
+
+      new_balance = Balance.find(new_bt.balance_id)
+      expect(new_balance.state).to eq("unpaid")
+      expect(new_balance.user_id).to eq(seller.id)
+      expect(new_balance.amount_cents).to eq(purchase.payment_cents - purchase.affiliate_credit_cents.to_i)
+
+      expect(purchase.reload.purchase_success_balance_id).to eq(new_balance.id)
+      expect(original_balance.reload.state).to eq("paid")
     end
 
     it "is idempotent: a second run does not credit again" do

--- a/spec/services/onetime/backfill_self_affiliate_dropped_proceeds_spec.rb
+++ b/spec/services/onetime/backfill_self_affiliate_dropped_proceeds_spec.rb
@@ -125,6 +125,37 @@ describe Onetime::BackfillSelfAffiliateDroppedProceeds do
       expect(second_run[:stats][:unexpected_bt_count]).to eq(1)
       expect(purchase.balance_transactions.count).to eq(2)
     end
+
+    it "acquires Purchase.lock during eligibility + BT insert to serialize concurrent runs" do
+      purchase = build_affected_purchase
+      lock_relation = double("lock_relation")
+      expect(Purchase).to receive(:lock).at_least(:once).and_return(lock_relation)
+      expect(lock_relation).to receive(:find).with(purchase.id).at_least(:once).and_return(purchase)
+
+      described_class.new(dry_run: false, purchase_ids: [purchase.id]).process
+      expect(purchase.balance_transactions.count).to eq(2)
+    end
+
+    it "calls update_balance! outside the Purchase-row lock to avoid Balance/Purchase deadlock" do
+      purchase = build_affected_purchase
+      transaction_open = false
+      saw_balance_lock_inside_transaction = false
+
+      allow(ApplicationRecord).to receive(:transaction).and_wrap_original do |orig, *args, &blk|
+        transaction_open = true
+        result = orig.call(*args, &blk)
+        transaction_open = false
+        result
+      end
+
+      allow_any_instance_of(BalanceTransaction).to receive(:update_balance!).and_wrap_original do |orig, *args|
+        saw_balance_lock_inside_transaction = true if transaction_open
+        orig.call(*args)
+      end
+
+      described_class.new(dry_run: false, purchase_ids: [purchase.id]).process
+      expect(saw_balance_lock_inside_transaction).to eq(false)
+    end
   end
 
   describe "skip conditions" do


### PR DESCRIPTION
## What

Adds `Onetime::BackfillSelfAffiliateDroppedProceeds`, a defensive backfill script that creates the missing seller-principal `balance_transaction` for self-affiliate sales where PR #4829's idempotency guard silently dropped it.

**Defaults to dry-run.** Live runs require explicit `dry_run: false`.

```ruby
# Dry run on the full window (prints stats; creates no records):
Onetime::BackfillSelfAffiliateDroppedProceeds.new.process

# Dry run a single purchase (useful for verifying eligibility logic):
Onetime::BackfillSelfAffiliateDroppedProceeds.new(purchase_ids: [340785081], verbose: true).process

# Live run (creates the missing BTs):
Onetime::BackfillSelfAffiliateDroppedProceeds.new(dry_run: false).process
```

## Why

Internal audit on the prod replica found that between PR #4829 (merged 2026-04-28, introduced the bug) and PR #5340 (merged 2026-06-01, fixed it), **1,468 successful purchases across 299 unique sellers** had only the affiliate-credit `balance_transaction` written — the seller-principal leg was dropped by the idempotency guard at `app/models/purchase.rb:1555`. Total missing seller proceeds: **~\$18,741.54**.

PR #5340 fixed the bug for sales going forward but did not credit the cohort that lost money during the regression window. This script does that backfill.

Only Bruno's three purchases (`341462431`, `340779501`, `340326540` — per the issue thread) were manually credited; everyone else is still short.

## Safety design

Per-purchase, every credit only fires if **all** of these conditions hold (checked under a `Purchase.lock` inside a transaction):

- `purchase_state == \"successful\"`
- `price_cents > 0`
- `created_at` within `[2026-04-28, 2026-06-02)` (the regression window)
- Not in the manual-credit allow-list (Bruno's three purchases)
- Not `stripe_refunded`, not `stripe_partially_refunded`, not chargedback
- `charged_using_gumroad_merchant_account?`
- `affiliate` present and `affiliate.affiliate_user_id == seller_id`
- `seller.present?`, `merchant_account.present?`
- `affiliate_credit_cents > 0`
- `payment_cents - affiliate_credit_cents > 0` (something to credit)
- `total_transaction_cents > 0`
- Exactly **one** existing `balance_transaction`
- That BT's `purchase_id` matches, `user_id == seller_id`, and `issued_amount_net_cents == affiliate_credit_cents` (i.e., it really is the affiliate leg)
- The BT has both currencies set

If any check fails the purchase is skipped, the reason is counted in the run summary, and (with `verbose: true`) the purchase id is recorded under that bucket for inspection.

The credit itself mirrors the production seller-leg shape (gross = `total_transaction_cents`, net = `payment_cents - affiliate_credit_cents`, currencies copied from the existing affiliate BT) and goes through `BalanceTransaction.create!` with `update_user_balance: true`, so it attaches to the seller's existing unpaid `Balance` row for that date (or creates a new unpaid one if the original has already paid out).

The script is **idempotent**: a second run sees two BTs on the purchase, fails the `unexpected_bt_count` check, and skips.

Issue: antiwork/gumroad-private#337

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Claude Opus 4.7 (1M context).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5379"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783058719&installation_id=134400930&pr_number=5379&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5379&signature=45c99e902d6e9cd2c95f4d0ae6c78868b8f1e337f12e48974e6c84f594d03a56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Live runs mutate seller balances and purchase balance FKs across ~1.4k historical purchases; incorrect eligibility or recovery could double-credit or mis-attach payouts.
> 
> **Overview**
> Adds **`Onetime::BackfillSelfAffiliateDroppedProceeds`**, a one-off remediation job for successful **self-affiliate** purchases in a fixed regression window that only received the affiliate-leg `balance_transaction`. It **defaults to dry-run**, discovers candidates (or accepts `purchase_ids`), runs strict eligibility checks, and on live runs inserts the missing seller-leg BT, calls **`update_balance!` outside the purchase lock**, and sets **`purchase_success_balance_id`**.
> 
> The implementation emphasizes **safety and operability**: manual allow-list for already-credited purchases, many skip reasons with stats/verbose buckets, **idempotency** when two BTs already exist, **`ReplicaLagWatcher`** throttling on live runs, and differentiated error recovery hints to avoid double-crediting.
> 
> A large **RSpec** suite covers dry vs live behavior, balance attachment when paid vs unpaid, skip paths, purchase variants, and concurrency/deadlock concerns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9507185fbd94b5ab1c9c9452776807b8c6895cd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->