### PR TITLE
Label the wishlist Add to cart button (icon + text)

### DIFF
--- a/app/javascript/components/Wishlist/index.tsx
+++ b/app/javascript/components/Wishlist/index.tsx
@@ -149,22 +149,20 @@ const WishlistItemCard = ({
       badge={
         item.purchasable ? (
           <div style={{ position: "absolute", top: "var(--spacer-4)", right: "var(--spacer-4)" }}>
-            <WithTooltip position="top" tip="Add to cart">
-              <NavigationButton
-                href={addToCartUrl(item)}
-                color="primary"
-                aria-label="Add to cart"
-                onClick={() =>
-                  trackCtaClick({
-                    sellerId: item.product.seller?.id,
-                    permalink: item.product.permalink,
-                    name: item.product.name,
-                  })
-                }
-              >
-                <Cart pack="filled" className="size-5" />
-              </NavigationButton>
-            </WithTooltip>
+            <NavigationButton
+              href={addToCartUrl(item)}
+              color="primary"
+              onClick={() =>
+                trackCtaClick({
+                  sellerId: item.product.seller?.id,
+                  permalink: item.product.permalink,
+                  name: item.product.name,
+                })
+              }
+            >
+              <Cart pack="filled" className="size-5" />
+              Add to cart
+            </NavigationButton>
           </div>
         ) : null
       }


### PR DESCRIPTION
## What

Replaces the icon-only, tooltip-wrapped **Add to cart** badge on each wishlist product card with a labeled "Add to cart" button (cart icon + text).

This is a public-facing primary conversion CTA — its meaning shouldn't depend on a hover tooltip. Part of the labeled-button pass (follows #5402 product edit, #5388 profile edit).

## Changes

- `app/javascript/components/Wishlist/index.tsx` — the Add to cart `NavigationButton` now renders the Cart icon **and** the text "Add to cart", dropping the `WithTooltip` wrapper and `aria-label`.

## Notes

- Same accessible name (`Add to cart`) and `href`, so the existing `spec/requests/wishlists/wishlist_show_spec.rb` `click_on "Add to cart"` assertions still hold — no spec changes needed.
- The other tooltips in this file (Remove this product / Gift this product) are intentionally left as icon + tooltip; only the primary CTA is labeled.

## Test plan

```
bundle exec rspec spec/requests/wishlists/wishlist_show_spec.rb
```

Verified locally: prettier + eslint clean on the changed file. (`:system` specs run in CI — the local test env's CloudFront RSA key won't load from a bare shell on this machine for any branch.)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783166143&installation_id=134400930&pr_number=5403&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5403&signature=6739acc9ffa14a12f4d794939d5247056dd663eaeb9bd71864522849ea225aa7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-component presentation change to a public CTA; same URL, tracking, and accessible name for existing request specs.
> 
> **Overview**
> Wishlist product cards now show a **visible “Add to cart”** primary action (cart icon + label) instead of an icon-only control that relied on a hover tooltip.
> 
> The purchasable-item badge still uses the same `NavigationButton` link and `trackCtaClick` behavior; only the `WithTooltip` wrapper and `aria-label` are removed in favor of on-button text. Other wishlist actions (remove, gift) stay icon + tooltip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3cdc1da4ea2404f9b79ec5f51d754ca28e6aa4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->