### PR TITLE
Add onetime task to delete events rows with legacy email

### DIFF
--- a/app/services/onetime/delete_events_with_email.rb
+++ b/app/services/onetime/delete_events_with_email.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Deletes `events` rows that still have a value in the legacy `email` column.
+#
+# No current code path writes `events.email` — the column is a vestige of an older
+# tracking design. The only rows that hold a value are old ones, and that value is
+# buyer PII (`GdprBuyerErasureService` looks events up by it). Clearing these rows
+# removes the residual PII and lets us drop the column later without a value-bearing
+# legacy column getting in the way.
+#
+# The table is one of the largest in the database, so we delete in primary-key batches
+# and pause between batches whenever a replica falls more than 10 seconds behind.
+module Onetime
+  class DeleteEventsWithEmail
+    BATCH_SIZE = 1_000
+    MAX_LAG_ALLOWED_SECONDS = 10
+
+    def self.process(batch_size: BATCH_SIZE)
+      new.process(batch_size:)
+    end
+
+    def process(batch_size: BATCH_SIZE)
+      deleted = 0
+
+      Event.where.not(email: nil).in_batches(of: batch_size) do |batch|
+        ReplicaLagWatcher.watch(max_lag_allowed: MAX_LAG_ALLOWED_SECONDS)
+        deleted += batch.delete_all
+        puts "deleted #{deleted} events so far"
+      end
+
+      puts "done: deleted #{deleted} events with email present"
+      deleted
+    end
+  end
+end

--- a/spec/services/onetime/delete_events_with_email_spec.rb
+++ b/spec/services/onetime/delete_events_with_email_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Onetime::DeleteEventsWithEmail do
+  describe ".process" do
+    it "deletes events that have an email and keeps events without one" do
+      with_email = create(:event, email: "buyer@example.com")
+      without_email = create(:event, email: nil)
+
+      described_class.process
+
+      expect(Event.exists?(with_email.id)).to be(false)
+      expect(Event.exists?(without_email.id)).to be(true)
+    end
+
+    it "deletes across multiple batches and returns the total number deleted" do
+      create_list(:event, 3, email: "buyer@example.com")
+      create(:event, email: nil)
+
+      expect(described_class.process(batch_size: 1)).to eq(3)
+      expect(Event.where.not(email: nil).count).to eq(0)
+    end
+
+    it "pauses for replica lag, allowing up to 10 seconds of delay, between batches" do
+      create(:event, email: "buyer@example.com")
+
+      expect(ReplicaLagWatcher).to receive(:watch).with(max_lag_allowed: 10).at_least(:once)
+
+      described_class.process
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds `Onetime::DeleteEventsWithEmail`, a onetime task that deletes every `events` row that still has a value in the legacy `email` column. It deletes in primary-key batches of 1,000 and calls `ReplicaLagWatcher.watch(max_lag_allowed: 10)` between batches, pausing whenever a replica falls more than 10 seconds behind.

```ruby
Onetime::DeleteEventsWithEmail.process
# or, to tune the batch size:
Onetime::DeleteEventsWithEmail.process(batch_size: 500)
```

## Why

No current code path writes `events.email`. The four `Events#create_event` callers (`create_user_event`, `create_post_event`, `create_purchase_event`, `create_service_charge_event`) and `CreateMissingPurchaseEventsWorker` never set it — the column is a vestige of an older tracking design. The only rows that hold a value are old ones, and that value is buyer PII (`GdprBuyerErasureService#anonymize_events!` locates events by it).

Clearing these rows removes residual buyer PII now and is the groundwork for dropping the column entirely: with no value-bearing legacy data left, the eventual `DROP COLUMN` is unambiguous.

`events` is one of the largest tables in the database, so the task cannot delete in a single statement. It iterates by primary key (`in_batches`) and throttles on replica lag with a 10-second allowance, consistent with the existing onetime tasks (`MigratePuertoRicoToUsState`, the backfill tasks).

## Scope / follow-up

This PR only deletes the data. It does **not** drop the column or change `GdprBuyerErasureService`. The column removal is a separate step (remove code usages → `ignored_columns` → deploy → drop), and on a table this size the `DROP COLUMN` itself needs an online schema change (PT-OSC) or an INSTANT DDL on MySQL 8.0.29+.

## Test Results

`bundle exec rspec spec/services/onetime/delete_events_with_email_spec.rb` — 3 examples, 0 failures. `rubocop` clean.

- deletes events that have an email and keeps events without one
- deletes across multiple batches and returns the total number deleted
- pauses for replica lag, allowing up to 10 seconds of delay, between batches

---

🤖 AI disclosure: drafted with Claude Opus 4.8.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5382"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783089165&installation_id=134400930&pr_number=5382&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5382&signature=f32ff279959f6e1d7a5fb6b3fd4251e19f48d1cd78dfba5c769517760e7cb497"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bulk hard-deletes on a very large production table can stress replicas and load; mitigated by batching and ReplicaLagWatcher, but operational impact during the run is non-trivial.
> 
> **Overview**
> Adds **`Onetime::DeleteEventsWithEmail`**, a one-off job to remove legacy `events` rows where `email` is still set (stale buyer PII). Rows with `email: nil` are left untouched.
> 
> The task scans with `Event.where.not(email: nil).in_batches`, runs **`ReplicaLagWatcher.watch(max_lag_allowed: 10)`** before each batch, and **`delete_all`** in chunks of 1,000 (configurable via `.process(batch_size:)`). It logs progress and returns the total deleted count.
> 
> Specs cover selective deletion, multi-batch totals, and replica-lag throttling. **Column drop and GDPR service changes are out of scope** for this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd818d9ffbb87e3ec1f7d25d0ffb9dafa53f2f1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->