### PR TITLE
Drop creator_opted_in from GA; rename buyer-currency variant to display_mode

### DIFF
--- a/app/helpers/currency_helper.rb
+++ b/app/helpers/currency_helper.rb
@@ -103,12 +103,11 @@ module CurrencyHelper
 
     default_props = {
       product_id: product.external_id,
-      creator_opted_in:,
       buyer_currency_shown: product_currency,
       product_currency:,
       buyer_local_price_cents: nil,
       rate: nil,
-      variant: "default",
+      display_mode: "default",
     }
 
     return default_props unless creator_opted_in
@@ -129,12 +128,11 @@ module CurrencyHelper
 
     {
       product_id: product.external_id,
-      creator_opted_in:,
       buyer_currency_shown: buyer_currency,
       product_currency:,
       buyer_local_price_cents: local_price_cents,
       rate: rate.to_f,
-      variant: "buyer_local",
+      display_mode: "buyer_local",
     }
   rescue StandardError
     # Graceful degradation: never re-raise. Re-deriving product_currency here could raise
@@ -150,17 +148,16 @@ module CurrencyHelper
     end
     {
       product_id: product.external_id,
-      creator_opted_in: false,
       buyer_currency_shown: safe_product_currency,
       product_currency: safe_product_currency,
       buyer_local_price_cents: nil,
       rate: nil,
-      variant: "default",
+      display_mode: "default",
     }
   end
 
   def buyer_local_price_props(product:, original_price_cents: nil, buyer_currency_display:)
-    return {} unless buyer_currency_display&.dig(:variant) == "buyer_local"
+    return {} unless buyer_currency_display&.dig(:display_mode) == "buyer_local"
 
     buyer_currency = buyer_currency_display[:buyer_currency_shown]
     rate = BigDecimal(buyer_currency_display[:rate].to_s)

--- a/app/javascript/data/google_analytics.ts
+++ b/app/javascript/data/google_analytics.ts
@@ -70,10 +70,9 @@ export function trackProductEvent(config: AnalyticsConfig | undefined, data: Pro
         value,
         ...(data.buyer_currency_display
           ? {
-              creator_opted_in: data.buyer_currency_display.creator_opted_in,
               buyer_currency_shown: data.buyer_currency_display.buyer_currency_shown,
               product_currency: data.buyer_currency_display.product_currency,
-              variant: data.buyer_currency_display.variant,
+              display_mode: data.buyer_currency_display.display_mode,
             }
           : {}),
       };
@@ -94,12 +93,11 @@ export function trackProductEvent(config: AnalyticsConfig | undefined, data: Pro
       logGumroadEvent("buyer_currency_display_view", {
         ...payload,
         product_id: data.product_id,
-        creator_opted_in: data.creator_opted_in,
         buyer_currency_shown: data.buyer_currency_shown,
         product_currency: data.product_currency,
         buyer_local_price_cents: data.buyer_local_price_cents,
         rate: data.rate,
-        variant: data.variant,
+        display_mode: data.display_mode,
       });
       break;
   }

--- a/app/javascript/parsers/product.ts
+++ b/app/javascript/parsers/product.ts
@@ -34,12 +34,11 @@ export type RatingsWithPercentages = Ratings & { percentages: Tuple<number, 5> }
 
 export type BuyerCurrencyDisplay = {
   product_id: string;
-  creator_opted_in: boolean;
   buyer_currency_shown: string;
   product_currency: CurrencyCode;
   buyer_local_price_cents: number | null;
   rate: number | null;
-  variant: "buyer_local" | "default";
+  display_mode: "buyer_local" | "default";
 };
 
 export type CardProduct = {

--- a/app/javascript/utils/user_analytics.ts
+++ b/app/javascript/utils/user_analytics.ts
@@ -85,7 +85,7 @@ export function trackProductEvent(id: string | undefined, data: ProductAnalytics
 
 export function trackBuyerCurrencyDisplayView(id: string | undefined, data: BuyerCurrencyDisplay | undefined) {
   if (!data) return;
-  if (data.variant !== "buyer_local") return;
+  if (data.display_mode !== "buyer_local") return;
 
   let alreadyTracked = false;
   try {

--- a/spec/helpers/buyer_local_currency_helper_spec.rb
+++ b/spec/helpers/buyer_local_currency_helper_spec.rb
@@ -123,7 +123,7 @@ describe CurrencyHelper do
 
       props = helper.buyer_currency_display_props(product:, price_cents: 1000, ip: "1.2.3.4")
 
-      expect(props).to include(creator_opted_in: false, variant: "default", rate: nil)
+      expect(props).to include(display_mode: "default", rate: nil)
     end
 
     it "returns a safe static default without re-raising when an operation raises" do
@@ -139,7 +139,7 @@ describe CurrencyHelper do
 
       expect(props).to include(
         product_id: "prod_abc",
-        variant: "default",
+        display_mode: "default",
         buyer_local_price_cents: nil,
         rate: nil
       )
@@ -171,7 +171,7 @@ describe CurrencyHelper do
 
       expect(props[:buyer_currency_shown]).to eq("usd")
       expect(props[:product_currency]).to eq("usd")
-      expect(props[:variant]).to eq("default")
+      expect(props[:display_mode]).to eq("default")
     end
   end
 end

--- a/spec/presenters/checkout_presenter_spec.rb
+++ b/spec/presenters/checkout_presenter_spec.rb
@@ -147,12 +147,11 @@ describe CheckoutPresenter do
             price_cents: 100,
             buyer_currency_display: {
               product_id: product.external_id,
-              creator_opted_in: false,
               buyer_currency_shown: "usd",
               product_currency: "usd",
               buyer_local_price_cents: nil,
               rate: nil,
-              variant: "default"
+              display_mode: "default"
             },
             pwyw: nil,
             installment_plan: nil,
@@ -670,12 +669,11 @@ describe CheckoutPresenter do
                                  price_cents: 0,
                                  buyer_currency_display: {
                                    product_id: @product.external_id,
-                                   creator_opted_in: false,
                                    buyer_currency_shown: "usd",
                                    product_currency: "usd",
                                    buyer_local_price_cents: nil,
                                    rate: nil,
-                                   variant: "default"
+                                   display_mode: "default"
                                  },
                                  installment_plan: nil,
                                  is_tiered_membership: true,

--- a/spec/presenters/product_presenter/buyer_local_currency_spec.rb
+++ b/spec/presenters/product_presenter/buyer_local_currency_spec.rb
@@ -51,12 +51,11 @@ describe "ProductPresenter buyer local currency props" do
       expect(props[:buyer_local_price_cents]).to eq(800)
       expect(props[:buyer_currency_display]).to eq(
         product_id: product.external_id,
-        creator_opted_in: true,
         buyer_currency_shown: "eur",
         product_currency: "usd",
         buyer_local_price_cents: 800,
         rate: 0.8,
-        variant: "buyer_local"
+        display_mode: "buyer_local"
       )
     end
 
@@ -85,12 +84,11 @@ describe "ProductPresenter buyer local currency props" do
       expect(props).not_to have_key(:buyer_local_original_price_cents)
       expect(props[:buyer_currency_display]).to eq(
         product_id: product.external_id,
-        creator_opted_in: false,
         buyer_currency_shown: "usd",
         product_currency: "usd",
         buyer_local_price_cents: nil,
         rate: nil,
-        variant: "default"
+        display_mode: "default"
       )
     end
 
@@ -115,12 +113,11 @@ describe "ProductPresenter buyer local currency props" do
       expect(props).not_to have_key(:buyer_local_original_price_cents)
       expect(props[:buyer_currency_display]).to eq(
         product_id: product.external_id,
-        creator_opted_in: true,
         buyer_currency_shown: "usd",
         product_currency: "usd",
         buyer_local_price_cents: nil,
         rate: nil,
-        variant: "default"
+        display_mode: "default"
       )
     end
 
@@ -148,12 +145,11 @@ describe "ProductPresenter buyer local currency props" do
       expect(props).not_to have_key(:buyer_local_price_cents)
       expect(props[:buyer_currency_display]).to eq(
         product_id: product.external_id,
-        creator_opted_in: true,
         buyer_currency_shown: "eur",
         product_currency: "eur",
         buyer_local_price_cents: nil,
         rate: nil,
-        variant: "default"
+        display_mode: "default"
       )
     end
 
@@ -170,7 +166,7 @@ describe "ProductPresenter buyer local currency props" do
 
       expect(props).not_to have_key(:buyer_currency)
       expect(props).not_to have_key(:buyer_local_price_cents)
-      expect(props[:buyer_currency_display]).to include(variant: "default", buyer_local_price_cents: nil, rate: nil)
+      expect(props[:buyer_currency_display]).to include(display_mode: "default", buyer_local_price_cents: nil, rate: nil)
     end
   end
 
@@ -186,12 +182,11 @@ describe "ProductPresenter buyer local currency props" do
       expect(props[:buyer_local_price_cents]).to eq(800)
       expect(props[:buyer_currency_display]).to eq(
         product_id: product.external_id,
-        creator_opted_in: true,
         buyer_currency_shown: "eur",
         product_currency: "usd",
         buyer_local_price_cents: 800,
         rate: 0.8,
-        variant: "buyer_local"
+        display_mode: "buyer_local"
       )
     end
 
@@ -231,12 +226,11 @@ describe "ProductPresenter buyer local currency props" do
       expect(props).not_to have_key(:buyer_local_price_cents)
       expect(props[:buyer_currency_display]).to eq(
         product_id: product.external_id,
-        creator_opted_in: true,
         buyer_currency_shown: "eur",
         product_currency: "eur",
         buyer_local_price_cents: nil,
         rate: nil,
-        variant: "default"
+        display_mode: "default"
       )
     end
   end

--- a/spec/presenters/product_presenter/card_spec.rb
+++ b/spec/presenters/product_presenter/card_spec.rb
@@ -32,12 +32,11 @@ describe ProductPresenter::Card do
             price_cents: 100,
             buyer_currency_display: {
               product_id: product.external_id,
-              creator_opted_in: false,
               buyer_currency_shown: "usd",
               product_currency: "usd",
               buyer_local_price_cents: nil,
               rate: nil,
-              variant: "default"
+              display_mode: "default"
             },
             thumbnail_url: nil,
             native_type: Link::NATIVE_TYPE_DIGITAL,

--- a/spec/presenters/product_presenter/product_props_spec.rb
+++ b/spec/presenters/product_presenter/product_props_spec.rb
@@ -53,12 +53,11 @@ describe ProductPresenter::ProductProps do
               currency_code: Currency::USD,
               buyer_currency_display: {
                 product_id: product.external_id,
-                creator_opted_in: false,
                 buyer_currency_shown: "usd",
                 product_currency: "usd",
                 buyer_local_price_cents: nil,
                 rate: nil,
-                variant: "default"
+                display_mode: "default"
               },
               custom_view_content_button_text: nil,
               custom_button_text_option: nil,
@@ -295,12 +294,11 @@ describe ProductPresenter::ProductProps do
               currency_code: Currency::USD,
               buyer_currency_display: {
                 product_id: product.external_id,
-                creator_opted_in: false,
                 buyer_currency_shown: "usd",
                 product_currency: "usd",
                 buyer_local_price_cents: nil,
                 rate: nil,
-                variant: "default"
+                display_mode: "default"
               },
               custom_view_content_button_text: nil,
               custom_button_text_option: nil,

--- a/spec/presenters/product_presenter_spec.rb
+++ b/spec/presenters/product_presenter_spec.rb
@@ -96,12 +96,11 @@ describe ProductPresenter do
             currency_code: Currency::USD,
             buyer_currency_display: {
               product_id: product.external_id,
-              creator_opted_in: false,
               buyer_currency_shown: "usd",
               product_currency: "usd",
               buyer_local_price_cents: nil,
               rate: nil,
-              variant: "default"
+              display_mode: "default"
             },
             custom_view_content_button_text: nil,
             custom_button_text_option: nil,

--- a/spec/requests/products/buyer_local_currency_display_spec.rb
+++ b/spec/requests/products/buyer_local_currency_display_spec.rb
@@ -44,12 +44,11 @@ describe "Buyer-local currency end-to-end display (#5281)", type: :request, iner
         expect(props["buyer_local_currency_rate"]).to eq(0.8)
         expect(props["buyer_currency_display"]).to include(
           "product_id" => product.external_id,
-          "creator_opted_in" => true,
           "buyer_currency_shown" => "eur",
           "product_currency" => "usd",
           "buyer_local_price_cents" => 800,
           "rate" => 0.8,
-          "variant" => "buyer_local",
+          "display_mode" => "buyer_local",
         )
       end
 
@@ -73,10 +72,9 @@ describe "Buyer-local currency end-to-end display (#5281)", type: :request, iner
         expect(props).not_to have_key("buyer_currency")
         expect(props).not_to have_key("buyer_local_price_cents")
         expect(props["buyer_currency_display"]).to include(
-          "creator_opted_in" => true,
           "buyer_currency_shown" => "usd",
           "product_currency" => "usd",
-          "variant" => "default",
+          "display_mode" => "default",
         )
       end
     end
@@ -92,8 +90,7 @@ describe "Buyer-local currency end-to-end display (#5281)", type: :request, iner
 
         expect(props).not_to have_key("buyer_currency")
         expect(props["buyer_currency_display"]).to include(
-          "creator_opted_in" => false,
-          "variant" => "default",
+          "display_mode" => "default",
         )
       end
     end
@@ -107,7 +104,7 @@ describe "Buyer-local currency end-to-end display (#5281)", type: :request, iner
 
         expect(response).to be_successful
         props = JSON.parse(response.body)["props"]["product"]
-        expect(props["buyer_currency_display"]).to include("variant" => "default")
+        expect(props["buyer_currency_display"]).to include("display_mode" => "default")
         expect(props).not_to have_key("buyer_local_price_cents")
       end
     end
@@ -145,23 +142,22 @@ describe "Buyer-local currency end-to-end display (#5281)", type: :request, iner
 
       expect(event["buyer_currency_display"]).to include(
         "product_id" => product.external_id,
-        "creator_opted_in" => true,
         "buyer_currency_shown" => "eur",
         "product_currency" => "usd",
         "buyer_local_price_cents" => 800,
         "rate" => 0.8,
-        "variant" => "buyer_local",
+        "display_mode" => "buyer_local",
       )
     end
 
-    it "omits buyer_currency_display.variant=buyer_local for a US buyer's purchase" do
+    it "omits buyer_currency_display.display_mode=buyer_local for a US buyer's purchase" do
       purchase.update!(ip_address: us_ip)
 
       get url_redirect_download_page_path(id: url_redirect.token),
           headers: { "X-Inertia" => "true", "REMOTE_ADDR" => us_ip }
 
       event = JSON.parse(response.body)["props"]["seller_analytics"]["purchase_event"]
-      expect(event["buyer_currency_display"]).to include("variant" => "default")
+      expect(event["buyer_currency_display"]).to include("display_mode" => "default")
     end
 
     context "when the seller has no third-party analytics configured" do

--- a/spec/requests/purchases/product/buyer_local_currency_display_spec.rb
+++ b/spec/requests/purchases/product/buyer_local_currency_display_spec.rb
@@ -122,12 +122,11 @@ describe "Buyer-local currency display (#5281)", type: :system, js: true do
       payload = wait_for_gtag_event("buyer_currency_display_view").last
       expect(payload).to include(
         "product_id" => @product.external_id,
-        "creator_opted_in" => true,
         "buyer_currency_shown" => "eur",
         "product_currency" => "usd",
         "buyer_local_price_cents" => 800,
         "rate" => 0.8,
-        "variant" => "buyer_local",
+        "display_mode" => "buyer_local",
         "send_to" => "gumroad",
       )
     end


### PR DESCRIPTION
## What

Two cleanups to the buyer-local-currency analytics added in #5281:

- **Remove the `creator_opted_in` field from GA.** It was attached to the seller-facing `purchase` event and the Gumroad-internal `buyer_currency_display_view` event. On the frontend it was *only* read to populate those two payloads, so it's removed end-to-end — the GA payloads, the `BuyerCurrencyDisplay` TS type, and the backend `buyer_currency_display_props` output.
- **Rename the `variant` discriminator to `display_mode`** (values unchanged: `"buyer_local"` / `"default"`).

## Why

- `creator_opted_in` isn't useful as an analytics dimension: every localized impression already implies the creator opted in (the field was always derivable from `display_mode`/`buyer_currency_shown`), so it added a redundant column to every GA event without telling us anything new.
- `variant` collides with **product variants**, which appear all over the codebase (`variant_category`, `variant_attributes`, `alive_variants`, bundle `variant:`…). In a GA event named for currency display, `variant` reads ambiguously. `display_mode` says what it is: which currency presentation the buyer actually saw.

The `creator_opted_in` **local variable** in `CurrencyHelper#buyer_currency_display_props` is intentionally kept — it's still the opt-in gate (`return default_props unless creator_opted_in`) that decides whether to localize at all. It simply no longer ships to the client.

## Scope

No behavior change to what checkout charges, to fallback handling, or to when the `buyer_currency_display_view` event fires (still gated on `display_mode === "buyer_local"` + session-dedup). This is a pure analytics-payload/naming change.

## Test Results

- `bundle exec rubocop` — clean on all 9 touched Ruby files
- `DISABLE_TYPE_CHECKED=1 npx eslint` + `npx tsc --noEmit` — clean on touched TS (the only tsc error is a pre-existing `vite/client` env issue, unrelated)
- `bundle exec rspec` — buyer-currency helper/presenter specs green. Remaining failures in the run (`We couldn't charge your card`, `settings_presenter_spec:255`) reproduce on `origin/main` and are local payment-processor env issues unrelated to this diff.

---

This PR was written with AI assistance (Claude Opus 4.8).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5390"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783110781&installation_id=134400930&pr_number=5390&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5390&signature=242a0f00a6b63caa445559e4ebb617d4df997aefe4abea802e09e23c794054cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Payload and naming-only change to analytics and `buyer_currency_display`; localization gating and charge currency are unchanged.
> 
> **Overview**
> This PR **cleans up buyer-local-currency analytics and API shape** without changing when localization runs or what buyers are charged.
> 
> **`creator_opted_in` is dropped** from `buyer_currency_display` everywhere it was serialized (Ruby `buyer_currency_display_props`, `BuyerCurrencyDisplay` in TypeScript, and Google Analytics `purchase` / `buyer_currency_display_view` payloads). The seller opt-in check remains server-side only as a local variable that gates whether localization is attempted.
> 
> The **`variant` field is renamed to `display_mode`** (`"buyer_local"` / `"default"` unchanged). Call sites that branched on `variant`—including `buyer_local_price_props`, `trackBuyerCurrencyDisplayView`, and GA—now use `display_mode`.
> 
> Specs and presenter expectations are updated to match the slimmer hash and new key name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d0f525f7db88edd220fc69e18cf39ddfe3cc08f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->