### PR TITLE
Sync EU e-publication VAT rates with current law (audit follow-up)

### DIFF
--- a/db/seeds/020_development_staging/eu_tax_rates.rb
+++ b/db/seeds/020_development_staging/eu_tax_rates.rb
@@ -36,26 +36,26 @@ ZipTaxRate.find_or_create_by(country: "AT", flags: 2).update(combined_rate: 0.10
 ZipTaxRate.find_or_create_by(country: "BE", flags: 2).update(combined_rate: 0.06) # Belgium
 ZipTaxRate.find_or_create_by(country: "BG", flags: 2).update(combined_rate: 0.09) # Bulgaria
 ZipTaxRate.find_or_create_by(country: "HR", flags: 2).update(combined_rate: 0.25) # Croatia
-ZipTaxRate.find_or_create_by(country: "CY", flags: 2).update(combined_rate: 0.19) # Cyprus
+ZipTaxRate.find_or_create_by(country: "CY", flags: 2).update(combined_rate: 0.05) # Cyprus
 ZipTaxRate.find_or_create_by(country: "CZ", flags: 2).update(combined_rate: 0.10) # Czech Republic
-ZipTaxRate.find_or_create_by(country: "DK", flags: 2).update(combined_rate: 0.25) # Denmark
+ZipTaxRate.find_or_create_by(country: "DK", flags: 2).update(combined_rate: 0.00) # Denmark (effective 2026-07-01)
 ZipTaxRate.find_or_create_by(country: "EE", flags: 2).update(combined_rate: 0.20) # Estonia
 ZipTaxRate.find_or_create_by(country: "FI", flags: 2).update(combined_rate: 0.10) # Finland
 ZipTaxRate.find_or_create_by(country: "FR", flags: 2).update(combined_rate: 0.055) # France
 ZipTaxRate.find_or_create_by(country: "DE", flags: 2).update(combined_rate: 0.07) # Germany
 ZipTaxRate.find_or_create_by(country: "GR", flags: 2).update(combined_rate: 0.06) # Greece
-ZipTaxRate.find_or_create_by(country: "HU", flags: 2).update(combined_rate: 0.27) # Hungary
+ZipTaxRate.find_or_create_by(country: "HU", flags: 2).update(combined_rate: 0.05) # Hungary
 ZipTaxRate.find_or_create_by(country: "IE", flags: 2).update(combined_rate: 0.00) # Ireland
 ZipTaxRate.find_or_create_by(country: "IT", flags: 2).update(combined_rate: 0.04) # Italy
-ZipTaxRate.find_or_create_by(country: "LV", flags: 2).update(combined_rate: 0.21) # Latvia
-ZipTaxRate.find_or_create_by(country: "LT", flags: 2).update(combined_rate: 0.21) # Lithuania
+ZipTaxRate.find_or_create_by(country: "LV", flags: 2).update(combined_rate: 0.05) # Latvia
+ZipTaxRate.find_or_create_by(country: "LT", flags: 2).update(combined_rate: 0.05) # Lithuania
 ZipTaxRate.find_or_create_by(country: "LU", flags: 2).update(combined_rate: 0.03) # Luxembourg
 ZipTaxRate.find_or_create_by(country: "MT", flags: 2).update(combined_rate: 0.05) # Malta
 ZipTaxRate.find_or_create_by(country: "NL", flags: 2).update(combined_rate: 0.09) # Netherlands
 ZipTaxRate.find_or_create_by(country: "PL", flags: 2).update(combined_rate: 0.05) # Poland
 ZipTaxRate.find_or_create_by(country: "PT", flags: 2).update(combined_rate: 0.06) # Portugal
 ZipTaxRate.find_or_create_by(country: "RO", flags: 2).update(combined_rate: 0.05) # Romania
-ZipTaxRate.find_or_create_by(country: "SK", flags: 2).update(combined_rate: 0.20) # Slovakia
+ZipTaxRate.find_or_create_by(country: "SK", flags: 2).update(combined_rate: 0.05) # Slovakia
 ZipTaxRate.find_or_create_by(country: "SI", flags: 2).update(combined_rate: 0.05) # Slovenia
 ZipTaxRate.find_or_create_by(country: "ES", flags: 2).update(combined_rate: 0.04) # Spain
 ZipTaxRate.find_or_create_by(country: "SE", flags: 2).update(combined_rate: 0.06) # Sweden

--- a/db/seeds/020_development_staging/eu_tax_rates.rb
+++ b/db/seeds/020_development_staging/eu_tax_rates.rb
@@ -36,7 +36,7 @@ ZipTaxRate.find_or_create_by(country: "AT", flags: 2).update(combined_rate: 0.10
 ZipTaxRate.find_or_create_by(country: "BE", flags: 2).update(combined_rate: 0.06) # Belgium
 ZipTaxRate.find_or_create_by(country: "BG", flags: 2).update(combined_rate: 0.09) # Bulgaria
 ZipTaxRate.find_or_create_by(country: "HR", flags: 2).update(combined_rate: 0.05) # Croatia
-ZipTaxRate.find_or_create_by(country: "CY", flags: 2).update(combined_rate: 0.05) # Cyprus
+ZipTaxRate.find_or_create_by(country: "CY", flags: 2).update(combined_rate: 0.03) # Cyprus
 ZipTaxRate.find_or_create_by(country: "CZ", flags: 2).update(combined_rate: 0.10) # Czech Republic
 ZipTaxRate.find_or_create_by(country: "DK", flags: 2).update(combined_rate: 0.25) # Denmark
 ZipTaxRate.find_or_create_by(country: "EE", flags: 2).update(combined_rate: 0.20) # Estonia
@@ -44,7 +44,7 @@ ZipTaxRate.find_or_create_by(country: "FI", flags: 2).update(combined_rate: 0.10
 ZipTaxRate.find_or_create_by(country: "FR", flags: 2).update(combined_rate: 0.055) # France
 ZipTaxRate.find_or_create_by(country: "DE", flags: 2).update(combined_rate: 0.07) # Germany
 ZipTaxRate.find_or_create_by(country: "GR", flags: 2).update(combined_rate: 0.06) # Greece
-ZipTaxRate.find_or_create_by(country: "HU", flags: 2).update(combined_rate: 0.05) # Hungary
+ZipTaxRate.find_or_create_by(country: "HU", flags: 2).update(combined_rate: 0.27) # Hungary
 ZipTaxRate.find_or_create_by(country: "IE", flags: 2).update(combined_rate: 0.00) # Ireland
 ZipTaxRate.find_or_create_by(country: "IT", flags: 2).update(combined_rate: 0.04) # Italy
 ZipTaxRate.find_or_create_by(country: "LV", flags: 2).update(combined_rate: 0.05) # Latvia

--- a/db/seeds/020_development_staging/eu_tax_rates.rb
+++ b/db/seeds/020_development_staging/eu_tax_rates.rb
@@ -40,7 +40,7 @@ ZipTaxRate.find_or_create_by(country: "CY", flags: 2).update(combined_rate: 0.03
 ZipTaxRate.find_or_create_by(country: "CZ", flags: 2).update(combined_rate: 0.00) # Czech Republic (zero rate since 2024-01-01)
 ZipTaxRate.find_or_create_by(country: "DK", flags: 2).update(combined_rate: 0.25) # Denmark
 ZipTaxRate.find_or_create_by(country: "EE", flags: 2).update(combined_rate: 0.09) # Estonia
-ZipTaxRate.find_or_create_by(country: "FI", flags: 2).update(combined_rate: 0.135) # Finland (effective 2026-01-01)
+ZipTaxRate.find_or_create_by(country: "FI", flags: 2).update(combined_rate: 0.10) # Finland
 ZipTaxRate.find_or_create_by(country: "FR", flags: 2).update(combined_rate: 0.055) # France
 ZipTaxRate.find_or_create_by(country: "DE", flags: 2).update(combined_rate: 0.07) # Germany
 ZipTaxRate.find_or_create_by(country: "GR", flags: 2).update(combined_rate: 0.06) # Greece

--- a/db/seeds/020_development_staging/eu_tax_rates.rb
+++ b/db/seeds/020_development_staging/eu_tax_rates.rb
@@ -47,7 +47,7 @@ ZipTaxRate.find_or_create_by(country: "GR", flags: 2).update(combined_rate: 0.06
 ZipTaxRate.find_or_create_by(country: "HU", flags: 2).update(combined_rate: 0.27) # Hungary
 ZipTaxRate.find_or_create_by(country: "IE", flags: 2).update(combined_rate: 0.00) # Ireland
 ZipTaxRate.find_or_create_by(country: "IT", flags: 2).update(combined_rate: 0.04) # Italy
-ZipTaxRate.find_or_create_by(country: "LV", flags: 2).update(combined_rate: 0.05) # Latvia
+ZipTaxRate.find_or_create_by(country: "LV", flags: 2).update(combined_rate: 0.21) # Latvia
 ZipTaxRate.find_or_create_by(country: "LT", flags: 2).update(combined_rate: 0.05) # Lithuania
 ZipTaxRate.find_or_create_by(country: "LU", flags: 2).update(combined_rate: 0.03) # Luxembourg
 ZipTaxRate.find_or_create_by(country: "MT", flags: 2).update(combined_rate: 0.05) # Malta

--- a/db/seeds/020_development_staging/eu_tax_rates.rb
+++ b/db/seeds/020_development_staging/eu_tax_rates.rb
@@ -34,13 +34,13 @@ ZipTaxRate.find_or_create_by(country: "GB").update(combined_rate: 0.20)
 # https://www.amazon.com/gp/help/customer/display.html?nodeId=GSF5MREL4MX7PTVG
 ZipTaxRate.find_or_create_by(country: "AT", flags: 2).update(combined_rate: 0.10) # Austria
 ZipTaxRate.find_or_create_by(country: "BE", flags: 2).update(combined_rate: 0.06) # Belgium
-ZipTaxRate.find_or_create_by(country: "BG", flags: 2).update(combined_rate: 0.09) # Bulgaria
+ZipTaxRate.find_or_create_by(country: "BG", flags: 2).update(combined_rate: 0.20) # Bulgaria (reduced rate is for print books only; e-books at standard rate)
 ZipTaxRate.find_or_create_by(country: "HR", flags: 2).update(combined_rate: 0.05) # Croatia
 ZipTaxRate.find_or_create_by(country: "CY", flags: 2).update(combined_rate: 0.03) # Cyprus
-ZipTaxRate.find_or_create_by(country: "CZ", flags: 2).update(combined_rate: 0.10) # Czech Republic
+ZipTaxRate.find_or_create_by(country: "CZ", flags: 2).update(combined_rate: 0.00) # Czech Republic (zero rate since 2024-01-01)
 ZipTaxRate.find_or_create_by(country: "DK", flags: 2).update(combined_rate: 0.25) # Denmark
-ZipTaxRate.find_or_create_by(country: "EE", flags: 2).update(combined_rate: 0.20) # Estonia
-ZipTaxRate.find_or_create_by(country: "FI", flags: 2).update(combined_rate: 0.10) # Finland
+ZipTaxRate.find_or_create_by(country: "EE", flags: 2).update(combined_rate: 0.09) # Estonia
+ZipTaxRate.find_or_create_by(country: "FI", flags: 2).update(combined_rate: 0.135) # Finland (effective 2026-01-01)
 ZipTaxRate.find_or_create_by(country: "FR", flags: 2).update(combined_rate: 0.055) # France
 ZipTaxRate.find_or_create_by(country: "DE", flags: 2).update(combined_rate: 0.07) # Germany
 ZipTaxRate.find_or_create_by(country: "GR", flags: 2).update(combined_rate: 0.06) # Greece
@@ -54,7 +54,7 @@ ZipTaxRate.find_or_create_by(country: "MT", flags: 2).update(combined_rate: 0.05
 ZipTaxRate.find_or_create_by(country: "NL", flags: 2).update(combined_rate: 0.09) # Netherlands
 ZipTaxRate.find_or_create_by(country: "PL", flags: 2).update(combined_rate: 0.05) # Poland
 ZipTaxRate.find_or_create_by(country: "PT", flags: 2).update(combined_rate: 0.06) # Portugal
-ZipTaxRate.find_or_create_by(country: "RO", flags: 2).update(combined_rate: 0.05) # Romania
+ZipTaxRate.find_or_create_by(country: "RO", flags: 2).update(combined_rate: 0.11) # Romania
 ZipTaxRate.find_or_create_by(country: "SK", flags: 2).update(combined_rate: 0.05) # Slovakia
 ZipTaxRate.find_or_create_by(country: "SI", flags: 2).update(combined_rate: 0.05) # Slovenia
 ZipTaxRate.find_or_create_by(country: "ES", flags: 2).update(combined_rate: 0.04) # Spain

--- a/db/seeds/020_development_staging/eu_tax_rates.rb
+++ b/db/seeds/020_development_staging/eu_tax_rates.rb
@@ -34,7 +34,7 @@ ZipTaxRate.find_or_create_by(country: "GB").update(combined_rate: 0.20)
 # https://www.amazon.com/gp/help/customer/display.html?nodeId=GSF5MREL4MX7PTVG
 ZipTaxRate.find_or_create_by(country: "AT", flags: 2).update(combined_rate: 0.10) # Austria
 ZipTaxRate.find_or_create_by(country: "BE", flags: 2).update(combined_rate: 0.06) # Belgium
-ZipTaxRate.find_or_create_by(country: "BG", flags: 2).update(combined_rate: 0.20) # Bulgaria (reduced rate is for print books only; e-books at standard rate)
+ZipTaxRate.find_or_create_by(country: "BG", flags: 2).update(combined_rate: 0.09) # Bulgaria
 ZipTaxRate.find_or_create_by(country: "HR", flags: 2).update(combined_rate: 0.05) # Croatia
 ZipTaxRate.find_or_create_by(country: "CY", flags: 2).update(combined_rate: 0.03) # Cyprus
 ZipTaxRate.find_or_create_by(country: "CZ", flags: 2).update(combined_rate: 0.00) # Czech Republic (zero rate since 2024-01-01)

--- a/db/seeds/020_development_staging/eu_tax_rates.rb
+++ b/db/seeds/020_development_staging/eu_tax_rates.rb
@@ -38,7 +38,7 @@ ZipTaxRate.find_or_create_by(country: "BG", flags: 2).update(combined_rate: 0.09
 ZipTaxRate.find_or_create_by(country: "HR", flags: 2).update(combined_rate: 0.25) # Croatia
 ZipTaxRate.find_or_create_by(country: "CY", flags: 2).update(combined_rate: 0.05) # Cyprus
 ZipTaxRate.find_or_create_by(country: "CZ", flags: 2).update(combined_rate: 0.10) # Czech Republic
-ZipTaxRate.find_or_create_by(country: "DK", flags: 2).update(combined_rate: 0.00) # Denmark (effective 2026-07-01)
+ZipTaxRate.find_or_create_by(country: "DK", flags: 2).update(combined_rate: 0.25) # Denmark
 ZipTaxRate.find_or_create_by(country: "EE", flags: 2).update(combined_rate: 0.20) # Estonia
 ZipTaxRate.find_or_create_by(country: "FI", flags: 2).update(combined_rate: 0.10) # Finland
 ZipTaxRate.find_or_create_by(country: "FR", flags: 2).update(combined_rate: 0.055) # France


### PR DESCRIPTION
Related to antiwork/gumroad-private#467 (comprehensive audit follow-up to the Croatia fix #5395).

## What

Comprehensive audit of all EU e-publication VAT seed values against PwC Worldwide Tax Summaries and national tax authorities. Six rows are corrected. Five countries are deliberately excluded.

### Updates that fix buyer over-charging (toggle was a no-op or under-applied)

| Country | Seed Old | Seed New | Prod Old | Source |
|---|---|---|---|---|
| Cyprus (CY) | 0.19 | **0.03** | 0.19 → 0.03 | Cyprus VAT Act amendment July 2023: 3% super-reduced for "books, newspapers and periodicals provided in either physical or electronic form or both" ([EY](https://www.ey.com/en_gl/technical/tax-alerts/cyprus-introduces-3--vat-rate-and-adds-goods-to-0--vat-list), [PwC](https://taxsummaries.pwc.com/cyprus/corporate/other-taxes), [KPMG](https://kpmg.com/cy/en/home/insights/2023/07/new-vat-rates-as-from-21-july-2023.html)) |
| Lithuania (LT) | 0.21 | **0.05** | 0.21 → 0.05 | 5% super-reduced for "electronic books and electronic non-periodical information publications" ([PwC](https://taxsummaries.pwc.com/lithuania/corporate/other-taxes)) |
| Slovakia (SK) | 0.20 | **0.05** | 0.23 → 0.05 | 5% super-reduced for printed books and e-books ([PwC](https://taxsummaries.pwc.com/slovak-republic/corporate/other-taxes)) |

### Seed-only updates (production already has the correct rate)

| Country | Seed Old | Seed New | Source |
|---|---|---|---|
| Czech Republic (CZ) | 0.10 | **0.00** | Zero rate on books in printed or electronic form, effective 2024-01-01 ([PwC](https://taxsummaries.pwc.com/czech-republic/corporate/other-taxes)) |
| Estonia (EE) | 0.20 | **0.09** | 9% reduced rate "to books, periodicals both on physical medium and electronically" ([PwC](https://taxsummaries.pwc.com/estonia/corporate/other-taxes)) |
| Romania (RO) | 0.05 | **0.11** | 11% reduced rate on "books, newspapers and magazines, in physical or electronic format" ([PwC](https://taxsummaries.pwc.com/romania/corporate/other-taxes)) |

### Countries deliberately excluded from this PR

- **Denmark (DK)**: Zero rate on books incl. e-books is effective **2026-07-01**, not today. Will be handled in a separate PR after the effective date.
- **Hungary (HU)**: Hungary's VAT Act Annex 3 applies 5% only to physical books (and audiobooks); digital books remain at the 27% standard rate ([PwC](https://taxsummaries.pwc.com/hungary/corporate/other-taxes), [KPMG Hungary](https://kpmg.com/hu/en/home/insights/2020/11/adoriado-2020-11-10.html)). The existing prod row (ID 51205, 0.27) is already at the standard rate, which is correct.
- **Bulgaria (BG)**: A single 2020 source (International Publishers Association) indicates Bulgaria's 9% reduced rate is "print books only." PwC and other sources are ambiguous. Single-source evidence is insufficient to push an under-charge → over-charge swap; deferred pending Tax/Compliance review.
- **Finland (FI)**: Finnish Tax Administration ([vero.fi](https://www.vero.fi/en/businesses-and-corporations/taxes-and-charges/vat/rates-of-vat/)) splits e-publications: **e-books at 13.5%** (since 2026-01-01) and **e-newspapers/e-magazines at 10%**. Gumroad's `is_epublication?` toggle cannot distinguish the two. Deferred pending Compliance decision on Gumroad's FI e-pub product mix and back-remittance plan for past under-collection (since 2025-01-01).
- **Latvia (LV)**: Latvia's 5% reduced rate ([PwC](https://taxsummaries.pwc.com/latvia/corporate/other-taxes)) applies only to e-books in qualifying languages (Latvian, Latgalian, Liv, or official languages of EU/EEA/Swiss/EU-candidate/OECD member states) under the 2026 amendment. Gumroad's `is_epublication?` toggle cannot distinguish qualifying-language books from non-qualifying-language ones (e.g., Russian, Chinese, Arabic). Deferred pending Compliance decision on how to handle the language restriction within Gumroad's data model.

## Why

The Croatia bug (antiwork/gumroad-private#467, fix #5395) surfaced a class of drift: `UpdateTaxRatesJob` excludes e-publication rate rows from its automatic refresh (`ZipTaxRate.not_is_epublication_rate.alive.where(country: country_code).first`), so any e-publication row that was hand-set in 2021 has been frozen since. An exhaustive audit against PwC Worldwide Tax Summaries and national tax authorities surfaced six EU e-publication rows that diverge from current law and were verified across multiple authoritative sources with no within-country ambiguity.

## Production console script (CY, LT, SK)

Run this in a production Rails console after Tax/Compliance signs off. Soft-deletes the three stale e-publication rows and creates new ones at the corrected rates. Mirrors the pattern used for Croatia in #5395 (chosen over in-place `update!` because the quarterly VAT report reads `combined_rate` per row, so in-place changes would distort historical reporting for purchases already linked to the old row).

```ruby
EPUB_RATE_UPDATES = {
  "CY" => { old_id: 51197, new_rate: 0.03 },
  "LT" => { old_id: 51209, new_rate: 0.05 },
  "SK" => { old_id: 51216, new_rate: 0.05 },
}

# Pre-flight: confirm the existing rows are what we expect before mutating anything.
EPUB_RATE_UPDATES.each do |country, cfg|
  row = ZipTaxRate.find(cfg[:old_id])
  raise "#{country} row #{cfg[:old_id]} unexpected: country=#{row.country} flags=#{row.flags} alive=#{row.alive?}" unless row.country == country && row.flags == 2 && row.alive?
end
puts "Pre-flight OK"

# Apply updates.
ActiveRecord::Base.transaction do
  EPUB_RATE_UPDATES.each do |country, cfg|
    ZipTaxRate.find(cfg[:old_id]).mark_deleted!
    new_row = ZipTaxRate.create!(country: country, flags: 2, combined_rate: cfg[:new_rate])
    puts "#{country}: old #{cfg[:old_id]} soft-deleted, new row #{new_row.id} at #{new_row.combined_rate}"
  end
end

# Verification: each country should now have exactly one alive e-pub row at the new rate.
EPUB_RATE_UPDATES.each_key do |country|
  alive_epub = ZipTaxRate.alive.where(country: country).is_epublication_rate.pluck(:id, :combined_rate)
  puts "#{country}: #{alive_epub.inspect}"
end
```

Expected verification output: one row per country at the new rate, none of which is an old ID from the table above.

---

This PR was implemented with AI assistance using Claude Opus 4.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)