### PR TITLE
Add OAuth device authorization flow

### DIFF
--- a/app/controllers/concerns/oauth_client_authentication.rb
+++ b/app/controllers/concerns/oauth_client_authentication.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module OauthClientAuthentication
+  extend ActiveSupport::Concern
+
+  private
+    def authenticate_oauth_application
+      client_id, client_secret = oauth_client_credentials
+      return [nil, :invalid_request, "client_id is required"] if client_id.blank?
+
+      oauth_application = OauthApplication.alive.find_by(uid: client_id)
+      return [nil, :invalid_client, "Client authentication failed due to unknown client"] if oauth_application.blank?
+      return [oauth_application, nil, nil] unless oauth_application.confidential?
+      return [oauth_application, nil, nil] if valid_oauth_client_secret?(oauth_application, client_secret)
+
+      [nil, :invalid_client, "Client authentication failed"]
+    end
+
+    def requested_oauth_scope_for(oauth_application)
+      requested_scope = params[:scope]
+      return requested_scope if requested_scope.is_a?(String) && requested_scope.present?
+      return if requested_scope.present?
+
+      (Doorkeeper.configuration.default_scopes & oauth_application_scopes(oauth_application)).to_s
+    end
+
+    def valid_oauth_scope?(oauth_application, scopes)
+      return false unless scopes.is_a?(String) && scopes.present?
+
+      Doorkeeper::OAuth::Helpers::ScopeChecker.valid?(
+        scope_str: scopes,
+        server_scopes: Doorkeeper.configuration.scopes,
+        app_scopes: oauth_application_scopes(oauth_application)
+      )
+    end
+
+    def render_oauth_json_error(error, description, status: :bad_request, extra: {})
+      headers.merge!("Cache-Control" => "no-store, no-cache")
+      render json: { error:, error_description: description }.merge(extra), status:
+    end
+
+    def oauth_request_user_agent
+      request.user_agent.to_s.first(255)
+    end
+
+    def oauth_client_credentials
+      basic_client_id, basic_client_secret = ActionController::HttpAuthentication::Basic.user_name_and_password(request)
+      [params[:client_id].presence || basic_client_id, params[:client_secret].presence || basic_client_secret]
+    end
+
+    def valid_oauth_client_secret?(oauth_application, client_secret)
+      return false if client_secret.blank?
+      return false if oauth_application.secret.bytesize != client_secret.to_s.bytesize
+
+      ActiveSupport::SecurityUtils.secure_compare(oauth_application.secret, client_secret.to_s)
+    end
+
+    def oauth_application_scopes(oauth_application)
+      Doorkeeper::OAuth::Scopes.from_string(oauth_application.scopes.to_s)
+    end
+end

--- a/app/controllers/concerns/oauth_client_authentication.rb
+++ b/app/controllers/concerns/oauth_client_authentication.rb
@@ -21,7 +21,7 @@ module OauthClientAuthentication
       return requested_scope if requested_scope.is_a?(String) && requested_scope.present?
       return if requested_scope.present?
 
-      (Doorkeeper.configuration.default_scopes & oauth_application_scopes(oauth_application)).to_s
+      oauth_application_scopes(oauth_application).to_s
     end
 
     def valid_oauth_scope?(oauth_application, scopes)

--- a/app/controllers/concerns/oauth_client_authentication.rb
+++ b/app/controllers/concerns/oauth_client_authentication.rb
@@ -36,7 +36,12 @@ module OauthClientAuthentication
 
     def render_oauth_json_error(error, description, status: :bad_request, extra: {})
       headers.merge!("Cache-Control" => "no-store, no-cache")
+      headers["WWW-Authenticate"] = %(Basic realm="Doorkeeper") if basic_oauth_authentication_failure?(status)
       render json: { error:, error_description: description }.merge(extra), status:
+    end
+
+    def basic_oauth_authentication_failure?(status)
+      status == :unauthorized && ActionController::HttpAuthentication::Basic.has_basic_credentials?(request)
     end
 
     def oauth_request_user_agent

--- a/app/controllers/oauth/device_authorizations_controller.rb
+++ b/app/controllers/oauth/device_authorizations_controller.rb
@@ -9,6 +9,7 @@ class Oauth::DeviceAuthorizationsController < ApplicationController
 
   def new
     load_device_authorization
+    set_revoked_access_error
 
     if @device_authorization.present? && @error_message.blank? && !user_signed_in?
       redirect_to login_path(next: oauth_device_authorization_path(user_code: @user_code))
@@ -69,6 +70,13 @@ class Oauth::DeviceAuthorizationsController < ApplicationController
       elsif user_signed_in? && impersonating?
         @error_message = "Stop impersonating before authorizing an OAuth application."
       end
+    end
+
+    def set_revoked_access_error
+      return if @device_authorization.blank? || @error_message.present? || !user_signed_in?
+      return unless @device_authorization.access_revoked_after_creation_for?(current_user)
+
+      @error_message = "This code is invalid or expired."
     end
 
     def oauth_scope_description(scope)

--- a/app/controllers/oauth/device_authorizations_controller.rb
+++ b/app/controllers/oauth/device_authorizations_controller.rb
@@ -10,6 +10,7 @@ class Oauth::DeviceAuthorizationsController < ApplicationController
   def new
     load_device_authorization
     set_approved_decision
+    set_denied_decision
 
     if @device_authorization.present? && @error_message.blank? && !user_signed_in?
       redirect_to login_path(next: oauth_device_authorization_path(user_code: @user_code))
@@ -65,7 +66,7 @@ class Oauth::DeviceAuthorizationsController < ApplicationController
         @error_message = "This code has expired."
       elsif !@device_authorization.oauth_application.alive? || !@device_authorization.oauth_application.device_authorization_enabled?
         @error_message = "This code is invalid."
-      elsif !@device_authorization.pending? && !approved_by_current_user?
+      elsif !@device_authorization.pending? && !terminal_for_current_user?
         @error_message = "This code is invalid or expired."
       elsif user_signed_in? && impersonating?
         @error_message = "Stop impersonating before authorizing an OAuth application."
@@ -74,13 +75,32 @@ class Oauth::DeviceAuthorizationsController < ApplicationController
 
     def set_approved_decision
       return if @device_authorization.blank? || @error_message.present?
-      return unless approved_by_current_user?
+      return unless approved_or_consumed_by_current_user?
 
       @decision = :approved
     end
 
-    def approved_by_current_user?
-      user_signed_in? && !impersonating? && @device_authorization.approved? && @device_authorization.resource_owner_id == current_user.id
+    def set_denied_decision
+      return if @device_authorization.blank? || @error_message.present?
+      return unless denied_by_current_user?
+
+      @decision = :denied
+    end
+
+    def terminal_for_current_user?
+      approved_or_consumed_by_current_user? || denied_by_current_user?
+    end
+
+    def approved_or_consumed_by_current_user?
+      device_authorization_owned_by_current_user? && (@device_authorization.approved? || @device_authorization.consumed?)
+    end
+
+    def denied_by_current_user?
+      device_authorization_owned_by_current_user? && @device_authorization.denied?
+    end
+
+    def device_authorization_owned_by_current_user?
+      user_signed_in? && !impersonating? && @device_authorization.resource_owner_id == current_user.id
     end
 
     def oauth_scope_description(scope)

--- a/app/controllers/oauth/device_authorizations_controller.rb
+++ b/app/controllers/oauth/device_authorizations_controller.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class Oauth::DeviceAuthorizationsController < ApplicationController
+  MAX_USER_CODE_HANDOFFS = 20
+  USER_CODE_HANDOFF_SESSION_KEY = :oauth_device_authorization_user_code_handoffs
+
   before_action :hide_layouts
   before_action :hide_from_search_results
   before_action :authenticate_user!, only: :create
@@ -13,7 +16,8 @@ class Oauth::DeviceAuthorizationsController < ApplicationController
     set_denied_decision
 
     if @device_authorization.present? && @error_message.blank? && !user_signed_in?
-      redirect_to login_path(next: oauth_device_authorization_path(user_code: @user_code))
+      handoff = store_user_code_handoff
+      redirect_to login_path(next: oauth_device_authorization_path(handoff:))
     end
   end
 
@@ -25,15 +29,11 @@ class Oauth::DeviceAuthorizationsController < ApplicationController
       return render :new, status: :unprocessable_entity
     end
 
-    if impersonating?
-      @error_message = "Stop impersonating before authorizing an OAuth application."
-      return render :new, status: :unprocessable_entity
-    end
-
     case params[:decision]
     when "deny"
       if @device_authorization.deny!(resource_owner: current_user, ip_address: request.remote_ip, user_agent: request.user_agent.to_s.first(255))
         @decision = :denied
+        clear_user_code_handoff
       else
         @error_message = "This code is invalid or expired."
         return render :new, status: :unprocessable_entity
@@ -41,6 +41,7 @@ class Oauth::DeviceAuthorizationsController < ApplicationController
     when "approve"
       if @device_authorization.approve!(resource_owner: current_user, ip_address: request.remote_ip, user_agent: request.user_agent.to_s.first(255))
         @decision = :approved
+        clear_user_code_handoff
       else
         @error_message = "This code is invalid or expired."
         return render :new, status: :unprocessable_entity
@@ -55,7 +56,7 @@ class Oauth::DeviceAuthorizationsController < ApplicationController
 
   private
     def load_device_authorization
-      @user_code = OauthDeviceAuthorization.format_user_code(params[:user_code])
+      @user_code = OauthDeviceAuthorization.format_user_code(user_code_from_params_or_session)
       return if @user_code.blank?
 
       @device_authorization = OauthDeviceAuthorization.find_by_user_code(@user_code)
@@ -71,6 +72,60 @@ class Oauth::DeviceAuthorizationsController < ApplicationController
       elsif user_signed_in? && impersonating?
         @error_message = "Stop impersonating before authorizing an OAuth application."
       end
+    end
+
+    def user_code_from_params_or_session
+      params[:user_code].presence || user_code_from_handoff
+    end
+
+    def store_user_code_handoff
+      handoff = SecureRandom.urlsafe_base64(16)
+      handoffs = pruned_user_code_handoffs
+      handoffs.delete_if { |_key, entry| user_code_from_handoff_entry(entry) == @user_code }
+      handoffs[handoff] = { "user_code" => @user_code, "created_at" => Time.current.to_i }
+      session[USER_CODE_HANDOFF_SESSION_KEY] = handoffs.sort_by { |_key, entry| handoff_created_at(entry) }.last(MAX_USER_CODE_HANDOFFS).to_h
+      handoff
+    end
+
+    def user_code_from_handoff
+      @handoff = params[:handoff].presence
+      return if @handoff.blank?
+
+      handoffs = pruned_user_code_handoffs
+      sync_user_code_handoffs(handoffs)
+      user_code_from_handoff_entry(handoffs[@handoff])
+    end
+
+    def clear_user_code_handoff
+      handoff = params[:handoff].presence
+      return if handoff.blank?
+
+      handoffs = user_code_handoffs
+      handoffs.delete(handoff)
+      sync_user_code_handoffs(handoffs)
+    end
+
+    def pruned_user_code_handoffs
+      cutoff = OauthDeviceAuthorization::EXPIRES_IN.ago.to_i
+      user_code_handoffs.select { |_key, entry| handoff_created_at(entry) >= cutoff && user_code_from_handoff_entry(entry).present? }
+    end
+
+    def user_code_handoffs
+      handoffs = session[USER_CODE_HANDOFF_SESSION_KEY]
+      handoffs.is_a?(Hash) ? handoffs : {}
+    end
+
+    def user_code_from_handoff_entry(entry)
+      entry.is_a?(Hash) ? entry["user_code"] : nil
+    end
+
+    def handoff_created_at(entry)
+      entry.is_a?(Hash) ? entry["created_at"].to_i : 0
+    end
+
+    def sync_user_code_handoffs(handoffs)
+      session[USER_CODE_HANDOFF_SESSION_KEY] = handoffs
+      session.delete(USER_CODE_HANDOFF_SESSION_KEY) if handoffs.blank?
     end
 
     def set_approved_decision

--- a/app/controllers/oauth/device_authorizations_controller.rb
+++ b/app/controllers/oauth/device_authorizations_controller.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+class Oauth::DeviceAuthorizationsController < ApplicationController
+  before_action :hide_layouts
+  before_action :hide_from_search_results
+  before_action :authenticate_user!, only: :create
+
+  helper_method :oauth_scope_description
+
+  def new
+    load_device_authorization
+
+    if @device_authorization.present? && !user_signed_in?
+      redirect_to login_path(next: oauth_device_authorization_path(user_code: @user_code))
+    end
+  end
+
+  def create
+    load_device_authorization
+
+    if @device_authorization.blank? || !@device_authorization.approvable?
+      @error_message ||= "This code is invalid or expired."
+      return render :new, status: :unprocessable_entity
+    end
+
+    if impersonating?
+      @error_message = "Stop impersonating before authorizing an OAuth application."
+      return render :new, status: :unprocessable_entity
+    end
+
+    case params[:decision]
+    when "deny"
+      @device_authorization.deny!(resource_owner: current_user, ip_address: request.remote_ip, user_agent: request.user_agent.to_s.first(255))
+      @decision = :denied
+    when "approve"
+      @device_authorization.approve!(resource_owner: current_user, ip_address: request.remote_ip, user_agent: request.user_agent.to_s.first(255))
+      @decision = :approved
+    else
+      @error_message = "Choose whether to authorize or deny this application."
+      return render :new, status: :unprocessable_entity
+    end
+
+    render :new
+  end
+
+  private
+    def load_device_authorization
+      @user_code = OauthDeviceAuthorization.format_user_code(params[:user_code])
+      return if @user_code.blank?
+
+      @device_authorization = OauthDeviceAuthorization.find_by_user_code(@user_code)
+
+      if @device_authorization.blank?
+        @error_message = "This code is invalid."
+      elsif @device_authorization.expired?
+        @error_message = "This code has expired."
+      elsif user_signed_in? && impersonating?
+        @error_message = "Stop impersonating before authorizing an OAuth application."
+      end
+    end
+
+    def oauth_scope_description(scope)
+      case scope
+      when "creator_api" then "Creator API"
+      when "edit_products" then "Create new products and edit your existing products."
+      when "ifttt" then "See your sales data."
+      when "mark_sales_as_shipped" then "Mark your sales as shipped."
+      when "mobile_api" then "Mobile API"
+      when "refund_sales" then "Refund your sales."
+      when "edit_sales" then "Refund your sales and resend purchase receipts to customers."
+      when "revenue_share" then "Revenue Share"
+      when "unfurl" then "Fetch public information of any product to preview it in Notion."
+      when "view_profile" then "See your profile data."
+      when "view_public" then "See your public information (name, bio)."
+      when "view_sales" then "See your sales data."
+      when "view_payouts" then "See your payouts data."
+      when "view_tax_data" then "See your tax forms and annual earnings summary."
+      when "account" then "Full access to your account."
+      else scope.to_s.humanize
+      end
+    end
+
+    def hide_layouts
+      @hide_layouts = true
+    end
+
+    def hide_from_search_results
+      headers["X-Robots-Tag"] = "noindex"
+    end
+end

--- a/app/controllers/oauth/device_authorizations_controller.rb
+++ b/app/controllers/oauth/device_authorizations_controller.rb
@@ -10,7 +10,7 @@ class Oauth::DeviceAuthorizationsController < ApplicationController
   def new
     load_device_authorization
 
-    if @device_authorization.present? && !user_signed_in?
+    if @device_authorization.present? && @error_message.blank? && !user_signed_in?
       redirect_to login_path(next: oauth_device_authorization_path(user_code: @user_code))
     end
   end
@@ -18,7 +18,7 @@ class Oauth::DeviceAuthorizationsController < ApplicationController
   def create
     load_device_authorization
 
-    if @device_authorization.blank? || !@device_authorization.approvable?
+    if @device_authorization.blank? || @error_message.present? || !@device_authorization.approvable?
       @error_message ||= "This code is invalid or expired."
       return render :new, status: :unprocessable_entity
     end
@@ -62,6 +62,10 @@ class Oauth::DeviceAuthorizationsController < ApplicationController
         @error_message = "This code is invalid."
       elsif @device_authorization.expired?
         @error_message = "This code has expired."
+      elsif !@device_authorization.oauth_application.alive? || !@device_authorization.oauth_application.device_authorization_enabled?
+        @error_message = "This code is invalid."
+      elsif !@device_authorization.pending?
+        @error_message = "This code is invalid or expired."
       elsif user_signed_in? && impersonating?
         @error_message = "Stop impersonating before authorizing an OAuth application."
       end

--- a/app/controllers/oauth/device_authorizations_controller.rb
+++ b/app/controllers/oauth/device_authorizations_controller.rb
@@ -30,11 +30,19 @@ class Oauth::DeviceAuthorizationsController < ApplicationController
 
     case params[:decision]
     when "deny"
-      @device_authorization.deny!(resource_owner: current_user, ip_address: request.remote_ip, user_agent: request.user_agent.to_s.first(255))
-      @decision = :denied
+      if @device_authorization.deny!(resource_owner: current_user, ip_address: request.remote_ip, user_agent: request.user_agent.to_s.first(255))
+        @decision = :denied
+      else
+        @error_message = "This code is invalid or expired."
+        return render :new, status: :unprocessable_entity
+      end
     when "approve"
-      @device_authorization.approve!(resource_owner: current_user, ip_address: request.remote_ip, user_agent: request.user_agent.to_s.first(255))
-      @decision = :approved
+      if @device_authorization.approve!(resource_owner: current_user, ip_address: request.remote_ip, user_agent: request.user_agent.to_s.first(255))
+        @decision = :approved
+      else
+        @error_message = "This code is invalid or expired."
+        return render :new, status: :unprocessable_entity
+      end
     else
       @error_message = "Choose whether to authorize or deny this application."
       return render :new, status: :unprocessable_entity

--- a/app/controllers/oauth/device_authorizations_controller.rb
+++ b/app/controllers/oauth/device_authorizations_controller.rb
@@ -9,6 +9,7 @@ class Oauth::DeviceAuthorizationsController < ApplicationController
 
   def new
     load_device_authorization
+    set_approved_decision
     set_revoked_access_error
 
     if @device_authorization.present? && @error_message.blank? && !user_signed_in?
@@ -65,18 +66,30 @@ class Oauth::DeviceAuthorizationsController < ApplicationController
         @error_message = "This code has expired."
       elsif !@device_authorization.oauth_application.alive? || !@device_authorization.oauth_application.device_authorization_enabled?
         @error_message = "This code is invalid."
-      elsif !@device_authorization.pending?
+      elsif !@device_authorization.pending? && !approved_by_current_user?
         @error_message = "This code is invalid or expired."
       elsif user_signed_in? && impersonating?
         @error_message = "Stop impersonating before authorizing an OAuth application."
       end
     end
 
+    def set_approved_decision
+      return if @device_authorization.blank? || @error_message.present?
+      return unless approved_by_current_user?
+
+      @decision = :approved
+    end
+
     def set_revoked_access_error
       return if @device_authorization.blank? || @error_message.present? || !user_signed_in?
+      return unless @device_authorization.pending?
       return unless @device_authorization.access_revoked_after_creation_for?(current_user)
 
       @error_message = "This code is invalid or expired."
+    end
+
+    def approved_by_current_user?
+      user_signed_in? && !impersonating? && @device_authorization.approved? && @device_authorization.resource_owner_id == current_user.id
     end
 
     def oauth_scope_description(scope)

--- a/app/controllers/oauth/device_authorizations_controller.rb
+++ b/app/controllers/oauth/device_authorizations_controller.rb
@@ -85,6 +85,7 @@ class Oauth::DeviceAuthorizationsController < ApplicationController
       return unless @device_authorization.pending?
       return unless @device_authorization.access_revoked_after_creation_for?(current_user)
 
+      @device_authorization.deny!(resource_owner: current_user, ip_address: request.remote_ip, user_agent: request.user_agent.to_s.first(255))
       @error_message = "This code is invalid or expired."
     end
 

--- a/app/controllers/oauth/device_authorizations_controller.rb
+++ b/app/controllers/oauth/device_authorizations_controller.rb
@@ -10,7 +10,6 @@ class Oauth::DeviceAuthorizationsController < ApplicationController
   def new
     load_device_authorization
     set_approved_decision
-    set_revoked_access_error
 
     if @device_authorization.present? && @error_message.blank? && !user_signed_in?
       redirect_to login_path(next: oauth_device_authorization_path(user_code: @user_code))
@@ -78,15 +77,6 @@ class Oauth::DeviceAuthorizationsController < ApplicationController
       return unless approved_by_current_user?
 
       @decision = :approved
-    end
-
-    def set_revoked_access_error
-      return if @device_authorization.blank? || @error_message.present? || !user_signed_in?
-      return unless @device_authorization.pending?
-      return unless @device_authorization.access_revoked_after_creation_for?(current_user)
-
-      @device_authorization.deny!(resource_owner: current_user, ip_address: request.remote_ip, user_agent: request.user_agent.to_s.first(255))
-      @error_message = "This code is invalid or expired."
     end
 
     def approved_by_current_user?

--- a/app/controllers/oauth/device_authorizations_controller.rb
+++ b/app/controllers/oauth/device_authorizations_controller.rb
@@ -62,10 +62,10 @@ class Oauth::DeviceAuthorizationsController < ApplicationController
 
       if @device_authorization.blank?
         @error_message = "This code is invalid."
-      elsif @device_authorization.expired?
-        @error_message = "This code has expired."
       elsif !@device_authorization.oauth_application.alive? || !@device_authorization.oauth_application.device_authorization_enabled?
         @error_message = "This code is invalid."
+      elsif @device_authorization.expired? && !expired_terminal_for_current_user?
+        @error_message = "This code has expired."
       elsif !@device_authorization.pending? && !terminal_for_current_user?
         @error_message = "This code is invalid or expired."
       elsif user_signed_in? && impersonating?
@@ -91,8 +91,20 @@ class Oauth::DeviceAuthorizationsController < ApplicationController
       approved_or_consumed_by_current_user? || denied_by_current_user?
     end
 
+    def expired_terminal_for_current_user?
+      consumed_by_current_user? || denied_by_current_user?
+    end
+
     def approved_or_consumed_by_current_user?
-      device_authorization_owned_by_current_user? && (@device_authorization.approved? || @device_authorization.consumed?)
+      approved_by_current_user? || consumed_by_current_user?
+    end
+
+    def approved_by_current_user?
+      device_authorization_owned_by_current_user? && @device_authorization.approved?
+    end
+
+    def consumed_by_current_user?
+      device_authorization_owned_by_current_user? && @device_authorization.consumed?
     end
 
     def denied_by_current_user?

--- a/app/controllers/oauth/device_codes_controller.rb
+++ b/app/controllers/oauth/device_codes_controller.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class Oauth::DeviceCodesController < ApplicationController
+  include OauthClientAuthentication
+
+  skip_before_action :verify_authenticity_token
+
+  def create
+    oauth_application, error, error_description = authenticate_oauth_application
+    return render_oauth_json_error(error, error_description, status: error == :invalid_client ? :unauthorized : :bad_request) if error
+    return render_oauth_json_error(:unauthorized_client, "Client is not allowed to use device authorization") unless oauth_application.device_authorization_enabled?
+
+    scopes = requested_oauth_scope_for(oauth_application)
+    return render_oauth_json_error(:invalid_scope, "The requested scope is invalid") unless valid_oauth_scope?(oauth_application, scopes)
+
+    _device_authorization, device_code, user_code = OauthDeviceAuthorization.create_for!(
+      oauth_application:,
+      scopes:,
+      ip_address: request.remote_ip,
+      user_agent: oauth_request_user_agent
+    )
+
+    headers.merge!("Cache-Control" => "no-store, no-cache")
+    render json: {
+      device_code:,
+      user_code:,
+      verification_uri: oauth_device_authorization_url(host: DOMAIN, protocol: PROTOCOL),
+      verification_uri_complete: oauth_device_authorization_url(host: DOMAIN, protocol: PROTOCOL, user_code:),
+      expires_in: OauthDeviceAuthorization::EXPIRES_IN.to_i,
+      interval: OauthDeviceAuthorization::POLL_INTERVAL.to_i,
+    }
+  end
+end

--- a/app/controllers/oauth/tokens_controller.rb
+++ b/app/controllers/oauth/tokens_controller.rb
@@ -24,10 +24,17 @@ class Oauth::TokensController < Doorkeeper::TokensController
       device_authorization = OauthDeviceAuthorization.find_by_device_code(params[:device_code])
       return render_oauth_json_error(:expired_token, "Device code is invalid or expired") if device_authorization.blank?
 
-      status, value = device_authorization.poll!(oauth_application:, ip_address: request.remote_ip, user_agent: oauth_request_user_agent)
+      oauth_application.with_lock do
+        status, value = device_authorization.poll!(oauth_application:, ip_address: request.remote_ip, user_agent: oauth_request_user_agent)
+        render_device_access_token_response(status, value)
+      end
+    end
 
+    def render_device_access_token_response(status, value)
       case status
       when OauthDeviceAuthorization::POLL_APPROVED
+        return render_oauth_json_error(:access_denied, "Access was denied") if value.reload.revoked?
+
         response = Doorkeeper::OAuth::TokenResponse.new(value)
         headers.merge!(response.headers)
         render json: response.body, status: response.status

--- a/app/controllers/oauth/tokens_controller.rb
+++ b/app/controllers/oauth/tokens_controller.rb
@@ -22,7 +22,9 @@ class Oauth::TokensController < Doorkeeper::TokensController
       return render_oauth_json_error(:invalid_request, "device_code is required") if params[:device_code].blank?
 
       device_authorization = OauthDeviceAuthorization.find_by_device_code(params[:device_code])
-      status, value = device_authorization&.poll!(oauth_application:, ip_address: request.remote_ip, user_agent: oauth_request_user_agent)
+      return render_oauth_json_error(:expired_token, "Device code is invalid or expired") if device_authorization.blank?
+
+      status, value = device_authorization.poll!(oauth_application:, ip_address: request.remote_ip, user_agent: oauth_request_user_agent)
 
       case status
       when OauthDeviceAuthorization::POLL_APPROVED

--- a/app/controllers/oauth/tokens_controller.rb
+++ b/app/controllers/oauth/tokens_controller.rb
@@ -24,8 +24,10 @@ class Oauth::TokensController < Doorkeeper::TokensController
       device_authorization = OauthDeviceAuthorization.find_by_device_code(params[:device_code])
       return render_oauth_json_error(:expired_token, "Device code is invalid or expired") if device_authorization.blank?
 
-      oauth_application.with_lock do
-        status, value = device_authorization.poll!(oauth_application:, ip_address: request.remote_ip, user_agent: oauth_request_user_agent)
+      status, value = device_authorization.poll!(oauth_application:, ip_address: request.remote_ip, user_agent: oauth_request_user_agent)
+      if status == OauthDeviceAuthorization::POLL_APPROVED
+        oauth_application.with_lock { render_device_access_token_response(status, value) }
+      else
         render_device_access_token_response(status, value)
       end
     end

--- a/app/controllers/oauth/tokens_controller.rb
+++ b/app/controllers/oauth/tokens_controller.rb
@@ -26,6 +26,7 @@ class Oauth::TokensController < Doorkeeper::TokensController
 
       status, value = device_authorization.poll!(oauth_application:, ip_address: request.remote_ip, user_agent: oauth_request_user_agent)
       if status == OauthDeviceAuthorization::POLL_APPROVED
+        # Hold the app lock through render so revoke_access_for cannot revoke this token before the response is committed.
         oauth_application.with_lock { render_device_access_token_response(status, value) }
       else
         render_device_access_token_response(status, value)

--- a/app/controllers/oauth/tokens_controller.rb
+++ b/app/controllers/oauth/tokens_controller.rb
@@ -12,7 +12,8 @@ class Oauth::TokensController < Doorkeeper::TokensController
 
   private
     def device_access_token_request?
-      request.path == oauth_token_path && params[:grant_type] == OauthDeviceAuthorization::GRANT_TYPE
+      request.path.match?(%r{\A#{Regexp.escape(oauth_token_path)}(?:\.[^/]+)?\z}) &&
+        params[:grant_type] == OauthDeviceAuthorization::GRANT_TYPE
     end
 
     def create_device_access_token

--- a/app/controllers/oauth/tokens_controller.rb
+++ b/app/controllers/oauth/tokens_controller.rb
@@ -1,9 +1,45 @@
 # frozen_string_literal: true
 
 class Oauth::TokensController < Doorkeeper::TokensController
+  include OauthClientAuthentication
   include LogrageHelper
 
+  def create
+    return create_device_access_token if device_access_token_request?
+
+    super
+  end
+
   private
+    def device_access_token_request?
+      request.path == oauth_token_path && params[:grant_type] == OauthDeviceAuthorization::GRANT_TYPE
+    end
+
+    def create_device_access_token
+      oauth_application, error, error_description = authenticate_oauth_application
+      return render_oauth_json_error(error, error_description, status: error == :invalid_client ? :unauthorized : :bad_request) if error
+      return render_oauth_json_error(:unauthorized_client, "Client is not allowed to use device authorization") unless oauth_application.device_authorization_enabled?
+      return render_oauth_json_error(:invalid_request, "device_code is required") if params[:device_code].blank?
+
+      device_authorization = OauthDeviceAuthorization.find_by_device_code(params[:device_code])
+      status, value = device_authorization&.poll!(oauth_application:, ip_address: request.remote_ip, user_agent: oauth_request_user_agent)
+
+      case status
+      when OauthDeviceAuthorization::POLL_APPROVED
+        response = Doorkeeper::OAuth::TokenResponse.new(value)
+        headers.merge!(response.headers)
+        render json: response.body, status: response.status
+      when OauthDeviceAuthorization::POLL_AUTHORIZATION_PENDING
+        render_oauth_json_error(:authorization_pending, "Authorization is pending")
+      when OauthDeviceAuthorization::POLL_SLOW_DOWN
+        render_oauth_json_error(:slow_down, "Polling too quickly", extra: { interval: value })
+      when OauthDeviceAuthorization::POLL_ACCESS_DENIED
+        render_oauth_json_error(:access_denied, "Access was denied")
+      else
+        render_oauth_json_error(:expired_token, "Device code is invalid or expired")
+      end
+    end
+
     def strategy
       # default to authorization code
       params[:grant_type] = "authorization_code" if params[:grant_type].blank?

--- a/app/controllers/oauth/tokens_controller.rb
+++ b/app/controllers/oauth/tokens_controller.rb
@@ -27,7 +27,8 @@ class Oauth::TokensController < Doorkeeper::TokensController
 
       status, value = device_authorization.poll!(oauth_application:, ip_address: request.remote_ip, user_agent: oauth_request_user_agent)
       if status == OauthDeviceAuthorization::POLL_APPROVED
-        # Hold the app lock through render so revoke_access_for cannot revoke this token before the response is committed.
+        # Re-acquire the app lock for render; render_device_access_token_response reloads the token
+        # in case revoke_access_for landed after poll! released its locks.
         oauth_application.with_lock { render_device_access_token_response(status, value) }
       else
         render_device_access_token_response(status, value)

--- a/app/models/oauth_application.rb
+++ b/app/models/oauth_application.rb
@@ -77,10 +77,11 @@ class OauthApplication < Doorkeeper::Application
 
     with_lock do
       # Coordinate with device token polling on this application row before revoking tokens.
+      # Pending codes have no owner yet; approve! rejects codes created before this revocation.
       device_authorizations
         .where(
           resource_owner_id: user.id,
-          status: [OauthDeviceAuthorization::STATUS_PENDING, OauthDeviceAuthorization::STATUS_APPROVED]
+          status: OauthDeviceAuthorization::STATUS_APPROVED
         )
         .update_all(status: OauthDeviceAuthorization::STATUS_DENIED, denied_at: revoked_at, updated_at: revoked_at)
       Doorkeeper::AccessToken.revoke_all_for(id, user)

--- a/app/models/oauth_application.rb
+++ b/app/models/oauth_application.rb
@@ -8,6 +8,7 @@ class OauthApplication < Doorkeeper::Application
   has_many :resource_subscriptions, dependent: :destroy
   has_many :affiliate_credits
   has_many :links, foreign_key: :affiliate_application_id
+  has_many :device_authorizations, class_name: "OauthDeviceAuthorization", foreign_key: :oauth_application_id, dependent: :destroy
 
   belongs_to :owner, class_name: "User", optional: true
 

--- a/app/models/oauth_application.rb
+++ b/app/models/oauth_application.rb
@@ -78,14 +78,18 @@ class OauthApplication < Doorkeeper::Application
     with_lock do
       # Coordinate with device token polling on this application row before revoking tokens.
       # Pending codes have no owner yet; approve! rejects codes created before this revocation.
-      device_authorizations
-        .where(
-          resource_owner_id: user.id,
-          status: OauthDeviceAuthorization::STATUS_APPROVED
-        )
-        .update_all(status: OauthDeviceAuthorization::STATUS_DENIED, denied_at: revoked_at, updated_at: revoked_at)
+      deny_approved_device_authorizations_for(user, denied_at: revoked_at)
       Doorkeeper::AccessToken.revoke_all_for(id, user)
       resource_subscriptions.where(user:).alive.update_all(deleted_at: revoked_at)
+    end
+  end
+
+  def revoke_access_tokens_for(user)
+    revoked_at = Time.current
+
+    with_lock do
+      deny_approved_device_authorizations_for(user, denied_at: revoked_at)
+      Doorkeeper::AccessToken.revoke_all_for(id, user)
     end
   end
 
@@ -96,6 +100,15 @@ class OauthApplication < Doorkeeper::Application
   end
 
   private
+    def deny_approved_device_authorizations_for(user, denied_at:)
+      device_authorizations
+        .where(
+          resource_owner_id: user.id,
+          status: OauthDeviceAuthorization::STATUS_APPROVED
+        )
+        .update_all(status: OauthDeviceAuthorization::STATUS_DENIED, denied_at:, updated_at: denied_at)
+    end
+
     def ensure_access_grant_exists
       access_grants.where(resource_owner_id: owner.id,
                           scopes: Doorkeeper.configuration.public_scopes.join(" "),

--- a/app/models/oauth_application.rb
+++ b/app/models/oauth_application.rb
@@ -70,9 +70,8 @@ class OauthApplication < Doorkeeper::Application
   def revoke_access_for(user)
     revoked_at = Time.current
 
-    transaction do
-      # Deny device authorizations before revoking tokens so in-flight polls either see the denial
-      # or mint a token that the following revoke sweep catches.
+    with_lock do
+      # Coordinate with device token polling on this application row before revoking tokens.
       device_authorizations
         .where(
           resource_owner_id: user.id,

--- a/app/models/oauth_application.rb
+++ b/app/models/oauth_application.rb
@@ -68,8 +68,20 @@ class OauthApplication < Doorkeeper::Application
   end
 
   def revoke_access_for(user)
-    Doorkeeper::AccessToken.revoke_all_for(id, user)
-    resource_subscriptions.where(user:).alive.update_all(deleted_at: Time.current)
+    revoked_at = Time.current
+
+    transaction do
+      # Deny device authorizations before revoking tokens so in-flight polls either see the denial
+      # or mint a token that the following revoke sweep catches.
+      device_authorizations
+        .where(
+          resource_owner_id: user.id,
+          status: [OauthDeviceAuthorization::STATUS_PENDING, OauthDeviceAuthorization::STATUS_APPROVED]
+        )
+        .update_all(status: OauthDeviceAuthorization::STATUS_DENIED, denied_at: revoked_at, updated_at: revoked_at)
+      Doorkeeper::AccessToken.revoke_all_for(id, user)
+      resource_subscriptions.where(user:).alive.update_all(deleted_at: revoked_at)
+    end
   end
 
   def icon_url

--- a/app/models/oauth_application.rb
+++ b/app/models/oauth_application.rb
@@ -30,11 +30,16 @@ class OauthApplication < Doorkeeper::Application
   end
 
   def mark_deleted!
-    transaction do
-      access_grants.where(revoked_at: nil).update_all(revoked_at: Time.current)
-      access_tokens.where(revoked_at: nil).update_all(revoked_at: Time.current)
-      resource_subscriptions.alive.update_all(deleted_at: Time.current)
-      update!(deleted_at: Time.current)
+    deleted_at = Time.current
+
+    with_lock do
+      access_grants.where(revoked_at: nil).update_all(revoked_at: deleted_at)
+      access_tokens.where(revoked_at: nil).update_all(revoked_at: deleted_at)
+      device_authorizations
+        .where(status: [OauthDeviceAuthorization::STATUS_PENDING, OauthDeviceAuthorization::STATUS_APPROVED])
+        .update_all(status: OauthDeviceAuthorization::STATUS_DENIED, denied_at: deleted_at, updated_at: deleted_at)
+      resource_subscriptions.alive.update_all(deleted_at:)
+      update!(deleted_at:)
     end
   end
 

--- a/app/models/oauth_device_authorization.rb
+++ b/app/models/oauth_device_authorization.rb
@@ -8,6 +8,7 @@ class OauthDeviceAuthorization < ApplicationRecord
   EXPIRES_IN = 10.minutes
   POLL_INTERVAL = 5.seconds
   SLOW_DOWN_INTERVAL = 10.seconds
+  MAX_CODE_GENERATION_ATTEMPTS = 3
 
   STATUS_PENDING = "pending"
   STATUS_APPROVED = "approved"
@@ -29,22 +30,28 @@ class OauthDeviceAuthorization < ApplicationRecord
   validates :status, inclusion: { in: [STATUS_PENDING, STATUS_APPROVED, STATUS_DENIED, STATUS_CONSUMED] }
 
   def self.create_for!(oauth_application:, scopes:, ip_address:, user_agent:)
-    device_code = generate_device_code
-    user_code = generate_user_code
+    attempts = 0
 
-    device_authorization = create!(
-      oauth_application:,
-      scopes:,
-      device_code_digest: digest(device_code),
-      user_code_digest: digest(normalize_user_code(user_code)),
-      expires_at: EXPIRES_IN.from_now,
-      created_ip_address: ip_address,
-      created_user_agent: user_agent
-    )
+    begin
+      attempts += 1
+      device_code = generate_device_code
+      user_code = generate_user_code
 
-    [device_authorization, device_code, user_code]
-  rescue ActiveRecord::RecordNotUnique
-    retry
+      device_authorization = create!(
+        oauth_application:,
+        scopes:,
+        device_code_digest: digest(device_code),
+        user_code_digest: digest(normalize_user_code(user_code)),
+        expires_at: EXPIRES_IN.from_now,
+        created_ip_address: ip_address,
+        created_user_agent: user_agent
+      )
+
+      [device_authorization, device_code, user_code]
+    rescue ActiveRecord::RecordNotUnique
+      retry if attempts < MAX_CODE_GENERATION_ATTEMPTS
+      raise
+    end
   end
 
   def self.find_by_device_code(device_code)
@@ -131,8 +138,8 @@ class OauthDeviceAuthorization < ApplicationRecord
       elsif denied?
         [POLL_ACCESS_DENIED, nil]
       elsif pending?
-        update_poll_metadata!(ip_address:, user_agent:)
-        polled_too_recently? ? [POLL_SLOW_DOWN, SLOW_DOWN_INTERVAL.to_i] : [POLL_AUTHORIZATION_PENDING, nil]
+        previous_last_polled_at = update_poll_metadata!(ip_address:, user_agent:)
+        polled_too_recently?(previous_last_polled_at) ? [POLL_SLOW_DOWN, SLOW_DOWN_INTERVAL.to_i] : [POLL_AUTHORIZATION_PENDING, nil]
       else
         update_poll_metadata!(ip_address:, user_agent:)
         access_token = issue_access_token!
@@ -154,17 +161,18 @@ class OauthDeviceAuthorization < ApplicationRecord
     end
 
     def update_poll_metadata!(ip_address:, user_agent:)
-      @previous_last_polled_at = last_polled_at
+      previous_last_polled_at = last_polled_at
       update!(
         last_polled_at: Time.current,
         last_poll_ip_address: ip_address,
         last_poll_user_agent: user_agent,
         poll_count: poll_count + 1
       )
+      previous_last_polled_at
     end
 
-    def polled_too_recently?
-      @previous_last_polled_at.present? && @previous_last_polled_at > POLL_INTERVAL.ago
+    def polled_too_recently?(previous_last_polled_at)
+      previous_last_polled_at.present? && previous_last_polled_at > POLL_INTERVAL.ago
     end
 
     def issue_access_token!

--- a/app/models/oauth_device_authorization.rb
+++ b/app/models/oauth_device_authorization.rb
@@ -14,6 +14,8 @@ class OauthDeviceAuthorization < ApplicationRecord
   STATUS_APPROVED = "approved"
   STATUS_DENIED = "denied"
   STATUS_CONSUMED = "consumed"
+  STATUSES = [STATUS_PENDING, STATUS_APPROVED, STATUS_DENIED, STATUS_CONSUMED].freeze
+  EXPIRABLE_STATUSES = [STATUS_PENDING, STATUS_APPROVED, STATUS_CONSUMED].freeze
 
   POLL_AUTHORIZATION_PENDING = "authorization_pending"
   POLL_SLOW_DOWN = "slow_down"
@@ -27,7 +29,9 @@ class OauthDeviceAuthorization < ApplicationRecord
 
   validates :device_code_digest, :user_code_digest, :scopes, :status, :expires_at, presence: true
   validates :device_code_digest, :user_code_digest, uniqueness: true
-  validates :status, inclusion: { in: [STATUS_PENDING, STATUS_APPROVED, STATUS_DENIED, STATUS_CONSUMED] }
+  validates :status, inclusion: { in: STATUSES }
+
+  scope :expired_for_cleanup, -> { where(status: EXPIRABLE_STATUSES).where("expires_at <= ?", Time.current) }
 
   def self.create_for!(oauth_application:, scopes:, ip_address:, user_agent:)
     attempts = 0
@@ -168,6 +172,8 @@ class OauthDeviceAuthorization < ApplicationRecord
     end
 
     result
+  rescue ActiveRecord::RecordNotFound
+    [POLL_EXPIRED_TOKEN, nil]
   end
 
   private

--- a/app/models/oauth_device_authorization.rb
+++ b/app/models/oauth_device_authorization.rb
@@ -8,6 +8,7 @@ class OauthDeviceAuthorization < ApplicationRecord
   EXPIRES_IN = 10.minutes
   POLL_INTERVAL = 5.seconds
   SLOW_DOWN_INTERVAL = 10.seconds
+  SLOW_DOWN_INCREMENT = 5.seconds
   MAX_CODE_GENERATION_ATTEMPTS = 3
 
   STATUS_PENDING = "pending"
@@ -27,7 +28,7 @@ class OauthDeviceAuthorization < ApplicationRecord
   belongs_to :resource_owner, class_name: "User", optional: true
   belongs_to :access_token, class_name: "Doorkeeper::AccessToken", optional: true
 
-  validates :device_code_digest, :user_code_digest, :scopes, :status, :expires_at, presence: true
+  validates :device_code_digest, :user_code_digest, :scopes, :status, :expires_at, :poll_interval_seconds, presence: true
   validates :device_code_digest, :user_code_digest, uniqueness: true
   validates :status, inclusion: { in: STATUSES }
 
@@ -162,8 +163,10 @@ class OauthDeviceAuthorization < ApplicationRecord
         elsif expired?
           [POLL_EXPIRED_TOKEN, nil]
         elsif pending?
-          previous_last_polled_at = update_poll_metadata!(ip_address:, user_agent:)
-          polled_too_recently?(previous_last_polled_at) ? [POLL_SLOW_DOWN, SLOW_DOWN_INTERVAL.to_i] : [POLL_AUTHORIZATION_PENDING, nil]
+          too_recent = polled_too_recently?
+          next_poll_interval_seconds = too_recent ? poll_interval_seconds + SLOW_DOWN_INCREMENT.to_i : poll_interval_seconds
+          update_poll_metadata!(ip_address:, user_agent:, poll_interval_seconds: next_poll_interval_seconds)
+          too_recent ? [POLL_SLOW_DOWN, next_poll_interval_seconds] : [POLL_AUTHORIZATION_PENDING, nil]
         else
           if access_revoked_after_creation_for?(resource_owner)
             mark_denied!(resource_owner:, ip_address:, user_agent:)
@@ -193,19 +196,18 @@ class OauthDeviceAuthorization < ApplicationRecord
   private_class_method :generate_device_code, :generate_user_code
 
   private
-    def update_poll_metadata!(ip_address:, user_agent:)
-      previous_last_polled_at = last_polled_at
+    def update_poll_metadata!(ip_address:, user_agent:, poll_interval_seconds: self.poll_interval_seconds)
       update!(
         last_polled_at: Time.current,
         last_poll_ip_address: ip_address,
         last_poll_user_agent: user_agent,
-        poll_count: poll_count + 1
+        poll_count: poll_count + 1,
+        poll_interval_seconds:
       )
-      previous_last_polled_at
     end
 
-    def polled_too_recently?(previous_last_polled_at)
-      previous_last_polled_at.present? && previous_last_polled_at > POLL_INTERVAL.ago
+    def polled_too_recently?
+      last_polled_at.present? && last_polled_at > poll_interval_seconds.seconds.ago
     end
 
     def mark_denied!(resource_owner:, ip_address:, user_agent:)

--- a/app/models/oauth_device_authorization.rb
+++ b/app/models/oauth_device_authorization.rb
@@ -4,6 +4,7 @@ require "digest"
 
 class OauthDeviceAuthorization < ApplicationRecord
   GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code"
+  DEVICE_REDIRECT_URI = GRANT_TYPE
   EXPIRES_IN = 10.minutes
   POLL_INTERVAL = 5.seconds
   SLOW_DOWN_INTERVAL = 10.seconds
@@ -125,15 +126,15 @@ class OauthDeviceAuthorization < ApplicationRecord
     result = nil
 
     with_lock do
-      update_poll_metadata!(ip_address:, user_agent:)
-
       result = if oauth_application != self.oauth_application || expired? || consumed?
         [POLL_EXPIRED_TOKEN, nil]
       elsif denied?
         [POLL_ACCESS_DENIED, nil]
       elsif pending?
+        update_poll_metadata!(ip_address:, user_agent:)
         polled_too_recently? ? [POLL_SLOW_DOWN, SLOW_DOWN_INTERVAL.to_i] : [POLL_AUTHORIZATION_PENDING, nil]
       else
+        update_poll_metadata!(ip_address:, user_agent:)
         access_token = issue_access_token!
         update!(status: STATUS_CONSUMED, consumed_at: Time.current, access_token:)
         [POLL_APPROVED, access_token]
@@ -182,7 +183,7 @@ class OauthDeviceAuthorization < ApplicationRecord
       oauth_application.access_grants.where(
         resource_owner_id:,
         scopes:,
-        redirect_uri: oauth_application.redirect_uri
+        redirect_uri: DEVICE_REDIRECT_URI
       ).first_or_create! { |access_grant| access_grant.expires_in = 60.years }
     end
 end

--- a/app/models/oauth_device_authorization.rb
+++ b/app/models/oauth_device_authorization.rb
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+
+require "digest"
+
+class OauthDeviceAuthorization < ApplicationRecord
+  GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code"
+  EXPIRES_IN = 10.minutes
+  POLL_INTERVAL = 5.seconds
+  SLOW_DOWN_INTERVAL = 10.seconds
+
+  STATUS_PENDING = "pending"
+  STATUS_APPROVED = "approved"
+  STATUS_DENIED = "denied"
+  STATUS_CONSUMED = "consumed"
+
+  POLL_AUTHORIZATION_PENDING = "authorization_pending"
+  POLL_SLOW_DOWN = "slow_down"
+  POLL_EXPIRED_TOKEN = "expired_token"
+  POLL_ACCESS_DENIED = "access_denied"
+  POLL_APPROVED = "approved"
+
+  belongs_to :oauth_application, class_name: "OauthApplication"
+  belongs_to :resource_owner, class_name: "User", optional: true
+  belongs_to :access_token, class_name: "Doorkeeper::AccessToken", optional: true
+
+  validates :device_code_digest, :user_code_digest, :scopes, :status, :expires_at, presence: true
+  validates :device_code_digest, :user_code_digest, uniqueness: true
+  validates :status, inclusion: { in: [STATUS_PENDING, STATUS_APPROVED, STATUS_DENIED, STATUS_CONSUMED] }
+
+  def self.create_for!(oauth_application:, scopes:, ip_address:, user_agent:)
+    device_code = generate_device_code
+    user_code = generate_user_code
+
+    device_authorization = create!(
+      oauth_application:,
+      scopes:,
+      device_code_digest: digest(device_code),
+      user_code_digest: digest(normalize_user_code(user_code)),
+      expires_at: EXPIRES_IN.from_now,
+      created_ip_address: ip_address,
+      created_user_agent: user_agent
+    )
+
+    [device_authorization, device_code, user_code]
+  rescue ActiveRecord::RecordNotUnique
+    retry
+  end
+
+  def self.find_by_device_code(device_code)
+    return if device_code.blank?
+
+    find_by(device_code_digest: digest(device_code))
+  end
+
+  def self.find_by_user_code(user_code)
+    normalized_user_code = normalize_user_code(user_code)
+    return if normalized_user_code.blank?
+
+    find_by(user_code_digest: digest(normalized_user_code))
+  end
+
+  def self.digest(value)
+    Digest::SHA256.hexdigest(value.to_s)
+  end
+
+  def self.normalize_user_code(user_code)
+    user_code.to_s.upcase.gsub(/[^A-Z0-9]/, "")
+  end
+
+  def self.format_user_code(user_code)
+    normalized_user_code = normalize_user_code(user_code)
+    return "" if normalized_user_code.blank?
+    return "GRD-#{normalized_user_code.delete_prefix("GRD").scan(/.{1,4}/).join("-")}" if normalized_user_code.start_with?("GRD")
+
+    normalized_user_code.scan(/.{1,4}/).join("-")
+  end
+
+  def pending? = status == STATUS_PENDING
+  def approved? = status == STATUS_APPROVED
+  def denied? = status == STATUS_DENIED
+  def consumed? = status == STATUS_CONSUMED
+  def expired? = expires_at <= Time.current
+  def approvable? = pending? && !expired?
+  def scope_list = scopes.split
+
+  def approve!(resource_owner:, ip_address:, user_agent:)
+    approved = false
+
+    with_lock do
+      if approvable?
+        update!(
+          resource_owner:,
+          status: STATUS_APPROVED,
+          approved_at: Time.current,
+          approved_ip_address: ip_address,
+          approved_user_agent: user_agent
+        )
+        approved = true
+      end
+    end
+
+    approved
+  end
+
+  def deny!(resource_owner:, ip_address:, user_agent:)
+    denied = false
+
+    with_lock do
+      if approvable?
+        update!(
+          resource_owner:,
+          status: STATUS_DENIED,
+          denied_at: Time.current,
+          denied_ip_address: ip_address,
+          denied_user_agent: user_agent
+        )
+        denied = true
+      end
+    end
+
+    denied
+  end
+
+  def poll!(oauth_application:, ip_address:, user_agent:)
+    result = nil
+
+    with_lock do
+      update_poll_metadata!(ip_address:, user_agent:)
+
+      result = if oauth_application != self.oauth_application || expired? || consumed?
+        [POLL_EXPIRED_TOKEN, nil]
+      elsif denied?
+        [POLL_ACCESS_DENIED, nil]
+      elsif pending?
+        polled_too_recently? ? [POLL_SLOW_DOWN, SLOW_DOWN_INTERVAL.to_i] : [POLL_AUTHORIZATION_PENDING, nil]
+      else
+        access_token = issue_access_token!
+        update!(status: STATUS_CONSUMED, consumed_at: Time.current, access_token:)
+        [POLL_APPROVED, access_token]
+      end
+    end
+
+    result
+  end
+
+  private
+    def self.generate_device_code
+      SecureRandom.urlsafe_base64(32)
+    end
+
+    def self.generate_user_code
+      "GRD-#{SecureRandom.alphanumeric(8).upcase.scan(/.{1,4}/).join("-")}"
+    end
+
+    def update_poll_metadata!(ip_address:, user_agent:)
+      @previous_last_polled_at = last_polled_at
+      update!(
+        last_polled_at: Time.current,
+        last_poll_ip_address: ip_address,
+        last_poll_user_agent: user_agent,
+        poll_count: poll_count + 1
+      )
+    end
+
+    def polled_too_recently?
+      @previous_last_polled_at.present? && @previous_last_polled_at > POLL_INTERVAL.ago
+    end
+
+    def issue_access_token!
+      ensure_access_grant_exists!
+
+      Doorkeeper.config.access_token_model.create_for(
+        application: oauth_application,
+        resource_owner: resource_owner_id,
+        scopes:,
+        expires_in: Doorkeeper.config.access_token_expires_in,
+        use_refresh_token: Doorkeeper.config.refresh_token_enabled?
+      )
+    end
+
+    def ensure_access_grant_exists!
+      oauth_application.access_grants.where(
+        resource_owner_id:,
+        scopes:,
+        redirect_uri: oauth_application.redirect_uri
+      ).first_or_create! { |access_grant| access_grant.expires_in = 60.years }
+    end
+end

--- a/app/models/oauth_device_authorization.rb
+++ b/app/models/oauth_device_authorization.rb
@@ -96,6 +96,8 @@ class OauthDeviceAuthorization < ApplicationRecord
   def scope_list = scopes.split
 
   def access_revoked_after_creation_for?(resource_owner)
+    return false if resource_owner.blank?
+
     # oauth_access_tokens.revoked_at is second precision, so same-second revokes must invalidate the code.
     revocation_cutoff = created_at.change(usec: 0)
 
@@ -163,10 +165,15 @@ class OauthDeviceAuthorization < ApplicationRecord
           previous_last_polled_at = update_poll_metadata!(ip_address:, user_agent:)
           polled_too_recently?(previous_last_polled_at) ? [POLL_SLOW_DOWN, SLOW_DOWN_INTERVAL.to_i] : [POLL_AUTHORIZATION_PENDING, nil]
         else
-          update_poll_metadata!(ip_address:, user_agent:)
-          access_token = issue_access_token!
-          update!(status: STATUS_CONSUMED, consumed_at: Time.current, access_token:)
-          [POLL_APPROVED, access_token]
+          if access_revoked_after_creation_for?(resource_owner)
+            mark_denied!(resource_owner:, ip_address:, user_agent:)
+            [POLL_ACCESS_DENIED, nil]
+          else
+            update_poll_metadata!(ip_address:, user_agent:)
+            access_token = issue_access_token!
+            update!(status: STATUS_CONSUMED, consumed_at: Time.current, access_token:)
+            [POLL_APPROVED, access_token]
+          end
         end
       end
     end

--- a/app/models/oauth_device_authorization.rb
+++ b/app/models/oauth_device_authorization.rb
@@ -15,7 +15,7 @@ class OauthDeviceAuthorization < ApplicationRecord
   STATUS_DENIED = "denied"
   STATUS_CONSUMED = "consumed"
   STATUSES = [STATUS_PENDING, STATUS_APPROVED, STATUS_DENIED, STATUS_CONSUMED].freeze
-  EXPIRABLE_STATUSES = [STATUS_PENDING, STATUS_APPROVED, STATUS_CONSUMED].freeze
+  EXPIRABLE_STATUSES = STATUSES
 
   POLL_AUTHORIZATION_PENDING = "authorization_pending"
   POLL_SLOW_DOWN = "slow_down"
@@ -176,15 +176,16 @@ class OauthDeviceAuthorization < ApplicationRecord
     [POLL_EXPIRED_TOKEN, nil]
   end
 
+  def self.generate_device_code
+    SecureRandom.urlsafe_base64(32)
+  end
+
+  def self.generate_user_code
+    "GRD-#{SecureRandom.alphanumeric(8).upcase.scan(/.{1,4}/).join("-")}"
+  end
+  private_class_method :generate_device_code, :generate_user_code
+
   private
-    def self.generate_device_code
-      SecureRandom.urlsafe_base64(32)
-    end
-
-    def self.generate_user_code
-      "GRD-#{SecureRandom.alphanumeric(8).upcase.scan(/.{1,4}/).join("-")}"
-    end
-
     def update_poll_metadata!(ip_address:, user_agent:)
       previous_last_polled_at = last_polled_at
       update!(

--- a/app/models/oauth_device_authorization.rb
+++ b/app/models/oauth_device_authorization.rb
@@ -91,19 +91,37 @@ class OauthDeviceAuthorization < ApplicationRecord
   def approvable? = pending? && !expired?
   def scope_list = scopes.split
 
+  def access_revoked_after_creation_for?(resource_owner)
+    revocation_cutoff = created_at.change(usec: 0)
+
+    oauth_application.access_tokens
+      .where(resource_owner_id: resource_owner.id)
+      .where("revoked_at >= ?", revocation_cutoff)
+      .exists? &&
+      !oauth_application.access_tokens
+        .where(resource_owner_id: resource_owner.id, revoked_at: nil)
+        .exists?
+  end
+
   def approve!(resource_owner:, ip_address:, user_agent:)
     approved = false
 
-    with_lock do
-      if approvable?
-        update!(
-          resource_owner:,
-          status: STATUS_APPROVED,
-          approved_at: Time.current,
-          approved_ip_address: ip_address,
-          approved_user_agent: user_agent
-        )
-        approved = true
+    oauth_application.with_lock do
+      with_lock do
+        if approvable?
+          if access_revoked_after_creation_for?(resource_owner)
+            mark_denied!(resource_owner:, ip_address:, user_agent:)
+          else
+            update!(
+              resource_owner:,
+              status: STATUS_APPROVED,
+              approved_at: Time.current,
+              approved_ip_address: ip_address,
+              approved_user_agent: user_agent
+            )
+            approved = true
+          end
+        end
       end
     end
 
@@ -113,16 +131,12 @@ class OauthDeviceAuthorization < ApplicationRecord
   def deny!(resource_owner:, ip_address:, user_agent:)
     denied = false
 
-    with_lock do
-      if approvable?
-        update!(
-          resource_owner:,
-          status: STATUS_DENIED,
-          denied_at: Time.current,
-          denied_ip_address: ip_address,
-          denied_user_agent: user_agent
-        )
-        denied = true
+    oauth_application.with_lock do
+      with_lock do
+        if approvable?
+          mark_denied!(resource_owner:, ip_address:, user_agent:)
+          denied = true
+        end
       end
     end
 
@@ -132,21 +146,23 @@ class OauthDeviceAuthorization < ApplicationRecord
   def poll!(oauth_application:, ip_address:, user_agent:)
     result = nil
 
-    with_lock do
-      result = if oauth_application != self.oauth_application || consumed?
-        [POLL_EXPIRED_TOKEN, nil]
-      elsif denied?
-        [POLL_ACCESS_DENIED, nil]
-      elsif expired?
-        [POLL_EXPIRED_TOKEN, nil]
-      elsif pending?
-        previous_last_polled_at = update_poll_metadata!(ip_address:, user_agent:)
-        polled_too_recently?(previous_last_polled_at) ? [POLL_SLOW_DOWN, SLOW_DOWN_INTERVAL.to_i] : [POLL_AUTHORIZATION_PENDING, nil]
-      else
-        update_poll_metadata!(ip_address:, user_agent:)
-        access_token = issue_access_token!
-        update!(status: STATUS_CONSUMED, consumed_at: Time.current, access_token:)
-        [POLL_APPROVED, access_token]
+    oauth_application.with_lock do
+      with_lock do
+        result = if oauth_application != self.oauth_application || consumed?
+          [POLL_EXPIRED_TOKEN, nil]
+        elsif denied?
+          [POLL_ACCESS_DENIED, nil]
+        elsif expired?
+          [POLL_EXPIRED_TOKEN, nil]
+        elsif pending?
+          previous_last_polled_at = update_poll_metadata!(ip_address:, user_agent:)
+          polled_too_recently?(previous_last_polled_at) ? [POLL_SLOW_DOWN, SLOW_DOWN_INTERVAL.to_i] : [POLL_AUTHORIZATION_PENDING, nil]
+        else
+          update_poll_metadata!(ip_address:, user_agent:)
+          access_token = issue_access_token!
+          update!(status: STATUS_CONSUMED, consumed_at: Time.current, access_token:)
+          [POLL_APPROVED, access_token]
+        end
       end
     end
 
@@ -175,6 +191,16 @@ class OauthDeviceAuthorization < ApplicationRecord
 
     def polled_too_recently?(previous_last_polled_at)
       previous_last_polled_at.present? && previous_last_polled_at > POLL_INTERVAL.ago
+    end
+
+    def mark_denied!(resource_owner:, ip_address:, user_agent:)
+      update!(
+        resource_owner:,
+        status: STATUS_DENIED,
+        denied_at: Time.current,
+        denied_ip_address: ip_address,
+        denied_user_agent: user_agent
+      )
     end
 
     def issue_access_token!

--- a/app/models/oauth_device_authorization.rb
+++ b/app/models/oauth_device_authorization.rb
@@ -133,10 +133,12 @@ class OauthDeviceAuthorization < ApplicationRecord
     result = nil
 
     with_lock do
-      result = if oauth_application != self.oauth_application || expired? || consumed?
+      result = if oauth_application != self.oauth_application || consumed?
         [POLL_EXPIRED_TOKEN, nil]
       elsif denied?
         [POLL_ACCESS_DENIED, nil]
+      elsif expired?
+        [POLL_EXPIRED_TOKEN, nil]
       elsif pending?
         previous_last_polled_at = update_poll_metadata!(ip_address:, user_agent:)
         polled_too_recently?(previous_last_polled_at) ? [POLL_SLOW_DOWN, SLOW_DOWN_INTERVAL.to_i] : [POLL_AUTHORIZATION_PENDING, nil]

--- a/app/models/oauth_device_authorization.rb
+++ b/app/models/oauth_device_authorization.rb
@@ -92,6 +92,7 @@ class OauthDeviceAuthorization < ApplicationRecord
   def scope_list = scopes.split
 
   def access_revoked_after_creation_for?(resource_owner)
+    # oauth_access_tokens.revoked_at is second precision, so same-second revokes must invalidate the code.
     revocation_cutoff = created_at.change(usec: 0)
 
     oauth_application.access_tokens

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -852,7 +852,7 @@ class User < ApplicationRecord
 
     application = OauthApplication.find_by(uid: OauthApplication::MOBILE_API_OAUTH_APPLICATION_UID)
     if application.present?
-      Doorkeeper::AccessToken.revoke_all_for(application.id, self)
+      application.revoke_access_tokens_for(self)
     end
   end
 

--- a/app/sidekiq/delete_expired_oauth_device_authorizations_job.rb
+++ b/app/sidekiq/delete_expired_oauth_device_authorizations_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class DeleteExpiredOauthDeviceAuthorizationsWorker
+class DeleteExpiredOauthDeviceAuthorizationsJob
   include Sidekiq::Job
   sidekiq_options retry: 5, queue: :low
 

--- a/app/sidekiq/delete_expired_oauth_device_authorizations_worker.rb
+++ b/app/sidekiq/delete_expired_oauth_device_authorizations_worker.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class DeleteExpiredOauthDeviceAuthorizationsWorker
+  include Sidekiq::Job
+  sidekiq_options retry: 5, queue: :low
+
+  DELETION_BATCH_SIZE = 100
+
+  def perform
+    loop do
+      ReplicaLagWatcher.watch
+      rows = OauthDeviceAuthorization.expired_for_cleanup.limit(DELETION_BATCH_SIZE)
+      deleted_rows = rows.delete_all
+      break if deleted_rows < DELETION_BATCH_SIZE
+    end
+  end
+end

--- a/app/views/oauth/device_authorizations/new.html.erb
+++ b/app/views/oauth/device_authorizations/new.html.erb
@@ -34,10 +34,12 @@
     <footer class="flex flex-col gap-4 p-4 text-center">
       <%= form_tag oauth_device_authorization_path, method: :post, style: "display: contents" do %>
         <%= hidden_field_tag :user_code, @user_code %>
+        <%= hidden_field_tag :handoff, @handoff if @handoff.present? %>
         <%= button_tag "Authorize", name: "decision", value: "approve", class: "inline-flex items-center justify-center gap-2 cursor-pointer border border-border rounded font-[inherit] no-underline transition-transform hover:-translate-1 hover:shadow active:translate-0 active:shadow-none disabled:opacity-30 disabled:hover:translate-0 disabled:hover:shadow-none bg-accent text-accent-foreground px-4 py-3 text-base leading-snug" %>
       <% end %>
       <%= form_tag oauth_device_authorization_path, method: :post, style: "display: contents" do %>
         <%= hidden_field_tag :user_code, @user_code %>
+        <%= hidden_field_tag :handoff, @handoff if @handoff.present? %>
         <%= button_tag "Deny", name: "decision", value: "deny", class: "inline-flex items-center justify-center gap-2 cursor-pointer border border-border rounded font-[inherit] no-underline transition-transform hover:-translate-1 hover:shadow active:translate-0 active:shadow-none disabled:opacity-30 disabled:hover:translate-0 disabled:hover:shadow-none bg-white text-black hover:bg-pink hover:text-black px-4 py-3 text-base leading-snug" %>
       <% end %>
     </footer>

--- a/app/views/oauth/device_authorizations/new.html.erb
+++ b/app/views/oauth/device_authorizations/new.html.erb
@@ -1,0 +1,65 @@
+<main class="grid divide-y divide-border bg-background border border-border rounded mx-auto my-4 h-min max-w-md w-[calc(100%-2rem)]">
+  <% if @decision == :approved %>
+    <header class="flex flex-col gap-4 p-4 text-center">
+      <h2>Authorization complete</h2>
+      <p>Return to the application that requested access.</p>
+    </header>
+  <% elsif @decision == :denied %>
+    <header class="flex flex-col gap-4 p-4 text-center">
+      <h2>Authorization denied</h2>
+      <p>The application will not receive access to your account.</p>
+    </header>
+  <% elsif @error_message.blank? && @device_authorization.present? && @device_authorization.approvable? && user_signed_in? && !impersonating? %>
+    <header class="flex flex-col gap-4 p-4 text-center">
+      <div>
+        <%= image_tag @device_authorization.oauth_application.icon_url || image_path("gumroad_app.png"), size: "72" %>
+      </div>
+      <h2>
+        Authorize
+        <strong><%= @device_authorization.oauth_application.name %></strong>
+        to use your account?
+      </h2>
+      <p>Code <strong><%= @user_code %></strong></p>
+    </header>
+    <% if @device_authorization.scope_list.present? %>
+      <div class="flex flex-col gap-4 p-4">
+        <h4 class="font-bold">This application will be able to:</h4>
+        <ul>
+          <% @device_authorization.scope_list.each do |scope| %>
+            <li><%= oauth_scope_description(scope) %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+    <footer class="flex flex-col gap-4 p-4 text-center">
+      <%= form_tag oauth_device_authorization_path, method: :post, style: "display: contents" do %>
+        <%= hidden_field_tag :user_code, @user_code %>
+        <%= button_tag "Authorize", name: "decision", value: "approve", class: "inline-flex items-center justify-center gap-2 cursor-pointer border border-border rounded font-[inherit] no-underline transition-transform hover:-translate-1 hover:shadow active:translate-0 active:shadow-none disabled:opacity-30 disabled:hover:translate-0 disabled:hover:shadow-none bg-accent text-accent-foreground px-4 py-3 text-base leading-snug" %>
+      <% end %>
+      <%= form_tag oauth_device_authorization_path, method: :post, style: "display: contents" do %>
+        <%= hidden_field_tag :user_code, @user_code %>
+        <%= button_tag "Deny", name: "decision", value: "deny", class: "inline-flex items-center justify-center gap-2 cursor-pointer border border-border rounded font-[inherit] no-underline transition-transform hover:-translate-1 hover:shadow active:translate-0 active:shadow-none disabled:opacity-30 disabled:hover:translate-0 disabled:hover:shadow-none bg-white text-black hover:bg-pink hover:text-black px-4 py-3 text-base leading-snug" %>
+      <% end %>
+    </footer>
+  <% else %>
+    <header class="flex flex-col gap-4 p-4 text-center">
+      <h2>Enter device code</h2>
+      <p>Paste the code shown by the application requesting access.</p>
+    </header>
+    <div class="flex flex-col gap-4 p-4">
+      <% if @error_message.present? %>
+        <p><%= @error_message %></p>
+      <% end %>
+      <%= form_tag oauth_device_authorization_path, method: :get, class: "flex flex-col gap-4" do %>
+        <%= text_field_tag :user_code, @user_code, autofocus: true, placeholder: "GRD-ABCD-1234", class: "w-full rounded border border-border bg-background p-3" %>
+        <%= button_tag "Continue", type: "submit", class: "inline-flex items-center justify-center gap-2 cursor-pointer border border-border rounded font-[inherit] no-underline transition-transform hover:-translate-1 hover:shadow active:translate-0 active:shadow-none disabled:opacity-30 disabled:hover:translate-0 disabled:hover:shadow-none bg-accent text-accent-foreground px-4 py-3 text-base leading-snug" %>
+      <% end %>
+    </div>
+  <% end %>
+</main>
+
+<% if user_signed_in? %>
+  <% content_for :footer do %>
+    <%= render("doorkeeper/authorizations/footer", logged_in_user: logged_in_user) %>
+  <% end %>
+<% end %>

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -7,4 +7,4 @@
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
 Rails.application.config.filter_parameters += %i[password cc_number number expiry_date cc_expiry cvc account_number account_number_repeated passphrase
                                                  chargeable tax_id individual_tax_id business_tax_id ssn_first_three ssn_middle_two ssn_last_four
-                                                 access_token mobile_token device_code user_code]
+                                                 access_token mobile_token device_code user_code client_secret]

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -7,4 +7,4 @@
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
 Rails.application.config.filter_parameters += %i[password cc_number number expiry_date cc_expiry cvc account_number account_number_repeated passphrase
                                                  chargeable tax_id individual_tax_id business_tax_id ssn_first_three ssn_middle_two ssn_last_four
-                                                 access_token mobile_token]
+                                                 access_token mobile_token device_code user_code]

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -186,12 +186,13 @@ class Rack::Attack
   throttle_with_exponential_backoff(name: "oauth_device_authorization_decision/ip", requests: 10, period: 60.seconds) do |req|
     req.remote_ip if req.path.match?(%r{\A/oauth/device(?:\.[^/]+)?\z}) && req.post?
   end
-  throttle_by_ip path: "/oauth/token", requests: 3000, period: 60.seconds # Initial: 3000rpm, Max: 15000 requests/9 hours
+  throttle_with_exponential_backoff(name: "oauth_token/ip", requests: 3000, period: 60.seconds) do |req|
+    req.remote_ip if req.path.match?(%r{\A/oauth/token(?:\.[^/]+)?\z})
+  end
   throttle("oauth_device_token/ip/device_code", limit: 120, period: 60.seconds) do |req|
-    if req.path == "/oauth/token" && req.post?
-      request_params = req.params
-      json_params = req.json_params if req.media_type&.include?("json")
-      request_params = json_params.merge(req.GET) if json_params.is_a?(Hash)
+    if req.path.match?(%r{\A/oauth/token(?:\.[^/]+)?\z}) && req.post?
+      body_params = req.media_type&.include?("json") ? req.json_params : req.POST
+      request_params = body_params.is_a?(Hash) ? body_params.merge(req.GET) : req.GET
       if request_params["grant_type"] == "urn:ietf:params:oauth:grant-type:device_code"
         "#{req.remote_ip}:#{Digest::SHA256.hexdigest(request_params["device_code"].to_s)}"
       end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -191,7 +191,7 @@ class Rack::Attack
     if req.path == "/oauth/token" && req.post?
       request_params = req.params
       json_params = req.json_params if req.media_type&.include?("json")
-      request_params = json_params.merge(request_params) if json_params.is_a?(Hash)
+      request_params = json_params.merge(req.GET) if json_params.is_a?(Hash)
       if request_params["grant_type"] == "urn:ietf:params:oauth:grant-type:device_code"
         "#{req.remote_ip}:#{Digest::SHA256.hexdigest(request_params["device_code"].to_s)}"
       end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -176,7 +176,14 @@ class Rack::Attack
   throttle_by_ip_for_period path: "/purchases", requests: 50, period: 1.hour
 
   throttle_by_ip path: "/oauth/device/code", method: :post, requests: 20, period: 60.seconds
-  throttle_by_ip path: "/oauth/device", method: :post, requests: 10, period: 60.seconds
+  throttle_with_exponential_backoff(name: "oauth_device_authorization_lookup/ip", requests: 30, period: 60.seconds) do |req|
+    if req.path.match?(%r{\A/oauth/device(?:\.[^/]+)?\z}) && ["GET", "HEAD"].include?(req.request_method)
+      req.remote_ip
+    end
+  end
+  throttle_with_exponential_backoff(name: "oauth_device_authorization_decision/ip", requests: 10, period: 60.seconds) do |req|
+    req.remote_ip if req.path.match?(%r{\A/oauth/device(?:\.[^/]+)?\z}) && req.post?
+  end
   throttle_by_ip path: "/oauth/token", requests: 3000, period: 60.seconds # Initial: 3000rpm, Max: 15000 requests/9 hours
   throttle("oauth_device_token/ip/device_code", limit: 120, period: 60.seconds) do |req|
     if req.path == "/oauth/token" && req.post?

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -190,6 +190,8 @@ class Rack::Attack
   throttle("oauth_device_token/ip/device_code", limit: 120, period: 60.seconds) do |req|
     if req.path == "/oauth/token" && req.post?
       request_params = req.params
+      json_params = req.json_params if req.media_type&.include?("json")
+      request_params = json_params.merge(request_params) if json_params.is_a?(Hash)
       if request_params["grant_type"] == "urn:ietf:params:oauth:grant-type:device_code"
         "#{req.remote_ip}:#{Digest::SHA256.hexdigest(request_params["device_code"].to_s)}"
       end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "digest"
+
 class Rack::Attack
   redis_url    = ENV.fetch("RACK_ATTACK_REDIS_HOST")
   redis_client = Redis.new(url: "redis://#{redis_url}")
@@ -173,7 +175,19 @@ class Rack::Attack
 
   throttle_by_ip_for_period path: "/purchases", requests: 50, period: 1.hour
 
+  throttle_by_ip path: "/oauth/device/code", method: :post, requests: 20, period: 60.seconds
+  throttle_by_ip path: "/oauth/device", method: :post, requests: 10, period: 60.seconds
   throttle_by_ip path: "/oauth/token", requests: 3000, period: 60.seconds # Initial: 3000rpm, Max: 15000 requests/9 hours
+  throttle("oauth_device_token/ip/device_code", limit: 120, period: 60.seconds) do |req|
+    if req.path == "/oauth/token" && req.post?
+      request_params = req.params
+      if request_params["grant_type"] == "urn:ietf:params:oauth:grant-type:device_code"
+        "#{req.remote_ip}:#{Digest::SHA256.hexdigest(request_params["device_code"].to_s)}"
+      end
+    end
+  rescue Rack::QueryParser::InvalidParameterError, TypeError
+    nil
+  end
 
   # Spammers have been abusing follower's endpoints. This degrades our email reputation since we send confirmation email to each follower.
   # The following rules impose stricter and per-creator rate-limiting to prevent spammers from creating followers through a distributed attack.

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -175,7 +175,9 @@ class Rack::Attack
 
   throttle_by_ip_for_period path: "/purchases", requests: 50, period: 1.hour
 
-  throttle_by_ip path: "/oauth/device/code", method: :post, requests: 20, period: 60.seconds
+  throttle_with_exponential_backoff(name: "oauth_device_code/ip", requests: 20, period: 60.seconds) do |req|
+    req.remote_ip if req.path.match?(%r{\A/oauth/device/code(?:\.[^/]+)?\z}) && req.post?
+  end
   throttle_with_exponential_backoff(name: "oauth_device_authorization_lookup/ip", requests: 30, period: 60.seconds) do |req|
     if req.path.match?(%r{\A/oauth/device(?:\.[^/]+)?\z}) && ["GET", "HEAD"].include?(req.request_method)
       req.remote_ip

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,10 @@ Rails.application.routes.draw do
     controllers tokens: "oauth/tokens"
   end
 
+  post "/oauth/device/code" => "oauth/device_codes#create", as: :oauth_device_code
+  get "/oauth/device" => "oauth/device_authorizations#new", as: :oauth_device_authorization
+  post "/oauth/device" => "oauth/device_authorizations#create"
+
   namespace :oauth do
     resource :mobile_pre_authorization, only: [:new] do
       get :switch_account, on: :member

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -36,7 +36,7 @@ forcefully_finish_long_running_community_chat_recap_runs:
   description: Forcefully finishes long running community chat recap runs
 delete_expired_oauth_device_authorizations:
   cron: "15 * * * *" # Every hour
-  class: DeleteExpiredOauthDeviceAuthorizationsWorker
+  class: DeleteExpiredOauthDeviceAuthorizationsJob
   description: Deletes expired OAuth device authorizations
 
 # Daily in format: [minute] [hour] * * *

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -34,6 +34,10 @@ forcefully_finish_long_running_community_chat_recap_runs:
   cron: "0 */2 * * *" # Every 2 hours
   class: ForceFinishLongRunningCommunityChatRecapRunsJob
   description: Forcefully finishes long running community chat recap runs
+delete_expired_oauth_device_authorizations:
+  cron: "15 * * * *" # Every hour
+  class: DeleteExpiredOauthDeviceAuthorizationsWorker
+  description: Deletes expired OAuth device authorizations
 
 # Daily in format: [minute] [hour] * * *
 sync_radar_value_lists:

--- a/db/migrate/20260604140000_create_oauth_device_authorizations.rb
+++ b/db/migrate/20260604140000_create_oauth_device_authorizations.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class CreateOauthDeviceAuthorizations < ActiveRecord::Migration[7.1]
+  def change
+    create_table :oauth_device_authorizations do |t|
+      t.integer :oauth_application_id, null: false
+      t.integer :resource_owner_id
+      t.integer :access_token_id
+      t.string :device_code_digest, null: false
+      t.string :user_code_digest, null: false
+      t.string :scopes, null: false
+      t.string :status, null: false, default: "pending"
+      t.datetime :expires_at, null: false
+      t.datetime :last_polled_at
+      t.integer :poll_count, null: false, default: 0
+      t.datetime :approved_at
+      t.datetime :denied_at
+      t.datetime :consumed_at
+      t.string :created_ip_address
+      t.string :approved_ip_address
+      t.string :denied_ip_address
+      t.string :last_poll_ip_address
+      t.string :created_user_agent
+      t.string :approved_user_agent
+      t.string :denied_user_agent
+      t.string :last_poll_user_agent
+      t.timestamps
+      t.index :oauth_application_id
+      t.index :resource_owner_id
+      t.index :access_token_id
+      t.index :device_code_digest, unique: true
+      t.index :user_code_digest, unique: true
+      t.index [:status, :expires_at]
+    end
+  end
+end

--- a/db/migrate/20260604140000_create_oauth_device_authorizations.rb
+++ b/db/migrate/20260604140000_create_oauth_device_authorizations.rb
@@ -13,6 +13,7 @@ class CreateOauthDeviceAuthorizations < ActiveRecord::Migration[7.1]
       t.datetime :expires_at, null: false
       t.datetime :last_polled_at
       t.integer :poll_count, null: false, default: 0
+      t.integer :poll_interval_seconds, null: false, default: 5
       t.datetime :approved_at
       t.datetime :denied_at
       t.datetime :consumed_at

--- a/db/migrate/20260604141000_add_device_authorization_enabled_to_oauth_applications.rb
+++ b/db/migrate/20260604141000_add_device_authorization_enabled_to_oauth_applications.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDeviceAuthorizationEnabledToOauthApplications < ActiveRecord::Migration[7.1]
+  def change
+    add_column :oauth_applications, :device_authorization_enabled, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1292,8 +1292,41 @@ ActiveRecord::Schema[7.1].define(version: 2026_11_30_000005) do
     t.datetime "deleted_at", precision: nil
     t.string "scopes", default: "", null: false
     t.boolean "confidential", default: false, null: false
+    t.boolean "device_authorization_enabled", default: false, null: false
     t.index ["owner_id", "owner_type"], name: "index_oauth_applications_on_owner_id_and_owner_type"
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
+  end
+
+  create_table "oauth_device_authorizations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.integer "oauth_application_id", null: false
+    t.integer "resource_owner_id"
+    t.integer "access_token_id"
+    t.string "device_code_digest", null: false
+    t.string "user_code_digest", null: false
+    t.string "scopes", null: false
+    t.string "status", default: "pending", null: false
+    t.datetime "expires_at", null: false
+    t.datetime "last_polled_at"
+    t.integer "poll_count", default: 0, null: false
+    t.datetime "approved_at"
+    t.datetime "denied_at"
+    t.datetime "consumed_at"
+    t.string "created_ip_address"
+    t.string "approved_ip_address"
+    t.string "denied_ip_address"
+    t.string "last_poll_ip_address"
+    t.string "created_user_agent"
+    t.string "approved_user_agent"
+    t.string "denied_user_agent"
+    t.string "last_poll_user_agent"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["access_token_id"], name: "index_oauth_device_authorizations_on_access_token_id"
+    t.index ["device_code_digest"], name: "index_oauth_device_authorizations_on_device_code_digest", unique: true
+    t.index ["oauth_application_id"], name: "index_oauth_device_authorizations_on_oauth_application_id"
+    t.index ["resource_owner_id"], name: "index_oauth_device_authorizations_on_resource_owner_id"
+    t.index ["status", "expires_at"], name: "index_oauth_device_authorizations_on_status_and_expires_at"
+    t.index ["user_code_digest"], name: "index_oauth_device_authorizations_on_user_code_digest", unique: true
   end
 
   create_table "offer_codes", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1308,6 +1308,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_11_30_000005) do
     t.datetime "expires_at", null: false
     t.datetime "last_polled_at"
     t.integer "poll_count", default: 0, null: false
+    t.integer "poll_interval_seconds", default: 5, null: false
     t.datetime "approved_at"
     t.datetime "denied_at"
     t.datetime "consumed_at"

--- a/spec/config/initializers/filter_parameter_logging_spec.rb
+++ b/spec/config/initializers/filter_parameter_logging_spec.rb
@@ -4,6 +4,22 @@ require "spec_helper"
 
 describe "filter parameter logging configuration" do
   it "filters OAuth device flow bearer secrets" do
-    expect(Rails.application.config.filter_parameters).to include(:client_secret, :device_code, :user_code)
+    filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
+    parameters = {
+      client_secret: "secret",
+      device_code: "device-code",
+      user_code: "user-code",
+      visible: "safe",
+      nested: { "client_secret" => "nested-secret" },
+    }
+    filtered_parameters = {
+      client_secret: "[FILTERED]",
+      device_code: "[FILTERED]",
+      user_code: "[FILTERED]",
+      visible: "safe",
+      nested: { "client_secret" => "[FILTERED]" },
+    }
+
+    expect(filter.filter(parameters)).to eq(filtered_parameters)
   end
 end

--- a/spec/config/initializers/filter_parameter_logging_spec.rb
+++ b/spec/config/initializers/filter_parameter_logging_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "filter parameter logging configuration" do
+  it "filters OAuth device flow bearer secrets" do
+    expect(Rails.application.config.filter_parameters).to include(:client_secret, :device_code, :user_code)
+  end
+end

--- a/spec/models/oauth_application_spec.rb
+++ b/spec/models/oauth_application_spec.rb
@@ -200,6 +200,45 @@ describe OauthApplication do
 
       expect(@oauth_application.access_tokens).to all be_revoked
     end
+
+    it "denies outstanding device authorizations" do
+      pending_authorization = create(
+        :oauth_device_authorization,
+        oauth_application: @oauth_application,
+        status: OauthDeviceAuthorization::STATUS_PENDING,
+        device_code: "pending-deleted-app",
+        user_code: "GRD-PEND-DEL1"
+      )
+      approved_authorization = create(
+        :oauth_device_authorization,
+        oauth_application: @oauth_application,
+        status: OauthDeviceAuthorization::STATUS_APPROVED,
+        device_code: "approved-deleted-app",
+        user_code: "GRD-APPR-DEL1"
+      )
+      consumed_authorization = create(
+        :oauth_device_authorization,
+        oauth_application: @oauth_application,
+        status: OauthDeviceAuthorization::STATUS_CONSUMED,
+        device_code: "consumed-deleted-app",
+        user_code: "GRD-CONS-DEL1"
+      )
+      denied_authorization = create(
+        :oauth_device_authorization,
+        oauth_application: @oauth_application,
+        status: OauthDeviceAuthorization::STATUS_DENIED,
+        denied_at: 1.day.ago,
+        device_code: "denied-deleted-app",
+        user_code: "GRD-DENY-DEL1"
+      )
+
+      @oauth_application.mark_deleted!
+
+      expect(pending_authorization.reload).to have_attributes(status: OauthDeviceAuthorization::STATUS_DENIED, denied_at: be_present)
+      expect(approved_authorization.reload).to have_attributes(status: OauthDeviceAuthorization::STATUS_DENIED, denied_at: be_present)
+      expect(consumed_authorization.reload).to have_attributes(status: OauthDeviceAuthorization::STATUS_CONSUMED, denied_at: nil)
+      expect(denied_authorization.reload).to have_attributes(status: OauthDeviceAuthorization::STATUS_DENIED, denied_at: be_present)
+    end
   end
 
   describe "#revoke_access_for" do

--- a/spec/models/oauth_application_spec.rb
+++ b/spec/models/oauth_application_spec.rb
@@ -272,8 +272,8 @@ describe OauthApplication do
       expect(@oauth_application.resource_subscriptions.where(user: @subscriber_2).alive.count).to eq(1)
     end
 
-    it "denies outstanding device authorizations for the user" do
-      pending_authorization = create(
+    it "denies approved device authorizations for the user" do
+      pending_authorization_with_owner = create(
         :oauth_device_authorization,
         oauth_application: @oauth_application,
         resource_owner: @subscriber_1,
@@ -307,7 +307,7 @@ describe OauthApplication do
 
       @oauth_application.revoke_access_for(@subscriber_1)
 
-      expect(pending_authorization.reload).to have_attributes(status: OauthDeviceAuthorization::STATUS_DENIED, denied_at: be_present)
+      expect(pending_authorization_with_owner.reload).to have_attributes(status: OauthDeviceAuthorization::STATUS_PENDING, denied_at: nil)
       expect(approved_authorization.reload).to have_attributes(status: OauthDeviceAuthorization::STATUS_DENIED, denied_at: be_present)
       expect(other_user_authorization.reload).to have_attributes(status: OauthDeviceAuthorization::STATUS_APPROVED, denied_at: nil)
       expect(unauthenticated_pending_authorization.reload).to have_attributes(status: OauthDeviceAuthorization::STATUS_PENDING, denied_at: nil)

--- a/spec/models/oauth_application_spec.rb
+++ b/spec/models/oauth_application_spec.rb
@@ -232,5 +232,73 @@ describe OauthApplication do
       expect(@oauth_application.resource_subscriptions.where(user: @subscriber_1).alive.count).to eq(0)
       expect(@oauth_application.resource_subscriptions.where(user: @subscriber_2).alive.count).to eq(1)
     end
+
+    it "denies outstanding device authorizations for the user" do
+      pending_authorization = create(
+        :oauth_device_authorization,
+        oauth_application: @oauth_application,
+        resource_owner: @subscriber_1,
+        status: OauthDeviceAuthorization::STATUS_PENDING,
+        device_code: "pending-subscriber-1",
+        user_code: "GRD-PEN1-0001"
+      )
+      approved_authorization = create(
+        :oauth_device_authorization,
+        oauth_application: @oauth_application,
+        resource_owner: @subscriber_1,
+        status: OauthDeviceAuthorization::STATUS_APPROVED,
+        device_code: "approved-subscriber-1",
+        user_code: "GRD-APP1-0001"
+      )
+      other_user_authorization = create(
+        :oauth_device_authorization,
+        oauth_application: @oauth_application,
+        resource_owner: @subscriber_2,
+        status: OauthDeviceAuthorization::STATUS_APPROVED,
+        device_code: "approved-subscriber-2",
+        user_code: "GRD-APP2-0001"
+      )
+      unauthenticated_pending_authorization = create(
+        :oauth_device_authorization,
+        oauth_application: @oauth_application,
+        status: OauthDeviceAuthorization::STATUS_PENDING,
+        device_code: "pending-unauthenticated",
+        user_code: "GRD-PEND-0000"
+      )
+
+      @oauth_application.revoke_access_for(@subscriber_1)
+
+      expect(pending_authorization.reload).to have_attributes(status: OauthDeviceAuthorization::STATUS_DENIED, denied_at: be_present)
+      expect(approved_authorization.reload).to have_attributes(status: OauthDeviceAuthorization::STATUS_DENIED, denied_at: be_present)
+      expect(other_user_authorization.reload).to have_attributes(status: OauthDeviceAuthorization::STATUS_APPROVED, denied_at: nil)
+      expect(unauthenticated_pending_authorization.reload).to have_attributes(status: OauthDeviceAuthorization::STATUS_PENDING, denied_at: nil)
+    end
+
+    it "does not mint a device token if the client polls while access is being revoked" do
+      device_authorization = create(
+        :oauth_device_authorization,
+        oauth_application: @oauth_application,
+        resource_owner: @subscriber_1,
+        status: OauthDeviceAuthorization::STATUS_APPROVED
+      )
+      poll_result = nil
+
+      expect(Doorkeeper::AccessToken).to receive(:revoke_all_for).with(@oauth_application.id, @subscriber_1).and_wrap_original do |method, *args|
+        expect do
+          poll_result = device_authorization.reload.poll!(
+            oauth_application: @oauth_application,
+            ip_address: "203.0.113.20",
+            user_agent: "RSpec"
+          )
+        end.not_to change { Doorkeeper::AccessToken.count }
+
+        method.call(*args)
+      end
+
+      @oauth_application.revoke_access_for(@subscriber_1)
+
+      expect(poll_result).to eq([OauthDeviceAuthorization::POLL_ACCESS_DENIED, nil])
+      expect(device_authorization.reload).to have_attributes(status: OauthDeviceAuthorization::STATUS_DENIED, access_token: nil)
+    end
   end
 end

--- a/spec/models/oauth_device_authorization_spec.rb
+++ b/spec/models/oauth_device_authorization_spec.rb
@@ -56,6 +56,32 @@ describe OauthDeviceAuthorization do
   describe "#poll!" do
     let(:oauth_application) { create(:oauth_application, scopes: "view_profile", confidential: false, device_authorization_enabled: true) }
 
+    it "denies an approved authorization if access was revoked before polling" do
+      resource_owner = create(:user)
+      create("doorkeeper/access_token", application: oauth_application, resource_owner_id: resource_owner.id, scopes: "view_profile")
+      device_authorization = create(
+        :oauth_device_authorization,
+        oauth_application:,
+        resource_owner:,
+        status: described_class::STATUS_APPROVED,
+        created_at: 1.minute.ago
+      )
+      Doorkeeper::AccessToken.revoke_all_for(oauth_application.id, resource_owner)
+
+      expect do
+        expect(device_authorization.poll!(oauth_application:, ip_address: "203.0.113.10", user_agent: "RSpec"))
+          .to eq([described_class::POLL_ACCESS_DENIED, nil])
+      end.not_to change { Doorkeeper::AccessToken.count }
+
+      expect(device_authorization.reload).to have_attributes(
+        status: described_class::STATUS_DENIED,
+        denied_at: be_present,
+        access_token: nil,
+        denied_ip_address: "203.0.113.10",
+        denied_user_agent: "RSpec"
+      )
+    end
+
     it "returns expired_token if cleanup deletes the authorization before the row lock" do
       device_authorization = create(:oauth_device_authorization, oauth_application:, expires_at: 1.second.ago)
       allow(device_authorization).to receive(:with_lock).and_raise(ActiveRecord::RecordNotFound)

--- a/spec/models/oauth_device_authorization_spec.rb
+++ b/spec/models/oauth_device_authorization_spec.rb
@@ -6,6 +6,11 @@ describe OauthDeviceAuthorization do
   describe ".create_for!" do
     let(:oauth_application) { create(:oauth_application, scopes: "view_profile", confidential: false, device_authorization_enabled: true) }
 
+    it "keeps code generation private" do
+      expect(described_class).not_to respond_to(:generate_device_code)
+      expect(described_class).not_to respond_to(:generate_user_code)
+    end
+
     it "retries code collisions before creating the authorization" do
       attempts = 0
       allow(described_class).to receive(:create!) do |attributes|

--- a/spec/models/oauth_device_authorization_spec.rb
+++ b/spec/models/oauth_device_authorization_spec.rb
@@ -47,4 +47,16 @@ describe OauthDeviceAuthorization do
       expect(attempts).to eq(described_class::MAX_CODE_GENERATION_ATTEMPTS)
     end
   end
+
+  describe "#poll!" do
+    let(:oauth_application) { create(:oauth_application, scopes: "view_profile", confidential: false, device_authorization_enabled: true) }
+
+    it "returns expired_token if cleanup deletes the authorization before the row lock" do
+      device_authorization = create(:oauth_device_authorization, oauth_application:, expires_at: 1.second.ago)
+      allow(device_authorization).to receive(:with_lock).and_raise(ActiveRecord::RecordNotFound)
+
+      expect(device_authorization.poll!(oauth_application:, ip_address: "203.0.113.10", user_agent: "RSpec"))
+        .to eq([described_class::POLL_EXPIRED_TOKEN, nil])
+    end
+  end
 end

--- a/spec/models/oauth_device_authorization_spec.rb
+++ b/spec/models/oauth_device_authorization_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe OauthDeviceAuthorization do
+  describe ".create_for!" do
+    let(:oauth_application) { create(:oauth_application, scopes: "view_profile", confidential: false, device_authorization_enabled: true) }
+
+    it "retries code collisions before creating the authorization" do
+      attempts = 0
+      allow(described_class).to receive(:create!) do |attributes|
+        attempts += 1
+        raise ActiveRecord::RecordNotUnique.new("collision") if attempts == 1
+
+        described_class.new(attributes).tap(&:save!)
+      end
+
+      device_authorization, device_code, user_code = described_class.create_for!(
+        oauth_application:,
+        scopes: "view_profile",
+        ip_address: "203.0.113.10",
+        user_agent: "RSpec"
+      )
+
+      expect(attempts).to eq(2)
+      expect(device_authorization).to be_persisted
+      expect(described_class.find_by_device_code(device_code)).to eq(device_authorization)
+      expect(described_class.find_by_user_code(user_code)).to eq(device_authorization)
+    end
+
+    it "raises after the maximum number of code collisions" do
+      attempts = 0
+      allow(described_class).to receive(:create!) do
+        attempts += 1
+        raise ActiveRecord::RecordNotUnique.new("collision")
+      end
+
+      expect do
+        described_class.create_for!(
+          oauth_application:,
+          scopes: "view_profile",
+          ip_address: "203.0.113.10",
+          user_agent: "RSpec"
+        )
+      end.to raise_error(ActiveRecord::RecordNotUnique)
+
+      expect(attempts).to eq(described_class::MAX_CODE_GENERATION_ATTEMPTS)
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2772,6 +2772,22 @@ describe User, :vcr do
       end
     end
 
+    it "denies approved device authorizations for the mobile application" do
+      device_authorization = create(
+        :oauth_device_authorization,
+        oauth_application:,
+        resource_owner: user,
+        status: OauthDeviceAuthorization::STATUS_APPROVED
+      )
+
+      user.invalidate_active_sessions!
+
+      expect(device_authorization.reload).to have_attributes(
+        status: OauthDeviceAuthorization::STATUS_DENIED,
+        denied_at: be_present,
+        access_token: nil
+      )
+    end
   end
 
   describe "#invalidate_browser_sessions!" do

--- a/spec/requests/oauth_device_authorizations_spec.rb
+++ b/spec/requests/oauth_device_authorizations_spec.rb
@@ -53,6 +53,15 @@ describe "OAuth device authorizations", type: :request do
       expect(response.parsed_body).to include("error" => "invalid_scope")
     end
 
+    it "uses the application's scopes when scope is omitted" do
+      expect do
+        post oauth_device_code_path, params: { client_id: oauth_application.uid }
+      end.to change { OauthDeviceAuthorization.count }.by(1)
+
+      expect(response).to have_http_status(:ok)
+      expect(OauthDeviceAuthorization.last).to have_attributes(scopes: "view_profile edit_products")
+    end
+
     it "rejects non-scalar scopes" do
       expect do
         post oauth_device_code_path, params: { client_id: oauth_application.uid, scope: { bad: "1" } }
@@ -175,9 +184,22 @@ describe "OAuth device authorizations", type: :request do
       )
       expect(access_token).to have_attributes(application_id: oauth_application.id, resource_owner_id: user.id)
       expect(access_token.scopes.to_s).to eq("view_profile")
-      expect(Doorkeeper::AccessGrant.where(application_id: oauth_application.id, resource_owner_id: user.id, scopes: "view_profile")).to exist
+      expect(Doorkeeper::AccessGrant.where(
+        application_id: oauth_application.id,
+        resource_owner_id: user.id,
+        scopes: "view_profile",
+        redirect_uri: OauthDeviceAuthorization::DEVICE_REDIRECT_URI
+      )).to exist
       expect(OauthDeviceAuthorization.last).to have_attributes(status: OauthDeviceAuthorization::STATUS_CONSUMED, access_token:)
       expect(OauthApplication.authorized_for(user)).to include(oauth_application)
+
+      consumed_authorization = OauthDeviceAuthorization.last
+      consumed_poll_count = consumed_authorization.poll_count
+      post oauth_token_path, params: { grant_type: OauthDeviceAuthorization::GRANT_TYPE, client_id: oauth_application.uid, device_code: body["device_code"] }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to include("error" => "expired_token")
+      expect(consumed_authorization.reload).to have_attributes(poll_count: consumed_poll_count)
 
       oauth_application.revoke_access_for(user)
 
@@ -209,6 +231,32 @@ describe "OAuth device authorizations", type: :request do
 
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response.body).to include("Choose whether to authorize or deny this application.")
+      expect(OauthDeviceAuthorization.last).to have_attributes(status: OauthDeviceAuthorization::STATUS_PENDING, resource_owner: nil)
+    end
+
+    it "does not show approval success when the approval transition loses a race" do
+      body = create_device_code
+      sign_in user
+      allow_any_instance_of(OauthDeviceAuthorization).to receive(:approve!).and_return(false)
+
+      submit_device_authorization(body["user_code"], decision: "approve")
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("This code is invalid or expired.")
+      expect(response.body).not_to include("Authorization complete")
+      expect(OauthDeviceAuthorization.last).to have_attributes(status: OauthDeviceAuthorization::STATUS_PENDING, resource_owner: nil)
+    end
+
+    it "does not show denial success when the denial transition loses a race" do
+      body = create_device_code
+      sign_in user
+      allow_any_instance_of(OauthDeviceAuthorization).to receive(:deny!).and_return(false)
+
+      submit_device_authorization(body["user_code"], decision: "deny")
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("This code is invalid or expired.")
+      expect(response.body).not_to include("Authorization denied")
       expect(OauthDeviceAuthorization.last).to have_attributes(status: OauthDeviceAuthorization::STATUS_PENDING, resource_owner: nil)
     end
 
@@ -248,13 +296,33 @@ describe "OAuth device authorizations", type: :request do
       expect(Doorkeeper::AccessToken.count).to eq(0)
     end
 
+    it "exchanges approved codes when the device application has no browser redirect URI" do
+      oauth_application.update_column(:redirect_uri, "")
+      body = create_device_code
+      sign_in user
+      submit_device_authorization(body["user_code"], decision: "approve")
+
+      expect do
+        post oauth_token_path, params: { grant_type: OauthDeviceAuthorization::GRANT_TYPE, client_id: oauth_application.uid, device_code: body["device_code"] }
+      end.to change { Doorkeeper::AccessToken.count }.by(1)
+
+      expect(response).to have_http_status(:ok)
+      expect(Doorkeeper::AccessGrant.where(
+        application_id: oauth_application.id,
+        resource_owner_id: user.id,
+        scopes: "view_profile",
+        redirect_uri: OauthDeviceAuthorization::DEVICE_REDIRECT_URI
+      )).to exist
+    end
+
     it "returns expired_token for expired codes" do
-      create(:oauth_device_authorization, oauth_application:, device_code: "expired-device-code", expires_at: 1.second.ago)
+      device_authorization = create(:oauth_device_authorization, oauth_application:, device_code: "expired-device-code", expires_at: 1.second.ago)
 
       post oauth_token_path, params: { grant_type: OauthDeviceAuthorization::GRANT_TYPE, client_id: oauth_application.uid, device_code: "expired-device-code" }
 
       expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body).to include("error" => "expired_token")
+      expect(device_authorization.reload).to have_attributes(poll_count: 0, last_polled_at: nil)
     end
   end
 

--- a/spec/requests/oauth_device_authorizations_spec.rb
+++ b/spec/requests/oauth_device_authorizations_spec.rb
@@ -362,12 +362,42 @@ describe "OAuth device authorizations", type: :request do
       expect(response.body).not_to include("This code is invalid or expired.")
     end
 
+    it "shows completion when the approving user reloads after the client polls" do
+      body = create_device_code
+      sign_in user
+
+      submit_device_authorization(body["user_code"], decision: "approve")
+      post oauth_token_path, params: { grant_type: OauthDeviceAuthorization::GRANT_TYPE, client_id: oauth_application.uid, device_code: body["device_code"] }
+      get oauth_device_authorization_path, params: { user_code: body["user_code"] }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Authorization complete")
+      expect(response.body).not_to include("This code is invalid or expired.")
+      expect(OauthDeviceAuthorization.last).to have_attributes(status: OauthDeviceAuthorization::STATUS_CONSUMED)
+    end
+
     it "does not show completion for an approved code to a different user" do
       body = create_device_code
       other_user = create(:named_user, name: "Other User", email: "other@example.com")
       sign_in user
 
       submit_device_authorization(body["user_code"], decision: "approve")
+      sign_out user
+      sign_in other_user
+      get oauth_device_authorization_path, params: { user_code: body["user_code"] }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("This code is invalid or expired.")
+      expect(response.body).not_to include("Authorization complete")
+    end
+
+    it "does not show completion for a consumed code to a different user" do
+      body = create_device_code
+      other_user = create(:named_user, name: "Other User", email: "other@example.com")
+      sign_in user
+
+      submit_device_authorization(body["user_code"], decision: "approve")
+      post oauth_token_path, params: { grant_type: OauthDeviceAuthorization::GRANT_TYPE, client_id: oauth_application.uid, device_code: body["device_code"] }
       sign_out user
       sign_in other_user
       get oauth_device_authorization_path, params: { user_code: body["user_code"] }
@@ -441,6 +471,33 @@ describe "OAuth device authorizations", type: :request do
       expect(response.body).to include("This code is invalid or expired.")
       expect(response.body).not_to include("Authorization denied")
       expect(OauthDeviceAuthorization.last).to have_attributes(status: OauthDeviceAuthorization::STATUS_PENDING, resource_owner: nil)
+    end
+
+    it "shows denial when the denying user reloads" do
+      body = create_device_code
+      sign_in user
+
+      submit_device_authorization(body["user_code"], decision: "deny")
+      get oauth_device_authorization_path, params: { user_code: body["user_code"] }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Authorization denied")
+      expect(response.body).not_to include("This code is invalid or expired.")
+    end
+
+    it "does not show denial for a denied code to a different user" do
+      body = create_device_code
+      other_user = create(:named_user, name: "Other User", email: "other@example.com")
+      sign_in user
+
+      submit_device_authorization(body["user_code"], decision: "deny")
+      sign_out user
+      sign_in other_user
+      get oauth_device_authorization_path, params: { user_code: body["user_code"] }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("This code is invalid or expired.")
+      expect(response.body).not_to include("Authorization denied")
     end
 
     it "does not approve a code after device authorization is disabled for the client" do

--- a/spec/requests/oauth_device_authorizations_spec.rb
+++ b/spec/requests/oauth_device_authorizations_spec.rb
@@ -120,12 +120,59 @@ describe "OAuth device authorizations", type: :request do
   end
 
   describe "GET /oauth/device" do
-    it "redirects to login with the code preserved before showing approval details" do
+    it "redirects to login without leaking the code before showing approval details" do
       body = create_device_code
 
       get oauth_device_authorization_path, params: { user_code: body["user_code"] }
 
-      expect(response).to redirect_to(login_path(next: oauth_device_authorization_path(user_code: body["user_code"])))
+      next_path = login_next_path
+      expect(response).to redirect_to(login_path(next: next_path))
+      expect(response.location).not_to include("user_code")
+      expect(next_path).to start_with(oauth_device_authorization_path)
+      expect(next_path).to include("handoff=")
+
+      sign_in user
+      get next_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Authorize")
+      expect(response.body).to include("Gumroad CLI")
+      expect(response.body).to include("See your profile data.")
+
+      get next_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Authorize")
+      expect(response.body).to include("Gumroad CLI")
+    end
+
+    it "keeps concurrent logged-out device approval handoffs separate" do
+      first_body = create_device_code
+      other_application = create(:oauth_application, owner: user, name: "Other CLI", scopes: "view_profile", confidential: false, device_authorization_enabled: true)
+      post oauth_device_code_path, params: { client_id: other_application.uid, scope: "view_profile" }
+      second_body = response.parsed_body
+
+      get oauth_device_authorization_path, params: { user_code: first_body["user_code"] }
+      first_next_path = login_next_path
+      get oauth_device_authorization_path, params: { user_code: second_body["user_code"] }
+      second_next_path = login_next_path
+
+      expect(first_next_path).not_to eq(second_next_path)
+      expect(first_next_path).not_to include("user_code")
+      expect(second_next_path).not_to include("user_code")
+
+      sign_in user
+      get first_next_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Gumroad CLI")
+      expect(response.body).not_to include("Other CLI")
+
+      get second_next_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Other CLI")
+      expect(response.body).not_to include("Gumroad CLI")
     end
 
     it "shows the application and scopes after login" do
@@ -725,6 +772,10 @@ describe "OAuth device authorizations", type: :request do
     authenticity_token = authenticity_token_node["value"] || authenticity_token_node["content"]
 
     post oauth_device_authorization_path, params: { user_code:, decision:, authenticity_token: }
+  end
+
+  def login_next_path
+    Rack::Utils.parse_query(URI(response.location).query)["next"]
   end
 
   def stub_vite_layout_helpers

--- a/spec/requests/oauth_device_authorizations_spec.rb
+++ b/spec/requests/oauth_device_authorizations_spec.rb
@@ -130,6 +130,17 @@ describe "OAuth device authorizations", type: :request do
       expect(response.body).to include("See your profile data.")
     end
 
+    it "shows expired codes without redirecting to login" do
+      device_authorization = create(:oauth_device_authorization, oauth_application:, user_code: "GRD-EXPR-0001", expires_at: 1.second.ago)
+
+      get oauth_device_authorization_path, params: { user_code: "GRD-EXPR-0001" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response).not_to be_redirect
+      expect(response.body).to include("This code has expired.")
+      expect(device_authorization.reload).to have_attributes(status: OauthDeviceAuthorization::STATUS_PENDING, resource_owner: nil)
+    end
+
     it "blocks approval while the signed-in admin is impersonating another user" do
       body = create_device_code
       admin = create(:admin_user)
@@ -257,6 +268,44 @@ describe "OAuth device authorizations", type: :request do
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response.body).to include("This code is invalid or expired.")
       expect(response.body).not_to include("Authorization denied")
+      expect(OauthDeviceAuthorization.last).to have_attributes(status: OauthDeviceAuthorization::STATUS_PENDING, resource_owner: nil)
+    end
+
+    it "does not approve a code after device authorization is disabled for the client" do
+      body = create_device_code
+      oauth_application.update!(device_authorization_enabled: false)
+      sign_in user
+
+      get oauth_device_authorization_path, params: { user_code: body["user_code"] }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("This code is invalid.")
+      expect(response.body).not_to include("This application will be able to:")
+
+      submit_device_authorization(body["user_code"], decision: "approve")
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("This code is invalid.")
+      expect(response.body).not_to include("Authorization complete")
+      expect(OauthDeviceAuthorization.last).to have_attributes(status: OauthDeviceAuthorization::STATUS_PENDING, resource_owner: nil)
+    end
+
+    it "does not approve a code after the client is deleted" do
+      body = create_device_code
+      oauth_application.mark_deleted!
+      sign_in user
+
+      get oauth_device_authorization_path, params: { user_code: body["user_code"] }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("This code is invalid.")
+      expect(response.body).not_to include("This application will be able to:")
+
+      submit_device_authorization(body["user_code"], decision: "approve")
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("This code is invalid.")
+      expect(response.body).not_to include("Authorization complete")
       expect(OauthDeviceAuthorization.last).to have_attributes(status: OauthDeviceAuthorization::STATUS_PENDING, resource_owner: nil)
     end
 

--- a/spec/requests/oauth_device_authorizations_spec.rb
+++ b/spec/requests/oauth_device_authorizations_spec.rb
@@ -488,11 +488,19 @@ describe "OAuth device authorizations", type: :request do
 
       expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body).to include("error" => "authorization_pending")
+      expect(OauthDeviceAuthorization.last.poll_interval_seconds).to eq(OauthDeviceAuthorization::POLL_INTERVAL.to_i)
 
       post oauth_token_path, params: { grant_type: OauthDeviceAuthorization::GRANT_TYPE, client_id: oauth_application.uid, device_code: body["device_code"] }
 
       expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body).to include("error" => "slow_down", "interval" => OauthDeviceAuthorization::SLOW_DOWN_INTERVAL.to_i)
+      expect(OauthDeviceAuthorization.last.poll_interval_seconds).to eq(OauthDeviceAuthorization::SLOW_DOWN_INTERVAL.to_i)
+
+      travel OauthDeviceAuthorization::POLL_INTERVAL + 1.second
+      post oauth_token_path, params: { grant_type: OauthDeviceAuthorization::GRANT_TYPE, client_id: oauth_application.uid, device_code: body["device_code"] }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to include("error" => "slow_down", "interval" => (OauthDeviceAuthorization::SLOW_DOWN_INTERVAL + OauthDeviceAuthorization::SLOW_DOWN_INCREMENT).to_i)
     end
 
     it "does not run the device grant on OAuth token alias routes" do

--- a/spec/requests/oauth_device_authorizations_spec.rb
+++ b/spec/requests/oauth_device_authorizations_spec.rb
@@ -469,6 +469,20 @@ describe "OAuth device authorizations", type: :request do
       expect(device_authorization.reload).to have_attributes(poll_count: 0, last_polled_at: nil)
     end
 
+    it "exchanges approved codes on formatted OAuth token routes" do
+      body = create_device_code
+      sign_in user
+      submit_device_authorization(body["user_code"], decision: "approve")
+
+      expect do
+        post "#{oauth_token_path}.json", params: { grant_type: OauthDeviceAuthorization::GRANT_TYPE, client_id: oauth_application.uid, device_code: body["device_code"] }
+      end.to change { Doorkeeper::AccessToken.count }.by(1)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include("access_token" => Doorkeeper::AccessToken.last.token)
+      expect(OauthDeviceAuthorization.last).to have_attributes(status: OauthDeviceAuthorization::STATUS_CONSUMED)
+    end
+
     it "returns expired_token for unknown device codes" do
       post oauth_token_path, params: { grant_type: OauthDeviceAuthorization::GRANT_TYPE, client_id: oauth_application.uid, device_code: "unknown-device-code" }
 

--- a/spec/requests/oauth_device_authorizations_spec.rb
+++ b/spec/requests/oauth_device_authorizations_spec.rb
@@ -217,6 +217,39 @@ describe "OAuth device authorizations", type: :request do
       expect(access_token.reload).to be_revoked
     end
 
+    it "does not exchange an approved code after the user revokes the application" do
+      access_token = create(
+        "doorkeeper/access_token",
+        application: oauth_application,
+        resource_owner_id: user.id,
+        scopes: "view_profile"
+      )
+      body = create_device_code
+      sign_in user
+
+      submit_device_authorization(body["user_code"], decision: "approve")
+      device_authorization = OauthDeviceAuthorization.last
+      oauth_application.revoke_access_for(user)
+
+      expect(access_token.reload).to be_revoked
+      expect(device_authorization.reload).to have_attributes(
+        status: OauthDeviceAuthorization::STATUS_DENIED,
+        denied_at: be_present,
+        access_token: nil
+      )
+      expect do
+        post oauth_token_path,
+             params: {
+               grant_type: OauthDeviceAuthorization::GRANT_TYPE,
+               client_id: oauth_application.uid,
+               device_code: body["device_code"]
+             }
+      end.not_to change { Doorkeeper::AccessToken.count }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to include("error" => "access_denied")
+    end
+
     it "does not exchange an approved code after device authorization is disabled for the client" do
       body = create_device_code
       sign_in user

--- a/spec/requests/oauth_device_authorizations_spec.rb
+++ b/spec/requests/oauth_device_authorizations_spec.rb
@@ -250,6 +250,45 @@ describe "OAuth device authorizations", type: :request do
       expect(response.parsed_body).to include("error" => "access_denied")
     end
 
+    it "does not approve a pending code after the user revokes the application" do
+      access_token = create(
+        "doorkeeper/access_token",
+        application: oauth_application,
+        resource_owner_id: user.id,
+        scopes: "view_profile"
+      )
+      body = create_device_code
+      device_authorization = OauthDeviceAuthorization.last
+      oauth_application.revoke_access_for(user)
+      sign_in user
+
+      get oauth_device_authorization_path, params: { user_code: body["user_code"] }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("This code is invalid or expired.")
+      expect(response.body).not_to include("This application will be able to:")
+
+      expect do
+        submit_device_authorization(body["user_code"], decision: "approve")
+      end.not_to change { Doorkeeper::AccessToken.count }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("This code is invalid or expired.")
+      expect(response.body).not_to include("Authorization complete")
+      expect(access_token.reload).to be_revoked
+      expect(device_authorization.reload).to have_attributes(
+        status: OauthDeviceAuthorization::STATUS_DENIED,
+        denied_at: be_present,
+        resource_owner: user,
+        access_token: nil
+      )
+
+      post oauth_token_path, params: { grant_type: OauthDeviceAuthorization::GRANT_TYPE, client_id: oauth_application.uid, device_code: body["device_code"] }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to include("error" => "access_denied")
+    end
+
     it "does not return a successful token response when the issued token is revoked before rendering" do
       body = create_device_code
       sign_in user

--- a/spec/requests/oauth_device_authorizations_spec.rb
+++ b/spec/requests/oauth_device_authorizations_spec.rb
@@ -265,8 +265,21 @@ describe "OAuth device authorizations", type: :request do
       get oauth_device_authorization_path, params: { user_code: body["user_code"] }
 
       expect(response).to have_http_status(:ok)
+      expect(response.body).to include("This application will be able to:")
+      expect(device_authorization.reload).to have_attributes(
+        status: OauthDeviceAuthorization::STATUS_PENDING,
+        denied_at: nil,
+        resource_owner: nil,
+        access_token: nil
+      )
+
+      expect do
+        submit_device_authorization(body["user_code"], decision: "approve")
+      end.not_to change { Doorkeeper::AccessToken.count }
+
+      expect(response).to have_http_status(:unprocessable_entity)
       expect(response.body).to include("This code is invalid or expired.")
-      expect(response.body).not_to include("This application will be able to:")
+      expect(response.body).not_to include("Authorization complete")
       expect(device_authorization.reload).to have_attributes(
         status: OauthDeviceAuthorization::STATUS_DENIED,
         denied_at: be_present,
@@ -278,14 +291,37 @@ describe "OAuth device authorizations", type: :request do
 
       expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body).to include("error" => "access_denied")
+      expect(access_token.reload).to be_revoked
+    end
 
-      expect do
-        submit_device_authorization(body["user_code"], decision: "approve")
-      end.not_to change { Doorkeeper::AccessToken.count }
+    it "does not deny another user's pending code when a revoked user views it" do
+      revoked_user = create(:user)
+      access_token = create(
+        "doorkeeper/access_token",
+        application: oauth_application,
+        resource_owner_id: revoked_user.id,
+        scopes: "view_profile"
+      )
+      body = create_device_code
+      device_authorization = OauthDeviceAuthorization.last
+      oauth_application.revoke_access_for(revoked_user)
+      sign_in revoked_user
 
-      expect(response).to have_http_status(:unprocessable_entity)
-      expect(response.body).to include("This code is invalid or expired.")
-      expect(response.body).not_to include("Authorization complete")
+      get oauth_device_authorization_path, params: { user_code: body["user_code"] }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("This application will be able to:")
+      expect(device_authorization.reload).to have_attributes(
+        status: OauthDeviceAuthorization::STATUS_PENDING,
+        denied_at: nil,
+        resource_owner: nil,
+        access_token: nil
+      )
+
+      post oauth_token_path, params: { grant_type: OauthDeviceAuthorization::GRANT_TYPE, client_id: oauth_application.uid, device_code: body["device_code"] }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to include("error" => "authorization_pending")
       expect(access_token.reload).to be_revoked
     end
 

--- a/spec/requests/oauth_device_authorizations_spec.rb
+++ b/spec/requests/oauth_device_authorizations_spec.rb
@@ -333,6 +333,13 @@ describe "OAuth device authorizations", type: :request do
       expect(device_authorization.reload).to have_attributes(poll_count: 0, last_polled_at: nil)
     end
 
+    it "returns expired_token for unknown device codes" do
+      post oauth_token_path, params: { grant_type: OauthDeviceAuthorization::GRANT_TYPE, client_id: oauth_application.uid, device_code: "unknown-device-code" }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to include("error" => "expired_token")
+    end
+
     it "returns access_denied after the user denies the code" do
       body = create_device_code
       sign_in user

--- a/spec/requests/oauth_device_authorizations_spec.rb
+++ b/spec/requests/oauth_device_authorizations_spec.rb
@@ -1,0 +1,281 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "OAuth device authorizations", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { create(:named_user, name: "Gianfranco", email: "gianfranco@example.com") }
+  let(:oauth_application) { create(:oauth_application, owner: user, name: "Gumroad CLI", scopes: "view_profile edit_products", confidential: false, device_authorization_enabled: true) }
+
+  before do
+    host! DOMAIN
+    stub_vite_layout_helpers
+  end
+
+  describe "POST /oauth/device/code" do
+    it "creates a pending device authorization and returns the device flow payload" do
+      expect do
+        post oauth_device_code_path, params: { client_id: oauth_application.uid, scope: "view_profile" }, headers: { "REMOTE_ADDR" => "203.0.113.10", "HTTP_USER_AGENT" => "Gumroad CLI" }
+      end.to change { OauthDeviceAuthorization.count }.by(1)
+
+      body = response.parsed_body
+      device_authorization = OauthDeviceAuthorization.last
+
+      expect(response).to have_http_status(:ok)
+      expect(body).to include(
+        "device_code" => be_present,
+        "user_code" => a_string_matching(/\AGRD-[A-Z0-9]{4}-[A-Z0-9]{4}\z/),
+        "verification_uri" => oauth_device_authorization_url,
+        "verification_uri_complete" => oauth_device_authorization_url(user_code: body["user_code"]),
+        "expires_in" => OauthDeviceAuthorization::EXPIRES_IN.to_i,
+        "interval" => OauthDeviceAuthorization::POLL_INTERVAL.to_i
+      )
+      expect(device_authorization).to have_attributes(
+        oauth_application:,
+        scopes: "view_profile",
+        status: OauthDeviceAuthorization::STATUS_PENDING,
+        created_ip_address: "203.0.113.10",
+        created_user_agent: "Gumroad CLI"
+      )
+      expect(device_authorization.device_code_digest).to eq(OauthDeviceAuthorization.digest(body["device_code"]))
+      expect(device_authorization.user_code_digest).to eq(OauthDeviceAuthorization.digest(OauthDeviceAuthorization.normalize_user_code(body["user_code"])))
+      expect(device_authorization.device_code_digest).not_to eq(body["device_code"])
+      expect(device_authorization.user_code_digest).not_to eq(body["user_code"])
+    end
+
+    it "rejects scopes the application cannot request" do
+      expect do
+        post oauth_device_code_path, params: { client_id: oauth_application.uid, scope: "mobile_api" }
+      end.not_to change { OauthDeviceAuthorization.count }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to include("error" => "invalid_scope")
+    end
+
+    it "rejects non-scalar scopes" do
+      expect do
+        post oauth_device_code_path, params: { client_id: oauth_application.uid, scope: { bad: "1" } }
+      end.not_to change { OauthDeviceAuthorization.count }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to include("error" => "invalid_scope")
+    end
+
+    it "rejects clients that are not opted in to device authorization" do
+      unauthorized_application = create(:oauth_application, owner: user, scopes: "view_profile", confidential: false, device_authorization_enabled: false)
+
+      expect do
+        post oauth_device_code_path, params: { client_id: unauthorized_application.uid, scope: "view_profile" }
+      end.not_to change { OauthDeviceAuthorization.count }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to include("error" => "unauthorized_client")
+    end
+
+    it "returns canonical Gumroad verification URLs when called from the API host" do
+      host! API_DOMAIN
+
+      post oauth_device_code_path, params: { client_id: oauth_application.uid, scope: "view_profile" }
+
+      body = response.parsed_body
+      expect(response).to have_http_status(:ok)
+      expect(body).to include(
+        "verification_uri" => oauth_device_authorization_url(host: DOMAIN, protocol: PROTOCOL),
+        "verification_uri_complete" => oauth_device_authorization_url(host: DOMAIN, protocol: PROTOCOL, user_code: body["user_code"])
+      )
+    end
+
+    it "requires the client secret for confidential applications" do
+      confidential_application = create(:oauth_application, owner: user, scopes: "view_profile", confidential: true, secret: "client-secret", device_authorization_enabled: true)
+
+      post oauth_device_code_path, params: { client_id: confidential_application.uid, scope: "view_profile" }
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.parsed_body).to include("error" => "invalid_client")
+
+      post oauth_device_code_path, params: { client_id: confidential_application.uid, client_secret: "client-secret", scope: "view_profile" }
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET /oauth/device" do
+    it "redirects to login with the code preserved before showing approval details" do
+      body = create_device_code
+
+      get oauth_device_authorization_path, params: { user_code: body["user_code"] }
+
+      expect(response).to redirect_to(login_path(next: oauth_device_authorization_path(user_code: body["user_code"])))
+    end
+
+    it "shows the application and scopes after login" do
+      body = create_device_code
+      sign_in user
+
+      get oauth_device_authorization_path, params: { user_code: body["user_code"] }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Authorize")
+      expect(response.body).to include("Gumroad CLI")
+      expect(response.body).to include("See your profile data.")
+    end
+
+    it "blocks approval while the signed-in admin is impersonating another user" do
+      body = create_device_code
+      admin = create(:admin_user)
+      sign_in admin
+      $redis.set(RedisKey.impersonated_user(admin.id), user.id)
+
+      get oauth_device_authorization_path, params: { user_code: body["user_code"] }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Stop impersonating before authorizing an OAuth application.")
+      expect(response.body).not_to include("This application will be able to:")
+
+      expect do
+        submit_device_authorization(body["user_code"], decision: "approve")
+      end.not_to change { Doorkeeper::AccessToken.count }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(OauthDeviceAuthorization.last).to have_attributes(status: OauthDeviceAuthorization::STATUS_PENDING, resource_owner: nil)
+    ensure
+      $redis.del(RedisKey.impersonated_user(admin.id)) if defined?(admin) && admin&.persisted?
+    end
+  end
+
+  describe "POST /oauth/device and POST /oauth/token" do
+    it "lets the user approve a code and lets the polling client exchange it for a normal token" do
+      body = create_device_code
+      sign_in user
+
+      submit_device_authorization(body["user_code"], decision: "approve")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Authorization complete")
+      expect(OauthDeviceAuthorization.last).to have_attributes(
+        status: OauthDeviceAuthorization::STATUS_APPROVED,
+        resource_owner: user,
+        approved_at: be_present
+      )
+
+      expect do
+        post oauth_token_path, params: { grant_type: OauthDeviceAuthorization::GRANT_TYPE, client_id: oauth_application.uid, device_code: body["device_code"] }
+      end.to change { Doorkeeper::AccessToken.count }.by(1)
+
+      token_body = response.parsed_body
+      access_token = Doorkeeper::AccessToken.last
+
+      expect(response).to have_http_status(:ok)
+      expect(token_body).to include(
+        "access_token" => access_token.token,
+        "token_type" => "Bearer",
+        "refresh_token" => access_token.refresh_token,
+        "scope" => "view_profile"
+      )
+      expect(access_token).to have_attributes(application_id: oauth_application.id, resource_owner_id: user.id)
+      expect(access_token.scopes.to_s).to eq("view_profile")
+      expect(Doorkeeper::AccessGrant.where(application_id: oauth_application.id, resource_owner_id: user.id, scopes: "view_profile")).to exist
+      expect(OauthDeviceAuthorization.last).to have_attributes(status: OauthDeviceAuthorization::STATUS_CONSUMED, access_token:)
+      expect(OauthApplication.authorized_for(user)).to include(oauth_application)
+
+      oauth_application.revoke_access_for(user)
+
+      expect(access_token.reload).to be_revoked
+    end
+
+    it "does not exchange an approved code after device authorization is disabled for the client" do
+      body = create_device_code
+      sign_in user
+      submit_device_authorization(body["user_code"], decision: "approve")
+      oauth_application.update!(device_authorization_enabled: false)
+
+      expect do
+        post oauth_token_path, params: { grant_type: OauthDeviceAuthorization::GRANT_TYPE, client_id: oauth_application.uid, device_code: body["device_code"] }
+      end.not_to change { Doorkeeper::AccessToken.count }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to include("error" => "unauthorized_client")
+      expect(OauthDeviceAuthorization.last).to have_attributes(status: OauthDeviceAuthorization::STATUS_APPROVED, access_token: nil)
+    end
+
+    it "does not approve malformed authorization decisions" do
+      body = create_device_code
+      sign_in user
+
+      expect do
+        submit_device_authorization(body["user_code"], decision: "maybe")
+      end.not_to change { Doorkeeper::AccessToken.count }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("Choose whether to authorize or deny this application.")
+      expect(OauthDeviceAuthorization.last).to have_attributes(status: OauthDeviceAuthorization::STATUS_PENDING, resource_owner: nil)
+    end
+
+    it "returns authorization_pending and slow_down while the user has not approved the code" do
+      body = create_device_code
+
+      post oauth_token_path, params: { grant_type: OauthDeviceAuthorization::GRANT_TYPE, client_id: oauth_application.uid, device_code: body["device_code"] }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to include("error" => "authorization_pending")
+
+      post oauth_token_path, params: { grant_type: OauthDeviceAuthorization::GRANT_TYPE, client_id: oauth_application.uid, device_code: body["device_code"] }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to include("error" => "slow_down", "interval" => OauthDeviceAuthorization::SLOW_DOWN_INTERVAL.to_i)
+    end
+
+    it "does not run the device grant on OAuth token alias routes" do
+      body = create_device_code
+      device_authorization = OauthDeviceAuthorization.last
+
+      post "/ifttt/v1/oauth2/token", params: { grant_type: OauthDeviceAuthorization::GRANT_TYPE, client_id: oauth_application.uid, device_code: body["device_code"] }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(device_authorization.reload).to have_attributes(poll_count: 0, last_polled_at: nil)
+    end
+
+    it "returns access_denied after the user denies the code" do
+      body = create_device_code
+      sign_in user
+
+      submit_device_authorization(body["user_code"], decision: "deny")
+      post oauth_token_path, params: { grant_type: OauthDeviceAuthorization::GRANT_TYPE, client_id: oauth_application.uid, device_code: body["device_code"] }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to include("error" => "access_denied")
+      expect(Doorkeeper::AccessToken.count).to eq(0)
+    end
+
+    it "returns expired_token for expired codes" do
+      create(:oauth_device_authorization, oauth_application:, device_code: "expired-device-code", expires_at: 1.second.ago)
+
+      post oauth_token_path, params: { grant_type: OauthDeviceAuthorization::GRANT_TYPE, client_id: oauth_application.uid, device_code: "expired-device-code" }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to include("error" => "expired_token")
+    end
+  end
+
+  def create_device_code
+    post oauth_device_code_path, params: { client_id: oauth_application.uid, scope: "view_profile" }
+    response.parsed_body
+  end
+
+  def submit_device_authorization(user_code, decision:)
+    get oauth_device_authorization_path, params: { user_code: }
+    doc = Nokogiri::HTML(response.body)
+    authenticity_token_node = doc.at_css("input[name='authenticity_token']") || doc.at_css("meta[name='csrf-token']")
+    authenticity_token = authenticity_token_node["value"] || authenticity_token_node["content"]
+
+    post oauth_device_authorization_path, params: { user_code:, decision:, authenticity_token: }
+  end
+
+  def stub_vite_layout_helpers
+    allow(ViteRuby.instance.manifest).to receive(:resolve_entries).and_return({ stylesheets: ["/vite-test.css"] })
+    allow_any_instance_of(ActionView::Base).to receive(:vite_client_tag).and_return("")
+    allow_any_instance_of(ActionView::Base).to receive(:vite_react_refresh_tag).and_return("")
+    allow_any_instance_of(ActionView::Base).to receive(:vite_typescript_tag).and_return("")
+  end
+end

--- a/spec/requests/oauth_device_authorizations_spec.rb
+++ b/spec/requests/oauth_device_authorizations_spec.rb
@@ -403,7 +403,7 @@ describe "OAuth device authorizations", type: :request do
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response.body).to include("This code is invalid.")
       expect(response.body).not_to include("Authorization complete")
-      expect(OauthDeviceAuthorization.last).to have_attributes(status: OauthDeviceAuthorization::STATUS_PENDING, resource_owner: nil)
+      expect(OauthDeviceAuthorization.last).to have_attributes(status: OauthDeviceAuthorization::STATUS_DENIED, denied_at: be_present, resource_owner: nil)
     end
 
     it "returns authorization_pending and slow_down while the user has not approved the code" do

--- a/spec/requests/oauth_device_authorizations_spec.rb
+++ b/spec/requests/oauth_device_authorizations_spec.rb
@@ -372,6 +372,19 @@ describe "OAuth device authorizations", type: :request do
       expect(response.body).not_to include("This code is invalid or expired.")
     end
 
+    it "shows expiry when the approving user reloads after the approved code expires before polling" do
+      body = create_device_code
+      sign_in user
+
+      submit_device_authorization(body["user_code"], decision: "approve")
+      OauthDeviceAuthorization.last.update!(expires_at: 1.second.ago)
+      get oauth_device_authorization_path, params: { user_code: body["user_code"] }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("This code has expired.")
+      expect(response.body).not_to include("Authorization complete")
+    end
+
     it "shows completion when the approving user reloads after the client polls" do
       body = create_device_code
       sign_in user
@@ -384,6 +397,21 @@ describe "OAuth device authorizations", type: :request do
       expect(response.body).to include("Authorization complete")
       expect(response.body).not_to include("This code is invalid or expired.")
       expect(OauthDeviceAuthorization.last).to have_attributes(status: OauthDeviceAuthorization::STATUS_CONSUMED)
+    end
+
+    it "shows completion when the approving user reloads after the consumed code expires" do
+      body = create_device_code
+      sign_in user
+
+      submit_device_authorization(body["user_code"], decision: "approve")
+      post oauth_token_path, params: { grant_type: OauthDeviceAuthorization::GRANT_TYPE, client_id: oauth_application.uid, device_code: body["device_code"] }
+      OauthDeviceAuthorization.last.update!(expires_at: 1.second.ago)
+      get oauth_device_authorization_path, params: { user_code: body["user_code"] }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Authorization complete")
+      expect(response.body).not_to include("This code has expired.")
+      expect(response.body).not_to include("This code is invalid or expired.")
     end
 
     it "does not show completion for an approved code to a different user" do
@@ -492,6 +520,20 @@ describe "OAuth device authorizations", type: :request do
 
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("Authorization denied")
+      expect(response.body).not_to include("This code is invalid or expired.")
+    end
+
+    it "shows denial when the denying user reloads after the code expires" do
+      body = create_device_code
+      sign_in user
+
+      submit_device_authorization(body["user_code"], decision: "deny")
+      OauthDeviceAuthorization.last.update!(expires_at: 1.second.ago)
+      get oauth_device_authorization_path, params: { user_code: body["user_code"] }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Authorization denied")
+      expect(response.body).not_to include("This code has expired.")
       expect(response.body).not_to include("This code is invalid or expired.")
     end
 

--- a/spec/requests/oauth_device_authorizations_spec.rb
+++ b/spec/requests/oauth_device_authorizations_spec.rb
@@ -314,6 +314,45 @@ describe "OAuth device authorizations", type: :request do
       expect(Doorkeeper::AccessToken.last).to be_revoked
     end
 
+    it "shows completion when the approving user reloads before the client polls" do
+      body = create_device_code
+      sign_in user
+
+      submit_device_authorization(body["user_code"], decision: "approve")
+      get oauth_device_authorization_path, params: { user_code: body["user_code"] }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Authorization complete")
+      expect(response.body).not_to include("This code is invalid or expired.")
+    end
+
+    it "does not show completion for an approved code to a different user" do
+      body = create_device_code
+      other_user = create(:named_user, name: "Other User", email: "other@example.com")
+      sign_in user
+
+      submit_device_authorization(body["user_code"], decision: "approve")
+      sign_out user
+      sign_in other_user
+      get oauth_device_authorization_path, params: { user_code: body["user_code"] }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("This code is invalid or expired.")
+      expect(response.body).not_to include("Authorization complete")
+    end
+
+    it "does not show completion when approving an already approved code again" do
+      body = create_device_code
+      sign_in user
+
+      submit_device_authorization(body["user_code"], decision: "approve")
+      submit_device_authorization(body["user_code"], decision: "approve")
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("This code is invalid or expired.")
+      expect(response.body).not_to include("Authorization complete")
+    end
+
     it "does not exchange an approved code after device authorization is disabled for the client" do
       body = create_device_code
       sign_in user

--- a/spec/requests/oauth_device_authorizations_spec.rb
+++ b/spec/requests/oauth_device_authorizations_spec.rb
@@ -107,6 +107,16 @@ describe "OAuth device authorizations", type: :request do
 
       expect(response).to have_http_status(:ok)
     end
+
+    it "sets a Basic challenge when Basic client authentication fails" do
+      confidential_application = create(:oauth_application, owner: user, scopes: "view_profile", confidential: true, secret: "client-secret", device_authorization_enabled: true)
+
+      post oauth_device_code_path, params: { scope: "view_profile" }, headers: basic_authorization_header(confidential_application.uid, "wrong-secret")
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.headers["WWW-Authenticate"]).to eq(%(Basic realm="Doorkeeper"))
+      expect(response.parsed_body).to include("error" => "invalid_client")
+    end
   end
 
   describe "GET /oauth/device" do
@@ -591,6 +601,16 @@ describe "OAuth device authorizations", type: :request do
       expect(response.parsed_body).to include("error" => "expired_token")
     end
 
+    it "sets a Basic challenge when device grant Basic client authentication fails" do
+      confidential_application = create(:oauth_application, owner: user, scopes: "view_profile", confidential: true, secret: "client-secret", device_authorization_enabled: true)
+
+      post oauth_token_path, params: { grant_type: OauthDeviceAuthorization::GRANT_TYPE }, headers: basic_authorization_header(confidential_application.uid, "wrong-secret")
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.headers["WWW-Authenticate"]).to eq(%(Basic realm="Doorkeeper"))
+      expect(response.parsed_body).to include("error" => "invalid_client")
+    end
+
     it "returns access_denied after the user denies the code" do
       body = create_device_code
       sign_in user
@@ -650,6 +670,10 @@ describe "OAuth device authorizations", type: :request do
   def create_device_code
     post oauth_device_code_path, params: { client_id: oauth_application.uid, scope: "view_profile" }
     response.parsed_body
+  end
+
+  def basic_authorization_header(client_id, client_secret)
+    { "Authorization" => ActionController::HttpAuthentication::Basic.encode_credentials(client_id, client_secret) }
   end
 
   def submit_device_authorization(user_code, decision:)

--- a/spec/requests/oauth_device_authorizations_spec.rb
+++ b/spec/requests/oauth_device_authorizations_spec.rb
@@ -267,15 +267,6 @@ describe "OAuth device authorizations", type: :request do
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("This code is invalid or expired.")
       expect(response.body).not_to include("This application will be able to:")
-
-      expect do
-        submit_device_authorization(body["user_code"], decision: "approve")
-      end.not_to change { Doorkeeper::AccessToken.count }
-
-      expect(response).to have_http_status(:unprocessable_entity)
-      expect(response.body).to include("This code is invalid or expired.")
-      expect(response.body).not_to include("Authorization complete")
-      expect(access_token.reload).to be_revoked
       expect(device_authorization.reload).to have_attributes(
         status: OauthDeviceAuthorization::STATUS_DENIED,
         denied_at: be_present,
@@ -287,6 +278,15 @@ describe "OAuth device authorizations", type: :request do
 
       expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body).to include("error" => "access_denied")
+
+      expect do
+        submit_device_authorization(body["user_code"], decision: "approve")
+      end.not_to change { Doorkeeper::AccessToken.count }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("This code is invalid or expired.")
+      expect(response.body).not_to include("Authorization complete")
+      expect(access_token.reload).to be_revoked
     end
 
     it "does not return a successful token response when the issued token is revoked before rendering" do

--- a/spec/requests/oauth_device_authorizations_spec.rb
+++ b/spec/requests/oauth_device_authorizations_spec.rb
@@ -250,6 +250,31 @@ describe "OAuth device authorizations", type: :request do
       expect(response.parsed_body).to include("error" => "access_denied")
     end
 
+    it "does not return a successful token response when the issued token is revoked before rendering" do
+      body = create_device_code
+      sign_in user
+      submit_device_authorization(body["user_code"], decision: "approve")
+      allow_any_instance_of(OauthDeviceAuthorization).to receive(:poll!).and_wrap_original do |method, *args, **kwargs|
+        kwargs = args.pop if kwargs.empty? && args.last.is_a?(Hash)
+        status, access_token = method.call(*args, **kwargs)
+        access_token.update!(revoked_at: Time.current) if status == OauthDeviceAuthorization::POLL_APPROVED
+        [status, access_token]
+      end
+
+      expect do
+        post oauth_token_path,
+             params: {
+               grant_type: OauthDeviceAuthorization::GRANT_TYPE,
+               client_id: oauth_application.uid,
+               device_code: body["device_code"]
+             }
+      end.to change { Doorkeeper::AccessToken.count }.by(1)
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to include("error" => "access_denied")
+      expect(Doorkeeper::AccessToken.last).to be_revoked
+    end
+
     it "does not exchange an approved code after device authorization is disabled for the client" do
       body = create_device_code
       sign_in user
@@ -378,6 +403,20 @@ describe "OAuth device authorizations", type: :request do
       sign_in user
 
       submit_device_authorization(body["user_code"], decision: "deny")
+      post oauth_token_path, params: { grant_type: OauthDeviceAuthorization::GRANT_TYPE, client_id: oauth_application.uid, device_code: body["device_code"] }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to include("error" => "access_denied")
+      expect(Doorkeeper::AccessToken.count).to eq(0)
+    end
+
+    it "returns access_denied for denied codes after they expire" do
+      body = create_device_code
+      sign_in user
+
+      submit_device_authorization(body["user_code"], decision: "deny")
+      OauthDeviceAuthorization.last.update!(expires_at: 1.second.ago)
+
       post oauth_token_path, params: { grant_type: OauthDeviceAuthorization::GRANT_TYPE, client_id: oauth_application.uid, device_code: body["device_code"] }
 
       expect(response).to have_http_status(:bad_request)

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -30,6 +30,76 @@ describe "Rack::Attack throttle", type: :request do
 
       expect(response.status).not_to eq(500)
     end
+
+    it "throttles JSON device grant polls by IP and device code" do
+      reset_rack_attack!
+
+      travel_to(Time.current) do
+        120.times do |i|
+          request = Rack::Attack::Request.new(
+            Rack::MockRequest.env_for(
+              "/oauth/token",
+              method: "POST",
+              input: { grant_type: OauthDeviceAuthorization::GRANT_TYPE, device_code: "json-device-code" }.to_json,
+              "CONTENT_TYPE" => "application/json",
+              "HTTP_CF_CONNECTING_IP" => "203.0.113.40"
+            )
+          )
+
+          expect(Rack::Attack.configuration.throttled?(request)).to be(false), "request #{i + 1} unexpectedly throttled"
+        end
+
+        request = Rack::Attack::Request.new(
+          Rack::MockRequest.env_for(
+            "/oauth/token",
+            method: "POST",
+            input: { grant_type: OauthDeviceAuthorization::GRANT_TYPE, device_code: "json-device-code" }.to_json,
+            "CONTENT_TYPE" => "application/json",
+            "HTTP_CF_CONNECTING_IP" => "203.0.113.40"
+          )
+        )
+
+        expect(Rack::Attack.configuration.throttled?(request)).to be(true)
+      end
+    ensure
+      reset_rack_attack!
+    end
+
+    it "throttles JSON content-type device grant polls with query params" do
+      reset_rack_attack!
+
+      query = "grant_type=#{Rack::Utils.escape(OauthDeviceAuthorization::GRANT_TYPE)}&device_code=query-device-code"
+
+      travel_to(Time.current) do
+        120.times do |i|
+          request = Rack::Attack::Request.new(
+            Rack::MockRequest.env_for(
+              "/oauth/token?#{query}",
+              method: "POST",
+              input: {}.to_json,
+              "CONTENT_TYPE" => "application/json",
+              "HTTP_CF_CONNECTING_IP" => "203.0.113.50"
+            )
+          )
+
+          expect(Rack::Attack.configuration.throttled?(request)).to be(false), "request #{i + 1} unexpectedly throttled"
+        end
+
+        request = Rack::Attack::Request.new(
+          Rack::MockRequest.env_for(
+            "/oauth/token?#{query}",
+            method: "POST",
+            input: {}.to_json,
+            "CONTENT_TYPE" => "application/json",
+            "HTTP_CF_CONNECTING_IP" => "203.0.113.50"
+          )
+        )
+
+        expect(Rack::Attack.configuration.throttled?(request)).to be(true)
+      end
+    ensure
+      reset_rack_attack!
+    end
   end
 
   describe "POST /oauth/device/code issuance throttle" do

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -38,7 +38,7 @@ describe "Rack::Attack throttle", type: :request do
         120.times do |i|
           request = Rack::Attack::Request.new(
             Rack::MockRequest.env_for(
-              "/oauth/token",
+              i.even? ? "/oauth/token" : "/oauth/token.json",
               method: "POST",
               input: { grant_type: OauthDeviceAuthorization::GRANT_TYPE, device_code: "json-device-code" }.to_json,
               "CONTENT_TYPE" => "application/json",
@@ -51,7 +51,7 @@ describe "Rack::Attack throttle", type: :request do
 
         request = Rack::Attack::Request.new(
           Rack::MockRequest.env_for(
-            "/oauth/token",
+            "/oauth/token.json",
             method: "POST",
             input: { grant_type: OauthDeviceAuthorization::GRANT_TYPE, device_code: "json-device-code" }.to_json,
             "CONTENT_TYPE" => "application/json",
@@ -128,6 +128,42 @@ describe "Rack::Attack throttle", type: :request do
             input: { grant_type: OauthDeviceAuthorization::GRANT_TYPE, device_code: "body-device-code-over" }.to_json,
             "CONTENT_TYPE" => "application/json",
             "HTTP_CF_CONNECTING_IP" => "203.0.113.60"
+          )
+        )
+
+        expect(Rack::Attack.configuration.throttled?(request)).to be(true)
+      end
+    ensure
+      reset_rack_attack!
+    end
+
+    it "uses query params over form body params for the device code throttle key" do
+      reset_rack_attack!
+
+      query = "grant_type=#{Rack::Utils.escape(OauthDeviceAuthorization::GRANT_TYPE)}&device_code=query-device-code"
+
+      travel_to(Time.current) do
+        120.times do |i|
+          request = Rack::Attack::Request.new(
+            Rack::MockRequest.env_for(
+              "/oauth/token?#{query}",
+              method: "POST",
+              input: "grant_type=#{Rack::Utils.escape(OauthDeviceAuthorization::GRANT_TYPE)}&device_code=body-device-code-#{i}",
+              "CONTENT_TYPE" => "application/x-www-form-urlencoded",
+              "HTTP_CF_CONNECTING_IP" => "203.0.113.70"
+            )
+          )
+
+          expect(Rack::Attack.configuration.throttled?(request)).to be(false), "request #{i + 1} unexpectedly throttled"
+        end
+
+        request = Rack::Attack::Request.new(
+          Rack::MockRequest.env_for(
+            "/oauth/token?#{query}",
+            method: "POST",
+            input: "grant_type=#{Rack::Utils.escape(OauthDeviceAuthorization::GRANT_TYPE)}&device_code=body-device-code-over",
+            "CONTENT_TYPE" => "application/x-www-form-urlencoded",
+            "HTTP_CF_CONNECTING_IP" => "203.0.113.70"
           )
         )
 

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -100,6 +100,42 @@ describe "Rack::Attack throttle", type: :request do
     ensure
       reset_rack_attack!
     end
+
+    it "uses query params over JSON body params for the device code throttle key" do
+      reset_rack_attack!
+
+      query = "grant_type=#{Rack::Utils.escape(OauthDeviceAuthorization::GRANT_TYPE)}&device_code=query-device-code"
+
+      travel_to(Time.current) do
+        120.times do |i|
+          request = Rack::Attack::Request.new(
+            Rack::MockRequest.env_for(
+              "/oauth/token?#{query}",
+              method: "POST",
+              input: { grant_type: OauthDeviceAuthorization::GRANT_TYPE, device_code: "body-device-code-#{i}" }.to_json,
+              "CONTENT_TYPE" => "application/json",
+              "HTTP_CF_CONNECTING_IP" => "203.0.113.60"
+            )
+          )
+
+          expect(Rack::Attack.configuration.throttled?(request)).to be(false), "request #{i + 1} unexpectedly throttled"
+        end
+
+        request = Rack::Attack::Request.new(
+          Rack::MockRequest.env_for(
+            "/oauth/token?#{query}",
+            method: "POST",
+            input: { grant_type: OauthDeviceAuthorization::GRANT_TYPE, device_code: "body-device-code-over" }.to_json,
+            "CONTENT_TYPE" => "application/json",
+            "HTTP_CF_CONNECTING_IP" => "203.0.113.60"
+          )
+        )
+
+        expect(Rack::Attack.configuration.throttled?(request)).to be(true)
+      end
+    ensure
+      reset_rack_attack!
+    end
   end
 
   describe "POST /oauth/device/code issuance throttle" do

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -32,6 +32,39 @@ describe "Rack::Attack throttle", type: :request do
     end
   end
 
+  describe "POST /oauth/device/code issuance throttle" do
+    before { reset_rack_attack! }
+    after { reset_rack_attack! }
+
+    it "shares one throttle bucket across formatted route variants" do
+      travel_to(Time.current) do
+        20.times do |i|
+          request = Rack::Attack::Request.new(
+            Rack::MockRequest.env_for(
+              i.even? ? "/oauth/device/code" : "/oauth/device/code.json",
+              method: "POST",
+              input: "",
+              "HTTP_CF_CONNECTING_IP" => "203.0.113.30"
+            )
+          )
+
+          expect(Rack::Attack.configuration.throttled?(request)).to be(false), "request #{i + 1} unexpectedly throttled"
+        end
+
+        request = Rack::Attack::Request.new(
+          Rack::MockRequest.env_for(
+            "/oauth/device/code.xml",
+            method: "POST",
+            input: "",
+            "HTTP_CF_CONNECTING_IP" => "203.0.113.30"
+          )
+        )
+
+        expect(Rack::Attack.configuration.throttled?(request)).to be(true)
+      end
+    end
+  end
+
   describe "GET /oauth/device user code lookup throttle" do
     before { reset_rack_attack! }
     after { reset_rack_attack! }

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -32,6 +32,72 @@ describe "Rack::Attack throttle", type: :request do
     end
   end
 
+  describe "GET /oauth/device user code lookup throttle" do
+    before { reset_rack_attack! }
+    after { reset_rack_attack! }
+
+    it "throttles repeated lookup attempts from the same IP" do
+      travel_to(Time.current) do
+        30.times do |i|
+          request = Rack::Attack::Request.new(
+            Rack::MockRequest.env_for(
+              i.even? ? "/oauth/device?user_code=GRD-TEST-#{i.to_s.rjust(4, "0")}" : "/oauth/device.json?user_code=GRD-TEST-#{i.to_s.rjust(4, "0")}",
+              method: i.even? ? "GET" : "HEAD",
+              input: "",
+              "HTTP_CF_CONNECTING_IP" => "203.0.113.10"
+            )
+          )
+
+          expect(Rack::Attack.configuration.throttled?(request)).to be(false), "request #{i + 1} unexpectedly throttled"
+        end
+
+        request = Rack::Attack::Request.new(
+          Rack::MockRequest.env_for(
+            "/oauth/device.json?user_code=GRD-TEST-OVER",
+            method: "HEAD",
+            input: "",
+            "HTTP_CF_CONNECTING_IP" => "203.0.113.10"
+          )
+        )
+
+        expect(Rack::Attack.configuration.throttled?(request)).to be(true)
+      end
+    end
+  end
+
+  describe "POST /oauth/device authorization decision throttle" do
+    before { reset_rack_attack! }
+    after { reset_rack_attack! }
+
+    it "shares one throttle bucket across formatted route variants" do
+      travel_to(Time.current) do
+        10.times do |i|
+          request = Rack::Attack::Request.new(
+            Rack::MockRequest.env_for(
+              i.even? ? "/oauth/device" : "/oauth/device.json",
+              method: "POST",
+              input: "",
+              "HTTP_CF_CONNECTING_IP" => "203.0.113.20"
+            )
+          )
+
+          expect(Rack::Attack.configuration.throttled?(request)).to be(false), "request #{i + 1} unexpectedly throttled"
+        end
+
+        request = Rack::Attack::Request.new(
+          Rack::MockRequest.env_for(
+            "/oauth/device.xml",
+            method: "POST",
+            input: "",
+            "HTTP_CF_CONNECTING_IP" => "203.0.113.20"
+          )
+        )
+
+        expect(Rack::Attack.configuration.throttled?(request)).to be(true)
+      end
+    end
+  end
+
   describe "PUT /api/v2/products/:id per-token throttle" do
     before { reset_rack_attack! }
     after { reset_rack_attack! }

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -22,6 +22,16 @@ describe "Rack::Attack throttle", type: :request do
     end
   end
 
+  describe "POST /oauth/token device grant throttle with malformed params" do
+    it "does not raise when the params parser rejects malformed form params" do
+      post "/oauth/token",
+           params: "grant_type=#{Rack::Utils.escape(OauthDeviceAuthorization::GRANT_TYPE)}&grant_type[bad]=1",
+           headers: { "CONTENT_TYPE" => "application/x-www-form-urlencoded" }
+
+      expect(response.status).not_to eq(500)
+    end
+  end
+
   describe "PUT /api/v2/products/:id per-token throttle" do
     before { reset_rack_attack! }
     after { reset_rack_attack! }

--- a/spec/sidekiq/delete_expired_oauth_device_authorizations_job_spec.rb
+++ b/spec/sidekiq/delete_expired_oauth_device_authorizations_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe DeleteExpiredOauthDeviceAuthorizationsWorker do
+describe DeleteExpiredOauthDeviceAuthorizationsJob do
   describe "#perform" do
     it "deletes expired device authorizations in batches" do
       stub_const("#{described_class}::DELETION_BATCH_SIZE", 1)

--- a/spec/sidekiq/delete_expired_oauth_device_authorizations_worker_spec.rb
+++ b/spec/sidekiq/delete_expired_oauth_device_authorizations_worker_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe DeleteExpiredOauthDeviceAuthorizationsWorker do
+  describe "#perform" do
+    it "deletes expired device authorizations in batches" do
+      stub_const("#{described_class}::DELETION_BATCH_SIZE", 1)
+
+      expired_pending = create(:oauth_device_authorization, expires_at: 1.second.ago)
+      expired_consumed = create(:oauth_device_authorization, status: OauthDeviceAuthorization::STATUS_CONSUMED, expires_at: 1.second.ago)
+      expired_denied = create(:oauth_device_authorization, status: OauthDeviceAuthorization::STATUS_DENIED, expires_at: 1.second.ago)
+      active_authorization = create(:oauth_device_authorization, expires_at: 1.day.from_now)
+
+      expect do
+        described_class.new.perform
+      end.to change { OauthDeviceAuthorization.count }.by(-2)
+
+      expect { expired_pending.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { expired_consumed.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect(expired_denied.reload).to be_present
+      expect(active_authorization.reload).to be_present
+    end
+  end
+end

--- a/spec/sidekiq/delete_expired_oauth_device_authorizations_worker_spec.rb
+++ b/spec/sidekiq/delete_expired_oauth_device_authorizations_worker_spec.rb
@@ -14,11 +14,11 @@ describe DeleteExpiredOauthDeviceAuthorizationsWorker do
 
       expect do
         described_class.new.perform
-      end.to change { OauthDeviceAuthorization.count }.by(-2)
+      end.to change { OauthDeviceAuthorization.count }.by(-3)
 
       expect { expired_pending.reload }.to raise_error(ActiveRecord::RecordNotFound)
       expect { expired_consumed.reload }.to raise_error(ActiveRecord::RecordNotFound)
-      expect(expired_denied.reload).to be_present
+      expect { expired_denied.reload }.to raise_error(ActiveRecord::RecordNotFound)
       expect(active_authorization.reload).to be_present
     end
   end

--- a/spec/support/factories/oauth_device_authorizations.rb
+++ b/spec/support/factories/oauth_device_authorizations.rb
@@ -10,8 +10,8 @@ FactoryBot.define do
     created_user_agent { "RSpec" }
 
     transient do
-      device_code { "device-code" }
-      user_code { "GRD-ABCD-1234" }
+      sequence(:device_code) { |n| "device-code-#{n}" }
+      sequence(:user_code) { |n| "GRD-#{n.to_s.rjust(8, "0").scan(/.{1,4}/).join("-")}" }
     end
 
     device_code_digest { OauthDeviceAuthorization.digest(device_code) }

--- a/spec/support/factories/oauth_device_authorizations.rb
+++ b/spec/support/factories/oauth_device_authorizations.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :oauth_device_authorization do
+    association :oauth_application
+    scopes { "view_profile" }
+    status { OauthDeviceAuthorization::STATUS_PENDING }
+    expires_at { OauthDeviceAuthorization::EXPIRES_IN.from_now }
+    created_ip_address { "203.0.113.1" }
+    created_user_agent { "RSpec" }
+
+    transient do
+      device_code { "device-code" }
+      user_code { "GRD-ABCD-1234" }
+    end
+
+    device_code_digest { OauthDeviceAuthorization.digest(device_code) }
+    user_code_digest { OauthDeviceAuthorization.digest(OauthDeviceAuthorization.normalize_user_code(user_code)) }
+  end
+end


### PR DESCRIPTION
Ref antiwork/gumroad-cli#123

## What

Adds the device authorization flow for OAuth clients, including user and device endpoints plus token polling support.
It also lets applications opt in to the flow and adds throttling for device-code polling.

## Why

This enables devices and other constrained clients to sign in without a full browser-based login flow.
The implementation follows the standard device-code exchange so polling, approval, denial, and expiry are handled consistently.

---

This PR was implemented with AI assistance using gpt‑5.5 xhigh.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> New authentication surface (token issuance, client secrets, session handoffs) with locking/revocation logic; mistakes could allow unauthorized access or break existing OAuth revokes.
> 
> **Overview**
> Adds **OAuth 2.0 device authorization** so constrained clients (e.g. CLI) can sign in without a full browser redirect loop.
> 
> **Flow:** Opt-in apps call `POST /oauth/device/code` to get `device_code` / `user_code` and verification URLs. Users approve or deny at `GET`/`POST /oauth/device` (login handoff keeps the user code out of redirect URLs). Clients poll `POST /oauth/token` with the device grant for `authorization_pending`, `slow_down`, or a Doorkeeper access token once approved.
> 
> **Implementation:** New `OauthDeviceAuthorization` model stores SHA-256 digests of codes, tracks pending → approved/denied/consumed, enforces poll intervals, and mints tokens under app-level locks. Shared `OauthClientAuthentication` handles client id/secret and scope checks. Revoking access, deleting apps, or invalidating mobile sessions now denies in-flight device authorizations so tokens cannot be issued after revocation.
> 
> **Hardening:** `device_authorization_enabled` on applications, parameter filtering for secrets, Rack::Attack limits on device endpoints and per-device-code polling, and an hourly job to delete expired rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cc3edaaa065a707a654baa9f994cb954364d784. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->