### PR TITLE
Fix Stripe KYC dead-end when more_kyc_needed email arrives

### DIFF
--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -904,7 +904,7 @@ module StripeMerchantAccountManager
     return if all_fields_needed.empty?
 
     document_verification_error = verification_errors.select { |_field, error| error[:code].starts_with?("verification_document") }.first
-    skip_more_kyc_email = requirements_only_soft_future?(requirements, new_requests, requirements_due_at)
+    skip_more_kyc_email = requirements_only_soft_future?(requirements, new_requests, all_fields_needed, requirements_due_at)
     email_sent = if document_verification_error.present?
       ContactingCreatorMailer.stripe_document_verification_failed(user.id, document_verification_error[1][:reason]).deliver_later(queue: "critical")
     elsif verification_errors.present?
@@ -942,7 +942,7 @@ module StripeMerchantAccountManager
   SOFT_FUTURE_REQUIREMENT_GRACE_PERIOD = 30.days
 
   private_class_method
-  def self.requirements_only_soft_future?(requirements, new_requests, requirements_due_at)
+  def self.requirements_only_soft_future?(requirements, new_requests, all_fields_needed, requirements_due_at)
     return false if new_requests.blank?
     return false unless requirements_due_at.blank? || requirements_due_at > SOFT_FUTURE_REQUIREMENT_GRACE_PERIOD.from_now
 
@@ -956,6 +956,9 @@ module StripeMerchantAccountManager
       StripeUserComplianceInfoFieldMap.map(normalized).presence || normalized
     end
 
-    new_requests.all? { |request| soft_field_names.include?(request.field_needed) }
+    return false unless new_requests.all? { |request| soft_field_names.include?(request.field_needed) }
+    return false unless Array(all_fields_needed).all? { |field| soft_field_names.include?(field) }
+
+    true
   end
 end

--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -904,10 +904,13 @@ module StripeMerchantAccountManager
     return if all_fields_needed.empty?
 
     document_verification_error = verification_errors.select { |_field, error| error[:code].starts_with?("verification_document") }.first
+    skip_more_kyc_email = requirements_only_soft_future?(requirements, new_requests, requirements_due_at)
     email_sent = if document_verification_error.present?
       ContactingCreatorMailer.stripe_document_verification_failed(user.id, document_verification_error[1][:reason]).deliver_later(queue: "critical")
     elsif verification_errors.present?
       ContactingCreatorMailer.stripe_identity_verification_failed(user.id, verification_errors.first[1][:reason]).deliver_later(queue: "critical")
+    elsif skip_more_kyc_email
+      nil
     else
       ContactingCreatorMailer.more_kyc_needed(user.id, all_fields_needed).deliver_later(queue: "critical")
     end
@@ -934,5 +937,25 @@ module StripeMerchantAccountManager
     return unless user_has_stripe_connect_merchant_account?(bank_account.user)
 
     update_bank_account(bank_account.user, passphrase: GlobalConfig.get("STRONGBOX_GENERAL_PASSWORD"))
+  end
+
+  SOFT_FUTURE_REQUIREMENT_GRACE_PERIOD = 30.days
+
+  private_class_method
+  def self.requirements_only_soft_future?(requirements, new_requests, requirements_due_at)
+    return false if new_requests.blank?
+    return false unless requirements_due_at.blank? || requirements_due_at > SOFT_FUTURE_REQUIREMENT_GRACE_PERIOD.from_now
+
+    eventually_due_only = (requirements["eventually_due"] || []) -
+                          (requirements["currently_due"] || []) -
+                          (requirements["past_due"] || [])
+    return false if eventually_due_only.empty?
+
+    soft_field_names = eventually_due_only.map do |raw_field|
+      normalized = raw_field.gsub(/^person_\w+\./, "individual.")
+      StripeUserComplianceInfoFieldMap.map(normalized).presence || normalized
+    end
+
+    new_requests.all? { |request| soft_field_names.include?(request.field_needed) }
   end
 end

--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -943,7 +943,7 @@ module StripeMerchantAccountManager
 
   private_class_method
   def self.requirements_only_soft_future?(requirements, new_requests, all_fields_needed, requirements_due_at)
-    return false if new_requests.blank?
+    return false if Array(all_fields_needed).empty?
     return false unless requirements_due_at.blank? || requirements_due_at > SOFT_FUTURE_REQUIREMENT_GRACE_PERIOD.from_now
 
     eventually_due_only = (requirements["eventually_due"] || []) -
@@ -956,7 +956,9 @@ module StripeMerchantAccountManager
       StripeUserComplianceInfoFieldMap.map(normalized).presence || normalized
     end
 
-    return false unless new_requests.all? { |request| soft_field_names.include?(request.field_needed) }
+    if new_requests.present?
+      return false unless new_requests.all? { |request| soft_field_names.include?(request.field_needed) }
+    end
     return false unless Array(all_fields_needed).all? { |field| soft_field_names.include?(field) }
 
     true

--- a/app/controllers/settings/payments_controller.rb
+++ b/app/controllers/settings/payments_controller.rb
@@ -177,7 +177,12 @@ class Settings::PaymentsController < Settings::BaseController
   def remediation
     authorize
 
-    if current_seller.stripe_account.blank? || current_seller.user_compliance_info_requests.requested.blank?
+    if current_seller.stripe_account.blank?
+      redirect_to settings_payments_path, notice: "Thanks! You're all set." and return
+    end
+
+    has_local_requests = current_seller.user_compliance_info_requests.requested.exists?
+    if !has_local_requests && !stripe_account_has_open_requirements?(current_seller.stripe_account)
       redirect_to settings_payments_path, notice: "Thanks! You're all set." and return
     end
 
@@ -272,5 +277,21 @@ class Settings::PaymentsController < Settings::BaseController
       disabled_reason = stripe_account["requirements"]["disabled_reason"]
       merchant_account.update!(stripe_disabled_reason: disabled_reason) if disabled_reason.present?
     rescue Stripe::StripeError, ActiveRecord::ActiveRecordError
+    end
+
+    def stripe_account_has_open_requirements?(merchant_account)
+      stripe_account = Stripe::Account.retrieve(merchant_account.charge_processor_merchant_id)
+      requirements = stripe_account["requirements"] || {}
+      future_requirements = stripe_account["future_requirements"] || {}
+      [
+        requirements["currently_due"],
+        requirements["past_due"],
+        requirements["eventually_due"],
+        future_requirements["currently_due"],
+        future_requirements["past_due"],
+      ].any?(&:present?)
+    rescue Stripe::StripeError => e
+      ErrorNotifier.notify(e, context: { user_id: current_seller.id })
+      false
     end
 end

--- a/app/controllers/settings/payments_controller.rb
+++ b/app/controllers/settings/payments_controller.rb
@@ -202,15 +202,24 @@ class Settings::PaymentsController < Settings::BaseController
     safe_redirect_to settings_payments_path and return if current_seller.stripe_account.blank?
 
     stripe_account = Stripe::Account.retrieve(current_seller.stripe_account.charge_processor_merchant_id)
+    requirements = stripe_account["requirements"] || {}
+    future_requirements = stripe_account["future_requirements"] || {}
 
-    if stripe_account["requirements"]["currently_due"].blank? && stripe_account["requirements"]["past_due"].blank?
+    hard_requirements_clear = requirements["currently_due"].blank? && requirements["past_due"].blank?
+    if hard_requirements_clear
       # We're marking the pending compliance request as provided on our end here if it is no longer due on Stripe.
       # We'll get a account.updated webhook event and mark these requests as provided there as well,
       # but doing it here instead of waiting on the webhook, so that the respective compliance request notice is removed
       # from the page immediately.
       current_seller.user_compliance_info_requests.requested.each(&:mark_provided!)
-      flash[:notice] = "Thanks! You're all set."
     end
+
+    nothing_open_on_stripe = hard_requirements_clear &&
+                             requirements["eventually_due"].blank? &&
+                             future_requirements["currently_due"].blank? &&
+                             future_requirements["past_due"].blank? &&
+                             future_requirements["eventually_due"].blank?
+    flash[:notice] = "Thanks! You're all set." if nothing_open_on_stripe
 
     safe_redirect_to settings_payments_path
   end

--- a/app/controllers/settings/payments_controller.rb
+++ b/app/controllers/settings/payments_controller.rb
@@ -289,6 +289,7 @@ class Settings::PaymentsController < Settings::BaseController
         requirements["eventually_due"],
         future_requirements["currently_due"],
         future_requirements["past_due"],
+        future_requirements["eventually_due"],
       ].any?(&:present?)
     rescue Stripe::StripeError => e
       ErrorNotifier.notify(e, context: { user_id: current_seller.id })

--- a/app/views/contacting_creator_mailer/more_kyc_needed.html.erb
+++ b/app/views/contacting_creator_mailer/more_kyc_needed.html.erb
@@ -6,6 +6,6 @@
       <li><%= field_needed_tag %></li>
     <% end %>
   </ul>
-  <p><%= link_to("Provide your information", settings_payments_url, class: "button primary") %></p>
-  <p>Or you can click here: <%= link_to settings_payments_url, settings_payments_url %></p>
+  <p><%= link_to("Provide your information", remediation_settings_payments_url, class: "button primary") %></p>
+  <p>Or you can click here: <%= link_to remediation_settings_payments_url, remediation_settings_payments_url %></p>
 </div>

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -11961,5 +11961,16 @@ describe StripeMerchantAccountManager, :vcr do
                                             ))
       end.to have_enqueued_mail(ContactingCreatorMailer, :more_kyc_needed)
     end
+
+    it "still emails when an outstanding currently_due field remains alongside a new soft eventually_due field" do
+      create(:user_compliance_info_request, user:, field_needed: UserComplianceInfoFields::Business::TAX_ID)
+
+      expect do
+        described_class.handle_stripe_event(stripe_event(
+                                              currently_due: ["business.tax_id"],
+                                              eventually_due: ["individual.id_number"]
+                                            ))
+      end.to have_enqueued_mail(ContactingCreatorMailer, :more_kyc_needed)
+    end
   end
 end

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -11972,5 +11972,13 @@ describe StripeMerchantAccountManager, :vcr do
                                             ))
       end.to have_enqueued_mail(ContactingCreatorMailer, :more_kyc_needed)
     end
+
+    it "does not re-notify on the monthly path when every outstanding requested field is soft" do
+      create(:user_compliance_info_request, user:, field_needed: UserComplianceInfoFields::Individual::TAX_ID, created_at: 2.months.ago)
+
+      expect do
+        described_class.handle_stripe_event(stripe_event(eventually_due: ["individual.id_number"]))
+      end.not_to have_enqueued_mail(ContactingCreatorMailer, :more_kyc_needed)
+    end
   end
 end

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -11905,4 +11905,61 @@ describe StripeMerchantAccountManager, :vcr do
       end
     end
   end
+
+  describe "soft-future requirement skip" do
+    let(:user) { create(:user) }
+    let(:merchant_account) { create(:merchant_account, user:) }
+
+    before { create(:user_compliance_info, user:, country: Compliance::Countries::USA.common_name) }
+
+    def stripe_event(eventually_due:, currently_due: [], past_due: [], deadline: 90.days.from_now.to_i)
+      {
+        "api_version" => API_VERSION,
+        "type" => "account.updated",
+        "id" => "stripe-event-id-soft",
+        "account" => merchant_account.charge_processor_merchant_id,
+        "user_id" => merchant_account.charge_processor_merchant_id,
+        "data" => {
+          "object" => {
+            "object" => "account",
+            "id" => merchant_account.charge_processor_merchant_id,
+            "business_type" => "individual",
+            "charges_enabled" => true,
+            "payouts_enabled" => true,
+            "requirements" => {
+              "current_deadline" => deadline,
+              "currently_due" => currently_due,
+              "eventually_due" => eventually_due,
+              "past_due" => past_due
+            }
+          }
+        }
+      }
+    end
+
+    it "records the request but does not email when the only new field is in eventually_due with a far-future deadline" do
+      expect do
+        described_class.handle_stripe_event(stripe_event(eventually_due: ["individual.id_number"]))
+      end.not_to have_enqueued_mail(ContactingCreatorMailer, :more_kyc_needed)
+      expect(user.user_compliance_info_requests.requested.count).to eq(1)
+    end
+
+    it "emails as usual when the new field is currently_due even if other fields are eventually_due" do
+      expect do
+        described_class.handle_stripe_event(stripe_event(
+                                              currently_due: ["individual.id_number"],
+                                              eventually_due: ["company.tax_id"]
+                                            ))
+      end.to have_enqueued_mail(ContactingCreatorMailer, :more_kyc_needed)
+    end
+
+    it "emails as usual when the eventually_due field has a near-term deadline" do
+      expect do
+        described_class.handle_stripe_event(stripe_event(
+                                              eventually_due: ["individual.id_number"],
+                                              deadline: 7.days.from_now.to_i
+                                            ))
+      end.to have_enqueued_mail(ContactingCreatorMailer, :more_kyc_needed)
+    end
+  end
 end

--- a/spec/controllers/settings/payments_controller_spec.rb
+++ b/spec/controllers/settings/payments_controller_spec.rb
@@ -1972,8 +1972,51 @@ describe Settings::PaymentsController, :vcr, type: :controller, inertia: true do
       expect(response).to redirect_to settings_payments_url
     end
 
-    it "does noting and redirects to payments settings page if there's no pending stripe information request" do
-      StripeMerchantAccountManager.create_account(user, passphrase: "1234")
+    it "does nothing and redirects to payments settings page if there's no pending stripe information request and Stripe agrees" do
+      merchant_account = StripeMerchantAccountManager.create_account(user, passphrase: "1234")
+      allow(Stripe::Account).to receive(:retrieve).with(merchant_account.charge_processor_merchant_id).and_return(
+        Stripe::Account.construct_from(
+          id: merchant_account.charge_processor_merchant_id,
+          object: "account",
+          requirements: { "currently_due" => [], "past_due" => [], "eventually_due" => [] },
+          future_requirements: { "currently_due" => [], "past_due" => [] }
+        )
+      )
+
+      get :remediation
+
+      expect(response).to redirect_to settings_payments_url
+    end
+
+    it "opens a Stripe AccountLink when local has no pending requests but Stripe still has open requirements" do
+      merchant_account = StripeMerchantAccountManager.create_account(user, passphrase: "1234")
+      stripe_connect_account_id = merchant_account.charge_processor_merchant_id
+      allow(Stripe::Account).to receive(:retrieve).with(stripe_connect_account_id).and_return(
+        Stripe::Account.construct_from(
+          id: stripe_connect_account_id,
+          object: "account",
+          requirements: { "currently_due" => [], "past_due" => [], "eventually_due" => ["individual.id_number"] },
+          future_requirements: { "currently_due" => [], "past_due" => [] }
+        )
+      )
+      expect(Stripe::AccountLink).to receive(:create).with({
+                                                             account: stripe_connect_account_id,
+                                                             refresh_url: remediation_settings_payments_url,
+                                                             return_url: verify_stripe_remediation_settings_payments_url,
+                                                             type: "account_update",
+                                                           }).and_call_original
+
+      get :remediation
+
+      expect(response.location).to match(Regexp.new("https://connect.stripe.com/setup/c/#{stripe_connect_account_id}/"))
+    end
+
+    it "falls back to the 'Thanks' redirect when Stripe::Account.retrieve raises and local has no pending requests" do
+      merchant_account = StripeMerchantAccountManager.create_account(user, passphrase: "1234")
+      allow(Stripe::Account).to receive(:retrieve).with(merchant_account.charge_processor_merchant_id).and_raise(
+        Stripe::APIConnectionError.new("Stripe is down")
+      )
+      expect(ErrorNotifier).to receive(:notify).with(instance_of(Stripe::APIConnectionError), context: { user_id: user.id })
 
       get :remediation
 

--- a/spec/controllers/settings/payments_controller_spec.rb
+++ b/spec/controllers/settings/payments_controller_spec.rb
@@ -2158,5 +2158,39 @@ describe Settings::PaymentsController, :vcr, type: :controller, inertia: true do
       expect(response).to redirect_to settings_payments_url
       expect(flash[:notice]).to eq("Thanks! You're all set.")
     end
+
+    it "does not show the 'Thanks' notice when Stripe still lists eventually_due requirements" do
+      pending_request = create(:user_compliance_info_request, user:, field_needed: UserComplianceInfoFields::Individual::TAX_ID)
+      allow(Stripe::Account).to receive(:retrieve).with(stripe_connect_account_id).and_return(
+        Stripe::Account.construct_from(
+          id: stripe_connect_account_id,
+          object: "account",
+          requirements: { "currently_due" => [], "past_due" => [], "eventually_due" => ["individual.id_number"] },
+          future_requirements: { "currently_due" => [], "past_due" => [], "eventually_due" => [] }
+        )
+      )
+
+      get :verify_stripe_remediation
+
+      expect(response).to redirect_to settings_payments_url
+      expect(flash[:notice]).to be_nil
+      expect(pending_request.reload).to be_provided
+    end
+
+    it "does not show the 'Thanks' notice when Stripe still lists future_requirements.eventually_due" do
+      allow(Stripe::Account).to receive(:retrieve).with(stripe_connect_account_id).and_return(
+        Stripe::Account.construct_from(
+          id: stripe_connect_account_id,
+          object: "account",
+          requirements: { "currently_due" => [], "past_due" => [], "eventually_due" => [] },
+          future_requirements: { "currently_due" => [], "past_due" => [], "eventually_due" => ["individual.id_number"] }
+        )
+      )
+
+      get :verify_stripe_remediation
+
+      expect(response).to redirect_to settings_payments_url
+      expect(flash[:notice]).to be_nil
+    end
   end
 end

--- a/spec/controllers/settings/payments_controller_spec.rb
+++ b/spec/controllers/settings/payments_controller_spec.rb
@@ -2011,6 +2011,24 @@ describe Settings::PaymentsController, :vcr, type: :controller, inertia: true do
       expect(response.location).to match(Regexp.new("https://connect.stripe.com/setup/c/#{stripe_connect_account_id}/"))
     end
 
+    it "opens a Stripe AccountLink when Stripe still has future_requirements.eventually_due (volume-threshold case)" do
+      merchant_account = StripeMerchantAccountManager.create_account(user, passphrase: "1234")
+      stripe_connect_account_id = merchant_account.charge_processor_merchant_id
+      allow(Stripe::Account).to receive(:retrieve).with(stripe_connect_account_id).and_return(
+        Stripe::Account.construct_from(
+          id: stripe_connect_account_id,
+          object: "account",
+          requirements: { "currently_due" => [], "past_due" => [], "eventually_due" => [] },
+          future_requirements: { "currently_due" => [], "past_due" => [], "eventually_due" => ["individual.id_number"] }
+        )
+      )
+      expect(Stripe::AccountLink).to receive(:create).and_call_original
+
+      get :remediation
+
+      expect(response.location).to match(Regexp.new("https://connect.stripe.com/setup/c/#{stripe_connect_account_id}/"))
+    end
+
     it "falls back to the 'Thanks' redirect when Stripe::Account.retrieve raises and local has no pending requests" do
       merchant_account = StripeMerchantAccountManager.create_account(user, passphrase: "1234")
       allow(Stripe::Account).to receive(:retrieve).with(merchant_account.charge_processor_merchant_id).and_raise(

--- a/spec/mailers/contacting_creator_mailer_spec.rb
+++ b/spec/mailers/contacting_creator_mailer_spec.rb
@@ -1920,6 +1920,18 @@ describe ContactingCreatorMailer do
     end
   end
 
+  describe "#more_kyc_needed" do
+    let!(:seller) { create(:named_seller) }
+
+    it "links the call-to-action to the remediation endpoint so sellers reach Stripe's hosted upload flow" do
+      mail = ContactingCreatorMailer.more_kyc_needed(seller.id, %w[individual_tax_id])
+
+      expect(mail.to).to eq([seller.email])
+      expect(mail.body.encoded).to have_link("Provide your information", href: remediation_settings_payments_url)
+      expect(mail.body.encoded).not_to have_link("Provide your information", href: settings_payments_url)
+    end
+  end
+
   describe "#suspended_due_to_stripe_risk" do
     let(:seller) { create(:named_seller) }
 

--- a/spec/support/fixtures/vcr_cassettes/Settings_PaymentsController/GET_remediation/does_nothing_and_redirects_to_payments_settings_page_if_there_s_no_pending_stripe_information_request_and_Stripe_agrees.yml
+++ b/spec/support/fixtures/vcr_cassettes/Settings_PaymentsController/GET_remediation/does_nothing_and_redirects_to_payments_settings_page_if_there_s_no_pending_stripe_information_request_and_Stripe_agrees.yml
@@ -1,0 +1,373 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/accounts
+    body:
+      encoding: UTF-8
+      string: type=custom&requested_capabilities[0]=card_payments&requested_capabilities[1]=transfers&country=US&default_currency=usd&metadata[user_id]=6&metadata[tos_agreement_id]=4DkQVXx73ayoDvqFb5T1xA%3D%3D&metadata[user_compliance_info_id]=cVKeSFQEc3ynlAuU_njaDQ%3D%3D&metadata[bank_account_id]=4DkQVXx73ayoDvqFb5T1xA%3D%3D&tos_acceptance[date]=1780559333&tos_acceptance[ip]=54.234.242.13&business_type=individual&business_profile[name]=Chuck+Bartowski&business_profile[url]=https%3A%2F%2Fvipul.gumroad.com%2F&business_profile[product_description]=Chuck+Bartowski&individual[first_name]=Chuck&individual[last_name]=Bartowski&individual[email]=edgarcecda1c4_3%40gumroad.com&individual[phone]=0000000000&individual[dob][day]=1&individual[dob][month]=1&individual[dob][year]=1901&individual[address][line1]=address_full_match&individual[address][city]=San+Francisco&individual[address][state]=California&individual[address][postal_code]=94107&individual[address][country]=US&individual[id_number]=000000000&bank_account[country]=US&bank_account[currency]=usd&bank_account[account_number]=000<STRONGBOX_GENERAL_PASSWORD>56789&bank_account[routing_number]=110000000&settings[payouts][schedule][interval]=manual&settings[payouts][debit_negative_balances]=true
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Idempotency-Key:
+      - 5a43b78f-a1dc-4cb6-8f9f-2d123ca44247
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Is-MacBook-Air.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56
+        PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132 arm64","hostname":"Is-MacBook-Air.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 04 Jun 2026 07:48:58 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '6843'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=gep4cuMKV-Y2wfe-Dsmz9ciNEFElYYo4bJkzPmx8C6hvdhKVnrIB5p-qOs5Whm7G_-PGtIve0qKegKzS;
+        report-to csp
+      Idempotency-Key:
+      - 5a43b78f-a1dc-4cb6-8f9f-2d123ca44247
+      Original-Request:
+      - req_Z1jiHPh4c57eFj
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=gep4cuMKV-Y2wfe-Dsmz9ciNEFElYYo4bJkzPmx8C6hvdhKVnrIB5p-qOs5Whm7G_-PGtIve0qKegKzS&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=gep4cuMKV-Y2wfe-Dsmz9ciNEFElYYo4bJkzPmx8C6hvdhKVnrIB5p-qOs5Whm7G_-PGtIve0qKegKzS&t=1"
+      Request-Id:
+      - req_Z1jiHPh4c57eFj
+      Stripe-Notice:
+      - '2 notices for this request: (1) You are using an outdated API version (2023-10-16).
+        We recommend upgrading to the latest API version, 2026-05-27.dahlia. See https://docs.stripe.com/upgrades
+        (2) We recommend building your integration using Accounts v2. See https://docs.stripe.com/api/v2/core/accounts'
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1TeW1KEUPVHSk2ZK",
+          "object": "account",
+          "business_profile": {
+            "annual_revenue": null,
+            "estimated_worker_count": null,
+            "mcc": null,
+            "minority_owned_business_designation": null,
+            "name": "Chuck Bartowski",
+            "product_description": "Chuck Bartowski",
+            "specified_commercial_transactions_act_url": null,
+            "support_address": null,
+            "support_email": null,
+            "support_phone": null,
+            "support_url": null,
+            "url": "https://vipul.gumroad.com/"
+          },
+          "business_type": "individual",
+          "capabilities": {
+            "card_payments": "inactive",
+            "transfers": "active"
+          },
+          "charges_enabled": false,
+          "company": {
+            "address": {
+              "city": "San Francisco",
+              "country": "US",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "94107",
+              "state": "California"
+            },
+            "directors_provided": true,
+            "executives_provided": true,
+            "name": null,
+            "owners_provided": true,
+            "phone": "+10000000000",
+            "tax_id_provided": false,
+            "verification": {
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              }
+            }
+          },
+          "controller": {
+            "fees": {
+              "payer": "application_custom"
+            },
+            "is_controller": true,
+            "losses": {
+              "payments": "application"
+            },
+            "requirement_collection": "application",
+            "stripe_dashboard": {
+              "type": "none"
+            },
+            "type": "application"
+          },
+          "country": "US",
+          "created": 1780559336,
+          "default_currency": "usd",
+          "details_submitted": true,
+          "email": null,
+          "external_accounts": {
+            "object": "list",
+            "data": [
+              {
+                "id": "ba_1TeW1KEUPVHSk2ZKP19YnFUZ",
+                "object": "bank_account",
+                "account": "acct_1TeW1KEUPVHSk2ZK",
+                "account_holder_name": null,
+                "account_holder_type": null,
+                "account_type": null,
+                "available_payout_methods": [
+                  "standard",
+                  "instant"
+                ],
+                "bank_name": "STRIPE TEST BANK",
+                "country": "US",
+                "currency": "usd",
+                "default_for_currency": true,
+                "fingerprint": "l0OxwqZbI4t8wVSU",
+                "future_requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "last4": "6789",
+                "metadata": {},
+                "requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "routing_number": "110000000",
+                "status": "new"
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/accounts/acct_1TeW1KEUPVHSk2ZK/external_accounts"
+          },
+          "future_requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [],
+            "disabled_reason": null,
+            "errors": [],
+            "eventually_due": [],
+            "past_due": [],
+            "pending_verification": []
+          },
+          "individual": {
+            "id": "person_1TeW1LEUPVHSk2ZK5PMh351B",
+            "object": "person",
+            "account": "acct_1TeW1KEUPVHSk2ZK",
+            "address": {
+              "city": "San Francisco",
+              "country": "US",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "94107",
+              "state": "California"
+            },
+            "created": 1780559335,
+            "dob": {
+              "day": 1,
+              "month": 1,
+              "year": 1901
+            },
+            "email": "edgarcecda1c4_3@gumroad.com",
+            "first_name": "Chuck",
+            "future_requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "id_number_provided": true,
+            "last_name": "Bartowski",
+            "metadata": {},
+            "phone": "+10000000000",
+            "relationship": {
+              "authorizer": false,
+              "director": false,
+              "executive": false,
+              "legal_guardian": false,
+              "owner": false,
+              "percent_ownership": null,
+              "representative": true,
+              "title": null
+            },
+            "requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": [
+                "address.city",
+                "address.line1",
+                "address.postal_code",
+                "address.state",
+                "id_number",
+                "verification.document"
+              ]
+            },
+            "ssn_last_4_provided": true,
+            "verification": {
+              "additional_document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "details": null,
+              "details_code": null,
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "status": "pending"
+            }
+          },
+          "metadata": {
+            "bank_account_id": "4DkQVXx73ayoDvqFb5T1xA==",
+            "tos_agreement_id": "4DkQVXx73ayoDvqFb5T1xA==",
+            "user_compliance_info_id": "cVKeSFQEc3ynlAuU_njaDQ==",
+            "user_id": "6"
+          },
+          "payouts_enabled": false,
+          "requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [
+              "business_profile.mcc"
+            ],
+            "disabled_reason": "requirements.past_due",
+            "errors": [],
+            "eventually_due": [
+              "business_profile.mcc"
+            ],
+            "past_due": [
+              "business_profile.mcc"
+            ],
+            "pending_verification": [
+              "individual.address.city",
+              "individual.address.line1",
+              "individual.address.postal_code",
+              "individual.address.state",
+              "individual.id_number",
+              "individual.verification.document"
+            ]
+          },
+          "settings": {
+            "bacs_debit_payments": {
+              "display_name": null,
+              "service_user_number": null
+            },
+            "branding": {
+              "icon": null,
+              "logo": null,
+              "primary_color": null,
+              "secondary_color": null
+            },
+            "card_issuing": {
+              "tos_acceptance": {
+                "date": null,
+                "ip": null
+              }
+            },
+            "card_payments": {
+              "decline_on": {
+                "avs_failure": false,
+                "cvc_failure": false
+              },
+              "statement_descriptor_prefix": "CHUCK BART",
+              "statement_descriptor_prefix_kana": null,
+              "statement_descriptor_prefix_kanji": null
+            },
+            "dashboard": {
+              "display_name": "Chuck Bartowski",
+              "timezone": "Etc/UTC"
+            },
+            "invoices": {
+              "default_account_tax_ids": null,
+              "hosted_payment_method_save": "offer"
+            },
+            "payments": {
+              "statement_descriptor": "CHUCK BARTOWSKI",
+              "statement_descriptor_kana": null,
+              "statement_descriptor_kanji": null
+            },
+            "payouts": {
+              "debit_negative_balances": true,
+              "schedule": {
+                "delay_days": 2,
+                "interval": "manual"
+              },
+              "statement_descriptor": null
+            },
+            "sepa_debit_payments": {}
+          },
+          "tos_acceptance": {
+            "date": 1780559333,
+            "ip": "54.234.242.13",
+            "user_agent": null
+          },
+          "type": "custom"
+        }
+  recorded_at: Thu, 04 Jun 2026 07:48:58 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/Settings_PaymentsController/GET_remediation/falls_back_to_the_Thanks_redirect_when_Stripe_Account_retrieve_raises_and_local_has_no_pending_requests.yml
+++ b/spec/support/fixtures/vcr_cassettes/Settings_PaymentsController/GET_remediation/falls_back_to_the_Thanks_redirect_when_Stripe_Account_retrieve_raises_and_local_has_no_pending_requests.yml
@@ -1,0 +1,375 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/accounts
+    body:
+      encoding: UTF-8
+      string: type=custom&requested_capabilities[0]=card_payments&requested_capabilities[1]=transfers&country=US&default_currency=usd&metadata[user_id]=6&metadata[tos_agreement_id]=qXyyQQfPkWq7Mt9c4ot2YA%3D%3D&metadata[user_compliance_info_id]=rUFoI3aoSiVffxRgqZLJBA%3D%3D&metadata[bank_account_id]=qXyyQQfPkWq7Mt9c4ot2YA%3D%3D&tos_acceptance[date]=1780559346&tos_acceptance[ip]=54.234.242.13&business_type=individual&business_profile[name]=Chuck+Bartowski&business_profile[url]=https%3A%2F%2Fvipul.gumroad.com%2F&business_profile[product_description]=Chuck+Bartowski&individual[first_name]=Chuck&individual[last_name]=Bartowski&individual[email]=edgarbcb7f28d_7%40gumroad.com&individual[phone]=0000000000&individual[dob][day]=1&individual[dob][month]=1&individual[dob][year]=1901&individual[address][line1]=address_full_match&individual[address][city]=San+Francisco&individual[address][state]=California&individual[address][postal_code]=94107&individual[address][country]=US&individual[id_number]=000000000&bank_account[country]=US&bank_account[currency]=usd&bank_account[account_number]=000<STRONGBOX_GENERAL_PASSWORD>56789&bank_account[routing_number]=110000000&settings[payouts][schedule][interval]=manual&settings[payouts][debit_negative_balances]=true
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_BfrMgDBUI9kYpv","request_duration_ms":467}}'
+      Idempotency-Key:
+      - 8d6f2e80-8a2a-4780-9b94-da46df4bd65d
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Is-MacBook-Air.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56
+        PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132 arm64","hostname":"Is-MacBook-Air.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 04 Jun 2026 07:49:10 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '6843'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=yrUQU17aoKZkaHOEn2OnieOLkpi6oK7y36fusTX-njNA3v5tHV1xjsNggS9GPegF4r-RgJEyUxGMjYWE;
+        report-to csp
+      Idempotency-Key:
+      - 8d6f2e80-8a2a-4780-9b94-da46df4bd65d
+      Original-Request:
+      - req_QbxBr0ktX5aFQP
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=yrUQU17aoKZkaHOEn2OnieOLkpi6oK7y36fusTX-njNA3v5tHV1xjsNggS9GPegF4r-RgJEyUxGMjYWE&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=yrUQU17aoKZkaHOEn2OnieOLkpi6oK7y36fusTX-njNA3v5tHV1xjsNggS9GPegF4r-RgJEyUxGMjYWE&t=1"
+      Request-Id:
+      - req_QbxBr0ktX5aFQP
+      Stripe-Notice:
+      - '2 notices for this request: (1) You are using an outdated API version (2023-10-16).
+        We recommend upgrading to the latest API version, 2026-05-27.dahlia. See https://docs.stripe.com/upgrades
+        (2) We recommend building your integration using Accounts v2. See https://docs.stripe.com/api/v2/core/accounts'
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1TeW1WIddoWIJLDK",
+          "object": "account",
+          "business_profile": {
+            "annual_revenue": null,
+            "estimated_worker_count": null,
+            "mcc": null,
+            "minority_owned_business_designation": null,
+            "name": "Chuck Bartowski",
+            "product_description": "Chuck Bartowski",
+            "specified_commercial_transactions_act_url": null,
+            "support_address": null,
+            "support_email": null,
+            "support_phone": null,
+            "support_url": null,
+            "url": "https://vipul.gumroad.com/"
+          },
+          "business_type": "individual",
+          "capabilities": {
+            "card_payments": "inactive",
+            "transfers": "active"
+          },
+          "charges_enabled": false,
+          "company": {
+            "address": {
+              "city": "San Francisco",
+              "country": "US",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "94107",
+              "state": "California"
+            },
+            "directors_provided": true,
+            "executives_provided": true,
+            "name": null,
+            "owners_provided": true,
+            "phone": "+10000000000",
+            "tax_id_provided": false,
+            "verification": {
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              }
+            }
+          },
+          "controller": {
+            "fees": {
+              "payer": "application_custom"
+            },
+            "is_controller": true,
+            "losses": {
+              "payments": "application"
+            },
+            "requirement_collection": "application",
+            "stripe_dashboard": {
+              "type": "none"
+            },
+            "type": "application"
+          },
+          "country": "US",
+          "created": 1780559348,
+          "default_currency": "usd",
+          "details_submitted": true,
+          "email": null,
+          "external_accounts": {
+            "object": "list",
+            "data": [
+              {
+                "id": "ba_1TeW1WIddoWIJLDKeE1c0F7W",
+                "object": "bank_account",
+                "account": "acct_1TeW1WIddoWIJLDK",
+                "account_holder_name": null,
+                "account_holder_type": null,
+                "account_type": null,
+                "available_payout_methods": [
+                  "standard",
+                  "instant"
+                ],
+                "bank_name": "STRIPE TEST BANK",
+                "country": "US",
+                "currency": "usd",
+                "default_for_currency": true,
+                "fingerprint": "l0OxwqZbI4t8wVSU",
+                "future_requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "last4": "6789",
+                "metadata": {},
+                "requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "routing_number": "110000000",
+                "status": "new"
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/accounts/acct_1TeW1WIddoWIJLDK/external_accounts"
+          },
+          "future_requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [],
+            "disabled_reason": null,
+            "errors": [],
+            "eventually_due": [],
+            "past_due": [],
+            "pending_verification": []
+          },
+          "individual": {
+            "id": "person_1TeW1XIddoWIJLDK0UaS4yjV",
+            "object": "person",
+            "account": "acct_1TeW1WIddoWIJLDK",
+            "address": {
+              "city": "San Francisco",
+              "country": "US",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "94107",
+              "state": "California"
+            },
+            "created": 1780559347,
+            "dob": {
+              "day": 1,
+              "month": 1,
+              "year": 1901
+            },
+            "email": "edgarbcb7f28d_7@gumroad.com",
+            "first_name": "Chuck",
+            "future_requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "id_number_provided": true,
+            "last_name": "Bartowski",
+            "metadata": {},
+            "phone": "+10000000000",
+            "relationship": {
+              "authorizer": false,
+              "director": false,
+              "executive": false,
+              "legal_guardian": false,
+              "owner": false,
+              "percent_ownership": null,
+              "representative": true,
+              "title": null
+            },
+            "requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": [
+                "address.city",
+                "address.line1",
+                "address.postal_code",
+                "address.state",
+                "id_number",
+                "verification.document"
+              ]
+            },
+            "ssn_last_4_provided": true,
+            "verification": {
+              "additional_document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "details": null,
+              "details_code": null,
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "status": "pending"
+            }
+          },
+          "metadata": {
+            "bank_account_id": "qXyyQQfPkWq7Mt9c4ot2YA==",
+            "tos_agreement_id": "qXyyQQfPkWq7Mt9c4ot2YA==",
+            "user_compliance_info_id": "rUFoI3aoSiVffxRgqZLJBA==",
+            "user_id": "6"
+          },
+          "payouts_enabled": false,
+          "requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [
+              "business_profile.mcc"
+            ],
+            "disabled_reason": "requirements.past_due",
+            "errors": [],
+            "eventually_due": [
+              "business_profile.mcc"
+            ],
+            "past_due": [
+              "business_profile.mcc"
+            ],
+            "pending_verification": [
+              "individual.address.city",
+              "individual.address.line1",
+              "individual.address.postal_code",
+              "individual.address.state",
+              "individual.id_number",
+              "individual.verification.document"
+            ]
+          },
+          "settings": {
+            "bacs_debit_payments": {
+              "display_name": null,
+              "service_user_number": null
+            },
+            "branding": {
+              "icon": null,
+              "logo": null,
+              "primary_color": null,
+              "secondary_color": null
+            },
+            "card_issuing": {
+              "tos_acceptance": {
+                "date": null,
+                "ip": null
+              }
+            },
+            "card_payments": {
+              "decline_on": {
+                "avs_failure": false,
+                "cvc_failure": false
+              },
+              "statement_descriptor_prefix": "CHUCK BART",
+              "statement_descriptor_prefix_kana": null,
+              "statement_descriptor_prefix_kanji": null
+            },
+            "dashboard": {
+              "display_name": "Chuck Bartowski",
+              "timezone": "Etc/UTC"
+            },
+            "invoices": {
+              "default_account_tax_ids": null,
+              "hosted_payment_method_save": "offer"
+            },
+            "payments": {
+              "statement_descriptor": "CHUCK BARTOWSKI",
+              "statement_descriptor_kana": null,
+              "statement_descriptor_kanji": null
+            },
+            "payouts": {
+              "debit_negative_balances": true,
+              "schedule": {
+                "delay_days": 2,
+                "interval": "manual"
+              },
+              "statement_descriptor": null
+            },
+            "sepa_debit_payments": {}
+          },
+          "tos_acceptance": {
+            "date": 1780559346,
+            "ip": "54.234.242.13",
+            "user_agent": null
+          },
+          "type": "custom"
+        }
+  recorded_at: Thu, 04 Jun 2026 07:49:10 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/Settings_PaymentsController/GET_remediation/opens_a_Stripe_AccountLink_when_Stripe_still_has_future_requirements_eventually_due_volume-threshold_case_.yml
+++ b/spec/support/fixtures/vcr_cassettes/Settings_PaymentsController/GET_remediation/opens_a_Stripe_AccountLink_when_Stripe_still_has_future_requirements_eventually_due_volume-threshold_case_.yml
@@ -1,0 +1,473 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/accounts
+    body:
+      encoding: UTF-8
+      string: type=custom&requested_capabilities[0]=card_payments&requested_capabilities[1]=transfers&country=US&default_currency=usd&metadata[user_id]=6&metadata[tos_agreement_id]=oPvh5CbX29i7R1BayohpAQ%3D%3D&metadata[user_compliance_info_id]=iqZUuCAuAbqt3aLadEozuA%3D%3D&metadata[bank_account_id]=oPvh5CbX29i7R1BayohpAQ%3D%3D&tos_acceptance[date]=1780560440&tos_acceptance[ip]=54.234.242.13&business_type=individual&business_profile[name]=Chuck+Bartowski&business_profile[url]=https%3A%2F%2Fvipul.gumroad.com%2F&business_profile[product_description]=Chuck+Bartowski&individual[first_name]=Chuck&individual[last_name]=Bartowski&individual[email]=edgara283d891_7%40gumroad.com&individual[phone]=0000000000&individual[dob][day]=1&individual[dob][month]=1&individual[dob][year]=1901&individual[address][line1]=address_full_match&individual[address][city]=San+Francisco&individual[address][state]=California&individual[address][postal_code]=94107&individual[address][country]=US&individual[id_number]=000000000&bank_account[country]=US&bank_account[currency]=usd&bank_account[account_number]=000<STRONGBOX_GENERAL_PASSWORD>56789&bank_account[routing_number]=110000000&settings[payouts][schedule][interval]=manual&settings[payouts][debit_negative_balances]=true
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_BfrMgDBUI9kYpv","request_duration_ms":1}}'
+      Idempotency-Key:
+      - df829119-1821-409e-891c-8bb45a92309e
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Is-MacBook-Air.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56
+        PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132 arm64","hostname":"Is-MacBook-Air.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 04 Jun 2026 08:07:24 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '6843'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=S3rxa3T6yPWRslOfJZ7qspek4zQBsK7WPwJaLSh5KJb6F2TDKGqMGXou4nnqNhUmwTJw9ZtBBd01d2zV;
+        report-to csp
+      Idempotency-Key:
+      - df829119-1821-409e-891c-8bb45a92309e
+      Original-Request:
+      - req_RIYUKSBSAThf2W
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=S3rxa3T6yPWRslOfJZ7qspek4zQBsK7WPwJaLSh5KJb6F2TDKGqMGXou4nnqNhUmwTJw9ZtBBd01d2zV&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=S3rxa3T6yPWRslOfJZ7qspek4zQBsK7WPwJaLSh5KJb6F2TDKGqMGXou4nnqNhUmwTJw9ZtBBd01d2zV&t=1"
+      Request-Id:
+      - req_RIYUKSBSAThf2W
+      Stripe-Notice:
+      - '2 notices for this request: (1) You are using an outdated API version (2023-10-16).
+        We recommend upgrading to the latest API version, 2026-05-27.dahlia. See https://docs.stripe.com/upgrades
+        (2) We recommend building your integration using Accounts v2. See https://docs.stripe.com/api/v2/core/accounts'
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1TeWJAIPYiNwgqJ2",
+          "object": "account",
+          "business_profile": {
+            "annual_revenue": null,
+            "estimated_worker_count": null,
+            "mcc": null,
+            "minority_owned_business_designation": null,
+            "name": "Chuck Bartowski",
+            "product_description": "Chuck Bartowski",
+            "specified_commercial_transactions_act_url": null,
+            "support_address": null,
+            "support_email": null,
+            "support_phone": null,
+            "support_url": null,
+            "url": "https://vipul.gumroad.com/"
+          },
+          "business_type": "individual",
+          "capabilities": {
+            "card_payments": "inactive",
+            "transfers": "active"
+          },
+          "charges_enabled": false,
+          "company": {
+            "address": {
+              "city": "San Francisco",
+              "country": "US",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "94107",
+              "state": "California"
+            },
+            "directors_provided": true,
+            "executives_provided": true,
+            "name": null,
+            "owners_provided": true,
+            "phone": "+10000000000",
+            "tax_id_provided": false,
+            "verification": {
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              }
+            }
+          },
+          "controller": {
+            "fees": {
+              "payer": "application_custom"
+            },
+            "is_controller": true,
+            "losses": {
+              "payments": "application"
+            },
+            "requirement_collection": "application",
+            "stripe_dashboard": {
+              "type": "none"
+            },
+            "type": "application"
+          },
+          "country": "US",
+          "created": 1780560442,
+          "default_currency": "usd",
+          "details_submitted": true,
+          "email": null,
+          "external_accounts": {
+            "object": "list",
+            "data": [
+              {
+                "id": "ba_1TeWJAIPYiNwgqJ2PSgkX4dD",
+                "object": "bank_account",
+                "account": "acct_1TeWJAIPYiNwgqJ2",
+                "account_holder_name": null,
+                "account_holder_type": null,
+                "account_type": null,
+                "available_payout_methods": [
+                  "standard",
+                  "instant"
+                ],
+                "bank_name": "STRIPE TEST BANK",
+                "country": "US",
+                "currency": "usd",
+                "default_for_currency": true,
+                "fingerprint": "l0OxwqZbI4t8wVSU",
+                "future_requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "last4": "6789",
+                "metadata": {},
+                "requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "routing_number": "110000000",
+                "status": "new"
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/accounts/acct_1TeWJAIPYiNwgqJ2/external_accounts"
+          },
+          "future_requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [],
+            "disabled_reason": null,
+            "errors": [],
+            "eventually_due": [],
+            "past_due": [],
+            "pending_verification": []
+          },
+          "individual": {
+            "id": "person_1TeWJBIPYiNwgqJ2xb7iH1eG",
+            "object": "person",
+            "account": "acct_1TeWJAIPYiNwgqJ2",
+            "address": {
+              "city": "San Francisco",
+              "country": "US",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "94107",
+              "state": "California"
+            },
+            "created": 1780560441,
+            "dob": {
+              "day": 1,
+              "month": 1,
+              "year": 1901
+            },
+            "email": "edgara283d891_7@gumroad.com",
+            "first_name": "Chuck",
+            "future_requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "id_number_provided": true,
+            "last_name": "Bartowski",
+            "metadata": {},
+            "phone": "+10000000000",
+            "relationship": {
+              "authorizer": false,
+              "director": false,
+              "executive": false,
+              "legal_guardian": false,
+              "owner": false,
+              "percent_ownership": null,
+              "representative": true,
+              "title": null
+            },
+            "requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": [
+                "address.city",
+                "address.line1",
+                "address.postal_code",
+                "address.state",
+                "id_number",
+                "verification.document"
+              ]
+            },
+            "ssn_last_4_provided": true,
+            "verification": {
+              "additional_document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "details": null,
+              "details_code": null,
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "status": "pending"
+            }
+          },
+          "metadata": {
+            "bank_account_id": "oPvh5CbX29i7R1BayohpAQ==",
+            "tos_agreement_id": "oPvh5CbX29i7R1BayohpAQ==",
+            "user_compliance_info_id": "iqZUuCAuAbqt3aLadEozuA==",
+            "user_id": "6"
+          },
+          "payouts_enabled": false,
+          "requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [
+              "business_profile.mcc"
+            ],
+            "disabled_reason": "requirements.past_due",
+            "errors": [],
+            "eventually_due": [
+              "business_profile.mcc"
+            ],
+            "past_due": [
+              "business_profile.mcc"
+            ],
+            "pending_verification": [
+              "individual.address.city",
+              "individual.address.line1",
+              "individual.address.postal_code",
+              "individual.address.state",
+              "individual.id_number",
+              "individual.verification.document"
+            ]
+          },
+          "settings": {
+            "bacs_debit_payments": {
+              "display_name": null,
+              "service_user_number": null
+            },
+            "branding": {
+              "icon": null,
+              "logo": null,
+              "primary_color": null,
+              "secondary_color": null
+            },
+            "card_issuing": {
+              "tos_acceptance": {
+                "date": null,
+                "ip": null
+              }
+            },
+            "card_payments": {
+              "decline_on": {
+                "avs_failure": false,
+                "cvc_failure": false
+              },
+              "statement_descriptor_prefix": "CHUCK BART",
+              "statement_descriptor_prefix_kana": null,
+              "statement_descriptor_prefix_kanji": null
+            },
+            "dashboard": {
+              "display_name": "Chuck Bartowski",
+              "timezone": "Etc/UTC"
+            },
+            "invoices": {
+              "default_account_tax_ids": null,
+              "hosted_payment_method_save": "offer"
+            },
+            "payments": {
+              "statement_descriptor": "CHUCK BARTOWSKI",
+              "statement_descriptor_kana": null,
+              "statement_descriptor_kanji": null
+            },
+            "payouts": {
+              "debit_negative_balances": true,
+              "schedule": {
+                "delay_days": 2,
+                "interval": "manual"
+              },
+              "statement_descriptor": null
+            },
+            "sepa_debit_payments": {}
+          },
+          "tos_acceptance": {
+            "date": 1780560440,
+            "ip": "54.234.242.13",
+            "user_agent": null
+          },
+          "type": "custom"
+        }
+  recorded_at: Thu, 04 Jun 2026 08:07:24 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/account_links
+    body:
+      encoding: UTF-8
+      string: account=acct_1TeWJAIPYiNwgqJ2&refresh_url=http%3A%2F%2Fapp.test.gumroad.com%3A31337%2Fsettings%2Fpayments%2Fremediation&return_url=http%3A%2F%2Fapp.test.gumroad.com%3A31337%2Fsettings%2Fpayments%2Fverify_stripe_remediation&type=account_update
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_RIYUKSBSAThf2W","request_duration_ms":4477}}'
+      Idempotency-Key:
+      - e452b029-aa3e-4b88-a368-2266ad00a085
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Is-MacBook-Air.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56
+        PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132 arm64","hostname":"Is-MacBook-Air.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 04 Jun 2026 08:07:25 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '165'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=S3rxa3T6yPWRslOfJZ7qspek4zQBsK7WPwJaLSh5KJb6F2TDKGqMGXou4nnqNhUmwTJw9ZtBBd01d2zV;
+        report-to csp
+      Idempotency-Key:
+      - e452b029-aa3e-4b88-a368-2266ad00a085
+      Original-Request:
+      - req_oy2UOqFqdBmYCT
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=S3rxa3T6yPWRslOfJZ7qspek4zQBsK7WPwJaLSh5KJb6F2TDKGqMGXou4nnqNhUmwTJw9ZtBBd01d2zV&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=S3rxa3T6yPWRslOfJZ7qspek4zQBsK7WPwJaLSh5KJb6F2TDKGqMGXou4nnqNhUmwTJw9ZtBBd01d2zV&t=1"
+      Request-Id:
+      - req_oy2UOqFqdBmYCT
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-05-27.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "object": "account_link",
+          "created": 1780560445,
+          "expires_at": 1780560745,
+          "url": "https://connect.stripe.com/setup/c/acct_1TeWJAIPYiNwgqJ2/Jf4XIt3EaWsM"
+        }
+  recorded_at: Thu, 04 Jun 2026 08:07:25 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/Settings_PaymentsController/GET_remediation/opens_a_Stripe_AccountLink_when_local_has_no_pending_requests_but_Stripe_still_has_open_requirements.yml
+++ b/spec/support/fixtures/vcr_cassettes/Settings_PaymentsController/GET_remediation/opens_a_Stripe_AccountLink_when_local_has_no_pending_requests_but_Stripe_still_has_open_requirements.yml
@@ -1,0 +1,473 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/accounts
+    body:
+      encoding: UTF-8
+      string: type=custom&requested_capabilities[0]=card_payments&requested_capabilities[1]=transfers&country=US&default_currency=usd&metadata[user_id]=6&metadata[tos_agreement_id]=FYUj2xiXNPPT0J2o02Wr-g%3D%3D&metadata[user_compliance_info_id]=oPvh5CbX29i7R1BayohpAQ%3D%3D&metadata[bank_account_id]=FYUj2xiXNPPT0J2o02Wr-g%3D%3D&tos_acceptance[date]=1780559339&tos_acceptance[ip]=54.234.242.13&business_type=individual&business_profile[name]=Chuck+Bartowski&business_profile[url]=https%3A%2F%2Fvipul.gumroad.com%2F&business_profile[product_description]=Chuck+Bartowski&individual[first_name]=Chuck&individual[last_name]=Bartowski&individual[email]=edgar38eedf4e_5%40gumroad.com&individual[phone]=0000000000&individual[dob][day]=1&individual[dob][month]=1&individual[dob][year]=1901&individual[address][line1]=address_full_match&individual[address][city]=San+Francisco&individual[address][state]=California&individual[address][postal_code]=94107&individual[address][country]=US&individual[id_number]=000000000&bank_account[country]=US&bank_account[currency]=usd&bank_account[account_number]=000<STRONGBOX_GENERAL_PASSWORD>56789&bank_account[routing_number]=110000000&settings[payouts][schedule][interval]=manual&settings[payouts][debit_negative_balances]=true
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_Z1jiHPh4c57eFj","request_duration_ms":4679}}'
+      Idempotency-Key:
+      - a7ef620d-21ed-4f8f-be36-a56de23616f7
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Is-MacBook-Air.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56
+        PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132 arm64","hostname":"Is-MacBook-Air.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 04 Jun 2026 07:49:04 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '6843'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=yrUQU17aoKZkaHOEn2OnieOLkpi6oK7y36fusTX-njNA3v5tHV1xjsNggS9GPegF4r-RgJEyUxGMjYWE;
+        report-to csp
+      Idempotency-Key:
+      - a7ef620d-21ed-4f8f-be36-a56de23616f7
+      Original-Request:
+      - req_8HhffN4jwgg5vs
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=yrUQU17aoKZkaHOEn2OnieOLkpi6oK7y36fusTX-njNA3v5tHV1xjsNggS9GPegF4r-RgJEyUxGMjYWE&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=yrUQU17aoKZkaHOEn2OnieOLkpi6oK7y36fusTX-njNA3v5tHV1xjsNggS9GPegF4r-RgJEyUxGMjYWE&t=1"
+      Request-Id:
+      - req_8HhffN4jwgg5vs
+      Stripe-Notice:
+      - '2 notices for this request: (1) You are using an outdated API version (2023-10-16).
+        We recommend upgrading to the latest API version, 2026-05-27.dahlia. See https://docs.stripe.com/upgrades
+        (2) We recommend building your integration using Accounts v2. See https://docs.stripe.com/api/v2/core/accounts'
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1TeW1QEuR3hpMpeP",
+          "object": "account",
+          "business_profile": {
+            "annual_revenue": null,
+            "estimated_worker_count": null,
+            "mcc": null,
+            "minority_owned_business_designation": null,
+            "name": "Chuck Bartowski",
+            "product_description": "Chuck Bartowski",
+            "specified_commercial_transactions_act_url": null,
+            "support_address": null,
+            "support_email": null,
+            "support_phone": null,
+            "support_url": null,
+            "url": "https://vipul.gumroad.com/"
+          },
+          "business_type": "individual",
+          "capabilities": {
+            "card_payments": "inactive",
+            "transfers": "active"
+          },
+          "charges_enabled": false,
+          "company": {
+            "address": {
+              "city": "San Francisco",
+              "country": "US",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "94107",
+              "state": "California"
+            },
+            "directors_provided": true,
+            "executives_provided": true,
+            "name": null,
+            "owners_provided": true,
+            "phone": "+10000000000",
+            "tax_id_provided": false,
+            "verification": {
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              }
+            }
+          },
+          "controller": {
+            "fees": {
+              "payer": "application_custom"
+            },
+            "is_controller": true,
+            "losses": {
+              "payments": "application"
+            },
+            "requirement_collection": "application",
+            "stripe_dashboard": {
+              "type": "none"
+            },
+            "type": "application"
+          },
+          "country": "US",
+          "created": 1780559342,
+          "default_currency": "usd",
+          "details_submitted": true,
+          "email": null,
+          "external_accounts": {
+            "object": "list",
+            "data": [
+              {
+                "id": "ba_1TeW1QEuR3hpMpePX91xCHUL",
+                "object": "bank_account",
+                "account": "acct_1TeW1QEuR3hpMpeP",
+                "account_holder_name": null,
+                "account_holder_type": null,
+                "account_type": null,
+                "available_payout_methods": [
+                  "standard",
+                  "instant"
+                ],
+                "bank_name": "STRIPE TEST BANK",
+                "country": "US",
+                "currency": "usd",
+                "default_for_currency": true,
+                "fingerprint": "l0OxwqZbI4t8wVSU",
+                "future_requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "last4": "6789",
+                "metadata": {},
+                "requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "routing_number": "110000000",
+                "status": "new"
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/accounts/acct_1TeW1QEuR3hpMpeP/external_accounts"
+          },
+          "future_requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [],
+            "disabled_reason": null,
+            "errors": [],
+            "eventually_due": [],
+            "past_due": [],
+            "pending_verification": []
+          },
+          "individual": {
+            "id": "person_1TeW1QEuR3hpMpePxrfOHgbz",
+            "object": "person",
+            "account": "acct_1TeW1QEuR3hpMpeP",
+            "address": {
+              "city": "San Francisco",
+              "country": "US",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "94107",
+              "state": "California"
+            },
+            "created": 1780559341,
+            "dob": {
+              "day": 1,
+              "month": 1,
+              "year": 1901
+            },
+            "email": "edgar38eedf4e_5@gumroad.com",
+            "first_name": "Chuck",
+            "future_requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "id_number_provided": true,
+            "last_name": "Bartowski",
+            "metadata": {},
+            "phone": "+10000000000",
+            "relationship": {
+              "authorizer": false,
+              "director": false,
+              "executive": false,
+              "legal_guardian": false,
+              "owner": false,
+              "percent_ownership": null,
+              "representative": true,
+              "title": null
+            },
+            "requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": [
+                "address.city",
+                "address.line1",
+                "address.postal_code",
+                "address.state",
+                "id_number",
+                "verification.document"
+              ]
+            },
+            "ssn_last_4_provided": true,
+            "verification": {
+              "additional_document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "details": null,
+              "details_code": null,
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "status": "pending"
+            }
+          },
+          "metadata": {
+            "bank_account_id": "FYUj2xiXNPPT0J2o02Wr-g==",
+            "tos_agreement_id": "FYUj2xiXNPPT0J2o02Wr-g==",
+            "user_compliance_info_id": "oPvh5CbX29i7R1BayohpAQ==",
+            "user_id": "6"
+          },
+          "payouts_enabled": false,
+          "requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [
+              "business_profile.mcc"
+            ],
+            "disabled_reason": "requirements.past_due",
+            "errors": [],
+            "eventually_due": [
+              "business_profile.mcc"
+            ],
+            "past_due": [
+              "business_profile.mcc"
+            ],
+            "pending_verification": [
+              "individual.address.city",
+              "individual.address.line1",
+              "individual.address.postal_code",
+              "individual.address.state",
+              "individual.id_number",
+              "individual.verification.document"
+            ]
+          },
+          "settings": {
+            "bacs_debit_payments": {
+              "display_name": null,
+              "service_user_number": null
+            },
+            "branding": {
+              "icon": null,
+              "logo": null,
+              "primary_color": null,
+              "secondary_color": null
+            },
+            "card_issuing": {
+              "tos_acceptance": {
+                "date": null,
+                "ip": null
+              }
+            },
+            "card_payments": {
+              "decline_on": {
+                "avs_failure": false,
+                "cvc_failure": false
+              },
+              "statement_descriptor_prefix": "CHUCK BART",
+              "statement_descriptor_prefix_kana": null,
+              "statement_descriptor_prefix_kanji": null
+            },
+            "dashboard": {
+              "display_name": "Chuck Bartowski",
+              "timezone": "Etc/UTC"
+            },
+            "invoices": {
+              "default_account_tax_ids": null,
+              "hosted_payment_method_save": "offer"
+            },
+            "payments": {
+              "statement_descriptor": "CHUCK BARTOWSKI",
+              "statement_descriptor_kana": null,
+              "statement_descriptor_kanji": null
+            },
+            "payouts": {
+              "debit_negative_balances": true,
+              "schedule": {
+                "delay_days": 2,
+                "interval": "manual"
+              },
+              "statement_descriptor": null
+            },
+            "sepa_debit_payments": {}
+          },
+          "tos_acceptance": {
+            "date": 1780559339,
+            "ip": "54.234.242.13",
+            "user_agent": null
+          },
+          "type": "custom"
+        }
+  recorded_at: Thu, 04 Jun 2026 07:49:04 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/account_links
+    body:
+      encoding: UTF-8
+      string: account=acct_1TeW1QEuR3hpMpeP&refresh_url=http%3A%2F%2Fapp.test.gumroad.com%3A31337%2Fsettings%2Fpayments%2Fremediation&return_url=http%3A%2F%2Fapp.test.gumroad.com%3A31337%2Fsettings%2Fpayments%2Fverify_stripe_remediation&type=account_update
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_8HhffN4jwgg5vs","request_duration_ms":4922}}'
+      Idempotency-Key:
+      - c90dbc87-9c35-4efc-a31d-855b4936457a
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Is-MacBook-Air.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56
+        PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132 arm64","hostname":"Is-MacBook-Air.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 04 Jun 2026 07:49:05 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '165'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=yrUQU17aoKZkaHOEn2OnieOLkpi6oK7y36fusTX-njNA3v5tHV1xjsNggS9GPegF4r-RgJEyUxGMjYWE;
+        report-to csp
+      Idempotency-Key:
+      - c90dbc87-9c35-4efc-a31d-855b4936457a
+      Original-Request:
+      - req_BfrMgDBUI9kYpv
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=yrUQU17aoKZkaHOEn2OnieOLkpi6oK7y36fusTX-njNA3v5tHV1xjsNggS9GPegF4r-RgJEyUxGMjYWE&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=yrUQU17aoKZkaHOEn2OnieOLkpi6oK7y36fusTX-njNA3v5tHV1xjsNggS9GPegF4r-RgJEyUxGMjYWE&t=1"
+      Request-Id:
+      - req_BfrMgDBUI9kYpv
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-05-27.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "object": "account_link",
+          "created": 1780559345,
+          "expires_at": 1780559645,
+          "url": "https://connect.stripe.com/setup/c/acct_1TeW1QEuR3hpMpeP/ukP1xPlexqN4"
+        }
+  recorded_at: Thu, 04 Jun 2026 07:49:05 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/Settings_PaymentsController/GET_verify_stripe_remediation/does_not_show_the_Thanks_notice_when_Stripe_still_lists_eventually_due_requirements.yml
+++ b/spec/support/fixtures/vcr_cassettes/Settings_PaymentsController/GET_verify_stripe_remediation/does_not_show_the_Thanks_notice_when_Stripe_still_lists_eventually_due_requirements.yml
@@ -1,0 +1,375 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/accounts
+    body:
+      encoding: UTF-8
+      string: type=custom&requested_capabilities[0]=card_payments&requested_capabilities[1]=transfers&country=US&default_currency=usd&metadata[user_id]=6&metadata[tos_agreement_id]=_8BSwwFdLk9hVbpOK_eCpQ%3D%3D&metadata[user_compliance_info_id]=VzIOgvSI0peKdgd-vSra4A%3D%3D&metadata[bank_account_id]=_8BSwwFdLk9hVbpOK_eCpQ%3D%3D&tos_acceptance[date]=1780563443&tos_acceptance[ip]=54.234.242.13&business_type=individual&business_profile[name]=Chuck+Bartowski&business_profile[url]=https%3A%2F%2Fvipul.gumroad.com%2F&business_profile[product_description]=Chuck+Bartowski&individual[first_name]=Chuck&individual[last_name]=Bartowski&individual[email]=edgarb5e83f51_3%40gumroad.com&individual[phone]=0000000000&individual[dob][day]=1&individual[dob][month]=1&individual[dob][year]=1901&individual[address][line1]=address_full_match&individual[address][city]=San+Francisco&individual[address][state]=California&individual[address][postal_code]=94107&individual[address][country]=US&individual[id_number]=000000000&bank_account[country]=US&bank_account[currency]=usd&bank_account[account_number]=000<STRONGBOX_GENERAL_PASSWORD>56789&bank_account[routing_number]=110000000&settings[payouts][schedule][interval]=manual&settings[payouts][debit_negative_balances]=true
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_GLRopbzsZy1kFn","request_duration_ms":1}}'
+      Idempotency-Key:
+      - 5ebe378d-f51a-4674-8ea1-e82c01f08c43
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Is-MacBook-Air.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56
+        PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132 arm64","hostname":"Is-MacBook-Air.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 04 Jun 2026 08:57:27 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '6843'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=DQOjZ7y6GdYS5t7ikF_oxJFCC2JqM3dE0WcTfphTtHHe6Qer_pYjlZlTYxH-Fh-VoZ_4SmVueQoc1AM8;
+        report-to csp
+      Idempotency-Key:
+      - 5ebe378d-f51a-4674-8ea1-e82c01f08c43
+      Original-Request:
+      - req_Ooeag41UKhibvF
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=DQOjZ7y6GdYS5t7ikF_oxJFCC2JqM3dE0WcTfphTtHHe6Qer_pYjlZlTYxH-Fh-VoZ_4SmVueQoc1AM8&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=DQOjZ7y6GdYS5t7ikF_oxJFCC2JqM3dE0WcTfphTtHHe6Qer_pYjlZlTYxH-Fh-VoZ_4SmVueQoc1AM8&t=1"
+      Request-Id:
+      - req_Ooeag41UKhibvF
+      Stripe-Notice:
+      - '2 notices for this request: (1) You are using an outdated API version (2023-10-16).
+        We recommend upgrading to the latest API version, 2026-05-27.dahlia. See https://docs.stripe.com/upgrades
+        (2) We recommend building your integration using Accounts v2. See https://docs.stripe.com/api/v2/core/accounts'
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1TeX5cIHlwjBPqnQ",
+          "object": "account",
+          "business_profile": {
+            "annual_revenue": null,
+            "estimated_worker_count": null,
+            "mcc": null,
+            "minority_owned_business_designation": null,
+            "name": "Chuck Bartowski",
+            "product_description": "Chuck Bartowski",
+            "specified_commercial_transactions_act_url": null,
+            "support_address": null,
+            "support_email": null,
+            "support_phone": null,
+            "support_url": null,
+            "url": "https://vipul.gumroad.com/"
+          },
+          "business_type": "individual",
+          "capabilities": {
+            "card_payments": "inactive",
+            "transfers": "active"
+          },
+          "charges_enabled": false,
+          "company": {
+            "address": {
+              "city": "San Francisco",
+              "country": "US",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "94107",
+              "state": "California"
+            },
+            "directors_provided": true,
+            "executives_provided": true,
+            "name": null,
+            "owners_provided": true,
+            "phone": "+10000000000",
+            "tax_id_provided": false,
+            "verification": {
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              }
+            }
+          },
+          "controller": {
+            "fees": {
+              "payer": "application_custom"
+            },
+            "is_controller": true,
+            "losses": {
+              "payments": "application"
+            },
+            "requirement_collection": "application",
+            "stripe_dashboard": {
+              "type": "none"
+            },
+            "type": "application"
+          },
+          "country": "US",
+          "created": 1780563445,
+          "default_currency": "usd",
+          "details_submitted": true,
+          "email": null,
+          "external_accounts": {
+            "object": "list",
+            "data": [
+              {
+                "id": "ba_1TeX5cIHlwjBPqnQKyeqHUHF",
+                "object": "bank_account",
+                "account": "acct_1TeX5cIHlwjBPqnQ",
+                "account_holder_name": null,
+                "account_holder_type": null,
+                "account_type": null,
+                "available_payout_methods": [
+                  "standard",
+                  "instant"
+                ],
+                "bank_name": "STRIPE TEST BANK",
+                "country": "US",
+                "currency": "usd",
+                "default_for_currency": true,
+                "fingerprint": "l0OxwqZbI4t8wVSU",
+                "future_requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "last4": "6789",
+                "metadata": {},
+                "requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "routing_number": "110000000",
+                "status": "new"
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/accounts/acct_1TeX5cIHlwjBPqnQ/external_accounts"
+          },
+          "future_requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [],
+            "disabled_reason": null,
+            "errors": [],
+            "eventually_due": [],
+            "past_due": [],
+            "pending_verification": []
+          },
+          "individual": {
+            "id": "person_1TeX5cIHlwjBPqnQ7igDQal3",
+            "object": "person",
+            "account": "acct_1TeX5cIHlwjBPqnQ",
+            "address": {
+              "city": "San Francisco",
+              "country": "US",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "94107",
+              "state": "California"
+            },
+            "created": 1780563444,
+            "dob": {
+              "day": 1,
+              "month": 1,
+              "year": 1901
+            },
+            "email": "edgarb5e83f51_3@gumroad.com",
+            "first_name": "Chuck",
+            "future_requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "id_number_provided": true,
+            "last_name": "Bartowski",
+            "metadata": {},
+            "phone": "+10000000000",
+            "relationship": {
+              "authorizer": false,
+              "director": false,
+              "executive": false,
+              "legal_guardian": false,
+              "owner": false,
+              "percent_ownership": null,
+              "representative": true,
+              "title": null
+            },
+            "requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": [
+                "address.city",
+                "address.line1",
+                "address.postal_code",
+                "address.state",
+                "id_number",
+                "verification.document"
+              ]
+            },
+            "ssn_last_4_provided": true,
+            "verification": {
+              "additional_document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "details": null,
+              "details_code": null,
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "status": "pending"
+            }
+          },
+          "metadata": {
+            "bank_account_id": "_8BSwwFdLk9hVbpOK_eCpQ==",
+            "tos_agreement_id": "_8BSwwFdLk9hVbpOK_eCpQ==",
+            "user_compliance_info_id": "VzIOgvSI0peKdgd-vSra4A==",
+            "user_id": "6"
+          },
+          "payouts_enabled": false,
+          "requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [
+              "business_profile.mcc"
+            ],
+            "disabled_reason": "requirements.past_due",
+            "errors": [],
+            "eventually_due": [
+              "business_profile.mcc"
+            ],
+            "past_due": [
+              "business_profile.mcc"
+            ],
+            "pending_verification": [
+              "individual.address.city",
+              "individual.address.line1",
+              "individual.address.postal_code",
+              "individual.address.state",
+              "individual.id_number",
+              "individual.verification.document"
+            ]
+          },
+          "settings": {
+            "bacs_debit_payments": {
+              "display_name": null,
+              "service_user_number": null
+            },
+            "branding": {
+              "icon": null,
+              "logo": null,
+              "primary_color": null,
+              "secondary_color": null
+            },
+            "card_issuing": {
+              "tos_acceptance": {
+                "date": null,
+                "ip": null
+              }
+            },
+            "card_payments": {
+              "decline_on": {
+                "avs_failure": false,
+                "cvc_failure": false
+              },
+              "statement_descriptor_prefix": "CHUCK BART",
+              "statement_descriptor_prefix_kana": null,
+              "statement_descriptor_prefix_kanji": null
+            },
+            "dashboard": {
+              "display_name": "Chuck Bartowski",
+              "timezone": "Etc/UTC"
+            },
+            "invoices": {
+              "default_account_tax_ids": null,
+              "hosted_payment_method_save": "offer"
+            },
+            "payments": {
+              "statement_descriptor": "CHUCK BARTOWSKI",
+              "statement_descriptor_kana": null,
+              "statement_descriptor_kanji": null
+            },
+            "payouts": {
+              "debit_negative_balances": true,
+              "schedule": {
+                "delay_days": 2,
+                "interval": "manual"
+              },
+              "statement_descriptor": null
+            },
+            "sepa_debit_payments": {}
+          },
+          "tos_acceptance": {
+            "date": 1780563443,
+            "ip": "54.234.242.13",
+            "user_agent": null
+          },
+          "type": "custom"
+        }
+  recorded_at: Thu, 04 Jun 2026 08:57:27 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/Settings_PaymentsController/GET_verify_stripe_remediation/does_not_show_the_Thanks_notice_when_Stripe_still_lists_future_requirements_eventually_due.yml
+++ b/spec/support/fixtures/vcr_cassettes/Settings_PaymentsController/GET_verify_stripe_remediation/does_not_show_the_Thanks_notice_when_Stripe_still_lists_future_requirements_eventually_due.yml
@@ -1,0 +1,375 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/accounts
+    body:
+      encoding: UTF-8
+      string: type=custom&requested_capabilities[0]=card_payments&requested_capabilities[1]=transfers&country=US&default_currency=usd&metadata[user_id]=6&metadata[tos_agreement_id]=exAa43cnKGvc0NgwMnbxiA%3D%3D&metadata[user_compliance_info_id]=uxmeOEZHZD70RyDsPF4kiw%3D%3D&metadata[bank_account_id]=exAa43cnKGvc0NgwMnbxiA%3D%3D&tos_acceptance[date]=1780563448&tos_acceptance[ip]=54.234.242.13&business_type=individual&business_profile[name]=Chuck+Bartowski&business_profile[url]=https%3A%2F%2Fvipul.gumroad.com%2F&business_profile[product_description]=Chuck+Bartowski&individual[first_name]=Chuck&individual[last_name]=Bartowski&individual[email]=edgar66dfaf75_5%40gumroad.com&individual[phone]=0000000000&individual[dob][day]=1&individual[dob][month]=1&individual[dob][year]=1901&individual[address][line1]=address_full_match&individual[address][city]=San+Francisco&individual[address][state]=California&individual[address][postal_code]=94107&individual[address][country]=US&individual[id_number]=000000000&bank_account[country]=US&bank_account[currency]=usd&bank_account[account_number]=000<STRONGBOX_GENERAL_PASSWORD>56789&bank_account[routing_number]=110000000&settings[payouts][schedule][interval]=manual&settings[payouts][debit_negative_balances]=true
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_Ooeag41UKhibvF","request_duration_ms":3613}}'
+      Idempotency-Key:
+      - d8b5a2e9-a0a0-4a32-a898-c0ff4fbe743e
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Is-MacBook-Air.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56
+        PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132 arm64","hostname":"Is-MacBook-Air.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 04 Jun 2026 08:57:33 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '6843'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=DQOjZ7y6GdYS5t7ikF_oxJFCC2JqM3dE0WcTfphTtHHe6Qer_pYjlZlTYxH-Fh-VoZ_4SmVueQoc1AM8;
+        report-to csp
+      Idempotency-Key:
+      - d8b5a2e9-a0a0-4a32-a898-c0ff4fbe743e
+      Original-Request:
+      - req_HgXhhXSX8Lwk8M
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=DQOjZ7y6GdYS5t7ikF_oxJFCC2JqM3dE0WcTfphTtHHe6Qer_pYjlZlTYxH-Fh-VoZ_4SmVueQoc1AM8&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=DQOjZ7y6GdYS5t7ikF_oxJFCC2JqM3dE0WcTfphTtHHe6Qer_pYjlZlTYxH-Fh-VoZ_4SmVueQoc1AM8&t=1"
+      Request-Id:
+      - req_HgXhhXSX8Lwk8M
+      Stripe-Notice:
+      - '2 notices for this request: (1) You are using an outdated API version (2023-10-16).
+        We recommend upgrading to the latest API version, 2026-05-27.dahlia. See https://docs.stripe.com/upgrades
+        (2) We recommend building your integration using Accounts v2. See https://docs.stripe.com/api/v2/core/accounts'
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1TeX5hEyvi3mTR6L",
+          "object": "account",
+          "business_profile": {
+            "annual_revenue": null,
+            "estimated_worker_count": null,
+            "mcc": null,
+            "minority_owned_business_designation": null,
+            "name": "Chuck Bartowski",
+            "product_description": "Chuck Bartowski",
+            "specified_commercial_transactions_act_url": null,
+            "support_address": null,
+            "support_email": null,
+            "support_phone": null,
+            "support_url": null,
+            "url": "https://vipul.gumroad.com/"
+          },
+          "business_type": "individual",
+          "capabilities": {
+            "card_payments": "inactive",
+            "transfers": "active"
+          },
+          "charges_enabled": false,
+          "company": {
+            "address": {
+              "city": "San Francisco",
+              "country": "US",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "94107",
+              "state": "California"
+            },
+            "directors_provided": true,
+            "executives_provided": true,
+            "name": null,
+            "owners_provided": true,
+            "phone": "+10000000000",
+            "tax_id_provided": false,
+            "verification": {
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              }
+            }
+          },
+          "controller": {
+            "fees": {
+              "payer": "application_custom"
+            },
+            "is_controller": true,
+            "losses": {
+              "payments": "application"
+            },
+            "requirement_collection": "application",
+            "stripe_dashboard": {
+              "type": "none"
+            },
+            "type": "application"
+          },
+          "country": "US",
+          "created": 1780563451,
+          "default_currency": "usd",
+          "details_submitted": true,
+          "email": null,
+          "external_accounts": {
+            "object": "list",
+            "data": [
+              {
+                "id": "ba_1TeX5hEyvi3mTR6Lu8txDNqo",
+                "object": "bank_account",
+                "account": "acct_1TeX5hEyvi3mTR6L",
+                "account_holder_name": null,
+                "account_holder_type": null,
+                "account_type": null,
+                "available_payout_methods": [
+                  "standard",
+                  "instant"
+                ],
+                "bank_name": "STRIPE TEST BANK",
+                "country": "US",
+                "currency": "usd",
+                "default_for_currency": true,
+                "fingerprint": "l0OxwqZbI4t8wVSU",
+                "future_requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "last4": "6789",
+                "metadata": {},
+                "requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "routing_number": "110000000",
+                "status": "new"
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/accounts/acct_1TeX5hEyvi3mTR6L/external_accounts"
+          },
+          "future_requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [],
+            "disabled_reason": null,
+            "errors": [],
+            "eventually_due": [],
+            "past_due": [],
+            "pending_verification": []
+          },
+          "individual": {
+            "id": "person_1TeX5hEyvi3mTR6LWaQG3Qre",
+            "object": "person",
+            "account": "acct_1TeX5hEyvi3mTR6L",
+            "address": {
+              "city": "San Francisco",
+              "country": "US",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "94107",
+              "state": "California"
+            },
+            "created": 1780563450,
+            "dob": {
+              "day": 1,
+              "month": 1,
+              "year": 1901
+            },
+            "email": "edgar66dfaf75_5@gumroad.com",
+            "first_name": "Chuck",
+            "future_requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "id_number_provided": true,
+            "last_name": "Bartowski",
+            "metadata": {},
+            "phone": "+10000000000",
+            "relationship": {
+              "authorizer": false,
+              "director": false,
+              "executive": false,
+              "legal_guardian": false,
+              "owner": false,
+              "percent_ownership": null,
+              "representative": true,
+              "title": null
+            },
+            "requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": [
+                "address.city",
+                "address.line1",
+                "address.postal_code",
+                "address.state",
+                "id_number",
+                "verification.document"
+              ]
+            },
+            "ssn_last_4_provided": true,
+            "verification": {
+              "additional_document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "details": null,
+              "details_code": null,
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "status": "pending"
+            }
+          },
+          "metadata": {
+            "bank_account_id": "exAa43cnKGvc0NgwMnbxiA==",
+            "tos_agreement_id": "exAa43cnKGvc0NgwMnbxiA==",
+            "user_compliance_info_id": "uxmeOEZHZD70RyDsPF4kiw==",
+            "user_id": "6"
+          },
+          "payouts_enabled": false,
+          "requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [
+              "business_profile.mcc"
+            ],
+            "disabled_reason": "requirements.past_due",
+            "errors": [],
+            "eventually_due": [
+              "business_profile.mcc"
+            ],
+            "past_due": [
+              "business_profile.mcc"
+            ],
+            "pending_verification": [
+              "individual.address.city",
+              "individual.address.line1",
+              "individual.address.postal_code",
+              "individual.address.state",
+              "individual.id_number",
+              "individual.verification.document"
+            ]
+          },
+          "settings": {
+            "bacs_debit_payments": {
+              "display_name": null,
+              "service_user_number": null
+            },
+            "branding": {
+              "icon": null,
+              "logo": null,
+              "primary_color": null,
+              "secondary_color": null
+            },
+            "card_issuing": {
+              "tos_acceptance": {
+                "date": null,
+                "ip": null
+              }
+            },
+            "card_payments": {
+              "decline_on": {
+                "avs_failure": false,
+                "cvc_failure": false
+              },
+              "statement_descriptor_prefix": "CHUCK BART",
+              "statement_descriptor_prefix_kana": null,
+              "statement_descriptor_prefix_kanji": null
+            },
+            "dashboard": {
+              "display_name": "Chuck Bartowski",
+              "timezone": "Etc/UTC"
+            },
+            "invoices": {
+              "default_account_tax_ids": null,
+              "hosted_payment_method_save": "offer"
+            },
+            "payments": {
+              "statement_descriptor": "CHUCK BARTOWSKI",
+              "statement_descriptor_kana": null,
+              "statement_descriptor_kanji": null
+            },
+            "payouts": {
+              "debit_negative_balances": true,
+              "schedule": {
+                "delay_days": 2,
+                "interval": "manual"
+              },
+              "statement_descriptor": null
+            },
+            "sepa_debit_payments": {}
+          },
+          "tos_acceptance": {
+            "date": 1780563448,
+            "ip": "54.234.242.13",
+            "user_agent": null
+          },
+          "type": "custom"
+        }
+  recorded_at: Thu, 04 Jun 2026 08:57:33 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
## What

Closes the silent dead-end where sellers received the "We need more information from you" email but landed on a blank Payment Settings page with no upload control.

- **Email button now routes through remediation.** `more_kyc_needed.html.erb` links to `remediation_settings_payments_url` (matches `stripe_remediation.html.erb`). The button always goes through the controller that decides whether to open Stripe's hosted upload or show the "Thanks!" message.
- **Remediation controller trusts Stripe when local state disagrees.** `Settings::PaymentsController#remediation` no longer short-circuits to "Thanks!" the moment `user_compliance_info_requests.requested` is empty. It first checks the live Stripe account — if any of `requirements.currently_due | past_due | eventually_due` or `future_requirements.currently_due | past_due | eventually_due` has anything, it opens an AccountLink. On Stripe lookup failure we fall through to the conservative "Thanks!" path.
- **Verify return path is consistent.** `verify_stripe_remediation` now only flashes "Thanks! You're all set." when *every* requirements bucket on Stripe is empty; the mark-provided behavior for `currently_due`/`past_due` is unchanged so clearing those still wipes UI banners promptly.
- **Skip non-actionable emails.** `StripeMerchantAccountManager#handle_stripe_info_requirements` skips queuing `more_kyc_needed` when every new request maps only to `requirements["eventually_due"]` and the current deadline is more than 30 days away (the volume-threshold soft requirement Stripe issues on US accounts before they hit \$500k / equivalent). Pre-existing outstanding non-soft fields still cause the email to fire. The request is still recorded; we just stop emailing about it until Stripe actually moves it to `currently_due` / `past_due`.

## Why

[Private issue: antiwork/gumroad-private#469](https://github.com/antiwork/gumroad-private/issues/469) — reproduced sequence:

1. Stripe webhook 1: an identity-document field appears in `requirements["currently_due"]` → we create a `UserComplianceInfoRequest` and queue `more_kyc_needed`.
2. Webhook 2 (~60s later): Stripe re-categorises the same field into `future_requirements["eventually_due"]` (the volume-threshold variant). Our `stripe_fields_needed` excludes that bucket, so the still-pending request gets marked `provided`.
3. The seller clicks "Provide your information" — the button hit `settings_payments_url`. `SettingsPresenter#account_status_details` gates both `compliance_actions` and `needs_id_upload` on `user_compliance_info_requests.requested.exists?`. With the request now `provided`, the section is empty — blank page, no banner, no upload control, no toast.

Stripe's account still has the requirement open in `future_requirements["eventually_due"]` (volume-threshold). A Stripe hosted Account Link would surface the upload UI today — the only thing blocking the seller is our local gate.

`stripe_remediation` (the risk-requirement email) already routes through `remediation_settings_payments_url`, so the dead-end was specific to `more_kyc_needed`. This PR brings them in line and gives the remediation endpoint a Stripe-source-of-truth fallback so the next case like this one resolves itself.

---

Generated with Claude Opus 4.7 (1M context).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes seller-facing payout/KYC email timing and remediation redirects against live Stripe state; misclassification of soft vs hard requirements could delay needed emails or show premature “all set” messages.
> 
> **Overview**
> Fixes a **Stripe KYC dead-end** where sellers got `more_kyc_needed` but landed on an empty Payment Settings page after local compliance requests were marked provided while Stripe still had open requirements (e.g. volume-threshold fields in `future_requirements.eventually_due`).
> 
> The **`more_kyc_needed`** email CTA now points at **`remediation_settings_payments_url`** so it goes through the same hosted Account Link flow as other remediation mail. **`Settings::PaymentsController#remediation`** no longer bails out when there are no local `requested` compliance rows; it **retrieves the live Stripe account** and opens an Account Link if any of `requirements` / `future_requirements` due lists are non-empty (with a safe “Thanks!” fallback if Stripe lookup fails). **`verify_stripe_remediation`** only flashes success when **every** tracked requirement bucket on Stripe is empty, while still clearing local requests when `currently_due` / `past_due` are clear.
> 
> **`StripeMerchantAccountManager`** still records soft `eventually_due`-only needs but **skips queuing `more_kyc_needed`** when all outstanding fields are only in `requirements.eventually_due` (not `currently_due` / `past_due`) and the deadline is more than **30 days** out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfa6481194dc0da49a8e3be3deaaa39e24a39133. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->