### PR TITLE
Stop error-notifying for charge events on unrelated connected-account charges

### DIFF
--- a/app/models/concerns/purchase/charge_events_handler.rb
+++ b/app/models/concerns/purchase/charge_events_handler.rb
@@ -3,6 +3,18 @@
 module Purchase::ChargeEventsHandler
   extend ActiveSupport::Concern
 
+  # Event types that require action from us when matched to a Gumroad charge. For all other types (e.g. a
+  # `charge.succeeded` or other informational event) a missing chargeable is benign: it means the charge was not
+  # created by Gumroad. This happens routinely for connected Stripe accounts, where we receive webhooks for every
+  # charge the account processes, including ones unrelated to Gumroad. We ignore those instead of notifying.
+  ACTIONABLE_EVENT_TYPES_WITHOUT_CHARGEABLE = [
+    ChargeEvent::TYPE_DISPUTE_FORMALIZED,
+    ChargeEvent::TYPE_DISPUTE_WON,
+    ChargeEvent::TYPE_DISPUTE_LOST,
+    ChargeEvent::TYPE_SETTLEMENT_DECLINED,
+    ChargeEvent::TYPE_CHARGE_REFUND_UPDATED,
+  ].freeze
+
   class_methods do
     def handle_charge_event(event)
       logger.info("Charge event: #{event.to_h.to_json}")
@@ -10,8 +22,10 @@ module Purchase::ChargeEventsHandler
       chargeable = Charge::Chargeable.find_by_stripe_event(event)
 
       if chargeable.nil?
-        ErrorNotifier.notify("Could not find a Chargeable on Gumroad for Stripe Charge ID: #{event.charge_id}, " \
-                  "charge reference: #{event.charge_reference} for event id: #{event.charge_event_id}.")
+        if ACTIONABLE_EVENT_TYPES_WITHOUT_CHARGEABLE.include?(event.type)
+          ErrorNotifier.notify("Could not find a Chargeable on Gumroad for Stripe Charge ID: #{event.charge_id}, " \
+                    "charge reference: #{event.charge_reference} for event id: #{event.charge_event_id}.")
+        end
         return
       end
 

--- a/spec/models/concerns/purchase/charge_events_handler_spec.rb
+++ b/spec/models/concerns/purchase/charge_events_handler_spec.rb
@@ -22,6 +22,37 @@ describe Purchase::ChargeEventsHandler, :vcr do
     end
   end
 
+  describe "charge event with no matching chargeable" do
+    context "when the event requires action" do
+      it "notifies for a dispute formalized event" do
+        expect(ErrorNotifier).to receive(:notify).with(/Could not find a Chargeable/)
+        Purchase.handle_charge_event(build(:charge_event_dispute_formalized, charge_id: "py_nonexistent", charge_reference: nil))
+      end
+
+      it "notifies for a settlement declined event" do
+        expect(ErrorNotifier).to receive(:notify).with(/Could not find a Chargeable/)
+        Purchase.handle_charge_event(build(:charge_event_settlement_declined, charge_id: "py_nonexistent", charge_reference: nil))
+      end
+    end
+
+    context "when the event does not require action" do
+      it "ignores an informational event from an unrelated connected account charge" do
+        expect(ErrorNotifier).not_to receive(:notify)
+        Purchase.handle_charge_event(build(:charge_event_informational, charge_id: "py_nonexistent", charge_reference: nil))
+      end
+
+      it "ignores a charge succeeded event from an unrelated connected account charge" do
+        expect(ErrorNotifier).not_to receive(:notify)
+        Purchase.handle_charge_event(build(:charge_event_charge_succeeded, charge_id: "py_nonexistent", charge_reference: nil))
+      end
+
+      it "ignores a payment failed event from an unrelated connected account charge" do
+        expect(ErrorNotifier).not_to receive(:notify)
+        Purchase.handle_charge_event(build(:charge_event_payment_failed, charge_id: "py_nonexistent", charge_reference: nil))
+      end
+    end
+  end
+
   describe "setting the purchase fee from a charge event" do
     before do
       @l = create(:product)


### PR DESCRIPTION
## What

Restrict the "Could not find a Chargeable on Gumroad for Stripe Charge ID…" error notification in `Purchase::ChargeEventsHandler.handle_charge_event` to only fire for charge event types that genuinely require a matched chargeable: disputes, settlement declines, and refund updates. Informational, `charge.succeeded`, and `payment_intent.payment_failed` events with no matching chargeable are now silently ignored.

## Why

Gumroad subscribes to Stripe Connect webhooks for creators' connected accounts (`ForeignWebhooksController#stripe_connect`). It therefore receives `charge.*` events for **every** charge those accounts process — including charges Gumroad never created (the creators' own direct Stripe usage).

Those foreign charges:
- carry no Gumroad `purchase` metadata or combined-charge `transfer_group`, so `charge_reference` is blank,
- match no `Purchase#stripe_transaction_id` and no `ProcessorPaymentIntent`,

so `Charge::Chargeable.find_by_stripe_event` returns `nil` and we called `ErrorNotifier.notify` for each one. This is the root cause of a Sentry issue with **~1.87M events** since 2026-03-26 (~28k/day), all `py_…` charge IDs with empty charge references.

For informational / succeeded / payment-failed events a missing chargeable is benign — the charge isn't ours and there is nothing to act on. The handler already early-returns for similar known-irrelevant cases (`charge.failed`, Twitter-created charges). Only dispute, settlement-declined, and refund-updated events have financial consequences that warrant alerting when the charge can't be located, so the notification is scoped to those.

## Test Results

Added coverage in `charge_events_handler_spec.rb`:
- notifies for dispute-formalized and settlement-declined events with no matching chargeable
- does **not** notify for informational / charge-succeeded / payment-failed events with no matching chargeable

```
5 examples, 0 failures
```

The "does not notify" cases fail against the previous unconditional-notify code, so the tests are valid.

---

🤖 Written by Claude Opus 4.8 (1M context).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5420"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783268712&installation_id=134400930&pr_number=5420&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5420&signature=04cfa86eb1dff85fc91779a5e717bef779c421dad57261fc0f88bd36966c0bc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to when ErrorNotifier fires on unmatched events; dispute/settlement/refund gaps still alert.
> 
> **Overview**
> **Narrows Sentry noise** when Stripe Connect webhooks arrive for charges Gumroad did not create. In `Purchase::ChargeEventsHandler.handle_charge_event`, the “Could not find a Chargeable…” alert now runs only if the event type is in a new `ACTIONABLE_EVENT_TYPES_WITHOUT_CHARGEABLE` list (disputes, settlement declined, refund updated). Informational, `charge.succeeded`, and payment-failed events with no match still return early but **no longer** notify.
> 
> Specs cover both paths: alerts for dispute/settlement-declined with no chargeable; silence for informational / succeeded / failed with no chargeable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2910bf3fb703f23785217e4ce177adf7212a3f69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->