### PR TITLE
Update Croatia e-publication VAT rate from 25% to 5%

### DIFF
--- a/db/seeds/020_development_staging/eu_tax_rates.rb
+++ b/db/seeds/020_development_staging/eu_tax_rates.rb
@@ -35,7 +35,7 @@ ZipTaxRate.find_or_create_by(country: "GB").update(combined_rate: 0.20)
 ZipTaxRate.find_or_create_by(country: "AT", flags: 2).update(combined_rate: 0.10) # Austria
 ZipTaxRate.find_or_create_by(country: "BE", flags: 2).update(combined_rate: 0.06) # Belgium
 ZipTaxRate.find_or_create_by(country: "BG", flags: 2).update(combined_rate: 0.09) # Bulgaria
-ZipTaxRate.find_or_create_by(country: "HR", flags: 2).update(combined_rate: 0.25) # Croatia
+ZipTaxRate.find_or_create_by(country: "HR", flags: 2).update(combined_rate: 0.05) # Croatia
 ZipTaxRate.find_or_create_by(country: "CY", flags: 2).update(combined_rate: 0.19) # Cyprus
 ZipTaxRate.find_or_create_by(country: "CZ", flags: 2).update(combined_rate: 0.10) # Czech Republic
 ZipTaxRate.find_or_create_by(country: "DK", flags: 2).update(combined_rate: 0.25) # Denmark


### PR DESCRIPTION
Fixes antiwork/gumroad-private#467

## What

Updates the Croatia e-publication VAT rate in the EU tax-rate seeds from 25% to 5%. Production (`ZipTaxRate` ID 51196) was soft-deleted and a new row was created via Rails console with the correct 5% rate. This PR keeps dev/staging seeds in line so a re-seed doesn't silently revert the rate.

## Why

Croatia applies a 5% reduced VAT rate to books, including electronic publications, per the EU Directive 2018/1713 that permits e-book/print rate parity ([PwC Croatia VAT summary](https://taxsummaries.pwc.com/croatia/corporate/other-taxes)). The previous seed value of 25% (identical to the standard rate) meant that the e-publication toggle had no effect for Croatian buyers, so every Croatian buyer of an e-publication-flagged product was being overcharged 20 percentage points of VAT.

The bug surfaced through support ticket d0982fce (purchase 341803202). The buyer has been refunded the 909¢ overcharge directly.

No code change needed. `SalesTaxCalculator` already returns the `country: "HR", flags: 2` row for HR buyers on e-publication products, so a `combined_rate` of 0.05 propagates through to the correct 5% VAT.

This mirrors the Ireland precedent (#5065).

---

This PR was implemented with AI assistance using Claude Opus 4.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783146546&installation_id=134400930&pr_number=5395&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5395&signature=e63c9db095a00c8aef4ed76b71afac45088d1c90bc9087802393cf86309c18fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single seed value change for dev/staging; production tax behavior was already corrected separately.
> 
> **Overview**
> Updates the Croatia **e-publication** (`flags: 2`) VAT seed in `eu_tax_rates.rb` from **25%** to **5%**, matching the reduced rate for electronic books and keeping dev/staging in sync with production after the live `ZipTaxRate` fix.
> 
> No application logic changes—`SalesTaxCalculator` already selects this row for Croatian e-publication purchases; only the seeded `combined_rate` was wrong (same as standard VAT, so buyers were overcharged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdab0001ac629d30ca59538cb0873291ecd1bf25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->