### PR TITLE
Label the product page edit button and place it above the card

### DIFF
--- a/app/javascript/components/Product/Layout.tsx
+++ b/app/javascript/components/Product/Layout.tsx
@@ -37,7 +37,6 @@ import { ImageUploadSettingsContext } from "$app/components/RichTextEditor";
 import { showAlert } from "$app/components/server-components/Alert";
 import { useIsAboveBreakpoint } from "$app/components/useIsAboveBreakpoint";
 import { useRefToLatest } from "$app/components/useRefToLatest";
-import { WithTooltip } from "$app/components/WithTooltip";
 
 export type Props = ProductProps & { main_section_index: number } & (SectionsProps | EditSectionsProps);
 
@@ -269,7 +268,6 @@ const CtaBar = ({
         bottom: isDesktop ? undefined : 0,
         left: 0,
         right: 0,
-        // Render above the product edit button
         zIndex: "var(--z-index-menubar)",
         marginTop: hasHero ? "var(--border-width)" : undefined,
       }}
@@ -338,31 +336,17 @@ const CtaBar = ({
 
 const EditButton = ({ product }: { product: Product }) => {
   const appDomain = useAppDomain();
-  const isDesktop = useIsAboveBreakpoint("lg");
 
   if (!product.can_edit) return null;
 
   return (
-    <div
-      style={{
-        position: "absolute",
-        top: isDesktop ? "var(--spacer-3)" : "var(--spacer-4)",
-        right: isDesktop ? undefined : "var(--spacer-4)",
-        left: isDesktop ? "var(--spacer-3)" : undefined,
-        // Render above the product `article`
-        zIndex: "var(--z-index-overlay)",
-      }}
+    <NavigationButton
+      className="mb-4"
+      color="filled"
+      href={Routes.edit_link_url({ id: product.permalink }, { host: appDomain })}
     >
-      <WithTooltip tip="Edit product" position={isDesktop ? "right" : "left"}>
-        <NavigationButton
-          color="filled"
-          size="icon"
-          href={Routes.edit_link_url({ id: product.permalink }, { host: appDomain })}
-          aria-label="Edit product"
-        >
-          <Pencil className="size-5" />
-        </NavigationButton>
-      </WithTooltip>
-    </div>
+      <Pencil className="size-5" />
+      Edit product
+    </NavigationButton>
   );
 };

--- a/app/javascript/components/Product/Layout.tsx
+++ b/app/javascript/components/Product/Layout.tsx
@@ -345,7 +345,7 @@ const EditButton = ({ product }: { product: Product }) => {
       color="filled"
       href={Routes.edit_link_url({ id: product.permalink }, { host: appDomain })}
     >
-      <Pencil className="size-5" />
+      <Pencil className="size-5" aria-hidden="true" />
       Edit product
     </NavigationButton>
   );


### PR DESCRIPTION
## What

The owner-only edit affordance on the product page was an icon-only button that floated over the top corner of the product card and needed a hover tooltip to explain itself. This gives it a visible **"Edit product"** label and moves it into normal flow **above** the card, aligned to the card's left edge — same position on desktop and mobile.

## Why

A text label is self-evident everywhere. The old absolute placement worked for a small square icon but, once widened into a labeled button, it straddled the card's top border and read as a layout glitch. Placing it above the card removes the collision and keeps placement consistent across breakpoints.

## Before / After

|         | Before | After |
|---------|--------|-------|
| **Desktop** | <img width="480" alt="Before Desktop" src="https://github.com/user-attachments/assets/91454d2f-1f81-46d9-ad79-f974fd121952" /> | <img width="480" alt="After Desktop" src="https://github.com/user-attachments/assets/8e47a845-6dbb-47c5-83c7-e0bc1f60331a" /> |
| **Mobile**  | <img width="240" alt="Before Mobile" src="https://github.com/user-attachments/assets/74228cc3-aa03-49e3-80e9-8a93fc54b9dc" /> | <img width="240" alt="After Mobile" src="https://github.com/user-attachments/assets/34e3bd24-7c7f-420e-ac4c-c8b665b85bce" /> |

---

This PR was implemented with AI assistance using Claude Opus 4.8.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783181760&installation_id=134400930&pr_number=5408&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5408&signature=aee88b42787a31bb529e14bef220abb4c1fa94c418c738359c2d7bd8d0b6aa89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change to seller edit affordance; no auth, checkout, or data path changes.
> 
> **Overview**
> The owner-only **Edit product** control on the product page is no longer an absolutely positioned icon-only `NavigationButton` with a `WithTooltip` hover label. It is now a labeled `NavigationButton` with visible **Edit product** text and a pencil icon, sitting in normal document flow **above** the product card (`mb-4`) instead of overlaying a corner of the card.
> 
> Breakpoint-specific positioning and the `useIsAboveBreakpoint` / `WithTooltip` wiring were removed from `EditButton` so placement is consistent on desktop and mobile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b39c16372c5e1889a6a7a6d363752f08b2bd958. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->