### PR TITLE
Enable CLI device authorization

### DIFF
--- a/db/migrate/20260604142000_enable_device_authorization_for_gumroad_cli.rb
+++ b/db/migrate/20260604142000_enable_device_authorization_for_gumroad_cli.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class EnableDeviceAuthorizationForGumroadCli < ActiveRecord::Migration[7.1]
+  CLI_CLIENT_ID = "oljO5HmcOWvCZ5wbitpXPXk3u0LjAb5GdAEBBU5hwKA"
+
+  def up
+    oauth_applications
+      .where(uid: CLI_CLIENT_ID)
+      .update_all(device_authorization_enabled: true, updated_at: Time.current)
+  end
+
+  def down
+    oauth_applications
+      .where(uid: CLI_CLIENT_ID)
+      .update_all(device_authorization_enabled: false, updated_at: Time.current)
+  end
+
+  private
+    def oauth_applications
+      Class.new(ActiveRecord::Base) do
+        self.table_name = "oauth_applications"
+      end
+    end
+end

--- a/db/migrate/20260604142000_enable_device_authorization_for_gumroad_cli.rb
+++ b/db/migrate/20260604142000_enable_device_authorization_for_gumroad_cli.rb
@@ -4,9 +4,16 @@ class EnableDeviceAuthorizationForGumroadCli < ActiveRecord::Migration[7.1]
   CLI_CLIENT_ID = "oljO5HmcOWvCZ5wbitpXPXk3u0LjAb5GdAEBBU5hwKA"
 
   def up
-    oauth_applications
+    updated_count = oauth_applications
       .where(uid: CLI_CLIENT_ID)
       .update_all(device_authorization_enabled: true, updated_at: Time.current)
+
+    return unless updated_count.zero?
+
+    message = "Gumroad CLI OAuth application #{CLI_CLIENT_ID} was not found"
+    raise ActiveRecord::RecordNotFound, message if Rails.env.production?
+
+    say "#{message}; skipping production-only opt-in"
   end
 
   def down


### PR DESCRIPTION
Ref antiwork/gumroad-cli#123

## What

Enables OAuth device authorization for the existing Gumroad CLI OAuth application when the device authorization migration deploys.

## Why

The new device authorization column defaults to disabled for safety. The CLI client is the intended first device-flow consumer, so it needs an explicit opt-in before the CLI starts using the new flow.

---

This PR was implemented with AI assistance using gpt‑5.5 xhigh.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783278297&installation_id=134400930&pr_number=5423&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5423&signature=5650b388073c69215135db2f3ecc818d11abf225ff406c845b171689984087bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth client configuration in production; a missing CLI app record will block deploy, but scope is limited to one known client ID.
> 
> **Overview**
> Adds a follow-up data migration that **opts the Gumroad CLI OAuth client** into the new device authorization flow by setting `device_authorization_enabled` to `true` on the `oauth_applications` row matching the hard-coded CLI `uid`.
> 
> **`up`** updates that row in place; if no row matches, production deploys **fail** with `RecordNotFound`, while non-production environments log and skip. **`down`** turns the flag off again for rollback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55e616245d04f2aa3f6cf81ebb02862054e98208. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->