### PR TITLE
Custom HTML: allow safe outbound links and video embeds

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -948,11 +948,12 @@ class LinksController < ApplicationController
       # A buyer can navigate straight to /l/:id/landing/embed (top-level, not
       # framed), where the iframe sandbox doesn't apply — without this the
       # seller's inline scripts would run on the real subdomain origin. Matches
-      # the wrapper iframe's sandbox: scripts + forms, no same-origin/top-nav.
-      "sandbox allow-scripts allow-forms",
+      # the wrapper iframe's sandbox: scripts + forms + popups, no same-origin/top-nav.
+      "sandbox allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox",
       "default-src 'none'",
       "script-src 'unsafe-inline' https://cdn.tailwindcss.com https://cdn.jsdelivr.net https://unpkg.com",
       "style-src 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com https://fonts.bunny.net",
+      "frame-src https://www.youtube-nocookie.com https://www.youtube.com https://player.vimeo.com",
       "img-src data: blob: #{PAGE_ASSET_HOSTS}",
       # Mirror img-src so the <audio>/<video>/<source> tags the sanitizer
       # allows actually load — without this they'd inherit default-src 'none'.
@@ -1096,7 +1097,7 @@ class LinksController < ApplicationController
               id="gumroad-landing-frame"
               src="#{iframe_src}"
               title="#{title}"
-              sandbox="allow-scripts allow-forms"
+              sandbox="allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox"
             ></iframe>
             <script nonce="#{ERB::Util.h(nonce)}" data-cfasync="false">
               var frame = document.getElementById("gumroad-landing-frame");

--- a/app/services/ai/page_sanitizer.rb
+++ b/app/services/ai/page_sanitizer.rb
@@ -15,6 +15,14 @@ class Ai::PageSanitizer
     fonts.bunny.net
   ].freeze
 
+  ALLOWED_IFRAME_HOSTS = %w[
+    www.youtube-nocookie.com
+    youtube-nocookie.com
+    www.youtube.com
+    youtube.com
+    player.vimeo.com
+  ].freeze
+
   # `html`/`head`/`body` are intentionally absent — they're handled first by
   # the WRAPPER_TAGS unwrap in scrub_node, so listing them here would be dead,
   # misleading allowlist entries.
@@ -104,9 +112,21 @@ class Ai::PageSanitizer
       return
     end
 
-    # Overwrite unconditionally — a seller-supplied permissive value
-    # (e.g. `allow-same-origin`) should not survive the sanitizer.
-    node["sandbox"] = "allow-scripts" if node.name == "iframe"
+    if node.name == "iframe"
+      if document_source_data_url?(node.name, "src", node["src"])
+        node["sandbox"] = "allow-scripts"
+      else
+        unless allowed_iframe_src?(node["src"])
+          record_removed_tag(report, node, "iframe src host not allowed")
+          node.remove
+          return
+        end
+
+        # Overwrite unconditionally — a seller-supplied permissive value should
+        # not survive the sanitizer.
+        node["sandbox"] = "allow-scripts allow-same-origin allow-presentation"
+      end
+    end
     if node.name == "form" && node["action"].present?
       record_removed_attribute(report, node, "action", node["action"], "form action removed")
       node.remove_attribute("action")
@@ -122,6 +142,8 @@ class Ai::PageSanitizer
       record_removed_attribute(report, node, attribute.name, attribute.value, reason)
       node.remove_attribute(attribute.name)
     end
+
+    node["rel"] = "noopener noreferrer" if node.name == "a" && node["target"].to_s.strip.casecmp("_blank").zero?
   end
 
   def self.attribute_removal_reason(tag_name, name, value)
@@ -224,6 +246,10 @@ class Ai::PageSanitizer
     https_host_in?(node["href"], ALLOWED_STYLESHEET_HOSTS)
   end
 
+  def self.allowed_iframe_src?(src)
+    https_host_in?(src, ALLOWED_IFRAME_HOSTS)
+  end
+
   def self.https_host_in?(url, hosts)
     return false if url.blank?
 
@@ -250,5 +276,5 @@ class Ai::PageSanitizer
     decoded.gsub(/[[:space:]\u0000-\u001f]+/, "").downcase
   end
 
-  private_class_method :scrub_node, :allowed_tag?, :allowed_attribute?, :event_handler_attribute?, :dangerous_url_attribute?, :document_source_data_url?, :srcset_url_removal_reason, :srcset_urls, :allowed_script_src?, :allowed_stylesheet_link?, :https_host_in?, :unsafe_target_reason, :normalize_url, :finalize_report, :record_removed_tag, :record_removed_attribute, :report_cap_reached?, :dangerous_url_reason, :strip_control_chars, :attribute_removal_reason
+  private_class_method :scrub_node, :allowed_tag?, :allowed_attribute?, :event_handler_attribute?, :dangerous_url_attribute?, :document_source_data_url?, :srcset_url_removal_reason, :srcset_urls, :allowed_script_src?, :allowed_stylesheet_link?, :allowed_iframe_src?, :https_host_in?, :unsafe_target_reason, :normalize_url, :finalize_report, :record_removed_tag, :record_removed_attribute, :report_cap_reached?, :dangerous_url_reason, :strip_control_chars, :attribute_removal_reason
 end

--- a/app/services/ai/page_sanitizer.rb
+++ b/app/services/ai/page_sanitizer.rb
@@ -15,11 +15,14 @@ class Ai::PageSanitizer
     fonts.bunny.net
   ].freeze
 
+  # Canonical embed hosts only (www variants). These must stay aligned with the
+  # `frame-src` list in CUSTOM_HTML_CSP (links_controller.rb): an apex host that
+  # passed sanitization but was missing from frame-src would be silently
+  # CSP-blocked at render with no save-time signal. Apex URLs are rejected here
+  # so the seller gets the "iframe src host not allowed" report entry instead.
   ALLOWED_IFRAME_HOSTS = %w[
     www.youtube-nocookie.com
-    youtube-nocookie.com
     www.youtube.com
-    youtube.com
     player.vimeo.com
   ].freeze
 
@@ -34,10 +37,10 @@ class Ai::PageSanitizer
   ].freeze
 
   ALLOWED_ATTRIBUTES = %w[
-    accept accept-charset alt aria-describedby aria-hidden aria-label aria-labelledby aria-live aria-pressed async autocomplete autofocus autoplay checked cite class
+    accept accept-charset allow allowfullscreen alt aria-describedby aria-hidden aria-label aria-labelledby aria-live aria-pressed async autocomplete autofocus autoplay checked cite class
     charset cols colspan content contenteditable controls coords crossorigin datetime defer dir disabled download draggable enctype
     fill for form height hidden href id kind label lang loading loop max maxlength media method min minlength multiple muted name pattern placeholder playsinline poster
-    preserveaspectratio readonly rel required role rows rowspan sandbox scope selected shape size sizes span spellcheck src srcset step style tabindex target title translate type
+    preserveaspectratio readonly referrerpolicy rel required role rows rowspan sandbox scope selected shape size sizes span spellcheck src srcset step style tabindex target title translate type
     value viewbox width xmlns x y x1 y1 x2 y2 cx cy r rx ry d stroke stroke-width stroke-linecap stroke-linejoin fill-rule clip-rule clip-path points transform offset stop-color
     stop-opacity
   ].freeze
@@ -123,8 +126,12 @@ class Ai::PageSanitizer
         end
 
         # Overwrite unconditionally — a seller-supplied permissive value should
-        # not survive the sanitizer.
-        node["sandbox"] = "allow-scripts allow-same-origin allow-presentation"
+        # not survive the sanitizer. The parent document's sandbox (CUSTOM_HTML_CSP)
+        # grants neither allow-same-origin nor allow-presentation, and a nested
+        # browsing context's active sandbox is the union of restrictions, so those
+        # tokens would be dead here. Keep just allow-scripts — public video
+        # playback works via the postMessage IFrame API regardless of opaque origin.
+        node["sandbox"] = "allow-scripts"
       end
     end
     if node.name == "form" && node["action"].present?

--- a/spec/controllers/links_controller_custom_html_spec.rb
+++ b/spec/controllers/links_controller_custom_html_spec.rb
@@ -34,7 +34,9 @@ describe LinksController, :vcr, type: :controller do
 
     it "sandboxes the iframe without top-navigation and mediates checkout via postMessage" do
       get :show, params: { id: product.unique_permalink }
-      expect(response.body).to include(%(sandbox="allow-scripts allow-forms"))
+      expect(response.body).to include(%(sandbox="allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox"))
+      expect(response.body).to include("allow-popups")
+      expect(response.body).not_to include("allow-same-origin")
       expect(response.body).not_to include("allow-top-navigation")
       # The wrapper owns the base checkout URL; seller HTML sends either the
       # "gumroad:checkout" signal (string) or a structured payload with selection.
@@ -129,6 +131,10 @@ describe LinksController, :vcr, type: :controller do
     it "applies the strict CSP and iframe-friendly response headers" do
       get :landing_iframe_content, params: { id: product.unique_permalink }
       expect(response.headers["Content-Security-Policy"]).to eq(CUSTOM_HTML_CSP)
+      expect(response.headers["Content-Security-Policy"]).to include("sandbox allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox")
+      expect(response.headers["Content-Security-Policy"]).to include("frame-src https://www.youtube-nocookie.com https://www.youtube.com https://player.vimeo.com")
+      expect(response.headers["Content-Security-Policy"]).not_to include("allow-same-origin")
+      expect(response.headers["Content-Security-Policy"]).not_to include("allow-top-navigation")
       expect(response.headers["X-Frame-Options"]).to eq("SAMEORIGIN")
       expect(response.headers["Referrer-Policy"]).to eq("no-referrer")
       expect(response.headers["Content-Type"]).to include("text/html")

--- a/spec/requests/pages_landing_embed_csp_spec.rb
+++ b/spec/requests/pages_landing_embed_csp_spec.rb
@@ -21,6 +21,7 @@ describe "GET /l/:id/landing/embed CSP", type: :request do
     expect(csp).to include("default-src 'none'")
     expect(csp).to include("script-src 'unsafe-inline'")
     expect(csp).to include("connect-src 'none'")
+    expect(csp).to include("frame-src https://www.youtube-nocookie.com https://www.youtube.com https://player.vimeo.com")
     # Images/media are locked to Gumroad's own CDN hosts — no bare `https:` wildcard,
     # so a seller's page can't beacon data out via an arbitrary-host image/media GET.
     img_sources = csp[/img-src([^;]*)/, 1].split
@@ -39,7 +40,8 @@ describe "GET /l/:id/landing/embed CSP", type: :request do
     csp = response.headers["Content-Security-Policy"]
     # CSP sandbox applies whether the doc is framed or loaded directly — the
     # iframe attribute alone wouldn't cover a direct navigation to this URL.
-    expect(csp).to include("sandbox allow-scripts allow-forms")
+    expect(csp).to include("sandbox allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox")
+    expect(csp).to include("allow-popups")
     expect(csp).not_to include("allow-same-origin")
     expect(csp).not_to include("allow-top-navigation")
   end

--- a/spec/services/ai/page_sanitizer_spec.rb
+++ b/spec/services/ai/page_sanitizer_spec.rb
@@ -111,21 +111,42 @@ describe Ai::PageSanitizer do
       sanitized = described_class.sanitize(%(<iframe src="https://www.youtube-nocookie.com/embed/abc"></iframe>))
 
       expect(sanitized).to include(%(src="https://www.youtube-nocookie.com/embed/abc"))
-      expect(sanitized).to include(%(sandbox="allow-scripts allow-same-origin allow-presentation"))
+      expect(sanitized).to include(%(sandbox="allow-scripts"))
     end
 
     it "keeps Vimeo embeds" do
       sanitized = described_class.sanitize(%(<iframe src="https://player.vimeo.com/video/123"></iframe>))
 
       expect(sanitized).to include(%(src="https://player.vimeo.com/video/123"))
-      expect(sanitized).to include(%(sandbox="allow-scripts allow-same-origin allow-presentation"))
+      expect(sanitized).to include(%(sandbox="allow-scripts"))
+    end
+
+    it "preserves the YouTube share-snippet permission attributes (fullscreen/PiP)" do
+      sanitized = described_class.sanitize(
+        %(<iframe src="https://www.youtube.com/embed/abc" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>)
+      )
+
+      expect(sanitized).to include("allow=")
+      expect(sanitized).to include("picture-in-picture")
+      expect(sanitized).to include("referrerpolicy=")
+      expect(sanitized).to include("allowfullscreen")
     end
 
     it "overwrites permissive iframe sandbox attributes (seller can't widen the policy)" do
       sanitized = described_class.sanitize(%(<iframe src="https://www.youtube.com/embed/abc" sandbox="allow-scripts allow-same-origin allow-top-navigation"></iframe>))
 
-      expect(sanitized).to include(%(sandbox="allow-scripts allow-same-origin allow-presentation"))
+      expect(sanitized).to include(%(sandbox="allow-scripts"))
       expect(sanitized).not_to include("allow-top-navigation")
+      expect(sanitized).not_to include("allow-same-origin")
+    end
+
+    it "rejects apex (non-www) YouTube hosts so the sanitizer stays aligned with frame-src CSP" do
+      result = described_class.sanitize_with_report(%(<iframe src="https://youtube.com/embed/abc"></iframe>))
+
+      expect(result.html).not_to include("<iframe")
+      expect(result.report[:removed_tags]).to contain_exactly(
+        hash_including(tag: "iframe", reason: "iframe src host not allowed")
+      )
     end
 
     it "strips iframes from unapproved hosts" do

--- a/spec/services/ai/page_sanitizer_spec.rb
+++ b/spec/services/ai/page_sanitizer_spec.rb
@@ -64,6 +64,27 @@ describe Ai::PageSanitizer do
       expect(sanitized).to include(%(target="_blank"))
     end
 
+    it "adds noopener noreferrer to links that open in a new tab" do
+      sanitized = described_class.sanitize(%(<a href="https://creator.com" target="_blank">Creator</a>))
+
+      expect(sanitized).to include(%(target="_blank"))
+      expect(sanitized).to include(%(rel="noopener noreferrer"))
+    end
+
+    it "overwrites weak rel values on links that open in a new tab" do
+      sanitized = described_class.sanitize(%(<a href="https://creator.com" target="_blank" rel="opener">Creator</a>))
+
+      expect(sanitized).to include(%(rel="noopener noreferrer"))
+      expect(sanitized).not_to include(%(rel="opener"))
+    end
+
+    it "does not force rel on same-tab links" do
+      sanitized = described_class.sanitize(%(<a href="https://x.com">Same tab</a>))
+
+      expect(sanitized).to include(%(<a href="https://x.com">Same tab</a>))
+      expect(sanitized).not_to include("rel=")
+    end
+
     it "strips deeply encoded javascript URLs from links" do
       sanitized = described_class.sanitize(%(<a href="java%25252573cript:alert(1)">Click</a>))
 
@@ -86,18 +107,49 @@ describe Ai::PageSanitizer do
       expect(sanitized).not_to include("Content-Security-Policy")
     end
 
-    it "adds sandbox attributes to iframes without one" do
-      sanitized = described_class.sanitize(%(<iframe src="https://example.com/embed"></iframe>))
+    it "keeps YouTube embeds with the required video sandbox" do
+      sanitized = described_class.sanitize(%(<iframe src="https://www.youtube-nocookie.com/embed/abc"></iframe>))
 
-      expect(sanitized).to include(%(sandbox="allow-scripts"))
+      expect(sanitized).to include(%(src="https://www.youtube-nocookie.com/embed/abc"))
+      expect(sanitized).to include(%(sandbox="allow-scripts allow-same-origin allow-presentation"))
+    end
+
+    it "keeps Vimeo embeds" do
+      sanitized = described_class.sanitize(%(<iframe src="https://player.vimeo.com/video/123"></iframe>))
+
+      expect(sanitized).to include(%(src="https://player.vimeo.com/video/123"))
+      expect(sanitized).to include(%(sandbox="allow-scripts allow-same-origin allow-presentation"))
     end
 
     it "overwrites permissive iframe sandbox attributes (seller can't widen the policy)" do
-      sanitized = described_class.sanitize(%(<iframe src="https://example.com" sandbox="allow-scripts allow-same-origin allow-top-navigation"></iframe>))
+      sanitized = described_class.sanitize(%(<iframe src="https://www.youtube.com/embed/abc" sandbox="allow-scripts allow-same-origin allow-top-navigation"></iframe>))
 
-      expect(sanitized).to include(%(sandbox="allow-scripts"))
-      expect(sanitized).not_to include("allow-same-origin")
+      expect(sanitized).to include(%(sandbox="allow-scripts allow-same-origin allow-presentation"))
       expect(sanitized).not_to include("allow-top-navigation")
+    end
+
+    it "strips iframes from unapproved hosts" do
+      result = described_class.sanitize_with_report(%(<iframe src="https://evil.com/x"></iframe><p>Safe</p>))
+
+      expect(result.html).not_to include("<iframe")
+      expect(result.html).to include("<p>Safe</p>")
+      expect(result.report[:removed_tags]).to contain_exactly(
+        hash_including(tag: "iframe", reason: "iframe src host not allowed")
+      )
+    end
+
+    it "strips userinfo-spoofed iframe URLs" do
+      sanitized = described_class.sanitize(%(<iframe src="https://www.youtube.com@evil.com/x"></iframe>))
+
+      expect(sanitized).not_to include("<iframe")
+      expect(sanitized).not_to include("evil.com")
+    end
+
+    it "strips non-https YouTube iframe URLs" do
+      sanitized = described_class.sanitize(%(<iframe src="http://www.youtube.com/embed/abc"></iframe>))
+
+      expect(sanitized).not_to include("<iframe")
+      expect(sanitized).not_to include("youtube.com")
     end
 
     it "removes form action attributes" do


### PR DESCRIPTION
Fixes antiwork/gumroad-private#463

## What

Custom HTML now supports safe outbound `target="_blank"` links and allowlisted YouTube/Vimeo embeds on the custom landing runtime present in current `main`.

The sanitizer now forces `rel="noopener noreferrer"` on `_blank` anchors, overwriting seller-supplied weaker `rel` values. It also limits iframe `src` hosts to the **www** YouTube no-cookie, YouTube, and Vimeo player hosts over HTTPS (apex/no-www URLs are rejected at save time so they can't pass sanitization only to be CSP-blocked at render), removes non-video iframe hosts at save/preview time with `iframe src host not allowed`, preserves the YouTube share-snippet permission attributes (`allow`, `allowfullscreen`, `referrerpolicy`) so fullscreen/PiP work, and forces the video iframe sandbox to `allow-scripts`.

The custom HTML runtime CSP now includes an explicit `frame-src` for the allowed video providers and permits popups with `allow-popups allow-popups-to-escape-sandbox`. The wrapper iframe sandbox was updated to match so external links can open normally.

Note: `app/services/pages/renderer.rb` / `Pages::Renderer` is not present on this branch or current `origin/main`; it exists only on `fork/spike/profile-custom-html-extend-settings`. This PR updates the runtime surface that exists on `main`.

## Why

The save-time sanitizer already preserved `_blank` links and iframes, but runtime sandbox/CSP blocked both useful behaviors: popups were disallowed and nested frames inherited `default-src 'none'`. This keeps checkout posture conservative while making the intended creator HTML work.

The nested allowlisted video iframe gets `sandbox="allow-scripts"` only. A nested browsing context's active sandbox is the union of restrictions, and the parent (`CUSTOM_HTML_CSP`) grants neither `allow-same-origin` nor `allow-presentation`, so those tokens would be dead on the inner frame; public playback works via the postMessage IFrame API regardless. The top-level seller sandbox still does not allow same-origin or top navigation, so seller HTML remains on an opaque origin and cannot navigate the buyer tab. `connect-src 'none'`, script hosts, and checkout mediation remain unchanged.

## Test Results

- `bundle exec rspec spec/services/ai/page_sanitizer_spec.rb` — 55 examples, 0 failures
- `bundle exec rspec spec/controllers/links_controller_custom_html_spec.rb` — 27 examples, 0 failures
- `bundle exec rspec spec/requests/pages_landing_embed_csp_spec.rb` — 2 examples, 0 failures
- `bundle exec rspec spec/controllers/api/v2/links_controller_custom_html_spec.rb` — 34 examples, 0 failures
- `bundle exec rspec spec/requests/products/show/custom_html_spec.rb` — 2 examples, 0 failures
- `bundle exec rubocop app/services/ai/page_sanitizer.rb app/controllers/links_controller.rb` — 2 files inspected, no offenses detected

`bundle exec rubocop app/services/ai/page_sanitizer.rb app/services/pages/renderer.rb app/controllers/links_controller.rb` could not run exactly because `app/services/pages/renderer.rb` does not exist in current `main`.

---

This PR was implemented with AI assistance using Claude Opus 4.8, per the requested commit disclosure.

Prompts used:

- Implement antiwork/gumroad-private#463 for custom HTML outbound links and allowlisted video embeds.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5391"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783115413&installation_id=134400930&pr_number=5391&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5391&signature=41cb178d658ffcd855b5cdd6ac61e8e35c501c2a28fb693bce0dcc72c05ee01b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches seller-controlled HTML, CSP, and iframe sandboxing on a public buyer-facing surface; changes are narrowly scoped to allowlisted hosts and stricter link/iframe handling rather than broad relaxations.
> 
> **Overview**
> Custom HTML landing pages can now use **safe `target="_blank"` links** and **allowlisted YouTube/Vimeo embeds** without breaking the existing checkout sandbox.
> 
> **Runtime (LinksController):** `CUSTOM_HTML_CSP` and the product wrapper iframe sandbox gain **`allow-popups`** and **`allow-popups-to-escape-sandbox`** so creator links can open in a new tab. CSP adds **`frame-src`** for `www.youtube-nocookie.com`, `www.youtube.com`, and `player.vimeo.com`. Same-origin and top navigation stay disallowed.
> 
> **Save-time (Ai::PageSanitizer):** Iframe `src` is restricted to those HTTPS **www** hosts (apex YouTube is rejected with **`iframe src host not allowed`** so it matches `frame-src`). Allowed video iframes keep **`sandbox="allow-scripts"`** only; seller-widened sandbox tokens are still stripped. **`rel="noopener noreferrer"`** is forced on `_blank` anchors (overwriting weak `rel`). YouTube embed permission attributes (`allow`, `allowfullscreen`, `referrerpolicy`) are allowlisted.
> 
> Specs assert CSP/sandbox parity, sanitizer behavior, and popup-related tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 404bb9cf1d906734aca089f0f0ba9c07770daa03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->