### PR TITLE
Label the UTM 'Generate new short link' button

### DIFF
--- a/app/javascript/components/UtmLinks/UtmLinkForm.tsx
+++ b/app/javascript/components/UtmLinks/UtmLinkForm.tsx
@@ -19,7 +19,6 @@ import { InputGroup } from "$app/components/ui/InputGroup";
 import { Label } from "$app/components/ui/Label";
 import { Pill } from "$app/components/ui/Pill";
 import { Textarea } from "$app/components/ui/Textarea";
-import { WithTooltip } from "$app/components/WithTooltip";
 
 type UtmLinkFormData = {
   utm_link: {
@@ -185,7 +184,9 @@ export const UtmLinkForm = (pageProps: UtmLinkFormProps | UtmLinkEditProps) => {
     router.reload({
       only: ["additional_metadata"],
       onSuccess: (page) => {
-        const additionalMetadata = typia.assert<UtmLinkFormAdditionalMetadata | undefined>(page.props.additional_metadata);
+        const additionalMetadata = typia.assert<UtmLinkFormAdditionalMetadata | undefined>(
+          page.props.additional_metadata,
+        );
         const newPermalink = additionalMetadata?.new_permalink;
         if (newPermalink) {
           setShortUrl((shortUrl) => ({ ...shortUrl, permalink: newPermalink }));
@@ -349,16 +350,14 @@ export const UtmLinkForm = (pageProps: UtmLinkFormProps | UtmLinkEditProps) => {
                   </Button>
                 </CopyToClipboard>
                 {!isEditing && (
-                  <WithTooltip tip="Generate new short link">
-                    <Button
-                      size="icon"
-                      onClick={generateNewPermalink}
-                      disabled={isLoadingNewPermalink}
-                      aria-label="Generate new short link"
-                    >
-                      <RefreshCcw className="size-5" />
-                    </Button>
-                  </WithTooltip>
+                  <Button
+                    onClick={generateNewPermalink}
+                    disabled={isLoadingNewPermalink}
+                    aria-label="Generate new short link"
+                  >
+                    <RefreshCcw className="size-5" />
+                    Generate
+                  </Button>
                 )}
               </div>
             </div>


### PR DESCRIPTION
## What

Labels the regenerate-permalink button in the UTM link form. It was icon-only (a refresh/recycle glyph) with the action conveyed only via a hover tooltip.

A refresh icon doesn't obviously read as "generate a new short link" — the icon→action mapping is genuinely ambiguous — so a visible label helps more here than on a typical toolbar icon. Part of the labeled-button pass (follows #5402, #5388, #5403).

## Changes

- `app/javascript/components/UtmLinks/UtmLinkForm.tsx` — the button now renders the refresh icon **and** the text "Generate", dropping the `WithTooltip` wrapper and `size="icon"`. Removed the now-unused `WithTooltip` import.

## Notes

- Kept `aria-label="Generate new short link"` so the existing `spec/requests/analytics/utm_links_spec.rb` `click_on "Generate new short link"` assertion still resolves by accessible name.
- The adjacent "Copy short link" button keeps its icon + tooltip — only the ambiguous regenerate action is labeled.

## Test plan

```
bundle exec rspec spec/requests/analytics/utm_links_spec.rb
```

Verified locally: prettier + eslint clean on the changed file. (`:system` specs run in CI — the local test env's CloudFront RSA key won't load from a bare shell on this machine for any branch.)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783166244&installation_id=134400930&pr_number=5404&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5404&signature=ac97e968ad4cec7a8db74599b2299a9e46d1eca75317165f7f6f4f3534dd8208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-component UI copy and layout change with no backend or auth impact.
> 
> **Overview**
> The UTM link create form’s **regenerate short link** control is no longer icon-only with a hover tooltip. It now shows the refresh icon plus visible **Generate** text, and the unused `WithTooltip` import is removed. **`aria-label="Generate new short link"`** is unchanged so request specs that click by that name still work; the copy-short-link control stays icon + tooltip.
> 
> A trivial formatting-only wrap was applied to the `typia.assert` call in the permalink reload handler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fddd7c8c67e87677349507bad1fdc5b18101e2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->