### PR TITLE
Scope TaxJar Sentry suppression to 'already imported' duplicates only

### DIFF
--- a/app/business/sales_tax/taxjar/taxjar_api.rb
+++ b/app/business/sales_tax/taxjar/taxjar_api.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class TaxjarApi
+  TRANSACTION_ALREADY_IMPORTED_ERROR_MESSAGE = "already imported"
+
   def initialize
     @client = Taxjar::Client.new(api_key: TAXJAR_API_KEY, headers: { "x-api-version" => "2022-01-24" }, api_url: TAXJAR_ENDPOINT)
     @cache = Redis::Namespace.new(:taxjar_calculations, redis: $redis)
@@ -80,10 +82,15 @@ class TaxjarApi
       raise e
     rescue *TaxjarErrors::CLIENT => e
       Rails.logger.error "TaxJar Client Error: #{e.inspect}"
-      ErrorNotifier.notify(e) unless e.is_a?(Taxjar::Error::BadRequest) || e.is_a?(Taxjar::Error::NotFound) || e.is_a?(Taxjar::Error::UnprocessableEntity)
+      ErrorNotifier.notify(e) unless e.is_a?(Taxjar::Error::BadRequest) || e.is_a?(Taxjar::Error::NotFound) || transaction_already_imported?(e)
       raise e
     rescue *TaxjarErrors::SERVER => e
       Rails.logger.error "TaxJar Server Error: #{e.inspect}"
       raise e
+    end
+
+    def transaction_already_imported?(error)
+      error.is_a?(Taxjar::Error::UnprocessableEntity) &&
+        error.message.to_s.include?(TRANSACTION_ALREADY_IMPORTED_ERROR_MESSAGE)
     end
 end

--- a/spec/business/sales_tax/taxjar/taxjar_api_spec.rb
+++ b/spec/business/sales_tax/taxjar/taxjar_api_spec.rb
@@ -299,10 +299,28 @@ describe TaxjarApi, :vcr do
       end.to raise_error(Taxjar::Error::BadRequest)
     end
 
-    it "propagates a TaxJar UnprocessableEntity error without notifying error tracker" do
-      expect_any_instance_of(Taxjar::Client).to receive(:tax_for_order).and_raise(Taxjar::Error::UnprocessableEntity)
+    it "propagates an 'already imported' UnprocessableEntity error without notifying error tracker" do
+      expect_any_instance_of(Taxjar::Client).to receive(:tax_for_order)
+        .and_raise(Taxjar::Error::UnprocessableEntity.new("Provider tranx already imported for your user account", 422))
 
       expect(ErrorNotifier).not_to receive(:notify)
+
+      expect do
+        described_class.new.calculate_tax_for_order(origin:,
+                                                    destination:,
+                                                    nexus_address:,
+                                                    quantity: 1,
+                                                    product_tax_code: nil,
+                                                    unit_price_dollars: 100.0,
+                                                    shipping_dollars: 20.0)
+      end.to raise_error(Taxjar::Error::UnprocessableEntity)
+    end
+
+    it "notifies error tracker and propagates other UnprocessableEntity errors" do
+      expect_any_instance_of(Taxjar::Client).to receive(:tax_for_order)
+        .and_raise(Taxjar::Error::UnprocessableEntity.new("to_zip is not a valid postal code", 422))
+
+      expect(ErrorNotifier).to receive(:notify).exactly(:once)
 
       expect do
         described_class.new.calculate_tax_for_order(origin:,


### PR DESCRIPTION
## What

Narrow the TaxJar `UnprocessableEntity` Sentry suppression in `TaxjarApi#with_caching` so it skips **only** the benign "Provider tranx already imported" duplicate-import 422, matched on the `already imported` detail message. Every other `UnprocessableEntity` is reported to Sentry again.

## Why

The monthly/summary sales-tax reporting jobs (`CreateUsStateMonthlySalesReportsJob`, `CreateUsStatesSalesSummaryReportJob`) push every in-range purchase to TaxJar via `create_order_transaction`. TaxJar returns HTTP 422 (`UnprocessableEntity`, "Provider tranx already imported for your user account") for any purchase already imported on a prior run, so re-running a report month produces a flood of duplicate-import 422s. This was the root cause of a Sentry issue with ~230k events.

PR #5415 fixed the noise by excluding **all** `UnprocessableEntity` errors from `ErrorNotifier.notify`. That works, but it's broader than intended: genuine 422 validation failures (invalid `to_zip`, bad amounts, unknown product tax codes) are now silently swallowed too, so we'd lose visibility into real data problems in tax reporting.

This change keeps the duplicate-import noise suppressed — that re-import is idempotent and expected — while restoring Sentry reporting for all other `UnprocessableEntity` errors. The duplicate case is still rescued at both job call sites, so behavior there is unchanged.

## Test Results

`spec/business/sales_tax/taxjar/taxjar_api_spec.rb`:
- "already imported" `UnprocessableEntity` propagates **without** notifying the error tracker
- other `UnprocessableEntity` errors notify the error tracker and propagate

```
10 examples, 0 failures
```

The "other UnprocessableEntity notifies" test fails against #5415's blanket exclusion, so the change is covered.

---

🤖 Written by Claude Opus 4.8 (1M context).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783269067&installation_id=134400930&pr_number=5421&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5421&signature=affc3759693b61e28f55b110e30d60aa964e0d0dedceaa2b9498724542e61173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to error-notification filtering in the TaxJar client wrapper; behavior for raising errors is unchanged and covered by specs.
> 
> **Overview**
> **TaxJar** error reporting in `TaxjarApi#with_caching` no longer skips Sentry for every `UnprocessableEntity`. It now suppresses `ErrorNotifier` only when the error is an `UnprocessableEntity` whose message includes **`already imported`** (duplicate transaction import), via a new `transaction_already_imported?` helper and constant.
> 
> Other **422** failures (e.g. invalid postal code) are **reported to Sentry again** while still being re-raised. Specs split the old blanket test into cases for duplicate-import vs other `UnprocessableEntity` errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0dae84bc8b0ac7b155fd72abb3c7393d35c35bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->