### PR TITLE
Locate GDPR-erased events by purchase id, and make re-runs safe

### DIFF
--- a/app/services/gdpr_buyer_erasure_service.rb
+++ b/app/services/gdpr_buyer_erasure_service.rb
@@ -39,7 +39,12 @@ class GdprBuyerErasureService
 
     @anonymized_email = generate_anonymized_email
 
-    purchases = Purchase.where(email: email, purchaser_id: nil)
+    # Match the anonymized email too, so a re-run after a partial failure can
+    # still rebuild @purchase_ids: anonymize_purchases! rewrites the buyer's
+    # purchase email to @anonymized_email (deterministic), and the downstream
+    # steps that key off purchase ids (events, charges, custom fields) would
+    # otherwise have no way to locate those purchases on a second run.
+    purchases = Purchase.where(purchaser_id: nil, email: [email, @anonymized_email])
     @purchase_ids = purchases.pluck(:id)
     @credit_card_ids = purchases.where.not(credit_card_id: nil).distinct.pluck(:credit_card_id)
     candidate_browser_guids = purchases.where.not(browser_guid: nil).distinct.pluck(:browser_guid)
@@ -95,6 +100,7 @@ class GdprBuyerErasureService
       skipped << step_name
       Rails.logger.warn("GDPR buyer erasure: step '#{step_name}' timed out for #{@anonymized_email} and was skipped (non-critical): #{e.class}")
     end
+
     def generate_anonymized_email
       digest = OpenSSL::HMAC.hexdigest("SHA256", Rails.application.secret_key_base, email)[0..15]
       "buyer-#{digest}@#{ANONYMIZED_EMAIL_DOMAIN}"
@@ -129,7 +135,9 @@ class GdprBuyerErasureService
     end
 
     def anonymize_events!
-      counts[:events] = Event.where(email: email).update_all(
+      return if @purchase_ids.empty?
+
+      counts[:events] = Event.where(purchase_id: @purchase_ids).update_all(
         email: nil,
         ip_address: nil,
         ip_country: nil,

--- a/spec/services/gdpr_buyer_erasure_service_spec.rb
+++ b/spec/services/gdpr_buyer_erasure_service_spec.rb
@@ -95,9 +95,8 @@ describe GdprBuyerErasureService do
         expect(unrelated_purchase.email).to eq("other@example.com")
       end
 
-      it "anonymizes all PII columns on matching events rows" do
-        event = Event.new(
-          email: buyer_email,
+      def build_event(attrs)
+        Event.new({
           ip_address: "9.9.9.9",
           ip_country: "US",
           ip_state: "NY",
@@ -109,8 +108,11 @@ describe GdprBuyerErasureService do
           browser_plugins: "Flash, Java",
           browser_guid: "guid_event",
           event_name: "purchase",
-        )
-        event.save!(validate: false)
+        }.merge(attrs)).tap { _1.save!(validate: false) }
+      end
+
+      it "anonymizes all PII columns on events tied to the buyer's purchases" do
+        event = build_event(purchase_id: purchase1.id, email: buyer_email)
 
         described_class.new(buyer_email, performed_by: admin).perform!
 
@@ -125,6 +127,45 @@ describe GdprBuyerErasureService do
         expect(event.fingerprint).to be_nil
         expect(event.browser_fingerprint).to be_nil
         expect(event.browser_plugins).to be_nil
+        expect(event.browser_guid).to be_nil
+      end
+
+      it "anonymizes events located by purchase even when the email column is empty" do
+        event = build_event(purchase_id: purchase2.id, email: nil)
+
+        described_class.new(buyer_email, performed_by: admin).perform!
+
+        event.reload
+        expect(event.ip_address).to be_nil
+        expect(event.browser_guid).to be_nil
+      end
+
+      it "leaves events tied to unrelated purchases untouched" do
+        event = build_event(purchase_id: unrelated_purchase.id, email: "other@example.com")
+
+        described_class.new(buyer_email, performed_by: admin).perform!
+
+        event.reload
+        expect(event.ip_address).to eq("9.9.9.9")
+        expect(event.browser_guid).to eq("guid_event")
+      end
+
+      it "anonymizes events on a re-run after the events step was skipped, even though purchases were already anonymized" do
+        event = build_event(purchase_id: purchase1.id, email: buyer_email)
+
+        first_run = described_class.new(buyer_email, performed_by: admin)
+        allow(first_run).to receive(:anonymize_events!).and_raise(ActiveRecord::LockWaitTimeout, "Lock wait timeout exceeded")
+        first_result = first_run.perform!
+
+        expect(first_result[:skipped]).to include(:events)
+        expect(purchase1.reload.email).to end_with("@deleted.gumroad.com")
+        expect(event.reload.ip_address).to eq("9.9.9.9")
+
+        second_result = described_class.new(buyer_email, performed_by: admin).perform!
+
+        expect(second_result[:skipped]).to be_empty
+        expect(second_result[:counts][:events]).to eq(1)
+        expect(event.reload.ip_address).to be_nil
         expect(event.browser_guid).to be_nil
       end
 


### PR DESCRIPTION
## What

Two changes to `GdprBuyerErasureService`:

1. `anonymize_events!` now locates the buyer's events with `Event.where(purchase_id: @purchase_ids)` instead of `Event.where(email: email)`.
2. `@purchase_ids` is now built by matching **both** the original buyer email and the deterministic anonymized email: `Purchase.where(purchaser_id: nil, email: [email, @anonymized_email])`.

## Why

**Locating events by purchase id.** The email lookup ties erasure to the legacy `events.email` column, which is unindexed and on its way out (see the events-email cleanup work). It's also about to become *insufficient*: once recurring subscription charges stop copying the original buyer's email into new event rows, those recurring-charge events have a `purchase_id` but no `email`, and the email lookup would silently miss them. `purchase_id` is indexed (`index_events_on_purchase_id`) and covers every event tied to the buyer's purchases — correct now and after the column is gone.

**Re-run safety.** Switching events to `purchase_id` alone introduces a hazard. `@purchase_ids` is derived from `Purchase.where(email: ...)`, and `anonymize_purchases!` rewrites that email to `@anonymized_email`. The service is deliberately best-effort per step (a lock-wait timeout on a contended table like `events` is recorded as `skipped` rather than aborting the whole erasure — see #438). So if purchases succeed but the events step is skipped, a re-run with the original email could no longer rebuild `@purchase_ids`, and the events PII would be stranded with no way to finish.

Because `@anonymized_email` is a deterministic HMAC of the original email, matching both forms lets a re-run find the already-anonymized purchases and complete the events step. This also makes the existing `charges` and `purchase_custom_fields` steps (which key off `@purchase_ids`) re-runnable, closing a pre-existing gap.

## Relationship to other PRs

Part of the `events.email` decommission:
- #5383 stops recurring charges from copying the email forward (the reason the email lookup would start missing events).
- #5382 clears existing rows.
- This PR removes the last email-based *read* of `events.email`, so the column can eventually be dropped.

## Test Results

`bundle exec rspec spec/services/gdpr_buyer_erasure_service_spec.rb` — 36 examples, 0 failures. `rubocop` clean.

New/updated specs:
- events PII anonymized for events tied to the buyer's purchases
- events located by purchase even when the email column is empty (the post-#5383 recurring-charge case)
- events tied to unrelated purchases left untouched
- events anonymized on a **re-run** after the events step was skipped, even though purchases were already anonymized (fails without the dual-email `@purchase_ids` match)

---

🤖 AI disclosure: written with Claude Opus 4.8.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783091158&installation_id=134400930&pr_number=5385&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5385&signature=298dbc1cdb3f61beeccf449a91837d4a8fda273a106b4d3111f1dd1599240b74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GDPR PII deletion behavior (which events/rows are updated); incorrect scoping could leave PII or touch unrelated data, though specs target purchase boundaries and re-run safety.
> 
> **Overview**
> **Guest buyer GDPR erasure** now finds purchases by both the original email and the deterministic anonymized email, so a **re-run after a partial failure** (e.g. purchases anonymized but `events` skipped on lock timeout) can still rebuild `@purchase_ids` and finish charges, custom fields, and events.
> 
> **Event PII** is cleared with `Event.where(purchase_id: @purchase_ids)` instead of matching `events.email`, covering events with no email (e.g. recurring charges) and dropping reliance on the legacy unindexed email column. Specs add coverage for purchase-scoped anonymization, unrelated purchases left alone, and completing events on a second run after a skipped events step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5a742ad50e606aa8ec8b548416d426553dad15b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->