### PR TITLE
Ignore delivered emails without our provider header in customer email observer

### DIFF
--- a/app/observers/email_delivery_observer/handle_customer_email_info.rb
+++ b/app/observers/email_delivery_observer/handle_customer_email_info.rb
@@ -49,7 +49,12 @@ module EmailDeliveryObserver::HandleCustomerEmailInfo
     end
 
     def parse_message_headers(message)
-      email_provider = message.header[MailerInfo.header_name(:email_provider)].value
+      email_provider_header = message.header[MailerInfo.header_name(:email_provider)]
+      # Emails not sent through ApplicationMailer (e.g. Devise auth emails) lack our provider header.
+      # They carry no purchase/charge to track, so ignore them instead of treating it as a parse failure.
+      return [nil, nil, nil] if email_provider_header.nil?
+
+      email_provider = email_provider_header.value
 
       case email_provider
       when MailerInfo::EMAIL_PROVIDER_SENDGRID

--- a/spec/observers/email_delivery_observer/handle_customer_email_info_spec.rb
+++ b/spec/observers/email_delivery_observer/handle_customer_email_info_spec.rb
@@ -219,5 +219,23 @@ describe EmailDeliveryObserver::HandleCustomerEmailInfo do
         end
       end
     end
+
+    context "when the email provider header is missing" do
+      let(:message) { instance_double(Mail::Message) }
+
+      before do
+        allow(message).to receive(:header).and_return({})
+      end
+
+      it "ignores the email without raising or notifying" do
+        expect(ErrorNotifier).not_to receive(:notify)
+
+        expect do
+          expect do
+            EmailDeliveryObserver::HandleCustomerEmailInfo.perform(message)
+          end.not_to raise_error
+        end.not_to change { CustomerEmailInfo.count }
+      end
+    end
   end
 end


### PR DESCRIPTION
## What

Make `EmailDeliveryObserver::HandleCustomerEmailInfo#parse_message_headers` return early and ignore a delivered email when it has no `X-GUM-Email-Provider` header, instead of crashing on `nil.value`.

## Why

`EmailDeliveryObserver` is registered globally and fires for **every** delivered email via `Mail.inform_observers`. `parse_message_headers` read `message.header[MailerInfo.header_name(:email_provider)].value` unconditionally — but only emails sent through `ApplicationMailer` get that header (set in `ApplicationMailer#set_custom_headers`).

`UserSignupMailer < Devise::Mailer` (not `ApplicationMailer`), so Devise auth emails — `confirmation_instructions`, password reset, unlock, etc. — deliver with **no** provider header. `message.header[...]` returns `nil`, and `nil.value` raised `NoMethodError`, which the `rescue` re-wrapped as `InvalidHeaderError` and sent to Sentry.

This is the root cause of a Sentry issue with ~500k events (`EmailDeliveryObserver::HandleCustomerEmailInfo::InvalidHeaderError: Failed to parse  header: undefined method 'value' for nil`). The Sentry stacktrace confirms it exactly:

- crash at `handle_customer_email_info.rb:52`, re-raised at `:63`, during `Mail.inform_observers` inside `ActionMailer::MailDeliveryJob`
- breadcrumbs: `process.action_mailer {"action": "confirmation_instructions", "mailer": "UserSignupMailer"}` and the rendered template `user_signup_mailer/confirmation_instructions.html.erb`
- `handled = yes` — it's the `ErrorNotifier.notify` capture from `rescue InvalidHeaderError`, so the mail job itself didn't fail; it was pure Sentry noise

These auth emails carry no purchase/charge for the observer to track, so the correct behavior is to ignore them. Guarding in the observer (rather than only adding the header to `UserSignupMailer`) is the robust fix, since any non-`ApplicationMailer` delivery — Devise or otherwise — would otherwise hit the same crash. Genuine header parse failures for emails that **do** carry our provider header still raise `InvalidHeaderError` and notify.

## Test Results

`spec/observers/email_delivery_observer/handle_customer_email_info_spec.rb` — added "when the email provider header is missing" → ignores the email without raising or notifying. The header-parsing examples pass:

```
3 examples, 0 failures
```
(SendGrid-invalid, Resend-invalid, and the new missing-header case.)

Note: 18 unrelated examples in this file fail on a clean `main` in my local env (the `purchase` factory triggers a real card charge needing Stripe/VCR setup) — pre-existing and untouched by this change.

---

🤖 Written by Claude Opus 4.8 (1M context).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5422"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783269532&installation_id=134400930&pr_number=5422&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5422&signature=b03966cc76a2c6f124219bbf7fbb899414cab47f17fe0dd5666dc881eb6760b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small guard in the delivery observer; only skips tracking for untracked mail and leaves real header parse errors unchanged.
> 
> **Overview**
> Stops **Sentry noise** from the global `EmailDeliveryObserver` when delivered mail has no `X-GUM-Email-Provider` header (e.g. Devise/`UserSignupMailer` auth emails). **`parse_message_headers`** now returns `[nil, nil, nil]` when that header is absent so **`build_message_info`** treats the message as ignorable instead of calling `.value` on `nil` and raising **`InvalidHeaderError`**.
> 
> SendGrid/Resend messages that **do** include the provider header still follow the existing parse path; malformed headers still notify via **`ErrorNotifier`**. A spec covers the missing-header case (no notify, no **`CustomerEmailInfo`** write).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4726e8635503d0c7e2b82b55e4574a88d2826d56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->