### PR TITLE
Fix restart guard so seller-cancelled subs can re-subscribe at checkout

### DIFF
--- a/app/javascript/data/subscription.ts
+++ b/app/javascript/data/subscription.ts
@@ -34,7 +34,7 @@ export const updateSubscription = async (
   data: UpdateSubscriptionPayload,
 ): Promise<
   | { type: "done"; message: string; next: string | null }
-  | { type: "error"; message: string }
+  | { type: "error"; message: string; restartAtCheckoutUrl?: string }
   | {
       type: "requires_card_action";
       client_secret: string;
@@ -67,12 +67,18 @@ export const updateSubscription = async (
         purchase: responseData.purchase,
       };
     }
-    return { type: "error", message: responseData.error_message };
+    return {
+      type: "error",
+      message: responseData.error_message,
+      ...("restart_at_checkout_url" in responseData && responseData.restart_at_checkout_url
+        ? { restartAtCheckoutUrl: responseData.restart_at_checkout_url }
+        : {}),
+    };
   }
   return { type: "error", message: "Sorry, something went wrong." };
 };
 type UpdateSubscriptionResponse =
-  | { success: false; error_message: string }
+  | { success: false; error_message: string; restart_at_checkout_url?: string }
   | { success: true; success_message: string; next?: string | null }
   | {
       success: true;

--- a/app/javascript/pages/Subscriptions/Manage.tsx
+++ b/app/javascript/pages/Subscriptions/Manage.tsx
@@ -288,6 +288,13 @@ export default function SubscriptionsManage() {
           router.reload();
         }
       });
+    } else if (result.restartAtCheckoutUrl) {
+      const escape = (s: string) => s.replace(/[&<>"']/gu, (c) => `&#${c.charCodeAt(0)};`);
+      showAlert(
+        `${escape(result.message)} <a href="${escape(result.restartAtCheckoutUrl)}">Subscribe from the product page</a>`,
+        "error",
+        { html: true },
+      );
     } else {
       showAlert(result.message, "error", { html: true });
     }

--- a/app/services/subscription/updater_service.rb
+++ b/app/services/subscription/updater_service.rb
@@ -42,8 +42,13 @@ class Subscription::UpdaterService
     self.calculate_upgrade_cost_as_of = Time.current.end_of_day
     self.prorated_discount_price_cents = subscription.prorated_discount_price_cents(calculate_as_of: calculate_upgrade_cost_as_of)
 
-    if is_resubscribing && (subscription.cancelled_by_seller? || product.deleted?)
-      return { success: false, error_message: "This subscription cannot be restarted." }
+    if is_resubscribing && product.deleted?
+      return { success: false, error_message: "This product is no longer available, so this membership can't be restarted." }
+    end
+
+    if is_resubscribing && subscription.cancelled_by_seller? && use_existing_card?
+      checkout_link = "<a href=\"#{ERB::Util.html_escape(product.long_url)}\">subscribe again from the product page</a>"
+      return { success: false, error_message: "This membership was cancelled by the creator. To continue, please #{checkout_link}." }
     end
 
     if is_resubscribing && subscription.is_installment_plan? && subscription.charges_completed?

--- a/app/services/subscription/updater_service.rb
+++ b/app/services/subscription/updater_service.rb
@@ -47,8 +47,11 @@ class Subscription::UpdaterService
     end
 
     if is_resubscribing && subscription.cancelled_by_seller? && use_existing_card?
-      checkout_link = "<a href=\"#{ERB::Util.html_escape(product.long_url)}\">subscribe again from the product page</a>"
-      return { success: false, error_message: "This membership was cancelled by the creator. To continue, please #{checkout_link}." }
+      return {
+        success: false,
+        error_message: "This membership was cancelled by the creator. To continue, please subscribe again from the product page.",
+        restart_at_checkout_url: product.long_url,
+      }
     end
 
     if is_resubscribing && subscription.is_installment_plan? && subscription.charges_completed?

--- a/spec/services/subscription/restart_at_checkout_service_spec.rb
+++ b/spec/services/subscription/restart_at_checkout_service_spec.rb
@@ -530,7 +530,7 @@ describe Subscription::RestartAtCheckoutService do
           )
         end
 
-        it "returns an error" do
+        it "returns a seller-cancelled error when no new payment method is being attached" do
           result = described_class.new(
             subscription: subscription,
             product: product,
@@ -539,7 +539,7 @@ describe Subscription::RestartAtCheckoutService do
           ).perform
 
           expect(result[:success]).to be false
-          expect(result[:error_message]).to eq("This subscription cannot be restarted.")
+          expect(result[:error_message]).to eq("This membership was cancelled by the creator. To continue, please subscribe again from the product page.")
         end
       end
 
@@ -559,7 +559,7 @@ describe Subscription::RestartAtCheckoutService do
           product.update!(deleted_at: 1.hour.ago)
         end
 
-        it "returns an error" do
+        it "returns a product-unavailable error" do
           result = described_class.new(
             subscription: subscription,
             product: product,
@@ -568,7 +568,7 @@ describe Subscription::RestartAtCheckoutService do
           ).perform
 
           expect(result[:success]).to be false
-          expect(result[:error_message]).to eq("This subscription cannot be restarted.")
+          expect(result[:error_message]).to eq("This product is no longer available, so this membership can't be restarted.")
         end
       end
     end

--- a/spec/services/subscription/updater_service_spec.rb
+++ b/spec/services/subscription/updater_service_spec.rb
@@ -590,7 +590,7 @@ describe Subscription::UpdaterService, :vcr do
         end
 
         context "when the membership was cancelled by the creator" do
-          it "blocks restarting with the existing card and surfaces a link to the product checkout" do
+          it "blocks restarting with the existing card and surfaces the product checkout URL alongside a plain text message" do
             @subscription.update!(cancelled_by_buyer: false)
 
             result = Subscription::UpdaterService.new(
@@ -602,9 +602,9 @@ describe Subscription::UpdaterService, :vcr do
             ).perform
 
             expect(result[:success]).to eq false
-            expect(result[:error_message]).to include("This membership was cancelled by the creator.")
-            expect(result[:error_message]).to include("subscribe again from the product page")
-            expect(result[:error_message]).to include("href=\"#{@product.long_url}\"")
+            expect(result[:error_message]).to eq "This membership was cancelled by the creator. To continue, please subscribe again from the product page."
+            expect(result[:error_message]).not_to include("<")
+            expect(result[:restart_at_checkout_url]).to eq @product.long_url
             expect(@subscription.reload).not_to be_alive
           end
 

--- a/spec/services/subscription/updater_service_spec.rb
+++ b/spec/services/subscription/updater_service_spec.rb
@@ -590,7 +590,7 @@ describe Subscription::UpdaterService, :vcr do
         end
 
         context "when the membership was cancelled by the creator" do
-          it "does not allow restarting the membership" do
+          it "blocks restarting with the existing card and surfaces a link to the product checkout" do
             @subscription.update!(cancelled_by_buyer: false)
 
             result = Subscription::UpdaterService.new(
@@ -602,8 +602,27 @@ describe Subscription::UpdaterService, :vcr do
             ).perform
 
             expect(result[:success]).to eq false
-            expect(result[:error_message]).to eq "This subscription cannot be restarted."
+            expect(result[:error_message]).to include("This membership was cancelled by the creator.")
+            expect(result[:error_message]).to include("subscribe again from the product page")
+            expect(result[:error_message]).to include("href=\"#{@product.long_url}\"")
             expect(@subscription.reload).not_to be_alive
+          end
+
+          it "allows restart-at-checkout to proceed past the seller-cancelled guard when a new payment method is being attached" do
+            @subscription.update!(cancelled_by_buyer: false)
+            allow(CardParamsHelper).to receive(:build_chargeable).and_return(nil)
+
+            result = Subscription::UpdaterService.new(
+              subscription: @subscription,
+              gumroad_guid: @gumroad_guid,
+              params: existing_card_params.merge(use_existing_card: false, paypal_order_id: "PAYID-TEST"),
+              logged_in_user: @user,
+              remote_ip: @remote_ip,
+            ).perform
+
+            expect(result[:success]).to eq false
+            expect(result[:error_message]).not_to include("This membership was cancelled by the creator.")
+            expect(result[:error_message]).to include("couldn't charge")
           end
         end
 
@@ -620,8 +639,23 @@ describe Subscription::UpdaterService, :vcr do
             ).perform
 
             expect(result[:success]).to eq false
-            expect(result[:error_message]).to eq "This subscription cannot be restarted."
+            expect(result[:error_message]).to eq "This product is no longer available, so this membership can't be restarted."
             expect(@subscription.reload).not_to be_alive
+          end
+
+          it "blocks restart even when a new payment method is being attached" do
+            @product.mark_deleted!
+
+            result = Subscription::UpdaterService.new(
+              subscription: @subscription,
+              gumroad_guid: @gumroad_guid,
+              params: existing_card_params.merge(use_existing_card: false, paypal_order_id: "PAYID-TEST"),
+              logged_in_user: @user,
+              remote_ip: @remote_ip,
+            ).perform
+
+            expect(result[:success]).to eq false
+            expect(result[:error_message]).to eq "This product is no longer available, so this membership can't be restarted."
           end
         end
       end

--- a/spec/support/fixtures/vcr_cassettes/Subscription_UpdaterService/_perform/tiered_membership_subscription/restarting_a_membership/when_the_membership_was_cancelled_by_the_creator/allows_restart-at-checkout_to_proceed_past_the_seller-cancelled_guard_when_a_new_payment_method_is_being_attached.yml
+++ b/spec/support/fixtures/vcr_cassettes/Subscription_UpdaterService/_perform/tiered_membership_subscription/restarting_a_membership/when_the_membership_was_cancelled_by_the_creator/allows_restart-at-checkout_to_proceed_past_the_seller-cancelled_guard_when_a_new_payment_method_is_being_attached.yml
@@ -1,0 +1,786 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_Hy3lwzhewjDwiQ","request_duration_ms":1}}'
+      Idempotency-Key:
+      - 71c7564e-a939-48f4-880f-b267e164b013
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Is-MacBook-Air.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56
+        PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132 arm64","hostname":"Is-MacBook-Air.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 04 Jun 2026 07:56:14 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=pOsGQ0xKsxNSjF7weenm_zdftrVILYfxyiCSo8SdRMM4fPIu-CmkSnXB_62GZuxZPy-yPKCBRWAyxXVJ;
+        report-to csp
+      Idempotency-Key:
+      - 71c7564e-a939-48f4-880f-b267e164b013
+      Original-Request:
+      - req_kV24QxVp8EaRUn
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=pOsGQ0xKsxNSjF7weenm_zdftrVILYfxyiCSo8SdRMM4fPIu-CmkSnXB_62GZuxZPy-yPKCBRWAyxXVJ&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=pOsGQ0xKsxNSjF7weenm_zdftrVILYfxyiCSo8SdRMM4fPIu-CmkSnXB_62GZuxZPy-yPKCBRWAyxXVJ&t=1"
+      Request-Id:
+      - req_kV24QxVp8EaRUn
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-05-27.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TeW8PIBOqvOFDrftKOT3ydG",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 6,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1780559773,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Thu, 04 Jun 2026 07:56:13 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1TeW8PIBOqvOFDrftKOT3ydG
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_kV24QxVp8EaRUn","request_duration_ms":439}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Is-MacBook-Air.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56
+        PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132 arm64","hostname":"Is-MacBook-Air.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 04 Jun 2026 07:56:14 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=pOsGQ0xKsxNSjF7weenm_zdftrVILYfxyiCSo8SdRMM4fPIu-CmkSnXB_62GZuxZPy-yPKCBRWAyxXVJ;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=pOsGQ0xKsxNSjF7weenm_zdftrVILYfxyiCSo8SdRMM4fPIu-CmkSnXB_62GZuxZPy-yPKCBRWAyxXVJ&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=pOsGQ0xKsxNSjF7weenm_zdftrVILYfxyiCSo8SdRMM4fPIu-CmkSnXB_62GZuxZPy-yPKCBRWAyxXVJ&t=1"
+      Request-Id:
+      - req_WlL4G1giLFNpjW
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-05-27.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TeW8PIBOqvOFDrftKOT3ydG",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 6,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1780559773,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Thu, 04 Jun 2026 07:56:14 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers
+    body:
+      encoding: UTF-8
+      string: description=1128&email=edgar5885ddb8_5%40gumroad.com&payment_method=pm_1TeW8PIBOqvOFDrftKOT3ydG
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_WlL4G1giLFNpjW","request_duration_ms":348}}'
+      Idempotency-Key:
+      - 43d4bd1e-cbc5-4bfc-9900-3dabf1ac23bf
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Is-MacBook-Air.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56
+        PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132 arm64","hostname":"Is-MacBook-Air.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 04 Jun 2026 07:56:15 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '669'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=pOsGQ0xKsxNSjF7weenm_zdftrVILYfxyiCSo8SdRMM4fPIu-CmkSnXB_62GZuxZPy-yPKCBRWAyxXVJ;
+        report-to csp
+      Idempotency-Key:
+      - 43d4bd1e-cbc5-4bfc-9900-3dabf1ac23bf
+      Original-Request:
+      - req_EzFyeAE1f2UNSS
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=pOsGQ0xKsxNSjF7weenm_zdftrVILYfxyiCSo8SdRMM4fPIu-CmkSnXB_62GZuxZPy-yPKCBRWAyxXVJ&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=pOsGQ0xKsxNSjF7weenm_zdftrVILYfxyiCSo8SdRMM4fPIu-CmkSnXB_62GZuxZPy-yPKCBRWAyxXVJ&t=1"
+      Request-Id:
+      - req_EzFyeAE1f2UNSS
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-05-27.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "cus_UdnjDUtS1yG9Ro",
+          "object": "customer",
+          "address": null,
+          "balance": 0,
+          "created": 1780559774,
+          "currency": null,
+          "customer_account": null,
+          "default_source": null,
+          "delinquent": false,
+          "description": "1128",
+          "discount": null,
+          "email": "edgar5885ddb8_5@gumroad.com",
+          "invoice_prefix": "N2KLUVZA",
+          "invoice_settings": {
+            "custom_fields": null,
+            "default_payment_method": null,
+            "footer": null,
+            "rendering_options": null
+          },
+          "livemode": false,
+          "metadata": {},
+          "name": null,
+          "next_invoice_sequence": 1,
+          "phone": null,
+          "preferred_locales": [],
+          "shipping": null,
+          "tax_exempt": "none",
+          "test_clock": null
+        }
+  recorded_at: Thu, 04 Jun 2026 07:56:15 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=599&currency=usd&description=You+bought+http%3A%2F%2Fedgar901749324.test.gumroad.com%3A31337%2Fl%2Fr%21&metadata[purchase]=eWhc9fplpk3uuUURAPQnNQ%3D%3D&transfer_group=329&payment_method_types[0]=card&off_session=true&confirm=true&customer=cus_UdnjDUtS1yG9Ro&payment_method=pm_1TeW8PIBOqvOFDrftKOT3ydG&statement_descriptor_suffix=edgar901749324
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_EzFyeAE1f2UNSS","request_duration_ms":869}}'
+      Idempotency-Key:
+      - b4586215-1853-45ee-89ce-c506b48e9922
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Is-MacBook-Air.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56
+        PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132 arm64","hostname":"Is-MacBook-Air.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 04 Jun 2026 07:56:16 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1653'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=pOsGQ0xKsxNSjF7weenm_zdftrVILYfxyiCSo8SdRMM4fPIu-CmkSnXB_62GZuxZPy-yPKCBRWAyxXVJ;
+        report-to csp
+      Idempotency-Key:
+      - b4586215-1853-45ee-89ce-c506b48e9922
+      Original-Request:
+      - req_DEhTCANCkErZax
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=pOsGQ0xKsxNSjF7weenm_zdftrVILYfxyiCSo8SdRMM4fPIu-CmkSnXB_62GZuxZPy-yPKCBRWAyxXVJ&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=pOsGQ0xKsxNSjF7weenm_zdftrVILYfxyiCSo8SdRMM4fPIu-CmkSnXB_62GZuxZPy-yPKCBRWAyxXVJ&t=1"
+      Request-Id:
+      - req_DEhTCANCkErZax
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-05-27.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3TeW8RIBOqvOFDrf0pXweHzh",
+          "object": "payment_intent",
+          "amount": 599,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 599,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3TeW8RIBOqvOFDrf0pXweHzh_secret_Arz5nlnUkDpbQslgm2SxFpJOm",
+          "confirmation_method": "automatic",
+          "created": 1780559775,
+          "currency": "usd",
+          "customer": "cus_UdnjDUtS1yG9Ro",
+          "customer_account": null,
+          "description": "You bought http://edgar901749324.test.gumroad.com:31337/l/r!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3TeW8RIBOqvOFDrf0qOxAwKb",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "eWhc9fplpk3uuUURAPQnNQ=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1TeW8PIBOqvOFDrftKOT3ydG",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar901749324",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "329"
+        }
+  recorded_at: Wed, 01 Apr 2020 00:00:00 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TeW8RIBOqvOFDrf0qOxAwKb?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_DEhTCANCkErZax","request_duration_ms":1165}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Is-MacBook-Air.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56
+        PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132 arm64","hostname":"Is-MacBook-Air.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 04 Jun 2026 07:56:17 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3807'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=pOsGQ0xKsxNSjF7weenm_zdftrVILYfxyiCSo8SdRMM4fPIu-CmkSnXB_62GZuxZPy-yPKCBRWAyxXVJ;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=pOsGQ0xKsxNSjF7weenm_zdftrVILYfxyiCSo8SdRMM4fPIu-CmkSnXB_62GZuxZPy-yPKCBRWAyxXVJ&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=pOsGQ0xKsxNSjF7weenm_zdftrVILYfxyiCSo8SdRMM4fPIu-CmkSnXB_62GZuxZPy-yPKCBRWAyxXVJ&t=1"
+      Request-Id:
+      - req_lIiDSZ2zcntFi1
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-05-27.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TeW8RIBOqvOFDrf0qOxAwKb",
+          "object": "charge",
+          "amount": 599,
+          "amount_captured": 599,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3TeW8RIBOqvOFDrf0HBFErRa",
+            "object": "balance_transaction",
+            "amount": 599,
+            "available_on": 1781136000,
+            "balance_type": "payments",
+            "created": 1780559776,
+            "currency": "usd",
+            "description": "You bought http://edgar901749324.test.gumroad.com:31337/l/r!",
+            "exchange_rate": null,
+            "fee": 47,
+            "fee_details": [
+              {
+                "amount": 47,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 552,
+            "reporting_category": "charge",
+            "source": "ch_3TeW8RIBOqvOFDrf0qOxAwKb",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR901749324",
+          "captured": true,
+          "created": 1780559776,
+          "currency": "usd",
+          "customer": "cus_UdnjDUtS1yG9Ro",
+          "description": "You bought http://edgar901749324.test.gumroad.com:31337/l/r!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "eWhc9fplpk3uuUURAPQnNQ=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 47,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TeW8RIBOqvOFDrf0pXweHzh",
+          "payment_method": "pm_1TeW8PIBOqvOFDrftKOT3ydG",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 599,
+              "authorization_code": "727416",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 6,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 599,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKKHfhNEGMgaZIhfuHRo6LBZy6rlBfK9-kg2hEUiVC092y0mak5YC7h6_rZkiFzrHkTl-newleX__Ln9g",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar901749324",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "329"
+        }
+  recorded_at: Wed, 01 Apr 2020 00:00:00 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/Subscription_UpdaterService/_perform/tiered_membership_subscription/restarting_a_membership/when_the_membership_was_cancelled_by_the_creator/blocks_restarting_with_the_existing_card_and_surfaces_the_product_checkout_URL_alongside_a_plain_text_message.yml
+++ b/spec/support/fixtures/vcr_cassettes/Subscription_UpdaterService/_perform/tiered_membership_subscription/restarting_a_membership/when_the_membership_was_cancelled_by_the_creator/blocks_restarting_with_the_existing_card_and_surfaces_the_product_checkout_URL_alongside_a_plain_text_message.yml
@@ -1,0 +1,784 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Idempotency-Key:
+      - d4c72f89-0010-42f5-8920-887bbc6e2e04
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Is-MacBook-Air.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56
+        PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132 arm64","hostname":"Is-MacBook-Air.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 04 Jun 2026 08:14:05 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=85Wap_i6hlBIS30ks_TAwJbsrUEWnO_hMRbHl-Q17CI9l9uxyaZBUexOQZ_ui-_nE7EAz0Pq0qUdWaEV;
+        report-to csp
+      Idempotency-Key:
+      - d4c72f89-0010-42f5-8920-887bbc6e2e04
+      Original-Request:
+      - req_lPY1kynSv02Vo7
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=85Wap_i6hlBIS30ks_TAwJbsrUEWnO_hMRbHl-Q17CI9l9uxyaZBUexOQZ_ui-_nE7EAz0Pq0qUdWaEV&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=85Wap_i6hlBIS30ks_TAwJbsrUEWnO_hMRbHl-Q17CI9l9uxyaZBUexOQZ_ui-_nE7EAz0Pq0qUdWaEV&t=1"
+      Request-Id:
+      - req_lPY1kynSv02Vo7
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-05-27.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TeWPhIBOqvOFDrfm4RVa3FJ",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 6,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1780560845,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Thu, 04 Jun 2026 08:14:05 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1TeWPhIBOqvOFDrfm4RVa3FJ
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_lPY1kynSv02Vo7","request_duration_ms":2373}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Is-MacBook-Air.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56
+        PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132 arm64","hostname":"Is-MacBook-Air.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 04 Jun 2026 08:14:07 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=jpjBtlaufQgyXD3fU0VVNyXak--uzUX-wW1Zhouv5p3SA0WsjpJQm49L8wesVznBb4sqs6xmhZrmISTv;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=jpjBtlaufQgyXD3fU0VVNyXak--uzUX-wW1Zhouv5p3SA0WsjpJQm49L8wesVznBb4sqs6xmhZrmISTv&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=jpjBtlaufQgyXD3fU0VVNyXak--uzUX-wW1Zhouv5p3SA0WsjpJQm49L8wesVznBb4sqs6xmhZrmISTv&t=1"
+      Request-Id:
+      - req_vm82ZgGIy8VAW4
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-05-27.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1TeWPhIBOqvOFDrfm4RVa3FJ",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 6,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1780560845,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Thu, 04 Jun 2026 08:14:07 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers
+    body:
+      encoding: UTF-8
+      string: description=1220&email=edgard5bb970f_1%40gumroad.com&payment_method=pm_1TeWPhIBOqvOFDrfm4RVa3FJ
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_vm82ZgGIy8VAW4","request_duration_ms":1365}}'
+      Idempotency-Key:
+      - 2de0641d-5e13-4a85-b035-d5b1c9620fce
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Is-MacBook-Air.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56
+        PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132 arm64","hostname":"Is-MacBook-Air.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 04 Jun 2026 08:14:08 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '669'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=jpjBtlaufQgyXD3fU0VVNyXak--uzUX-wW1Zhouv5p3SA0WsjpJQm49L8wesVznBb4sqs6xmhZrmISTv;
+        report-to csp
+      Idempotency-Key:
+      - 2de0641d-5e13-4a85-b035-d5b1c9620fce
+      Original-Request:
+      - req_tmuaNo4mJtWpFz
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=jpjBtlaufQgyXD3fU0VVNyXak--uzUX-wW1Zhouv5p3SA0WsjpJQm49L8wesVznBb4sqs6xmhZrmISTv&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=jpjBtlaufQgyXD3fU0VVNyXak--uzUX-wW1Zhouv5p3SA0WsjpJQm49L8wesVznBb4sqs6xmhZrmISTv&t=1"
+      Request-Id:
+      - req_tmuaNo4mJtWpFz
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-05-27.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "cus_Udo14KvzBtSxvc",
+          "object": "customer",
+          "address": null,
+          "balance": 0,
+          "created": 1780560847,
+          "currency": null,
+          "customer_account": null,
+          "default_source": null,
+          "delinquent": false,
+          "description": "1220",
+          "discount": null,
+          "email": "edgard5bb970f_1@gumroad.com",
+          "invoice_prefix": "3MFJETJI",
+          "invoice_settings": {
+            "custom_fields": null,
+            "default_payment_method": null,
+            "footer": null,
+            "rendering_options": null
+          },
+          "livemode": false,
+          "metadata": {},
+          "name": null,
+          "next_invoice_sequence": 1,
+          "phone": null,
+          "preferred_locales": [],
+          "shipping": null,
+          "tax_exempt": "none",
+          "test_clock": null
+        }
+  recorded_at: Thu, 04 Jun 2026 08:14:08 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=599&currency=usd&description=You+bought+http%3A%2F%2Fedgar2f854b132.test.gumroad.com%3A31337%2Fl%2Fc%21&metadata[purchase]=Lp74x5G7-ULMpxmssECxkQ%3D%3D&transfer_group=379&payment_method_types[0]=card&off_session=true&confirm=true&customer=cus_Udo14KvzBtSxvc&payment_method=pm_1TeWPhIBOqvOFDrfm4RVa3FJ&statement_descriptor_suffix=edgar2f854b132
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_tmuaNo4mJtWpFz","request_duration_ms":1289}}'
+      Idempotency-Key:
+      - 51f18cc7-64c9-4b78-a0b4-e9dc07cc46c1
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Is-MacBook-Air.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56
+        PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132 arm64","hostname":"Is-MacBook-Air.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 04 Jun 2026 08:14:10 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1653'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=jpjBtlaufQgyXD3fU0VVNyXak--uzUX-wW1Zhouv5p3SA0WsjpJQm49L8wesVznBb4sqs6xmhZrmISTv;
+        report-to csp
+      Idempotency-Key:
+      - 51f18cc7-64c9-4b78-a0b4-e9dc07cc46c1
+      Original-Request:
+      - req_z6QNNF3rf7FwRS
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=jpjBtlaufQgyXD3fU0VVNyXak--uzUX-wW1Zhouv5p3SA0WsjpJQm49L8wesVznBb4sqs6xmhZrmISTv&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=jpjBtlaufQgyXD3fU0VVNyXak--uzUX-wW1Zhouv5p3SA0WsjpJQm49L8wesVznBb4sqs6xmhZrmISTv&t=1"
+      Request-Id:
+      - req_z6QNNF3rf7FwRS
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-05-27.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3TeWPmIBOqvOFDrf1P8DWwI6",
+          "object": "payment_intent",
+          "amount": 599,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 599,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3TeWPmIBOqvOFDrf1P8DWwI6_secret_s2Fmbw2OcOGmfkqTwR7CogIpt",
+          "confirmation_method": "automatic",
+          "created": 1780560850,
+          "currency": "usd",
+          "customer": "cus_Udo14KvzBtSxvc",
+          "customer_account": null,
+          "description": "You bought http://edgar2f854b132.test.gumroad.com:31337/l/c!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3TeWPmIBOqvOFDrf1WBhk1JV",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "Lp74x5G7-ULMpxmssECxkQ=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1TeWPhIBOqvOFDrfm4RVa3FJ",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar2f854b132",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "379"
+        }
+  recorded_at: Wed, 01 Apr 2020 00:00:00 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3TeWPmIBOqvOFDrf1WBhk1JV?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_z6QNNF3rf7FwRS","request_duration_ms":1136}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Is-MacBook-Air.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56
+        PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132 arm64","hostname":"Is-MacBook-Air.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 04 Jun 2026 08:14:11 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3807'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=jpjBtlaufQgyXD3fU0VVNyXak--uzUX-wW1Zhouv5p3SA0WsjpJQm49L8wesVznBb4sqs6xmhZrmISTv;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=jpjBtlaufQgyXD3fU0VVNyXak--uzUX-wW1Zhouv5p3SA0WsjpJQm49L8wesVznBb4sqs6xmhZrmISTv&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=jpjBtlaufQgyXD3fU0VVNyXak--uzUX-wW1Zhouv5p3SA0WsjpJQm49L8wesVznBb4sqs6xmhZrmISTv&t=1"
+      Request-Id:
+      - req_QezucyeQFFkoCX
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-05-27.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3TeWPmIBOqvOFDrf1WBhk1JV",
+          "object": "charge",
+          "amount": 599,
+          "amount_captured": 599,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3TeWPmIBOqvOFDrf1YAagrvQ",
+            "object": "balance_transaction",
+            "amount": 599,
+            "available_on": 1781136000,
+            "balance_type": "payments",
+            "created": 1780560850,
+            "currency": "usd",
+            "description": "You bought http://edgar2f854b132.test.gumroad.com:31337/l/c!",
+            "exchange_rate": null,
+            "fee": 47,
+            "fee_details": [
+              {
+                "amount": 47,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 552,
+            "reporting_category": "charge",
+            "source": "ch_3TeWPmIBOqvOFDrf1WBhk1JV",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR2F854B132",
+          "captured": true,
+          "created": 1780560850,
+          "currency": "usd",
+          "customer": "cus_Udo14KvzBtSxvc",
+          "description": "You bought http://edgar2f854b132.test.gumroad.com:31337/l/c!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "Lp74x5G7-ULMpxmssECxkQ=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 64,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3TeWPmIBOqvOFDrf1P8DWwI6",
+          "payment_method": "pm_1TeWPhIBOqvOFDrfm4RVa3FJ",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 599,
+              "authorization_code": "454413",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 6,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 599,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKNPnhNEGMgYPK0uHviw6LBaN-wIxjW8QNJH93Z-m6GUJ3zUWqCeVpoKmd61S0IwKuAgXgthRNKQDXcog",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar2f854b132",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "379"
+        }
+  recorded_at: Wed, 01 Apr 2020 00:00:00 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/Subscription_UpdaterService/_perform/tiered_membership_subscription/restarting_a_membership/when_the_product_is_deleted/blocks_restart_even_when_a_new_payment_method_is_being_attached.yml
+++ b/spec/support/fixtures/vcr_cassettes/Subscription_UpdaterService/_perform/tiered_membership_subscription/restarting_a_membership/when_the_product_is_deleted/blocks_restart_even_when_a_new_payment_method_is_being_attached.yml
@@ -5,24 +5,24 @@ http_interactions:
     uri: https://api.stripe.com/v1/payment_methods
     body:
       encoding: UTF-8
-      string: type=card&card[number]=4242+4242+4242+4242&card[exp_month]=12&card[exp_year]=2023&card[cvc]=123
+      string: type=card&card[token]=tok_visa
     headers:
       User-Agent:
-      - Stripe/v1 RubyBindings/10.3.0
+      - Stripe/v1 RubyBindings/12.5.0
       Authorization:
       - Bearer <STRIPE_API_KEY>
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_I4DdLEMc3nK8QE","request_duration_ms":488}}'
+      - '{"last_request_metrics":{"request_id":"req_zZZMD7JG8kCwt6","request_duration_ms":1}}'
       Idempotency-Key:
-      - 3d269e39-8e9a-4c54-b6a2-ac4a63c4fefa
+      - 51f42302-48f9-4361-a212-8a42e505983d
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
-      - '{"bindings_version":"10.3.0","lang":"ruby","lang_version":"3.2.2 p53 (2023-03-30)","platform":"arm64-darwin20","engine":"ruby","publisher":"stripe","uname":"Darwin
-        Harbakshs-MacBook-Air.local 20.5.0 Darwin Kernel Version 20.5.0: Sat May  8
-        05:10:31 PDT 2021; root:xnu-7195.121.3~9/RELEASE_ARM64_T8101 arm64","hostname":"Harbakshs-MacBook-Air.local"}'
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Is-MacBook-Air.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56
+        PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132 arm64","hostname":"Is-MacBook-Air.local"}'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -35,17 +35,17 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Sun, 24 Dec 2023 22:13:25 GMT
+      - Thu, 04 Jun 2026 07:55:07 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '931'
+      - '1122'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
       - 'true'
       Access-Control-Allow-Methods:
-      - GET,HEAD,PUT,PATCH,POST,DELETE
+      - GET, HEAD, PUT, PATCH, POST, DELETE
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Expose-Headers:
@@ -56,31 +56,45 @@ http_interactions:
       Cache-Control:
       - no-cache, no-store
       Content-Security-Policy:
-      - report-uri https://q.stripe.com/csp-report?p=v1%2Fpayment_methods; block-all-mixed-content;
-        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
-        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=cNYxuGMnMzgO5XMFesJoL0pop9k3IYrjLSyfQr5AxMJxodc6XqoXFRTKQrvcK8GZcPQ1ATKbmIPvYIGo;
+        report-to csp
       Idempotency-Key:
-      - 3d269e39-8e9a-4c54-b6a2-ac4a63c4fefa
+      - 51f42302-48f9-4361-a212-8a42e505983d
       Original-Request:
-      - req_sP4OCKzUjLJQWX
+      - req_vkOyRpVbA6zVQ0
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=cNYxuGMnMzgO5XMFesJoL0pop9k3IYrjLSyfQr5AxMJxodc6XqoXFRTKQrvcK8GZcPQ1ATKbmIPvYIGo&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=cNYxuGMnMzgO5XMFesJoL0pop9k3IYrjLSyfQr5AxMJxodc6XqoXFRTKQrvcK8GZcPQ1ATKbmIPvYIGo&t=1"
       Request-Id:
-      - req_sP4OCKzUjLJQWX
+      - req_vkOyRpVbA6zVQ0
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-05-27.dahlia. See https://docs.stripe.com/upgrades
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
       - '2023-10-16'
       Vary:
       - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
       X-Stripe-Routing-Context-Priority-Tier:
       - api-testmode
+      X-Wc:
+      - 3c3
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
     body:
       encoding: UTF-8
       string: |-
         {
-          "id": "pm_0OQzvF9e1RjUNIyYHOoNyecw",
+          "id": "pm_1TeW7LIBOqvOFDrfB8o52aXv",
           "object": "payment_method",
+          "allow_redisplay": "unspecified",
           "billing_details": {
             "address": {
               "city": null,
@@ -92,7 +106,8 @@ http_interactions:
             },
             "email": null,
             "name": null,
-            "phone": null
+            "phone": null,
+            "tax_id": null
           },
           "card": {
             "brand": "visa",
@@ -102,9 +117,10 @@ http_interactions:
               "cvc_check": "unchecked"
             },
             "country": "US",
-            "exp_month": 12,
-            "exp_year": 2023,
-            "fingerprint": "W691J2Ye3VDoq6Ij",
+            "display_brand": "visa",
+            "exp_month": 6,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
             "funding": "credit",
             "generated_from": null,
             "last4": "4242",
@@ -114,39 +130,42 @@ http_interactions:
               ],
               "preferred": null
             },
+            "regulated_status": "unregulated",
             "three_d_secure_usage": {
               "supported": true
             },
             "wallet": null
           },
-          "created": 1703456005,
+          "created": 1780559707,
           "customer": null,
+          "customer_account": null,
           "livemode": false,
           "metadata": {},
+          "shared_payment_granted_token": null,
           "type": "card"
         }
-  recorded_at: Sun, 24 Dec 2023 22:13:25 GMT
+  recorded_at: Thu, 04 Jun 2026 07:55:07 GMT
 - request:
     method: get
-    uri: https://api.stripe.com/v1/payment_methods/pm_0OQzvF9e1RjUNIyYHOoNyecw
+    uri: https://api.stripe.com/v1/payment_methods/pm_1TeW7LIBOqvOFDrfB8o52aXv
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Stripe/v1 RubyBindings/10.3.0
+      - Stripe/v1 RubyBindings/12.5.0
       Authorization:
       - Bearer <STRIPE_API_KEY>
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_sP4OCKzUjLJQWX","request_duration_ms":487}}'
+      - '{"last_request_metrics":{"request_id":"req_vkOyRpVbA6zVQ0","request_duration_ms":398}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
-      - '{"bindings_version":"10.3.0","lang":"ruby","lang_version":"3.2.2 p53 (2023-03-30)","platform":"arm64-darwin20","engine":"ruby","publisher":"stripe","uname":"Darwin
-        Harbakshs-MacBook-Air.local 20.5.0 Darwin Kernel Version 20.5.0: Sat May  8
-        05:10:31 PDT 2021; root:xnu-7195.121.3~9/RELEASE_ARM64_T8101 arm64","hostname":"Harbakshs-MacBook-Air.local"}'
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Is-MacBook-Air.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56
+        PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132 arm64","hostname":"Is-MacBook-Air.local"}'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -159,17 +178,17 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Sun, 24 Dec 2023 22:13:25 GMT
+      - Thu, 04 Jun 2026 07:55:07 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '931'
+      - '1122'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
       - 'true'
       Access-Control-Allow-Methods:
-      - GET,HEAD,PUT,PATCH,POST,DELETE
+      - GET, HEAD, PUT, PATCH, POST, DELETE
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Expose-Headers:
@@ -180,26 +199,39 @@ http_interactions:
       Cache-Control:
       - no-cache, no-store
       Content-Security-Policy:
-      - report-uri https://q.stripe.com/csp-report?p=v1%2Fpayment_methods%2F%3Apayment_method;
-        block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action
-        'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample';
-        style-src 'self'
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=cNYxuGMnMzgO5XMFesJoL0pop9k3IYrjLSyfQr5AxMJxodc6XqoXFRTKQrvcK8GZcPQ1ATKbmIPvYIGo;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=cNYxuGMnMzgO5XMFesJoL0pop9k3IYrjLSyfQr5AxMJxodc6XqoXFRTKQrvcK8GZcPQ1ATKbmIPvYIGo&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=cNYxuGMnMzgO5XMFesJoL0pop9k3IYrjLSyfQr5AxMJxodc6XqoXFRTKQrvcK8GZcPQ1ATKbmIPvYIGo&t=1"
       Request-Id:
-      - req_n5z9fRQ5xM5WPe
+      - req_kDDr6fXR31zic3
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-05-27.dahlia. See https://docs.stripe.com/upgrades
       Stripe-Version:
       - '2023-10-16'
       Vary:
       - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
       X-Stripe-Routing-Context-Priority-Tier:
       - api-testmode
+      X-Wc:
+      - 3c3
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
     body:
       encoding: UTF-8
       string: |-
         {
-          "id": "pm_0OQzvF9e1RjUNIyYHOoNyecw",
+          "id": "pm_1TeW7LIBOqvOFDrfB8o52aXv",
           "object": "payment_method",
+          "allow_redisplay": "unspecified",
           "billing_details": {
             "address": {
               "city": null,
@@ -211,7 +243,8 @@ http_interactions:
             },
             "email": null,
             "name": null,
-            "phone": null
+            "phone": null,
+            "tax_id": null
           },
           "card": {
             "brand": "visa",
@@ -221,9 +254,10 @@ http_interactions:
               "cvc_check": "unchecked"
             },
             "country": "US",
-            "exp_month": 12,
-            "exp_year": 2023,
-            "fingerprint": "W691J2Ye3VDoq6Ij",
+            "display_brand": "visa",
+            "exp_month": 6,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
             "funding": "credit",
             "generated_from": null,
             "last4": "4242",
@@ -233,41 +267,44 @@ http_interactions:
               ],
               "preferred": null
             },
+            "regulated_status": "unregulated",
             "three_d_secure_usage": {
               "supported": true
             },
             "wallet": null
           },
-          "created": 1703456005,
+          "created": 1780559707,
           "customer": null,
+          "customer_account": null,
           "livemode": false,
           "metadata": {},
+          "shared_payment_granted_token": null,
           "type": "card"
         }
-  recorded_at: Sun, 24 Dec 2023 22:13:25 GMT
+  recorded_at: Thu, 04 Jun 2026 07:55:07 GMT
 - request:
     method: post
     uri: https://api.stripe.com/v1/customers
     body:
       encoding: UTF-8
-      string: description=45&email=edgar4cdcb67c_89%40gumroad.com&payment_method=pm_0OQzvF9e1RjUNIyYHOoNyecw
+      string: description=1122&email=edgar85f28184_13%40gumroad.com&payment_method=pm_1TeW7LIBOqvOFDrfB8o52aXv
     headers:
       User-Agent:
-      - Stripe/v1 RubyBindings/10.3.0
+      - Stripe/v1 RubyBindings/12.5.0
       Authorization:
       - Bearer <STRIPE_API_KEY>
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_n5z9fRQ5xM5WPe","request_duration_ms":348}}'
+      - '{"last_request_metrics":{"request_id":"req_kDDr6fXR31zic3","request_duration_ms":291}}'
       Idempotency-Key:
-      - 56ca9fcb-a3d5-4c17-9ba6-0be36985923e
+      - 278d0006-e6dd-4788-b382-f06eb593a8be
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
-      - '{"bindings_version":"10.3.0","lang":"ruby","lang_version":"3.2.2 p53 (2023-03-30)","platform":"arm64-darwin20","engine":"ruby","publisher":"stripe","uname":"Darwin
-        Harbakshs-MacBook-Air.local 20.5.0 Darwin Kernel Version 20.5.0: Sat May  8
-        05:10:31 PDT 2021; root:xnu-7195.121.3~9/RELEASE_ARM64_T8101 arm64","hostname":"Harbakshs-MacBook-Air.local"}'
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Is-MacBook-Air.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56
+        PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132 arm64","hostname":"Is-MacBook-Air.local"}'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -280,17 +317,17 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Sun, 24 Dec 2023 22:13:26 GMT
+      - Thu, 04 Jun 2026 07:55:08 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '640'
+      - '670'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
       - 'true'
       Access-Control-Allow-Methods:
-      - GET,HEAD,PUT,PATCH,POST,DELETE
+      - GET, HEAD, PUT, PATCH, POST, DELETE
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Expose-Headers:
@@ -301,41 +338,55 @@ http_interactions:
       Cache-Control:
       - no-cache, no-store
       Content-Security-Policy:
-      - report-uri https://q.stripe.com/csp-report?p=v1%2Fcustomers; block-all-mixed-content;
-        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
-        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=cNYxuGMnMzgO5XMFesJoL0pop9k3IYrjLSyfQr5AxMJxodc6XqoXFRTKQrvcK8GZcPQ1ATKbmIPvYIGo;
+        report-to csp
       Idempotency-Key:
-      - 56ca9fcb-a3d5-4c17-9ba6-0be36985923e
+      - 278d0006-e6dd-4788-b382-f06eb593a8be
       Original-Request:
-      - req_UmCkTaLNm2mKmx
+      - req_hoHU4FC0ZSV4sR
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=cNYxuGMnMzgO5XMFesJoL0pop9k3IYrjLSyfQr5AxMJxodc6XqoXFRTKQrvcK8GZcPQ1ATKbmIPvYIGo&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=cNYxuGMnMzgO5XMFesJoL0pop9k3IYrjLSyfQr5AxMJxodc6XqoXFRTKQrvcK8GZcPQ1ATKbmIPvYIGo&t=1"
       Request-Id:
-      - req_UmCkTaLNm2mKmx
+      - req_hoHU4FC0ZSV4sR
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-05-27.dahlia. See https://docs.stripe.com/upgrades
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
       - '2023-10-16'
       Vary:
       - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
       X-Stripe-Routing-Context-Priority-Tier:
       - api-testmode
+      X-Wc:
+      - 3c3
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
     body:
       encoding: UTF-8
       string: |-
         {
-          "id": "cus_PFUvsHCOg5lTGF",
+          "id": "cus_Udni1D2PUBEQrC",
           "object": "customer",
           "address": null,
           "balance": 0,
-          "created": 1703456005,
+          "created": 1780559708,
           "currency": null,
+          "customer_account": null,
           "default_source": null,
           "delinquent": false,
-          "description": "45",
+          "description": "1122",
           "discount": null,
-          "email": "edgar4cdcb67c_89@gumroad.com",
-          "invoice_prefix": "C73ADBED",
+          "email": "edgar85f28184_13@gumroad.com",
+          "invoice_prefix": "F6TGNAXL",
           "invoice_settings": {
             "custom_fields": null,
             "default_payment_method": null,
@@ -352,30 +403,30 @@ http_interactions:
           "tax_exempt": "none",
           "test_clock": null
         }
-  recorded_at: Sun, 24 Dec 2023 22:13:26 GMT
+  recorded_at: Thu, 04 Jun 2026 07:55:08 GMT
 - request:
     method: post
     uri: https://api.stripe.com/v1/payment_intents
     body:
       encoding: UTF-8
-      string: amount=599&currency=usd&description=You+bought+http%3A%2F%2Fedgarbbc6800b46.test.gumroad.com%3A31337%2Fl%2Fb&metadata[purchase]=oy8Z4iNnA2K6GX8Pon6iAw%3D%3D&transfer_group=44&payment_method_types[0]=card&off_session=true&confirm=true&customer=cus_PFUvsHCOg5lTGF&payment_method=pm_0OQzvF9e1RjUNIyYHOoNyecw&statement_descriptor_suffix=edgarbbc6800b46
+      string: amount=599&currency=usd&description=You+bought+http%3A%2F%2Fedgar47a2f8fb8.test.gumroad.com%3A31337%2Fl%2Fp%21&metadata[purchase]=g3YMU-XAt_051t3Gs9GjZQ%3D%3D&transfer_group=326&payment_method_types[0]=card&off_session=true&confirm=true&customer=cus_Udni1D2PUBEQrC&payment_method=pm_1TeW7LIBOqvOFDrfB8o52aXv&statement_descriptor_suffix=edgar47a2f8fb8
     headers:
       User-Agent:
-      - Stripe/v1 RubyBindings/10.3.0
+      - Stripe/v1 RubyBindings/12.5.0
       Authorization:
       - Bearer <STRIPE_API_KEY>
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_UmCkTaLNm2mKmx","request_duration_ms":833}}'
+      - '{"last_request_metrics":{"request_id":"req_hoHU4FC0ZSV4sR","request_duration_ms":832}}'
       Idempotency-Key:
-      - 4aef7a73-9d40-4ed3-a2ce-d165424120d3
+      - 3d77c728-88b6-4c17-9763-47910757e55f
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
-      - '{"bindings_version":"10.3.0","lang":"ruby","lang_version":"3.2.2 p53 (2023-03-30)","platform":"arm64-darwin20","engine":"ruby","publisher":"stripe","uname":"Darwin
-        Harbakshs-MacBook-Air.local 20.5.0 Darwin Kernel Version 20.5.0: Sat May  8
-        05:10:31 PDT 2021; root:xnu-7195.121.3~9/RELEASE_ARM64_T8101 arm64","hostname":"Harbakshs-MacBook-Air.local"}'
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Is-MacBook-Air.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56
+        PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132 arm64","hostname":"Is-MacBook-Air.local"}'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -388,17 +439,17 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Sun, 24 Dec 2023 22:13:28 GMT
+      - Thu, 04 Jun 2026 07:55:10 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '1494'
+      - '1653'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
       - 'true'
       Access-Control-Allow-Methods:
-      - GET,HEAD,PUT,PATCH,POST,DELETE
+      - GET, HEAD, PUT, PATCH, POST, DELETE
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Expose-Headers:
@@ -409,30 +460,43 @@ http_interactions:
       Cache-Control:
       - no-cache, no-store
       Content-Security-Policy:
-      - report-uri https://q.stripe.com/csp-report?p=v1%2Fpayment_intents; block-all-mixed-content;
-        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
-        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=cNYxuGMnMzgO5XMFesJoL0pop9k3IYrjLSyfQr5AxMJxodc6XqoXFRTKQrvcK8GZcPQ1ATKbmIPvYIGo;
+        report-to csp
       Idempotency-Key:
-      - 4aef7a73-9d40-4ed3-a2ce-d165424120d3
+      - 3d77c728-88b6-4c17-9763-47910757e55f
       Original-Request:
-      - req_0GtjyvnjIyISd0
+      - req_Zai8apfjWwVbe4
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=cNYxuGMnMzgO5XMFesJoL0pop9k3IYrjLSyfQr5AxMJxodc6XqoXFRTKQrvcK8GZcPQ1ATKbmIPvYIGo&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=cNYxuGMnMzgO5XMFesJoL0pop9k3IYrjLSyfQr5AxMJxodc6XqoXFRTKQrvcK8GZcPQ1ATKbmIPvYIGo&t=1"
       Request-Id:
-      - req_0GtjyvnjIyISd0
+      - req_Zai8apfjWwVbe4
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-05-27.dahlia. See https://docs.stripe.com/upgrades
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
       - '2023-10-16'
       Vary:
       - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
       X-Stripe-Routing-Context-Priority-Tier:
       - api-testmode
+      X-Wc:
+      - 3c3
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
     body:
       encoding: UTF-8
       string: |-
         {
-          "id": "pi_2OQzvH9e1RjUNIyY0xC4mwLf",
+          "id": "pi_3TeW7NIBOqvOFDrf0h8bFILY",
           "object": "payment_intent",
           "amount": 599,
           "amount_capturable": 0,
@@ -446,22 +510,27 @@ http_interactions:
           "canceled_at": null,
           "cancellation_reason": null,
           "capture_method": "automatic",
-          "client_secret": "pi_2OQzvH9e1RjUNIyY0xC4mwLf_secret_P9HqFNtvOLCsjDjGmvA9cqbc5",
+          "client_secret": "pi_3TeW7NIBOqvOFDrf0h8bFILY_secret_wNfMlmRVI7RqsReDcGCwd80J3",
           "confirmation_method": "automatic",
-          "created": 1703456007,
+          "created": 1780559709,
           "currency": "usd",
-          "customer": "cus_PFUvsHCOg5lTGF",
-          "description": "You bought http://edgarbbc6800b46.test.gumroad.com:31337/l/b",
+          "customer": "cus_Udni1D2PUBEQrC",
+          "customer_account": null,
+          "description": "You bought http://edgar47a2f8fb8.test.gumroad.com:31337/l/p!",
+          "excluded_payment_method_types": null,
           "invoice": null,
           "last_payment_error": null,
-          "latest_charge": "ch_2OQzvH9e1RjUNIyY0jgLLJvN",
+          "latest_charge": "ch_3TeW7NIBOqvOFDrf033Mj24E",
           "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
           "metadata": {
-            "purchase": "oy8Z4iNnA2K6GX8Pon6iAw=="
+            "purchase": "g3YMU-XAt_051t3Gs9GjZQ=="
           },
           "next_action": null,
           "on_behalf_of": null,
-          "payment_method": "pm_0OQzvF9e1RjUNIyYHOoNyecw",
+          "payment_method": "pm_1TeW7LIBOqvOFDrfB8o52aXv",
           "payment_method_configuration_details": null,
           "payment_method_options": {
             "card": {
@@ -478,36 +547,37 @@ http_interactions:
           "receipt_email": null,
           "review": null,
           "setup_future_usage": null,
+          "shared_payment_granted_token": null,
           "shipping": null,
           "source": null,
           "statement_descriptor": null,
-          "statement_descriptor_suffix": "edgarbbc6800b46",
+          "statement_descriptor_suffix": "edgar47a2f8fb8",
           "status": "succeeded",
           "transfer_data": null,
-          "transfer_group": "44"
+          "transfer_group": "326"
         }
   recorded_at: Wed, 01 Apr 2020 00:00:00 GMT
 - request:
     method: get
-    uri: https://api.stripe.com/v1/charges/ch_2OQzvH9e1RjUNIyY0jgLLJvN?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    uri: https://api.stripe.com/v1/charges/ch_3TeW7NIBOqvOFDrf033Mj24E?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Stripe/v1 RubyBindings/10.3.0
+      - Stripe/v1 RubyBindings/12.5.0
       Authorization:
       - Bearer <STRIPE_API_KEY>
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_0GtjyvnjIyISd0","request_duration_ms":1209}}'
+      - '{"last_request_metrics":{"request_id":"req_Zai8apfjWwVbe4","request_duration_ms":977}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
-      - '{"bindings_version":"10.3.0","lang":"ruby","lang_version":"3.2.2 p53 (2023-03-30)","platform":"arm64-darwin20","engine":"ruby","publisher":"stripe","uname":"Darwin
-        Harbakshs-MacBook-Air.local 20.5.0 Darwin Kernel Version 20.5.0: Sat May  8
-        05:10:31 PDT 2021; root:xnu-7195.121.3~9/RELEASE_ARM64_T8101 arm64","hostname":"Harbakshs-MacBook-Air.local"}'
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Is-MacBook-Air.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56
+        PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132 arm64","hostname":"Is-MacBook-Air.local"}'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -520,17 +590,17 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Sun, 24 Dec 2023 22:13:29 GMT
+      - Thu, 04 Jun 2026 07:55:10 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '3505'
+      - '3807'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
       - 'true'
       Access-Control-Allow-Methods:
-      - GET,HEAD,PUT,PATCH,POST,DELETE
+      - GET, HEAD, PUT, PATCH, POST, DELETE
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Expose-Headers:
@@ -541,54 +611,67 @@ http_interactions:
       Cache-Control:
       - no-cache, no-store
       Content-Security-Policy:
-      - report-uri https://q.stripe.com/csp-report?p=v1%2Fcharges%2F%3Acharge; block-all-mixed-content;
-        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
-        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-<RPUSH_CONSUMER_FCM_FIREBASE_PROJECT_ID>';
+        style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri
+        https://q.stripe.com/csp-violation?q=cNYxuGMnMzgO5XMFesJoL0pop9k3IYrjLSyfQr5AxMJxodc6XqoXFRTKQrvcK8GZcPQ1ATKbmIPvYIGo;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=cNYxuGMnMzgO5XMFesJoL0pop9k3IYrjLSyfQr5AxMJxodc6XqoXFRTKQrvcK8GZcPQ1ATKbmIPvYIGo&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=cNYxuGMnMzgO5XMFesJoL0pop9k3IYrjLSyfQr5AxMJxodc6XqoXFRTKQrvcK8GZcPQ1ATKbmIPvYIGo&t=1"
       Request-Id:
-      - req_aDEfXt5VTyDERB
+      - req_BFgjvoCewB8bGY
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-05-27.dahlia. See https://docs.stripe.com/upgrades
       Stripe-Version:
       - '2023-10-16'
       Vary:
       - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
       X-Stripe-Routing-Context-Priority-Tier:
       - api-testmode
+      X-Wc:
+      - 3c3
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
     body:
       encoding: UTF-8
       string: |-
         {
-          "id": "ch_2OQzvH9e1RjUNIyY0jgLLJvN",
+          "id": "ch_3TeW7NIBOqvOFDrf033Mj24E",
           "object": "charge",
           "amount": 599,
           "amount_captured": 599,
           "amount_refunded": 0,
-          "amount_updates": [],
           "application": null,
           "application_fee": null,
           "application_fee_amount": null,
           "balance_transaction": {
-            "id": "txn_2OQzvH9e1RjUNIyY0yjQgJGL",
+            "id": "txn_3TeW7NIBOqvOFDrf0RnRRFdv",
             "object": "balance_transaction",
             "amount": 599,
-            "available_on": 1703635200,
-            "created": 1703456007,
+            "available_on": 1781136000,
+            "balance_type": "payments",
+            "created": 1780559709,
             "currency": "usd",
-            "description": "You bought http://edgarbbc6800b46.test.gumroad.com:31337/l/b",
+            "description": "You bought http://edgar47a2f8fb8.test.gumroad.com:31337/l/p!",
             "exchange_rate": null,
-            "fee": 35,
+            "fee": 47,
             "fee_details": [
               {
-                "amount": 35,
+                "amount": 47,
                 "application": null,
                 "currency": "usd",
                 "description": "Stripe processing fees",
                 "type": "stripe_fee"
               }
             ],
-            "net": 564,
+            "net": 552,
             "reporting_category": "charge",
-            "source": "ch_2OQzvH9e1RjUNIyY0jgLLJvN",
+            "source": "ch_3TeW7NIBOqvOFDrf033Mj24E",
             "status": "pending",
             "type": "charge"
           },
@@ -603,14 +686,15 @@ http_interactions:
             },
             "email": null,
             "name": null,
-            "phone": null
+            "phone": null,
+            "tax_id": null
           },
-          "calculated_statement_descriptor": "GUMRD.COM* EDGARBBC680",
+          "calculated_statement_descriptor": "STRIPE* EDGAR47A2F8FB8",
           "captured": true,
-          "created": 1703456007,
+          "created": 1780559709,
           "currency": "usd",
-          "customer": "cus_PFUvsHCOg5lTGF",
-          "description": "You bought http://edgarbbc6800b46.test.gumroad.com:31337/l/b",
+          "customer": "cus_Udni1D2PUBEQrC",
+          "description": "You bought http://edgar47a2f8fb8.test.gumroad.com:31337/l/p!",
           "destination": null,
           "dispute": null,
           "disputed": false,
@@ -621,24 +705,28 @@ http_interactions:
           "invoice": null,
           "livemode": false,
           "metadata": {
-            "purchase": "oy8Z4iNnA2K6GX8Pon6iAw=="
+            "purchase": "g3YMU-XAt_051t3Gs9GjZQ=="
           },
           "on_behalf_of": null,
           "order": null,
           "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
             "network_status": "approved_by_network",
             "reason": null,
             "risk_level": "normal",
-            "risk_score": 26,
+            "risk_score": 42,
             "seller_message": "Payment complete.",
             "type": "authorized"
           },
           "paid": true,
-          "payment_intent": "pi_2OQzvH9e1RjUNIyY0xC4mwLf",
-          "payment_method": "pm_0OQzvF9e1RjUNIyYHOoNyecw",
+          "payment_intent": "pi_3TeW7NIBOqvOFDrf0h8bFILY",
+          "payment_method": "pm_1TeW7LIBOqvOFDrfB8o52aXv",
           "payment_method_details": {
             "card": {
               "amount_authorized": 599,
+              "authorization_code": "870844",
               "brand": "visa",
               "checks": {
                 "address_line1_check": null,
@@ -646,12 +734,13 @@ http_interactions:
                 "cvc_check": "pass"
               },
               "country": "US",
-              "exp_month": 12,
-              "exp_year": 2023,
+              "ds_transaction_id": null,
+              "exp_month": 6,
+              "exp_year": 2027,
               "extended_authorization": {
                 "status": "disabled"
               },
-              "fingerprint": "W691J2Ye3VDoq6Ij",
+              "fingerprint": "hsksJCaNjbEGzjqP",
               "funding": "credit",
               "incremental_authorization": {
                 "status": "unavailable"
@@ -666,11 +755,14 @@ http_interactions:
               "network_token": {
                 "used": false
               },
+              "network_transaction_id": "104115107115746",
               "overcapture": {
                 "maximum_amount_capturable": 599,
                 "status": "unavailable"
               },
+              "regulated_status": "unregulated",
               "three_d_secure": null,
+              "transaction_link_id": null,
               "wallet": null
             },
             "type": "card"
@@ -678,17 +770,17 @@ http_interactions:
           "radar_options": {},
           "receipt_email": null,
           "receipt_number": null,
-          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaIgogOWUxUmpVTkl5WUdwQTlDZmgzUm1ReHhUemIxYWFrcEUoiNqirAYyBl7K9Ci_QzosFowHALtBJw5k0B2tMwbMoEMNnRrUkUSJeGt4uFSdCYs9FHSWBoK4OnMaRsA",
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKN7ehNEGMgbnhEMbqyg6LBZs396T4f2Pa8ldlCUM1B9Qs1ILUfGYy1XKb3heRw6aIDGOvvindUib1gps",
           "refunded": false,
           "review": null,
           "shipping": null,
           "source": null,
           "source_transfer": null,
           "statement_descriptor": null,
-          "statement_descriptor_suffix": "edgarbbc6800b46",
+          "statement_descriptor_suffix": "edgar47a2f8fb8",
           "status": "succeeded",
           "transfer_data": null,
-          "transfer_group": "44"
+          "transfer_group": "326"
         }
   recorded_at: Wed, 01 Apr 2020 00:00:00 GMT
 recorded_with: VCR 6.2.0


### PR DESCRIPTION
## What

Closes the dead-end for buyers whose subscriptions were cancelled by the seller by branching the restart error and scoping the guard.

- **Layer 1 — branched error messages.** `Subscription::UpdaterService#perform` no longer collapses seller-cancelled and product-deleted into a single "This subscription cannot be restarted." Both cases now produce specific copy. For the seller-cancelled case the service returns a plain‑text message plus a separate `restart_at_checkout_url` field; `Subscriptions/Manage.tsx` escapes both and renders a clickable "Subscribe from the product page" link in the alert. The checkout error renderer (which doesn't opt into HTML) sees only plain text.
- **Layer 2 — narrow the seller-cancelled guard to existing-card restarts only.** The guard now triggers only when `use_existing_card?` is true. `Subscription::RestartAtCheckoutService` sets `use_existing_card: false` whenever new payment method params are present (`stripe_payment_method_id` / `stripe_customer_id` / `stripe_setup_intent_id` / `paypal_order_id`), so the checkout-with-new-payment-method path passes the guard. Downstream `supports_card?` (`app/services/subscription/updater_service.rb:138-142`) validates the freshly-attached card against the seller's remaining processors, so PayPal-only or Stripe-only sellers route correctly without an explicit check here.
- Product-deleted still blocks both routes — that takes precedence over the new-payment-method exception.

## Why

[Private issue: antiwork/gumroad-private#468](https://github.com/antiwork/gumroad-private/issues/468).

A seller disconnected one payment processor and now relies only on the other. A bulk force-cancel of their active subscriptions (via support) set each row's `cancelled_at`/`deactivated_at` with `cancelled_by_buyer: false`, so `Subscription#cancelled_by_seller?` returns true. That tripped the single guard at `app/services/subscription/updater_service.rb:45` for both restart routes:

- `/manage` Restart button (uses the saved card from the now-disconnected processor, which would charge a dead credential anyway)
- Product page "Resubscribe" CTA → checkout → `RestartAtCheckoutService` (which IS attaching a fresh payment method from the seller's remaining processor)

The first should keep failing — the saved card no longer routes to anything. The second is exactly what the seller is asking us to enable, and the buyer is supplying everything we need: a new payment method that the seller's remaining processor supports.

This PR keeps the original guard's intent (buyers can't unilaterally revive a sub a creator deliberately cancelled by reusing the existing card) and opens only the explicit "checkout with a new payment method" path, while making the error message actionable for the rest.

---

Generated with Claude Opus 4.7 (1M context).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes subscription restart and billing guardrails (who can revive seller-cancelled subs and when charges run); scope is limited but touches payment flows and user-facing error handling.
> 
> **Overview**
> **Subscription restart** no longer uses one generic “cannot be restarted” message. **Deleted products** always block restart with dedicated copy; **creator-cancelled** memberships block only when the buyer tries to restart with the **saved card**, and the API returns plain text plus `restart_at_checkout_url` (product `long_url`).
> 
> On **Manage**, that error is shown as an HTML alert with an escaped **Subscribe from the product page** link. The client layer (`updateSubscription`) forwards the optional URL from JSON.
> 
> **Checkout with a new payment method** can proceed past the creator-cancelled guard because the guard is tied to `use_existing_card?` (checkout already sets `use_existing_card: false` when Stripe/PayPal params are present). Specs and VCR cassettes cover existing-card blocking, new-card bypass, and deleted-product blocking for both paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de1bad62feb84ce035ef3644ed9e3840b2d7f316. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->