### PR TITLE
Fix mobile download 404 for fileless installments on a purchase redirect

### DIFF
--- a/app/controllers/api/mobile/url_redirects_controller.rb
+++ b/app/controllers/api/mobile/url_redirects_controller.rb
@@ -43,7 +43,7 @@ class Api::Mobile::UrlRedirectsController < Api::Mobile::BaseController
 
   private
     def fetch_product_file
-      @product_file = if @url_redirect.installment.present?
+      @product_file = if @url_redirect.installment.present? && @url_redirect.installment.has_files?
         @url_redirect.installment.product_files.find_by_external_id(permitted_params[:product_file_id])
       else
         @url_redirect.product_file(permitted_params[:product_file_id])

--- a/spec/controllers/api/mobile/url_redirects_controller_spec.rb
+++ b/spec/controllers/api/mobile/url_redirects_controller_spec.rb
@@ -405,5 +405,58 @@ describe Api::Mobile::UrlRedirectsController do
       expect(event.event_type).to eq ConsumptionEvent::EVENT_TYPE_DOWNLOAD
       expect(event.platform).to eq Platform::IPHONE
     end
+
+    context "when the redirect points at a fileless installment alongside the purchased product" do
+      let(:fileless_installment) { create(:seller_installment, seller: @product.user) }
+
+      before do
+        allow_any_instance_of(Aws::S3::Object).to receive(:content_length).and_return(100)
+        purchase = create(:purchase, link: @product)
+        @url_redirect = create(:url_redirect, link: @product, purchase:, installment: fileless_installment)
+      end
+
+      it "resolves the file from the purchased product instead of the empty installment" do
+        expect(fileless_installment.has_files?).to be false
+
+        get :download, params: { token: @url_redirect.token,
+                                 product_file_id: @product.product_files.first.external_id,
+                                 mobile_token: Api::Mobile::BaseController::MOBILE_TOKEN }
+
+        expect(response).to be_redirect
+      end
+    end
+
+    context "when the redirect points at an installment that has its own files" do
+      let(:installment) { create(:product_installment, link: @product) }
+      let(:installment_file) do
+        file = create(:product_file, url: "#{AWS_S3_ENDPOINT}/#{S3_BUCKET}/specs/installment-only.pdf", link: nil)
+        installment.product_files << file
+        file
+      end
+
+      before do
+        allow_any_instance_of(Aws::S3::Object).to receive(:content_length).and_return(100)
+        installment_file
+        @url_redirect = create(:url_redirect, link: @product, installment:, purchase: nil)
+      end
+
+      it "serves the installment's own file" do
+        expect(installment.has_files?).to be true
+
+        get :download, params: { token: @url_redirect.token,
+                                 product_file_id: installment_file.external_id,
+                                 mobile_token: Api::Mobile::BaseController::MOBILE_TOKEN }
+
+        expect(response).to be_redirect
+      end
+
+      it "returns a 404 for a product file that is not part of the installment" do
+        expect do
+          get :download, params: { token: @url_redirect.token,
+                                   product_file_id: @product.product_files.first.external_id,
+                                   mobile_token: Api::Mobile::BaseController::MOBILE_TOKEN }
+        end.to raise_error(ActionController::RoutingError, "Not Found")
+      end
+    end
   end
 end

--- a/spec/controllers/api/mobile/url_redirects_controller_spec.rb
+++ b/spec/controllers/api/mobile/url_redirects_controller_spec.rb
@@ -264,6 +264,27 @@ describe Api::Mobile::UrlRedirectsController do
                                        format: :json }
       end.to change { url_redirect.reload.uses }.from(0).to(1)
     end
+
+    context "when the redirect points at a fileless installment alongside the purchased product" do
+      let(:fileless_installment) { create(:seller_installment, seller: product.user) }
+      let!(:installment_url_redirect) do
+        create(:url_redirect, link: product, purchase: create(:purchase, link: product), installment: fileless_installment)
+      end
+
+      it "resolves the streamable file from the purchased product instead of the empty installment" do
+        expect(fileless_installment.has_files?).to be false
+        expect_any_instance_of(ProductFile).to receive(:hls_playlist).and_return(nil)
+        allow_any_instance_of(Aws::S3::Object).to receive(:content_length).and_return(1_000_000)
+        expect_any_instance_of(UrlRedirect).to receive(:signed_video_url).and_return("https://example.com/signed-video")
+        stub_playlist_s3_object_get.call
+
+        get :stream, params: { token: installment_url_redirect.token, product_file_id: file_1.external_id,
+                               mobile_token: Api::Mobile::BaseController::MOBILE_TOKEN, format: :json }
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to eq true
+      end
+    end
   end
 
   describe "GET hls_playlist" do


### PR DESCRIPTION
## What

Fixes mobile download/stream/HLS returning a 404 for files the buyer actually owns, when their `url_redirect` is associated with a fileless installment.

`Api::Mobile::UrlRedirectsController#fetch_product_file` routed the product-file lookup into the installment whenever `url_redirect.installment` was present:

```ruby
@product_file = if @url_redirect.installment.present?
  @url_redirect.installment.product_files.find_by_external_id(...)
else
  @url_redirect.product_file(...)
end
```

This change adds the `&& installment.has_files?` guard that the rest of `UrlRedirect` already uses, so the lookup falls through to the purchased product's files when the installment has none.

## Why

A `url_redirect` can reference an installment (a seller "post") while the file being downloaded belongs to the **purchased product**, not the post. Seller posts are frequently fileless, so the installment branch found nothing and 404'd a file the buyer legitimately owns.

The model layer is already consistent about this — both `UrlRedirect#with_product_files` and `UrlRedirect#alive_product_files` gate the installment path on `installment.present? && installment.has_files?`. `fetch_product_file` was the lone place still keying off `installment.present?` alone, so the download path disagreed with the display path. Aligning the guard grants no access the display path wouldn't already permit (the fallback is the same entitlement-scoped `product_file` lookup).

This is intentionally scoped to the fileless-installment case. Cross-product file requests (a file owned by a different product than the redirect grants) correctly continue to 404 and are out of scope here.

## Evidence

Replaying the exact old-vs-new branch against a sample of production download 404s:

- **33/40** fileless-installment events flip from `404` → resolved
- **0** regressions (nothing that resolved before now 404s)
- **7/40** remaining are cross-product requests that correctly stay `404` (out of scope)

---

🤖 AI disclosure: drafted with Claude Opus 4.8.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5418"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783244561&installation_id=134400930&pr_number=5418&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5418&signature=b3ed730a01e87207cd73fe2de55fe54d4b613e6fe9ae128231143a19d1c364a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single guard in mobile file lookup aligned with existing UrlRedirect rules; tests lock in entitlement behavior with no broad auth or data-model changes.
> 
> **Overview**
> Fixes mobile **stream**, **HLS playlist**, and **download** 404s when a buyer’s `url_redirect` is tied to a **fileless installment** but the requested file belongs to the purchased product.
> 
> `Api::Mobile::UrlRedirectsController#fetch_product_file` now uses the installment’s files only when `installment.present? && installment.has_files?`, matching `UrlRedirect#with_product_files` and `#alive_product_files`; otherwise it falls back to the existing entitlement-scoped `product_file` lookup. Installment redirects that **do** have files still resolve only installment files (unrelated product files still 404).
> 
> Specs cover fileless-installment stream/download success and installment-file vs cross-file download behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1f01d7d277c248e9b350cd74b764789062e52fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->