### PR TITLE
Fetch Git LFS objects when copying deployment secrets

### DIFF
--- a/.buildkite/scripts/copy_secrets.sh
+++ b/.buildkite/scripts/copy_secrets.sh
@@ -13,16 +13,26 @@ copy_secrets() {
     return 1
   fi
 
+  if ! command -v git-lfs >/dev/null 2>&1; then
+    logger "Error: git-lfs is not installed. The deployment repo stores *.mmdb files (e.g. lib/GeoIP2-City.mmdb) via Git LFS; install git-lfs on the agent."
+    return 1
+  fi
+
   logger "Cloning deployment repo with secrets"
   CREDENTIALS_TMP_DIR="/tmp/gumroad-deployment-credentials"
   rm -rf "$CREDENTIALS_TMP_DIR"
   git clone --depth 1 $CREDENTIALS_REPO "$CREDENTIALS_TMP_DIR"
+
+  logger "Fetching Git LFS objects"
+  git -C "$CREDENTIALS_TMP_DIR" lfs install --local
+  git -C "$CREDENTIALS_TMP_DIR" lfs pull
+
   local app_dir=$(pwd)
 
   logger "Copying files"
   cd "$CREDENTIALS_TMP_DIR"
 
-  files_to_remove=(".git" ".gitignore" "README.md" "copy_into" "docs")
+  files_to_remove=(".git" ".gitattributes" ".gitignore" "README.md" "copy_into" "docs")
   for file in "${files_to_remove[@]}"; do
     rm -rf "$file"
   done
@@ -41,6 +51,14 @@ copy_secrets() {
   done
   rm -rf "$CREDENTIALS_TMP_DIR"
   cd "$app_dir"
+
+  logger "Verifying Git LFS files resolved"
+  while IFS= read -r -d '' mmdb; do
+    if head -c 64 "$mmdb" | grep -q "git-lfs"; then
+      logger "Error: $mmdb is a Git LFS pointer, not the real file. LFS objects were not fetched."
+      return 1
+    fi
+  done < <(find "$app_dir/lib" -name '*.mmdb' -print0)
 
   logger "Secrets copied successfully"
   return 0


### PR DESCRIPTION
## What

Updates `.buildkite/scripts/copy_secrets.sh` so the deploy pipeline correctly materializes `lib/GeoIP2-City.mmdb` once the deployment repo moves `*.mmdb` to Git LFS ([gumroad-deployment#31](https://github.com/antiwork/gumroad-deployment/pull/31)).

- Require `git-lfs` before cloning the credentials repo, with a clear error if it is missing.
- Run `git lfs install --local` + `git lfs pull` after the clone so LFS-backed files become real content instead of pointers.
- Strip the deployment repo's new `.gitattributes` so its LFS rules do not leak into the app working tree.
- After copying, verify no `*.mmdb` under `lib/` is still an LFS pointer, failing the build loudly if LFS objects were not fetched.

## Why

`copy_secrets.sh` clones the deployment repo with `git clone --depth 1` and copies every file into the app tree. `lib/GeoIP2-City.mmdb` is gitignored in this repo (`.gitignore:66`) and is supplied entirely by that copy step.

Once `*.mmdb` is tracked via Git LFS, a plain `git clone` only fetches the real database if `git-lfs` is installed and its smudge filter is active on the Buildkite agent. If it is not, the checkout produces a ~130-byte LFS pointer, which gets copied to `lib/GeoIP2-City.mmdb`. At boot, `config/initializers/geoip.rb:6` does:

```ruby
GEOIP = File.exist?(database_path) ? MaxMind::GeoIP2::Reader.new(database: database_path) : nil
```

The pointer file passes `File.exist?`, so `MaxMind::GeoIP2::Reader.new` raises `InvalidDatabaseError` and the app fails to boot — a silent infra change surfacing as a runtime crash.

Making LFS handling explicit (and validating the result) keeps the file pullable after the deployment PR merges, and turns a possible boot-time crash into an early, obvious build failure with an actionable message.

This belongs in the gumroad repo rather than the deployment PR because the pipeline uses its own `copy_secrets.sh` clone path, not the deployment repo's `copy_into` helper (which `copy_secrets.sh` explicitly removes).

### Agent requirement

This assumes the Buildkite agent AMI has `git-lfs` installed. If it does not, this change fails fast with a clear message instead of crashing at app boot. Installing `git-lfs` on the agent image is the follow-up if that guard trips.

## Before/After

Non-user-facing CI change — video walkthrough of a deploy build's secret-copy step to be attached before marking ready for review.

## Test Results

`bash -n .buildkite/scripts/copy_secrets.sh` passes (syntax check). The script runs only on Buildkite agents during `build_web` / `deploy_branch` / `deploy_production`, so end-to-end verification is a preview-app deploy against the LFS-converted deployment repo.

---

AI disclosure: drafted with Claude Opus 4.8.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783093069&installation_id=134400930&pr_number=5386&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5386&signature=5fa41f5dfea9609a33f0135f05fd150806431f106cd2ac574958cb44ab560ec8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to secret copy; depends on git-lfs on agents but fails fast with a clear error if missing.
> 
> **Overview**
> Updates **`copy_secrets.sh`** so Buildkite deploys materialize **Git LFS**–backed secrets (notably **`lib/GeoIP2-City.mmdb`**) after the deployment repo moves `*.mmdb` to LFS.
> 
> The script now **requires `git-lfs`**, runs **`lfs install` + `lfs pull`** on the shallow credentials clone, drops **`.gitattributes`** from the copied tree, and **fails the build** if any `lib/*.mmdb` is still an LFS pointer—avoiding a boot-time **`MaxMind::GeoIP2::Reader`** crash when a pointer passes **`File.exist?`** in **`geoip.rb`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7088c874a2c90b7f8a18a06dda3a15325e9f5f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->