### PR TITLE
Label the product page edit button (icon + text)

### DIFF
--- a/app/javascript/components/Product/Layout.tsx
+++ b/app/javascript/components/Product/Layout.tsx
@@ -37,7 +37,6 @@ import { ImageUploadSettingsContext } from "$app/components/RichTextEditor";
 import { showAlert } from "$app/components/server-components/Alert";
 import { useIsAboveBreakpoint } from "$app/components/useIsAboveBreakpoint";
 import { useRefToLatest } from "$app/components/useRefToLatest";
-import { WithTooltip } from "$app/components/WithTooltip";
 
 export type Props = ProductProps & { main_section_index: number } & (SectionsProps | EditSectionsProps);
 
@@ -353,16 +352,10 @@ const EditButton = ({ product }: { product: Product }) => {
         zIndex: "var(--z-index-overlay)",
       }}
     >
-      <WithTooltip tip="Edit product" position={isDesktop ? "right" : "left"}>
-        <NavigationButton
-          color="filled"
-          size="icon"
-          href={Routes.edit_link_url({ id: product.permalink }, { host: appDomain })}
-          aria-label="Edit product"
-        >
-          <Pencil className="size-5" />
-        </NavigationButton>
-      </WithTooltip>
+      <NavigationButton color="filled" href={Routes.edit_link_url({ id: product.permalink }, { host: appDomain })}>
+        <Pencil className="size-5" />
+        Edit product
+      </NavigationButton>
     </div>
   );
 };


### PR DESCRIPTION
## What

Replaces the pencil-only, tooltip-wrapped "Edit product" affordance on the public product page with a labeled **"Edit product"** button (icon + text), on the creator's own product.

Mirrors the same change made to the profile edit button in #5388 — icon-only buttons are easy to miss and lean on hover to disambiguate, so the visible label makes the action explicit.

## Changes

- `app/javascript/components/Product/Layout.tsx` — `EditButton` now renders `<NavigationButton>` with the Pencil icon **and** the text "Edit product", dropping `size="icon"`.
- Removed the now-unused `WithTooltip` wrapper (and its import) — the visible label replaces the hover tooltip.

## Notes

- The button keeps the same accessible name (`Edit product`) and `href` (`edit_link_url`), so the existing assertions in `spec/requests/products/show/show_spec.rb` (`have_link("Edit product", href: …)`) still hold — no spec changes needed.
- `can_edit` gating and the fixed/absolute positioning are unchanged.

## Test plan

```
bundle exec rspec spec/requests/products/show/show_spec.rb -e "product edit button"
```

Verified locally: prettier + eslint clean on the changed file. (Couldn't run the `:system` spec locally — the test env's CloudFront RSA key fails to load from a bare shell on this machine for any branch — so leaning on CI for that.)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783165537&installation_id=134400930&pr_number=5402&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5402&signature=f9c2cc638ec27ee74d97640404613720aa5e378e801d7dfd74483c6d3844f36e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-component UI copy/layout change with no auth, routing, or data logic changes.
> 
> **Overview**
> On the public product page (when the viewer can edit), the floating **Edit product** control is no longer an icon-only button with a hover tooltip. It is now a filled `NavigationButton` with the pencil icon and visible **Edit product** label, matching the profile edit affordance pattern from #5388.
> 
> The `WithTooltip` wrapper and its import are removed; placement, `can_edit` gating, and the same `edit_link_url` link target are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed600b7581c408df982d1d0208bf26e051b47da0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->