### PR TITLE
Label the Export buttons (icon + text) for consistency

### DIFF
--- a/app/javascript/components/Audience/CustomersPage.tsx
+++ b/app/javascript/components/Audience/CustomersPage.tsx
@@ -357,13 +357,12 @@ const CustomersPage = ({
             </Popover>
             <Popover open={exportPopoverOpen} onOpenChange={setExportPopoverOpen}>
               <PopoverAnchor>
-                <WithTooltip tip="Export">
-                  <PopoverTrigger aria-label="Export" asChild>
-                    <Button size="icon">
-                      <ArrowInDownSquareHalf className="size-5" />
-                    </Button>
-                  </PopoverTrigger>
-                </WithTooltip>
+                <PopoverTrigger aria-label="Export" asChild>
+                  <Button>
+                    <ArrowInDownSquareHalf className="size-5" />
+                    Export
+                  </Button>
+                </PopoverTrigger>
               </PopoverAnchor>
               <PopoverContent>
                 <div className="flex flex-col gap-4">

--- a/app/javascript/components/Payouts/index.tsx
+++ b/app/javascript/components/Payouts/index.tsx
@@ -353,17 +353,15 @@ const Period = ({ payoutPeriodData }: { payoutPeriodData: PayoutPeriodData }) =>
         {"type" in payoutPeriodData && payoutPeriodData.type === "instant" ? <Pill size="small">Instant</Pill> : null}
         <span style={{ marginLeft: "auto" }}>{payoutPeriodData.displayable_payout_period_range}</span>
         {payoutPeriodData.status === "completed" && payoutPeriodData.payment_external_id ? (
-          <WithTooltip position="top" tip="Export">
-            <Button
-              size="icon"
-              color="primary"
-              disabled={isCSVDownloadInProgress}
-              onClick={handleRequestPayoutCSV}
-              aria-label="Export"
-            >
-              <ArrowInDownSquareHalf className="size-5" />
-            </Button>
-          </WithTooltip>
+          <Button
+            color="primary"
+            disabled={isCSVDownloadInProgress}
+            onClick={handleRequestPayoutCSV}
+            aria-label="Export"
+          >
+            <ArrowInDownSquareHalf className="size-5" />
+            Export
+          </Button>
         ) : null}
       </div>
       <Card style={{ marginTop: "var(--spacer-4)" }}>

--- a/app/javascript/pages/Affiliates/Index.tsx
+++ b/app/javascript/pages/Affiliates/Index.tsx
@@ -362,15 +362,14 @@ export default function AffiliatesIndex() {
                       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
                         Affiliates
                         <div className="text-base">
-                          <WithTooltip tip="Export" position="top">
-                            <a
-                              href={Routes.export_affiliates_path()}
-                              className={buttonVariants({ size: "default", color: "primary" })}
-                              aria-label="Export"
-                            >
-                              <ArrowInDownSquareHalf className="size-5" />
-                            </a>
-                          </WithTooltip>
+                          <a
+                            href={Routes.export_affiliates_path()}
+                            className={buttonVariants({ size: "default", color: "primary" })}
+                            aria-label="Export"
+                          >
+                            <ArrowInDownSquareHalf className="size-5" />
+                            Export
+                          </a>
                         </div>
                       </div>
                     </TableCaption>

--- a/app/javascript/pages/Audience/Index.tsx
+++ b/app/javascript/pages/Audience/Index.tsx
@@ -18,7 +18,6 @@ import { Popover, PopoverAnchor, PopoverContent, PopoverTrigger } from "$app/com
 import { InputGroup } from "$app/components/ui/InputGroup";
 import { Placeholder, PlaceholderImage } from "$app/components/ui/Placeholder";
 import { useOnChange } from "$app/components/useOnChange";
-import { WithTooltip } from "$app/components/WithTooltip";
 
 import placeholder from "$assets/images/placeholders/audience.png";
 
@@ -48,13 +47,12 @@ function Audience() {
           <div className="flex w-full gap-2">
             <Popover>
               <PopoverAnchor>
-                <WithTooltip tip="Export" position="bottom">
-                  <PopoverTrigger aria-label="Export" asChild>
-                    <Button size="icon">
-                      <ArrowInDownSquareHalf aria-label="Download" className="size-5" />
-                    </Button>
-                  </PopoverTrigger>
-                </WithTooltip>
+                <PopoverTrigger aria-label="Export" asChild>
+                  <Button>
+                    <ArrowInDownSquareHalf aria-label="Download" className="size-5" />
+                    Export
+                  </Button>
+                </PopoverTrigger>
               </PopoverAnchor>
               <PopoverContent sideOffset={4}>
                 <ExportSubscribersPopover />

--- a/app/javascript/pages/Followers/Index.tsx
+++ b/app/javascript/pages/Followers/Index.tsx
@@ -17,7 +17,6 @@ import { Sheet, SheetHeader } from "$app/components/ui/Sheet";
 import { Table, TableBody, TableCaption, TableCell, TableHead, TableHeader, TableRow } from "$app/components/ui/Table";
 import { useDebouncedCallback } from "$app/components/useDebouncedCallback";
 import { useUserAgentInfo } from "$app/components/UserAgent";
-import { WithTooltip } from "$app/components/WithTooltip";
 
 import placeholder from "$assets/images/placeholders/followers.png";
 
@@ -96,13 +95,12 @@ export default function FollowersPage() {
           ) : null}
           <Popover>
             <PopoverAnchor>
-              <WithTooltip tip="Export" position="bottom">
-                <PopoverTrigger aria-label="Export" asChild>
-                  <Button size="icon">
-                    <ArrowInDownSquareHalf aria-label="Download" className="size-5" />
-                  </Button>
-                </PopoverTrigger>
-              </WithTooltip>
+              <PopoverTrigger aria-label="Export" asChild>
+                <Button>
+                  <ArrowInDownSquareHalf aria-label="Download" className="size-5" />
+                  Export
+                </Button>
+              </PopoverTrigger>
             </PopoverAnchor>
             <PopoverContent sideOffset={4}>
               <ExportSubscribersPopover />

--- a/app/javascript/pages/Payouts/Index.tsx
+++ b/app/javascript/pages/Payouts/Index.tsx
@@ -105,17 +105,16 @@ const Period = ({ payoutPeriodData }: { payoutPeriodData: PayoutPeriodData }) =>
         {"type" in payoutPeriodData && payoutPeriodData.type === "instant" ? <Pill size="small">Instant</Pill> : null}
         <span style={{ marginLeft: "auto" }}>{payoutPeriodData.displayable_payout_period_range}</span>
         {payoutPeriodData.status === "completed" && payoutPeriodData.payment_external_id ? (
-          <WithTooltip position="top" tip="Export" className="shrink-0">
-            <Button
-              size="icon"
-              color="primary"
-              disabled={isCSVDownloadInProgress}
-              onClick={handleRequestPayoutCSV}
-              aria-label="Export"
-            >
-              <ArrowInDownSquareHalf className="size-5" />
-            </Button>
-          </WithTooltip>
+          <Button
+            color="primary"
+            className="shrink-0"
+            disabled={isCSVDownloadInProgress}
+            onClick={handleRequestPayoutCSV}
+            aria-label="Export"
+          >
+            <ArrowInDownSquareHalf className="size-5" />
+            Export
+          </Button>
         ) : null}
       </div>
       <Card style={{ marginTop: "var(--spacer-4)" }}>


### PR DESCRIPTION
## What

Labels the CSV/data **Export** buttons across the dashboard. They were icon-only (download-arrow glyph) with the action conveyed only via a hover tooltip. This labels them consistently as "Export" (icon + text) on every surface that has one — doing the whole group together so they stay uniform.

Part of the labeled-button pass (follows #5402 product edit, #5388 profile edit, #5403 wishlist, #5404 UTM).

## Surfaces changed (6)

- `components/Audience/CustomersPage.tsx` — Audience › Customers
- `pages/Audience/Index.tsx` — Audience › Following
- `pages/Followers/Index.tsx` — Followers
- `components/Payouts/index.tsx` + `pages/Payouts/Index.tsx` — payout-period header export
- `pages/Affiliates/Index.tsx` — Affiliates table export

## Changes

- Each Export control now renders the download-arrow icon **and** the text "Export", dropping the `WithTooltip` wrapper and `size="icon"`.
- Removed two now-unused `WithTooltip` imports (`pages/Audience`, `pages/Followers`); the other files keep the import for their remaining tooltips.
- Kept `aria-label="Export"` everywhere, so the existing `spec/requests/balance_pages_spec.rb` `click_on "Export"` assertion still resolves by accessible name.

## Notes

- This is a deliberate consistency pass on a repeated affordance — unlike one-off icon buttons in dense action clusters (Edit/Delete/Remove in tables), the Export button is a single prominent action per page, so a label reads cleanly without bloating a toolbar.

## Test plan

```
bundle exec rspec spec/requests/balance_pages_spec.rb
```

Verified locally: prettier + eslint clean on the changed regions of all 6 files. (`:system` specs run in CI — the local test env's CloudFront RSA key won't load from a bare shell on this machine for any branch.)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5405"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783166468&installation_id=134400930&pr_number=5405&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5405&signature=17dc1e1198eb4f36802dcea6b539e067899009bbfeca94300adb47da0d05f4e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only React changes with no export logic, routes, or permissions touched.
> 
> **Overview**
> Standardizes **Export** across six dashboard surfaces (Sales/Customers, Audience Following, Followers, Affiliates, and payout-period headers) so the control shows the download icon **and** visible **Export** text instead of icon-only with a hover tooltip.
> 
> Each change drops the `WithTooltip` wrapper and `size="icon"` on those buttons/links; `aria-label="Export"` is unchanged so existing specs (e.g. `click_on "Export"`) still work. Unused `WithTooltip` imports are removed on Audience and Followers pages only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5421305a46950458530ff38cc9e36ebe2d62102. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->