### PR TITLE
 Fix custom landing pages blanking when seller scripts read localStorage/cookies

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -962,6 +962,55 @@ class LinksController < ApplicationController
       "form-action 'self'",
     ].join("; ") + ";"
 
+    # Loaded in <head> so it runs before any seller script (without becoming the
+    # body's first child). On the opaque origin (allow-scripts, no
+    # allow-same-origin) localStorage/sessionStorage/document.cookie throw, so a
+    # seller script reading them on load throws and halts — commonly a theme
+    # toggle — leaving the page blank. In-memory stand-ins let those scripts run
+    # instead of throwing; nothing persists, which already matched this origin.
+    # data-cfasync stops Rocket Loader deferring it.
+    SANDBOX_COMPAT_SCRIPT = <<~HTML
+      <script data-cfasync="false" data-gumroad-sandbox-shim>
+        (function () {
+          function memStorage() {
+            var store = Object.create(null);
+            return {
+              getItem: function (k) { return Object.prototype.hasOwnProperty.call(store, k) ? store[k] : null; },
+              setItem: function (k, v) { store[k] = String(v); },
+              removeItem: function (k) { delete store[k]; },
+              clear: function () { store = {}; },
+              key: function (i) { return Object.keys(store)[i] || null; },
+              get length() { return Object.keys(store).length; }
+            };
+          }
+          ["localStorage", "sessionStorage"].forEach(function (name) {
+            var throws = false;
+            try { void window[name]; } catch (e) { throws = true; }
+            if (throws) {
+              try { Object.defineProperty(window, name, { value: memStorage(), configurable: true }); } catch (e) {}
+            }
+          });
+          var cookieThrows = false;
+          try { void document.cookie; } catch (e) { cookieThrows = true; }
+          if (cookieThrows) {
+            var jar = Object.create(null);
+            try {
+              Object.defineProperty(document, "cookie", {
+                configurable: true,
+                get: function () { return Object.keys(jar).map(function (k) { return k + "=" + jar[k]; }).join("; "); },
+                set: function (v) {
+                  var first = String(v).split(";")[0];
+                  var eq = first.indexOf("=");
+                  if (eq < 1) { return; }
+                  jar[first.slice(0, eq).trim()] = first.slice(eq + 1).trim();
+                }
+              });
+            } catch (e) {}
+          }
+        })();
+      </script>
+    HTML
+
     def render_custom_html_if_present
       return unless custom_html_visible?
       # Buyer clicked Buy — fall through to the show action's checkout-bearing
@@ -979,6 +1028,7 @@ class LinksController < ApplicationController
           <head>
             <meta charset="utf-8">
             <meta name="viewport" content="width=device-width, initial-scale=1">
+            #{SANDBOX_COMPAT_SCRIPT}
             #{self.class.pages_tailwind_inline}
           </head>
           <body>

--- a/spec/requests/pages_landing_embed_storage_shim_spec.rb
+++ b/spec/requests/pages_landing_embed_storage_shim_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# The custom landing page renders on an opaque origin (sandbox allow-scripts,
+# no allow-same-origin), where reading localStorage / sessionStorage /
+# document.cookie throws SecurityError. The embed document injects a
+# compatibility shim BEFORE the seller's markup so a storage-touching seller
+# script (e.g. a theme toggle) runs instead of throwing and blanking the page.
+describe "GET /l/:id/landing/embed storage shim", type: :request do
+  let(:seller) { create(:user, username: "shimseller") }
+  let(:product) do
+    create(
+      :product,
+      user: seller,
+      custom_html: %(<main><div id="creator-marker">SELLER CONTENT</div><button data-gumroad-action="buy">Buy</button></main>)
+    )
+  end
+
+  before { Feature.activate_user(:custom_html_pages, seller) }
+
+  def get_embed
+    get "/l/#{product.unique_permalink}/landing/embed", headers: { "HOST" => VALID_REQUEST_HOSTS.first }
+  end
+
+  it "injects the sandbox compatibility shim into the embed document" do
+    get_embed
+
+    expect(response).to be_successful
+    expect(response.body).to include("data-gumroad-sandbox-shim")
+  end
+
+  it "provides in-memory stand-ins for localStorage, sessionStorage and document.cookie" do
+    get_embed
+
+    body = response.body
+    expect(body).to include("localStorage")
+    expect(body).to include("sessionStorage")
+    expect(body).to include('Object.defineProperty(document, "cookie"')
+  end
+
+  it "loads the shim in the head, before <body>, so it runs first without being the body's first child" do
+    get_embed
+
+    body = response.body
+    shim_index = body.index("data-gumroad-sandbox-shim")
+    body_tag_index = body.index("<body")
+    seller_index = body.index("creator-marker")
+
+    expect(shim_index).to be_present
+    expect(body_tag_index).to be_present
+    expect(seller_index).to be_present
+    expect(shim_index).to be < body_tag_index
+    expect(shim_index).to be < seller_index
+  end
+end

--- a/spec/requests/products/show/custom_html_spec.rb
+++ b/spec/requests/products/show/custom_html_spec.rb
@@ -36,4 +36,39 @@ describe "Custom HTML product page", type: :system, js: true do
       expect(page).to have_text("Qty: 2")
     end
   end
+
+  context "when a seller script reads sandbox-restricted storage on load" do
+    let(:product) do
+      create(
+        :product,
+        user: seller,
+        custom_html: <<~HTML
+          <main>
+            <h1>Custom landing</h1>
+            <div id="reveal-ls" style="display:none">localStorage reveal worked</div>
+            <div id="reveal-ck" style="display:none">cookie reveal worked</div>
+            <button type="button" data-gumroad-action="buy">Buy</button>
+          </main>
+          <script>
+            if (localStorage.getItem("theme") !== "never") {
+              document.getElementById("reveal-ls").style.display = "block";
+            }
+          </script>
+          <script>
+            var cookie = document.cookie;
+            document.getElementById("reveal-ck").style.display = "block";
+          </script>
+        HTML
+      )
+    end
+
+    it "reveals content gated behind localStorage and document.cookie instead of blanking" do
+      visit short_link_path(product)
+
+      within_frame(find("iframe#gumroad-landing-frame")) do
+        expect(page).to have_text("localStorage reveal worked")
+        expect(page).to have_text("cookie reveal worked")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What

Custom landing pages run in a sandboxed iframe (no `allow-same-origin`), so reading `localStorage`, `sessionStorage`, or `document.cookie` throws. A seller's inline script throws on load, halting the rest of the script and leaving the page blank below the hero.

A small shim is injected into the page's `<head>` (before any seller script) that provides in-memory stand-ins for those APIs, so the reads return empty instead of throwing and the script runs to completion.

## Why

Some landing pages show blank sections because their "theme toggle" throws on `localStorage` before its reveal animations are set up. It's a common pattern, so the fix belongs on the platform, not in each page.

## Test Results

Request spec (shim in `<head>` before seller markup, covers all three APIs) and a system spec (a storage/cookie-gated page now renders; buy flow still works). All pass locally and fail when the shim is reverted.

---

Implemented with AI assistance (Claude Opus 4.8).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to custom HTML embed document generation and client-side polyfills; no auth, checkout, or persistence changes beyond existing opaque-origin behavior.
> 
> **Overview**
> Custom landing **embed** documents now inject a **head-loaded sandbox compatibility script** before seller markup and Tailwind, so scripts that touch `localStorage`, `sessionStorage`, or `document.cookie` on an opaque sandbox origin get **in-memory stand-ins** instead of throwing and halting (which often left the page blank below the hero).
> 
> **Tests** add a request spec on `GET /l/:id/landing/embed` (shim marker, APIs, order before `<body>`/seller content) and a system spec where storage/cookie reads on load still reveal gated content inside `iframe#gumroad-landing-frame`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df233c24deff416541b724faaacb84fa7b585103. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->