### PR TITLE
Add admin API endpoint to list a user's credits

### DIFF
--- a/app/controllers/api/internal/admin/users_controller.rb
+++ b/app/controllers/api/internal/admin/users_controller.rb
@@ -138,6 +138,21 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
     render json: internal_admin_user_success_payload(user, unpaid_balance_payload(RefundUnpaidPurchasesWorker.unpaid_balance_summary_for(user)))
   end
 
+  def credits
+    user = find_internal_admin_user_for_read_or_render(include_deleted: true)
+    return unless user
+
+    records, pagination = paginate_with_cursor(
+      user.credits.includes(:crediting_user),
+      order: [[:created_at, :desc], [:id, :desc]]
+    )
+
+    render json: internal_admin_user_success_payload(user, {
+                                                       credits: records.map { serialize_credit(_1) },
+                                                       pagination:,
+                                                     })
+  end
+
   def reset_password
     user = find_internal_admin_user_for_write_or_render
     return unless user
@@ -826,6 +841,7 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
         id: credit.id.to_s,
         amount_cents: credit.amount_cents,
         reason: credit.reason,
+        crediting_user_id: credit.crediting_user&.external_id,
         created_at: credit.created_at.iso8601
       }
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -362,6 +362,7 @@ Rails.application.routes.draw do
               get :related
               get :suspension
               get :unpaid_balance
+              get :credits
               post :reset_password
               post :update_email
               post :two_factor_authentication

--- a/db/migrate/20261130000005_add_index_to_credits_on_user_id_and_created_at.rb
+++ b/db/migrate/20261130000005_add_index_to_credits_on_user_id_and_created_at.rb
@@ -2,6 +2,6 @@
 
 class AddIndexToCreditsOnUserIdAndCreatedAt < ActiveRecord::Migration[7.1]
   def change
-    add_index :credits, [:user_id, :created_at, :id], name: "index_credits_on_user_id_and_created_at"
+    add_index :credits, [:user_id, :created_at, :id]
   end
 end

--- a/db/migrate/20261130000005_add_index_to_credits_on_user_id_and_created_at.rb
+++ b/db/migrate/20261130000005_add_index_to_credits_on_user_id_and_created_at.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIndexToCreditsOnUserIdAndCreatedAt < ActiveRecord::Migration[7.1]
+  def change
+    add_index :credits, [:user_id, :created_at, :id], name: "index_credits_on_user_id_and_created_at"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_11_30_000004) do
+ActiveRecord::Schema[7.1].define(version: 2026_11_30_000005) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -731,6 +731,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_11_30_000004) do
     t.text "reason"
     t.index ["balance_id"], name: "index_credits_on_balance_id"
     t.index ["dispute_id"], name: "index_credits_on_dispute_id"
+    t.index ["user_id", "created_at", "id"], name: "index_credits_on_user_id_and_created_at"
   end
 
   create_table "custom_domains", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -731,7 +731,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_11_30_000005) do
     t.text "reason"
     t.index ["balance_id"], name: "index_credits_on_balance_id"
     t.index ["dispute_id"], name: "index_credits_on_dispute_id"
-    t.index ["user_id", "created_at", "id"], name: "index_credits_on_user_id_and_created_at"
+    t.index ["user_id", "created_at", "id"], name: "index_credits_on_user_id_and_created_at_and_id"
   end
 
   create_table "custom_domains", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -2173,6 +2173,116 @@ describe Api::Internal::Admin::UsersController do
                      extra_params: { expected_purchase_count: 0, expected_total_amount_cents: 0 }
   end
 
+  describe "GET credits" do
+    let!(:gumroad_merchant_account) { create(:merchant_account, user: nil) }
+    let(:user) { create(:user) }
+
+    include_examples "admin api authorization required", :get, :credits
+
+    def credit_ids
+      response.parsed_body["credits"].map { _1["id"] }
+    end
+
+    it "returns bad request when neither user_id nor email is provided" do
+      get :credits
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "email or user_id is required" }.as_json)
+    end
+
+    it "returns not found when the user does not exist" do
+      get :credits, params: { user_id: "missing" }
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
+    end
+
+    it "returns an empty list with cursor pagination metadata" do
+      get :credits, params: { user_id: user.external_id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(
+        "success" => true,
+        "user_id" => user.external_id,
+        "credits" => [],
+        "pagination" => { "next" => nil, "limit" => 20 }
+      )
+    end
+
+    it "looks up soft-deleted users" do
+      deleted_user = create(:user, :deleted)
+
+      get :credits, params: { user_id: deleted_user.external_id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["user_id"]).to eq(deleted_user.external_id)
+    end
+
+    it "lists credits newest first with the crediting user, amount, and reason" do
+      older = Credit.create_for_credit!(user:, amount_cents: 500, crediting_user: admin_user, reason: "Older goodwill")
+      older.update_columns(created_at: 2.hours.ago)
+      newer = Credit.create_for_credit!(user:, amount_cents: 1500, crediting_user: admin_user, reason: "Newer goodwill")
+
+      get :credits, params: { user_id: user.external_id }
+
+      expect(response).to have_http_status(:ok)
+      expect(credit_ids).to eq([newer.id.to_s, older.id.to_s])
+      expect(response.parsed_body["credits"].first).to eq(
+        "id" => newer.id.to_s,
+        "amount_cents" => 1500,
+        "reason" => "Newer goodwill",
+        "crediting_user_id" => admin_user.external_id,
+        "created_at" => newer.created_at.iso8601
+      )
+    end
+
+    it "surfaces zero-amount and system-generated credits, with a null crediting_user_id for the latter" do
+      zero = Credit.create_for_credit!(user:, amount_cents: 0, crediting_user: admin_user, reason: "Engineering script leftover")
+      system_credit = Credit.create_for_credit!(user:, amount_cents: 250, crediting_user: admin_user, reason: nil)
+      system_credit.update_columns(crediting_user_id: nil)
+
+      get :credits, params: { user_id: user.external_id }
+
+      payloads = response.parsed_body["credits"].index_by { _1["id"] }
+      expect(payloads[zero.id.to_s]).to include("amount_cents" => 0, "crediting_user_id" => admin_user.external_id)
+      expect(payloads[system_credit.id.to_s]).to include("crediting_user_id" => nil, "reason" => nil)
+    end
+
+    it "returns bad request when the cursor is invalid" do
+      get :credits, params: { user_id: user.external_id, cursor: "invalid" }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq({ success: false, message: "invalid cursor" }.as_json)
+    end
+
+    it "preloads crediting users instead of issuing one query per credit" do
+      3.times do |index|
+        crediting_user = create(:admin_user, name: "Admin #{index}")
+        Credit.create_for_credit!(user:, amount_cents: 100, crediting_user:, reason: "Goodwill #{index}")
+      end
+      select_queries = []
+      counter = lambda do |*, payload|
+        sql = payload[:sql].to_s.squish
+        next if payload[:name] == "SCHEMA"
+        next unless sql.start_with?("SELECT")
+        next if sql.include?("`admin_api_tokens`")
+        next if sql.include?("`oauth_access_tokens`")
+
+        select_queries << sql
+      end
+
+      ActiveSupport::Notifications.subscribed(counter, "sql.active_record") do
+        get :credits, params: { user_id: user.external_id }
+      end
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["credits"].length).to eq(3)
+      expect(select_queries.length).to be <= 4, "expected at most 4 SELECTs but got #{select_queries.length}:\n#{select_queries.join("\n")}"
+    end
+
+    include_examples "supports user lookup by user_id", :credits, method: :get
+  end
+
   describe "POST add_credit" do
     let!(:gumroad_merchant_account) { create(:merchant_account, user: nil) }
     let(:user) { create(:user) }
@@ -2246,7 +2356,8 @@ describe Api::Internal::Admin::UsersController do
       expect(response.parsed_body["credit"]).to include(
         "id" => credit.id.to_s,
         "amount_cents" => 1000,
-        "reason" => reason
+        "reason" => reason,
+        "crediting_user_id" => admin_user.external_id
       )
       expect(user.comments.reload.last.content).to eq("issued $10 credit — #{reason}.")
     end

--- a/spec/routing/api_internal_admin_contract_spec.rb
+++ b/spec/routing/api_internal_admin_contract_spec.rb
@@ -20,6 +20,7 @@ describe "internal admin API routing" do
     expect(route_for("/internal/admin/users/related", :get)).to include(controller: "api/internal/admin/users", action: "related")
     expect(route_for("/internal/admin/users/suspension", :get)).to include(controller: "api/internal/admin/users", action: "suspension")
     expect(route_for("/internal/admin/users/unpaid_balance", :get)).to include(controller: "api/internal/admin/users", action: "unpaid_balance")
+    expect(route_for("/internal/admin/users/credits", :get)).to include(controller: "api/internal/admin/users", action: "credits")
     expect(route_for("/internal/admin/payouts", :get)).to include(controller: "api/internal/admin/payouts", action: "index")
   end
 


### PR DESCRIPTION
Closes antiwork/gumroad-private#453

## What

Adds `GET /api/internal/admin/users/credits`. Read endpoint that lists a user's credits (id, amount_cents, reason, crediting_user_id, created_at), newest first, with the same cursor pagination as the other admin list endpoints.

Exposes `crediting_user_id` on the shared credit serializer and adds a `(user_id, created_at, id)` index on `credits` to back the query.

## Why

The `add_credit` write endpoint already exists; the read path was the missing half. It lets the trust-budget system (antiwork/gumroad-private#422) reconcile recommended vs. actually-issued credits, and lets support confirm a credit landed — including the known zero-amount credits left by old scripts. The positive-only and per-call cap guardrails will live in the CLI, so the server stays a thin primitive over the existing `Credit.create_for_credit!`.

---

This PR was implemented with AI assistance using Claude Opus 4.8.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only admin API backed by existing credit records and patterns; index migration is additive with no auth or payout logic changes.
> 
> **Overview**
> Adds **`GET /api/internal/admin/users/credits`**, a read-only admin list that returns a user’s credits (newest first) with the same **cursor pagination** pattern as other internal admin list endpoints. Lookups allow **soft-deleted users**; each row includes amount, reason, timestamps, and **`crediting_user_id`** (admin external id, or null for system-generated credits).
> 
> Extends the shared **`serialize_credit`** payload so **`add_credit`** responses also expose **`crediting_user_id`**. Adds a composite index on **`credits (user_id, created_at, id)`** to support the paginated query, plus controller, routing, and contract specs (including N+1 guard via `includes(:crediting_user)`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6abbdb12602cb98c0176389d61e98f9d052f56cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->