### PR TITLE
Clarify affiliate cookie duration in help center (30 days direct vs 7 days Gumroad Affiliates)

### DIFF
--- a/app/views/help_center/articles/contents/_249-affiliate-faq.html.erb
+++ b/app/views/help_center/articles/contents/_249-affiliate-faq.html.erb
@@ -19,7 +19,7 @@
   <p>You can also go to your <a href="https://gumroad.com/products/affiliated">affiliated products dashboard</a> to see all the products you're affiliated with, how much money you've made on those products, and quickly copy your links: </p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/635696038a552811521e7e2f/file-oWnn2GNjtB.png" %></figure>
   <h3 id="Gumroad-Affiliate-Program-0awON">Gumroad Affiliate Program</h3>
-  <p>Any product on <a href="https://gumroad.com/discover">Gumroad Discover</a> is available for you to become an affiliate for. You don’t have to reach out to these creators to request to be an affiliate for their products. From the <a href="https://gumroad.com/products/affiliated?affiliates=true">Gumroad global affiliates dashboard</a>, you can generate affiliate links for <a href="https://gumroad.com/discover">Gumroad Discover</a>, specific products, and creator profile pages. These links, which are specific to this one’s affiliate account, will add a browser cookie when clicked and track any purchases made via this link. This cookie will only be active for seven days. </p>
+  <p>Any product on <a href="https://gumroad.com/discover">Gumroad Discover</a> is available for you to become an affiliate for. You don’t have to reach out to these creators to request to be an affiliate for their products. From the <a href="https://gumroad.com/products/affiliated?affiliates=true">Gumroad Affiliates dashboard</a>, you can generate affiliate links for <a href="https://gumroad.com/discover">Gumroad Discover</a>, specific products, and creator profile pages. These links, which are specific to this one’s affiliate account, will add a browser cookie when clicked and track any purchases made via this link. This cookie is active for seven days. (If instead a creator adds you as one of their own affiliates directly, those links use a longer 30-day cookie.) </p>
   <p>Note: Some products on Gumroad Discover are not eligible to be an affiliate as some creators have chosen to opt out of the program.</p>
   <h3 id="sticky">Sticky affiliate links</h3>
   <p>You may want to create a "sticky" affiliate URL with your affiliate ID as a URL parameter. </p>
@@ -45,7 +45,7 @@
   <h3 id="not-credited">Other reasons you might not be credited for a sale</h3>
   <ul>
     <li>The customer's web browser does not accept cookies. </li>
-    <li>The customer did not buy the product within 30 days of clicking your link. Our cookies expire after 30 days. </li>
+    <li>The customer did not buy the product within the cookie window after clicking your link. For links from the Gumroad Affiliates program, the cookie expires after 7 days. For links from a creator who added you as one of their own affiliates directly, it expires after 30 days. </li>
     <li>The customer clicked a different affiliate's link <strong>after</strong> they clicked yours and bought the product.</li>
   </ul>
   <h3 id="shortened">Can the affiliate links be shortened/personalized?</h3>

--- a/app/views/help_center/articles/contents/_333-affiliates-on-gumroad.html.erb
+++ b/app/views/help_center/articles/contents/_333-affiliates-on-gumroad.html.erb
@@ -42,7 +42,7 @@
     <li>You add them as an affiliate to your product(s). </li>
     <li>They are sent an affiliate link that looks something like this:<a href="https://www.gumroad.com/a/1234567"> www.gumroad.com/a/1234567</a></li>
     <li>Note the "/a/" in it. That signifies that this is an affiliate link. They share that link with the world. </li>
-    <li>When a customer clicks that link, their browser is "cookied" for 30 days. If they buy the products that your affiliate is assigned within 30 days, your affiliate is credited with the sale. We take our fee, and you and your affiliate split the remainder. </li>
+    <li>When a customer clicks that link, their browser is "cookied" for 30 days. If they buy the products that your affiliate is assigned within 30 days, your affiliate is credited with the sale. We take our fee, and you and your affiliate split the remainder. (This 30-day cookie applies to your own affiliates — the ones you add directly. Links generated through the <a href="#Gumroad-Affiliates">Gumroad Affiliates</a> program use a shorter 7-day cookie.) </li>
     <li>After 7 days, your affiliate can be paid out for that sale. The same <a href="13-getting-paid"> payout rules</a> apply!</li>
   </ul>
   <p>To get started, go to your <a href="https://gumroad.com/affiliates">Affiliates Dashboard</a>. You can find the link in the main sidebar, under Analytics.</p>
@@ -70,7 +70,7 @@
   <p>If you leave this field blank, the unique link your affiliate receives will redirect to the Gumroad product page to which the affiliate has been assigned. </p>
   <p>If you have added multiple products to the affiliate, their unique link will go to your Gumroad profile page, where customers can buy any of the products that you've displayed. Your affiliate will also receive unique affiliate links for each individual product, in case they want to share specific products at different times or in different places.</p>
   <p>Finally, click "Add affiliate". We’ll send them a unique link to share via their email. </p>
-  <p>Once your affiliate starts sharing their unique link, we’ll set a cookie for customers when they visit the link. As long as a customer purchases your product within 30 days of visiting the affiliate’s link, the affiliate will get credit for the sale.</p>
+  <p>Once your affiliate starts sharing their unique link, we’ll set a cookie for customers when they visit the link. As long as a customer purchases your product within 30 days of visiting the affiliate’s link, the affiliate will get credit for the sale. (Note: this 30-day window applies to your own affiliates. <a href="#Gumroad-Affiliates">Gumroad Affiliates</a> links use a 7-day cookie.)</p>
   <h3 id="Method-2-Let-affiliates-sign-up-on-their-own"><span>Method 2: Let affiliates sign up on their own</span></h3>
   <p>To allow people to request to be your affiliate, first go to <a href="https://gumroad.com/affiliate_requests/onboarding_form"> your Affiliate Signup Form</a>. </p>
   <p>The “Affiliate link” section gives you a link that allows anyone to request to become your affiliate.</p>
@@ -121,7 +121,7 @@
   <p>In addition to affiliating with individual creators as described above under 'Your Affiliates', users can affiliate with Gumroad directly. Instead of reaching out to each creator individually, Gumroad Affiliates can generate their own links to help creators promote their work. This is a great way of casting your net out wide and expanding your sales funnel. </p>
   <p><span>Gumroad Affiliates earn a fixed 10% commission on each sale. </span></p>
   <h3 id="Generating-Gumroad-Affiliate-links"><span>Generating Gumroad Affiliate links</span></h3>
-  <p>From the <a href="https://gumroad.com/products/affiliated?affiliates=true"> Gumroad Affiliates dashboard</a>, anyone can generate affiliate links for <a href="https://gumroad.com/discover"> Gumroad Discover</a>, specific products, and creator profile pages. These links, which are specific to this one’s affiliate account, will add a browser cookie when clicked and track any purchases made via this link. This cookie will only be active for 7 days. </p>
+  <p>From the <a href="https://gumroad.com/products/affiliated?affiliates=true"> Gumroad Affiliates dashboard</a>, anyone can generate affiliate links for <a href="https://gumroad.com/discover"> Gumroad Discover</a>, specific products, and creator profile pages. These links, which are specific to this one’s affiliate account, will add a browser cookie when clicked and track any purchases made via this link. This cookie is active for 7 days. (Your own affiliates — the ones you add directly under <a href="#Your-Affiliates---How-does-it-work">Your Affiliates</a> — use a longer 30-day cookie.) </p>
   <figure><%= image_tag "https://lh7-us.googleusercontent.com/docsz/AD_4nXfWF_6JKykXwTIWX-SrPwIDtQdlQ1gSkK34yxos0Lwr-LblF4eEXlrk0vndGFx0iIX6UdWRTHy8A1KjuVQpH19hP59k9hN0kpbpRlJ3f0mDfwdEteghb8RdNKy9usbsEAM644EkjGG3wdMCjhcwyQigkEJD?key=IlXfEmf2yu_7yhYw2YKmPA" %></figure>
   <h3 id="Opting-out-of-Gumroad-Affiliates"><span>Opting out of Gumroad Affiliates</span></h3>
   <p>If you do not wish to promote your products through Gumroad Affiliates, you can easily opt-out. Just go to your <a href="https://gumroad.com/affiliates/onboarding"> Affiliates Dashboard</a> and toggle “Opt out of the Gumroad Affiliate Program”. Make sure to click on “Save changes”. </p>
@@ -149,7 +149,7 @@
   <ul>
     <li>The customer's web browser does not accept "cookies." Our affiliate feature can only work if a browser accepts cookies. (Unless you are using a <a href="249-affiliate-faq#Stickyaffiliatelinks"> sticky link</a>).</li>
     <li>The sale was refunded - when that happens your affiliate commission is refunded, as well. </li>
-    <li>The customer did not buy the product within 30 days of clicking your link. Our cookies expire after 30 days. Gumroad affiliate cookies expire after 7 days.</li>
+    <li>The customer did not buy the product within the cookie window after clicking your link. For your own affiliates, the cookie expires after 30 days. For <a href="#Gumroad-Affiliates">Gumroad Affiliates</a> links, it expires after 7 days.</li>
     <li>The customer clicked a different affiliate's link after they clicked yours.</li>
   </ul>
   <h3 id="Order-of-Affiliate-Sales"><span>Order of Affiliate Sales</span></h3>


### PR DESCRIPTION
## What

Clarifies the affiliate cookie duration in two help-center articles (`333-affiliates-on-gumroad` and `249-affiliate-faq`). Every cookie-duration mention now states which affiliate program it applies to:

- **Direct affiliates** (creator-invited) → **30-day** cookie
- **Gumroad Affiliates / global program** links → **7-day** cookie

Also fixes a directly self-contradictory line in `333` that stated cookies expire after 30 days and after 7 days in the same sentence.

## Why

The two articles used both "30 days" and "7 days" for the affiliate cookie window without distinguishing which number applies to which program. One bullet in `333` read: *"Our cookies expire after 30 days. Gumroad affiliate cookies expire after 7 days."* — two contradictory sentences back to back. Depending on which paragraph a creator landed on, they got a different answer, and the FAQ (`249`) listed a bare "30 days" in a section primarily read by global-program affiliates (whose real window is 7 days).

The durations are set in code and are unambiguous:

- `DirectAffiliate::AFFILIATE_COOKIE_LIFETIME_DAYS = 30` (`app/models/direct_affiliate.rb`)
- `GlobalAffiliate::AFFILIATE_COOKIE_LIFETIME_DAYS = 7` (`app/models/global_affiliate.rb`)

Both `cookie_lifetime` methods return `AFFILIATE_COOKIE_LIFETIME_DAYS.days`, and `app/controllers/concerns/affiliate_cookie.rb` sets the browser cookie to `expires: affiliate.class.cookie_lifetime.from_now`. So both documented numbers were correct — they just describe two different affiliate types, which the articles never made explicit.

## Test plan

- Help-center articles are static `.erb` partials; no behavior change, no specs affected.
- Verified tag balance in both files after editing (`<h3>`, `<div>`, `<p>` opens == closes).
- Confirmed no remaining contradictory or unlabeled cookie-duration lines via grep.
- Reviewer: render both articles in the help center and confirm each cookie-duration mention names its program (direct = 30 days, Gumroad Affiliates = 7 days).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5392"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783138093&installation_id=134400930&pr_number=5392&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5392&signature=c9a7f3620ab5f409d2757d18fef1df853d70414ae3490cf80b6b27fa0f1c2bac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static help-center copy only; no application logic, cookies, or payout behavior changes.
> 
> **Overview**
> Updates two help-center articles (`_249-affiliate-faq` and `_333-affiliates-on-gumroad`) so every mention of affiliate cookie duration names **which program** it applies to: **30 days** for creator-added (“Your”) affiliates and **7 days** for **Gumroad Affiliates** / Discover links.
> 
> The copy no longer mixes those windows in one breath (e.g. a single bullet that said both 30 and 7 days without context). Small wording tweaks include renaming “Gumroad global affiliates dashboard” to **Gumroad Affiliates dashboard** and cross-linking between the two programs where cookie length is explained.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1815596deff2a64fb603e36f49835d227af04ea0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->