### PR TITLE
Fix Côte d'Ivoire IBAN validation rejecting valid IBANs

### DIFF
--- a/app/models/cote_d_ivoire_bank_account.rb
+++ b/app/models/cote_d_ivoire_bank_account.rb
@@ -3,7 +3,17 @@
 class CoteDIvoireBankAccount < BankAccount
   BANK_ACCOUNT_TYPE = "CI"
 
-  validate :validate_account_number, if: -> { Rails.env.production? }
+  # Côte d'Ivoire IBAN: CI + 2 check digits + 5-char bank code + 19-digit account number = 28 chars.
+  # We validate the structure ourselves instead of delegating to Ibandit's per-field
+  # `*_format` regexes: in Ibandit 1.26.1 the CI structure has `bank_code_format` and
+  # `account_number_format` set to `nil`, which compile to `/\A\z/` (matches only the empty
+  # string), so every structurally-valid CI IBAN is rejected as "format is invalid". We still
+  # use Ibandit's working country-code / check-digit / length / character checks for the parts
+  # of the standard it validates correctly.
+  IBAN_FORMAT_REGEX = /\ACI[0-9]{2}[A-Z0-9]{5}[0-9]{19}\z/
+  private_constant :IBAN_FORMAT_REGEX
+
+  validate :validate_account_number
 
   def bank_account_type
     BANK_ACCOUNT_TYPE
@@ -28,9 +38,19 @@ class CoteDIvoireBankAccount < BankAccount
     }
   end
 
-    private
-      def validate_account_number
-        return if Ibandit::IBAN.new(account_number_decrypted).valid?
+  private
+    def validate_account_number
+      decrypted = account_number_decrypted
+      if decrypted.blank?
         errors.add :base, "The account number is invalid."
+        return
       end
+      iban = Ibandit::IBAN.new(decrypted)
+      return if IBAN_FORMAT_REGEX.match?(iban.iban) &&
+                iban.valid_country_code? &&
+                iban.valid_check_digits? &&
+                iban.valid_length? &&
+                iban.valid_characters?
+      errors.add :base, "The account number is invalid."
+    end
 end

--- a/spec/models/cote_d_ivoire_bank_account_spec.rb
+++ b/spec/models/cote_d_ivoire_bank_account_spec.rb
@@ -30,4 +30,46 @@ describe CoteDIvoireBankAccount do
       expect(create(:cote_d_ivoire_bank_account).routing_number).to be nil
     end
   end
+
+  describe "#validate_account_number" do
+    it "allows a valid 28-character CI IBAN" do
+      ba = build(:cote_d_ivoire_bank_account, account_number: "CI73CI1231234567890123456789")
+      expect(ba).to be_valid
+    end
+
+    it "allows a valid CI IBAN entered with spaces and lowercase" do
+      ba = build(:cote_d_ivoire_bank_account, account_number: "ci73 ci12 3123 4567 8901 2345 6789")
+      expect(ba).to be_valid
+    end
+
+    it "rejects an IBAN with invalid check digits" do
+      ba = build(:cote_d_ivoire_bank_account, account_number: "CI00CI1231234567890123456789")
+      expect(ba).not_to be_valid
+      expect(ba.errors.full_messages).to include("The account number is invalid.")
+    end
+
+    it "rejects an IBAN with the wrong country code" do
+      ba = build(:cote_d_ivoire_bank_account, account_number: "GB73CI1231234567890123456789")
+      expect(ba).not_to be_valid
+      expect(ba.errors.full_messages).to include("The account number is invalid.")
+    end
+
+    it "rejects an IBAN that is too short" do
+      ba = build(:cote_d_ivoire_bank_account, account_number: "CI73CI123123456789012345678")
+      expect(ba).not_to be_valid
+      expect(ba.errors.full_messages).to include("The account number is invalid.")
+    end
+
+    it "rejects an account number with a non-digit in the account portion" do
+      ba = build(:cote_d_ivoire_bank_account, account_number: "CI73CI123123456789012345678X")
+      expect(ba).not_to be_valid
+      expect(ba.errors.full_messages).to include("The account number is invalid.")
+    end
+
+    it "rejects a blank account number" do
+      ba = build(:cote_d_ivoire_bank_account, account_number: "")
+      expect(ba).not_to be_valid
+      expect(ba.errors.full_messages).to include("The account number is invalid.")
+    end
+  end
 end


### PR DESCRIPTION
## What

Fixes Côte d'Ivoire (CI) bank-account IBAN validation, which rejected structurally-valid Ivorian IBANs with "The account number is invalid." CI is a bank-payout-only country (no PayPal payout option), so an affected seller had no payout path at all.

Fixes an internal issue (details tracked privately).

## Why

`CoteDIvoireBankAccount#validate_account_number` delegated to `Ibandit::IBAN#valid?`. In Ibandit 1.26.1 (pinned in `Gemfile.lock`, no app-side override) the CI IBAN structure ships with `bank_code_format` and `account_number_format` set to `nil`. Ibandit's `valid_bank_code_format?` / `valid_account_number_format?` then test the value against `entire_string_regex(nil)`, which compiles to `/\A\z/` — a regex that matches only the empty string. So every non-empty CI bank/account code fails "format is invalid", even though the country code, check digits, length, and characters are all correct.

Reproduced against Ibandit 1.26.1 with a synthetic valid CI IBAN:

```ruby
i = Ibandit::IBAN.new("CI73CI1231234567890123456789")
i.valid?               # => false
i.valid_check_digits?  # => true   (check digits are fine)
i.errors               # => {bank_code: "format is invalid", account_number: "format is invalid"}
Ibandit.structures["CI"][:bank_code_format]       # => nil
Ibandit.structures["CI"][:account_number_format]  # => nil
```

### Approach

Mirror the existing broken-country fixes (El Salvador, Guyana, Sri Lanka): validate the CI IBAN structure ourselves instead of trusting Ibandit's incomplete per-field format regexes.

- Enforce the CI layout with a local regex: `CI` + 2 check digits + 5-char bank code + 19-digit account number = 28 chars.
- Keep Ibandit for the parts it validates correctly: `valid_country_code?`, `valid_check_digits?` (mod-97), `valid_length?`, `valid_characters?`.
- Normalize input via `Ibandit::IBAN#iban` (uppercases and strips spaces/dashes), so a seller pasting a spaced IBAN still validates.

No `stripe_account_number` override is needed: for IBAN countries the merchant manager already sends the decrypted IBAN straight to Stripe as `account_number`, which is the format Stripe expects for CI. Verified the existing `StripeMerchantAccountManager` CI spec still passes.

I also dropped the `if: -> { Rails.env.production? }` guard so validation runs in all environments — this is what makes the new spec meaningful (and matches how El Salvador/Guyana/Sri Lanka validate). The factory IBAN is structurally valid, so existing specs that build CI accounts are unaffected.

### On the zero-payout history

There were CI bank accounts on file but no completed payouts through the CI bank path. The most likely explanation is that this validation blocked the save path for most sellers; the few saved records predate or bypassed it. This PR fixes the validation reproducibly. If a second issue exists at the Stripe payout layer it would need separate production verification, but the merchant-account creation path works in test with a valid IBAN.

## Before / After

Before: valid CI IBAN → "The account number is invalid." (no payout path).
After: valid CI IBAN saves; malformed IBANs (bad check digit, wrong country, wrong length, non-digit account, blank) are still rejected.

_Non-user-facing model/validation change; walkthrough video of the Settings → Payments save flow to follow._

## Test Results

`bundle exec rspec spec/models/cote_d_ivoire_bank_account_spec.rb` → 12 examples, 0 failures.
Revert check: with the old `Ibandit#valid?` logic restored, the new valid-IBAN specs fail, confirming the tests fail when the fix is reverted.
`StripeMerchantAccountManager` CI individual spec → 1 example, 0 failures.

All IBANs used in tests and this description are synthetic, not real account numbers.

---

AI disclosure: drafted with Claude Opus 4.6. The agent reproduced the Ibandit 1.26.1 CI structure bug, mirrored the El Salvador/Guyana/Sri Lanka validation pattern, added model specs with synthetic IBANs, and verified the tests fail on revert.
