### PR TITLE
Prevent products from embedding files owned by another product

### DIFF
--- a/app/models/rich_content.rb
+++ b/app/models/rich_content.rb
@@ -56,8 +56,41 @@ class RichContent < ApplicationRecord
   validates :entity, presence: true
   validates :description, json: { schema: DESCRIPTION_JSON_SCHEMA, message: :invalid }
 
+  before_save :strip_cross_product_file_embeds
+
   def embedded_product_file_ids_in_order
     description.flat_map { select_file_embed_ids(_1) }.compact.uniq
+  end
+
+  def owning_product
+    entity.is_a?(Link) ? entity : entity.try(:link)
+  end
+
+  def cross_product_file_embed_ids
+    product = owning_product
+    return [] if product.nil?
+
+    embedded_ids = embedded_product_file_ids_in_order
+    return [] if embedded_ids.empty?
+
+    ProductFile.where(id: embedded_ids).where.not(link_id: product.id).pluck(:id)
+  end
+
+  def self.reject_file_embeds(nodes, product_file_ids)
+    Array(nodes).filter_map do |node|
+      if node["type"] == FILE_EMBED_NODE_TYPE
+        raw_id = node.dig("attrs", "id")
+        decrypted_id = raw_id.present? ? ObfuscateIds.decrypt(raw_id) : nil
+        next if decrypted_id.present? && product_file_ids.include?(decrypted_id)
+        node
+      elsif node["content"].is_a?(Array)
+        remaining = reject_file_embeds(node["content"], product_file_ids)
+        next if node["type"] == FILE_EMBED_GROUP_NODE_TYPE && remaining.empty?
+        node.merge("content" => remaining)
+      else
+        node
+      end
+    end
   end
 
   def custom_field_nodes
@@ -83,6 +116,15 @@ class RichContent < ApplicationRecord
   end
 
   private
+    def strip_cross_product_file_embeds
+      return unless will_save_change_to_description?
+
+      foreign_ids = cross_product_file_embed_ids
+      return if foreign_ids.empty?
+
+      self.description = self.class.reject_file_embeds(description, foreign_ids.to_set)
+    end
+
     def select_file_embed_ids(node)
       if node["type"] == FILE_EMBED_NODE_TYPE
         id = node.dig("attrs", "id")

--- a/app/models/rich_content.rb
+++ b/app/models/rich_content.rb
@@ -55,8 +55,7 @@ class RichContent < ApplicationRecord
 
   validates :entity, presence: true
   validates :description, json: { schema: DESCRIPTION_JSON_SCHEMA, message: :invalid }
-
-  before_save :strip_cross_product_file_embeds
+  validate :embedded_files_belong_to_product, if: :will_save_change_to_description?
 
   def embedded_product_file_ids_in_order
     description.flat_map { select_file_embed_ids(_1) }.compact.uniq
@@ -116,13 +115,14 @@ class RichContent < ApplicationRecord
   end
 
   private
-    def strip_cross_product_file_embeds
-      return unless will_save_change_to_description?
+    def embedded_files_belong_to_product
+      return unless description.is_a?(Array)
 
       foreign_ids = cross_product_file_embed_ids
       return if foreign_ids.empty?
 
-      self.description = self.class.reject_file_embeds(description, foreign_ids.to_set)
+      external_ids = foreign_ids.map { ObfuscateIds.encrypt(_1) }
+      errors.add(:base, "File embeds reference files not belonging to this product: #{external_ids.join(", ")}")
     end
 
     def select_file_embed_ids(node)

--- a/app/models/rich_content.rb
+++ b/app/models/rich_content.rb
@@ -67,11 +67,11 @@ class RichContent < ApplicationRecord
   end
 
   def cross_product_file_embed_ids
-    product = owning_product
-    return [] if product.nil?
-
     embedded_ids = embedded_product_file_ids_in_order
     return [] if embedded_ids.empty?
+
+    product = owning_product
+    return [] if product.nil?
 
     ProductFile.where(id: embedded_ids).where.not(link_id: product.id).pluck(:id)
   end
@@ -83,7 +83,7 @@ class RichContent < ApplicationRecord
         decrypted_id = raw_id.present? ? ObfuscateIds.decrypt(raw_id) : nil
         next if decrypted_id.present? && product_file_ids.include?(decrypted_id)
         node
-      elsif node["content"].is_a?(Array)
+      elsif node["content"].is_a?(Array) && node["type"].in?(FILE_EMBED_CONTAINER_NODE_TYPES)
         remaining = reject_file_embeds(node["content"], product_file_ids)
         next if node["type"] == FILE_EMBED_GROUP_NODE_TYPE && remaining.empty?
         node.merge("content" => remaining)

--- a/app/services/onetime/remove_cross_product_file_embeds.rb
+++ b/app/services/onetime/remove_cross_product_file_embeds.rb
@@ -17,14 +17,11 @@ module Onetime
           foreign_ids = rich_content.cross_product_file_embed_ids
           next if foreign_ids.empty?
 
-          product = rich_content.owning_product
-          next if product.nil?
-
           cleaned += 1
           puts "[#{self.class.name}] rich_content=#{rich_content.id} entity=#{rich_content.entity_type}##{rich_content.entity_id} removing=#{foreign_ids.sort}"
           next if dry_run
 
-          remediate!(rich_content, product, foreign_ids)
+          remediate!(rich_content, foreign_ids)
         end
       end
 
@@ -33,7 +30,7 @@ module Onetime
     end
 
     private
-      def remediate!(rich_content, product, foreign_ids)
+      def remediate!(rich_content, foreign_ids)
         ApplicationRecord.connection.stick_to_primary!
         ApplicationRecord.transaction do
           rich_content.update!(description: RichContent.reject_file_embeds(rich_content.description, foreign_ids.to_set))

--- a/app/services/onetime/remove_cross_product_file_embeds.rb
+++ b/app/services/onetime/remove_cross_product_file_embeds.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Onetime
+  class RemoveCrossProductFileEmbeds
+    BATCH_SIZE = 100
+
+    def self.process(dry_run: true, batch_size: BATCH_SIZE)
+      new.process(dry_run:, batch_size:)
+    end
+
+    def process(dry_run: true, batch_size: BATCH_SIZE)
+      cleaned = 0
+
+      RichContent.alive.in_batches(of: batch_size) do |batch|
+        ReplicaLagWatcher.watch
+        batch.each do |rich_content|
+          foreign_ids = rich_content.cross_product_file_embed_ids
+          next if foreign_ids.empty?
+
+          product = rich_content.owning_product
+          next if product.nil?
+
+          cleaned += 1
+          puts "[#{self.class.name}] rich_content=#{rich_content.id} entity=#{rich_content.entity_type}##{rich_content.entity_id} removing=#{foreign_ids.sort}"
+          next if dry_run
+
+          remediate!(rich_content, product, foreign_ids)
+        end
+      end
+
+      puts "[#{self.class.name}] done dry_run=#{dry_run} cleaned=#{cleaned}"
+      { cleaned: }
+    end
+
+    private
+      def remediate!(rich_content, product, foreign_ids)
+        ApplicationRecord.connection.stick_to_primary!
+        ApplicationRecord.transaction do
+          rich_content.update!(description: RichContent.reject_file_embeds(rich_content.description, foreign_ids.to_set))
+
+          entity = rich_content.entity
+          if entity.is_a?(BaseVariant)
+            stale_join_files = entity.product_files.where(id: foreign_ids)
+            entity.product_files.delete(stale_join_files)
+          end
+        end
+      end
+  end
+end

--- a/app/services/product_duplicator_service.rb
+++ b/app/services/product_duplicator_service.rb
@@ -322,22 +322,27 @@ class ProductDuplicatorService
       original_entity.alive_rich_contents.find_each do |original_entity_rich_content|
         duplicate_entity_rich_content = original_entity_rich_content.dup
         duplicate_entity_rich_content.entity = duplicate_entity
-        update_file_embed_ids_in_rich_content(duplicate_entity_rich_content.description)
+        duplicate_entity_rich_content.description = remap_file_embed_ids_in_rich_content(duplicate_entity_rich_content.description)
         duplicate_entity_rich_content.save!
       end
     end
 
-    def update_file_embed_ids_in_rich_content(content)
-      content.each do |node|
-        update_file_embed_ids_in_rich_content(node["content"]) if node["type"] == RichContent::FILE_EMBED_GROUP_NODE_TYPE
+    def remap_file_embed_ids_in_rich_content(content)
+      Array(content).filter_map do |node|
+        if node["type"] == "fileEmbed"
+          old_external_id = node.dig("attrs", "id")
+          next node if old_external_id.blank?
 
-        next if node["type"] != "fileEmbed"
-        next if node.dig("attrs", "id").blank?
+          new_external_id = product_file_external_ids_mapping[old_external_id]
+          next nil if new_external_id.blank?
 
-        new_product_file_external_id = product_file_external_ids_mapping[node.dig("attrs", "id")]
-        next if new_product_file_external_id.blank?
-
-        node["attrs"]["id"] = new_product_file_external_id
+          node["attrs"]["id"] = new_external_id
+          node
+        elsif node["content"].is_a?(Array)
+          node.merge("content" => remap_file_embed_ids_in_rich_content(node["content"]))
+        else
+          node
+        end
       end
     end
 end

--- a/spec/models/rich_content_spec.rb
+++ b/spec/models/rich_content_spec.rb
@@ -74,7 +74,7 @@ describe RichContent do
     end
   end
 
-  describe "stripping cross-product file embeds on save" do
+  describe "rejecting cross-product file embeds" do
     let(:product) { create(:product) }
     let(:own_file) { create(:product_file, link: product) }
     let(:foreign_file) { create(:product_file, link: create(:product)) }
@@ -83,39 +83,58 @@ describe RichContent do
       { "type" => "fileEmbed", "attrs" => { "id" => file.external_id, "uid" => SecureRandom.uuid } }
     end
 
-    it "removes embeds for files owned by another product from a product's content" do
-      rich_content = create(:product_rich_content, entity: product, description: [embed(own_file), embed(foreign_file)])
-      expect(rich_content.reload.embedded_product_file_ids_in_order).to eq([own_file.id])
+    it "rejects a product's content embedding a file owned by another product" do
+      rich_content = build(:product_rich_content, entity: product, description: [embed(own_file), embed(foreign_file)])
+      expect(rich_content).to be_invalid
+      expect(rich_content.errors.full_messages.first).to include("not belonging to this product")
+      expect(rich_content.errors.full_messages.first).to include(foreign_file.external_id)
     end
 
-    it "removes foreign embeds from a variant's content" do
+    it "rejects a variant's content embedding a file owned by another product" do
       variant = create(:variant, variant_category: create(:variant_category, link: product))
-      rich_content = create(:rich_content, entity: variant, description: [embed(own_file), embed(foreign_file)])
-      expect(rich_content.reload.embedded_product_file_ids_in_order).to eq([own_file.id])
+      rich_content = build(:rich_content, entity: variant, description: [embed(own_file), embed(foreign_file)])
+      expect(rich_content).to be_invalid
+      expect(rich_content.errors.full_messages.first).to include("not belonging to this product")
     end
 
-    it "preserves embeds for the product's own files" do
+    it "rejects a foreign embed nested inside a file embed group" do
+      description = [{ "type" => "fileEmbedGroup", "attrs" => { "uid" => SecureRandom.uuid, "name" => "Files" }, "content" => [embed(foreign_file)] }]
+      rich_content = build(:product_rich_content, entity: product, description:)
+      expect(rich_content).to be_invalid
+      expect(rich_content.errors.full_messages.first).to include("not belonging to this product")
+    end
+
+    it "allows content that only embeds the product's own files" do
       another_own_file = create(:product_file, link: product)
       rich_content = create(:product_rich_content, entity: product, description: [embed(own_file), embed(another_own_file)])
       expect(rich_content.reload.embedded_product_file_ids_in_order).to match_array([own_file.id, another_own_file.id])
     end
 
-    it "prunes a file embed group left empty after removing a foreign embed" do
-      description = [{ "type" => "fileEmbedGroup", "attrs" => { "uid" => SecureRandom.uuid, "name" => "Files" }, "content" => [embed(foreign_file)] }]
-      rich_content = create(:product_rich_content, entity: product, description:)
-      expect(rich_content.reload.description).to eq([])
+    it "allows content with no file embeds" do
+      rich_content = build(:product_rich_content, entity: product, description: [{ "type" => "paragraph", "content" => [{ "type" => "text", "text" => "Hello" }] }])
+      expect(rich_content).to be_valid
+    end
+  end
+
+  describe ".reject_file_embeds" do
+    let(:product) { create(:product) }
+    let(:keep_file) { create(:product_file, link: product) }
+    let(:drop_file) { create(:product_file, link: product) }
+
+    def embed(file)
+      { "type" => "fileEmbed", "attrs" => { "id" => file.external_id, "uid" => SecureRandom.uuid } }
     end
 
-    it "keeps own-product embeds inside a file embed group while dropping the foreign one" do
-      description = [{ "type" => "fileEmbedGroup", "attrs" => { "uid" => SecureRandom.uuid, "name" => "Files" }, "content" => [embed(own_file), embed(foreign_file)] }]
-      rich_content = create(:product_rich_content, entity: product, description:)
-      expect(rich_content.reload.embedded_product_file_ids_in_order).to eq([own_file.id])
+    it "removes embeds whose decrypted id is in the rejection set" do
+      nodes = [embed(keep_file), embed(drop_file)]
+      result = described_class.reject_file_embeds(nodes, Set[drop_file.id])
+      expect(result.length).to eq(1)
+      expect(ObfuscateIds.decrypt(result.first.dig("attrs", "id"))).to eq(keep_file.id)
     end
 
-    it "leaves content without foreign embeds untouched" do
-      description = [{ "type" => "paragraph", "content" => [{ "type" => "text", "text" => "Hello" }] }, embed(own_file)]
-      rich_content = create(:product_rich_content, entity: product, description:)
-      expect(rich_content.reload.description).to eq(description)
+    it "prunes a file embed group left empty after removal" do
+      nodes = [{ "type" => "fileEmbedGroup", "attrs" => { "uid" => SecureRandom.uuid }, "content" => [embed(drop_file)] }]
+      expect(described_class.reject_file_embeds(nodes, Set[drop_file.id])).to eq([])
     end
   end
 

--- a/spec/models/rich_content_spec.rb
+++ b/spec/models/rich_content_spec.rb
@@ -74,6 +74,51 @@ describe RichContent do
     end
   end
 
+  describe "stripping cross-product file embeds on save" do
+    let(:product) { create(:product) }
+    let(:own_file) { create(:product_file, link: product) }
+    let(:foreign_file) { create(:product_file, link: create(:product)) }
+
+    def embed(file)
+      { "type" => "fileEmbed", "attrs" => { "id" => file.external_id, "uid" => SecureRandom.uuid } }
+    end
+
+    it "removes embeds for files owned by another product from a product's content" do
+      rich_content = create(:product_rich_content, entity: product, description: [embed(own_file), embed(foreign_file)])
+      expect(rich_content.reload.embedded_product_file_ids_in_order).to eq([own_file.id])
+    end
+
+    it "removes foreign embeds from a variant's content" do
+      variant = create(:variant, variant_category: create(:variant_category, link: product))
+      rich_content = create(:rich_content, entity: variant, description: [embed(own_file), embed(foreign_file)])
+      expect(rich_content.reload.embedded_product_file_ids_in_order).to eq([own_file.id])
+    end
+
+    it "preserves embeds for the product's own files" do
+      another_own_file = create(:product_file, link: product)
+      rich_content = create(:product_rich_content, entity: product, description: [embed(own_file), embed(another_own_file)])
+      expect(rich_content.reload.embedded_product_file_ids_in_order).to match_array([own_file.id, another_own_file.id])
+    end
+
+    it "prunes a file embed group left empty after removing a foreign embed" do
+      description = [{ "type" => "fileEmbedGroup", "attrs" => { "uid" => SecureRandom.uuid, "name" => "Files" }, "content" => [embed(foreign_file)] }]
+      rich_content = create(:product_rich_content, entity: product, description:)
+      expect(rich_content.reload.description).to eq([])
+    end
+
+    it "keeps own-product embeds inside a file embed group while dropping the foreign one" do
+      description = [{ "type" => "fileEmbedGroup", "attrs" => { "uid" => SecureRandom.uuid, "name" => "Files" }, "content" => [embed(own_file), embed(foreign_file)] }]
+      rich_content = create(:product_rich_content, entity: product, description:)
+      expect(rich_content.reload.embedded_product_file_ids_in_order).to eq([own_file.id])
+    end
+
+    it "leaves content without foreign embeds untouched" do
+      description = [{ "type" => "paragraph", "content" => [{ "type" => "text", "text" => "Hello" }] }, embed(own_file)]
+      rich_content = create(:product_rich_content, entity: product, description:)
+      expect(rich_content.reload.description).to eq(description)
+    end
+  end
+
   describe "#has_license_key?" do
     let(:product) { create(:product) }
 
@@ -216,5 +261,4 @@ describe RichContent do
       )
     end
   end
-
 end

--- a/spec/services/onetime/remove_cross_product_file_embeds_spec.rb
+++ b/spec/services/onetime/remove_cross_product_file_embeds_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Onetime::RemoveCrossProductFileEmbeds do
+  let(:product) { create(:product) }
+  let(:own_file) { create(:product_file, link: product) }
+  let(:foreign_file) { create(:product_file, link: create(:product)) }
+  let(:variant) { create(:variant, variant_category: create(:variant_category, link: product)) }
+
+  def embed(file)
+    { "type" => "fileEmbed", "attrs" => { "id" => file.external_id, "uid" => SecureRandom.uuid } }
+  end
+
+  def seed_dirty_variant_content!
+    rich_content = create(:rich_content, entity: variant, description: [embed(own_file)])
+    rich_content.update_column(:description, [embed(own_file), embed(foreign_file)])
+    variant.product_files << own_file
+    variant.product_files << foreign_file
+    rich_content
+  end
+
+  describe ".process" do
+    it "removes cross-product embeds and stale join rows from variant content" do
+      rich_content = seed_dirty_variant_content!
+
+      described_class.process(dry_run: false)
+
+      expect(rich_content.reload.embedded_product_file_ids_in_order).to eq([own_file.id])
+      expect(variant.reload.product_files.pluck(:id)).to eq([own_file.id])
+    end
+
+    it "reports without mutating anything on a dry run" do
+      rich_content = seed_dirty_variant_content!
+
+      result = described_class.process(dry_run: true)
+
+      expect(result[:cleaned]).to eq(1)
+      expect(rich_content.reload.embedded_product_file_ids_in_order).to match_array([own_file.id, foreign_file.id])
+      expect(variant.reload.product_files.pluck(:id)).to match_array([own_file.id, foreign_file.id])
+    end
+
+    it "leaves content that only embeds the product's own files untouched" do
+      rich_content = create(:rich_content, entity: variant, description: [embed(own_file)])
+
+      result = described_class.process(dry_run: false)
+
+      expect(result[:cleaned]).to eq(0)
+      expect(rich_content.reload.embedded_product_file_ids_in_order).to eq([own_file.id])
+    end
+  end
+end

--- a/spec/sidekiq/delete_product_files_archives_worker_spec.rb
+++ b/spec/sidekiq/delete_product_files_archives_worker_spec.rb
@@ -40,8 +40,8 @@ describe DeleteProductFilesArchivesWorker do
 
 
     folder3_id = SecureRandom.uuid
-    product_file_5 = create(:product_file)
-    product_file_6 = create(:product_file)
+    product_file_5 = create(:product_file, link: @product)
+    product_file_6 = create(:product_file, link: @product)
     variant_category = create(:variant_category, title: "versions", link: @product)
     @variant = create(:variant, variant_category:, name: "mac")
     @variant.product_files = [product_file_5, product_file_6]


### PR DESCRIPTION
## What

Stops a product's content from delivering files that belong to a **different** product.

- Adds a validation on `RichContent` that rejects content embedding a `ProductFile` owned by another product, with a "not belonging to this product" message. It sits on the polymorphic entity, so it covers product-level content, variant-level content, the internal product editor, the public API, and product duplication in one place. This matches the existing rejection contract already enforced for the v2 variants endpoint (`Api::V2::VariantsController#update`).
- `ProductDuplicatorService` now drops file embeds whose source file was not copied (i.e. references another product) while remapping ids, so a duplicate never produces content that would fail the validation.
- Adds `Onetime::RemoveCrossProductFileEmbeds` to clean already-affected content: it strips the foreign embeds and deletes the stale `base_variants_product_files` join rows. Dry-run by default.

## Why

A support ticket reported buyers receiving files they didn't pay for. On a confirmed order, the purchased variant's stored content embedded several files owned by **other** products. File delivery (`UrlRedirect#alive_product_files`) faithfully serves a variant's embedded file ids, so the buyer downloaded all of them.

The extra embeds were invisible in the product editor — it only resolves files the product owns — so the seller saw a single correct file and couldn't remove the rest, and re-saving the variant just re-persisted the hidden nodes.

Root cause: the v2 variants endpoint already rejects cross-product embeds, but the **internal product editor** save path (and product duplication) did not. The file picker surfaces every file the seller owns across products, so embeds from other products could be saved through the editor and compounded as new products were created from previous ones.

A platform-wide sample (1,500 recent variants with embeds) found **zero** legitimate cross-product embeds, so rejecting them enforces an invariant the data already holds without affecting any real use.

The check is placed on the model (rather than duplicated per controller) so every write path enforces the same rule. Duplication is treated as a copy operation: unmapped embeds are dropped rather than rejected, since they can't be valid in the new product.

---

AI disclosure: drafted with Claude Opus 4.8. Prompts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches buyer file delivery invariants and bulk data remediation on `RichContent`; scope is focused but incorrect remediation could alter stored content.
> 
> **Overview**
> **Blocks cross-product file embeds** on `RichContent` so product and variant content cannot reference `ProductFile` rows owned by another product. A new validation runs when `description` changes, using `owning_product`, `cross_product_file_embed_ids`, and the same “not belonging to this product” error shape already used on the v2 variants update path.
> 
> **Remediation and copy paths:** `RichContent.reject_file_embeds` strips targeted embeds (including empty `fileEmbedGroup` nodes). `Onetime::RemoveCrossProductFileEmbeds` scans alive records in batches (dry-run by default), removes foreign embeds, and for variants deletes stale `base_variants_product_files` joins. **Product duplication** now assigns remapped descriptions via `remap_file_embed_ids_in_rich_content`, **dropping** embeds with no copied file instead of leaving invalid references.
> 
> Specs cover validation, rejection helper, the onetime task, and a worker example fix so variant files belong to the product under test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a68c5253ff8cb8a1615718992f9520ee8dcca694. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->