### PR TITLE
Treat SMTP 550 fatal errors as permanent in mailers

### DIFF
--- a/app/mailers/concerns/rescue_smtp_errors.rb
+++ b/app/mailers/concerns/rescue_smtp_errors.rb
@@ -12,7 +12,7 @@ module RescueSmtpErrors
       end
     end
 
-    rescue_from Net::SMTPAuthenticationError, Net::SMTPSyntaxError do |exception|
+    rescue_from Net::SMTPAuthenticationError, Net::SMTPSyntaxError, Net::SMTPFatalError do |exception|
       Rails.logger.error "Mailer Error: #{exception.inspect}"
     end
   end

--- a/spec/mailers/concerns/rescue_smtp_errors_spec.rb
+++ b/spec/mailers/concerns/rescue_smtp_errors_spec.rb
@@ -42,5 +42,11 @@ describe RescueSmtpErrors do
 
       expect { mailer_class.welcome.deliver_now }.to_not raise_error
     end
+
+    it "does not raise Net::SMTPFatalError" do
+      allow_any_instance_of(mailer_class).to receive(:welcome).and_raise(Net::SMTPFatalError.new(nil))
+
+      expect { mailer_class.welcome.deliver_now }.to_not raise_error
+    end
   end
 end


### PR DESCRIPTION
## What

Adds `Net::SMTPFatalError` to the exceptions swallowed by `RescueSmtpErrors`, so a permanent SMTP 550 is logged once rather than propagating out of the mailer and being retried.

## Why

Resend rejects emails sent to addresses with non-ASCII characters with a `550 Invalid` ... `field` error, raised as `Net::SMTPFatalError`. `RescueSmtpErrors` only rescued `Net::SMTPAuthenticationError` and `Net::SMTPSyntaxError`, so the 550 bubbled out of `ActionMailer::MailDeliveryJob` and Sidekiq retried it up to 25 times (`config/initializers/sidekiq.rb` default `retry: 25`).

A 5xx is a *permanent* failure — retrying can never succeed. The pointless retries turned a handful of bad recipient addresses into a 36,684-event Sentry storm ([GUMROAD-K](https://gumroad-to.sentry.io/issues/7366782180/), with single-hour bursts over 12k). Rescuing `Net::SMTPFatalError` stops the retry amplification at the source.

This is intentionally scoped to the retry-amplification half of the problem. Preventing non-ASCII addresses from being stored in the first place (tightening `EmailFormatValidator`) is a separate change.

## Test Results

```
bundle exec rspec spec/mailers/concerns/rescue_smtp_errors_spec.rb
5 examples, 0 failures
```

Added a spec asserting `Net::SMTPFatalError` no longer raises out of `deliver_now`.

---

🤖 AI disclosure: written with Claude Opus 4.8.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad/pr/5424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783280046&installation_id=134400930&pr_number=5424&repository=antiwork%2Fgumroad&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad%2Fpull%2F5424&signature=73468a6678d3a0dc745c3c0bd2665bcaa135ae8a796d288a1422243e0d99e2ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change matching existing SMTP rescue behavior; permanent failures are logged and dropped instead of retried, with no change to successful sends or other exception types.
> 
> **Overview**
> Extends **`RescueSmtpErrors`** so **`Net::SMTPFatalError`** (e.g. permanent SMTP 550 from Resend on invalid recipients) is handled like existing auth/syntax SMTP failures: log once and do not re-raise.
> 
> That stops **`ActionMailer::MailDeliveryJob`** / Sidekiq from retrying deliveries that cannot succeed, which was amplifying a small set of bad addresses into large Sentry volume.
> 
> Adds a mailer concern spec that **`deliver_now`** does not raise when **`Net::SMTPFatalError`** is raised.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 715412cdb5aeda291855c7ede09af59e676e472d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->